### PR TITLE
fix(file-writer): only create file if content to write

### DIFF
--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -49,8 +49,8 @@ ${chalk.bold(str.slice(0, 5).toUpperCase())}
 
 // Helper functions
 export const getKeys = (obj): string[] => Object.keys(obj || {})
-export const filterByArray = (obj: any, arr: string[]): any => {
-  return arr.reduce((memo, key) => {
+export const filterByKeys = (obj: any, keys: string[]): any => {
+  return keys.reduce((memo, key) => {
     if (obj[key]) {
       memo[key] = obj[key]
     }


### PR DESCRIPTION
Previously the file writer would create the `error.log` even when there were no errors (cause that's basically the Winston (our file logging framework) default). That felt kind of silly when using the create command which would basically create a new project full of empty error logs.

However, once a log file has been created for the first time it stays there. In the case of the `error.log` file, it's truncated each time (there are persistent log files under `.garden/logs`).

Does that make sense? Should we perhaps move the `error.log` to something like `garden_tmp` and remove it if there are no errors? Or just leave it as is?