### PR TITLE
fix(templates): add prefix to versionString

### DIFF
--- a/garden-service/src/config/config-context.ts
+++ b/garden-service/src/config/config-context.ts
@@ -188,7 +188,7 @@ class EnvironmentContext extends ConfigContext {
 }
 
 const exampleOutputs = { endpoint: "http://my-service/path/to/endpoint" }
-const exampleVersion = "v17ad4cb3fd"
+const exampleVersion = "v-v17ad4cb3fd"
 
 class ModuleContext extends ConfigContext {
   @schema(

--- a/garden-service/test/helpers.ts
+++ b/garden-service/test/helpers.ts
@@ -45,7 +45,7 @@ import timekeeper = require("timekeeper")
 export const dataDir = resolve(__dirname, "data")
 export const examplesDir = resolve(__dirname, "..", "..", "examples")
 export const testNow = new Date()
-export const testModuleVersionString = "1234512345"
+export const testModuleVersionString = "v-1234512345"
 export const testModuleVersion: ModuleVersion = {
   versionString: testModuleVersionString,
   dirtyTimestamp: null,

--- a/garden-service/test/src/commands/deploy.ts
+++ b/garden-service/test/src/commands/deploy.ts
@@ -20,7 +20,7 @@ const placeholderTaskResult = (moduleName, taskName, command) => ({
   taskName,
   command,
   version: {
-    versionString: "1",
+    versionString: "v-1",
     dirtyTimestamp: null,
     dependencyVersions: {},
   },

--- a/garden-service/test/src/vcs/base.ts
+++ b/garden-service/test/src/vcs/base.ts
@@ -74,7 +74,7 @@ describe("VcsHandler", () => {
       const result = await handler.resolveVersion(module, [])
 
       expect(result).to.eql({
-        versionString: versionA.latestCommit,
+        versionString: `v-${versionA.latestCommit}`,
         dirtyTimestamp: null,
         dependencyVersions: {},
       })
@@ -93,7 +93,7 @@ describe("VcsHandler", () => {
       const result = await handler.resolveVersion(module, [])
 
       expect(result).to.eql({
-        versionString: "abcdef-1234",
+        versionString: "v-abcdef-1234",
         dirtyTimestamp: 1234,
         dependencyVersions: {},
       })
@@ -116,7 +116,7 @@ describe("VcsHandler", () => {
       handler.setTestVersion(moduleC.path, versionC)
 
       expect(await handler.resolveVersion(moduleC, [moduleA, moduleB])).to.eql({
-        versionString: "asdfgh-123",
+        versionString: "v-asdfgh-123",
         dirtyTimestamp: 123,
         dependencyVersions: {
           "module-a": versionA,
@@ -142,7 +142,7 @@ describe("VcsHandler", () => {
       handler.setTestVersion(moduleC.path, versionC)
 
       expect(await handler.resolveVersion(moduleC, [moduleA, moduleB])).to.eql({
-        versionString: "qwerty-456",
+        versionString: "v-qwerty-456",
         dirtyTimestamp: 456,
         dependencyVersions: {
           "module-a": versionA,
@@ -169,7 +169,7 @@ describe("VcsHandler", () => {
       handler.setTestVersion(moduleC.path, versionC)
 
       expect(await handler.resolveVersion(moduleC, [moduleA, moduleB])).to.eql({
-        versionString: "v5ff3a146d9",
+        versionString: "v-5ff3a146d9",
         dirtyTimestamp: null,
         dependencyVersions: {
           "module-a": versionA,
@@ -199,7 +199,7 @@ describe("VcsHandler", () => {
         handler.setTestVersion(moduleC.path, versionC)
 
         expect(await handler.resolveVersion(moduleC, [moduleA, moduleB])).to.eql({
-          versionString: "vcfa6d28ec5-1234",
+          versionString: "v-cfa6d28ec5-1234",
           dirtyTimestamp: 1234,
           dependencyVersions: {
             "module-a": versionA,


### PR DESCRIPTION
Added the "version-" prefix to the versionString field on ModuleVersion.

This should resolve an issue where module versions would be read as numbers when used as template variables when the first several characters of the commit hash were numbers.

@eysi09 and I have come across this error a couple of times during CI. Here's an example:

![screenshot 2019-02-18 at 14 06 22](https://user-images.githubusercontent.com/382137/52956223-f6c52a80-338e-11e9-82e9-00d18ec94ed9.png)
