### PR TITLE
refactor: remove explicit helm and stern installation dependencies

### DIFF
--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -65,7 +65,7 @@ The things the script will check for are the following:
   installed, and whether Kubernetes has been enabled as the default orchestrator.
 * Node.js - The script will install it via Chocolatey if it is missing, but note that _if you already have Node.js
   installed, please make sure it is version 8.x or newer._
-* Git, rsync, Helm and stern. The script will install those if they are missing.
+* Git and rsync. The script will install those if they are missing.
 
 To run the script, open PowerShell as an Administrator and run:
 
@@ -83,8 +83,6 @@ You need the following dependencies on your local machine to use Garden:
 * [Docker](https://docs.docker.com/)
 * Git
 * rsync
-* stern
-* [Helm](https://github.com/kubernetes/helm)
 * Local installation of Kubernetes and kubectl
 
 #### Step 1: Docker
@@ -98,8 +96,7 @@ For local Kubernetes, you can use [Minikube](https://github.com/kubernetes/minik
 
 #### Step 3: Install other dependencies
 
-Use your preferred method or package manager to install `node` (version 8.x or higher), `git`, `rsync` and
-[Helm](https://github.com/kubernetes/helm).
+Use your preferred method or package manager to install `node` (version 8.x or higher), `git` and `rsync`.
 
 #### Step 4: Install `garden-cli`
 

--- a/garden-service/package-lock.json
+++ b/garden-service/package-lock.json
@@ -800,6 +800,15 @@
       "integrity": "sha512-dA5z2WlP7uurAiveIWTDRgfr1U58Qdmo6doDeAyJlYFQ3vnUOW7BqJ+tl+M8FaLcflhrVvwIfzxJJvlz6anx4A==",
       "dev": true
     },
+    "@types/tar": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/tar/-/tar-4.0.0.tgz",
+      "integrity": "sha512-YybbEHNngcHlIWVCYsoj7Oo1JU9JqONuAlt1LlTH/lmL8BMhbzdFUgReY87a05rY1j8mfK47Del+TCkaLAXwLw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/through": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.29.tgz",
@@ -840,6 +849,14 @@
       "resolved": "https://registry.npmjs.org/@types/uniqid/-/uniqid-4.1.2.tgz",
       "integrity": "sha512-ZXl2rFZtJ6kdk7uureET6B3ebhoMhlJtiLRqhk5atKbc6YgabpxSjDZRPksbUdQT7ulIzg2X08e5esVJ2AAVkQ==",
       "dev": true
+    },
+    "@types/unzip": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@types/unzip/-/unzip-0.1.1.tgz",
+      "integrity": "sha512-skD6Um7Pk2l7y+tVOKSgOA9vXViyhk/qJYmr17Ek4Uw3Zgo/DWPScphTPztPbApTIngyYSJnkEW87xrHzRYaew==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/vinyl": {
       "version": "2.0.2",
@@ -1494,6 +1511,15 @@
       "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
       "dev": true
     },
+    "binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+      "requires": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      }
+    },
     "binary-extensions": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
@@ -1584,6 +1610,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -1694,6 +1725,14 @@
         "get-func-name": "^2.0.0",
         "pathval": "^1.0.0",
         "type-detect": "^4.0.0"
+      }
+    },
+    "chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+      "requires": {
+        "traverse": ">=0.3.0 <0.4"
       }
     },
     "chalk": {
@@ -3257,6 +3296,14 @@
         "universalify": "^0.1.0"
       }
     },
+    "fs-minipass": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+      "requires": {
+        "minipass": "^2.2.1"
+      }
+    },
     "fs-mkdirp-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
@@ -3797,6 +3844,27 @@
           "version": "3.0.2",
           "resolved": false,
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+        }
+      }
+    },
+    "fstream": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+      "integrity": "sha1-czfwWPu7vvqMn1YaKMqwhJICyYg=",
+      "requires": {
+        "graceful-fs": "~3.0.2",
+        "inherits": "~2.0.0",
+        "mkdirp": "0.5",
+        "rimraf": "2"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "3.0.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+          "requires": {
+            "natives": "^1.1.0"
+          }
         }
       }
     },
