### PR TITLE
feat(build): Handle config changes in auto-reload.

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -206,10 +206,13 @@ export class GardenCli {
       }
 
       const logger = RootLogNode.initialize({ level, writers })
-      const garden = await Garden.factory(root, { env, logger })
-
-      // TODO: enforce that commands always output DeepPrimitiveMap
-      const result = await command.action(garden.pluginContext, parsedArgs, parsedOpts)
+      let garden
+      let result
+      do {
+        garden = await Garden.factory(root, { env, logger })
+        // TODO: enforce that commands always output DeepPrimitiveMap
+        result = await command.action(garden.pluginContext, parsedArgs, parsedOpts)
+      } while (result.restartRequired)
 
       // We attach the action result to cli context so that we can process it in the parse method
       cliContext.details.result = result

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -18,6 +18,7 @@ import {
 import { BuildTask } from "../tasks/build"
 import { TaskResults } from "../task-graph"
 import dedent = require("dedent")
+import { processModules } from "../process"
 
 export const buildArguments = {
   module: new StringParameter({
@@ -59,8 +60,9 @@ export class BuildCommand extends Command<typeof buildArguments, typeof buildOpt
 
     ctx.log.header({ emoji: "hammer", command: "Build" })
 
-    const results = await ctx.processModules({
+    const results = await processModules({
       modules,
+      pluginContext: ctx,
       watch: opts.watch,
       process: async (module) => {
         return [await BuildTask.factory({ ctx, module, force: opts.force })]

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -17,6 +17,7 @@ import {
   StringParameter,
 } from "./base"
 import { TaskResults } from "../task-graph"
+import { processServices } from "../process"
 
 export const deployArgs = {
   service: new StringParameter({
@@ -75,9 +76,10 @@ export class DeployCommand extends Command<typeof deployArgs, typeof deployOpts>
     const force = opts.force
     const forceBuild = opts["force-build"]
 
-    const results = await ctx.processServices({
+    const results = await processServices({
       services,
       watch,
+      pluginContext: ctx,
       process: async (service) => {
         return [await DeployTask.factory({ ctx, service, force, forceBuild })]
       },

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -18,6 +18,7 @@ import { join } from "path"
 import { STATIC_DIR } from "../constants"
 import chalk from "chalk"
 import moment = require("moment")
+import { processModules } from "../process"
 
 const imgcatPath = join(STATIC_DIR, "imgcat")
 const bannerPath = join(STATIC_DIR, "garden-banner-1-half.png")
@@ -60,8 +61,9 @@ export class DevCommand extends Command {
       return {}
     }
 
-    await ctx.processModules({
+    await processModules({
       modules,
+      pluginContext: ctx,
       watch: true,
       process: async (module) => {
         const testTasks: Task[] = await module.getTestTasks({})

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -65,9 +65,9 @@ export class PushCommand extends Command<typeof pushArgs, typeof pushOpts> {
     const names = args.module ? args.module.split(",") : undefined
     const modules = await ctx.getModules(names)
 
-    const result = await pushModules(ctx, modules, !!opts["force-build"], !!opts["allow-dirty"])
+    const results = await pushModules(ctx, modules, !!opts["force-build"], !!opts["allow-dirty"])
 
-    return handleTaskResults(ctx, "push", result)
+    return handleTaskResults(ctx, "push", { taskResults: results })
   }
 }
 

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -16,6 +16,7 @@ import {
   CommandResult,
 } from "./base"
 import { TaskResults } from "../task-graph"
+import { processModules } from "../process"
 
 export const testArgs = {
   module: new StringParameter({
@@ -75,8 +76,9 @@ export class TestCommand extends Command<typeof testArgs, typeof testOpts> {
     const force = opts.force
     const forceBuild = opts["force-build"]
 
-    const results = await ctx.processModules({
+    const results = await processModules({
       modules,
+      pluginContext: ctx,
       watch: opts.watch,
       process: async (module) => module.getTestTasks({ name, force, forceBuild }),
     })

--- a/src/plugins/kubernetes/local.ts
+++ b/src/plugins/kubernetes/local.ts
@@ -39,6 +39,7 @@ import {
   isSystemGarden,
 } from "./system"
 import { readFile } from "fs-extra"
+import { processServices } from "../../process"
 
 // TODO: split this into separate plugins to handle Docker for Mac and Minikube
 
@@ -96,15 +97,16 @@ async function configureLocalEnvironment(
 
     const services = await sysCtx.getServices(provider.config._systemServices)
 
-    const results = await sysCtx.processServices({
+    const results = await processServices({
       services,
+      pluginContext: ctx,
       watch: false,
       process: async (service) => {
         return [await DeployTask.factory({ ctx: sysCtx, service, force, forceBuild: false })]
       },
     })
 
-    const failed = values(results).filter(r => !!r.error).length
+    const failed = values(results.taskResults).filter(r => !!r.error).length
 
     if (failed) {
       throw new PluginError(`local-kubernetes: ${failed} errors occurred when configuring environments`, {

--- a/src/process.ts
+++ b/src/process.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2018 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import Bluebird = require("bluebird")
+import { Module } from "./types/module"
+import { Service } from "./types/service"
+import { Task } from "./types/task"
+import { TaskResults } from "./task-graph"
+import {
+  AutoReloadDependants,
+  autoReloadModules,
+  computeAutoReloadDependants,
+  FSWatcher,
+  withDependants,
+} from "./watch"
+import { padEnd, values, flatten } from "lodash"
+import { getNames, registerCleanupFunction } from "./util"
+import { PluginContext } from "./plugin-context"
+
+export type ProcessModule = (module: Module) => Promise<Task[]>
+export type ProcessService = (service: Service) => Promise<Task[]>
+
+export interface ProcessModulesParams {
+  pluginContext: PluginContext
+  modules: Module[]
+  watch: boolean
+  process: ProcessModule
+}
+
+export interface ProcessServicesParams {
+  pluginContext: PluginContext
+  services: Service[]
+  watch: boolean
+  process: ProcessService
+}
+
+export interface ProcessResults {
+  taskResults: TaskResults
+  restartRequired?: boolean
+}
+
+export async function processModules({ pluginContext, modules, watch, process }: ProcessModulesParams):
+  Promise<ProcessResults> {
+
+  const ctx = pluginContext
+  // TODO: log errors as they happen, instead of after processing all tasks
+  const logErrors = (taskResults: TaskResults) => {
+    for (const result of values(taskResults).filter(r => !!r.error)) {
+      const divider = padEnd("", 80, "—")
+
+      ctx.log.error(`\nFailed ${result.description}. Here is the output:`)
+      ctx.log.error(divider)
+      ctx.log.error(result.error + "")
+      ctx.log.error(divider + "\n")
+    }
+  }
+
+  for (const module of modules) {
+    const tasks = await process(module)
+    await Bluebird.map(tasks, ctx.addTask)
+  }
+
+  const results = await ctx.processTasks()
+  logErrors(results)
+
+  if (!watch) {
+    return {
+      taskResults: results,
+      restartRequired: false,
+    }
+  }
+
+  const modulesToWatch = await autoReloadModules(modules)
+  const autoReloadDependants = await computeAutoReloadDependants(ctx)
+
+  const watcher = new FSWatcher(ctx)
+
+  const restartPromise = new Promise(async (resolve) => {
+
+    // TODO: should the prefix here be different or set explicitly per run?
+    await watcher.watchModules(modulesToWatch, "addTasksForAutoReload/",
+      async (changedModules: Module[], configChanged: boolean) => {
+
+        ctx.log.debug({ msg: `Files changed for modules ${changedModules.map(m => m.name).join(", ")}` })
+        const restartNeeded = await handleChanges(ctx, autoReloadDependants, process, changedModules, configChanged)
+
+        if (restartNeeded) {
+          resolve()
+        }
+
+        logErrors(await ctx.processTasks())
+
+      })
+
+    registerCleanupFunction("clearAutoReloadWatches", () => {
+      watcher.end()
+    })
+
+  })
+
+  await restartPromise
+  watcher.end()
+
+  return {
+    taskResults: {}, // TODO: Return latest results for each task baseKey processed between restarts?
+    restartRequired: true,
+  }
+
+}
+
+// Returns true if the command that requested the watch needs to be restarted.
+export async function handleChanges(
+  pluginContext: PluginContext,
+  autoReloadDependants: AutoReloadDependants,
+  process: ProcessModule,
+  modules: Module[],
+  configChanged: boolean): Promise<boolean> {
+
+  const ctx = pluginContext
+
+  if (configChanged) {
+    ctx.log.debug({ msg: `Config changed, reloading.` })
+    return true
+  }
+
+  for (const module of await withDependants(modules, autoReloadDependants)) {
+    await Bluebird.map(process(module), ctx.addTask)
+  }
+
+  return false
+
+}
+
+export async function processServices({ pluginContext, services, watch, process }: ProcessServicesParams):
+  Promise<ProcessResults> {
+
+  const serviceNames = getNames(services)
+  const modules = Array.from(new Set(services.map(s => s.module)))
+
+  return processModules({
+    pluginContext,
+    modules,
+    watch,
+    process: async (module) => {
+      const moduleServices = await module.getServices()
+      const servicesToDeploy = moduleServices.filter(s => serviceNames.includes(s.name))
+      return flatten(await Bluebird.map(servicesToDeploy, process))
+    },
+  })
+
+}

--- a/src/util/keyed-set.ts
+++ b/src/util/keyed-set.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2018 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+  A simple set data structure that uses a custom key function for equality comparisons.
+
+  Useful for sets of non-scalar entries, where the built-in Set data structure's === comparison is not suitable.
+*/
+export class KeyedSet<V> {
+  private map: Map<string, V>
+
+  constructor(private keyFn: (V) => string) {
+    this.map = new Map()
+  }
+
+  add(entry: V): KeyedSet<V> {
+    this.map.set(this.keyFn(entry), entry)
+    return this
+  }
+
+  delete(entry: V): boolean {
+    return this.map.delete(this.keyFn(entry))
+  }
+
+  has(entry: V): boolean {
+    return this.map.has(this.keyFn(entry))
+  }
+
+  hasKey(key: string): boolean {
+    return this.map.has(key)
+  }
+
+  // Returns set members in insertion order.
+  entries(): V[] {
+    return Array.from(this.map.values())
+  }
+
+  size(): number {
+    return this.map.size
+  }
+
+  clear(): void {
+    this.map = new Map()
+  }
+
+}


### PR DESCRIPTION
Before this change, each module directory was watched separately for
changes during auto-reload, and didn't properly handle module- or
project-level configuration changes since the auto-reload watch was
started.

Here, we consolidate the module-level watches into a single
project-level watch, and call the originating command with a fresh
PluginContext when configuration changes. This includes the addition or
removal of modules during the lifetime of the watch.