### PR TITLE
refactor: split provider from KubeApi

### DIFF
--- a/garden-service/src/config/project.ts
+++ b/garden-service/src/config/project.ts
@@ -31,7 +31,7 @@ export const providerConfigBaseSchema = Joi.object()
   .unknown(true)
   .meta({ extendable: true })
 
-export interface Provider<T extends ProviderConfig = any> {
+export interface Provider<T extends ProviderConfig = ProviderConfig> {
   name: string
   config: T
 }
@@ -151,5 +151,5 @@ export const projectSchema = Joi.object()
 // this is used for default handlers in the action handler
 export const defaultProvider: Provider = {
   name: "_default",
-  config: {},
+  config: { name: "_default" },
 }

--- a/garden-service/src/plugin-context.ts
+++ b/garden-service/src/plugin-context.ts
@@ -15,6 +15,7 @@ import {
   projectSourcesSchema,
   environmentSchema,
   providerConfigBaseSchema,
+  ProviderConfig,
 } from "./config/project"
 import { joiIdentifier, joiIdentifierMap } from "./config/common"
 import { PluginError } from "./exceptions"
@@ -37,8 +38,8 @@ const providerSchema = Joi.object()
     config: providerConfigBaseSchema,
   })
 
-export interface PluginContext extends WrappedFromGarden {
-  provider: Provider
+export interface PluginContext<C extends ProviderConfig = ProviderConfig> extends WrappedFromGarden {
+  provider: Provider<C>
   providers: { [name: string]: Provider }
 }
 

--- a/garden-service/src/plugins/kubernetes/api.ts
+++ b/garden-service/src/plugins/kubernetes/api.ts
@@ -23,7 +23,6 @@ import { safeLoad } from "js-yaml"
 import { zip, omitBy, isObject } from "lodash"
 import { GardenBaseError } from "../../exceptions"
 import { homedir } from "os"
-import { KubernetesProvider } from "./kubernetes"
 import { KubernetesResource } from "./types"
 import * as dedent from "dedent"
 
@@ -72,7 +71,6 @@ export class KubernetesError extends GardenBaseError {
 }
 
 export class KubeApi {
-  public context: string
   private config: KubeConfig
 
   public apiExtensions: Apiextensions_v1beta1Api
@@ -82,8 +80,7 @@ export class KubeApi {
   public policy: Policy_v1beta1Api
   public rbac: RbacAuthorization_v1Api
 
-  constructor(public provider: KubernetesProvider) {
-    this.context = provider.config.context
+  constructor(public context: string) {
     this.config = getConfig(this.context)
 
     for (const [name, cls] of Object.entries(apiTypes)) {

--- a/garden-service/src/plugins/kubernetes/container/handlers.ts
+++ b/garden-service/src/plugins/kubernetes/container/handlers.ts
@@ -23,7 +23,7 @@ async function configure(params: ConfigureModuleParams<ContainerModule>) {
   const config = await configureContainerModule(params)
 
   // validate ingress specs
-  const provider: KubernetesProvider = params.ctx.provider
+  const provider = <KubernetesProvider>params.ctx.provider
 
   for (const serviceConfig of config.serviceConfigs) {
     for (const ingressSpec of serviceConfig.spec.ingresses) {

--- a/garden-service/src/plugins/kubernetes/container/logs.ts
+++ b/garden-service/src/plugins/kubernetes/container/logs.ts
@@ -10,11 +10,13 @@ import { GetServiceLogsParams } from "../../../types/plugin/params"
 import { ContainerModule } from "../../container/config"
 import { getAppNamespace } from "../namespace"
 import { getKubernetesLogs } from "../logs"
+import { KubernetesPluginContext } from "../kubernetes"
 
 export async function getServiceLogs(params: GetServiceLogsParams<ContainerModule>) {
   const { ctx, service } = params
-  const context = ctx.provider.config.context
-  const namespace = await getAppNamespace(ctx, ctx.provider)
+  const k8sCtx = <KubernetesPluginContext>ctx
+  const context = k8sCtx.provider.config.context
+  const namespace = await getAppNamespace(k8sCtx, k8sCtx.provider)
   const selector = `service=${service.name}`
 
   return getKubernetesLogs({ ...params, context, namespace, selector })

--- a/garden-service/src/plugins/kubernetes/helm/build.ts
+++ b/garden-service/src/plugins/kubernetes/helm/build.ts
@@ -16,9 +16,11 @@ import { dumpYaml } from "../../../util/util"
 import { LogEntry } from "../../../logger/log-entry"
 import { getNamespace } from "../namespace"
 import { apply as jsonMerge } from "json-merge-patch"
+import { KubernetesPluginContext } from "../kubernetes"
 
 export async function buildHelmModule({ ctx, module, log }: BuildModuleParams<HelmModule>): Promise<BuildResult> {
-  const namespace = await getNamespace({ ctx, provider: ctx.provider, skipCreate: true })
+  const k8sCtx = <KubernetesPluginContext>ctx
+  const namespace = await getNamespace({ ctx: k8sCtx, provider: k8sCtx.provider, skipCreate: true })
   const context = ctx.provider.config.context
   const baseModule = getBaseModule(module)
 

--- a/garden-service/src/plugins/kubernetes/helm/common.ts
+++ b/garden-service/src/plugins/kubernetes/helm/common.ts
@@ -25,6 +25,7 @@ import { Module } from "../../../types/module"
 import { findByName } from "../../../util/util"
 import { deline } from "../../../util/string"
 import { getAnnotation } from "../util"
+import { KubernetesPluginContext } from "../kubernetes"
 
 /**
  * Returns true if the specified Helm module contains a template (as opposed to just referencing a remote template).
@@ -38,9 +39,10 @@ export async function containsSource(config: HelmModuleConfig) {
  * Render the template in the specified Helm module (locally), and return all the resources in the chart.
  */
 export async function getChartResources(ctx: PluginContext, module: Module, log: LogEntry) {
+  const k8sCtx = <KubernetesPluginContext>ctx
   const chartPath = await getChartPath(module)
   const valuesPath = getValuesPath(chartPath)
-  const namespace = await getNamespace({ ctx, provider: ctx.provider, skipCreate: true })
+  const namespace = await getNamespace({ ctx: k8sCtx, provider: k8sCtx.provider, skipCreate: true })
   const context = ctx.provider.config.context
   const releaseName = getReleaseName(module)
 
@@ -266,7 +268,8 @@ async function renderHelmTemplateString(
 ): Promise<string> {
   const tempFilePath = join(chartPath, "templates", cryptoRandomString(16))
   const valuesPath = getValuesPath(chartPath)
-  const namespace = await getNamespace({ ctx, provider: ctx.provider, skipCreate: true })
+  const k8sCtx = <KubernetesPluginContext>ctx
+  const namespace = await getNamespace({ ctx: k8sCtx, provider: k8sCtx.provider, skipCreate: true })
   const releaseName = getReleaseName(module)
   const context = ctx.provider.config.context
 

--- a/garden-service/src/plugins/kubernetes/helm/deployment.ts
+++ b/garden-service/src/plugins/kubernetes/helm/deployment.ts
@@ -23,7 +23,7 @@ import {
 import { getReleaseStatus, getServiceStatus } from "./status"
 import { configureHotReload, HotReloadableResource } from "../hot-reload"
 import { apply } from "../kubectl"
-import { KubernetesProvider } from "../kubernetes"
+import { KubernetesPluginContext } from "../kubernetes"
 import { ContainerHotReloadSpec } from "../../container/config"
 import { getHotReloadSpec } from "./hot-reload"
 
@@ -41,10 +41,11 @@ export async function deployService(
     hotReloadSpec = getHotReloadSpec(service)
   }
 
-  const provider: KubernetesProvider = ctx.provider
+  const k8sCtx = <KubernetesPluginContext>ctx
+  const provider = k8sCtx.provider
   const chartPath = await getChartPath(module)
   const valuesPath = getValuesPath(chartPath)
-  const namespace = await getAppNamespace(ctx, provider)
+  const namespace = await getAppNamespace(k8sCtx, provider)
   const context = provider.config.context
   const releaseName = getReleaseName(module)
 
@@ -101,8 +102,9 @@ export async function deployService(
 export async function deleteService(params: DeleteServiceParams): Promise<ServiceStatus> {
   const { ctx, log, module } = params
 
-  const namespace = await getAppNamespace(ctx, ctx.provider)
-  const context = ctx.provider.config.context
+  const k8sCtx = <KubernetesPluginContext>ctx
+  const namespace = await getAppNamespace(k8sCtx, k8sCtx.provider)
+  const context = k8sCtx.provider.config.context
   const releaseName = getReleaseName(module)
 
   await helm(namespace, context, log, "delete", "--purge", releaseName)

--- a/garden-service/src/plugins/kubernetes/helm/logs.ts
+++ b/garden-service/src/plugins/kubernetes/helm/logs.ts
@@ -10,11 +10,13 @@ import { GetServiceLogsParams } from "../../../types/plugin/params"
 import { getAppNamespace } from "../namespace"
 import { getKubernetesLogs } from "../logs"
 import { HelmModule } from "./config"
+import { KubernetesPluginContext } from "../kubernetes"
 
 export async function getServiceLogs(params: GetServiceLogsParams<HelmModule>) {
   const { ctx, service } = params
-  const context = ctx.provider.config.context
-  const namespace = await getAppNamespace(ctx, ctx.provider)
+  const k8sCtx = <KubernetesPluginContext>ctx
+  const context = k8sCtx.provider.config.context
+  const namespace = await getAppNamespace(k8sCtx, k8sCtx.provider)
   const selector = `app.kubernetes.io/name=${service.name}`
 
   return getKubernetesLogs({ ...params, context, namespace, selector })

--- a/garden-service/src/plugins/kubernetes/helm/run.ts
+++ b/garden-service/src/plugins/kubernetes/helm/run.ts
@@ -15,14 +15,16 @@ import { findServiceResource, getChartResources, getResourceContainer, getServic
 import { PluginContext } from "../../../plugin-context"
 import { LogEntry } from "../../../logger/log-entry"
 import { ConfigurationError } from "../../../exceptions"
+import { KubernetesPluginContext } from "../kubernetes"
 
 export async function runHelmModule(
   {
     ctx, module, command, ignoreError = true, interactive, runtimeContext, timeout, log,
   }: RunModuleParams<HelmModule>,
 ): Promise<RunResult> {
-  const context = ctx.provider.config.context
-  const namespace = await getAppNamespace(ctx, ctx.provider)
+  const k8sCtx = <KubernetesPluginContext>ctx
+  const context = k8sCtx.provider.config.context
+  const namespace = await getAppNamespace(k8sCtx, k8sCtx.provider)
   const serviceResourceSpec = getServiceResourceSpec(module)
 
   if (!serviceResourceSpec) {
@@ -33,7 +35,7 @@ export async function runHelmModule(
     )
   }
 
-  const image = await getImage(ctx, module, log, serviceResourceSpec)
+  const image = await getImage(k8sCtx, module, log, serviceResourceSpec)
 
   return runPod({
     context,
@@ -51,11 +53,12 @@ export async function runHelmModule(
 export async function runHelmTask(
   { ctx, log, module, task, interactive, runtimeContext, timeout }: RunTaskParams<HelmModule>,
 ): Promise<RunTaskResult> {
-  const context = ctx.provider.config.context
-  const namespace = await getAppNamespace(ctx, ctx.provider)
+  const k8sCtx = <KubernetesPluginContext>ctx
+  const context = k8sCtx.provider.config.context
+  const namespace = await getAppNamespace(k8sCtx, k8sCtx.provider)
 
   const args = task.spec.args
-  const image = await getImage(ctx, module, log, task.spec.resource || getServiceResourceSpec(module))
+  const image = await getImage(k8sCtx, module, log, task.spec.resource || getServiceResourceSpec(module))
 
   const res = await runPod({
     context,

--- a/garden-service/src/plugins/kubernetes/helm/tiller.ts
+++ b/garden-service/src/plugins/kubernetes/helm/tiller.ts
@@ -22,7 +22,7 @@ import chalk from "chalk"
 const serviceAccountName = "garden-tiller"
 
 export async function checkTillerStatus(ctx: PluginContext, provider: KubernetesProvider, log: LogEntry) {
-  const api = new KubeApi(provider)
+  const api = new KubeApi(provider.config.context)
   const namespace = await getAppNamespace(ctx, provider)
 
   const resources = [

--- a/garden-service/src/plugins/kubernetes/hot-reload.ts
+++ b/garden-service/src/plugins/kubernetes/hot-reload.ts
@@ -26,6 +26,7 @@ import { PluginContext } from "../../plugin-context"
 import { LogEntry } from "../../logger/log-entry"
 import { getResourceContainer } from "./helm/common"
 import { waitForContainerService } from "./container/status"
+import { KubernetesPluginContext } from "./kubernetes"
 
 export const RSYNC_PORT = 873
 export const RSYNC_PORT_NAME = "garden-rsync"
@@ -283,7 +284,8 @@ async function getLocalRsyncPort(ctx: PluginContext, log: LogEntry, targetDeploy
     return rsyncLocalPort
   }
 
-  const namespace = await getAppNamespace(ctx, ctx.provider)
+  const k8sCtx = <KubernetesPluginContext>ctx
+  const namespace = await getAppNamespace(k8sCtx, k8sCtx.provider)
 
   // Forward random free local port to the remote rsync container.
   rsyncLocalPort = await getPort()
@@ -292,7 +294,7 @@ async function getLocalRsyncPort(ctx: PluginContext, log: LogEntry, targetDeploy
   log.debug(`Forwarding local port ${rsyncLocalPort} to ${targetDeployment} sync container port ${RSYNC_PORT}`)
 
   // TODO: use the API directly instead of kubectl (need to reverse engineer kubectl a bit to get how that works)
-  const proc = kubectl(ctx.provider.config.context, namespace)
+  const proc = kubectl(k8sCtx.provider.config.context, namespace)
     .spawn(["port-forward", targetDeployment, portMapping])
 
   return new Promise((resolve) => {

--- a/garden-service/src/plugins/kubernetes/kubernetes.ts
+++ b/garden-service/src/plugins/kubernetes/kubernetes.ts
@@ -17,6 +17,7 @@ import { getSecret, setSecret, deleteSecret } from "./secrets"
 import { containerRegistryConfigSchema, ContainerRegistryConfig } from "../container/config"
 import { getRemoteEnvironmentStatus, prepareRemoteEnvironment, cleanupEnvironment } from "./init"
 import { containerHandlers } from "./container/handlers"
+import { PluginContext } from "../../plugin-context"
 
 export const name = "kubernetes"
 
@@ -49,6 +50,7 @@ export interface KubernetesConfig extends KubernetesBaseConfig {
 }
 
 export type KubernetesProvider = Provider<KubernetesConfig>
+export type KubernetesPluginContext = PluginContext<KubernetesConfig>
 
 export const k8sContextSchema = Joi.string()
   .required()

--- a/garden-service/src/plugins/kubernetes/namespace.ts
+++ b/garden-service/src/plugins/kubernetes/namespace.ts
@@ -85,7 +85,7 @@ export async function getNamespace(
   }
 
   if (!skipCreate) {
-    const api = new KubeApi(provider)
+    const api = new KubeApi(provider.config.context)
     await ensureNamespace(api, namespace)
   }
 

--- a/garden-service/src/plugins/kubernetes/secrets.ts
+++ b/garden-service/src/plugins/kubernetes/secrets.ts
@@ -9,14 +9,15 @@
 import { V1Secret } from "@kubernetes/client-node"
 
 import { KubeApi } from "./api"
-import { SecretRef } from "./kubernetes"
+import { SecretRef, KubernetesPluginContext } from "./kubernetes"
 import { ConfigurationError } from "../../exceptions"
 import { GetSecretParams, SetSecretParams, DeleteSecretParams } from "../../types/plugin/params"
 import { getMetadataNamespace } from "./namespace"
 
 export async function getSecret({ ctx, key }: GetSecretParams) {
-  const api = new KubeApi(ctx.provider)
-  const ns = await getMetadataNamespace(ctx, ctx.provider)
+  const k8sCtx = <KubernetesPluginContext>ctx
+  const api = new KubeApi(k8sCtx.provider.config.context)
+  const ns = await getMetadataNamespace(k8sCtx, k8sCtx.provider)
 
   try {
     const res = await api.core.readNamespacedSecret(key, ns)
@@ -32,8 +33,9 @@ export async function getSecret({ ctx, key }: GetSecretParams) {
 
 export async function setSecret({ ctx, key, value }: SetSecretParams) {
   // we store configuration in a separate metadata namespace, so that configs aren't cleared when wiping the namespace
-  const api = new KubeApi(ctx.provider)
-  const ns = await getMetadataNamespace(ctx, ctx.provider)
+  const k8sCtx = <KubernetesPluginContext>ctx
+  const api = new KubeApi(k8sCtx.provider.config.context)
+  const ns = await getMetadataNamespace(k8sCtx, k8sCtx.provider)
   const body = {
     body: {
       apiVersion: "v1",
@@ -63,8 +65,9 @@ export async function setSecret({ ctx, key, value }: SetSecretParams) {
 }
 
 export async function deleteSecret({ ctx, key }: DeleteSecretParams) {
-  const api = new KubeApi(ctx.provider)
-  const ns = await getMetadataNamespace(ctx, ctx.provider)
+  const k8sCtx = <KubernetesPluginContext>ctx
+  const api = new KubeApi(k8sCtx.provider.config.context)
+  const ns = await getMetadataNamespace(k8sCtx, k8sCtx.provider)
 
   try {
     await api.core.deleteNamespacedSecret(key, ns, <any>{})

--- a/garden-service/src/plugins/kubernetes/test.ts
+++ b/garden-service/src/plugins/kubernetes/test.ts
@@ -16,12 +16,14 @@ import { Module } from "../../types/module"
 import { ModuleVersion } from "../../vcs/base"
 import { HelmModule } from "./helm/config"
 import { PluginContext } from "../../plugin-context"
+import { KubernetesPluginContext } from "./kubernetes"
 
 export async function getTestResult(
   { ctx, module, testName, version }: GetTestResultParams<ContainerModule | HelmModule>,
 ) {
-  const api = new KubeApi(ctx.provider)
-  const ns = await getMetadataNamespace(ctx, ctx.provider)
+  const k8sCtx = <KubernetesPluginContext>ctx
+  const api = new KubeApi(k8sCtx.provider.config.context)
+  const ns = await getMetadataNamespace(k8sCtx, k8sCtx.provider)
   const resultKey = getTestResultKey(module, testName, version)
 
   try {
@@ -49,14 +51,15 @@ export async function storeTestResult(
   { ctx, module, testName, result }:
     { ctx: PluginContext, module: Module, testName: string, result: RunResult },
 ) {
-  const api = new KubeApi(ctx.provider)
+  const k8sCtx = <KubernetesPluginContext>ctx
+  const api = new KubeApi(k8sCtx.provider.config.context)
 
   const testResult: TestResult = {
     ...result,
     testName,
   }
 
-  const ns = await getMetadataNamespace(ctx, ctx.provider)
+  const ns = await getMetadataNamespace(k8sCtx, k8sCtx.provider)
   const resultKey = getTestResultKey(module, testName, result.version)
   const body = {
     apiVersion: "v1",


### PR DESCRIPTION
This is to facilitate use of the `KubeApi` class e.g. in integration tests, where some k8s operations need to be run outside of a Garden project.