### PR TITLE
fix: add axios as dependency (was dev dependency)

### DIFF
--- a/garden-cli/package.json
+++ b/garden-cli/package.json
@@ -23,6 +23,7 @@
   ],
   "dependencies": {
     "@kubernetes/client-node": "^0.5.2",
+    "axios": "^0.18.0",
     "ansi-escapes": "^3.1.0",
     "async-exit-hook": "^2.0.1",
     "async-lock": "^1.1.3",
@@ -104,7 +105,6 @@
     "@types/string-width": "^2.0.0",
     "@types/uniqid": "^4.1.2",
     "@types/wrap-ansi": "^3.0.0",
-    "axios": "^0.18.0",
     "chai": "^4.1.2",
     "gulp": "^4.0.0",
     "gulp-cached": "^1.1.1",


### PR DESCRIPTION
This issue breaks the garden-cli npm package. Once merged we should cut a new patch release.  