### PR TITLE
fix(container): allow setting nodePort=true on container modules

### DIFF
--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -681,7 +681,7 @@ services:
 
 [services](#services) > [ports](#services[].ports[]) > nodePort
 
-Set this to expose the service on the specified port on the host node (may not be supported by all providers).
+Set this to expose the service on the specified port on the host node (may not be supported by all providers). Set to `true` to have the cluster pick a port automatically, which is most often advisable if the cluster is shared by multiple users.
 
 | Type     | Required |
 | -------- | -------- |

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -686,7 +686,7 @@ services:
 
 [services](#services) > [ports](#services[].ports[]) > nodePort
 
-Set this to expose the service on the specified port on the host node (may not be supported by all providers).
+Set this to expose the service on the specified port on the host node (may not be supported by all providers). Set to `true` to have the cluster pick a port automatically, which is most often advisable if the cluster is shared by multiple users.
 
 | Type     | Required |
 | -------- | -------- |

--- a/garden-service/src/plugins/container/config.ts
+++ b/garden-service/src/plugins/container/config.ts
@@ -47,7 +47,7 @@ export interface ServicePortSpec {
   // Defaults to containerPort
   servicePort: number
   hostPort?: number
-  nodePort?: number | null
+  nodePort?: number | true
 }
 
 export interface ServiceVolumeSpec {
@@ -247,9 +247,12 @@ export const portSchema = joi.object()
     hostPort: joi.number()
       .meta({ deprecated: true }),
     nodePort: joi.number()
+      .allow(true)
       .description(deline`
-        Set this to expose the service on the specified port on the host node
-        (may not be supported by all providers).`),
+        Set this to expose the service on the specified port on the host node (may not be supported by all providers).
+        Set to \`true\` to have the cluster pick a port automatically, which is most often advisable if the cluster is
+        shared by multiple users.
+      `),
   })
 
 const volumeSchema = joi.object()

--- a/garden-service/test/unit/src/plugins/kubernetes/container/service.ts
+++ b/garden-service/test/unit/src/plugins/kubernetes/container/service.ts
@@ -4,6 +4,7 @@ import { gardenPlugin } from "../../../../../../src/plugins/container/container"
 import { resolve } from "path"
 import { Garden } from "../../../../../../src/garden"
 import { expect } from "chai"
+import { ContainerService } from "../../../../../../src/plugins/container/config"
 
 describe("createServiceResources", () => {
   const projectRoot = resolve(dataDir, "test-project-container")
@@ -48,7 +49,7 @@ describe("createServiceResources", () => {
 
   it("should add annotations if configured", async () => {
     const graph = await garden.getConfigGraph()
-    const service = await graph.getService("service-a")
+    const service: ContainerService = await graph.getService("service-a")
 
     service.spec.annotations = { my: "annotation" }
 
@@ -78,6 +79,123 @@ describe("createServiceResources", () => {
             service: "service-a",
           },
           type: "ClusterIP",
+        },
+      },
+    ])
+  })
+
+  it("should create a NodePort service if a nodePort is specified", async () => {
+    const graph = await garden.getConfigGraph()
+    const service: ContainerService = await graph.getService("service-a")
+
+    service.spec.ports[0].nodePort = 12345
+
+    const resources = await createServiceResources(service, "my-namespace")
+
+    expect(resources).to.eql([
+      {
+        apiVersion: "v1",
+        kind: "Service",
+        metadata: {
+          name: "service-a",
+          namespace: "my-namespace",
+          annotations: {},
+        },
+        spec: {
+          ports: [
+            {
+              name: "http",
+              protocol: "TCP",
+              targetPort: 8080,
+              port: 8080,
+            },
+          ],
+          selector: {
+            service: "service-a",
+          },
+          type: "ClusterIP",
+        },
+      },
+      {
+        apiVersion: "v1",
+        kind: "Service",
+        metadata: {
+          name: "service-a-nodeport",
+          namespace: "my-namespace",
+          annotations: {},
+        },
+        spec: {
+          ports: [
+            {
+              name: "http",
+              protocol: "TCP",
+              targetPort: 8080,
+              port: 8080,
+              nodePort: 12345,
+            },
+          ],
+          selector: {
+            service: "service-a",
+          },
+          type: "NodePort",
+        },
+      },
+    ])
+  })
+
+  it("should create a NodePort service without nodePort set if nodePort is specified as true", async () => {
+    const graph = await garden.getConfigGraph()
+    const service: ContainerService = await graph.getService("service-a")
+
+    service.spec.ports[0].nodePort = true
+
+    const resources = await createServiceResources(service, "my-namespace")
+
+    expect(resources).to.eql([
+      {
+        apiVersion: "v1",
+        kind: "Service",
+        metadata: {
+          name: "service-a",
+          namespace: "my-namespace",
+          annotations: {},
+        },
+        spec: {
+          ports: [
+            {
+              name: "http",
+              protocol: "TCP",
+              targetPort: 8080,
+              port: 8080,
+            },
+          ],
+          selector: {
+            service: "service-a",
+          },
+          type: "ClusterIP",
+        },
+      },
+      {
+        apiVersion: "v1",
+        kind: "Service",
+        metadata: {
+          name: "service-a-nodeport",
+          namespace: "my-namespace",
+          annotations: {},
+        },
+        spec: {
+          ports: [
+            {
+              name: "http",
+              protocol: "TCP",
+              targetPort: 8080,
+              port: 8080,
+            },
+          ],
+          selector: {
+            service: "service-a",
+          },
+          type: "NodePort",
         },
       },
     ])

--- a/garden-service/test/unit/src/plugins/kubernetes/container/service.ts
+++ b/garden-service/test/unit/src/plugins/kubernetes/container/service.ts
@@ -108,29 +108,6 @@ describe("createServiceResources", () => {
               protocol: "TCP",
               targetPort: 8080,
               port: 8080,
-            },
-          ],
-          selector: {
-            service: "service-a",
-          },
-          type: "ClusterIP",
-        },
-      },
-      {
-        apiVersion: "v1",
-        kind: "Service",
-        metadata: {
-          name: "service-a-nodeport",
-          namespace: "my-namespace",
-          annotations: {},
-        },
-        spec: {
-          ports: [
-            {
-              name: "http",
-              protocol: "TCP",
-              targetPort: 8080,
-              port: 8080,
               nodePort: 12345,
             },
           ],
@@ -157,29 +134,6 @@ describe("createServiceResources", () => {
         kind: "Service",
         metadata: {
           name: "service-a",
-          namespace: "my-namespace",
-          annotations: {},
-        },
-        spec: {
-          ports: [
-            {
-              name: "http",
-              protocol: "TCP",
-              targetPort: 8080,
-              port: 8080,
-            },
-          ],
-          selector: {
-            service: "service-a",
-          },
-          type: "ClusterIP",
-        },
-      },
-      {
-        apiVersion: "v1",
-        kind: "Service",
-        metadata: {
-          name: "service-a-nodeport",
           namespace: "my-namespace",
           annotations: {},
         },


### PR DESCRIPTION
This allows the cluster to automatically pick a nodePort, which is
often preferable to hard-coding it.

Closes #1057 

cc @Eronarn