### PR TITLE
improvement(k8s): cluster cleanup command now also cleans build sync dir

### DIFF
--- a/garden-service/src/plugins/kubernetes/container/build.ts
+++ b/garden-service/src/plugins/kubernetes/container/build.ts
@@ -35,7 +35,7 @@ const buildTimeout = 600
 const kanikoImage = "gcr.io/kaniko-project/executor:v0.8.0"
 const registryPort = 5000
 const syncDataVolumeName = "garden-build-sync"
-const syncDeploymentName = "garden-build-sync"
+export const buildSyncDeploymentName = "garden-build-sync"
 
 export async function k8sGetContainerBuildStatus(
   params: GetBuildStatusParams<ContainerModule>,
@@ -130,7 +130,7 @@ const remoteBuild: BuildHandler = async (params) => {
     ctx,
     log,
     namespace: systemNamespace,
-    targetDeployment: `Deployment/${syncDeploymentName}`,
+    targetDeployment: `Deployment/${buildSyncDeploymentName}`,
     port: RSYNC_PORT,
   })
 
@@ -215,7 +215,7 @@ const remoteBuild: BuildHandler = async (params) => {
   }
 }
 
-interface BuilderExecParams {
+export interface BuilderExecParams {
   provider: KubernetesProvider,
   log: LogEntry,
   args: string[],


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature. 
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @benstov, @10ko.
-->

**What this PR does / why we need it**:

Previously, workspace directories that we synced to the cluster for in-cluster building would just pile up. Now they are cleaned up when you run `garden plugins kubernetes cleanup-cluster-registry`
