### PR TITLE
fix(k8s): skip setMinikubeDockerEnv when vm-driver=None

### DIFF
--- a/garden-service/src/plugins/kubernetes/local/minikube.ts
+++ b/garden-service/src/plugins/kubernetes/local/minikube.ts
@@ -13,7 +13,15 @@ import * as execa from "execa"
  * TODO: it would be better to explicitly provide those to docker instead of using process.env
  */
 export async function setMinikubeDockerEnv() {
-  const minikubeEnv = await execa.stdout("minikube", ["docker-env", "--shell=bash"])
+  let minikubeEnv
+  try {
+    minikubeEnv = await execa.stdout("minikube", ["docker-env", "--shell=bash"])
+  } catch (err) {
+    if (err.contains("driver does not support")) {
+      return;
+    }
+    throw err;
+  }
   for (const line of minikubeEnv.split("\n")) {
     const matched = line.match(/^export (\w+)="(.+)"$/)
     if (matched) {


### PR DESCRIPTION
https://github.com/garden-io/garden/issues/907