### PR TITLE
improvement: updated PATH to include all gcloud bin-s

### DIFF
--- a/garden-service/gcloud.Dockerfile
+++ b/garden-service/gcloud.Dockerfile
@@ -6,5 +6,5 @@ RUN apk add --no-cache python \
   && mkdir -p /gcloud \
   && curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz | tar xz -C /gcloud \
   && /gcloud/google-cloud-sdk/install.sh --quiet \
-  && ln -s /gcloud/google-cloud-sdk/bin/gcloud /usr/local/bin/gcloud \
+  && ln -s /gcloud/google-cloud-sdk/bin/* /usr/local/bin/ \
   && chmod +x /usr/local/bin/gcloud


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature. 
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @benstov, @10ko.
-->
**What this PR does / why we need it**:
This includes a change on the dockerfile for the garden-dev image. The old version would put in the PATH only the `gcloud` executable, while other ones might be needed.

**Which issue(s) this PR fixes**:
I was having an issue when trying to build an image and push it to gcr. The command
`gcloud auth configure-docker` will not work if `docker-credential-gcloud` is not in the path.

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
No