### PR TITLE
improvement(dashboard): add graph filters to global context

### DIFF
--- a/dashboard/src/components/group-filter.tsx
+++ b/dashboard/src/components/group-filter.tsx
@@ -46,7 +46,7 @@ const FilterGroup = styled.ul`
 `
 export type Filters<T extends string> = {
   [key in T]: {
-    label: string
+    label: string,
     selected: boolean,
     readonly?: boolean,
   }

--- a/dashboard/src/containers/graph.tsx
+++ b/dashboard/src/containers/graph.tsx
@@ -12,9 +12,11 @@ import Graph from "../components/graph"
 import PageError from "../components/page-error"
 import { EventContext } from "../context/events"
 import { DataContext } from "../context/data"
-import { UiStateContext } from "../context/ui"
+import { UiStateContext, StackGraphSupportedFilterKeys } from "../context/ui"
 import { NodeInfo } from "./node-info"
 import Spinner from "../components/spinner"
+import { Filters } from "../components/group-filter"
+import { capitalize } from "lodash"
 
 const Wrapper = styled.div`
 padding-left: .75rem;
@@ -31,8 +33,8 @@ export default () => {
   useEffect(loadGraph, [])
 
   const {
-    actions: { selectGraphNode },
-    state: { selectedGraphNode, isSidebarOpen },
+    actions: { selectGraphNode, stackGraphToggleItemsView },
+    state: { selectedGraphNode, isSidebarOpen, stackGraph: { filters } },
   } = useContext(UiStateContext)
 
   if (config.error || graph.error) {
@@ -62,6 +64,19 @@ export default () => {
     }
   }
 
+  const createFiltersState =
+    (allGroupFilters, type): Filters<StackGraphSupportedFilterKeys> => {
+      return ({
+        ...allGroupFilters,
+        [type]: {
+          label: capitalize(type),
+          selected: filters[type],
+        },
+      })
+    }
+
+  const graphFilters = Object.keys(filters).reduce(createFiltersState, {}) as Filters<StackGraphSupportedFilterKeys>
+
   return (
     <Wrapper className="row">
       <div className={moreInfoPane ? "col-xs-7 col-sm-7 col-md-8 col-lg-8 col-xl-8" : "col-xs"}>
@@ -71,6 +86,8 @@ export default () => {
           layoutChanged={isSidebarOpen}
           config={config.data}
           graph={graph.data}
+          filters={graphFilters}
+          onFilter={stackGraphToggleItemsView}
         />
       </div>
       {moreInfoPane}

--- a/dashboard/src/context/ui.tsx
+++ b/dashboard/src/context/ui.tsx
@@ -35,7 +35,8 @@ export type StackGraphSupportedFilterKeys = Exclude<RenderedNodeType, "publish">
 
 interface UiActions {
   toggleSidebar: () => void
-  overviewToggleItemsView: (itemToToggle: OverviewSupportedFilterKeys) => void
+  overviewToggleItemsView: (filterKey: OverviewSupportedFilterKeys) => void
+  stackGraphToggleItemsView: (filterKey: StackGraphSupportedFilterKeys) => void
   selectGraphNode: SelectGraphNode
   selectIngress: SelectIngress
   clearGraphNodeSelection: () => void
@@ -84,14 +85,27 @@ const useUiState = () => {
     })
   }
 
-  const overviewToggleItemsView = (itemToToggle: OverviewSupportedFilterKeys) => {
+  const overviewToggleItemsView = (filterKey: OverviewSupportedFilterKeys) => {
     setState({
       ...uiState,
       overview: {
         ...uiState.overview,
         filters: {
           ...uiState.overview.filters,
-          [itemToToggle]: !uiState.overview.filters[itemToToggle],
+          [filterKey]: !uiState.overview.filters[filterKey],
+        },
+      },
+    })
+  }
+
+  const stackGraphToggleItemsView = (filterKey: StackGraphSupportedFilterKeys) => {
+    setState({
+      ...uiState,
+      stackGraph: {
+        ...uiState.stackGraph,
+        filters: {
+          ...uiState.stackGraph.filters,
+          [filterKey]: !uiState.stackGraph.filters[filterKey],
         },
       },
     })
@@ -124,6 +138,7 @@ const useUiState = () => {
     actions: {
       toggleSidebar,
       overviewToggleItemsView,
+      stackGraphToggleItemsView,
       selectGraphNode,
       clearGraphNodeSelection,
       selectIngress,


### PR DESCRIPTION
Useful for many cases such as making the filters still valid if the user leave the page and comes back