### PR TITLE
fix(cli): detect missing services in --hot option

### DIFF
--- a/garden-service/src/commands/deploy.ts
+++ b/garden-service/src/commands/deploy.ts
@@ -90,7 +90,14 @@ export class DeployCommand extends Command<Args, Opts> {
     }
 
     const hotReloadServiceNames = opts["hot-reload"] || []
-    const watch = opts.watch || hotReloadServiceNames.length > 0
+
+    let watch
+    if (hotReloadServiceNames.length > 0) {
+      await initGraph.getServices(hotReloadServiceNames) // validate the existence of these services
+      watch = true
+    } else {
+      watch = opts.watch
+    }
 
     // TODO: make this a task
     await garden.actions.prepareEnvironment({ log })

--- a/garden-service/src/commands/dev.ts
+++ b/garden-service/src/commands/dev.ts
@@ -78,8 +78,6 @@ export class DevCommand extends Command<Args, Opts> {
   }
 
   async action({ garden, log, logFooter, opts }: CommandParams<Args, Opts>): Promise<CommandResult> {
-    await garden.actions.prepareEnvironment({ log })
-
     const graph = await garden.getConfigGraph()
     const modules = await graph.getModules()
 
@@ -91,6 +89,11 @@ export class DevCommand extends Command<Args, Opts> {
     }
 
     const hotReloadServiceNames = opts["hot-reload"] || []
+    if (hotReloadServiceNames.length > 0) {
+      await graph.getServices(hotReloadServiceNames) // validate the existence of these services
+    }
+
+    await garden.actions.prepareEnvironment({ log })
 
     const tasksForModule = (watch: boolean) => {
       return async (updatedGraph: ConfigGraph, module: Module) => {


### PR DESCRIPTION
Fixes https://github.com/garden-io/garden/issues/599.

Before, the deploy and dev commands didn't validate that the service names passed to the `--hot`/`--hot-reload` option referred to existing services.

Also moved some config-level validation in the dev command before the `prepareEnvironment` call for faster feedback on config errors.