### PR TITLE
chore: remove PR type section from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,24 +3,9 @@
 1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
 2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
 3. Ensure you have added or ran the appropriate tests for your PR.
-4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature. 
-5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @benstov, @10ko.
+4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
+5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
 -->
-
-**What type of PR is this?**
-> Uncomment all that apply and add labels to the PR accordingly:
-<!-- * **chore**: Changes to the build process or auxiliary tools and libraries such as documentation generation.-->
-<!-- * **ci**: Changes to the CI configuration. -->
-<!-- * **docs**: Documentation only changes. -->
-<!-- * **feat**: A new feature. -->
-<!-- * **fix**: A bug fix. -->
-<!-- * **improvement**: Changes that improve a current implementation without adding a new feature or fixing a bug. -->
-<!-- * **perf**: A code change that improves performance. -->
-<!-- * **refactor**: A code change that neither fixes a bug nor adds a feature. -->
-<!-- * **revert**: A commit that reverts a previous commit. It should begin with `revert: `, followed by the header of the reverted commit. In the body it should say: `This reverts commit <hash>.`, where the hash is the SHA of the commit being reverted. -->
-<!-- * **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing
-  semi-colons, etc). -->
-<!-- * **test**: Adding missing or correcting existing tests. -->
 
 **What this PR does / why we need it**:
 


### PR DESCRIPTION

**What type of PR is this?**
* **chore**: Changes to the build process or auxiliary tools and libraries such as documentation generation.

**What this PR does / why we need it**:

Removes the **What type of PR is this** section seen above. It's superfluous since the commit messages already contain the type.
