### PR TITLE
fix(ext-tools): handle end of stream event

### DIFF
--- a/garden-service/src/util/ext-tools.ts
+++ b/garden-service/src/util/ext-tools.ts
@@ -171,6 +171,11 @@ export class BinaryCmd extends Cmd {
         // validate sha256 if provided
         const sha256 = hash.read()
 
+        // end of stream event
+        if (sha256 === null) {
+          return
+        }
+
         if (this.spec.sha256 && sha256 !== this.spec.sha256) {
           reject(new DownloadError(
             `Invalid checksum from ${this.spec.url} (got ${sha256})`,


### PR DESCRIPTION
When validating the hash of a downloaded binary, `hash.read()` returns
`null` at the end of stream event. This wasn't handled properly before.