### PR TITLE
fix(helm): allow duplicate keys in template

### DIFF
--- a/garden-service/test/data/test-projects/helm/duplicate-keys-in-template/.helmignore
+++ b/garden-service/test/data/test-projects/helm/duplicate-keys-in-template/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/garden-service/test/data/test-projects/helm/duplicate-keys-in-template/Chart.yaml
+++ b/garden-service/test/data/test-projects/helm/duplicate-keys-in-template/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: duplicate-keys-in-template
+version: 0.1.0

--- a/garden-service/test/data/test-projects/helm/duplicate-keys-in-template/garden.yml
+++ b/garden-service/test/data/test-projects/helm/duplicate-keys-in-template/garden.yml
@@ -1,0 +1,4 @@
+module:
+  description: Helm chart for the duplicate-keys-in-template container
+  type: helm
+  name: duplicate-keys-in-template

--- a/garden-service/test/data/test-projects/helm/duplicate-keys-in-template/templates/service.yaml
+++ b/garden-service/test/data/test-projects/helm/duplicate-keys-in-template/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: duplicate-keys-in-template
+spec:
+  type: {{ .Values.service.type }}
+  type: {{ .Values.service.type }}
+  selector:
+    app: duplicate-keys-in-template
+  ports:
+  - port: 80
+    name: http

--- a/garden-service/test/data/test-projects/helm/duplicate-keys-in-template/values.yaml
+++ b/garden-service/test/data/test-projects/helm/duplicate-keys-in-template/values.yaml
@@ -1,0 +1,29 @@
+# Default values for node-service.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/garden-service/test/src/plugins/kubernetes/helm/common.ts
+++ b/garden-service/test/src/plugins/kubernetes/helm/common.ts
@@ -433,6 +433,11 @@ describe("Helm common functions", () => {
         },
       ])
     })
+
+    it("should handle duplicate keys in template", async () => {
+      const module = await graph.getModule("duplicate-keys-in-template")
+      expect(await getChartResources(ctx, module, log)).to.not.throw
+    })
   })
 
   describe("getBaseModule", () => {


### PR DESCRIPTION
Prevents "duplicated mapping key" errors when loading remote charts with duplicate keys (e.g. official ambassador chart).

When loading the template with `{ json: true }`, duplicate keys in a mapping will override values rather than throwing an error.

However, this behavior is broken for the `safeLoadAll` function, see: https://github.com/nodeca/js-yaml/issues/456. We therefore need to use the `loadAll` function. See the following link for a conversation on using `loadAll` in this context: https://github.com/kubeapps/kubeapps/issues/636.