### PR TITLE
refactor: get rid of native OpenSSL dependency

### DIFF
--- a/garden-cli/package-lock.json
+++ b/garden-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "garden-cli",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1173,6 +1173,11 @@
         "safer-buffer": "~2.1.0"
       }
     },
+    "asn1js": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-1.2.12.tgz",
+      "integrity": "sha1-h9XueXWWri0qPLAkciDcQv/D8hE="
+    },
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -1646,6 +1651,15 @@
           "dev": true,
           "optional": true
         }
+      }
+    },
+    "certpem": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/certpem/-/certpem-1.1.2.tgz",
+      "integrity": "sha512-rqddNO1OdN6o7j1C486Os9USHgGEyoBSRHDgVAqx0jVAmGlgGQ1XPCrrl2KKxzdWBNC184V3gpV5BsvcDDQ+Vg==",
+      "requires": {
+        "asn1js": "^1.2.12",
+        "pkijs": "^1.3.27"
       }
     },
     "chai": {
@@ -8740,6 +8754,11 @@
         "find-up": "^2.1.0"
       }
     },
+    "pkijs": {
+      "version": "1.3.33",
+      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-1.3.33.tgz",
+      "integrity": "sha1-ponvYhE7fDSOH/wJll0iOeW7TJI="
+    },
     "plugin-error": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
@@ -11095,13 +11114,6 @@
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.2"
-      }
-    },
-    "x509": {
-      "version": "github:stormwin/node-x509#40140051e55b2ef5bef73a4412bcdf8e2b672c6a",
-      "from": "github:stormwin/node-x509",
-      "requires": {
-        "nan": "2.10.0"
       }
     },
     "xdg-basedir": {

--- a/garden-cli/package.json
+++ b/garden-cli/package.json
@@ -28,6 +28,7 @@
     "async-lock": "^1.1.3",
     "axios": "^0.18.0",
     "bluebird": "^3.5.1",
+    "certpem": "^1.1.2",
     "chalk": "^2.4.1",
     "child-process-promise": "^2.2.1",
     "chokidar": "^2.0.4",
@@ -70,8 +71,7 @@
     "uniqid": "^5.0.3",
     "uuid": "^3.3.2",
     "winston": "^3.0.0",
-    "wrap-ansi": "^3.0.1",
-    "x509": "github:stormwin/node-x509"
+    "wrap-ansi": "^3.0.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^7.0.0",


### PR DESCRIPTION
By removing the x509 library, in favor of the (admittedly odd) certpem/pkijs libs

Closes #261 