### PR TITLE
fix: Cache results to skip superfluous tasks.

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -40,7 +40,7 @@ export class BuildCommand extends Command<typeof buildArguments, typeof buildOpt
     ctx.log.header({ emoji: "hammer", command: "build" })
 
     const result = await ctx.processModules(modules, opts.watch, async (module) => {
-      await ctx.addTask(new BuildTask(ctx, module, opts.force))
+      await ctx.addTask(await BuildTask.factory({ ctx, module, force: opts.force }))
     })
 
     ctx.log.info("")

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -57,7 +57,7 @@ export class DeployCommand extends Command<typeof deployArgs, typeof deployOpts>
     const result = await ctx.processModules(modules, watch, async (module) => {
       const servicesToDeploy = await module.getServices()
       for (const service of servicesToDeploy) {
-        await ctx.addTask(new DeployTask(ctx, service, force, forceBuild))
+        await ctx.addTask(await DeployTask.factory({ ctx, service, force, forceBuild }))
       }
     })
 

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -53,7 +53,7 @@ export class DevCommand extends Command {
       const tasks = testTasks.concat(deployTasks)
 
       if (tasks.length === 0) {
-        await ctx.addTask(new BuildTask(ctx, module, false))
+        await ctx.addTask(await BuildTask.factory({ ctx, module, force: false }))
       } else {
         await Bluebird.map(tasks, ctx.addTask)
       }

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -72,7 +72,7 @@ export async function pushModules(
       )
     }
 
-    const task = new PushTask(ctx, module, forceBuild)
+    const task = await PushTask.factory({ ctx, module, forceBuild })
     await ctx.addTask(task)
   }
 

