### PR TITLE
chore(demo-project): re-insert remote env

### DIFF
--- a/examples/demo-project/garden.yml
+++ b/examples/demo-project/garden.yml
@@ -4,3 +4,11 @@ environments:
   - name: local
     providers:
       - name: local-kubernetes
+  - name: remote
+    providers:
+      - name: kubernetes
+        # Replace these values as appropriate
+        context: gke_garden-dev-200012_europe-west1-b_garden-dev-1
+        namespace: ${local.env.USER || "default"}-demo-project
+        defaultHostname: ${local.env.USER || "default"}-demo-project.dev-1.sys.garden
+        buildMode: cluster-docker


### PR DESCRIPTION
It fell between the cracks when we re-named from simple-project.