### PR TITLE
feat: don't restart command when config is invalid

### DIFF
--- a/garden-service/src/events.ts
+++ b/garden-service/src/events.ts
@@ -56,9 +56,13 @@ export interface Events {
   configAdded: {
     path: string,
   },
+  configRemoved: {
+    path: string,
+  },
   projectConfigChanged: {},
   moduleConfigChanged: {
     name: string,
+    path: string,
   },
   moduleSourcesChanged: {
     name: string,

--- a/garden-service/src/watch.ts
+++ b/garden-service/src/watch.ts
@@ -86,12 +86,16 @@ export class Watcher {
         this.invalidateCached(modules)
 
         if (changedModule) {
-          this.garden.events.emit("moduleConfigChanged", { name: changedModule.name })
+          this.garden.events.emit("moduleConfigChanged", { name: changedModule.name, path })
         } else if (filename === MODULE_CONFIG_FILENAME) {
           if (parsed.dir === this.garden.projectRoot) {
             this.garden.events.emit("projectConfigChanged", {})
           } else {
-            this.garden.events.emit("configAdded", { path })
+            if (type === "added") {
+              this.garden.events.emit("configAdded", { path })
+            } else {
+              this.garden.events.emit("configRemoved", { path })
+            }
           }
         }
 

--- a/garden-service/test/src/watch.ts
+++ b/garden-service/test/src/watch.ts
@@ -33,9 +33,10 @@ describe("Watcher", () => {
   }
 
   it("should emit a moduleConfigChanged changed event when module config is changed", async () => {
-    emitEvent("change", resolve(modulePath, "garden.yml"))
+    const path = resolve(modulePath, "garden.yml")
+    emitEvent("change", path)
     expect(garden.events.log).to.eql([
-      { name: "moduleConfigChanged", payload: { name: "module-a" } },
+      { name: "moduleConfigChanged", payload: { name: "module-a", path } },
     ])
   })
 
@@ -68,6 +69,14 @@ describe("Watcher", () => {
     emitEvent("add", path)
     expect(garden.events.log).to.eql([
       { name: "configAdded", payload: { path } },
+    ])
+  })
+
+  it("should emit a configRemoved event when removing a garden.yml file", async () => {
+    const path = resolve(garden.projectRoot, "module-b", "garden.yml")
+    emitEvent("unlink", path)
+    expect(garden.events.log).to.eql([
+      { name: "configRemoved", payload: { path } },
     ])
   })
 


### PR DESCRIPTION
Fixes https://github.com/garden-io/garden/issues/512.

Before restarting a watch-mode command when a config file is changed/added/removed, attempt creating a new Garden instance using the project's (and its modules') updated config before performing the restart.

If a configuration error was introduced by the change, log an error message and keep the existing Garden instance instead of restarting.