### PR TITLE
fix: fix dev command terminating on config change

### DIFF
--- a/garden-service/src/cli/cli.ts
+++ b/garden-service/src/cli/cli.ts
@@ -7,36 +7,26 @@
  */
 
 import * as sywac from "sywac"
-import { merge, intersection, range } from "lodash"
+import { intersection, merge, range } from "lodash"
 import { resolve } from "path"
 import { safeDump } from "js-yaml"
 import { coreCommands } from "../commands/commands"
-import stringify = require("json-stringify-safe")
 
 import { DeepPrimitiveMap } from "../config/common"
-import {
-  getEnumKeys,
-  shutdown,
-  sleep,
-} from "../util/util"
+import { getEnumKeys, shutdown, sleep } from "../util/util"
 import {
   BooleanParameter,
-  Command,
   ChoicesParameter,
+  Command,
+  CommandResult,
+  EnvironmentOption,
   Parameter,
   StringParameter,
-  EnvironmentOption,
-  CommandResult,
 } from "../commands/base"
-import {
-  GardenError,
-  PluginError,
-  toGardenError,
-  InternalError,
-} from "../exceptions"
-import { Garden, ContextOpts } from "../garden"
+import { GardenError, InternalError, PluginError, toGardenError } from "../exceptions"
+import { ContextOpts, Garden } from "../garden"
 
-import { Logger, LoggerType, getLogger } from "../logger/logger"
+import { getLogger, Logger, LoggerType } from "../logger/logger"
 import { LogLevel } from "../logger/log-node"
 import { BasicTerminalWriter } from "../logger/writers/basic-terminal-writer"
 import { FancyTerminalWriter } from "../logger/writers/fancy-terminal-writer"
@@ -44,20 +34,21 @@ import { FileWriter } from "../logger/writers/file-writer"
 import { Writer } from "../logger/writers/base"
 
 import {
-  falsifyConflictingParams,
+  envSupportsEmoji,
   failOnInvalidOptions,
+  falsifyConflictingParams,
+  filterByKeys,
   getArgSynopsis,
   getKeys,
   getOptionSynopsis,
-  filterByKeys,
   prepareArgConfig,
   prepareOptionConfig,
   styleConfig,
-  envSupportsEmoji,
 } from "./helpers"
 import { GardenConfig } from "../config/base"
 import { defaultEnvironments } from "../config/project"
 import { ERROR_LOG_FILENAME } from "../constants"
