### PR TITLE
Add garden-debug script.

### DIFF
--- a/bin/garden-debug
+++ b/bin/garden-debug
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+garden_root=$(cd `dirname $0` && cd $(git rev-parse --show-toplevel) && pwd)
+node --inspect ${garden_root}/build/src/bin/garden.js "$@"


### PR DESCRIPTION
For debugging with the Chrome dev tools. Running `garden-debug` instead of `garden` allows you to add a breakpoint via a `debugger` statement that Chrome catches. See also [this Medium post](https://medium.com/the-node-js-collection/debugging-node-js-with-google-chrome-4965b5f910f4).