### PR TITLE
Templating refactor watch fixes

### DIFF
--- a/garden-cli/src/commands/build.ts
+++ b/garden-cli/src/commands/build.ts
@@ -72,8 +72,8 @@ export class BuildCommand extends Command<typeof buildArguments, typeof buildOpt
       garden,
       modules,
       watch: opts.watch,
-      process: async (module) => [new BuildTask({ ctx, module, force: opts.force })],
-      processWatchChange: async (module: Module) => {
+      handler: async (module) => [new BuildTask({ ctx, module, force: opts.force })],
+      changeHandler: async (module: Module) => {
         return (await withDependants(ctx, [module], autoReloadDependants))
           .filter(m => moduleNames.includes(m.name))
           .map(m => new BuildTask({ ctx, module: m, force: true }))

--- a/garden-cli/src/commands/build.ts
+++ b/garden-cli/src/commands/build.ts
@@ -19,6 +19,8 @@ import { BuildTask } from "../tasks/build"
 import { TaskResults } from "../task-graph"
 import dedent = require("dedent")
 import { processModules } from "../process"
+import { computeAutoReloadDependants, withDependants } from "../watch"
+import { Module } from "../types/module"
 
 export const buildArguments = {
   module: new StringsParameter({
@@ -56,18 +58,25 @@ export class BuildCommand extends Command<typeof buildArguments, typeof buildOpt
   async action(
     { ctx, args, opts, garden }: CommandParams<BuildArguments, BuildOptions>,
   ): Promise<CommandResult<TaskResults>> {
+
     await garden.clearBuilds()
+
+    const autoReloadDependants = await computeAutoReloadDependants(ctx)
     const modules = await ctx.getModules(args.module)
+    const moduleNames = modules.map(m => m.name)
 
     ctx.log.header({ emoji: "hammer", command: "Build" })
 
     const results = await processModules({
-      modules,
       ctx,
       garden,
+      modules,
       watch: opts.watch,
-      process: async (module) => {
-        return [new BuildTask({ ctx, module, force: opts.force })]
+      process: async (module) => [new BuildTask({ ctx, module, force: opts.force })],
+      processWatchChange: async (module: Module) => {
+        return (await withDependants(ctx, [module], autoReloadDependants))
+          .filter(m => moduleNames.includes(m.name))
+          .map(m => new BuildTask({ ctx, module: m, force: true }))
       },
     })
 

--- a/garden-cli/src/commands/create/project.ts
+++ b/garden-cli/src/commands/create/project.ts
@@ -32,7 +32,7 @@ import {
   ModuleConfigOpts,
   ProjectConfigOpts,
   moduleSchema,
-} from "../create/config-templates"
+} from "./config-templates"
 import { getChildDirNames } from "../../util/util"
 import { validate, joiIdentifier } from "../../config/common"
 import { projectSchema } from "../../config/project"

--- a/garden-cli/src/commands/dev.ts
+++ b/garden-cli/src/commands/dev.ts
@@ -25,7 +25,7 @@ import { readFile } from "fs-extra"
 import { Module } from "../types/module"
 import { getTestTasks } from "./test"
 import { computeAutoReloadDependants, withDependants } from "../watch"
-import { getDeployTasks } from "./deploy"
+import { getDeployTasks } from "../tasks/deploy"
 
 const ansiBannerPath = join(STATIC_DIR, "garden-banner-2.txt")
 
@@ -58,9 +58,9 @@ export class DevCommand extends Command {
 
     if (modules.length === 0) {
       if (modules.length === 0) {
-        ctx.log.info({msg: "No modules found in project."})
+        ctx.log.info({ msg: "No modules found in project." })
       }
-      ctx.log.info({msg: "Aborting..."})
+      ctx.log.info({ msg: "Aborting..." })
       return {}
     }
 
@@ -72,14 +72,15 @@ export class DevCommand extends Command {
           : [module]
 
         const testTasks: Task[] = flatten(await Bluebird.map(
-          testModules, m => getTestTasks({ctx, module: m})))
+          testModules, m => getTestTasks({ ctx, module: m })))
 
         const deployTasks = await getDeployTasks({
-          ctx, module, force: watch, forceBuild: watch, includeDependants: watch })
+          ctx, module, force: watch, forceBuild: watch, includeDependants: watch,
+        })
         const tasks = testTasks.concat(deployTasks)
 
         if (tasks.length === 0) {
-          return [new BuildTask({ctx, module, force: watch})]
+          return [new BuildTask({ ctx, module, force: watch })]
         } else {
           return tasks
         }
@@ -92,8 +93,8 @@ export class DevCommand extends Command {
       garden,
       modules,
       watch: true,
-      process: tasksForModule(false),
-      processWatchChange: tasksForModule(true),
+      handler: tasksForModule(false),
+      changeHandler: tasksForModule(true),
     })
 
     return {}

--- a/garden-cli/src/commands/test.ts
+++ b/garden-cli/src/commands/test.ts
@@ -95,8 +95,8 @@ export class TestCommand extends Command<typeof testArgs, typeof testOpts> {
       garden,
       modules,
       watch: opts.watch,
-      process: async (module) => getTestTasks({ ctx, module, name, force, forceBuild }),
-      processWatchChange: async (module) => {
+      handler: async (module) => getTestTasks({ ctx, module, name, force, forceBuild }),
+      changeHandler: async (module) => {
         const modulesToProcess = await withDependants(ctx, [module], autoReloadDependants)
         return flatten(await Bluebird.map(
           modulesToProcess,

--- a/garden-cli/src/plugin-context.ts
+++ b/garden-cli/src/plugin-context.ts
@@ -78,7 +78,7 @@ import {
 import { Omit } from "./util/util"
 import { RuntimeContext } from "./types/service"
 import { processServices, ProcessResults } from "./process"
-import { getDeployTasks } from "./commands/deploy"
+import { getDeployTasks } from "./tasks/deploy"
 
 export type PluginContextGuard = {
   readonly [P in keyof (PluginActionParams | ModuleActionParams<any>)]: (...args: any[]) => Promise<any>
@@ -474,8 +474,9 @@ export function createPluginContext(garden: Garden): PluginContext {
         garden,
         ctx,
         watch: false,
-        process: async (module) => getDeployTasks({
-          ctx, module, serviceNames, force, forceBuild, includeDependants: false }),
+        handler: async (module) => getDeployTasks({
+          ctx, module, serviceNames, force, forceBuild, includeDependants: false,
+        }),
       })
     },
 

--- a/garden-cli/src/plugin-context.ts
+++ b/garden-cli/src/plugin-context.ts
@@ -78,7 +78,7 @@ import {
 import { Omit } from "./util/util"
 import { RuntimeContext } from "./types/service"
 import { processServices, ProcessResults } from "./process"
-import { DeployTask } from "./tasks/deploy"
+import { getDeployTasks } from "./commands/deploy"
 
 export type PluginContextGuard = {
   readonly [P in keyof (PluginActionParams | ModuleActionParams<any>)]: (...args: any[]) => Promise<any>
@@ -468,14 +468,14 @@ export function createPluginContext(garden: Garden): PluginContext {
 
     deployServices: async ({ serviceNames, force = false, forceBuild = false }: DeployServicesParams) => {
       const services = await ctx.getServices(serviceNames)
+
       return processServices({
         services,
         garden,
         ctx,
         watch: false,
-        process: async (service) => {
-          return [new DeployTask({ ctx, service, force, forceBuild })]
-        },
+        process: async (module) => getDeployTasks({
+          ctx, module, serviceNames, force, forceBuild, includeDependants: false }),
       })
     },
 

--- a/garden-cli/src/plugins/openfaas.ts
+++ b/garden-cli/src/plugins/openfaas.ts
@@ -50,7 +50,7 @@ import { appsApi } from "./kubernetes/api"
 import { waitForObjects, checkDeploymentStatus } from "./kubernetes/status"
 import { systemSymbol } from "./kubernetes/system"
 import { BaseServiceSpec } from "../config/service"
-import { getDeployTasks } from "../commands/deploy"
+import { getDeployTasks } from "../tasks/deploy"
 
 const systemProjectPath = join(STATIC_DIR, "openfaas", "system")
 const stackFilename = "stack.yml"
@@ -105,14 +105,15 @@ export const gardenPlugin = () => ({
 
       const services = await ofCtx.getServices()
       const deployTasksForModule = async (module) => getDeployTasks({
-        ctx: ofCtx, module, force, forceBuild: false, includeDependants: false })
+        ctx: ofCtx, module, force, forceBuild: false, includeDependants: false,
+      })
 
       const results = await processServices({
         garden: ofGarden,
         ctx: ofCtx,
         services,
         watch: false,
-        process: deployTasksForModule,
+        handler: deployTasksForModule,
       })
 
       const failed = values(results.taskResults).filter(r => !!r.error).length

--- a/garden-cli/src/task-graph.ts
+++ b/garden-cli/src/task-graph.ts
@@ -207,7 +207,7 @@ export class TaskGraph {
     const task = node.task
     for (const d of await task.getDependencies()) {
 
-      if (this.resultCache.get(d.getBaseKey(), d.version.versionString)) {
+      if (!d.force && this.resultCache.get(d.getBaseKey(), d.version.versionString)) {
         continue
       }
 

--- a/garden-cli/src/tasks/base.ts
+++ b/garden-cli/src/tasks/base.ts
@@ -13,12 +13,14 @@ import { v1 as uuidv1 } from "uuid"
 export class TaskDefinitionError extends Error { }
 
 export interface TaskParams {
+  force?: boolean
   version: ModuleVersion
 }
 
 export abstract class Task {
   abstract type: string
   id: string
+  force: boolean
   version: ModuleVersion
 
   dependencies: Task[]
@@ -26,6 +28,7 @@ export abstract class Task {
   constructor(initArgs: TaskParams) {
     this.dependencies = []
     this.id = uuidv1() // uuidv1 is timestamp-based
+    this.force = !!initArgs.force
     this.version = initArgs.version
   }
 

--- a/garden-cli/src/tasks/build.ts
+++ b/garden-cli/src/tasks/build.ts
@@ -25,13 +25,11 @@ export class BuildTask extends Task {
 
   private ctx: PluginContext
   private module: Module
-  private force: boolean
 
-  constructor({ ctx, module, force }: BuildTaskParams) {
-    super({ version: module.version })
+  constructor({ ctx, force, module }: BuildTaskParams) {
+    super({ force, version: module.version })
     this.ctx = ctx
     this.module = module
-    this.force = force
   }
 
   async getDependencies(): Promise<BuildTask[]> {

--- a/garden-cli/src/tasks/deploy.ts
+++ b/garden-cli/src/tasks/deploy.ts
@@ -11,7 +11,7 @@ import chalk from "chalk"
 import { LogEntry } from "../logger/logger"
 import { PluginContext } from "../plugin-context"
 import { BuildTask } from "./build"
-import { Task } from "../tasks/base"
+import { Task } from "./base"
 import {
   Service,
   ServiceStatus,
@@ -32,15 +32,13 @@ export class DeployTask extends Task {
 
   private ctx: PluginContext
   private service: Service
-  private force: boolean
   private forceBuild: boolean
   private logEntry?: LogEntry
 
   constructor({ ctx, service, force, forceBuild, logEntry }: DeployTaskParams) {
-    super({ version: service.module.version })
+    super({ force, version: service.module.version })
     this.ctx = ctx
     this.service = service
-    this.force = force
     this.forceBuild = forceBuild
     this.logEntry = logEntry
   }
@@ -53,7 +51,7 @@ export class DeployTask extends Task {
       return new DeployTask({
         service,
         ctx: this.ctx,
-        force: this.force,
+        force: false,
         forceBuild: this.forceBuild,
       })
     })

--- a/garden-cli/src/tasks/deploy.ts
+++ b/garden-cli/src/tasks/deploy.ts
@@ -6,6 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import { flatten } from "lodash"
 import * as Bluebird from "bluebird"
 import chalk from "chalk"
 import { LogEntry } from "../logger/logger"
@@ -18,6 +19,9 @@ import {
   prepareRuntimeContext,
 } from "../types/service"
 import { EntryStyle } from "../logger/types"
+import { Module } from "../types/module"
+import { withDependants, computeAutoReloadDependants } from "../watch"
+import { getNames } from "../util/util"
 
 export interface DeployTaskParams {
   ctx: PluginContext
@@ -112,4 +116,27 @@ export class DeployTask extends Task {
 
     return result
   }
+}
+
+export async function getDeployTasks(
+  { ctx, module, serviceNames, force = false, forceBuild = false, includeDependants = false }:
+    {
+      ctx: PluginContext, module: Module, serviceNames?: string[] | null,
+      force?: boolean, forceBuild?: boolean, includeDependants?: boolean,
+    },
+) {
+
+  const modulesToProcess = includeDependants
+    ? (await withDependants(ctx, [module], await computeAutoReloadDependants(ctx)))
+    : [module]
+
+  const moduleServices = flatten(await Bluebird.map(
+    modulesToProcess,
+    m => ctx.getServices(getNames(m.serviceConfigs))))
+
+  const servicesToProcess = serviceNames
+    ? moduleServices.filter(s => serviceNames.includes(s.name))
+    : moduleServices
+
+  return servicesToProcess.map(service => new DeployTask({ ctx, service, force, forceBuild }))
 }

--- a/garden-cli/src/tasks/test.ts
+++ b/garden-cli/src/tasks/test.ts
@@ -39,11 +39,10 @@ export class TestTask extends Task {
   private ctx: PluginContext
   private module: Module
   private testConfig: TestConfig
-  private force: boolean
   private forceBuild: boolean
 
   constructor({ ctx, module, testConfig, force, forceBuild, version }: TestTaskParams & TaskParams) {
-    super({ version })
+    super({ force, version })
     this.ctx = ctx
     this.module = module
     this.testConfig = testConfig

--- a/garden-cli/test/src/watch.ts
+++ b/garden-cli/test/src/watch.ts
@@ -3,7 +3,6 @@ import { mapValues } from "lodash"
 import { join } from "path"
 import {
   AutoReloadDependants,
-  autoReloadModules,
   computeAutoReloadDependants,
 } from "../../src/watch"
 import { makeTestGarden } from "../helpers"
@@ -17,15 +16,6 @@ export function dependantModuleNames(ard: AutoReloadDependants): { [key: string]
 }
 
 describe("watch", () => {
-  describe("autoReloadModules", () => {
-    it("should include build and service dependencies of requested modules", async () => {
-      const ctx = (await makeTestGarden(projectRoot)).getPluginContext()
-      const moduleNames = (await autoReloadModules(ctx, await ctx.getModules(["module-e", "module-d"])))
-        .map(m => m.name).sort()
-
-      expect(moduleNames.sort()).to.eql(["module-a", "module-b", "module-c", "module-d", "module-e"])
-    })
-  })
 
   describe("computeAutoReloadDependants", () => {
     it("should include build and service dependants of requested modules", async () => {
@@ -40,4 +30,5 @@ describe("watch", () => {
       })
     })
   })
+
 })


### PR DESCRIPTION
(pushing this on behalf of @thsig)

Each command's process function now explicitly controls which tasks are
added to the TaskGraph when a module is processed, with a separate
callback (processWatchChanges) for handling changes in watch mode. This
was previously controlled in garden-cli/src/process.ts.

This commit fixes

#193,

and a few other cases where the watch logic's behavior deviated from its
specification (in docs / help strings).

Following is a summary of the watch logic's behavior after these changes:

- `garden build -w` rebuilds changed modules, their build dependencies,
  and their build dependants.
- `garden build -w some-module` rebuilds only `some-module` and its
  dependencies when it changes (ignoring changes to other modules as
  usual).
- `garden deploy -w` redeploys changed modules and their service
  dependants. It also rebuilds the changed module, its build
  dependencies and its build dependants.
- `garden dev` behaves the same way as `garden deploy -w` in this
  regard.
- `garden deploy -w some-module` redeploys only `some-module` when it
  changes (ignoring changes to other modules as usual).
- `garden test -w` re-runs test dependencies and test dependants
  in addition to the changed module's tests.