### PR TITLE
fix(status): return more correct/granular statuses

### DIFF
--- a/garden-service/src/plugins/kubernetes/container/status.ts
+++ b/garden-service/src/plugins/kubernetes/container/status.ts
@@ -18,6 +18,7 @@ import { ContainerModule } from "../../container/config"
 import { KubeApi } from "../api"
 import { compareDeployedObjects } from "../status"
 import { getIngresses } from "./ingress"
+import { getAppNamespace } from "../namespace"
 
 export async function getContainerServiceStatus(
   { ctx, module, service, runtimeContext, log, hotReload }: GetServiceStatusParams<ContainerModule>,
@@ -26,10 +27,11 @@ export async function getContainerServiceStatus(
   // TODO: hash and compare all the configuration files (otherwise internal changes don't get deployed)
   const version = module.version
   const api = new KubeApi(ctx.provider)
+  const namespace = await getAppNamespace(ctx, ctx.provider)
 
   // FIXME: [objects, matched] and ingresses can be run in parallel
   const objects = await createContainerObjects(ctx, service, runtimeContext, hotReload)
-  const { state, remoteObjects } = await compareDeployedObjects(ctx, objects, log)
+  const { state, remoteObjects } = await compareDeployedObjects(ctx, api, namespace, objects, log)
   const ingresses = await getIngresses(service, api)
 
   return {


### PR DESCRIPTION
Fixes https://github.com/garden-io/garden/issues/377.

Previously, deployed but unhealthy services would be reported as "ready" by the `get status` command. This is fixed here.