### PR TITLE
feat: add test/task statuses to get status command

### DIFF
--- a/garden-service/src/actions.ts
+++ b/garden-service/src/actions.ts
@@ -92,10 +92,6 @@ export interface EnvironmentStatus {
   services: { [name: string]: ServiceStatus }
 }
 
-export interface EnvironmentOverview {
-  modules: { [name: string]: ServiceStatus }[]
-}
-
 export interface DeployServicesParams {
   log: LogEntry
   serviceNames?: string[]

--- a/garden-service/src/cli/cli.ts
+++ b/garden-service/src/cli/cli.ts
@@ -276,6 +276,7 @@ export class GardenCli {
       await command.prepare({
         log,
         logFooter,
+        output,
         args: parsedArgs,
         opts: parsedOpts,
       })
@@ -292,6 +293,7 @@ export class GardenCli {
           garden,
           log,
           logFooter,
+          output,
           args: parsedArgs,
           opts: parsedOpts,
         })

--- a/garden-service/src/commands/base.ts
+++ b/garden-service/src/commands/base.ts
@@ -210,6 +210,7 @@ export interface PrepareParams<T extends Parameters = {}, U extends Parameters =
   opts: ParameterValues<U>
   log: LogEntry
   logFooter: LogEntry
+  output?: string
 }
 
 export interface CommandParams<T extends Parameters = {}, U extends Parameters = {}> extends PrepareParams<T, U> {

--- a/garden-service/src/commands/get/get-status.ts
+++ b/garden-service/src/commands/get/get-status.ts
@@ -6,6 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import * as Bluebird from "bluebird"
+import { flatten, fromPairs } from "lodash"
 import { deepFilter } from "../../util/util"
 import {
   Command,
@@ -13,13 +15,41 @@ import {
   CommandParams,
 } from "../base"
 import { EnvironmentStatus } from "../../actions"
+import { Garden } from "../../garden"
+import { ConfigGraph } from "../../config-graph"
+import { getTaskVersion } from "../../tasks/task"
+import { LogEntry } from "../../logger/log-entry"
+import { getTestVersion } from "../../tasks/test"
+
+type RunStatus = "not-completed" | "completed"
+
+interface TestStatuses { [testKey: string]: RunStatus }
+interface TaskStatuses { [taskKey: string]: RunStatus }
+
+// Value is "completed" if the test/task has been run for the current version.
+export interface StatusCommandResult extends EnvironmentStatus {
+  testStatuses: TestStatuses
+  taskStatuses: TaskStatuses
+}
 
 export class GetStatusCommand extends Command {
   name = "status"
   help = "Outputs the status of your environment."
 
-  async action({ garden, log }: CommandParams): Promise<CommandResult<EnvironmentStatus>> {
+  async action({ garden, log, output }: CommandParams): Promise<CommandResult<EnvironmentStatus>> {
     const status = await garden.actions.getStatus({ log })
+
+    let result
+    if (output) {
+      const graph = await garden.getConfigGraph()
+      result = await Bluebird.props({
+        ...status,
+        testStatuses: getTestStatuses(garden, graph, log),
+        taskStatuses: getTaskStatuses(garden, graph, log),
+      })
+    } else {
+      result = status
+    }
 
     // TODO: we should change the status format because this will remove services called "detail"
     const withoutDetail = deepFilter(status, (_, key) => key !== "detail")
@@ -27,6 +57,28 @@ export class GetStatusCommand extends Command {
     // TODO: do a nicer print of this by default
     log.info({ data: withoutDetail })
 
-    return { result: status }
+    return { result }
   }
+}
+
+async function getTestStatuses(garden: Garden, configGraph: ConfigGraph, log: LogEntry) {
+  const modules = await configGraph.getModules()
+  return fromPairs(flatten(await Bluebird.map(modules, async (module) => {
+    return Bluebird.map(module.testConfigs, async (testConfig) => {
+      const testVersion = await getTestVersion(garden, configGraph, module, testConfig)
+      const done = !!(await garden.actions.getTestResult({
+        module, log, testVersion, testName: testConfig.name,
+      }))
+      return [`${module.name}.${testConfig.name}`, done ? "completed" : "not-completed"]
+    })
+  })))
+}
+
+async function getTaskStatuses(garden: Garden, configGraph: ConfigGraph, log: LogEntry): Promise<TaskStatuses> {
+  const tasks = await configGraph.getTasks()
+  return fromPairs(await Bluebird.map(tasks, async (task) => {
+    const taskVersion = await getTaskVersion(garden, configGraph, task)
+    const done = !!(await garden.actions.getTaskResult({ task, taskVersion, log }))
+    return [task.name, done ? "completed" : "not-completed"]
+  }))
 }


### PR DESCRIPTION
When the get status command is called with json or yaml as the output option, test and task statuses for the latest test/task versions are included in the command result.