### PR TITLE
refactor(go-cli): use docker sdk and keep containers running

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,105 @@
 
 
 [[projects]]
+  digest = "1:f9ae348e1f793dcf9ed930ed47136a67343dbd6809c5c91391322267f4476892"
+  name = "github.com/Microsoft/go-winio"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "97e4973ce50b2ff5f09635a57e2b88a037aae829"
+  version = "v0.4.11"
+
+[[projects]]
+  digest = "1:3cabbabc9e0e4aa7e12b882bdc213f41cf8bd2b2ce2a7b5e0aceaf8a6a78049b"
+  name = "github.com/docker/distribution"
+  packages = [
+    "digest",
+    "reference",
+  ]
+  pruneopts = "UT"
+  revision = "48294d928ced5dd9b378f7fd7c6f5da3ff3f2c89"
+  version = "v2.6.2"
+
+[[projects]]
+  digest = "1:c4c7064c2c67a0a00815918bae489dd62cd88d859d24c95115d69b00b3d33334"
+  name = "github.com/docker/docker"
+  packages = [
+    "api/types",
+    "api/types/blkiodev",
+    "api/types/container",
+    "api/types/events",
+    "api/types/filters",
+    "api/types/mount",
+    "api/types/network",
+    "api/types/reference",
+    "api/types/registry",
+    "api/types/strslice",
+    "api/types/swarm",
+    "api/types/time",
+    "api/types/versions",
+    "api/types/volume",
+    "client",
+    "pkg/tlsconfig",
+  ]
+  pruneopts = "UT"
+  revision = "092cba3727bb9b4a2f0e922cd6c0f93ea270e363"
+  version = "v1.13.1"
+
+[[projects]]
+  digest = "1:811c86996b1ca46729bad2724d4499014c4b9effd05ef8c71b852aad90deb0ce"
+  name = "github.com/docker/go-connections"
+  packages = [
+    "nat",
+    "sockets",
+    "tlsconfig",
+  ]
+  pruneopts = "UT"
+  revision = "7395e3f8aa162843a74ed6d48e79627d9792ac55"
+  version = "v0.4.0"
+
+[[projects]]
+  digest = "1:6f82cacd0af5921e99bf3f46748705239b36489464f4529a1589bc895764fb18"
+  name = "github.com/docker/go-units"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "47565b4f722fb6ceae66b95f853feed578a4a51c"
+  version = "v0.3.3"
+
+[[projects]]
   digest = "1:78bbb1ba5b7c3f2ed0ea1eab57bdd3859aec7e177811563edc41198a760b06af"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
   pruneopts = "UT"
   revision = "ae18d6b8b3205b561c79e8e5f69bff09736185f4"
   version = "v1.0.0"
+
+[[projects]]
+  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:d9f9f45d3383b93ce1c7e744b3ede6974917ae4d100e1a7abfc2906e5e5e2e28"
+  name = "golang.org/x/net"
+  packages = [
+    "context",
+    "context/ctxhttp",
+    "internal/socks",
+    "proxy",
+  ]
+  pruneopts = "UT"
+  revision = "9b4f9f5ad5197c79fd623a3638e70d8b26cef344"
+
+[[projects]]
+  branch = "master"
+  digest = "1:68a4638398cf8c864a6aa50c8853ebe7935f939aa3acf7e44cb35b67852e9fef"
+  name = "golang.org/x/sys"
+  packages = ["windows"]
+  pruneopts = "UT"
+  revision = "d989b31c87461dc8ab2f1cac6792814e27fadea9"
 
 [[projects]]
   digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
@@ -21,6 +114,12 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/docker/docker/api/types",
+    "github.com/docker/docker/api/types/container",
+    "github.com/docker/docker/api/types/filters",
+    "github.com/docker/docker/api/types/mount",
+    "github.com/docker/docker/api/types/volume",
+    "github.com/docker/docker/client",
     "github.com/mitchellh/go-homedir",
     "gopkg.in/yaml.v2",
   ]

--- a/garden-cli/config.go
+++ b/garden-cli/config.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/garden-io/garden/garden-cli/util"
 	"gopkg.in/yaml.v2"
 )
 
