### PR TITLE
fix: fix 'cannot read property error of null' error

### DIFF
--- a/garden-service/src/commands/base.ts
+++ b/garden-service/src/commands/base.ts
@@ -315,7 +315,7 @@ export abstract class Command<T extends Parameters = {}, U extends Parameters = 
 export async function handleTaskResults(
   log: LogEntry, taskType: string, results: ProcessResults,
 ): Promise<CommandResult<TaskResults>> {
-  const failed = Object.values(results.taskResults).filter(r => !!r.error).length
+  const failed = Object.values(results.taskResults).filter(r => r && r.error).length
 
   if (failed) {
     const error = new RuntimeError(`${failed} ${taskType} task(s) failed!`, {

--- a/garden-service/src/garden.ts
+++ b/garden-service/src/garden.ts
@@ -432,7 +432,7 @@ export class Garden {
       })
       const taskResults = await this.processTasks(tasks)
 
-      const failed = Object.values(taskResults).filter(r => !!r.error)
+      const failed = Object.values(taskResults).filter(r => r && r.error)
 
       if (failed.length) {
         const messages = failed.map(r => `- ${r.name}: ${r.error!.message}`)

--- a/garden-service/src/plugins/kubernetes/system.ts
+++ b/garden-service/src/plugins/kubernetes/system.ts
@@ -200,7 +200,7 @@ export async function prepareSystemServices(
       forceBuild: force,
     })
 
-    const failed = values(results.taskResults).filter(r => !!r.error).length
+    const failed = values(results.taskResults).filter(r => r && r.error).length
 
     if (failed) {
       throw new PluginError(`${provider.name}: ${failed} errors occurred when configuring environment`, {


### PR DESCRIPTION
This would routinely come up when one or more tasks fail in execution.