### PR TITLE
fix(k8s): update deprecated Deployment API versions ahead of 1.16

### DIFF
--- a/examples/istio/reviews/templates/reviews.yaml
+++ b/examples/istio/reviews/templates/reviews.yaml
@@ -11,7 +11,7 @@ spec:
   selector:
     app: reviews
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: reviews-v1
@@ -30,7 +30,7 @@ spec:
         ports:
         - containerPort: 9080
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: reviews-v2
@@ -49,7 +49,7 @@ spec:
         ports:
         - containerPort: 9080
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: reviews-v3

--- a/examples/kubernetes-module/redis/redis.yml
+++ b/examples/kubernetes-module/redis/redis.yml
@@ -129,7 +129,7 @@ spec:
 ---
 # Source: redis/templates/redis-slave-deployment.yaml
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis-slave

--- a/garden-service/src/plugins/kubernetes/container/deployment.ts
+++ b/garden-service/src/plugins/kubernetes/container/deployment.ts
@@ -267,7 +267,7 @@ function deploymentConfig(service: Service, configuredReplicas: number, namespac
   // TODO: moar type-safety
   return {
     kind: "Deployment",
-    apiVersion: "extensions/v1beta1",
+    apiVersion: "apps/v1",
     metadata: {
       name: service.name,
       annotations: {


### PR DESCRIPTION
See https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
