### PR TITLE
fix: delete outdated system namespaces

### DIFF
--- a/garden-service/src/actions.ts
+++ b/garden-service/src/actions.ts
@@ -181,8 +181,10 @@ export class ActionHelper implements TypeGuard {
     // sequentially go through the preparation steps, to allow plugins to request user input
     for (const [name, handler] of Object.entries(handlers)) {
       const status = statuses[name] || { ready: false }
+      const needForce = status.detail && !!status.detail.needForce
+      const forcePrep = force || needForce
 
-      if (status.ready && !force) {
+      if (status.ready && !forcePrep) {
         continue
       }
 
@@ -192,7 +194,7 @@ export class ActionHelper implements TypeGuard {
         msg: "Preparing environment...",
       })
 
-      await handler({ ...this.commonParams(handler, log), force, status, log: envLogEntry })
+      await handler({ ...this.commonParams(handler, log), force: forcePrep, status, log: envLogEntry })
 
       envLogEntry.setSuccess("Configured")
 

--- a/garden-service/src/cli/cli.ts
+++ b/garden-service/src/cli/cli.ts
@@ -12,7 +12,7 @@ import { resolve } from "path"
 import { safeDump } from "js-yaml"
 import { coreCommands } from "../commands/commands"
 import { DeepPrimitiveMap } from "../config/common"
-import { shutdown, sleep } from "../util/util"
+import { shutdown, sleep, getPackageVersion } from "../util/util"
 import {
   BooleanParameter,
   ChoicesParameter,
@@ -42,7 +42,6 @@ import {
   prepareArgConfig,
   prepareOptionConfig,
   styleConfig,
-  getPackageVersion,
   getLogLevelChoices,
   parseLogLevel,
 } from "./helpers"

--- a/garden-service/src/cli/helpers.ts
+++ b/garden-service/src/cli/helpers.ts
@@ -199,8 +199,3 @@ export function failOnInvalidOptions(argv, ctx) {
     ctx.cliMessage(`Received invalid flag(s): ${invalid.join(", ")}`)
   }
 }
-
-export function getPackageVersion(): String {
-  const version = require("../../package.json").version
-  return version
-}

--- a/garden-service/src/commands/version.ts
+++ b/garden-service/src/commands/version.ts
@@ -11,8 +11,8 @@ import {
   CommandResult,
   CommandParams,
 } from "./base"
-import { getPackageVersion } from "../cli/helpers"
 import chalk from "chalk"
+import { getPackageVersion } from "../util/util"
 
 export class VersionCommand extends Command {
   name = "version"

--- a/garden-service/src/plugins/kubernetes/namespace.ts
+++ b/garden-service/src/plugins/kubernetes/namespace.ts
@@ -11,7 +11,9 @@ import { KubeApi } from "./api"
 import { KubernetesProvider } from "./kubernetes"
 import { name as providerName } from "./kubernetes"
 import { AuthenticationError } from "../../exceptions"
+import { getPackageVersion } from "../../util/util"
 
+const GARDEN_VERSION = getPackageVersion()
 const created: { [name: string]: boolean } = {}
 
 export async function ensureNamespace(api: KubeApi, namespace: string) {
@@ -26,19 +28,26 @@ export async function ensureNamespace(api: KubeApi, namespace: string) {
 
     if (!created[namespace]) {
       // TODO: the types for all the create functions in the library are currently broken
-      await api.core.createNamespace(<any>{
-        apiVersion: "v1",
-        kind: "Namespace",
-        metadata: {
-          name: namespace,
-          annotations: {
-            "garden.io/generated": "true",
-          },
-        },
-      })
+      await createNamespace(api, namespace)
       created[namespace] = true
     }
   }
+}
+
+// Note: Does not check whether the namespace already exists.
+export async function createNamespace(api: KubeApi, namespace: string) {
+  // TODO: the types for all the create functions in the library are currently broken
+  return api.core.createNamespace(<any>{
+    apiVersion: "v1",
+    kind: "Namespace",
+    metadata: {
+      name: namespace,
+      annotations: {
+        "garden.io/generated": "true",
+        "garden.io/version": GARDEN_VERSION,
+      },
+    },
+  })
 }
 
 export async function getNamespace(

--- a/garden-service/src/util/util.ts
+++ b/garden-service/src/util/util.ts
@@ -61,6 +61,11 @@ export function registerCleanupFunction(name: string, func: HookCallback) {
   exitHook(func)
 }
 
+export function getPackageVersion(): String {
+  const version = require("../../package.json").version
+  return version
+}
+
 /*
   Warning: Don't make any async calls in the loop body when using this function, since this may cause
   funky concurrency behavior.

--- a/garden-service/static/kubernetes/system/ingress-controller/garden.yml
+++ b/garden-service/static/kubernetes/system/ingress-controller/garden.yml
@@ -3,6 +3,7 @@ module:
   name: ingress-controller
   type: helm
   chart: stable/nginx-ingress
+  releaseName: garden-nginx
   dependencies:
     - default-backend
   version: 0.25.1

--- a/garden-service/test/src/cli/helpers.ts
+++ b/garden-service/test/src/cli/helpers.ts
@@ -7,8 +7,9 @@
  */
 
 import { expect } from "chai"
-import { getPackageVersion, parseLogLevel, getLogLevelChoices } from "../../../src/cli/helpers"
+import { parseLogLevel, getLogLevelChoices } from "../../../src/cli/helpers"
 import { expectError } from "../../helpers"
+import { getPackageVersion } from "../../../src/util/util"
 
 describe("helpers", () => {
   const validLogLevels = ["error", "warn", "info", "verbose", "debug", "silly", "0", "1", "2", "3", "4", "5"]


### PR DESCRIPTION
* Add a version annotation to k8s namespaces created by the framework.

* If the garden-system / garden-system--metadata namespaces have
versions corresponding to another release than is currently being used,
they're deleted and recreated.

* Added a releaseName to the k8s ingress-controller system module.