### PR TITLE
fix(vcs): exclude .garden from version hashing

### DIFF
--- a/garden-service/src/vcs/git.ts
+++ b/garden-service/src/vcs/git.ts
@@ -71,7 +71,7 @@ export class GitHandler extends VcsHandler {
     let ignored: string[] = []
 
     try {
-      lines = await git("ls-files", "-s", "--other", path)
+      lines = await git("ls-files", "-s", "--other", "--exclude=.garden", path)
       ignored = await git("ls-files", "--ignored", "--exclude-per-directory=.gardenignore", path)
     } catch (err) {
       // if we get 128 we're not in a repo root, so we get no files


### PR DESCRIPTION
This fixes an error where flat projects (i.e. those with a module whose config is co-located with the project config, and that don't define an include pattern) could not be deployed.