@@ -5910,6 +5978,38 @@
         "object-visit": "^1.0.0"
       }
     },
+    "match-stream": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
+      "integrity": "sha1-mesFAJOzTf+t5CG5rAtBCpz6F88=",
+      "requires": {
+        "buffers": "~0.1.1",
+        "readable-stream": "~1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
     "matchdep": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/matchdep/-/matchdep-2.0.0.tgz",
@@ -6038,6 +6138,30 @@
       "requires": {
         "arrify": "^1.0.1",
         "is-plain-obj": "^1.1.0"
+      }
+    },
+    "minipass": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
+      "integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+        }
+      }
+    },
+    "minizlib": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+      "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+      "requires": {
+        "minipass": "^2.2.1"
       }
     },
     "mixin-deep": {
@@ -6184,6 +6308,11 @@
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.1"
       }
+    },
+    "natives": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.5.tgz",
+      "integrity": "sha512-1pJ+02gl2KJgCPFtpZGtuD4lGSJnIZvvFHCQTOeDRMSXjfu2GmYWuhI8NFMA4W2I5NNFRbfy/YCiVt4CgNpP8A=="
     },
     "nconf": {
       "version": "0.10.0",
@@ -9008,6 +9137,11 @@
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
+    "over": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/over/-/over-0.0.5.tgz",
+      "integrity": "sha1-8phS5w/X4l82DgE6jsRMgq7bVwg="
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -9388,6 +9522,40 @@
       "version": "1.1.29",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
       "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+    },
+    "pullstream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pullstream/-/pullstream-0.4.1.tgz",
+      "integrity": "sha1-1vs79a7Wl+gxFQ6xACwlo/iuExQ=",
+      "requires": {
+        "over": ">= 0.0.5 < 1",
+        "readable-stream": "~1.0.31",
+        "setimmediate": ">= 1.0.2 < 2",
+        "slice-stream": ">= 1.0.0 < 2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
     },
     "pump": {
       "version": "1.0.3",
@@ -9774,7 +9942,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "dev": true,
       "requires": {
         "glob": "^7.0.5"
       }
@@ -9886,6 +10053,11 @@
           }
         }
       }
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "setprototypeof": {
       "version": "1.1.0",
@@ -10009,6 +10181,37 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "requires": {
         "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "slice-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-stream/-/slice-stream-1.0.0.tgz",
+      "integrity": "sha1-WzO9ZvATsaf4ZGCwPUY97DmtPqA=",
+      "requires": {
+        "readable-stream": "~1.0.31"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
       }
     },
     "smart-buffer": {
@@ -10799,6 +11002,27 @@
       "resolved": "https://registry.npmjs.org/sywac/-/sywac-1.2.1.tgz",
       "integrity": "sha512-bf8agjBAV9mm90k2nWoobe48bO/XugTS86W4dGYTpzVlfFv1cmWsRrQ9hUKIfoDaIRaXIta/BLFINmmxfV+otg=="
     },
+    "tar": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.6.tgz",
+      "integrity": "sha512-tMkTnh9EdzxyfW+6GK6fCahagXsnYk6kE6S9Gr9pjVdys769+laCTbodXDhPAjzVtEBazRgP0gYqOjnk9dQzLg==",
+      "requires": {
+        "chownr": "^1.0.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.3.3",
+        "minizlib": "^1.1.0",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.2"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+        }
+      }
+    },
     "tar-fs": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.12.0.tgz",
@@ -11059,6 +11283,11 @@
         "psl": "^1.1.24",
         "punycode": "^1.4.1"
       }
