### PR TITLE
chore(build): skip build-container in build task

### DIFF
--- a/garden-service/gulpfile.ts
+++ b/garden-service/gulpfile.ts
@@ -52,9 +52,8 @@ module.exports = (gulp) => {
       .pipe(gulp.dest(destDir)),
   )
 
-  gulp.task("build", gulp.series(
-    gulp.parallel("add-version-files", "generate-docs", "pegjs", "tsc"),
-    "build-container",
+  gulp.task("build", gulp.parallel(
+    "add-version-files", "generate-docs", "pegjs", "tsc",
   ))
 
   gulp.task("build-ci", gulp.parallel(


### PR DESCRIPTION
The `build-container` gulp task is unnecessary for the standard `build` gulp task. However, we don't remove it, since it is still useful in other contexts (e.g. CI).