### PR TITLE
fix(dashboard): limit number of log lines that are fetched (#461)

### DIFF
--- a/dashboard/src/api/index.ts
+++ b/dashboard/src/api/index.ts
@@ -11,10 +11,14 @@ import axios from "axios"
 import {
   FetchConfigResponse,
   FetchStatusResponse,
-  FetchLogResponse,
+  FetchLogsResponse,
   ApiRequest,
   FetchGraphResponse,
 } from "./types"
+
+export type FetchLogsParam = string[]
+
+const MAX_LOG_LINES = 5000
 
 export async function fetchConfig(): Promise<FetchConfigResponse> {
   return apiPost<FetchConfigResponse>("get.config")
@@ -28,9 +32,9 @@ export async function fetchStatus(): Promise<FetchStatusResponse> {
   return apiPost<FetchStatusResponse>("get.status")
 }
 
-export async function fetchLogs(services?: string[]): Promise<FetchLogResponse> {
-  const params = services ? { service: services } : {}
-  return apiPost<FetchLogResponse>("logs", params)
+export async function fetchLogs(services: FetchLogsParam): Promise<FetchLogsResponse> {
+  const tail = Math.floor(MAX_LOG_LINES / services.length)
+  return apiPost<FetchLogsResponse>("logs", { services, tail })
 }
 
 async function apiPost<T>(command: string, parameters: {} = {}): Promise<T> {

--- a/dashboard/src/api/types.ts
+++ b/dashboard/src/api/types.ts
@@ -101,7 +101,7 @@ export interface ServiceLogEntry {
   msg: string
 }
 
-export type FetchLogResponse = ServiceLogEntry[]
+export type FetchLogsResponse = ServiceLogEntry[]
 
 export interface ApiRequest {
   command: string

--- a/dashboard/src/components/card.tsx
+++ b/dashboard/src/components/card.tsx
@@ -22,7 +22,7 @@ const Wrapper = styled.div`
   box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
 `
 
-const Title = styled.h3`
+export const CardTitle = styled.h3`
   ${fontMedium};
   font-size: 1.3rem;
   margin: 0;
@@ -32,7 +32,7 @@ const Card: React.SFC<CardProps> = ({ children, title }) => {
   const titleEl = title
     ? (
       <div className="pl-1 pr-1 pb-1">
-        <Title>{title}</Title>
+        <CardTitle>{title}</CardTitle>
       </div>
     )
     : null

--- a/dashboard/src/components/graph/index.tsx
+++ b/dashboard/src/components/graph/index.tsx
@@ -170,8 +170,7 @@ const Status = styled.p`
 `
 
 const ProcessSpinner = styled(Spinner)`
-  margin: 20px 0 0 20px;
-  font-size: 12px;
+  margin: 16px 0 0 20px;
 `
 
 class Chart extends Component<Props, State> {
@@ -296,34 +295,27 @@ class Chart extends Component<Props, State> {
     const chartHeightEstimate = `100vh - 15rem`
 
     let spinner = null
-    let status = "Ready"
+    let status = ""
     if (message && message.name !== "taskGraphComplete") {
       status = "Processing..."
-      spinner = <ProcessSpinner />
+      spinner = <ProcessSpinner background={colors.white} fontSize="2px" />
     }
 
     return (
       <Card>
         <div>
           <div>
-            <p>
-              <Span><span className={css`color: ${colors.gardenGreen};`}>—  </span>Ready</Span>
-              <Span><span className={css`color: ${colors.gardenPink};`}>--  </span>Pending</Span>
-              <Span><span className={css`color: red;`}>—  </span>Error</Span>
-            </p>
-            <div>
-              {taskTypes.map(type => (
-                <label className="ml-1" key={type}>
-                  {capitalize(type)}
-                  <input
-                    type={"checkbox"}
-                    name={type}
-                    checked={!this.state.filters[type]}
-                    onChange={this.onCheckboxChange}
-                  />
-                </label>
-              ))}
-            </div>
+            {taskTypes.map(type => (
+              <label className="ml-1" key={type}>
+                {capitalize(type)}
+                <input
+                  type={"checkbox"}
+                  name={type}
+                  checked={!this.state.filters[type]}
+                  onChange={this.onCheckboxChange}
+                />
+              </label>
+            ))}
           </div>
           <div className={css`
             height: calc(${chartHeightEstimate});
@@ -331,9 +323,17 @@ class Chart extends Component<Props, State> {
           </div>
           <div className={cls(css`
             display: flex;
-          `, "ml-1 pb-1")}>
-            <Status>{status}</Status>
-            {spinner}
+            justify-content: space-between;
+          `, "ml-1 mr-1 pb-1")}>
+            <div>
+              <Status>{status}</Status>
+              {spinner}
+            </div>
+            <p>
+              <Span><span className={css`color: ${colors.gardenGreen};`}>—  </span>Ready</Span>
+              <Span><span className={css`color: ${colors.gardenPink};`}>--  </span>Pending</Span>
+              <Span><span className={css`color: red;`}>—  </span>Error</Span>
+            </p>
           </div>
         </div>
       </Card>

--- a/dashboard/src/components/logs.tsx
+++ b/dashboard/src/components/logs.tsx
@@ -6,20 +6,39 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import styled from "@emotion/styled/macro"
 import { flatten, max } from "lodash"
 import React, { Component } from "react"
 
 import Terminal from "./terminal"
-import { FetchConfigResponse, FetchLogResponse } from "../api/types"
+import { FetchConfigResponse, FetchLogsResponse } from "../api/types"
+import Card, { CardTitle } from "./card"
+import { colors } from "../styles/variables"
+import { LoadLogs } from "../context/data"
 
 interface Props {
   config: FetchConfigResponse
-  logs: FetchLogResponse
+  logs: FetchLogsResponse
+  loadLogs: LoadLogs
 }
 
 interface State {
   selectedService: string
 }
+
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+`
+
+const Icon = styled.i`
+  color: ${colors.gardenPink};
+  font-size: 1.5rem;
+  cursor: pointer;
+  :active {
+    color: ${colors.gardenPinkLighten(0.7)}
+  }
+`
 
 class Logs extends Component<Props, State> {
 
@@ -31,10 +50,16 @@ class Logs extends Component<Props, State> {
       selectedService: "all",
     }
     this.handleChange = this.handleChange.bind(this)
+    this.refresh = this.refresh.bind(this)
   }
 
   handleChange(event) {
     this.setState({ selectedService: event.target.value })
+  }
+
+  refresh() {
+    const serviceNames = flatten(this.props.config.modules.map(m => m.serviceNames))
+    this.props.loadLogs(serviceNames, true)
   }
 
   render() {
@@ -58,12 +83,20 @@ class Logs extends Component<Props, State> {
             ))}
           </select>
         </div>
-        <Terminal
-          entries={filteredLogs}
-          sectionPad={maxServiceName}
-          title={title}
-          showServiceName={selectedService === "all"}
-        />
+        <Card>
+          <div>
+            <Header className="pl-1 pr-1 pb-1">
+              <CardTitle>{title}</CardTitle>
+              <Icon className={"fas fa-sync-alt"} onClick={this.refresh} />
+            </Header>
+            <Terminal
+              entries={filteredLogs}
+              sectionPad={maxServiceName}
+              title={title}
+              showServiceName={selectedService === "all"}
+            />
+          </div>
+        </Card>
       </div>
     )
   }

--- a/dashboard/src/components/terminal.tsx
+++ b/dashboard/src/components/terminal.tsx
@@ -10,7 +10,6 @@ import styled from "@emotion/styled/macro"
 import { padEnd } from "lodash"
 import React from "react"
 
-import Card from "./card"
 import { colors } from "../styles/variables"
 import { ServiceLogEntry } from "../api/types"
 
@@ -24,7 +23,7 @@ interface Props {
 const Term = styled.div`
   background-color: ${colors.lightBlack};
   border-radius: 2px;
-  max-height: 25rem;
+  max-height: 45rem;
   overflow-y: auto;
 `
 
@@ -44,26 +43,24 @@ const Timestamp = styled.span`
 
 // FIXME Use whitespace instead of dots for the sectinon padding.
 // For some reason whitespace is not rendered inside spans.
-const Terminal: React.SFC<Props> = ({ entries, sectionPad, showServiceName, title }) => {
+const Terminal: React.SFC<Props> = ({ entries, sectionPad, showServiceName }) => {
   return (
-    <Card title={title}>
-      <Term className="p-1">
-        <code>
-          {entries.map((e, idx) => {
-            const service = showServiceName
-              ? <Service>{padEnd(e.serviceName, sectionPad + 3, ".")}</Service>
-              : ""
-            return (
-              <P key={idx}>
-                {service}
-                <Timestamp>[{e.timestamp}] </Timestamp>
-                {e.msg}
-              </P>
-            )
-          })}
-        </code>
-      </Term>
-    </Card>
+    <Term className="p-1">
+      <code>
+        {entries.map((e, idx) => {
+          const service = showServiceName
+            ? <Service>{padEnd(e.serviceName, sectionPad + 3, ".")}</Service>
+            : ""
+          return (
+            <P key={idx}>
+              {service}
+              <Timestamp>[{e.timestamp}] </Timestamp>
+              {e.msg}
+            </P>
+          )
+        })}
+      </code>
+    </Term>
   )
 }
 

--- a/dashboard/src/containers/logs.tsx
+++ b/dashboard/src/containers/logs.tsx
@@ -6,6 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import { flatten } from "lodash"
 import React, { useContext, useEffect } from "react"
 
 import PageError from "../components/page-error"
@@ -15,19 +16,38 @@ import { DataContext } from "../context/data"
 
 export default () => {
   const {
-    actions: { loadLogs, loadConfig },
-    store: { config, logs },
+    actions: { loadConfig },
+    store: { config },
   } = useContext(DataContext)
 
   useEffect(loadConfig, [])
-  useEffect(loadLogs, [])
 
-  const isLoading = !config.data || !logs.data || config.loading || logs.loading
-  const error = config.error || logs.error
+  const isLoading = !config.data || config.loading
 
   return (
-    <LoadWrapper error={error} ErrorComponent={PageError} loading={isLoading}>
-      <Logs config={config.data} logs={logs.data} />
+    <LoadWrapper error={config.error} ErrorComponent={PageError} loading={isLoading}>
+      <LogsContainer />
     </LoadWrapper>
   )
+}
+
+const LogsContainer = () => {
+  const {
+    actions: { loadLogs },
+    store: { config, logs },
+  } = useContext(DataContext)
+
+  const serviceNames = flatten(config.data.modules.map(m => m.serviceNames))
+  useEffect(() => {
+    loadLogs(serviceNames)
+  }, [])
+
+  const isLoading = !logs.data
+
+  return (
+    <LoadWrapper error={logs.error} ErrorComponent={PageError} loading={isLoading}>
+      <Logs loadLogs={loadLogs} config={config.data} logs={logs.data} />
+    </LoadWrapper>
+  )
+
 }

--- a/dashboard/src/styles/variables.ts
+++ b/dashboard/src/styles/variables.ts
@@ -19,6 +19,10 @@ export const fontRegular = `${fontFamily};font-weight: 400;`
 export const fontMedium = `${fontFamily};font-weight: 500;`
 export const fontItalic = `${fontFamily};font-style: italic;`
 
+function gardenPinkLighten(pct: number) {
+  return `rgba(218, 69, 162, ${pct})`
+}
+
 export const colors = {
   azure: "#00aeef",
   lightWhite: "rgba(255, 255, 255, 0.15)",
@@ -31,6 +35,7 @@ export const colors = {
   gardenGrey: "#f8faff",
   gardenPink: "#da45a2",
   gardenPinkRgba: "rgba(218, 69, 162, 0)",
+  gardenPinkLighten,
   blueyGrey: "#98a6b6",
   iceCold: "#a5f1e6",
   darkGreen: "#277379",

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -445,7 +445,8 @@ Examples:
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
-  | `--tail` | `-t` | boolean | Continuously stream new logs from the service(s).
+  | `--follow` | `-f` | boolean | Continuously stream new logs from the service(s).
+  | `--tail` | `-t` | number | Number of lines to show for each service. Defaults to -1, showing all log lines.
 
 ### garden publish
 

--- a/garden-service/src/plugins/kubernetes/logs.ts
+++ b/garden-service/src/plugins/kubernetes/logs.ts
@@ -23,8 +23,8 @@ interface GetKubernetesLogsParams extends GetServiceLogsParams {
 
 export async function getKubernetesLogs(params: GetKubernetesLogsParams) {
   // Currently Stern doesn't support just returning the logs and exiting, it can only follow
-  const proc = params.tail
-    ? await tailLogs(params)
+  const proc = params.follow
+    ? await followLogs(params)
     : await getLogs(params)
 
   return new Promise<GetServiceLogsResult>((resolve, reject) => {
@@ -36,13 +36,14 @@ export async function getKubernetesLogs(params: GetKubernetesLogsParams) {
   })
 }
 
-async function tailLogs({ context, namespace, service, selector, stream, log }: GetKubernetesLogsParams) {
+async function followLogs({ context, namespace, service, selector, stream, log, tail }: GetKubernetesLogsParams) {
   const args = [
     "--color", "never",
     "--context", context,
     "--namespace", namespace,
     "--output", "json",
     "--selector", selector,
+    "--tail", String(tail),
     "--timestamps",
   ]
 
@@ -66,11 +67,12 @@ async function tailLogs({ context, namespace, service, selector, stream, log }: 
   return proc
 }
 
-async function getLogs({ context, namespace, service, selector, stream }: GetKubernetesLogsParams) {
+async function getLogs({ context, namespace, service, selector, stream, tail }: GetKubernetesLogsParams) {
   // TODO: do this via API instead of kubectl
   const kubectlArgs = [
     "logs",
     "--selector", selector,
+    "--tail", String(tail),
     "--timestamps=true",
   ]
 

--- a/garden-service/src/types/plugin/params.ts
+++ b/garden-service/src/types/plugin/params.ts
@@ -276,7 +276,8 @@ export interface GetServiceLogsParams<M extends Module = Module, S extends Modul
   extends PluginServiceActionParamsBase<M, S> {
   runtimeContext: RuntimeContext
   stream: Stream<ServiceLogEntry>
-  tail: boolean
+  follow: boolean
+  tail: number
   startTime?: Date
 }
 export const getServiceLogsParamsSchema = serviceActionParamsSchema
@@ -284,8 +285,11 @@ export const getServiceLogsParamsSchema = serviceActionParamsSchema
     runtimeContext: runtimeContextSchema,
     stream: Joi.object()
       .description("A Stream object, to write the logs to."),
-    tail: Joi.boolean()
+    follow: Joi.boolean()
       .description("Whether to keep listening for logs until aborted."),
+    tail: Joi.number()
+      .description("Number of lines to get from end of log. Defaults to -1, showing all log lines.")
+      .default(-1),
     startTime: Joi.date()
       .optional()
       .description("If set, only return logs that are as new or newer than this date."),

--- a/garden-service/test/src/actions.ts
+++ b/garden-service/test/src/actions.ts
@@ -291,7 +291,7 @@ describe("ActionHelper", () => {
     describe("getServiceLogs", () => {
       it("should correctly call the corresponding plugin handler", async () => {
         const stream = new Stream<ServiceLogEntry>()
-        const result = await actions.getServiceLogs({ log, service, stream, tail: false })
+        const result = await actions.getServiceLogs({ log, service, stream, follow: false, tail: -1 })
         expect(result).to.eql({})
       })
     })


### PR DESCRIPTION
This is really just to prevent the browser from crashing on the user if the logs are huge. We still need better log support for the dashboard in general. E.g:

* Improve UI
* Fetch logs for individual services
* Merge new log entries with those already in the data sore