### PR TITLE
fix(delete-env): delete services before calling cleanupEnvironment

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -106,8 +106,8 @@ Examples:
 
 Deletes a running environment.
 
-This will trigger providers to clear up any deployments in a Garden environment and reset it.
-When you then run `garden init`, the environment will be reconfigured.
+This will delete all services in the specified environment, and trigger providers to clear up any other resources
+and reset it. When you then run `garden init` or `garden deploy`, the environment will be reconfigured.
 
 This can be useful if you find the environment to be in an inconsistent state, or need/want to free up
 resources.

--- a/examples/vote-helm/postgres/garden.yml
+++ b/examples/vote-helm/postgres/garden.yml
@@ -30,7 +30,7 @@ tasks:
       --host, postgres,
       --port=5432,
       -d, postgres,
-      -c "TRUNCATE votes"
+      -c, "TRUNCATE votes"
     ]
     env:
       PGPASSWORD: postgres

--- a/examples/vote-helm/postgres/garden.yml
+++ b/examples/vote-helm/postgres/garden.yml
@@ -16,7 +16,7 @@ tasks:
       --host, postgres,
       --port=5432,
       -d, postgres,
-      -c, "'CREATE TABLE IF NOT EXISTS votes (id VARCHAR(255) NOT NULL UNIQUE, vote VARCHAR(255) NOT NULL, created_at timestamp default NULL)'"
+      -c, "CREATE TABLE IF NOT EXISTS votes (id VARCHAR(255) NOT NULL UNIQUE, vote VARCHAR(255) NOT NULL, created_at timestamp default NULL)"
     ]
     env:
       PGPASSWORD: postgres
@@ -30,7 +30,7 @@ tasks:
       --host, postgres,
       --port=5432,
       -d, postgres,
-      -c "'TRUNCATE votes'"
+      -c "TRUNCATE votes"
     ]
     env:
       PGPASSWORD: postgres

--- a/garden-service/src/actions.ts
+++ b/garden-service/src/actions.ts
@@ -331,11 +331,26 @@ export class ActionHelper implements TypeGuard {
       msg: "Deleting...",
       status: "active",
     })
-    return this.callServiceHandler({
+
+    const status = await this.getServiceStatus({ ...params, hotReload: false })
+
+    if (status.state === "missing") {
+      log.setSuccess({
+        section: params.service.name,
+        msg: "Not found",
+      })
+      return status
+    }
+
+    const result = this.callServiceHandler({
       params: { ...params, log },
       actionType: "deleteService",
       defaultHandler: dummyDeleteServiceHandler,
     })
+
+    log.setSuccess()
+
+    return result
   }
 
   async execInService(params: ServiceActionHelperParams<ExecInServiceParams>): Promise<ExecInServiceResult> {


### PR DESCRIPTION
This addresses issues where services contain resources that the provider
isn't directly aware of, e.g. when Helm charts deploy cluster-wide resources.

Closes #855