### PR TITLE
fix(config): ignore empty docs in garden.yml files

### DIFF
--- a/garden-service/src/config/base.ts
+++ b/garden-service/src/config/base.ts
@@ -44,6 +44,9 @@ export async function loadConfig(projectRoot: string, path: string): Promise<Gar
     throw new ConfigurationError(`Could not parse ${basename(absPath)} in directory ${path} as valid YAML`, err)
   }
 
+  // Ignore empty resources
+  rawSpecs = rawSpecs.filter(Boolean)
+
   const resources: GardenResource[] = flatten(rawSpecs.map(s => prepareResources(s, path, projectRoot)))
 
   const projectSpecs = resources.filter(s => s.kind === "Project")

--- a/garden-service/test/unit/data/test-projects/empty-doc/garden.yml
+++ b/garden-service/test/unit/data/test-projects/empty-doc/garden.yml
@@ -1,0 +1,4 @@
+---
+kind: Project
+name: foo
+---

--- a/garden-service/test/unit/src/config/base.ts
+++ b/garden-service/test/unit/src/config/base.ts
@@ -2,6 +2,7 @@ import { expect } from "chai"
 import { loadConfig, findProjectConfig } from "../../../../src/config/base"
 import { resolve } from "path"
 import { dataDir, expectError, getDataDir } from "../../../helpers"
+import { DEFAULT_API_VERSION } from "../../../../src/constants"
 
 const projectPathA = resolve(dataDir, "test-project-a")
 const modulePathA = resolve(projectPathA, "module-a")
@@ -316,6 +317,18 @@ describe("loadConfig", () => {
     expect(parsed).to.eql([])
   })
 
+  it("should ignore empty documents in multi-doc YAML", async () => {
+    const path = resolve(dataDir, "test-projects", "empty-doc")
+    const parsed = await loadConfig(path, path)
+    expect(parsed).to.eql([
+      {
+        apiVersion: DEFAULT_API_VERSION,
+        kind: "Project",
+        name: "foo",
+        path,
+      },
+    ])
+  })
 })
 
 describe("findProjectConfig", async () => {


### PR DESCRIPTION
**What this PR does / why we need it**:

Before, we'd throw an error if you'd, for example, end a `garden.yml` with a `---` line. Now we just ignore empty docs in multi-doc YAMLs.