### PR TITLE
fix(task-graph): emit and handle taskCancelled events

### DIFF
--- a/dashboard/src/components/graph/graph.scss
+++ b/dashboard/src/components/graph/graph.scss
@@ -19,6 +19,10 @@
     stroke: #02f2b4;
   }
 
+  g.taskCancelled > rect {
+    stroke: #BBB;
+  }
+
   g.taskError > rect {
     stroke: red;
   }

--- a/dashboard/src/components/graph/index.tsx
+++ b/dashboard/src/components/graph/index.tsx
@@ -384,7 +384,7 @@ class Chart extends Component<Props, ChartState> {
             <Span>
               <span
                 className={css`
-                    color: ${colors.gardenGreen};
+                    color: ${colors.taskState.ready};
                   `}
               >
                 —{" "}
@@ -394,7 +394,7 @@ class Chart extends Component<Props, ChartState> {
             <Span>
               <span
                 className={css`
-                    color: ${colors.gardenPink};
+                    color: ${colors.taskState.pending};
                   `}
               >
                 —{" "}
@@ -404,7 +404,7 @@ class Chart extends Component<Props, ChartState> {
             <Span>
               <span
                 className={css`
-                    color: ${colors.gardenPink};
+                    color: ${colors.taskState.processing};
                   `}
               >
                 --{" "}
@@ -414,7 +414,17 @@ class Chart extends Component<Props, ChartState> {
             <Span>
               <span
                 className={css`
-                    color: red;
+                 color: ${colors.taskState.cancelled};
+                  `}
+              >
+                —{" "}
+              </span>
+              Cancelled
+              </Span>
+            <Span>
+              <span
+                className={css`
+                 color: ${colors.taskState.error};
                   `}
               >
                 —{" "}

--- a/dashboard/src/context/events.tsx
+++ b/dashboard/src/context/events.tsx
@@ -17,11 +17,11 @@ import { Extends } from "garden-service/build/src/util/util"
 
 // FIXME: We shouldn't repeat the keys for both the type and the set below
 export type SupportedEventName = Extends<
-  EventName, "taskPending" | "taskProcessing" | "taskComplete" | "taskGraphComplete" | "taskError"
+  EventName, "taskPending" | "taskProcessing" | "taskComplete" | "taskGraphComplete" | "taskError" | "taskCancelled"
 >
 
 export const supportedEventNames: Set<SupportedEventName> = new Set(
-  ["taskPending", "taskProcessing", "taskComplete", "taskGraphComplete", "taskError"],
+  ["taskPending", "taskProcessing", "taskComplete", "taskGraphComplete", "taskError", "taskCancelled"],
 )
 
 export type WsEventMessage = ServerWebsocketMessage & {

--- a/dashboard/src/styles/variables.ts
+++ b/dashboard/src/styles/variables.ts
@@ -94,4 +94,11 @@ export const colors = {
       },
     },
   },
+  taskState: {
+    cancelled: "#BBB",
+    pending: "#ed83cc",
+    processing: "#ed83cc",
+    ready: "#66ffcc",
+    error: "red",
+  },
 }

--- a/garden-service/src/events.ts
+++ b/garden-service/src/events.ts
@@ -84,6 +84,12 @@ export interface Events {
     key: string,
     version: ModuleVersion,
   },
+  taskCancelled: {
+    cancelledAt: Date,
+    type: string
+    key: string,
+    name: string,
+  },
   taskComplete: TaskResult,
   taskError: TaskResult,
   taskGraphProcessing: {

--- a/garden-service/src/task-graph.ts
+++ b/garden-service/src/task-graph.ts
@@ -283,8 +283,15 @@ export class TaskGraph {
 
   // Recursively remove node's dependants, without removing node.
   private cancelDependants(node: TaskNode) {
+    const cancelledAt = new Date()
     for (const dependant of this.getDependants(node)) {
       this.logTaskComplete(dependant, false)
+      this.garden.events.emit("taskCancelled", {
+        cancelledAt,
+        key: dependant.getKey(),
+        name: dependant.task.getName(),
+        type: dependant.getType(),
+      })
       this.remove(dependant)
     }
     this.rebuild()

--- a/garden-service/src/task-graph.ts
+++ b/garden-service/src/task-graph.ts
@@ -119,6 +119,11 @@ export class TaskGraph {
         key: task.getKey(),
         version: task.version,
       })
+    } else {
+      const result = this.resultCache.get(task.getKey(), task.version.versionString)
+      if (result) {
+        this.garden.events.emit("taskComplete", result)
+      }
     }
   }
 

--- a/garden-service/test/unit/src/task-graph.ts
+++ b/garden-service/test/unit/src/task-graph.ts
@@ -19,12 +19,6 @@ interface TestTaskOptions {
   throwError?: boolean
 }
 
-const testTaskVersion = {
-  versionString: "12345-6789",
-  dependencyVersions: {},
-  files: [],
-}
-
 class TestTask extends BaseTask {
   type: TaskType = "test"
   name: string
@@ -159,6 +153,13 @@ describe("task-graph", () => {
       await graph.process([repeatedTask])
 
       expect(garden.events.eventLog).to.eql([
+        {
+          name: "taskComplete",
+          payload: {
+            dependencyResults: {}, description: "a", key: task.getKey(), type: "test", name: "a",
+            output: { dependencyResults: {}, result: "result-a" },
+          },
+        },
         { name: "taskGraphProcessing", payload: { startedAt: now } },
         { name: "taskGraphComplete", payload: { completedAt: now } },
       ])


### PR DESCRIPTION
Emit taskCancelled events when dependants of failed tasks are cancelled.

This is a new event type.

Closes #925.