### PR TITLE
fix(k8s): avoid "no deployed releases" errors after Helm install failure

### DIFF
--- a/garden-service/src/plugins/kubernetes/helm/deployment.ts
+++ b/garden-service/src/plugins/kubernetes/helm/deployment.ts
@@ -59,6 +59,9 @@ export async function deployService(
       "--name", releaseName,
       "--namespace", namespace,
       "--values", valuesPath,
+      // Make sure chart gets purged if it fails to install
+      "--atomic",
+      "--timeout", "600",
     ]
     if (force) {
       installArgs.push("--replace")

--- a/garden-service/src/plugins/kubernetes/helm/helm-cli.ts
+++ b/garden-service/src/plugins/kubernetes/helm/helm-cli.ts
@@ -49,5 +49,7 @@ export async function helm(namespace: string, context: string, log: LogEntry, ..
   return helmCmd.stdout({
     log,
     args,
+    // Helm itself will time out pretty reliably, so we shouldn't time out early on our side.
+    timeout: 3600,
   })
 }


### PR DESCRIPTION
Fixes #1045 