### PR TITLE
fix: test result versions now correctly account for test dependencies

### DIFF
--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -219,7 +219,7 @@ export class Module<
   }
 
   async getVersion(force?: boolean): Promise<TreeVersion> {
-    return this.ctx.getModuleVersion(this, force)
+    return this.ctx.getModuleVersion(this.name, force)
   }
 
   async getBuildPath() {

--- a/test/data/test-project-test-deps/garden.yml
+++ b/test/data/test-project-test-deps/garden.yml
@@ -1,0 +1,6 @@
+project:
+  name: test-project-test-deps
+  environments:
+    - name: local
+      providers:
+        - name: test-plugin

--- a/test/data/test-project-test-deps/module-a/garden.yml
+++ b/test/data/test-project-test-deps/module-a/garden.yml
@@ -1,0 +1,11 @@
+module:
+  name: module-a
+  type: test
+  services:
+    - name: service-a
+      command: [echo, OK]
+  tests:
+    - name: integ
+      dependencies:
+        - service-b
+      command: [echo, OK]

--- a/test/data/test-project-test-deps/module-b/garden.yml
+++ b/test/data/test-project-test-deps/module-b/garden.yml
@@ -1,0 +1,6 @@
+module:
+  name: module-b
+  type: test
+  services:
+    - name: service-b
+      command: [echo, OK]

--- a/test/src/tasks/deploy.ts
+++ b/test/src/tasks/deploy.ts
@@ -1,6 +1,5 @@
 import { expect } from "chai"
 import { resolve } from "path"
-import * as td from "testdouble"
 import {
   dataDir,
   makeTestGarden,
@@ -38,7 +37,6 @@ describe("DeployTask", () => {
     await task.process()
 
     const versionStringA = (await serviceA.module.getVersion()).versionString
-    const versionStringB = (await serviceB.module.getVersion()).versionString
 
     expect(actionParams.service.config).to.eql({
       name: "service-b",

--- a/test/src/tasks/test.ts
+++ b/test/src/tasks/test.ts
@@ -1,0 +1,69 @@
+import { expect } from "chai"
+import { resolve } from "path"
+import {
+  replace,
+  when,
+} from "testdouble"
+import { TestTask } from "../../../src/tasks/test"
+import { Module } from "../../../src/types/module"
+import {
+  NEW_MODULE_VERSION,
+  TreeVersion,
+} from "../../../src/vcs/base"
+import {
+  dataDir,
+  makeTestGarden,
+} from "../../helpers"
+
+const getVersion = Module.prototype.getVersion
+
+describe("TestTask", () => {
+  let stub: any
+
+  // remove the Module.getVersion() stub
+  beforeEach(() => {
+    stub = Module.prototype.getVersion
+    Module.prototype.getVersion = getVersion
+  })
+
+  afterEach(() => {
+    Module.prototype.getVersion = stub
+  })
+
+  it("should correctly resolve version for tests with dependencies", async () => {
+    process.env.TEST_VARIABLE = "banana"
+
+    const garden = await makeTestGarden(resolve(dataDir, "test-project-test-deps"))
+    const ctx = garden.pluginContext
+
+    const getModuleVersion = replace(ctx, "getModuleVersion")
+
+    when(getModuleVersion("module-a", undefined)).thenResolve(<TreeVersion>{
+      versionString: "1234512345",
+      latestCommit: NEW_MODULE_VERSION,
+      dirtyTimestamp: null,
+    })
+
+    const dirtyTimestamp = 123456789
+    const moduleBVersion: TreeVersion = {
+      versionString: NEW_MODULE_VERSION + "-" + dirtyTimestamp,
+      latestCommit: NEW_MODULE_VERSION,
+      dirtyTimestamp,
+    }
+
+    when(getModuleVersion("module-b", undefined)).thenResolve(moduleBVersion)
+
+    const moduleA = await ctx.getModule("module-a")
+    const testConfig = moduleA.tests[0]
+
+    const task = await TestTask.factory({
+      ctx,
+      module: moduleA,
+      testConfig,
+      force: true,
+      forceBuild: false,
+    })
+
+    expect(task.version).to.eql(moduleBVersion)
+  })
+})


### PR DESCRIPTION
Previously, if you'd change code in a test dependency, the test would
not be re-run if previously passed, because the resolved version did
not factor in the dependency.