### PR TITLE
fix(vcs): don't fork a process for every untracked file

### DIFF
--- a/garden-service/package-lock.json
+++ b/garden-service/package-lock.json
@@ -5247,6 +5247,15 @@
         }
       }
     },
+    "hasha": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.0.0.tgz",
+      "integrity": "sha512-PqWdhnQhq6tqD32hZv+l1e5mJHNSudjnaAzgAHfkGiU0ABN6lmbZF8abJIulQHbZ7oiHhP8yL6O910ICMc+5pw==",
+      "requires": {
+        "is-stream": "^1.1.0",
+        "type-fest": "^0.3.0"
+      }
+    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
@@ -11623,6 +11632,11 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
+    },
+    "type-fest": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
     },
     "type-is": {
       "version": "1.6.16",

--- a/garden-service/package.json
+++ b/garden-service/package.json
@@ -52,6 +52,7 @@
     "fs-extra": "^7.0.1",
     "get-port": "^4.0.0",
     "has-ansi": "^3.0.0",
+    "hasha": "^5.0.0",
     "ignore": "^5.0.4",
     "indent-string": "^3.2.0",
     "inquirer": "^6.2.1",

--- a/garden-service/test/unit/src/vcs/git.ts
+++ b/garden-service/test/unit/src/vcs/git.ts
@@ -124,6 +124,17 @@ describe("GitHandler", () => {
       ])
     })
   })
+
+  describe("hashObject", () => {
+    it("should return the same result as `git hash-object` for a file", async () => {
+      const path = resolve(tmpPath, "foo.txt")
+      await createFile(path)
+
+      const expected = (await git("hash-object", path))[0]
+
+      expect(await handler.hashObject(path)).to.equal(expected)
+    })
+  })
 })
 
 describe("git", () => {


### PR DESCRIPTION
This solves an issue where Garden would flood spawned processes with
a huge amount of source files. This could happen, for example, when
library directories (e.g. node_modules) weren't ignored.