### PR TITLE
docs: add missing links to summary

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,8 @@
     * [Container](./reference/module-types/container.md)
     * [Exec](./reference/module-types/exec.md)
     * [Helm](./reference/module-types/helm.md)
+    * [Kubernetes](./reference/module-types/kubernetes.md)
+    * [Maven Container](./reference/module-types/maven-container.md)
     * [OpenFaaS](./reference/module-types/openfaas.md)
   * [Providers](./reference/providers/README.md)
     * [Kubernetes](./reference/providers/kubernetes.md)


### PR DESCRIPTION
If a link is not included in the "SUMMARY" file, it won't work correctly
and will point to Github instead of docs.garden.io. Our "SUMMARY" file
is the docs/README.md file. This can be configured in the
`.gitbook.yaml` config file.