### PR TITLE
fix: include resolved config in module version

### DIFF
--- a/garden-service/package-lock.json
+++ b/garden-service/package-lock.json
@@ -6016,7 +6016,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
       "requires": {
         "jsonify": "~0.0.0"
       }
@@ -6037,8 +6036,7 @@
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsonparse": {
       "version": "1.3.1",

--- a/garden-service/package.json
+++ b/garden-service/package.json
@@ -58,6 +58,7 @@
     "joi": "^14.3.0",
     "js-yaml": "^3.12.0",
     "json-merge-patch": "^0.2.3",
+    "json-stable-stringify": "^1.0.1",
     "json-stringify-safe": "^5.0.1",
     "klaw": "^3.0.0",
     "koa": "^2.6.2",

--- a/garden-service/src/config/module.ts
+++ b/garden-service/src/config/module.ts
@@ -7,6 +7,7 @@
  */
 
 import dedent = require("dedent")
+import stableStringify = require("json-stable-stringify")
 import * as Joi from "joi"
 import { ServiceConfig, ServiceSpec } from "./service"
 import {
@@ -146,3 +147,7 @@ export const moduleConfigSchema = baseModuleSpecSchema
       .description("The module spec, as defined by the provider plugin."),
   })
   .description("The configuration for a module.")
+
+export function serializeConfig(moduleConfig: ModuleConfig) {
+  return stableStringify(moduleConfig)
+}

--- a/garden-service/test/unit/data/test-project-variable-versioning/garden.yml
+++ b/garden-service/test/unit/data/test-project-variable-versioning/garden.yml
@@ -1,0 +1,9 @@
+project:
+  name: test-project-variable-versioning
+  environmentDefaults:
+    variables:
+      echo-string: OK
+  environments:
+    - name: local
+      providers:
+        - name: test-plugin

--- a/garden-service/test/unit/data/test-project-variable-versioning/module-a/garden.yml
+++ b/garden-service/test/unit/data/test-project-variable-versioning/module-a/garden.yml
@@ -1,0 +1,8 @@
+module:
+  name: module-a
+  type: test
+  build:
+    command: [echo, "${variables.echo-string}"]
+  tests:
+    - name: unit
+      command: [echo, OK]

--- a/garden-service/test/unit/data/test-project-variable-versioning/module-b/garden.yml
+++ b/garden-service/test/unit/data/test-project-variable-versioning/module-b/garden.yml
@@ -1,0 +1,8 @@
+module:
+  name: module-b
+  type: test
+  build:
+    command: [echo, beans]
+  tests:
+    - name: unit
+      command: [echo, OK]


### PR DESCRIPTION
Module versions now also include a serialized version of the resolved module config (hashed together with versions / dirty timestamps).

This fixes an issue where changes to project variables used in a module's config would not result in the module's version changing when recomputed.

This was the case because the version was based only on the latest commit and dirty timestamp of the module in question, and those of its dependencies, which doesn't factor in changes to project-level variables.