### PR TITLE
fix: allow env variables to be lower case

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -295,7 +295,7 @@ module:
             target:
 
   # Key/value map of environment variables. Keys must be valid POSIX environment variable names
-  # (must be uppercase, may not start with `GARDEN`) and values must be primitives.
+  # (must not start with `GARDEN`) and values must be primitives.
   #
   # Optional.
   env: 
@@ -331,7 +331,7 @@ module:
         -
 
       # Key/value map of environment variables. Keys must be valid POSIX environment variable
-      # names (must be uppercase, may not start with `GARDEN`) and values must be primitives.
+      # names (must not start with `GARDEN`) and values must be primitives.
       #
       # Optional.
       env: 
@@ -519,7 +519,7 @@ module:
           port:
 
       # Key/value map of environment variables. Keys must be valid POSIX environment variable
-      # names (must be uppercase, may not start with `GARDEN`) and values must be primitives.
+      # names (must not start with `GARDEN`) and values must be primitives.
       #
       # Optional.
       env: 
@@ -640,7 +640,7 @@ module:
         -
 
       # Key/value map of environment variables. Keys must be valid POSIX environment variable
-      # names (must be uppercase, may not start with `GARDEN`) and values must be primitives.
+      # names (must not start with `GARDEN`) and values must be primitives.
       #
       # Optional.
       env: 

--- a/garden-service/src/config/common.ts
+++ b/garden-service/src/config/common.ts
@@ -31,7 +31,7 @@ export const joiPrimitive = () => Joi.alternatives().try(Joi.number(), Joi.strin
 export const absolutePathRegex = /^\/.*/ // Note: Only checks for the leading slash
 export const identifierRegex = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/
 export const userIdentifierRegex = /^(?!garden)[a-z][a-z0-9]*(-[a-z0-9]+)*$/
-export const envVarRegex = /^(?!GARDEN)[A-Z_][A-Z0-9_]*$/
+export const envVarRegex = /^(?!garden)[a-z_][a-z0-9_]*$/i
 
 export const joiIdentifier = () => Joi.string()
   .regex(identifierRegex)
@@ -64,20 +64,13 @@ export const joiVariables = () => Joi
   .unknown(false)
   .description("Key/value map. Keys may contain letters and numbers, and values must be primitives.")
 
-export const joiEnvVarName = () => Joi
-  .string().regex(envVarRegex)
-  .description(
-    "Valid POSIX environment variable name (may contain letters, numbers and underscores and must start with a " +
-    "letter). Must be uppercase, and must not start with `GARDEN`.",
-  )
-
 export const joiEnvVars = () => Joi
   .object().pattern(envVarRegex, joiPrimitive())
   .default(() => ({}), "{}")
   .unknown(false)
   .description(
     "Key/value map of environment variables. Keys must be valid POSIX environment variable names " +
-    "(must be uppercase, may not start with `GARDEN`) and values must be primitives.",
+    "(must not start with `GARDEN`) and values must be primitives.",
   )
 
 export const joiArray = (schema) => Joi

--- a/garden-service/test/src/types/common.ts
+++ b/garden-service/test/src/types/common.ts
@@ -5,20 +5,36 @@ import { identifierRegex, validate, envVarRegex } from "../../../src/config/comm
 import { expectError } from "../../helpers"
 
 describe("envVarRegex", () => {
-  it("should accept a valid env var name", () => {
-    expect(envVarRegex.test("MY_ENV_VAR")).to.be.true
+  it("should fail on invalid env variables", () => {
+    const testCases = [
+      "GARDEN",
+      "garden",
+      "GARDEN_ENV_VAR",
+      "garden_",
+      "123",
+      ".",
+      "MY-ENV_VAR",
+    ]
+    for (const tc of testCases) {
+      const result = envVarRegex.test(tc)
+      expect(result, tc).to.be.false
+    }
   })
 
-  it("should disallow dashes", () => {
-    expect(envVarRegex.test("MY-ENV_VAR")).to.be.false
-  })
-
-  it("should disallow lowercase chars", () => {
-    expect(envVarRegex.test("my_env_var")).to.be.false
-  })
-
-  it("should disallow strings starting with GARDEN", () => {
-    expect(envVarRegex.test("GARDEN_ENV_VAR")).to.be.false
+  it("should pass on valid env variables", () => {
+    const testCases = [
+      "GAR",
+      "_test_",
+      "MY_ENV_VAR",
+      "A_123",
+      "_2134",
+      "a_b_c",
+      "A_B_C_",
+    ]
+    for (const tc of testCases) {
+      const result = envVarRegex.test(tc)
+      expect(result, tc).to.be.true
+    }
   })
 })
 


### PR DESCRIPTION
We should allow the same set of variables that bash/docker/k8s would allow. 

Fixes #369 

Also https://www.ietf.org/rfc/rfc2119.txt regarding usage of may/must :) 