### PR TITLE
fix: fixes to hot reload source/target handling

### DIFF
--- a/docs/reference/config-files-reference.md
+++ b/docs/reference/config-files-reference.md
@@ -663,11 +663,15 @@ module:
         # top-level directory. Must be a relative path if provided. Defaults to the module's
         # top-level directory if no value is provided.
         #
+        # Example: "src"
+        #
         # Optional.
         source: .
 
         # POSIX-style absolute path to sync the directory to inside the container. The root path
         # (i.e. "/") is not allowed.
+        #
+        # Example: "/app/src"
         #
         # Required.
         target:

--- a/garden-service/src/plugins/kubernetes/actions.ts
+++ b/garden-service/src/plugins/kubernetes/actions.ts
@@ -159,7 +159,7 @@ export async function hotReload(
       .nodePort
 
     await Bluebird.map(hotReloadConfig.sync, async ({ source, target }) => {
-      const src = rsyncSourcePath(module, source)
+      const src = rsyncSourcePath(module.path, source)
       const destination = `rsync://${hostname}:${rsyncNodePort}/volume/${rsyncTargetPath(target)}`
       await execa("rsync", ["-vrptgo", src, destination])
     })

--- a/garden-service/test/src/plugins/kubernetes/deployment.ts
+++ b/garden-service/test/src/plugins/kubernetes/deployment.ts
@@ -1,0 +1,82 @@
+import { expect } from "chai"
+import { makeCopyCommands, removeTrailingSlashes, rsyncTargetPath } from "../../../../src/plugins/kubernetes/deployment"
+
+describe("deployment", () => {
+
+  describe("removeTrailingSlashes", () => {
+    const paths = [
+      ["/foo/bar", "/foo/bar"],
+      ["/foo/bar/", "/foo/bar"],
+      ["/foo", "/foo"],
+      ["/foo/", "/foo"],
+      ["/foo/bar//", "/foo/bar"],
+    ]
+
+    for (const path of paths) {
+      it(`handles paths correctly for ${path[0]}`, () => {
+        expect(removeTrailingSlashes(path[0])).to.eql(path[1])
+      })
+    }
+  })
+
+  describe("rsyncTargetPath", () => {
+    const paths = [
+      // Adds missing slash
+      ["/foo/bar", "foo/bar/"],
+      // Makes sure it doesn't add more to sub paths
+      ["/foo/bar/", "foo/bar/"],
+      // Handles basic 1 directory path with absolute path
+      ["/foo", "foo/"],
+      // Makes sure only a single slash is added
+      ["/foo/", "foo/"],
+      // Removes duplicate slashes (should never happen)
+      ["/foo/bar//", "foo/bar/"],
+    ]
+
+    for (const path of paths) {
+      it(`handles paths correctly for ${path[0]}`, () => {
+        expect(rsyncTargetPath(path[0])).to.eql(path[1])
+      })
+    }
+  })
+
+  describe("makeCopyCommands", () => {
+    // Test cases for each type
+    const configs: any[] = [
+      // Source is missing slash
+      [
+        [{ source: "src", target: "/app/src" }],
+        "mkdir -p /.garden/hot_reload/app/src/ && cp -r src/. /.garden/hot_reload/app/src/",
+      ],
+      // Source ends on slash
+      [
+        [{ source: "src/", target: "/app/src" }],
+        "mkdir -p /.garden/hot_reload/app/src/ && cp -r src/. /.garden/hot_reload/app/src/",
+      ],
+      // Base root of the module
+      [
+        [{ source: ".", target: "/app" }],
+        "mkdir -p /.garden/hot_reload/app/ && cp -r ./. /.garden/hot_reload/app/",
+      ],
+      // Subdirectory not ending on a slash
+      [
+        [{ source: "src/foo", target: "/app/foo" }],
+        "mkdir -p /.garden/hot_reload/app/foo/ && cp -r src/foo/. /.garden/hot_reload/app/foo/",
+      ],
+      // Multiple pairs
+      [
+        [
+          { source: "src1", target: "/app/src1" },
+          { source: "src2", target: "/app/src2" },
+        ],
+        "mkdir -p /.garden/hot_reload/app/src1/ && cp -r src1/. /.garden/hot_reload/app/src1/ && " +
+        "mkdir -p /.garden/hot_reload/app/src2/ && cp -r src2/. /.garden/hot_reload/app/src2/",
+      ],
+    ]
+    for (const config of configs) {
+      it("correctly generates copy commands for the hot reload init container", () => {
+        expect(makeCopyCommands(config[0])).to.eql(config[1])
+      })
+    }
+  })
+})


### PR DESCRIPTION
Fixes issues with handling subpaths as hotreload sync targets with differences between the way `cp` and `rysync` and `k8s` handle the paths. 

Solves issues with trying to sync `src` into `/app/src` and other edge cases where hotreloading would only work after a first change was made to the source. 

Also originally both the source and target needed to be in the exact correct format for things to work regarding trailing slashes. 

@thsig I also made 2 small changes that should have zero impact on code but really bugged me.

1. Changed the sync container name to not include `-container` it's annoying to suffix things by what they are.
2. Changed the volume to be called `garden-sync` so removed `-volume` and the `-${service-name}` this volume isn't a global variable its only shared with in this deployment so is there a reason to add the service name to it?  

As far as I know with garden services result in multiple deployments + services? 