### PR TITLE
improvement: removed get debug-info request

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -37,5 +37,6 @@ about: Create a report to help make garden better
 <!-- Please run and copy and paste the results  -->
 `garden version`
 
-<!-- Please run the "get debug-info" command and attach the output zip file -->
-`garden get debug-info`
+`kubectl version`
+
+`docker version`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:
Remove the instructions to attach output of `garden get debug-info`. 
At the current stage the command output might contain sensitive info and needs to be reworked before asking our users to use it again.

**Which issue(s) this PR fixes**:
This is a first workaround for #1024

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
no 