### PR TITLE
feat(k8s): add uninstall-garden-services command

### DIFF
--- a/docs/using-garden/remote-kubernetes.md
+++ b/docs/using-garden/remote-kubernetes.md
@@ -55,6 +55,14 @@ To initialize or update your cluster-wide services, run:
 garden --env=<environment-name> plugins kubernetes cluster-init
 ```
 
+To later uninstall the installed services, you can run:
+
+```sh
+garden --env=<environment-name> plugins kubernetes uninstall-garden-services
+```
+
+This will remove all services from the `garden-system` namespace, as well as any installed cluster-scoped resources.
+
 ## Building and pushing images
 
 Garden supports multiple methods for building images and making them available to the cluster. Below we detail how

--- a/garden-service/src/commands/delete.ts
+++ b/garden-service/src/commands/delete.ts
@@ -20,7 +20,6 @@ import { ServiceStatus, getServiceRuntimeContext, ServiceStatusMap } from "../ty
 import { printHeader } from "../logger/util"
 import { DeleteSecretResult } from "../types/plugin/provider/deleteSecret"
 import { EnvironmentStatusMap } from "../types/plugin/provider/getEnvironmentStatus"
-import chalk from "chalk"
 
 export class DeleteCommand extends Command {
   name = "delete"
@@ -103,27 +102,9 @@ export class DeleteEnvironmentCommand extends Command {
     printHeader(headerLog, `Deleting ${garden.environmentName} environment`, "skull_and_crossbones")
 
     const actions = await garden.getActionHelper()
-    const graph = await garden.getConfigGraph()
+    const result = await actions.deleteEnvironment(log)
 
-    const servicesLog = log.info({ msg: chalk.white("Deleting services..."), status: "active" })
-
-    const services = await graph.getServices()
-    const serviceStatuses: { [key: string]: ServiceStatus } = {}
-
-    await Bluebird.map(services, async (service) => {
-      const runtimeContext = await getServiceRuntimeContext(garden, graph, service)
-      serviceStatuses[service.name] = await actions.deleteService({ log: servicesLog, service, runtimeContext })
-    })
-
-    servicesLog.setSuccess()
-
-    log.info("")
-
-    const envLog = log.info({ msg: chalk.white("Cleaning up environments..."), status: "active" })
-    const environmentStatuses = await actions.cleanupEnvironment({ log: envLog })
-    envLog.setSuccess()
-
-    return { result: { serviceStatuses, environmentStatuses } }
+    return { result }
   }
 }
 

--- a/garden-service/src/plugins/kubernetes/commands/uninstall-garden-services.ts
+++ b/garden-service/src/plugins/kubernetes/commands/uninstall-garden-services.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2018 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import chalk from "chalk"
+import { PluginCommand } from "../../../types/plugin/command"
+import { getKubernetesSystemVariables } from "../init"
+import { KubernetesPluginContext } from "../config"
+import { getSystemGarden } from "../system"
+
+export const uninstallGardenServices: PluginCommand = {
+  name: "uninstall-garden-services",
+  description: "Clean up all installed cluster-wide Garden services.",
+
+  handler: async ({ ctx, log }) => {
+    const entry = log.info({
+      msg: chalk.bold.magenta(
+        `Removing cluster-wide services for ${chalk.white(ctx.environmentName)} environment`,
+      ),
+    })
+
+    const k8sCtx = <KubernetesPluginContext>ctx
+    const variables = getKubernetesSystemVariables(k8sCtx.provider.config)
+
+    const sysGarden = await getSystemGarden(k8sCtx, variables || {})
+    const actions = await sysGarden.getActionHelper()
+
+    const result = await actions.deleteEnvironment(entry)
+
+    log.info(chalk.green("Done!"))
+
+    return { result }
+  },
+}

--- a/garden-service/src/plugins/kubernetes/init.ts
+++ b/garden-service/src/plugins/kubernetes/init.ts
@@ -35,7 +35,7 @@ import { combineStates, ServiceStatusMap } from "../../types/service"
  */
 export async function getEnvironmentStatus({ ctx, log }: GetEnvironmentStatusParams): Promise<EnvironmentStatus> {
   const k8sCtx = <KubernetesPluginContext>ctx
-  const variables = getVariables(k8sCtx.provider.config)
+  const variables = getKubernetesSystemVariables(k8sCtx.provider.config)
 
   const sysGarden = await getSystemGarden(k8sCtx, variables || {})
   const sysCtx = <KubernetesPluginContext>await sysGarden.getPluginContext(k8sCtx.provider.name)
@@ -131,7 +131,7 @@ export async function prepareSystem(
 ) {
   const k8sCtx = <KubernetesPluginContext>ctx
   const provider = k8sCtx.provider
-  const variables = getVariables(provider.config)
+  const variables = getKubernetesSystemVariables(provider.config)
 
   const systemReady = status.detail && !!status.detail.systemReady && !force
   const systemServiceNames = k8sCtx.provider.config._systemServices
@@ -206,7 +206,7 @@ export async function cleanupEnvironment({ ctx, log }: CleanupEnvironmentParams)
   return {}
 }
 
-function getVariables(config: KubernetesConfig) {
+export function getKubernetesSystemVariables(config: KubernetesConfig) {
   return {
     "namespace": systemNamespace,
 

--- a/garden-service/src/plugins/kubernetes/kubernetes.ts
+++ b/garden-service/src/plugins/kubernetes/kubernetes.ts
@@ -24,6 +24,7 @@ import { configSchema } from "./config"
 import { ConfigurationError } from "../../exceptions"
 import { cleanupClusterRegistry } from "./commands/cleanup-cluster-registry"
 import { clusterInit } from "./commands/cluster-init"
+import { uninstallGardenServices } from "./commands/uninstall-garden-services"
 
 export const name = "kubernetes"
 
@@ -92,6 +93,7 @@ export function gardenPlugin(): GardenPlugin {
     commands: [
       cleanupClusterRegistry,
       clusterInit,
+      uninstallGardenServices,
     ],
     actions: {
       configureProvider,


### PR DESCRIPTION
This cleans up everything in the garden-system namespace, as well as
related cluster-wide resources.