### PR TITLE
Add automatic markdown link validator 

### DIFF
--- a/bin/check-docs
+++ b/bin/check-docs
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+# linter before git check so we can lint docs even if they are 'dirty'
+find docs -name '*.md' -type f -exec markdown-link-check  {} \;
+
+git diff --quiet HEAD -- docs/ || (echo 'generated docs are not up-to-date!' && exit 1)

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -5,7 +5,7 @@ Represents the current configuration and status of any running services in the [
 inspected and modified via the Garden CLI's `environment` command.
 
 Several named environment configurations may be defined (e.g. _dev_, _testing_, ...) in the [project's
-`garden.yml`](../guides/configuration.md#project-configuration).
+`garden.yml`](../using-garden/configuration-files.md#project-configuration).
 
 #### Module
 The basic unit of configuration in Garden. A module is defined by its

--- a/package-lock.json
+++ b/package-lock.json
@@ -1475,7 +1475,7 @@
     },
     "ansi-colors": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "dev": true,
       "requires": {
@@ -5924,6 +5924,12 @@
         "is-windows": "^1.0.1"
       }
     },
+    "is-absolute-url": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+      "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
+      "dev": true
+    },
     "is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -6119,6 +6125,15 @@
         "is-unc-path": "^1.0.0"
       }
     },
+    "is-relative-url": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative-url/-/is-relative-url-2.0.0.tgz",
+      "integrity": "sha1-cpAtf+BLPUeS59sV+duEtyBMnO8=",
+      "dev": true,
+      "requires": {
+        "is-absolute-url": "^2.0.0"
+      }
+    },
     "is-retry-allowed": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
@@ -6190,6 +6205,23 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
+    },
+    "isemail": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+      "dev": true,
+      "requires": {
+        "punycode": "2.x.x"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        }
+      }
     },
     "isexe": {
       "version": "2.0.0",
@@ -6391,6 +6423,26 @@
         "object.map": "^1.0.0",
         "rechoir": "^0.6.2",
         "resolve": "^1.1.7"
+      }
+    },
+    "link-check": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/link-check/-/link-check-4.4.4.tgz",
+      "integrity": "sha512-yvowNBZEMOFH9nGLiJ5/YV68PBMVTo4opC2SzcACO8g4gSPTB9Rwa5GIziOX9Z5Er3Yf01DHoOyVV2LeApIw8w==",
+      "dev": true,
+      "requires": {
+        "is-relative-url": "^2.0.0",
+        "isemail": "^3.1.2",
+        "ms": "^2.1.1",
+        "request": "^2.87.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
       }
     },
     "load-json-file": {
@@ -6727,6 +6779,54 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "markdown-link-check": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/markdown-link-check/-/markdown-link-check-3.7.2.tgz",
+      "integrity": "sha512-rt6d75iz0Bw9LHmN+DT1a7kiVrkK3gsGhPVB/PwwZDq8LHlILQToC/hwq9tE2CUDg8OdZOV1+7j8vuG9Mu4sIQ==",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.1",
+        "chalk": "^2.4.1",
+        "commander": "^2.16.0",
+        "link-check": "^4.4.4",
+        "lodash": "^4.17.10",
+        "markdown-link-extractor": "^1.2.0",
+        "progress": "^2.0.0",
+        "request": "^2.87.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.10"
+          }
+        },
+        "commander": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+          "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+          "dev": true
+        }
+      }
+    },
+    "markdown-link-extractor": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-link-extractor/-/markdown-link-extractor-1.2.0.tgz",
+      "integrity": "sha512-1unDsoZSSiF5oGFu/2y8M3E2I2YhWT/jiKGTQxa1IAmkC1OcyHo9OYNu3qCuVSj5Ty87+mFtgQxJPUfc08WirA==",
+      "dev": true,
+      "requires": {
+        "marked": "^0.4.0"
+      }
+    },
+    "marked": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
+      "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==",
+      "dev": true
     },
     "matchdep": {
       "version": "2.0.0",
@@ -7865,7 +7965,7 @@
     },
     "pretty-hrtime": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
     },
@@ -7879,6 +7979,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
+      "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
       "dev": true
     },
     "promise": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "husky": "^0.15.0-rc.13",
     "lerna": "^3.0.4",
     "lodash": "^4.17.11",
+    "markdown-link-check": "^3.7.2",
     "shx": "^0.3.2",
     "snyk": "^1.90.2",
     "ts-node": "^7.0.1",
@@ -41,7 +42,7 @@
   },
   "scripts": {
     "build": "npm run clean && gulp build",
-    "check-docs": "git diff --quiet HEAD -- docs/ || (echo 'generated docs are not up-to-date!' && exit 1)",
+    "check-docs": "./bin/check-docs",
     "check-licenses": "gulp check-licenses",
     "check-package-lock": "git diff --quiet HEAD -- package-lock.json || (echo 'package-lock.json is dirty!' && exit 1)",
     "clean": "lerna run clean && git clean -X -f",


### PR DESCRIPTION
Adds automatic markdown linter for links. 

Can be run locally 

`npm run check-docs` 

Thinking we should split `check-docs` and `lint-docs` but kinda on the fence here

This also happens during CI now as well.

Closes #330 

Will rebase once #359  is merged.