### PR TITLE
Fix builder storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,8 +180,7 @@ Garden, as a company, is also a proud member of the [CNCF](https://www.cncf.io/)
 
 ## Analytics
 
-When running Garden for the first time, we'll ask you to opt in to our analytics.  
-We are trying to make Garden the best tool possible, and it's very useful for us to inform the future development of Garden with data on how it's being used.  
+When running Garden for the first time, we'll ask you to opt in to our analytics. We are trying to make Garden the best tool possible, and it's very useful for us to inform the future development of Garden with data on how it's being used.
 
 When you opt-in we will collect information about the commands you run, the tasks getting executed, the project and operating system. We care about your privacy and we take special care to anonymize all the information. For example, we hash module names, and use randomly generated IDs to identify projects.
 

--- a/docs/using-garden/in-cluster-building.md
+++ b/docs/using-garden/in-cluster-building.md
@@ -59,11 +59,9 @@ all users of the clusters, along with a handful of other supporting services. En
 
 In this mode, builds are executed as follows:
 
-1. Your code (build context) is synchronized to a sync service in the cluster, making it available to the
-   Docker daemon.
+1. Your code (build context) is synchronized to a sync service in the cluster, making it available to the Docker daemon.
 2. A build is triggered in the Docker daemon.
-3. The built image is pushed to an in-cluster registry (which is automatically installed), which makes it available
-   to the cluster.
+3. The built image is pushed to an in-cluster registry (which is automatically installed), which makes it available to the cluster.
 
 After enabling this mode (we currently still default to the `local` mode), you will need to run `garden init` for each
 applicable environment, in order to install the
@@ -131,13 +129,11 @@ garden --env=<your-environment> plugins kubernetes cleanup-cluster-registry
 
 The command does the following:
 
-1. Looks through all Pods in the cluster to see which images/tags are in use, and flags all other images as deleted in
-   the in-cluster registry.
+1. Looks through all Pods in the cluster to see which images/tags are in use, and flags all other images as deleted in the in-cluster registry.
 2. Restarts the registry in read-only mode.
 3. Runs the registry garbage collection.
 4. Restarts the registry again without the read-only mode.
-5. When using the `cluster-docker` build mode, we additionally untag in the Docker daemon all images that are no longer
-   in the registry, and then clean up the dangling image layers by running `docker image prune`.
+5. When using the `cluster-docker` build mode, we additionally untag in the Docker daemon all images that are no longer in the registry, and then clean up the dangling image layers by running `docker image prune`.
 
 There are plans to do this automatically when disk-space runs low, but for now you can run this manually or set up
 your own cron jobs.

--- a/examples/demo-project/garden.yml
+++ b/examples/demo-project/garden.yml
@@ -11,6 +11,7 @@ environments:
         context: gke_garden-dev-200012_europe-west1-b_garden-dev-1
         namespace: ${local.env.USER || local.username}-demo-project
         defaultHostname: ${local.env.USER || local.username}-demo-project.dev-1.sys.garden
+        buildMode: cluster-docker
   - name: testing
     providers:
       - name: kubernetes

--- a/garden-service/static/kubernetes/system/docker-daemon/templates/volume.yaml
+++ b/garden-service/static/kubernetes/system/docker-daemon/templates/volume.yaml
@@ -7,7 +7,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: {{ .Values.storage.request }}
+      storage: {{ .Values.storage.size }}
 {{- if .Values.storage.storageClass }}
 {{- if (eq "-" .Values.storage.storageClass) }}
   storageClassName: ""

--- a/garden-service/static/kubernetes/system/docker-daemon/values.yaml
+++ b/garden-service/static/kubernetes/system/docker-daemon/values.yaml
@@ -23,7 +23,7 @@ resources:
     cpu: 200m
     memory: 256Mi
 storage:
-  request: 20Gi
+  size: 20Gi
 registry:
   hostname: garden-docker-registry
 


### PR DESCRIPTION
**What type of PR is this?**

**fix**: A bug fix.

**What this PR does / why we need it**:

The storage size for the `garden-docker-data` PVC wasn't being populated by the value set in the project level `garden.yml` (under the `provider.storage.builder.size` field).

**Which issue(s) this PR fixes**:

Fixes #956 
