### PR TITLE
docs: wrong example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Set up your environment, build the services and deploy the project by running:
     garden deploy
 ```
 
-The services are now running on the Garden framework. You can see for yourself by querying the `/hello` endpoint of `go-service`’s running container:
+The services are now running on the Garden framework. You can see for yourself by querying the `/hello-backend` endpoint of `backend`’s running container:
 
 ```sh
     garden call backend/hello-backend

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Clone the repo and change into the `demo-project` directory:
 
 ```sh
     git clone https://github.com/garden-io/garden.git
-    cd garden/examples/simple-project
+    cd garden/examples/demo-project
 ```
 
 Set up your environment, build the services and deploy the project by running:
@@ -73,7 +73,7 @@ Set up your environment, build the services and deploy the project by running:
 The services are now running on the Garden framework. You can see for yourself by querying the `/hello` endpoint of `go-service`’s running container:
 
 ```sh
-    garden call go-service/hello-go
+    garden call backend/hello-backend
 ```
 
 To run tests for all modules:


### PR DESCRIPTION
In #quick-start of the README we mention the `demo-project` but still have the commands for `simple-project`. I'm assuming we want to use the ones for `demo-project` as that's @edvald 's latest change to the README.