### PR TITLE
Improve hello world example

### DIFF
--- a/docs/examples/hello-world.md
+++ b/docs/examples/hello-world.md
@@ -36,7 +36,7 @@ _Note: `source` refers to the path within the dependency module being specified,
 Runtime dependencies, on the other hand, are irrelevant at build time, but required for execution. For example, as we can see in the `app.js` file, the `hello-container` module depends on `hello-function` being up and running:
 
 ```js
-const functionEndpoint = process.env.GARDEN_SERVICES_HELLO_FUNCTION_ENDPOINT
+const functionEndpoint = process.env.FUNCTION_ENDPOINT
 ```
 
 So let's see how to make sure `hello-function` is running before `hello-container`:
@@ -48,6 +48,8 @@ module:
   name: hello-container
   services:
     ...
+      env:
+        FUNCTION_ENDPOINT: ${services.hello-function.outputs.endpoint}
       dependencies:
         - hello-function
 ```

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -1,0 +1,57 @@
+<p align="center">
+
+  <a href="https://docs.openfaas.com/" style="margin-right: 1.5em;">
+    <img alt="openfaas" src="https://blog.alexellis.io/content/images/2017/08/faas_side.png" width="100" />
+  </a>
+  <a href="https://www.docker.com/" style="margin-right: 1.5em;">
+    <img alt="docker" src="https://upload.wikimedia.org/wikipedia/commons/4/4e/Docker_%28container_engine%29_logo.svg" width="100" />
+  </a>
+  <a href="https://www.npmjs.com/">
+    <img alt="npm" src="https://upload.wikimedia.org/wikipedia/commons/d/db/Npm-logo.svg" width="60" />
+  </a>
+</p>
+
+# Example project using NPM, OpenFaaS, and Docker
+
+This project shows how you can configure Garden to use dependencies (NPM package), functions (OpenFaaS), and containers (Docker).
+
+```sh
+# Build dependency
+hello-container -> hello-npm-package
+# Runtime dependency
+hello-container -> hello-function (openfaas)
+```
+
+## Usage
+
+Use the `deploy` command to deploy the project:
+
+```sh
+garden deploy
+```
+
+Use the `call` command to get the output of the hello-container endpoint:
+```sh
+$ garden call hello-container/hello
+
+✔ Sending HTTP GET request to http://hello-world.local.app.garden/hello
+
+200 OK
+
+{
+  "message": "Hello there, I'm an OpenFaaS function"
+}
+
+```
+
+or call the function directly:
+
+```sh
+$ garden call hello-function/function/hello-function
+
+✔ Sending HTTP GET request to http://hello-world.local.app.garden/function/hello-function
+
+200 OK
+
+an OpenFaaS function
+```

--- a/examples/hello-world/services/hello-container/app.js
+++ b/examples/hello-world/services/hello-container/app.js
@@ -4,7 +4,7 @@ const hello = require("./libraries/hello-npm-package")
 
 const app = express()
 
-const functionEndpoint = process.env.GARDEN_SERVICES_HELLO_FUNCTION_ENDPOINT
+const functionEndpoint = process.env.FUNCTION_ENDPOINT
 
 app.get("/hello", (req, res) => {
   // Query the example cloud function and return the response

--- a/examples/hello-world/services/hello-container/garden.yml
+++ b/examples/hello-world/services/hello-container/garden.yml
@@ -30,5 +30,7 @@ module:
       command: [npm, test]
     - name: integ
       command: [npm, run, integ]
+      env:
+        FUNCTION_ENDPOINT: ${services.hello-function.outputs.endpoint}
       dependencies:
         - hello-function


### PR DESCRIPTION
Fixes #325 

We can also better document it instead of being explicit, but I think this is more clear as a hello-world example.

I like the idea of the readme's in the example/xx/README.md being kinda a quick start compared to a full walkthrough like https://docs.garden.io/examples/hello-world  

But happy to change that?
