### PR TITLE
fix(build): always sync sources when building

### DIFF
--- a/garden-service/src/tasks/build.ts
+++ b/garden-service/src/tasks/build.ts
@@ -66,6 +66,14 @@ export class BuildTask extends BaseTask {
   async process(): Promise<BuildResult> {
     const module = this.module
 
+    const log = this.log.info({
+      section: this.getName(),
+      msg: `Syncing sources...`,
+      status: "active",
+    })
+
+    await this.garden.buildDir.syncFromSrc(this.module)
+
     if (!this.force) {
       const status = await this.garden.actions.getBuildStatus({ log: this.log, module })
 
@@ -76,11 +84,7 @@ export class BuildTask extends BaseTask {
       }
     }
 
-    const log = this.log.info({
-      section: this.getName(),
-      msg: `Building version ${module.version.versionString}...`,
-      status: "active",
-    })
+    log.setState({ msg: `Building version ${module.version.versionString}...` })
 
     let result: BuildResult
     try {


### PR DESCRIPTION
This addresses an issue where status checks rely on build sources
having been staged.