### PR TITLE
fix(integ-tests): helper to remove .garden dirs

### DIFF
--- a/garden-service/test/integ-helpers.ts
+++ b/garden-service/test/integ-helpers.ts
@@ -1,5 +1,9 @@
 import * as execa from "execa"
+import * as Bluebird from "bluebird"
+import { remove } from "fs-extra"
 import { get, intersection } from "lodash"
+import { resolve } from "path"
+import { GARDEN_DIR_NAME } from "../src/constants"
 import { KubeApi } from "../src/plugins/kubernetes/api"
 import { deleteNamespaces } from "../src/plugins/kubernetes/init"
 import { TaskLogStatus } from "../src/logger/log-entry"
@@ -7,6 +11,12 @@ import { JsonLogEntry } from "../src/logger/writers/json-terminal-writer"
 import { getAllNamespaces } from "../src/plugins/kubernetes/namespace"
 import { getExampleProjects } from "./helpers"
 import { WatchTestConditionState } from "./run-garden"
+
+export async function removeExampleDotGardenDirs() {
+  await Bluebird.map(Object.values(getExampleProjects()), (projectRoot) => {
+    return remove(resolve(projectRoot, GARDEN_DIR_NAME))
+  })
+}
 
 export async function deleteExampleNamespaces(includeSystemNamespaces = false) {
   const namespacesToDelete: string[] = []

--- a/garden-service/test/integ/src/pre-release.ts
+++ b/garden-service/test/integ/src/pre-release.ts
@@ -12,7 +12,7 @@ import {
   runGarden,
   taskCompletedStep,
 } from "../../run-garden"
-import { deleteExampleNamespaces, searchLog } from "../../integ-helpers"
+import { deleteExampleNamespaces, searchLog, removeExampleDotGardenDirs } from "../../integ-helpers"
 
 // TODO: Add test for verifying that CLI returns with an error when called with an unknown command
 
@@ -21,8 +21,9 @@ describe("PreReleaseTests", () => {
   const simpleProjectPath = resolve(examplesDir, "simple-project")
 
   before(async () => {
-    mlog.log("deleting example project namespaces")
+    mlog.log("deleting example project namespaces and .garden folders")
     await deleteExampleNamespaces(false)
+    await removeExampleDotGardenDirs()
   })
 
   after(async () => {


### PR DESCRIPTION
Just a quick tweak that came to mind since I've been looking into the build dir / the `.garden` dir.

Removing the `.garden` dirs of the projects used before running the integration tests makes for a more neutral/standardised initial state.