### PR TITLE
fix: do not run dependant tasks unless updated services depend on them

### DIFF
--- a/garden-service/src/actions.ts
+++ b/garden-service/src/actions.ts
@@ -72,7 +72,7 @@ import { mapValues, values, keyBy, omit } from "lodash"
 import { Omit } from "./util/util"
 import { RuntimeContext } from "./types/service"
 import { processServices, ProcessResults } from "./process"
-import { getTasksForModule } from "./tasks/helpers"
+import { getDependantTasksForModule } from "./tasks/helpers"
 import { LogEntry } from "./logger/log-entry"
 import { createPluginContext } from "./plugin-context"
 import { CleanupEnvironmentParams } from "./types/plugin/params"
@@ -364,7 +364,7 @@ export class ActionHelper implements TypeGuard {
       garden: this.garden,
       log,
       watch: false,
-      handler: async (module) => getTasksForModule({
+      handler: async (module) => getDependantTasksForModule({
         garden: this.garden,
         log,
         module,

--- a/garden-service/src/commands/deploy.ts
+++ b/garden-service/src/commands/deploy.ts
@@ -18,7 +18,7 @@ import {
   StringsParameter,
 } from "./base"
 import { hotReloadAndLog, validateHotReloadOpt } from "./helpers"
-import { getTasksForModule, getHotReloadModuleNames } from "../tasks/helpers"
+import { getDependantTasksForModule, getHotReloadModuleNames } from "../tasks/helpers"
 import { TaskResults } from "../task-graph"
 import { processServices } from "../process"
 import { logHeader } from "../logger/util"
@@ -108,7 +108,7 @@ export class DeployCommand extends Command<Args, Opts> {
       logFooter,
       services,
       watch,
-      handler: async (module) => getTasksForModule({
+      handler: async (module) => getDependantTasksForModule({
         garden,
         log,
         module,
@@ -121,7 +121,7 @@ export class DeployCommand extends Command<Args, Opts> {
         if (hotReloadModuleNames.has(module.name)) {
           await hotReloadAndLog(garden, log, module)
         }
-        return getTasksForModule({
+        return getDependantTasksForModule({
           garden, log, module, hotReloadServiceNames, force: true, forceBuild: opts["force-build"],
           fromWatch: true, includeDependants: true,
         })

--- a/garden-service/src/commands/dev.ts
+++ b/garden-service/src/commands/dev.ts
@@ -17,7 +17,7 @@ import { join } from "path"
 
 import { BaseTask } from "../tasks/base"
 import { hotReloadAndLog, validateHotReloadOpt } from "./helpers"
-import { getTasksForModule, getHotReloadModuleNames } from "../tasks/helpers"
+import { getDependantTasksForModule, getHotReloadModuleNames } from "../tasks/helpers"
 import {
   Command,
   CommandResult,
@@ -110,7 +110,7 @@ export class DevCommand extends Command<Args, Opts> {
         const testTasks: BaseTask[] = flatten(await Bluebird.map(
           testModules, m => getTestTasks({ garden, log, module: m })))
 
-        return testTasks.concat(await getTasksForModule({
+        return testTasks.concat(await getDependantTasksForModule({
           garden,
           log,
           module,

--- a/garden-service/test/src/commands/deploy.ts
+++ b/garden-service/test/src/commands/deploy.ts
@@ -96,7 +96,7 @@ describe("DeployCommand", () => {
     const log = garden.log
     const command = new DeployCommand()
 
-    const { result } = await command.action({
+    const { result, errors } = await command.action({
       garden,
       log,
       args: {
@@ -109,6 +109,10 @@ describe("DeployCommand", () => {
         "force-build": true,
       },
     })
+
+    if (errors) {
+      throw errors[0]
+    }
 
     expect(taskResultOutputs(result!)).to.eql({
       "build.module-a": { fresh: true, buildLog: "A" },
@@ -131,7 +135,7 @@ describe("DeployCommand", () => {
     const log = garden.log
     const command = new DeployCommand()
 
-    const { result } = await command.action({
+    const { result, errors } = await command.action({
       garden,
       log,
       args: {
@@ -144,6 +148,10 @@ describe("DeployCommand", () => {
         "force-build": true,
       },
     })
+
+    if (errors) {
+      throw errors[0]
+    }
 
     expect(taskResultOutputs(result!)).to.eql({
       "build.module-a": { fresh: true, buildLog: "A" },


### PR DESCRIPTION
Tasks should not run if they are leaf nodes after watch triggers.
Otherwise tasks that have no dependants get run automatically, and we
want users to be able to define tasks that are only run manually.