### PR TITLE
feat(core): allow .yaml endings for Garden config files

### DIFF
--- a/examples/gatsby-hot-reload/.dockerignore
+++ b/examples/gatsby-hot-reload/.dockerignore
@@ -1,3 +1,3 @@
 node_modules
-garden.yaml
+garden.yml
 .git

--- a/garden-service/src/commands/base.ts
+++ b/garden-service/src/commands/base.ts
@@ -7,7 +7,7 @@
  */
 
 import Joi = require("joi")
-import { GardenError, RuntimeError, InternalError } from "../exceptions"
+import { GardenError, RuntimeError, InternalError, ParameterError } from "../exceptions"
 import { TaskResults } from "../task-graph"
 import { LoggerType } from "../logger/logger"
 import { ProcessResults } from "../process"
@@ -15,8 +15,6 @@ import { Garden } from "../garden"
 import { LogEntry } from "../logger/log-entry"
 import { printFooter } from "../logger/util"
 import { GlobalOptions } from "../cli/cli"
-
-export class ValidationError extends Error { }
 
 export interface ParameterConstructor<T> {
   help: string,
@@ -139,7 +137,10 @@ export class IntegerParameter extends Parameter<number> {
     try {
       return parseInt(input, 10)
     } catch {
-      throw new ValidationError(`Could not parse "${input}" as integer`)
+      throw new ParameterError(`Could not parse "${input}" as integer`, {
+        expectedType: "integer",
+        input,
+      })
     }
   }
 }
@@ -164,7 +165,10 @@ export class ChoicesParameter extends Parameter<string> {
     if (this.choices.includes(input)) {
       return input
     } else {
-      throw new ValidationError(`"${input}" is not a valid argument`)
+      throw new ParameterError(`"${input}" is not a valid argument`, {
+        expectedType: `One of: ${this.choices.join(", ")}`,
+        input,
+      })
     }
   }
 

--- a/garden-service/src/config/base.ts
+++ b/garden-service/src/config/base.ts
@@ -6,14 +6,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { join, sep, resolve, relative } from "path"
+import { sep, resolve, relative, basename } from "path"
 import * as yaml from "js-yaml"
 import { readFile } from "fs-extra"
 import { omit, flatten, isPlainObject, find } from "lodash"
 import { baseModuleSpecSchema, ModuleResource } from "./module"
 import { ConfigurationError } from "../exceptions"
-import { CONFIG_FILENAME, DEFAULT_API_VERSION } from "../constants"
+import { DEFAULT_API_VERSION } from "../constants"
 import { ProjectResource } from "../config/project"
