### PR TITLE
test(integ): perf & cleanup improvements

### DIFF
--- a/garden-service/test/integ/src/integ-helpers.ts
+++ b/garden-service/test/integ/src/integ-helpers.ts
@@ -1,9 +1,10 @@
 import { resolve } from "path"
 import { expect } from "chai"
-import { findTasks } from "../../integ-helpers"
+import { findTasks, deleteExampleNamespaces, deleteSystemMetadataNamespace } from "../../integ-helpers"
 import { examplesDir } from "../../helpers"
 import { runGarden, GardenWatch, dashboardUpStep, touchFileStep, taskCompletedStep } from "../../run-garden"
 import { JsonLogEntry } from "../../../src/logger/writers/json-terminal-writer"
+import { getLogger } from "../../../src/logger/logger"
 
 const voteExamplePath = resolve(examplesDir, "vote")
 
@@ -13,7 +14,11 @@ describe("integ-helpers", () => {
 
   describe("findTasks", () => {
 
+    const log = getLogger().placeholder()
+
     before(async () => {
+      await deleteSystemMetadataNamespace(log)
+      await deleteExampleNamespaces(log)
       testEntries = await runGarden(voteExamplePath, ["test"])
     })
 

--- a/garden-service/test/integ/src/pre-release.ts
+++ b/garden-service/test/integ/src/pre-release.ts
@@ -12,7 +12,13 @@ import {
   runGarden,
   taskCompletedStep,
 } from "../../run-garden"
-import { deleteExampleNamespaces, searchLog, removeExampleDotGardenDirs } from "../../integ-helpers"
+import {
+  deleteExampleNamespaces,
+  searchLog,
+  removeExampleDotGardenDirs,
+  deleteSystemMetadataNamespace,
+  deleteExistingNamespaces,
+} from "../../integ-helpers"
 import { getLogger } from "../../../src/logger/logger"
 
 // TODO: Add test for verifying that CLI returns with an error when called with an unknown command
@@ -24,7 +30,8 @@ describe("PreReleaseTests", () => {
 
   before(async () => {
     mlog.log("deleting example project namespaces and .garden folders")
-    await deleteExampleNamespaces(log, false)
+    await deleteSystemMetadataNamespace(log)
+    await deleteExampleNamespaces(log)
     await removeExampleDotGardenDirs()
   })
 
@@ -65,7 +72,7 @@ describe("PreReleaseTests", () => {
     })
 
     after(async () => {
-      await deleteExampleNamespaces(log, false)
+      await deleteExistingNamespaces(log, ["simple-project"])
     })
 
   })
@@ -89,7 +96,7 @@ describe("PreReleaseTests", () => {
     })
 
     after(async () => {
-      await deleteExampleNamespaces(log, false)
+      await deleteExampleNamespaces(log, ["tasks"])
     })
 
   })
@@ -133,7 +140,7 @@ describe("PreReleaseTests", () => {
     })
 
     after(async () => {
-      await deleteExampleNamespaces(log, false)
+      await deleteExampleNamespaces(log, ["hot-reload"])
     })
 
   })
@@ -158,7 +165,7 @@ describe("PreReleaseTests", () => {
     })
 
     after(async () => {
-      await deleteExampleNamespaces(log, false)
+      await deleteExampleNamespaces(log, ["vote-helm"])
     })
 
   })
@@ -179,7 +186,7 @@ describe("PreReleaseTests", () => {
   })
 
   after(async () => {
-    await deleteExampleNamespaces(log, false)
+    await deleteExampleNamespaces(log, ["remote-sources"])
   })
 
 })


### PR DESCRIPTION
Deleting app namespaces after each sequence seems to improve performance and reduce stalling (at least when executing locally).