### PR TITLE
fix: make global CLI opts available to commands

### DIFF
--- a/garden-service/package-lock.json
+++ b/garden-service/package-lock.json
@@ -476,7 +476,7 @@
     },
     "@types/accepts": {
       "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
+      "resolved": "http://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
       "requires": {
         "@types/node": "*"
@@ -2390,7 +2390,7 @@
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
         "readable-stream": "^2.3.5",
@@ -6925,12 +6925,12 @@
         },
         "resolve": {
           "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
         },
         "source-map": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
           "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
           "optional": true,
           "requires": {
@@ -7967,7 +7967,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {

--- a/garden-service/src/cli/cli.ts
+++ b/garden-service/src/cli/cli.ts
@@ -36,7 +36,7 @@ import { Writer } from "../logger/writers/base"
 import {
   envSupportsEmoji,
   failOnInvalidOptions,
-  falsifyConflictingParams,
+  negateConflictingParams,
   filterByKeys,
   getArgSynopsis,
   getKeys,
@@ -140,6 +140,8 @@ export const GLOBAL_OPTIONS = {
   }),
 }
 
+export type GlobalOptions = typeof GLOBAL_OPTIONS
+
 function initLogger({ level, logEnabled, loggerType, emoji }: {
   level: LogLevel, logEnabled: boolean, loggerType: LoggerType, emoji: boolean,
 }) {
@@ -182,7 +184,7 @@ export class GardenCli {
       .showHelpByDefault()
       .check((argv, _ctx) => {
         // NOTE: Need to mutate argv!
-        merge(argv, falsifyConflictingParams(argv, GLOBAL_OPTIONS))
+        merge(argv, negateConflictingParams(argv, GLOBAL_OPTIONS))
       })
       .style(styleConfig)
 
@@ -276,7 +278,6 @@ export class GardenCli {
       await command.prepare({
         log,
         logFooter,
-        output,
         args: parsedArgs,
         opts: parsedOpts,
       })
@@ -293,7 +294,6 @@ export class GardenCli {
           garden,
           log,
           logFooter,
-          output,
           args: parsedArgs,
           opts: parsedOpts,
         })

--- a/garden-service/src/cli/helpers.ts
+++ b/garden-service/src/cli/helpers.ts
@@ -72,7 +72,7 @@ export type FalsifiedParams = { [key: string]: false }
 /**
  * Returns the params that need to be overridden set to false
  */
-export function falsifyConflictingParams(argv, params: ParameterValues<any>): FalsifiedParams {
+export function negateConflictingParams(argv, params: ParameterValues<any>): FalsifiedParams {
   return reduce(argv, (acc: {}, val: any, key: string) => {
     const param = params[key]
     const overrides = (param || {}).overrides || []

--- a/garden-service/src/commands/base.ts
+++ b/garden-service/src/commands/base.ts
@@ -14,6 +14,7 @@ import { ProcessResults } from "../process"
 import { Garden } from "../garden"
 import { LogEntry } from "../logger/log-entry"
 import { logHeader } from "../logger/util"
+import { GlobalOptions } from "../cli/cli"
 
 export class ValidationError extends Error { }
 
@@ -207,10 +208,9 @@ export interface CommandResult<T = any> {
 
 export interface PrepareParams<T extends Parameters = {}, U extends Parameters = {}> {
   args: ParameterValues<T>
-  opts: ParameterValues<U>
+  opts: ParameterValues<GlobalOptions & U>
   log: LogEntry
   logFooter: LogEntry
-  output?: string
 }
 
 export interface CommandParams<T extends Parameters = {}, U extends Parameters = {}> extends PrepareParams<T, U> {

--- a/garden-service/src/commands/get/get-status.ts
+++ b/garden-service/src/commands/get/get-status.ts
@@ -36,11 +36,11 @@ export class GetStatusCommand extends Command {
   name = "status"
   help = "Outputs the status of your environment."
 
-  async action({ garden, log, output }: CommandParams): Promise<CommandResult<EnvironmentStatus>> {
+  async action({ garden, log, opts }: CommandParams): Promise<CommandResult<EnvironmentStatus>> {
     const status = await garden.actions.getStatus({ log })
 
     let result
-    if (output) {
+    if (opts.output) {
       const graph = await garden.getConfigGraph()
       result = await Bluebird.props({
         ...status,

--- a/garden-service/src/commands/update-remote/all.ts
+++ b/garden-service/src/commands/update-remote/all.ts
@@ -33,7 +33,7 @@ export class UpdateRemoteAllCommand extends Command {
         garden update-remote all # update all remote sources and modules in the project
   `
 
-  async action({ garden, log, logFooter }: CommandParams): Promise<CommandResult<UpdateRemoteAllResult>> {
+  async action({ garden, log, logFooter, opts }: CommandParams): Promise<CommandResult<UpdateRemoteAllResult>> {
     logHeader({ log, emoji: "hammer_and_wrench", command: "update-remote all" })
 
     const sourcesCmd = new UpdateRemoteSourcesCommand()
@@ -43,15 +43,15 @@ export class UpdateRemoteAllCommand extends Command {
       garden,
       log,
       logFooter,
+      opts,
       args: { sources: undefined },
-      opts: {},
     })
     const { result: moduleSources } = await modulesCmd.action({
       garden,
       log,
       logFooter,
+      opts,
       args: { modules: undefined },
-      opts: {},
     })
 
     return { result: { projectSources: projectSources!, moduleSources: moduleSources! } }

--- a/garden-service/test/helpers.ts
+++ b/garden-service/test/helpers.ts
@@ -9,6 +9,7 @@
 import * as td from "testdouble"
 import * as Joi from "joi"
 import { resolve, join } from "path"
+import { extend } from "lodash"
 import { remove, readdirSync, existsSync } from "fs-extra"
 import { containerModuleSpecSchema, containerTestSchema, containerTaskSchema } from "../src/plugins/container/config"
 import { testExecModule, buildExecModule, execBuildSpecSchema } from "../src/plugins/exec"
@@ -42,6 +43,7 @@ import { SourceConfig } from "../src/config/project"
 import { BuildDir } from "../src/build-dir"
 import { LogEntry } from "../src/logger/log-entry"
 import timekeeper = require("timekeeper")
+import { GLOBAL_OPTIONS } from "../src/cli/cli"
 
 export const dataDir = resolve(__dirname, "unit", "data")
 export const examplesDir = resolve(__dirname, "..", "..", "examples")
@@ -384,6 +386,10 @@ export function stubExtSources(garden: Garden) {
 export function getExampleProjects() {
   const names = readdirSync(examplesDir).filter(n => existsSync(join(examplesDir, n, CONFIG_FILENAME)))
   return fromPairs(names.map(n => [n, join(examplesDir, n)]))
+}
+
+export function withDefaultGlobalOpts(opts: any) {
+  return extend(mapValues(GLOBAL_OPTIONS, (opt) => opt.defaultValue), opts)
 }
 
 export function freezeTime(date?: Date) {

--- a/garden-service/test/unit/src/commands/build.ts
+++ b/garden-service/test/unit/src/commands/build.ts
@@ -1,6 +1,6 @@
 import { BuildCommand } from "../../../../src/commands/build"
 import { expect } from "chai"
-import { makeTestGardenA } from "../../../helpers"
+import { makeTestGardenA, withDefaultGlobalOpts } from "../../../helpers"
 import { taskResultOutputs } from "../../../helpers"
 
 describe("commands.build", () => {
@@ -15,7 +15,7 @@ describe("commands.build", () => {
       log,
       logFooter,
       args: { modules: undefined },
-      opts: { watch: false, force: true },
+      opts: withDefaultGlobalOpts({ watch: false, force: true }),
     })
 
     expect(taskResultOutputs(result!)).to.eql({
@@ -36,7 +36,7 @@ describe("commands.build", () => {
       log,
       logFooter,
       args: { modules: ["module-b"] },
-      opts: { watch: false, force: true },
+      opts: withDefaultGlobalOpts({ watch: false, force: true }),
     })
 
     expect(taskResultOutputs(result!)).to.eql({

--- a/garden-service/test/unit/src/commands/call.ts
+++ b/garden-service/test/unit/src/commands/call.ts
@@ -6,7 +6,7 @@ import { PluginFactory } from "../../../../src/types/plugin/plugin"
 import { GetServiceStatusParams } from "../../../../src/types/plugin/params"
 import { ServiceStatus } from "../../../../src/types/service"
 import nock = require("nock")
-import { configureTestModule } from "../../../helpers"
+import { configureTestModule, withDefaultGlobalOpts } from "../../../helpers"
 
 const testProvider: PluginFactory = () => {
   const testStatuses: { [key: string]: ServiceStatus } = {
@@ -71,7 +71,7 @@ describe("commands.call", () => {
       log,
       logFooter: log,
       args: { serviceAndPath: "service-a/path-a" },
-      opts: {},
+      opts: withDefaultGlobalOpts({}),
     })
 
     expect(result.url).to.equal("http://service-a.test-project-b.local.app.garden:32000/path-a")
@@ -96,7 +96,7 @@ describe("commands.call", () => {
       log,
       logFooter: log,
       args: { serviceAndPath: "service-a" },
-      opts: {},
+      opts: withDefaultGlobalOpts({}),
     })
 
     expect(result.url).to.equal("http://service-a.test-project-b.local.app.garden:32000/path-a")
@@ -120,7 +120,7 @@ describe("commands.call", () => {
       log,
       logFooter: log,
       args: { serviceAndPath: "service-b" },
-      opts: {},
+      opts: withDefaultGlobalOpts({}),
     })
 
     expect(result.url).to.equal("http://service-b.test-project-b.local.app.garden:32000/")
@@ -141,7 +141,7 @@ describe("commands.call", () => {
         log,
         logFooter: log,
         args: { serviceAndPath: "service-d/path-d" },
-        opts: {},
+        opts: withDefaultGlobalOpts({}),
       })
     } catch (err) {
       expect(err.type).to.equal("runtime")
@@ -162,7 +162,7 @@ describe("commands.call", () => {
         log,
         logFooter: log,
         args: { serviceAndPath: "service-c/path-c" },
-        opts: {},
+        opts: withDefaultGlobalOpts({}),
       })
     } catch (err) {
       expect(err.type).to.equal("parameter")
@@ -183,7 +183,7 @@ describe("commands.call", () => {
         log,
         logFooter: log,
         args: { serviceAndPath: "service-a/bla" },
-        opts: {},
+        opts: withDefaultGlobalOpts({}),
       })
     } catch (err) {
       expect(err.type).to.equal("parameter")

--- a/garden-service/test/unit/src/commands/delete.ts
+++ b/garden-service/test/unit/src/commands/delete.ts
@@ -6,7 +6,7 @@ import {
 import { Garden } from "../../../../src/garden"
 import { EnvironmentStatus } from "../../../../src/types/plugin/outputs"
 import { PluginFactory } from "../../../../src/types/plugin/plugin"
-import { expectError, makeTestGardenA, getDataDir, configureTestModule } from "../../../helpers"
+import { expectError, makeTestGardenA, getDataDir, configureTestModule, withDefaultGlobalOpts } from "../../../helpers"
 import { expect } from "chai"
 import { ServiceStatus } from "../../../../src/types/service"
 import { DeleteServiceParams } from "../../../../src/types/plugin/params"
@@ -30,7 +30,7 @@ describe("DeleteSecretCommand", () => {
       log,
       logFooter: log,
       args: { provider, key },
-      opts: {},
+      opts: withDefaultGlobalOpts({}),
     })
 
     expect(await garden.actions.getSecret({ log, pluginName, key })).to.eql({ value: null })
@@ -47,7 +47,7 @@ describe("DeleteSecretCommand", () => {
         log,
         logFooter: log,
         args: { provider, key: "foo" },
-        opts: {},
+        opts: withDefaultGlobalOpts({}),
       }),
       "not-found",
     )
@@ -85,7 +85,7 @@ describe("DeleteEnvironmentCommand", () => {
     const garden = await Garden.factory(projectRootB, { plugins })
     const log = garden.log
 
-    const { result } = await command.action({ garden, log, logFooter: log, args: {}, opts: {} })
+    const { result } = await command.action({ garden, log, logFooter: log, args: {}, opts: withDefaultGlobalOpts({}) })
 
     expect(result!["test-plugin"]["ready"]).to.be.false
   })
@@ -132,7 +132,7 @@ describe("DeleteServiceCommand", () => {
       log,
       logFooter: log,
       args: { services: ["service-a"] },
-      opts: {},
+      opts: withDefaultGlobalOpts({}),
     })
     expect(result).to.eql({
       "service-a": { state: "unknown", ingresses: [] },
@@ -148,7 +148,7 @@ describe("DeleteServiceCommand", () => {
       log,
       logFooter: log,
       args: { services: ["service-a", "service-b"] },
-      opts: {},
+      opts: withDefaultGlobalOpts({}),
     })
     expect(result).to.eql({
       "service-a": { state: "unknown", ingresses: [] },

--- a/garden-service/test/unit/src/commands/deploy.ts
+++ b/garden-service/test/unit/src/commands/deploy.ts
@@ -10,7 +10,7 @@ import {
   RunTaskParams,
 } from "../../../../src/types/plugin/params"
 import { ServiceState, ServiceStatus } from "../../../../src/types/service"
-import { taskResultOutputs, configureTestModule } from "../../../helpers"
+import { taskResultOutputs, configureTestModule, withDefaultGlobalOpts } from "../../../helpers"
 import { RunTaskResult } from "../../../../src/types/plugin/outputs"
 
 const placeholderTimestamp = new Date()
@@ -100,12 +100,12 @@ describe("DeployCommand", () => {
       args: {
         services: undefined,
       },
-      opts: {
+      opts: withDefaultGlobalOpts({
         "hot-reload": undefined,
         "watch": false,
         "force": false,
         "force-build": true,
-      },
+      }),
     })
 
     if (errors) {
@@ -137,12 +137,12 @@ describe("DeployCommand", () => {
       args: {
         services: ["service-b"],
       },
-      opts: {
+      opts: withDefaultGlobalOpts({
         "hot-reload": undefined,
         "watch": false,
         "force": false,
         "force-build": true,
-      },
+      }),
     })
 
     if (errors) {

--- a/garden-service/test/unit/src/commands/get/get-config.ts
+++ b/garden-service/test/unit/src/commands/get/get-config.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai"
-import { makeTestGardenA } from "../../../../helpers"
+import { makeTestGardenA, withDefaultGlobalOpts } from "../../../../helpers"
 import { GetConfigCommand } from "../../../../../src/commands/get/get-config"
 import { sortBy } from "lodash"
 
@@ -17,7 +17,7 @@ describe("GetConfigCommand", () => {
       log,
       logFooter: log,
       args: { provider },
-      opts: {},
+      opts: withDefaultGlobalOpts({}),
     })
 
     const config = {

--- a/garden-service/test/unit/src/commands/get/get-graph.ts
+++ b/garden-service/test/unit/src/commands/get/get-graph.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai"
-import { dataDir, makeTestGarden } from "../../../../helpers"
+import { dataDir, makeTestGarden, withDefaultGlobalOpts } from "../../../../helpers"
 import { GetGraphCommand } from "../../../../../src/commands/get/get-graph"
 import { resolve } from "path"
 
@@ -18,7 +18,7 @@ describe("GetGraphCommand", () => {
       log,
       logFooter: log,
       args: { provider },
-      opts: {},
+      opts: withDefaultGlobalOpts({}),
     })
 
     expect(Object.keys(res.result!).sort()).to.eql(["nodes", "relationships"])

--- a/garden-service/test/unit/src/commands/get/get-secret.ts
+++ b/garden-service/test/unit/src/commands/get/get-secret.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai"
-import { expectError, makeTestGardenA } from "../../../../helpers"
+import { expectError, makeTestGardenA, withDefaultGlobalOpts } from "../../../../helpers"
 import { GetSecretCommand } from "../../../../../src/commands/get/get-secret"
 
 describe("GetSecretCommand", () => {
@@ -23,7 +23,7 @@ describe("GetSecretCommand", () => {
       log,
       logFooter: log,
       args: { provider, key: "project.mykey" },
-      opts: {},
+      opts: withDefaultGlobalOpts({}),
     })
 
     expect(res).to.eql({ "project.mykey": "myvalue" })
@@ -40,7 +40,7 @@ describe("GetSecretCommand", () => {
         log,
         logFooter: log,
         args: { provider, key: "project.mykey" },
-        opts: {},
+        opts: withDefaultGlobalOpts({}),
       }),
       "not-found",
     )

--- a/garden-service/test/unit/src/commands/get/get-tasks.ts
+++ b/garden-service/test/unit/src/commands/get/get-tasks.ts
@@ -1,5 +1,5 @@
 import { resolve } from "path"
-import { makeTestGarden, dataDir } from "../../../../helpers"
+import { makeTestGarden, dataDir, withDefaultGlobalOpts } from "../../../../helpers"
 import { GetTasksCommand } from "../../../../../src/commands/get/get-tasks"
 
 describe("GetTasksCommand", () => {
@@ -15,7 +15,7 @@ describe("GetTasksCommand", () => {
       log,
       logFooter: log,
       args: { tasks: undefined },
-      opts: {},
+      opts: withDefaultGlobalOpts({}),
     })
   })
 
@@ -29,7 +29,7 @@ describe("GetTasksCommand", () => {
       log,
       logFooter: log,
       args: { tasks: ["task-a"] },
-      opts: {},
+      opts: withDefaultGlobalOpts({}),
     })
   })
 })

--- a/garden-service/test/unit/src/commands/link.ts
+++ b/garden-service/test/unit/src/commands/link.ts
@@ -8,6 +8,7 @@ import {
   cleanProject,
   stubExtSources,
   makeTestGarden,
+  withDefaultGlobalOpts,
 } from "../../../helpers"
 import { LinkSourceCommand } from "../../../../src/commands/link/source"
 import { Garden } from "../../../../src/garden"
@@ -40,7 +41,7 @@ describe("LinkCommand", () => {
           module: "module-a",
           path: join(projectRoot, "mock-local-path", "module-a"),
         },
-        opts: {},
+        opts: withDefaultGlobalOpts({}),
       })
 
       const { linkedModuleSources } = await garden.localConfigStore.get()
@@ -59,7 +60,7 @@ describe("LinkCommand", () => {
           module: "module-a",
           path: join("mock-local-path", "module-a"),
         },
-        opts: {},
+        opts: withDefaultGlobalOpts({}),
       })
 
       const { linkedModuleSources } = await garden.localConfigStore.get()
@@ -80,7 +81,7 @@ describe("LinkCommand", () => {
               module: "banana",
               path: "",
             },
-            opts: {},
+            opts: withDefaultGlobalOpts({}),
           })
         ),
         "parameter",
@@ -111,7 +112,7 @@ describe("LinkCommand", () => {
           source: "source-a",
           path: join(projectRoot, "mock-local-path", "source-a"),
         },
-        opts: {},
+        opts: withDefaultGlobalOpts({}),
       })
 
       const { linkedProjectSources } = await garden.localConfigStore.get()
@@ -130,7 +131,7 @@ describe("LinkCommand", () => {
           source: "source-a",
           path: join("mock-local-path", "source-a"),
         },
-        opts: {},
+        opts: withDefaultGlobalOpts({}),
       })
 
       const { linkedProjectSources } = await garden.localConfigStore.get()

--- a/garden-service/test/unit/src/commands/publish.ts
+++ b/garden-service/test/unit/src/commands/publish.ts
@@ -5,7 +5,7 @@ import { expect } from "chai"
 import { Garden } from "../../../../src/garden"
 import { PluginFactory } from "../../../../src/types/plugin/plugin"
 import { PublishCommand } from "../../../../src/commands/publish"
-import { makeTestGardenA, configureTestModule } from "../../../helpers"
+import { makeTestGardenA, configureTestModule, withDefaultGlobalOpts } from "../../../helpers"
 import { taskResultOutputs } from "../../../helpers"
 
 const projectRootB = join(__dirname, "..", "..", "data", "test-project-b")
@@ -57,10 +57,10 @@ describe("PublishCommand", () => {
       args: {
         modules: undefined,
       },
-      opts: {
+      opts: withDefaultGlobalOpts({
         "allow-dirty": false,
         "force-build": false,
-      },
+      }),
     })
 
     expect(taskResultOutputs(result!)).to.eql({
@@ -84,10 +84,10 @@ describe("PublishCommand", () => {
       args: {
         modules: undefined,
       },
-      opts: {
+      opts: withDefaultGlobalOpts({
         "allow-dirty": false,
         "force-build": true,
-      },
+      }),
     })
 
     expect(taskResultOutputs(result!)).to.eql({
@@ -111,10 +111,10 @@ describe("PublishCommand", () => {
       args: {
         modules: ["module-a"],
       },
-      opts: {
+      opts: withDefaultGlobalOpts({
         "allow-dirty": false,
         "force-build": false,
-      },
+      }),
     })
 
     expect(taskResultOutputs(result!)).to.eql({
@@ -135,10 +135,10 @@ describe("PublishCommand", () => {
       args: {
         modules: ["module-c"],
       },
-      opts: {
+      opts: withDefaultGlobalOpts({
         "allow-dirty": false,
         "force-build": false,
-      },
+      }),
     })
 
     expect(taskResultOutputs(result!)).to.eql({
@@ -160,10 +160,10 @@ describe("PublishCommand", () => {
       args: {
         modules: ["module-a"],
       },
-      opts: {
+      opts: withDefaultGlobalOpts({
         "allow-dirty": false,
         "force-build": false,
-      },
+      }),
     })
 
     expect(taskResultOutputs(result!)).to.eql({

--- a/garden-service/test/unit/src/commands/run/module.ts
+++ b/garden-service/test/unit/src/commands/run/module.ts
@@ -4,6 +4,7 @@ import {
   makeTestGardenA,
   testModuleVersion,
   testNow,
+  withDefaultGlobalOpts,
 } from "../../../../helpers"
 import { expect } from "chai"
 import { Garden } from "../../../../../src/garden"
@@ -27,7 +28,7 @@ describe("RunModuleCommand", () => {
       log,
       logFooter: log,
       args: { module: "module-a", command: [] },
-      opts: { "interactive": false, "force-build": false },
+      opts: withDefaultGlobalOpts({ "interactive": false, "force-build": false }),
     })
 
     const expected: RunResult = {
@@ -50,7 +51,7 @@ describe("RunModuleCommand", () => {
       log,
       logFooter: log,
       args: { module: "module-a", command: ["my", "command"] },
-      opts: { "interactive": false, "force-build": false },
+      opts: withDefaultGlobalOpts({ "interactive": false, "force-build": false }),
     })
 
     const expected: RunResult = {

--- a/garden-service/test/unit/src/commands/run/service.ts
+++ b/garden-service/test/unit/src/commands/run/service.ts
@@ -4,6 +4,7 @@ import {
   makeTestGardenA,
   testModuleVersion,
   testNow,
+  withDefaultGlobalOpts,
 } from "../../../../helpers"
 import { expect } from "chai"
 import { Garden } from "../../../../../src/garden"
@@ -28,7 +29,7 @@ describe("RunServiceCommand", () => {
       log,
       logFooter: log,
       args: { service: "service-a" },
-      opts: { "force-build": false },
+      opts: withDefaultGlobalOpts({ "force-build": false }),
     })
 
     const expected: RunResult = {

--- a/garden-service/test/unit/src/commands/run/task.ts
+++ b/garden-service/test/unit/src/commands/run/task.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai"
 import { omit } from "lodash"
 import { RunTaskCommand } from "../../../../../src/commands/run/task"
-import { makeTestGardenA } from "../../../../helpers"
+import { makeTestGardenA, withDefaultGlobalOpts } from "../../../../helpers"
 
 describe("RunTaskCommand", () => {
 
@@ -15,7 +15,7 @@ describe("RunTaskCommand", () => {
       log,
       logFooter: log,
       args: { task: "task-a" },
-      opts: { "force-build": false },
+      opts: withDefaultGlobalOpts({ "force-build": false }),
     })
 
     const expected = {

--- a/garden-service/test/unit/src/commands/scan.ts
+++ b/garden-service/test/unit/src/commands/scan.ts
@@ -1,6 +1,6 @@
 import { Garden } from "../../../../src/garden"
 import { ScanCommand } from "../../../../src/commands/scan"
-import { getExampleProjects } from "../../../helpers"
+import { getExampleProjects, withDefaultGlobalOpts } from "../../../helpers"
 
 describe("ScanCommand", () => {
   for (const [name, path] of Object.entries(getExampleProjects())) {
@@ -14,7 +14,7 @@ describe("ScanCommand", () => {
         log,
         logFooter: log,
         args: {},
-        opts: {},
+        opts: withDefaultGlobalOpts({}),
       })
     })
   }

--- a/garden-service/test/unit/src/commands/set.ts
+++ b/garden-service/test/unit/src/commands/set.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai"
 import { SetSecretCommand } from "../../../../src/commands/set"
-import { makeTestGardenA } from "../../../helpers"
+import { makeTestGardenA, withDefaultGlobalOpts } from "../../../helpers"
 
 describe("SetSecretCommand", () => {
   const pluginName = "test-plugin"
@@ -16,7 +16,7 @@ describe("SetSecretCommand", () => {
       log,
       logFooter: log,
       args: { provider, key: "mykey", value: "myvalue" },
-      opts: {},
+      opts: withDefaultGlobalOpts({}),
     })
 
     expect(await garden.actions.getSecret({ log, pluginName, key: "mykey" })).to.eql({ value: "myvalue" })

--- a/garden-service/test/unit/src/commands/test.ts
+++ b/garden-service/test/unit/src/commands/test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai"
 import { TestCommand } from "../../../../src/commands/test"
 import * as isSubset from "is-subset"
-import { makeTestGardenA, taskResultOutputs } from "../../../helpers"
+import { makeTestGardenA, taskResultOutputs, withDefaultGlobalOpts } from "../../../helpers"
 
 describe("commands.test", () => {
   it("should run all tests in a simple project", async () => {
@@ -14,7 +14,7 @@ describe("commands.test", () => {
       log,
       logFooter: log,
       args: { modules: undefined },
-      opts: { "name": undefined, "force": true, "force-build": true, "watch": false },
+      opts: withDefaultGlobalOpts({ "name": undefined, "force": true, "force-build": true, "watch": false }),
     })
 
     expect(isSubset(taskResultOutputs(result!), {
@@ -52,7 +52,7 @@ describe("commands.test", () => {
       log,
       logFooter: log,
       args: { modules: ["module-a"] },
-      opts: { "name": undefined, "force": true, "force-build": true, "watch": false },
+      opts: withDefaultGlobalOpts({ "name": undefined, "force": true, "force-build": true, "watch": false }),
     })
 
     expect(isSubset(taskResultOutputs(result!), {

--- a/garden-service/test/unit/src/commands/unlink.ts
+++ b/garden-service/test/unit/src/commands/unlink.ts
@@ -8,6 +8,7 @@ import {
   stubExtSources,
   cleanProject,
   makeTestGarden,
+  withDefaultGlobalOpts,
 } from "../../../helpers"
 import { LinkSourceCommand } from "../../../../src/commands/link/source"
 import { UnlinkSourceCommand } from "../../../../src/commands/unlink/source"
@@ -36,7 +37,7 @@ describe("UnlinkCommand", () => {
           module: "module-a",
           path: join(projectRoot, "mock-local-path", "module-a"),
         },
-        opts: {},
+        opts: withDefaultGlobalOpts({}),
       })
       await linkCmd.action({
         garden,
@@ -46,7 +47,7 @@ describe("UnlinkCommand", () => {
           module: "module-b",
           path: join(projectRoot, "mock-local-path", "module-b"),
         },
-        opts: {},
+        opts: withDefaultGlobalOpts({}),
       })
       await linkCmd.action({
         garden,
@@ -56,7 +57,7 @@ describe("UnlinkCommand", () => {
           module: "module-c",
           path: join(projectRoot, "mock-local-path", "module-c"),
         },
-        opts: {},
+        opts: withDefaultGlobalOpts({}),
       })
     })
 
@@ -70,7 +71,7 @@ describe("UnlinkCommand", () => {
         log,
         logFooter: log,
         args: { modules: ["module-a", "module-b"] },
-        opts: { all: false },
+        opts: withDefaultGlobalOpts({ all: false }),
       })
       const { linkedModuleSources } = await garden.localConfigStore.get()
       expect(linkedModuleSources).to.eql([
@@ -84,7 +85,7 @@ describe("UnlinkCommand", () => {
         log,
         logFooter: log,
         args: { modules: undefined },
-        opts: { all: true },
+        opts: withDefaultGlobalOpts({ all: true }),
       })
       const { linkedModuleSources } = await garden.localConfigStore.get()
       expect(linkedModuleSources).to.eql([])
@@ -110,7 +111,7 @@ describe("UnlinkCommand", () => {
           source: "source-a",
           path: join(projectRoot, "mock-local-path", "source-a"),
         },
-        opts: {},
+        opts: withDefaultGlobalOpts({}),
       })
       await linkCmd.action({
         garden,
@@ -120,7 +121,7 @@ describe("UnlinkCommand", () => {
           source: "source-b",
           path: join(projectRoot, "mock-local-path", "source-b"),
         },
-        opts: {},
+        opts: withDefaultGlobalOpts({}),
       })
       await linkCmd.action({
         garden,
@@ -130,7 +131,7 @@ describe("UnlinkCommand", () => {
           source: "source-c",
           path: join(projectRoot, "mock-local-path", "source-c"),
         },
-        opts: {},
+        opts: withDefaultGlobalOpts({}),
       })
     })
 
@@ -144,7 +145,7 @@ describe("UnlinkCommand", () => {
         log,
         logFooter: log,
         args: { sources: ["source-a", "source-b"] },
-        opts: { all: false },
+        opts: withDefaultGlobalOpts({ all: false }),
       })
       const { linkedProjectSources } = await garden.localConfigStore.get()
       expect(linkedProjectSources).to.eql([
@@ -158,7 +159,7 @@ describe("UnlinkCommand", () => {
         log,
         logFooter: log,
         args: { sources: undefined },
-        opts: { all: true },
+        opts: withDefaultGlobalOpts({ all: true }),
       })
       const { linkedProjectSources } = await garden.localConfigStore.get()
       expect(linkedProjectSources).to.eql([])

--- a/garden-service/test/unit/src/commands/update-remote.ts
+++ b/garden-service/test/unit/src/commands/update-remote.ts
@@ -10,7 +10,14 @@ import { expect } from "chai"
 import { join } from "path"
 import { mkdirp, pathExists } from "fs-extra"
 
-import { getDataDir, expectError, stubExtSources, stubGitCli, makeTestGarden } from "../../../helpers"
+import {
+  getDataDir,
+  expectError,
+  stubExtSources,
+  stubGitCli,
+  makeTestGarden,
+  withDefaultGlobalOpts,
+} from "../../../helpers"
 import { UpdateRemoteSourcesCommand } from "../../../../src/commands/update-remote/sources"
 import { UpdateRemoteModulesCommand } from "../../../../src/commands/update-remote/modules"
 import { Garden } from "../../../../src/garden"
@@ -36,7 +43,7 @@ describe("UpdateRemoteCommand", () => {
         log,
         logFooter: log,
         args: { sources: undefined },
-        opts: {},
+        opts: withDefaultGlobalOpts({}),
       })
       expect(result!.map(s => s.name).sort()).to.eql(["source-a", "source-b", "source-c"])
     })
@@ -47,7 +54,7 @@ describe("UpdateRemoteCommand", () => {
         log,
         logFooter: log,
         args: { sources: ["source-a"] },
-        opts: {},
+        opts: withDefaultGlobalOpts({}),
       })
       expect(result!.map(s => s.name).sort()).to.eql(["source-a"])
     })
@@ -60,7 +67,7 @@ describe("UpdateRemoteCommand", () => {
         log,
         logFooter: log,
         args: { sources: undefined },
-        opts: {},
+        opts: withDefaultGlobalOpts({}),
       })
       expect(await pathExists(stalePath)).to.be.false
     })
@@ -73,7 +80,7 @@ describe("UpdateRemoteCommand", () => {
             log,
             logFooter: log,
             args: { sources: ["banana"] },
-            opts: {},
+            opts: withDefaultGlobalOpts({}),
           })
         ),
         "parameter",
@@ -100,7 +107,7 @@ describe("UpdateRemoteCommand", () => {
         log,
         logFooter: log,
         args: { modules: undefined },
-        opts: {},
+        opts: withDefaultGlobalOpts({}),
       })
       expect(result!.map(s => s.name).sort()).to.eql(["module-a", "module-b", "module-c"])
     })
@@ -111,7 +118,7 @@ describe("UpdateRemoteCommand", () => {
         log,
         logFooter: log,
         args: { modules: ["module-a"] },
-        opts: {},
+        opts: withDefaultGlobalOpts({}),
       })
       expect(result!.map(s => s.name).sort()).to.eql(["module-a"])
     })
@@ -124,7 +131,7 @@ describe("UpdateRemoteCommand", () => {
         log,
         logFooter: log,
         args: { modules: undefined },
-        opts: {},
+        opts: withDefaultGlobalOpts({}),
       })
       expect(await pathExists(stalePath)).to.be.false
     })
@@ -137,7 +144,7 @@ describe("UpdateRemoteCommand", () => {
             log,
             logFooter: log,
             args: { modules: ["banana"] },
-            opts: {},
+            opts: withDefaultGlobalOpts({}),
           })
         ),
         "parameter",

--- a/garden-service/test/unit/src/commands/validate.ts
+++ b/garden-service/test/unit/src/commands/validate.ts
@@ -1,7 +1,7 @@
 import { join } from "path"
 import { Garden } from "../../../../src/garden"
 import { ValidateCommand } from "../../../../src/commands/validate"
-import { expectError, getExampleProjects } from "../../../helpers"
+import { expectError, getExampleProjects, withDefaultGlobalOpts } from "../../../helpers"
 
 describe("commands.validate", () => {
   // validate all of the example projects
@@ -16,7 +16,7 @@ describe("commands.validate", () => {
         log,
         logFooter: log,
         args: {},
-        opts: {},
+        opts: withDefaultGlobalOpts({}),
       })
     })
   }
@@ -38,7 +38,7 @@ describe("commands.validate", () => {
       log,
       logFooter: log,
       args: {},
-      opts: {},
+      opts: withDefaultGlobalOpts({}),
     }), "configuration")
   })
 })


### PR DESCRIPTION
Make global CLI options (such as `output`) available in the `opts` command parameter.