### PR TITLE
fix: fixed bug in configuring flat-config modules

### DIFF
--- a/garden-service/src/config/base.ts
+++ b/garden-service/src/config/base.ts
@@ -131,7 +131,6 @@ function prepareConfigDoc(spec: any, path: string, projectRoot: string): ConfigD
 
   if (configKinds.has(kind)) {
     const { specKey, validationSchema } = configKindSettings[kind]
-    delete spec.kind
     const preparedSpec = prepareFlatConfigDoc(spec, path)
     const validated = validateWithPath({
       config: preparedSpec,
@@ -154,11 +153,15 @@ function prepareConfigDoc(spec: any, path: string, projectRoot: string): ConfigD
  * The spec defines either a project or a module (determined by its "kind" field).
  */
 function prepareFlatConfigDoc(spec: any, path: string): ConfigDoc {
-  if (spec.kind === "Project") {
+
+  const kind = spec.kind
+  delete spec.kind
+
+  if (kind === "Project") {
     spec = prepareProjectConfig(spec, path)
   }
 
-  if (spec.kind === "Module") {
+  if (kind === "Module") {
     spec = prepareModuleConfig(spec, path)
   }
 
@@ -222,6 +225,7 @@ function prepareProjectConfig(projectSpec: any, path: string): ProjectConfig {
 }
 
 function prepareModuleConfig(moduleSpec: any, path: string): ModuleConfig {
+
   // Built-in keys are validated here and the rest are put into the `spec` field
   const module = {
     apiVersion: moduleSpec.apiVersion,

--- a/garden-service/test/src/config/base.ts
+++ b/garden-service/test/src/config/base.ts
@@ -208,7 +208,7 @@ describe("loadConfig", () => {
 
     expect(parsed!.project).to.eql({
       apiVersion: "garden.io/v0",
-      defaultEnvironment: "",
+      defaultEnvironment: "local",
       environmentDefaults: {
         providers: [],
         variables: { some: "variable" },
@@ -233,14 +233,22 @@ describe("loadConfig", () => {
     })
 
     expect(parsed!.modules).to.eql([{
+      apiVersion: "garden.io/v0",
       name: "module-from-project-config",
       type: "test",
+      description: undefined,
       build: {
         command: ["echo", "project"],
         dependencies: [],
       },
-      apiVersion: "garden.io/v0",
       allowPublish: true,
+      outputs: {},
+      path: projectPathFlat,
+      repositoryUrl: undefined,
+      serviceConfigs: [],
+      spec: {},
+      taskConfigs: [],
+      testConfigs: [],
     }])
   })
 


### PR DESCRIPTION
This addresses an issue where config files defining Helm modules with the flat config style would result in the Helm module not having its path attribute set.

This PR is a simplified version of https://github.com/garden-io/garden/pull/554/files (which I'm closing), omitting the changes to the `vote-helm` project (and thus only consists of the bugfix itself).