### PR TITLE
refactor: rename endpoints to ingresses

### DIFF
--- a/docs/examples/simple-project.md
+++ b/docs/examples/simple-project.md
@@ -112,11 +112,11 @@ module:
       ports:
         - name: http
           containerPort: 8080
-      endpoints:
+      ingresses:
         - path: /hello-node
           port: http
 ```
-The [services](../guides/configuration.md#Services) directive is specific to container modules, and defines the services exposed by the module. In this case, our containerized Node.js server. The sub-directives tell Garden how to start the service and which endpoints to expose.
+The [services](../guides/configuration.md#Services) directive is specific to container modules, and defines the services exposed by the module. In this case, our containerized Node.js server. The sub-directives tell Garden how to start the service and which ingress endpoints to expose.
 
 ## Deploying
 
@@ -132,7 +132,7 @@ Garden can now deploy our service to a local Kubernetes cluster:
 $ garden deploy
 ```
 
-To verify that everything is working, we can call the service at the `/hello-node` endpoint defined in `/services/node-service/app.js`:
+To verify that everything is working, we can call the service at the `/hello-node` ingress defined in `/services/node-service/app.js`:
 
 ```sh
 $ garden call node-service/hello-node
@@ -160,7 +160,7 @@ module:
       ports:
         - name: http
           containerPort: 80
-      endpoints:
+      ingresses:
         - path: /hello-go
           port: http
 ```
@@ -290,7 +290,7 @@ module:
       ports:
         - name: http
           containerPort: 8080
-      endpoints:
+      ingresses:
         - path: /
           port: http
       dependencies:

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -140,7 +140,7 @@ module:
       ports:
         - name: http
           containerPort: 8080
-      endpoints:
+      ingresses:
         - path: /hello
           port: http
       healthCheck:

--- a/docs/guides/glossary.md
+++ b/docs/guides/glossary.md
@@ -1,23 +1,23 @@
 # Glossary
 
 #### Environment
