### PR TITLE
Upgrade kubernetes client to 0.7.2

### DIFF
--- a/garden-service/package-lock.json
+++ b/garden-service/package-lock.json
@@ -331,25 +331,6 @@
         "find-up": "^2.1.0"
       }
     },
-    "@drubin/client-node": {
-      "version": "0.7.1-rc1",
-      "resolved": "https://registry.npmjs.org/@drubin/client-node/-/client-node-0.7.1-rc1.tgz",
-      "integrity": "sha512-zrKHtQCAnQMunZpUdA578R2vYvg8O6Ge2BT23JWGQkJe5BKNBccrT52zxF85Gua0QgEaKPmTUYAYMq6ALZPOSg==",
-      "requires": {
-        "base-64": "^0.1.0",
-        "bluebird": "^3.5.2",
-        "byline": "^5.0.0",
-        "execa": "^1.0.0",
-        "isomorphic-ws": "^4.0.1",
-        "js-yaml": "^3.12.0",
-        "jsonpath": "^1.0.0",
-        "request": "^2.88.0",
-        "shelljs": "^0.8.2",
-        "tslib": "^1.9.3",
-        "underscore": "^1.9.1",
-        "ws": "^6.1.0"
-      }
-    },
     "@gulp-sourcemaps/identity-map": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-1.0.2.tgz",
@@ -379,6 +360,25 @@
       "requires": {
         "normalize-path": "^2.0.1",
         "through2": "^2.0.3"
+      }
+    },
+    "@kubernetes/client-node": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.7.2.tgz",
+      "integrity": "sha512-lIHRApAhhSfA3muxAv4XTcNVokDfyfZP4NWwWKmK2kFBUNSDfGFmoIuJRKWL2s3aNMjbblwGrQo2YGZvtSo8nw==",
+      "requires": {
+        "base-64": "^0.1.0",
+        "bluebird": "^3.5.2",
+        "byline": "^5.0.0",
+        "execa": "^1.0.0",
+        "isomorphic-ws": "^4.0.1",
+        "js-yaml": "^3.12.0",
+        "jsonpath": "^1.0.0",
+        "request": "^2.88.0",
+        "shelljs": "^0.8.2",
+        "tslib": "^1.9.3",
+        "underscore": "^1.9.1",
+        "ws": "^6.1.0"
       }
     },
     "@marionebl/sander": {

--- a/garden-service/package.json
+++ b/garden-service/package.json
@@ -22,7 +22,7 @@
     "static"
   ],
   "dependencies": {
-    "@drubin/client-node": "0.7.1-rc1",
+    "@kubernetes/client-node": "0.7.2",
     "@types/koa-static": "^4.0.0",
     "ansi-escapes": "^3.1.0",
     "async-exit-hook": "^2.0.1",
@@ -127,7 +127,6 @@
     "@types/unzip": "^0.1.1",
     "@types/unzipper": "^0.9.1",
     "@types/wrap-ansi": "^3.0.0",
-    "@types/ws": "^6.0.1",
     "chai": "^4.2.0",
     "gulp": "^4.0.0",
     "gulp-cached": "^1.1.1",

--- a/garden-service/src/plugins/kubernetes/api.ts
+++ b/garden-service/src/plugins/kubernetes/api.ts
@@ -15,7 +15,7 @@ import {
   Apiextensions_v1beta1Api,
   V1Secret,
   Policy_v1beta1Api,
-} from "@drubin/client-node"
+} from "@kubernetes/client-node"
 import { join } from "path"
 import { readFileSync } from "fs"
 import { safeLoad } from "js-yaml"

--- a/garden-service/src/plugins/kubernetes/secrets.ts
+++ b/garden-service/src/plugins/kubernetes/secrets.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { V1Secret } from "@drubin/client-node"
+import { V1Secret } from "@kubernetes/client-node"
 
 import { KubeApi } from "./api"
 import { SecretRef } from "./kubernetes"

--- a/garden-service/src/plugins/kubernetes/status.ts
+++ b/garden-service/src/plugins/kubernetes/status.ts
@@ -24,13 +24,13 @@ import {
   V1StatefulSet,
   V1StatefulSetSpec,
   V1DeploymentStatus,
-} from "@drubin/client-node"
+} from "@kubernetes/client-node"
 import { some, zip, isArray, isPlainObject, pickBy, mapValues } from "lodash"
 import { KubernetesProvider } from "./kubernetes"
 import { isSubset } from "../../util/is-subset"
 import { LogEntry } from "../../logger/log-entry"
 import { getContainerServiceStatus } from "./deployment"
-import { V1ReplicationController, V1ReplicaSet } from "@drubin/client-node"
+import { V1ReplicationController, V1ReplicaSet } from "@kubernetes/client-node"
 import dedent = require("dedent")
 
 export interface RolloutStatus {


### PR DESCRIPTION
Switch back to official kubernetes node-client. As a side affect this also includes changes for `exec` as a local auth method (which will allow us to properly make use of gke/* clusters)

Before when accessing a gke cluster we would have to run something to refresh the token externally before using garden. 