### PR TITLE
feat: user no longer needs to run `env config` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ it's pretty straightforward, promise :)
 
 To spin it up, `cd` to any of the directories under `examples/` and run:
 
-    garden env configure
     garden deploy
     
 If you've deployed the `hello-world` project, you can try querying the `/hello` endpoint:

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -38,6 +38,9 @@ export class DeployCommand extends Command<typeof deployArgs, typeof deployOpts>
 
     const names = args.service ? args.service.split(",") : undefined
 
+    // TODO: make this a task
+    await ctx.configureEnvironment()
+
     const result = await ctx.deployServices({
       names,
       force: !!opts.force,

--- a/src/plugin-context.ts
+++ b/src/plugin-context.ts
@@ -197,14 +197,22 @@ export function createPluginContext(garden: Garden): PluginContext {
       const handlers = garden.getActionHandlers("configureEnvironment")
       const env = garden.getEnvironment()
 
+      const statuses = await ctx.getEnvironmentStatus()
+
       await Bluebird.each(toPairs(handlers), async ([name, handler]) => {
+        const status = statuses[name] || { configured: false }
+
+        if (status.configured) {
+          return
+        }
+
         const logEntry = garden.log.info({
           entryStyle: EntryStyle.activity,
           section: name,
           msg: "Configuring...",
         })
 
-        await handler({ ...commonParams(handler), env, logEntry })
+        await handler({ ...commonParams(handler), status, env, logEntry })
 
         logEntry.setSuccess("Configured")
       })

--- a/src/plugins/google/common.ts
+++ b/src/plugins/google/common.ts
@@ -56,9 +56,7 @@ export async function getEnvironmentStatus() {
   return output
 }
 
-export async function configureEnvironment({ ctx }: ConfigureEnvironmentParams) {
-  const status = await getEnvironmentStatus()
-
+export async function configureEnvironment({ ctx, status }: ConfigureEnvironmentParams) {
   if (!status.detail.sdkInstalled) {
     throw new ConfigurationError(
       "Google Cloud SDK is not installed. " +

--- a/src/plugins/kubernetes/actions.ts
+++ b/src/plugins/kubernetes/actions.ts
@@ -87,15 +87,8 @@ export async function getEnvironmentStatus({ ctx, provider }: GetEnvironmentStat
 }
 
 export async function configureEnvironment(
-  { ctx, provider, env, logEntry }: ConfigureEnvironmentParams,
+  { ctx, provider, status, logEntry }: ConfigureEnvironmentParams,
 ) {
-  // TODO: use Helm 3 when it's released instead of this custom/manual stuff
-  const status = await getEnvironmentStatus({ ctx, provider, env, logEntry })
-
-  if (status.configured) {
-    return
-  }
-
   const context = provider.config.context
 
   if (!status.detail.namespaceReady) {

--- a/src/plugins/kubernetes/local.ts
+++ b/src/plugins/kubernetes/local.ts
@@ -47,25 +47,26 @@ export async function getLocalEnvironmentStatus(
 }
 
 async function configureLocalEnvironment(
-  { ctx, provider, env, logEntry }: ConfigureEnvironmentParams,
+  { ctx, provider, env, status, logEntry }: ConfigureEnvironmentParams,
 ) {
-  const status = await getLocalEnvironmentStatus({ ctx, provider, env, logEntry })
-
-  if (status.configured) {
-    return
-  }
-
-  await configureEnvironment({ ctx, provider, env, logEntry })
+  await configureEnvironment({ ctx, provider, env, status, logEntry })
 
   if (!isSystemGarden(provider)) {
     const sysGarden = await getSystemGarden(provider)
+    const sysProvider = {
+      name: provider.name,
+      config: sysGarden.config.providers[provider.name],
+    }
+    const sysStatus = await getEnvironmentStatus({
+      ctx: sysGarden.pluginContext,
+      provider: sysProvider,
+      env,
+    })
     await configureEnvironment({
       ctx: sysGarden.pluginContext,
       env: sysGarden.getEnvironment(),
-      provider: {
-        name: provider.name,
-        config: sysGarden.config.providers[provider.name],
-      },
+      provider: sysProvider,
+      status: sysStatus,
       logEntry,
     })
     await sysGarden.pluginContext.deployServices({ logEntry })

--- a/src/plugins/local/local-docker-swarm.ts
+++ b/src/plugins/local/local-docker-swarm.ts
@@ -11,8 +11,11 @@ import { exec } from "child-process-promise"
 import { DeploymentError } from "../../exceptions"
 import { PluginContext } from "../../plugin-context"
 import {
-  DeployServiceParams, ExecInServiceParams, GetServiceOutputsParams, GetServiceStatusParams,
+  ExecInServiceParams,
+  GetServiceOutputsParams,
+  GetServiceStatusParams,
   GardenPlugin,
+  DeployServiceParams,
 } from "../../types/plugin"
 import { ContainerModule } from "../container"
 import {
@@ -230,11 +233,7 @@ async function getEnvironmentStatus() {
 }
 
 async function configureEnvironment() {
-  const status = await getEnvironmentStatus()
-
-  if (!status.configured) {
-    await getDocker().swarmInit({})
-  }
+  await getDocker().swarmInit({})
 }
 
 async function getServiceStatus({ ctx, service }: GetServiceStatusParams<ContainerModule>): Promise<ServiceStatus> {

--- a/src/plugins/local/local-google-cloud-functions.ts
+++ b/src/plugins/local/local-google-cloud-functions.ts
@@ -106,14 +106,7 @@ async function getEnvironmentStatus({ ctx }: GetEnvironmentStatusParams) {
   return { configured: status.state === "ready" }
 }
 
-async function configureEnvironment({ ctx, provider, env, logEntry }: ConfigureEnvironmentParams) {
-  const status = await getEnvironmentStatus({ ctx, provider, env })
-
-  // TODO: This check should happen ahead of calling this handler
-  if (status.configured) {
-    return
-  }
-
+async function configureEnvironment({ ctx, logEntry }: ConfigureEnvironmentParams) {
   const service = await getEmulatorService(ctx)
 
   // We mount the project root into the container, so we can exec deploy any function in there later.

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -45,7 +45,8 @@ export interface GetEnvironmentStatusParams extends PluginActionParamsBase {
 }
 
 export interface ConfigureEnvironmentParams extends PluginActionParamsBase {
-  env: Environment,
+  env: Environment
+  status: EnvironmentStatus
 }
 
 export interface DestroyEnvironmentParams extends PluginActionParamsBase {


### PR DESCRIPTION
Further improvement on this would be to make initialization for each
provider a task in the task graph, but that'll take a bit more doing
(will for example need plugin dependency definitions).