### PR TITLE
docs: fix links in glossary & configuration guide

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -2,10 +2,11 @@
 
 Garden is configured via `garden.yml` configuration files.
 
-The [project-wide](#project) `garden.yml` file should be located in the top-level directory of the project's Git 
+The [project-wide](#project-configuration) `garden.yml` file should be located in the top-level directory of the 
+project's Git 
 repository.
 
-In addition, each of the project's [modules](../other/glossary#module)' `garden.yml` should be located in that module's 
+In addition, each of the project's [modules](../guides/glossary.md#module)' `garden.yml` should be located in that module's 
 top-level 
 directory.
 
@@ -48,8 +49,8 @@ project:
           default-project: garden-hello-world
 ```
 The project-wide `garden.yml` defines the project's name, the default providers used for each
-[plugin](../other/glossary#plugin) the project requires (via the `global` directive), and
-[environment](../other/glossary#environment)-specific provider overrides as is appropriate for each of the project's
+[plugin](../guides/glossary.md#plugin) the project requires (via the `global` directive), and
+[environment](../guides/glossary.md#environment)-specific provider overrides as is appropriate for each of the project's
 configured environments (`local` and `dev` under the `environments` directive above).
 
 Here, project-wide configuration variables can also be specified (global, and/or environment-specific). These are 
@@ -86,7 +87,7 @@ Note that module names must be unique within a given project. An error will be t
 modules use the same name.
 
 #### type
-A [module](../other/glossary.md#module)'s `type` specifies its plugin type. Garden interprets this according to the 
+A [module](../guides/glossary.md#module)'s `type` specifies its plugin type. Garden interprets this according to the 
 active environment's configured provider for the specified plugin type.
 
 For example,
@@ -100,7 +101,7 @@ A module's build configuration is specified via the `build` directive.
 Under `build`, the `command` subdirective sets the CLI command run during builds. A module's build command is executed 
 with its working directory set to a copy of the module's top-level directory, located at
 `[project-root]/.garden/build/[module-name]`. This internal directory is referred to as the module's
-[build directory](../other/glossary.md#build-directory).
+[build directory](../guides/glossary.md#build-directory).
 
 The `.garden` directory should not be modified by users, since this may lead to unexpected errors when the Garden CLI
 tools are used in the project.

--- a/docs/guides/glossary.md
+++ b/docs/guides/glossary.md
@@ -5,7 +5,7 @@ Represents the current configuration and status of any running services in the [
 inspected and modified via the Garden CLI's `environment` command.
 
 Several named environment configurations may be defined (e.g. _dev_, _testing_, ...) in the [project's 
-`garden.yml`](../guides/configuration.md#projects).
+`garden.yml`](../guides/configuration.md#project-configuration).
 
 #### Module
 The basic unit of configuration in Garden. A module is defined by its
@@ -14,7 +14,7 @@ directory,
 which 
 is a subdirectory of the [project](#project) repository's top-level directory.
 
-Each module has a [plugin](#plugin) type, and may define one or more [services](#sevice).
+Each module has a [plugin](#plugin) type, and may define one or more [services](#service).
 
 Essentially, a project is organized into modules at the granularity of its *build* steps. A module's build step may 
 depend on one or more other modules, as specified in its `garden.yml`, in which case those modules will be built 
@@ -26,7 +26,7 @@ A [module's](#module) plugin type defines its behavior when it is built, deploye
 (such as NPM modules) are under development.
 
 #### Project
-The top-level unit of organization in Garden. A project consists of one or more [modules](#modules), along with a 
+The top-level unit of organization in Garden. A project consists of one or more [modules](#module), along with a 
 project-level [`garden.yml` configuration file](../guides/configuration.md#project-configuration).
 
 Garden CLI commands are run in the context of a project, and are aware of all its modules and services.


### PR DESCRIPTION
This one is short and simple, just wanted to get these links fixed ASAP.