### PR TITLE
fix: use unique names for a service's ingresses

### DIFF
--- a/examples/simple-project/services/node-service/garden.yml
+++ b/examples/simple-project/services/node-service/garden.yml
@@ -7,6 +7,10 @@ module:
       ports:
         - name: http
           containerPort: 8080
+      healthCheck:
+        httpGet:
+          path: /hello-node
+          port: http
       ingresses:
         - path: /hello-node
           port: http

--- a/garden-service/src/plugins/kubernetes/container/ingress.ts
+++ b/garden-service/src/plugins/kubernetes/container/ingress.ts
@@ -33,7 +33,7 @@ export async function createIngressResources(
 
   const allIngresses = await getIngressesWithCert(service, api, provider)
 
-  return Bluebird.map(allIngresses, async (ingress) => {
+  return Bluebird.map(allIngresses, async (ingress, index) => {
     const rules = [{
       host: ingress.hostname,
       http: {
@@ -74,7 +74,7 @@ export async function createIngressResources(
       apiVersion: "extensions/v1beta1",
       kind: "Ingress",
       metadata: {
-        name: service.name,
+        name: `${service.name}-${index}`,
         annotations,
         namespace,
       },

--- a/garden-service/test/unit/src/plugins/kubernetes/container/ingress.ts
+++ b/garden-service/test/unit/src/plugins/kubernetes/container/ingress.ts
@@ -408,7 +408,7 @@ describe("createIngressResources", () => {
       apiVersion: "extensions/v1beta1",
       kind: "Ingress",
       metadata: {
-        name: service.name,
+        name: `${service.name}-0`,
         annotations: {
           "ingress.kubernetes.io/force-ssl-redirect": "false",
           "kubernetes.io/ingress.class": "nginx",
@@ -450,7 +450,7 @@ describe("createIngressResources", () => {
       apiVersion: "extensions/v1beta1",
       kind: "Ingress",
       metadata: {
-        name: service.name,
+        name: `${service.name}-0`,
         annotations: {
           "ingress.kubernetes.io/force-ssl-redirect": "false",
           "kubernetes.io/ingress.class": "nginx",
@@ -502,7 +502,7 @@ describe("createIngressResources", () => {
         apiVersion: "extensions/v1beta1",
         kind: "Ingress",
         metadata: {
-          name: service.name,
+          name: `${service.name}-0`,
           annotations: {
             "ingress.kubernetes.io/force-ssl-redirect": "false",
             "kubernetes.io/ingress.class": "nginx",
@@ -530,7 +530,7 @@ describe("createIngressResources", () => {
         apiVersion: "extensions/v1beta1",
         kind: "Ingress",
         metadata: {
-          name: service.name,
+          name: `${service.name}-1`,
           annotations: {
             "ingress.kubernetes.io/force-ssl-redirect": "false",
             "kubernetes.io/ingress.class": "nginx",
@@ -575,7 +575,7 @@ describe("createIngressResources", () => {
       apiVersion: "extensions/v1beta1",
       kind: "Ingress",
       metadata: {
-        name: service.name,
+        name: `${service.name}-0`,
         annotations: {
           "ingress.kubernetes.io/force-ssl-redirect": "true",
           "kubernetes.io/ingress.class": "nginx",
@@ -722,7 +722,7 @@ describe("createIngressResources", () => {
       apiVersion: "extensions/v1beta1",
       kind: "Ingress",
       metadata: {
-        name: service.name,
+        name: `${service.name}-0`,
         annotations: {
           "ingress.kubernetes.io/force-ssl-redirect": "true",
           "kubernetes.io/ingress.class": "nginx",
@@ -788,7 +788,7 @@ describe("createIngressResources", () => {
       apiVersion: "extensions/v1beta1",
       kind: "Ingress",
       metadata: {
-        name: service.name,
+        name: `${service.name}-0`,
         annotations: {
           "ingress.kubernetes.io/force-ssl-redirect": "true",
           "kubernetes.io/ingress.class": "nginx",


### PR DESCRIPTION
Before this fix, services defining multiple ingresses would only have the last configured ingress deployed to the cluster (since each ingress for a given service had `metadata.name = service.name`).