### PR TITLE
ci: move garden bin to HOME dir in test-dist job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,11 +308,14 @@ jobs:
       - *attach-workspace
       - run: sudo apt-get update && sudo apt-get -y install rsync
       - run:
-          name: Extract binary
-          command: tar xvfz ./garden-service/dist/*linux-amd64.tar.gz
+          name: Extract binary and add to $HOME dir
+          command: |
+            GARDEN_DIR=${HOME}/.garden
+            mkdir -p ${GARDEN_DIR}
+            tar xvfz ./garden-service/dist/*linux-amd64.tar.gz --strip-components=1 -C ${GARDEN_DIR}
       - run:
           name: Deploy demo-project with binary
-          command: linux-amd64/garden deploy --root examples/demo-project --env testing --logger-type basic
+          command: $HOME/.garden/garden deploy --root examples/demo-project --env testing --logger-type basic
       - run:
           name: Cleanup
           command: kubectl delete --wait=false $(kubectl get ns -o name | grep $CIRCLE_BUILD_NUM) || true


### PR DESCRIPTION
**What this PR does / why we need it**:

The previous version ran the Garden bin from the `garden` root dir which is a git repo. Turns out, that bypassed a bug which only crops up if the binary is not in a git repo at all. So now we've moved the binary to the `$HOME/.garden` dir.