+import { getConfigFilePath } from "../util/fs"
 
 export interface GardenResource {
   apiVersion: string
@@ -26,7 +27,7 @@ const baseModuleSchemaKeys = Object.keys(baseModuleSpecSchema.describe().childre
 
 export async function loadConfig(projectRoot: string, path: string): Promise<GardenResource[]> {
   // TODO: nicer error messages when load/validation fails
-  const absPath = join(path, CONFIG_FILENAME)
+  const absPath = await getConfigFilePath(path)
   let fileData: Buffer
   let rawSpecs: any[]
 
@@ -40,7 +41,7 @@ export async function loadConfig(projectRoot: string, path: string): Promise<Gar
   try {
     rawSpecs = yaml.safeLoadAll(fileData.toString()) || []
   } catch (err) {
-    throw new ConfigurationError(`Could not parse ${CONFIG_FILENAME} in directory ${path} as valid YAML`, err)
+    throw new ConfigurationError(`Could not parse ${basename(absPath)} in directory ${path} as valid YAML`, err)
   }
 
   const resources: GardenResource[] = flatten(rawSpecs.map(s => prepareResources(s, path, projectRoot)))

--- a/garden-service/src/constants.ts
+++ b/garden-service/src/constants.ts
@@ -10,7 +10,6 @@ import { resolve, join } from "path"
 
 export const isPkg = !!(<any>process).pkg
 
-export const CONFIG_FILENAME = "garden.yml"
 export const LOCAL_CONFIG_FILENAME = "local-config.yml"
 export const GARDEN_SERVICE_ROOT = isPkg ? resolve(process.execPath, "..") : resolve(__dirname, "..", "..")
 export const STATIC_DIR = join(GARDEN_SERVICE_ROOT, "static")

--- a/garden-service/src/types/module.ts
+++ b/garden-service/src/types/module.ts
@@ -6,7 +6,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { resolve } from "path"
 import { flatten, uniq, cloneDeep, keyBy } from "lodash"
 import { getNames } from "../util/util"
 import { TestSpec } from "../config/test"
@@ -20,7 +19,7 @@ import * as Joi from "joi"
 import { joiArray, joiIdentifier, joiIdentifierMap } from "../config/common"
 import { ConfigGraph } from "../config-graph"
 import * as Bluebird from "bluebird"
-import { CONFIG_FILENAME } from "../constants"
+import { getConfigFilePath } from "../util/fs"
 
 export interface FileCopySpec {
   source: string
@@ -96,7 +95,7 @@ export interface ModuleConfigMap<T extends ModuleConfig = ModuleConfig> {
 }
 
 export async function moduleFromConfig(garden: Garden, graph: ConfigGraph, config: ModuleConfig): Promise<Module> {
-  const configPath = resolve(config.path, CONFIG_FILENAME)
+  const configPath = await getConfigFilePath(config.path)
   const version = await garden.resolveVersion(config.name, config.build.dependencies)
 
   // Always include configuration file

--- a/garden-service/test/helpers.ts
+++ b/garden-service/test/helpers.ts
@@ -26,7 +26,7 @@ import { Garden, GardenOpts } from "../src/garden"
 import { ModuleConfig } from "../src/config/module"
 import { mapValues, fromPairs } from "lodash"
 import { ModuleVersion } from "../src/vcs/vcs"
-import { CONFIG_FILENAME, GARDEN_SERVICE_ROOT } from "../src/constants"
+import { GARDEN_SERVICE_ROOT } from "../src/constants"
 import { EventBus, Events } from "../src/events"
 import { ValueOf } from "../src/util/util"
 import { Ignorer } from "../src/util/fs"
@@ -400,7 +400,10 @@ export function stubExtSources(garden: Garden) {
 }
 
 export function getExampleProjects() {
-  const names = readdirSync(examplesDir).filter(n => existsSync(join(examplesDir, n, CONFIG_FILENAME)))
+  const names = readdirSync(examplesDir).filter(n => {
+    const basePath = join(examplesDir, n)
+    return existsSync(join(basePath, "garden.yml")) || existsSync(join(basePath, "garden.yaml"))
+  })
   return fromPairs(names.map(n => [n, join(examplesDir, n)]))
 }
 

--- a/garden-service/test/unit/data/test-project-duplicate-yaml-file-extensions/garden.yaml
+++ b/garden-service/test/unit/data/test-project-duplicate-yaml-file-extensions/garden.yaml
@@ -1,0 +1,11 @@
+project:
+  name: test-project-a
+  environmentDefaults:
+    variables:
+      some: variable
+  environments:
+    - name: local
+      providers:
+        - name: test-plugin
+        - name: test-plugin-b
+    - name: other

--- a/garden-service/test/unit/data/test-project-duplicate-yaml-file-extensions/garden.yml
+++ b/garden-service/test/unit/data/test-project-duplicate-yaml-file-extensions/garden.yml
@@ -1,0 +1,11 @@
+project:
+  name: test-project-a
+  environmentDefaults:
+    variables:
+      some: variable
+  environments:
+    - name: local
+      providers:
+        - name: test-plugin
+        - name: test-plugin-b
+    - name: other

--- a/garden-service/test/unit/data/test-project-yaml-file-extensions/garden.yaml
+++ b/garden-service/test/unit/data/test-project-yaml-file-extensions/garden.yaml
@@ -1,0 +1,11 @@
+project:
+  name: test-project-a
+  environmentDefaults:
+    variables:
+      some: variable
+  environments:
+    - name: local
+      providers:
+        - name: test-plugin
+        - name: test-plugin-b
+    - name: other

--- a/garden-service/test/unit/data/test-project-yaml-file-extensions/module-no-config/foo.yml
+++ b/garden-service/test/unit/data/test-project-yaml-file-extensions/module-no-config/foo.yml
@@ -1,0 +1,3 @@
+module:
+  name: module-foo
+  type: test

--- a/garden-service/test/unit/data/test-project-yaml-file-extensions/module-yaml/garden.yaml
+++ b/garden-service/test/unit/data/test-project-yaml-file-extensions/module-yaml/garden.yaml
@@ -1,0 +1,3 @@
+module:
+  name: module-yaml
+  type: test

--- a/garden-service/test/unit/data/test-project-yaml-file-extensions/module-yml/garden.yml
+++ b/garden-service/test/unit/data/test-project-yaml-file-extensions/module-yml/garden.yml
@@ -1,0 +1,3 @@
+module:
+  name: module-yml
+  type: test

--- a/garden-service/test/unit/src/build-dir.ts
+++ b/garden-service/test/unit/src/build-dir.ts
@@ -4,7 +4,7 @@ import { pathExists, readdir } from "fs-extra"
 import { expect } from "chai"
 import { BuildTask } from "../../../src/tasks/build"
 import { makeTestGarden, dataDir } from "../../helpers"
-import { CONFIG_FILENAME } from "../../../src/constants"
+import { getConfigFilePath } from "../../../src/util/fs"
 
 /*
   Module dependency diagram for test-project-build-products
@@ -52,7 +52,7 @@ describe("BuildDir", () => {
     const buildDirA = await garden.buildDir.buildPath(moduleA.name)
 
     const copiedPaths = [
-      join(buildDirA, CONFIG_FILENAME),
+      await getConfigFilePath(buildDirA),
       join(buildDirA, "some-dir", "some-file"),
     ]
 

--- a/garden-service/test/unit/src/commands/get/get-debug-info.ts
+++ b/garden-service/test/unit/src/commands/get/get-debug-info.ts
@@ -19,10 +19,11 @@ import {
   GetDebugInfoCommand,
 } from "../../../../../src/commands/get/get-debug-info"
 import { readdirSync, remove, pathExists, readJSONSync } from "fs-extra"
-import { CONFIG_FILENAME, ERROR_LOG_FILENAME } from "../../../../../src/constants"
+import { ERROR_LOG_FILENAME } from "../../../../../src/constants"
 import { join, relative } from "path"
 import { Garden } from "../../../../../src/garden"
 import { LogEntry } from "../../../../../src/logger/log-entry"
+import { getConfigFilePath } from "../../../../../src/util/fs"
 
 const debugZipFileRegex = new RegExp(/debug-info-.*?.zip/)
 
@@ -98,7 +99,7 @@ describe("GetDebugInfoCommand", () => {
       await collectBasicDebugInfo(garden.projectRoot, garden.gardenDirPath, log)
 
       // we first check if the main garden.yml exists
-      expect(await pathExists(join(gardenDebugTmp, CONFIG_FILENAME))).to.equal(true)
+      expect(await pathExists(await getConfigFilePath(gardenDebugTmp))).to.equal(true)
       const graph = await garden.getConfigGraph()
 
       // Check that each module config files have been copied over and
@@ -110,7 +111,7 @@ describe("GetDebugInfoCommand", () => {
         expect(await pathExists(join(gardenDebugTmp, moduleRelativePath))).to.equal(true)
 
         // Checks config file is copied over
-        expect(await pathExists(join(gardenDebugTmp, moduleRelativePath, CONFIG_FILENAME))).to.equal(true)
+        expect(await pathExists(await getConfigFilePath(join(gardenDebugTmp, moduleRelativePath)))).to.equal(true)
 
         // Checks error logs are copied over if they exist
         if (await pathExists(join(module.path, ERROR_LOG_FILENAME))) {

--- a/garden-service/test/unit/src/garden.ts
+++ b/garden-service/test/unit/src/garden.ts
@@ -51,6 +51,16 @@ describe("Garden", () => {
       expect(garden).to.be.ok
     })
 
+    it("should initialize a project with config files with yaml and yml extensions", async () => {
+      const garden = await makeTestGarden(getDataDir("test-project-yaml-file-extensions"))
+      expect(garden).to.be.ok
+    })
+
+    it("should throw if a project has config files with yaml and yml extensions in the same dir", async () => {
+      const path = getDataDir("test-project-duplicate-yaml-file-extensions")
+      await expectError(async () => makeTestGarden(path), "validation")
+    })
+
     it("should parse and resolve the config from the project root", async () => {
       const garden = await makeTestGardenA()
       const projectRoot = garden.projectRoot
@@ -687,6 +697,12 @@ describe("Garden", () => {
           "Module module-a is declared multiple times (in 'module-a/garden.yml' and 'module-b/garden.yml')",
         ),
       )
+    })
+
+    it("should scan and add modules with config files with yaml and yml extensions", async () => {
+      const garden = await makeTestGarden(getDataDir("test-project-yaml-file-extensions"))
+      const modules = await garden.resolveModuleConfigs()
+      expect(getNames(modules).sort()).to.eql(["module-yaml", "module-yml"])
     })
   })
 


### PR DESCRIPTION
With this PR, users can now name their Garden config files either `garden.yml` or `garden.yaml`.

Closes #562 