### PR TITLE
fix: removed single quote from CREATE TABLE statement

### DIFF
--- a/examples/vote/services/postgres/garden.yml
+++ b/examples/vote/services/postgres/garden.yml
@@ -28,7 +28,7 @@ tasks:
       --host=db,
       --port=5432,
       -d, postgres,
-      -c, "'CREATE TABLE IF NOT EXISTS votes (id VARCHAR(255) NOT NULL UNIQUE, vote VARCHAR(255) NOT NULL, created_at timestamp default NULL)'"
+      -c, "CREATE TABLE IF NOT EXISTS votes (id VARCHAR(255) NOT NULL UNIQUE, vote VARCHAR(255) NOT NULL, created_at timestamp default NULL)"
     ]
     dependencies:
       - db


### PR DESCRIPTION
The single quote in the `CREATE TABLE` statement were making the service fail on deploy.