### PR TITLE
fix(log): log footer line was duplicated after config reload

### DIFF
--- a/garden-service/src/cli/cli.ts
+++ b/garden-service/src/cli/cli.ts
@@ -268,6 +268,7 @@ export class GardenCli {
 
       // We pass a separate placeholder to the action method, so that commands can easily have a footer
       // section in their log output.
+      logger.info("")   // Put one line between the body and the footer
       const logFooter = logger.placeholder()
 
       const contextOpts: GardenOpts = { environmentName: env, log }

--- a/garden-service/src/process.ts
+++ b/garden-service/src/process.ts
@@ -88,15 +88,12 @@ export async function processModules(
   }
 
   if (watch && !!logFooter) {
-    logFooter.info("")
-    const statusLine = logFooter.placeholder()
-
     garden.events.on("taskGraphProcessing", () => {
-      statusLine.setState({ emoji: "hourglass_flowing_sand", msg: "Processing..." })
+      logFooter.setState({ emoji: "hourglass_flowing_sand", msg: "Processing..." })
     })
 
     garden.events.on("taskGraphComplete", () => {
-      statusLine.setState({ emoji: "clock2", msg: chalk.gray("Waiting for code changes") })
+      logFooter.setState({ emoji: "clock2", msg: chalk.gray("Waiting for code changes") })
     })
   }
 


### PR DESCRIPTION
A side effect of this is that we always add a blank line at the bottom
of the console when using the fancy logger. I think it looks nice
in most cases, but we may want to adjust some logging later.