### PR TITLE
fix: some commands terminate with double new line

### DIFF
--- a/garden-service/src/commands/base.ts
+++ b/garden-service/src/commands/base.ts
@@ -13,7 +13,7 @@ import { LoggerType } from "../logger/logger"
 import { ProcessResults } from "../process"
 import { Garden } from "../garden"
 import { LogEntry } from "../logger/log-entry"
-import { logHeader } from "../logger/util"
+import { logFooter } from "../logger/util"
 import { GlobalOptions } from "../cli/cli"
 
 export class ValidationError extends Error { }
@@ -304,7 +304,7 @@ export async function handleTaskResults(
   }
 
   if (!results.restartRequired) {
-    logHeader({ log, emoji: "heavy_check_mark", command: `Done!` })
+    logFooter({ log, emoji: "heavy_check_mark", command: `Done!` })
   }
   return {
     result: results.taskResults,

--- a/garden-service/src/commands/init.ts
+++ b/garden-service/src/commands/init.ts
@@ -12,7 +12,7 @@ import {
   CommandResult,
   CommandParams,
 } from "./base"
-import { logHeader } from "../logger/util"
+import { logHeader, logFooter } from "../logger/util"
 import dedent = require("dedent")
 
 const initOpts = {
@@ -47,7 +47,7 @@ export class InitCommand extends Command {
     await garden.actions.prepareEnvironment({ log, force: opts.force, allowUserInput: true })
 
     log.info("")
-    logHeader({ log, emoji: "heavy_check_mark", command: `Done!` })
+    logFooter({ log, emoji: "heavy_check_mark", command: `Done!` })
 
     return { result: {} }
   }

--- a/garden-service/src/commands/run/task.ts
+++ b/garden-service/src/commands/run/task.ts
@@ -17,7 +17,7 @@ import {
 import dedent = require("dedent")
 import { TaskTask } from "../../tasks/task"
 import { TaskResult } from "../../task-graph"
-import { logHeader } from "../../logger/util"
+import { logHeader, logFooter } from "../../logger/util"
 
 const runArgs = {
   task: new StringParameter({
@@ -66,7 +66,7 @@ export class RunTaskCommand extends Command<Args, Opts> {
       log.info("")
       log.info(chalk.white(result.output.output))
       log.info("")
-      logHeader({ log, emoji: "heavy_check_mark", command: `Done!` })
+      logFooter({ log, emoji: "heavy_check_mark", command: `Done!` })
     }
 
     return { result }

--- a/garden-service/src/logger/util.ts
+++ b/garden-service/src/logger/util.ts
@@ -118,15 +118,20 @@ interface LogHeaderOptions {
   log: LogEntry
   command: string
   emoji?: EmojiName
-  level?: LogLevel
+  level?: LogLevel,
+  newLine?: boolean,
 }
 
-export function logHeader({ log, command, emoji, level = LogLevel.info }: LogHeaderOptions): LogEntry {
+export function logHeader({ log, command, emoji, level = LogLevel.info, newLine = true }: LogHeaderOptions): LogEntry {
   const msg = combine([
     [chalk.bold.magenta(command)],
     [emoji && log.root.useEmoji ? " " + printEmoji(emoji) : ""],
-    ["\n"],
+    [newLine ? "\n" : ""],
   ])
   const lvlStr = LogLevel[level]
   return log[lvlStr](msg)
+}
+
+export function logFooter(opts: LogHeaderOptions): LogEntry {
+  return logHeader({ ...opts, newLine: false })
 }


### PR DESCRIPTION
Introduce a new function called logFooter() to be used instead of logHeader(). 
It's (for now) just a wrapper around logHeader with the only differences being semantically more clear and implementing a new flag for adding a new line at the end of the command.
It can be extendend if we need to add more fancy logging at the end of a command.

Fixes #769