### PR TITLE
fix(k8s): cluster registry only worked when service CIDR was 10.x.x.x/y

### DIFF
--- a/garden-service/static/kubernetes/system/registry-proxy/templates/daemonset.yaml
+++ b/garden-service/static/kubernetes/system/registry-proxy/templates/daemonset.yaml
@@ -29,21 +29,17 @@ spec:
             - /bin/sh
             - -c
             - |
-              # Copy the registry certs to the host
-              # cp -r /certs/localhost /etc/docker/certs.d/localhost:5000
+              # (Roughly) figure out the CIDR range in the cluster. This is important because we don't want to allow
+              # public connections here, in case there's no firewall in front of the cluster to block external access
+              # to the hostPort.
+              export CIDR_RANGE=$(echo $KUBERNETES_SERVICE_HOST | cut -d '.' -f 1).0.0.0/8
               # Proxy node connections on 127.0.0.1:5000 to the docker registry
-              socat -d TCP-LISTEN:5000,fork,range=10.0.0.0/8 TCP:{{ .Values.registry.hostname }}:5000
+              socat -d TCP-LISTEN:5000,fork,range=$CIDR_RANGE TCP:{{ .Values.registry.hostname }}:5000
           ports:
             - name: docker
               containerPort: 5000
               hostPort: 5000
               protocol: TCP
-          # livenessProbe:
-          #   tcpSocket:
-          #     port: 5000
-          # readinessProbe:
-          #   tcpSocket:
-          #     port: 5000
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
Run `garden plugins kubernetes cluster-init` for your environment after
upgrading to deploy the change.