-Represents the current configuration and status of any running services in the [project](#project), which may be 
+Represents the current configuration and status of any running services in the [project](#project), which may be
 inspected and modified via the Garden CLI's `environment` command.
 
-Several named environment configurations may be defined (e.g. _dev_, _testing_, ...) in the [project's 
+Several named environment configurations may be defined (e.g. _dev_, _testing_, ...) in the [project's
 `garden.yml`](../guides/configuration.md#project-configuration).
 
 #### Module
 The basic unit of configuration in Garden. A module is defined by its
-[`garden.yml` configuration file](../guides/configuration.md#module-configuration), located in the module's top-level 
-directory, 
-which 
+[`garden.yml` configuration file](../guides/configuration.md#module-configuration), located in the module's top-level
+directory,
+which
 is a subdirectory of the [project](#project) repository's top-level directory.
 
 Each module has a [plugin](#plugin) type, and may define one or more [services](#service).
 
-Essentially, a project is organized into modules at the granularity of its *build* steps. A module's build step may 
-depend on one or more other modules, as specified in its `garden.yml`, in which case those modules will be built 
+Essentially, a project is organized into modules at the granularity of its *build* steps. A module's build step may
+depend on one or more other modules, as specified in its `garden.yml`, in which case those modules will be built
 first, and their build output made available to the requiring module's build step.
 
 #### Plugin
@@ -26,21 +26,21 @@ A [module's](#module) plugin type defines its behavior when it is built, deploye
 (such as NPM modules) are under development.
 
 #### Project
-The top-level unit of organization in Garden. A project consists of one or more [modules](#module), along with a 
+The top-level unit of organization in Garden. A project consists of one or more [modules](#module), along with a
 project-level [`garden.yml` configuration file](../guides/configuration.md#project-configuration).
 
 Garden CLI commands are run in the context of a project, and are aware of all its modules and services.
 
 Currently, Garden projects assume that all their modules are rooted in subdirectories of the same Git repository, with
-the project-level `garden.yml` located in the repository's top-level directory. In a future release, this mono-repo 
+the project-level `garden.yml` located in the repository's top-level directory. In a future release, this mono-repo
 structure will be made optional.
 
 #### Provider
 An implementation of a [plugin type](#plugin) (e.g. `local-kubernetes` for the `container` plugin).
 
 #### Service
-The unit of deployment in Garden. Services are defined in their parent [module](#module)'s `garden.yml`, each 
-exposing [one or more endpoints](../guides/configuration.md#services).
+The unit of deployment in Garden. Services are defined in their parent [module](#module)'s `garden.yml`, each
+exposing [one or more ingress endpoints](../guides/configuration.md#services).
 
-Services may depend on services defined in other modules, in which case those services will be deployed first, and 
+Services may depend on services defined in other modules, in which case those services will be deployed first, and
 their deployment output made available to the requiring service's deploy step.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -52,9 +52,9 @@ Examples:
 
 ### garden call
 
-Call a service endpoint.
+Call a service ingress endpoint.
 
-This command resolves the deployed external endpoint for the given service and path, calls the given endpoint and
+This command resolves the deployed ingress endpoint for the given service and path, calls the given endpoint and
 outputs the result.
 
 Examples:
@@ -62,7 +62,7 @@ Examples:
     garden call my-container
     garden call my-container/some-path
 
-Note: Currently only supports simple GET requests for HTTP/HTTPS endpoints.
+Note: Currently only supports simple GET requests for HTTP/HTTPS ingresses.
 
 ##### Usage
 
@@ -72,7 +72,7 @@ Note: Currently only supports simple GET requests for HTTP/HTTPS endpoints.
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
-  | `serviceAndPath` | Yes | The name of the service(s) to call followed by the endpoint path (e.g. my-container/somepath).
+  | `serviceAndPath` | Yes | The name of the service(s) to call followed by the ingress path (e.g. my-container/somepath).
 
 ### garden create project
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -481,14 +481,14 @@ module:
       # Optional.
       daemon: false
 
-      # List of endpoints that the service exposes.
+      # List of ingress endpoints that the service exposes.
       #
       # Example:
       #   - path: /api
       #     port: http
       #
       # Optional.
-      endpoints: 
+      ingresses: 
         - # The hostname that should route to this service. Defaults to the default hostname
           # configured
           # in the provider configuration.

--- a/docs/reference/template-strings.md
+++ b/docs/reference/template-strings.md
@@ -105,7 +105,7 @@ modules:
 # Example:
 #   my-service:
 #     outputs:
-#       endpoint: 'http://my-service/path/to/endpoint'
+#       ingress: 'http://my-service/path/to/endpoint'
 #     version: v17ad4cb3fd
 #
 services: 

--- a/examples/hello-world/services/hello-container/garden.yml
+++ b/examples/hello-world/services/hello-container/garden.yml
@@ -8,7 +8,7 @@ module:
       ports:
         - name: http
           containerPort: 8080
-      endpoints:
+      ingresses:
         - path: /hello
           port: http
       healthCheck:

--- a/examples/local-tls/README.md
+++ b/examples/local-tls/README.md
@@ -42,7 +42,7 @@ file, but you may also edit it directly (it's at `/etc/hosts` on most platforms)
 
 ## Usage
 
-Once you've completed the above, you can run deploy example project and the exposed endpoints will be secured with TLS!
+Once you've completed the above, you can run deploy example project and the exposed ingress endpoints will be secured with TLS!
 
 Deploy the project:
 

--- a/examples/local-tls/services/go-service/garden.yml
+++ b/examples/local-tls/services/go-service/garden.yml
@@ -7,6 +7,6 @@ module:
       ports:
         - name: http
           containerPort: 80
-      endpoints:
+      ingresses:
         - path: /
           port: http

--- a/examples/local-tls/services/node-service/garden.yml
+++ b/examples/local-tls/services/node-service/garden.yml
@@ -8,7 +8,7 @@ module:
       ports:
         - name: http
           containerPort: 8080
-      endpoints:
+      ingresses:
         - path: /hello
           port: http
         - path: /call-go-service

--- a/examples/multi-container/services/result/garden.yml
+++ b/examples/multi-container/services/result/garden.yml
@@ -5,7 +5,7 @@ module:
   services:
     - name: result
       command: [nodemon, server.js]
-      endpoints:
+      ingresses:
         - path: /
           port: ui
       ports:

--- a/examples/multi-container/services/vote/garden.yml
+++ b/examples/multi-container/services/vote/garden.yml
@@ -5,7 +5,7 @@ module:
   services:
     - name: vote
       command: [python, app.py]
-      endpoints:
+      ingresses:
         - path: /vote/
           port: interface
       ports:

--- a/examples/simple-project/services/go-service/garden.yml
+++ b/examples/simple-project/services/go-service/garden.yml
@@ -7,6 +7,6 @@ module:
       ports:
         - name: http
           containerPort: 80
-      endpoints:
+      ingresses:
         - path: /hello-go
           port: http

--- a/examples/simple-project/services/node-service/garden.yml
+++ b/examples/simple-project/services/node-service/garden.yml
@@ -8,7 +8,7 @@ module:
       ports:
         - name: http
           containerPort: 8080
-      endpoints:
+      ingresses:
         - path: /hello-node
           port: http
         - path: /call-go-service

--- a/garden-cli/src/commands/call.ts
+++ b/garden-cli/src/commands/call.ts
@@ -20,12 +20,12 @@ import { splitFirst } from "../util/util"
 import { ParameterError, RuntimeError } from "../exceptions"
 import { EntryStyle } from "../logger/types"
 import { pick, find } from "lodash"
-import { ServiceEndpoint, getEndpointUrl } from "../types/service"
+import { ServiceIngress, getIngressUrl } from "../types/service"
 import dedent = require("dedent")
 
 const callArgs = {
   serviceAndPath: new StringParameter({
-    help: "The name of the service(s) to call followed by the endpoint path (e.g. my-container/somepath).",
+    help: "The name of the service(s) to call followed by the ingress path (e.g. my-container/somepath).",
     required: true,
   }),
 }
@@ -34,10 +34,10 @@ type Args = typeof callArgs
 
 export class CallCommand extends Command<Args> {
   name = "call"
-  help = "Call a service endpoint."
+  help = "Call a service ingress endpoint."
 
   description = dedent`
-    This command resolves the deployed external endpoint for the given service and path, calls the given endpoint and
+    This command resolves the deployed ingress endpoint for the given service and path, calls the given endpoint and
     outputs the result.
 
     Examples:
@@ -45,7 +45,7 @@ export class CallCommand extends Command<Args> {
         garden call my-container
         garden call my-container/some-path
 
-    Note: Currently only supports simple GET requests for HTTP/HTTPS endpoints.
+    Note: Currently only supports simple GET requests for HTTP/HTTPS ingresses.
   `
 
   arguments = callArgs
@@ -64,31 +64,31 @@ export class CallCommand extends Command<Args> {
       })
     }
 
-    if (!status.endpoints) {
-      throw new ParameterError(`Service ${service.name} has no active endpoints`, {
+    if (!status.ingresses) {
+      throw new ParameterError(`Service ${service.name} has no active ingresses`, {
         serviceName: service.name,
         serviceStatus: status,
       })
     }
 
     // find the correct endpoint to call
-    let matchedEndpoint: ServiceEndpoint | null = null
+    let matchedIngress: ServiceIngress | null = null
     let matchedPath
 
     // we can't easily support raw TCP or UDP in a command like this
-    const endpoints = status.endpoints.filter(e => e.protocol === "http" || e.protocol === "https")
+    const ingresses = status.ingresses.filter(e => e.protocol === "http" || e.protocol === "https")
 
     if (!path) {
       // if no path is specified and there's a root endpoint (path === "/") we use that
-      const rootEndpoint = <ServiceEndpoint>find(endpoints, e => e.path === "/")
+      const rootIngress = <ServiceIngress>find(ingresses, e => e.path === "/")
 
-      if (rootEndpoint) {
-        matchedEndpoint = rootEndpoint
+      if (rootIngress) {
+        matchedIngress = rootIngress
         matchedPath = "/"
       } else {
         // if there's no root endpoint, pick the first endpoint
-        matchedEndpoint = endpoints[0]
-        matchedPath = endpoints[0].path
+        matchedIngress = ingresses[0]
+        matchedPath = ingresses[0].path
       }
 
       path = matchedPath
@@ -96,32 +96,32 @@ export class CallCommand extends Command<Args> {
     } else {
       path = "/" + path
 
-      for (const endpoint of status.endpoints) {
-        if (endpoint.path) {
-          if (path.startsWith(endpoint.path) && (!matchedPath || endpoint.path.length > matchedPath.length)) {
-            matchedEndpoint = endpoint
-            matchedPath = endpoint.path
+      for (const ingress of status.ingresses) {
+        if (ingress.path) {
+          if (path.startsWith(ingress.path) && (!matchedPath || ingress.path.length > matchedPath.length)) {
+            matchedIngress = ingress
+            matchedPath = ingress.path
           }
         } else if (!matchedPath) {
-          matchedEndpoint = endpoint
+          matchedIngress = ingress
         }
       }
     }
 
-    if (!matchedEndpoint) {
-      throw new ParameterError(`Service ${service.name} does not have an HTTP/HTTPS endpoint at ${path}`, {
+    if (!matchedIngress) {
+      throw new ParameterError(`Service ${service.name} does not have an HTTP/HTTPS ingress at ${path}`, {
         serviceName: service.name,
         path,
-        availableEndpoints: status.endpoints,
+        availableIngresses: status.ingresses,
       })
     }
 
-    const url = resolve(getEndpointUrl(matchedEndpoint), path || matchedPath)
+    const url = resolve(getIngressUrl(matchedIngress), path || matchedPath)
     // TODO: support POST requests with request body
     const method = "get"
 
     const entry = garden.log.info({
-      msg: chalk.cyan(`Sending ${matchedEndpoint.protocol.toUpperCase()} GET request to `) + url + "\n",
+      msg: chalk.cyan(`Sending ${matchedIngress.protocol.toUpperCase()} GET request to `) + url + "\n",
       entryStyle: EntryStyle.activity,
     })
 
@@ -132,7 +132,7 @@ export class CallCommand extends Command<Args> {
       method,
       url,
       headers: {
-        host: matchedEndpoint.hostname,
+        host: matchedIngress.hostname,
       },
     })
 

--- a/garden-cli/src/commands/create/config-templates.ts
+++ b/garden-cli/src/commands/create/config-templates.ts
@@ -63,7 +63,7 @@ export function containerTemplate(moduleName: string): DeepPartial<ContainerModu
           name: "http",
           containerPort: 8080,
         }],
-        endpoints: [{
+        ingresses: [{
           path: "/",
           port: "http",
         }],

--- a/garden-cli/src/config/config-context.ts
+++ b/garden-cli/src/config/config-context.ts
@@ -204,7 +204,7 @@ class ModuleContext extends ConfigContext {
   }
 }
 
-const exampleOutputs = { endpoint: "http://my-service/path/to/endpoint" }
+const exampleOutputs = { ingress: "http://my-service/path/to/endpoint" }
 
 class ServiceContext extends ConfigContext {
   @schema(
@@ -217,7 +217,7 @@ class ServiceContext extends ConfigContext {
   @schema(Joi.string().description("The current version of the service.").example(exampleVersion))
   public version: string
 
-  // TODO: add endpoints
+  // TODO: add ingresses
 
   constructor(root: ConfigContext, service: Service, outputs: PrimitiveMap) {
     super(root)

--- a/garden-cli/src/plugins/container.ts
+++ b/garden-cli/src/plugins/container.ts
@@ -30,7 +30,7 @@ import {
   ValidateModuleParams,
   PushModuleParams,
 } from "../types/plugin/params"
-import { Service, endpointHostnameSchema } from "../types/service"
+import { Service, ingressHostnameSchema } from "../types/service"
 import { DEFAULT_PORT_PROTOCOL } from "../constants"
 import { splitFirst } from "../util/util"
 import { keyBy } from "lodash"
@@ -38,7 +38,7 @@ import { genericTestSchema, GenericTestSpec } from "./generic"
 import { ModuleSpec, ModuleConfig } from "../config/module"
 import { BaseServiceSpec, ServiceConfig, baseServiceSchema } from "../config/service"
 
-export interface ContainerEndpointSpec {
+export interface ContainerIngressSpec {
   hostname?: string
   path: string
   port: string
@@ -73,7 +73,7 @@ export interface ServiceHealthCheckSpec {
 export interface ContainerServiceSpec extends BaseServiceSpec {
   command: string[],
   daemon: boolean
-  endpoints: ContainerEndpointSpec[],
+  ingresses: ContainerIngressSpec[],
   env: PrimitiveMap,
   healthCheck?: ServiceHealthCheckSpec,
   ports: ServicePortSpec[],
@@ -82,9 +82,9 @@ export interface ContainerServiceSpec extends BaseServiceSpec {
 
 export type ContainerServiceConfig = ServiceConfig<ContainerServiceSpec>
 
-const endpointSchema = Joi.object()
+const ingressSchema = Joi.object()
   .keys({
-    hostname: endpointHostnameSchema,
+    hostname: ingressHostnameSchema,
     path: Joi.string().uri(<any>{ relativeOnly: true })
       .default("/")
       .description("The path which should be routed to the service."),
@@ -154,8 +154,8 @@ const serviceSchema = baseServiceSchema
     daemon: Joi.boolean()
       .default(false)
       .description("Whether to run the service as a daemon (to ensure only one runs per node)."),
-    endpoints: joiArray(endpointSchema)
-      .description("List of endpoints that the service exposes.")
+    ingresses: joiArray(ingressSchema)
+      .description("List of ingress endpoints that the service exposes.")
       .example([{
         path: "/api",
         port: "http",
@@ -278,13 +278,13 @@ export async function validateContainerModule({ moduleConfig }: ValidateModulePa
     const definedPorts = spec.ports
     const portsByName = keyBy(spec.ports, "name")
 
-    for (const endpoint of spec.endpoints) {
-      const endpointPort = endpoint.port
+    for (const ingress of spec.ingresses) {
+      const ingressPort = ingress.port
 
-      if (!portsByName[endpointPort]) {
+      if (!portsByName[ingressPort]) {
         throw new ConfigurationError(
-          `Service ${name} does not define port ${endpointPort} defined in endpoint`,
-          { definedPorts, endpointPort },
+          `Service ${name} does not define port ${ingressPort} defined in ingress`,
+          { definedPorts, ingressPort },
         )
       }
     }

--- a/garden-cli/src/plugins/google/google-app-engine.ts
+++ b/garden-cli/src/plugins/google/google-app-engine.ts
@@ -104,7 +104,7 @@ export const gardenPlugin = (): GardenPlugin => ({
         const project = getProject(service, ctx.provider)
 
         return {
-          endpoint: `https://${GOOGLE_CLOUD_DEFAULT_REGION}-${project}.cloudfunctions.net/${service.name}`,
+          ingress: `https://${GOOGLE_CLOUD_DEFAULT_REGION}-${project}.cloudfunctions.net/${service.name}`,
         }
       },
     },

--- a/garden-cli/src/plugins/google/google-cloud-functions.ts
+++ b/garden-cli/src/plugins/google/google-cloud-functions.ts
@@ -18,7 +18,7 @@ import {
   GetServiceStatusParams,
   ValidateModuleParams,
 } from "../../types/plugin/params"
-import { ServiceState, ServiceStatus, endpointHostnameSchema } from "../../types/service"
+import { ServiceState, ServiceStatus, ingressHostnameSchema } from "../../types/service"
 import {
   resolve,
 } from "path"
@@ -48,7 +48,7 @@ const gcfServiceSchema = baseServiceSchema
   .keys({
     entrypoint: Joi.string()
       .description("The entrypoint for the function (exported name in the function's module)"),
-    hostname: endpointHostnameSchema,
+    hostname: ingressHostnameSchema,
     path: Joi.string()
       .default(".")
       .description("The path of the module that contains the function."),
@@ -134,7 +134,7 @@ export const gardenPlugin = (): GardenPlugin => ({
         const project = getProject(service, ctx.provider)
 
         return {
-          endpoint: `https://${GOOGLE_CLOUD_DEFAULT_REGION}-${project}.cloudfunctions.net/${service.name}`,
+          ingress: `https://${GOOGLE_CLOUD_DEFAULT_REGION}-${project}.cloudfunctions.net/${service.name}`,
         }
       },
     },

--- a/garden-cli/src/plugins/kubernetes/actions.ts
+++ b/garden-cli/src/plugins/kubernetes/actions.ts
@@ -56,26 +56,26 @@ const MAX_STORED_USERNAMES = 5
 export async function validate(params: ValidateModuleParams<ContainerModule>) {
   const config = await validateContainerModule(params)
 
-  // validate endpoint specs
+  // validate ingress specs
   const provider: KubernetesProvider = params.ctx.provider
 
   for (const serviceConfig of config.serviceConfigs) {
-    for (const endpointSpec of serviceConfig.spec.endpoints) {
-      const hostname = endpointSpec.hostname || provider.config.defaultHostname
+    for (const ingressSpec of serviceConfig.spec.ingresses) {
+      const hostname = ingressSpec.hostname || provider.config.defaultHostname
 
       if (!hostname) {
         throw new ConfigurationError(
-          `No hostname configured for one of the endpoints on service ${serviceConfig.name}. ` +
-          `Please configure a default hostname or specify a hostname for the endpoint.`,
+          `No hostname configured for one of the ingresses on service ${serviceConfig.name}. ` +
+          `Please configure a default hostname or specify a hostname for the ingress.`,
           {
             serviceName: serviceConfig.name,
-            endpointSpec,
+            ingressSpec,
           },
         )
       }
 
       // make sure the hostname is set
-      endpointSpec.hostname = hostname
+      ingressSpec.hostname = hostname
     }
   }
 }

--- a/garden-cli/src/plugins/kubernetes/deployment.ts
+++ b/garden-cli/src/plugins/kubernetes/deployment.ts
@@ -19,7 +19,7 @@ import {
   set,
 } from "lodash"
 import { RuntimeContext, ServiceStatus } from "../../types/service"
-import { createIngresses, getEndpoints } from "./ingress"
+import { createIngresses, getIngresses } from "./ingress"
 import { createServices } from "./service"
 import { waitForObjects, compareDeployedObjects } from "./status"
 import { applyMany } from "./kubectl"
@@ -50,10 +50,10 @@ export async function getContainerServiceStatus(
   const objects = await createContainerObjects(ctx, service, runtimeContext)
   const matched = await compareDeployedObjects(ctx, objects)
   const api = new KubeApi(ctx.provider)
-  const endpoints = await getEndpoints(service, api)
+  const ingresses = await getIngresses(service, api)
 
   return {
-    endpoints,
+    ingresses,
     state: matched ? "ready" : "outdated",
     version: matched ? version.versionString : undefined,
   }

--- a/garden-cli/src/plugins/local/local-docker-swarm.ts
+++ b/garden-cli/src/plugins/local/local-docker-swarm.ts
@@ -110,7 +110,7 @@ export const gardenPlugin = (): GardenPlugin => ({
           UpdateConfig: {
             Parallelism: 1,
           },
-          EndpointSpec: {
+          IngressSpec: {
             Ports: ports,
           },
         }

--- a/garden-cli/src/plugins/local/local-google-cloud-functions.ts
+++ b/garden-cli/src/plugins/local/local-google-cloud-functions.ts
@@ -44,11 +44,11 @@ export const gardenPlugin = (): GardenPlugin => ({
             name: s.name,
             dependencies: s.dependencies,
             outputs: {
-              endpoint: `http://${s.name}:${emulatorPort}/local/local/${functionEntrypoint}`,
+              ingress: `http://${s.name}:${emulatorPort}/local/local/${functionEntrypoint}`,
             },
             command: ["/app/start.sh", functionEntrypoint],
             daemon: false,
-            endpoints: [{
+            ingresses: [{
               name: "default",
               hostname: s.spec.hostname,
               port: "http",

--- a/garden-cli/src/plugins/openfaas.ts
+++ b/garden-cli/src/plugins/openfaas.ts
@@ -24,7 +24,7 @@ import {
 } from "../types/plugin/params"
 import {
   ServiceStatus,
-  ServiceEndpoint,
+  ServiceIngress,
   Service,
 } from "../types/service"
 import {
@@ -263,7 +263,7 @@ async function writeStackFile(
 async function getServiceStatus({ ctx, service }: GetServiceStatusParams<OpenFaasModule>) {
   const k8sProvider = getK8sProvider(ctx)
 
-  const endpoints: ServiceEndpoint[] = [{
+  const ingresses: ServiceIngress[] = [{
     hostname: getExternalGatewayHostname(ctx.provider, k8sProvider),
     path: getServicePath(service),
     port: k8sProvider.config.ingressHttpPort,
@@ -292,7 +292,7 @@ async function getServiceStatus({ ctx, service }: GetServiceStatusParams<OpenFaa
   return {
     state: status.state,
     version,
-    endpoints,
+    ingresses,
   }
 }
 

--- a/garden-cli/test/data/test-project-auto-reload/module-a/garden.yml
+++ b/garden-cli/test/data/test-project-auto-reload/module-a/garden.yml
@@ -4,7 +4,7 @@ module:
   image: scratch
   services:
     - name: service-a
-      endpoints:
+      ingresses:
         - path: /path-b
           port: http
       ports:

--- a/garden-cli/test/data/test-project-auto-reload/module-b/garden.yml
+++ b/garden-cli/test/data/test-project-auto-reload/module-b/garden.yml
@@ -6,7 +6,7 @@ module:
     - name: service-b
       dependencies:
         - service-a
-      endpoints:
+      ingresses:
         - path: /path-b
           port: http
       ports:

--- a/garden-cli/test/data/test-project-auto-reload/module-c/garden.yml
+++ b/garden-cli/test/data/test-project-auto-reload/module-c/garden.yml
@@ -4,7 +4,7 @@ module:
   image: scratch
   services:
     - name: service-c
-      endpoints:
+      ingresses:
         - path: /path-c
           port: http
       ports:

--- a/garden-cli/test/data/test-project-auto-reload/module-d/garden.yml
+++ b/garden-cli/test/data/test-project-auto-reload/module-d/garden.yml
@@ -6,7 +6,7 @@ module:
     - name: service-d
       dependencies:
         - service-b
-      endpoints:
+      ingresses:
         - path: /path-d
           port: http
       ports:

--- a/garden-cli/test/data/test-project-auto-reload/module-e/garden.yml
+++ b/garden-cli/test/data/test-project-auto-reload/module-e/garden.yml
@@ -6,7 +6,7 @@ module:
     - name: service-e
       dependencies:
         - service-c
-      endpoints:
+      ingresses:
         - path: /path-e
           port: http
       ports:

--- a/garden-cli/test/data/test-project-auto-reload/module-f/garden.yml
+++ b/garden-cli/test/data/test-project-auto-reload/module-f/garden.yml
@@ -6,7 +6,7 @@ module:
     - name: service-f
       dependencies:
         - service-c
-      endpoints:
+      ingresses:
         - path: /path-f
           port: http
       ports:

--- a/garden-cli/test/data/test-project-b/module-a/garden.yml
+++ b/garden-cli/test/data/test-project-b/module-a/garden.yml
@@ -3,7 +3,7 @@ module:
   type: container
   services:
     - name: service-a
-      endpoints:
+      ingresses:
         - path: /path-a
           port: http
       ports:

--- a/garden-cli/test/data/test-project-b/module-b/garden.yml
+++ b/garden-cli/test/data/test-project-b/module-b/garden.yml
@@ -3,7 +3,7 @@ module:
   type: container
   services:
     - name: service-b
-      endpoints:
+      ingresses:
         - path: /path-b
           port: http
       ports:

--- a/garden-cli/test/data/test-project-b/module-c/garden.yml
+++ b/garden-cli/test/data/test-project-b/module-c/garden.yml
@@ -4,14 +4,14 @@ module:
   allowPush: false
   services:
     - name: service-c
-      endpoints:
+      ingresses:
         - path: /path-c
           port: http
       ports:
         - name: http
           containerPort: 8080
     - name: service-d
-      endpoints:
+      ingresses:
         - path: /path-d
           port: http
       ports:

--- a/garden-cli/test/data/test-project-circular-deps/module-a/garden.yml
+++ b/garden-cli/test/data/test-project-circular-deps/module-a/garden.yml
@@ -3,7 +3,7 @@ module:
   type: generic
   services:
     - name: service-a
-      endpoints:
+      ingresses:
         - path: /path-a
           containerPort: 8080
       dependencies:

--- a/garden-cli/test/data/test-project-circular-deps/module-b/garden.yml
+++ b/garden-cli/test/data/test-project-circular-deps/module-b/garden.yml
@@ -3,7 +3,7 @@ module:
   type: generic
   services:
     - name: service-b
-      endpoints:
+      ingresses:
         - path: /path-b
           containerPort: 8080
       dependencies:

--- a/garden-cli/test/data/test-project-circular-deps/module-c/garden.yml
+++ b/garden-cli/test/data/test-project-circular-deps/module-c/garden.yml
@@ -4,7 +4,7 @@ module:
   allowPush: false
   services:
     - name: service-c
-      endpoints:
+      ingresses:
         - path: /path-c
           containerPort: 8080
       dependencies:

--- a/garden-cli/test/data/test-project-container/module-a/garden.yml
+++ b/garden-cli/test/data/test-project-container/module-a/garden.yml
@@ -6,7 +6,7 @@ module:
       ports:
         - name: http
           containerPort: 8080
-      endpoints:
+      ingresses:
         - path: /
           port: http
       healthCheck:

--- a/garden-cli/test/data/test-project-create-command/module-a/child-module-a/garden.yml
+++ b/garden-cli/test/data/test-project-create-command/module-a/child-module-a/garden.yml
@@ -7,5 +7,5 @@ module:
       ports:
         - name: http
           containerPort: 8080
-      endpoints:
+      ingresses:
         - port: http

--- a/garden-cli/test/data/test-project-create-command/module-a/garden.yml
+++ b/garden-cli/test/data/test-project-create-command/module-a/garden.yml
@@ -7,5 +7,5 @@ module:
       ports:
         - name: http
           containerPort: 8080
-      endpoints:
+      ingresses:
         - port: http

--- a/garden-cli/test/data/test-project-create-command/module-b/child-module-b/garden.yml
+++ b/garden-cli/test/data/test-project-create-command/module-b/child-module-b/garden.yml
@@ -7,5 +7,5 @@ module:
       ports:
         - name: http
           containerPort: 8080
-      endpoints:
+      ingresses:
         - port: http

--- a/garden-cli/test/data/test-project-create-command/module-b/garden.yml
+++ b/garden-cli/test/data/test-project-create-command/module-b/garden.yml
@@ -7,5 +7,5 @@ module:
       ports:
         - name: http
           containerPort: 8080
-      endpoints:
+      ingresses:
         - port: http

--- a/garden-cli/test/src/commands/call.ts
+++ b/garden-cli/test/src/commands/call.ts
@@ -12,7 +12,7 @@ const testProvider: PluginFactory = () => {
   const testStatuses: { [key: string]: ServiceStatus } = {
     "service-a": {
       state: "ready",
-      endpoints: [{
+      ingresses: [{
         hostname: "service-a.test-project-b.local.app.garden",
         path: "/path-a",
         protocol: "http",
@@ -21,7 +21,7 @@ const testProvider: PluginFactory = () => {
     },
     "service-b": {
       state: "ready",
-      endpoints: [{
+      ingresses: [{
         hostname: "service-b.test-project-b.local.app.garden",
         path: "/",
         port: 32000,
@@ -58,7 +58,7 @@ describe("commands.call", () => {
     nock.enableNetConnect()
   })
 
-  it("should find the endpoint for a service and call it with the specified path", async () => {
+  it("should find the ingress for a service and call it with the specified path", async () => {
     const garden = await Garden.factory(projectRootB, { plugins: [testProvider] })
     const command = new CallCommand()
 
@@ -93,7 +93,7 @@ describe("commands.call", () => {
     expect(result.response.data).to.equal("bla")
   })
 
-  it("should otherwise use the first defined endpoint if no path is requested", async () => {
+  it("should otherwise use the first defined ingress if no path is requested", async () => {
     const garden = await Garden.factory(projectRootB, { plugins: [testProvider] })
     const command = new CallCommand()
 
@@ -124,7 +124,7 @@ describe("commands.call", () => {
     throw new Error("Expected error")
   })
 
-  it("should error if service has no endpoints", async () => {
+  it("should error if service has no ingresses", async () => {
     const garden = await Garden.factory(projectRootB, { plugins: [testProvider] })
     const command = new CallCommand()
 
@@ -138,7 +138,7 @@ describe("commands.call", () => {
     throw new Error("Expected error")
   })
 
-  it("should error if service has no matching endpoints", async () => {
+  it("should error if service has no matching ingresses", async () => {
     const garden = await Garden.factory(projectRootB, { plugins: [testProvider] })
     const command = new CallCommand()
 

--- a/garden-cli/test/src/commands/delete.ts
+++ b/garden-cli/test/src/commands/delete.ts
@@ -82,11 +82,11 @@ describe("DeleteServiceCommand", () => {
     const testStatuses: { [key: string]: ServiceStatus } = {
       "service-a": {
         state: "unknown",
-        endpoints: [],
+        ingresses: [],
       },
       "service-b": {
         state: "unknown",
-        endpoints: [],
+        ingresses: [],
       },
     }
 
@@ -113,7 +113,7 @@ describe("DeleteServiceCommand", () => {
 
     const { result } = await command.action({ garden, args: { service: ["service-a"] }, opts: {} })
     expect(result).to.eql({
-      "service-a": { state: "unknown", endpoints: [] },
+      "service-a": { state: "unknown", ingresses: [] },
     })
   })
 
@@ -122,8 +122,8 @@ describe("DeleteServiceCommand", () => {
 
     const { result } = await command.action({ garden, args: { service: ["service-a", "service-b"] }, opts: {} })
     expect(result).to.eql({
-      "service-a": { state: "unknown", endpoints: [] },
-      "service-b": { state: "unknown", endpoints: [] },
+      "service-a": { state: "unknown", ingresses: [] },
+      "service-b": { state: "unknown", ingresses: [] },
     })
   })
 })

--- a/garden-cli/test/src/commands/deploy.ts
+++ b/garden-cli/test/src/commands/deploy.ts
@@ -18,7 +18,7 @@ const testProvider: PluginFactory = () => {
   const testStatuses: { [key: string]: ServiceStatus } = {
     "service-a": {
       state: "ready",
-      endpoints: [{
+      ingresses: [{
         hostname: "service-a.test-project-b.local.app.garden",
         path: "/path-a",
         port: 80,

--- a/garden-cli/test/src/plugins/container.ts
+++ b/garden-cli/test/src/plugins/container.ts
@@ -208,7 +208,7 @@ describe("plugins.container", () => {
               command: ["echo"],
               dependencies: [],
               daemon: false,
-              endpoints: [
+              ingresses: [
                 {
                   path: "/",
                   port: "http",
@@ -262,7 +262,7 @@ describe("plugins.container", () => {
                 command: ["echo"],
                 dependencies: [],
                 daemon: false,
-                endpoints: [{
+                ingresses: [{
                   path: "/",
                   port: "http",
                 }],
@@ -295,7 +295,7 @@ describe("plugins.container", () => {
                 command: ["echo"],
                 dependencies: [],
                 daemon: false,
-                endpoints: [{
+                ingresses: [{
                   path: "/",
                   port: "http",
                 }],
@@ -326,7 +326,7 @@ describe("plugins.container", () => {
         })
       })
 
-      it("should fail with invalid port in endpoint spec", async () => {
+      it("should fail with invalid port in ingress spec", async () => {
         const moduleConfig: ContainerModuleConfig = {
           allowPush: false,
           build: {
@@ -345,7 +345,7 @@ describe("plugins.container", () => {
               command: ["echo"],
               dependencies: [],
               daemon: false,
-              endpoints: [
+              ingresses: [
                 {
                   path: "/",
                   port: "bla",
@@ -394,7 +394,7 @@ describe("plugins.container", () => {
               command: ["echo"],
               dependencies: [],
               daemon: false,
-              endpoints: [],
+              ingresses: [],
               env: {},
               healthCheck: {
                 httpGet: {
@@ -438,7 +438,7 @@ describe("plugins.container", () => {
               command: ["echo"],
               dependencies: [],
               daemon: false,
-              endpoints: [],
+              ingresses: [],
               env: {},
               healthCheck: {
                 tcpPort: "bla",

--- a/garden-cli/test/src/plugins/kubernetes/ingress.ts
+++ b/garden-cli/test/src/plugins/kubernetes/ingress.ts
@@ -13,7 +13,7 @@ import { dataDir, makeTestGarden, expectError } from "../../../helpers"
 import { Garden } from "../../../../src/garden"
 import { moduleFromConfig } from "../../../../src/types/module"
 import { createIngresses } from "../../../../src/plugins/kubernetes/ingress"
-import { ServicePortProtocol, ContainerEndpointSpec } from "../../../../src/plugins/container"
+import { ServicePortProtocol, ContainerIngressSpec } from "../../../../src/plugins/container"
 
 const kubeConfigEnvVar = process.env.KUBECONFIG
 const namespace = "my-namespace"
@@ -306,13 +306,13 @@ describe("createIngresses", () => {
     }))
   })
 
-  async function getTestService(...endpoints: ContainerEndpointSpec[]): Promise<ContainerService> {
+  async function getTestService(...ingresses: ContainerIngressSpec[]): Promise<ContainerService> {
     const spec: ContainerServiceSpec = {
       name: "my-service",
       command: [],
       daemon: false,
       dependencies: [],
-      endpoints,
+      ingresses,
       env: {},
       outputs: {},
       ports,
@@ -417,7 +417,7 @@ describe("createIngresses", () => {
     }])
   })
 
-  it("should group endpoints by hostname", async () => {
+  it("should group ingresses by hostname", async () => {
     const service = await getTestService(
       {
         path: "/here",
@@ -534,7 +534,7 @@ describe("createIngresses", () => {
     }])
   })
 
-  it("should map a configured TLS certificate to an endpoint", async () => {
+  it("should map a configured TLS certificate to an ingress", async () => {
     const service = await getTestService(
       {
         path: "/",
@@ -582,7 +582,7 @@ describe("createIngresses", () => {
     }])
   })
 
-  it("should group multiple endpoints by TLS certificate", async () => {
+  it("should group multiple ingresses by TLS certificate", async () => {
     const service = await getTestService(
       {
         path: "/",
@@ -747,7 +747,7 @@ describe("createIngresses", () => {
     await expectError(async () => await createIngresses(api, namespace, service), "configuration")
   })
 
-  it("should correctly match an endpoint to a wildcard certificate", async () => {
+  it("should correctly match an ingress to a wildcard certificate", async () => {
     const service = await getTestService(
       {
         hostname: "something.wildcarddomain.com",


### PR DESCRIPTION
BREAKING CHANGES:

Any `garden.yml` file that includes an `endpoints` key will need to
be updated. Sorry. But this should be much clearer for users.

Closes #258 

_Note that this is branched off the #275 PR branch, please just review and don't merge this._