### PR TITLE
feat(k8s): optionally enable ingress controll for remote k8s

### DIFF
--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -581,6 +581,14 @@ Specify which namespace to deploy services to (defaults to <project name>). Note
 | Type | Required |
 | ---- | -------- |
 | `string` | No
+### `environments[].providers[].setupIngressController`
+[environments](#environments) > [providers](#environments[].providers[]) > setupIngressController
+
+Set this to `nginx` to install/enable the NGINX ingress controller.
+
+| Type | Required |
+| ---- | -------- |
+| `string` | No
 
 
 ## Complete YAML schema
@@ -643,4 +651,5 @@ environments:
         ingressHttpPort: 80
         ingressHttpsPort: 443
         namespace:
+        setupIngressController: false
 ```

--- a/garden-service/src/plugins/kubernetes/config.ts
+++ b/garden-service/src/plugins/kubernetes/config.ts
@@ -274,5 +274,9 @@ export const configSchema = kubernetesConfigBase
         "Specify which namespace to deploy services to (defaults to <project name>). " +
         "Note that the framework generates other namespaces as well with this name as a prefix.",
       ),
+    setupIngressController: Joi.string()
+      .allow("nginx", false, null)
+      .default(false)
+      .description("Set this to `nginx` to install/enable the NGINX ingress controller."),
     _system: Joi.any().meta({ internal: true }),
   })

--- a/garden-service/src/plugins/kubernetes/kubernetes.ts
+++ b/garden-service/src/plugins/kubernetes/kubernetes.ts
@@ -26,8 +26,14 @@ import { ConfigurationError } from "../../exceptions"
 export const name = "kubernetes"
 
 export async function configureProvider({ projectName, config }: ConfigureProviderParams<KubernetesConfig>) {
+  config._systemServices = []
+
   if (!config.namespace) {
     config.namespace = projectName
+  }
+
+  if (config.setupIngressController === "nginx") {
+    config._systemServices.push("ingress-controller", "default-backend")
   }
 
   if (config.buildMode === "cluster-docker") {
@@ -47,7 +53,7 @@ export async function configureProvider({ projectName, config }: ConfigureProvid
     }
 
     // Deploy build services on init
-    config._systemServices = ["docker-daemon", "docker-registry", "registry-proxy"]
+    config._systemServices.push("docker-daemon", "docker-registry", "registry-proxy")
 
   } else if (!config.deploymentRegistry) {
     throw new ConfigurationError(


### PR DESCRIPTION
Note that the base branch is `remote-build`. We can either merge this into that one or wait until #808 is merged and change the base branch to `master`.

I'll update the "Remote Cluster" docs in a separate PR to avoid link check errors. 