### PR TITLE
fix: undefined service key during garden status

### DIFF
--- a/src/plugin-context.ts
+++ b/src/plugin-context.ts
@@ -451,7 +451,7 @@ export function createPluginContext(garden: Garden): PluginContext {
           .then( svc => {
             svc["name"] = service.name
             return svc
-          })
+          }),
       )
 
       return {

--- a/src/plugin-context.ts
+++ b/src/plugin-context.ts
@@ -446,7 +446,12 @@ export function createPluginContext(garden: Garden): PluginContext {
       const services = await ctx.getServices()
 
       const serviceStatus = await Bluebird.map(
-        services, (service: Service<any>) => ctx.getServiceStatus({ serviceName: service.name }),
+        services, (service: Service<any>) =>
+          ctx.getServiceStatus({ serviceName: service.name })
+          .then( svc => {
+            svc["name"] = service.name
+            return svc
+          })
       )
 
       return {


### PR DESCRIPTION
#134 Normally running garden deploy produces the following output
```
providers:
  local-kubernetes:
    configured: true
    detail:
      namespaceReady: true
      metadataNamespaceReady: true
      systemReady: true
services:
  undefined:
    endpoints:
      - protocol: http
        hostname: hello-function.hello-world.local.app.garden
        port: 32000
        url: 'http://hello-function.hello-world.local.app.garden:32000'
    runningReplicas: 1
    detail:
      resourceVersion: 2323881
      lastMessage: CREATE Ingress garden--hello--hello-world/hello-function
    state: ready
    lastMessage: ''
```

which prints only the `hello-container` service.  Shouldn't `hello-function` be also printed out during garden status as it is also deployed to k8s ? With this PR garden deploy prints both the `hello-container and hello-function`. I am not sure if this is the intended behaviour. please advice. With this PR the output would be

```
providers:
  local-kubernetes:
    configured: true
    detail:
      namespaceReady: true
      metadataNamespaceReady: true
      systemReady: true
services:
  hello-container:
    endpoints:
      - protocol: http
        hostname: hello-container.hello-world.local.app.garden
        port: 32000
        url: 'http://hello-container.hello-world.local.app.garden:32000'
        paths:
           - /hello
    runningReplicas: 1
    detail:
      resourceVersion: 16815
    state: ready
    lastMessage: ''
    name: hello-container
  hello-function:
    endpoints:
      - protocol: http
        hostname: hello-function.hello-world.local.app.garden
        port: 32000
        url: 'http://hello-function.hello-world.local.app.garden:32000'
    runningReplicas: 1
    detail:
      resourceVersion: 16757
    state: ready
    lastMessage: ''
    name: hello-function
``` 

Let me know if any changes are required