### PR TITLE
fix(k8s): ensure env is prepared

### DIFF
--- a/garden-service/src/plugins/kubernetes/helm/tiller.ts
+++ b/garden-service/src/plugins/kubernetes/helm/tiller.ts
@@ -35,8 +35,15 @@ export async function checkTillerStatus(ctx: PluginContext, provider: Kubernetes
   return combineStates(statuses.map(s => s.state))
 }
 
-export async function installTiller(ctx: PluginContext, provider: KubernetesProvider, log: LogEntry) {
-  if (await checkTillerStatus(ctx, provider, log) === "ready") {
+interface InstallTillerParams {
+  ctx: PluginContext
+  provider: KubernetesProvider
+  log: LogEntry
+  force?: boolean
+}
+
+export async function installTiller({ ctx, log, provider, force = false }: InstallTillerParams) {
+  if (!force && await checkTillerStatus(ctx, provider, log) === "ready") {
     return
   }
 

--- a/garden-service/src/plugins/openfaas/openfaas.ts
+++ b/garden-service/src/plugins/openfaas/openfaas.ts
@@ -154,7 +154,7 @@ export function gardenPlugin(): GardenPlugin {
         const k8sProviderName = getK8sProvider(openFaasCtx).name
         const ofCtx = <OpenFaasPluginContext>(await ofGarden.getPluginContext(k8sProviderName))
         const ofK8sProvider = getK8sProvider(ofCtx)
-        await installTiller(ctx, ofK8sProvider, log)
+        await installTiller({ ctx, provider: ofK8sProvider, log, force })
 
         const results = await ofGarden.actions.deployServices({ log, force })
         const failed = values(results.taskResults).filter(r => !!r.error).length

--- a/garden-service/src/types/service.ts
+++ b/garden-service/src/types/service.ts
@@ -147,6 +147,10 @@ export interface ServiceStatus {
   detail?: any
 }
 
+export interface ServiceStatusMap {
+  [key: string]: ServiceStatus
+}
+
 export const serviceStatusSchema = Joi.object()
   .keys({
     providerId: Joi.string()


### PR DESCRIPTION
Before, Garden would not deploy Tiller to the project namespace nor create the system namespaces for the Kubernetes provider. This was because the Kubernetes provider doesn't have any system services.

I also used the chance to refactor `getEnvironmentStatus` and `prepareEnvironment` handlers for the K8s provider since the control flow was a bit hard to follow. In particular because `getEnvironmentStatus` triggers a call to `actions.getStatus` which again calls `getEnvironmentStatus` for the system context. This lead to some code paths never being executed which caused #773  and #770.

After the refactor, most of the logic is hoisted to the top level handlers and `getEnvironmentStatus` is no longer called recursively. 

Fixes #773.
Fixes #770. 