### PR TITLE
fix: ensure module build paths have trailing slash (for rsync)

### DIFF
--- a/examples/hello-world/services/hello-function/garden.yml
+++ b/examples/hello-world/services/hello-function/garden.yml
@@ -12,5 +12,5 @@ module:
     dependencies:
       - name: hello-npm-package
         copy:
-          - source: "*"
+          - source: "./"
             target: libraries/hello-npm-package/

--- a/src/build-dir.ts
+++ b/src/build-dir.ts
@@ -12,6 +12,7 @@ import {
   join,
   parse,
   resolve,
+  sep,
 } from "path"
 import {
   emptyDir,
@@ -46,7 +47,7 @@ export class BuildDir {
 
   async syncFromSrc(module: Module) {
     await this.sync(
-      resolve(this.projectRoot, module.path, "*"),
+      resolve(this.projectRoot, module.path) + sep,
       await this.buildPath(module),
     )
   }


### PR DESCRIPTION
Rsync won't copy dot files if the source path ends with a wildcard.
Rather it should have a trailing slash.

Bad: `path/to/dir/*`
Good: `path/to/dir/`