### PR TITLE
fix(examples): use different ingress hostnames for vote-helm example

### DIFF
--- a/docs/using-garden/using-helm-charts.md
+++ b/docs/using-garden/using-helm-charts.md
@@ -226,7 +226,7 @@ module:
     ingress:
       enabled: true
       paths: [/]
-      hosts: [result.local.app.garden]
+      hosts: [result-helm.local.app.garden]
   tests:
     - name: integ
       args: [echo, ok]

--- a/examples/vote-helm/result-image/views/app.js
+++ b/examples/vote-helm/result-image/views/app.js
@@ -3,8 +3,8 @@ var socket = io.connect({
   transports:['polling'],
   // path: "/result/views/socket.io",
 });
-// https://vote.local.app.garden/socket.io/?EIO=3&transport=polling&t=1544105126936-2
-// https://vote.local.app.garden/result/views/socket.io/?EIO=3&transport=polling&t=1544104159102-166
+// https://vote-helm.local.app.garden/socket.io/?EIO=3&transport=polling&t=1544105126936-2
+// https://vote-helm.local.app.garden/result/views/socket.io/?EIO=3&transport=polling&t=1544104159102-166
 
 var bg1 = document.getElementById('background-stats-1');
 var bg2 = document.getElementById('background-stats-2');

--- a/examples/vote-helm/result/garden.yml
+++ b/examples/vote-helm/result/garden.yml
@@ -16,7 +16,7 @@ module:
     ingress:
       enabled: true
       paths: [/]
-      hosts: [result.local.app.garden]
+      hosts: [result-helm.local.app.garden]
   tests:
     - name: integ
       args: [echo, ok]

--- a/examples/vote-helm/vote-image/vue.config.js
+++ b/examples/vote-helm/vote-image/vue.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   devServer: {
     disableHostCheck: true,
-    public: 'http://vote.local.app.garden',
+    public: 'http://vote-helm.local.app.garden',
   },
 };

--- a/examples/vote-helm/vote/garden.yml
+++ b/examples/vote-helm/vote/garden.yml
@@ -13,7 +13,7 @@ module:
     ingress:
       enabled: true
       paths: [/]
-      hosts: [vote.local.app.garden]
+      hosts: [vote-helm.local.app.garden]
   tests:
     - name: integ
       args: [npm, run, test:integ]

--- a/garden-service/src/plugins/kubernetes/hot-reload.ts
+++ b/garden-service/src/plugins/kubernetes/hot-reload.ts
@@ -312,6 +312,8 @@ async function getLocalRsyncPort(ctx: PluginContext, log: LogEntry, targetDeploy
 
     proc.stdout.on("data", (line) => {
       // This is unfortunately the best indication that we have that the connection is up...
+      log.silly(`[${targetDeployment} port forwarder] ${line}`)
+
       if (line.toString().includes("Forwarding from ")) {
         const portForward = { proc, rsyncLocalPort }
         registeredPortForwards[targetDeployment] = portForward


### PR DESCRIPTION
This avoids confusion/conflict when trying out both the vote and
vote-helm examples.