### PR TITLE
fix(create-module-command): type option should be an enum

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -136,7 +136,7 @@ Examples:
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
   | `--name` |  | boolean | Assigns a custom name to the module. (Defaults to name of the current directory.)
-  | `--type` |  | string | Type of module. Check out &#x27;https://docs.garden.io&#x27; for available types
+  | `--type` |  | `container` `function` `npm-package`  | Type of module.
 
 ### garden delete config
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -136,7 +136,7 @@ Examples:
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
   | `--name` |  | boolean | Assigns a custom name to the module. (Defaults to name of the current directory.)
-  | `--type` |  | `container` `function` `npm-package`  | Type of module.
+  | `--type` |  | `container` `google-cloud-function` `npm-package`  | Type of module.
 
 ### garden delete config
 

--- a/src/commands/create/config-templates.ts
+++ b/src/commands/create/config-templates.ts
@@ -24,7 +24,7 @@ import { BaseModuleSpec, ModuleConfig, baseModuleSpecSchema } from "../../types/
  */
 export const MODULE_PROVIDER_MAP = {
   container: "local-kubernetes",
-  function: "local-google-cloud-functions",
+  "google-cloud-function": "local-google-cloud-functions",
   "npm-package": "npm-package",
 }
 
@@ -72,11 +72,11 @@ export function containerTemplate(moduleName: string): DeepPartial<ContainerModu
   }
 }
 
-export function functionTemplate(moduleName: string): DeepPartial<GcfModuleSpec> {
+export function googleCloudFunctionTemplate(moduleName: string): DeepPartial<GcfModuleSpec> {
   return {
     functions: [{
-      name: `${moduleName}-function`,
-      entrypoint: camelCase(`${moduleName}-function`),
+      name: `${moduleName}-google-cloud-function`,
+      entrypoint: camelCase(`${moduleName}-google-cloud-function`),
     }],
   }
 }

--- a/src/commands/create/helpers.ts
+++ b/src/commands/create/helpers.ts
@@ -9,7 +9,7 @@
 import * as Joi from "joi"
 import {
   containerTemplate,
-  functionTemplate,
+  googleCloudFunctionTemplate,
   npmPackageTemplate,
   ModuleConfigOpts,
   ModuleType,
@@ -27,7 +27,7 @@ import { MODULE_CONFIG_FILENAME } from "../../constants"
 export function prepareNewModuleConfig(name: string, type: ModuleType, path: string): ModuleConfigOpts {
   const moduleTypeTemplate = {
     container: containerTemplate,
-    function: functionTemplate,
+    "google-cloud-function": googleCloudFunctionTemplate,
     "npm-package": npmPackageTemplate,
   }[type]
   return {

--- a/src/commands/create/module.ts
+++ b/src/commands/create/module.ts
@@ -18,6 +18,7 @@ import {
   StringParameter,
   ParameterValues,
   BooleanParameter,
+  ChoicesParameter,
 } from "../base"
 import { ParameterError, GardenBaseError } from "../../exceptions"
 import { availableModuleTypes, ModuleType, moduleSchema, ModuleConfigOpts } from "./config-templates"
@@ -33,8 +34,9 @@ export const createModuleOptions = {
   name: new BooleanParameter({
     help: "Assigns a custom name to the module. (Defaults to name of the current directory.)",
   }),
-  type: new StringParameter({
-    help: "Type of module. Check out 'https://docs.garden.io' for available types",
+  type: new ChoicesParameter({
+    help: "Type of module.",
+    choices: availableModuleTypes,
   }),
 }
 

--- a/src/commands/create/prompts.ts
+++ b/src/commands/create/prompts.ts
@@ -38,7 +38,7 @@ const moduleTypeChoices: ModuleTypeChoice[] = [
   },
   {
     name: `google-cloud-function (${chalk.red.italic("experimental")})`,
-    value: "function",
+    value: "google-cloud-function",
   },
   {
     name: `npm package (${chalk.red.italic("experimental")})`,

--- a/test/src/commands/create/module.ts
+++ b/test/src/commands/create/module.ts
@@ -65,13 +65,13 @@ describe("CreateModuleCommand", () => {
       path: ctx.projectRoot,
     })
   })
-  // garden create module --type=function
+  // garden create module --type=google-cloud-function
   it("should optionally create a module of a specific type (without prompting)", async () => {
     const ctx = await makeTestContext(projectRoot)
-    const { result } = await cmd.action(ctx, { "module-dir": "" }, { name: "", type: "function" })
+    const { result } = await cmd.action(ctx, { "module-dir": "" }, { name: "", type: "google-cloud-function" })
     expect(pick(result.module, ["name", "type", "path"])).to.eql({
       name: "test-project-create-command",
-      type: "function",
+      type: "google-cloud-function",
       path: ctx.projectRoot,
     })
   })


### PR DESCRIPTION
Looks like another rebase regression. This is how it should've been in the first place. 