### PR TITLE
Allow explicitly picking port for api in dev cmd

### DIFF
--- a/garden-service/src/commands/serve.ts
+++ b/garden-service/src/commands/serve.ts
@@ -11,14 +11,14 @@ import { LoggerType } from "../logger/logger"
 import { IntegerParameter } from "./base"
 import { Command, CommandResult, CommandParams } from "./base"
 import { sleep } from "../util/util"
-import { startServer } from "../server/server"
+import { startServer, DEFAULT_PORT } from "../server/server"
 
 const serveArgs = {}
 
 const serveOpts = {
   port: new IntegerParameter({
     help: `The port number for the Garden service to listen on.`,
-    defaultValue: 9777,
+    defaultValue: DEFAULT_PORT,
   }),
 }
 

--- a/garden-service/src/process.ts
+++ b/garden-service/src/process.ts
@@ -144,7 +144,9 @@ export async function processModules(
 
   // Experimental HTTP API and dashboard server.
   if (process.env.GARDEN_ENABLE_SERVER === "1") {
-    await startServer(garden, log)
+    // allow overriding automatic port picking
+    const port = Number(process.env.GARDEN_SERVER_PORT) || undefined
+    await startServer(garden, log, port)
   }
 
   await restartPromise

--- a/garden-service/src/server/server.ts
+++ b/garden-service/src/server/server.ts
@@ -24,6 +24,8 @@ export const DASHBOARD_BUILD_PATH = resolve(
   isPkg ? process.execPath : __dirname, "..", "..", "..", "garden-dashboard", "build",
 )
 
+export const DEFAULT_PORT = 9777
+
 /**
  * Start an HTTP server that exposes commands and events for the given Garden instance.
  *


### PR DESCRIPTION
via GARDEN_SERVER_PORT env variable

`GARDEN_SERVER_PORT=9778 GARDEN_ENABLE_SERVER=1 garden dev`

This should solve a bunch of hacks getting the dashboard port to update every time you run the a command. 