### PR TITLE
fix: module versions are now handled properly across multiple repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ node_modules
 
 # Runtime files
 .garden
-.garden-version
 tmp/
 
 # TS cache on the CI
@@ -30,6 +29,7 @@ src/**/*.js
 src/**/*.map
 src/**/*.d.ts
 static/bin/garden.js
+static/**/.garden-version
 support/**/*.js
 support/**/*.map
 support/**/*.d.ts

--- a/src/plugins/kubernetes/actions.ts
+++ b/src/plugins/kubernetes/actions.ts
@@ -34,7 +34,7 @@ import {
   SetConfigParams,
   TestModuleParams,
 } from "../../types/plugin/params"
-import { TreeVersion } from "../../vcs/base"
+import { ModuleVersion } from "../../vcs/base"
 import {
   ContainerModule,
   helpers,
@@ -543,6 +543,6 @@ export async function logout({ ctx }: PluginActionParamsBase): Promise<LoginStat
   return { loggedIn: false }
 }
 
-function getTestResultKey(module: ContainerModule, testName: string, version: TreeVersion) {
+function getTestResultKey(module: ContainerModule, testName: string, version: ModuleVersion) {
   return `test-result--${module.name}--${testName}--${version.versionString}`
 }

--- a/src/plugins/kubernetes/specs-module.ts
+++ b/src/plugins/kubernetes/specs-module.ts
@@ -42,7 +42,7 @@ import {
   TestConfig,
   TestSpec,
 } from "../../types/test"
-import { TreeVersion } from "../../vcs/base"
+import { ModuleVersion } from "../../vcs/base"
 import {
   applyMany,
 } from "./kubectl"
@@ -141,7 +141,7 @@ export const kubernetesSpecHandlers = {
   },
 }
 
