### PR TITLE
fix(task-graph): ensure graph node keys and event payload keys match

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -6707,7 +6707,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6728,12 +6729,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6748,17 +6751,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6875,7 +6881,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6887,6 +6894,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6901,6 +6909,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6908,12 +6917,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6932,6 +6943,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7012,7 +7024,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7024,6 +7037,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7109,7 +7123,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7145,6 +7160,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7164,6 +7180,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7207,12 +7224,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -16932,7 +16951,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -16953,12 +16973,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -16973,17 +16995,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -17100,7 +17125,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -17112,6 +17138,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -17126,6 +17153,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -17133,12 +17161,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.2.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.1",
                 "yallist": "^3.0.0"
@@ -17157,6 +17187,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -17237,7 +17268,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -17249,6 +17281,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -17334,7 +17367,8 @@
             "safe-buffer": {
               "version": "5.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -17370,6 +17404,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -17389,6 +17424,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -17432,12 +17468,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },

--- a/dashboard/src/api/types.ts
+++ b/dashboard/src/api/types.ts
@@ -84,7 +84,12 @@ export interface FetchConfigResponse {
   moduleConfigs: ModuleConfig[]
 }
 
-export type RenderedNode = { type: RenderedNodeType, name: string }
+export type RenderedNode = {
+  type: RenderedNodeType,
+  name: string,
+  key: string,
+  moduleName: string,
+}
 
 export type RenderedNodeType = "build" | "deploy" | "run" | "test" | "push" | "publish"
 

--- a/garden-service/package-lock.json
+++ b/garden-service/package-lock.json
@@ -3808,7 +3808,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": false,
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3829,12 +3830,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": false,
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3849,17 +3852,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": false,
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3976,7 +3982,8 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": false,
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3988,6 +3995,7 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4002,6 +4010,7 @@
           "version": "3.0.4",
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4009,12 +4018,14 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": false,
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4033,6 +4044,7 @@
           "version": "0.5.1",
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4113,7 +4125,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": false,
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4125,6 +4138,7 @@
           "version": "1.4.0",
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4210,7 +4224,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "resolved": false,
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4246,6 +4261,7 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4265,6 +4281,7 @@
           "version": "3.0.1",
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4308,12 +4325,14 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": false,
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": false,
-          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+          "optional": true
         }
       }
     },
@@ -7498,6 +7517,7 @@
           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -7867,7 +7887,8 @@
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -7963,6 +7984,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -8015,7 +8037,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
           "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -8318,7 +8341,8 @@
           "version": "1.6.1",
           "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
           "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/garden-service/src/task-graph.ts
