### PR TITLE
fix(config): recursion error with invalid template strings

### DIFF
--- a/garden-service/src/template-string-parser.pegjs
+++ b/garden-service/src/template-string-parser.pegjs
@@ -12,16 +12,6 @@ TemplateString
   / InvalidFormatString
   / $(.*) { return [text()] }
 
-NestedTemplateString
-  = a:(FormatString)+ b:NestedTemplateString? {
-    return [...a, ...(b || [])]
-  }
-  / a:Prefix b:(FormatString)+ c:NestedTemplateString? {
-    return [a, ...b, ...(c || [])]
-  }
-  / InvalidFormatString
-  / Suffix { return [text()] }
-
 FormatString
   = FormatStart key:Key FormatEnd {
       return options.getKey(key)
@@ -44,9 +34,6 @@ FormatString
   }
   / FormatStart a:StringLiteral FormatEnd {
       return a
-  }
-  / FormatStart s:NestedTemplateString FormatEnd {
-      return options.resolve(s)
   }
 
 InvalidFormatString


### PR DESCRIPTION
BREAKING CHANGE:

This removes the previously deprecated ability to do nested formatting
strings. It's not a helpful feature for most cases, and just complicates
the parser logic. Also wasn't documented really, so it should be safe to
remove without a minor version bump.