### PR TITLE
feat: add env var for setting max task concurrency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ version: 2.1
       - image: circleci/node:10
         environment:
           GARDEN_DISABLE_VERSION_CHECK: "true"
+          GARDEN_TASK_CONCURRENCY_LIMIT: "10"
 
   # Attach's the current saved workspace
   attach-workspace: &attach-workspace

--- a/garden-service/src/task-graph.ts
+++ b/garden-service/src/task-graph.ts
@@ -41,6 +41,10 @@ export interface TaskResults {
 
 export const DEFAULT_CONCURRENCY = 6
 
+const concurrencyFromEnv = process.env.GARDEN_TASK_CONCURRENCY_LIMIT
+
+export const TASK_CONCURRENCY = (concurrencyFromEnv && parseInt(concurrencyFromEnv, 10)) || DEFAULT_CONCURRENCY
+
 export class TaskGraph {
   private roots: TaskNodeMap
   private index: TaskNodeMap
@@ -57,7 +61,7 @@ export class TaskGraph {
   private resultCache: ResultCache
   private opQueue: PQueue
 
-  constructor(private garden: Garden, private log: LogEntry, private concurrency: number = DEFAULT_CONCURRENCY) {
+  constructor(private garden: Garden, private log: LogEntry, private concurrency: number = TASK_CONCURRENCY) {
     this.roots = new TaskNodeMap()
     this.index = new TaskNodeMap()
     this.inProgress = new TaskNodeMap()


### PR DESCRIPTION
The `GARDEN_TASK_CONCURRENCY_LIMIT` env variable can now be used to override the task graph's default concurrency limit. Values should be integers.

Also set this env variable to 10 in our CircleCI config.