### PR TITLE
improve: get debug-info output

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -349,8 +349,8 @@ Outputs the status of your environment for debug purposes.
 Examples:
 
 garden get debug-info                    # create a zip file at the root of the project with debug information
-garden get debug-info --format yaml      # output the provider info as yaml files (default as json)
-garden get debug-info --include-project  # Include the provider info for the project namespace. Default is disabled
+garden get debug-info --format yaml      # output provider info as YAML files (default is JSON)
+garden get debug-info --include-project  # include provider info for the project namespace (disabled by default)
 
 ##### Usage
 
@@ -361,7 +361,7 @@ garden get debug-info --include-project  # Include the provider info for the pro
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
   | `--format` |  | `json` `yaml`  | The output format for plugin-generated debug info.
-  | `--include-project` |  | boolean | Includes the provider info for the project namespace.
+  | `--include-project` |  | boolean | Include project-specific information from configured providers.     Note that this may include sensitive data, depending on the provider and your configuration.
 
 ### garden init
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -348,8 +348,9 @@ Outputs the status of your environment for debug purposes.
 
 Examples:
 
-garden get debug-info                # create a zip file at the root of the project with debug information
-garden get debug-info --format yaml  # output the provider info as yaml files (default as json)
+garden get debug-info                    # create a zip file at the root of the project with debug information
+garden get debug-info --format yaml      # output the provider info as yaml files (default as json)
+garden get debug-info --include-project  # Include the provider info for the project namespace. Default is disabled
 
 ##### Usage
 
@@ -360,6 +361,7 @@ garden get debug-info --format yaml  # output the provider info as yaml files (d
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
   | `--format` |  | `json` `yaml`  | The output format for plugin-generated debug info.
+  | `--include-project` |  | boolean | Includes the provider info for the project namespace.
 
 ### garden init
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -361,7 +361,8 @@ garden get debug-info --include-project  # include provider info for the project
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
   | `--format` |  | `json` `yaml`  | The output format for plugin-generated debug info.
-  | `--include-project` |  | boolean | Include project-specific information from configured providers.     Note that this may include sensitive data, depending on the provider and your configuration.
+  | `--include-project` |  | boolean | Include project-specific information from configured providers.
+Note that this may include sensitive data, depending on the provider and your configuration.
 
 ### garden init
 

