### PR TITLE
fix: improved error messages for call command

### DIFF
--- a/garden-service/src/commands/call.ts
+++ b/garden-service/src/commands/call.ts
@@ -65,7 +65,7 @@ export class CallCommand extends Command<Args> {
       })
     }
 
-    if (!status.ingresses) {
+    if (!status.ingresses || status.ingresses.length === 0) {
       throw new ParameterError(`Service ${service.name} has no active ingresses`, {
         serviceName: service.name,
         serviceStatus: status,


### PR DESCRIPTION
Before this commit, running `garden call some-service` when `some-service` defines no ingresses would result in a cryptic error message (`Cannot read property 'path' of undefined`).

Now, the command outputs `Service user has no active ingresses` in such cases instead.