### PR TITLE
fix(dashboard): stackgraph loses ws status when drawn

### DIFF
--- a/dashboard/src/containers/graph.tsx
+++ b/dashboard/src/containers/graph.tsx
@@ -42,6 +42,13 @@ export default () => {
   if (!config.data || !graph.data || config.loading || graph.loading) {
     return <Spinner />
   }
+  if (message && message.type === "event") {
+    const nodeToUpdate = graph.data.nodes.find(node => node.key === (message.payload && message.payload["key"]))
+    if (nodeToUpdate) {
+      nodeToUpdate.status = message.name
+      graph.data = { ...graph.data }
+    }
+  }
 
   let moreInfoPane: React.ReactNode = null
   if (selectedGraphNode && graph.data) {
@@ -59,7 +66,6 @@ export default () => {
     <Wrapper className="row">
       <div className={moreInfoPane ? "col-xs-7 col-sm-7 col-md-8 col-lg-8 col-xl-8" : "col-xs"}>
         <Graph
-          message={message}
           onGraphNodeSelected={selectGraphNode}
           selectedGraphNode={selectedGraphNode}
           layoutChanged={isSidebarOpen}

--- a/dashboard/src/context/data.tsx
+++ b/dashboard/src/context/data.tsx
@@ -27,10 +27,19 @@ import { TaskResultOutput } from "garden-cli/src/commands/get/get-task-result"
 import { StatusCommandResult } from "garden-cli/src/commands/get/get-status"
 import { TestResultOutput } from "garden-cli/src/commands/get/get-test-result"
 import { AxiosError } from "axios"
+import { RenderedNode } from "garden-cli/src/config-graph"
+import { SupportedEventName } from "./events"
 
 interface StoreCommon {
   error?: AxiosError
   loading: boolean
+}
+
+export interface RenderedNodeWithStatus extends RenderedNode {
+  status?: SupportedEventName
+}
+export interface GraphOutputWithNodeStatus extends GraphOutput {
+  nodes: RenderedNodeWithStatus[],
 }
 
 // This is the global data store
@@ -42,7 +51,7 @@ interface Store {
     data?: StatusCommandResult,
   },
   graph: StoreCommon & {
-    data?: GraphOutput,
+    data?: GraphOutputWithNodeStatus,
   },
   logs: StoreCommon & {
     data?: ServiceLogEntry[],


### PR DESCRIPTION
Symptom: The dashboard stack graph resets when I click a node. For example, if a test is broken, so a node has a red border, and I click it, the color goes back to green. Same applies if I click something while some nodes are pending/processing.

Fix: merged the event status into the graph object (in graph container) being passed to the graph component(graph/index)