### PR TITLE
docs: fix backend service URL in demo project

### DIFF
--- a/docs/examples/demo-project.md
+++ b/docs/examples/demo-project.md
@@ -217,7 +217,7 @@ Calling the `backend` from the `frontend` is straightforward from within the app
 ```javascript
 const request = require('request-promise')
 
-const backendServiceEndpoint = `http://demo-project.local.app.garden/hello-backend`;
+const backendServiceEndpoint = `http://backend/hello-backend`;
 
 app.get('/call-backend', (req, res) => {
   // Query the backend and return the response


### PR DESCRIPTION
While following the demo-project tutorial, reaching this step:
https://docs.garden.io/examples/demo-project#communication-between-services:


I ended up getting the following error from the frontend service at http://demo-project.local.app.garden/call-backend: 

```
{
error: {
name: "RequestError",
message: "Error: connect ECONNREFUSED 127.0.0.1:80",
cause: {
errno: "ECONNREFUSED",
code: "ECONNREFUSED",
syscall: "connect",
address: "127.0.0.1",
port: 80
},
error: {
errno: "ECONNREFUSED",
code: "ECONNREFUSED",
syscall: "connect",
address: "127.0.0.1",
port: 80
},
options: {
uri: "http://demo-project.local.app.garden/hello-backend",
method: "GET",
simple: true,
resolveWithFullResponse: false,
transform2xxOnly: false
}
},
message: "Unable to reach service at http://demo-project.local.app.garden/hello-backend"
}
```

The domain `backend.local.app.garden` points to 127.0.0.1.

Used within a container running in the Kubernetes network, this will just point to the current container's localhost.

Using the automatically created `backend` service domain instead fixes the issue and I get the proper `hello` response back from the backend 🎉 

Edit: switched from `backend.demo-project.svc.cluster.local` to simply use `backend`.