### PR TITLE
fix(vcs): handle case when file is removed while listing VCS files

### DIFF
--- a/garden-service/src/watch.ts
+++ b/garden-service/src/watch.ts
@@ -93,9 +93,9 @@ export class Watcher {
     const _this = this
 
     return (path: string) => {
+      // Make sure Promise errors are handled appropriately.
       listener(path)
         .catch(err => {
-          console.log("catch", err)
           _this.watcher.emit("error", err)
         })
     }


### PR DESCRIPTION
This can happen routinely if, for example, editors create temporary files that are then quickly removed.