### PR TITLE
 feat(container): allow configuring # of replicas for container services

### DIFF
--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -303,7 +303,7 @@ The names of any services that this service depends on at runtime, and the names
 
 [services](#services) > annotations
 
-Annotations to attach to the service (Note: May not be applicable to all providers)
+Annotations to attach to the service (Note: May not be applicable to all providers).
 
 | Type | Required |
 | ---- | -------- |
@@ -351,7 +351,7 @@ services:
 
 [services](#services) > daemon
 
-Whether to run the service as a daemon (to ensure only one runs per node).
+Whether to run the service as a daemon (to ensure exactly one instance runs per node). May not be supported by all providers.
 
 | Type | Required |
 | ---- | -------- |
@@ -652,6 +652,17 @@ Set this to expose the service on the specified port on the host node (may not b
 | ---- | -------- |
 | `number` | No
 
+### `services[].replicas`
+
+[services](#services) > replicas
+
+The number of instances of the service to deploy.
+Note: This setting may be overridden or ignored in some cases. For example, when running with `daemon: true`, with hot-reloading enabled, or if the provider doesn't support multiple replicas.
+
+| Type | Required |
+| ---- | -------- |
+| `number` | No
+
 ### `services[].volumes[]`
 
 [services](#services) > volumes
@@ -929,6 +940,7 @@ services:
         servicePort: <containerPort>
         hostPort:
         nodePort:
+    replicas: 1
     volumes:
       - name:
         containerPath:

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -308,7 +308,7 @@ The names of any services that this service depends on at runtime, and the names
 
 [services](#services) > annotations
 
-Annotations to attach to the service (Note: May not be applicable to all providers)
+Annotations to attach to the service (Note: May not be applicable to all providers).
 
 | Type | Required |
 | ---- | -------- |
@@ -356,7 +356,7 @@ services:
 
 [services](#services) > daemon
 
-Whether to run the service as a daemon (to ensure only one runs per node).
+Whether to run the service as a daemon (to ensure exactly one instance runs per node). May not be supported by all providers.
 
 | Type | Required |
 | ---- | -------- |
@@ -652,6 +652,17 @@ services:
 [services](#services) > [ports](#services[].ports[]) > nodePort
 
 Set this to expose the service on the specified port on the host node (may not be supported by all providers).
+
+| Type | Required |
+| ---- | -------- |
+| `number` | No
+
+### `services[].replicas`
+
+[services](#services) > replicas
+
+The number of instances of the service to deploy.
+Note: This setting may be overridden or ignored in some cases. For example, when running with `daemon: true`, with hot-reloading enabled, or if the provider doesn't support multiple replicas.
 
 | Type | Required |
 | ---- | -------- |
@@ -964,6 +975,7 @@ services:
         servicePort: <containerPort>
         hostPort:
         nodePort:
+    replicas: 1
     volumes:
       - name:
         containerPath:

--- a/docs/using-garden/configuration-files.md
+++ b/docs/using-garden/configuration-files.md
@@ -399,15 +399,14 @@ key:
 kind: Project
 ...
 variables:
-  global-memory-limit: 100
+  default-replicas: 3
 ---
 kind: Module
 ...
 services:
   - name: my-service
     ...
-    limits:
-      memory: ${var.global-memory-limit}   # <- resolves to a number, as opposed to the string "100"
+    replicas: ${var.default-replicas}   # <- resolves to a number, as opposed to the string "3"
 ```
 
 If, however, the template string is not the whole string being interpolated, but a component of it, the value is

--- a/examples/demo-project/README.md
+++ b/examples/demo-project/README.md
@@ -1,0 +1,3 @@
+# Demo project
+
+A very basic demo project for Garden. Used in the [Quick Start guide](https://docs.garden.io/basics/quick-start).

--- a/examples/project-variables/README.md
+++ b/examples/project-variables/README.md
@@ -1,0 +1,10 @@
+# Project variables
+
+This variant of the basic [demo project](../demo-project/README.md) demonstrate the use of project variables.
+
+In this example, we set a project variable in the [project config](./garden.yml) called `service-replicas` and
+reference that variable in the module configs, in this case to set the number of replicas per service.
+
+We also show how you can alternate these variables by the environment you're running, by overriding the default value
+in the `local` environment. In this case, we only want _one_ replica of each service while developing locally, but
+default to three when deploying remotely.

--- a/examples/project-variables/backend/.dockerignore
+++ b/examples/project-variables/backend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+Dockerfile
+garden.yml
+app.yaml

--- a/examples/project-variables/backend/.gitignore
+++ b/examples/project-variables/backend/.gitignore
@@ -1,0 +1,27 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+.vscode/settings.json
+webserver/*server*

--- a/examples/project-variables/backend/Dockerfile
+++ b/examples/project-variables/backend/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.8.3-alpine
+MAINTAINER Aurelien PERRIER <a.perrier89@gmail.com>
+
+ENV webserver_path /go/src/github.com/perriea/webserver/
+ENV PATH $PATH:$webserver_path
+
+WORKDIR $webserver_path
+COPY webserver/ .
+
+RUN go build .
+
+ENTRYPOINT ./webserver
+
+EXPOSE 8080

--- a/examples/project-variables/backend/garden.yml
+++ b/examples/project-variables/backend/garden.yml
@@ -1,0 +1,14 @@
+kind: Module
+name: backend
+description: Backend service container
+type: container
+services:
+  - name: backend
+    replicas: ${var.service-replicas}   # <- Refers to the variable set in the project config
+    ports:
+      - name: http
+        containerPort: 8080
+        servicePort: 80
+    ingresses:
+      - path: /hello-backend
+        port: http

--- a/examples/project-variables/backend/webserver/main.go
+++ b/examples/project-variables/backend/webserver/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, "Hello from Go!")
+}
+
+func main() {
+	http.HandleFunc("/hello-backend", handler)
+	fmt.Println("Server running...")
+
+	http.ListenAndServe(":8080", nil)
+}

--- a/examples/project-variables/frontend/.dockerignore
+++ b/examples/project-variables/frontend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+Dockerfile
+garden.yml
+app.yaml

--- a/examples/project-variables/frontend/Dockerfile
+++ b/examples/project-variables/frontend/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:9-alpine
+
+ENV PORT=8080
+EXPOSE ${PORT}
+WORKDIR /app
+
+ADD package.json /app
+RUN npm install
+
+ADD . /app
+
+CMD ["npm", "start"]

--- a/examples/project-variables/frontend/app.js
+++ b/examples/project-variables/frontend/app.js
@@ -1,0 +1,28 @@
+const express = require('express');
+const request = require('request-promise')
+const app = express();
+
+const backendServiceEndpoint = `http://backend/hello-backend`
+// const backendServiceEndpoint = `http://demo-project.local.app.garden/hello-backend`
+
+app.get('/hello-frontend', (req, res) => res.send('Hello from the frontend!'));
+
+app.get('/call-backend', (req, res) => {
+  // Query the backend and return the response
+  request.get(backendServiceEndpoint)
+    .then(message => {
+      message = `Backend says: '${message}'`
+      res.json({
+        message,
+      })
+    })
+    .catch(err => {
+      res.statusCode = 500
+      res.json({
+        error: err,
+        message: "Unable to reach service at " + backendServiceEndpoint,
+      })
+    });
+});
+
+module.exports = { app }

--- a/examples/project-variables/frontend/garden.yml
+++ b/examples/project-variables/frontend/garden.yml
@@ -1,0 +1,28 @@
+kind: Module
+name: frontend
+description: Frontend service container
+type: container
+services:
+  - name: frontend
+    replicas: ${var.service-replicas}   # <- Refers to the variable set in the project config
+    ports:
+      - name: http
+        containerPort: 8080
+    healthCheck:
+      httpGet:
+        path: /hello-frontend
+        port: http
+    ingresses:
+      - path: /hello-frontend
+        port: http
+      - path: /call-backend
+        port: http
+    dependencies:
+      - backend
+tests:
+  - name: unit
+    args: [npm, test]
+  - name: integ
+    args: [npm, run, integ]
+    dependencies:
+      - backend

--- a/examples/project-variables/frontend/main.js
+++ b/examples/project-variables/frontend/main.js
@@ -1,0 +1,3 @@
+const { app } = require('./app');
+
+app.listen(process.env.PORT, '0.0.0.0', () => console.log('Frontend service started'));

--- a/examples/project-variables/frontend/package.json
+++ b/examples/project-variables/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "description": "Simple Node.js docker service",
+  "main": "main.js",
+  "scripts": {
+    "start": "node main.js",
+    "test": "echo OK",
+    "integ": "node_modules/mocha/bin/mocha test/integ.js"
+  },
+  "author": "garden.io <info@garden.io>",
+  "license": "ISC",
+  "dependencies": {
+    "express": "^4.16.2",
+    "request": "^2.83.0",
+    "request-promise": "^4.2.2"
+  },
+  "devDependencies": {
+    "mocha": "^5.1.1",
+    "supertest": "^3.0.0"
+  }
+}

--- a/examples/project-variables/frontend/test/integ.js
+++ b/examples/project-variables/frontend/test/integ.js
@@ -1,0 +1,17 @@
+const supertest = require("supertest")
+const { app } = require("../app")
+
+describe('GET /call-backend', () => {
+  const agent = supertest.agent(app)
+
+  it('should respond with a message from the backend service', (done) => {
+    agent
+      .get("/call-backend")
+      .expect(200, { message: "Backend says: 'Hello from Go!'" })
+      .end((err) => {
+        if (err) return done(err)
+        done()
+      })
+  })
+})
+

--- a/examples/project-variables/garden.yml
+++ b/examples/project-variables/garden.yml
@@ -1,0 +1,19 @@
+kind: Project
+name: project-variables
+variables:
+  # This variable is referenced in the module configs, and overridden in the local project below
+  service-replicas: 3
+environments:
+  - name: local
+    providers:
+      - name: local-kubernetes
+    variables:
+      # We only want one replica of each service when developing locally
+      service-replicas: 1
+  - name: testing
+    providers:
+      - name: kubernetes
+        context: gke_garden-dev-200012_europe-west1-b_garden-dev-1
+        namespace: ${project.name}-testing-${local.env.CIRCLE_BUILD_NUM || "default"}
+        defaultHostname: ${project.name}-testing.dev-1.sys.garden
+        buildMode: cluster-docker

--- a/garden-service/src/plugins/kubernetes/container/logs.ts
+++ b/garden-service/src/plugins/kubernetes/container/logs.ts
@@ -14,12 +14,19 @@ import { KubernetesPluginContext } from "../config"
 import { createDeployment } from "./deployment"
 
 export async function getServiceLogs(params: GetServiceLogsParams<ContainerModule>) {
-  const { ctx, log, service } = params
+  const { ctx, log, service, runtimeContext } = params
   const k8sCtx = <KubernetesPluginContext>ctx
   const context = k8sCtx.provider.config.context
   const namespace = await getAppNamespace(k8sCtx, log, k8sCtx.provider)
 
-  const resources = [await createDeployment(k8sCtx.provider, service, params.runtimeContext, namespace, false)]
+  const resources = [await createDeployment({
+    provider: k8sCtx.provider,
+    service,
+    runtimeContext,
+    namespace,
+    enableHotReload: false,
+    log,
+  })]
 
   return getAllLogs({ ...params, context, namespace, resources })
 }

--- a/garden-service/src/plugins/local/local-google-cloud-functions.ts
+++ b/garden-service/src/plugins/local/local-google-cloud-functions.ts
@@ -95,6 +95,7 @@ export const gardenPlugin = (): GardenPlugin => ({
                 servicePort: emulatorPort,
               },
             ],
+            replicas: 1,
             volumes: [],
           }
 

--- a/garden-service/test/integ/garden.yml
+++ b/garden-service/test/integ/garden.yml
@@ -21,6 +21,8 @@ tests:
     command: [npm, run, integ-full, --, --only=tasks, --showlog=true, --env=testing]
   - name: hot-reload # Tests for hot-reload are currently being skipped
     command: [npm, run, integ-full, --, --only=hot-reload, --showlog=true, --env=testing]
+  - name: project-variables
+    command: [npm, run, integ-full, --, --only=project-variables, --showlog=true, --env=testing]
   - name: vote-helm
     command: [npm, run, integ-full, --, --only=vote-helm, --showlog=true, --env=testing]
   - name: vote

--- a/garden-service/test/unit/src/plugins/container.ts
+++ b/garden-service/test/unit/src/plugins/container.ts
@@ -419,6 +419,7 @@ describe("plugins.container", () => {
                 containerPort: 8080,
                 servicePort: 8080,
               }],
+              replicas: 1,
               volumes: [],
             }],
             tasks: [{
@@ -485,6 +486,7 @@ describe("plugins.container", () => {
                   memory: 456,
                 },
                 ports: [{ name: "http", protocol: "TCP", containerPort: 8080, servicePort: 8080 }],
+                replicas: 1,
                 volumes: [],
               }],
             tasks:
@@ -535,6 +537,7 @@ describe("plugins.container", () => {
                   memory: 456,
                 },
                 ports: [{ name: "http", protocol: "TCP", containerPort: 8080, servicePort: 8080 }],
+                replicas: 1,
                 volumes: [],
               },
             }],
@@ -606,6 +609,7 @@ describe("plugins.container", () => {
               limits: defaultContainerLimits,
               env: {},
               ports: [],
+              replicas: 1,
               volumes: [],
             }],
             tasks: [{
@@ -666,6 +670,7 @@ describe("plugins.container", () => {
               },
               limits: defaultContainerLimits,
               ports: [],
+              replicas: 1,
               volumes: [],
             }],
             tasks: [{
@@ -717,6 +722,7 @@ describe("plugins.container", () => {
               },
               limits: defaultContainerLimits,
               ports: [],
+              replicas: 1,
               volumes: [],
             }],
             tasks: [{

--- a/garden-service/test/unit/src/plugins/kubernetes/container/ingress.ts
+++ b/garden-service/test/unit/src/plugins/kubernetes/container/ingress.ts
@@ -345,6 +345,7 @@ describe("createIngressResources", () => {
       ingresses,
       limits: defaultContainerLimits,
       ports,
+      replicas: 1,
       volumes: [],
     }
     const moduleConfig = {


### PR DESCRIPTION
Also added `project-variables` project to showcase the usage.

_Note: This is based off the template-string-improvement branch, since that was necessary to complete this. Please review but don't merge._