### PR TITLE
feat: render results as JSON for json logger

### DIFF
--- a/garden-service/src/commands/get/get-config.ts
+++ b/garden-service/src/commands/get/get-config.ts
@@ -6,8 +6,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import * as yaml from "js-yaml"
-import { highlightYaml } from "../../util/util"
 import { Command, CommandResult, CommandParams } from "../base"
 import { ConfigDump } from "../../garden"
 
@@ -18,10 +16,8 @@ export class GetConfigCommand extends Command {
   async action({ garden, log }: CommandParams): Promise<CommandResult<ConfigDump>> {
     const config = await garden.dumpConfig()
 
-    const yamlConfig = yaml.safeDump(config, { noRefs: true, skipInvalid: true })
-
-    // TODO: do a nicer print of this by default and use --yaml/--json options for exporting
-    log.info(highlightYaml(yamlConfig))
+    // TODO: do a nicer print of this by default
+    log.info({ data: config })
 
     return { result: config }
   }

--- a/garden-service/src/commands/get/get-graph.ts
+++ b/garden-service/src/commands/get/get-graph.ts
@@ -6,9 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import * as yaml from "js-yaml"
 import { RenderedEdge, RenderedNode } from "../../config-graph"
-import { highlightYaml } from "../../util/util"
 import {
   Command,
   CommandResult,
@@ -29,9 +27,7 @@ export class GetGraphCommand extends Command {
     const renderedGraph = graph.render()
     const output: GraphOutput = { nodes: renderedGraph.nodes, relationships: renderedGraph.relationships }
 
-    const yamlGraph = yaml.safeDump(renderedGraph, { noRefs: true, skipInvalid: true })
-
-    log.info(highlightYaml(yamlGraph))
+    log.info({ data: renderedGraph })
 
     return { result: output }
 

--- a/garden-service/src/commands/get/get-status.ts
+++ b/garden-service/src/commands/get/get-status.ts
@@ -6,8 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import * as yaml from "js-yaml"
-import { highlightYaml, deepFilter } from "../../util/util"
+import { deepFilter } from "../../util/util"
 import {
   Command,
   CommandResult,
@@ -25,10 +24,8 @@ export class GetStatusCommand extends Command {
     // TODO: we should change the status format because this will remove services called "detail"
     const withoutDetail = deepFilter(status, (_, key) => key !== "detail")
 
-    const yamlStatus = yaml.safeDump(withoutDetail, { noRefs: true, skipInvalid: true })
-
-    // TODO: do a nicer print of this by default and use --yaml/--json options for exporting
-    log.info(highlightYaml(yamlStatus))
+    // TODO: do a nicer print of this by default
+    log.info({ data: withoutDetail })
 
     return { result: status }
   }

--- a/garden-service/src/commands/get/get-task-result.ts
+++ b/garden-service/src/commands/get/get-task-result.ts
@@ -6,7 +6,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import * as yaml from "js-yaml"
 import { ConfigGraph } from "../../config-graph"
 import {
   Command,
@@ -15,7 +14,6 @@ import {
   StringParameter,
 } from "../base"
 import { logHeader } from "../../logger/util"
-import { highlightYaml } from "../../util/util"
 import { getTaskVersion } from "../../tasks/task"
 import { RunTaskResult } from "../../types/plugin/outputs"
 import chalk from "chalk"
@@ -75,13 +73,8 @@ export class GetTaskResultCommand extends Command<Args> {
         startedAt: taskResult.startedAt,
         completedAt: taskResult.completedAt,
       }
-      const yamlStatus = yaml.safeDump(taskResult, {
-        noRefs: true,
-        skipInvalid: true,
-      })
 
-      log.info(highlightYaml(yamlStatus))
-
+      log.info({ data: taskResult })
       return { result: output }
     } else {
       log.info(

--- a/garden-service/src/commands/get/get-test-result.ts
+++ b/garden-service/src/commands/get/get-test-result.ts
@@ -12,11 +12,10 @@ import {
   CommandParams,
   StringParameter,
 } from "../base"
-import * as yaml from "js-yaml"
 import { NotFoundError } from "../../exceptions"
 import { TestResult } from "../../types/plugin/outputs"
 import { getTestVersion } from "../../tasks/test"
-import { findByName, getNames, highlightYaml } from "../../util/util"
+import { findByName, getNames } from "../../util/util"
 import { logHeader } from "../../logger/util"
 import chalk from "chalk"
 
@@ -98,12 +97,8 @@ export class GetTestResultCommand extends Command<Args> {
         version: testResult.version.versionString,
         output: testResult.output,
       }
-      const yamlStatus = yaml.safeDump(testResult, {
-        noRefs: true,
-        skipInvalid: true,
-      })
 
-      log.info(highlightYaml(yamlStatus))
+      log.info({ data: testResult })
       return { result: output }
     } else {
       const errorMessage = `Could not find results for test '${testName}'`

--- a/garden-service/src/logger/log-entry.ts
+++ b/garden-service/src/logger/log-entry.ts
@@ -34,6 +34,7 @@ export interface TaskMetadata {
 
 export interface UpdateOpts {
   msg?: string | string[]
+  data?: any // to be rendered as e.g. YAML or JSON
   section?: string
   emoji?: EmojiName
   symbol?: LogSymbol

--- a/garden-service/src/logger/writers/json-terminal-writer.ts
+++ b/garden-service/src/logger/writers/json-terminal-writer.ts
@@ -14,6 +14,7 @@ import { formatForJSON } from "../renderers"
 
 export interface JsonLogEntry {
   msg: string,
+  data?: any,
   section?: string,
   durationMs?: number,
   metadata?: LogEntryMetadata,
@@ -26,7 +27,8 @@ export class JsonTerminalWriter extends Writer {
     const level = this.level || logger.level
     if (level >= entry.level) {
       const jsonEntry = formatForJSON(entry)
-      return jsonEntry.msg ? JSON.stringify(jsonEntry) : null
+      const empty = !(jsonEntry.msg || jsonEntry.data)
+      return empty ? null : JSON.stringify(jsonEntry)
     }
     return null
   }


### PR DESCRIPTION
When the JSON logger type is being used (via -`-logger-type=json`), command results are rendered to the log as JSON objects instead of YAML strings. This facilitates parsing e.g. by testing code and other instrumentation.

Highlighted YAML remains the default rendering method (e.g. for the basic and fancy loggers).