### PR TITLE
Cli updates

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -13,11 +13,17 @@ The following option flags can be used with any of the CLI commands:
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
+  | `--version` | `-v` | string | Show the current CLI version.
+  | `--help` | `-h` | string | Show help
   | `--root` | `-r` | string | Override project root directory (defaults to working directory).
-  | `--silent` | `-s` | boolean | Suppress log output.
+  | `--silent` | `-s` | boolean | Suppress log output. Same as setting --logger-type&#x3D;quiet.
   | `--env` | `-e` | string | The environment (and optionally namespace) to work against.
-  | `--logger-type` |  | `quiet` `basic` `fancy` `json`  | Set logger type: fancy: updates log lines in-place when their status changes (e.g. when tasks complete), basic: appends a new log line when a log line&#x27;s status changes, json: same as basic, but renders log lines as JSON, quiet: uppresses all log output,
-  | `--loglevel` | `-l` | `error` `warn` `info` `verbose` `debug` `silly` `0` `1` `2` `3` `4` `5`  | Set logger level. Values can be either string or numeric and are prioritized from 0 to 5 (highest to lowest) as follows: error: 0, warn: 1, info: 2, verbose: 3, debug: 4, silly: 5.
+  | `--logger-type` |  | `quiet` `basic` `fancy` `json`  | Set logger type.
+[1mfancy:[22m updates log lines in-place when their status changes (e.g. when tasks complete),
+[1mbasic:[22m appends a new log line when a log line&#x27;s status changes,
+[1mjson:[22m same as basic, but renders log lines as JSON,
+[1mquiet:[22m suppresses all log output, same as --silent.
+  | `--log-level` | `-l` | `error` `warn` `info` `verbose` `debug` `silly` `0` `1` `2` `3` `4` `5`  | Set logger level. Values can be either string or numeric and are prioritized from 0 to 5 (highest to lowest) as follows: error: 0, warn: 1, info: 2, verbose: 3, debug: 4, silly: 5.
   | `--output` | `-o` | `json` `yaml`  | Output command result in specified format (note: disables progress logging and interactive functionality).
   | `--emoji` |  | boolean | Enable emoji in output (defaults to true if the environment supports it).
 
@@ -439,6 +445,16 @@ Examples:
 | -------- | ----- | ---- | ----------- |
   | `--follow` | `-f` | boolean | Continuously stream new logs from the service(s).
   | `--tail` | `-t` | number | Number of lines to show for each service. Defaults to -1, showing all log lines.
+
+### garden options
+
+Print global options
+
+Prints all global options (options that can be applied to any command).
+
+##### Usage
+
+    garden options 
 
 ### garden publish
 

--- a/garden-service/package-lock.json
+++ b/garden-service/package-lock.json
@@ -2904,6 +2904,41 @@
         "yargs": "^13.0.0"
       }
     },
+    "cli-table3": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
+      "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
+      "requires": {
+        "colors": "^1.1.2",
+        "object-assign": "^4.1.0",
+        "string-width": "^2.1.1"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+          "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
+          "optional": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
     "cli-truncate": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-1.1.0.tgz",

--- a/garden-service/package.json
+++ b/garden-service/package.json
@@ -37,6 +37,7 @@
     "chokidar": "^3.0.0",
     "cli-cursor": "^3.0.0",
     "cli-highlight": "^2.1.1",
+    "cli-table3": "^0.5.1",
     "cli-truncate": "^1.1.0",
     "cross-spawn": "^6.0.5",
     "cryo": "0.0.6",

--- a/garden-service/src/cli/cli.ts
+++ b/garden-service/src/cli/cli.ts
@@ -259,17 +259,14 @@ export class GardenCli {
       const level = parseLogLevel(logLevel)
       const logger = initLogger({ level, loggerType, emoji })
 
-      // Currently we initialise an empty placeholder log entry and pass that to the
-      // framework as opposed to the logger itself. This is mainly for type conformity.
-      // A log entry has the same capabilities as the logger itself (they both extend a log node)
-      // but can additionally be updated after it's created, whereas the logger can create only new
-      // entries (i.e. print new lines).
+      // Currently we initialise empty placeholder entries and pass those to the
+      // framework as opposed to the logger itself. This is to give better control over where on
+      // the screen the logs are printed.
+      const headerLog = logger.placeholder()
+      logger.info("") // Put one line between the header and the body
       const log = logger.placeholder()
-
-      // We pass a separate placeholder to the action method, so that commands can easily have a footer
-      // section in their log output.
-      logger.info("")   // Put one line between the body and the footer
-      const logFooter = logger.placeholder()
+      logger.info("") // Put one line between the body and the footer
+      const footerLog = logger.placeholder()
 
       const contextOpts: GardenOpts = { environmentName: env, log }
       if (command.noProject) {
@@ -280,7 +277,8 @@ export class GardenCli {
 
       await command.prepare({
         log,
-        logFooter,
+        headerLog,
+        footerLog,
         args: parsedArgs,
         opts: parsedOpts,
       })
@@ -297,7 +295,8 @@ export class GardenCli {
           result = await command.action({
             garden,
             log,
-            logFooter,
+            footerLog,
+            headerLog,
             args: parsedArgs,
             opts: parsedOpts,
           })

--- a/garden-service/src/cli/helpers.ts
+++ b/garden-service/src/cli/helpers.ts
@@ -60,6 +60,14 @@ export const filterByKeys = (obj: any, keys: string[]): any => {
   }, {})
 }
 
+/**
+ * The maximum width of the help text that the CLI outputs. E.g. when running "garden --help" or "garden options".
+ */
+export function helpTextMaxWidth() {
+  const cols = process.stdout.columns || 100
+  return Math.min(100, cols)
+}
+
 // Add platforms/terminals?
 export function envSupportsEmoji() {
   return process.platform === "darwin"

--- a/garden-service/src/commands/base.ts
+++ b/garden-service/src/commands/base.ts
@@ -13,7 +13,7 @@ import { LoggerType } from "../logger/logger"
 import { ProcessResults } from "../process"
 import { Garden } from "../garden"
 import { LogEntry } from "../logger/log-entry"
-import { logFooter } from "../logger/util"
+import { printFooter } from "../logger/util"
 import { GlobalOptions } from "../cli/cli"
 
 export class ValidationError extends Error { }
@@ -210,7 +210,8 @@ export interface PrepareParams<T extends Parameters = {}, U extends Parameters =
   args: ParameterValues<T>
   opts: ParameterValues<GlobalOptions & U>
   log: LogEntry
-  logFooter: LogEntry
+  headerLog: LogEntry
+  footerLog: LogEntry
 }
 
 export interface CommandParams<T extends Parameters = {}, U extends Parameters = {}> extends PrepareParams<T, U> {
@@ -304,7 +305,7 @@ export async function handleTaskResults(
   }
 
   if (!results.restartRequired) {
-    logFooter({ log, emoji: "heavy_check_mark", command: `Done!` })
+    printFooter(log)
   }
   return {
     result: results.taskResults,

--- a/garden-service/src/commands/build.ts
+++ b/garden-service/src/commands/build.ts
@@ -19,7 +19,7 @@ import { BuildTask } from "../tasks/build"
 import { TaskResults } from "../task-graph"
 import dedent = require("dedent")
 import { processModules } from "../process"
-import { logHeader } from "../logger/util"
+import { printHeader } from "../logger/util"
 import { startServer, GardenServer } from "../server/server"
 
 const buildArguments = {
@@ -61,16 +61,16 @@ export class BuildCommand extends Command<Args, Opts> {
 
   private server: GardenServer
 
-  async prepare({ log, logFooter, opts }: PrepareParams<Args, Opts>) {
-    logHeader({ log, emoji: "hammer", command: "Build" })
+  async prepare({ headerLog, footerLog, opts }: PrepareParams<Args, Opts>) {
+    printHeader(headerLog, "Build", "hammer")
 
     if (!!opts.watch) {
-      this.server = await startServer(logFooter)
+      this.server = await startServer(footerLog)
     }
   }
 
   async action(
-    { args, opts, garden, log, logFooter }: CommandParams<Args, Opts>,
+    { args, opts, garden, log, footerLog }: CommandParams<Args, Opts>,
   ): Promise<CommandResult<TaskResults>> {
     if (this.server) {
       this.server.setGarden(garden)
@@ -86,7 +86,7 @@ export class BuildCommand extends Command<Args, Opts> {
       garden,
       graph: await garden.getConfigGraph(),
       log,
-      logFooter,
+      footerLog,
       modules,
       watch: opts.watch,
       handler: async (_, module) => [new BuildTask({ garden, log, module, force: opts.force })],
@@ -98,6 +98,6 @@ export class BuildCommand extends Command<Args, Opts> {
       },
     })
 
-    return handleTaskResults(log, "build", results)
+    return handleTaskResults(footerLog, "build", results)
   }
 }

--- a/garden-service/src/commands/commands.ts
+++ b/garden-service/src/commands/commands.ts
@@ -26,6 +26,7 @@ import { UpdateRemoteCommand } from "./update-remote/update-remote"
 import { ValidateCommand } from "./validate"
 import { ExecCommand } from "./exec"
 import { ServeCommand } from "./serve"
+import { OptionsCommand } from "./options"
 
 export const coreCommands: Command[] = [
   new BuildCommand(),
@@ -38,6 +39,7 @@ export const coreCommands: Command[] = [
   new InitCommand(),
   new LinkCommand(),
   new LogsCommand(),
+  new OptionsCommand(),
   new PublishCommand(),
   new RunCommand(),
   new ScanCommand(),

--- a/garden-service/src/commands/delete.ts
+++ b/garden-service/src/commands/delete.ts
@@ -17,7 +17,7 @@ import {
 import { NotFoundError } from "../exceptions"
 import dedent = require("dedent")
 import { ServiceStatus, getServiceRuntimeContext } from "../types/service"
-import { logHeader } from "../logger/util"
+import { printHeader } from "../logger/util"
 import { DeleteSecretResult } from "../types/plugin/provider/deleteSecret"
 import { EnvironmentStatusMap } from "../types/plugin/provider/getEnvironmentStatus"
 
@@ -93,8 +93,8 @@ export class DeleteEnvironmentCommand extends Command {
     resources.
   `
 
-  async action({ garden, log }: CommandParams): Promise<CommandResult<EnvironmentStatusMap>> {
-    logHeader({ log, emoji: "skull_and_crossbones", command: `Deleting ${garden.environmentName} environment` })
+  async action({ garden, log, headerLog }: CommandParams): Promise<CommandResult<EnvironmentStatusMap>> {
+    printHeader(headerLog, `Deleting ${garden.environmentName} environment`, "skull_and_crossbones")
 
     const actions = await garden.getActionHelper()
     const result = await actions.cleanupEnvironment({ log })
@@ -127,7 +127,7 @@ export class DeleteServiceCommand extends Command {
         garden delete service my-service # deletes my-service
   `
 
-  async action({ garden, log, args }: CommandParams<DeleteServiceArgs>): Promise<CommandResult> {
+  async action({ garden, log, headerLog, args }: CommandParams<DeleteServiceArgs>): Promise<CommandResult> {
     const graph = await garden.getConfigGraph()
     const services = await graph.getServices(args.services)
 
@@ -136,7 +136,7 @@ export class DeleteServiceCommand extends Command {
       return { result: {} }
     }
 
-    logHeader({ log, emoji: "skull_and_crossbones", command: `Delete service` })
+    printHeader(headerLog, "Delete service", "skull_and_crossbones")
 
     const result: { [key: string]: ServiceStatus } = {}
 

--- a/garden-service/src/commands/deploy.ts
+++ b/garden-service/src/commands/deploy.ts
@@ -21,7 +21,7 @@ import {
 import { getDependantTasksForModule } from "../tasks/helpers"
 import { TaskResults } from "../task-graph"
 import { processServices } from "../process"
-import { logHeader } from "../logger/util"
+import { printHeader } from "../logger/util"
 import { HotReloadTask } from "../tasks/hot-reload"
 import { BaseTask } from "../tasks/base"
 import { getHotReloadServiceNames, validateHotReloadServiceNames } from "./helpers"
@@ -84,15 +84,15 @@ export class DeployCommand extends Command<Args, Opts> {
 
   private server: GardenServer
 
-  async prepare({ log, logFooter, opts }: PrepareParams<Args, Opts>) {
-    logHeader({ log, emoji: "rocket", command: "Deploy" })
+  async prepare({ headerLog, footerLog, opts }: PrepareParams<Args, Opts>) {
+    printHeader(headerLog, "Deploy", "rocket")
 
     if (!!opts.watch || !!opts["hot-reload"]) {
-      this.server = await startServer(logFooter)
+      this.server = await startServer(footerLog)
     }
   }
 
-  async action({ garden, log, logFooter, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<TaskResults>> {
+  async action({ garden, log, footerLog, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<TaskResults>> {
     if (this.server) {
       this.server.setGarden(garden)
     }
@@ -128,7 +128,7 @@ export class DeployCommand extends Command<Args, Opts> {
       garden,
       graph: initGraph,
       log,
-      logFooter,
+      footerLog,
       services,
       watch,
       handler: async (graph, module) => getDependantTasksForModule({
@@ -158,6 +158,6 @@ export class DeployCommand extends Command<Args, Opts> {
       },
     })
 
-    return handleTaskResults(log, "deploy", results)
+    return handleTaskResults(footerLog, "deploy", results)
   }
 }

--- a/garden-service/src/commands/dev.ts
+++ b/garden-service/src/commands/dev.ts
@@ -77,17 +77,17 @@ export class DevCommand extends Command<Args, Opts> {
 
   private server: GardenServer
 
-  async prepare({ log, logFooter }: PrepareParams<Args, Opts>) {
+  async prepare({ log, footerLog }: PrepareParams<Args, Opts>) {
     // print ANSI banner image
     const data = await readFile(ansiBannerPath)
     log.info(data.toString())
 
     log.info(chalk.gray.italic(`\nGood ${getGreetingTime()}! Let's get your environment wired up...\n`))
 
-    this.server = await startServer(logFooter)
+    this.server = await startServer(footerLog)
   }
 
-  async action({ garden, log, logFooter, opts }: CommandParams<Args, Opts>): Promise<CommandResult> {
+  async action({ garden, log, footerLog, opts }: CommandParams<Args, Opts>): Promise<CommandResult> {
     this.server.setGarden(garden)
 
     const actions = await garden.getActionHelper()
@@ -97,7 +97,7 @@ export class DevCommand extends Command<Args, Opts> {
     const modules = await graph.getModules()
 
     if (modules.length === 0) {
-      logFooter && logFooter.setState({ msg: "" })
+      footerLog && footerLog.setState({ msg: "" })
       log.info({ msg: "No modules found in project." })
       log.info({ msg: "Aborting..." })
       return {}
@@ -155,14 +155,14 @@ export class DevCommand extends Command<Args, Opts> {
       garden,
       graph,
       log,
-      logFooter,
+      footerLog,
       modules,
       watch: true,
       handler: tasksForModule(false),
       changeHandler: tasksForModule(true),
     })
 
-    return handleTaskResults(log, "dev", results)
+    return handleTaskResults(footerLog, "dev", results)
   }
 }
 

--- a/garden-service/src/commands/exec.ts
+++ b/garden-service/src/commands/exec.ts
@@ -9,7 +9,7 @@
 import chalk from "chalk"
 import { LoggerType } from "../logger/logger"
 import { ExecInServiceResult } from "../types/plugin/service/execInService"
-import { logHeader } from "../logger/util"
+import { printHeader } from "../logger/util"
 import {
   Command,
   CommandResult,
@@ -63,15 +63,17 @@ export class ExecCommand extends Command<Args> {
   options = runOpts
   loggerType: LoggerType = "basic"
 
-  async action({ garden, log, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<ExecInServiceResult>> {
+  async action(
+    { garden, log, headerLog, args, opts }: CommandParams<Args, Opts>,
+  ): Promise<CommandResult<ExecInServiceResult>> {
     const serviceName = args.service
     const command = args.command || []
 
-    logHeader({
-      log,
-      emoji: "runner",
-      command: `Running command ${chalk.cyan(command.join(" "))} in service ${chalk.cyan(serviceName)}`,
-    })
+    printHeader(
+      headerLog,
+      `Running command ${chalk.cyan(command.join(" "))} in service ${chalk.cyan(serviceName)}`,
+      "runner",
+    )
 
     const graph = await garden.getConfigGraph()
     const service = await graph.getService(serviceName)

--- a/garden-service/src/commands/get/get-task-result.ts
+++ b/garden-service/src/commands/get/get-task-result.ts
@@ -13,7 +13,7 @@ import {
   CommandParams,
   StringParameter,
 } from "../base"
-import { logHeader } from "../../logger/util"
+import { printHeader } from "../../logger/util"
 import { getTaskVersion } from "../../tasks/task"
 import { RunTaskResult } from "../../types/plugin/task/runTask"
 import chalk from "chalk"
@@ -42,11 +42,7 @@ export class GetTaskResultCommand extends Command<Args> {
 
   arguments = getTaskResultArgs
 
-  async action({
-    garden,
-    log,
-    args,
-  }: CommandParams<Args>): Promise<CommandResult<TaskResultOutput>> {
+  async action({ garden, log, headerLog, args }: CommandParams<Args>): Promise<CommandResult<TaskResultOutput>> {
     const taskName = args.name
 
     const graph: ConfigGraph = await garden.getConfigGraph()
@@ -62,11 +58,11 @@ export class GetTaskResultCommand extends Command<Args> {
       },
     )
 
-    logHeader({
-      log,
-      emoji: "rocket",
-      command: `Task result for task ${chalk.cyan(taskName)}`,
-    })
+    printHeader(
+      headerLog,
+      `Task result for task ${chalk.cyan(taskName)}`,
+      "rocket",
+    )
 
     if (taskResult !== null) {
       const output: TaskResultOutput = {

--- a/garden-service/src/commands/get/get-tasks.ts
+++ b/garden-service/src/commands/get/get-tasks.ts
@@ -16,7 +16,7 @@ import {
   StringsParameter,
   PrepareParams,
 } from "../base"
-import { logHeader } from "../../logger/util"
+import { printHeader } from "../../logger/util"
 import { Task } from "../../types/task"
 
 const getTasksArgs = {
@@ -61,8 +61,8 @@ export class GetTasksCommand extends Command<Args> {
 
   arguments = getTasksArgs
 
-  async prepare({ log }: PrepareParams<Args>) {
-    logHeader({ log, emoji: "open_book", command: "Tasks" })
+  async prepare({ headerLog }: PrepareParams<Args>) {
+    printHeader(headerLog, "Tasks", "open_book")
   }
 
   async action({ args, garden, log }: CommandParams<Args>): Promise<CommandResult> {

--- a/garden-service/src/commands/get/get-test-result.ts
+++ b/garden-service/src/commands/get/get-test-result.ts
@@ -16,7 +16,7 @@ import { NotFoundError } from "../../exceptions"
 import { TestResult } from "../../types/plugin/module/getTestResult"
 import { getTestVersion } from "../../tasks/test"
 import { findByName, getNames } from "../../util/util"
-import { logHeader } from "../../logger/util"
+import { printHeader } from "../../logger/util"
 import chalk from "chalk"
 
 export interface TestResultOutput {
@@ -47,21 +47,17 @@ export class GetTestResultCommand extends Command<Args> {
 
   arguments = getTestResultArgs
 
-  async action({
-    garden,
-    log,
-    args,
-  }: CommandParams<Args>): Promise<CommandResult<TestResultOutput>> {
+  async action({ garden, log, headerLog, args }: CommandParams<Args>): Promise<CommandResult<TestResultOutput>> {
     const testName = args.name
     const moduleName = args.module
 
-    logHeader({
-      log,
-      emoji: "heavy_check_mark",
-      command: `Test result for test ${chalk.cyan(testName)} in module ${chalk.cyan(
+    printHeader(
+      headerLog,
+      `Test result for test ${chalk.cyan(testName)} in module ${chalk.cyan(
         moduleName,
       )}`,
-    })
+      "heavy_check_mark",
+    )
 
     const graph = await garden.getConfigGraph()
     const actions = await garden.getActionHelper()

--- a/garden-service/src/commands/init.ts
+++ b/garden-service/src/commands/init.ts
@@ -12,7 +12,7 @@ import {
   CommandResult,
   CommandParams,
 } from "./base"
-import { logHeader, logFooter } from "../logger/util"
+import { printHeader, printFooter } from "../logger/util"
 import dedent = require("dedent")
 
 const initOpts = {
@@ -40,15 +40,14 @@ export class InitCommand extends Command {
 
   options = initOpts
 
-  async action({ garden, log, opts }: CommandParams<{}, Opts>): Promise<CommandResult<{}>> {
+  async action({ garden, log, footerLog, headerLog, opts }: CommandParams<{}, Opts>): Promise<CommandResult<{}>> {
     const name = garden.environmentName
-    logHeader({ log, emoji: "gear", command: `Initializing ${name} environment` })
+    printHeader(headerLog, `Initializing ${name} environment`, "gear")
 
     const actions = await garden.getActionHelper()
     await actions.prepareEnvironment({ log, force: opts.force, manualInit: true })
 
-    log.info("")
-    logFooter({ log, emoji: "heavy_check_mark", command: `Done!` })
+    printFooter(footerLog)
 
     return { result: {} }
   }

--- a/garden-service/src/commands/link/module.ts
+++ b/garden-service/src/commands/link/module.ts
@@ -19,7 +19,7 @@ import {
   CommandParams,
 } from "../base"
 import { LinkedSource } from "../../config-store"
-import { logHeader } from "../../logger/util"
+import { printHeader } from "../../logger/util"
 import {
   addLinkedSources,
   hasRemoteSource,
@@ -53,8 +53,8 @@ export class LinkModuleCommand extends Command<Args> {
         garden link module my-module path/to/my-module # links my-module to its local version at the given path
   `
 
-  async action({ garden, log, args }: CommandParams<Args>): Promise<CommandResult<LinkedSource[]>> {
-    logHeader({ log, emoji: "link", command: "link module" })
+  async action({ garden, log, headerLog, args }: CommandParams<Args>): Promise<CommandResult<LinkedSource[]>> {
+    printHeader(headerLog, "link module", "link")
 
     const sourceType = "module"
 

--- a/garden-service/src/commands/link/source.ts
+++ b/garden-service/src/commands/link/source.ts
@@ -20,7 +20,7 @@ import {
 import { addLinkedSources } from "../../util/ext-source-util"
 import { LinkedSource } from "../../config-store"
 import { CommandParams } from "../base"
-import { logHeader } from "../../logger/util"
+import { printHeader } from "../../logger/util"
 
 const linkSourceArguments = {
   source: new StringParameter({
@@ -50,8 +50,8 @@ export class LinkSourceCommand extends Command<Args> {
         garden link source my-source path/to/my-source # links my-source to its local version at the given path
   `
 
-  async action({ garden, log, args }: CommandParams<Args>): Promise<CommandResult<LinkedSource[]>> {
-    logHeader({ log, emoji: "link", command: "link source" })
+  async action({ garden, log, headerLog, args }: CommandParams<Args>): Promise<CommandResult<LinkedSource[]>> {
+    printHeader(headerLog, "link source", "link")
 
     const sourceType = "project"
 

--- a/garden-service/src/commands/options.ts
+++ b/garden-service/src/commands/options.ts
@@ -27,7 +27,7 @@ const tableConfig: CliTable.TableConstructorOptions = {
     "right": "", "right-mid": "", "middle": "",
   },
   wordWrap: true,
-  truncate: " ",
+  truncate: " ", // We need this to prevent ellipsis (empty string does not work)
 }
 
 export class OptionsCommand extends Command {

--- a/garden-service/src/commands/options.ts
+++ b/garden-service/src/commands/options.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2018 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import {
+  Command,
+  CommandParams,
+  CommandResult,
+  Parameter,
+} from "./base"
+import stringWidth = require("string-width")
+import { maxBy, zip } from "lodash"
+import * as CliTable from "cli-table3"
+import { GLOBAL_OPTIONS } from "../cli/cli"
+import { helpTextMaxWidth } from "../cli/helpers"
+import chalk from "chalk"
+
+const tableConfig: CliTable.TableConstructorOptions = {
+  chars: {
+    "top": "", "top-mid": "", "top-left": "", "top-right": "",
+    "bottom": "", "bottom-mid": "", "bottom-left": "", "bottom-right": "",
+    "left": "", "left-mid": "", "mid": " ", "mid-mid": "",
+    "right": "", "right-mid": "", "middle": "",
+  },
+  wordWrap: true,
+  truncate: " ",
+}
+
+export class OptionsCommand extends Command {
+  name = "options"
+  help = "Print global options"
+
+  description = "Prints all global options (options that can be applied to any command)."
+
+  async action({ log }: CommandParams): Promise<CommandResult> {
+    const sortedOpts = Object.keys(GLOBAL_OPTIONS).sort()
+    const optNames = sortedOpts.map(optName => {
+      const option = <Parameter<any>>GLOBAL_OPTIONS[optName]
+      const alias = option.alias ? `-${option.alias}, ` : ""
+      return chalk.green(`  ${alias}--${optName}  `)
+    })
+
+    const helpTexts = sortedOpts.map(optName => {
+      const option = <Parameter<any>>GLOBAL_OPTIONS[optName]
+      let out = option.help
+      let hints = ""
+      if (option.hints) {
+        hints = option.hints
+      } else {
+        hints = `\n[${option.type}]`
+        if (option.defaultValue) {
+          hints += ` [default: ${option.defaultValue}]`
+        }
+      }
+      return out + chalk.gray(hints)
+    })
+
+    const nameColWidth = stringWidth(maxBy(optNames, n => stringWidth(n)) || "") + 1
+    const textColWidth = helpTextMaxWidth() - nameColWidth
+    const table = new CliTable({ ...tableConfig, colWidths: [nameColWidth, textColWidth] }) as CliTable.HorizontalTable
+
+    table.push(...zip(optNames, helpTexts))
+
+    log.info("")
+    log.info(chalk.white.bold("GLOBAL OPTIONS"))
+    log.info(table.toString())
+
+    return {}
+  }
+}

--- a/garden-service/src/commands/publish.ts
+++ b/garden-service/src/commands/publish.ts
@@ -19,7 +19,7 @@ import { PublishTask } from "../tasks/publish"
 import { TaskResults } from "../task-graph"
 import { Garden } from "../garden"
 import { LogEntry } from "../logger/log-entry"
-import { logHeader } from "../logger/util"
+import { printHeader } from "../logger/util"
 import dedent = require("dedent")
 
 const publishArgs = {
@@ -60,15 +60,17 @@ export class PublishCommand extends Command<Args, Opts> {
   arguments = publishArgs
   options = publishOpts
 
-  async action({ garden, log, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<TaskResults>> {
-    logHeader({ log, emoji: "rocket", command: "Publish modules" })
+  async action(
+    { garden, log, headerLog, footerLog, args, opts }: CommandParams<Args, Opts>,
+  ): Promise<CommandResult<TaskResults>> {
+    printHeader(headerLog, "Publish modules", "rocket")
 
     const graph = await garden.getConfigGraph()
     const modules = await graph.getModules(args.modules)
 
     const results = await publishModules(garden, log, modules, !!opts["force-build"], !!opts["allow-dirty"])
 
-    return handleTaskResults(log, "publish", { taskResults: results })
+    return handleTaskResults(footerLog, "publish", { taskResults: results })
   }
 }
 

--- a/garden-service/src/commands/run/module.ts
+++ b/garden-service/src/commands/run/module.ts
@@ -18,7 +18,7 @@ import {
 } from "../base"
 import { printRuntimeContext, runtimeContextForServiceDeps } from "./run"
 import dedent = require("dedent")
-import { logHeader } from "../../logger/util"
+import { printHeader } from "../../logger/util"
 import { BuildTask } from "../../tasks/build"
 
 const runArgs = {
@@ -67,7 +67,7 @@ export class RunModuleCommand extends Command<Args, Opts> {
   arguments = runArgs
   options = runOpts
 
-  async action({ garden, log, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<RunResult>> {
+  async action({ garden, log, headerLog, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<RunResult>> {
     const moduleName = args.module
 
     const graph = await garden.getConfigGraph()
@@ -77,11 +77,7 @@ export class RunModuleCommand extends Command<Args, Opts> {
       ? `Running command ${chalk.white(args.command.join(" "))} in module ${chalk.white(moduleName)}`
       : `Running module ${chalk.white(moduleName)}`
 
-    logHeader({
-      log,
-      emoji: "runner",
-      command: msg,
-    })
+    printHeader(headerLog, msg, "runner")
 
     const actions = await garden.getActionHelper()
     await actions.prepareEnvironment({ log })

--- a/garden-service/src/commands/run/service.ts
+++ b/garden-service/src/commands/run/service.ts
@@ -17,7 +17,7 @@ import {
 } from "../base"
 import { printRuntimeContext, runtimeContextForServiceDeps } from "./run"
 import dedent = require("dedent")
-import { logHeader } from "../../logger/util"
+import { printHeader } from "../../logger/util"
 import { BuildTask } from "../../tasks/build"
 
 const runArgs = {
@@ -52,17 +52,17 @@ export class RunServiceCommand extends Command<Args, Opts> {
   arguments = runArgs
   options = runOpts
 
-  async action({ garden, log, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<RunResult>> {
+  async action({ garden, log, headerLog, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<RunResult>> {
     const serviceName = args.service
     const graph = await garden.getConfigGraph()
     const service = await graph.getService(serviceName)
     const module = service.module
 
-    logHeader({
-      log,
-      emoji: "runner",
-      command: `Running service ${chalk.cyan(serviceName)} in module ${chalk.cyan(module.name)}`,
-    })
+    printHeader(
+      headerLog,
+      `Running service ${chalk.cyan(serviceName)} in module ${chalk.cyan(module.name)}`,
+      "runner",
+    )
 
     const actions = await garden.getActionHelper()
     await actions.prepareEnvironment({ log })

--- a/garden-service/src/commands/run/task.ts
+++ b/garden-service/src/commands/run/task.ts
@@ -17,7 +17,7 @@ import {
 import dedent = require("dedent")
 import { TaskTask } from "../../tasks/task"
 import { TaskResult } from "../../task-graph"
-import { logHeader, logFooter } from "../../logger/util"
+import { printHeader, printFooter } from "../../logger/util"
 
 const runArgs = {
   task: new StringParameter({
@@ -49,13 +49,15 @@ export class RunTaskCommand extends Command<Args, Opts> {
   arguments = runArgs
   options = runOpts
 
-  async action({ garden, log, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<TaskResult>> {
+  async action(
+    { garden, log, headerLog, footerLog, args, opts }: CommandParams<Args, Opts>,
+  ): Promise<CommandResult<TaskResult>> {
     const graph = await garden.getConfigGraph()
     const task = await graph.getTask(args.task)
 
     const msg = `Running task ${chalk.white(task.name)}`
 
-    logHeader({ log, emoji: "runner", command: msg })
+    printHeader(headerLog, msg, "runner")
 
     const actions = await garden.getActionHelper()
     await actions.prepareEnvironment({ log })
@@ -66,8 +68,7 @@ export class RunTaskCommand extends Command<Args, Opts> {
     if (!result.error) {
       log.info("")
       log.info(chalk.white(result.output.output))
-      log.info("")
-      logFooter({ log, emoji: "heavy_check_mark", command: `Done!` })
+      printFooter(footerLog)
     }
 
     return { result }

--- a/garden-service/src/commands/run/test.ts
+++ b/garden-service/src/commands/run/test.ts
@@ -23,7 +23,7 @@ import {
 import { printRuntimeContext } from "./run"
 import dedent = require("dedent")
 import { prepareRuntimeContext } from "../../types/service"
-import { logHeader } from "../../logger/util"
+import { printHeader } from "../../logger/util"
 import { BuildTask } from "../../tasks/build"
 import { getTestVersion } from "../../tasks/test"
 
@@ -67,7 +67,7 @@ export class RunTestCommand extends Command<Args, Opts> {
   arguments = runArgs
   options = runOpts
 
-  async action({ garden, log, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<RunResult>> {
+  async action({ garden, log, headerLog, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<RunResult>> {
     const moduleName = args.module
     const testName = args.test
 
@@ -84,11 +84,11 @@ export class RunTestCommand extends Command<Args, Opts> {
       })
     }
 
-    logHeader({
-      log,
-      emoji: "runner",
-      command: `Running test ${chalk.cyan(testName)} in module ${chalk.cyan(moduleName)}`,
-    })
+    printHeader(
+      headerLog,
+      `Running test ${chalk.cyan(testName)} in module ${chalk.cyan(moduleName)}`,
+      "runner",
+    )
 
     const actions = await garden.getActionHelper()
     await actions.prepareEnvironment({ log })

--- a/garden-service/src/commands/serve.ts
+++ b/garden-service/src/commands/serve.ts
@@ -43,8 +43,8 @@ export class ServeCommand extends Command<Args, Opts> {
 
   private server: GardenServer
 
-  async prepare({ logFooter, opts }: PrepareParams<Args, Opts>) {
-    this.server = await startServer(logFooter, opts.port)
+  async prepare({ footerLog, opts }: PrepareParams<Args, Opts>) {
+    this.server = await startServer(footerLog, opts.port)
   }
 
   async action({ garden }: CommandParams<Args, Opts>): Promise<CommandResult<{}>> {

--- a/garden-service/src/commands/test.ts
+++ b/garden-service/src/commands/test.ts
@@ -24,7 +24,7 @@ import { TaskResults } from "../task-graph"
 import { processModules } from "../process"
 import { Module } from "../types/module"
 import { getTestTasks } from "../tasks/test"
-import { logHeader } from "../logger/util"
+import { printHeader } from "../logger/util"
 import { GardenServer, startServer } from "../server/server"
 
 const testArgs = {
@@ -76,19 +76,15 @@ export class TestCommand extends Command<Args, Opts> {
 
   private server: GardenServer
 
-  async prepare({ log, logFooter, opts }: PrepareParams<Args, Opts>) {
-    logHeader({
-      log,
-      emoji: "thermometer",
-      command: `Running tests`,
-    })
+  async prepare({ headerLog, footerLog, opts }: PrepareParams<Args, Opts>) {
+    printHeader(headerLog, `Running tests`, "thermometer")
 
     if (!!opts.watch) {
-      this.server = await startServer(logFooter)
+      this.server = await startServer(footerLog)
     }
   }
 
-  async action({ garden, log, logFooter, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<TaskResults>> {
+  async action({ garden, log, footerLog, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<TaskResults>> {
     if (this.server) {
       this.server.setGarden(garden)
     }
@@ -114,7 +110,7 @@ export class TestCommand extends Command<Args, Opts> {
       garden,
       graph,
       log,
-      logFooter,
+      footerLog,
       modules,
       watch: opts.watch,
       handler: async (updatedGraph, module) => getTestTasks({
@@ -128,6 +124,6 @@ export class TestCommand extends Command<Args, Opts> {
       },
     })
 
-    return handleTaskResults(log, "test", results)
+    return handleTaskResults(footerLog, "test", results)
   }
 }

--- a/garden-service/src/commands/unlink/module.ts
+++ b/garden-service/src/commands/unlink/module.ts
@@ -16,7 +16,7 @@ import {
   CommandParams,
 } from "../base"
 import { removeLinkedSources } from "../../util/ext-source-util"
-import { logHeader } from "../../logger/util"
+import { printHeader } from "../../logger/util"
 import {
   localConfigKeys,
   LinkedSource,
@@ -54,8 +54,10 @@ export class UnlinkModuleCommand extends Command<Args, Opts> {
         garden unlink module --all      # unlink all modules
   `
 
-  async action({ garden, log, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<LinkedSource[]>> {
-    logHeader({ log, emoji: "chains", command: "unlink module" })
+  async action(
+    { garden, log, headerLog, args, opts }: CommandParams<Args, Opts>,
+  ): Promise<CommandResult<LinkedSource[]>> {
+    printHeader(headerLog, "unlink module", "chains")
 
     const sourceType = "module"
 

--- a/garden-service/src/commands/unlink/source.ts
+++ b/garden-service/src/commands/unlink/source.ts
@@ -16,7 +16,7 @@ import {
   CommandParams,
 } from "../base"
 import { removeLinkedSources } from "../../util/ext-source-util"
-import { logHeader } from "../../logger/util"
+import { printHeader } from "../../logger/util"
 import {
   localConfigKeys,
   LinkedSource,
@@ -54,8 +54,10 @@ export class UnlinkSourceCommand extends Command<Args, Opts> {
         garden unlink source --all      # unlinks all sources
   `
 
-  async action({ garden, log, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<LinkedSource[]>> {
-    logHeader({ log, emoji: "chains", command: "unlink source" })
+  async action(
+    { garden, log, headerLog, args, opts }: CommandParams<Args, Opts>,
+  ): Promise<CommandResult<LinkedSource[]>> {
+    printHeader(headerLog, "unlink source", "chains")
 
     const sourceType = "project"
 

--- a/garden-service/src/commands/update-remote/all.ts
+++ b/garden-service/src/commands/update-remote/all.ts
@@ -16,7 +16,7 @@ import {
 import { UpdateRemoteSourcesCommand } from "./sources"
 import { UpdateRemoteModulesCommand } from "./modules"
 import { SourceConfig } from "../../config/project"
-import { logHeader } from "../../logger/util"
+import { printHeader } from "../../logger/util"
 
 export interface UpdateRemoteAllResult {
   projectSources: SourceConfig[],
@@ -33,8 +33,10 @@ export class UpdateRemoteAllCommand extends Command {
         garden update-remote all # update all remote sources and modules in the project
   `
 
-  async action({ garden, log, logFooter, opts }: CommandParams): Promise<CommandResult<UpdateRemoteAllResult>> {
-    logHeader({ log, emoji: "hammer_and_wrench", command: "update-remote all" })
+  async action(
+    { garden, log, headerLog, footerLog, opts }: CommandParams,
+  ): Promise<CommandResult<UpdateRemoteAllResult>> {
+    printHeader(headerLog, "update-remote all", "hammer_and_wrench")
 
     const sourcesCmd = new UpdateRemoteSourcesCommand()
     const modulesCmd = new UpdateRemoteModulesCommand()
@@ -42,14 +44,16 @@ export class UpdateRemoteAllCommand extends Command {
     const { result: projectSources } = await sourcesCmd.action({
       garden,
       log,
-      logFooter,
+      footerLog,
+      headerLog,
       opts,
       args: { sources: undefined },
     })
     const { result: moduleSources } = await modulesCmd.action({
       garden,
       log,
-      logFooter,
+      footerLog,
+      headerLog,
       opts,
       args: { modules: undefined },
     })

--- a/garden-service/src/commands/update-remote/modules.ts
+++ b/garden-service/src/commands/update-remote/modules.ts
@@ -20,7 +20,7 @@ import { SourceConfig } from "../../config/project"
 import { ParameterError } from "../../exceptions"
 import { pruneRemoteSources } from "./helpers"
 import { hasRemoteSource } from "../../util/ext-source-util"
-import { logHeader } from "../../logger/util"
+import { printHeader } from "../../logger/util"
 
 const updateRemoteModulesArguments = {
   modules: new StringsParameter({
@@ -45,8 +45,8 @@ export class UpdateRemoteModulesCommand extends Command<Args> {
         garden update-remote modules my-module  # update remote module my-module
   `
 
-  async action({ garden, log, args }: CommandParams<Args>): Promise<CommandResult<SourceConfig[]>> {
-    logHeader({ log, emoji: "hammer_and_wrench", command: "update-remote modules" })
+  async action({ garden, log, headerLog, args }: CommandParams<Args>): Promise<CommandResult<SourceConfig[]>> {
+    printHeader(headerLog, "update-remote modules", "hammer_and_wrench")
 
     const { modules: moduleNames } = args
     const graph = await garden.getConfigGraph()

--- a/garden-service/src/commands/update-remote/sources.ts
+++ b/garden-service/src/commands/update-remote/sources.ts
@@ -19,7 +19,7 @@ import {
 import { ParameterError } from "../../exceptions"
 import { pruneRemoteSources } from "./helpers"
 import { SourceConfig } from "../../config/project"
-import { logHeader } from "../../logger/util"
+import { printHeader } from "../../logger/util"
 
 const updateRemoteSourcesArguments = {
   sources: new StringsParameter({
@@ -43,10 +43,8 @@ export class UpdateRemoteSourcesCommand extends Command<Args> {
         garden update-remote sources my-source  # update remote source my-source
   `
 
-  async action(
-    { garden, log, args }: CommandParams<Args>,
-  ): Promise<CommandResult<SourceConfig[]>> {
-    logHeader({ log, emoji: "hammer_and_wrench", command: "update-remote sources" })
+  async action({ garden, log, headerLog, args }: CommandParams<Args>): Promise<CommandResult<SourceConfig[]>> {
+    printHeader(headerLog, "update-remote sources", "hammer_and_wrench")
 
     const { sources } = args
 

--- a/garden-service/src/commands/validate.ts
+++ b/garden-service/src/commands/validate.ts
@@ -11,7 +11,7 @@ import {
   CommandParams,
   CommandResult,
 } from "./base"
-import { logHeader } from "../logger/util"
+import { printHeader } from "../logger/util"
 import dedent = require("dedent")
 
 export class ValidateCommand extends Command {
@@ -22,8 +22,8 @@ export class ValidateCommand extends Command {
     Throws an error and exits with code 1 if something's not right in your garden.yml files.
   `
 
-  async action({ garden, log }: CommandParams): Promise<CommandResult> {
-    logHeader({ log, emoji: "heavy_check_mark", command: "validate" })
+  async action({ garden, headerLog }: CommandParams): Promise<CommandResult> {
+    printHeader(headerLog, "validate", "heavy_check_mark")
 
     const graph = await garden.getConfigGraph()
     await graph.getModules()

--- a/garden-service/src/logger/logger.ts
+++ b/garden-service/src/logger/logger.ts
@@ -20,7 +20,7 @@ import { parseLogLevel } from "../cli/helpers"
 export type LoggerType = "quiet" | "basic" | "fancy" | "json"
 export const LOGGER_TYPES = new Set<LoggerType>(["quiet", "basic", "fancy", "json"])
 
-export function getCommonConfig(loggerType: LoggerType): LoggerConfig {
+export function getLoggerConfig(loggerType: LoggerType): LoggerConfig {
   const configs: { [key in LoggerType]: LoggerConfig } = {
     quiet: {
       level: LogLevel.info,
@@ -39,6 +39,19 @@ export function getCommonConfig(loggerType: LoggerType): LoggerConfig {
     },
   }
   return configs[loggerType]
+}
+
+export function getWriterInstance(loggerType: LoggerType) {
+  switch (loggerType) {
+    case "basic":
+      return new BasicTerminalWriter()
+    case "fancy":
+      return new FancyTerminalWriter()
+    case "json":
+      return new JsonTerminalWriter()
+    case "quiet":
+      return undefined
+  }
 }
 
 export interface LoggerConfig {
@@ -89,7 +102,8 @@ export class Logger extends LogNode {
         })
       }
 
-      instance = new Logger({ ...getCommonConfig(loggerType), level: config.level })
+      const writer = getWriterInstance(loggerType)
+      instance = new Logger({ writers: writer ? [writer] : undefined, level: config.level })
       instance.debug(`Setting logger type to ${loggerType} (from GARDEN_LOGGER_TYPE)`)
     } else {
       instance = new Logger(config)

--- a/garden-service/src/logger/util.ts
+++ b/garden-service/src/logger/util.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { LogNode, LogLevel } from "./log-node"
+import { LogNode } from "./log-node"
 import { LogEntry, CreateOpts, EmojiName } from "./log-entry"
 import { combine, printEmoji } from "./renderers"
 import chalk from "chalk"
@@ -114,24 +114,18 @@ export function getTerminalWidth(stream: NodeJS.WriteStream = process.stdout) {
   return columns
 }
 
-interface LogHeaderOptions {
-  log: LogEntry
-  command: string
-  emoji?: EmojiName
-  level?: LogLevel,
-  newLine?: boolean,
-}
-
-export function logHeader({ log, command, emoji, level = LogLevel.info, newLine = true }: LogHeaderOptions): LogEntry {
+function printWithEmoji(log: LogEntry, text: string, emoji?: EmojiName) {
   const msg = combine([
-    [chalk.bold.magenta(command)],
+    [chalk.bold.magenta(text)],
     [emoji && log.root.useEmoji ? " " + printEmoji(emoji) : ""],
-    [newLine ? "\n" : ""],
   ])
-  const lvlStr = LogLevel[level]
-  return log[lvlStr](msg)
+  return log.info(msg)
 }
 
-export function logFooter(opts: LogHeaderOptions): LogEntry {
-  return logHeader({ ...opts, newLine: false })
+export function printHeader(log: LogEntry, command: string, emoji?: EmojiName): LogEntry {
+  return printWithEmoji(log, command, emoji)
+}
+
+export function printFooter(log: LogEntry) {
+  return printWithEmoji(log, "Done!", "heavy_check_mark")
 }

--- a/garden-service/src/process.ts
+++ b/garden-service/src/process.ts
@@ -28,7 +28,7 @@ interface ProcessParams {
   garden: Garden
   graph: ConfigGraph
   log: LogEntry
-  logFooter?: LogEntry
+  footerLog?: LogEntry
   watch: boolean
   handler: ProcessHandler
   // use this if the behavior should be different on watcher changes than on initial processing
@@ -49,7 +49,7 @@ export interface ProcessResults {
 }
 
 export async function processServices(
-  { garden, graph, log, logFooter, services, watch, handler, changeHandler }: ProcessServicesParams,
+  { garden, graph, log, footerLog, services, watch, handler, changeHandler }: ProcessServicesParams,
 ): Promise<ProcessResults> {
 
   const modules = Array.from(new Set(services.map(s => s.module)))
@@ -59,7 +59,7 @@ export async function processServices(
     garden,
     graph,
     log,
-    logFooter,
+    footerLog,
     watch,
     handler,
     changeHandler,
@@ -67,7 +67,7 @@ export async function processServices(
 }
 
 export async function processModules(
-  { garden, graph, log, logFooter, modules, watch, handler, changeHandler }: ProcessModulesParams,
+  { garden, graph, log, footerLog, modules, watch, handler, changeHandler }: ProcessModulesParams,
 ): Promise<ProcessResults> {
 
   log.debug("Starting processModules")
@@ -87,13 +87,13 @@ export async function processModules(
 
   const tasks: BaseTask[] = flatten(await Bluebird.map(modules, module => handler(graph, module)))
 
-  if (watch && !!logFooter) {
+  if (watch && !!footerLog) {
     garden.events.on("taskGraphProcessing", () => {
-      logFooter.setState({ emoji: "hourglass_flowing_sand", msg: "Processing..." })
+      footerLog.setState({ emoji: "hourglass_flowing_sand", msg: "Processing..." })
     })
 
     garden.events.on("taskGraphComplete", () => {
-      logFooter.setState({ emoji: "clock2", msg: chalk.gray("Waiting for code changes") })
+      footerLog.setState({ emoji: "clock2", msg: chalk.gray("Waiting for code changes") })
     })
   }
 

--- a/garden-service/src/server/commands.ts
+++ b/garden-service/src/server/commands.ts
@@ -80,7 +80,8 @@ export async function resolveRequest(
   return command.action({
     garden: cmdGarden,
     log: cmdLog,
-    logFooter: cmdLog,
+    headerLog: cmdLog,
+    footerLog: cmdLog,
     args: cmdArgs,
     opts: cmdOpts,
   })

--- a/garden-service/test/unit/src/commands/build.ts
+++ b/garden-service/test/unit/src/commands/build.ts
@@ -7,13 +7,14 @@ describe("commands.build", () => {
   it("should build all modules in a project", async () => {
     const garden = await makeTestGardenA()
     const log = garden.log
-    const logFooter = garden.log
+    const footerLog = garden.log
     const command = new BuildCommand()
 
     const { result } = await command.action({
       garden,
       log,
-      logFooter,
+      headerLog: log,
+      footerLog,
       args: { modules: undefined },
       opts: withDefaultGlobalOpts({ watch: false, force: true }),
     })
@@ -28,13 +29,14 @@ describe("commands.build", () => {
   it("should optionally build single module and its dependencies", async () => {
     const garden = await makeTestGardenA()
     const log = garden.log
-    const logFooter = garden.log
+    const footerLog = garden.log
     const command = new BuildCommand()
 
     const { result } = await command.action({
       garden,
       log,
-      logFooter,
+      headerLog: log,
+      footerLog,
       args: { modules: ["module-b"] },
       opts: withDefaultGlobalOpts({ watch: false, force: true }),
     })

--- a/garden-service/test/unit/src/commands/call.ts
+++ b/garden-service/test/unit/src/commands/call.ts
@@ -69,7 +69,8 @@ describe("commands.call", () => {
     const { result } = await command.action({
       garden,
       log,
-      logFooter: log,
+      headerLog: log,
+      footerLog: log,
       args: { serviceAndPath: "service-a/path-a" },
       opts: withDefaultGlobalOpts({}),
     })
@@ -94,7 +95,8 @@ describe("commands.call", () => {
     const { result } = await command.action({
       garden,
       log,
-      logFooter: log,
+      headerLog: log,
+      footerLog: log,
       args: { serviceAndPath: "service-a" },
       opts: withDefaultGlobalOpts({}),
     })
@@ -118,7 +120,8 @@ describe("commands.call", () => {
     const { result } = await command.action({
       garden,
       log,
-      logFooter: log,
+      headerLog: log,
+      footerLog: log,
       args: { serviceAndPath: "service-b" },
       opts: withDefaultGlobalOpts({}),
     })
@@ -139,7 +142,8 @@ describe("commands.call", () => {
       await command.action({
         garden,
         log,
-        logFooter: log,
+        headerLog: log,
+        footerLog: log,
         args: { serviceAndPath: "service-d/path-d" },
         opts: withDefaultGlobalOpts({}),
       })
@@ -160,7 +164,8 @@ describe("commands.call", () => {
       await command.action({
         garden,
         log,
-        logFooter: log,
+        headerLog: log,
+        footerLog: log,
         args: { serviceAndPath: "service-c/path-c" },
         opts: withDefaultGlobalOpts({}),
       })
@@ -181,7 +186,8 @@ describe("commands.call", () => {
       await command.action({
         garden,
         log,
-        logFooter: log,
+        headerLog: log,
+        footerLog: log,
         args: { serviceAndPath: "service-a/bla" },
         opts: withDefaultGlobalOpts({}),
       })

--- a/garden-service/test/unit/src/commands/delete.ts
+++ b/garden-service/test/unit/src/commands/delete.ts
@@ -29,7 +29,8 @@ describe("DeleteSecretCommand", () => {
     await command.action({
       garden,
       log,
-      logFooter: log,
+      headerLog: log,
+      footerLog: log,
       args: { provider, key },
       opts: withDefaultGlobalOpts({}),
     })
@@ -46,7 +47,8 @@ describe("DeleteSecretCommand", () => {
       async () => await command.action({
         garden,
         log,
-        logFooter: log,
+        headerLog: log,
+        footerLog: log,
         args: { provider, key: "foo" },
         opts: withDefaultGlobalOpts({}),
       }),
@@ -86,7 +88,14 @@ describe("DeleteEnvironmentCommand", () => {
     const garden = await Garden.factory(projectRootB, { plugins })
     const log = garden.log
 
-    const { result } = await command.action({ garden, log, logFooter: log, args: {}, opts: withDefaultGlobalOpts({}) })
+    const { result } = await command.action({
+      garden,
+      log,
+      footerLog: log,
+      headerLog: log,
+      args: {},
+      opts: withDefaultGlobalOpts({}),
+    })
 
     expect(result!["test-plugin"]["ready"]).to.be.false
   })
@@ -131,7 +140,8 @@ describe("DeleteServiceCommand", () => {
     const { result } = await command.action({
       garden,
       log,
-      logFooter: log,
+      headerLog: log,
+      footerLog: log,
       args: { services: ["service-a"] },
       opts: withDefaultGlobalOpts({}),
     })
@@ -147,7 +157,8 @@ describe("DeleteServiceCommand", () => {
     const { result } = await command.action({
       garden,
       log,
-      logFooter: log,
+      headerLog: log,
+      footerLog: log,
       args: { services: ["service-a", "service-b"] },
       opts: withDefaultGlobalOpts({}),
     })

--- a/garden-service/test/unit/src/commands/deploy.ts
+++ b/garden-service/test/unit/src/commands/deploy.ts
@@ -93,7 +93,8 @@ describe("DeployCommand", () => {
     const { result, errors } = await command.action({
       garden,
       log,
-      logFooter: log,
+      headerLog: log,
+      footerLog: log,
       args: {
         services: undefined,
       },
@@ -130,7 +131,8 @@ describe("DeployCommand", () => {
     const { result, errors } = await command.action({
       garden,
       log,
-      logFooter: log,
+      headerLog: log,
+      footerLog: log,
       args: {
         services: ["service-b"],
       },

--- a/garden-service/test/unit/src/commands/get/get-config.ts
+++ b/garden-service/test/unit/src/commands/get/get-config.ts
@@ -15,7 +15,8 @@ describe("GetConfigCommand", () => {
     const res = await command.action({
       garden,
       log,
-      logFooter: log,
+      headerLog: log,
+      footerLog: log,
       args: { provider },
       opts: withDefaultGlobalOpts({}),
     })

--- a/garden-service/test/unit/src/commands/get/get-debug-info.ts
+++ b/garden-service/test/unit/src/commands/get/get-debug-info.ts
@@ -63,7 +63,8 @@ describe("GetDebugInfoCommand", () => {
         const res = await command.action({
           garden,
           log,
-          logFooter: log,
+          headerLog: log,
+          footerLog: log,
           args: {},
           opts: withDefaultGlobalOpts({ format: "json" }),
         })

--- a/garden-service/test/unit/src/commands/get/get-graph.ts
+++ b/garden-service/test/unit/src/commands/get/get-graph.ts
@@ -16,7 +16,8 @@ describe("GetGraphCommand", () => {
     const res = await command.action({
       garden,
       log,
-      logFooter: log,
+      headerLog: log,
+      footerLog: log,
       args: { provider },
       opts: withDefaultGlobalOpts({}),
     })

--- a/garden-service/test/unit/src/commands/get/get-secret.ts
+++ b/garden-service/test/unit/src/commands/get/get-secret.ts
@@ -22,7 +22,8 @@ describe("GetSecretCommand", () => {
     const res = await command.action({
       garden,
       log,
-      logFooter: log,
+      headerLog: log,
+      footerLog: log,
       args: { provider, key: "project.mykey" },
       opts: withDefaultGlobalOpts({}),
     })
@@ -39,7 +40,8 @@ describe("GetSecretCommand", () => {
       async () => await command.action({
         garden,
         log,
-        logFooter: log,
+        headerLog: log,
+        footerLog: log,
         args: { provider, key: "project.mykey" },
         opts: withDefaultGlobalOpts({}),
       }),

--- a/garden-service/test/unit/src/commands/get/get-task-result.ts
+++ b/garden-service/test/unit/src/commands/get/get-task-result.ts
@@ -19,9 +19,10 @@ describe("GetTaskResultCommand", () => {
         await command.action({
           garden,
           log,
+          headerLog: log,
+          footerLog: log,
           args: { name },
           opts: withDefaultGlobalOpts({}),
-          logFooter: log,
         }),
       "parameter",
     )
@@ -37,9 +38,10 @@ describe("GetTaskResultCommand", () => {
     const res = await command.action({
       garden,
       log,
+      footerLog: log,
+      headerLog: log,
       args: { name },
       opts: withDefaultGlobalOpts({}),
-      logFooter: log,
     })
 
     expect(pick(res.result, ["output", "name"])).to.eql({ output: null, name })

--- a/garden-service/test/unit/src/commands/get/get-tasks.ts
+++ b/garden-service/test/unit/src/commands/get/get-tasks.ts
@@ -13,7 +13,8 @@ describe("GetTasksCommand", () => {
     await command.action({
       garden,
       log,
-      logFooter: log,
+      headerLog: log,
+      footerLog: log,
       args: { tasks: undefined },
       opts: withDefaultGlobalOpts({}),
     })
@@ -27,7 +28,8 @@ describe("GetTasksCommand", () => {
     await command.action({
       garden,
       log,
-      logFooter: log,
+      headerLog: log,
+      footerLog: log,
       args: { tasks: ["task-a"] },
       opts: withDefaultGlobalOpts({}),
     })

--- a/garden-service/test/unit/src/commands/get/get-test-result.ts
+++ b/garden-service/test/unit/src/commands/get/get-test-result.ts
@@ -20,9 +20,10 @@ describe("GetTestResultCommand", () => {
         await command.action({
           garden,
           log,
+          headerLog: log,
+          footerLog: log,
           args: { name, module },
           opts: withDefaultGlobalOpts({}),
-          logFooter: log,
         }),
       "parameter",
     )
@@ -39,9 +40,10 @@ describe("GetTestResultCommand", () => {
     const res = await command.action({
       garden,
       log,
+      headerLog: log,
+      footerLog: log,
       args: { name, module },
       opts: withDefaultGlobalOpts({}),
-      logFooter: log,
     })
 
     expect(pick(res.result, ["output", "name", "module"])).to.eql({ output: null, name, module })

--- a/garden-service/test/unit/src/commands/link.ts
+++ b/garden-service/test/unit/src/commands/link.ts
@@ -36,7 +36,8 @@ describe("LinkCommand", () => {
       await cmd.action({
         garden,
         log,
-        logFooter: log,
+        headerLog: log,
+        footerLog: log,
         args: {
           module: "module-a",
           path: join(projectRoot, "mock-local-path", "module-a"),
@@ -55,7 +56,8 @@ describe("LinkCommand", () => {
       await cmd.action({
         garden,
         log,
-        logFooter: log,
+        headerLog: log,
+        footerLog: log,
         args: {
           module: "module-a",
           path: join("mock-local-path", "module-a"),
@@ -75,7 +77,8 @@ describe("LinkCommand", () => {
         async () => cmd.action({
           garden,
           log,
-          logFooter: log,
+          headerLog: log,
+          footerLog: log,
           args: {
             module: "banana",
             path: "",
@@ -105,7 +108,8 @@ describe("LinkCommand", () => {
       await cmd.action({
         garden,
         log,
-        logFooter: log,
+        headerLog: log,
+        footerLog: log,
         args: {
           source: "source-a",
           path: join(projectRoot, "mock-local-path", "source-a"),
@@ -124,7 +128,8 @@ describe("LinkCommand", () => {
       await cmd.action({
         garden,
         log,
-        logFooter: log,
+        headerLog: log,
+        footerLog: log,
         args: {
           source: "source-a",
           path: join("mock-local-path", "source-a"),

--- a/garden-service/test/unit/src/commands/publish.ts
+++ b/garden-service/test/unit/src/commands/publish.ts
@@ -53,7 +53,8 @@ describe("PublishCommand", () => {
     const { result } = await command.action({
       garden,
       log,
-      logFooter: log,
+      headerLog: log,
+      footerLog: log,
       args: {
         modules: undefined,
       },
@@ -80,7 +81,8 @@ describe("PublishCommand", () => {
     const { result } = await command.action({
       garden,
       log,
-      logFooter: log,
+      headerLog: log,
+      footerLog: log,
       args: {
         modules: undefined,
       },
@@ -107,7 +109,8 @@ describe("PublishCommand", () => {
     const { result } = await command.action({
       garden,
       log,
-      logFooter: log,
+      headerLog: log,
+      footerLog: log,
       args: {
         modules: ["module-a"],
       },
@@ -131,7 +134,8 @@ describe("PublishCommand", () => {
     const { result } = await command.action({
       garden,
       log,
-      logFooter: log,
+      headerLog: log,
+      footerLog: log,
       args: {
         modules: ["module-c"],
       },
@@ -156,7 +160,8 @@ describe("PublishCommand", () => {
     const { result } = await command.action({
       garden,
       log,
-      logFooter: log,
+      headerLog: log,
+      footerLog: log,
       args: {
         modules: ["module-a"],
       },

--- a/garden-service/test/unit/src/commands/run/module.ts
+++ b/garden-service/test/unit/src/commands/run/module.ts
@@ -26,7 +26,8 @@ describe("RunModuleCommand", () => {
     const { result } = await cmd.action({
       garden,
       log,
-      logFooter: log,
+      headerLog: log,
+      footerLog: log,
       args: { module: "module-a", command: [] },
       opts: withDefaultGlobalOpts({ "interactive": false, "force-build": false }),
     })
@@ -49,7 +50,8 @@ describe("RunModuleCommand", () => {
     const { result } = await cmd.action({
       garden,
       log,
-      logFooter: log,
+      headerLog: log,
+      footerLog: log,
       args: { module: "module-a", command: ["my", "command"] },
       opts: withDefaultGlobalOpts({ "interactive": false, "force-build": false }),
     })

--- a/garden-service/test/unit/src/commands/run/service.ts
+++ b/garden-service/test/unit/src/commands/run/service.ts
@@ -27,7 +27,8 @@ describe("RunServiceCommand", () => {
     const { result } = await cmd.action({
       garden,
       log,
-      logFooter: log,
+      headerLog: log,
+      footerLog: log,
       args: { service: "service-a" },
       opts: withDefaultGlobalOpts({ "force-build": false }),
     })

--- a/garden-service/test/unit/src/commands/run/task.ts
+++ b/garden-service/test/unit/src/commands/run/task.ts
@@ -13,7 +13,8 @@ describe("RunTaskCommand", () => {
     const { result } = await cmd.action({
       garden,
       log,
-      logFooter: log,
+      headerLog: log,
+      footerLog: log,
       args: { task: "task-a" },
       opts: withDefaultGlobalOpts({ "force-build": false }),
     })

--- a/garden-service/test/unit/src/commands/scan.ts
+++ b/garden-service/test/unit/src/commands/scan.ts
@@ -12,7 +12,8 @@ describe("ScanCommand", () => {
       await command.action({
         garden,
         log,
-        logFooter: log,
+        headerLog: log,
+        footerLog: log,
         args: {},
         opts: withDefaultGlobalOpts({}),
       })

--- a/garden-service/test/unit/src/commands/set.ts
+++ b/garden-service/test/unit/src/commands/set.ts
@@ -14,7 +14,8 @@ describe("SetSecretCommand", () => {
     await command.action({
       garden,
       log,
-      logFooter: log,
+      headerLog: log,
+      footerLog: log,
       args: { provider, key: "mykey", value: "myvalue" },
       opts: withDefaultGlobalOpts({}),
     })

--- a/garden-service/test/unit/src/commands/test.ts
+++ b/garden-service/test/unit/src/commands/test.ts
@@ -12,7 +12,8 @@ describe("commands.test", () => {
     const { result } = await command.action({
       garden,
       log,
-      logFooter: log,
+      headerLog: log,
+      footerLog: log,
       args: { modules: undefined },
       opts: withDefaultGlobalOpts({ "name": undefined, "force": true, "force-build": true, "watch": false }),
     })
@@ -50,7 +51,8 @@ describe("commands.test", () => {
     const { result } = await command.action({
       garden,
       log,
-      logFooter: log,
+      headerLog: log,
+      footerLog: log,
       args: { modules: ["module-a"] },
       opts: withDefaultGlobalOpts({ "name": undefined, "force": true, "force-build": true, "watch": false }),
     })

--- a/garden-service/test/unit/src/commands/unlink.ts
+++ b/garden-service/test/unit/src/commands/unlink.ts
@@ -32,7 +32,8 @@ describe("UnlinkCommand", () => {
       await linkCmd.action({
         garden,
         log,
-        logFooter: log,
+        headerLog: log,
+        footerLog: log,
         args: {
           module: "module-a",
           path: join(projectRoot, "mock-local-path", "module-a"),
@@ -42,7 +43,8 @@ describe("UnlinkCommand", () => {
       await linkCmd.action({
         garden,
         log,
-        logFooter: log,
+        headerLog: log,
+        footerLog: log,
         args: {
           module: "module-b",
           path: join(projectRoot, "mock-local-path", "module-b"),
@@ -52,7 +54,8 @@ describe("UnlinkCommand", () => {
       await linkCmd.action({
         garden,
         log,
-        logFooter: log,
+        headerLog: log,
+        footerLog: log,
         args: {
           module: "module-c",
           path: join(projectRoot, "mock-local-path", "module-c"),
@@ -69,7 +72,8 @@ describe("UnlinkCommand", () => {
       await unlinkCmd.action({
         garden,
         log,
-        logFooter: log,
+        headerLog: log,
+        footerLog: log,
         args: { modules: ["module-a", "module-b"] },
         opts: withDefaultGlobalOpts({ all: false }),
       })
@@ -83,7 +87,8 @@ describe("UnlinkCommand", () => {
       await unlinkCmd.action({
         garden,
         log,
-        logFooter: log,
+        headerLog: log,
+        footerLog: log,
         args: { modules: undefined },
         opts: withDefaultGlobalOpts({ all: true }),
       })
@@ -106,7 +111,8 @@ describe("UnlinkCommand", () => {
       await linkCmd.action({
         garden,
         log,
-        logFooter: log,
+        headerLog: log,
+        footerLog: log,
         args: {
           source: "source-a",
           path: join(projectRoot, "mock-local-path", "source-a"),
@@ -116,7 +122,8 @@ describe("UnlinkCommand", () => {
       await linkCmd.action({
         garden,
         log,
-        logFooter: log,
+        headerLog: log,
+        footerLog: log,
         args: {
           source: "source-b",
           path: join(projectRoot, "mock-local-path", "source-b"),
@@ -126,7 +133,8 @@ describe("UnlinkCommand", () => {
       await linkCmd.action({
         garden,
         log,
-        logFooter: log,
+        headerLog: log,
+        footerLog: log,
         args: {
           source: "source-c",
           path: join(projectRoot, "mock-local-path", "source-c"),
@@ -143,7 +151,8 @@ describe("UnlinkCommand", () => {
       await unlinkCmd.action({
         garden,
         log,
-        logFooter: log,
+        headerLog: log,
+        footerLog: log,
         args: { sources: ["source-a", "source-b"] },
         opts: withDefaultGlobalOpts({ all: false }),
       })
@@ -157,7 +166,8 @@ describe("UnlinkCommand", () => {
       await unlinkCmd.action({
         garden,
         log,
-        logFooter: log,
+        headerLog: log,
+        footerLog: log,
         args: { sources: undefined },
         opts: withDefaultGlobalOpts({ all: true }),
       })

--- a/garden-service/test/unit/src/commands/update-remote.ts
+++ b/garden-service/test/unit/src/commands/update-remote.ts
@@ -41,7 +41,8 @@ describe("UpdateRemoteCommand", () => {
       const { result } = await cmd.action({
         garden,
         log,
-        logFooter: log,
+        headerLog: log,
+        footerLog: log,
         args: { sources: undefined },
         opts: withDefaultGlobalOpts({}),
       })
@@ -52,7 +53,8 @@ describe("UpdateRemoteCommand", () => {
       const { result } = await cmd.action({
         garden,
         log,
-        logFooter: log,
+        headerLog: log,
+        footerLog: log,
         args: { sources: ["source-a"] },
         opts: withDefaultGlobalOpts({}),
       })
@@ -65,7 +67,8 @@ describe("UpdateRemoteCommand", () => {
       await cmd.action({
         garden,
         log,
-        logFooter: log,
+        headerLog: log,
+        footerLog: log,
         args: { sources: undefined },
         opts: withDefaultGlobalOpts({}),
       })
@@ -78,7 +81,8 @@ describe("UpdateRemoteCommand", () => {
           await cmd.action({
             garden,
             log,
-            logFooter: log,
+            headerLog: log,
+            footerLog: log,
             args: { sources: ["banana"] },
             opts: withDefaultGlobalOpts({}),
           })
@@ -105,7 +109,8 @@ describe("UpdateRemoteCommand", () => {
       const { result } = await cmd.action({
         garden,
         log,
-        logFooter: log,
+        headerLog: log,
+        footerLog: log,
         args: { modules: undefined },
         opts: withDefaultGlobalOpts({}),
       })
@@ -116,7 +121,8 @@ describe("UpdateRemoteCommand", () => {
       const { result } = await cmd.action({
         garden,
         log,
-        logFooter: log,
+        headerLog: log,
+        footerLog: log,
         args: { modules: ["module-a"] },
         opts: withDefaultGlobalOpts({}),
       })
@@ -129,7 +135,8 @@ describe("UpdateRemoteCommand", () => {
       await cmd.action({
         garden,
         log,
-        logFooter: log,
+        headerLog: log,
+        footerLog: log,
         args: { modules: undefined },
         opts: withDefaultGlobalOpts({}),
       })
@@ -142,7 +149,8 @@ describe("UpdateRemoteCommand", () => {
           await cmd.action({
             garden,
             log,
-            logFooter: log,
+            headerLog: log,
+            footerLog: log,
             args: { modules: ["banana"] },
             opts: withDefaultGlobalOpts({}),
           })

--- a/garden-service/test/unit/src/commands/validate.ts
+++ b/garden-service/test/unit/src/commands/validate.ts
@@ -14,7 +14,8 @@ describe("commands.validate", () => {
       await command.action({
         garden,
         log,
-        logFooter: log,
+        headerLog: log,
+        footerLog: log,
         args: {},
         opts: withDefaultGlobalOpts({}),
       })
@@ -36,7 +37,8 @@ describe("commands.validate", () => {
     await expectError(async () => await command.action({
       garden,
       log,
-      logFooter: log,
+      headerLog: log,
+      footerLog: log,
       args: {},
       opts: withDefaultGlobalOpts({}),
     }), "configuration")


### PR DESCRIPTION
This PR contains a handful of small CLI improvements and refactors:

- Rename the `--loglevel` flag to `--log-level` for consistency.
- Remove Global Options from CLI help output and use a dedicated command instead.
- Add log header to commands, along with necessary refactors. 

Closes #668. 