### PR TITLE
fix: stream container build output and cap max buffer size

### DIFF
--- a/garden-service/src/plugins/container/helpers.ts
+++ b/garden-service/src/plugins/container/helpers.ts
@@ -6,12 +6,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import execa = require("execa")
-
 import { pathExists } from "fs-extra"
 import { join } from "path"
 import { ConfigurationError } from "../../exceptions"
-import { splitFirst } from "../../util/util"
+import { splitFirst, spawn } from "../../util/util"
 import { ModuleConfig } from "../../config/module"
 import { ContainerModule, ContainerRegistryConfig, defaultTag, defaultNamespace } from "./config"
 
@@ -147,7 +145,8 @@ export const containerHelpers = {
 
   async dockerCli(module: ContainerModule, args: string[]) {
     // TODO: use dockerode instead of CLI
-    return execa.stdout("docker", args, { cwd: module.buildPath, maxBuffer: 1024 * 1024 })
+    const output = await spawn("docker", args, { cwd: module.buildPath })
+    return output.output || ""
   },
 
   async hasDockerfile(module: ContainerModule) {


### PR DESCRIPTION
This is a quick fix for #399 (addresses point one in this [comment](https://github.com/garden-io/garden/issues/399#issuecomment-443343277)).

A few things:

* I opted not to append the `stderr` to the `output` string in the `spawn` function since the error is already printed at the top of the error message. This also conforms to how the container build output was displayed before this change.
* We now only print the last hundred lines of the output in case of an error. Should this be more?
* The `MAX_BUFFER_SIZE` is pretty arbitrary, any thoughts?