### PR TITLE
fix(k8s): allow unknown fields in provider config

### DIFF
--- a/garden-service/src/plugins/kubernetes/kubernetes.ts
+++ b/garden-service/src/plugins/kubernetes/kubernetes.ts
@@ -120,7 +120,6 @@ export const kubernetesConfigBase = providerConfigBaseSchema
     _systemServices: joiArray(joiIdentifier())
       .meta({ internal: true }),
   })
-  .unknown(false)
 
 export const configSchema = kubernetesConfigBase
   .keys({


### PR DESCRIPTION
This fixes a regression from a recent PR which caused provider config schema validations during environment status checks to fail.