### PR TITLE
feat(k8s): cache task results

### DIFF
--- a/garden-service/src/actions.ts
+++ b/garden-service/src/actions.ts
@@ -37,9 +37,9 @@ import {
   TestResult,
   PluginActionOutputs,
   PublishResult,
-  RunTaskResult,
   TaskActionOutputs,
   HotReloadServiceResult,
+  RunTaskResult,
 } from "./types/plugin/outputs"
 import {
   BuildModuleParams,
@@ -70,6 +70,7 @@ import {
   PluginTaskActionParamsBase,
   RunTaskParams,
   TaskActionParams,
+  GetTaskResultParams,
 } from "./types/plugin/params"
 import { Service, ServiceStatus, getServiceRuntimeContext } from "./types/service"
 import { mapValues, values, keyBy, omit, pickBy, fromPairs } from "lodash"
@@ -327,6 +328,14 @@ export class ActionHelper implements TypeGuard {
 
   async runTask(params: TaskActionHelperParams<RunTaskParams>): Promise<RunTaskResult> {
     return this.callTaskHandler({ params, actionType: "runTask" })
+  }
+
+  async getTaskResult(params: TaskActionHelperParams<GetTaskResultParams>): Promise<RunTaskResult | null> {
+    return this.callTaskHandler({
+      params,
+      actionType: "getTaskResult",
+      defaultHandler: async () => null,
+    })
   }
 
   //endregion

--- a/garden-service/src/commands/run/task.ts
+++ b/garden-service/src/commands/run/task.ts
@@ -59,7 +59,7 @@ export class RunTaskCommand extends Command<Args, Opts> {
 
     await garden.actions.prepareEnvironment({ log })
 
-    const taskTask = new TaskTask({ garden, graph, task, log, force: true, forceBuild: opts["force-build"] })
+    const taskTask = await TaskTask.factory({ garden, graph, task, log, force: true, forceBuild: opts["force-build"] })
     await garden.addTask(taskTask)
 
     const result = (await garden.processTasks())[taskTask.getBaseKey()]

--- a/garden-service/src/commands/run/test.ts
+++ b/garden-service/src/commands/run/test.ts
@@ -25,6 +25,7 @@ import dedent = require("dedent")
 import { prepareRuntimeContext } from "../../types/service"
 import { logHeader } from "../../logger/util"
 import { PushTask } from "../../tasks/push"
+import { getTestVersion } from "../../tasks/test"
 
 const runArgs = {
   module: new StringParameter({
@@ -101,6 +102,8 @@ export class RunTestCommand extends Command<Args, Opts> {
 
     printRuntimeContext(log, runtimeContext)
 
+    const testVersion = await getTestVersion(garden, graph, module, testConfig)
+
     const result = await garden.actions.testModule({
       log,
       module,
@@ -108,6 +111,7 @@ export class RunTestCommand extends Command<Args, Opts> {
       runtimeContext,
       silent: false,
       testConfig,
+      testVersion,
     })
 
     return { result }

--- a/garden-service/src/plugins/kubernetes/container/handlers.ts
+++ b/garden-service/src/plugins/kubernetes/container/handlers.ts
@@ -19,6 +19,7 @@ import { getContainerServiceStatus } from "./status"
 import { getTestResult } from "../test"
 import { ContainerModule } from "../../container/config"
 import { configureMavenContainerModule, MavenContainerModule } from "../../maven-container/maven-container"
+import { getTaskResult } from "../task-results"
 
 async function configure(params: ConfigureModuleParams<ContainerModule>) {
   const config = await configureContainerModule(params)
@@ -46,6 +47,7 @@ export const containerHandlers = {
   runModule: runContainerModule,
   runService: runContainerService,
   runTask: runContainerTask,
+  getTaskResult,
   testModule: testContainerModule,
 }
 

--- a/garden-service/src/plugins/kubernetes/container/test.ts
+++ b/garden-service/src/plugins/kubernetes/container/test.ts
@@ -14,7 +14,7 @@ import { runContainerModule } from "./run"
 import { storeTestResult } from "../test"
 
 export async function testContainerModule(
-  { ctx, interactive, module, runtimeContext, testConfig, log }:
+  { ctx, interactive, module, runtimeContext, testConfig, testVersion, log }:
     TestModuleParams<ContainerModule>,
 ): Promise<TestResult> {
   const testName = testConfig.name
@@ -32,5 +32,5 @@ export async function testContainerModule(
     log,
   })
 
-  return storeTestResult({ ctx, module, testName, result })
+  return storeTestResult({ ctx, module, testName, testVersion, result })
 }

--- a/garden-service/src/plugins/kubernetes/helm/test.ts
+++ b/garden-service/src/plugins/kubernetes/helm/test.ts
@@ -17,7 +17,7 @@ import { findServiceResource, getChartResources, getResourceContainer, getServic
 import { KubernetesPluginContext } from "../kubernetes"
 
 export async function testHelmModule(
-  { ctx, log, interactive, module, runtimeContext, testConfig }:
+  { ctx, log, interactive, module, runtimeContext, testConfig, testVersion }:
     TestModuleParams<HelmModule>,
 ): Promise<TestResult> {
   const testName = testConfig.name
@@ -48,5 +48,5 @@ export async function testHelmModule(
     log,
   })
 
-  return storeTestResult({ ctx: k8sCtx, module, testName, result })
+  return storeTestResult({ ctx: k8sCtx, module, testName, testVersion, result })
 }

--- a/garden-service/src/plugins/kubernetes/task-results.ts
+++ b/garden-service/src/plugins/kubernetes/task-results.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2018 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { GetTaskResultParams } from "../../types/plugin/params"
+import { ContainerModule } from "../container/config"
+import { HelmModule } from "./helm/config"
+import { ModuleVersion } from "../../vcs/base"
+import { KubernetesPluginContext, KubernetesProvider } from "./kubernetes"
+import { KubeApi } from "./api"
+import { getMetadataNamespace } from "./namespace"
+import { RunTaskResult } from "../../types/plugin/outputs"
+import { deserializeValues, serializeValues } from "../../util/util"
+import { PluginContext } from "../../plugin-context"
+
+export async function getTaskResult(
+  { ctx, task, taskVersion }: GetTaskResultParams<ContainerModule | HelmModule>,
+): Promise<RunTaskResult | null> {
+  const k8sCtx = <KubernetesPluginContext>ctx
+  const api = new KubeApi(k8sCtx.provider.config.context)
+  const ns = await getMetadataNamespace(k8sCtx, k8sCtx.provider)
+  const resultKey = getTaskResultKey(task.name, taskVersion)
+
+  try {
+    const res = await api.core.readNamespacedConfigMap(resultKey, ns)
+    return <RunTaskResult>deserializeValues(res.body.data)
+  } catch (err) {
+    if (err.code === 404) {
+      return null
+    } else {
+      throw err
+    }
+  }
+}
+
+export function getTaskResultKey(taskName: string, version: ModuleVersion) {
+  return `task-result--${taskName}--${version.versionString}`
+}
+
+/**
+ * Store a task run result as a ConfigMap in the cluster.
+ *
+ * TODO: Implement a CRD for this.
+ */
+export async function storeTaskResult(
+  { ctx, taskName, taskVersion, result }:
+    { ctx: PluginContext, taskName: string, taskVersion: ModuleVersion, result: RunTaskResult },
+): Promise<RunTaskResult> {
+  const provider = <KubernetesProvider>ctx.provider
+  const api = new KubeApi(provider.config.context)
+  const ns = await getMetadataNamespace(ctx, provider)
+  const resultKey = getTaskResultKey(taskName, taskVersion)
+
+  const body = {
+    apiVersion: "v1",
+    kind: "ConfigMap",
+    metadata: {
+      name: resultKey,
+      annotations: {
+        "garden.io/generated": "true",
+      },
+    },
+    data: serializeValues(result),
+  }
+
+  try {
+    await api.core.createNamespacedConfigMap(ns, <any>body)
+  } catch (err) {
+    if (err.code === 409) {
+      await api.core.patchNamespacedConfigMap(resultKey, ns, body)
+    } else {
+      throw err
+    }
+  }
+
+  return result
+}

--- a/garden-service/src/plugins/kubernetes/test.ts
+++ b/garden-service/src/plugins/kubernetes/test.ts
@@ -19,12 +19,12 @@ import { PluginContext } from "../../plugin-context"
 import { KubernetesPluginContext } from "./kubernetes"
 
 export async function getTestResult(
-  { ctx, module, testName, version }: GetTestResultParams<ContainerModule | HelmModule>,
-) {
+  { ctx, module, testName, testVersion }: GetTestResultParams<ContainerModule | HelmModule>,
+): Promise<TestResult | null> {
   const k8sCtx = <KubernetesPluginContext>ctx
   const api = new KubeApi(k8sCtx.provider.config.context)
   const ns = await getMetadataNamespace(k8sCtx, k8sCtx.provider)
-  const resultKey = getTestResultKey(module, testName, version)
+  const resultKey = getTestResultKey(module, testName, testVersion)
 
   try {
     const res = await api.core.readNamespacedConfigMap(resultKey, ns)
@@ -48,9 +48,9 @@ export function getTestResultKey(module: Module, testName: string, version: Modu
  * TODO: Implement a CRD for this.
  */
 export async function storeTestResult(
-  { ctx, module, testName, result }:
-    { ctx: PluginContext, module: Module, testName: string, result: RunResult },
-) {
+  { ctx, module, testName, testVersion, result }:
+    { ctx: PluginContext, module: Module, testName: string, testVersion: ModuleVersion, result: RunResult },
+): Promise<TestResult> {
   const k8sCtx = <KubernetesPluginContext>ctx
   const api = new KubeApi(k8sCtx.provider.config.context)
 
@@ -60,7 +60,7 @@ export async function storeTestResult(
   }
 
   const ns = await getMetadataNamespace(k8sCtx, k8sCtx.provider)
-  const resultKey = getTestResultKey(module, testName, result.version)
+  const resultKey = getTestResultKey(module, testName, testVersion)
   const body = {
     apiVersion: "v1",
     kind: "ConfigMap",

--- a/garden-service/src/tasks/deploy.ts
+++ b/garden-service/src/tasks/deploy.ts
@@ -72,13 +72,13 @@ export class DeployTask extends BaseTask {
     if (this.fromWatch && includes(this.hotReloadServiceNames, this.service.name)) {
       return deployTasks
     } else {
-      const taskTasks = deps.task.map(task => {
-        return new TaskTask({
+      const taskTasks = await Bluebird.map(deps.task, (task) => {
+        return TaskTask.factory({
           task,
           garden: this.garden,
           log: this.log,
           graph: this.graph,
-          force: false,
+          force: this.force,
           forceBuild: this.forceBuild,
         })
       })

--- a/garden-service/src/tasks/task.ts
+++ b/garden-service/src/tasks/task.ts
@@ -6,8 +6,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import * as Bluebird from "bluebird"
 import chalk from "chalk"
-import { BaseTask } from "../tasks/base"
+import { BaseTask, TaskParams } from "../tasks/base"
 import { Garden } from "../garden"
 import { Task } from "../types/task"
 import { PushTask } from "./push"
@@ -16,6 +17,7 @@ import { LogEntry } from "../logger/log-entry"
 import { RunTaskResult } from "../types/plugin/outputs"
 import { prepareRuntimeContext } from "../types/service"
 import { DependencyGraphNodeType, ConfigGraph } from "../config-graph"
+import { ModuleVersion } from "../vcs/base"
 
 export interface TaskTaskParams {
   garden: Garden
@@ -34,11 +36,18 @@ export class TaskTask extends BaseTask { // ... to be renamed soon.
   private task: Task
   private forceBuild: boolean
 
-  constructor({ garden, log, graph, task, force, forceBuild }: TaskTaskParams) {
-    super({ garden, log, force, version: task.module.version })
+  constructor({ garden, log, graph, task, version, force, forceBuild }: TaskTaskParams & TaskParams) {
+    super({ garden, log, force, version })
     this.graph = graph
     this.task = task
+    this.force = force
     this.forceBuild = forceBuild
+  }
+
+  static async factory(initArgs: TaskTaskParams): Promise<TaskTask> {
+    const { garden, graph, task } = initArgs
+    const version = await getTaskVersion(garden, graph, task)
+    return new TaskTask({ ...initArgs, version })
   }
 
   async getDependencies(): Promise<BaseTask[]> {
@@ -64,8 +73,8 @@ export class TaskTask extends BaseTask { // ... to be renamed soon.
       })
     })
 
-    const taskTasks = deps.task.map(task => {
-      return new TaskTask({
+    const taskTasks = await Bluebird.map(deps.task, (task) => {
+      return TaskTask.factory({
         task,
         log: this.log,
         garden: this.garden,
@@ -91,6 +100,18 @@ export class TaskTask extends BaseTask { // ... to be renamed soon.
     const task = this.task
     const module = task.module
 
+    // TODO: Re-enable this logic when we've started providing task graph results to process methods.
+
+    // const cachedResult = await this.getTaskReosult()
+
+    // if (cachedResult && cachedResult.success) {
+    //   this.log.info({
+    //     section: task.name,
+    //   }).setSuccess({ msg: chalk.green("Already run") })
+
+    //   return cachedResult
+    // }
+
     const log = this.log.info({
       section: task.name,
       msg: "Running",
@@ -108,6 +129,7 @@ export class TaskTask extends BaseTask { // ... to be renamed soon.
         log,
         runtimeContext,
         interactive: false,
+        taskVersion: this.version,
       })
     } catch (err) {
       log.setError()
@@ -120,4 +142,27 @@ export class TaskTask extends BaseTask { // ... to be renamed soon.
 
   }
 
+  //   private async getTaskResult(): Promise<RunTaskResult | null> {
+  //     if (this.force) {
+  //       return null
+  //     }
+
+  //     return this.garden.actions.getTaskResult({
+  //       log: this.log,
+  //       task: this.task,
+  //       taskVersion: this.version,
+  //     })
+  //   }
+
+}
+
+/**
+ * Determine the version of the task run, based on the version of the module and each of its dependencies.
+ */
+export async function getTaskVersion(
+  garden: Garden, graph: ConfigGraph, task: Task,
+): Promise<ModuleVersion> {
+  const { module } = task
+  const moduleDeps = await graph.resolveDependencyModules(module.build.dependencies, task.config.dependencies)
+  return garden.resolveVersion(module.name, moduleDeps)
 }

--- a/garden-service/src/tasks/test.ts
+++ b/garden-service/src/tasks/test.ts
@@ -130,6 +130,7 @@ export class TestTask extends BaseTask {
         runtimeContext,
         silent: true,
         testConfig: this.testConfig,
+        testVersion: this.version,
       })
     } catch (err) {
       log.setError()
@@ -145,7 +146,7 @@ export class TestTask extends BaseTask {
     return result
   }
 
-  private async getTestResult() {
+  private async getTestResult(): Promise<TestResult | null> {
     if (this.force) {
       return null
     }
@@ -154,7 +155,7 @@ export class TestTask extends BaseTask {
       log: this.log,
       module: this.module,
       testName: this.testConfig.name,
-      version: this.version,
+      testVersion: this.version,
     })
   }
 }
@@ -192,7 +193,7 @@ async function getTestDependencies(graph: ConfigGraph, testConfig: TestConfig) {
 /**
  * Determine the version of the test run, based on the version of the module and each of its dependencies.
  */
-async function getTestVersion(
+export async function getTestVersion(
   garden: Garden, graph: ConfigGraph, module: Module, testConfig: TestConfig,
 ): Promise<ModuleVersion> {
   const moduleDeps = await graph.resolveDependencyModules(module.build.dependencies, testConfig.dependencies)

--- a/garden-service/src/types/plugin/outputs.ts
+++ b/garden-service/src/types/plugin/outputs.ts
@@ -302,16 +302,7 @@ export const runTaskResultSchema = Joi.object()
       .description("The output log from the run."),
   })
 
-export interface TaskStatus {
-  done: boolean
-}
-
-export const taskStatusSchema = Joi.object()
-  .keys({
-    done: Joi.boolean()
-      .required()
-      .description("Whether the task has been successfully executed for the module's current version."),
-  })
+export const getTaskResultSchema = runTaskResultSchema.allow(null)
 
 export interface PluginActionOutputs {
   configureProvider: Promise<ConfigureProviderResult>
@@ -336,8 +327,8 @@ export interface ServiceActionOutputs {
 }
 
 export interface TaskActionOutputs {
-  getTaskStatus: Promise<TaskStatus>
   runTask: Promise<RunTaskResult>
+  getTaskResult: Promise<RunTaskResult | null>
 }
 
 export interface ModuleActionOutputs extends ServiceActionOutputs {

--- a/garden-service/src/types/plugin/plugin.ts
+++ b/garden-service/src/types/plugin/plugin.ts
@@ -44,7 +44,7 @@ import {
   testModuleParamsSchema,
   getTestResultParamsSchema,
   publishModuleParamsSchema,
-  getTaskStatusParamsSchema,
+  getTaskResultParamsSchema,
   runTaskParamsSchema,
   configureProviderParamsSchema,
 } from "./params"
@@ -71,8 +71,8 @@ import {
   testResultSchema,
   configureModuleResultSchema,
   publishModuleResultSchema,
-  taskStatusSchema,
   runTaskResultSchema,
+  getTaskResultSchema,
   configureProviderResultSchema,
 } from "./outputs"
 
@@ -263,13 +263,17 @@ export const serviceActionDescriptions: { [P in ServiceActionName]: PluginAction
 
 export const taskActionDescriptions: { [P in TaskActionName]: PluginActionDescription } = {
   // TODO: see if this is actually necessary or useful
-  getTaskStatus: {
+  getTaskResult: {
     description: dedent`
-      Check and return the execution status of a task, i.e. whether the task has been successfully
-      completed for the module's current version.
+      Retrieve the task result for the specified version. Use this along with the \`runTask\` handler
+      to avoid running the same task repeatedly when its dependencies haven't changed.
+
+      Note that the version string provided to this handler may be a hash of the module's version, as
+      well as any runtime dependencies configured for the task, so it may not match the current version
+      of the module itself.
     `,
-    paramsSchema: getTaskStatusParamsSchema,
-    resultSchema: taskStatusSchema,
+    paramsSchema: getTaskResultParamsSchema,
+    resultSchema: getTaskResultSchema,
   },
   runTask: {
     description: dedent`

--- a/garden-service/test/unit/src/actions.ts
+++ b/garden-service/test/unit/src/actions.ts
@@ -27,7 +27,7 @@ import {
   execInServiceParamsSchema,
   getServiceLogsParamsSchema,
   runServiceParamsSchema,
-  getTaskStatusParamsSchema,
+  getTaskResultParamsSchema,
   runTaskParamsSchema,
   getEnvironmentStatusParamsSchema,
   prepareEnvironmentParamsSchema,
@@ -218,6 +218,7 @@ describe("ActionHelper", () => {
             timeout: 1234,
             spec: {},
           },
+          testVersion: module.version,
         })
         expect(result).to.eql({
           moduleName: module.name,
@@ -238,7 +239,7 @@ describe("ActionHelper", () => {
           log,
           module,
           testName: "test",
-          version: module.version,
+          testVersion: module.version,
         })
         expect(result).to.eql({
           moduleName: module.name,
@@ -331,6 +332,7 @@ describe("ActionHelper", () => {
           envVars: { FOO: "bar" },
           dependencies: {},
         },
+        taskVersion: task.module.version,
       })
       expect(result).to.eql({
         moduleName: task.module.name,
@@ -582,10 +584,18 @@ const testPlugin: PluginFactory = async () => ({
         }
       },
 
-      getTaskStatus: async (params) => {
-        validate(params, getTaskStatusParamsSchema)
+      getTaskResult: async (params) => {
+        validate(params, getTaskResultParamsSchema)
+        const module = params.task.module
         return {
-          done: true,
+          moduleName: module.name,
+          taskName: params.task.name,
+          command: ["foo"],
+          completedAt: now,
+          output: "bla bla",
+          success: true,
+          startedAt: now,
+          version: params.module.version,
         }
       },
 


### PR DESCRIPTION
Added caching for task results. Similarly to the caching for test runs that was already in place, these are stored by version as `ConfigMap`s.

The version used to index these results includes the task's module's current version, along with the module versions of the task's runtime dependencies (if any). This is the same formula that is used for
computing test task versions.

A versioning bug was also fixed for the test result caching functionality. Here, the version used was just the test config's module's version, whereas now the corresponding test task's version
is used to index it instead (the same as is now also used to cache task results).