### PR TITLE
chore: add workaround field to Github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -18,6 +18,10 @@ about: Create a report to help make garden better
 <!-- Use one of our examples or link to a minimal example showing the issue -->
 <!-- Try to include commands run or output -->
 
+### Workaround
+
+<!-- If applicable, a way to work around the issue until it has been resolved. -->
+
 ### Suggested solution(s)
 
 <!-- How could we solve this bug? What changes would need to made? -->


### PR DESCRIPTION
I figured it would make sense to add a field to the bug report template to demonstrate how to work around the issue until it has been resolved.