### PR TITLE
fix(core): chokidar watcher on mac could segfault after reloading config

### DIFF
--- a/garden-service/src/garden.ts
+++ b/garden-service/src/garden.ts
@@ -106,7 +106,7 @@ export class Garden {
   private modulesScanned: boolean
   private readonly registeredPlugins: { [key: string]: PluginFactory }
   private readonly taskGraph: TaskGraph
-  private readonly watcher: Watcher
+  private watcher: Watcher
 
   public readonly configStore: ConfigStore
   public readonly globalConfigStore: GlobalConfigStore
@@ -167,7 +167,6 @@ export class Garden {
 
     this.taskGraph = new TaskGraph(this, this.log)
     this.events = new EventBus(this.log)
-    this.watcher = new Watcher(this, this.log)
 
     // Register plugins
     for (const [name, pluginFactory] of Object.entries({ ...builtinPlugins, ...params.plugins })) {
@@ -234,7 +233,7 @@ export class Garden {
    * Clean up before shutting down.
    */
   async close() {
-    this.watcher.stop()
+    this.watcher && this.watcher.stop()
   }
 
   getPluginContext(providerName: string) {
@@ -255,7 +254,7 @@ export class Garden {
    */
   async startWatcher(graph: ConfigGraph) {
     const modules = await graph.getModules()
-    this.watcher.start(modules)
+    this.watcher = new Watcher(this, this.log, modules)
   }
 
   private registerPlugin(name: string, moduleOrFactory: RegisterPluginParam) {

--- a/garden-service/src/util/util.ts
+++ b/garden-service/src/util/util.ts
@@ -50,7 +50,7 @@ export type Unpacked<T> =
 
 const MAX_BUFFER_SIZE = 1024 * 1024
 
-export function shutdown(code) {
+export function shutdown(code?: number) {
   // This is a good place to log exitHookNames if needed.
   process.exit(code)
 }

--- a/garden-service/test/mocha.integ.opts
+++ b/garden-service/test/mocha.integ.opts
@@ -5,5 +5,6 @@
 --watch-extensions js,json,pegjs
 --reporter spec
 --timeout 0
+--exit
 build/test/setup.js
 build/test/integ/src/**/*.js

--- a/garden-service/test/mocha.opts
+++ b/garden-service/test/mocha.opts
@@ -5,5 +5,6 @@
 --watch-extensions js,json,pegjs
 --reporter spec
 --timeout 20000
+--exit
 build/test/setup.js
 build/test/unit/**/*.js


### PR DESCRIPTION
Turns out chokidar and the native fsevents module don't like it when multiple
instances are created in a single process, even if one is closed before the
other starts. Fixed it by making a global instance and reconfiguring on
reload instead. See https://github.com/fsevents/fsevents/issues/273 for
a discussion on this issue.