### PR TITLE
chore: use lerna to update version (as opposed to npm)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,12 +259,13 @@ jobs:
       - checkout
       - *attach-workspace
       - run:
-          # Note that we currently flag all releases as drafts and pre-releases. This is because of an issue with lerna that prevents us from creating actual pre-releases. See https://github.com/garden-io/garden/issues/972.
-          # Once the issue is resolved, we should add -prerelease flag to pre-releases and -draft flag
-          # to normal releases.
           name: Create a release on GitHub. If the release is a pre-release we publish it right away, otherwise we make a draft.
           command: |
             VERSION="v$(cat garden-service/package.json | jq -r .version)"
+            PRERELEASE=""
+            DRAFT=-draft
+            # If pre-release, we flag it as pre-release and not as a draft
+            if [[ $VERSION == *"-"* ]]; then DRAFT=""; PRERELEASE=-prerelease; f
             ghr \
               -t ${GITHUB_TOKEN} \
               -u ${CIRCLE_PROJECT_USERNAME} \
@@ -272,8 +273,8 @@ jobs:
               -c ${CIRCLE_SHA1} \
               -n ${VERSION} \
               -delete \
-              -prerelease \
-              -draft \
+              ${PRERELEASE} \
+              ${DRAFT} \
               ${VERSION} ./garden-service/dist
   release-service-dist-next:
     <<: *release-config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,11 +152,11 @@ jobs:
     steps:
       - build_service_dist:
           version: $(./garden-service/bin/garden --version)
-  build-dist-next:
+  build-dist-master:
     <<: *node-config
     steps:
       - build_service_dist:
-          version: next
+          version: master
   lint:
     <<: *node-config
     steps:
@@ -276,14 +276,14 @@ jobs:
               ${PRERELEASE} \
               ${DRAFT} \
               ${VERSION} ./garden-service/dist
-  release-service-dist-next:
+  release-service-dist-master:
     <<: *release-config
     steps:
       - *attach-workspace
       - run:
-          name: Publish a pre-release on GitHub with the tag 'next'
+          name: Publish a pre-release on GitHub with the tag 'master'
           command: |
-            VERSION=next
+            VERSION=master
             ghr \
               -t ${GITHUB_TOKEN} \
               -u ${CIRCLE_PROJECT_USERNAME} \
@@ -328,7 +328,7 @@ workflows:
       # Duplicated here so we can reference steps that depends on it
       - build:
           <<: *only-master
-      - build-dist-next:
+      - build-dist-master:
           <<: *only-master
           requires:
             - build
@@ -346,11 +346,11 @@ workflows:
           <<: *only-master
           context: docker
           requires:
-            - build-dist-next
-      - release-service-dist-next:
+            - build-dist-master
+      - release-service-dist-master:
           <<: *only-master
           requires:
-            - build-dist-next
+            - build-dist-master
 
   tags:
     jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,7 +194,7 @@ and does the following:
 * Commits the changes, tags the commit, and pushes the tag and branch.
 * Pushing the tag triggers a CI process the creates the release artifacts and publishes them to Github. If the the release is not a pre-release, we create a draft instead of actually publishing.
 
-On every merge to `master` we also publish an **unstable** release with the version `next` that is always flagged as a pre-release.
+On every merge to `master` we also publish an **unstable** release with the version `master` that is always flagged as a pre-release.
 
 ### Steps
 

--- a/bin/release.ts
+++ b/bin/release.ts
@@ -7,8 +7,9 @@ import chalk from "chalk"
 import parseArgs = require("minimist")
 import deline = require("deline")
 import { join, resolve } from "path"
-import { ReplaceResults } from "replace-in-file"
-const replace = require("replace-in-file")
+import * as Replace from "replace-in-file"
+
+const replace = Replace.default
 
 type ReleaseType = "minor" | "patch" | "preminor" | "prepatch" | "prerelease"
 const RELEASE_TYPES = ["minor", "patch", "preminor", "prepatch", "prerelease"]
@@ -47,11 +48,13 @@ async function release() {
     throw new Error(`Invalid release type ${releaseType}, available types are: ${RELEASE_TYPES.join(", ")}`)
   }
 
-  // Bump package.json and package-lock.json version. Returns the version that was set.
-  const version = await execa.stdout("npm", [
-    "version", "--no-git-tag-version", releaseType,
+  // Update package.json versions
+  await execa.stdout("lerna", [
+    "version", "--no-git-tag-version", "--yes", releaseType,
   ], { cwd: gardenServiceRoot })
 
+  // Read the version from garden-service/package.json after setting it (rather than parsing the lerna output)
+  const version = require("../garden-service/package.json").version
   const branchName = `release-${version}`
 
   // Check if branch already exists locally
@@ -203,7 +206,7 @@ async function updateExampleLinks(version: string) {
     from: /github\.com\/garden-io\/garden\/tree\/[^\/]*\/examples/g,
     to: `github.com/garden-io/garden/tree/${version}/examples`,
   }
-  const results = await replace(options) as ReplaceResults[]
+  const results = await replace(options)
   console.log("Modified files:", results.filter(r => r.hasChanged).map(r => r.file).join(", "))
 }
 


### PR DESCRIPTION
**What type of PR is this?**

* **chore**: Changes to the build process or auxiliary tools and libraries such as documentation generation.

**What this PR does / why we need it**:

This fixes issue were lerna bootstrap would fail because the dashboard couldn't find the garden-service package.

**Which issue(s) this PR fixes**:

Fixes #972 