### PR TITLE
fix: don't emit taskPending if task is skipped

### DIFF
--- a/garden-service/src/task-graph.ts
+++ b/garden-service/src/task-graph.ts
@@ -96,13 +96,15 @@ export class TaskGraph {
   }
 
   private async addTaskInternal(task: BaseTask) {
-    this.garden.events.emit("taskPending", {
-      addedAt: new Date(),
-      key: task.getKey(),
-      version: task.version,
-    })
     await this.addNodeWithDependencies(task)
     await this.rebuild()
+    if (this.index.getNode(task)) {
+      this.garden.events.emit("taskPending", {
+        addedAt: new Date(),
+        key: task.getKey(),
+        version: task.version,
+      })
+    }
   }
 
   private getNode(task: BaseTask): TaskNode | null {


### PR DESCRIPTION
Fixes https://github.com/garden-io/garden/issues/540.

This fixes an issue in `TaskGraph` where `taskPending` events were emitted for tasks with up-to-date cached results. This led to the task graph UI on the dashboard displaying the nodes corresponding to skipped tasks in a permanent pending state.

This was addressed by only emitting the event if the task was, in fact, added to `TaskGraph`'s index.