+import stringify = require("json-stringify-safe")
 
 const OUTPUT_RENDERERS = {
   json: (data: DeepPrimitiveMap) => {
@@ -283,6 +274,8 @@ export class GardenCli {
       }
       let garden: Garden
       let result
+      await command.printHeader(log)
+
       do {
         garden = await Garden.factory(root, contextOpts)
 

--- a/garden-service/src/commands/base.ts
+++ b/garden-service/src/commands/base.ts
@@ -272,6 +272,13 @@ export abstract class Command<T extends Parameters = {}, U extends Parameters = 
     }
   }
 
+  /**
+   * Called by the CLI before the command's action is run, but is not called again
+   * if the command restarts. Useful for commands in watch mode.
+   */
+  async printHeader(_: LogEntry) {
+  }
+
   // Note: Due to a current TS limitation (apparently covered by https://github.com/Microsoft/TypeScript/issues/7011),
   // subclass implementations need to explicitly set the types in the implemented function signature. So for now we
   // can't enforce the types of `args` and `opts` automatically at the abstract class level and have to specify

--- a/garden-service/src/commands/build.ts
+++ b/garden-service/src/commands/build.ts
@@ -58,17 +58,17 @@ export class BuildCommand extends Command<BuildArguments, BuildOptions> {
   arguments = buildArguments
   options = buildOptions
 
+  async printHeader(log) {
+    logHeader({ log, emoji: "hammer", command: "Build" })
+  }
+
   async action(
     { args, opts, garden, log }: CommandParams<BuildArguments, BuildOptions>,
   ): Promise<CommandResult<TaskResults>> {
-
     await garden.clearBuilds()
-
     const modules = await garden.getModules(args.module)
     const dependencyGraph = await garden.getDependencyGraph()
     const moduleNames = modules.map(m => m.name)
-
-    logHeader({ log, emoji: "hammer", command: "Build" })
 
     const results = await processModules({
       garden,

--- a/garden-service/src/commands/deploy.ts
+++ b/garden-service/src/commands/deploy.ts
@@ -73,6 +73,10 @@ export class DeployCommand extends Command<Args, Opts> {
   arguments = deployArgs
   options = deployOpts
 
+  async printHeader(log) {
+    logHeader({ log, emoji: "rocket", command: "Deploy" })
+  }
+
   async action({ garden, log, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<TaskResults>> {
     const services = await garden.getServices(args.service)
 
@@ -93,8 +97,6 @@ export class DeployCommand extends Command<Args, Opts> {
     } else {
       watch = opts.watch
     }
-
-    logHeader({ log, emoji: "rocket", command: "Deploy" })
 
     // TODO: make this a task
     await garden.actions.prepareEnvironment({ log })

--- a/garden-service/src/commands/dev.ts
+++ b/garden-service/src/commands/dev.ts
@@ -24,6 +24,7 @@ import {
   CommandResult,
   CommandParams,
   StringsParameter,
+  handleTaskResults,
 } from "./base"
 import { STATIC_DIR } from "../constants"
 import { processModules } from "../process"
@@ -65,13 +66,15 @@ export class DevCommand extends Command<Args, Opts> {
 
   options = devOpts
 
-  async action({ garden, log, opts }: CommandParams<Args, Opts>): Promise<CommandResult> {
+  async printHeader(log) {
     // print ANSI banner image
     const data = await readFile(ansiBannerPath)
     log.info(data.toString())
 
     log.info(chalk.gray.italic(`\nGood ${getGreetingTime()}! Let's get your environment wired up...\n`))
+  }
 
+  async action({ garden, log, opts }: CommandParams<Args, Opts>): Promise<CommandResult> {
     await garden.actions.prepareEnvironment({ log })
 
     const modules = await garden.getModules()
@@ -127,7 +130,7 @@ export class DevCommand extends Command<Args, Opts> {
 
     }
 
-    await processModules({
+    const results = await processModules({
       garden,
       log,
       modules,
@@ -136,7 +139,8 @@ export class DevCommand extends Command<Args, Opts> {
       changeHandler: tasksForModule(true),
     })
 
-    return {}
+    return handleTaskResults(log, "dev", results)
+
   }
 }
 

--- a/garden-service/src/commands/test.ts
+++ b/garden-service/src/commands/test.ts
@@ -72,6 +72,14 @@ export class TestCommand extends Command<Args, Opts> {
   arguments = testArgs
   options = testOpts
 
+  async printHeader(log) {
+    logHeader({
+      log,
+      emoji: "thermometer",
+      command: `Running tests`,
+    })
+  }
+
   async action({ garden, log, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<TaskResults>> {
     const dependencyGraph = await garden.getDependencyGraph()
     let modules: Module[]
@@ -81,12 +89,6 @@ export class TestCommand extends Command<Args, Opts> {
       // All modules are included in this case, so there's no need to compute dependants.
       modules = await garden.getModules()
     }
-
-    logHeader({
-      log,
-      emoji: "thermometer",
-      command: `Running tests`,
-    })
 
     await garden.actions.prepareEnvironment({ log })
 


### PR DESCRIPTION
Resolves https://github.com/garden-io/garden/issues/389.

Also added a `headerRendered` instance var to commands accepting the watch flag, to prevent commands re-rendering their header on restart.

I decided not to add `headerRendered` to the base `Command` class for starters. Thoughts?