### PR TITLE
WIP: fix(k8s): split command and args

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -547,10 +547,29 @@ module:
       outputs: 
         {}
 
-      # The arguments to run the container with when starting the service.
+      # The command to run the container with when starting the service.
+      # Equivalent to
+      # Docker's entrypoint
+      # Kubernetes's command
+      #
+      # Example:
+      #   - /bin/echo
       #
       # Optional.
       command: 
+        -
+
+      # The arguments to pass to the command run when starting the service.
+      # Equivalent to
+      # Docker's cmd
+      # Kubernetes's args
+      #
+      # Example:
+      #   - hello
+      #   - world
+      #
+      # Optional.
+      args: 
         -
 
       # Whether to run the service as a daemon (to ensure only one runs per node).

--- a/garden-service/src/plugins/container.ts
+++ b/garden-service/src/plugins/container.ts
@@ -84,6 +84,7 @@ export interface ServiceHealthCheckSpec {
 
 export interface ContainerServiceSpec extends BaseServiceSpec {
   command: string[],
+  args: string[],
   daemon: boolean
   ingresses: ContainerIngressSpec[],
   env: PrimitiveMap,
@@ -213,7 +214,23 @@ const volumeSchema = Joi.object()
 const serviceSchema = baseServiceSchema
   .keys({
     command: Joi.array().items(Joi.string())
-      .description("The arguments to run the container with when starting the service."),
+      .example([
+        ["/bin/echo"],
+      ])
+      .description(dedent`The command to run the container with when starting the service.
+        Equivalent to
+        Docker's entrypoint
+        Kubernetes's command
+      `),
+    args: Joi.array().items(Joi.string())
+      .example([
+        ["hello", "world"],
+      ])
+      .description(dedent`The arguments to pass to the command run when starting the service.
+        Equivalent to
+        Docker's cmd
+        Kubernetes's args
+      `),
     daemon: Joi.boolean()
       .default(false)
       .description("Whether to run the service as a daemon (to ensure only one runs per node)."),

--- a/garden-service/src/plugins/kubernetes/deployment.ts
+++ b/garden-service/src/plugins/kubernetes/deployment.ts
@@ -180,7 +180,10 @@ export async function createDeployment(
   }
 
   if (service.spec.command && service.spec.command.length > 0) {
-    container.args = service.spec.command
+    container.command = service.spec.command
+  }
+  if (service.spec.args && service.spec.args.length > 0) {
+    container.args = service.spec.args
   }
 
   // if (config.entrypoint) {

--- a/garden-service/src/plugins/local/local-google-cloud-functions.ts
+++ b/garden-service/src/plugins/local/local-google-cloud-functions.ts
@@ -46,7 +46,8 @@ export const gardenPlugin = (): GardenPlugin => ({
             outputs: {
               ingress: `http://${s.name}:${emulatorPort}/local/local/${functionEntrypoint}`,
             },
-            command: ["/app/start.sh", functionEntrypoint],
+            command: ["/app/start.sh"],
+            args: [functionEntrypoint],
             daemon: false,
             ingresses: [{
               name: "default",


### PR DESCRIPTION
fix(k8s): split command and args so they match the semantics of kubernetes

By making this split we actuallly need to make very little code changes but it changes have knock on effect which I wanted to get feedback on. 

Currently this isn't the only place we use commands/args. We do it with `hotreloadCommand` and all task comamnds.

Currently although broken they behave in the same way. When doing this split we will need to provide a way for users to use custom args/commands in those as well. 

Because `args` actually maps more closely to docker's CMD most of our tasks could potentially look like this

```yaml
tasks:
    - name: ruby-migration
      args: [rake, db:migrate]
```

Since we assume the entrypoint would be `bundle exec` or some form of init handler.

@thsig @edvald Thoughts? I haven't actually gone and fully updated tasks and hotreloading wanted to get some throughts before going further.

BREAKING CHANGE:
After upgrading, any project which uses a custom `command`
will need to change their garden.yaml to use the `args` instead.

Example with a Dockerfile

```docker
ENTRYPOINT["/bin/echo ]
```

and garden.yml of

    command: ["hello", "worlld"]

would become

    args: ["hello", "world]
    command: ["/bin/echo] # this is line is optional