### PR TITLE
Fix serve command logs

### DIFF
--- a/garden-service/src/commands/logs.ts
+++ b/garden-service/src/commands/logs.ts
@@ -95,7 +95,7 @@ export class LogsCommand extends Command<Args, Opts> {
     })
 
     await Bluebird.map(services, async (service: Service<any>) => {
-      const voidLog = log.placeholder(LogLevel.silly, { preserveLevel: true })
+      const voidLog = log.placeholder(LogLevel.silly, { childEntriesInheritLevel: true })
       const status = await garden.actions.getServiceStatus({ log: voidLog, service, hotReload: false })
 
       if (status.state === "ready" || status.state === "outdated") {

--- a/garden-service/src/logger/log-entry.ts
+++ b/garden-service/src/logger/log-entry.ts
@@ -31,7 +31,7 @@ export interface UpdateOpts {
   error?: GardenError
   status?: EntryStatus
   indent?: number
-  preserveLevel?: boolean
+  childEntriesInheritLevel?: boolean
 }
 
 export interface CreateOpts extends UpdateOpts {
@@ -110,9 +110,9 @@ export class LogEntry extends LogNode {
       ...resolveParam(param),
     }
 
-    // If preserveLevel is set to true, all children must have a level geq the level
+    // If childEntriesInheritLevel is set to true, all children must have a level geq the level
     // of the parent entry that set the flag.
-    const parentWithPreserveFlag = findParentEntry(this, entry => !!entry.opts.preserveLevel)
+    const parentWithPreserveFlag = findParentEntry(this, entry => !!entry.opts.childEntriesInheritLevel)
     const childLevel = parentWithPreserveFlag ? Math.max(parentWithPreserveFlag.level, level) : level
 
     return new LogEntry({

--- a/garden-service/src/server/commands.ts
+++ b/garden-service/src/server/commands.ts
@@ -71,7 +71,7 @@ export async function resolveRequest(
   const cmdGarden = await Garden.factory(garden.projectRoot, garden.opts)
 
   // We generally don't want actions to log anything in the server.
-  const cmdLog = log.placeholder(LogLevel.silly)
+  const cmdLog = log.placeholder(LogLevel.silly, { preserveLevel: true })
 
   const cmdArgs = mapParams(ctx, request.parameters, command.arguments)
   const cmdOpts = mapParams(ctx, request.parameters, command.options)

--- a/garden-service/src/server/commands.ts
+++ b/garden-service/src/server/commands.ts
@@ -71,7 +71,7 @@ export async function resolveRequest(
   const cmdGarden = await Garden.factory(garden.projectRoot, garden.opts)
 
   // We generally don't want actions to log anything in the server.
-  const cmdLog = log.placeholder(LogLevel.silly, { preserveLevel: true })
+  const cmdLog = log.placeholder(LogLevel.silly, { childEntriesInheritLevel: true })
 
   const cmdArgs = mapParams(ctx, request.parameters, command.arguments)
   const cmdOpts = mapParams(ctx, request.parameters, command.options)

--- a/garden-service/test/logger/log-entry.ts
+++ b/garden-service/test/logger/log-entry.ts
@@ -41,9 +41,9 @@ describe("LogEntry", () => {
     ]
     expect(indents).to.eql([undefined, 1, 2, 3, 2, 3])
   })
-  context("preserveLevel is set to true", () => {
+  context("childEntriesInheritLevel is set to true", () => {
     it("should create a log entry whose children inherit the parent level", () => {
-      const verbose = logger.verbose({ preserveLevel: true })
+      const verbose = logger.verbose({ childEntriesInheritLevel: true })
       const error = verbose.error("")
       const silly = verbose.silly("")
       const deepError = error.error("")


### PR DESCRIPTION
Also renames `preserveLevel` to `childEntriesInheritLevel`. Although it really should just be `bequeathLevel`.