### PR TITLE
feat(container): add `build.targetImage` parameter

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -313,26 +313,6 @@ Specify how to build the module. Note that plugins may define additional keys on
 | Type | Required |
 | ---- | -------- |
 | `object` | No
-### `module.build.command[]`
-[module](#module) > [build](#module.build) > command
-
-The command to run inside the module's directory to perform the build.
-
-| Type | Required |
-| ---- | -------- |
-| `array[string]` | No
-
-Example:
-```yaml
-module:
-  ...
-  build:
-    ...
-    command:
-      - npm
-      - run
-      - build
-```
 ### `module.build.dependencies[]`
 [module](#module) > [build](#module.build) > dependencies
 
@@ -395,8 +375,6 @@ module:
   repositoryUrl:
   allowPublish: true
   build:
-    command:
-      []
     dependencies:
       - name:
         copy:

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -13,6 +13,72 @@ Configuration for a container module.
 | Type | Required |
 | ---- | -------- |
 | `object` | No
+### `module.build`
+[module](#module) > build
+
+Specify how to build the module. Note that plugins may define additional keys on this object.
+
+| Type | Required |
+| ---- | -------- |
+| `object` | No
+### `module.build.dependencies[]`
+[module](#module) > [build](#module.build) > dependencies
+
+A list of modules that must be built before this module is built.
+
+| Type | Required |
+| ---- | -------- |
+| `array[object]` | No
+
+Example:
+```yaml
+module:
+  ...
+  build:
+    ...
+    dependencies:
+      - name: some-other-module-name
+```
+### `module.build.dependencies[].name`
+[module](#module) > [build](#module.build) > [dependencies](#module.build.dependencies[]) > name
+
+Module name to build ahead of this module.
+
+| Type | Required |
+| ---- | -------- |
+| `string` | Yes
+### `module.build.dependencies[].copy[]`
+[module](#module) > [build](#module.build) > [dependencies](#module.build.dependencies[]) > copy
+
+Specify one or more files or directories to copy from the built dependency to this module.
+
+| Type | Required |
+| ---- | -------- |
+| `array[object]` | No
+### `module.build.dependencies[].copy[].source`
+[module](#module) > [build](#module.build) > [dependencies](#module.build.dependencies[]) > [copy](#module.build.dependencies[].copy[]) > source
+
+POSIX-style path or filename of the directory or file(s) to copy to the target.
+
+| Type | Required |
+| ---- | -------- |
+| `string` | Yes
+### `module.build.dependencies[].copy[].target`
+[module](#module) > [build](#module.build) > [dependencies](#module.build.dependencies[]) > [copy](#module.build.dependencies[].copy[]) > target
+
+POSIX-style path or filename to copy the directory or file(s) to (defaults to same as source path).
+
+| Type | Required |
+| ---- | -------- |
+| `string` | No
+### `module.build.targetImage`
+[module](#module) > [build](#module.build) > targetImage
+
+For multi-stage Dockerfiles, specify which image to build (see https://docs.docker.com/engine/reference/commandline/build/#specifying-target-build-stage---target for details).
+
+| Type | Required |
+| ---- | -------- |
+| `string` | No
 ### `module.buildArgs`
 [module](#module) > buildArgs
 
@@ -491,6 +557,13 @@ module:
 ## Complete YAML schema
 ```yaml
 module:
+  build:
+    dependencies:
+      - name:
+        copy:
+          - source:
+            target: ''
+    targetImage:
   buildArgs: {}
   image:
   hotReload:

--- a/docs/reference/module-types/exec.md
+++ b/docs/reference/module-types/exec.md
@@ -13,6 +13,84 @@ The module specification for an exec module.
 | Type | Required |
 | ---- | -------- |
 | `object` | No
+### `module.build`
+[module](#module) > build
+
+Specify how to build the module. Note that plugins may define additional keys on this object.
+
+| Type | Required |
+| ---- | -------- |
+| `object` | No
+### `module.build.dependencies[]`
+[module](#module) > [build](#module.build) > dependencies
+
+A list of modules that must be built before this module is built.
+
+| Type | Required |
+| ---- | -------- |
+| `array[object]` | No
+
+Example:
+```yaml
+module:
+  ...
+  build:
+    ...
+    dependencies:
+      - name: some-other-module-name
+```
+### `module.build.dependencies[].name`
+[module](#module) > [build](#module.build) > [dependencies](#module.build.dependencies[]) > name
+
+Module name to build ahead of this module.
+
+| Type | Required |
+| ---- | -------- |
+| `string` | Yes
+### `module.build.dependencies[].copy[]`
+[module](#module) > [build](#module.build) > [dependencies](#module.build.dependencies[]) > copy
+
+Specify one or more files or directories to copy from the built dependency to this module.
+
+| Type | Required |
+| ---- | -------- |
+| `array[object]` | No
+### `module.build.dependencies[].copy[].source`
+[module](#module) > [build](#module.build) > [dependencies](#module.build.dependencies[]) > [copy](#module.build.dependencies[].copy[]) > source
+
+POSIX-style path or filename of the directory or file(s) to copy to the target.
+
+| Type | Required |
+| ---- | -------- |
+| `string` | Yes
+### `module.build.dependencies[].copy[].target`
+[module](#module) > [build](#module.build) > [dependencies](#module.build.dependencies[]) > [copy](#module.build.dependencies[].copy[]) > target
+
+POSIX-style path or filename to copy the directory or file(s) to (defaults to same as source path).
+
+| Type | Required |
+| ---- | -------- |
+| `string` | No
+### `module.build.command[]`
+[module](#module) > [build](#module.build) > command
+
+The command to run inside the module's directory to perform the build.
+
+| Type | Required |
+| ---- | -------- |
+| `array[string]` | No
+
+Example:
+```yaml
+module:
+  ...
+  build:
+    ...
+    command:
+      - npm
+      - run
+      - build
+```
 ### `module.env`
 [module](#module) > env
 
@@ -122,6 +200,14 @@ Key/value map of environment variables. Keys must be valid POSIX environment var
 ## Complete YAML schema
 ```yaml
 module:
+  build:
+    dependencies:
+      - name:
+        copy:
+          - source:
+            target: ''
+    command:
+      []
   env: {}
   tasks:
     - name:

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -30,6 +30,64 @@ module:
   ...
   base: "my-base-chart"
 ```
+### `module.build`
+[module](#module) > build
+
+Specify how to build the module. Note that plugins may define additional keys on this object.
+
+| Type | Required |
+| ---- | -------- |
+| `object` | No
+### `module.build.dependencies[]`
+[module](#module) > [build](#module.build) > dependencies
+
+A list of modules that must be built before this module is built.
+
+| Type | Required |
+| ---- | -------- |
+| `array[object]` | No
+
+Example:
+```yaml
+module:
+  ...
+  build:
+    ...
+    dependencies:
+      - name: some-other-module-name
+```
+### `module.build.dependencies[].name`
+[module](#module) > [build](#module.build) > [dependencies](#module.build.dependencies[]) > name
+
+Module name to build ahead of this module.
+
+| Type | Required |
+| ---- | -------- |
+| `string` | Yes
+### `module.build.dependencies[].copy[]`
+[module](#module) > [build](#module.build) > [dependencies](#module.build.dependencies[]) > copy
+
+Specify one or more files or directories to copy from the built dependency to this module.
+
+| Type | Required |
+| ---- | -------- |
+| `array[object]` | No
+### `module.build.dependencies[].copy[].source`
+[module](#module) > [build](#module.build) > [dependencies](#module.build.dependencies[]) > [copy](#module.build.dependencies[].copy[]) > source
+
+POSIX-style path or filename of the directory or file(s) to copy to the target.
+
+| Type | Required |
+| ---- | -------- |
+| `string` | Yes
+### `module.build.dependencies[].copy[].target`
+[module](#module) > [build](#module.build) > [dependencies](#module.build.dependencies[]) > [copy](#module.build.dependencies[].copy[]) > target
+
+POSIX-style path or filename to copy the directory or file(s) to (defaults to same as source path).
+
+| Type | Required |
+| ---- | -------- |
+| `string` | No
 ### `module.chart`
 [module](#module) > chart
 
@@ -421,6 +479,12 @@ Map of values to pass to Helm when rendering the templates. May include arrays a
 ```yaml
 module:
   base:
+  build:
+    dependencies:
+      - name:
+        copy:
+          - source:
+            target: ''
   chart:
   chartPath: .
   dependencies: []

--- a/docs/reference/module-types/openfaas.md
+++ b/docs/reference/module-types/openfaas.md
@@ -13,6 +13,84 @@ The module specification for an OpenFaaS module.
 | Type | Required |
 | ---- | -------- |
 | `object` | No
+### `module.build`
+[module](#module) > build
+
+Specify how to build the module. Note that plugins may define additional keys on this object.
+
+| Type | Required |
+| ---- | -------- |
+| `object` | No
+### `module.build.dependencies[]`
+[module](#module) > [build](#module.build) > dependencies
+
+A list of modules that must be built before this module is built.
+
+| Type | Required |
+| ---- | -------- |
+| `array[object]` | No
+
+Example:
+```yaml
+module:
+  ...
+  build:
+    ...
+    dependencies:
+      - name: some-other-module-name
+```
+### `module.build.dependencies[].name`
+[module](#module) > [build](#module.build) > [dependencies](#module.build.dependencies[]) > name
+
+Module name to build ahead of this module.
+
+| Type | Required |
+| ---- | -------- |
+| `string` | Yes
+### `module.build.dependencies[].copy[]`
+[module](#module) > [build](#module.build) > [dependencies](#module.build.dependencies[]) > copy
+
+Specify one or more files or directories to copy from the built dependency to this module.
+
+| Type | Required |
+| ---- | -------- |
+| `array[object]` | No
+### `module.build.dependencies[].copy[].source`
+[module](#module) > [build](#module.build) > [dependencies](#module.build.dependencies[]) > [copy](#module.build.dependencies[].copy[]) > source
+
+POSIX-style path or filename of the directory or file(s) to copy to the target.
+
+| Type | Required |
+| ---- | -------- |
+| `string` | Yes
+### `module.build.dependencies[].copy[].target`
+[module](#module) > [build](#module.build) > [dependencies](#module.build.dependencies[]) > [copy](#module.build.dependencies[].copy[]) > target
+
+POSIX-style path or filename to copy the directory or file(s) to (defaults to same as source path).
+
+| Type | Required |
+| ---- | -------- |
+| `string` | No
+### `module.build.command[]`
+[module](#module) > [build](#module.build) > command
+
+The command to run inside the module's directory to perform the build.
+
+| Type | Required |
+| ---- | -------- |
+| `array[string]` | No
+
+Example:
+```yaml
+module:
+  ...
+  build:
+    ...
+    command:
+      - npm
+      - run
+      - build
+```
 ### `module.env`
 [module](#module) > env
 
@@ -154,6 +232,14 @@ The OpenFaaS language template to use to build this function.
 ## Complete YAML schema
 ```yaml
 module:
+  build:
+    dependencies:
+      - name:
+        copy:
+          - source:
+            target: ''
+    command:
+      []
   env: {}
   tasks:
     - name:

--- a/garden-service/src/config/base.ts
+++ b/garden-service/src/config/base.ts
@@ -225,34 +225,36 @@ function prepareProjectConfig(projectSpec: any, path: string): ProjectConfig {
 }
 
 function prepareModuleConfig(moduleSpec: any, path: string): ModuleConfig {
+  /**
+   * We allow specifying modules by name only as a shorthand:
+   *   dependencies:
+   *   - foo-module
+   *   - name: foo-module // same as the above
+   */
+  const dependencies = moduleSpec.build && moduleSpec.build.dependencies
+    ? moduleSpec.build.dependencies.map(dep => typeof dep === "string" ? { name: dep, copy: [] } : dep)
+    : []
 
   // Built-in keys are validated here and the rest are put into the `spec` field
   const module = {
     apiVersion: moduleSpec.apiVersion,
     allowPublish: moduleSpec.allowPublish,
-    build: moduleSpec.build,
+    build: {
+      dependencies,
+    },
     description: moduleSpec.description,
     name: moduleSpec.name,
     outputs: {},
     path,
     repositoryUrl: moduleSpec.repositoryUrl,
     serviceConfigs: [],
-    spec: omit(moduleSpec, baseModuleSchemaKeys),
+    spec: {
+      ...omit(moduleSpec, baseModuleSchemaKeys),
+      build: { ...moduleSpec.build, dependencies },
+    },
     testConfigs: [],
     type: moduleSpec.type,
     taskConfigs: [],
-  }
-
-  /*
-    We allow specifying modules by name only as a shorthand:
-
-      dependencies:
-        - foo-module
-        - name: foo-module // same as the above
-    */
-  if (module.build && module.build.dependencies) {
-    module.build.dependencies = module.build.dependencies
-      .map(dep => (typeof dep) === "string" ? { name: dep } : dep)
   }
 
   return module

--- a/garden-service/src/plugins/container/config.ts
+++ b/garden-service/src/plugins/container/config.ts
@@ -20,7 +20,7 @@ import {
 } from "../../config/common"
 import { Service, ingressHostnameSchema } from "../../types/service"
 import { DEFAULT_PORT_PROTOCOL } from "../../constants"
-import { ModuleSpec, ModuleConfig } from "../../config/module"
+import { ModuleSpec, ModuleConfig, baseBuildSpecSchema, BaseBuildSpec } from "../../config/module"
 import { CommonServiceSpec, ServiceConfig, baseServiceSchema } from "../../config/service"
 import { baseTaskSpecSchema, BaseTaskSpec } from "../../config/task"
 import { baseTestSpecSchema, BaseTestSpec } from "../../config/test"
@@ -280,7 +280,12 @@ export const containerTaskSchema = baseTaskSpecSchema
   })
   .description("A task that can be run in the container.")
 
+interface ContainerBuildSpec extends BaseBuildSpec {
+  targetImage?: string
+}
+
 export interface ContainerModuleSpec extends ModuleSpec {
+  build: ContainerBuildSpec,
   buildArgs: PrimitiveMap,
   image?: string,
   dockerfile?: string,
@@ -297,6 +302,15 @@ export const defaultTag = "latest"
 
 export const containerModuleSpecSchema = Joi.object()
   .keys({
+    build: baseBuildSpecSchema
+      .keys({
+        targetImage: Joi.string()
+          .description(deline`
+            For multi-stage Dockerfiles, specify which image to build (see
+            https://docs.docker.com/engine/reference/commandline/build/#specifying-target-build-stage---target for
+            details).
+          `),
+      }),
     buildArgs: Joi.object()
       .pattern(/.+/, joiPrimitive())
       .default(() => ({}), "{}")

--- a/garden-service/src/plugins/container/container.ts
+++ b/garden-service/src/plugins/container/container.ts
@@ -192,6 +192,10 @@ export const gardenPlugin = (): GardenPlugin => ({
           cmdOpts.push(buildArgs)
         }
 
+        if (module.spec.build.targetImage) {
+          cmdOpts.push("--target", module.spec.build.targetImage)
+        }
+
         if (module.spec.dockerfile) {
           cmdOpts.push("--file", containerHelpers.getDockerfilePathFromModule(module))
         }

--- a/garden-service/src/plugins/kubernetes/helm/config.ts
+++ b/garden-service/src/plugins/kubernetes/helm/config.ts
@@ -30,6 +30,7 @@ import { BaseTestSpec, baseTestSpecSchema } from "../../../config/test"
 import { BaseTaskSpec } from "../../../config/task"
 import { Service } from "../../../types/service"
 import { ContainerModule } from "../../container/config"
+import { baseBuildSpecSchema } from "../../../config/module"
 
 // A Helm Module always maps to a single Service
 export type HelmModuleSpec = HelmServiceSpec
@@ -159,6 +160,7 @@ export const helmModuleSpecSchema = Joi.object().keys({
       Each of those can be overridden in this module. They will be merged with a JSON Merge Patch (RFC 7396).`,
     )
     .example("my-base-chart"),
+  build: baseBuildSpecSchema,
   chart: Joi.string()
     .description(
       deline`A valid Helm chart name or URI (same as you'd input to \`helm install\`).

--- a/garden-service/test/helpers.ts
+++ b/garden-service/test/helpers.ts
@@ -11,7 +11,7 @@ import * as Joi from "joi"
 import { resolve, join } from "path"
 import { remove, readdirSync, existsSync } from "fs-extra"
 import { containerModuleSpecSchema, containerTestSchema, containerTaskSchema } from "../src/plugins/container/config"
-import { testExecModule, buildExecModule } from "../src/plugins/exec"
+import { testExecModule, buildExecModule, execBuildSpecSchema } from "../src/plugins/exec"
 import { TaskResults } from "../src/task-graph"
 import { validate, PrimitiveMap, joiArray } from "../src/config/common"
 import {
@@ -88,6 +88,7 @@ const testModuleTaskSchema = containerTaskSchema
 
 export const testModuleSpecSchema = containerModuleSpecSchema
   .keys({
+    build: execBuildSpecSchema,
     tests: joiArray(testModuleTestSchema),
     tasks: joiArray(testModuleTaskSchema),
   })
@@ -225,7 +226,7 @@ const defaultModuleConfig: ModuleConfig = {
   name: "test",
   path: "bla",
   allowPublish: false,
-  build: { command: [], dependencies: [] },
+  build: { dependencies: [] },
   outputs: {},
   spec: {
     services: [

--- a/garden-service/test/src/config/base.ts
+++ b/garden-service/test/src/config/base.ts
@@ -82,11 +82,15 @@ describe("loadConfig", () => {
         description: undefined,
         repositoryUrl: undefined,
         allowPublish: true,
-        build: { command: ["echo", "A"], dependencies: [] },
+        build: { dependencies: [] },
         outputs: {},
         path: modulePathA,
 
         spec: {
+          build: {
+            command: ["echo", "A"],
+            dependencies: [],
+          },
           services: [{ name: "service-a" }],
           tasks: [{
             name: "task-a",
@@ -143,11 +147,16 @@ describe("loadConfig", () => {
       description: undefined,
       repositoryUrl: undefined,
       allowPublish: true,
-      build: { command: ["echo", "project"], dependencies: [] },
+      build: { dependencies: [] },
       outputs: {},
       path: projectPathMultipleModules,
       serviceConfigs: [],
-      spec: {},
+      spec: {
+        build: {
+          command: ["echo", "project"],
+          dependencies: [],
+        },
+      },
       testConfigs: [],
       taskConfigs: [],
     }])
@@ -165,7 +174,6 @@ describe("loadConfig", () => {
         description: undefined,
         repositoryUrl: undefined,
         build: {
-          command: ["echo", "A1"],
           dependencies: [
             { name: "module-from-project-config", copy: [] },
           ],
@@ -174,6 +182,12 @@ describe("loadConfig", () => {
         path: modulePathAMultiple,
         serviceConfigs: [],
         spec: {
+          build: {
+            command: ["echo", "A1"],
+            dependencies: [
+              { name: "module-from-project-config", copy: [] },
+            ],
+          },
           services: [{ name: "service-a1" }],
           tests: [{ name: "unit", command: ["echo", "OK"] }],
           tasks: [{ name: "task-a1", command: ["echo", "OK"] }],
@@ -188,11 +202,15 @@ describe("loadConfig", () => {
         allowPublish: true,
         description: undefined,
         repositoryUrl: undefined,
-        build: { command: ["echo", "A2"], dependencies: [] },
+        build: { dependencies: [] },
         outputs: {},
         path: modulePathAMultiple,
         serviceConfigs: [],
         spec: {
+          build: {
+            command: ["echo", "A2"],
+            dependencies: [],
+          },
           services: [{ name: "service-a2" }],
           tests: [{ name: "unit", command: ["echo", "OK"] }],
           tasks: [{ name: "task-a2", command: ["echo", "OK"] }],
@@ -238,7 +256,6 @@ describe("loadConfig", () => {
       type: "test",
       description: undefined,
       build: {
-        command: ["echo", "project"],
         dependencies: [],
       },
       allowPublish: true,
@@ -246,7 +263,12 @@ describe("loadConfig", () => {
       path: projectPathFlat,
       repositoryUrl: undefined,
       serviceConfigs: [],
-      spec: {},
+      spec: {
+        build: {
+          command: ["echo", "project"],
+          dependencies: [],
+        },
+      },
       taskConfigs: [],
       testConfigs: [],
     }])

--- a/garden-service/test/src/plugins/exec.ts
+++ b/garden-service/test/src/plugins/exec.ts
@@ -39,6 +39,9 @@ describe("exec plugin", () => {
     } = modules
 
     expect(moduleA.build).to.eql({
+      dependencies: [],
+    })
+    expect(moduleA.spec.build).to.eql({
       command: ["echo", "A"],
       dependencies: [],
     })
@@ -85,6 +88,9 @@ describe("exec plugin", () => {
     ])
 
     expect(moduleB.build).to.eql({
+      dependencies: [{ name: "module-a", copy: [] }],
+    })
+    expect(moduleB.spec.build).to.eql({
       command: ["echo", "B"],
       dependencies: [{ name: "module-a", copy: [] }],
     })
@@ -106,6 +112,9 @@ describe("exec plugin", () => {
     ])
 
     expect(moduleC.build).to.eql({
+      dependencies: [{ name: "module-b", copy: [] }],
+    })
+    expect(moduleC.spec.build).to.eql({
       command: [],
       dependencies: [{ name: "module-b", copy: [] }],
     })

--- a/garden-service/test/src/plugins/kubernetes/helm/config.ts
+++ b/garden-service/test/src/plugins/kubernetes/helm/config.ts
@@ -43,7 +43,6 @@ describe("validateHelmModule", () => {
       allowPublish: true,
       build: {
         dependencies: [],
-        command: [],
       },
       description: "The API backend for the voting UI",
       apiVersion: "garden.io/v0",
@@ -60,6 +59,9 @@ describe("validateHelmModule", () => {
           outputs: {},
           sourceModuleName: "api-image",
           spec: {
+            build: {
+              dependencies: [],
+            },
             chartPath: ".",
             dependencies: [],
             releaseName: "api-release",
@@ -88,6 +90,9 @@ describe("validateHelmModule", () => {
         },
       ],
       spec: {
+        build: {
+          dependencies: [],
+        },
         chartPath: ".",
         dependencies: [],
         releaseName: "api-release",


### PR DESCRIPTION
Allows referencing a specific image in a multi-stage Dockerfile.

Needed a refactor to be able to add a field to the build schema.