### PR TITLE
fix(install): Add -UseBasicParsing to Windows installer

### DIFF
--- a/support/install.ps1
+++ b/support/install.ps1
@@ -124,7 +124,7 @@ md -Force $gardenTmpPath | Out-Null
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 # Download and extract the archive to $gardenBinPath
-$latestRelease = Invoke-WebRequest "https://github.com/garden-io/garden/releases/latest" -Headers @{"Accept"="application/json"}
+$latestRelease = Invoke-WebRequest "https://github.com/garden-io/garden/releases/latest" -UseBasicParsing -Headers @{"Accept"="application/json"}
 # The releases are returned in the format {"id":3622206,"tag_name":"hello-1.0.0.11",...}, we have to extract the tag_name.
 $json = $latestRelease.Content | ConvertFrom-Json
 $latestVersion = $json.tag_name


### PR DESCRIPTION
I tried installing Garden on Windows and got the following error:

`Invoke-WebRequest : The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer's first launch configuration is not complete. Specify the UseBasicParsing parameter and try again.`

This commit fixes that.