### PR TITLE
fix(run): correctly ignore task dependencies

### DIFF
--- a/garden-service/src/commands/run/module.ts
+++ b/garden-service/src/commands/run/module.ts
@@ -16,13 +16,8 @@ import {
   CommandResult,
   StringsParameter,
 } from "../base"
-import {
-  uniq,
-  flatten,
-} from "lodash"
-import { printRuntimeContext } from "./run"
+import { printRuntimeContext, runtimeContextForServiceDeps } from "./run"
 import dedent = require("dedent")
-import { prepareRuntimeContext } from "../../types/service"
 import { logHeader } from "../../logger/util"
 import { PushTask } from "../../tasks/push"
 
@@ -95,11 +90,7 @@ export class RunModuleCommand extends Command<Args, Opts> {
 
     const command = args.command || []
 
-    // combine all dependencies for all services in the module, to be sure we have all the context we need
-    const depNames = uniq(flatten(module.serviceConfigs.map(s => s.dependencies)))
-    const deps = await graph.getServices(depNames)
-
-    const runtimeContext = await prepareRuntimeContext(garden, graph, module, deps)
+    const runtimeContext = await runtimeContextForServiceDeps(garden, graph, module)
 
     printRuntimeContext(log, runtimeContext)
 

--- a/garden-service/src/commands/run/run.ts
+++ b/garden-service/src/commands/run/run.ts
@@ -7,7 +7,7 @@
  */
 
 import { safeDump } from "js-yaml"
-import { RuntimeContext } from "../../types/service"
+import { RuntimeContext, prepareRuntimeContext } from "../../types/service"
 import { highlightYaml } from "../../util/util"
 import { Command } from "../base"
 import { RunModuleCommand } from "./module"
@@ -15,6 +15,9 @@ import { RunServiceCommand } from "./service"
 import { RunTaskCommand } from "./task"
 import { RunTestCommand } from "./test"
 import { LogEntry } from "../../logger/log-entry"
+import { ConfigGraph } from "../../config-graph"
+import { Module } from "../../types/module"
+import { Garden } from "../../garden"
 
 export class RunCommand extends Command {
   name = "run"
@@ -28,6 +31,13 @@ export class RunCommand extends Command {
   ]
 
   async action() { return {} }
+}
+
+export async function runtimeContextForServiceDeps(garden: Garden, graph: ConfigGraph, module: Module) {
+  const depNames = module.serviceDependencyNames
+  const allServices = await graph.getServices()
+  const deps = allServices.filter(s => depNames.includes(s.name))
+  return prepareRuntimeContext(garden, graph, module, deps)
 }
 
 export function printRuntimeContext(log: LogEntry, runtimeContext: RuntimeContext) {

--- a/garden-service/src/commands/run/service.ts
+++ b/garden-service/src/commands/run/service.ts
@@ -15,9 +15,8 @@ import {
   CommandResult,
   StringParameter,
 } from "../base"
-import { printRuntimeContext } from "./run"
+import { printRuntimeContext, runtimeContextForServiceDeps } from "./run"
 import dedent = require("dedent")
-import { prepareRuntimeContext } from "../../types/service"
 import { logHeader } from "../../logger/util"
 import { PushTask } from "../../tasks/push"
 
@@ -70,9 +69,7 @@ export class RunServiceCommand extends Command<Args, Opts> {
     const pushTask = new PushTask({ garden, log, module, force: opts["force-build"] })
     await garden.processTasks([pushTask])
 
-    const dependencies = await graph.getServices(module.serviceDependencyNames)
-    const runtimeContext = await prepareRuntimeContext(garden, graph, module, dependencies)
-
+    const runtimeContext = await runtimeContextForServiceDeps(garden, graph, module)
     printRuntimeContext(log, runtimeContext)
 
     const result = await garden.actions.runService({


### PR DESCRIPTION
Before this fix, the run module and run service commands would fail if any of the corresponding module's services had a task dependency.

For example, `garden run module hello "node"` and `garden run service hello` in the `tasks` example project both failed before this change (because the `hello` service has a task dependency).