### PR TITLE
chore: don't run integ tests before push

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-push": "npm run check-all && npm test && npm run integ"
+      "pre-push": "npm run check-all && npm test"
     }
   },
   "snyk": true


### PR DESCRIPTION
**What type of PR is this?**
* **chore**: Changes to the build process or auxiliary tools and libraries such as documentation 

**What this PR does / why we need it**:

With this PR we no longer run integ tests before pushing. We're already running more comprehensive integ tests in CI so these are kind of superfluous and just slow us down. 