### PR TITLE
document defaultHostname in using remote clusters

### DIFF
--- a/docs/using-garden/remote-clusters.md
+++ b/docs/using-garden/remote-clusters.md
@@ -58,6 +58,7 @@ project:
     providers:
     - name: kubernetes
       context: my-dev-context
+      defaultHostname: mydomain.com
       tlsCertificates:
       - name: main
         # Optionally set particular hostnames to use this certificate for


### PR DESCRIPTION
Otherwise this will fail on e.g. the simple project with:

```
No hostname configured for one of the ingresses on service go-service. Please configure a default hostname or specify a hostname for the ingress.
```