### PR TITLE
fix(create-command): add project key to generated config and fix tests

### DIFF
--- a/garden-service/src/commands/create/helpers.ts
+++ b/garden-service/src/commands/create/helpers.ts
@@ -8,13 +8,8 @@
 
 import * as Joi from "joi"
 import {
-  containerTemplate,
-  googleCloudFunctionTemplate,
-  npmPackageTemplate,
-  ModuleConfigOpts,
   ModuleType,
   moduleTemplate,
-  ConfigOpts,
 } from "./config-templates"
 import { join } from "path"
 import { pathExists } from "fs-extra"
@@ -22,28 +17,19 @@ import { validate } from "../../config/common"
 import { dumpYaml } from "../../util/util"
 import { MODULE_CONFIG_FILENAME } from "../../constants"
 import { LogNode } from "../../logger/log-node"
+import { NewModuleOpts, CommonOpts } from "./project"
 
-export function prepareNewModuleConfig(name: string, type: ModuleType, path: string): ModuleConfigOpts {
-  const moduleTypeTemplate = {
-    container: containerTemplate,
-    "google-cloud-function": googleCloudFunctionTemplate,
-    "npm-package": npmPackageTemplate,
-  }[type]
+export function prepareNewModuleOpts(name: string, type: ModuleType, path: string): NewModuleOpts {
   return {
     name,
     type,
     path,
-    config: {
-      module: {
-        ...moduleTemplate(name, type),
-        ...moduleTypeTemplate(name),
-      },
-    },
+    config: moduleTemplate(name, type),
   }
 }
 
-export async function dumpConfig(configOpts: ConfigOpts, schema: Joi.Schema, logger: LogNode) {
-  const { config, name, path } = configOpts
+export async function dumpConfig(opts: CommonOpts, schema: Joi.Schema, logger: LogNode) {
+  const { config, name, path } = opts
   const yamlPath = join(path, MODULE_CONFIG_FILENAME)
   const task = logger.info({
     msg: `Writing config for ${name}`,

--- a/garden-service/src/commands/create/module.ts
+++ b/garden-service/src/commands/create/module.ts
@@ -8,6 +8,7 @@
 
 import { basename, join } from "path"
 import dedent = require("dedent")
+import { ensureDir } from "fs-extra"
 
 import {
   Command,
@@ -17,14 +18,15 @@ import {
   CommandParams,
 } from "../base"
 import { ParameterError, GardenBaseError } from "../../exceptions"
-import { availableModuleTypes, ModuleType, moduleSchema, ModuleConfigOpts } from "./config-templates"
+import { availableModuleTypes, ModuleType } from "./config-templates"
 import {
-  prepareNewModuleConfig,
+  prepareNewModuleOpts,
   dumpConfig,
 } from "./helpers"
 import { prompts } from "./prompts"
 import { validate, joiIdentifier } from "../../config/common"
-import { ensureDir } from "fs-extra"
+import { NewModuleOpts } from "./project"
+import { configSchema } from "../../config/base"
 
 const createModuleOptions = {
   name: new StringParameter({
@@ -47,7 +49,7 @@ type Opts = typeof createModuleOptions
 
 interface CreateModuleResult extends CommandResult {
   result: {
-    module?: ModuleConfigOpts,
+    module?: NewModuleOpts,
   }
 }
 
@@ -102,14 +104,14 @@ export class CreateModuleCommand extends Command<Args, Opts> {
       }
     }
 
-    const module = prepareNewModuleConfig(moduleName, type, moduleRoot)
+    const moduleOpts = prepareNewModuleOpts(moduleName, type, moduleRoot)
     try {
-      await dumpConfig(module, moduleSchema, garden.log)
+      await dumpConfig(moduleOpts, configSchema, garden.log)
     } catch (err) {
       errors.push(err)
     }
     return {
-      result: { module },
+      result: { module: moduleOpts },
       errors,
     }
   }

--- a/garden-service/test/src/commands/create/config-templates.ts
+++ b/garden-service/test/src/commands/create/config-templates.ts
@@ -6,35 +6,34 @@ import {
   moduleTemplate,
 } from "../../../../src/commands/create/config-templates"
 import { validate } from "../../../../src/config/common"
-import { baseModuleSpecSchema } from "../../../../src/config/module"
-import { projectSchema } from "../../../../src/config/project"
+import { configSchema } from "../../../../src/config/base"
 
 describe("ConfigTemplates", () => {
   describe("projectTemplate", () => {
     for (const moduleType of availableModuleTypes) {
       it(`should be valid for module type ${moduleType}`, async () => {
         const config = projectTemplate("my-project", [moduleType])
-        expect(() => validate(config, projectSchema)).to.not.throw()
+        expect(() => validate(config, configSchema)).to.not.throw()
       })
     }
     it("should be valid for multiple module types", async () => {
       const config = projectTemplate("my-project", availableModuleTypes)
-      expect(() => validate(config, projectSchema)).to.not.throw()
+      expect(() => validate(config, configSchema)).to.not.throw()
     })
     it("should be valid for multiple modules of same type", async () => {
       const config = projectTemplate("my-project", [availableModuleTypes[0], availableModuleTypes[0]])
-      expect(() => validate(config, projectSchema)).to.not.throw()
+      expect(() => validate(config, configSchema)).to.not.throw()
     })
     it("should be valid if no modules", async () => {
       const config = projectTemplate("my-project", [])
-      expect(() => validate(config, projectSchema)).to.not.throw()
+      expect(() => validate(config, configSchema)).to.not.throw()
     })
   })
   describe("moduleTemplate", () => {
     for (const moduleType of availableModuleTypes) {
       it(`should be valid for module type ${moduleType}`, async () => {
         const config = moduleTemplate("my-module", moduleType)
-        expect(() => validate(config, baseModuleSpecSchema)).to.not.throw()
+        expect(() => validate(config, configSchema)).to.not.throw()
       })
     }
   })

--- a/garden-service/test/src/commands/create/project.ts
+++ b/garden-service/test/src/commands/create/project.ts
@@ -54,8 +54,8 @@ describe("CreateProjectCommand", () => {
       args: { "project-dir": "" },
       opts: { name: "", "module-dirs": [] },
     })
-    const modules = result.moduleConfigs.map(m => pick(m, ["name", "type", "path"]))
-    const project = pick(result.projectConfig, ["name", "path"])
+    const modules = result.modules.map(m => pick(m, ["name", "type", "path"]))
+    const project = pick(result.project, ["name", "path"])
 
     expect({ modules, project }).to.eql({
       modules: [
@@ -77,7 +77,7 @@ describe("CreateProjectCommand", () => {
       args: { "project-dir": "new-project" },
       opts: { name: "", "module-dirs": [] },
     })
-    expect(pick(result.projectConfig, ["name", "path"])).to.eql({
+    expect(pick(result.project, ["name", "path"])).to.eql({
       name: "new-project",
       path: join(garden.projectRoot, "new-project"),
     })
@@ -91,7 +91,7 @@ describe("CreateProjectCommand", () => {
       args: { "project-dir": "" },
       opts: { name: "my-project", "module-dirs": [] },
     })
-    expect(pick(result.projectConfig, ["name", "path"])).to.eql({
+    expect(pick(result.project, ["name", "path"])).to.eql({
       name: "my-project",
       path: join(garden.projectRoot),
     })
@@ -105,7 +105,7 @@ describe("CreateProjectCommand", () => {
       args: { "project-dir": "" },
       opts: { name: "", "module-dirs": ["."] },
     })
-    expect(result.moduleConfigs.map(m => pick(m, ["name", "type", "path"]))).to.eql([
+    expect(result.modules.map(m => pick(m, ["name", "type", "path"]))).to.eql([
       { type: "container", name: "module-a", path: join(garden.projectRoot, "module-a") },
       { type: "container", name: "module-b", path: join(garden.projectRoot, "module-b") },
     ])
@@ -119,7 +119,7 @@ describe("CreateProjectCommand", () => {
       args: { "project-dir": "" },
       opts: { name: "", "module-dirs": ["module-a", "module-b"] },
     })
-    expect(result.moduleConfigs.map(m => pick(m, ["name", "type", "path"]))).to.eql([
+    expect(result.modules.map(m => pick(m, ["name", "type", "path"]))).to.eql([
       { type: "container", name: "child-module-a", path: join(garden.projectRoot, "module-a", "child-module-a") },
       { type: "container", name: "child-module-b", path: join(garden.projectRoot, "module-b", "child-module-b") },
     ])


### PR DESCRIPTION
The `project` key was missing at the top of the project level `garden.yml` file generated by the create command. Furthermore, the tests were validating the generated config against the projectSchema instead of the entire configSchema. 