### PR TITLE
fix: don't watch project-level log files

### DIFF
--- a/garden-service/src/util/util.ts
+++ b/garden-service/src/util/util.ts
@@ -131,6 +131,7 @@ export async function getIgnorer(rootPath: string): Promise<Ignorer> {
   ig.add([
     "node_modules",
     ".git",
+    "*.log",
     GARDEN_DIR_NAME,
   ])
 


### PR DESCRIPTION
Added `*.log` to the list of path patterns ignored by default.

Previously, running `garden get status` in a project where

* Another Garden command is running in watch mode, and

* A service from a module at the project level (i.e. with its
module config in the project-wide `garden.yml`) is deployed
with hot reloading enabled,

would erroneously trigger a hot reload of that service, due to the
project-level `error.log` getting touched during the execution of
`garden get status`.

Fixes https://github.com/garden-io/garden/issues/387.