+    },
+    "traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
     },
     "trim-newlines": {
       "version": "2.0.0",
@@ -11461,6 +11690,42 @@
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+        }
+      }
+    },
+    "unzip": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/unzip/-/unzip-0.1.11.tgz",
+      "integrity": "sha1-iXScY7BY19kNYZ+GuYqhU107l/A=",
+      "requires": {
+        "binary": ">= 0.3.0 < 1",
+        "fstream": ">= 0.1.30 < 1",
+        "match-stream": ">= 0.0.2 < 1",
+        "pullstream": ">= 0.4.1 < 1",
+        "readable-stream": "~1.0.31",
+        "setimmediate": ">= 1.0.1 < 2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },

--- a/garden-service/package.json
+++ b/garden-service/package.json
@@ -23,6 +23,7 @@
   ],
   "dependencies": {
     "@kubernetes/client-node": "^0.5.2",
+    "@types/unzip": "^0.1.1",
     "ansi-escapes": "^3.1.0",
     "async-exit-hook": "^2.0.1",
     "async-lock": "^1.1.3",
@@ -65,10 +66,12 @@
     "string-width": "^2.1.1",
     "strip-ansi": "^4.0.0",
     "sywac": "^1.2.1",
+    "tar": "^4.4.6",
     "terminal-link": "^1.1.0",
     "ts-stream": "^1.0.1",
     "typescript-memoize": "^1.0.0-alpha.3",
     "uniqid": "^5.0.3",
+    "unzip": "^0.1.11",
     "uuid": "^3.3.2",
     "winston": "^3.0.0",
     "wrap-ansi": "^3.0.1"
@@ -104,6 +107,7 @@
     "@types/path-is-inside": "^1.0.0",
     "@types/prettyjson": "0.0.28",
     "@types/string-width": "^2.0.0",
+    "@types/tar": "^4.0.0",
     "@types/uniqid": "^4.1.2",
     "@types/wrap-ansi": "^3.0.0",
     "chai": "^4.1.2",

--- a/garden-service/src/constants.ts
+++ b/garden-service/src/constants.ts
@@ -26,3 +26,6 @@ export const GARDEN_ANNOTATION_KEYS_SERVICE = GARDEN_ANNOTATION_PREFIX + "servic
 export const GARDEN_ANNOTATION_KEYS_VERSION = GARDEN_ANNOTATION_PREFIX + "version"
 
 export const DEFAULT_TEST_TIMEOUT = 60 * 1000
+
+export type SupportedPlatform = "linux" | "darwin" | "win32"
+export const SUPPORTED_PLATFORMS: SupportedPlatform[] = ["linux", "darwin", "win32"]

--- a/garden-service/src/garden.ts
+++ b/garden-service/src/garden.ts
@@ -57,6 +57,7 @@ import {
   ConfigurationError,
   ParameterError,
   PluginError,
+  RuntimeError,
 } from "./exceptions"
 import { VcsHandler, ModuleVersion } from "./vcs/base"
 import { GitHandler } from "./vcs/git"
@@ -99,6 +100,8 @@ import { LogLevel } from "./logger/log-node"
 import { ActionHelper } from "./actions"
 import { createPluginContext } from "./plugin-context"
 import { ModuleAndServiceActions, Plugins, RegisterPluginParam } from "./types/plugin/plugin"
+import { SUPPORTED_PLATFORMS, SupportedPlatform } from "./constants"
+import { platform, arch } from "os"
 
 export interface ActionHandlerMap<T extends keyof PluginActions> {
   [actionName: string]: PluginActions[T]
@@ -162,6 +165,18 @@ export class Garden {
     public readonly buildDir: BuildDir,
     logger?: Logger,
   ) {
+    // make sure we're on a supported platform
+    const currentPlatform = platform()
+    const currentArch = arch()
+
+    if (!SUPPORTED_PLATFORMS.includes(<SupportedPlatform>currentPlatform)) {
+      throw new RuntimeError(`Unsupported platform: ${currentPlatform}`, { platform: currentPlatform })
+    }
+
+    if (currentArch !== "x64") {
+      throw new RuntimeError(`Unsupported CPU architecture: ${currentArch}`, { arch: currentArch })
+    }
+
     this.modulesScanned = false
     this.log = logger || getLogger()
     // TODO: Support other VCS options.

--- a/garden-service/src/plugins/kubernetes/init.ts
+++ b/garden-service/src/plugins/kubernetes/init.ts
@@ -273,7 +273,7 @@ async function configureSystemServices(
   const sysCtx = sysGarden.getPluginContext(provider.name)
 
   // TODO: need to add logic here to wait for tiller to be ready
-  await helm(sysCtx.provider,
+  await helm(sysCtx.provider, logEntry,
     "init", "--wait",
     "--service-account", "default",
     "--upgrade",

--- a/garden-service/src/plugins/plugins.ts
+++ b/garden-service/src/plugins/plugins.ts
@@ -5,6 +5,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+
 import { mapValues } from "lodash"
 
 const generic = require("./generic")

--- a/garden-service/src/util/ext-source-util.ts
+++ b/garden-service/src/util/ext-source-util.ts
@@ -6,7 +6,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { createHash } from "crypto"
 import { uniqBy } from "lodash"
 import chalk from "chalk"
 import pathIsInside = require("path-is-inside")
@@ -23,6 +22,7 @@ import { ParameterError } from "../exceptions"
 import { Module } from "../types/module"
 import { join } from "path"
 import { Garden } from "../garden"
+import { hashString } from "./util"
 
 export type ExternalSourceType = "project" | "module"
 
@@ -41,9 +41,7 @@ export function getRemoteSourcePath({ name, url, sourceType }:
 }
 
 export function hashRepoUrl(url: string) {
-  const urlHash = createHash("sha256")
-  urlHash.update(url)
-  return urlHash.digest("hex").slice(0, 10)
+  return hashString(url, 10)
 }
 
 export function hasRemoteSource(module: Module): boolean {

--- a/garden-service/src/util/ext-tools.ts
+++ b/garden-service/src/util/ext-tools.ts
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2018 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { platform, homedir } from "os"
+import { pathExists, createWriteStream, ensureDir } from "fs-extra"
+import { ConfigurationError, ParameterError, GardenBaseError } from "../exceptions"
+import { join } from "path"
+import { hashString } from "./util"
+import Axios from "axios"
+import * as execa from "execa"
+import * as tar from "tar"
+import { SupportedPlatform } from "../constants"
+import { LogEntry } from "../logger/log-entry"
+import { Extract } from "unzip"
+import { createHash } from "crypto"
+
+const globalGardenPath = join(homedir(), ".garden")
+const toolsPath = join(globalGardenPath, "tools")
+
+interface ExecParams {
+  cwd?: string
+  logEntry?: LogEntry
+  args?: string[]
+}
+
+abstract class Cmd {
+  abstract async exec(params: ExecParams): Promise<execa.ExecaReturns>
+  abstract async stdout(params: ExecParams): Promise<string>
+}
+
+interface BinarySpec {
+  url: string
+  sha256?: string               // optionally specify sha256 checksum for validation
+  extract?: {
+    format: "tar" | "zip",      // note: the "tar" format also supports gzip compression
+    executablePath: string[],   // the path of the executable in the archive
+  }
+}
+
+// TODO: support different architectures? (the Garden class currently errors on non-x64 archs, and many tools may
+// only be available in x64).
+interface BinaryCmdSpec {
+  name: string
+  specs: { [key in SupportedPlatform]: BinarySpec }
+}
+
+export class DownloadError extends GardenBaseError {
+  type = "download"
+}
+
+/**
+ * This helper class allows you to declare a tool dependency by providing a URL to a single-file binary,
+ * or an archive containing an executable, for each of our supported platforms. When executing the tool,
+ * the appropriate URL for the current platform will be downloaded and cached in the user's home directory
+ * (under .garden/tools/<name>/<url-hash>).
+ *
+ * Note: The binary or archive currently needs to be self-contained and work without further installation steps.
+ */
+export class BinaryCmd extends Cmd {
+  name: string
+  spec: BinarySpec
+
+  private toolDir: string
+  private targetFilename: string
+  private downloadPath: string
+  private executablePath: string
+
+  constructor(spec: BinaryCmdSpec) {
+    super()
+
+    const currentPlatform = platform()
+    const platformSpec = spec.specs[currentPlatform]
+
+    if (!platformSpec) {
+      throw new ConfigurationError(
+        `Command ${spec.name} doesn't have a spec for this platform (${currentPlatform})`,
+        { spec, currentPlatform },
+      )
+    }
+
+    this.name = spec.name
+    this.spec = platformSpec
+    this.toolDir = join(toolsPath, this.name)
+    this.targetFilename = hashString(this.spec.url, 16)
+    this.downloadPath = join(this.toolDir, this.targetFilename)
+
+    const executableSubpath = this.spec.extract
+      ? this.spec.extract.executablePath
+      : [this.name]
+    this.executablePath = join(this.downloadPath, ...executableSubpath)
+  }
+
+  private async download(logEntry?: LogEntry) {
+    if (await pathExists(this.executablePath)) {
+      return
+    }
+
+    logEntry && logEntry.setState(`Fetching ${this.name}...`)
+    const debug = logEntry && logEntry.debug(`Downloading ${this.spec.url}...`)
+
+    const response = await Axios({
+      method: "GET",
+      url: this.spec.url,
+      responseType: "stream",
+    })
+    let endStream = response.data
+    let extractor
+
+    await ensureDir(this.downloadPath)
+
+    // compute the sha256 checksum
+    const hash = createHash("sha256")
+    hash.setEncoding("hex")
+    response.data.pipe(hash)
+
+    // return a promise and resolve when download finishes
+    return new Promise((resolve, reject) => {
+      response.data.on("error", (err) => {
+        logEntry && logEntry.setError(`Failed fetching ${this.spec.url}`)
+        reject(err)
+      })
+
+      if (!this.spec.extract) {
+        response.data.pipe(createWriteStream(this.executablePath))
+      } else {
+        const format = this.spec.extract.format
+
+        if (format === "tar") {
+          extractor = tar.x({
+            C: this.downloadPath,
+            strict: true,
+            onwarn: entry => console.log(entry),
+          })
+        } else if (format === "zip") {
+          extractor = Extract({ path: this.downloadPath })
+        } else {
+          reject(new ParameterError(`Invalid archive format: ${format}`, { name: this.name, spec: this.spec }))
+        }
+
+        response.data.pipe(extractor)
+
+        extractor.on("error", (err) => {
+          logEntry && logEntry.setError(`Failed extracting ${format} archive ${this.spec.url}`)
+          reject(err)
+        })
+      }
+
+      endStream.on("end", (_) => {
+        // validate sha256 if provided
+        const sha256 = hash.read()
+
+        if (this.spec.sha256 && sha256 !== this.spec.sha256) {
+          reject(new DownloadError(
+            `Invalid checksum from ${this.spec.url} (got ${sha256})`,
+            { name: this.name, spec: this.spec, sha256 },
+          ))
+        }
+
+        pathExists(this.executablePath, (err, exists) => {
+          if (err) {
+            reject(err)
+          }
+
+          if (!exists) {
+            reject(new ConfigurationError(
+              `Archive ${this.spec.url} does not contain a file at ${join(...this.spec.extract!.executablePath)}`,
+              { name: this.name, spec: this.spec },
+            ))
+          }
+
+          debug && debug.setSuccess("Done")
+          logEntry && logEntry.setSuccess(`Fetched ${this.name}`)
+          resolve()
+        })
+      })
+    })
+  }
+
+  async exec({ cwd, args, logEntry }: ExecParams) {
+    await this.download(logEntry)
+    return execa(this.executablePath, args || [], { cwd })
+  }
+
+  async stdout(params: ExecParams) {
+    const res = await this.exec(params)
+    return res.stdout
+  }
+}

--- a/garden-service/src/util/is-subset.ts
+++ b/garden-service/src/util/is-subset.ts
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2018 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
 // NOTE: copied this from the is-subset package to avoid issues with their package manifest
 // (https://github.com/studio-b12/is-subset/pull/9)
 

--- a/garden-service/src/util/util.ts
+++ b/garden-service/src/util/util.ts
@@ -25,6 +25,7 @@ import chalk from "chalk"
 import hasAnsi = require("has-ansi")
 import { safeDump } from "js-yaml"
 import { GARDEN_DIR_NAME } from "../constants"
+import { createHash } from "crypto"
 // NOTE: Importing from ignore/ignore doesn't work on Windows
 const ignore = require("ignore")
 
@@ -456,4 +457,10 @@ export function pickKeys<T extends object, U extends keyof T>(obj: T, keys: U[],
   }
 
   return picked
+}
+
+export function hashString(s: string, length: number) {
+  const urlHash = createHash("sha256")
+  urlHash.update(s)
+  return urlHash.digest("hex").slice(0, length)
 }

--- a/garden-service/support/homebrew-formula.rb
+++ b/garden-service/support/homebrew-formula.rb
@@ -8,7 +8,6 @@ class GardenCli < Formula
 
   depends_on "node"
   depends_on "rsync"
-  depends_on "stern"
   depends_on "python" => :build
 
   def install

--- a/garden-service/support/install.ps1
+++ b/garden-service/support/install.ps1
@@ -5,12 +5,11 @@
 # 1. Checks whether Hyper-V is enabled.
 # 2. Checks whether Docker is installed.
 # 3. Checks whether Kubernetes is the default orchestrator for Docker.
-# 4. Installs Stern.
-# 5. Check if Chocolatey is installed, installs it if missing.
-# 6. Installs the listed dependencies using Chocolatey if they're not already
-#    present (currently git, nodejs, rsync, and kubernetes-helm).
-# 7. Installs or updates the windows-build-tools NPM package.
-# 8. Installs or updates the garden-cli NPM package.
+# 4. Check if Chocolatey is installed, installs it if missing.
+# 5. Installs the listed dependencies using Chocolatey if they're not already
+#    present (currently git, nodejs, rsync).
+# 6. Installs or updates the windows-build-tools NPM package.
+# 7. Installs or updates the garden-cli NPM package.
 #
 # To execute it run the following command in PowerShell:
 # Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/garden-io/garden/master/garden-cli/support/install.ps1'))
@@ -51,17 +50,6 @@ Function CheckKubernetes {
         return $false
     } else {
         Write-Host "- Kubernetes is enabled."
-    }
-    return $true
-}
-
-Function CheckStern {
-    if ((CheckIfExists("stern")) -eq $false) {
-        Write-Host "- Stern not found. Installing it..."
-        [Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls"
-        Invoke-WebRequest -Uri "https://github.com/wercker/stern/releases/download/1.7.0/stern_windows_amd64.exe" -OutFile "$Env:SystemRoot\system32\stern.exe"
-    ​} else {
-        Write-Host "- Stern is installed."
     }
     return $true
 }
@@ -141,7 +129,6 @@ Please note that you may need to answer prompts during the installation.
 if ((CheckHyperV) -eq $false) { return }
 if ((CheckDocker) -eq $false) { return }
 if ((CheckKubernetes) -eq $false) { return }
-if ((CheckStern) -eq $false) { return }
 if ((CheckChocolatey) -eq $false) { return }
 
 # chocDeps lists the chocolatey dependencies to be installed. It consists of
@@ -151,7 +138,6 @@ if ((CheckChocolatey) -eq $false) { return }
 $chocDeps = (("git","git"),
              ("rsync","rsync"),
              ("node","nodejs"),
-             ("helm","kubernetes-helm"))
 CheckChocolateyDeps($chocDeps)
 [Console]::ResetColor()
 
@@ -181,7 +167,7 @@ Please head over to https://docs.garden.io for more information on how to get st
 # Notes for testing:
 #
 # npm uninstall -g garden-cli windows-build-tools
-# choco uninstall git nodejs rsync kubernetes-helm
+# choco uninstall git nodejs rsync
 # rm -r -fo C:\ProgramData\chocolatey
 #
 # choco pack

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -20,7 +20,7 @@ gulp.task("check-licenses", () =>
   gulp.src([...tsSources, pegjsSources])
     .pipe(checkLicense({
       path: licenseHeaderPath,
-      blocking: false,
+      blocking: true,
       logInfo: false,
       logError: true,
     })),


### PR DESCRIPTION
We now automatically fetch helm when needed via the new tool helper.

Note: We still install Helm via package dependencies, because it's
really no bother for the user, but we don't need to explicitly list
it in docs.

Before completing this and using for more tools, I wanted to float the idea and see if it makes sense to everyone...