### PR TITLE
refactor: rename project.global to project.environmentDefaults (#131)

### DIFF
--- a/examples/hello-world/garden.yml
+++ b/examples/hello-world/garden.yml
@@ -1,6 +1,6 @@
 project:
   name: hello-world
-  global:
+  environmentDefaults:
     providers:
       - name: container
       - name: npm-package

--- a/src/garden.ts
+++ b/src/garden.ts
@@ -215,7 +215,7 @@ export class Garden {
     }
 
     const projectName = parsedConfig.project.name
-    const globalConfig = parsedConfig.project.global || {}
+    const environmentDefaults = parsedConfig.project.environmentDefaults || {}
 
     const parts = env.split(".")
     const environment = parts[0]
@@ -248,7 +248,7 @@ export class Garden {
 
     const mergedProviders = merge(
       {},
-      keyBy(globalConfig.providers, "name"),
+      keyBy(environmentDefaults.providers, "name"),
       keyBy(envConfig.providers, "name"),
     )
 
@@ -256,7 +256,7 @@ export class Garden {
     const projectEnvConfig: EnvironmentConfig = {
       name: environment,
       providers: values(mergedProviders),
-      variables: merge({}, globalConfig.variables, envConfig.variables),
+      variables: merge({}, environmentDefaults.variables, envConfig.variables),
     }
 
     const buildDir = await BuildDir.factory(projectRoot)

--- a/src/plugins/kubernetes/system.ts
+++ b/src/plugins/kubernetes/system.ts
@@ -29,7 +29,7 @@ export async function getSystemGarden(provider: KubernetesProvider): Promise<Gar
       path: systemProjectPath,
       project: {
         name: "garden-system",
-        global: {
+        environmentDefaults: {
           providers: [
             { name: "container" },
           ],

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -32,7 +32,7 @@ export interface EnvironmentConfig extends CommonEnvironmentConfig {
 export interface ProjectConfig {
   name: string
   defaultEnvironment: string
-  global: CommonEnvironmentConfig
+  environmentDefaults: CommonEnvironmentConfig
   environments: EnvironmentConfig[]
 }
 
@@ -75,7 +75,7 @@ export const environmentSchema = Joi.object().keys({
     .description("A key/value map of variables that modules can reference when using this environment."),
 })
 
-const defaultGlobal = {
+const environmentDefaults = {
   providers: defaultProviders,
   variables: {},
 }
@@ -88,8 +88,8 @@ export const projectSchema = Joi.object()
     defaultEnvironment: Joi.string()
       .default("", "<first specified environment>")
       .description("The default environment to use when calling commands without the `--env` parameter."),
-    global: environmentSchema
-      .default(() => defaultGlobal, JSON.stringify(defaultGlobal))
+    environmentDefaults: environmentSchema
+      .default(() => environmentDefaults, JSON.stringify(environmentDefaults))
       .description(
         "Default environment settings, that are inherited (but can be overridden) by each configured environment",
     ),

--- a/test/data/test-project-a/garden.yml
+++ b/test/data/test-project-a/garden.yml
@@ -1,6 +1,6 @@
 project:
   name: test-project-a
-  global:
+  environmentDefaults:
     variables:
       some: variable
   environments:

--- a/test/data/test-project-b/garden.yml
+++ b/test/data/test-project-b/garden.yml
@@ -1,6 +1,6 @@
 project:
   name: test-project-b
-  global:
+  environmentDefaults:
     providers: []
   environments:
     - name: local

--- a/test/data/test-project-templated/garden.yml
+++ b/test/data/test-project-templated/garden.yml
@@ -1,6 +1,6 @@
 project:
   name: test-project-templated
-  global:
+  environmentDefaults:
     variables:
       some: ${local.env.TEST_VARIABLE}
       service-a-build-command: echo OK

--- a/test/src/types/config.ts
+++ b/test/src/types/config.ts
@@ -14,7 +14,7 @@ describe("loadConfig", () => {
     expect(parsed.project).to.eql({
       name: "test-project-a",
       defaultEnvironment: "local",
-      global: {
+      environmentDefaults: {
         providers: [],
         variables: { some: "variable" },
       },


### PR DESCRIPTION
BREAKING CHANGE:
Existing garden.yml files will need to be updated if they use the
project.global key.

Closes #131 