--- a/src/commands/run/module.ts
+++ b/src/commands/run/module.ts
@@ -64,7 +64,7 @@ export class RunModuleCommand extends Command<typeof runArgs, typeof runOpts> {
 
     await ctx.configureEnvironment()
 
-    const buildTask = new BuildTask(ctx, module, opts["force-build"])
+    const buildTask = await BuildTask.factory({ ctx, module, force: opts["force-build"] })
     await ctx.addTask(buildTask)
     await ctx.processTasks()
 

--- a/src/commands/run/service.ts
+++ b/src/commands/run/service.ts
@@ -51,7 +51,7 @@ export class RunServiceCommand extends Command<typeof runArgs, typeof runOpts> {
 
     await ctx.configureEnvironment()
 
-    const buildTask = new BuildTask(ctx, module, opts["force-build"])
+    const buildTask = await BuildTask.factory({ ctx, module, force: opts["force-build"] })
     await ctx.addTask(buildTask)
     await ctx.processTasks()
 

--- a/src/commands/run/test.ts
+++ b/src/commands/run/test.ts
@@ -71,7 +71,7 @@ export class RunTestCommand extends Command<typeof runArgs, typeof runOpts> {
 
     await ctx.configureEnvironment()
 
-    const buildTask = new BuildTask(ctx, module, opts["force-build"])
+    const buildTask = await BuildTask.factory({ ctx, module, force: opts["force-build"] })
     await ctx.addTask(buildTask)
     await ctx.processTasks()
 

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -57,7 +57,7 @@ export class TestCommand extends Command<typeof testArgs, typeof testOpts> {
 
     const results = await ctx.processModules(modules, opts.watch, async (module) => {
       const tasks = await module.getTestTasks({ group, force, forceBuild })
-      await Bluebird.map(tasks, ctx.addTask)
+      return Bluebird.map(tasks, ctx.addTask)
     })
 
     const failed = values(results).filter(r => !!r.error).length

--- a/src/plugin-context.ts
+++ b/src/plugin-context.ts
@@ -6,6 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import Bluebird = require("bluebird")
 import chalk from "chalk"
 import { Stream } from "ts-stream"
 import { NotFoundError } from "./exceptions"
@@ -48,7 +49,6 @@ import {
   RuntimeContext,
   ServiceStatus,
 } from "./types/service"
-import Bluebird = require("bluebird")
 import {
   mapValues,
   toPairs,
@@ -367,10 +367,10 @@ export function createPluginContext(garden: Garden): PluginContext {
     deployServices: async ({ names, force = false, forceBuild = false, logEntry }) => {
       const services = await ctx.getServices(names)
 
-      for (const service of services) {
-        const task = new DeployTask(ctx, service, force, forceBuild, logEntry)
+      await Bluebird.map(services, async (service) => {
+        const task = await DeployTask.factory({ ctx, service, force, forceBuild, logEntry })
         await ctx.addTask(task)
-      }
+      })
 
       return ctx.processTasks()
     },

--- a/src/tasks/test.ts
+++ b/src/tasks/test.ts
@@ -6,14 +6,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import * as Bluebird from "bluebird"
+import chalk from "chalk"
 import { PluginContext } from "../plugin-context"
 import { Module, TestSpec } from "../types/module"
 import { BuildTask } from "./build"
 import { DeployTask } from "./deploy"
 import { TestResult } from "../types/plugin"
-import { Task } from "../types/task"
+import { Task, TaskParams, TaskVersion } from "../types/task"
 import { EntryStyle } from "../logger/types"
-import chalk from "chalk"
 
 class TestError extends Error {
   toString() {
@@ -21,15 +22,35 @@ class TestError extends Error {
   }
 }
 
-export class TestTask<T extends Module> extends Task {
+export interface TestTaskParams extends TaskParams {
+  ctx: PluginContext
+  module: Module
+  testSpec: TestSpec
+  force: boolean
+  forceBuild: boolean
+}
+
+export class TestTask extends Task {
   type = "test"
 
-  constructor(
-    private ctx: PluginContext,
-    private module: T, private testSpec: TestSpec,
-    private force: boolean, private forceBuild: boolean,
-  ) {
-    super()
+  private ctx: PluginContext
+  private module: Module
+  private testSpec: TestSpec
+  private force: boolean
+  private forceBuild: boolean
+
+  constructor(initArgs: TestTaskParams & TaskVersion) {
+    super(initArgs)
+    this.ctx = initArgs.ctx
+    this.module = initArgs.module
+    this.testSpec = initArgs.testSpec
+    this.force = initArgs.force
+    this.forceBuild = initArgs.forceBuild
+  }
+
+  static async factory(initArgs: TestTaskParams): Promise<TestTask> {
+    initArgs.version = await initArgs.module.getVersion()
+    return new TestTask(<TestTaskParams & TaskVersion>initArgs)
   }
 
   async getDependencies() {
@@ -39,15 +60,23 @@ export class TestTask<T extends Module> extends Task {
       return []
     }
 
-    const deps: Task[] = [new BuildTask(this.ctx, this.module, this.forceBuild)]
-
     const services = await this.ctx.getServices(this.testSpec.dependencies)
 
+    const deps: Promise<Task>[] = [BuildTask.factory({
+      ctx: this.ctx, module: this.module,
+      force: this.forceBuild,
+    })]
+
     for (const service of services) {
-      deps.push(new DeployTask(this.ctx, service, false, this.forceBuild))
+      deps.push(DeployTask.factory({
+        service,
+        ctx: this.ctx,
+        force: false,
+        forceBuild: this.forceBuild,
+      }))
     }
 
-    return deps
+    return Bluebird.all(deps)
   }
 
   getName() {

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -7,19 +7,30 @@
  */
 
 import { TaskResults } from "../task-graph"
+import { TreeVersion } from "../vcs/base"
 import { v1 as uuidv1 } from "uuid"
 
 export class TaskDefinitionError extends Error { }
 
+export interface TaskVersion {
+  version: TreeVersion
+}
+
+export interface TaskParams {
+  version?: TreeVersion
+}
+
 export abstract class Task {
   abstract type: string
   id: string
+  version: TreeVersion
 
   dependencies: Task[]
 
-  constructor() {
+  constructor(initArgs: TaskParams & TaskVersion) {
     this.dependencies = []
     this.id = uuidv1() // uuidv1 is timestamp-based
+    this.version = initArgs.version
   }
 
   async getDependencies(): Promise<Task[]> {
@@ -39,11 +50,4 @@ export abstract class Task {
   abstract getDescription(): string
 
   abstract async process(dependencyResults: TaskResults): Promise<any>
-}
-
-// Ensures that the task's version has been computed before it is used further.
-export async function makeTask(taskClass, initArgs) {
-  const task = new taskClass(...initArgs)
-  await task.getVersion()
-  return task
 }

--- a/test/src/build-dir.ts
+++ b/test/src/build-dir.ts
@@ -1,3 +1,4 @@
+import * as Bluebird from "bluebird"
 const nodetree = require("nodetree")
 import { join } from "path"
 import { pathExists, readdir } from "fs-extra"
@@ -69,9 +70,11 @@ describe("BuildDir", () => {
       await garden.clearBuilds()
       const modules = await garden.getModules()
 
-      for (const module of modules) {
-        await garden.addTask(new BuildTask(garden.pluginContext, module, false))
-      }
+      await Bluebird.map(modules, async (module) => {
+        return garden.addTask(await BuildTask.factory({
+          module, ctx: garden.pluginContext, force: false,
+        }))
+      })
 
       await garden.processTasks()
       const modulesByName = keyBy(modules, "name")

--- a/test/src/task-graph.ts
+++ b/test/src/task-graph.ts
@@ -21,7 +21,13 @@ class TestTask extends Task {
     private callback?: (name: string, result: any) => Promise<void>,
     id: string = "",
   ) {
-    super()
+    super({
+      version: {
+        versionString: "12345#6789",
+        latestCommit: "12345",
+        dirtyTimestamp: 6789,
+      },
+    })
     this.name = name
     this.id = id
 
@@ -40,6 +46,10 @@ class TestTask extends Task {
 
   getKey(): string {
     return this.id ? `${this.name}.${this.id}` : this.name
+  }
+
+  async getVersion() {
+    return this.version
   }
 
   getDescription() {

--- a/test/src/tasks/deploy.ts
+++ b/test/src/tasks/deploy.ts
@@ -23,7 +23,7 @@ describe("DeployTask", () => {
     const serviceA = await ctx.getService("service-a")
     const serviceB = await ctx.getService("service-b")
 
-    const task = new DeployTask(ctx, serviceB, false, false)
+    const task = await DeployTask.factory({ctx, service: serviceB, force: false, forceBuild: false})
     let actionParams: any = {}
 
     stubModuleAction(


### PR DESCRIPTION
Before these changes, while e.g. running `garden deploy -w`, changing
tracked files in a module would also trigger redeploys of its
dependencies, even if their version was unchanged since their last
deployment.

To fix this, a result cache was added to TaskGraph. When a task is
added, any dependencies having cached results matching their current
VCS version (including their dirty timestamps, if any) are not added to
the graph.

Since results are cached by version in addition to their baseKey, tasks
are now initialized via an async factory method, which ensures that
their version has been fetched before they are added to the task graph.

Note that for performance reasons, some tests skip this step, using a
stubbed version and calling the constructor directly.