### PR TITLE
fix(core): potential race-condition when parsing modules

### DIFF
--- a/src/garden.ts
+++ b/src/garden.ts
@@ -40,6 +40,7 @@ import {
   pluginActionDescriptions,
   pluginModuleSchema,
   pluginSchema,
+  Provider,
   RegisterPluginParam,
 } from "./types/plugin"
 import { EnvironmentConfig } from "./types/project"
@@ -708,9 +709,14 @@ export class Garden {
       return null
     }
 
-    const moduleName = moduleConfig.name
+    const parseHandler = await this.getModuleActionHandler("parseModule", moduleConfig.type)
+    const env = this.getEnvironment()
+    const provider: Provider = {
+      name: parseHandler["pluginName"],
+      config: this.config.providers[parseHandler["pluginName"]],
+    }
 
-    const { module, services, tests } = await this.pluginContext.parseModule({ moduleName, moduleConfig })
+    const { module, services, tests } = await parseHandler({ env, provider, moduleConfig })
 
     return new Module(this.pluginContext, module, services, tests)
   }

--- a/src/types/plugin/params.ts
+++ b/src/types/plugin/params.ts
@@ -46,8 +46,10 @@ export interface PluginServiceActionParamsBase<T extends Module = Module> extend
   runtimeContext?: RuntimeContext
 }
 
-export interface ParseModuleParams<T extends Module = Module> extends PluginActionParamsBase {
-  module?: T
+export interface ParseModuleParams<T extends Module = Module> {
+  env: Environment
+  provider: Provider
+  logEntry?: LogEntry
   moduleConfig: T["_ConfigType"]
 }
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -97,7 +97,7 @@ export const testPlugin: PluginFactory = (): GardenPlugin => {
       test: {
         testModule: testGenericModule,
 
-        async parseModule({ ctx, moduleConfig }: ParseModuleParams<TestModule>) {
+        async parseModule({ moduleConfig }: ParseModuleParams<TestModule>) {
           moduleConfig.spec = validate(
             moduleConfig.spec,
             containerModuleSpecSchema,

--- a/test/src/plugins/container.ts
+++ b/test/src/plugins/container.ts
@@ -41,7 +41,7 @@ describe("container", () => {
   const provider = { name: "container", config: {} }
 
   async function getTestModule(moduleConfig: ContainerModuleConfig) {
-    const parseResults = await parseModule!({ ctx, env, provider, moduleConfig })
+    const parseResults = await parseModule!({ env, provider, moduleConfig })
     return new ContainerModule(ctx, parseResults.module, parseResults.services, parseResults.tests)
   }
 
@@ -220,7 +220,7 @@ describe("container", () => {
           },
         }
 
-        await parseModule({ ctx, env, provider, moduleConfig })
+        await parseModule({ env, provider, moduleConfig })
       })
 
       it("should fail with invalid port in endpoint spec", async () => {
@@ -263,7 +263,7 @@ describe("container", () => {
         }
 
         await expectError(
-          () => parseModule({ ctx, env, provider, moduleConfig }),
+          () => parseModule({ env, provider, moduleConfig }),
           "configuration",
         )
       })
@@ -303,7 +303,7 @@ describe("container", () => {
         }
 
         await expectError(
-          () => parseModule({ ctx, env, provider, moduleConfig }),
+          () => parseModule({ env, provider, moduleConfig }),
           "configuration",
         )
       })
@@ -340,7 +340,7 @@ describe("container", () => {
         }
 
         await expectError(
-          () => parseModule({ ctx, env, provider, moduleConfig }),
+          () => parseModule({ env, provider, moduleConfig }),
           "configuration",
         )
       })


### PR DESCRIPTION
I came across this when working on something else. Basically we should
not hand the plugin context to the `parseModule` handlers, because they
could then try to engage with other modules while we are still loading
them.