### PR TITLE
chore: fix broken tmp-promise dependency

### DIFF
--- a/garden-service/package-lock.json
+++ b/garden-service/package-lock.json
@@ -11629,11 +11629,12 @@
       }
     },
     "tmp-promise": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-2.0.0.tgz",
-      "integrity": "sha512-kChVEhT3MTvFKrFEiKZEgDpIzUDj/EAsivMW/x0dFYPtymbLU0IkJeEJLHQ5UZfxacV3fi85NBqDDI4vT0QsYA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-1.1.0.tgz",
+      "integrity": "sha512-8+Ah9aB1IRXCnIOxXZ0uFozV1nMU5xiu7hhFVUSxZ3bYu+psD4TzagCzVbexUCgNNGJnsmNDQlS4nG3mTyoNkw==",
       "dev": true,
       "requires": {
+        "bluebird": "^3.5.0",
         "tmp": "0.1.0"
       },
       "dependencies": {

--- a/garden-service/package.json
+++ b/garden-service/package.json
@@ -162,7 +162,7 @@
     "testdouble": "^3.11.0",
     "testdouble-chai": "^0.5.0",
     "timekeeper": "^2.2.0",
-    "tmp-promise": "^2.0.0",
+    "tmp-promise": "^1.1.0",
     "touch": "^3.1.0",
     "ts-node": "^8.1.0",
     "tslint": "^5.16.0",


### PR DESCRIPTION
They seem to have pulled the 2.0 release that we had upgraded to.