### PR TITLE
fix(cli): use ansi-escapes fork for better Terminal.app rendering

### DIFF
--- a/garden-service/package-lock.json
+++ b/garden-service/package-lock.json
@@ -1198,11 +1198,17 @@
       }
     },
     "ansi-escapes": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.1.0.tgz",
-      "integrity": "sha512-2VY/iCUZTDLD/qxptS3Zn3c6k2MeIbYqjRXqM8T5oC7N2mMjh3xIU3oYru6cHGbldFa9h5i8N0fP65UaUqrMWA==",
+      "version": "github:garden-io/ansi-escapes#1d8f56bdb67c04475ee0d1d192008602e74a890e",
+      "from": "github:garden-io/ansi-escapes#fix-terminal-app",
       "requires": {
-        "type-fest": "^0.3.0"
+        "type-fest": "^0.5.2"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
+          "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw=="
+        }
       }
     },
     "ansi-gray": {

--- a/garden-service/package.json
+++ b/garden-service/package.json
@@ -27,7 +27,7 @@
     "@kubernetes/client-node": "git+https://github.com/garden-io/javascript.git#client-cert-auth",
     "JSONStream": "^1.3.5",
     "analytics-node": "3.3.0",
-    "ansi-escapes": "^4.1.0",
+    "ansi-escapes": "github:garden-io/ansi-escapes#fix-terminal-app",
     "archiver": "^3.0.0",
     "async-exit-hook": "^2.0.1",
     "async-lock": "^1.2.0",


### PR DESCRIPTION
**What this PR does / why we need it**:

Use own fork of the `ansi-escapes` library since the official one contains a bug that messes up fancy logger rendering on macOS Terminal.app.

Here's the [relevant issue](https://github.com/sindresorhus/ansi-escapes/issues/15) and here's [our PR for the fix](https://github.com/sindresorhus/ansi-escapes/pull/16).

We'll switch back to the upstream once the PR's been merged.

**Which issue(s) this PR fixes**:

Fixes #1040 