### PR TITLE
Re-model Logger as a tree-like data structure

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@ import { Parameter, Command, StringParameter } from "./commands/base"
 import { ValidateCommand } from "./commands/validate"
 import { PluginError } from "./exceptions"
 import { GardenContext } from "./context"
-import { getLogger, Logger } from "./logger"
+import { getLogger, RootLogNode } from "./logger"
 import { resolve } from "path"
 import { BuildCommand } from "./commands/build"
 import { EnvironmentStatusCommand } from "./commands/environment/status"
@@ -29,7 +29,7 @@ export class GardenCli {
   // TODO: I don't particularly like Caporal.js, we might want to replace it at some point -JE
   program: any
   commands: { [key: string]: Command } = {}
-  logger: Logger
+  logger: RootLogNode
 
   constructor() {
     this.logger = getLogger()

--- a/src/commands/call.ts
+++ b/src/commands/call.ts
@@ -109,11 +109,11 @@ export class CallCommand extends Command<typeof callArgs> {
 
     try {
       res = await req
-      entry.success()
+      entry.setSuccess()
       ctx.log.info({ msg: chalk.green(`\n${res.status} ${res.statusText}\n`) })
     } catch (err) {
       res = err.response
-      entry.error()
+      entry.setError()
       ctx.log.info({ msg: chalk.red(`\n${res.status} ${res.statusText}\n`) })
     }
 

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -50,7 +50,7 @@ export class DevCommand extends Command<Opts> {
     while (true) {
       // TODO: actually do stuff
       await sleep(10000)
-      watchEntry.update({ emoji: "koala", msg: `Waiting for code changes...` })
+      watchEntry.setState({ emoji: "koala", msg: `Waiting for code changes...` })
     }
   }
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -10,7 +10,7 @@ import { ConfigurationError, ParameterError, PluginError } from "./exceptions"
 import { VcsHandler } from "./vcs/base"
 import { GitHandler } from "./vcs/git"
 import { Task, TaskGraph } from "./task-graph"
-import { getLogger, LogEntry, Logger } from "./logger"
+import { getLogger, LogEntry, RootLogNode } from "./logger"
 import {
   BuildStatus, pluginActionNames, PluginActions, PluginFactory, Plugin,
 } from "./types/plugin"
@@ -33,7 +33,7 @@ const builtinPlugins = [
 ]
 
 export class GardenContext {
-  public readonly log: Logger
+  public readonly log: RootLogNode
   public readonly actionHandlers: PluginActionMap
   public readonly projectName: string
   public readonly config: ProjectConfig
@@ -52,7 +52,7 @@ export class GardenContext {
 
   constructor(
     public projectRoot: string,
-    { logger, plugins = [] }: { logger?: Logger, plugins?: PluginFactory[] } = {},
+    { logger, plugins = [] }: { logger?: RootLogNode, plugins?: PluginFactory[] } = {},
   ) {
     this.modulesScanned = false
     this.log = logger || getLogger()

--- a/src/logger/util.ts
+++ b/src/logger/util.ts
@@ -18,6 +18,10 @@ export function getNodeListFromTree<T extends Node>(node: T): T[] {
   return arr.concat(flatten(node.children.map(child => getNodeListFromTree(child))))
 }
 
+export function getChildNodes<T extends Node>(node: T): T[] {
+  return getNodeListFromTree(node).slice(1)
+}
+
 export function traverseTree<T extends Node>(root: T, visitNode: Function): void {
   let stack: any[] = []
   stack.push(root)

--- a/src/logger/writers.ts
+++ b/src/logger/writers.ts
@@ -1,0 +1,148 @@
+import * as logUpdate from "log-update"
+import * as cliCursor from "cli-cursor"
+import { getChildNodes, interceptStream } from "./util"
+
+import {
+  EntryStatus,
+  LogLevel,
+} from "./types"
+
+import { LogEntry, RootLogNode } from "./index"
+
+const INTERVAL_DELAY = 100
+
+export interface ConsoleWriter {
+  rootLogNode: RootLogNode
+  level: LogLevel
+  render(entry: LogEntry): string | string[] | null
+  write(entry: LogEntry): void
+  stop(): void
+}
+
+export class BasicConsoleWriter implements ConsoleWriter {
+  public rootLogNode: RootLogNode
+  public level: LogLevel
+
+  constructor(level: LogLevel, rootLogNode: RootLogNode) {
+    this.level = level
+    this.rootLogNode = rootLogNode
+  }
+
+  render(entry: LogEntry): string | null {
+    if (this.level >= entry.level) {
+      return entry.render()
+    }
+    return null
+  }
+
+  write(entry: LogEntry) {
+    const out = this.render(entry)
+    if (out) {
+      console.log(out)
+    }
+  }
+
+  // No op
+  stop() { }
+}
+
+export class FancyConsoleWriter implements ConsoleWriter {
+  private logUpdate: any
+  private intervalID: NodeJS.Timer | null
+
+  public rootLogNode: RootLogNode
+  public level: LogLevel
+
+  constructor(level: LogLevel, rootLogNode: RootLogNode) {
+    this.level = level
+    this.rootLogNode = rootLogNode
+    this.intervalID = null
+    this.logUpdate = this.initLogUpdate()
+  }
+
+  private initLogUpdate(): any {
+    // Create custom stream that calls write method with the 'noIntercept' option.
+    const stream = {
+      ...process.stdout,
+      write: (str, enc, cb) => (<any>process.stdout.write)(str, enc, cb, { noIntercept: true }),
+    }
+    const makeOpts = (msg: string) => ({
+      // Remove trailing new line from console writes since Logger already handles it
+      msg: msg.replace(/\n$/, ""),
+      notOriginatedFromLogger: true,
+    })
+    // NOTE: On every write, log-update library calls the cli-cursor library to hide the cursor
+    // which the cli-cursor library does via stderr write. This causes an infinite loop as
+    // the stderr writes are intercepted and funneled back to the Logger.
+    // Therefore we manually toggle the cursor using the custom stream from above.
+    //
+    // log-update types are missing the `opts?: {showCursor?: boolean}` parameter
+    const customLogUpdate = (<any>logUpdate.create)(<any>stream, { showCursor: true })
+    cliCursor.hide(stream)
+
+    const restoreStreamFns = [
+      interceptStream(process.stdout, msg => this.rootLogNode.info(makeOpts(msg))),
+      interceptStream(process.stderr, msg => this.rootLogNode.error(makeOpts(msg))),
+    ]
+
+    const cleanUp = () => {
+      cliCursor.show(stream)
+      restoreStreamFns.forEach(restoreStream => restoreStream())
+      logUpdate.done()
+    }
+    customLogUpdate.cleanUp = cleanUp
+
+    return customLogUpdate
+  }
+
+  private startLoop(): void {
+    if (!this.intervalID) {
+      this.intervalID = setInterval(this.write.bind(this), INTERVAL_DELAY)
+    }
+  }
+
+  private stopLoop(): void {
+    if (this.intervalID) {
+      clearInterval(this.intervalID)
+      this.intervalID = null
+    }
+  }
+
+  write(): void {
+    const out = this.render()
+    if (out) {
+      this.logUpdate(out.join("\n"))
+    }
+  }
+
+  // Has a side effect in that it starts/stops the rendering loop depending on
+  // whether or not active entries were found while building output
+  render(): string[] | null {
+    let hasActiveEntries = false
+    const entries = <any>getChildNodes(this.rootLogNode)
+    const out = entries.reduce((acc: string[], e: LogEntry) => {
+      if (e.status === EntryStatus.ACTIVE) {
+        hasActiveEntries = true
+      }
+      if (this.level >= e.level) {
+        acc.push(e.render())
+      }
+      return acc
+    }, [])
+    if (hasActiveEntries) {
+      this.startLoop()
+    } else {
+      this.stopLoop()
+    }
+    if (out.length) {
+      return out
+    }
+    return null
+  }
+
+  stop() {
+    this.stopLoop()
+    this.logUpdate.cleanUp()
+  }
+
+}

--- a/src/plugins/container.ts
+++ b/src/plugins/container.ts
@@ -184,7 +184,7 @@ export class ContainerModuleHandler implements Plugin<ContainerModule> {
 
   async buildModule({ ctx, module, logEntry }: BuildModuleParams<ContainerModule>) {
     if (!!module.image) {
-      logEntry && logEntry.update({ msg: `Fetching image ${module.image}...` })
+      logEntry && logEntry.setState({ msg: `Fetching image ${module.image}...` })
       await module.pullImage(ctx)
       return { fetched: true }
     }
@@ -192,7 +192,7 @@ export class ContainerModuleHandler implements Plugin<ContainerModule> {
     const identifier = await module.getImageId()
 
     // build doesn't exist, so we create it
-    logEntry && logEntry.update({ msg: `Building ${identifier}...` })
+    logEntry && logEntry.setState({ msg: `Building ${identifier}...` })
 
     // TODO: log error if it occurs
     // TODO: stream output to log if at debug log level

--- a/src/plugins/kubernetes/index.ts
+++ b/src/plugins/kubernetes/index.ts
@@ -116,7 +116,7 @@ export class KubernetesProvider implements Plugin<ContainerModule> {
     })
 
     if (!status.detail.systemNamespaceReady) {
-      entry.update({ section: "kubernetes", msg: `Creating garden system namespace` })
+      entry.setState({ section: "kubernetes", msg: `Creating garden system namespace` })
       await this.coreApi().namespaces.post({
         body: {
           apiVersion: "v1",
@@ -132,7 +132,7 @@ export class KubernetesProvider implements Plugin<ContainerModule> {
     }
 
     if (!status.detail.namespaceReady) {
-      entry.update({ section: "kubernetes", msg: `Creating namespace ${env.namespace}` })
+      entry.setState({ section: "kubernetes", msg: `Creating namespace ${env.namespace}` })
       await this.coreApi().namespaces.post({
         body: {
           apiVersion: "v1",
@@ -148,13 +148,13 @@ export class KubernetesProvider implements Plugin<ContainerModule> {
     }
 
     if (!status.detail.dashboardReady) {
-      entry.update({ section: "kubernetes", msg: `Configuring dashboard` })
+      entry.setState({ section: "kubernetes", msg: `Configuring dashboard` })
       // TODO: deploy this as a service
       await this.kubectl(GARDEN_SYSTEM_NAMESPACE).call(["apply", "-f", dashboardSpecPath])
     }
 
     if (!status.detail.ingressControllerReady) {
-      entry.update({ section: "kubernetes", msg: `Configuring ingress controller` })
+      entry.setState({ section: "kubernetes", msg: `Configuring ingress controller` })
       const gardenEnv = this.getSystemEnv(env)
       await this.deployService({
         ctx,
@@ -171,7 +171,7 @@ export class KubernetesProvider implements Plugin<ContainerModule> {
       })
     }
 
-    entry.success({ section: "kubernetes", msg: "Environment configured" })
+    entry.setSuccess({ section: "kubernetes", msg: "Environment configured" })
   }
 
   async getServiceStatus({ ctx, service, env }: GetServiceStatusParams<ContainerModule>): Promise<ServiceStatus> {

--- a/src/task-graph.ts
+++ b/src/task-graph.ts
@@ -109,7 +109,7 @@ export class TaskGraph {
     const loop = async () => {
       if (_this.index.length === 0) {
         // done!
-        this.logEntryMap.counter.done({ symbol: LogSymbolType.info })
+        this.logEntryMap.counter.setDone({ symbol: LogSymbolType.info })
         return
       }
 
@@ -126,7 +126,7 @@ export class TaskGraph {
 
         try {
           this.logTask(node)
-          this.logEntryMap.inProgress.update({ msg: inProgressToStr(this.inProgress.getNodes()) })
+          this.logEntryMap.inProgress.setState({ msg: inProgressToStr(this.inProgress.getNodes()) })
 
           const dependencyKeys = (await node.task.getDependencies()).map(d => getIndexKey(d))
           const dependencyResults = pick(results, dependencyKeys)
@@ -177,8 +177,8 @@ export class TaskGraph {
 
   private logTaskComplete(node: TaskNode) {
     const entry = this.logEntryMap[node.getKey()]
-    entry && entry.success()
-    this.logEntryMap.counter.update({ msg: remainingTasksToStr(this.index.length) })
+    entry && entry.setSuccess()
+    this.logEntryMap.counter.setState({ msg: remainingTasksToStr(this.index.length) })
   }
 
   private initLogging() {

--- a/src/tasks/build.ts
+++ b/src/tasks/build.ts
@@ -34,11 +34,11 @@ export class BuildTask extends Task {
       const result = await this.ctx.buildModule(this.module, entry)
       const buildTime = (new Date().getTime()) - startTime
 
-      entry.success({ msg: chalk.green(`Done (took ${round(buildTime / 1000, 1)} sec)`), append: true })
+      entry.setSuccess({ msg: chalk.green(`Done (took ${round(buildTime / 1000, 1)} sec)`), append: true })
 
       return result
     } else {
-      entry.success({ msg: "Already built" })
+      entry.setSuccess({ msg: "Already built" })
       return { fresh: false }
     }
   }

--- a/src/tasks/deploy.ts
+++ b/src/tasks/deploy.ts
@@ -46,7 +46,7 @@ export class DeployTask extends Task {
     const version = await this.service.module.getVersion()
     const status = await this.ctx.getServiceStatus(this.service)
 
-    entry.update({ section: this.service.name, msg: "Deploying" })
+    entry.setState({ section: this.service.name, msg: "Deploying" })
 
     if (
       !this.force &&
@@ -54,7 +54,7 @@ export class DeployTask extends Task {
       status.state === "ready"
     ) {
       // already deployed and ready
-      entry.success({
+      entry.setSuccess({
         msg: `Version ${version} already deployed`,
         append: true,
       })
@@ -64,7 +64,7 @@ export class DeployTask extends Task {
     const serviceContext = { envVars: await this.prepareEnvVars(version) }
     const result = await this.ctx.deployService(this.service, serviceContext)
 
-    entry.success({ msg: chalk.green(`Ready`), append: true })
+    entry.setSuccess({ msg: chalk.green(`Ready`), append: true })
 
     return result
   }

--- a/src/tasks/test.ts
+++ b/src/tasks/test.ts
@@ -49,7 +49,7 @@ export class TestTask extends Task {
     const result = await this.ctx.testModule(this.module, this.testSpec)
 
     if (result.success) {
-      entry.success({ msg: chalk.green(`Success`), append: true })
+      entry.setSuccess({ msg: chalk.green(`Success`), append: true })
     } else {
       entry.error({ msg: chalk.red(`Failed!`), append: true })
     }

--- a/test/src/logger.ts
+++ b/test/src/logger.ts
@@ -1,10 +1,11 @@
 import { expect } from "chai"
 
-import { LogLevel, EntryStatus, LogSymbolType } from "../../src/logger/types"
-import { BasicLogger, FancyLogger } from "../../src/logger"
-import { getNodeListFromTree } from "../../src/logger/util"
+import { LogLevel, EntryStatus, LogSymbolType, LoggerType } from "../../src/logger/types"
+import { BasicConsoleWriter,  FancyConsoleWriter } from "../../src/logger/writers"
+import { RootLogNode } from "../../src/logger"
+import { getChildNodes } from "../../src/logger/util"
 
-const logger = new BasicLogger(LogLevel.silent)
+const logger = new RootLogNode(LogLevel.silent, LoggerType.basic)
 
 logger.error({ msg: "error" })
 logger.warn({ msg: "warn" })
@@ -13,58 +14,65 @@ logger.verbose({ msg: "verbose" })
 logger.debug({ msg: "debug" })
 logger.silly({ msg: "silly" })
 
-describe("Logger", () => {
-  it("should contain an ordered list of log entries", () => {
+describe("RootLogNode", () => {
 
-    const result = logger.entries
-    const levels = result.map(e => e.level)
+  describe("getLogEntries", () => {
+    it("should return an ordered list of log entries", () => {
 
-    expect(result).to.have.lengthOf(6)
-    expect(levels).to.eql([
-      LogLevel.error,
-      LogLevel.warn,
-      LogLevel.info,
-      LogLevel.verbose,
-      LogLevel.debug,
-      LogLevel.silly,
-    ])
+      const entries = logger.getLogEntries()
+      const levels = entries.map(e => e.level)
+
+      expect(entries).to.have.lengthOf(6)
+      expect(levels).to.eql([
+        LogLevel.error,
+        LogLevel.warn,
+        LogLevel.info,
+        LogLevel.verbose,
+        LogLevel.debug,
+        LogLevel.silly,
+      ])
+    })
   })
 
-  describe("nest", () => {
-    it("should nest new child entries", () => {
-      const prevLength = logger.entries.length
-      const entry = logger.entries[0]
-      const nested = entry.nest.info({ msg: "nested" })
-      const deepNested = nested.nest.info({ msg: "deep" })
+  describe("addNode", () => {
+    it("should add new child entries to respective node", () => {
+      const prevLength = logger.children.length
+      const entry = logger.children[0]
+      const nested = entry.info({ msg: "nested" })
+      const deepNested = nested.info({ msg: "deep" })
 
-      expect(logger.entries[0].children).to.have.lengthOf(1)
-      expect(logger.entries[0].children[0]).to.eql(nested)
-      expect(logger.entries[0].children[0].children[0]).to.eql(deepNested)
-      expect(logger.entries).to.have.lengthOf(prevLength)
+      expect(logger.children[0].children).to.have.lengthOf(1)
+      expect(logger.children[0].children[0]).to.eql(nested)
+      expect(logger.children[0].children[0].children[0]).to.eql(deepNested)
+      expect(logger.children).to.have.lengthOf(prevLength)
       expect(deepNested["depth"]).to.equal(2)
     })
   })
 
-  describe("BasicLogger.render", () => {
-    it("should return a string if level is geq to log entry level", () => {
-      const basic = new BasicLogger(LogLevel.silent)
-      basic.info({ msg: "" })
-      const out1 = basic.render()
-      basic.level = LogLevel.verbose
-      const out2 = basic.render()
+  describe("BasicConsoleWriter.render", () => {
+    it("should return a string if log level is geq than entry level", () => {
+      const logger2 = new RootLogNode(LogLevel.silent, LoggerType.basic)
+      const writer = new BasicConsoleWriter(LogLevel.silent, logger2)
+      const entry = logger2.info({ msg: "" })
+      const out1 = writer.render(entry)
+      writer.level = LogLevel.verbose
+      const out2 = writer.render(entry)
 
       expect(out1).to.a("null")
       expect(out2).to.be.a("string")
     })
   })
 
-  describe("FancyLogger.render", () => {
-    it("should return an array of strings if level is geq to entry level", () => {
-      const fancy = new FancyLogger(LogLevel.silent)
-      fancy.info({ msg: "" })
-      const out1 = fancy.render()
-      fancy.level = LogLevel.verbose
-      const out2 = fancy.render()
+  describe("FancyConsoleWriter.render", () => {
+    it("should return an array of strings if log level is geq than respective entry level", () => {
+      const logger3 = new RootLogNode(LogLevel.silent, LoggerType.basic)
+      const writer = new FancyConsoleWriter(LogLevel.silent, logger3)
+      const entry = logger3.info({ msg: "" })
+      const out1 = writer.render()
+      writer.level = LogLevel.verbose
+      const out2 = writer.render()
+
+      writer.stop()
 
       expect(out1).to.be.a("null")
       expect(out2).to.be.an("array").of.length(1)
@@ -72,38 +80,38 @@ describe("Logger", () => {
   })
 
   describe("LogEntry", () => {
-    const entry = logger.entries[0]
-    describe("update", () => {
+    const entry = logger.children[0]
+    describe("setState", () => {
       it("should update entry state and optionally append new msg to previous msg", () => {
-        entry.update({ msg: "new" })
+        entry.setState({ msg: "new" })
         expect(entry["opts"]["msg"]).to.equal("new")
-        entry.update({ msg: "new2", append: true })
+        entry.setState({ msg: "new2", append: true })
         expect(entry["opts"]["msg"]).to.eql(["new", "new2"])
       })
     })
-    describe("done", () => {
+    describe("setDone", () => {
       it("should update entry state and set status to done", () => {
-        entry.done()
+        entry.setDone()
         expect(entry["status"]).to.equal(EntryStatus.DONE)
       })
     })
-    describe("success", () => {
+    describe("setSuccess", () => {
       it("should update entry state and set status and symbol to success", () => {
-        entry.success()
+        entry.setSuccess()
         expect(entry["status"]).to.equal(EntryStatus.SUCCESS)
         expect(entry["opts"]["symbol"]).to.equal(LogSymbolType.success)
       })
     })
-    describe("error", () => {
+    describe("setError", () => {
       it("should update entry state and set status and symbol to error", () => {
-        entry.error()
+        entry.setError()
         expect(entry["status"]).to.equal(EntryStatus.ERROR)
         expect(entry["opts"]["symbol"]).to.equal(LogSymbolType.error)
       })
     })
-    describe("warn", () => {
+    describe("setWarn", () => {
       it("should update entry state and set status and symbol to warn", () => {
-        entry.warn()
+        entry.setWarn()
         expect(entry["status"]).to.equal(EntryStatus.WARN)
         expect(entry["opts"]["symbol"]).to.equal(LogSymbolType.warn)
       })
@@ -111,7 +119,7 @@ describe("Logger", () => {
   })
 
   describe("util", () => {
-    describe("getNodeListFromTree", () => {
+    describe("getChildNodes", () => {
       it("should convert an n-ary tree into an ordered list of nodes", () => {
         const graph = {
           children: [
@@ -119,26 +127,26 @@ describe("Logger", () => {
               children: [
                 {
                   children: [
-                    { children: [], idx: 4 },
+                    { children: [], id: 3 },
                   ],
-                  idx: 3,
+                  id: 2,
                 },
-                { children: [], idx: 5 },
-                { children: [], idx: 6 },
+                { children: [], id: 4 },
+                { children: [], id: 5 },
               ],
-              idx: 2,
+              id: 1,
             },
             {
               children: [
 
               ],
-              idx: 7,
+              id: 6,
             },
           ],
-          idx: 1,
+          id: "root",
         }
-        const nodeList = getNodeListFromTree(graph)
-        expect(nodeList.map(n => n.idx)).to.eql([1, 2, 3, 4, 5, 6, 7])
+        const nodeList = getChildNodes(graph)
+        expect(nodeList.map(n => n.id)).to.eql([1, 2, 3, 4, 5, 6])
       })
     })
   })


### PR DESCRIPTION
TL;DR: Log is now a tree-like data structure and writing has been abstracted into a separate class.

Since we added subtasks it made sense to model the logger as tree rather than a list of entries. So now the log is a graph (a rooted directed tree) that consists of `LogNode`s which can themselves create new child nodes. A `LogEntry` is a `LogNode` that is updatable and renderable. The `RootLogNode` uniquely determines the graph and is kind of like the `document` node in the DOM.

Writing has also been delegated to special writer classes which consume the graph. So the concern of writing on the one hand and handling the data on the other has been separated between the writers and the log respectively.

This should make adding more complex update methods to the log as well as different types of writers more future proof. 

Some changes have been made to the API, in particular it's no longer necessary to call `nest` when creating subtasks.