### PR TITLE
docs: add missing generated commands docs

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -16,7 +16,7 @@ The following option flags can be used with any of the CLI commands:
   | `--root` | `-r` | string | Override project root directory (defaults to working directory).
   | `--silent` | `-s` | boolean | Suppress log output.
   | `--env` | `-e` | string | The environment (and optionally namespace) to work against
-  | `--loglevel` | `-l` | `error` `warn` `info` `verbose` `debug` `silly` `0` `1` `2` `3` `4` `5`  | Set logger level, values can be either string or numeric
+  | `--loglevel` | `-l` | `error` `warn` `info` `verbose` `debug` `silly` `0` `1` `2` `3` `4` `5`  | Set logger level. Values can be either string or numeric and are prioritized from 0 to 5 (highest to lowest) as follows: error: 0, warn: 1, info: 2, verbose: 3, debug: 4, silly: 5
   | `--output` | `-o` | `json` `yaml`  | Output command result in specified format (note: disables progress logging).
 
 ### garden build


### PR DESCRIPTION
Not sure what happened but the generated docs were out of sync. 