### PR TITLE
feat(k8s): allow overriding release name in Helm modules

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -506,8 +506,8 @@ module:
       # Optional.
       dependencies: 
         # Valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and dashes,
-        # must start with a letter, and cannot end with a dash) and additionally cannot contain
-        # consecutive dashes, or be longer than 63 characters.
+        # must start with a letter, and cannot end with a dash) and must not be longer than 63
+        # characters.
         #
         # Optional.
         -
@@ -854,11 +854,15 @@ module:
   # Optional.
   dependencies: 
     # Valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and dashes, must
-    # start with a letter, and cannot end with a dash) and additionally cannot contain consecutive
-    # dashes, or be longer than 63 characters.
+    # start with a letter, and cannot end with a dash) and must not be longer than 63 characters.
     #
     # Optional.
     -
+
+  # Optionally override the release name used when installing (defaults to the module name).
+  #
+  # Optional.
+  releaseName:
 
   # The repository URL to fetch the chart from.
   #

--- a/garden-service/src/config/common.ts
+++ b/garden-service/src/config/common.ts
@@ -30,16 +30,16 @@ export const joiPrimitive = () => Joi.alternatives().try(Joi.number(), Joi.strin
   .description("Number, string or boolean")
 
 export const absolutePathRegex = /^\/.*/ // Note: Only checks for the leading slash
-export const identifierRegex = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/
-export const userIdentifierRegex = /^(?!garden)[a-z][a-z0-9]*(-[a-z0-9]+)*$/
+// from https://stackoverflow.com/a/12311250/3290965
+export const identifierRegex = /^(?![0-9]+$)(?!.*-$)(?!-)[a-z0-9-]{1,63}$/
+export const userIdentifierRegex = /^(?!garden)(?=.{1,63}$)[a-z][a-z0-9]*(-[a-z0-9]+)*$/
 export const envVarRegex = /^(?!garden)[a-z_][a-z0-9_]*$/i
 
 export const joiIdentifier = () => Joi.string()
   .regex(identifierRegex)
-  .max(63)
   .description(
     "Valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and dashes, must start with a letter, " +
-    "and cannot end with a dash) and additionally cannot contain consecutive dashes, or be longer than 63 characters.",
+    "and cannot end with a dash) and must not be longer than 63 characters.",
   )
 
 export const joiStringMap = (valueSchema: JoiObject) => Joi
@@ -47,7 +47,6 @@ export const joiStringMap = (valueSchema: JoiObject) => Joi
 
 export const joiUserIdentifier = () => Joi.string()
   .regex(userIdentifierRegex)
-  .max(63)
   .description(
     "Valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and dashes, must start with a letter, " +
     "and cannot end with a dash), cannot contain consecutive dashes or start with `garden`, " +

--- a/garden-service/src/plugins/kubernetes/helm/common.ts
+++ b/garden-service/src/plugins/kubernetes/helm/common.ts
@@ -115,10 +115,10 @@ export function getValuesPath(chartPath: string) {
 }
 
 /**
- * Get the release name to use for the module/chart (currently just the module name).
+ * Get the release name to use for the module/chart (the module name, unless overridden in config).
  */
 export function getReleaseName(module: HelmModule) {
-  return module.name
+  return module.spec.releaseName || module.name
 }
 
 /**

--- a/garden-service/src/plugins/kubernetes/helm/config.ts
+++ b/garden-service/src/plugins/kubernetes/helm/config.ts
@@ -129,6 +129,7 @@ export interface HelmServiceSpec extends ServiceSpec {
   chart?: string
   chartPath: string
   dependencies: string[]
+  releaseName?: string
   repo?: string
   serviceResource?: HelmResourceSpec
   skipDeploy: boolean
@@ -173,6 +174,8 @@ export const helmModuleSpecSchema = Joi.object().keys({
     .default("."),
   dependencies: joiArray(joiIdentifier())
     .description("List of names of services that should be deployed before this chart."),
+  releaseName: joiIdentifier()
+    .description("Optionally override the release name used when installing (defaults to the module name)."),
   repo: Joi.string()
     .description("The repository URL to fetch the chart from."),
   serviceResource: resourceSchema

--- a/garden-service/test/data/test-projects/helm/api/garden.yml
+++ b/garden-service/test/data/test-projects/helm/api/garden.yml
@@ -2,6 +2,7 @@ module:
   description: The API backend for the voting UI
   type: helm
   name: api
+  releaseName: api-release
   serviceResource:
     kind: Deployment
     containerModule: api-image

--- a/garden-service/test/src/config/common.ts
+++ b/garden-service/test/src/config/common.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai"
 import * as Joi from "joi"
 const stripAnsi = require("strip-ansi")
-import { identifierRegex, validate, envVarRegex } from "../../../src/config/common"
+import { identifierRegex, validate, envVarRegex, userIdentifierRegex } from "../../../src/config/common"
 import { expectError } from "../../helpers"
 
 describe("envVarRegex", () => {
@@ -38,33 +38,73 @@ describe("envVarRegex", () => {
   })
 })
 
+const validIdentifiers = {
+  "myname": "a valid identifier",
+  "my-name": "a valid identifier with a dash",
+  "my9-9name": "numbers in the middle of a string",
+  "o12345670123456701234567012345670123456701234567012345670123456": "a 63 char identifier",
+  "a": "a single char identifier",
+}
+
+const invalidIdentifiers = {
+  "01010": "string with only numbers",
+  "-abc": "starting with a dash",
+  "abc-": "ending with a dash",
+  "": "an empty string",
+  "o123456701234567012345670123456701234567012345670123456701234567": "a 64 char identifier",
+  "UPPER": "an uppercase string",
+  "upPer": "a partially uppercase string",
+}
+
 describe("identifierRegex", () => {
-  it("should accept a valid identifier", () => {
-    expect(identifierRegex.test("my-name")).to.be.true
+  for (const [value, description] of Object.entries(validIdentifiers)) {
+    it("should allow " + description, () => {
+      expect(identifierRegex.test(value)).to.be.true
+    })
+  }
+
+  for (const [value, description] of Object.entries(invalidIdentifiers)) {
+    it("should disallow " + description, () => {
+      expect(identifierRegex.test(value)).to.be.false
+    })
+  }
+
+  it("should allow consecutive dashes", () => {
+    expect(identifierRegex.test("my--name")).to.be.true
   })
 
-  it("should allow numbers in middle of the string", () => {
-    expect(identifierRegex.test("my9-9name")).to.be.true
+  it("should allow starting with a number", () => {
+    expect(identifierRegex.test("9name")).to.be.true
   })
 
-  it("should disallow ending with a dash", () => {
-    expect(identifierRegex.test("my-name-")).to.be.false
+  it("should allow strings starting with 'garden'", () => {
+    expect(identifierRegex.test("garden-party")).to.be.true
   })
+})
 
-  it("should disallow uppercase characters", () => {
-    expect(identifierRegex.test("myName")).to.be.false
-  })
+describe("userIdentifierRegex", () => {
+  for (const [value, description] of Object.entries(validIdentifiers)) {
+    it("should allow " + description, () => {
+      expect(userIdentifierRegex.test(value)).to.be.true
+    })
+  }
 
-  it("should disallow starting with a dash", () => {
-    expect(identifierRegex.test("-my-name")).to.be.false
+  for (const [value, description] of Object.entries(invalidIdentifiers)) {
+    it("should disallow " + description, () => {
+      expect(userIdentifierRegex.test(value)).to.be.false
+    })
+  }
+
+  it("should allow consecutive dashes", () => {
+    expect(userIdentifierRegex.test("my--name")).to.be.false
   })
 
   it("should disallow starting with a number", () => {
-    expect(identifierRegex.test("9name")).to.be.false
+    expect(userIdentifierRegex.test("9name")).to.be.false
   })
 
-  it("should disallow consecutive dashes", () => {
-    expect(identifierRegex.test("my--name")).to.be.false
+  it("should allow strings starting with 'garden'", () => {
+    expect(userIdentifierRegex.test("garden-party")).to.be.false
   })
 })
 

--- a/garden-service/test/src/plugins/kubernetes/helm/common.ts
+++ b/garden-service/test/src/plugins/kubernetes/helm/common.ts
@@ -75,11 +75,11 @@ describe("Helm common functions", () => {
           apiVersion: "v1",
           kind: "Service",
           metadata: {
-            name: "api",
+            name: "api-release",
             labels: {
               "app.kubernetes.io/name": "api",
               "helm.sh/chart": "api-0.1.0",
-              "app.kubernetes.io/instance": "api",
+              "app.kubernetes.io/instance": "api-release",
               "app.kubernetes.io/managed-by": "Tiller",
             },
             annotations: {},
@@ -96,7 +96,7 @@ describe("Helm common functions", () => {
             ],
             selector: {
               "app.kubernetes.io/name": "api",
-              "app.kubernetes.io/instance": "api",
+              "app.kubernetes.io/instance": "api-release",
             },
           },
         },
@@ -104,11 +104,11 @@ describe("Helm common functions", () => {
           apiVersion: "apps/v1",
           kind: "Deployment",
           metadata: {
-            name: "api",
+            name: "api-release",
             labels: {
               "app.kubernetes.io/name": "api",
               "helm.sh/chart": "api-0.1.0",
-              "app.kubernetes.io/instance": "api",
+              "app.kubernetes.io/instance": "api-release",
               "app.kubernetes.io/managed-by": "Tiller",
             },
             annotations: {},
@@ -118,14 +118,14 @@ describe("Helm common functions", () => {
             selector: {
               matchLabels: {
                 "app.kubernetes.io/name": "api",
-                "app.kubernetes.io/instance": "api",
+                "app.kubernetes.io/instance": "api-release",
               },
             },
             template: {
               metadata: {
                 labels: {
                   "app.kubernetes.io/name": "api",
-                  "app.kubernetes.io/instance": "api",
+                  "app.kubernetes.io/instance": "api-release",
                 },
               },
               spec: {
@@ -156,11 +156,11 @@ describe("Helm common functions", () => {
           apiVersion: "extensions/v1beta1",
           kind: "Ingress",
           metadata: {
-            name: "api",
+            name: "api-release",
             labels: {
               "app.kubernetes.io/name": "api",
               "helm.sh/chart": "api-0.1.0",
-              "app.kubernetes.io/instance": "api",
+              "app.kubernetes.io/instance": "api-release",
               "app.kubernetes.io/managed-by": "Tiller",
             },
             annotations: {},
@@ -174,7 +174,7 @@ describe("Helm common functions", () => {
                     {
                       path: "/",
                       backend: {
-                        serviceName: "api",
+                        serviceName: "api-release",
                         servicePort: "http",
                       },
                     },
@@ -509,9 +509,15 @@ describe("Helm common functions", () => {
   })
 
   describe("getReleaseName", () => {
-    it("should return the module name", async () => {
+    it("should return the module name if not overridden in config", async () => {
       const module = await garden.getModule("api")
+      delete module.spec.releaseName
       expect(getReleaseName(module)).to.equal("api")
+    })
+
+    it("should return the configured release name if any", async () => {
+      const module = await garden.getModule("api")
+      expect(getReleaseName(module)).to.equal("api-release")
     })
   })
 
@@ -671,7 +677,7 @@ describe("Helm common functions", () => {
       deployment.spec.template.spec.containers = []
       await expectError(
         () => getResourceContainer(deployment),
-        err => expect(err.message).to.equal("Deployment api has no containers configured."),
+        err => expect(err.message).to.equal("Deployment api-release has no containers configured."),
       )
     })
 
@@ -679,7 +685,7 @@ describe("Helm common functions", () => {
       const deployment = await getDeployment()
       await expectError(
         () => getResourceContainer(deployment, "foo"),
-        err => expect(err.message).to.equal("Could not find container 'foo' in Deployment 'api'"),
+        err => expect(err.message).to.equal("Could not find container 'foo' in Deployment 'api-release'"),
       )
     })
   })

--- a/garden-service/test/src/plugins/kubernetes/helm/config.ts
+++ b/garden-service/test/src/plugins/kubernetes/helm/config.ts
@@ -60,6 +60,7 @@ describe("validateHelmModule", () => {
           spec: {
             chartPath: ".",
             dependencies: [],
+            releaseName: "api-release",
             serviceResource: {
               kind: "Deployment",
               containerModule: "api-image",
@@ -87,6 +88,7 @@ describe("validateHelmModule", () => {
       spec: {
         chartPath: ".",
         dependencies: [],
+        releaseName: "api-release",
         serviceResource: {
           kind: "Deployment",
           containerModule: "api-image",

--- a/garden-service/test/src/plugins/kubernetes/helm/status.ts
+++ b/garden-service/test/src/plugins/kubernetes/helm/status.ts
@@ -15,6 +15,6 @@ describe("getServiceOutputs", () => {
 
     const result = await getServiceOutputs({ ctx, module, service, log: garden.log })
 
-    expect(result).to.eql({ "release-name": "api" })
+    expect(result).to.eql({ "release-name": "api-release" })
   })
 })


### PR DESCRIPTION
This is necessary for another fix I'm working on, but can be reviewed separately.