### PR TITLE
refactor: rename logEntry to log and require for tasks, cmds and actions

### DIFF
--- a/garden-service/src/actions.ts
+++ b/garden-service/src/actions.ts
@@ -123,7 +123,14 @@ export class ActionHelper implements TypeGuard {
     { pluginName, log }: ActionHelperParams<GetEnvironmentStatusParams>,
   ): Promise<EnvironmentStatusMap> {
     const handlers = this.garden.getActionHandlers("getEnvironmentStatus", pluginName)
-    return Bluebird.props(mapValues(handlers, h => h({ ...this.commonParams(h, log) })))
+    const logEntry = log.debug({
+      msg: "Getting status...",
+      status: "active",
+      section: `${this.garden.environment.name} environment`,
+    })
+    const res = await Bluebird.props(mapValues(handlers, h => h({ ...this.commonParams(h, logEntry) })))
+    logEntry.setSuccess("Ready")
+    return res
   }
 
   /**

--- a/garden-service/src/actions.ts
+++ b/garden-service/src/actions.ts
@@ -88,7 +88,8 @@ export interface ContextStatus {
 }
 
 export interface DeployServicesParams {
-  serviceNames?: string[],
+  log: LogEntry
+  serviceNames?: string[]
   force?: boolean
   forceBuild?: boolean
 }
@@ -119,10 +120,10 @@ export class ActionHelper implements TypeGuard {
   //===========================================================================
 
   async getEnvironmentStatus(
-    { pluginName }: ActionHelperParams<GetEnvironmentStatusParams>,
+    { pluginName, log }: ActionHelperParams<GetEnvironmentStatusParams>,
   ): Promise<EnvironmentStatusMap> {
     const handlers = this.garden.getActionHandlers("getEnvironmentStatus", pluginName)
-    return Bluebird.props(mapValues(handlers, h => h({ ...this.commonParams(h) })))
+    return Bluebird.props(mapValues(handlers, h => h({ ...this.commonParams(h, log) })))
   }
 
   /**
@@ -132,14 +133,14 @@ export class ActionHelper implements TypeGuard {
    * run `garden init`
    */
   async prepareEnvironment(
-    { force = false, pluginName, logEntry, allowUserInput = false }:
-      { force?: boolean, pluginName?: string, logEntry?: LogEntry, allowUserInput?: boolean },
+    { force = false, pluginName, log, allowUserInput = false }:
+      { force?: boolean, pluginName?: string, log: LogEntry, allowUserInput?: boolean },
   ) {
     const handlers = this.garden.getActionHandlers("prepareEnvironment", pluginName)
     // FIXME: We're calling getEnvironmentStatus before preparing the environment.
     // Results in 404 errors for unprepared/missing services.
     // See: https://github.com/garden-io/garden/issues/353
-    const statuses = await this.getEnvironmentStatus({ pluginName })
+    const statuses = await this.getEnvironmentStatus({ pluginName, log })
 
     const needUserInput = Object.entries(statuses)
       .map(([name, status]) => ({ ...status, name }))
@@ -167,13 +168,13 @@ export class ActionHelper implements TypeGuard {
         continue
       }
 
-      const envLogEntry = (logEntry || this.garden.log).info({
+      const envLogEntry = log.info({
         status: "active",
         section: name,
         msg: "Preparing environment...",
       })
 
-      await handler({ ...this.commonParams(handler), force, status, logEntry: envLogEntry })
+      await handler({ ...this.commonParams(handler, log), force, status, log: envLogEntry })
 
       envLogEntry.setSuccess("Configured")
 
@@ -184,11 +185,11 @@ export class ActionHelper implements TypeGuard {
   }
 
   async cleanupEnvironment(
-    { pluginName }: ActionHelperParams<CleanupEnvironmentParams>,
+    { pluginName, log }: ActionHelperParams<CleanupEnvironmentParams>,
   ): Promise<EnvironmentStatusMap> {
     const handlers = this.garden.getActionHandlers("cleanupEnvironment", pluginName)
-    await Bluebird.each(values(handlers), h => h({ ...this.commonParams(h) }))
-    return this.getEnvironmentStatus({ pluginName })
+    await Bluebird.each(values(handlers), h => h({ ...this.commonParams(h, log) }))
+    return this.getEnvironmentStatus({ pluginName, log })
   }
 
   async getSecret(params: RequirePluginName<ActionHelperParams<GetSecretParams>>): Promise<GetSecretResult> {
@@ -277,13 +278,13 @@ export class ActionHelper implements TypeGuard {
   }
 
   async deleteService(params: ServiceActionHelperParams<DeleteServiceParams>): Promise<ServiceStatus> {
-    const logEntry = this.garden.log.info({
+    const log = params.log.info({
       section: params.service.name,
       msg: "Deleting...",
       status: "active",
     })
     return this.callServiceHandler({
-      params: { ...params, logEntry },
+      params: { ...params, log },
       actionType: "deleteService",
       defaultHandler: dummyDeleteServiceHandler,
     })
@@ -330,14 +331,14 @@ export class ActionHelper implements TypeGuard {
     return keyBy(dependencies, "name")
   }
 
-  async getStatus(): Promise<ContextStatus> {
-    const envStatus: EnvironmentStatusMap = await this.getEnvironmentStatus({})
+  async getStatus({ log }: { log: LogEntry }): Promise<ContextStatus> {
+    const envStatus: EnvironmentStatusMap = await this.getEnvironmentStatus({ log })
     const services = keyBy(await this.garden.getServices(), "name")
 
     const serviceStatus = await Bluebird.props(mapValues(services, async (service: Service) => {
       const serviceDependencies = await this.garden.getServices(service.config.dependencies)
-      const runtimeContext = await prepareRuntimeContext(this.garden, service.module, serviceDependencies)
-      return this.getServiceStatus({ service, runtimeContext })
+      const runtimeContext = await prepareRuntimeContext(this.garden, log, service.module, serviceDependencies)
+      return this.getServiceStatus({ log, service, runtimeContext })
     }))
 
     return {
@@ -347,16 +348,18 @@ export class ActionHelper implements TypeGuard {
   }
 
   async deployServices(
-    { serviceNames, force = false, forceBuild = false }: DeployServicesParams,
+    { serviceNames, force = false, forceBuild = false, log }: DeployServicesParams,
   ): Promise<ProcessResults> {
     const services = await this.garden.getServices(serviceNames)
 
     return processServices({
       services,
       garden: this.garden,
+      log,
       watch: false,
       handler: async (module) => getTasksForModule({
         garden: this.garden,
+        log,
         module,
         hotReloadServiceNames: [],
         force,
@@ -368,11 +371,11 @@ export class ActionHelper implements TypeGuard {
   //endregion
 
   // TODO: find a nicer way to do this (like a type-safe wrapper function)
-  private commonParams(handler, logEntry?: LogEntry): PluginActionParamsBase {
+  private commonParams(handler, log: LogEntry): PluginActionParamsBase {
     return {
       ctx: createPluginContext(this.garden, handler["pluginName"]),
       // TODO: find a better way for handlers to log during execution
-      logEntry,
+      log,
     }
   }
 
@@ -391,7 +394,7 @@ export class ActionHelper implements TypeGuard {
       defaultHandler,
     })
     const handlerParams: PluginActionParams[T] = {
-      ...this.commonParams(handler),
+      ...this.commonParams(handler, <any>params.log),
       ...<object>params,
     }
     return (<Function>handler)(handlerParams)
@@ -413,7 +416,7 @@ export class ActionHelper implements TypeGuard {
     const buildDependencies = await this.getBuildDependencies(module)
 
     const handlerParams: any = {
-      ...this.commonParams(handler),
+      ...this.commonParams(handler, <any>params.log),
       ...<object>params,
       module: omit(module, ["_ConfigType"]),
       buildDependencies,
@@ -426,7 +429,7 @@ export class ActionHelper implements TypeGuard {
     { params, actionType, defaultHandler }:
       { params: ServiceActionHelperParams<ServiceActionParams[T]>, actionType: T, defaultHandler?: ServiceActions[T] },
   ): Promise<ServiceActionOutputs[T]> {
-    const { service } = <any>params
+    const { log, service } = <any>params
     const module = service.module
 
     const handler = await this.garden.getModuleActionHandler({
@@ -439,10 +442,10 @@ export class ActionHelper implements TypeGuard {
     // TODO: figure out why this doesn't compile without the casts
     const buildDependencies = await this.getBuildDependencies(module)
     const deps = await this.garden.getServices(service.config.dependencies)
-    const runtimeContext = ((<any>params).runtimeContext || await prepareRuntimeContext(this.garden, module, deps))
+    const runtimeContext = ((<any>params).runtimeContext || await prepareRuntimeContext(this.garden, log, module, deps))
 
     const handlerParams: any = {
-      ...this.commonParams(handler),
+      ...this.commonParams(handler, log),
       ...<object>params,
       module,
       runtimeContext,
@@ -473,7 +476,7 @@ export class ActionHelper implements TypeGuard {
     const buildDependencies = await this.getBuildDependencies(module)
 
     const handlerParams: any = {
-      ...this.commonParams(handler),
+      ...this.commonParams(handler, <any>params.log),
       ...<object>params,
       module,
       task,
@@ -484,8 +487,8 @@ export class ActionHelper implements TypeGuard {
   }
 }
 
-const dummyLogStreamer = async ({ service, logEntry }: GetServiceLogsParams) => {
-  logEntry && logEntry.warn({
+const dummyLogStreamer = async ({ service, log }: GetServiceLogsParams) => {
+  log.warn({
     section: service.name,
     msg: chalk.yellow(`No handler for log retrieval available for module type ${service.module.type}`),
   })
@@ -503,8 +506,8 @@ const dummyPublishHandler = async ({ module }) => {
   }
 }
 
-const dummyDeleteServiceHandler = async ({ module, logEntry }: DeleteServiceParams) => {
+const dummyDeleteServiceHandler = async ({ module, log }: DeleteServiceParams) => {
   const msg = `No delete service handler available for module type ${module.type}`
-  logEntry && logEntry.setError(msg)
+  log.setError(msg)
   return {}
 }

--- a/garden-service/src/cli/cli.ts
+++ b/garden-service/src/cli/cli.ts
@@ -238,9 +238,12 @@ export class GardenCli {
           contextOpts.config = MOCK_CONFIG
         }
         garden = await Garden.factory(root, contextOpts)
+        // Indent -1 so that the children of this entry get printed with indent 0
+        const log = garden.log.info({ indent: -1 })
         // TODO: enforce that commands always output DeepPrimitiveMap
         result = await command.action({
           garden,
+          log,
           args: parsedArgs,
           opts: parsedOpts,
         })

--- a/garden-service/src/commands/base.ts
+++ b/garden-service/src/commands/base.ts
@@ -14,6 +14,8 @@ import { TaskResults } from "../task-graph"
 import { LoggerType } from "../logger/logger"
 import { ProcessResults } from "../process"
 import { Garden } from "../garden"
+import { LogEntry } from "../logger/log-entry"
+import { logHeader } from "../logger/util"
 
 export class ValidationError extends Error { }
 
@@ -188,6 +190,7 @@ export interface CommandParams<T extends Parameters = {}, U extends Parameters =
   args: ParameterValues<T>
   opts: ParameterValues<U>
   garden: Garden
+  log: LogEntry
 }
 
 export abstract class Command<T extends Parameters = {}, U extends Parameters = {}> {
@@ -232,7 +235,7 @@ export abstract class Command<T extends Parameters = {}, U extends Parameters = 
 }
 
 export async function handleTaskResults(
-  garden: Garden, taskType: string, results: ProcessResults,
+  log: LogEntry, taskType: string, results: ProcessResults,
 ): Promise<CommandResult<TaskResults>> {
   const failed = Object.values(results.taskResults).filter(r => !!r.error).length
 
@@ -243,9 +246,9 @@ export async function handleTaskResults(
     return { errors: [error] }
   }
 
-  garden.log.info("")
+  log.info("")
   if (!results.restartRequired) {
-    garden.log.header({ emoji: "heavy_check_mark", command: `Done!` })
+    logHeader({ log, emoji: "heavy_check_mark", command: `Done!` })
   }
   return {
     result: results.taskResults,

--- a/garden-service/src/commands/create/module.ts
+++ b/garden-service/src/commands/create/module.ts
@@ -96,7 +96,8 @@ export class CreateModuleCommand extends Command<Args, Opts> {
     } else {
       // Prompt for type
       log.info("---------")
-      log.stop()
+      // Stop logger while prompting
+      log.stopAll()
       type = (await prompts.addConfigForModule(moduleName)).type
       log.info("---------")
       if (!type) {

--- a/garden-service/src/commands/create/module.ts
+++ b/garden-service/src/commands/create/module.ts
@@ -56,6 +56,7 @@ interface CreateModuleResult extends CommandResult {
 export class CreateModuleCommand extends Command<Args, Opts> {
   name = "module"
   help = "Creates a new Garden module."
+  header = { emoji: "house_with_garden", command: "create" }
 
   description = dedent`
     Examples:
@@ -70,7 +71,7 @@ export class CreateModuleCommand extends Command<Args, Opts> {
   arguments = createModuleArguments
   options = createModuleOptions
 
-  async action({ garden, args, opts }: CommandParams<Args, Opts>): Promise<CreateModuleResult> {
+  async action({ garden, args, opts, log }: CommandParams<Args, Opts>): Promise<CreateModuleResult> {
     let errors: GardenBaseError[] = []
 
     const moduleRoot = join(garden.projectRoot, (args["module-dir"] || "").trim())
@@ -82,8 +83,7 @@ export class CreateModuleCommand extends Command<Args, Opts> {
 
     await ensureDir(moduleRoot)
 
-    garden.log.header({ emoji: "house_with_garden", command: "create" })
-    garden.log.info(`Initializing new module ${moduleName}`)
+    log.info(`Initializing new module ${moduleName}`)
 
     let type: ModuleType
 
@@ -95,10 +95,10 @@ export class CreateModuleCommand extends Command<Args, Opts> {
       }
     } else {
       // Prompt for type
-      garden.log.info("---------")
-      garden.log.stop()
+      log.info("---------")
+      log.stop()
       type = (await prompts.addConfigForModule(moduleName)).type
-      garden.log.info("---------")
+      log.info("---------")
       if (!type) {
         return { result: {} }
       }
@@ -106,7 +106,7 @@ export class CreateModuleCommand extends Command<Args, Opts> {
 
     const moduleOpts = prepareNewModuleOpts(moduleName, type, moduleRoot)
     try {
-      await dumpConfig(moduleOpts, configSchema, garden.log)
+      await dumpConfig(moduleOpts, configSchema, log)
     } catch (err) {
       errors.push(err)
     }

--- a/garden-service/src/commands/create/project.ts
+++ b/garden-service/src/commands/create/project.ts
@@ -117,7 +117,7 @@ export class CreateProjectCommand extends Command<Args, Opts> {
     log.info(`Initializing new Garden project ${projectName}`)
     log.info("---------")
     // Stop logger while prompting
-    log.stop()
+    log.stopAll()
 
     if (moduleParentDirs.length > 0) {
       // If module-dirs option provided we scan for modules in the parent dir(s) and add them one by one

--- a/garden-service/src/commands/create/project.ts
+++ b/garden-service/src/commands/create/project.ts
@@ -100,7 +100,7 @@ export class CreateProjectCommand extends Command<Args, Opts> {
   arguments = createProjectArguments
   options = createProjectOptions
 
-  async action({ garden, args, opts }: CommandParams<Args, Opts>): Promise<CreateProjectResult> {
+  async action({ garden, args, opts, log }: CommandParams<Args, Opts>): Promise<CreateProjectResult> {
     let moduleOpts: NewModuleOpts[] = []
     let errors: GardenBaseError[] = []
 
@@ -114,11 +114,10 @@ export class CreateProjectCommand extends Command<Args, Opts> {
 
     await ensureDir(projectRoot)
 
-    garden.log.header({ emoji: "house_with_garden", command: "create" })
-    garden.log.info(`Initializing new Garden project ${projectName}`)
-    garden.log.info("---------")
+    log.info(`Initializing new Garden project ${projectName}`)
+    log.info("---------")
     // Stop logger while prompting
-    garden.log.stop()
+    log.stop()
 
     if (moduleParentDirs.length > 0) {
       // If module-dirs option provided we scan for modules in the parent dir(s) and add them one by one
@@ -141,13 +140,13 @@ export class CreateProjectCommand extends Command<Args, Opts> {
         .map(({ name, type }) => prepareNewModuleOpts(name, type, join(projectRoot, name)))
     }
 
-    garden.log.info("---------")
-    const taskLog = garden.log.info({ msg: "Setting up project", status: "active" })
+    log.info("---------")
+    const taskLog = log.info({ msg: "Setting up project", status: "active" })
 
     for (const module of moduleOpts) {
       await ensureDir(module.path)
       try {
-        await dumpConfig(module, configSchema, garden.log)
+        await dumpConfig(module, configSchema, log)
       } catch (err) {
         errors.push(err)
       }
@@ -160,7 +159,7 @@ export class CreateProjectCommand extends Command<Args, Opts> {
     }
 
     try {
-      await dumpConfig(projectOpts, configSchema, garden.log)
+      await dumpConfig(projectOpts, configSchema, log)
     } catch (err) {
       errors.push(err)
     }
@@ -172,7 +171,7 @@ export class CreateProjectCommand extends Command<Args, Opts> {
     }
 
     const docs = terminalLink("docs", "https://docs.garden.io")
-    garden.log.info(`Project created! Be sure to check out our ${docs} for how to get sarted!`)
+    log.info(`Project created! Be sure to check out our ${docs} for how to get sarted!`)
 
     return {
       result: {

--- a/garden-service/src/commands/dev.ts
+++ b/garden-service/src/commands/dev.ts
@@ -65,7 +65,7 @@ export class DevCommand extends Command<Args, Opts> {
   async action({ garden, log, opts }: CommandParams<Args, Opts>): Promise<CommandResult> {
     // print ANSI banner image
     const data = await readFile(ansiBannerPath)
-    console.log(data.toString())
+    log.info(data.toString())
 
     log.info(chalk.gray.italic(`\nGood ${getGreetingTime()}! Let's get your environment wired up...\n`))
 

--- a/garden-service/src/commands/exec.ts
+++ b/garden-service/src/commands/exec.ts
@@ -9,6 +9,7 @@
 import chalk from "chalk"
 import { LoggerType } from "../logger/logger"
 import { ExecInServiceResult } from "../types/plugin/outputs"
+import { logHeader } from "../logger/util"
 import {
   Command,
   CommandResult,
@@ -57,17 +58,18 @@ export class ExecCommand extends Command<Args> {
   options = runOpts
   loggerType = LoggerType.basic
 
-  async action({ garden, args }: CommandParams<Args>): Promise<CommandResult<ExecInServiceResult>> {
+  async action({ garden, log, args }: CommandParams<Args>): Promise<CommandResult<ExecInServiceResult>> {
     const serviceName = args.service
     const command = args.command || []
 
-    garden.log.header({
+    logHeader({
+      log,
       emoji: "runner",
       command: `Running command ${chalk.cyan(command.join(" "))} in service ${chalk.cyan(serviceName)}`,
     })
 
     const service = await garden.getService(serviceName)
-    const result = await garden.actions.execInService({ service, command, interactive: true })
+    const result = await garden.actions.execInService({ log, service, command, interactive: true })
 
     return { result }
   }

--- a/garden-service/src/commands/get.ts
+++ b/garden-service/src/commands/get.ts
@@ -60,15 +60,19 @@ export class GetSecretCommand extends Command<typeof getSecretArgs> {
 
   arguments = getSecretArgs
 
-  async action({ garden, args }: CommandParams<GetArgs>): Promise<CommandResult> {
+  async action({ garden, log, args }: CommandParams<GetArgs>): Promise<CommandResult> {
     const key = args.key
-    const { value } = await garden.actions.getSecret({ pluginName: args.provider, key })
+    const { value } = await garden.actions.getSecret({
+      pluginName: args.provider,
+      key,
+      log,
+    })
 
     if (value === null || value === undefined) {
       throw new NotFoundError(`Could not find config key ${key}`, { key })
     }
 
-    garden.log.info(value)
+    log.info(value)
 
     return { [key]: value }
   }
@@ -78,12 +82,12 @@ export class GetStatusCommand extends Command {
   name = "status"
   help = "Outputs the status of your environment."
 
-  async action({ garden }: CommandParams): Promise<CommandResult<ContextStatus>> {
-    const status = await garden.actions.getStatus()
+  async action({ garden, log }: CommandParams): Promise<CommandResult<ContextStatus>> {
+    const status = await garden.actions.getStatus({ log })
     const yamlStatus = yaml.safeDump(status, { noRefs: true, skipInvalid: true })
 
     // TODO: do a nicer print of this by default and add --yaml/--json options (maybe globally) for exporting
-    garden.log.info(highlightYaml(yamlStatus))
+    log.info(highlightYaml(yamlStatus))
 
     return { result: status }
   }

--- a/garden-service/src/commands/init.ts
+++ b/garden-service/src/commands/init.ts
@@ -12,6 +12,7 @@ import {
   CommandResult,
   CommandParams,
 } from "./base"
+import { logHeader } from "../logger/util"
 import dedent = require("dedent")
 
 const initOpts = {
@@ -36,14 +37,14 @@ export class InitCommand extends Command {
 
   options = initOpts
 
-  async action({ garden, opts }: CommandParams<{}, Opts>): Promise<CommandResult<{}>> {
+  async action({ garden, log, opts }: CommandParams<{}, Opts>): Promise<CommandResult<{}>> {
     const { name } = garden.environment
-    garden.log.header({ emoji: "gear", command: `Initializing ${name} environment` })
+    logHeader({ log, emoji: "gear", command: `Initializing ${name} environment` })
 
-    await garden.actions.prepareEnvironment({ force: opts.force, allowUserInput: true })
+    await garden.actions.prepareEnvironment({ log, force: opts.force, allowUserInput: true })
 
-    garden.log.info("")
-    garden.log.header({ emoji: "heavy_check_mark", command: `Done!` })
+    log.info("")
+    logHeader({ log, emoji: "heavy_check_mark", command: `Done!` })
 
     return { result: {} }
   }

--- a/garden-service/src/commands/link/module.ts
+++ b/garden-service/src/commands/link/module.ts
@@ -18,9 +18,8 @@ import {
   PathParameter,
   CommandParams,
 } from "../base"
-import {
-  LinkedSource,
-} from "../../config-store"
+import { LinkedSource } from "../../config-store"
+import { logHeader } from "../../logger/util"
 import {
   addLinkedSources,
   hasRemoteSource,
@@ -54,8 +53,8 @@ export class LinkModuleCommand extends Command<Args> {
         garden link module my-module path/to/my-module # links my-module to its local version at the given path
   `
 
-  async action({ garden, args }: CommandParams<Args>): Promise<CommandResult<LinkedSource[]>> {
-    garden.log.header({ emoji: "link", command: "link module" })
+  async action({ garden, log, args }: CommandParams<Args>): Promise<CommandResult<LinkedSource[]>> {
+    logHeader({ log, emoji: "link", command: "link module" })
 
     const sourceType = "module"
 
@@ -83,7 +82,7 @@ export class LinkModuleCommand extends Command<Args> {
       sources: [{ name: moduleName, path: absPath }],
     })
 
-    garden.log.info(`Linked module ${moduleName}`)
+    log.info(`Linked module ${moduleName}`)
 
     return { result: linkedModuleSources }
 

--- a/garden-service/src/commands/link/source.ts
+++ b/garden-service/src/commands/link/source.ts
@@ -20,6 +20,7 @@ import {
 import { addLinkedSources } from "../../util/ext-source-util"
 import { LinkedSource } from "../../config-store"
 import { CommandParams } from "../base"
+import { logHeader } from "../../logger/util"
 
 const linkSourceArguments = {
   source: new StringParameter({
@@ -49,8 +50,8 @@ export class LinkSourceCommand extends Command<Args> {
         garden link source my-source path/to/my-source # links my-source to its local version at the given path
   `
 
-  async action({ garden, args }: CommandParams<Args>): Promise<CommandResult<LinkedSource[]>> {
-    garden.log.header({ emoji: "link", command: "link source" })
+  async action({ garden, log, args }: CommandParams<Args>): Promise<CommandResult<LinkedSource[]>> {
+    logHeader({ log, emoji: "link", command: "link source" })
 
     const sourceType = "project"
 
@@ -78,7 +79,7 @@ export class LinkSourceCommand extends Command<Args> {
       sources: [{ name: sourceName, path: absPath }],
     })
 
-    garden.log.info(`Linked source ${sourceName}`)
+    log.info(`Linked source ${sourceName}`)
 
     return { result: linkedProjectSources }
   }

--- a/garden-service/src/commands/logs.ts
+++ b/garden-service/src/commands/logs.ts
@@ -55,7 +55,7 @@ export class LogsCommand extends Command<Args, Opts> {
   options = logsOpts
   loggerType = LoggerType.basic
 
-  async action({ garden, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<ServiceLogEntry[]>> {
+  async action({ garden, log, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<ServiceLogEntry[]>> {
     const tail = opts.tail
     const services = await garden.getServices(args.service)
 
@@ -74,7 +74,7 @@ export class LogsCommand extends Command<Args, Opts> {
         } catch { }
       }
 
-      garden.log.info({
+      log.info({
         section: entry.serviceName,
         msg: [timestamp, chalk.white(entry.msg)],
       })
@@ -85,9 +85,9 @@ export class LogsCommand extends Command<Args, Opts> {
     })
 
     await Bluebird.map(services, async (service: Service<any>) => {
-      const status = await garden.actions.getServiceStatus({ service })
+      const status = await garden.actions.getServiceStatus({ log, service })
       if (status.state === "ready" || status.state === "outdated") {
-        await garden.actions.getServiceLogs({ service, stream, tail })
+        await garden.actions.getServiceLogs({ log, service, stream, tail })
       } else {
         await stream.write({
           serviceName: service.name,

--- a/garden-service/src/commands/publish.ts
+++ b/garden-service/src/commands/publish.ts
@@ -19,6 +19,8 @@ import { PublishTask } from "../tasks/publish"
 import { RuntimeError } from "../exceptions"
 import { TaskResults } from "../task-graph"
 import { Garden } from "../garden"
+import { LogEntry } from "../logger/log-entry"
+import { logHeader } from "../logger/util"
 import dedent = require("dedent")
 
 const publishArgs = {
@@ -59,19 +61,20 @@ export class PublishCommand extends Command<Args, Opts> {
   arguments = publishArgs
   options = publishOpts
 
-  async action({ garden, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<TaskResults>> {
-    garden.log.header({ emoji: "rocket", command: "Publish modules" })
+  async action({ garden, log, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<TaskResults>> {
+    logHeader({ log, emoji: "rocket", command: "Publish modules" })
 
     const modules = await garden.getModules(args.module)
 
-    const results = await publishModules(garden, modules, !!opts["force-build"], !!opts["allow-dirty"])
+    const results = await publishModules(garden, log, modules, !!opts["force-build"], !!opts["allow-dirty"])
 
-    return handleTaskResults(garden, "publish", { taskResults: results })
+    return handleTaskResults(log, "publish", { taskResults: results })
   }
 }
 
 export async function publishModules(
   garden: Garden,
+  log: LogEntry,
   modules: Module<any>[],
   forceBuild: boolean,
   allowDirty: boolean,
@@ -87,7 +90,7 @@ export async function publishModules(
       )
     }
 
-    const task = new PublishTask({ garden, module, forceBuild })
+    const task = new PublishTask({ garden, log, module, forceBuild })
     await garden.addTask(task)
   }
 

--- a/garden-service/src/commands/run/run.ts
+++ b/garden-service/src/commands/run/run.ts
@@ -14,7 +14,7 @@ import { RunModuleCommand } from "./module"
 import { RunServiceCommand } from "./service"
 import { RunTaskCommand } from "./task"
 import { RunTestCommand } from "./test"
-import { Garden } from "../../garden"
+import { LogEntry } from "../../logger/log-entry"
 
 export class RunCommand extends Command {
   name = "run"
@@ -30,11 +30,11 @@ export class RunCommand extends Command {
   async action() { return {} }
 }
 
-export function printRuntimeContext(garden: Garden, runtimeContext: RuntimeContext) {
-  garden.log.verbose("-----------------------------------\n")
-  garden.log.verbose("Environment variables:")
-  garden.log.verbose(highlightYaml(safeDump(runtimeContext.envVars)))
-  garden.log.verbose("Dependencies:")
-  garden.log.verbose(highlightYaml(safeDump(runtimeContext.dependencies)))
-  garden.log.verbose("-----------------------------------\n")
+export function printRuntimeContext(log: LogEntry, runtimeContext: RuntimeContext) {
+  log.verbose("-----------------------------------\n")
+  log.verbose("Environment variables:")
+  log.verbose(highlightYaml(safeDump(runtimeContext.envVars)))
+  log.verbose("Dependencies:")
+  log.verbose(highlightYaml(safeDump(runtimeContext.dependencies)))
+  log.verbose("-----------------------------------\n")
 }

--- a/garden-service/src/commands/scan.ts
+++ b/garden-service/src/commands/scan.ts
@@ -20,7 +20,7 @@ export class ScanCommand extends Command {
   name = "scan"
   help = "Scans your project and outputs an overview of all modules."
 
-  async action({ garden }: CommandParams): Promise<CommandResult<DeepPrimitiveMap>> {
+  async action({ garden, log }: CommandParams): Promise<CommandResult<DeepPrimitiveMap>> {
     const modules = (await garden.getModules())
       .map(m => {
         m.services.forEach(s => delete s.module)
@@ -39,7 +39,7 @@ export class ScanCommand extends Command {
       }),
     }
 
-    garden.log.info(highlightYaml(safeDump(shortOutput, { noRefs: true, skipInvalid: true, sortKeys: true })))
+    log.info(highlightYaml(safeDump(shortOutput, { noRefs: true, skipInvalid: true, sortKeys: true })))
 
     return { result: <DeepPrimitiveMap><any>output }
   }

--- a/garden-service/src/commands/set.ts
+++ b/garden-service/src/commands/set.ts
@@ -64,10 +64,15 @@ export class SetSecretCommand extends Command<typeof setSecretArgs> {
 
   arguments = setSecretArgs
 
-  async action({ garden, args }: CommandParams<SetArgs>): Promise<CommandResult<SetSecretResult>> {
+  async action({ garden, log, args }: CommandParams<SetArgs>): Promise<CommandResult<SetSecretResult>> {
     const key = args.key
-    const result = await garden.actions.setSecret({ pluginName: args.provider, key, value: args.value })
-    garden.log.info(`Set config key ${args.key}`)
+    const result = await garden.actions.setSecret({
+      pluginName: args.provider,
+      key,
+      value: args.value,
+      log,
+    })
+    log.info(`Set config key ${args.key}`)
     return { result }
   }
 }

--- a/garden-service/src/commands/unlink/module.ts
+++ b/garden-service/src/commands/unlink/module.ts
@@ -16,6 +16,7 @@ import {
   CommandParams,
 } from "../base"
 import { removeLinkedSources } from "../../util/ext-source-util"
+import { logHeader } from "../../logger/util"
 import {
   localConfigKeys,
   LinkedSource,
@@ -53,8 +54,8 @@ export class UnlinkModuleCommand extends Command<Args, Opts> {
         garden unlink module --all      # unlink all modules
   `
 
-  async action({ garden, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<LinkedSource[]>> {
-    garden.log.header({ emoji: "chains", command: "unlink module" })
+  async action({ garden, log, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<LinkedSource[]>> {
+    logHeader({ log, emoji: "chains", command: "unlink module" })
 
     const sourceType = "module"
 
@@ -62,13 +63,13 @@ export class UnlinkModuleCommand extends Command<Args, Opts> {
 
     if (opts.all) {
       await garden.localConfigStore.set([localConfigKeys.linkedModuleSources], [])
-      garden.log.info("Unlinked all modules")
+      log.info("Unlinked all modules")
       return { result: [] }
     }
 
     const linkedModuleSources = await removeLinkedSources({ garden, sourceType, names: module })
 
-    garden.log.info(`Unlinked module(s) ${module}`)
+    log.info(`Unlinked module(s) ${module}`)
 
     return { result: linkedModuleSources }
   }

--- a/garden-service/src/commands/unlink/source.ts
+++ b/garden-service/src/commands/unlink/source.ts
@@ -16,6 +16,7 @@ import {
   CommandParams,
 } from "../base"
 import { removeLinkedSources } from "../../util/ext-source-util"
+import { logHeader } from "../../logger/util"
 import {
   localConfigKeys,
   LinkedSource,
@@ -53,8 +54,8 @@ export class UnlinkSourceCommand extends Command<Args, Opts> {
         garden unlink source --all      # unlinks all sources
   `
 
-  async action({ garden, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<LinkedSource[]>> {
-    garden.log.header({ emoji: "chains", command: "unlink source" })
+  async action({ garden, log, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<LinkedSource[]>> {
+    logHeader({ log, emoji: "chains", command: "unlink source" })
 
     const sourceType = "project"
 
@@ -62,13 +63,13 @@ export class UnlinkSourceCommand extends Command<Args, Opts> {
 
     if (opts.all) {
       await garden.localConfigStore.set([localConfigKeys.linkedProjectSources], [])
-      garden.log.info("Unlinked all sources")
+      log.info("Unlinked all sources")
       return { result: [] }
     }
 
     const linkedProjectSources = await removeLinkedSources({ garden, sourceType, names: source })
 
-    garden.log.info(`Unlinked source(s) ${source}`)
+    log.info(`Unlinked source(s) ${source}`)
 
     return { result: linkedProjectSources }
   }

--- a/garden-service/src/commands/update-remote/all.ts
+++ b/garden-service/src/commands/update-remote/all.ts
@@ -16,6 +16,7 @@ import {
 import { UpdateRemoteSourcesCommand } from "./sources"
 import { UpdateRemoteModulesCommand } from "./modules"
 import { SourceConfig } from "../../config/project"
+import { logHeader } from "../../logger/util"
 
 export interface UpdateRemoteAllResult {
   projectSources: SourceConfig[],
@@ -32,15 +33,24 @@ export class UpdateRemoteAllCommand extends Command {
         garden update-remote all # update all remote sources and modules in the project
   `
 
-  async action({ garden }: CommandParams): Promise<CommandResult<UpdateRemoteAllResult>> {
-
-    garden.log.header({ emoji: "hammer_and_wrench", command: "update-remote all" })
+  async action({ garden, log }: CommandParams): Promise<CommandResult<UpdateRemoteAllResult>> {
+    logHeader({ log, emoji: "hammer_and_wrench", command: "update-remote all" })
 
     const sourcesCmd = new UpdateRemoteSourcesCommand()
     const modulesCmd = new UpdateRemoteModulesCommand()
 
-    const { result: projectSources } = await sourcesCmd.action({ garden, args: { source: undefined }, opts: {} })
-    const { result: moduleSources } = await modulesCmd.action({ garden, args: { module: undefined }, opts: {} })
+    const { result: projectSources } = await sourcesCmd.action({
+      garden,
+      log,
+      args: { source: undefined },
+      opts: {},
+    })
+    const { result: moduleSources } = await modulesCmd.action({
+      garden,
+      log,
+      args: { module: undefined },
+      opts: {},
+    })
 
     return { result: { projectSources: projectSources!, moduleSources: moduleSources! } }
   }

--- a/garden-service/src/commands/update-remote/modules.ts
+++ b/garden-service/src/commands/update-remote/modules.ts
@@ -20,6 +20,7 @@ import { SourceConfig } from "../../config/project"
 import { ParameterError } from "../../exceptions"
 import { pruneRemoteSources } from "./helpers"
 import { hasRemoteSource } from "../../util/ext-source-util"
+import { logHeader } from "../../logger/util"
 
 const updateRemoteModulesArguments = {
   module: new StringsParameter({
@@ -44,10 +45,8 @@ export class UpdateRemoteModulesCommand extends Command<Args> {
         garden update-remote modules my-module  # update remote module my-module
   `
 
-  async action(
-    { garden, args }: CommandParams<Args>,
-  ): Promise<CommandResult<SourceConfig[]>> {
-    garden.log.header({ emoji: "hammer_and_wrench", command: "update-remote modules" })
+  async action({ garden, log, args }: CommandParams<Args>): Promise<CommandResult<SourceConfig[]>> {
+    logHeader({ log, emoji: "hammer_and_wrench", command: "update-remote modules" })
 
     const { module } = args
     const modules = await garden.getModules(module)
@@ -74,7 +73,7 @@ export class UpdateRemoteModulesCommand extends Command<Args> {
     // TODO Update remotes in parallel. Currently not possible since updating might
     // trigger a username and password prompt from git.
     for (const { name, repositoryUrl } of moduleSources) {
-      await garden.vcs.updateRemoteSource({ name, url: repositoryUrl, sourceType: "module", logEntry: garden.log })
+      await garden.vcs.updateRemoteSource({ name, url: repositoryUrl, sourceType: "module", log })
     }
 
     await pruneRemoteSources({ projectRoot: garden.projectRoot, type: "module", sources: moduleSources })

--- a/garden-service/src/commands/update-remote/sources.ts
+++ b/garden-service/src/commands/update-remote/sources.ts
@@ -19,6 +19,7 @@ import {
 import { ParameterError } from "../../exceptions"
 import { pruneRemoteSources } from "./helpers"
 import { SourceConfig } from "../../config/project"
+import { logHeader } from "../../logger/util"
 
 const updateRemoteSourcesArguments = {
   source: new StringsParameter({
@@ -43,9 +44,9 @@ export class UpdateRemoteSourcesCommand extends Command<Args> {
   `
 
   async action(
-    { garden, args }: CommandParams<Args>,
+    { garden, log, args }: CommandParams<Args>,
   ): Promise<CommandResult<SourceConfig[]>> {
-    garden.log.header({ emoji: "hammer_and_wrench", command: "update-remote sources" })
+    logHeader({ log, emoji: "hammer_and_wrench", command: "update-remote sources" })
 
     const { source } = args
 
@@ -69,7 +70,7 @@ export class UpdateRemoteSourcesCommand extends Command<Args> {
     // TODO Update remotes in parallel. Currently not possible since updating might
     // trigger a username and password prompt from git.
     for (const { name, repositoryUrl } of projectSources) {
-      await garden.vcs.updateRemoteSource({ name, url: repositoryUrl, sourceType: "project", logEntry: garden.log })
+      await garden.vcs.updateRemoteSource({ name, url: repositoryUrl, sourceType: "project", log })
     }
 
     await pruneRemoteSources({ projectRoot: garden.projectRoot, type: "project", sources: projectSources })

--- a/garden-service/src/commands/validate.ts
+++ b/garden-service/src/commands/validate.ts
@@ -11,6 +11,7 @@ import {
   CommandParams,
   CommandResult,
 } from "./base"
+import { logHeader } from "../logger/util"
 import dedent = require("dedent")
 
 export class ValidateCommand extends Command {
@@ -21,8 +22,8 @@ export class ValidateCommand extends Command {
     Throws an error and exits with code 1 if something's not right in your garden.yml files.
   `
 
-  async action({ garden }: CommandParams): Promise<CommandResult> {
-    garden.log.header({ emoji: "heavy_check_mark", command: "validate" })
+  async action({ garden, log }: CommandParams): Promise<CommandResult> {
+    logHeader({ log, emoji: "heavy_check_mark", command: "validate" })
 
     await garden.getModules()
 

--- a/garden-service/src/config/config-context.ts
+++ b/garden-service/src/config/config-context.ts
@@ -16,6 +16,7 @@ import { Service } from "../types/service"
 import { resolveTemplateString } from "../template-string"
 import * as Joi from "joi"
 import { Garden } from "../garden"
+import { LogEntry } from "../logger/log-entry"
 
 export type ContextKey = string[]
 
@@ -280,6 +281,7 @@ export class ModuleConfigContext extends ProjectConfigContext {
 
   constructor(
     garden: Garden,
+    log: LogEntry,
     environment: Environment,
     moduleConfigs: ModuleConfig[],
   ) {
@@ -303,7 +305,7 @@ export class ModuleConfigContext extends ProjectConfigContext {
         const service = await garden.getService(name)
         const outputs = {
           ...service.config.outputs,
-          ...await garden.actions.getServiceOutputs({ service }),
+          ...await garden.actions.getServiceOutputs({ log, service }),
         }
         return new ServiceContext(_this, service, outputs)
       }],

--- a/garden-service/src/garden.ts
+++ b/garden-service/src/garden.ts
@@ -203,7 +203,7 @@ export class Garden {
     this.actionHandlers = <PluginActionMap>fromPairs(pluginActionNames.map(n => [n, {}]))
     this.moduleActionHandlers = <ModuleActionMap>fromPairs(moduleActionNames.map(n => [n, {}]))
 
-    this.taskGraph = new TaskGraph(this)
+    this.taskGraph = new TaskGraph(this.log.info({ indent: -1 }))
     this.actions = new ActionHelper(this)
     this.hotReloadScheduler = new HotReloadScheduler()
   }
@@ -427,7 +427,7 @@ export class Garden {
       plugin = await factory({
         projectName: this.projectName,
         config,
-        logEntry: this.log,
+        log: this.log,
       })
     } catch (error) {
       throw new PluginError(`Unexpected error when loading plugin "${pluginName}": ${error}`, {
@@ -822,7 +822,7 @@ export class Garden {
       await this.detectCircularDependencies()
 
       const moduleConfigContext = new ModuleConfigContext(
-        this, this.environment, Object.values(this.moduleConfigs),
+        this, this.log.info({ indent: -1 }), this.environment, Object.values(this.moduleConfigs),
       )
       this.moduleConfigs = await resolveTemplateStrings(this.moduleConfigs, moduleConfigContext)
     })
@@ -987,7 +987,7 @@ export class Garden {
       return linked.path
     }
 
-    const path = await this.vcs.ensureRemoteSource({ name, sourceType, url: repositoryUrl, logEntry: this.log })
+    const path = await this.vcs.ensureRemoteSource({ name, sourceType, url: repositoryUrl, log: this.log })
 
     return path
   }

--- a/garden-service/src/garden.ts
+++ b/garden-service/src/garden.ts
@@ -56,7 +56,6 @@ import {
 import {
   DEFAULT_NAMESPACE,
   MODULE_CONFIG_FILENAME,
-  ERROR_LOG_FILENAME,
 } from "./constants"
 import {
   ConfigurationError,
@@ -75,7 +74,6 @@ import {
 } from "./task-graph"
 import {
   getLogger,
-  Logger,
 } from "./logger/logger"
 import {
   pluginActionNames,
@@ -103,13 +101,12 @@ import {
 } from "./util/ext-source-util"
 import { BuildDependencyConfig, ModuleConfig } from "./config/module"
 import { ProjectConfigContext, ModuleConfigContext } from "./config/config-context"
-import { FileWriter } from "./logger/writers/file-writer"
-import { LogLevel } from "./logger/log-node"
 import { ActionHelper } from "./actions"
 import { createPluginContext } from "./plugin-context"
 import { ModuleAndRuntimeActions, Plugins, RegisterPluginParam } from "./types/plugin/plugin"
 import { SUPPORTED_PLATFORMS, SupportedPlatform } from "./constants"
 import { platform, arch } from "os"
+import { LogEntry } from "./logger/log-entry"
 
 export interface ActionHandlerMap<T extends keyof PluginActions> {
   [actionName: string]: PluginActions[T]
@@ -136,20 +133,14 @@ export type ModuleActionMap = {
 export interface ContextOpts {
   config?: GardenConfig,
   env?: string,
-  logger?: Logger,
+  log?: LogEntry,
   plugins?: Plugins,
 }
 
 const scanLock = new AsyncLock()
 
-const fileWriterConfigs = [
-  { filename: "development.log" },
-  { filename: ERROR_LOG_FILENAME, level: LogLevel.error },
-  { filename: ERROR_LOG_FILENAME, level: LogLevel.error, path: ".", truncatePrevious: true },
-]
-
 export class Garden {
-  public readonly log: Logger
+  public readonly log: LogEntry
   public readonly actionHandlers: PluginActionMap
   public readonly moduleActionHandlers: ModuleActionMap
   public dependencyGraph: DependencyGraph
@@ -174,7 +165,7 @@ export class Garden {
     public readonly environment: Environment,
     public readonly projectSources: SourceConfig[] = [],
     public readonly buildDir: BuildDir,
-    logger?: Logger,
+    log?: LogEntry,
   ) {
     // make sure we're on a supported platform
     const currentPlatform = platform()
@@ -189,7 +180,7 @@ export class Garden {
     }
 
     this.modulesScanned = false
-    this.log = logger || getLogger()
+    this.log = log || getLogger().placeholder()
     // TODO: Support other VCS options.
     this.vcs = new GitHandler(this.projectRoot)
     this.localConfigStore = new LocalConfigStore(this.projectRoot)
@@ -203,12 +194,12 @@ export class Garden {
     this.actionHandlers = <PluginActionMap>fromPairs(pluginActionNames.map(n => [n, {}]))
     this.moduleActionHandlers = <ModuleActionMap>fromPairs(moduleActionNames.map(n => [n, {}]))
 
-    this.taskGraph = new TaskGraph(this.log.info({ indent: -1 }))
+    this.taskGraph = new TaskGraph(this.log)
     this.actions = new ActionHelper(this)
     this.hotReloadScheduler = new HotReloadScheduler()
   }
 
-  static async factory(currentDirectory: string, { env, config, logger, plugins = {} }: ContextOpts = {}) {
+  static async factory(currentDirectory: string, { env, config, log, plugins = {} }: ContextOpts = {}) {
     let parsedConfig: GardenConfig
 
     if (config) {
@@ -293,26 +284,13 @@ export class Garden {
 
     const buildDir = await BuildDir.factory(projectRoot)
 
-    // Register log writers
-    if (logger) {
-      for (const writerConfig of fileWriterConfigs) {
-        logger.writers.push(
-          await FileWriter.factory({
-            level: logger.level,
-            root: projectRoot,
-            ...writerConfig,
-          }),
-        )
-      }
-    }
-
     const garden = new Garden(
       projectRoot,
       projectName,
       environment,
       projectSources,
       buildDir,
-      logger,
+      log,
     )
 
     // Register plugins
@@ -822,7 +800,7 @@ export class Garden {
       await this.detectCircularDependencies()
 
       const moduleConfigContext = new ModuleConfigContext(
-        this, this.log.info({ indent: -1 }), this.environment, Object.values(this.moduleConfigs),
+        this, this.log, this.environment, Object.values(this.moduleConfigs),
       )
       this.moduleConfigs = await resolveTemplateStrings(this.moduleConfigs, moduleConfigContext)
     })

--- a/garden-service/src/logger/log-node.ts
+++ b/garden-service/src/logger/log-node.ts
@@ -43,36 +43,42 @@ export abstract class LogNode<T = LogEntry, U = CreateParam> {
     this.children = []
   }
 
-  abstract createNode(level: LogLevel, parent: LogNode<T, U>, param?: U): T
+  protected abstract createNode(level: LogLevel, param: U): T
 
-  protected appendNode(level: LogLevel, param?: U): T {
-    const node = this.createNode(level, this, param)
+  /**
+   * A placeholder entry is an empty entry whose children should be aligned with the parent context.
+   * Useful for setting a placeholder in the middle of the log that can later be populated.
+   */
+  abstract placeholder(level: LogLevel): T
+
+  protected appendNode(level: LogLevel, param: U): T {
+    const node = this.createNode(level, param)
     this.children.push(node)
     this.root.onGraphChange(node)
     return node
   }
 
-  silly(param?: U): T {
+  silly(param: U): T {
     return this.appendNode(LogLevel.silly, param)
   }
 
-  debug(param?: U): T {
+  debug(param: U): T {
     return this.appendNode(LogLevel.debug, param)
   }
 
-  verbose(param?: U): T {
+  verbose(param: U): T {
     return this.appendNode(LogLevel.verbose, param)
   }
 
-  info(param?: U): T {
+  info(param: U): T {
     return this.appendNode(LogLevel.info, param)
   }
 
-  warn(param?: U): T {
+  warn(param: U): T {
     return this.appendNode(LogLevel.warn, param)
   }
 
-  error(param?: U): T {
+  error(param: U): T {
     return this.appendNode(LogLevel.error, param)
   }
 

--- a/garden-service/src/logger/logger.ts
+++ b/garden-service/src/logger/logger.ts
@@ -8,7 +8,7 @@
 
 import chalk from "chalk"
 
-import { RootLogNode, LogNode } from "./log-node"
+import { RootLogNode } from "./log-node"
 import { LogEntry, CreateOpts, resolveParam } from "./log-entry"
 import { getChildEntries } from "./util"
 import { Writer } from "./writers/base"
@@ -60,7 +60,7 @@ export class Logger extends RootLogNode<LogEntry> {
     return Logger.instance
   }
 
-  static initialize(config: LoggerConfig) {
+  static initialize(config: LoggerConfig): Logger {
     if (Logger.instance) {
       throw new InternalError("Logger already initialized", {})
     }
@@ -94,8 +94,13 @@ export class Logger extends RootLogNode<LogEntry> {
     this.useEmoji = config.useEmoji === false ? false : true
   }
 
-  createNode(level: LogLevel, _parent: LogNode, opts: CreateOpts) {
+  protected createNode(level: LogLevel, opts: CreateOpts): LogEntry {
     return new LogEntry({ level, parent: this, opts: resolveParam(opts) })
+  }
+
+  placeholder(level: LogLevel = LogLevel.info): LogEntry {
+    // Ensure placeholder child entries align with parent context
+    return this.appendNode(level, { indent: - 1 })
   }
 
   onGraphChange(entry: LogEntry) {

--- a/garden-service/src/logger/logger.ts
+++ b/garden-service/src/logger/logger.ts
@@ -9,7 +9,7 @@
 import chalk from "chalk"
 
 import { RootLogNode, LogNode } from "./log-node"
-import { LogEntry, CreateOpts, resolveParam, EmojiName } from "./log-entry"
+import { LogEntry, CreateOpts, resolveParam } from "./log-entry"
 import { getChildEntries } from "./util"
 import { Writer } from "./writers/base"
 import { InternalError, ParameterError } from "../exceptions"
@@ -110,18 +110,7 @@ export class Logger extends RootLogNode<LogEntry> {
     return getChildEntries(this).filter(entry => entry.opts.section === section)
   }
 
-  header(
-    { command, emoji, level = LogLevel.info }: { command: string, emoji?: EmojiName, level?: LogLevel },
-  ): LogEntry {
-    const msg = combine([
-      [chalk.bold.magenta(command)],
-      [emoji && this.useEmoji ? " " + printEmoji(emoji) : ""],
-      ["\n"],
-    ])
-    const lvlStr = LogLevel[level]
-    return this[lvlStr](msg)
-  }
-
+  // FIXME: This isn't currently used anywhere, we should find this another place and purpose.
   finish(
     { showDuration = true, level = LogLevel.info }: { showDuration?: boolean, level?: LogLevel } = {},
   ): LogEntry {

--- a/garden-service/src/logger/util.ts
+++ b/garden-service/src/logger/util.ts
@@ -6,8 +6,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { LogNode } from "./log-node"
-import { LogEntry, CreateOpts } from "./log-entry"
+import { LogNode, LogLevel } from "./log-node"
+import { LogEntry, CreateOpts, EmojiName } from "./log-entry"
+import { combine, printEmoji } from "./renderers"
+import chalk from "chalk"
 
 export interface Node {
   children: any[]
@@ -104,4 +106,21 @@ export function getTerminalWidth(stream: NodeJS.WriteStream = process.stdout) {
   }
 
   return columns
+}
+
+interface LogHeaderOptions {
+  log: LogEntry
+  command: string
+  emoji?: EmojiName
+  level?: LogLevel
+}
+
+export function logHeader({ log, command, emoji, level = LogLevel.info }: LogHeaderOptions): LogEntry {
+  const msg = combine([
+    [chalk.bold.magenta(command)],
+    [emoji && log.root.useEmoji ? " " + printEmoji(emoji) : ""],
+    ["\n"],
+  ])
+  const lvlStr = LogLevel[level]
+  return log[lvlStr](msg)
 }

--- a/garden-service/src/logger/writers/fancy-terminal-writer.ts
+++ b/garden-service/src/logger/writers/fancy-terminal-writer.ts
@@ -137,24 +137,24 @@ export class FancyTerminalWriter extends Writer {
     )
   }
 
-  private handleGraphChange(logEntry: LogEntry, logger: Logger, didWrite: boolean = false) {
+  private handleGraphChange(log: LogEntry, logger: Logger, didWrite: boolean = false) {
     this.updatePending = false
 
     // Suspend processing and write immediately if a lot of data is being intercepted, e.g. when user is typing in input
-    if (logEntry.fromStdStream() && !didWrite) {
+    if (log.fromStdStream() && !didWrite) {
       const now = Date.now()
       const throttleProcessing = this.lastInterceptAt && (now - this.lastInterceptAt) < THROTTLE_MS
       this.lastInterceptAt = now
 
       if (throttleProcessing) {
         this.stopLoop()
-        this.stream.write(renderMsg(logEntry))
+        this.stream.write(renderMsg(log))
         this.updatePending = true
 
         // Resume processing if idle and original update is still pending
         setTimeout(() => {
           if (this.updatePending) {
-            this.handleGraphChange(logEntry, logger, true)
+            this.handleGraphChange(log, logger, true)
           }
         }, THROTTLE_MS)
         return
@@ -162,7 +162,7 @@ export class FancyTerminalWriter extends Writer {
     }
 
     const terminalEntries = this.toTerminalEntries(logger)
-    const nextEntry = terminalEntries.find(e => e.key === logEntry.key)
+    const nextEntry = terminalEntries.find(e => e.key === log.key)
 
     // Nothing to do, e.g. because entry level is higher than writer level
     if (!nextEntry) {
@@ -241,12 +241,12 @@ export class FancyTerminalWriter extends Writer {
     return terminalEntries.map(e => e.text).join("").split("\n")
   }
 
-  public onGraphChange(logEntry: LogEntry, logger: Logger): void {
+  public onGraphChange(log: LogEntry, logger: Logger): void {
     if (!this.stream) {
       this.stream = this.initStream(logger)
     }
 
-    this.handleGraphChange(logEntry, logger, false)
+    this.handleGraphChange(log, logger, false)
   }
 
   public stop(): void {

--- a/garden-service/src/plugins/google/common.ts
+++ b/garden-service/src/plugins/google/common.ts
@@ -61,7 +61,7 @@ export async function getEnvironmentStatus() {
   return output
 }
 
-export async function prepareEnvironment({ status, logEntry }: PrepareEnvironmentParams) {
+export async function prepareEnvironment({ status, log }: PrepareEnvironmentParams) {
   if (!status.detail.sdkInstalled) {
     throw new ConfigurationError(
       "Google Cloud SDK is not installed. " +
@@ -71,7 +71,7 @@ export async function prepareEnvironment({ status, logEntry }: PrepareEnvironmen
   }
 
   if (!status.detail.betaComponentsInstalled) {
-    logEntry && logEntry.info({
+    log.info({
       section: "google-cloud-functions",
       msg: `Installing gcloud SDK beta components...`,
     })
@@ -80,7 +80,7 @@ export async function prepareEnvironment({ status, logEntry }: PrepareEnvironmen
   }
 
   if (!status.detail.sdkInitialized) {
-    logEntry && logEntry.info({
+    log.info({
       section: "google-cloud-functions",
       msg: `Initializing SDK...`,
     })

--- a/garden-service/src/plugins/google/google-app-engine.ts
+++ b/garden-service/src/plugins/google/google-app-engine.ts
@@ -55,8 +55,8 @@ export const gardenPlugin = (): GardenPlugin => ({
         return {}
       },
 
-      async deployService({ ctx, service, runtimeContext, logEntry }: DeployServiceParams<GoogleAppEngineModule>) {
-        logEntry && logEntry.info({
+      async deployService({ ctx, service, runtimeContext, log }: DeployServiceParams<GoogleAppEngineModule>) {
+        log.info({
           section: service.name,
           msg: `Deploying app...`,
         })
@@ -72,7 +72,7 @@ export const gardenPlugin = (): GardenPlugin => ({
 
         if (config.healthCheck) {
           if (config.healthCheck.tcpPort || config.healthCheck.command) {
-            logEntry && logEntry.warn({
+            log.warn({
               section: service.name,
               msg: "GAE only supports httpGet health checks",
             })
@@ -94,7 +94,7 @@ export const gardenPlugin = (): GardenPlugin => ({
           "app", "deploy", "--quiet",
         ], { cwd: service.module.path })
 
-        logEntry && logEntry.info({ section: service.name, msg: `App deployed` })
+        log.info({ section: service.name, msg: `App deployed` })
 
         return {}
       },

--- a/garden-service/src/plugins/google/google-cloud-functions.ts
+++ b/garden-service/src/plugins/google/google-cloud-functions.ts
@@ -110,7 +110,7 @@ export const gardenPlugin = (): GardenPlugin => ({
       validate: parseGcfModule,
 
       async deployService(
-        { ctx, module, service, runtimeContext, logEntry, buildDependencies }: DeployServiceParams<GcfModule>,
+        { ctx, module, service, runtimeContext, log, buildDependencies }: DeployServiceParams<GcfModule>,
       ) {
         // TODO: provide env vars somehow to function
         const project = getProject(service, ctx.provider)
@@ -126,7 +126,7 @@ export const gardenPlugin = (): GardenPlugin => ({
           "--trigger-http",
         ])
 
-        return getServiceStatus({ ctx, module, service, runtimeContext, logEntry, buildDependencies })
+        return getServiceStatus({ ctx, module, service, runtimeContext, log, buildDependencies })
       },
 
       async getServiceOutputs({ ctx, service }: GetServiceOutputsParams<GcfModule>) {

--- a/garden-service/src/plugins/kubernetes/actions.ts
+++ b/garden-service/src/plugins/kubernetes/actions.ts
@@ -74,12 +74,12 @@ export async function validate(params: ValidateModuleParams<ContainerModule>) {
 }
 
 export async function deleteService(params: DeleteServiceParams): Promise<ServiceStatus> {
-  const { ctx, logEntry, service } = params
+  const { ctx, log, service } = params
   const namespace = await getAppNamespace(ctx, ctx.provider)
   const provider = ctx.provider
 
   await deleteContainerService(
-    { provider, namespace, serviceName: service.name, logEntry })
+    { provider, namespace, serviceName: service.name, log })
 
   return getContainerServiceStatus(params)
 }
@@ -135,13 +135,13 @@ export async function execInService(params: ExecInServiceParams<ContainerModule>
 }
 
 export async function hotReload(
-  { ctx, runtimeContext, module, buildDependencies }: HotReloadParams<ContainerModule>,
+  { ctx, log, runtimeContext, module, buildDependencies }: HotReloadParams<ContainerModule>,
 ): Promise<HotReloadResult> {
   const hotReloadConfig = module.spec.hotReload!
 
   const services = module.services
 
-  if (!await waitForServices(ctx, runtimeContext, services, buildDependencies)) {
+  if (!await waitForServices(ctx, log, runtimeContext, services, buildDependencies)) {
     // Service deployment timed out, skip hot reload
     return {}
   }
@@ -222,7 +222,7 @@ export async function runModule(
 }
 
 export async function runService(
-  { ctx, service, interactive, runtimeContext, timeout, logEntry, buildDependencies }:
+  { ctx, service, interactive, runtimeContext, timeout, log, buildDependencies }:
     RunServiceParams<ContainerModule>,
 ) {
   return runModule({
@@ -232,20 +232,20 @@ export async function runService(
     interactive,
     runtimeContext,
     timeout,
-    logEntry,
+    log,
     buildDependencies,
   })
 }
 
 export async function runTask(
-  { ctx, task, interactive, runtimeContext, logEntry, buildDependencies }:
+  { ctx, task, interactive, runtimeContext, log, buildDependencies }:
     RunTaskParams<ContainerModule>,
 ) {
   const result = await runModule({
     ctx,
     buildDependencies,
     interactive,
-    logEntry,
+    log,
     runtimeContext,
     module: task.module,
     command: task.spec.command || [],
@@ -260,7 +260,7 @@ export async function runTask(
 }
 
 export async function testModule(
-  { ctx, interactive, module, runtimeContext, testConfig, logEntry, buildDependencies }:
+  { ctx, interactive, module, runtimeContext, testConfig, log, buildDependencies }:
     TestModuleParams<ContainerModule>,
 ): Promise<TestResult> {
   const testName = testConfig.name
@@ -275,7 +275,7 @@ export async function testModule(
     interactive,
     runtimeContext,
     timeout,
-    logEntry,
+    log,
     buildDependencies,
   })
 

--- a/garden-service/src/plugins/kubernetes/init.ts
+++ b/garden-service/src/plugins/kubernetes/init.ts
@@ -147,12 +147,10 @@ export async function cleanupEnvironment({ ctx, log }: CleanupEnvironmentParams)
     // TODO: any cast is required until https://github.com/kubernetes-client/javascript/issues/52 is fixed
     await api.core.deleteNamespace(namespace, <any>{})
   } catch (err) {
-    entry && entry.setError(err.message)
+    entry.setError(err.message)
     const availableNamespaces = await getAllGardenNamespaces(api)
     throw new NotFoundError(err, { namespace, availableNamespaces })
   }
-
-  entry && entry.setSuccess()
 
   await logout({ ctx, log })
 
@@ -163,6 +161,7 @@ export async function cleanupEnvironment({ ctx, log }: CleanupEnvironmentParams)
 
     const nsNames = await getAllGardenNamespaces(api)
     if (!nsNames.includes(namespace)) {
+      entry.setSuccess()
       break
     }
 

--- a/garden-service/src/plugins/kubernetes/local.ts
+++ b/garden-service/src/plugins/kubernetes/local.ts
@@ -69,7 +69,7 @@ const configSchema = kubernetesConfigBase
 
 export const name = "local-kubernetes"
 
-export async function gardenPlugin({ projectName, config, logEntry }): Promise<GardenPlugin> {
+export async function gardenPlugin({ projectName, config, log }): Promise<GardenPlugin> {
   config = validate(config, configSchema, { context: "local-kubernetes provider config" })
 
   let context = config.context
@@ -84,14 +84,14 @@ export async function gardenPlugin({ projectName, config, logEntry }): Promise<G
     if (currentContext && supportedContexts.includes(currentContext)) {
       // prefer current context if set and supported
       context = currentContext
-      logEntry.debug({ section: name, msg: `Using current context: ${context}` })
+      log.debug({ section: name, msg: `Using current context: ${context}` })
     } else if (kubeConfig.contexts) {
       const availableContexts = kubeConfig.contexts.map(c => c.name)
 
       for (const supportedContext of supportedContexts) {
         if (availableContexts.includes(supportedContext)) {
           context = supportedContext
-          logEntry.debug({ section: name, msg: `Using detected context: ${context}` })
+          log.debug({ section: name, msg: `Using detected context: ${context}` })
           break
         }
       }
@@ -100,7 +100,7 @@ export async function gardenPlugin({ projectName, config, logEntry }): Promise<G
 
   if (!context) {
     context = supportedContexts[0]
-    logEntry.debug({ section: name, msg: `No kubectl context auto-detected, using default: ${context}` })
+    log.debug({ section: name, msg: `No kubectl context auto-detected, using default: ${context}` })
   }
 
   if (context === "minikube") {

--- a/garden-service/src/plugins/kubernetes/status.ts
+++ b/garden-service/src/plugins/kubernetes/status.ts
@@ -334,18 +334,18 @@ interface WaitParams {
   provider: KubernetesProvider,
   service: Service,
   objects: KubernetesObject[],
-  logEntry?: LogEntry,
+  log: LogEntry,
 }
 
 /**
  * Wait until the rollout is complete for each of the given Kubernetes objects
  */
-export async function waitForObjects({ ctx, provider, service, objects, logEntry }: WaitParams) {
+export async function waitForObjects({ ctx, provider, service, objects, log }: WaitParams) {
   let loops = 0
   let lastMessage
   const startTime = new Date().getTime()
 
-  logEntry && logEntry.verbose({
+  log.verbose({
     symbol: "info",
     section: service.name,
     msg: `Waiting for service to be ready...`,
@@ -379,7 +379,7 @@ export async function waitForObjects({ ctx, provider, service, objects, logEntry
 
       if (status.lastMessage && (!lastMessage || status.lastMessage !== lastMessage)) {
         lastMessage = status.lastMessage
-        logEntry && logEntry.verbose({
+        log.verbose({
           symbol: "info",
           section: service.name,
           msg: status.lastMessage,
@@ -400,7 +400,7 @@ export async function waitForObjects({ ctx, provider, service, objects, logEntry
     }
   }
 
-  logEntry && logEntry.verbose({ symbol: "info", section: service.name, msg: `Service deployed` })
+  log.verbose({ symbol: "info", section: service.name, msg: `Service deployed` })
 }
 
 /**
@@ -410,7 +410,7 @@ export async function waitForObjects({ ctx, provider, service, objects, logEntry
  * TODO: This function is repetitive of waitForObjects above.
  */
 export async function waitForServices(
-  ctx: PluginContext, runtimeContext: RuntimeContext, services: Service[], buildDependencies,
+  ctx: PluginContext, log: LogEntry, runtimeContext: RuntimeContext, services: Service[], buildDependencies,
 ): Promise<boolean> {
   let ready
   const startTime = new Date().getTime()
@@ -419,7 +419,7 @@ export async function waitForServices(
 
     ready = (await Bluebird.map(services, async (service) => {
       const state = (await getContainerServiceStatus({
-        ctx, buildDependencies, service, runtimeContext, module: service.module,
+        ctx, log, buildDependencies, service, runtimeContext, module: service.module,
       })).state
       return state === "ready" || state === "outdated"
     })).every(serviceReady => serviceReady)

--- a/garden-service/src/plugins/local/local-docker-swarm.ts
+++ b/garden-service/src/plugins/local/local-docker-swarm.ts
@@ -45,12 +45,12 @@ export const gardenPlugin = (): GardenPlugin => ({
       getServiceStatus,
 
       async deployService(
-        { ctx, module, service, runtimeContext, logEntry, buildDependencies }: DeployServiceParams<ContainerModule>,
+        { ctx, module, service, runtimeContext, log, buildDependencies }: DeployServiceParams<ContainerModule>,
       ) {
         // TODO: split this method up and test
         const { versionString } = service.module.version
 
-        logEntry && logEntry.info({ section: service.name, msg: `Deploying version ${versionString}` })
+        log.info({ section: service.name, msg: `Deploying version ${versionString}` })
 
         const identifier = await helpers.getLocalImageId(module)
         const ports = service.spec.ports.map(p => {
@@ -121,7 +121,7 @@ export const gardenPlugin = (): GardenPlugin => ({
           service,
           module,
           runtimeContext,
-          logEntry,
+          log,
           buildDependencies,
         })
         let swarmServiceStatus
@@ -131,14 +131,14 @@ export const gardenPlugin = (): GardenPlugin => ({
           const swarmService = await docker.getService(serviceStatus.providerId)
           swarmServiceStatus = await swarmService.inspect()
           opts.version = parseInt(swarmServiceStatus.Version.Index, 10)
-          logEntry && logEntry.verbose({
+          log.verbose({
             section: service.name,
             msg: `Updating existing Swarm service (version ${opts.version})`,
           })
           await swarmService.update(opts)
           serviceId = serviceStatus.providerId
         } else {
-          logEntry && logEntry.verbose({
+          log.verbose({
             section: service.name,
             msg: `Creating new Swarm service`,
           })
@@ -174,12 +174,12 @@ export const gardenPlugin = (): GardenPlugin => ({
           }
         }
 
-        logEntry && logEntry.info({
+        log.info({
           section: service.name,
           msg: `Ready`,
         })
 
-        return getServiceStatus({ ctx, module, service, runtimeContext, logEntry, buildDependencies })
+        return getServiceStatus({ ctx, module, service, runtimeContext, log, buildDependencies })
       },
 
       async getServiceOutputs({ ctx, service }: GetServiceOutputsParams<ContainerModule>) {
@@ -189,14 +189,14 @@ export const gardenPlugin = (): GardenPlugin => ({
       },
 
       async execInService(
-        { ctx, service, command, runtimeContext, logEntry, buildDependencies }: ExecInServiceParams<ContainerModule>,
+        { ctx, service, command, runtimeContext, log, buildDependencies }: ExecInServiceParams<ContainerModule>,
       ) {
         const status = await getServiceStatus({
           ctx,
           service,
           module: service.module,
           runtimeContext,
-          logEntry,
+          log,
           buildDependencies,
         })
 

--- a/garden-service/src/process.ts
+++ b/garden-service/src/process.ts
@@ -8,6 +8,8 @@
 
 import Bluebird = require("bluebird")
 import chalk from "chalk"
+import { padEnd } from "lodash"
+
 import { Module } from "./types/module"
 import { Service } from "./types/service"
 import { BaseTask } from "./tasks/base"
@@ -61,13 +63,21 @@ export async function processServices(
 export async function processModules(
   { garden, log, modules, watch, handler, changeHandler }: ProcessModulesParams,
 ): Promise<ProcessResults> {
+  // Let the user know if any modules are linked to a local path
+  const linkedModulesMsg = modules
+    .filter(m => isModuleLinked(m, garden))
+    .map(m => `${chalk.cyan(m.name)} linked to path ${chalk.white(m.path)}`)
+    .map(msg => "  " + msg) // indent list
+
+  if (linkedModulesMsg.length > 0) {
+    const divider = padEnd("", 80, "—")
+    log.info(divider)
+    log.info(chalk.gray(`Following modules are linked to a local path:\n${linkedModulesMsg.join("\n")}`))
+    log.info(divider)
+  }
+
   for (const module of modules) {
     const tasks = await handler(module)
-    if (isModuleLinked(module, garden)) {
-      log.info(
-        chalk.gray(`Reading module ${chalk.cyan(module.name)} from linked local path ${chalk.white(module.path)}`),
-      )
-    }
     await Bluebird.map(tasks, t => garden.addTask(t))
   }
 

--- a/garden-service/src/task-graph.ts
+++ b/garden-service/src/task-graph.ts
@@ -14,7 +14,6 @@ import { BaseTask, TaskDefinitionError } from "./tasks/base"
 
 import { LogEntry } from "./logger/log-entry"
 import { toGardenError } from "./exceptions"
-import { Garden } from "./garden"
 
 class TaskGraphError extends Error { }
 
@@ -46,7 +45,7 @@ export class TaskGraph {
   private resultCache: ResultCache
   private opQueue: PQueue
 
-  constructor(private garden: Garden, private concurrency: number = DEFAULT_CONCURRENCY) {
+  constructor(private log: LogEntry, private concurrency: number = DEFAULT_CONCURRENCY) {
     this.roots = new TaskNodeMap()
     this.index = new TaskNodeMap()
     this.inProgress = new TaskNodeMap()
@@ -251,7 +250,7 @@ export class TaskGraph {
 
   // Logging
   private logTask(node: TaskNode) {
-    const entry = this.garden.log.debug({
+    const entry = this.log.debug({
       section: "tasks",
       msg: `Processing task ${taskStyle(node.getKey())}`,
       status: "active",
@@ -269,12 +268,12 @@ export class TaskGraph {
 
   private initLogging() {
     if (!Object.keys(this.logEntryMap).length) {
-      const header = this.garden.log.debug("Processing tasks...")
-      const counter = this.garden.log.debug({
+      const header = this.log.debug("Processing tasks...")
+      const counter = this.log.debug({
         msg: remainingTasksToStr(this.index.length),
         status: "active",
       })
-      const inProgress = this.garden.log.debug(inProgressToStr(this.inProgress.getNodes()))
+      const inProgress = this.log.debug(inProgressToStr(this.inProgress.getNodes()))
       this.logEntryMap = {
         ...this.logEntryMap,
         header,
@@ -288,7 +287,7 @@ export class TaskGraph {
     const divider = padEnd("", 80, "—")
     const error = toGardenError(err)
     const msg = `\nFailed ${node.getDescription()}. Here is the output:\n${divider}\n${error.message}\n${divider}\n`
-    this.garden.log.error({ msg, error })
+    this.log.error({ msg, error })
   }
 }
 

--- a/garden-service/src/tasks/base.ts
+++ b/garden-service/src/tasks/base.ts
@@ -11,11 +11,13 @@ import { ModuleVersion } from "../vcs/base"
 import { v1 as uuidv1 } from "uuid"
 import { Garden } from "../garden"
 import { DependencyGraphNodeType } from "../dependency-graph"
+import { LogEntry } from "../logger/log-entry"
 
 export class TaskDefinitionError extends Error { }
 
 export interface TaskParams {
   garden: Garden
+  log: LogEntry
   force?: boolean
   version: ModuleVersion
 }
@@ -24,6 +26,7 @@ export abstract class BaseTask {
   abstract type: string
   abstract depType: DependencyGraphNodeType
   garden: Garden
+  log: LogEntry
   id: string
   force: boolean
   version: ModuleVersion
@@ -36,6 +39,7 @@ export abstract class BaseTask {
     this.id = uuidv1() // uuidv1 is timestamp-based
     this.force = !!initArgs.force
     this.version = initArgs.version
+    this.log = initArgs.log
   }
 
   async getDependencies(): Promise<BaseTask[]> {

--- a/garden-service/src/tasks/test.ts
+++ b/garden-service/src/tasks/test.ts
@@ -17,6 +17,7 @@ import { TestResult } from "../types/plugin/outputs"
 import { BaseTask, TaskParams } from "../tasks/base"
 import { prepareRuntimeContext } from "../types/service"
 import { Garden } from "../garden"
+import { LogEntry } from "../logger/log-entry"
 import { DependencyGraphNodeType } from "../dependency-graph"
 
 class TestError extends Error {
@@ -27,6 +28,7 @@ class TestError extends Error {
 
 export interface TestTaskParams {
   garden: Garden
+  log: LogEntry
   module: Module
   testConfig: TestConfig
   force: boolean
@@ -41,8 +43,8 @@ export class TestTask extends BaseTask {
   private testConfig: TestConfig
   private forceBuild: boolean
 
-  constructor({ garden, module, testConfig, force, forceBuild, version }: TestTaskParams & TaskParams) {
-    super({ garden, force, version })
+  constructor({ garden, log, module, testConfig, force, forceBuild, version }: TestTaskParams & TaskParams) {
+    super({ garden, log, force, version })
     this.module = module
     this.testConfig = testConfig
     this.force = force
@@ -67,6 +69,7 @@ export class TestTask extends BaseTask {
 
     const deps: BaseTask[] = [new BuildTask({
       garden: this.garden,
+      log: this.log,
       module: this.module,
       force: this.forceBuild,
     })]
@@ -74,6 +77,7 @@ export class TestTask extends BaseTask {
     for (const service of services) {
       deps.push(new DeployTask({
         garden: this.garden,
+        log: this.log,
         service,
         force: false,
         forceBuild: this.forceBuild,
@@ -96,7 +100,7 @@ export class TestTask extends BaseTask {
     const testResult = await this.getTestResult()
 
     if (testResult && testResult.success) {
-      const passedEntry = this.garden.log.info({
+      const passedEntry = this.log.info({
         section: this.module.name,
         msg: `${this.testConfig.name} tests`,
       })
@@ -104,18 +108,19 @@ export class TestTask extends BaseTask {
       return testResult
     }
 
-    const entry = this.garden.log.info({
+    const log = this.log.info({
       section: this.module.name,
       msg: `Running ${this.testConfig.name} tests`,
       status: "active",
     })
 
     const dependencies = await getTestDependencies(this.garden, this.testConfig)
-    const runtimeContext = await prepareRuntimeContext(this.garden, this.module, dependencies)
+    const runtimeContext = await prepareRuntimeContext(this.garden, log, this.module, dependencies)
 
     let result: TestResult
     try {
       result = await this.garden.actions.testModule({
+        log,
         interactive: false,
         module: this.module,
         runtimeContext,
@@ -123,13 +128,13 @@ export class TestTask extends BaseTask {
         testConfig: this.testConfig,
       })
     } catch (err) {
-      entry.setError()
+      log.setError()
       throw err
     }
     if (result.success) {
-      entry.setSuccess({ msg: chalk.green(`Success`), append: true })
+      log.setSuccess({ msg: chalk.green(`Success`), append: true })
     } else {
-      entry.setError({ msg: chalk.red(`Failed!`), append: true })
+      log.setError({ msg: chalk.red(`Failed!`), append: true })
       throw new TestError(result.output)
     }
 
@@ -142,6 +147,7 @@ export class TestTask extends BaseTask {
     }
 
     return this.garden.actions.getTestResult({
+      log: this.log,
       module: this.module,
       testName: this.testConfig.name,
       version: this.version,
@@ -150,25 +156,19 @@ export class TestTask extends BaseTask {
 }
 
 export async function getTestTasks(
-  { garden, module, name, force = false, forceBuild = false }:
-    { garden: Garden, module: Module, name?: string, force?: boolean, forceBuild?: boolean },
+  { garden, log, module, name, force = false, forceBuild = false }:
+    { garden: Garden, log: LogEntry, module: Module, name?: string, force?: boolean, forceBuild?: boolean },
 ) {
-  const tasks: Promise<TestTask>[] = []
+  const configs = module.testConfigs.filter(test => !name || test.name === name)
 
-  for (const test of module.testConfigs) {
-    if (name && test.name !== name) {
-      continue
-    }
-    tasks.push(TestTask.factory({
-      garden,
-      force,
-      forceBuild,
-      testConfig: test,
-      module,
-    }))
-  }
-
-  return Bluebird.all(tasks)
+  return Bluebird.map(configs, test => TestTask.factory({
+    garden,
+    log,
+    force,
+    forceBuild,
+    testConfig: test,
+    module,
+  }))
 }
 
 async function getTestDependencies(garden: Garden, testConfig: TestConfig) {

--- a/garden-service/src/types/plugin/params.ts
+++ b/garden-service/src/types/plugin/params.ts
@@ -25,7 +25,7 @@ export interface PluginActionContextParams {
 }
 
 export interface PluginActionParamsBase extends PluginActionContextParams {
-  logEntry?: LogEntry
+  log: LogEntry
 }
 
 // Note: not specifying this further because we will later remove it from the API
@@ -36,7 +36,7 @@ const actionParamsSchema = Joi.object()
   .keys({
     ctx: pluginContextSchema
       .required(),
-    logEntry: logEntrySchema,
+    log: logEntrySchema,
   })
 
 export interface PluginModuleActionParamsBase<T extends Module = Module> extends PluginActionParamsBase {
@@ -78,14 +78,14 @@ export const describeModuleTypeParamsSchema = Joi.object()
 
 export interface ValidateModuleParams<T extends Module = Module> {
   ctx: PluginContext
-  logEntry?: LogEntry
+  log?: LogEntry
   moduleConfig: T["_ConfigType"]
 }
 export const validateModuleParamsSchema = Joi.object()
   .keys({
     ctx: pluginContextSchema
       .required(),
-    logEntry: logEntrySchema,
+    log: logEntrySchema,
     moduleConfig: moduleConfigSchema
       .required(),
   })

--- a/garden-service/src/types/plugin/plugin.ts
+++ b/garden-service/src/types/plugin/plugin.ts
@@ -419,7 +419,7 @@ export interface GardenPlugin {
 
 export interface PluginFactoryParams<T extends Provider = any> {
   config: T["config"],
-  logEntry: LogNode,
+  log: LogNode,
   projectName: string,
 }
 

--- a/garden-service/src/types/service.ts
+++ b/garden-service/src/types/service.ts
@@ -16,6 +16,7 @@ import dedent = require("dedent")
 import { format } from "url"
 import { moduleVersionSchema } from "../vcs/base"
 import { Garden } from "../garden"
+import { LogEntry } from "../logger/log-entry"
 import normalizeUrl = require("normalize-url")
 
 export interface Service<M extends Module = Module> {
@@ -177,7 +178,7 @@ export const runtimeContextSchema = Joi.object()
   })
 
 export async function prepareRuntimeContext(
-  garden: Garden, module: Module, serviceDependencies: Service[],
+  garden: Garden, log: LogEntry, module: Module, serviceDependencies: Service[],
 ): Promise<RuntimeContext> {
   const buildDepKeys = module.build.dependencies.map(dep => getModuleKey(dep.name, dep.plugin))
   const buildDependencies: Module[] = await garden.getModules(buildDepKeys)
@@ -209,7 +210,13 @@ export async function prepareRuntimeContext(
     }
     const depContext = deps[dep.name]
 
-    const outputs = { ...await garden.actions.getServiceOutputs({ service: dep }), ...dep.config.outputs }
+    const outputs = {
+      ...await garden.actions.getServiceOutputs({
+        log,
+        service: dep,
+      }),
+      ...dep.config.outputs,
+    }
     const serviceEnvName = getEnvVarName(dep.name)
 
     validate(outputs, serviceOutputsSchema, { context: `outputs for service ${dep.name}` })

--- a/garden-service/src/vcs/base.ts
+++ b/garden-service/src/vcs/base.ts
@@ -75,7 +75,7 @@ export interface RemoteSourceParams {
   url: string,
   name: string,
   sourceType: ExternalSourceType,
-  logEntry: LogNode,
+  log: LogNode,
 }
 
 export abstract class VcsHandler {

--- a/garden-service/src/vcs/git.ts
+++ b/garden-service/src/vcs/git.ts
@@ -107,7 +107,7 @@ export class GitHandler extends VcsHandler {
   }
 
   // TODO Better auth handling
-  async ensureRemoteSource({ url, name, logEntry, sourceType }: RemoteSourceParams): Promise<string> {
+  async ensureRemoteSource({ url, name, log, sourceType }: RemoteSourceParams): Promise<string> {
     const remoteSourcesPath = join(this.projectRoot, this.getRemoteSourcesDirname(sourceType))
     await ensureDir(remoteSourcesPath)
     const git = helpers.gitCli(remoteSourcesPath)
@@ -116,7 +116,7 @@ export class GitHandler extends VcsHandler {
     const isCloned = await pathExists(absPath)
 
     if (!isCloned) {
-      const entry = logEntry.info({ section: name, msg: `Fetching from ${url}`, status: "active" })
+      const entry = log.info({ section: name, msg: `Fetching from ${url}`, status: "active" })
       const { repositoryUrl, hash } = parseGitUrl(url)
 
       try {
@@ -135,14 +135,14 @@ export class GitHandler extends VcsHandler {
     return absPath
   }
 
-  async updateRemoteSource({ url, name, sourceType, logEntry }: RemoteSourceParams) {
+  async updateRemoteSource({ url, name, sourceType, log }: RemoteSourceParams) {
     const absPath = join(this.projectRoot, this.getRemoteSourcePath(name, url, sourceType))
     const git = helpers.gitCli(absPath)
     const { repositoryUrl, hash } = parseGitUrl(url)
 
-    await this.ensureRemoteSource({ url, name, sourceType, logEntry })
+    await this.ensureRemoteSource({ url, name, sourceType, log })
 
-    const entry = logEntry.info({ section: name, msg: "Getting remote state", status: "active" })
+    const entry = log.info({ section: name, msg: "Getting remote state", status: "active" })
     await git("remote", ["update"])
 
     const remoteCommitId = getCommitIdFromRefList(await git("ls-remote", [repositoryUrl, hash]))

--- a/garden-service/test/helpers.ts
+++ b/garden-service/test/helpers.ts
@@ -150,10 +150,11 @@ export const testPlugin: PluginFactory = (): GardenPlugin => {
         async deployService() { return {} },
 
         async runService(
-          { ctx, service, interactive, runtimeContext, timeout, buildDependencies }: RunServiceParams,
+          { ctx, service, interactive, runtimeContext, timeout, log, buildDependencies }: RunServiceParams,
         ) {
           return runModule({
             ctx,
+            log,
             module: service.module,
             command: [service.name],
             interactive,

--- a/garden-service/test/helpers.ts
+++ b/garden-service/test/helpers.ts
@@ -165,13 +165,13 @@ export const testPlugin: PluginFactory = (): GardenPlugin => {
         },
 
         async runTask(
-          { ctx, task, interactive, runtimeContext, logEntry, buildDependencies }: RunTaskParams,
+          { ctx, task, interactive, runtimeContext, log, buildDependencies }: RunTaskParams,
         ) {
           const result = await runModule({
             ctx,
             buildDependencies,
             interactive,
-            logEntry,
+            log,
             runtimeContext,
             module: task.module,
             command: task.spec.command || [],

--- a/garden-service/test/src/actions.ts
+++ b/garden-service/test/src/actions.ts
@@ -52,7 +52,7 @@ describe("ActionHelper", () => {
   before(async () => {
     const plugins = { "test-plugin": testPlugin, "test-plugin-b": testPluginB }
     garden = await makeTestGardenA(plugins)
-    log = garden.log.info()
+    log = garden.log
     actions = garden.actions
     module = await garden.getModule("module-a")
     service = await garden.getService("service-a")
@@ -323,6 +323,7 @@ describe("ActionHelper", () => {
   describe("runTask", () => {
     it("should correctly call the corresponding plugin handler", async () => {
       const result = await actions.runTask({
+        log,
         task,
         interactive: true,
         runtimeContext: {

--- a/garden-service/test/src/actions.ts
+++ b/garden-service/test/src/actions.ts
@@ -10,6 +10,7 @@ import { Service } from "../../src/types/service"
 import { Task } from "../../src/types/task"
 import Stream from "ts-stream"
 import { ServiceLogEntry } from "../../src/types/plugin/outputs"
+import { LogEntry } from "../../src/logger/log-entry"
 import {
   describeModuleTypeParamsSchema,
   validateModuleParamsSchema,
@@ -42,6 +43,7 @@ const now = new Date()
 
 describe("ActionHelper", () => {
   let garden: Garden
+  let log: LogEntry
   let actions: ActionHelper
   let module: Module
   let service: Service
@@ -50,6 +52,7 @@ describe("ActionHelper", () => {
   before(async () => {
     const plugins = { "test-plugin": testPlugin, "test-plugin-b": testPluginB }
     garden = await makeTestGardenA(plugins)
+    log = garden.log.info()
     actions = garden.actions
     module = await garden.getModule("module-a")
     service = await garden.getService("service-a")
@@ -60,7 +63,7 @@ describe("ActionHelper", () => {
   describe("environment actions", () => {
     describe("getEnvironmentStatus", () => {
       it("should return a map of statuses for providers that have a getEnvironmentStatus handler", async () => {
-        const result = await actions.getEnvironmentStatus({})
+        const result = await actions.getEnvironmentStatus({ log })
         expect(result).to.eql({
           "test-plugin": { ready: false },
           "test-plugin-b": { ready: false },
@@ -68,7 +71,7 @@ describe("ActionHelper", () => {
       })
 
       it("should optionally filter to single plugin", async () => {
-        const result = await actions.getEnvironmentStatus({ pluginName: "test-plugin" })
+        const result = await actions.getEnvironmentStatus({ log, pluginName: "test-plugin" })
         expect(result).to.eql({
           "test-plugin": { ready: false },
         })
@@ -77,7 +80,7 @@ describe("ActionHelper", () => {
 
     describe("prepareEnvironment", () => {
       it("should prepare the environment for each configured provider", async () => {
-        const result = await actions.prepareEnvironment({})
+        const result = await actions.prepareEnvironment({ log })
         expect(result).to.eql({
           "test-plugin": true,
           "test-plugin-b": true,
@@ -85,7 +88,7 @@ describe("ActionHelper", () => {
       })
 
       it("should optionally filter to single plugin", async () => {
-        const result = await actions.prepareEnvironment({ pluginName: "test-plugin" })
+        const result = await actions.prepareEnvironment({ log, pluginName: "test-plugin" })
         expect(result).to.eql({
           "test-plugin": true,
         })
@@ -94,7 +97,7 @@ describe("ActionHelper", () => {
 
     describe("cleanupEnvironment", () => {
       it("should clean up environment for each configured provider", async () => {
-        const result = await actions.cleanupEnvironment({})
+        const result = await actions.cleanupEnvironment({ log })
         expect(result).to.eql({
           "test-plugin": { ready: false },
           "test-plugin-b": { ready: false },
@@ -102,7 +105,7 @@ describe("ActionHelper", () => {
       })
 
       it("should optionally filter to single plugin", async () => {
-        const result = await actions.cleanupEnvironment({ pluginName: "test-plugin" })
+        const result = await actions.cleanupEnvironment({ log, pluginName: "test-plugin" })
         expect(result).to.eql({
           "test-plugin": { ready: false },
         })
@@ -111,21 +114,21 @@ describe("ActionHelper", () => {
 
     describe("getSecret", () => {
       it("should retrieve a secret from the specified provider", async () => {
-        const result = await actions.getSecret({ pluginName: "test-plugin", key: "foo" })
+        const result = await actions.getSecret({ log, pluginName: "test-plugin", key: "foo" })
         expect(result).to.eql({ value: "foo" })
       })
     })
 
     describe("setSecret", () => {
       it("should set a secret via the specified provider", async () => {
-        const result = await actions.setSecret({ pluginName: "test-plugin", key: "foo", value: "boo" })
+        const result = await actions.setSecret({ log, pluginName: "test-plugin", key: "foo", value: "boo" })
         expect(result).to.eql({})
       })
     })
 
     describe("deleteSecret", () => {
       it("should delete a secret from the specified provider", async () => {
-        const result = await actions.deleteSecret({ pluginName: "test-plugin", key: "foo" })
+        const result = await actions.deleteSecret({ log, pluginName: "test-plugin", key: "foo" })
         expect(result).to.eql({ found: true })
       })
     })
@@ -134,7 +137,7 @@ describe("ActionHelper", () => {
   describe("module actions", () => {
     describe("getBuildStatus", () => {
       it("should correctly call the corresponding plugin handler", async () => {
-        const result = await actions.getBuildStatus({ module })
+        const result = await actions.getBuildStatus({ log, module })
         expect(result).to.eql({
           ready: true,
         })
@@ -143,14 +146,14 @@ describe("ActionHelper", () => {
 
     describe("build", () => {
       it("should correctly call the corresponding plugin handler", async () => {
-        const result = await actions.build({ module })
+        const result = await actions.build({ log, module })
         expect(result).to.eql({})
       })
     })
 
     describe("pushModule", () => {
       it("should correctly call the corresponding plugin handler", async () => {
-        const result = await actions.pushModule({ module })
+        const result = await actions.pushModule({ log, module })
         expect(result).to.eql({
           pushed: true,
         })
@@ -160,6 +163,7 @@ describe("ActionHelper", () => {
     describe("hotReload", () => {
       it("should correctly call the corresponding plugin handler", async () => {
         const result = await actions.hotReload({
+          log,
           module,
           runtimeContext: {
             envVars: { FOO: "bar" },
@@ -174,6 +178,7 @@ describe("ActionHelper", () => {
       it("should correctly call the corresponding plugin handler", async () => {
         const command = ["npm", "run"]
         const result = await actions.runModule({
+          log,
           module,
           command,
           interactive: true,
@@ -197,6 +202,7 @@ describe("ActionHelper", () => {
     describe("testModule", () => {
       it("should correctly call the corresponding plugin handler", async () => {
         const result = await actions.testModule({
+          log,
           module,
           interactive: true,
           runtimeContext: {
@@ -227,6 +233,7 @@ describe("ActionHelper", () => {
     describe("getTestResult", () => {
       it("should correctly call the corresponding plugin handler", async () => {
         const result = await actions.getTestResult({
+          log,
           module,
           testName: "test",
           version: module.version,
@@ -248,35 +255,35 @@ describe("ActionHelper", () => {
   describe("service actions", () => {
     describe("getServiceStatus", () => {
       it("should correctly call the corresponding plugin handler", async () => {
-        const result = await actions.getServiceStatus({ service })
+        const result = await actions.getServiceStatus({ log, service })
         expect(result).to.eql({ state: "ready" })
       })
     })
 
     describe("deployService", () => {
       it("should correctly call the corresponding plugin handler", async () => {
-        const result = await actions.deployService({ service, force: true })
+        const result = await actions.deployService({ log, service, force: true })
         expect(result).to.eql({ state: "ready" })
       })
     })
 
     describe("deleteService", () => {
       it("should correctly call the corresponding plugin handler", async () => {
-        const result = await actions.deleteService({ service })
+        const result = await actions.deleteService({ log, service })
         expect(result).to.eql({ state: "ready" })
       })
     })
 
     describe("getServiceOutputs", () => {
       it("should correctly call the corresponding plugin handler", async () => {
-        const result = await actions.getServiceOutputs({ service })
+        const result = await actions.getServiceOutputs({ log, service })
         expect(result).to.eql({ foo: "bar" })
       })
     })
 
     describe("execInService", () => {
       it("should correctly call the corresponding plugin handler", async () => {
-        const result = await actions.execInService({ service, command: ["foo"], interactive: false })
+        const result = await actions.execInService({ log, service, command: ["foo"], interactive: false })
         expect(result).to.eql({ code: 0, output: "bla bla" })
       })
     })
@@ -284,7 +291,7 @@ describe("ActionHelper", () => {
     describe("getServiceLogs", () => {
       it("should correctly call the corresponding plugin handler", async () => {
         const stream = new Stream<ServiceLogEntry>()
-        const result = await actions.getServiceLogs({ service, stream, tail: false })
+        const result = await actions.getServiceLogs({ log, service, stream, tail: false })
         expect(result).to.eql({})
       })
     })
@@ -292,6 +299,7 @@ describe("ActionHelper", () => {
     describe("runService", () => {
       it("should correctly call the corresponding plugin handler", async () => {
         const result = await actions.runService({
+          log,
           service,
           interactive: true,
           runtimeContext: {

--- a/garden-service/test/src/build-dir.ts
+++ b/garden-service/test/src/build-dir.ts
@@ -63,7 +63,7 @@ describe("BuildDir", () => {
 
   it("should sync dependency products to their specified destinations", async () => {
     const garden = await makeGarden()
-    const log = garden.log.info()
+    const log = garden.log
 
     try {
       await garden.clearBuilds()

--- a/garden-service/test/src/build-dir.ts
+++ b/garden-service/test/src/build-dir.ts
@@ -63,6 +63,8 @@ describe("BuildDir", () => {
 
   it("should sync dependency products to their specified destinations", async () => {
     const garden = await makeGarden()
+    const log = garden.log.info()
+
     try {
       await garden.clearBuilds()
       const modules = await garden.getModules()
@@ -70,6 +72,7 @@ describe("BuildDir", () => {
       await Bluebird.map(modules, async (module) => {
         return garden.addTask(new BuildTask({
           garden,
+          log,
           module,
           force: true,
         }))

--- a/garden-service/test/src/commands/build.ts
+++ b/garden-service/test/src/commands/build.ts
@@ -6,7 +6,7 @@ import { taskResultOutputs } from "../../helpers"
 describe("commands.build", () => {
   it("should build all modules in a project", async () => {
     const garden = await makeTestGardenA()
-    const log = garden.log.info()
+    const log = garden.log
     const command = new BuildCommand()
 
     const { result } = await command.action({
@@ -25,7 +25,7 @@ describe("commands.build", () => {
 
   it("should optionally build single module and its dependencies", async () => {
     const garden = await makeTestGardenA()
-    const log = garden.log.info()
+    const log = garden.log
     const command = new BuildCommand()
 
     const { result } = await command.action({

--- a/garden-service/test/src/commands/build.ts
+++ b/garden-service/test/src/commands/build.ts
@@ -6,10 +6,12 @@ import { taskResultOutputs } from "../../helpers"
 describe("commands.build", () => {
   it("should build all modules in a project", async () => {
     const garden = await makeTestGardenA()
+    const log = garden.log.info()
     const command = new BuildCommand()
 
     const { result } = await command.action({
       garden,
+      log,
       args: { module: undefined },
       opts: { watch: false, force: true },
     })
@@ -23,10 +25,12 @@ describe("commands.build", () => {
 
   it("should optionally build single module and its dependencies", async () => {
     const garden = await makeTestGardenA()
+    const log = garden.log.info()
     const command = new BuildCommand()
 
     const { result } = await command.action({
       garden,
+      log,
       args: { module: ["module-b"] },
       opts: { watch: false, force: true },
     })

--- a/garden-service/test/src/commands/call.ts
+++ b/garden-service/test/src/commands/call.ts
@@ -59,7 +59,7 @@ describe("commands.call", () => {
 
   it("should find the ingress for a service and call it with the specified path", async () => {
     const garden = await Garden.factory(projectRootB, { plugins })
-    const log = garden.log.info()
+    const log = garden.log
     const command = new CallCommand()
 
     nock("http://service-a.test-project-b.local.app.garden:32000")
@@ -83,7 +83,7 @@ describe("commands.call", () => {
 
   it("should default to the path '/' if that is exposed if no path is requested", async () => {
     const garden = await Garden.factory(projectRootB, { plugins })
-    const log = garden.log.info()
+    const log = garden.log
     const command = new CallCommand()
 
     nock("http://service-a.test-project-b.local.app.garden:32000")
@@ -106,7 +106,7 @@ describe("commands.call", () => {
 
   it("should otherwise use the first defined ingress if no path is requested", async () => {
     const garden = await Garden.factory(projectRootB, { plugins })
-    const log = garden.log.info()
+    const log = garden.log
     const command = new CallCommand()
 
     nock("http://service-b.test-project-b.local.app.garden:32000")
@@ -129,7 +129,7 @@ describe("commands.call", () => {
 
   it("should error if service isn't running", async () => {
     const garden = await Garden.factory(projectRootB, { plugins })
-    const log = garden.log.info()
+    const log = garden.log
     const command = new CallCommand()
 
     try {
@@ -149,7 +149,7 @@ describe("commands.call", () => {
 
   it("should error if service has no ingresses", async () => {
     const garden = await Garden.factory(projectRootB, { plugins })
-    const log = garden.log.info()
+    const log = garden.log
     const command = new CallCommand()
 
     try {
@@ -169,7 +169,7 @@ describe("commands.call", () => {
 
   it("should error if service has no matching ingresses", async () => {
     const garden = await Garden.factory(projectRootB, { plugins })
-    const log = garden.log.info()
+    const log = garden.log
     const command = new CallCommand()
 
     try {

--- a/garden-service/test/src/commands/call.ts
+++ b/garden-service/test/src/commands/call.ts
@@ -59,13 +59,19 @@ describe("commands.call", () => {
 
   it("should find the ingress for a service and call it with the specified path", async () => {
     const garden = await Garden.factory(projectRootB, { plugins })
+    const log = garden.log.info()
     const command = new CallCommand()
 
     nock("http://service-a.test-project-b.local.app.garden:32000")
       .get("/path-a")
       .reply(200, "bla")
 
-    const { result } = await command.action({ garden, args: { serviceAndPath: "service-a/path-a" }, opts: {} })
+    const { result } = await command.action({
+      garden,
+      log,
+      args: { serviceAndPath: "service-a/path-a" },
+      opts: {},
+    })
 
     expect(result.url).to.equal("http://service-a.test-project-b.local.app.garden:32000/path-a")
     expect(result.serviceName).to.equal("service-a")
@@ -77,13 +83,19 @@ describe("commands.call", () => {
 
   it("should default to the path '/' if that is exposed if no path is requested", async () => {
     const garden = await Garden.factory(projectRootB, { plugins })
+    const log = garden.log.info()
     const command = new CallCommand()
 
     nock("http://service-a.test-project-b.local.app.garden:32000")
       .get("/path-a")
       .reply(200, "bla")
 
-    const { result } = await command.action({ garden, args: { serviceAndPath: "service-a" }, opts: {} })
+    const { result } = await command.action({
+      garden,
+      log,
+      args: { serviceAndPath: "service-a" },
+      opts: {},
+    })
 
     expect(result.url).to.equal("http://service-a.test-project-b.local.app.garden:32000/path-a")
     expect(result.serviceName).to.equal("service-a")
@@ -94,13 +106,19 @@ describe("commands.call", () => {
 
   it("should otherwise use the first defined ingress if no path is requested", async () => {
     const garden = await Garden.factory(projectRootB, { plugins })
+    const log = garden.log.info()
     const command = new CallCommand()
 
     nock("http://service-b.test-project-b.local.app.garden:32000")
       .get("/")
       .reply(200, "bla")
 
-    const { result } = await command.action({ garden, args: { serviceAndPath: "service-b" }, opts: {} })
+    const { result } = await command.action({
+      garden,
+      log,
+      args: { serviceAndPath: "service-b" },
+      opts: {},
+    })
 
     expect(result.url).to.equal("http://service-b.test-project-b.local.app.garden:32000/")
     expect(result.serviceName).to.equal("service-b")
@@ -111,10 +129,16 @@ describe("commands.call", () => {
 
   it("should error if service isn't running", async () => {
     const garden = await Garden.factory(projectRootB, { plugins })
+    const log = garden.log.info()
     const command = new CallCommand()
 
     try {
-      await command.action({ garden, args: { serviceAndPath: "service-d/path-d" }, opts: {} })
+      await command.action({
+        garden,
+        log,
+        args: { serviceAndPath: "service-d/path-d" },
+        opts: {},
+      })
     } catch (err) {
       expect(err.type).to.equal("runtime")
       return
@@ -125,10 +149,16 @@ describe("commands.call", () => {
 
   it("should error if service has no ingresses", async () => {
     const garden = await Garden.factory(projectRootB, { plugins })
+    const log = garden.log.info()
     const command = new CallCommand()
 
     try {
-      await command.action({ garden, args: { serviceAndPath: "service-c/path-c" }, opts: {} })
+      await command.action({
+        garden,
+        log,
+        args: { serviceAndPath: "service-c/path-c" },
+        opts: {},
+      })
     } catch (err) {
       expect(err.type).to.equal("parameter")
       return
@@ -139,10 +169,16 @@ describe("commands.call", () => {
 
   it("should error if service has no matching ingresses", async () => {
     const garden = await Garden.factory(projectRootB, { plugins })
+    const log = garden.log.info()
     const command = new CallCommand()
 
     try {
-      await command.action({ garden, args: { serviceAndPath: "service-a/bla" }, opts: {} })
+      await command.action({
+        garden,
+        log,
+        args: { serviceAndPath: "service-a/bla" },
+        opts: {},
+      })
     } catch (err) {
       expect(err.type).to.equal("parameter")
       return

--- a/garden-service/test/src/commands/create/module.ts
+++ b/garden-service/test/src/commands/create/module.ts
@@ -35,7 +35,7 @@ describe("CreateModuleCommand", () => {
   it("should add a module config to the current directory", async () => {
     replaceAddConfigForModule()
     const garden = await makeTestGarden(projectRoot)
-    const log = garden.log.info()
+    const log = garden.log
 
     const { result } = await cmd.action({
       garden,
@@ -54,7 +54,7 @@ describe("CreateModuleCommand", () => {
   it("should add a module config to new-module directory", async () => {
     replaceAddConfigForModule()
     const garden = await makeTestGarden(projectRoot)
-    const log = garden.log.info()
+    const log = garden.log
 
     const { result } = await cmd.action({
       garden,
@@ -72,7 +72,7 @@ describe("CreateModuleCommand", () => {
   it("should optionally name the module my-module", async () => {
     replaceAddConfigForModule()
     const garden = await makeTestGarden(projectRoot)
-    const log = garden.log.info()
+    const log = garden.log
 
     const { result } = await cmd.action({
       garden,
@@ -89,7 +89,7 @@ describe("CreateModuleCommand", () => {
   // garden create module --type=google-cloud-function
   it("should optionally create a module of a specific type (without prompting)", async () => {
     const garden = await makeTestGarden(projectRoot)
-    const log = garden.log.info()
+    const log = garden.log
 
     const { result } = await cmd.action({
       garden,
@@ -107,7 +107,7 @@ describe("CreateModuleCommand", () => {
   it("should throw if module name is invalid when inherited from current directory", async () => {
     replaceAddConfigForModule()
     const garden = await makeTestGarden(projectRoot)
-    const log = garden.log.info()
+    const log = garden.log
 
     await expectError(
       async () => await cmd.action({
@@ -123,7 +123,7 @@ describe("CreateModuleCommand", () => {
   it("should throw if module name is invalid when explicitly specified", async () => {
     replaceAddConfigForModule()
     const garden = await makeTestGarden(projectRoot)
-    const log = garden.log.info()
+    const log = garden.log
 
     await expectError(
       async () => await cmd.action({
@@ -139,7 +139,7 @@ describe("CreateModuleCommand", () => {
   it("should throw if invalid type provided", async () => {
     replaceAddConfigForModule()
     const garden = await makeTestGarden(projectRoot)
-    const log = garden.log.info()
+    const log = garden.log
 
     await expectError(
       async () => await cmd.action({

--- a/garden-service/test/src/commands/create/module.ts
+++ b/garden-service/test/src/commands/create/module.ts
@@ -35,7 +35,15 @@ describe("CreateModuleCommand", () => {
   it("should add a module config to the current directory", async () => {
     replaceAddConfigForModule()
     const garden = await makeTestGarden(projectRoot)
-    const { result } = await cmd.action({ garden, args: { "module-dir": "" }, opts: { name: "", type: "" } })
+    const log = garden.log.info()
+
+    const { result } = await cmd.action({
+      garden,
+      log,
+      args: { "module-dir": "" },
+      opts: { name: "", type: "" },
+    })
+
     expect(pick(result.module, ["name", "type", "path"])).to.eql({
       name: "test-project-create-command",
       type: "container",
@@ -46,8 +54,11 @@ describe("CreateModuleCommand", () => {
   it("should add a module config to new-module directory", async () => {
     replaceAddConfigForModule()
     const garden = await makeTestGarden(projectRoot)
+    const log = garden.log.info()
+
     const { result } = await cmd.action({
       garden,
+      log,
       args: { "module-dir": "new-module" },
       opts: { name: "", type: "" },
     })
@@ -61,8 +72,11 @@ describe("CreateModuleCommand", () => {
   it("should optionally name the module my-module", async () => {
     replaceAddConfigForModule()
     const garden = await makeTestGarden(projectRoot)
+    const log = garden.log.info()
+
     const { result } = await cmd.action({
       garden,
+      log,
       args: { "module-dir": "" },
       opts: { name: "my-module", type: "" },
     })
@@ -75,8 +89,11 @@ describe("CreateModuleCommand", () => {
   // garden create module --type=google-cloud-function
   it("should optionally create a module of a specific type (without prompting)", async () => {
     const garden = await makeTestGarden(projectRoot)
+    const log = garden.log.info()
+
     const { result } = await cmd.action({
       garden,
+      log,
       args: { "module-dir": "" },
       opts: { name: "", type: "google-cloud-function" },
     })
@@ -90,8 +107,15 @@ describe("CreateModuleCommand", () => {
   it("should throw if module name is invalid when inherited from current directory", async () => {
     replaceAddConfigForModule()
     const garden = await makeTestGarden(projectRoot)
+    const log = garden.log.info()
+
     await expectError(
-      async () => await cmd.action({ garden, args: { "module-dir": "___" }, opts: { name: "", type: "" } }),
+      async () => await cmd.action({
+        garden,
+        log,
+        args: { "module-dir": "___" },
+        opts: { name: "", type: "" },
+      }),
       "configuration",
     )
   })
@@ -99,8 +123,15 @@ describe("CreateModuleCommand", () => {
   it("should throw if module name is invalid when explicitly specified", async () => {
     replaceAddConfigForModule()
     const garden = await makeTestGarden(projectRoot)
+    const log = garden.log.info()
+
     await expectError(
-      async () => await cmd.action({ garden, args: { "module-dir": "" }, opts: { name: "___", type: "" } }),
+      async () => await cmd.action({
+        garden,
+        log,
+        args: { "module-dir": "" },
+        opts: { name: "___", type: "" },
+      }),
       "configuration",
     )
   })
@@ -108,8 +139,15 @@ describe("CreateModuleCommand", () => {
   it("should throw if invalid type provided", async () => {
     replaceAddConfigForModule()
     const garden = await makeTestGarden(projectRoot)
+    const log = garden.log.info()
+
     await expectError(
-      async () => await cmd.action({ garden, args: { "module-dir": "" }, opts: { name: "", type: "banana" } }),
+      async () => await cmd.action({
+        garden,
+        log,
+        args: { "module-dir": "" },
+        opts: { name: "", type: "banana" },
+      }),
       "parameter",
     )
   })

--- a/garden-service/test/src/commands/create/project.ts
+++ b/garden-service/test/src/commands/create/project.ts
@@ -48,7 +48,7 @@ describe("CreateProjectCommand", () => {
 
   beforeEach(async () => {
     garden = await makeTestGarden(projectRoot)
-    log = garden.log.info()
+    log = garden.log
   })
 
   afterEach(async () => {

--- a/garden-service/test/src/commands/create/project.ts
+++ b/garden-service/test/src/commands/create/project.ts
@@ -6,6 +6,8 @@ import { join } from "path"
 import * as td from "testdouble"
 
 import { CreateProjectCommand } from "../../../../src/commands/create/project"
+import { LogEntry } from "../../../../src/logger/log-entry"
+import { Garden } from "../../../../src/garden"
 import {
   prompts,
   ModuleTypeAndName,
@@ -41,6 +43,14 @@ describe("CreateProjectCommand", () => {
   const projectRoot = join(__dirname, "../../..", "data", "test-project-create-command")
   const cmd = new CreateProjectCommand()
 
+  let garden: Garden
+  let log: LogEntry
+
+  beforeEach(async () => {
+    garden = await makeTestGarden(projectRoot)
+    log = garden.log.info()
+  })
+
   afterEach(async () => {
     await remove(join(projectRoot, "new-project"))
   })
@@ -48,9 +58,9 @@ describe("CreateProjectCommand", () => {
   // garden create project
   it("should create a project in the current directory", async () => {
     replaceRepeatAddModule()
-    const garden = await makeTestGarden(projectRoot)
     const { result } = await cmd.action({
       garden,
+      log,
       args: { "project-dir": "" },
       opts: { "name": "", "module-dirs": [] },
     })
@@ -71,9 +81,9 @@ describe("CreateProjectCommand", () => {
   // garden create project new-project
   it("should create a project in directory new-project", async () => {
     replaceRepeatAddModule()
-    const garden = await makeTestGarden(projectRoot)
     const { result } = await cmd.action({
       garden,
+      log,
       args: { "project-dir": "new-project" },
       opts: { "name": "", "module-dirs": [] },
     })
@@ -85,9 +95,9 @@ describe("CreateProjectCommand", () => {
   // garden create project --name=my-project
   it("should optionally create a project named my-project", async () => {
     replaceRepeatAddModule()
-    const garden = await makeTestGarden(projectRoot)
     const { result } = await cmd.action({
       garden,
+      log,
       args: { "project-dir": "" },
       opts: { "name": "my-project", "module-dirs": [] },
     })
@@ -99,9 +109,9 @@ describe("CreateProjectCommand", () => {
   // garden create project --module-dirs=.
   it("should optionally create module configs for modules in current directory", async () => {
     replaceAddConfigForModule()
-    const garden = await makeTestGarden(projectRoot)
     const { result } = await cmd.action({
       garden,
+      log,
       args: { "project-dir": "" },
       opts: { "name": "", "module-dirs": ["."] },
     })
@@ -113,9 +123,9 @@ describe("CreateProjectCommand", () => {
   // garden create project --module-dirs=module-a,module-b
   it("should optionally create module configs for modules in specified directories", async () => {
     replaceAddConfigForModule()
-    const garden = await makeTestGarden(projectRoot)
     const { result } = await cmd.action({
       garden,
+      log,
       args: { "project-dir": "" },
       opts: { "name": "", "module-dirs": ["module-a", "module-b"] },
     })
@@ -127,10 +137,10 @@ describe("CreateProjectCommand", () => {
   // garden create project ___
   it("should throw if project name is invalid when inherited from current directory", async () => {
     replaceRepeatAddModule()
-    const garden = await makeTestGarden(projectRoot)
     await expectError(
       async () => await cmd.action({
         garden,
+        log,
         args: { "project-dir": "___" },
         opts: { "name": "", "module-dirs": [] },
       }),
@@ -140,10 +150,10 @@ describe("CreateProjectCommand", () => {
   // garden create project --name=____
   it("should throw if project name is invalid when explicitly specified", async () => {
     replaceRepeatAddModule()
-    const garden = await makeTestGarden(projectRoot)
     await expectError(
       async () => await cmd.action({
         garden,
+        log,
         args: { "project-dir": "" },
         opts: { "name": "___", "module-dirs": [] },
       }),

--- a/garden-service/test/src/commands/delete.ts
+++ b/garden-service/test/src/commands/delete.ts
@@ -17,24 +17,26 @@ describe("DeleteSecretCommand", () => {
 
   it("should delete a secret", async () => {
     const garden = await makeTestGardenA()
+    const log = garden.log.info()
     const command = new DeleteSecretCommand()
 
     const key = "mykey"
     const value = "myvalue"
 
-    await garden.actions.setSecret({ key, value, pluginName })
+    await garden.actions.setSecret({ log, key, value, pluginName })
 
-    await command.action({ garden, args: { provider, key }, opts: {} })
+    await command.action({ garden, log, args: { provider, key }, opts: {} })
 
-    expect(await garden.actions.getSecret({ pluginName, key })).to.eql({ value: null })
+    expect(await garden.actions.getSecret({ log, pluginName, key })).to.eql({ value: null })
   })
 
   it("should throw on missing key", async () => {
     const garden = await makeTestGardenA()
+    const log = garden.log.info()
     const command = new DeleteSecretCommand()
 
     await expectError(
-      async () => await command.action({ garden, args: { provider, key: "foo" }, opts: {} }),
+      async () => await command.action({ garden, log, args: { provider, key: "foo" }, opts: {} }),
       "not-found",
     )
   })
@@ -69,8 +71,9 @@ describe("DeleteEnvironmentCommand", () => {
 
   it("should destroy environment", async () => {
     const garden = await Garden.factory(projectRootB, { plugins })
+    const log = garden.log.info()
 
-    const { result } = await command.action({ garden, args: {}, opts: {} })
+    const { result } = await command.action({ garden, log, args: {}, opts: {} })
 
     expect(result!["test-plugin"]["ready"]).to.be.false
   })
@@ -109,8 +112,9 @@ describe("DeleteServiceCommand", () => {
 
   it("should return the status of the deleted service", async () => {
     const garden = await Garden.factory(projectRootB, { plugins })
+    const log = garden.log.info()
 
-    const { result } = await command.action({ garden, args: { service: ["service-a"] }, opts: {} })
+    const { result } = await command.action({ garden, log, args: { service: ["service-a"] }, opts: {} })
     expect(result).to.eql({
       "service-a": { state: "unknown", ingresses: [] },
     })
@@ -118,8 +122,14 @@ describe("DeleteServiceCommand", () => {
 
   it("should return the status of the deleted services", async () => {
     const garden = await Garden.factory(projectRootB, { plugins })
+    const log = garden.log.info()
 
-    const { result } = await command.action({ garden, args: { service: ["service-a", "service-b"] }, opts: {} })
+    const { result } = await command.action({
+      garden,
+      log,
+      args: { service: ["service-a", "service-b"] },
+      opts: {},
+    })
     expect(result).to.eql({
       "service-a": { state: "unknown", ingresses: [] },
       "service-b": { state: "unknown", ingresses: [] },

--- a/garden-service/test/src/commands/delete.ts
+++ b/garden-service/test/src/commands/delete.ts
@@ -17,7 +17,7 @@ describe("DeleteSecretCommand", () => {
 
   it("should delete a secret", async () => {
     const garden = await makeTestGardenA()
-    const log = garden.log.info()
+    const log = garden.log
     const command = new DeleteSecretCommand()
 
     const key = "mykey"
@@ -32,7 +32,7 @@ describe("DeleteSecretCommand", () => {
 
   it("should throw on missing key", async () => {
     const garden = await makeTestGardenA()
-    const log = garden.log.info()
+    const log = garden.log
     const command = new DeleteSecretCommand()
 
     await expectError(
@@ -71,7 +71,7 @@ describe("DeleteEnvironmentCommand", () => {
 
   it("should destroy environment", async () => {
     const garden = await Garden.factory(projectRootB, { plugins })
-    const log = garden.log.info()
+    const log = garden.log
 
     const { result } = await command.action({ garden, log, args: {}, opts: {} })
 
@@ -112,7 +112,7 @@ describe("DeleteServiceCommand", () => {
 
   it("should return the status of the deleted service", async () => {
     const garden = await Garden.factory(projectRootB, { plugins })
-    const log = garden.log.info()
+    const log = garden.log
 
     const { result } = await command.action({ garden, log, args: { service: ["service-a"] }, opts: {} })
     expect(result).to.eql({
@@ -122,7 +122,7 @@ describe("DeleteServiceCommand", () => {
 
   it("should return the status of the deleted services", async () => {
     const garden = await Garden.factory(projectRootB, { plugins })
-    const log = garden.log.info()
+    const log = garden.log
 
     const { result } = await command.action({
       garden,

--- a/garden-service/test/src/commands/deploy.ts
+++ b/garden-service/test/src/commands/deploy.ts
@@ -93,10 +93,12 @@ describe("DeployCommand", () => {
 
   it("should build and deploy all modules in a project", async () => {
     const garden = await Garden.factory(projectRootB, { plugins })
+    const log = garden.log.info()
     const command = new DeployCommand()
 
     const { result } = await command.action({
       garden,
+      log,
       args: {
         service: undefined,
       },
@@ -126,10 +128,12 @@ describe("DeployCommand", () => {
 
   it("should optionally build and deploy single service and its dependencies", async () => {
     const garden = await Garden.factory(projectRootB, { plugins })
+    const log = garden.log.info()
     const command = new DeployCommand()
 
     const { result } = await command.action({
       garden,
+      log,
       args: {
         service: ["service-b"],
       },

--- a/garden-service/test/src/commands/deploy.ts
+++ b/garden-service/test/src/commands/deploy.ts
@@ -93,7 +93,7 @@ describe("DeployCommand", () => {
 
   it("should build and deploy all modules in a project", async () => {
     const garden = await Garden.factory(projectRootB, { plugins })
-    const log = garden.log.info()
+    const log = garden.log
     const command = new DeployCommand()
 
     const { result } = await command.action({
@@ -128,7 +128,7 @@ describe("DeployCommand", () => {
 
   it("should optionally build and deploy single service and its dependencies", async () => {
     const garden = await Garden.factory(projectRootB, { plugins })
-    const log = garden.log.info()
+    const log = garden.log
     const command = new DeployCommand()
 
     const { result } = await command.action({

--- a/garden-service/test/src/commands/get.ts
+++ b/garden-service/test/src/commands/get.ts
@@ -8,7 +8,7 @@ describe("GetSecretCommand", () => {
 
   it("should get a config variable", async () => {
     const garden = await makeTestGardenA()
-    const log = garden.log.info()
+    const log = garden.log
     const command = new GetSecretCommand()
 
     await garden.actions.setSecret({
@@ -30,7 +30,7 @@ describe("GetSecretCommand", () => {
 
   it("should throw on missing key", async () => {
     const garden = await makeTestGardenA()
-    const log = garden.log.info()
+    const log = garden.log
     const command = new GetSecretCommand()
 
     await expectError(

--- a/garden-service/test/src/commands/get.ts
+++ b/garden-service/test/src/commands/get.ts
@@ -8,21 +8,38 @@ describe("GetSecretCommand", () => {
 
   it("should get a config variable", async () => {
     const garden = await makeTestGardenA()
+    const log = garden.log.info()
     const command = new GetSecretCommand()
 
-    await garden.actions.setSecret({ pluginName, key: "project.mykey", value: "myvalue" })
+    await garden.actions.setSecret({
+      log,
+      pluginName,
+      key: "project.mykey",
+      value: "myvalue",
+    })
 
-    const res = await command.action({ garden, args: { provider, key: "project.mykey" }, opts: {} })
+    const res = await command.action({
+      garden,
+      log,
+      args: { provider, key: "project.mykey" },
+      opts: {},
+    })
 
     expect(res).to.eql({ "project.mykey": "myvalue" })
   })
 
   it("should throw on missing key", async () => {
     const garden = await makeTestGardenA()
+    const log = garden.log.info()
     const command = new GetSecretCommand()
 
     await expectError(
-      async () => await command.action({ garden, args: { provider, key: "project.mykey" }, opts: {} }),
+      async () => await command.action({
+        garden,
+        log,
+        args: { provider, key: "project.mykey" },
+        opts: {},
+      }),
       "not-found",
     )
   })

--- a/garden-service/test/src/commands/link.ts
+++ b/garden-service/test/src/commands/link.ts
@@ -23,7 +23,7 @@ describe("LinkCommand", () => {
 
     beforeEach(async () => {
       garden = await makeTestGarden(projectRoot)
-      log = garden.log.info()
+      log = garden.log
       stubExtSources(garden)
     })
 
@@ -91,7 +91,7 @@ describe("LinkCommand", () => {
 
     beforeEach(async () => {
       garden = await makeTestGarden(projectRoot)
-      log = garden.log.info()
+      log = garden.log
       stubExtSources(garden)
     })
 

--- a/garden-service/test/src/commands/link.ts
+++ b/garden-service/test/src/commands/link.ts
@@ -11,9 +11,11 @@ import {
 } from "../../helpers"
 import { LinkSourceCommand } from "../../../src/commands/link/source"
 import { Garden } from "../../../src/garden"
+import { LogEntry } from "../../../src/logger/log-entry"
 
 describe("LinkCommand", () => {
   let garden: Garden
+  let log: LogEntry
 
   describe("LinkModuleCommand", () => {
     const cmd = new LinkModuleCommand()
@@ -21,6 +23,7 @@ describe("LinkCommand", () => {
 
     beforeEach(async () => {
       garden = await makeTestGarden(projectRoot)
+      log = garden.log.info()
       stubExtSources(garden)
     })
 
@@ -31,6 +34,7 @@ describe("LinkCommand", () => {
     it("should link external modules", async () => {
       await cmd.action({
         garden,
+        log,
         args: {
           module: "module-a",
           path: join(projectRoot, "mock-local-path", "module-a"),
@@ -48,6 +52,7 @@ describe("LinkCommand", () => {
     it("should handle relative paths", async () => {
       await cmd.action({
         garden,
+        log,
         args: {
           module: "module-a",
           path: join("mock-local-path", "module-a"),
@@ -67,6 +72,7 @@ describe("LinkCommand", () => {
         async () => (
           await cmd.action({
             garden,
+            log,
             args: {
               module: "banana",
               path: "",
@@ -85,6 +91,7 @@ describe("LinkCommand", () => {
 
     beforeEach(async () => {
       garden = await makeTestGarden(projectRoot)
+      log = garden.log.info()
       stubExtSources(garden)
     })
 
@@ -95,6 +102,7 @@ describe("LinkCommand", () => {
     it("should link external sources", async () => {
       await cmd.action({
         garden,
+        log,
         args: {
           source: "source-a",
           path: join(projectRoot, "mock-local-path", "source-a"),
@@ -112,6 +120,7 @@ describe("LinkCommand", () => {
     it("should handle relative paths", async () => {
       await cmd.action({
         garden,
+        log,
         args: {
           source: "source-a",
           path: join("mock-local-path", "source-a"),

--- a/garden-service/test/src/commands/publish.ts
+++ b/garden-service/test/src/commands/publish.ts
@@ -10,6 +10,7 @@ import { PublishCommand } from "../../../src/commands/publish"
 import { makeTestGardenA } from "../../helpers"
 import { expectError, taskResultOutputs } from "../../helpers"
 import { ModuleVersion } from "../../../src/vcs/base"
+import { LogEntry } from "../../../src/logger/log-entry"
 
 const projectRootB = join(__dirname, "..", "..", "data", "test-project-b")
 
@@ -50,10 +51,12 @@ describe("PublishCommand", () => {
 
   it("should build and publish modules in a project", async () => {
     const garden = await getTestGarden()
+    const log = garden.log.info()
     const command = new PublishCommand()
 
     const { result } = await command.action({
       garden,
+      log,
       args: {
         module: undefined,
       },
@@ -74,10 +77,12 @@ describe("PublishCommand", () => {
 
   it("should optionally force new build", async () => {
     const garden = await getTestGarden()
+    const log = garden.log.info()
     const command = new PublishCommand()
 
     const { result } = await command.action({
       garden,
+      log,
       args: {
         module: undefined,
       },
@@ -98,10 +103,12 @@ describe("PublishCommand", () => {
 
   it("should optionally build selected module", async () => {
     const garden = await getTestGarden()
+    const log = garden.log.info()
     const command = new PublishCommand()
 
     const { result } = await command.action({
       garden,
+      log,
       args: {
         module: ["module-a"],
       },
@@ -119,10 +126,12 @@ describe("PublishCommand", () => {
 
   it("should respect allowPublish flag", async () => {
     const garden = await getTestGarden()
+    const log = garden.log.info()
     const command = new PublishCommand()
 
     const { result } = await command.action({
       garden,
+      log,
       args: {
         module: ["module-c"],
       },
@@ -139,12 +148,14 @@ describe("PublishCommand", () => {
 
   it("should fail gracefully if module does not have a provider for publish", async () => {
     const garden = await makeTestGardenA()
+    const log = garden.log.info()
     await garden.clearBuilds()
 
     const command = new PublishCommand()
 
     const { result } = await command.action({
       garden,
+      log,
       args: {
         module: ["module-a"],
       },
@@ -168,6 +179,7 @@ describe("PublishCommand", () => {
 
   context("module is dirty", () => {
     let garden
+    let log: LogEntry
 
     beforeEach(async () => {
       td.replace(Garden.prototype, "resolveVersion", async (): Promise<ModuleVersion> => {
@@ -178,6 +190,7 @@ describe("PublishCommand", () => {
         }
       })
       garden = await getTestGarden()
+      log = garden.log.info()
     })
 
     it("should throw if module is dirty", async () => {
@@ -185,6 +198,7 @@ describe("PublishCommand", () => {
 
       await expectError(() => command.action({
         garden,
+        log,
         args: {
           module: ["module-a"],
         },
@@ -200,6 +214,7 @@ describe("PublishCommand", () => {
 
       const { result } = await command.action({
         garden,
+        log,
         args: {
           module: ["module-a"],
         },

--- a/garden-service/test/src/commands/publish.ts
+++ b/garden-service/test/src/commands/publish.ts
@@ -51,7 +51,7 @@ describe("PublishCommand", () => {
 
   it("should build and publish modules in a project", async () => {
     const garden = await getTestGarden()
-    const log = garden.log.info()
+    const log = garden.log
     const command = new PublishCommand()
 
     const { result } = await command.action({
@@ -77,7 +77,7 @@ describe("PublishCommand", () => {
 
   it("should optionally force new build", async () => {
     const garden = await getTestGarden()
-    const log = garden.log.info()
+    const log = garden.log
     const command = new PublishCommand()
 
     const { result } = await command.action({
@@ -103,7 +103,7 @@ describe("PublishCommand", () => {
 
   it("should optionally build selected module", async () => {
     const garden = await getTestGarden()
-    const log = garden.log.info()
+    const log = garden.log
     const command = new PublishCommand()
 
     const { result } = await command.action({
@@ -126,7 +126,7 @@ describe("PublishCommand", () => {
 
   it("should respect allowPublish flag", async () => {
     const garden = await getTestGarden()
-    const log = garden.log.info()
+    const log = garden.log
     const command = new PublishCommand()
 
     const { result } = await command.action({
@@ -148,7 +148,7 @@ describe("PublishCommand", () => {
 
   it("should fail gracefully if module does not have a provider for publish", async () => {
     const garden = await makeTestGardenA()
-    const log = garden.log.info()
+    const log = garden.log
     await garden.clearBuilds()
 
     const command = new PublishCommand()
@@ -190,7 +190,7 @@ describe("PublishCommand", () => {
         }
       })
       garden = await getTestGarden()
-      log = garden.log.info()
+      log = garden.log
     })
 
     it("should throw if module is dirty", async () => {

--- a/garden-service/test/src/commands/run/module.ts
+++ b/garden-service/test/src/commands/run/module.ts
@@ -13,10 +13,12 @@ import * as td from "testdouble"
 describe("RunModuleCommand", () => {
   // TODO: test optional flags
   let garden
+  let log
 
   beforeEach(async () => {
     td.replace(Garden.prototype, "resolveVersion", async () => testModuleVersion)
     garden = await makeTestGardenA()
+    log = garden.log.info()
   })
 
   it("should run a module without a command param", async () => {
@@ -28,6 +30,7 @@ describe("RunModuleCommand", () => {
     const cmd = new RunModuleCommand()
     const { result } = await cmd.action({
       garden,
+      log,
       args: { module: "run-test", command: [] },
       opts: { "interactive": false, "force-build": false },
     })
@@ -54,6 +57,7 @@ describe("RunModuleCommand", () => {
     const cmd = new RunModuleCommand()
     const { result } = await cmd.action({
       garden,
+      log,
       args: { module: "run-test", command: ["my", "command"] },
       opts: { "interactive": false, "force-build": false },
     })

--- a/garden-service/test/src/commands/run/module.ts
+++ b/garden-service/test/src/commands/run/module.ts
@@ -18,7 +18,7 @@ describe("RunModuleCommand", () => {
   beforeEach(async () => {
     td.replace(Garden.prototype, "resolveVersion", async () => testModuleVersion)
     garden = await makeTestGardenA()
-    log = garden.log.info()
+    log = garden.log
   })
 
   it("should run a module without a command param", async () => {

--- a/garden-service/test/src/commands/run/service.ts
+++ b/garden-service/test/src/commands/run/service.ts
@@ -9,14 +9,17 @@ import {
 import { expect } from "chai"
 import { Garden } from "../../../../src/garden"
 import * as td from "testdouble"
+import { LogEntry } from "../../../../src/logger/log-entry"
 
 describe("RunServiceCommand", () => {
   // TODO: test optional flags
   let garden
+  let log: LogEntry
 
   beforeEach(async () => {
     td.replace(Garden.prototype, "resolveVersion", async () => testModuleVersion)
     garden = await makeTestGardenA()
+    log = garden.log.info()
   })
 
   it("should run a service", async () => {
@@ -28,6 +31,7 @@ describe("RunServiceCommand", () => {
     const cmd = new RunServiceCommand()
     const { result } = await cmd.action({
       garden,
+      log,
       args: { service: "test-service" },
       opts: { "force-build": false },
     })

--- a/garden-service/test/src/commands/run/service.ts
+++ b/garden-service/test/src/commands/run/service.ts
@@ -19,7 +19,7 @@ describe("RunServiceCommand", () => {
   beforeEach(async () => {
     td.replace(Garden.prototype, "resolveVersion", async () => testModuleVersion)
     garden = await makeTestGardenA()
-    log = garden.log.info()
+    log = garden.log
   })
 
   it("should run a service", async () => {

--- a/garden-service/test/src/commands/run/task.ts
+++ b/garden-service/test/src/commands/run/task.ts
@@ -7,9 +7,11 @@ describe("RunTaskCommand", () => {
 
   it("should run a task", async () => {
     const garden = await makeTestGardenA()
+    const log = garden.log
     const cmd = new RunTaskCommand()
 
     const { result } = await cmd.action({
+      log,
       garden,
       args: { task: "task-a" },
       opts: { "force-build": false },

--- a/garden-service/test/src/commands/scan.ts
+++ b/garden-service/test/src/commands/scan.ts
@@ -6,7 +6,7 @@ describe("ScanCommand", () => {
   for (const [name, path] of Object.entries(getExampleProjects())) {
     it(`should successfully scan the ${name} project`, async () => {
       const garden = await Garden.factory(path)
-      const log = garden.log.info()
+      const log = garden.log
       const command = new ScanCommand()
 
       await command.action({

--- a/garden-service/test/src/commands/scan.ts
+++ b/garden-service/test/src/commands/scan.ts
@@ -6,9 +6,15 @@ describe("ScanCommand", () => {
   for (const [name, path] of Object.entries(getExampleProjects())) {
     it(`should successfully scan the ${name} project`, async () => {
       const garden = await Garden.factory(path)
+      const log = garden.log.info()
       const command = new ScanCommand()
 
-      await command.action({ garden, args: {}, opts: {} })
+      await command.action({
+        garden,
+        log,
+        args: {},
+        opts: {},
+      })
     })
   }
 })

--- a/garden-service/test/src/commands/set.ts
+++ b/garden-service/test/src/commands/set.ts
@@ -8,7 +8,7 @@ describe("SetSecretCommand", () => {
 
   it("should set a config variable", async () => {
     const garden = await makeTestGardenA()
-    const log = garden.log.info()
+    const log = garden.log
     const command = new SetSecretCommand()
 
     await command.action({

--- a/garden-service/test/src/commands/set.ts
+++ b/garden-service/test/src/commands/set.ts
@@ -8,10 +8,16 @@ describe("SetSecretCommand", () => {
 
   it("should set a config variable", async () => {
     const garden = await makeTestGardenA()
+    const log = garden.log.info()
     const command = new SetSecretCommand()
 
-    await command.action({ garden, args: { provider, key: "mykey", value: "myvalue" }, opts: {} })
+    await command.action({
+      garden,
+      log,
+      args: { provider, key: "mykey", value: "myvalue" },
+      opts: {},
+    })
 
-    expect(await garden.actions.getSecret({ pluginName, key: "mykey" })).to.eql({ value: "myvalue" })
+    expect(await garden.actions.getSecret({ log, pluginName, key: "mykey" })).to.eql({ value: "myvalue" })
   })
 })

--- a/garden-service/test/src/commands/test.ts
+++ b/garden-service/test/src/commands/test.ts
@@ -6,7 +6,7 @@ import { makeTestGardenA, taskResultOutputs } from "../../helpers"
 describe("commands.test", () => {
   it("should run all tests in a simple project", async () => {
     const garden = await makeTestGardenA()
-    const log = garden.log.info()
+    const log = garden.log
     const command = new TestCommand()
 
     const { result } = await command.action({
@@ -43,7 +43,7 @@ describe("commands.test", () => {
 
   it("should optionally test single module", async () => {
     const garden = await makeTestGardenA()
-    const log = garden.log.info()
+    const log = garden.log
     const command = new TestCommand()
 
     const { result } = await command.action({

--- a/garden-service/test/src/commands/test.ts
+++ b/garden-service/test/src/commands/test.ts
@@ -6,10 +6,12 @@ import { makeTestGardenA, taskResultOutputs } from "../../helpers"
 describe("commands.test", () => {
   it("should run all tests in a simple project", async () => {
     const garden = await makeTestGardenA()
+    const log = garden.log.info()
     const command = new TestCommand()
 
     const { result } = await command.action({
       garden,
+      log,
       args: { module: undefined },
       opts: { "name": undefined, "force": true, "force-build": true, "watch": false },
     })
@@ -41,10 +43,12 @@ describe("commands.test", () => {
 
   it("should optionally test single module", async () => {
     const garden = await makeTestGardenA()
+    const log = garden.log.info()
     const command = new TestCommand()
 
     const { result } = await command.action({
       garden,
+      log,
       args: { module: ["module-a"] },
       opts: { "name": undefined, "force": true, "force-build": true, "watch": false },
     })

--- a/garden-service/test/src/commands/unlink.ts
+++ b/garden-service/test/src/commands/unlink.ts
@@ -25,7 +25,7 @@ describe("UnlinkCommand", () => {
 
     beforeEach(async () => {
       garden = await makeTestGarden(projectRoot)
-      log = garden.log.info()
+      log = garden.log
       stubExtSources(garden)
 
       await linkCmd.action({
@@ -93,7 +93,7 @@ describe("UnlinkCommand", () => {
 
     beforeEach(async () => {
       garden = await makeTestGarden(projectRoot)
-      log = garden.log.info()
+      log = garden.log
 
       stubExtSources(garden)
 

--- a/garden-service/test/src/commands/unlink.ts
+++ b/garden-service/test/src/commands/unlink.ts
@@ -12,9 +12,11 @@ import {
 import { LinkSourceCommand } from "../../../src/commands/link/source"
 import { UnlinkSourceCommand } from "../../../src/commands/unlink/source"
 import { Garden } from "../../../src/garden"
+import { LogEntry } from "../../../src/logger/log-entry"
 
 describe("UnlinkCommand", () => {
   let garden: Garden
+  let log: LogEntry
 
   describe("UnlinkModuleCommand", () => {
     const projectRoot = getDataDir("test-project-ext-module-sources")
@@ -23,10 +25,12 @@ describe("UnlinkCommand", () => {
 
     beforeEach(async () => {
       garden = await makeTestGarden(projectRoot)
+      log = garden.log.info()
       stubExtSources(garden)
 
       await linkCmd.action({
         garden,
+        log,
         args: {
           module: "module-a",
           path: join(projectRoot, "mock-local-path", "module-a"),
@@ -35,6 +39,7 @@ describe("UnlinkCommand", () => {
       })
       await linkCmd.action({
         garden,
+        log,
         args: {
           module: "module-b",
           path: join(projectRoot, "mock-local-path", "module-b"),
@@ -43,6 +48,7 @@ describe("UnlinkCommand", () => {
       })
       await linkCmd.action({
         garden,
+        log,
         args: {
           module: "module-c",
           path: join(projectRoot, "mock-local-path", "module-c"),
@@ -58,6 +64,7 @@ describe("UnlinkCommand", () => {
     it("should unlink the provided modules", async () => {
       await unlinkCmd.action({
         garden,
+        log,
         args: { module: ["module-a", "module-b"] },
         opts: { all: false },
       })
@@ -70,6 +77,7 @@ describe("UnlinkCommand", () => {
     it("should unlink all modules", async () => {
       await unlinkCmd.action({
         garden,
+        log,
         args: { module: undefined },
         opts: { all: true },
       })
@@ -85,10 +93,13 @@ describe("UnlinkCommand", () => {
 
     beforeEach(async () => {
       garden = await makeTestGarden(projectRoot)
+      log = garden.log.info()
+
       stubExtSources(garden)
 
       await linkCmd.action({
         garden,
+        log,
         args: {
           source: "source-a",
           path: join(projectRoot, "mock-local-path", "source-a"),
@@ -97,6 +108,7 @@ describe("UnlinkCommand", () => {
       })
       await linkCmd.action({
         garden,
+        log,
         args: {
           source: "source-b",
           path: join(projectRoot, "mock-local-path", "source-b"),
@@ -105,6 +117,7 @@ describe("UnlinkCommand", () => {
       })
       await linkCmd.action({
         garden,
+        log,
         args: {
           source: "source-c",
           path: join(projectRoot, "mock-local-path", "source-c"),
@@ -120,6 +133,7 @@ describe("UnlinkCommand", () => {
     it("should unlink the provided sources", async () => {
       await unlinkCmd.action({
         garden,
+        log,
         args: { source: ["source-a", "source-b"] },
         opts: { all: false },
       })
@@ -132,6 +146,7 @@ describe("UnlinkCommand", () => {
     it("should unlink all sources", async () => {
       await unlinkCmd.action({
         garden,
+        log,
         args: { source: undefined },
         opts: { all: true },
       })

--- a/garden-service/test/src/commands/update-remote.ts
+++ b/garden-service/test/src/commands/update-remote.ts
@@ -23,7 +23,7 @@ describe("UpdateRemoteCommand", () => {
 
     beforeEach(async () => {
       garden = await makeTestGarden(projectRoot)
-      log = garden.log.info()
+      log = garden.log
       stubGitCli()
     })
 
@@ -83,7 +83,7 @@ describe("UpdateRemoteCommand", () => {
 
     beforeEach(async () => {
       garden = await makeTestGarden(projectRoot)
-      log = garden.log.info()
+      log = garden.log
       stubExtSources(garden)
     })
 

--- a/garden-service/test/src/commands/update-remote.ts
+++ b/garden-service/test/src/commands/update-remote.ts
@@ -14,13 +14,16 @@ import { getDataDir, expectError, stubExtSources, stubGitCli, makeTestGarden } f
 import { UpdateRemoteSourcesCommand } from "../../../src/commands/update-remote/sources"
 import { UpdateRemoteModulesCommand } from "../../../src/commands/update-remote/modules"
 import { Garden } from "../../../src/garden"
+import { LogEntry } from "../../../src/logger/log-entry"
 
 describe("UpdateRemoteCommand", () => {
   describe("UpdateRemoteSourcesCommand", () => {
     let garden: Garden
+    let log: LogEntry
 
     beforeEach(async () => {
       garden = await makeTestGarden(projectRoot)
+      log = garden.log.info()
       stubGitCli()
     })
 
@@ -28,26 +31,46 @@ describe("UpdateRemoteCommand", () => {
     const cmd = new UpdateRemoteSourcesCommand()
 
     it("should update all project sources", async () => {
-      const { result } = await cmd.action({ garden, args: { source: undefined }, opts: {} })
+      const { result } = await cmd.action({
+        garden,
+        log,
+        args: { source: undefined },
+        opts: {},
+      })
       expect(result!.map(s => s.name).sort()).to.eql(["source-a", "source-b", "source-c"])
     })
 
     it("should update the specified project sources", async () => {
-      const { result } = await cmd.action({ garden, args: { source: ["source-a"] }, opts: {} })
+      const { result } = await cmd.action({
+        garden,
+        log,
+        args: { source: ["source-a"] },
+        opts: {},
+      })
       expect(result!.map(s => s.name).sort()).to.eql(["source-a"])
     })
 
     it("should remove stale remote project sources", async () => {
       const stalePath = join(projectRoot, ".garden", "sources", "project", "stale-source")
       await mkdirp(stalePath)
-      await cmd.action({ garden, args: { source: undefined }, opts: {} })
+      await cmd.action({
+        garden,
+        log,
+        args: { source: undefined },
+        opts: {},
+      })
       expect(await pathExists(stalePath)).to.be.false
     })
 
     it("should throw if project source is not found", async () => {
       await expectError(
         async () => (
-          await cmd.action({ garden, args: { source: ["banana"] }, opts: {} })
+          await cmd.action({
+            garden,
+            log,
+            args: { source: ["banana"] },
+            opts: {},
+          })
         ),
         "parameter",
       )
@@ -56,9 +79,11 @@ describe("UpdateRemoteCommand", () => {
 
   describe("UpdateRemoteModulesCommand", () => {
     let garden: Garden
+    let log: LogEntry
 
     beforeEach(async () => {
       garden = await makeTestGarden(projectRoot)
+      log = garden.log.info()
       stubExtSources(garden)
     })
 
@@ -66,26 +91,46 @@ describe("UpdateRemoteCommand", () => {
     const cmd = new UpdateRemoteModulesCommand()
 
     it("should update all modules sources", async () => {
-      const { result } = await cmd.action({ garden, args: { module: undefined }, opts: {} })
+      const { result } = await cmd.action({
+        garden,
+        log,
+        args: { module: undefined },
+        opts: {},
+      })
       expect(result!.map(s => s.name).sort()).to.eql(["module-a", "module-b", "module-c"])
     })
 
     it("should update the specified module sources", async () => {
-      const { result } = await cmd.action({ garden, args: { module: ["module-a"] }, opts: {} })
+      const { result } = await cmd.action({
+        garden,
+        log,
+        args: { module: ["module-a"] },
+        opts: {},
+      })
       expect(result!.map(s => s.name).sort()).to.eql(["module-a"])
     })
 
     it("should remove stale remote module sources", async () => {
       const stalePath = join(projectRoot, ".garden", "sources", "module", "stale-source")
       await mkdirp(stalePath)
-      await cmd.action({ garden, args: { module: undefined }, opts: {} })
+      await cmd.action({
+        garden,
+        log,
+        args: { module: undefined },
+        opts: {},
+      })
       expect(await pathExists(stalePath)).to.be.false
     })
 
     it("should throw if project source is not found", async () => {
       await expectError(
         async () => (
-          await cmd.action({ garden, args: { module: ["banana"] }, opts: {} })
+          await cmd.action({
+            garden,
+            log,
+            args: { module: ["banana"] },
+            opts: {},
+          })
         ),
         "parameter",
       )

--- a/garden-service/test/src/commands/validate.ts
+++ b/garden-service/test/src/commands/validate.ts
@@ -8,9 +8,15 @@ describe("commands.validate", () => {
   for (const [name, path] of Object.entries(getExampleProjects())) {
     it(`should successfully validate the ${name} project`, async () => {
       const garden = await Garden.factory(path)
+      const log = garden.log.info()
       const command = new ValidateCommand()
 
-      await command.action({ garden, args: {}, opts: {} })
+      await command.action({
+        garden,
+        log,
+        args: {},
+        opts: {},
+      })
     })
   }
 
@@ -23,8 +29,14 @@ describe("commands.validate", () => {
   it("should fail validating the bad-module project", async () => {
     const root = join(__dirname, "data", "validate", "bad-module")
     const garden = await Garden.factory(root)
+    const log = garden.log.info()
     const command = new ValidateCommand()
 
-    await expectError(async () => await command.action({ garden, args: {}, opts: {} }), "configuration")
+    await expectError(async () => await command.action({
+      garden,
+      log,
+      args: {},
+      opts: {},
+    }), "configuration")
   })
 })

--- a/garden-service/test/src/commands/validate.ts
+++ b/garden-service/test/src/commands/validate.ts
@@ -8,7 +8,7 @@ describe("commands.validate", () => {
   for (const [name, path] of Object.entries(getExampleProjects())) {
     it(`should successfully validate the ${name} project`, async () => {
       const garden = await Garden.factory(path)
-      const log = garden.log.info()
+      const log = garden.log
       const command = new ValidateCommand()
 
       await command.action({
@@ -29,7 +29,7 @@ describe("commands.validate", () => {
   it("should fail validating the bad-module project", async () => {
     const root = join(__dirname, "data", "validate", "bad-module")
     const garden = await Garden.factory(root)
-    const log = garden.log.info()
+    const log = garden.log
     const command = new ValidateCommand()
 
     await expectError(async () => await command.action({

--- a/garden-service/test/src/config/config-context.ts
+++ b/garden-service/test/src/config/config-context.ts
@@ -233,7 +233,7 @@ describe("ModuleConfigContext", () => {
     await garden.scanModules()
     c = new ModuleConfigContext(
       garden,
-      garden.log.info(),
+      garden.log,
       garden.environment,
       Object.values((<any>garden).moduleConfigs),
     )

--- a/garden-service/test/src/config/config-context.ts
+++ b/garden-service/test/src/config/config-context.ts
@@ -233,6 +233,7 @@ describe("ModuleConfigContext", () => {
     await garden.scanModules()
     c = new ModuleConfigContext(
       garden,
+      garden.log.info(),
       garden.environment,
       Object.values((<any>garden).moduleConfigs),
     )

--- a/garden-service/test/src/plugins/container.ts
+++ b/garden-service/test/src/plugins/container.ts
@@ -60,7 +60,7 @@ describe("plugins.container", () => {
 
   beforeEach(async () => {
     garden = await makeTestGarden(projectRoot, { container: gardenPlugin })
-    log = garden.log.info()
+    log = garden.log
     ctx = garden.getPluginContext("container")
 
     td.replace(garden.buildDir, "syncDependencyProducts", () => null)

--- a/garden-service/test/src/plugins/container.ts
+++ b/garden-service/test/src/plugins/container.ts
@@ -18,6 +18,7 @@ import {
 } from "../../helpers"
 import { moduleFromConfig } from "../../../src/types/module"
 import { ModuleConfig } from "../../../src/config/module"
+import { LogEntry } from "../../../src/logger/log-entry"
 
 describe("plugins.container", () => {
   const projectRoot = resolve(dataDir, "test-project-container")
@@ -55,9 +56,11 @@ describe("plugins.container", () => {
 
   let garden: Garden
   let ctx: PluginContext
+  let log: LogEntry
 
   beforeEach(async () => {
     garden = await makeTestGarden(projectRoot, { container: gardenPlugin })
+    log = garden.log.info()
     ctx = garden.getPluginContext("container")
 
     td.replace(garden.buildDir, "syncDependencyProducts", () => null)
@@ -521,7 +524,7 @@ describe("plugins.container", () => {
 
         td.replace(helpers, "imageExistsLocally", async () => true)
 
-        const result = await getBuildStatus({ ctx, module, buildDependencies: {} })
+        const result = await getBuildStatus({ ctx, log, module, buildDependencies: {} })
         expect(result).to.eql({ ready: true })
       })
 
@@ -530,7 +533,7 @@ describe("plugins.container", () => {
 
         td.replace(helpers, "imageExistsLocally", async () => false)
 
-        const result = await getBuildStatus({ ctx, module, buildDependencies: {} })
+        const result = await getBuildStatus({ ctx, log, module, buildDependencies: {} })
         expect(result).to.eql({ ready: false })
       })
     })
@@ -545,7 +548,7 @@ describe("plugins.container", () => {
         td.replace(helpers, "pullImage", async () => null)
         td.replace(helpers, "imageExistsLocally", async () => false)
 
-        const result = await build({ ctx, module, buildDependencies: {} })
+        const result = await build({ ctx, log, module, buildDependencies: {} })
 
         expect(result).to.eql({ fetched: true })
       })
@@ -561,7 +564,7 @@ describe("plugins.container", () => {
 
         const dockerCli = td.replace(helpers, "dockerCli")
 
-        const result = await build({ ctx, module, buildDependencies: {} })
+        const result = await build({ ctx, log, module, buildDependencies: {} })
 
         expect(result).to.eql({
           fresh: true,
@@ -584,7 +587,7 @@ describe("plugins.container", () => {
 
         const dockerCli = td.replace(helpers, "dockerCli")
 
-        const result = await build({ ctx, module, buildDependencies: {} })
+        const result = await build({ ctx, log, module, buildDependencies: {} })
 
         expect(result).to.eql({
           fresh: true,
@@ -611,7 +614,7 @@ describe("plugins.container", () => {
 
         td.replace(helpers, "hasDockerfile", async () => false)
 
-        const result = await publishModule({ ctx, module, buildDependencies: {} })
+        const result = await publishModule({ ctx, log, module, buildDependencies: {} })
         expect(result).to.eql({ published: false })
       })
 
@@ -626,7 +629,7 @@ describe("plugins.container", () => {
 
         const dockerCli = td.replace(helpers, "dockerCli")
 
-        const result = await publishModule({ ctx, module, buildDependencies: {} })
+        const result = await publishModule({ ctx, log, module, buildDependencies: {} })
         expect(result).to.eql({ message: "Published some/image:12345", published: true })
 
         td.verify(dockerCli(module, ["tag", "some/image:12345", "some/image:12345"]), { times: 0 })
@@ -644,7 +647,7 @@ describe("plugins.container", () => {
 
         const dockerCli = td.replace(helpers, "dockerCli")
 
-        const result = await publishModule({ ctx, module, buildDependencies: {} })
+        const result = await publishModule({ ctx, log, module, buildDependencies: {} })
         expect(result).to.eql({ message: "Published some/image:1.1", published: true })
 
         td.verify(dockerCli(module, ["tag", "some/image:12345", "some/image:1.1"]))

--- a/garden-service/test/src/plugins/generic.ts
+++ b/garden-service/test/src/plugins/generic.ts
@@ -25,7 +25,7 @@ describe("generic plugin", () => {
 
   beforeEach(async () => {
     garden = await makeTestGarden(projectRoot, { generic: gardenPlugin })
-    log = garden.log.info()
+    log = garden.log
     await garden.clearBuilds()
   })
 

--- a/garden-service/test/src/plugins/generic.ts
+++ b/garden-service/test/src/plugins/generic.ts
@@ -6,6 +6,7 @@ import {
 import { Garden } from "../../../src/garden"
 import { gardenPlugin } from "../../../src/plugins/generic"
 import { GARDEN_BUILD_VERSION_FILENAME } from "../../../src/constants"
+import { LogEntry } from "../../../src/logger/log-entry"
 import {
   writeModuleVersionFile,
   readModuleVersionFile,
@@ -20,9 +21,11 @@ describe("generic plugin", () => {
   const moduleName = "module-a"
 
   let garden: Garden
+  let log: LogEntry
 
   beforeEach(async () => {
     garden = await makeTestGarden(projectRoot, { generic: gardenPlugin })
+    log = garden.log.info()
     await garden.clearBuilds()
   })
 
@@ -35,7 +38,7 @@ describe("generic plugin", () => {
 
       await writeModuleVersionFile(versionFilePath, version)
 
-      const result = await garden.actions.getBuildStatus({ module })
+      const result = await garden.actions.getBuildStatus({ log, module })
 
       expect(result.ready).to.be.true
     })
@@ -48,7 +51,7 @@ describe("generic plugin", () => {
       const buildPath = module.buildPath
       const versionFilePath = join(buildPath, GARDEN_BUILD_VERSION_FILENAME)
 
-      await garden.actions.build({ module })
+      await garden.actions.build({ log, module })
 
       const versionFileContents = await readModuleVersionFile(versionFilePath)
 

--- a/garden-service/test/src/task-graph.ts
+++ b/garden-service/test/src/task-graph.ts
@@ -36,6 +36,7 @@ class TestTask extends BaseTask {
   ) {
     super({
       garden,
+      log: garden.log.info(),
       version: {
         versionString: "12345-6789",
         dirtyTimestamp: 6789,
@@ -92,7 +93,7 @@ describe("task-graph", () => {
 
     it("should successfully process a single task without dependencies", async () => {
       const garden = await getGarden()
-      const graph = new TaskGraph(garden)
+      const graph = new TaskGraph(garden.log.info())
       const task = new TestTask(garden, "a")
 
       await graph.addTask(task)
@@ -115,7 +116,7 @@ describe("task-graph", () => {
 
     it("should process multiple tasks in dependency order", async () => {
       const garden = await getGarden()
-      const graph = new TaskGraph(garden)
+      const graph = new TaskGraph(garden.log.info())
 
       const callbackResults = {}
       const resultOrder: string[] = []
@@ -207,7 +208,7 @@ describe("task-graph", () => {
 
     it("should recursively cancel a task's dependants when it throws an error", async () => {
       const garden = await getGarden()
-      const graph = new TaskGraph(garden)
+      const graph = new TaskGraph(garden.log.info())
 
       const resultOrder: string[] = []
 
@@ -248,7 +249,7 @@ describe("task-graph", () => {
       "should process a task as an inheritor of an existing, in-progress task when they have the same base key",
       async () => {
         const garden = await getGarden()
-        const graph = new TaskGraph(garden)
+        const graph = new TaskGraph(garden.log.info())
 
         let callbackResults = {}
         let resultOrder: string[] = []

--- a/garden-service/test/src/task-graph.ts
+++ b/garden-service/test/src/task-graph.ts
@@ -36,7 +36,7 @@ class TestTask extends BaseTask {
   ) {
     super({
       garden,
-      log: garden.log.info(),
+      log: garden.log,
       version: {
         versionString: "12345-6789",
         dirtyTimestamp: 6789,
@@ -93,7 +93,7 @@ describe("task-graph", () => {
 
     it("should successfully process a single task without dependencies", async () => {
       const garden = await getGarden()
-      const graph = new TaskGraph(garden.log.info())
+      const graph = new TaskGraph(garden.log)
       const task = new TestTask(garden, "a")
 
       await graph.addTask(task)
@@ -116,7 +116,7 @@ describe("task-graph", () => {
 
     it("should process multiple tasks in dependency order", async () => {
       const garden = await getGarden()
-      const graph = new TaskGraph(garden.log.info())
+      const graph = new TaskGraph(garden.log)
 
       const callbackResults = {}
       const resultOrder: string[] = []
@@ -208,7 +208,7 @@ describe("task-graph", () => {
 
     it("should recursively cancel a task's dependants when it throws an error", async () => {
       const garden = await getGarden()
-      const graph = new TaskGraph(garden.log.info())
+      const graph = new TaskGraph(garden.log)
 
       const resultOrder: string[] = []
 
@@ -249,7 +249,7 @@ describe("task-graph", () => {
       "should process a task as an inheritor of an existing, in-progress task when they have the same base key",
       async () => {
         const garden = await getGarden()
-        const graph = new TaskGraph(garden.log.info())
+        const graph = new TaskGraph(garden.log)
 
         let callbackResults = {}
         let resultOrder: string[] = []

--- a/garden-service/test/src/tasks/helpers.ts
+++ b/garden-service/test/src/tasks/helpers.ts
@@ -6,6 +6,7 @@ import { Garden } from "../../../src/garden"
 import { makeTestGarden, dataDir } from "../../helpers"
 import { getTasksForModule } from "../../../src/tasks/helpers"
 import { BaseTask } from "../../../src/tasks/base"
+import { LogEntry } from "../../../src/logger/log-entry"
 
 async function sortedBaseKeysWithDependencies(tasks: BaseTask[]): Promise<string[]> {
   return sortedBaseKeys(flatten([tasks].concat(await Bluebird.map(tasks, t => t.getDependencies()))))
@@ -18,9 +19,11 @@ function sortedBaseKeys(tasks: BaseTask[]): string[] {
 describe("TaskHelpers", () => {
 
   let garden: Garden
+  let log: LogEntry
 
   before(async () => {
     garden = await makeTestGarden(resolve(dataDir, "test-project-dependants"))
+    log = garden.log
   })
 
   /**
@@ -32,7 +35,7 @@ describe("TaskHelpers", () => {
     it("returns the correct set of tasks for the changed module", async () => {
       const module = await garden.getModule("good-morning")
       const tasks = await getTasksForModule({
-        garden, module, hotReloadServiceNames: [], force: true, forceBuild: true,
+        garden, log, module, hotReloadServiceNames: [], force: true, forceBuild: true,
         fromWatch: false, includeDependants: false,
       })
 
@@ -154,7 +157,7 @@ describe("TaskHelpers", () => {
         it(`returns the correct set of tasks for ${moduleName} and its dependants`, async () => {
           const module = await garden.getModule(<string>moduleName)
           const tasks = await getTasksForModule({
-            garden, module, hotReloadServiceNames: [], force: true, forceBuild: true,
+            garden, log, module, hotReloadServiceNames: [], force: true, forceBuild: true,
             fromWatch: true, includeDependants: true,
           })
           expect(sortedBaseKeys(tasks)).to.eql(withoutDependencies)
@@ -212,7 +215,7 @@ describe("TaskHelpers", () => {
         it(`returns the correct set of tasks for ${moduleName} and its dependants`, async () => {
           const module = await garden.getModule(<string>moduleName)
           const tasks = await getTasksForModule({
-            garden, module, hotReloadServiceNames: ["good-morning"], force: true, forceBuild: true,
+            garden, log, module, hotReloadServiceNames: ["good-morning"], force: true, forceBuild: true,
             fromWatch: true, includeDependants: true,
           })
           expect(sortedBaseKeys(tasks)).to.eql(withoutDependencies)

--- a/garden-service/test/src/tasks/test.ts
+++ b/garden-service/test/src/tasks/test.ts
@@ -12,7 +12,7 @@ describe("TestTask", () => {
 
   beforeEach(async () => {
     garden = await makeTestGarden(resolve(dataDir, "test-project-test-deps"))
-    log = garden.log.info()
+    log = garden.log
   })
 
   it("should correctly resolve version for tests with dependencies", async () => {

--- a/garden-service/test/src/tasks/test.ts
+++ b/garden-service/test/src/tasks/test.ts
@@ -4,12 +4,15 @@ import { TestTask } from "../../../src/tasks/test"
 import * as td from "testdouble"
 import { Garden } from "../../../src/garden"
 import { dataDir, makeTestGarden } from "../../helpers"
+import { LogEntry } from "../../../src/logger/log-entry"
 
 describe("TestTask", () => {
   let garden: Garden
+  let log: LogEntry
 
   beforeEach(async () => {
     garden = await makeTestGarden(resolve(dataDir, "test-project-test-deps"))
+    log = garden.log.info()
   })
 
   it("should correctly resolve version for tests with dependencies", async () => {
@@ -37,6 +40,7 @@ describe("TestTask", () => {
 
     const task = await TestTask.factory({
       garden,
+      log,
       module: moduleA,
       testConfig,
       force: true,


### PR DESCRIPTION
This leverages the recent changes to the logger that allow for empty
log entries.

_Note: This currently has an issue where the section part of log entries doesn't appear. Need input from @eysi09 to complete this._