### PR TITLE
fix: crash when deploy and docker not installed

### DIFF
--- a/garden-service/src/util/util.ts
+++ b/garden-service/src/util/util.ts
@@ -167,6 +167,14 @@ export function spawn(cmd: string, args: string[], opts: SpawnOpts = {}) {
       }, timeout * 1000)
     }
 
+    proc.on("error", (err) => {
+      let msg = `An error occurred while trying to run '${cmd}'.`
+      if ((<any>err).code === "ENOENT") {
+        msg = `${msg} Please make sure '${cmd}' is installed and in the $PATH.`
+      }
+      _reject(new RuntimeError(msg, { cmd, args, opts, result, err }))
+    })
+
     proc.on("close", (code) => {
       _timeout && clearTimeout(_timeout)
       result.code = code


### PR DESCRIPTION
Fixes #768.
The issue was due the fact we hadn't specify any handler for the `error` event which is the one emitted if the process cannot be spawned (which is the case if the command doesn't exist).

The output now it's something like this (from the vote-helm example):

```bash
18:07 $ g deploy
Deploy 🚀  

✔ providers                 → Getting status... → Ready
✔ base-chart                → Building version v-0141b6cf9d... → Done (took 0.4 sec)
 api-image                 → Getting build status...
✔ redis                     → Building version v-15f2b52f7f... → Done (took 1.6 sec)
✔ postgres                  → Building version v-4385910de3... → Done (took 1.4 sec)
 result-image              → Getting build status...
 vote-image                → Getting build status...

Failed building api-image. Here is the output:
————————————————————————————————————————————————————————————————————————————————
Unable to get docker version: An error occurred while trying to run 'docker'. Please make sure 'docker' is installed and in the $PATH.
————————————————————————————————————————————————————————————————————————————————


Failed building result-image. Here is the output:
————————————————————————————————————————————————————————————————————————————————
Unable to get docker version: An error occurred while trying to run 'docker'. Please make sure 'docker' is installed and in the $PATH.
————————————————————————————————————————————————————————————————————————————————


Failed building vote-image. Here is the output:
————————————————————————————————————————————————————————————————————————————————
Unable to get docker version: An error occurred while trying to run 'docker'. Please make sure 'docker' is installed and in the $PATH.
————————————————————————————————————————————————————————————————————————————————

 worker-image              → Getting build status...

Failed building worker-image. Here is the output:
————————————————————————————————————————————————————————————————————————————————
Unable to get docker version: An error occurred while trying to run 'docker'. Please make sure 'docker' is installed and in the $PATH.
————————————————————————————————————————————————————————————————————————————————

✔ postgres                  → Checking status... → Version v-4385910de3 already deployed
✔ redis                     → Checking status... → Version v-15f2b52f7f already deployed
✔ db-init                   → Running → Done (took 3 sec)

4 deploy task(s) failed!

See error.log for detailed error message
``` 

as well as the errors being logged in the `error.log`.

I guess this looks kinda ok, let me know if you'd like some other visual adjustments.
E.