### PR TITLE
fix: exclude symlinks to directories from hashing

### DIFF
--- a/garden-service/src/vcs/git.ts
+++ b/garden-service/src/vcs/git.ts
@@ -126,7 +126,12 @@ export class GitHandler extends VcsHandler {
         // If we can't compute the hash, i.e. the file is gone, we filter it out below
         let hash = ""
         try {
-          hash = await this.hashObject(resolvedPath) || ""
+          // "git ls-files" returns a symlink even if it points to a directory.
+          // We filter symlinked directories out, since hashObject() will fail to
+          // process them.
+          if (!(await stat(resolvedPath)).isDirectory()) {
+            hash = await this.hashObject(resolvedPath) || ""
+          }
         } catch (err) {
           // 128 = File no longer exists
           if (err.code !== 128 && err.code !== "ENOENT") {

--- a/garden-service/test/unit/src/vcs/git.ts
+++ b/garden-service/test/unit/src/vcs/git.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai"
 import * as tmp from "tmp-promise"
-import { createFile, writeFile, realpath, mkdir, remove } from "fs-extra"
+import { createFile, writeFile, realpath, mkdir, remove, symlink } from "fs-extra"
 import { join, resolve } from "path"
 
 import { expectError } from "../../../helpers"
@@ -225,6 +225,21 @@ describe("GitHandler", () => {
 
       await git("add", path)
       await git("commit", "-m", "foo")
+
+      const files = (await handler.getFiles(tmpPath, undefined, []))
+        .filter(f => !f.path.includes(ignoreFileName))
+
+      expect(files).to.eql([])
+    })
+
+    it("should exclude an untracked symlink to a directory", async () => {
+      const tmpDir2 = await tmp.dir({ unsafeCleanup: true })
+      const tmpPathB = await realpath(tmpDir2.path)
+
+      const name = "a-symlink-to-a-directory"
+      const path = resolve(tmpPath, name)
+
+      await symlink(tmpPathB, path)
 
       const files = (await handler.getFiles(tmpPath, undefined, []))
         .filter(f => !f.path.includes(ignoreFileName))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:
This PR fixes #1029, which was caused by bad handling of symlink when initializing garden.

**Which issue(s) this PR fixes**:

Fixes #1029

**Special notes for your reviewer**:
We use the git client to retrieve all the files from a project, from where to extract then the module config paths. The current implementation then doesn't allow the use of symlinks: the git client will never resolve a symlink if it's a directory. It will always treat it as file and (this is now fixed/prevented) would try to hash it using the node streams, failing.
From a design point of view, I am not 100% aware of all the reasons behinf choosing `git ls-files` instead of something else. What I find strange is the jump from "using a library" to retrieve files and "using bare node streams" to hash it. It would be nice to understand if it makes sense to convert the search function to the same node standard or viceversa if we can use the git client to do the hashing. 



**Does this PR introduce a user-facing change?**:
No