### PR TITLE
fix(k8s): enable publishing container modules when using remote builders

### DIFF
--- a/garden-service/src/actions.ts
+++ b/garden-service/src/actions.ts
@@ -285,7 +285,7 @@ export class ActionHelper implements TypeGuard {
   async publishModule<T extends Module>(
     params: ModuleActionHelperParams<PublishModuleParams<T>>,
   ): Promise<PublishResult> {
-    return this.callModuleHandler({ params, actionType: "publishModule", defaultHandler: dummyPublishHandler })
+    return this.callModuleHandler({ params, actionType: "publish", defaultHandler: dummyPublishHandler })
   }
 
   async runModule<T extends Module>(params: ModuleActionHelperParams<RunModuleParams<T>>): Promise<RunResult> {

--- a/garden-service/src/plugins/container/publish.ts
+++ b/garden-service/src/plugins/container/publish.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2018 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { ContainerModule } from "./config"
+import { PublishModuleParams } from "../../types/plugin/module/publishModule"
+import { containerHelpers } from "./helpers"
+
+export async function publishContainerModule({ module, log }: PublishModuleParams<ContainerModule>) {
+  if (!(await containerHelpers.hasDockerfile(module))) {
+    log.setState({ msg: `Nothing to publish` })
+    return { published: false }
+  }
+
+  const localId = await containerHelpers.getLocalImageId(module)
+  const remoteId = await containerHelpers.getPublicImageId(module)
+
+  log.setState({ msg: `Publishing image ${remoteId}...` })
+
+  if (localId !== remoteId) {
+    await containerHelpers.dockerCli(module, ["tag", localId, remoteId])
+  }
+
+  // TODO: stream output to log if at debug log level
+  await containerHelpers.dockerCli(module, ["push", remoteId])
+
+  return { published: true, message: `Published ${remoteId}` }
+}

--- a/garden-service/src/plugins/kubernetes/constants.ts
+++ b/garden-service/src/plugins/kubernetes/constants.ts
@@ -7,3 +7,5 @@
  */
 
 export const RSYNC_PORT = 873
+export const CLUSTER_REGISTRY_PORT = 5000
+export const CLUSTER_REGISTRY_DEPLOYMENT_NAME = "garden-docker-registry"

--- a/garden-service/src/plugins/kubernetes/container/handlers.ts
+++ b/garden-service/src/plugins/kubernetes/container/handlers.ts
@@ -21,6 +21,7 @@ import { ContainerModule } from "../../container/config"
 import { configureMavenContainerModule, MavenContainerModule } from "../../maven-container/maven-container"
 import { getTaskResult } from "../task-results"
 import { k8sBuildContainer, k8sGetContainerBuildStatus } from "./build"
+import { k8sPublishContainerModule } from "./publish"
 
 async function configure(params: ConfigureModuleParams<ContainerModule>) {
   params.moduleConfig = await configureContainerModule(params)
@@ -44,6 +45,7 @@ export const containerHandlers = {
   getServiceStatus: getContainerServiceStatus,
   getTestResult,
   hotReloadService: hotReloadContainer,
+  publish: k8sPublishContainerModule,
   runModule: runContainerModule,
   runService: runContainerService,
   runTask: runContainerTask,

--- a/garden-service/src/plugins/kubernetes/container/publish.ts
+++ b/garden-service/src/plugins/kubernetes/container/publish.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2018 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { ContainerModule } from "../../container/config"
+import { PublishModuleParams } from "../../../types/plugin/module/publishModule"
+import { containerHelpers } from "../../container/helpers"
+import { KubernetesPluginContext } from "../config"
+import { publishContainerModule } from "../../container/publish"
+import { getRegistryPortForward } from "./util"
+import execa = require("execa")
+
+export async function k8sPublishContainerModule(params: PublishModuleParams<ContainerModule>) {
+  const { ctx, module, log } = params
+  const k8sCtx = ctx as KubernetesPluginContext
+  const provider = k8sCtx.provider
+
+  if (!(await containerHelpers.hasDockerfile(module))) {
+    log.setState({ msg: `Nothing to publish` })
+    return { published: false }
+  }
+
+  if (provider.config.buildMode !== "local-docker") {
+    // First pull from the in-cluster registry, then resume standard publish flow.
+    // This does mean we require a local docker as a go-between, but the upside is that we can rely on the user's
+    // standard authentication setup, instead of having to re-implement or account for all the different ways the
+    // user might be authenticating with their registries.
+    log.setState(`Pulling from cluster container registry...`)
+
+    const fwd = await getRegistryPortForward(k8sCtx, log)
+
+    const imageId = await containerHelpers.getDeploymentImageId(module, ctx.provider.config.deploymentRegistry)
+    const pullImageName = containerHelpers.unparseImageId({
+      ...containerHelpers.parseImageId(imageId),
+      // Note: using localhost directly here has issues with Docker for Mac.
+      // https://github.com/docker/for-mac/issues/3611
+      host: `local.app.garden:${fwd.localPort}`,
+    })
+
+    await execa("docker", ["pull", pullImageName])
+  }
+
+  return publishContainerModule(params)
+}

--- a/garden-service/src/plugins/kubernetes/container/util.ts
+++ b/garden-service/src/plugins/kubernetes/container/util.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2018 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { resolve } from "url"
+import { ContainerModule } from "../../container/config"
+import { getPortForward } from "../util"
+import { systemNamespace } from "../system"
+import { CLUSTER_REGISTRY_DEPLOYMENT_NAME, CLUSTER_REGISTRY_PORT } from "../constants"
+import { containerHelpers } from "../../container/helpers"
+import { PluginError } from "../../../exceptions"
+import { PluginContext } from "../../../plugin-context"
+import { LogEntry } from "../../../logger/log-entry"
+import { KubernetesPluginContext } from "../config"
+import axios from "axios"
+
+export async function getRegistryPortForward(ctx: PluginContext, log: LogEntry) {
+  return getPortForward({
+    ctx,
+    log,
+    namespace: systemNamespace,
+    targetDeployment: `Deployment/${CLUSTER_REGISTRY_DEPLOYMENT_NAME}`,
+    port: CLUSTER_REGISTRY_PORT,
+  })
+}
+
+export async function getManifestFromRegistry(
+  ctx: KubernetesPluginContext, module: ContainerModule, log: LogEntry,
+) {
+  const url = await getImageRegistryUrl(ctx, module, log, `manifests/${module.version.versionString}`)
+
+  try {
+    const res = await axios({ url })
+    log.silly(res.data)
+    return res.data
+  } catch (err) {
+    if (err.response && err.response.status === 404) {
+      return null
+    } else {
+      throw new PluginError(`Could not query in-cluster registry: ${err}`, {
+        message: err.message,
+        response: err.response,
+      })
+    }
+  }
+}
+
+async function getImageRegistryUrl(ctx: KubernetesPluginContext, module: ContainerModule, log: LogEntry, path: string) {
+  const registryFwd = await getRegistryPortForward(ctx, log)
+  const imageId = await containerHelpers.getDeploymentImageId(module, ctx.provider.config.deploymentRegistry)
+  const imageName = containerHelpers.unparseImageId({
+    ...containerHelpers.parseImageId(imageId),
+    host: undefined,
+    tag: undefined,
+  })
+
+  const baseUrl = `http://localhost:${registryFwd.localPort}/v2/${imageName}/`
+
+  return resolve(baseUrl, path)
+}

--- a/garden-service/src/types/plugin/outputs.ts
+++ b/garden-service/src/types/plugin/outputs.ts
@@ -343,7 +343,7 @@ export interface ModuleActionOutputs extends ServiceActionOutputs {
   configure: Promise<ConfigureModuleResult>
   getBuildStatus: Promise<BuildStatus>
   build: Promise<BuildResult>
-  publishModule: Promise<PublishResult>
+  publish: Promise<PublishResult>
   runModule: Promise<RunResult>
   testModule: Promise<TestResult>
   getTestResult: Promise<TestResult | null>

--- a/garden-service/src/types/plugin/params.ts
+++ b/garden-service/src/types/plugin/params.ts
@@ -369,7 +369,7 @@ export interface ModuleActionParams<T extends Module = Module> {
   configure: ConfigureModuleParams<T>
   getBuildStatus: GetBuildStatusParams<T>
   build: BuildModuleParams<T>
-  publishModule: PublishModuleParams<T>
+  publish: PublishModuleParams<T>
   runModule: RunModuleParams<T>
   testModule: TestModuleParams<T>
   getTestResult: GetTestResultParams<T>

--- a/garden-service/src/types/plugin/plugin.ts
+++ b/garden-service/src/types/plugin/plugin.ts
@@ -163,7 +163,7 @@ export interface ModuleActionParams<T extends Module = Module> {
   configure: ConfigureModuleParams<T>
   getBuildStatus: GetBuildStatusParams<T>
   build: BuildModuleParams<T>
-  publishModule: PublishModuleParams<T>
+  publish: PublishModuleParams<T>
   runModule: RunModuleParams<T>
   testModule: TestModuleParams<T>
   getTestResult: GetTestResultParams<T>
@@ -174,7 +174,7 @@ export interface ModuleActionOutputs extends ServiceActionOutputs {
   configure: Promise<ConfigureModuleResult>
   getBuildStatus: Promise<BuildStatus>
   build: Promise<BuildResult>
-  publishModule: Promise<PublishResult>
+  publish: Promise<PublishResult>
   runModule: Promise<RunResult>
   testModule: Promise<TestResult>
   getTestResult: Promise<TestResult | null>
@@ -186,7 +186,7 @@ export const moduleActionDescriptions:
   configure,
   getBuildStatus,
   build,
-  publishModule,
+  publish: publishModule,
   runModule,
   testModule,
   getTestResult,

--- a/garden-service/test/unit/src/actions.ts
+++ b/garden-service/test/unit/src/actions.ts
@@ -467,8 +467,8 @@ const testPlugin: PluginFactory = async () => ({
         return {}
       },
 
-      publishModule: async (params) => {
-        validate(params, moduleActionDescriptions.publishModule.paramsSchema)
+      publish: async (params) => {
+        validate(params, moduleActionDescriptions.publish.paramsSchema)
         return { published: true }
       },
 

--- a/garden-service/test/unit/src/commands/publish.ts
+++ b/garden-service/test/unit/src/commands/publish.ts
@@ -29,7 +29,7 @@ const testProvider: PluginFactory = () => {
         configure: configureTestModule,
         getBuildStatus,
         build,
-        publishModule,
+        publish: publishModule,
       },
     },
   }

--- a/garden-service/test/unit/src/plugins/container.ts
+++ b/garden-service/test/unit/src/plugins/container.ts
@@ -29,7 +29,7 @@ describe("plugins.container", () => {
   const handler = gardenPlugin()
   const configure = handler.moduleActions!.container!.configure!
   const build = handler.moduleActions!.container!.build!
-  const publishModule = handler.moduleActions!.container!.publishModule!
+  const publishModule = handler.moduleActions!.container!.publish!
   const getBuildStatus = handler.moduleActions!.container!.getBuildStatus!
 
   const baseConfig: ModuleConfig<ContainerModuleSpec, any, any> = {


### PR DESCRIPTION
This has the caveat that you need to have a local Docker daemon running.
Avoiding that requirement would take much more work, since we'd need to
tackle all manner of authentication/key management issues.