### PR TITLE
docs: update links to examples

### DIFF
--- a/docs/examples/hello-world.md
+++ b/docs/examples/hello-world.md
@@ -6,9 +6,9 @@ In this example, we'll have a practical look at the main characteristics of a Ga
 - Ports, endpoints, and health check settings
 - Tests
 
-This project contains four configuration files. [This one](https://github.com/garden-io/garden/tree/v0.9.0/examples/hello-world/garden.yml) for project-wide settings, and three separate ones for each of the modules: [`hello-container`](https://github.com/garden-io/garden/tree/v0.9.0/examples/hello-world/services/hello-container/garden.yml), [`hello-function`](https://github.com/garden-io/garden/tree/v0.9.0/examples/hello-world/services/hello-function/garden.yml), and [`hello-npm-package`](https://github.com/garden-io/garden/tree/v0.9.0/examples/hello-world/libraries/hello-npm-package/garden.yml).
+This project contains four configuration files. [This one](https://github.com/garden-io/garden/tree/v0.9.0-docfix.1/examples/hello-world/garden.yml) for project-wide settings, and three separate ones for each of the modules: [`hello-container`](https://github.com/garden-io/garden/tree/v0.9.0-docfix.1/examples/hello-world/services/hello-container/garden.yml), [`hello-function`](https://github.com/garden-io/garden/tree/v0.9.0-docfix.1/examples/hello-world/services/hello-function/garden.yml), and [`hello-npm-package`](https://github.com/garden-io/garden/tree/v0.9.0-docfix.1/examples/hello-world/libraries/hello-npm-package/garden.yml).
 
-_Note: The source code for this project can be found at: [https://github.com/garden-io/garden/tree/v0.9.0/examples/hello-world](https://github.com/garden-io/garden/tree/v0.9.0/examples/hello-world)._
+_Note: The source code for this project can be found at: [https://github.com/garden-io/garden/tree/v0.9.0-docfix.1/examples/hello-world](https://github.com/garden-io/garden/tree/v0.9.0-docfix.1/examples/hello-world)._
 
 # Configuring dependencies
 

--- a/docs/examples/remote-sources.md
+++ b/docs/examples/remote-sources.md
@@ -10,11 +10,11 @@ Important concepts:
 
 > Remote _module_: The remote source code for a single Garden module. In this case, the `garden.yml` config file is stored in the main project repository while the module code itself is in the remote repository.
 
-_Note: The source code for this project can be found at: [https://github.com/garden-io/garden/tree/v0.9.0/examples/remote-sources](https://github.com/garden-io/garden/tree/v0.9.0/examples/remote-sources)._
+_Note: The source code for this project can be found at: [https://github.com/garden-io/garden/tree/v0.9.0-docfix.1/examples/remote-sources](https://github.com/garden-io/garden/tree/v0.9.0-docfix.1/examples/remote-sources)._
 
 ## About
 
-This project is the same as the [vote example](https://github.com/garden-io/garden/tree/v0.9.0/examples/vote)—except that in this case the services live in their own repositories. The repositories are:
+This project is the same as the [vote example](https://github.com/garden-io/garden/tree/v0.9.0-docfix.1/examples/vote)—except that in this case the services live in their own repositories. The repositories are:
 
 * [Database services](https://github.com/garden-io/garden-example-remote-sources-db-services) (contains the Postgres and Redis services)
 * [Web services](https://github.com/garden-io/garden-example-remote-sources-web-services) (contains the Python Vote web service and the Node.js Result web service)

--- a/docs/examples/simple-project.md
+++ b/docs/examples/simple-project.md
@@ -17,7 +17,7 @@ This tutorial assumes that you already have a running [installation of Garden](.
 
 ## Clone the example repo
 
-The code for this tutorial can be found in our Github repository under the [examples directory](https://github.com/garden-io/garden/tree/v0.9.0/examples). We'll use the [simple-project-start](https://github.com/garden-io/garden/tree/v0.9.0/examples/simple-project-start/) example and work our way from there. The final version is under [simple-project](https://github.com/garden-io/garden/tree/v0.9.0/examples/simple-project).
+The code for this tutorial can be found in our Github repository under the [examples directory](https://github.com/garden-io/garden/tree/v0.9.0/examples). We'll use the [simple-project-start](https://github.com/garden-io/garden/tree/v0.9.0-docfix.1/examples/simple-project-start/) example and work our way from there. The final version is under [simple-project](https://github.com/garden-io/garden/tree/v0.9.0-docfix.1/examples/simple-project).
 
 First, let's clone the examples repo, change into the directory, and take a look inside:
 

--- a/docs/examples/tls-project.md
+++ b/docs/examples/tls-project.md
@@ -5,7 +5,7 @@ This project shows how you can configure a TLS certificate to use for local deve
 For the example to work you need to configure a local certificate authority (CA) on your computer for development. We'll use
 [mkcert](https://github.com/FiloSottile/mkcert) for this purpose.
 
-_Note: The source code for this project can be found at: [https://github.com/garden-io/garden/tree/v0.9.0/examples/local-tls](https://github.com/garden-io/garden/tree/v0.9.0/examples/local-tls)._
+_Note: The source code for this project can be found at: [https://github.com/garden-io/garden/tree/v0.9.0-docfix.1/examples/local-tls](https://github.com/garden-io/garden/tree/v0.9.0-docfix.1/examples/local-tls)._
 
 ## Setup
 

--- a/examples/remote-sources/README.md
+++ b/examples/remote-sources/README.md
@@ -10,7 +10,7 @@ Important concepts:
 
 ## About
 
-This project is the same as the [vote example](https://github.com/garden-io/garden/tree/v0.9.0/examples/vote)—except that in this case the services live in their own repositories. The repositories are:
+This project is the same as the [vote example](https://github.com/garden-io/garden/tree/v0.9.0-docfix.1/examples/vote)—except that in this case the services live in their own repositories. The repositories are:
 
 * [Database services](https://github.com/garden-io/garden-example-remote-sources-db-services) (contains the Postgres and Redis services)
 * [Web services](https://github.com/garden-io/garden-example-remote-sources-web-services) (contains the Python Vote web service and the Node.js Result web service)

--- a/examples/simple-project/services/go-service/garden.yml
+++ b/examples/simple-project/services/go-service/garden.yml
@@ -1,5 +1,5 @@
 module:
-  name: go-service
+  name: go-module
   description: Go service container
   type: container
   services:

--- a/examples/simple-project/services/node-service/garden.yml
+++ b/examples/simple-project/services/node-service/garden.yml
@@ -1,5 +1,5 @@
 module:
-  name: node-service
+  name: node-module
   description: Node service container
   type: container
   services:


### PR DESCRIPTION
Usually the links to examples point to a specific release, say, v0.9.0. However, there were some issues with the docs at that tag, that we've since fixed. I've therefore created a new tag with the fixes, v0.9.0-docfix.1, and updated the links accordingly.