--- a/garden-service/package-lock.json
+++ b/garden-service/package-lock.json
@@ -163,7 +163,7 @@
       "dependencies": {
         "chalk": {
           "version": "2.3.1",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
           "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "dev": true,
           "requires": {
@@ -2668,7 +2668,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -3815,7 +3815,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
@@ -4517,7 +4517,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -4660,7 +4660,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -5549,7 +5549,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
@@ -6241,7 +6241,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "~1.1.2",
@@ -6640,7 +6640,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -6838,7 +6838,7 @@
         },
         "async": {
           "version": "1.5.2",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
         "escodegen": {
@@ -8558,7 +8558,7 @@
         },
         "async": {
           "version": "1.5.2",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
@@ -8605,7 +8605,7 @@
         },
         "os-locale": {
           "version": "1.4.0",
-          "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "dev": true,
           "requires": {
@@ -8625,7 +8625,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -8634,7 +8634,7 @@
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
           "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
@@ -8650,7 +8650,7 @@
         },
         "yargs": {
           "version": "3.32.0",
-          "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
           "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
           "dev": true,
           "requires": {
@@ -9890,7 +9890,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -10095,7 +10095,7 @@
         },
         "kind-of": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
           "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
         },
         "plugin-error": {
@@ -10117,7 +10117,7 @@
         },
         "readable-stream": {
           "version": "2.0.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -10135,12 +10135,12 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
         "through2": {
           "version": "2.0.1",
-          "resolved": "http://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
           "integrity": "sha1-OE51MU1J8y3hLuu4E2uOtrXVnak=",
           "requires": {
             "readable-stream": "~2.0.0",
@@ -10528,7 +10528,7 @@
       "dependencies": {
         "kind-of": {
           "version": "2.0.1",
-          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
           "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
           "dev": true,
           "requires": {
@@ -12646,7 +12646,7 @@
     },
     "xmlbuilder": {
       "version": "9.0.7",
-      "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
       "dev": true
     },

--- a/garden-service/src/actions.ts
+++ b/garden-service/src/actions.ts
@@ -451,9 +451,9 @@ export class ActionHelper implements TypeGuard {
     return { serviceStatuses, environmentStatuses }
   }
 
-  async getDebugInfo({ log }: { log: LogEntry }): Promise<DebugInfoMap> {
+  async getDebugInfo({ log, includeProject }: { log: LogEntry, includeProject: boolean }): Promise<DebugInfoMap> {
     const handlers = this.getActionHandlers("getDebugInfo")
-    return Bluebird.props(mapValues(handlers, async (h) => h({ ...await this.commonParams(h, log) })))
+    return Bluebird.props(mapValues(handlers, async (h) => h({ ...await this.commonParams(h, log), includeProject })))
   }
 
   //endregion

--- a/garden-service/src/cli/cli.ts
+++ b/garden-service/src/cli/cli.ts
@@ -322,8 +322,7 @@ export class GardenCli {
           // Other exceptions are handled within the implementation of "get debug-info".
           if (command.name === "debug-info") {
             // Use default Garden dir name as fallback since Garden class hasn't been initialised
-            await generateBasicDebugInfoReport(root, join(root, DEFAULT_GARDEN_DIR_NAME), log)
-            return
+            await generateBasicDebugInfoReport(root, join(root, DEFAULT_GARDEN_DIR_NAME), log, parsedOpts.format)
           }
           throw err
         }

--- a/garden-service/src/commands/get/get-debug-info.ts
+++ b/garden-service/src/commands/get/get-debug-info.ts
@@ -113,7 +113,7 @@ export async function collectBasicDebugInfo(root: string, gardenDirPath: string,
 export async function collectSystemDiagnostic(gardenDirPath: string, log: LogEntry) {
   const tempPath = join(gardenDirPath, TEMP_DEBUG_ROOT)
   await ensureDir(tempPath)
-  const dockerLog = log.info({ section: "docker", msg: "collecting info", status: "active" })
+  const dockerLog = log.info({ section: "Docker", msg: "collecting info", status: "active" })
   let dockerVersion = ""
   try {
     dockerVersion = await execa.stdout("docker", ["--version"])
@@ -123,7 +123,7 @@ export async function collectSystemDiagnostic(gardenDirPath: string, log: LogEnt
     log.error(error)
   }
   const systemLog = log.info({ section: "Operating System", msg: "collecting info", status: "active" })
-  const gardenLog = log.info({ section: "garden", msg: "collecting garden version", status: "active" })
+  const gardenLog = log.info({ section: "Garden", msg: "getting version", status: "active" })
 
   const systemInfo = {
     gardenVersion: getPackageVersion(),
@@ -158,7 +158,6 @@ export async function collectProviderDebugInfo(garden: Garden, log: LogEntry, fo
 
   // Create a provider folder and report for each provider.
   for (const [providerName, info] of Object.entries(providersDebugInfo)) {
-    // const entry = log.info({ section: providerName, msg: "collecting configuration", status: "active" })
     const prividerPath = join(tempPath, providerName)
     await ensureDir(prividerPath)
     const outputFileName = `${PROVIDER_INFO_FILENAME_NO_EXT}.${format}`
@@ -228,7 +227,8 @@ const debugInfoOptions = {
     defaultValue: "json",
   }),
   "include-project": new BooleanParameter({
-    help: "Includes the provider info for the project namespace.",
+    help: "Include project-specific information from configured providers. \
+    Note that this may include sensitive data, depending on the provider and your configuration.",
     defaultValue: false,
   }),
 }
@@ -252,8 +252,8 @@ export class GetDebugInfoCommand extends Command<Args, Opts> {
     Examples:
 
     garden get debug-info                    # create a zip file at the root of the project with debug information
-    garden get debug-info --format yaml      # output the provider info as yaml files (default as json)
-    garden get debug-info --include-project  # Include the provider info for the project namespace. Default is disabled
+    garden get debug-info --format yaml      # output provider info as YAML files (default is JSON)
+    garden get debug-info --include-project  # include provider info for the project namespace (disabled by default)
   `
 
   arguments = debugInfoArguments
@@ -306,8 +306,8 @@ export class GetDebugInfoCommand extends Command<Args, Opts> {
 
     footer.setWarn({
       msg: chalk.yellow(dedent`
-        NOTE: Please be aware the output file might contain sensitive information.
-        If you plan to make the file available to the general public (eg. github), please review manually the content.
+        NOTE: Please be aware that the output file might contain sensitive information.
+        If you plan to make the file available to the general public (eg. GitHub), please review the content first.
         If you need to share a file containing sensitive information with the Garden team, please contact us on
         the #garden-dev channel on https://slack.k8s.io.
       `), append: true,

--- a/garden-service/src/commands/get/get-debug-info.ts
+++ b/garden-service/src/commands/get/get-debug-info.ts
@@ -11,6 +11,7 @@ import {
   Command,
   CommandParams,
   ChoicesParameter,
+  BooleanParameter,
 } from "../base"
 import { findProjectConfig } from "../../config/base"
 import { ensureDir, copy, remove, pathExists, writeFile } from "fs-extra"
@@ -77,16 +78,27 @@ export async function collectBasicDebugInfo(root: string, gardenDirPath: string,
   // Copy all the service configuration files
   for (const configPath of paths) {
     const servicePath = dirname(configPath)
+    const gardenPathLog = log.info({
+      section: relative(root, servicePath) || "/", msg: "collecting info", status: "active",
+    })
     const tempServicePath = join(tempPath, relative(root, servicePath))
     await ensureDir(tempServicePath)
     const moduleConfigFilePath = await getConfigFilePath(servicePath)
     const moduleConfigFilename = basename(moduleConfigFilePath)
+    const gardenLog = gardenPathLog.info({
+      section: moduleConfigFilename, msg: "collecting garden.yml", status: "active",
+    })
     await copy(moduleConfigFilePath, join(tempServicePath, moduleConfigFilename))
-
+    gardenLog.setSuccess({ msg: chalk.green(`Done (took ${log.getDuration(1)} sec)`), append: true })
     // Check if error logs exist and copy them over if they do
     if (await pathExists(join(servicePath, ERROR_LOG_FILENAME))) {
+      const errorLog = gardenPathLog.info({
+        section: ERROR_LOG_FILENAME, msg: `collecting ${ERROR_LOG_FILENAME}`, status: "active",
+      })
       await copy(join(servicePath, ERROR_LOG_FILENAME), join(tempServicePath, ERROR_LOG_FILENAME))
+      errorLog.setSuccess({ msg: chalk.green(`Done (took ${log.getDuration(1)} sec)`), append: true })
     }
+    gardenPathLog.setSuccess({ msg: chalk.green(`Done (took ${log.getDuration(1)} sec)`), append: true })
   }
 }
 
@@ -101,14 +113,17 @@ export async function collectBasicDebugInfo(root: string, gardenDirPath: string,
 export async function collectSystemDiagnostic(gardenDirPath: string, log: LogEntry) {
   const tempPath = join(gardenDirPath, TEMP_DEBUG_ROOT)
   await ensureDir(tempPath)
-
+  const dockerLog = log.info({ section: "docker", msg: "collecting info", status: "active" })
   let dockerVersion = ""
   try {
     dockerVersion = await execa.stdout("docker", ["--version"])
+    dockerLog.setSuccess({ msg: chalk.green(`Done (took ${log.getDuration(1)} sec)`), append: true })
   } catch (error) {
     log.error("Error encountered while executing docker")
     log.error(error)
   }
+  const systemLog = log.info({ section: "Operating System", msg: "collecting info", status: "active" })
+  const gardenLog = log.info({ section: "garden", msg: "collecting garden version", status: "active" })
 
   const systemInfo = {
     gardenVersion: getPackageVersion(),
@@ -116,6 +131,9 @@ export async function collectSystemDiagnostic(gardenDirPath: string, log: LogEnt
     platformVersion: release(),
     dockerVersion,
   }
+
+  systemLog.setSuccess({ msg: chalk.green(`Done (took ${log.getDuration(1)} sec)`), append: true })
+  gardenLog.setSuccess({ msg: chalk.green(`Done (took ${log.getDuration(1)} sec)`), append: true })
 
   await writeFile(join(tempPath, SYSTEM_INFO_FILENAME), JSON.stringify(systemInfo, null, 4), "utf8")
 
@@ -129,20 +147,23 @@ export async function collectSystemDiagnostic(gardenDirPath: string, log: LogEnt
  * @param {Garden} garden The Garden instance
  * @param {LogEntry} log  Logger
  * @param {string} format The extension format dictating the extension of the report
+ * @param {string} includeProject Extended export
  */
-export async function collectProviderDebugInfo(garden: Garden, log: LogEntry, format: string) {
+export async function collectProviderDebugInfo(garden: Garden, log: LogEntry, format: string, includeProject: boolean) {
   const tempPath = join(garden.gardenDirPath, TEMP_DEBUG_ROOT)
   await ensureDir(tempPath)
   // Collect debug info from providers
   const actions = await garden.getActionHelper()
-  const providersDebugInfo = await actions.getDebugInfo({ log })
+  const providersDebugInfo = await actions.getDebugInfo({ log, includeProject })
 
   // Create a provider folder and report for each provider.
   for (const [providerName, info] of Object.entries(providersDebugInfo)) {
+    // const entry = log.info({ section: providerName, msg: "collecting configuration", status: "active" })
     const prividerPath = join(tempPath, providerName)
     await ensureDir(prividerPath)
     const outputFileName = `${PROVIDER_INFO_FILENAME_NO_EXT}.${format}`
     await writeFile(join(prividerPath, outputFileName), renderInfo(info, format), "utf8")
+
   }
 }
 
@@ -160,13 +181,13 @@ export async function generateBasicDebugInfoReport(root: string, gardenDirPath: 
   const tempPath = join(gardenDirPath, TEMP_DEBUG_ROOT)
   const entry = log.info({ msg: "Collecting basic debug info", status: "active" })
   // Collect project info
-  const projectEntry = entry.info({ section: "Project", msg: "collecting info", status: "active" })
-  await collectBasicDebugInfo(root, gardenDirPath, log)
+  const projectEntry = entry.info({ section: "Project configuration", msg: "collecting info", status: "active" })
+  await collectBasicDebugInfo(root, gardenDirPath, projectEntry)
   projectEntry.setSuccess({ msg: chalk.green(`Done (took ${projectEntry.getDuration(1)} sec)`), append: true })
 
   // Run system diagnostic
   const systemEntry = entry.info({ section: "System", msg: "collecting info", status: "active" })
-  await collectSystemDiagnostic(gardenDirPath, log)
+  await collectSystemDiagnostic(gardenDirPath, systemEntry)
   systemEntry.setSuccess({ msg: chalk.green(`Done (took ${systemEntry.getDuration(1)} sec)`), append: true })
 
   // Zip report folder
@@ -201,10 +222,14 @@ function renderInfo(info: any, format: string) {
 const debugInfoArguments = {}
 
 const debugInfoOptions = {
-  format: new ChoicesParameter({
+  "format": new ChoicesParameter({
     help: "The output format for plugin-generated debug info.",
     choices: ["json", "yaml"],
     defaultValue: "json",
+  }),
+  "include-project": new BooleanParameter({
+    help: "Includes the provider info for the project namespace.",
+    defaultValue: false,
   }),
 }
 
@@ -226,8 +251,9 @@ export class GetDebugInfoCommand extends Command<Args, Opts> {
   description = dedent`
     Examples:
 
-    garden get debug-info                # create a zip file at the root of the project with debug information
-    garden get debug-info --format yaml  # output the provider info as yaml files (default as json)
+    garden get debug-info                    # create a zip file at the root of the project with debug information
+    garden get debug-info --format yaml      # output the provider info as yaml files (default as json)
+    garden get debug-info --include-project  # Include the provider info for the project namespace. Default is disabled
   `
 
   arguments = debugInfoArguments
@@ -239,19 +265,19 @@ export class GetDebugInfoCommand extends Command<Args, Opts> {
     const entry = log.info({ msg: "Collecting debug info", status: "active" })
 
     // Collect project info
-    const projectEntry = entry.info({ section: "Project", msg: "collecting info", status: "active" })
-    await collectBasicDebugInfo(garden.projectRoot, garden.gardenDirPath, log)
+    const projectEntry = entry.info({ section: "Project configuration", msg: "collecting info", status: "active" })
+    await collectBasicDebugInfo(garden.projectRoot, garden.gardenDirPath, projectEntry)
     projectEntry.setSuccess({ msg: chalk.green(`Done (took ${projectEntry.getDuration(1)} sec)`), append: true })
 
     // Run system diagnostic
     const systemEntry = entry.info({ section: "System", msg: "collecting info", status: "active" })
-    await collectSystemDiagnostic(garden.projectRoot, log)
+    await collectSystemDiagnostic(garden.projectRoot, systemEntry)
     systemEntry.setSuccess({ msg: chalk.green(`Done (took ${systemEntry.getDuration(1)} sec)`), append: true })
 
     // Collect providers info
     const providerEntry = entry.info({ section: "Providers", msg: "collecting info", status: "active" })
     try {
-      await collectProviderDebugInfo(garden, log, opts.format)
+      await collectProviderDebugInfo(garden, providerEntry, opts.format, opts["include-project"])
       providerEntry.setSuccess({ msg: chalk.green(`Done (took ${systemEntry.getDuration(1)} sec)`), append: true })
     } catch (err) {
       // One or multiple providers threw an error while processing.
@@ -269,9 +295,23 @@ export class GetDebugInfoCommand extends Command<Args, Opts> {
 
     // Cleanup temporary folders
     await remove(tempPath)
+    const success = log.placeholder()
+    const footer = success.placeholder()
 
     entry.setSuccess({ msg: "Done", append: true })
-    log.info(`\nDone! Please find your report at  ${outputFilePath}.`)
+
+    success.setDone({
+      msg: chalk.green(`\nDone! Please find your report at  ${outputFilePath}.\n`),
+    })
+
+    footer.setWarn({
+      msg: chalk.yellow(dedent`
+        NOTE: Please be aware the output file might contain sensitive information.
+        If you plan to make the file available to the general public (eg. github), please review manually the content.
+        If you need to share a file containing sensitive information with the Garden team, please contact us on
+        the #garden-dev channel on https://slack.k8s.io.
+      `), append: true,
+    })
 
     return { result: 0 }
   }

--- a/garden-service/src/commands/get/get-debug-info.ts
+++ b/garden-service/src/commands/get/get-debug-info.ts
@@ -28,6 +28,7 @@ import { Garden } from "../../garden"
 import { zipFolder } from "../../util/archive"
 import chalk from "chalk"
 import { GitHandler } from "../../vcs/git"
+import { ValidationError } from "../../exceptions"
 
 export const TEMP_DEBUG_ROOT = "tmp"
 export const SYSTEM_INFO_FILENAME_NO_EXT = "system-info"
@@ -48,11 +49,9 @@ export async function collectBasicDebugInfo(root: string, gardenDirPath: string,
   // Find project definition
   const config = await findProjectConfig(root, true)
   if (!config) {
-    log.error(deline`
-      Couldn't find a garden.yml with a valid project definition.
-      Please run this command from the root of your Garden project.`)
-    process.exit(1)
-    return
+    throw new ValidationError(deline`
+      Couldn't find a garden.yml with a project definition.
+      Please run this command from the root of your Garden project.`, {})
   }
 
   // Create temporary folder inside .garden/ at root of project

--- a/garden-service/src/types/plugin/provider/getDebugInfo.ts
+++ b/garden-service/src/types/plugin/provider/getDebugInfo.ts
@@ -26,7 +26,11 @@ export const getDebugInfo = {
   description: dedent`
     Collects debug info from the provider.
   `,
-  paramsSchema: actionParamsSchema,
+  paramsSchema: actionParamsSchema
+    .keys({
+      includeProject: joi.boolean()
+        .description("If set, include project-specific information from configured providers."),
+    }),
   resultSchema: joi.object()
     .keys({
       info: joi.any()

--- a/garden-service/src/types/plugin/provider/getDebugInfo.ts
+++ b/garden-service/src/types/plugin/provider/getDebugInfo.ts
@@ -18,7 +18,9 @@ export interface DebugInfoMap {
   [key: string]: DebugInfo
 }
 
-export interface GetDebugInfoParams extends PluginActionParamsBase { }
+export interface GetDebugInfoParams extends PluginActionParamsBase {
+  includeProject: boolean,
+}
 
 export const getDebugInfo = {
   description: dedent`

--- a/garden-service/src/util/fs.ts
+++ b/garden-service/src/util/fs.ts
@@ -21,7 +21,7 @@ import { VcsHandler } from "../vcs/vcs"
 const VALID_CONFIG_FILENAMES = ["garden.yml", "garden.yaml"]
 const metadataFilename = "metadata.json"
 export const defaultDotIgnoreFiles = [".gitignore", ".gardenignore"]
-export const fixedExcludes = [".git", ".garden", "debug-info-*"]
+export const fixedExcludes = [".git", ".garden", "debug-info*/**"]
 
 /*
   Warning: Don't make any async calls in the loop body when using this function, since this may cause

--- a/garden-service/test/unit/src/commands/get/get-debug-info.ts
+++ b/garden-service/test/unit/src/commands/get/get-debug-info.ts
@@ -7,18 +7,19 @@
  */
 
 import { expect } from "chai"
+import * as yaml from "js-yaml"
 import { makeTestGardenA, cleanProject, withDefaultGlobalOpts } from "../../../../helpers"
 import {
   generateBasicDebugInfoReport,
   TEMP_DEBUG_ROOT,
   collectBasicDebugInfo,
-  SYSTEM_INFO_FILENAME,
+  SYSTEM_INFO_FILENAME_NO_EXT,
   collectSystemDiagnostic,
   collectProviderDebugInfo,
   PROVIDER_INFO_FILENAME_NO_EXT,
   GetDebugInfoCommand,
 } from "../../../../../src/commands/get/get-debug-info"
-import { readdirSync, remove, pathExists, readJSONSync } from "fs-extra"
+import { readdir, remove, pathExists, readJSON, readFile } from "fs-extra"
 import { ERROR_LOG_FILENAME } from "../../../../../src/constants"
 import { join, relative } from "path"
 import { Garden } from "../../../../../src/garden"
@@ -28,7 +29,7 @@ import { getConfigFilePath } from "../../../../../src/util/fs"
 const debugZipFileRegex = new RegExp(/debug-info-.*?.zip/)
 
 async function cleanupTmpDebugFiles(root: string, gardenDirPath: string) {
-  const allFiles = readdirSync(root)
+  const allFiles = await readdir(root)
   await remove(join(gardenDirPath, TEMP_DEBUG_ROOT))
   const deleteFilenames = allFiles.filter((fileName) => {
     return fileName.match(debugZipFileRegex)
@@ -72,7 +73,7 @@ describe("GetDebugInfoCommand", () => {
 
         expect(res.result).to.eql(0)
 
-        const gardenProjectRootFiles = readdirSync(garden.projectRoot)
+        const gardenProjectRootFiles = await readdir(garden.projectRoot)
         const zipFiles = gardenProjectRootFiles.filter((fileName) => {
           return fileName.match(debugZipFileRegex)
         })
@@ -85,7 +86,7 @@ describe("GetDebugInfoCommand", () => {
     it("should generate a zip file containing a *basic* debug info report in the root folder of the project",
       async () => {
         await generateBasicDebugInfoReport(garden.projectRoot, garden.gardenDirPath, log)
-        const gardenProjectRootFiles = readdirSync(garden.projectRoot)
+        const gardenProjectRootFiles = await readdir(garden.projectRoot)
         const zipFiles = gardenProjectRootFiles.filter((fileName) => {
           return fileName.match(debugZipFileRegex)
         })
@@ -123,17 +124,37 @@ describe("GetDebugInfoCommand", () => {
 
   describe("collectSystemDiagnostic", () => {
     it("should create a system info report in a temporary folder", async () => {
-      await collectSystemDiagnostic(garden.gardenDirPath, log)
+      const format = "json"
+      await collectSystemDiagnostic(garden.gardenDirPath, log, format)
 
       // Check if the temporary folder exists
       expect(await pathExists(gardenDebugTmp)).to.equal(true)
 
       // Checks if system debug file is created
-      const systemInfoFilePath = join(gardenDebugTmp, SYSTEM_INFO_FILENAME)
+      const systemInfoFilePath = join(gardenDebugTmp, `${SYSTEM_INFO_FILENAME_NO_EXT}.${format}`)
       expect(await pathExists(systemInfoFilePath)).to.equal(true)
 
       // Check structure of systemInfoFile
-      const systemInfoFile = readJSONSync(systemInfoFilePath)
+      const systemInfoFile = await readJSON(systemInfoFilePath)
+      expect(systemInfoFile).to.have.property("gardenVersion")
+      expect(systemInfoFile).to.have.property("platform")
+      expect(systemInfoFile).to.have.property("platformVersion")
+      expect(systemInfoFile).to.have.property("dockerVersion")
+    })
+
+    it("should create a system info report in a temporary folder with yaml format", async () => {
+      const format = "yaml"
+      await collectSystemDiagnostic(garden.gardenDirPath, log, format)
+
+      // Check if the temporary folder exists
+      expect(await pathExists(gardenDebugTmp)).to.equal(true)
+
+      // Checks if system debug file is created
+      const systemInfoFilePath = join(gardenDebugTmp, `${SYSTEM_INFO_FILENAME_NO_EXT}.${format}`)
+      expect(await pathExists(systemInfoFilePath)).to.equal(true)
+
+      // Check structure of systemInfoFile
+      const systemInfoFile = yaml.safeLoad(await readFile(systemInfoFilePath, "utf8"))
       expect(systemInfoFile).to.have.property("gardenVersion")
       expect(systemInfoFile).to.have.property("platform")
       expect(systemInfoFile).to.have.property("platformVersion")
@@ -159,7 +180,7 @@ describe("GetDebugInfoCommand", () => {
       expect(await pathExists(join(gardenDebugTmp, providerInfoFilePath))).to.equal(true)
 
       // Check structure of provider info file
-      const systemInfoFile = readJSONSync(join(gardenDebugTmp, providerInfoFilePath))
+      const systemInfoFile = await readJSON(join(gardenDebugTmp, providerInfoFilePath))
       expect(systemInfoFile).to.have.property("info")
 
     })

--- a/garden-service/test/unit/src/commands/get/get-debug-info.ts
+++ b/garden-service/test/unit/src/commands/get/get-debug-info.ts
@@ -147,7 +147,7 @@ describe("GetDebugInfoCommand", () => {
       const expectedProviderFolderName = "test-plugin"
       const providerInfoFilePath = join(expectedProviderFolderName, `${PROVIDER_INFO_FILENAME_NO_EXT}.${format}`)
 
-      await collectProviderDebugInfo(garden, log, format)
+      await collectProviderDebugInfo(garden, log, format, false)
 
       // Check if the temporary folder exists
       expect(await pathExists(gardenDebugTmp)).to.equal(true)

--- a/garden-service/test/unit/src/vcs/git.ts
+++ b/garden-service/test/unit/src/vcs/git.ts
@@ -5,6 +5,7 @@ import { join, resolve } from "path"
 
 import { expectError } from "../../../helpers"
 import { getCommitIdFromRefList, parseGitUrl, GitHandler } from "../../../../src/vcs/git"
+import { fixedExcludes } from "../../../../src/util/fs"
 
 // Overriding this to make sure any ignorefile name is respected
 const ignoreFileName = ".testignore"
@@ -227,6 +228,20 @@ describe("GitHandler", () => {
       await git("commit", "-m", "foo")
 
       const files = (await handler.getFiles(tmpPath, undefined, []))
+        .filter(f => !f.path.includes(ignoreFileName))
+
+      expect(files).to.eql([])
+    })
+
+    it("should exclude files that are exclude by default", async () => {
+      for (const exclude of fixedExcludes) {
+        const name = "foo.txt"
+        const updatedExclude = exclude.replace("**", "a-folder").replace("*", "-a-value/sisis")
+        const path = resolve(join(tmpPath, updatedExclude), name)
+        await createFile(path)
+      }
+
+      const files = (await handler.getFiles(tmpPath, undefined, [...fixedExcludes]))
         .filter(f => !f.path.includes(ignoreFileName))
 
       expect(files).to.eql([])


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:
As reported by @Eronarn, the `garden get debug-info` command might include sensitive data in the output file. This PR introduces a lot more logging in order to inform the user on what it is been extracted. It also changes the behaviour of the command when it comes to export data from the kubernetes cluster: by default the command will only dump data from the `garden-system` and `garden-system--metadata` namespaces. If the user uses the new flat `--include-project`, the command will dump the configuraition for the entire project as well. 

**Which issue(s) this PR fixes**:
Fixes #1024

**Special notes for your reviewer**:
@eronarn to run the PR code you please follow this steps:
 - `git clone git@github.com:garden-io/garden.git`
 - `cd garden`
 - `npm install`
 - `cd garden-service`
 - `npm run dev`

At this point you shuold be running the branch version.
You might encounter some conflict in case you have a stable version installed, in that case the fastest way would be to uninstall it temporarily (for example on Mac just run `brew uninstall garden-cli`. 
Of course, ping us if you have any issue. 

**Does this PR introduce a user-facing change?**:
Yes. See "What this PR does / why we need it" above.