### PR TITLE
refactor: rename task baseKey to key and key to id

### DIFF
--- a/garden-service/package-lock.json
+++ b/garden-service/package-lock.json
@@ -3808,8 +3808,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": false,
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "optional": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
@@ -3830,14 +3829,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": false,
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "optional": true
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3852,20 +3849,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": false,
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "optional": true
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "optional": true
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "optional": true
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3982,8 +3976,7 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": false,
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "optional": true
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
@@ -3995,7 +3988,6 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4010,7 +4002,6 @@
           "version": "3.0.4",
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4018,14 +4009,12 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": false,
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "optional": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4044,7 +4033,6 @@
           "version": "0.5.1",
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4125,8 +4113,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": false,
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "optional": true
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4138,7 +4125,6 @@
           "version": "1.4.0",
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4224,8 +4210,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "resolved": false,
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "optional": true
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4261,7 +4246,6 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4281,7 +4265,6 @@
           "version": "3.0.1",
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4325,14 +4308,12 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": false,
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "optional": true
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": false,
-          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "optional": true
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
         }
       }
     },
@@ -7526,7 +7507,6 @@
           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -7896,8 +7876,7 @@
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -7993,7 +7972,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -8046,8 +8024,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
           "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -8350,8 +8327,7 @@
           "version": "1.6.1",
           "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
           "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/garden-service/src/commands/run/task.ts
