### PR TITLE
Refactor plugin actions

### DIFF
--- a/src/plugins/container.ts
+++ b/src/plugins/container.ts
@@ -152,7 +152,7 @@ export class ContainerModuleHandler extends Plugin<ContainerModule> {
   name = "container-module"
   supportedModuleTypes = ["container"]
 
-  parseModule(context: GardenContext, config: ContainerModuleConfig) {
+  parseModule({ context, config }: { context: GardenContext, config: ContainerModuleConfig }) {
     config = <ContainerModuleConfig>Joi.attempt(config, containerSchema)
 
     const module = new ContainerModule(context, config)
@@ -168,7 +168,7 @@ export class ContainerModuleHandler extends Plugin<ContainerModule> {
     return module
   }
 
-  async getModuleBuildStatus(module: ContainerModule) {
+  async getModuleBuildStatus({ module }: { module: ContainerModule }) {
     const ready = !!module.image ? true : await module.imageExistsLocally()
 
     if (ready) {
@@ -182,7 +182,7 @@ export class ContainerModuleHandler extends Plugin<ContainerModule> {
     return { ready }
   }
 
-  async buildModule(module: ContainerModule) {
+  async buildModule({ module }: { module: ContainerModule }) {
     const self = this
 
     if (!!module.image) {

--- a/src/plugins/generic.ts
+++ b/src/plugins/generic.ts
@@ -8,16 +8,16 @@ export class GenericModuleHandler<T extends Module = Module> extends Plugin<T> {
   name = "generic"
   supportedModuleTypes = ["generic"]
 
-  parseModule(context: GardenContext, config: ModuleConfigType<T>) {
+  parseModule({ context, config }: { context: GardenContext, config: ModuleConfigType<T> }) {
     return new Module<ModuleConfigType<T>>(context, config)
   }
 
-  async getModuleBuildStatus(module: T): Promise<BuildStatus> {
+  async getModuleBuildStatus({ module }: { module: T }): Promise<BuildStatus> {
     // Each module handler should keep track of this for now. Defaults to return false if a build command is specified.
     return { ready: !module.config.build.command }
   }
 
-  async buildModule(module: T): Promise<BuildResult> {
+  async buildModule({ module }: { module: T }): Promise<BuildResult> {
     // By default we run the specified build command in the module root, if any.
     // TODO: Keep track of which version has been built (needs local data store/cache).
     if (module.config.build.command) {

--- a/src/plugins/google/google-app-engine.ts
+++ b/src/plugins/google/google-app-engine.ts
@@ -1,16 +1,16 @@
-import { Environment } from "../../types/common"
-import { ServiceContext, ServiceStatus } from "../../types/service"
+import { ServiceStatus } from "../../types/service"
 import { join } from "path"
 import { GOOGLE_CLOUD_DEFAULT_REGION, GoogleCloudProviderBase } from "./base"
-import { ContainerModule, ContainerService } from "../container"
+import { ContainerModule } from "../container"
 import { dumpYaml } from "../../util"
+import { PluginActionParams } from "../../types/plugin"
 
 // TODO: support built-in GAE types (not just custom/flex containers)
 export class GoogleAppEngineProvider extends GoogleCloudProviderBase<ContainerModule> {
   name = "google-app-engine"
   supportedModuleTypes = ["container"]
 
-  async getServiceStatus(_service: ContainerService, _env: Environment): Promise<ServiceStatus> {
+  async getServiceStatus(): Promise<ServiceStatus> {
     // TODO
     // const project = this.getProject(service, env)
     //
@@ -21,7 +21,7 @@ export class GoogleAppEngineProvider extends GoogleCloudProviderBase<ContainerMo
     return {}
   }
 
-  async deployService(service: ContainerService, serviceContext: ServiceContext, env: Environment) {
+  async deployService({ service, serviceContext, env }: PluginActionParams<ContainerModule>["deployService"]) {
     this.context.log.info({
       section: service.name,
       msg: `Deploying app...`,
@@ -63,7 +63,7 @@ export class GoogleAppEngineProvider extends GoogleCloudProviderBase<ContainerMo
     this.context.log.info({ section: service.name, msg: `App deployed` })
   }
 
-  async getServiceOutputs(service: ContainerService, env: Environment) {
+  async getServiceOutputs({ service, env }: PluginActionParams<ContainerModule>["getServiceOutputs"]) {
     // TODO: we may want to pull this from the service status instead, along with other outputs
     const project = this.getProject(service, env)
 

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,5 +1,4 @@
 import { ContainerModuleHandler } from "./container"
-import { LocalDockerSwarmProvider } from "./local/local-docker-swarm"
 import { GoogleCloudFunctionsProvider } from "./google/google-cloud-functions"
 import { LocalGoogleCloudFunctionsProvider } from "./local/local-google-cloud-functions"
 import { KubernetesProvider } from "./kubernetes"
@@ -14,6 +13,5 @@ export const defaultPlugins: PluginFactory[] = [
   KubernetesProvider,
   GoogleAppEngineProvider,
   GoogleCloudFunctionsProvider,
-  LocalDockerSwarmProvider,
   LocalGoogleCloudFunctionsProvider,
 ].map(pluginClass => (ctx) => new pluginClass(ctx))

--- a/test/src/commands/deploy.ts
+++ b/test/src/commands/deploy.ts
@@ -2,9 +2,9 @@ import { join } from "path"
 import { GardenContext } from "../../../src/context"
 import { DeployCommand } from "../../../src/commands/deploy"
 import { expect } from "chai"
-import { Plugin } from "../../../src/types/plugin"
+import { DeployServiceParams, GetServiceStatusParams, Plugin } from "../../../src/types/plugin"
 import { Module } from "../../../src/types/module"
-import { Service, ServiceState, ServiceStatus } from "../../../src/types/service"
+import { ServiceState, ServiceStatus } from "../../../src/types/service"
 import { defaultPlugins } from "../../../src/plugins"
 
 class TestProvider extends Plugin<Module> {
@@ -13,11 +13,11 @@ class TestProvider extends Plugin<Module> {
 
   testStatuses: { [key: string]: ServiceStatus } = {}
 
-  async getServiceStatus(service: Service<Module>): Promise<ServiceStatus> {
+  async getServiceStatus({ service }: GetServiceStatusParams): Promise<ServiceStatus> {
     return this.testStatuses[service.name] || {}
   }
 
-  async deployService(service: Service<Module>) {
+  async deployService({ service }: DeployServiceParams) {
     const newStatus = {
       version: "1",
       state: <ServiceState>"ready",


### PR DESCRIPTION
Plugin actions now always accept an object, which makes it easier to include keys on all actions and in general add new keys as we evolve the interfaces.