### PR TITLE
feat: automatic port forwarding for deployed services

### DIFF
--- a/garden-service/src/actions.ts
+++ b/garden-service/src/actions.ts
@@ -69,6 +69,8 @@ import { RunTaskParams, RunTaskResult } from "./types/plugin/task/runTask"
 import { Service, ServiceStatus, ServiceStatusMap, getServiceRuntimeContext } from "./types/service"
 import { Omit } from "./util/util"
 import { DebugInfoMap } from "./types/plugin/provider/getDebugInfo"
+import { GetPortForwardParams } from "./types/plugin/service/getPortForward"
+import { StopPortForwardParams } from "./types/plugin/service/stopPortForward"
 
 type TypeGuard = {
   readonly [P in keyof (PluginActionParams | ModuleActionParams<any>)]: (...args: any[]) => Promise<any>
@@ -343,6 +345,14 @@ export class ActionHelper implements TypeGuard {
 
   async runService(params: ServiceActionHelperParams<RunServiceParams>): Promise<RunResult> {
     return this.callServiceHandler({ params, actionType: "runService" })
+  }
+
+  async getPortForward(params: ServiceActionHelperParams<GetPortForwardParams>) {
+    return this.callServiceHandler({ params, actionType: "getPortForward" })
+  }
+
+  async stopPortForward(params: ServiceActionHelperParams<StopPortForwardParams>) {
+    return this.callServiceHandler({ params, actionType: "stopPortForward" })
   }
 
   //endregion

--- a/garden-service/src/cli/cli.ts
+++ b/garden-service/src/cli/cli.ts
@@ -283,13 +283,15 @@ export class GardenCli {
       let garden: Garden
       let result: any
 
-      await command.prepare({
+      const { persistent } = await command.prepare({
         log,
         headerLog,
         footerLog,
         args: parsedArgs,
         opts: parsedOpts,
       })
+
+      contextOpts.persistent = persistent
 
       do {
         try {

--- a/garden-service/src/commands/base.ts
+++ b/garden-service/src/commands/base.ts
@@ -238,6 +238,11 @@ export interface CommandParams<T extends Parameters = {}, U extends Parameters =
   garden: Garden
 }
 
+interface PrepareOutput {
+  // Commands should set this to true if the command is long-running
+  persistent: boolean
+}
+
 export abstract class Command<T extends Parameters = {}, U extends Parameters = {}> {
   abstract name: string
   abstract help: string
@@ -302,7 +307,8 @@ export abstract class Command<T extends Parameters = {}, U extends Parameters = 
    * Called by the CLI before the command's action is run, but is not called again
    * if the command restarts. Useful for commands in watch mode.
    */
-  async prepare(_: PrepareParams<T, U>) {
+  async prepare(_: PrepareParams<T, U>): Promise<PrepareOutput> {
+    return { persistent: false }
   }
 
   // Note: Due to a current TS limitation (apparently covered by https://github.com/Microsoft/TypeScript/issues/7011),

--- a/garden-service/src/commands/build.ts
+++ b/garden-service/src/commands/build.ts
@@ -64,9 +64,13 @@ export class BuildCommand extends Command<Args, Opts> {
   async prepare({ headerLog, footerLog, opts }: PrepareParams<Args, Opts>) {
     printHeader(headerLog, "Build", "hammer")
 
-    if (!!opts.watch) {
+    const persistent = !!opts.watch
+
+    if (persistent) {
       this.server = await startServer(footerLog)
     }
+
+    return { persistent }
   }
 
   async action(

--- a/garden-service/src/commands/deploy.ts
+++ b/garden-service/src/commands/deploy.ts
@@ -87,9 +87,13 @@ export class DeployCommand extends Command<Args, Opts> {
   async prepare({ headerLog, footerLog, opts }: PrepareParams<Args, Opts>) {
     printHeader(headerLog, "Deploy", "rocket")
 
-    if (!!opts.watch || !!opts["hot-reload"]) {
+    const persistent = !!opts.watch || !!opts["hot-reload"]
+
+    if (persistent) {
       this.server = await startServer(footerLog)
     }
+
+    return { persistent }
   }
 
   async action({ garden, log, footerLog, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<TaskResults>> {

--- a/garden-service/src/commands/dev.ts
+++ b/garden-service/src/commands/dev.ts
@@ -96,6 +96,8 @@ export class DevCommand extends Command<Args, Opts> {
     log.info(chalk.gray.italic(`Good ${getGreetingTime()}! Let's get your environment wired up...\n`))
 
     this.server = await startServer(footerLog)
+
+    return { persistent: true }
   }
 
   async action({ garden, log, footerLog, opts }: CommandParams<Args, Opts>): Promise<CommandResult> {

--- a/garden-service/src/commands/get/get-tasks.ts
+++ b/garden-service/src/commands/get/get-tasks.ts
@@ -63,6 +63,7 @@ export class GetTasksCommand extends Command<Args> {
 
   async prepare({ headerLog }: PrepareParams<Args>) {
     printHeader(headerLog, "Tasks", "open_book")
+    return { persistent: false }
   }
 
   async action({ args, garden, log }: CommandParams<Args>): Promise<CommandResult> {

--- a/garden-service/src/commands/serve.ts
+++ b/garden-service/src/commands/serve.ts
@@ -45,6 +45,7 @@ export class ServeCommand extends Command<Args, Opts> {
 
   async prepare({ footerLog, opts }: PrepareParams<Args, Opts>) {
     this.server = await startServer(footerLog, opts.port)
+    return { persistent: true }
   }
 
   async action({ garden }: CommandParams<Args, Opts>): Promise<CommandResult<{}>> {

--- a/garden-service/src/commands/test.ts
+++ b/garden-service/src/commands/test.ts
@@ -81,9 +81,13 @@ export class TestCommand extends Command<Args, Opts> {
   async prepare({ headerLog, footerLog, opts }: PrepareParams<Args, Opts>) {
     printHeader(headerLog, `Running tests`, "thermometer")
 
-    if (!!opts.watch) {
+    const persistent = !!opts.watch
+
+    if (persistent) {
       this.server = await startServer(footerLog)
     }
+
+    return { persistent }
   }
 
   async action({ garden, log, footerLog, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<TaskResults>> {

--- a/garden-service/src/garden.ts
+++ b/garden-service/src/garden.ts
@@ -72,6 +72,7 @@ export interface GardenOpts {
   config?: ProjectConfig,
   gardenDirPath?: string,
   environmentName?: string,
+  persistent?: boolean,
   log?: LogEntry,
   plugins?: Plugins,
 }
@@ -130,6 +131,7 @@ export class Garden {
   public readonly dotIgnoreFiles: string[]
   public readonly moduleIncludePatterns?: string[]
   public readonly moduleExcludePatterns: string[]
+  public readonly persistent: boolean
 
   constructor(params: GardenParams) {
     this.buildDir = params.buildDir
@@ -145,6 +147,7 @@ export class Garden {
     this.dotIgnoreFiles = params.dotIgnoreFiles
     this.moduleIncludePatterns = params.moduleIncludePatterns
     this.moduleExcludePatterns = params.moduleExcludePatterns || []
+    this.persistent = !!params.opts.persistent
 
     // make sure we're on a supported platform
     const currentPlatform = platform()

--- a/garden-service/src/plugins/google/google-cloud-functions.ts
+++ b/garden-service/src/plugins/google/google-cloud-functions.ts
@@ -151,8 +151,8 @@ export async function getServiceStatus(
   const state: ServiceState = status.status === "ACTIVE" ? "ready" : "unhealthy"
 
   return {
-    providerId,
-    providerVersion: status.versionId,
+    externalId: providerId,
+    externalVersion: status.versionId,
     version: status.labels[gardenAnnotationKey("version")],
     state,
     updatedAt: status.updateTime,

--- a/garden-service/src/plugins/kubernetes/container/build.ts
+++ b/garden-service/src/plugins/kubernetes/container/build.ts
@@ -12,7 +12,7 @@ import { containerHelpers } from "../../container/helpers"
 import { buildContainerModule, getContainerBuildStatus, getDockerBuildFlags } from "../../container/build"
 import { GetBuildStatusParams, BuildStatus } from "../../../types/plugin/module/getBuildStatus"
 import { BuildModuleParams, BuildResult } from "../../../types/plugin/module/build"
-import { getPortForward, getPods, millicpuToString, megabytesToString } from "../util"
+import { getPods, millicpuToString, megabytesToString } from "../util"
 import { systemNamespace } from "../system"
 import { RSYNC_PORT } from "../constants"
 import execa = require("execa")
@@ -26,6 +26,7 @@ import { runPod } from "../run"
 import { getRegistryHostname } from "../init"
 import { getManifestFromRegistry } from "./util"
 import { normalizeLocalRsyncPath } from "../../../util/fs"
+import { getPortForward } from "../port-forward"
 
 const dockerDaemonDeploymentName = "garden-docker-daemon"
 const dockerDaemonContainerName = "docker-daemon"
@@ -130,7 +131,7 @@ const remoteBuild: BuildHandler = async (params) => {
     ctx,
     log,
     namespace: systemNamespace,
-    targetDeployment: `Deployment/${buildSyncDeploymentName}`,
+    targetResource: `Deployment/${buildSyncDeploymentName}`,
     port: RSYNC_PORT,
   })
 

--- a/garden-service/src/plugins/kubernetes/container/handlers.ts
+++ b/garden-service/src/plugins/kubernetes/container/handlers.ts
@@ -22,6 +22,7 @@ import { configureMavenContainerModule, MavenContainerModule } from "../../maven
 import { getTaskResult } from "../task-results"
 import { k8sBuildContainer, k8sGetContainerBuildStatus } from "./build"
 import { k8sPublishContainerModule } from "./publish"
+import { getPortForwardHandler } from "../port-forward"
 
 async function configure(params: ConfigureModuleParams<ContainerModule>) {
   params.moduleConfig = await configureContainerModule(params)
@@ -41,6 +42,7 @@ export const containerHandlers = {
   deleteService,
   execInService,
   getBuildStatus: k8sGetContainerBuildStatus,
+  getPortForward: getPortForwardHandler,
   getServiceLogs,
   getServiceStatus: getContainerServiceStatus,
   getTestResult,

--- a/garden-service/src/plugins/kubernetes/container/util.ts
+++ b/garden-service/src/plugins/kubernetes/container/util.ts
@@ -8,7 +8,7 @@
 
 import { resolve } from "url"
 import { ContainerModule } from "../../container/config"
-import { getPortForward } from "../util"
+import { getPortForward } from "../port-forward"
 import { systemNamespace } from "../system"
 import { CLUSTER_REGISTRY_DEPLOYMENT_NAME, CLUSTER_REGISTRY_PORT } from "../constants"
 import { containerHelpers } from "../../container/helpers"
@@ -33,7 +33,7 @@ export async function getRegistryPortForward(ctx: PluginContext, log: LogEntry) 
     ctx,
     log,
     namespace: systemNamespace,
-    targetDeployment: `Deployment/${CLUSTER_REGISTRY_DEPLOYMENT_NAME}`,
+    targetResource: `Deployment/${CLUSTER_REGISTRY_DEPLOYMENT_NAME}`,
     port: CLUSTER_REGISTRY_PORT,
   })
 }

--- a/garden-service/src/plugins/kubernetes/helm/deployment.ts
+++ b/garden-service/src/plugins/kubernetes/helm/deployment.ts
@@ -27,6 +27,7 @@ import { ContainerHotReloadSpec } from "../../container/config"
 import { getHotReloadSpec } from "./hot-reload"
 import { DeployServiceParams } from "../../../types/plugin/service/deployService"
 import { DeleteServiceParams } from "../../../types/plugin/service/deleteService"
+import { getForwardablePorts } from "../port-forward"
 
 export async function deployService(
   { ctx, module, service, log, force, hotReload }: DeployServiceParams<HelmModule>,
@@ -100,7 +101,13 @@ export async function deployService(
   // they may be legitimately inconsistent.
   await waitForResources({ ctx, provider, serviceName: service.name, resources: chartResources, log })
 
-  return {}
+  const forwardablePorts = getForwardablePorts(chartResources)
+
+  return {
+    forwardablePorts,
+    state: "ready",
+    version: module.version.versionString,
+  }
 }
 
 export async function deleteService(params: DeleteServiceParams): Promise<ServiceStatus> {

--- a/garden-service/src/plugins/kubernetes/helm/handlers.ts
+++ b/garden-service/src/plugins/kubernetes/helm/handlers.ts
@@ -18,6 +18,7 @@ import { getServiceLogs } from "./logs"
 import { testHelmModule } from "./test"
 import { dedent } from "../../../util/string"
 import { joi } from "../../../config/common"
+import { getPortForwardHandler } from "../port-forward"
 
 const helmModuleOutputsSchema = joi.object()
   .keys({
@@ -44,6 +45,7 @@ export const helmHandlers: Partial<ModuleAndRuntimeActions<HelmModule>> = {
   deleteService,
   deployService,
   describeType,
+  getPortForward: getPortForwardHandler,
   getServiceLogs,
   getServiceStatus,
   getTestResult,

--- a/garden-service/src/plugins/kubernetes/kubernetes-module/handlers.ts
+++ b/garden-service/src/plugins/kubernetes/kubernetes-module/handlers.ts
@@ -28,6 +28,7 @@ import { DeployServiceParams } from "../../../types/plugin/service/deployService
 import { DeleteServiceParams } from "../../../types/plugin/service/deleteService"
 import { GetServiceLogsParams } from "../../../types/plugin/service/getServiceLogs"
 import { gardenAnnotationKey } from "../../../util/string"
+import { getForwardablePorts, getPortForwardHandler } from "../port-forward"
 
 export const kubernetesHandlers: Partial<ModuleAndRuntimeActions<KubernetesModule>> = {
   build,
@@ -35,6 +36,7 @@ export const kubernetesHandlers: Partial<ModuleAndRuntimeActions<KubernetesModul
   deleteService,
   deployService,
   describeType,
+  getPortForward: getPortForwardHandler,
   getServiceLogs,
   getServiceStatus,
 }
@@ -62,7 +64,10 @@ async function getServiceStatus(
 
   const { state, remoteObjects } = await compareDeployedObjects(k8sCtx, api, namespace, manifests, log, false)
 
+  const forwardablePorts = getForwardablePorts(remoteObjects)
+
   return {
+    forwardablePorts,
     state,
     version: state === "ready" ? module.version.versionString : undefined,
     detail: { remoteObjects },

--- a/garden-service/src/plugins/kubernetes/port-forward.ts
+++ b/garden-service/src/plugins/kubernetes/port-forward.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2018 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { ChildProcess } from "child_process"
+
+import getPort = require("get-port")
+const AsyncLock = require("async-lock")
+import { V1Service } from "@kubernetes/client-node"
+
+import { GetPortForwardParams, GetPortForwardResult } from "../../types/plugin/service/getPortForward"
+import { KubernetesProvider, KubernetesPluginContext } from "./config"
+import { getAppNamespace } from "./namespace"
+import { registerCleanupFunction } from "../../util/util"
+import { PluginContext } from "../../plugin-context"
+import { kubectl } from "./kubectl"
+import { KubernetesResource } from "./types"
+import { ForwardablePort } from "../../types/service"
+import { isBuiltIn } from "./util"
+import { LogEntry } from "../../logger/log-entry"
+
+// TODO: implement stopPortForward handler
+
+export interface PortForward {
+  targetResource: string
+  port: number
+  localPort: number
+  proc: ChildProcess
+}
+
+const registeredPortForwards: { [key: string]: PortForward } = {}
+const portForwardRegistrationLock = new AsyncLock()
+
+registerCleanupFunction("kill-port-forward-procs", () => {
+  for (const { targetResource, port } of Object.values(registeredPortForwards)) {
+    killPortForward(targetResource, port)
+  }
+})
+
+export function killPortForward(targetResource: string, port: number) {
+  const key = getPortForwardKey(targetResource, port)
+  const fwd = registeredPortForwards[key]
+  if (fwd) {
+    const { proc } = fwd
+    !proc.killed && proc.kill()
+  }
+}
+
+function getPortForwardKey(targetResource: string, port: number) {
+  return `${targetResource}:${port}`
+}
+
+/**
+ * Creates or re-uses an existing tunnel to a Kubernetes resources.
+ *
+ * We maintain a simple in-process cache of randomly allocated local ports that have been port-forwarded to a
+ * given port on a given Kubernetes resource.
+ */
+export async function getPortForward(
+  { ctx, log, namespace, targetResource, port }:
+    { ctx: PluginContext, log: LogEntry, namespace: string, targetResource: string, port: number },
+): Promise<PortForward> {
+  // Using lock here to avoid concurrency issues (multiple parallel requests for same forward).
+  const key = getPortForwardKey(targetResource, port)
+
+  return portForwardRegistrationLock.acquire("register-port-forward", (async () => {
+    let localPort: number
+
+    const registered = registeredPortForwards[key]
+
+    if (registered && !registered.proc.killed) {
+      log.debug(`Reusing local port ${registered.localPort} for ${targetResource}`)
+      return registered
+    }
+
+    const k8sCtx = <KubernetesPluginContext>ctx
+
+    // Forward random free local port to the remote rsync container.
+    localPort = await getPort()
+    const portMapping = `${localPort}:${port}`
+
+    log.debug(`Forwarding local port ${localPort} to ${targetResource} port ${port}`)
+
+    // TODO: use the API directly instead of kubectl (need to reverse engineer kubectl a bit to get how that works)
+    const portForwardArgs = ["port-forward", targetResource, portMapping]
+    log.silly(`Running 'kubectl ${portForwardArgs.join(" ")}'`)
+
+    const proc = await kubectl.spawn({ log, context: k8sCtx.provider.config.context, namespace, args: portForwardArgs })
+
+    return new Promise((resolve) => {
+      proc.on("error", (error) => {
+        !proc.killed && proc.kill()
+        throw error
+      })
+
+      proc.stdout!.on("data", (line) => {
+        // This is unfortunately the best indication that we have that the connection is up...
+        log.silly(`[${targetResource} port forwarder] ${line}`)
+
+        if (line.toString().includes("Forwarding from ")) {
+          const portForward = { targetResource, port, proc, localPort }
+          registeredPortForwards[key] = portForward
+          resolve(portForward)
+        }
+      })
+    })
+  }))
+}
+
+export async function getPortForwardHandler(
+  { ctx, log, service, targetPort }: GetPortForwardParams,
+): Promise<GetPortForwardResult> {
+  const provider = ctx.provider as KubernetesProvider
+  const namespace = await getAppNamespace(ctx, log, provider)
+  const targetResource = `Service/${service.name}`
+
+  const fwd = await getPortForward({ ctx, log, namespace, targetResource, port: targetPort })
+
+  return {
+    hostname: "localhost",
+    port: fwd.localPort,
+  }
+}
+
+/**
+ * Returns a list of forwardable ports based on the specified resources.
+ */
+export function getForwardablePorts(resources: KubernetesResource[]) {
+  const ports: ForwardablePort[] = []
+
+  for (const resource of resources) {
+    if (isBuiltIn(resource) && resource.kind === "Service") {
+      const service = resource as V1Service
+
+      for (const portSpec of service.spec!.ports || []) {
+        ports.push({
+          name: portSpec.name,
+          // TODO: not sure if/how possible but it would be good to deduce the protocol somehow
+          protocol: "TCP",
+          targetHostname: service.metadata!.name,
+          targetPort: portSpec.port,
+        })
+      }
+    }
+  }
+
+  return ports
+}

--- a/garden-service/src/plugins/local/local-docker-swarm.ts
+++ b/garden-service/src/plugins/local/local-docker-swarm.ts
@@ -117,8 +117,8 @@ export const gardenPlugin = (): GardenPlugin => ({
         let swarmServiceStatus
         let serviceId
 
-        if (serviceStatus.providerId) {
-          const swarmService = await docker.getService(serviceStatus.providerId)
+        if (serviceStatus.externalId) {
+          const swarmService = await docker.getService(serviceStatus.externalId)
           swarmServiceStatus = await swarmService.inspect()
           opts.version = parseInt(swarmServiceStatus.Version.Index, 10)
           log.verbose({
@@ -126,7 +126,7 @@ export const gardenPlugin = (): GardenPlugin => ({
             msg: `Updating existing Swarm service (version ${opts.version})`,
           })
           await swarmService.update(opts)
-          serviceId = serviceStatus.providerId
+          serviceId = serviceStatus.externalId
         } else {
           log.verbose({
             section: service.name,
@@ -263,7 +263,7 @@ async function getServiceStatus({ ctx, service }: GetServiceStatusParams<Contain
   const { lastState, lastError } = await getServiceState(swarmServiceStatus.ID)
 
   return {
-    providerId: swarmServiceStatus.ID,
+    externalId: swarmServiceStatus.ID,
     version,
     runningReplicas: swarmServiceStatus.Spec.Mode.Replicated.Replicas,
     state: mapContainerState(lastState),

--- a/garden-service/src/process.ts
+++ b/garden-service/src/process.ts
@@ -91,12 +91,12 @@ export async function processModules(
   if (watch && !!footerLog) {
     garden.events.on("taskGraphProcessing", () => {
       const emoji = printEmoji("hourglass_flowing_sand", footerLog)
-      footerLog.setState(`\n${emoji}Processing...`)
+      footerLog.setState(`\n${emoji} Processing...`)
     })
 
     garden.events.on("taskGraphComplete", () => {
       const emoji = printEmoji("clock2", footerLog)
-      footerLog.setState(`\n${emoji}${chalk.gray("Waiting for code changes...")}`)
+      footerLog.setState(`\n${emoji} ${chalk.gray("Waiting for code changes...")}`)
     })
   }
 

--- a/garden-service/src/proxy.ts
+++ b/garden-service/src/proxy.ts
@@ -1,0 +1,254 @@
+/*
+ * Copyright (C) 2018 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { isEqual, invert } from "lodash"
+import * as Bluebird from "bluebird"
+import { createServer, Server, Socket } from "net"
+const AsyncLock = require("async-lock")
+import getPort = require("get-port")
+import { Service, ServiceStatus, ForwardablePort } from "./types/service"
+import { Garden } from "./garden"
+import { registerCleanupFunction } from "./util/util"
+import { LogEntry } from "./logger/log-entry"
+import { GetPortForwardResult } from "./types/plugin/service/getPortForward"
+
+interface PortProxy {
+  key: string
+  localPort: number
+  localUrl: string
+  server: Server
+  service: Service
+  spec: ForwardablePort
+}
+
+const activeProxies: { [key: string]: PortProxy } = {}
+
+registerCleanupFunction("kill-service-port-proxies", () => {
+  for (const proxy of Object.values(activeProxies)) {
+    stopPortProxy(proxy)
+  }
+})
+
+const portLock = new AsyncLock()
+
+async function startPortProxy(garden: Garden, log: LogEntry, service: Service, spec: ForwardablePort) {
+  const key = getPortKey(service, spec)
+  let proxy = activeProxies[key]
+
+  if (!proxy) {
+    // Start new proxy
+    proxy = activeProxies[key] = await createProxy(garden, log, service, spec)
+  } else if (!isEqual(proxy.spec, spec)) {
+    // Stop existing proxy and create new one
+    stopPortProxy(proxy, log)
+    proxy = activeProxies[key] = await createProxy(garden, log, service, spec)
+  }
+
+  return proxy
+}
+
+// TODO: handle dead port forwards
+async function createProxy(garden: Garden, log: LogEntry, service: Service, spec: ForwardablePort): Promise<PortProxy> {
+  const actions = await garden.getActionHelper()
+  const key = getPortKey(service, spec)
+  let fwd: GetPortForwardResult
+
+  const getPortForward = async () => {
+    if (fwd) {
+      return fwd
+    }
+
+    await portLock.acquire(key, async () => {
+      if (fwd) {
+        return
+      }
+      log.debug(`Starting port forward to ${key}`)
+
+      try {
+        fwd = await actions.getPortForward({ service, log, ...spec })
+      } catch (err) {
+        log.error(`Error starting port forward to ${key}: ${err.message}`)
+      }
+
+      log.debug(`Successfully started port forward to ${key}`)
+    })
+
+    return fwd
+  }
+
+  const server = createServer((local) => {
+    let _remote: Socket
+
+    const getRemote = async () => {
+      if (!_remote) {
+        const { hostname, port } = await getPortForward()
+
+        log.debug(`Connecting to ${key} port forward at ${hostname}:${port}`)
+
+        _remote = new Socket()
+        _remote.connect(port, hostname)
+
+        _remote.on("data", (data) => {
+          if (!local.writable) {
+            _remote.end()
+          }
+          const flushed = local.write(data)
+          if (!flushed) {
+            _remote.pause()
+          }
+        })
+
+        _remote.on("drain", () => {
+          local.resume()
+        })
+
+        _remote.on("close", () => {
+          log.debug(`Connection from ${local.remoteAddress}:${local.remotePort} ended`)
+          local.end()
+        })
+
+        _remote.on("error", (err) => {
+          log.debug(`Remote socket error: ${err.message}`)
+        })
+      }
+      return _remote
+    }
+
+    local.on("connect", () => {
+      log.debug(`Connection from ${local.remoteAddress}:${local.remotePort}`)
+      // tslint:disable-next-line: no-floating-promises
+      getRemote()
+    })
+
+    const writeToRemote = (remote: Socket, data: Buffer) => {
+      if (!remote.writable) {
+        local.end()
+      }
+      const flushed = remote.write(data)
+      if (!flushed) {
+        local.pause()
+      }
+    }
+
+    local.on("data", (data) => {
+      if (_remote) {
+        writeToRemote(_remote, data)
+      } else {
+        getRemote()
+          .then((remote) => {
+            remote && writeToRemote(remote, data)
+          })
+          // Promises are appropriately handled in the getRemote function
+          .catch(() => { })
+      }
+    })
+
+    local.on("drain", () => {
+      _remote.resume()
+    })
+
+    local.on("close", () => {
+      _remote.end()
+    })
+
+    local.on("error", (err) => {
+      log.debug(`Local socket error: ${err.message}`)
+    })
+  })
+
+  const localPort = await getPort()
+  const host = `localhost:${localPort}`
+  // For convenience, we try to guess a protocol based on the target port, if no URL protocol is specified
+  const protocol = spec.urlProtocol || guessProtocol(spec)
+  const localUrl = protocol ? `${protocol.toLowerCase()}://${host}` : host
+
+  log.debug(`Starting proxy to ${key} on port ${localPort}`)
+  server.listen(localPort)
+
+  return { key, server, service, spec, localPort, localUrl }
+}
+
+function stopPortProxy(proxy: PortProxy, log?: LogEntry) {
+  // TODO: call stopPortForward handler
+  log && log.debug(`Stopping port forward to ${proxy.key}`)
+  delete activeProxies[proxy.key]
+  proxy.server.close()
+}
+
+export async function startPortProxies(garden: Garden, log: LogEntry, service: Service, status: ServiceStatus) {
+  return Bluebird.map(status.forwardablePorts || [], (spec) => {
+    return startPortProxy(garden, log, service, spec)
+  })
+}
+
+function getPortKey(service: Service, spec: ForwardablePort) {
+  return `${service.name}/${spec.targetHostname || ""}:${spec.targetPort}`
+}
+
+const standardProtocolPorts = {
+  acap: 674,
+  afp: 548,
+  dict: 2628,
+  dns: 53,
+  ftp: 21,
+  git: 9418,
+  gopher: 70,
+  http: 80,
+  https: 443,
+  imap: 143,
+  ipp: 631,
+  ipps: 631,
+  irc: 194,
+  ircs: 6697,
+  ldap: 389,
+  ldaps: 636,
+  mms: 1755,
+  msrp: 2855,
+  mtqp: 1038,
+  nfs: 111,
+  nntp: 119,
+  nntps: 563,
+  pop: 110,
+  postgres: 5432,
+  prospero: 1525,
+  redis: 6379,
+  rsync: 873,
+  rtsp: 554,
+  rtsps: 322,
+  rtspu: 5005,
+  sftp: 22,
+  smb: 445,
+  snmp: 161,
+  ssh: 22,
+  svn: 3690,
+  telnet: 23,
+  ventrilo: 3784,
+  vnc: 5900,
+  wais: 210,
+  // "ws": 80,
+  // "wss": 443,
+}
+
+const standardProtocolPortIndex = invert(standardProtocolPorts)
+
+function guessProtocol(spec: ForwardablePort) {
+  const port = spec.targetPort
+  let protocol = standardProtocolPortIndex[port]
+
+  if (protocol) {
+    return protocol
+  } else if (port >= 8000 && port < 9000) {
+    // 8xxx ports are commonly HTTP
+    return "http"
+  } else if (spec.name && standardProtocolPorts[spec.name]) {
+    // If the port spec name is a known protocol we return that
+    return spec.name
+  } else {
+    return null
+  }
+}

--- a/garden-service/src/types/plugin/plugin.ts
+++ b/garden-service/src/types/plugin/plugin.ts
@@ -41,6 +41,8 @@ import { mapValues } from "lodash"
 import { getDebugInfo, DebugInfo, GetDebugInfoParams } from "./provider/getDebugInfo"
 import { deline } from "../../util/string"
 import { pluginCommandSchema, PluginCommand } from "./command"
+import { getPortForward, GetPortForwardParams, GetPortForwardResult } from "./service/getPortForward"
+import { StopPortForwardParams, stopPortForward } from "./service/stopPortForward"
 
 export type ServiceActions<T extends Module = Module> = {
   [P in keyof ServiceActionParams<T>]: (params: ServiceActionParams<T>[P]) => ServiceActionOutputs[P]
@@ -115,33 +117,39 @@ export const pluginActionDescriptions: { [P in PluginActionName]: PluginActionDe
 }
 
 export interface ServiceActionParams<T extends Module = Module> {
-  getServiceStatus: GetServiceStatusParams<T>
   deployService: DeployServiceParams<T>
-  hotReloadService: HotReloadServiceParams<T>
   deleteService: DeleteServiceParams<T>
   execInService: ExecInServiceParams<T>
+  getPortForward: GetPortForwardParams<T>
   getServiceLogs: GetServiceLogsParams<T>
+  getServiceStatus: GetServiceStatusParams<T>
+  hotReloadService: HotReloadServiceParams<T>
   runService: RunServiceParams<T>
+  stopPortForward: StopPortForwardParams<T>
 }
 
 export interface ServiceActionOutputs {
-  getServiceStatus: Promise<ServiceStatus>
   deployService: Promise<ServiceStatus>
-  hotReloadService: Promise<HotReloadServiceResult>
   deleteService: Promise<ServiceStatus>
   execInService: Promise<ExecInServiceResult>
+  getPortForward: Promise<GetPortForwardResult>
   getServiceLogs: Promise<{}>
+  getServiceStatus: Promise<ServiceStatus>
+  hotReloadService: Promise<HotReloadServiceResult>
   runService: Promise<RunResult>
+  stopPortForward: Promise<{}>
 }
 
 export const serviceActionDescriptions: { [P in ServiceActionName]: PluginActionDescription } = {
-  getServiceStatus,
   deployService,
-  hotReloadService,
   deleteService,
   execInService,
+  getPortForward,
   getServiceLogs,
+  getServiceStatus,
+  hotReloadService,
   runService,
+  stopPortForward,
 }
 
 export interface TaskActionParams<T extends Module = Module> {

--- a/garden-service/src/types/plugin/service/getPortForward.ts
+++ b/garden-service/src/types/plugin/service/getPortForward.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2018 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { PluginServiceActionParamsBase, serviceActionParamsSchema } from "../base"
+import { dedent } from "../../../util/string"
+import { Module } from "../../module"
+import { ForwardablePort, forwardablePortKeys } from "../../service"
+import { joi } from "../../../config/common"
+
+export type GetPortForwardParams<M extends Module = Module, S extends Module = Module> =
+  PluginServiceActionParamsBase<M, S>
+  & ForwardablePort
+
+export interface GetPortForwardResult {
+  hostname: string
+  port: number
+}
+
+export const getPortForward = {
+  description: dedent`
+    Create a port forward tunnel to the specified service and port. When \`getServiceStatus\` returns one or more
+    \`forwardablePort\` specs, the Garden service creates an open port. When connections are made to that port,
+    this handler is called to create a tunnel, and the connection (and any subsequent connections) is forwarded to
+    the tunnel.
+
+    The tunnel should be persistent. If the tunnel stops listening to connections, this handler will be called again.
+
+    If there is a corresponding \`stopPortForward\` handler, it is called when cleaning up.
+  `,
+  paramsSchema: serviceActionParamsSchema
+    .keys(forwardablePortKeys),
+  resultSchema: joi.object()
+    .keys({
+      hostname: joi.string()
+        .hostname()
+        .description("The hostname of the port tunnel.")
+        .example("localhost"),
+      port: joi.number()
+        .integer()
+        .description("The port of the tunnel.")
+        .example(12345),
+    }),
+}

--- a/garden-service/src/types/plugin/service/stopPortForward.ts
+++ b/garden-service/src/types/plugin/service/stopPortForward.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2018 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { PluginServiceActionParamsBase, serviceActionParamsSchema } from "../base"
+import { dedent } from "../../../util/string"
+import { Module } from "../../module"
+import { ForwardablePort, forwardablePortKeys } from "../../service"
+import { joi } from "../../../config/common"
+
+export type StopPortForwardParams<M extends Module = Module, S extends Module = Module> =
+  PluginServiceActionParamsBase<M, S>
+  & ForwardablePort
+
+export const stopPortForward = {
+  description: dedent`
+    Close a port forward created by \`getPortForward\`.
+  `,
+  paramsSchema: serviceActionParamsSchema
+    .keys(forwardablePortKeys),
+  resultSchema: joi.object()
+    .keys({}),
+}

--- a/garden-service/test/unit/src/actions.ts
+++ b/garden-service/test/unit/src/actions.ts
@@ -232,21 +232,21 @@ describe("ActionHelper", () => {
     describe("getServiceStatus", () => {
       it("should correctly call the corresponding plugin handler", async () => {
         const result = await actions.getServiceStatus({ log, service, runtimeContext, hotReload: false })
-        expect(result).to.eql({ state: "ready" })
+        expect(result).to.eql({ forwardablePorts: [], state: "ready" })
       })
     })
 
     describe("deployService", () => {
       it("should correctly call the corresponding plugin handler", async () => {
         const result = await actions.deployService({ log, service, runtimeContext, force: true, hotReload: false })
-        expect(result).to.eql({ state: "ready" })
+        expect(result).to.eql({ forwardablePorts: [], state: "ready" })
       })
     })
 
     describe("deleteService", () => {
       it("should correctly call the corresponding plugin handler", async () => {
         const result = await actions.deleteService({ log, service, runtimeContext })
-        expect(result).to.eql({ state: "ready" })
+        expect(result).to.eql({ forwardablePorts: [], state: "ready" })
       })
     })
 
@@ -557,6 +557,19 @@ const testPlugin: PluginFactory = async () => ({
           startedAt: now,
           version: params.module.version.versionString,
         }
+      },
+
+      getPortForward: async (params) => {
+        validate(params, moduleActionDescriptions.getPortForward.paramsSchema)
+        return {
+          hostname: "bla",
+          port: 123,
+        }
+      },
+
+      stopPortForward: async (params) => {
+        validate(params, moduleActionDescriptions.stopPortForward.paramsSchema)
+        return {}
       },
 
       getTaskResult: async (params) => {

--- a/garden-service/test/unit/src/commands/delete.ts
+++ b/garden-service/test/unit/src/commands/delete.ts
@@ -121,10 +121,10 @@ describe("DeleteEnvironmentCommand", () => {
 
     expect(result!.environmentStatuses["test-plugin"]["ready"]).to.be.false
     expect(result!.serviceStatuses).to.eql({
-      "service-a": { state: "missing" },
-      "service-b": { state: "missing" },
-      "service-c": { state: "missing" },
-      "service-d": { state: "missing" },
+      "service-a": { forwardablePorts: [], state: "missing" },
+      "service-b": { forwardablePorts: [], state: "missing" },
+      "service-c": { forwardablePorts: [], state: "missing" },
+      "service-d": { forwardablePorts: [], state: "missing" },
     })
     expect(deletedServices.sort()).to.eql(["service-a", "service-b", "service-c", "service-d"])
   })
@@ -176,7 +176,7 @@ describe("DeleteServiceCommand", () => {
       opts: withDefaultGlobalOpts({}),
     })
     expect(result).to.eql({
-      "service-a": { state: "unknown", ingresses: [] },
+      "service-a": { forwardablePorts: [], state: "unknown", ingresses: [] },
     })
   })
 
@@ -193,8 +193,8 @@ describe("DeleteServiceCommand", () => {
       opts: withDefaultGlobalOpts({}),
     })
     expect(result).to.eql({
-      "service-a": { state: "unknown", ingresses: [] },
-      "service-b": { state: "unknown", ingresses: [] },
+      "service-a": { forwardablePorts: [], state: "unknown", ingresses: [] },
+      "service-b": { forwardablePorts: [], state: "unknown", ingresses: [] },
     })
   })
 })

--- a/garden-service/test/unit/src/commands/deploy.ts
+++ b/garden-service/test/unit/src/commands/deploy.ts
@@ -112,10 +112,10 @@ describe("DeployCommand", () => {
       "build.module-c": {},
       "task.task-a": taskResultA,
       "task.task-c": taskResultC,
-      "deploy.service-a": { version: "1", state: "ready" },
-      "deploy.service-b": { version: "1", state: "ready" },
-      "deploy.service-c": { version: "1", state: "ready" },
-      "deploy.service-d": { version: "1", state: "ready" },
+      "deploy.service-a": { forwardablePorts: [], version: "1", state: "ready" },
+      "deploy.service-b": { forwardablePorts: [], version: "1", state: "ready" },
+      "deploy.service-c": { forwardablePorts: [], version: "1", state: "ready" },
+      "deploy.service-d": { forwardablePorts: [], version: "1", state: "ready" },
     })
   })
 
@@ -150,8 +150,8 @@ describe("DeployCommand", () => {
       "build.module-c": {},
       "task.task-a": taskResultA,
       "task.task-c": taskResultC,
-      "deploy.service-a": { version: "1", state: "ready" },
-      "deploy.service-b": { version: "1", state: "ready" },
+      "deploy.service-a": { forwardablePorts: [], version: "1", state: "ready" },
+      "deploy.service-b": { forwardablePorts: [], version: "1", state: "ready" },
     })
   })
 })


### PR DESCRIPTION
This adds a built-in TCP proxy for long-running Garden processes,
that immediately opens a port for each forwardable service port (as
specified by providers) and creates a tunnel on-demand when the port is
accessed.

This should work for any TCP port, and is implemented here for the
kubernetes provider, but the proxy itself could be implemented for other
providers through the fairly simple `getPortForward` handler interface.

Unlike kubefwd, for example, this implementation avoids any
need to mess with domain names or host files (and by extension running
as root) since a random free port is assigned directly on localhost.
The tunnels are only created when a connection is first made, and are
then kept alive while the Garden agent is running.

Closes #967
