### PR TITLE
fix(logger): fix spinner pos

### DIFF
--- a/garden-service/src/logger/renderers.ts
+++ b/garden-service/src/logger/renderers.ts
@@ -16,7 +16,6 @@ import {
   flow,
   isArray,
   isEmpty,
-  padStart,
   reduce,
   kebabCase,
   repeat,
@@ -75,7 +74,7 @@ export function printEmoji(emoji: EmojiName) {
 
 /*** RENDERERS ***/
 export function leftPad(entry: LogEntry): string {
-  return padStart("", (entry.opts.indent || 0) * 3)
+  return "".padStart((entry.opts.indent || 0) * 3)
 }
 
 export function renderEmoji(entry: LogEntry): string {

--- a/garden-service/src/logger/writers/fancy-terminal-writer.ts
+++ b/garden-service/src/logger/writers/fancy-terminal-writer.ts
@@ -93,12 +93,11 @@ export class FancyTerminalWriter extends Writer {
   private spin(entries: TerminalEntryWithSpinner[], totalLines: number): void {
     entries.forEach(e => {
       let out = ""
-      const [x, y] = e.spinnerCoords
-      const termX = x === 0 ? x : x + 1
-      const termY = -(totalLines - y - 1)
+      const x = e.spinnerCoords[0]
+      const y = -(totalLines - e.spinnerCoords[1] - 1)
       out += ansiEscapes.cursorSavePosition
       out += ansiEscapes.cursorTo(0) // Ensure cursor is to the left
-      out += ansiEscapes.cursorMove(termX, termY)
+      out += ansiEscapes.cursorMove(x, y)
       out += spinnerStyle(this.tickSpinner(e.key))
       out += ansiEscapes.cursorRestorePosition
       this.stream.write(out)


### PR DESCRIPTION
Before this change the spinner was being updated at the wrong x coordinate which resulted in something like this:

<img width="668" alt="Screenshot 2019-05-17 at 07 46 25" src="https://user-images.githubusercontent.com/5373776/57905787-04982800-7878-11e9-96ce-5428708f1e40.png">

Not sure why it broke in the first place though. Perhaps another left-pad-gate since this depends on Lodash's `padStart` function. Checking back in the version history (without npm installing) still produced the error so it looks like a `node_modules` thing. In any case I changed to the native `String.padStart` function for good measure.