### PR TITLE
chore: updated bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -37,6 +37,5 @@ about: Create a report to help make garden better
 <!-- Please run and copy and paste the results  -->
 `garden version`
 
-`kubectl version`
-
-`docker version`
+<!-- Please run the "get debug-info" command and attach the output zip file -->
+`garden get debug-info`


### PR DESCRIPTION
Updated the Bug Report template to include the `garden get debug-info` command.