### PR TITLE
fix: handle blank build args appropriately

### DIFF
--- a/garden-service/src/plugins/container/build.ts
+++ b/garden-service/src/plugins/container/build.ts
@@ -70,7 +70,15 @@ export function getDockerBuildFlags(module: ContainerModule) {
   const args: string[] = []
 
   for (const [key, value] of Object.entries(module.spec.buildArgs)) {
-    args.push("--build-arg", `${key}=${value}`)
+
+    // 0 is falsy
+    if (value || value === 0) {
+      args.push("--build-arg", `${key}=${value}`)
+    } else {
+      // If the value of a build-arg is null, Docker pulls it from
+      // the environment: https://docs.docker.com/engine/reference/commandline/build/
+      args.push("--build-arg", `${key}`)
+    }
   }
 
   if (module.spec.build.targetImage) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Docker has special syntax where blank build args make it pull that key from the environment. We currently pass build args explicitly as null when they are.

**Which issue(s) this PR fixes**:

Fixes #1023 
