### PR TITLE
feat(versioncmd): adds version command to return current version

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -31,7 +31,7 @@ about: Create a report to help make garden better
 <!-- PLEASE FILL THIS OUT -->
 
 <!-- Please run and copy and paste the results  -->
-`garden -v`
+`garden version`
 
 `kubectl version`
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -801,3 +801,12 @@ Throws an error and exits with code 1 if something's not right in your garden.ym
 
     garden validate 
 
+### garden version
+
+Show&#x27;s the current cli version.
+
+
+##### Usage
+
+    garden version 
+

--- a/garden-service/src/cli/cli.ts
+++ b/garden-service/src/cli/cli.ts
@@ -42,6 +42,7 @@ import {
   prepareArgConfig,
   prepareOptionConfig,
   styleConfig,
+  getPackageVersion,
 } from "./helpers"
 import { GardenConfig } from "../config/base"
 import { defaultEnvironments } from "../config/project"
@@ -174,7 +175,7 @@ export class GardenCli {
   private fileWritersInitialized: boolean = false
 
   constructor() {
-    const version = require("../../package.json").version
+    const version = getPackageVersion()
     this.program = sywac
       .help("-h, --help", {
         group: GLOBAL_OPTIONS_GROUP_NAME,
@@ -183,6 +184,7 @@ export class GardenCli {
       .version("-v, --version", {
         version,
         group: GLOBAL_OPTIONS_GROUP_NAME,
+        description: "Show's the current cli version.",
         implicitCommand: false,
       })
       .showHelpByDefault()

--- a/garden-service/src/cli/helpers.ts
+++ b/garden-service/src/cli/helpers.ts
@@ -173,3 +173,8 @@ export function failOnInvalidOptions(argv, ctx) {
     ctx.cliMessage(`Received invalid flag(s): ${invalid.join(", ")}`)
   }
 }
+
+export function getPackageVersion(): String {
+  const version = require("../../package.json").version
+  return version
+}

--- a/garden-service/src/commands/commands.ts
+++ b/garden-service/src/commands/commands.ts
@@ -27,6 +27,7 @@ import { UpdateRemoteCommand } from "./update-remote/update-remote"
 import { ValidateCommand } from "./validate"
 import { ExecCommand } from "./exec"
 import { ServeCommand } from "./serve"
+import { VersionCommand } from "./version"
 
 export const coreCommands: Command[] = [
   new BuildCommand(),
@@ -49,4 +50,5 @@ export const coreCommands: Command[] = [
   new UnlinkCommand(),
   new UpdateRemoteCommand(),
   new ValidateCommand(),
+  new VersionCommand(),
 ]

--- a/garden-service/src/commands/version.ts
+++ b/garden-service/src/commands/version.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2018 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import {
+  Command,
+  CommandResult,
+  CommandParams,
+} from "./base"
+import { getPackageVersion } from "../cli/helpers"
+import chalk from "chalk"
+
+export class VersionCommand extends Command {
+  name = "version"
+  help = "Show's the current cli version."
+
+  async action({ log }: CommandParams<{}>): Promise<CommandResult<String>> {
+    const result = `${getPackageVersion()}`
+
+    log.info(`${chalk.white(result)}`)
+    return { result }
+  }
+}

--- a/garden-service/test/src/cli/helpers.ts
+++ b/garden-service/test/src/cli/helpers.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2018 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import { getPackageVersion } from "../../../src/cli/helpers"
+
+describe("helpers", () => {
+  describe("getPackageVersion", () => {
+    it("returns the version in package.json", async () => {
+      const version = require("../../../package.json").version
+      expect(getPackageVersion()).to.eq(version)
+    })
+  })
+})

--- a/garden-service/test/src/commands/version.ts
+++ b/garden-service/test/src/commands/version.ts
@@ -1,0 +1,19 @@
+import { expect } from "chai"
+import { VersionCommand } from "../../../src/commands/version"
+import { makeTestGardenA } from "../../helpers"
+
+describe("VersionCommand", () => {
+  it("should return the current package's version", async () => {
+    const command = new VersionCommand()
+    const garden = await makeTestGardenA()
+    const log = garden.log
+    const result = await command.action({
+      log,
+      garden,
+      args: {},
+      opts: {},
+    })
+
+    expect(result.result).to.eql(require("../../../package.json").version)
+  })
+})


### PR DESCRIPTION
Adds a version command so it matches all a bunch of other tools.

`garden version` and `garden -v` return the same result. 