+++ b/garden-service/src/commands/run/task.ts
@@ -60,7 +60,7 @@ export class RunTaskCommand extends Command<Args, Opts> {
     await garden.actions.prepareEnvironment({ log })
 
     const taskTask = await TaskTask.factory({ garden, graph, task, log, force: true, forceBuild: opts["force-build"] })
-    const result = (await garden.processTasks([taskTask]))[taskTask.getBaseKey()]
+    const result = (await garden.processTasks([taskTask]))[taskTask.getKey()]
 
     if (!result.error) {
       log.info("")

--- a/garden-service/src/logger/log-entry.ts
+++ b/garden-service/src/logger/log-entry.ts
@@ -25,9 +25,9 @@ export interface LogEntryMetadata { task?: TaskMetadata }
 
 export interface TaskMetadata {
   type: string,
-  baseKey: string,
+  key: string,
   status: TaskLogStatus,
-  id: string,
+  uid: string,
   versionString: string,
   durationMs?: number,
 }

--- a/garden-service/src/process.ts
+++ b/garden-service/src/process.ts
@@ -177,7 +177,7 @@ export async function processModules(
   await restartPromise
 
   return {
-    taskResults: {}, // TODO: Return latest results for each task baseKey processed between restarts?
+    taskResults: {}, // TODO: Return latest results for each task key processed between restarts?
     restartRequired: true,
   }
 

--- a/garden-service/src/tasks/base.ts
+++ b/garden-service/src/tasks/base.ts
@@ -33,7 +33,7 @@ export abstract class BaseTask {
   abstract depType: DependencyGraphNodeType
   garden: Garden
   log: LogEntry
-  id: string
+  uid: string
   force: boolean
   version: ModuleVersion
 
@@ -42,7 +42,7 @@ export abstract class BaseTask {
   constructor(initArgs: TaskParams) {
     this.garden = initArgs.garden
     this.dependencies = []
-    this.id = uuidv1() // uuidv1 is timestamp-based
+    this.uid = uuidv1() // uuidv1 is timestamp-based
     this.force = !!initArgs.force
     this.version = initArgs.version
     this.log = initArgs.log
@@ -54,12 +54,12 @@ export abstract class BaseTask {
 
   protected abstract getName(): string
 
-  getBaseKey(): string {
+  getKey(): string {
     return makeBaseKey(this.type, this.getName())
   }
 
-  getKey(): string {
-    return `${this.getBaseKey()}.${this.id}`
+  getId(): string {
+    return `${this.getKey()}.${this.uid}`
   }
 
   abstract getDescription(): string

--- a/garden-service/src/tasks/helpers.ts
+++ b/garden-service/src/tasks/helpers.ts
@@ -76,7 +76,7 @@ export async function getDependantTasksForModule(
 
   const outputTasks = [...pushTasks, ...deployTasks]
   log.silly(`getDependantTasksForModule called for module ${module.name}, returning the following tasks:`)
-  log.silly(`  ${outputTasks.map(t => t.getBaseKey()).join(", ")}`)
+  log.silly(`  ${outputTasks.map(t => t.getKey()).join(", ")}`)
 
   return outputTasks
 }

--- a/garden-service/test/integ/src/integ-helpers.ts
+++ b/garden-service/test/integ/src/integ-helpers.ts
@@ -18,15 +18,15 @@ describe("integ-helpers", () => {
     })
 
     const specs = [
-      { taskType: "build", baseKey: "build.result" },
-      { taskType: "deploy", baseKey: "deploy.redis" },
-      { taskType: "test", baseKey: "test.api.unit" },
+      { taskType: "build", key: "build.result" },
+      { taskType: "deploy", key: "deploy.redis" },
+      { taskType: "test", key: "test.api.unit" },
     ]
 
-    for (const { taskType, baseKey } of specs) {
+    for (const { taskType, key } of specs) {
       it(`should find a ${taskType} task`, () => {
-        const found = findTasks(testEntries, baseKey)[0]
-        expect(found, "entries not found").to.be.ok
+        const found = findTasks(testEntries, key)[0]
+        expect(found, `entries for ${key} not found`).to.be.ok
         const { startedIndex, completedIndex, executionTimeMs } = found
         expect([startedIndex, completedIndex, executionTimeMs]).to.not.include([null, undefined])
       })
@@ -39,8 +39,8 @@ describe("integ-helpers", () => {
     it("should run and produce the expected output for a test command in the vote example project", async () => {
       const logEntries = await runGarden(voteExamplePath, ["test"])
       expect(logEntries.length).to.be.greaterThan(0)
-      const found = findTasks(logEntries, "build.result")[0]
-      expect(found, "entries not found").to.be.ok
+      const found = findTasks(logEntries, "test.api.unit")[0]
+      expect(found, "entries for not test.api.unit found").to.be.ok
       const { startedIndex, completedIndex, executionTimeMs } = found
       expect([startedIndex, completedIndex, executionTimeMs]).to.not.include([null, undefined])
     })

--- a/garden-service/test/integ/src/pre-release.ts
+++ b/garden-service/test/integ/src/pre-release.ts
@@ -64,6 +64,10 @@ describe("PreReleaseTests", () => {
       await gardenWatch.run({ testSteps })
     })
 
+    after(async () => {
+      await deleteExampleNamespaces(log, false)
+    })
+
   })
 
   describe("tasks", () => {
@@ -82,6 +86,10 @@ describe("PreReleaseTests", () => {
       const logEntries = await runGarden(tasksProjectPath, ["call", "hello"])
       expect(searchLog(logEntries, /John, Paul, George, Ringo/), "expected to find populated usernames in log output")
         .to.eql("passed")
+    })
+
+    after(async () => {
+      await deleteExampleNamespaces(log, false)
     })
 
   })
@@ -124,6 +132,10 @@ describe("PreReleaseTests", () => {
 
     })
 
+    after(async () => {
+      await deleteExampleNamespaces(log, false)
+    })
+
   })
 
   describe("vote-helm: helm & dependency calculations", () => {
@@ -145,6 +157,10 @@ describe("PreReleaseTests", () => {
 
     })
 
+    after(async () => {
+      await deleteExampleNamespaces(log, false)
+    })
+
   })
 
   describe("remote sources", () => {
@@ -160,6 +176,10 @@ describe("PreReleaseTests", () => {
       expect(searchLog(logEntries, /200 OK/), "expected to find '200 OK' in log output").to.eql("passed")
       expect(searchLog(logEntries, /Cats/), "expected to find 'Cats' in log output").to.eql("passed")
     })
+  })
+
+  after(async () => {
+    await deleteExampleNamespaces(log, false)
   })
 
 })

--- a/garden-service/test/run-garden.ts
+++ b/garden-service/test/run-garden.ts
@@ -24,11 +24,11 @@ export function dashboardUpStep(): WatchTestStep {
   }
 }
 
-export function taskCompletedStep(baseKey: string, completedCount: number, description?: string): WatchTestStep {
+export function taskCompletedStep(key: string, completedCount: number, description?: string): WatchTestStep {
   return {
-    description: description || baseKey,
+    description: description || key,
     condition: async (logEntries: JsonLogEntry[]) => {
-      const tasks = findTasks(logEntries, baseKey)
+      const tasks = findTasks(logEntries, key)
       if (tasks.filter(t => t.completedIndex).length === completedCount) {
         return "passed"
       }
@@ -78,6 +78,9 @@ export function commandReloadedStep(): WatchTestStep {
  */
 export async function runGarden(dir: string, command: string[]): Promise<JsonLogEntry[]> {
   const out = (await execa(gardenBinPath, [...command, "--logger-type", "json", "-l", "4"], { cwd: dir })).stdout
+  if (showLog) {
+    console.log(out)
+  }
   return parseLogEntries(out.split("\n").filter(Boolean))
 }
 

--- a/garden-service/test/unit/src/tasks/helpers.ts
+++ b/garden-service/test/unit/src/tasks/helpers.ts
@@ -16,7 +16,7 @@ async function sortedBaseKeysdependencyTasks(tasks: BaseTask[]): Promise<string[
 }
 
 function sortedBaseKeys(tasks: BaseTask[]): string[] {
-  return uniq(tasks.map(t => t.getBaseKey())).sort()
+  return uniq(tasks.map(t => t.getKey())).sort()
 }
 
 describe("TaskHelpers", () => {


### PR DESCRIPTION
In short, `baseKey` is now called `key`, `key` is now called `id`, and `id` is now called `uid`. The same applies to the corresponding getter methods on `BaseTask`.

`baseKey` has always been a somewhat awkward term, and with some of the recent changes to the events emitted by the `TaskGraph`, it had started to become slightly confusing as well. The new terminology should be clearer and more intuitive.