### PR TITLE
improvement: install kubectl in garden-gcloud image

### DIFF
--- a/garden-service/gcloud.Dockerfile
+++ b/garden-service/gcloud.Dockerfile
@@ -7,4 +7,6 @@ RUN apk add --no-cache python \
   && curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz | tar xz -C /gcloud \
   && /gcloud/google-cloud-sdk/install.sh --quiet \
   && ln -s /gcloud/google-cloud-sdk/bin/* /usr/local/bin/ \
-  && chmod +x /usr/local/bin/gcloud
+  && chmod +x /usr/local/bin/gcloud \
+  && gcloud components install kubectl \
+  && ln -s /gcloud/google-cloud-sdk/bin/kubectl /usr/local/bin/kubectl


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:
This PR add the installation of `kubectl` in our gcloud image. It's useful to have available and it's required in other applications.

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
No