+++ b/garden-service/src/task-graph.ts
@@ -97,7 +97,7 @@ export class TaskGraph {
     if (this.index.getNode(task)) {
       this.garden.events.emit("taskPending", {
         addedAt: new Date(),
-        key: task.getKey(),
+        key: task.getBaseKey(),
         version: task.version,
       })
     }
@@ -165,7 +165,7 @@ export class TaskGraph {
         const baseKey = node.getBaseKey()
         const description = node.getDescription()
 
-        let result: TaskResult = { type, description, key: task.getKey() }
+        let result: TaskResult = { type, description, key: task.getBaseKey() }
 
         try {
           this.logTask(node)
@@ -181,7 +181,7 @@ export class TaskGraph {
           try {
             this.garden.events.emit("taskProcessing", {
               startedAt: new Date(),
-              key: task.getKey(),
+              key: task.getBaseKey(),
               version: task.version,
             })
             result = await node.process(dependencyResults)
@@ -454,7 +454,7 @@ class TaskNode {
 
     return {
       type: this.getType(),
-      key: this.getKey(),
+      key: this.getBaseKey(),
       description: this.getDescription(),
       output,
       dependencyResults,

--- a/garden-service/src/tasks/base.ts
+++ b/garden-service/src/tasks/base.ts
@@ -13,7 +13,13 @@ import { Garden } from "../garden"
 import { DependencyGraphNodeType } from "../config-graph"
 import { LogEntry } from "../logger/log-entry"
 
+export type TaskType = "build" | "deploy" | "publish" | "hot-reload" | "push" | "task" | "test"
+
 export class TaskDefinitionError extends Error { }
+
+export function makeBaseKey(type: TaskType, name: string) {
+  return `${type}.${name}`
+}
 
 export interface TaskParams {
   garden: Garden
@@ -23,7 +29,7 @@ export interface TaskParams {
 }
 
 export abstract class BaseTask {
-  abstract type: string
+  abstract type: TaskType
   abstract depType: DependencyGraphNodeType
   garden: Garden
   log: LogEntry
@@ -49,7 +55,7 @@ export abstract class BaseTask {
   protected abstract getName(): string
 
   getBaseKey(): string {
-    return `${this.type}.${this.getName()}`
+    return makeBaseKey(this.type, this.getName())
   }
 
   getKey(): string {

--- a/garden-service/src/tasks/build.ts
+++ b/garden-service/src/tasks/build.ts
@@ -10,7 +10,7 @@ import * as Bluebird from "bluebird"
 import chalk from "chalk"
 import { Module, getModuleKey } from "../types/module"
 import { BuildResult } from "../types/plugin/outputs"
-import { BaseTask } from "../tasks/base"
+import { BaseTask, TaskType } from "../tasks/base"
 import { Garden } from "../garden"
 import { DependencyGraphNodeType } from "../config-graph"
 import { LogEntry } from "../logger/log-entry"
@@ -26,7 +26,7 @@ export interface BuildTaskParams {
 }
 
 export class BuildTask extends BaseTask {
-  type = "build"
+  type: TaskType = "build"
   depType: DependencyGraphNodeType = "build"
 
   private module: Module

--- a/garden-service/src/tasks/deploy.ts
+++ b/garden-service/src/tasks/deploy.ts
@@ -10,7 +10,7 @@ import * as Bluebird from "bluebird"
 import chalk from "chalk"
 import { includes } from "lodash"
 import { LogEntry } from "../logger/log-entry"
-import { BaseTask } from "./base"
+import { BaseTask, TaskType } from "./base"
 import { Service, ServiceStatus, getServiceRuntimeContext, getIngressUrl } from "../types/service"
 import { Garden } from "../garden"
 import { PushTask } from "./push"
@@ -29,7 +29,7 @@ export interface DeployTaskParams {
 }
 
 export class DeployTask extends BaseTask {
-  type = "deploy"
+  type: TaskType = "deploy"
   depType: DependencyGraphNodeType = "service"
 
   private graph: ConfigGraph

--- a/garden-service/src/tasks/helpers.ts
+++ b/garden-service/src/tasks/helpers.ts
@@ -85,3 +85,7 @@ async function getModuleNames(dg: ConfigGraph, hotReloadServiceNames: string[]) 
   const services = await dg.getServices(hotReloadServiceNames)
   return uniq(services.map(s => s.module.name))
 }
+
+export function makeTestTaskName(moduleName: string, testConfigName: string) {
+  return `${moduleName}.${testConfigName}`
+}

--- a/garden-service/src/tasks/hot-reload.ts
+++ b/garden-service/src/tasks/hot-reload.ts
@@ -8,7 +8,7 @@
 
 import chalk from "chalk"
 import { LogEntry } from "../logger/log-entry"
-import { BaseTask } from "./base"
+import { BaseTask, TaskType } from "./base"
 import { Service, getServiceRuntimeContext } from "../types/service"
 import { Garden } from "../garden"
 import { DependencyGraphNodeType, ConfigGraph } from "../config-graph"
@@ -22,7 +22,7 @@ interface Params {
 }
 
 export class HotReloadTask extends BaseTask {
-  type = "hot-reload"
+  type: TaskType = "hot-reload"
   depType: DependencyGraphNodeType = "service"
 
   private graph: ConfigGraph

--- a/garden-service/src/tasks/publish.ts
+++ b/garden-service/src/tasks/publish.ts
@@ -10,7 +10,7 @@ import chalk from "chalk"
 import { BuildTask } from "./build"
 import { Module } from "../types/module"
 import { PublishResult } from "../types/plugin/outputs"
-import { BaseTask } from "../tasks/base"
+import { BaseTask, TaskType } from "../tasks/base"
 import { Garden } from "../garden"
 import { DependencyGraphNodeType } from "../config-graph"
 import { LogEntry } from "../logger/log-entry"
@@ -23,7 +23,7 @@ export interface PublishTaskParams {
 }
 
 export class PublishTask extends BaseTask {
-  type = "publish"
+  type: TaskType = "publish"
   depType: DependencyGraphNodeType = "publish"
 
   private module: Module

--- a/garden-service/src/tasks/push.ts
+++ b/garden-service/src/tasks/push.ts
@@ -11,7 +11,7 @@ import chalk from "chalk"
 import { BuildTask } from "./build"
 import { Module } from "../types/module"
 import { PushResult } from "../types/plugin/outputs"
-import { BaseTask } from "../tasks/base"
+import { BaseTask, TaskType } from "../tasks/base"
 import { Garden } from "../garden"
 import { DependencyGraphNodeType } from "../config-graph"
 import { LogEntry } from "../logger/log-entry"
@@ -26,7 +26,7 @@ export interface PushTaskParams {
 }
 
 export class PushTask extends BaseTask {
-  type = "push"
+  type: TaskType = "push"
   depType: DependencyGraphNodeType = "push"
 
   force: boolean

--- a/garden-service/src/tasks/task.ts
+++ b/garden-service/src/tasks/task.ts
@@ -8,7 +8,7 @@
 
 import * as Bluebird from "bluebird"
 import chalk from "chalk"
-import { BaseTask, TaskParams } from "../tasks/base"
+import { BaseTask, TaskParams, TaskType } from "../tasks/base"
 import { Garden } from "../garden"
 import { Task } from "../types/task"
 import { PushTask } from "./push"
@@ -29,7 +29,7 @@ export interface TaskTaskParams {
 }
 
 export class TaskTask extends BaseTask { // ... to be renamed soon.
-  type = "task"
+  type: TaskType = "task"
   depType: DependencyGraphNodeType = "task"
 
   private graph: ConfigGraph

--- a/garden-service/src/tasks/test.ts
+++ b/garden-service/src/tasks/test.ts
@@ -14,11 +14,12 @@ import { ModuleVersion } from "../vcs/vcs"
 import { PushTask } from "./push"
 import { DeployTask } from "./deploy"
 import { TestResult } from "../types/plugin/outputs"
-import { BaseTask, TaskParams } from "../tasks/base"
+import { BaseTask, TaskParams, TaskType } from "../tasks/base"
 import { prepareRuntimeContext } from "../types/service"
 import { Garden } from "../garden"
 import { LogEntry } from "../logger/log-entry"
 import { DependencyGraphNodeType, ConfigGraph } from "../config-graph"
+import { makeTestTaskName } from "./helpers"
 
 class TestError extends Error {
   toString() {
@@ -37,7 +38,7 @@ export interface TestTaskParams {
 }
 
 export class TestTask extends BaseTask {
-  type = "test"
+  type: TaskType = "test"
   depType: DependencyGraphNodeType = "test"
 
   private module: Module
@@ -92,7 +93,7 @@ export class TestTask extends BaseTask {
   }
 
   getName() {
-    return `${this.module.name}.${this.testConfig.name}`
+    return makeTestTaskName(this.module.name, this.testConfig.name)
   }
 
   getDescription() {

--- a/garden-service/test/unit/src/config-graph.ts
+++ b/garden-service/test/unit/src/config-graph.ts
@@ -221,7 +221,7 @@ describe("ConfigGraph", () => {
           type: "deploy",
           name: "service-c",
           moduleName: "module-c",
-          key: "service.service-c",
+          key: "deploy.service-c",
         },
         {
           type: "test",
@@ -251,13 +251,13 @@ describe("ConfigGraph", () => {
           type: "deploy",
           name: "service-a",
           moduleName: "module-a",
-          key: "service.service-a",
+          key: "deploy.service-a",
         },
         {
           type: "deploy",
           name: "service-b",
           moduleName: "module-b",
-          key: "service.service-b",
+          key: "deploy.service-b",
         },
       ])
     })
@@ -283,7 +283,7 @@ describe("DependencyGraphNode", () => {
         type: "deploy",
         name: "service-a",
         moduleName: "module-a",
-        key: "service.service-a",
+        key: "deploy.service-a",
       })
     })
     it("should render a run node", () => {

--- a/garden-service/test/unit/src/task-graph.ts
+++ b/garden-service/test/unit/src/task-graph.ts
@@ -1,6 +1,6 @@
 import { join } from "path"
 import { expect } from "chai"
-import { BaseTask } from "../../../src/tasks/base"
+import { BaseTask, TaskType } from "../../../src/tasks/base"
 import {
   TaskGraph,
   TaskResult,
@@ -22,7 +22,7 @@ interface TestTaskOptions {
 }
 
 class TestTask extends BaseTask {
-  type = "test"
+  type: TaskType = "test"
   depType: DependencyGraphNodeType = "test"
   name: string
   callback: TestTaskCallback | null
@@ -128,9 +128,9 @@ describe("task-graph", () => {
       const result = await graph.process([task])
 
       expect(garden.events.eventLog).to.eql([
-        { name: "taskPending", payload: { addedAt: now, key: task.getKey(), version: task.version } },
+        { name: "taskPending", payload: { addedAt: now, key: task.getBaseKey(), version: task.version } },
         { name: "taskGraphProcessing", payload: { startedAt: now } },
-        { name: "taskProcessing", payload: { startedAt: now, key: task.getKey(), version: task.version } },
+        { name: "taskProcessing", payload: { startedAt: now, key: task.getBaseKey(), version: task.version } },
         { name: "taskComplete", payload: result["a"] },
         { name: "taskGraphComplete", payload: { completedAt: now } },
       ])
@@ -167,9 +167,9 @@ describe("task-graph", () => {
       const result = await graph.process([task])
 
       expect(garden.events.eventLog).to.eql([
-        { name: "taskPending", payload: { addedAt: now, key: task.getKey(), version: task.version } },
+        { name: "taskPending", payload: { addedAt: now, key: task.getBaseKey(), version: task.version } },
         { name: "taskGraphProcessing", payload: { startedAt: now } },
-        { name: "taskProcessing", payload: { startedAt: now, key: task.getKey(), version: task.version } },
+        { name: "taskProcessing", payload: { startedAt: now, key: task.getBaseKey(), version: task.version } },
         { name: "taskError", payload: result["a"] },
         { name: "taskGraphComplete", payload: { completedAt: now } },
       ])
@@ -237,7 +237,7 @@ describe("task-graph", () => {
       const resultA: TaskResult = {
         type: "test",
         description: "a.a1",
-        key: "a.a1",
+        key: "a",
         output: {
           result: "result-a.a1",
           dependencyResults: {},
@@ -246,7 +246,7 @@ describe("task-graph", () => {
       }
       const resultB: TaskResult = {
         type: "test",
-        key: "b.b1",
+        key: "b",
         description: "b.b1",
         output: {
           result: "result-b.b1",
@@ -257,7 +257,7 @@ describe("task-graph", () => {
       const resultC: TaskResult = {
         type: "test",
         description: "c.c1",
-        key: "c.c1",
+        key: "c",
         output: {
           result: "result-c.c1",
           dependencyResults: { b: resultB },
@@ -272,7 +272,7 @@ describe("task-graph", () => {
         d: {
           type: "test",
           description: "d.d1",
-          key: "d.d1",
+          key: "d",
           output: {
             result: "result-d.d1",
             dependencyResults: {


### PR DESCRIPTION
In the dashboard, we match the keys emitted with the event payload
against the node keys returned by the get graph command.

This commit adds a generic makeBaseKey function that both the Task
classes and the config graph render function use.

Previously we emitted the task key, as opposed to just the base key.