### PR TITLE
fix(core): respect includes/excludes when syncing to build directory

### DIFF
--- a/garden-service/src/garden.ts
+++ b/garden-service/src/garden.ts
@@ -609,9 +609,9 @@ export class Garden {
       }
     }
 
-    const config = this.moduleConfigs[moduleName]
+    const config = await this.resolveModuleConfig(moduleName)
     const dependencyKeys = moduleDependencies.map(dep => getModuleKey(dep.name, dep.plugin))
-    const dependencies = Object.values(pickKeys(this.moduleConfigs, dependencyKeys, "module config"))
+    const dependencies = await this.resolveModuleConfigs(dependencyKeys)
     const cacheContexts = dependencies.concat([config]).map(c => getModuleCacheContext(c))
 
     const version = await this.vcs.resolveVersion(config, dependencies)

--- a/garden-service/src/tasks/build.ts
+++ b/garden-service/src/tasks/build.ts
@@ -67,7 +67,7 @@ export class BuildTask extends BaseTask {
 
     const log = this.log.info({
       section: this.getName(),
-      msg: `Staging build...`,
+      msg: `Preparing build (${module.version.files.length} files)...`,
       status: "active",
     })
 

--- a/garden-service/src/vcs/vcs.ts
+++ b/garden-service/src/vcs/vcs.ts
@@ -6,6 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import * as Joi from "@hapi/joi"
 import * as Bluebird from "bluebird"
 import { mapValues, keyBy, sortBy, omit } from "lodash"
 import { createHash } from "crypto"
@@ -85,7 +86,7 @@ export abstract class VcsHandler {
 
   // Note: explicitly requiring the include variable or null, to make sure it's specified
   async getTreeVersion(path: string, include: string[] | null): Promise<TreeVersion> {
-    const files = await this.getFiles(path, include || undefined)
+    const files = sortBy(await this.getFiles(path, include || undefined), "path")
     const contentHash = files.length > 0 ? hashFileHashes(files.map(f => f.hash)) : NEW_MODULE_VERSION
     return { contentHash, files: files.map(f => f.path) }
   }
@@ -140,12 +141,12 @@ export abstract class VcsHandler {
   /**
    * Returns the path to the remote source directory, relative to the project level Garden directory (.garden)
    */
-  getRemoteSourceRelPath(name, url, sourceType) {
+  getRemoteSourceRelPath(name: string, url: string, sourceType: ExternalSourceType) {
     return getRemoteSourceRelPath({ name, url, sourceType })
   }
 }
 
-async function readVersionFile(path: string, schema): Promise<any> {
+async function readVersionFile(path: string, schema: Joi.Schema): Promise<any> {
   if (!(await pathExists(path))) {
     return null
   }


### PR DESCRIPTION
This notably cascades neatly to anything that syncs _from_ the build
directory, so there should be no further action needed in e.g.
hot-reloading or remote-building code.

Fixes #968