### PR TITLE
fix(k8s): fix various issues with Kubernetes API queries

### DIFF
--- a/garden-service/src/plugins/openfaas/openfaas.ts
+++ b/garden-service/src/plugins/openfaas/openfaas.ts
@@ -45,6 +45,7 @@ import { keyBy, union } from "lodash"
 import { DEFAULT_API_VERSION } from "../../constants"
 import { ExecModuleConfig } from "../exec"
 import { ConfigureProviderParams } from "../../types/plugin/provider/configureProvider"
+import { V1Deployment } from "@kubernetes/client-node"
 
 export const stackFilename = "stack.yml"
 
@@ -411,7 +412,7 @@ async function getServiceStatus({ ctx, module, service, log }: GetServiceStatusP
   const namespace = await getAppNamespace(openFaasCtx, log, k8sProvider)
   const api = await KubeApi.factory(log, k8sProvider.config.context)
 
-  let deployment
+  let deployment: V1Deployment
 
   try {
     deployment = (await api.apps.readNamespacedDeployment(service.name, namespace)).body


### PR DESCRIPTION
Basically I've completely overhauled the API wrapper, so that it should
dynamically and consistently support any API resource properly. This is
much cleaner and more similar to how kubectl works internally, for example.