@@ -25,7 +26,7 @@ func findProject(cwd string) (string, string) {
 
 		if _, err := os.Stat(configPath); !os.IsNotExist(err) {
 			configYaml, err := ioutil.ReadFile(configPath)
-			check(err)
+			util.Check(err)
 
 			config := Config{}
 
@@ -53,7 +54,7 @@ func findProject(cwd string) (string, string) {
 // TODO: might wanna use a lockfile for concurrency here
 func getProjectID(projectDir string) string {
 	gardenDir := path.Join(projectDir, ".garden")
-	ensureDir(gardenDir)
+	util.EnsureDir(gardenDir)
 
 	idPath := path.Join(gardenDir, "id")
 
@@ -61,12 +62,12 @@ func getProjectID(projectDir string) string {
 
 	if _, err := os.Stat(idPath); !os.IsNotExist(err) {
 		idData, err := ioutil.ReadFile(idPath)
-		check(err)
+		util.Check(err)
 		projectID = strings.TrimSpace(string(idData))
 	} else {
-		projectID = randSeq(8)
+		projectID = util.RandSeq(8)
 		err := ioutil.WriteFile(idPath, []byte(projectID), 0644)
-		check(err)
+		util.Check(err)
 	}
 
 	return projectID
@@ -74,10 +75,10 @@ func getProjectID(projectDir string) string {
 
 func getGardenHomeDir() string {
 	// TODO: allow override via env var
-	homeDir := getHomeDir()
+	homeDir := util.GetHomeDir()
 	gardenHome := path.Join(homeDir, ".garden")
 
-	ensureDir(gardenHome)
+	util.EnsureDir(gardenHome)
 
 	return gardenHome
 }

--- a/garden-cli/constants.go
+++ b/garden-cli/constants.go
@@ -1,0 +1,10 @@
+package main
+
+// SyncImage is which docker image to use for syncing
+const SyncImage = "gardenengine/garden-sync:latest"
+
+// ServiceImage is which docker image to use for garden service
+const ServiceImage = "gardenengine/garden-service:latest"
+
+// ProjectPath is where to find the code inside ServiceImage
+const ProjectPath = "/project"

--- a/garden-cli/dockerutil/docker.go
+++ b/garden-cli/dockerutil/docker.go
@@ -1,12 +1,40 @@
 package dockerutil
 
 import (
+	"context"
 	"log"
 	"os"
 	"os/exec"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/volume"
+	"github.com/docker/docker/client"
+	"github.com/garden-io/garden/garden-cli/util"
 )
 
-// TODO: Use the Docker Golang SDK instead of shelling out here
+func RunContainer(
+	containerConfig container.Config, hostConfig container.HostConfig, containerName string,
+) (container.ContainerCreateCreatedBody, error) {
+	ctx := context.Background()
+	cli, err := client.NewEnvClient()
+	util.Check(err)
+
+	resp, err := cli.ContainerCreate(ctx, &containerConfig, &hostConfig, nil, containerName)
+	util.Check(err)
+
+	err = StartContainer(resp.ID)
+
+	return resp, err
+}
+
+func StartContainer(containerID string) error {
+	cli, err := client.NewEnvClient()
+	util.Check(err)
+
+	return cli.ContainerStart(context.Background(), containerID, types.ContainerStartOptions{})
+}
 
 func Exec(args []string, silent bool) error {
 	binary, err := exec.LookPath("docker")
@@ -26,31 +54,69 @@ func Exec(args []string, silent bool) error {
 	return cmd.Run()
 }
 
-// TODO Use Docker SDK
-func HasVolume(volumeName string) bool {
-	args := []string{"volume", "inspect", volumeName}
-	err := Exec(args, true)
-	if err != nil {
-		return false
+func FindContainer(containerName string) (types.Container, bool) {
+	cli, err := client.NewEnvClient()
+	util.Check(err)
+
+	containers, err := cli.ContainerList(context.Background(), types.ContainerListOptions{
+		All: true,
+	})
+	util.Check(err)
+
+	var container types.Container
+
+	for _, con := range containers {
+		if con.Names[0] == "/"+containerName {
+			container = con
+			return container, true
+		}
 	}
-	return true
+	return container, false
 }
 
-func MakeVolume(volumeName string) error {
-	args := []string{"volume", "create", "--name", volumeName}
-	return Exec(args, true)
+func StopContainer(id string) error {
+	cli, err := client.NewEnvClient()
+	util.Check(err)
+
+	err = cli.ContainerStop(context.Background(), id, nil)
+	return err
+}
+
+func CreateVolume(volumeName string) error {
+	cli, err := client.NewEnvClient()
+	util.Check(err)
+
+	_, err = cli.VolumeCreate(context.Background(), volume.VolumesCreateBody{
+		Name: volumeName,
+	})
+	return err
+}
+
+func FindVolume(volumeName string) (*types.Volume, bool) {
+	cli, err := client.NewEnvClient()
+	util.Check(err)
+
+	volumeResponse, err := cli.VolumeList(context.Background(), filters.NewArgs())
+	util.Check(err)
+
+	var volume *types.Volume
+
+	for _, vol := range volumeResponse.Volumes {
+		if vol.Name == volumeName {
+			volume = vol
+			return volume, true
+		}
+	}
+	return volume, false
 }
 
 func GetVolumeName(projectName string, projectID string) string {
 	return "garden-volume--" + projectName + "-" + projectID
 }
 
-// TODO Use Docker SDK
-func HasContainer(containerName string) bool {
-	args := []string{"inspect", containerName}
-	err := Exec(args, true)
-	if err != nil {
-		return false
-	}
-	return true
+func Ping() (types.Ping, error) {
+	cli, err := client.NewEnvClient()
+	util.Check(err)
+
+	return cli.Ping(context.Background())
 }

--- a/garden-cli/run.go
+++ b/garden-cli/run.go
@@ -2,51 +2,67 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"path"
 
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
 	"github.com/garden-io/garden/garden-cli/dockerutil"
+	"github.com/garden-io/garden/garden-cli/util"
 )
 
-func runGardenService(projectName string, gitRoot string, relPath string, watch bool, args []string) error {
-	homeDir := getHomeDir()
+func runGardenService(projectName string, gitRoot string, relPath string, args []string) error {
+	homeDir := util.GetHomeDir()
 	gardenHomeDir := getGardenHomeDir()
 	projectID := getProjectID(gitRoot)
 	containerName := "garden-service--" + projectName + "-" + projectID
-	workingDir := path.Join("/project", relPath)
+	workingDir := path.Join(ProjectPath, relPath)
 	volumeName := dockerutil.GetVolumeName(projectName, projectID)
 
-	// If the command requires a file system watch we mount the dedicated project volume,
-	// if not we just bind mount the project dir directly
-	var projectVolume string
-	if watch {
-		if !dockerutil.HasVolume(volumeName) {
-			log.Fatal("No volume found for project")
-		}
-		projectVolume = volumeName
-	} else {
-		projectVolume = gitRoot
+	serviceContainer, found := dockerutil.FindContainer(containerName)
+
+	if found && serviceContainer.State != "running" {
+		err := dockerutil.StartContainer(serviceContainer.ID)
+		util.Check(err)
 	}
 
-	dockerArgs := append(
-		[]string{
-			"run", "-i", "--tty", "--rm",
-			// Give the container direct access to the host network.
-			"--net", "host",
-			// Mount docker socket and configuration directories.
-			"--volume", "/var/run/docker.sock:/var/run/docker.sock",
-			"--volume", fmt.Sprintf("%s/.docker:/root/.docker", homeDir),
-			"--volume", fmt.Sprintf("%s:/root/.garden", gardenHomeDir),
-			"--volume", fmt.Sprintf("%s/.kube:/root/.kube", homeDir),
-			// Mount the project directory, either as a bind mount or as a named volume
-			"--volume", fmt.Sprintf("%s:/project:delegated", projectVolume),
-			"--workdir", workingDir,
-			"--name", containerName,
-			// TODO: use particular version of garden-service container
-			"garden-service",
-		},
-		args...,
-	)
+	if !found {
+		volumeMounts := []mount.Mount{
+			{
+				Type:   mount.TypeVolume,
+				Source: volumeName,
+				Target: ProjectPath,
+			},
+		}
+		bindMounts := []string{
+			"/var/run/docker.sock:/var/run/docker.sock",
+			fmt.Sprintf("%s/.docker:/root/.docker", homeDir),
+			fmt.Sprintf("%s/.kube:/root/.kube", homeDir),
+			// we mount ~/.git and ~/.ssh to allow the container to pull down private git repos
+			fmt.Sprintf("%s/.git:/root/.git", homeDir),
+			fmt.Sprintf("%s/.ssh:/root/.ssh", homeDir),
+			fmt.Sprintf("%s:/root/.garden", gardenHomeDir),
+		}
 
-	return dockerutil.Exec(dockerArgs, false)
+		containerConfig := container.Config{
+			Image:      ServiceImage,
+			Tty:        true,
+			OpenStdin:  true,
+			Cmd:        []string{"/bin/sh"},
+			WorkingDir: workingDir,
+		}
+
+		hostConfig := container.HostConfig{
+			Binds:       bindMounts,
+			Mounts:      volumeMounts,
+			AutoRemove:  true,
+			NetworkMode: "host", // TODO Test if correct
+		}
+
+		_, err := dockerutil.RunContainer(containerConfig, hostConfig, containerName)
+		util.Check(err)
+	}
+
+	// run the command inside the garden-service container
+	execArgs := append([]string{"exec", "-it", containerName, "garden"}, args...)
+	return dockerutil.Exec(execArgs, false)
 }

--- a/garden-cli/sync.go
+++ b/garden-cli/sync.go
@@ -2,37 +2,73 @@ package main
 
 import (
 	"fmt"
+	"log"
 
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
 	"github.com/garden-io/garden/garden-cli/dockerutil"
+	"github.com/garden-io/garden/garden-cli/util"
 )
 
-// TODO: Sync container life cycle management. At the moment, the sync runs in watch mode indefinitely.
-func runSyncContainer(projectName string, gitRoot string, relPath string) error {
-	homeDir := getHomeDir()
+func runSyncService(projectName string, gitRoot string, relPath string) error {
+	homeDir := util.GetHomeDir()
 	projectID := getProjectID(gitRoot)
 	containerName := "garden-sync--" + projectName + "-" + projectID
+	mountDir := "host-mount"
 	volumeName := dockerutil.GetVolumeName(projectName, projectID)
 
-	if !dockerutil.HasVolume(volumeName) {
-		dockerutil.MakeVolume(volumeName)
+	if _, found := dockerutil.FindVolume(volumeName); !found {
+		err := dockerutil.CreateVolume(volumeName)
+		util.Check(err)
 	}
 
-	if dockerutil.HasContainer(containerName) {
+	// Nothing to do
+	if _, found := dockerutil.FindContainer(containerName); found {
 		return nil
 	}
 
-	dockerArgs := []string{
-		"run", "-d", "--rm",
-		// Mount docker socket and configuration directories.
-		"--volume", "/var/run/docker.sock:/var/run/docker.sock",
-		"--volume", fmt.Sprintf("%s/.docker:/root/.docker", homeDir),
-		// Mount the project directory.
-		"--volume", fmt.Sprintf("%s:/host-mount:delegated", gitRoot),
-		// TODO Use delegated?
-		"--volume", fmt.Sprintf("%s:/project", volumeName),
-		"--name", containerName,
-		"garden-sync",
+	volumeMounts := []mount.Mount{
+		{
+			Type:   mount.TypeVolume,
+			Source: volumeName,
+			Target: ProjectPath,
+		},
+	}
+	binds := []string{
+		"/var/run/docker.sock:/var/run/docker.sock",
+		fmt.Sprintf("%s/.docker:/root/.docker", homeDir),
+		fmt.Sprintf("%s:/%s:delegated", gitRoot, mountDir),
 	}
 
-	return dockerutil.Exec(dockerArgs, false)
+	containerConfig := container.Config{
+		Image: SyncImage,
+		Cmd:   []string{"/bin/sh"},
+		Tty:   true,
+	}
+
+	hostConfig := container.HostConfig{
+		Binds:      binds,
+		Mounts:     volumeMounts,
+		AutoRemove: true,
+	}
+
+	log.Println("Starting Garden for this project for the first time, it may take a while for the project to sync")
+
+	_, err := dockerutil.RunContainer(containerConfig, hostConfig, containerName)
+	util.Check(err)
+
+	// first we sync the contents of the host-mount dir into the project volume and wait for it to finish
+	// (need the "echo yes" to get past the confirmation)
+	dockerutil.Exec([]string{
+		"exec", containerName,
+		"echo", "yes", "|", "unison", "-force", mountDir, mountDir, ProjectPath,
+	}, true)
+
+	// then we watch for changes in the background
+	dockerutil.Exec([]string{
+		"exec", "-d", containerName,
+		"unison", "-repeat", "watch", "-force", mountDir, mountDir, ProjectPath,
+	}, true)
+
+	return err
 }

--- a/garden-cli/util/util.go
+++ b/garden-cli/util/util.go
@@ -1,4 +1,4 @@
-package main
+package util
 
 import (
 	"math/rand"
@@ -9,7 +9,7 @@ import (
 )
 
 // Use this for unexpected errors, like system errors that we have no sensible way of dealing with.
-func check(err error) {
+func Check(err error) {
 	if err != nil {
 		panic(err)
 	}
@@ -18,7 +18,7 @@ func check(err error) {
 var letters = []rune("abcdefghijklmnopqrstuvwxyz1234567890")
 
 // Generate a random string of length n.
-func randSeq(n int) string {
+func RandSeq(n int) string {
 	rand.Seed(time.Now().UnixNano())
 	b := make([]rune, n)
 	for i := range b {
@@ -32,15 +32,15 @@ func int32Ptr(value int32) *int32 {
 }
 
 // Returns the current user's home directory, as an absolute path.
-func getHomeDir() string {
+func GetHomeDir() string {
 	homeDir, err := homedir.Dir()
-	check(err)
+	Check(err)
 	homeDir, err = homedir.Expand(homeDir)
-	check(err)
+	Check(err)
 	return homeDir
 }
 
 // Makes sure the given directory path exists.
-func ensureDir(path string) {
+func EnsureDir(path string) {
 	os.MkdirAll(path, os.ModePerm)
 }

--- a/garden-service/Dockerfile
+++ b/garden-service/Dockerfile
@@ -1,5 +1,10 @@
 FROM node:10.11.0-alpine
 
+# The current implementation of Garden expects the Helm and OpenFaas binaries at these specific paths.
+
+ARG HELM_PATH=/root/.garden/tools/helm/02a4751586d6a80f/
+ARG FAASCLI_PATH=/root/.garden/tools/faas-cli/826489a1731741fd/
+
 # system dependencies
 RUN apk add --no-cache \
   bash \
@@ -8,11 +13,13 @@ RUN apk add --no-cache \
   git \
   openssl \
   rsync \
-  && curl -L https://storage.googleapis.com/kubernetes-helm/helm-v2.11.0-linux-amd64.tar.gz | tar xvz --strip-components=1 -C /usr/local/bin linux-amd64/helm \
-  && chmod +x /usr/local/bin/helm \
-  && helm init --client-only \
-  && curl -L -o /usr/local/bin/faas-cli "https://github.com/openfaas/faas-cli/releases/download/0.7.3/faas-cli" \
-  && chmod +x /usr/local/bin/faas-cli \
+  && mkdir -p ${HELM_PATH} \
+  && curl -L https://storage.googleapis.com/kubernetes-helm/helm-v2.11.0-linux-amd64.tar.gz | tar xvz -C ${HELM_PATH}  \
+  && chmod +x ${HELM_PATH}/linux-amd64/helm \
+  && ${HELM_PATH}/linux-amd64/helm init --client-only \
+  && mkdir -p ${FAASCLI_PATH}} \
+  && curl -L -o ${FAASCLI_PATH}/faas-cli "https://github.com/openfaas/faas-cli/releases/download/0.7.3/faas-cli" \
+  && chmod +x ${FAASCLI_PATH}/faas-cli \
   && curl -L -o /usr/local/bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubectl" \
   && chmod +x /usr/local/bin/kubectl
 
@@ -34,7 +41,6 @@ ADD build /garden/build
 ADD static /garden/static
 
 WORKDIR /project
-ENTRYPOINT [ "garden" ]
 
 RUN ln -s /garden/static/bin/garden /bin/garden \
   && chmod +x /bin/garden

--- a/garden-service/gulpfile.ts
+++ b/garden-service/gulpfile.ts
@@ -36,7 +36,7 @@ const binDir = resolve(__dirname, "bin")
 module.exports = (gulp) => {
   gulp.task("add-version-files", () => spawn(join(binDir, "add-version-files.ts"), []))
 
-  gulp.task("build-container", () => spawn("docker", ["build", "-t", "garden-service", __dirname]))
+  gulp.task("build-container", () => spawn("docker", ["build", "-t", "gardenengine/garden-service:latest", __dirname]))
 
   gulp.task("generate-docs", () => spawn(join(binDir, "generate-docs.ts"), []))
 

--- a/garden-sync/Dockerfile
+++ b/garden-sync/Dockerfile
@@ -2,5 +2,3 @@ FROM alpine:3.8
 
 # system dependencies
 RUN apk add --no-cache unison
-
-CMD unison -repeat watch -force host-mount host-mount project

--- a/garden-sync/gulpfile.ts
+++ b/garden-sync/gulpfile.ts
@@ -10,7 +10,10 @@ import { join } from "path"
 import { spawn } from "../support/support-util"
 
 module.exports = (gulp) => {
-  gulp.task("build-container", () => spawn("docker", ["build", "-t", "garden-sync", join(__dirname)]))
+  gulp.task("build-container", () => spawn(
+    "docker",
+    ["build", "-t", "gardenengine/garden-sync:latest", join(__dirname)],
+  ))
 }
 
 if (process.cwd() === __dirname) {


### PR DESCRIPTION
An improved version of the Go CLI.

* Use Docker SDK where possible instead of shelling out
* Ensure sync is complete before running the command
* Keep the garden-service container running