### PR TITLE
fix(core): rsync error when running from dist build

### DIFF
--- a/garden-service/src/bin/add-version-files.ts
+++ b/garden-service/src/bin/add-version-files.ts
@@ -35,6 +35,10 @@ async function addVersionFiles() {
     const vcsHandler = new GitHandler(garden.gardenDirPath)
     const treeVersion = await vcsHandler.getTreeVersion(path, config.include || null)
 
+    treeVersion.files = treeVersion.files
+      .map(f => relative(path, f))
+      .filter(f => f !== ".garden-version")
+
     console.log(`${config.name} -> ${relative(STATIC_DIR, versionFilePath)}`)
 
     return writeFile(versionFilePath, JSON.stringify(treeVersion, null, 4) + "\n")

--- a/garden-service/src/build-dir.ts
+++ b/garden-service/src/build-dir.ts
@@ -38,7 +38,7 @@ export class BuildDir {
 
   async syncFromSrc(module: Module, log: LogEntry) {
     const files = module.version.files
-      .map(f => relative(module.path, f))
+      .map(f => isAbsolute(f) ? relative(module.path, f) : f)
 
     await this.sync({
       module,

--- a/garden-service/src/types/module.ts
+++ b/garden-service/src/types/module.ts
@@ -19,6 +19,7 @@ import { joiArray, joiIdentifier, joiIdentifierMap, joi } from "../config/common
 import { ConfigGraph } from "../config-graph"
 import * as Bluebird from "bluebird"
 import { getConfigFilePath } from "../util/fs"
+import { relative } from "path"
 
 export interface FileCopySpec {
   source: string
@@ -92,10 +93,12 @@ export interface ModuleConfigMap<T extends ModuleConfig = ModuleConfig> {
 
 export async function moduleFromConfig(garden: Garden, graph: ConfigGraph, config: ModuleConfig): Promise<Module> {
   const configPath = await getConfigFilePath(config.path)
+  const relativeConfigPath = relative(config.path, configPath)
   const version = await garden.resolveVersion(config.name, config.build.dependencies)
 
   // Always include configuration file
-  if (!version.files.includes(configPath)) {
+  // TODO: move this logic to resolveVersion()
+  if (!version.files.includes(configPath) && !version.files.includes(relativeConfigPath)) {
     version.files.push(configPath)
   }
 


### PR DESCRIPTION
The error was caused by the use of absolute path in .garden-version
files. This needs a more complete overhaul and testing to avoid future
issues, but does the trick for now.
