### PR TITLE
Module version cache fix

### DIFF
--- a/garden-cli/package-lock.json
+++ b/garden-cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "garden-cli",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/garden-cli/src/commands/dev.ts
+++ b/garden-cli/src/commands/dev.ts
@@ -23,9 +23,9 @@ import { STATIC_DIR } from "../constants"
 import { processModules } from "../process"
 import { readFile } from "fs-extra"
 import { Module } from "../types/module"
-import { getTestTasks } from "./test"
 import { computeAutoReloadDependants, withDependants } from "../watch"
 import { getDeployTasks } from "../tasks/deploy"
+import { getTestTasks } from "../tasks/test"
 
 const ansiBannerPath = join(STATIC_DIR, "garden-banner-2.txt")
 

--- a/garden-cli/src/commands/test.ts
+++ b/garden-cli/src/commands/test.ts
@@ -20,9 +20,8 @@ import {
 import { TaskResults } from "../task-graph"
 import { processModules } from "../process"
 import { Module } from "../types/module"
-import { TestTask } from "../tasks/test"
+import { getTestTasks } from "../tasks/test"
 import { computeAutoReloadDependants, withDependants } from "../watch"
-import { Garden } from "../garden"
 
 const testArgs = {
   module: new StringsParameter({
@@ -103,26 +102,4 @@ export class TestCommand extends Command<Args, Opts> {
 
     return handleTaskResults(garden, "test", results)
   }
-}
-
-export async function getTestTasks(
-  { garden, module, name, force = false, forceBuild = false }:
-    { garden: Garden, module: Module, name?: string, force?: boolean, forceBuild?: boolean },
-) {
-  const tasks: Promise<TestTask>[] = []
-
-  for (const test of module.testConfigs) {
-    if (name && test.name !== name) {
-      continue
-    }
-    tasks.push(TestTask.factory({
-      garden,
-      force,
-      forceBuild,
-      testConfig: test,
-      module,
-    }))
-  }
-
-  return Bluebird.all(tasks)
 }

--- a/garden-cli/src/garden.ts
+++ b/garden-cli/src/garden.ts
@@ -577,8 +577,9 @@ export class Garden {
    * and the versions of its dependencies (in sorted order).
    */
   async resolveVersion(moduleName: string, moduleDependencies: BuildDependencyConfig[], force = false) {
-    const config = this.moduleConfigs[moduleName]
-    const cacheKey = ["moduleVersions", moduleName]
+    const depModuleNames = moduleDependencies.map(m => m.name)
+    depModuleNames.sort()
+    const cacheKey = ["moduleVersions", moduleName, ...depModuleNames]
 
     if (!force) {
       const cached = <ModuleVersion>this.cache.get(cacheKey)
@@ -588,6 +589,7 @@ export class Garden {
       }
     }
 
+    const config = this.moduleConfigs[moduleName]
     const dependencyKeys = moduleDependencies.map(dep => getModuleKey(dep.name, dep.plugin))
     const dependencies = Object.values(pickKeys(this.moduleConfigs, dependencyKeys, "module config"))
     const cacheContexts = dependencies.concat([config]).map(c => getModuleCacheContext(c))

--- a/garden-cli/src/tasks/test.ts
+++ b/garden-cli/src/tasks/test.ts
@@ -146,6 +146,28 @@ export class TestTask extends Task {
   }
 }
 
+export async function getTestTasks(
+  { garden, module, name, force = false, forceBuild = false }:
+    { garden: Garden, module: Module, name?: string, force?: boolean, forceBuild?: boolean },
+) {
+  const tasks: Promise<TestTask>[] = []
+
+  for (const test of module.testConfigs) {
+    if (name && test.name !== name) {
+      continue
+    }
+    tasks.push(TestTask.factory({
+      garden,
+      force,
+      forceBuild,
+      testConfig: test,
+      module,
+    }))
+  }
+
+  return Bluebird.all(tasks)
+}
+
 async function getTestDependencies(garden: Garden, testConfig: TestConfig) {
   return garden.getServices(testConfig.dependencies)
 }

--- a/garden-cli/src/types/module.ts
+++ b/garden-cli/src/types/module.ts
@@ -91,5 +91,6 @@ export function getModuleCacheContext(config: ModuleConfig) {
 }
 
 export function getModuleKey(name: string, plugin?: string) {
-  return plugin ? `${plugin}--${name}` : name
+  const hasPrefix = !!name.match(/--/)
+  return (plugin && !hasPrefix) ? `${plugin}--${name}` : name
 }


### PR DESCRIPTION
Fixes: https://github.com/garden-io/garden/issues/307

**Include provided deps in module cache keys.**

`resolveVersion` now includes a sorted list of module names (from the provided dependencies) in the module version cache key.

**Prevent multiple prefixing in getModuleKey.**

Before, getModuleKey was not idempotent, leading to incorrect module keys when the plugin name got prefixed to the module name more than once.