-async function prepareSpecs(service: Service<KubernetesSpecsModule>, namespace: string, version: TreeVersion) {
+async function prepareSpecs(service: Service<KubernetesSpecsModule>, namespace: string, version: ModuleVersion) {
   return service.module.spec.specs.map((rawSpec) => {
     const spec = {
       metadata: {},

--- a/src/types/plugin/outputs.ts
+++ b/src/types/plugin/outputs.ts
@@ -7,7 +7,7 @@
  */
 
 import * as Joi from "joi"
-import { TreeVersion } from "../../vcs/base"
+import { ModuleVersion, moduleVersionSchema } from "../../vcs/base"
 import {
   joiArray,
   PrimitiveMap,
@@ -194,28 +194,12 @@ export const pushModuleResultSchema = Joi.object()
 export interface RunResult {
   moduleName: string
   command: string[]
-  version: TreeVersion
+  version: ModuleVersion
   success: boolean
   startedAt: Date
   completedAt: Date
   output: string
 }
-
-export const treeVersionSchema = Joi.object()
-  .keys({
-    versionString: Joi.string()
-      .required()
-      .description("String representation of the module version."),
-    latestCommit: Joi.string()
-      .required()
-      .description("The latest commit hash of the module source."),
-    dirtyTimestamp: Joi.number()
-      .allow(null)
-      .required()
-      .description(
-        "Set to the last modified time (as UNIX timestamp) if the module contains uncommitted changes, otherwise null.",
-    ),
-  })
 
 export const runResultSchema = Joi.object()
   .keys({
@@ -224,7 +208,7 @@ export const runResultSchema = Joi.object()
     command: Joi.array().items(Joi.string())
       .required()
       .description("The command that was run in the module."),
-    version: treeVersionSchema,
+    version: moduleVersionSchema,
     success: Joi.boolean()
       .required()
       .description("Whether the module was successfully run."),

--- a/src/types/plugin/params.ts
+++ b/src/types/plugin/params.ts
@@ -9,7 +9,7 @@
 import Stream from "ts-stream"
 import { LogEntry } from "../../logger/logger"
 import { PluginContext } from "../../plugin-context"
-import { TreeVersion } from "../../vcs/base"
+import { ModuleVersion } from "../../vcs/base"
 import {
   Environment,
   Primitive,
@@ -117,7 +117,7 @@ export interface TestModuleParams<T extends Module = Module> extends PluginModul
 
 export interface GetTestResultParams<T extends Module = Module> extends PluginModuleActionParamsBase<T> {
   testName: string
-  version: TreeVersion
+  version: ModuleVersion
 }
 
 export interface GetServiceStatusParams<T extends Module = Module> extends PluginServiceActionParamsBase<T> {

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -7,23 +7,23 @@
  */
 
 import { TaskResults } from "../task-graph"
-import { TreeVersion } from "../vcs/base"
+import { ModuleVersion } from "../vcs/base"
 import { v1 as uuidv1 } from "uuid"
 
 export class TaskDefinitionError extends Error { }
 
 export interface TaskVersion {
-  version: TreeVersion
+  version: ModuleVersion
 }
 
 export interface TaskParams {
-  version?: TreeVersion
+  version?: ModuleVersion
 }
 
 export abstract class Task {
   abstract type: string
   id: string
-  version: TreeVersion
+  version: ModuleVersion
 
   dependencies: Task[]
 

--- a/src/vcs/base.ts
+++ b/src/vcs/base.ts
@@ -6,17 +6,135 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import { Module } from "../types/module"
+import * as Bluebird from "bluebird"
+import { mapValues, keyBy, sortBy, orderBy, omit } from "lodash"
+import { createHash } from "crypto"
+import * as Joi from "joi"
+
 export const NEW_MODULE_VERSION = "0000000000"
 
 export interface TreeVersion {
-  versionString: string
   latestCommit: string
   dirtyTimestamp: number | null
 }
 
+export interface TreeVersions { [moduleName: string]: TreeVersion }
+
+export interface ModuleVersion {
+  versionString: string
+  dirtyTimestamp: number | null
+  dependencyVersions: TreeVersions
+}
+
+interface NamedTreeVersion extends TreeVersion {
+  name: string
+}
+
+const versionStringSchema = Joi.string()
+  .required()
+  .description("String representation of the module version.")
+
+const dirtyTimestampSchema = Joi.number()
+  .allow(null)
+  .required()
+  .description(
+    "Set to the last modified time (as UNIX timestamp) if the module contains uncommitted changes, otherwise null.",
+)
+
+export const treeVersionSchema = Joi.object()
+  .keys({
+    latestCommit: Joi.string()
+      .required()
+      .description("The latest commit hash of the module source."),
+    dirtyTimestamp: dirtyTimestampSchema,
+  })
+
+export const moduleVersionSchema = Joi.object()
+  .keys({
+    versionString: versionStringSchema,
+    dirtyTimestamp: dirtyTimestampSchema,
+    dependencyVersions: Joi.object()
+      .pattern(/.+/, treeVersionSchema)
+      .default(() => ({}), "{}")
+      .description("The version of each of the dependencies of the module."),
+  })
+
 export abstract class VcsHandler {
   constructor(protected projectRoot: string) { }
 
-  abstract async getTreeVersion(directories: string[]): Promise<TreeVersion>
-  abstract async sortVersions(versions: TreeVersion[]): Promise<TreeVersion[]>
+  abstract async getTreeVersion(paths: string[]): Promise<TreeVersion>
+
+  async resolveVersion(module: Module, dependencies: Module[]): Promise<ModuleVersion> {
+    const treeVersion = await this.getTreeVersion([module.path])
+
+    if (dependencies.length === 0) {
+      return {
+        versionString: treeVersion.latestCommit,
+        dirtyTimestamp: treeVersion.dirtyTimestamp,
+        dependencyVersions: {},
+      }
+    }
+
+    const namedDependencyVersions = await Bluebird.map(
+      dependencies,
+      async (m: Module) => ({ name: m.name, ...await this.getTreeVersion([m.path]) }),
+    )
+    const dependencyVersions = mapValues(keyBy(namedDependencyVersions, "name"), v => omit(v, "name"))
+
+    // keep the module at the top of the chain, dependencies sorted by name
+    const sortedDependencies = sortBy(namedDependencyVersions, "name")
+    const allVersions: NamedTreeVersion[] = [{ name: module.name, ...treeVersion }].concat(sortedDependencies)
+
+    const dirtyVersions = allVersions.filter(v => !!v.dirtyTimestamp)
+
+    if (dirtyVersions.length > 0) {
+      // if any modules are dirty, we resolve with the one(s) with the most recent timestamp
+      const latestDirty: NamedTreeVersion[] = []
+
+      for (const v of orderBy(dirtyVersions, "dirtyTimestamp", "desc")) {
+        if (latestDirty.length === 0 || v.dirtyTimestamp === latestDirty[0].dirtyTimestamp) {
+          latestDirty.push(v)
+        } else {
+          break
+        }
+      }
+
+      const dirtyTimestamp = latestDirty[0].dirtyTimestamp
+
+      if (latestDirty.length > 1) {
+        // if the last modified timestamp is common across multiple modules, hash their versions
+        const versionString = hashVersions(latestDirty)
+
+        return {
+          versionString,
+          dirtyTimestamp,
+          dependencyVersions,
+        }
+      } else {
+        // if there's just one module that was most recently modified, return that version
+        return {
+          versionString: `${latestDirty[0].latestCommit}-${dirtyTimestamp}`,
+          dirtyTimestamp,
+          dependencyVersions,
+        }
+      }
+    } else {
+      // otherwise derive the version from all the modules
+      const versionString = hashVersions(allVersions)
+
+      return {
+        versionString,
+        dirtyTimestamp: null,
+        dependencyVersions,
+      }
+    }
+  }
+}
+
+function hashVersions(versions: NamedTreeVersion[]) {
+  const versionHash = createHash("sha256")
+  versionHash.update(versions.map(v => `${v.name}_${v.latestCommit}`).join("."))
+  // this format is kinda arbitrary, but prefixing the "v" is useful to visually spot hashed versions
+  return "v" + versionHash.digest("hex").slice(0, 10)
 }

--- a/test/data/test-project-a/module-a/.garden-version
+++ b/test/data/test-project-a/module-a/.garden-version
@@ -1,0 +1,5 @@
+{
+  "versionString": "1234567890",
+  "dirtyTimestamp": null,
+  "dependencyVersions": {}
+}

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -32,15 +32,17 @@ import {
   RunServiceParams,
   SetConfigParams,
 } from "../src/types/plugin/params"
-import { TreeVersion } from "../src/vcs/base"
+import {
+  ModuleVersion,
+} from "../src/vcs/base"
 
 export const dataDir = resolve(__dirname, "data")
 export const testNow = new Date()
 export const testModuleVersionString = "1234512345"
-export const testModuleVersion: TreeVersion = {
+export const testModuleVersion: ModuleVersion = {
   versionString: testModuleVersionString,
-  latestCommit: testModuleVersionString,
   dirtyTimestamp: null,
+  dependencyVersions: {},
 }
 
 export function getDataDir(name: string) {

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,13 +1,6 @@
 import * as td from "testdouble"
 import { Module } from "../src/types/module"
 
-// Global before hooks
-beforeEach(() => {
-  td.replace(Module.prototype, "getVersion", () => ({
-    versionString: "0000000000",
-    latestCommit: "0000000000",
-    dirtyTimestamp: null,
-  }))
-})
-
+// Global hooks
+beforeEach(() => { })
 afterEach(() => td.reset())

--- a/test/src/commands/push.ts
+++ b/test/src/commands/push.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../src/types/plugin/plugin"
 import { Module } from "../../../src/types/module"
 import { PushCommand } from "../../../src/commands/push"
-import { TreeVersion } from "../../../src/vcs/base"
+import { ModuleVersion } from "../../../src/vcs/base"
 import {
   expectError,
   taskResultOutputs,
@@ -192,11 +192,11 @@ describe("PushCommand", () => {
 
   context("module is dirty", () => {
     beforeEach(() => {
-      td.replace(Module.prototype, "getVersion", async (): Promise<TreeVersion> => {
+      td.replace(Module.prototype, "getVersion", async (): Promise<ModuleVersion> => {
         return {
           versionString: "012345",
-          latestCommit: "012345",
           dirtyTimestamp: 12345,
+          dependencyVersions: {},
         }
       })
     })

--- a/test/src/task-graph.ts
+++ b/test/src/task-graph.ts
@@ -32,9 +32,9 @@ class TestTask extends Task {
   ) {
     super({
       version: {
-        versionString: "12345#6789",
-        latestCommit: "12345",
+        versionString: "12345-6789",
         dirtyTimestamp: 6789,
+        dependencyVersions: {},
       },
     })
     this.name = name

--- a/test/src/types/module.ts
+++ b/test/src/types/module.ts
@@ -9,7 +9,6 @@ import {
 import { expect } from "chai"
 import { loadConfig } from "../../../src/types/config"
 
-const getVersion = Module.prototype.getVersion
 const modulePathA = resolve(dataDir, "test-project-a", "module-a")
 
 describe("Module", () => {
@@ -46,37 +45,6 @@ describe("Module", () => {
       },
       type: "test",
       variables: {},
-    })
-  })
-
-  describe("getVersion", () => {
-    let stub: any
-
-    beforeEach(() => {
-      stub = Module.prototype.getVersion
-      Module.prototype.getVersion = getVersion
-    })
-
-    afterEach(() => {
-      Module.prototype.getVersion = stub
-    })
-
-    it("should use cached version if available", async () => {
-      const garden = await makeTestGardenA()
-      const ctx = garden.pluginContext
-      const config = await loadConfig(ctx.projectRoot, modulePathA)
-      const module = new Module(ctx, config.module!, [], [])
-
-      const cachedVersion = {
-        versionString: "0123456789",
-        latestCommit: "0123456789",
-        dirtyTimestamp: null,
-      }
-      garden.cache.set(["moduleVersions", module.name], cachedVersion, module.getCacheContext())
-
-      const version = await module.getVersion()
-
-      expect(version).to.eql(cachedVersion)
     })
   })
 

--- a/test/src/vcs/base.ts
+++ b/test/src/vcs/base.ts
@@ -1,0 +1,163 @@
+import { VcsHandler, NEW_MODULE_VERSION, TreeVersions, TreeVersion } from "../../../src/vcs/base"
+import { projectRootA, makeTestContextA } from "../../helpers"
+import { PluginContext } from "../../../src/plugin-context"
+import { expect } from "chai"
+
+class TestVcsHandler extends VcsHandler {
+  private testVersions: TreeVersions = {}
+
+  async getTreeVersion(paths: string[]) {
+    const versionString = NEW_MODULE_VERSION
+    return this.testVersions[paths[0]] || {
+      versionString,
+      latestCommit: versionString,
+      dirtyTimestamp: null,
+    }
+  }
+
+  setTestVersion(path: string, version: TreeVersion) {
+    this.testVersions[path] = version
+  }
+}
+
+describe("VcsHandler", () => {
+  let handler: TestVcsHandler
+  let ctx: PluginContext
+
+  beforeEach(async () => {
+    handler = new TestVcsHandler(projectRootA)
+    ctx = await makeTestContextA()
+  })
+
+  describe("resolveVersion", () => {
+    it("should return module version if there are no dependencies", async () => {
+      const module = await ctx.getModule("module-a")
+      const versionString = "abcdef"
+      const version = {
+        versionString,
+        latestCommit: versionString,
+        dirtyTimestamp: null,
+      }
+
+      handler.setTestVersion(module.path, version)
+
+      const result = await handler.resolveVersion(module, [])
+
+      expect(result).to.eql({
+        versionString,
+        dirtyTimestamp: null,
+        dependencyVersions: {},
+      })
+    })
+
+    it("should return the latest dirty version if any", async () => {
+      const [moduleA, moduleB, moduleC] = await ctx.getModules(["module-a", "module-b", "module-c"])
+
+      const versionStringA = "abcdef"
+      const versionA = {
+        versionString: versionStringA,
+        latestCommit: versionStringA,
+        dirtyTimestamp: null,
+      }
+      handler.setTestVersion(moduleA.path, versionA)
+
+      const versionB = {
+        versionString: "qwerty-456",
+        latestCommit: "qwerty",
+        dirtyTimestamp: 456,
+      }
+      handler.setTestVersion(moduleB.path, versionB)
+
+      const versionStringC = "asdfgh"
+      const versionC = {
+        versionString: versionStringC,
+        latestCommit: versionStringC,
+        dirtyTimestamp: 123,
+      }
+      handler.setTestVersion(moduleC.path, versionC)
+
+      expect(await handler.resolveVersion(moduleC, [moduleA, moduleB])).to.eql({
+        versionString: "qwerty-456",
+        dirtyTimestamp: 456,
+        dependencyVersions: {
+          "module-a": versionA,
+          "module-b": versionB,
+        },
+      })
+    })
+
+    it("should hash together the version of the module and all dependencies if none are dirty", async () => {
+      const [moduleA, moduleB, moduleC] = await ctx.getModules(["module-a", "module-b", "module-c"])
+
+      const versionStringA = "abcdef"
+      const versionA = {
+        versionString: versionStringA,
+        latestCommit: versionStringA,
+        dirtyTimestamp: null,
+      }
+      handler.setTestVersion(moduleA.path, versionA)
+
+      const versionStringB = "qwerty"
+      const versionB = {
+        versionString: versionStringB,
+        latestCommit: versionStringB,
+        dirtyTimestamp: null,
+      }
+      handler.setTestVersion(moduleB.path, versionB)
+
+      const versionStringC = "asdfgh"
+      const versionC = {
+        versionString: versionStringC,
+        latestCommit: versionStringC,
+        dirtyTimestamp: null,
+      }
+      handler.setTestVersion(moduleC.path, versionC)
+
+      expect(await handler.resolveVersion(moduleC, [moduleA, moduleB])).to.eql({
+        versionString: "vfd75ce5f36",
+        dirtyTimestamp: null,
+        dependencyVersions: {
+          "module-a": versionA,
+          "module-b": versionB,
+        },
+      })
+    })
+
+    it("should hash together the dirty versions if there are multiple with same timestamp", async () => {
+      const [moduleA, moduleB, moduleC] = await ctx.getModules(["module-a", "module-b", "module-c"])
+
+      const versionStringA = "abcdef"
+      const versionA = {
+        versionString: versionStringA,
+        latestCommit: versionStringA,
+        dirtyTimestamp: null,
+      }
+      handler.setTestVersion(moduleA.path, versionA)
+
+      const versionStringB = "qwerty"
+      const versionB = {
+        versionString: versionStringB,
+        latestCommit: versionStringB,
+        dirtyTimestamp: 1234,
+      }
+      handler.setTestVersion(moduleB.path, versionB)
+
+      const versionStringC = "asdfgh"
+      const versionC = {
+        versionString: versionStringC,
+        latestCommit: versionStringC,
+        dirtyTimestamp: 1234,
+      }
+      handler.setTestVersion(moduleC.path, versionC)
+
+      expect(await handler.resolveVersion(moduleC, [moduleA, moduleB])).to.eql({
+        versionString: "vcfa6d28ec5",
+        dirtyTimestamp: 1234,
+        dependencyVersions: {
+          "module-a": versionA,
+          "module-b": versionB,
+        },
+      })
+    })
+  })
+})


### PR DESCRIPTION
This refactor resolves issues with using plugin modules as dependencies,
and is important for multi-repo support. Basically we now hash versions
together instead of using the latest commit, which would of course only
work within a single repo.

One thing to look at here are how the versions are hashed together (see `src/vcs/base.ts`). Please let me know if you think it could/should be done differently.