### PR TITLE
fix: respect level when using logger type env var

### DIFF
--- a/garden-service/src/logger/logger.ts
+++ b/garden-service/src/logger/logger.ts
@@ -87,7 +87,7 @@ export class Logger extends LogNode {
         })
       }
 
-      instance = new Logger(getCommonConfig(loggerType))
+      instance = new Logger({ ...getCommonConfig(loggerType), level: config.level })
       instance.debug(`Setting logger type to ${loggerType} (from GARDEN_LOGGER_TYPE)`)
     } else {
       instance = new Logger(config)


### PR DESCRIPTION
Fixes https://github.com/garden-io/garden/issues/604.

Before this commit, the log level passed to a command with `-l`/`--logLevel` was ignored when used in conjunction with the `GARDEN_LOGGER_TYPE` env var.