### PR TITLE
Include path in error when config parsing fails.

### DIFF
--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -47,7 +47,7 @@ export async function loadConfig(path: string): Promise<Config> {
   try {
     config = <Config>yaml.safeLoad(fileData) || {}
   } catch (err) {
-    throw new ConfigurationError(`Could not parse ${CONFIG_FILENAME} as valid YAML`, err)
+    throw new ConfigurationError(`Could not parse ${CONFIG_FILENAME} in directory ${path} as valid YAML`, err)
   }
 
   config.dirname = Joi.attempt(parse(absPath).dir.split(sep).slice(-1)[0], joiIdentifier())


### PR DESCRIPTION
Currently, the message just reads: 
```
Error: Could not parse garden.yml as valid YAML
```

Which is not ideal when there are many `garden.yml`-s in the project. This commit adds the absolute path to the failing `garden.yml`'s enclosing dir.

Using the relative path from project root might be nicer, but would make calling this function more cumbersome in certain usage contexts, since it's sometimes used early in the init process.