### PR TITLE
improvement(k8s): add explicit cluster-init command for remote clusters

### DIFF
--- a/docs/using-garden/remote-clusters.md
+++ b/docs/using-garden/remote-clusters.md
@@ -39,6 +39,19 @@ The plugin will create two or more namespaces per user and project, one to run s
 metadata and configuration (this is so that your environment can be reset without
 clearing your configuration variables), and potentially more to support specific plugins/providers.
 
+## Initializing the cluster
+
+When you're connecting to a new cluster, or after you have updated your provider configuration or Garden itself,
+you need to install/update cluster-wide services that Garden needs to operate. When using `local-kubernetes` this
+happens automatically when you're deploying or testing, but for remote clusters this requires a manual step. This is
+so that different users don't end up "competing" with different configurations or versions.
+
+To initialize or update your cluster-wide services, run:
+
+```sh
+garden --env=<environment-name> plugins kubernetes cluster-init
+```
+
 ## Building and pushing images
 
 Garden supports multiple methods for building images and making them available to the cluster. Below we detail how

--- a/garden-service/src/commands/init.ts
+++ b/garden-service/src/commands/init.ts
@@ -45,7 +45,7 @@ export class InitCommand extends Command {
     printHeader(headerLog, `Initializing ${name} environment`, "gear")
 
     const actions = await garden.getActionHelper()
-    await actions.prepareEnvironment({ log, force: opts.force, manualInit: true })
+    await actions.prepareEnvironment({ log, force: opts.force })
 
     printFooter(footerLog)
 

--- a/garden-service/src/plugins/kubernetes/commands/cluster-init.ts
+++ b/garden-service/src/plugins/kubernetes/commands/cluster-init.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2018 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { PluginCommand } from "../../../types/plugin/command"
+import { prepareSystem, getEnvironmentStatus } from "../init"
+import chalk from "chalk"
+
+export const clusterInit: PluginCommand = {
+  name: "cluster-init",
+  description: "Initialize or update cluster-wide Garden services.",
+
+  handler: async ({ ctx, log }) => {
+    const entry = log.info({
+      msg: chalk.bold.magenta(
+        `Initializing/updating cluster-wide services for ${chalk.white(ctx.environmentName)} environment`,
+      ),
+    })
+
+    const status = await getEnvironmentStatus({ ctx, log })
+    let result = {}
+
+    if (status.ready) {
+      entry.info("All services already initialized!")
+    } else {
+      result = await prepareSystem({
+        ctx,
+        log: entry,
+        force: true,
+        status,
+        clusterInit: true,
+      })
+    }
+
+    log.info(chalk.green("Done!"))
+
+    return { result }
+  },
+}

--- a/garden-service/src/plugins/kubernetes/helm/tiller.ts
+++ b/garden-service/src/plugins/kubernetes/helm/tiller.ts
@@ -58,13 +58,15 @@ export async function installTiller({ ctx, log, provider, force = false }: Insta
 
   // Need to install the RBAC stuff ahead of Tiller
   const roleResources = getRoleResources(namespace)
+  entry.setState("Applying Tiller RBAC resources...")
   await apply({ log, context, manifests: roleResources, namespace })
-  await waitForResources({ ctx, provider, serviceName: "tiller", resources: roleResources, log })
+  await waitForResources({ ctx, provider, serviceName: "tiller", resources: roleResources, log: entry })
 
   const tillerResources = await getTillerResources(ctx, provider, log)
   const pruneSelector = "app=helm,name=tiller"
+  entry.setState("Deploying Tiller...")
   await apply({ log, context, manifests: tillerResources, namespace, pruneSelector })
-  await waitForResources({ ctx, provider, serviceName: "tiller", resources: tillerResources, log })
+  await waitForResources({ ctx, provider, serviceName: "tiller", resources: tillerResources, log: entry })
 
   entry.setSuccess({ msg: chalk.green(`Done (took ${entry.getDuration(1)} sec)`), append: true })
 }
@@ -82,7 +84,9 @@ async function getTillerResources(
     "--debug",
   )
 
-  return safeLoadAll(tillerManifests)
+  const resources = safeLoadAll(tillerManifests)
+
+  return resources
 }
 
 function getRoleResources(namespace: string) {

--- a/garden-service/src/plugins/kubernetes/kubernetes.ts
+++ b/garden-service/src/plugins/kubernetes/kubernetes.ts
@@ -23,6 +23,7 @@ import { KubernetesConfig, KubernetesPluginContext } from "./config"
 import { configSchema } from "./config"
 import { ConfigurationError } from "../../exceptions"
 import { cleanupClusterRegistry } from "./commands/cleanup-cluster-registry"
+import { clusterInit } from "./commands/cluster-init"
 
 export const name = "kubernetes"
 
@@ -90,6 +91,7 @@ export function gardenPlugin(): GardenPlugin {
     configSchema,
     commands: [
       cleanupClusterRegistry,
+      clusterInit,
     ],
     actions: {
       configureProvider,

--- a/garden-service/src/plugins/kubernetes/status/status.ts
+++ b/garden-service/src/plugins/kubernetes/status/status.ts
@@ -164,7 +164,7 @@ export async function waitForResources({ ctx, provider, serviceName, resources: 
   const statusLine = log.info({
     symbol: "info",
     section: serviceName,
-    msg: `Waiting for service to be ready...`,
+    msg: `Waiting for resources to be ready...`,
   })
 
   const api = await KubeApi.factory(log, provider.config.context)

--- a/garden-service/src/types/plugin/provider/getEnvironmentStatus.ts
+++ b/garden-service/src/types/plugin/provider/getEnvironmentStatus.ts
@@ -15,7 +15,6 @@ export interface GetEnvironmentStatusParams extends PluginActionParamsBase { }
 
 export interface EnvironmentStatus {
   ready: boolean
-  needManualInit?: boolean
   dashboardPages?: DashboardPage[]
   detail?: any
 }
@@ -29,11 +28,6 @@ export const environmentStatusSchema = joi.object()
     ready: joi.boolean()
       .required()
       .description("Set to true if the environment is fully configured for a provider."),
-    needManualInit: joi.boolean()
-      .description(
-        "Set to true if the environment needs user input to be initialized, " +
-        "and thus needs to be initialized via `garden init`.",
-      ),
     dashboardPages: dashboardPagesSchema,
     detail: joi.object()
       .meta({ extendable: true })
@@ -48,10 +42,6 @@ export const getEnvironmentStatus = {
 
     Called before \`prepareEnvironment\`. If this returns \`ready: true\`, the
     \`prepareEnvironment\` action is not called.
-
-    If this returns \`needManualInit: true\`, the process may throw an error and guide the user to
-    run \`garden init\`. Otherwise the \`prepareEnvironment\` handler may be run implicitly ahead of
-    actions like \`deployService\`, \`runModule\` etc.
   `,
   paramsSchema: actionParamsSchema,
   resultSchema: environmentStatusSchema,

--- a/garden-service/src/types/plugin/provider/prepareEnvironment.ts
+++ b/garden-service/src/types/plugin/provider/prepareEnvironment.ts
@@ -12,7 +12,6 @@ import { dedent } from "../../../util/string"
 import { joi } from "../../../config/common"
 
 export interface PrepareEnvironmentParams extends PluginActionParamsBase {
-  manualInit: boolean
   status: EnvironmentStatus
   force: boolean
 }
@@ -25,20 +24,12 @@ export const prepareEnvironment = {
     before deploying services.
 
     Called ahead of any service runtime actions (such as \`deployService\`,
-    \`runModule\` and \`testModule\`), unless \`getEnvironmentStatus\` returns \`ready: true\` or
-    \`needManualInit: true\`.
-
-    Important: If your handler does require user input, please be sure to indicate that via the
-    \`getEnvironmentStatus\` handler. If this provider's \`getEnvironmentStatus\` returns \`needManualInit: true\`,
-    this is only called via the \`garden init\` command, so that the handler can safely request user input via
-    the CLI.
+    \`runModule\` and \`testModule\`), unless \`getEnvironmentStatus\` returns \`ready: true\`.
   `,
   paramsSchema: actionParamsSchema
     .keys({
       force: joi.boolean()
         .description("Force re-configuration of the environment."),
-      manualInit: joi.boolean()
-        .description("Set to true if the environment is being explicitly initialized via `garden init`."),
       status: environmentStatusSchema,
     }),
   resultSchema: joi.object().keys({}),


### PR DESCRIPTION
This avoids complications relating to differing provider configurations
and Garden versions, by removing cluster-wide init from the standard
`garden init` flow and making it an explicit plugin command.

`local-kubernetes` environments are not affected by this, since they are
not shared between users/CI/etc.