### PR TITLE
fix: ensure module is up to date in watch handler

### DIFF
--- a/garden-service/src/process.ts
+++ b/garden-service/src/process.ts
@@ -161,7 +161,11 @@ export async function processModules(
       // Update the config graph
       graph = await garden.getConfigGraph()
 
-      await Bluebird.map(changeHandler!(graph, changedModule), (task) => garden.addTask(task))
+      // Make sure the module's version is up to date.
+      const refreshedModule = await graph.getModule(changedModule.name)
+      modulesByName[event.name] = refreshedModule
+
+      await Bluebird.map(changeHandler!(graph, refreshedModule), (task) => garden.addTask(task))
       await garden.processTasks()
     })
   })


### PR DESCRIPTION
Before this fix, the module provided to the change handlers of watch-mode commands didn't have an up-to-date version, reflecting the latest dirty timestamp of the changed module.

This resulted in errors due to version discrepancies between e.g. build and deploy tasks in watch mode commands.