### PR TITLE
fix(k8s): unhelpful error with conflicting namespace

### DIFF
--- a/garden-service/src/constants.ts
+++ b/garden-service/src/constants.ts
@@ -27,9 +27,6 @@ export const GARDEN_VERSIONFILE_NAME = ".garden-version"
 export const DEFAULT_PORT_PROTOCOL = "TCP"
 
 export const DEFAULT_API_VERSION = "garden.io/v0"
-export const GARDEN_ANNOTATION_PREFIX = "garden.io/"
-export const GARDEN_ANNOTATION_KEYS_SERVICE = GARDEN_ANNOTATION_PREFIX + "service"
-export const GARDEN_ANNOTATION_KEYS_VERSION = GARDEN_ANNOTATION_PREFIX + "version"
 
 export const DEFAULT_TEST_TIMEOUT = 60 * 1000
 

--- a/garden-service/src/plugins/google/google-cloud-functions.ts
+++ b/garden-service/src/plugins/google/google-cloud-functions.ts
@@ -11,7 +11,6 @@ import { Module } from "../../types/module"
 import { ServiceState, ServiceStatus, ingressHostnameSchema, Service } from "../../types/service"
 import { resolve } from "path"
 import * as Joi from "joi"
-import { GARDEN_ANNOTATION_KEYS_VERSION } from "../../constants"
 import { ExecTestSpec, execTestSchema } from "../exec"
 import {
   prepareEnvironment,
@@ -26,6 +25,7 @@ import { ConfigureModuleParams, ConfigureModuleResult } from "../../types/plugin
 import { DeployServiceParams } from "../../types/plugin/service/deployService"
 import { GetServiceStatusParams } from "../../types/plugin/service/getServiceStatus"
 import { ServiceLimitSpec } from "../container/config"
+import { gardenAnnotationKey } from "../../util/string"
 
 const gcfModuleSpecSchema = baseServiceSpecSchema
   .keys({
@@ -154,7 +154,7 @@ export async function getServiceStatus(
   return {
     providerId,
     providerVersion: status.versionId,
-    version: status.labels[GARDEN_ANNOTATION_KEYS_VERSION],
+    version: status.labels[gardenAnnotationKey("version")],
     state,
     updatedAt: status.updateTime,
     detail: status,

--- a/garden-service/src/plugins/kubernetes/container/deployment.ts
+++ b/garden-service/src/plugins/kubernetes/container/deployment.ts
@@ -15,7 +15,6 @@ import { waitForResources } from "../status"
 import { apply, deleteObjectsByLabel } from "../kubectl"
 import { getAppNamespace } from "../namespace"
 import { PluginContext } from "../../../plugin-context"
-import { GARDEN_ANNOTATION_KEYS_VERSION } from "../../../constants"
 import { KubeApi } from "../api"
 import { KubernetesProvider, KubernetesPluginContext } from "../config"
 import { configureHotReload } from "../hot-reload"
@@ -27,6 +26,7 @@ import { LogEntry } from "../../../logger/log-entry"
 import { DeployServiceParams } from "../../../types/plugin/service/deployService"
 import { DeleteServiceParams } from "../../../types/plugin/service/deleteService"
 import { millicpuToString, kilobytesToString } from "../util"
+import { gardenAnnotationKey } from "../../../util/string"
 
 export const DEFAULT_CPU_REQUEST = "10m"
 export const DEFAULT_MEMORY_REQUEST = "64Mi"
@@ -74,8 +74,8 @@ export async function createContainerObjects(
   const objects = [deployment, ...kubeservices, ...ingresses]
 
   return objects.map(obj => {
-    set(obj, ["metadata", "annotations", "garden.io/generated"], "true")
-    set(obj, ["metadata", "annotations", GARDEN_ANNOTATION_KEYS_VERSION], version.versionString)
+    set(obj, ["metadata", "annotations", gardenAnnotationKey("generated")], "true")
+    set(obj, ["metadata", "annotations", gardenAnnotationKey("version")], version.versionString)
     set(obj, ["metadata", "labels", "module"], service.module.name)
     set(obj, ["metadata", "labels", "service"], service.name)
     return obj

--- a/garden-service/src/plugins/kubernetes/kubernetes-module/handlers.ts
+++ b/garden-service/src/plugins/kubernetes/kubernetes-module/handlers.ts
@@ -17,7 +17,6 @@ import { getNamespace, getAppNamespace } from "../namespace"
 import { KubernetesPluginContext } from "../config"
 import { KubernetesResource } from "../types"
 import { ServiceStatus } from "../../../types/service"
-import { GARDEN_ANNOTATION_KEYS_SERVICE } from "../../../constants"
 import { compareDeployedObjects, waitForResources } from "../status"
 import { KubeApi } from "../api"
 import { ModuleAndRuntimeActions } from "../../../types/plugin/plugin"
@@ -28,6 +27,7 @@ import { GetServiceStatusParams } from "../../../types/plugin/service/getService
 import { DeployServiceParams } from "../../../types/plugin/service/deployService"
 import { DeleteServiceParams } from "../../../types/plugin/service/deleteService"
 import { GetServiceLogsParams } from "../../../types/plugin/service/getServiceLogs"
+import { gardenAnnotationKey } from "../../../util/string"
 
 export const kubernetesHandlers: Partial<ModuleAndRuntimeActions<KubernetesModule>> = {
   build,
@@ -111,7 +111,7 @@ async function deleteService(params: DeleteServiceParams): Promise<ServiceStatus
     log,
     context,
     namespace,
-    labelKey: GARDEN_ANNOTATION_KEYS_SERVICE,
+    labelKey: gardenAnnotationKey("service"),
     labelValue: service.name,
     objectTypes: uniq(manifests.map(m => m.kind)),
     includeUninitialized: false,
@@ -131,7 +131,7 @@ async function getServiceLogs(params: GetServiceLogsParams<KubernetesModule>) {
 }
 
 function getSelector(service: KubernetesService) {
-  return `${GARDEN_ANNOTATION_KEYS_SERVICE}=${service.name}`
+  return `${gardenAnnotationKey("service")}=${service.name}`
 }
 
 async function getManifests(module: KubernetesModule): Promise<KubernetesResource[]> {
@@ -144,8 +144,8 @@ async function getManifests(module: KubernetesModule): Promise<KubernetesResourc
 
   // Add a label, so that we can identify the manifests as part of this module, and prune if needed
   return manifests.map(manifest => {
-    set(manifest, ["metadata", "annotations", GARDEN_ANNOTATION_KEYS_SERVICE], module.name)
-    set(manifest, ["metadata", "labels", GARDEN_ANNOTATION_KEYS_SERVICE], module.name)
+    set(manifest, ["metadata", "annotations", gardenAnnotationKey("service")], module.name)
+    set(manifest, ["metadata", "labels", gardenAnnotationKey("service")], module.name)
     return manifest
   })
 }

--- a/garden-service/src/plugins/kubernetes/namespace.ts
+++ b/garden-service/src/plugins/kubernetes/namespace.ts
@@ -19,6 +19,7 @@ import { GetEnvironmentStatusParams } from "../../types/plugin/provider/getEnvir
 import { kubectl, KUBECTL_DEFAULT_TIMEOUT } from "./kubectl"
 import { LogEntry } from "../../logger/log-entry"
 import { ConfigStore } from "../../config-store"
+import { gardenAnnotationKey } from "../../util/string"
 
 const GARDEN_VERSION = getPackageVersion()
 type CreateNamespaceStatus = "pending" | "created"
@@ -52,8 +53,8 @@ export async function createNamespace(api: KubeApi, namespace: string) {
     metadata: {
       name: namespace,
       annotations: {
-        "garden.io/generated": "true",
-        "garden.io/version": GARDEN_VERSION,
+        [gardenAnnotationKey("generated")]: "true",
+        [gardenAnnotationKey("version")]: GARDEN_VERSION,
       },
     },
   })

--- a/garden-service/src/plugins/kubernetes/system.ts
+++ b/garden-service/src/plugins/kubernetes/system.ts
@@ -18,7 +18,7 @@ import { LogEntry } from "../../logger/log-entry"
 import { KubeApi } from "./api"
 import { createNamespace } from "./namespace"
 import { getPackageVersion } from "../../util/util"
-import { deline } from "../../util/string"
+import { deline, gardenAnnotationKey } from "../../util/string"
 import { deleteNamespaces } from "./namespace"
 import { PluginError } from "../../exceptions"
 import { DashboardPage } from "../../config/dashboard"
@@ -84,7 +84,8 @@ export async function systemNamespaceUpToDate(
     }
   }
 
-  const versionInCluster = namespaceResource.metadata.annotations["garden.io/version"]
+  const annotations = namespaceResource.metadata.annotations || {}
+  const versionInCluster = annotations[gardenAnnotationKey("version")]
 
   const upToDate = !!versionInCluster && semver.gte(semver.coerce(versionInCluster)!, SYSTEM_NAMESPACE_MIN_VERSION)
 

--- a/garden-service/src/util/string.ts
+++ b/garden-service/src/util/string.ts
@@ -13,3 +13,11 @@ import _deline = require("deline")
 // the import syntax, and it for some reason doesn't play nice with IDEs).
 export const dedent = _dedent
 export const deline = _deline
+
+const gardenAnnotationPrefix = "garden.io/"
+
+export type GardenAnnotationKey = "generated" | "service" | "version"
+
+export function gardenAnnotationKey(key: GardenAnnotationKey) {
+  return gardenAnnotationPrefix + key
+}


### PR DESCRIPTION
Cleaned up our annotations code slightly along the way. The actual fix is
in `garden-service/src/plugins/kubernetes/system.ts`, a rather simple one.

Fixes #818