### PR TITLE
fix(config): validation fix for template strings

### DIFF
--- a/garden-service/src/config/common.ts
+++ b/garden-service/src/config/common.ts
@@ -26,8 +26,11 @@ export const enumToArray = Enum => (
   Object.values(Enum).filter(k => typeof k === "string") as string[]
 )
 
-export const joiPrimitive = () => Joi.alternatives().try(Joi.number(), Joi.string(), Joi.boolean())
-  .description("Number, string or boolean")
+export const joiPrimitive = () => Joi.alternatives().try(
+  Joi.number(),
+  Joi.string().allow(""),
+  Joi.boolean(),
+).description("Number, string or boolean")
 
 export const absolutePathRegex = /^\/.*/ // Note: Only checks for the leading slash
 // from https://stackoverflow.com/a/12311250/3290965


### PR DESCRIPTION
Allow empty strings as default values for env vars used in template strings. For example, `${someVar || ""}`.

Previously, this would lead to a validation error due to `joiPrimitive` not permitting empty strings.