### PR TITLE
chore: added PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+<!--  Thanks for sending a pull request!  Here are some tips for you:
+
+1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
+2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
+3. Ensure you have added or ran the appropriate tests for your PR.
+4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature. 
+5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @benstov, @10ko.
+-->
+
+**What type of PR is this?**
+> Uncomment all that apply and add labels to the PR accordingly:
+<!-- * **chore**: Changes to the build process or auxiliary tools and libraries such as documentation generation.-->
+<!-- * **ci**: Changes to the CI configuration. -->
+<!-- * **docs**: Documentation only changes. -->
+<!-- * **feat**: A new feature. -->
+<!-- * **fix**: A bug fix. -->
+<!-- * **improvement**: Changes that improve a current implementation without adding a new feature or fixing a bug. -->
+<!-- * **perf**: A code change that improves performance. -->
+<!-- * **refactor**: A code change that neither fixes a bug nor adds a feature. -->
+<!-- * **revert**: A commit that reverts a previous commit. It should begin with `revert: `, followed by the header of the reverted commit. In the body it should say: `This reverts commit <hash>.`, where the hash is the SHA of the commit being reverted. -->
+<!-- * **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing
+  semi-colons, etc). -->
+<!-- * **test**: Adding missing or correcting existing tests. -->
+
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes**:
+
+Fixes #
+
+**Special notes for your reviewer**:
+
+**Does this PR introduce a user-facing change?**:


### PR DESCRIPTION
Introduces a PR template. 
I just took [the one from the kubernetes project](https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md) (thanks L) and adapted it to our needs (mostly removed stuff since our processes are a bit simpler for now).