### PR TITLE
fix(run): interactive run module/service commands not working

### DIFF
--- a/garden-service/src/commands/run/module.ts
+++ b/garden-service/src/commands/run/module.ts
@@ -106,6 +106,7 @@ export class RunModuleCommand extends Command<Args, Opts> {
       args: args.arguments || [],
       runtimeContext,
       interactive: opts.interactive,
+      timeout: opts.interactive ? 999999 : undefined,
     })
 
     return { result }

--- a/garden-service/src/commands/run/service.ts
+++ b/garden-service/src/commands/run/service.ts
@@ -78,6 +78,7 @@ export class RunServiceCommand extends Command<Args, Opts> {
       service,
       runtimeContext,
       interactive: true,
+      timeout: 999999,
     })
 
     return { result }

--- a/garden-service/src/plugins/kubernetes/run.ts
+++ b/garden-service/src/plugins/kubernetes/run.ts
@@ -60,12 +60,19 @@ export async function runPod(
     })
   }
 
+  if (interactive) {
+    spec.containers[0].stdin = true
+    spec.containers[0].stdinOnce = true
+    spec.containers[0].tty = true
+  }
+
+  const runPodName = podName || `run-${module.name}-${Math.round(new Date().getTime())}`
+
   const kubecmd = [
     "run",
-    podName || `run-${module.name}-${Math.round(new Date().getTime())}`,
+    runPodName,
     `--image=${image}`,
     "--restart=Never",
-    "--quiet",
     "--rm",
     // Need to attach to get the log output and exit code.
     "-i",
@@ -75,10 +82,12 @@ export async function runPod(
 
   if (interactive) {
     kubecmd.push("--tty")
+  } else {
+    kubecmd.push("--quiet")
   }
 
   const command = [...spec.containers[0].command || [], ...spec.containers[0].args || []]
-  log.verbose(`Running '${command.join(" ")}'`)
+  log.verbose(`Running '${command.join(" ")}' in Pod ${runPodName}`)
 
   const startedAt = new Date()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Basically running interactive commands via `garden run module` or `garden run service` was busted, after some refactors. Not sure how to best automate tests around this tbh, but it's something we need to look out for.

**Special notes for your reviewer**:

Please try messing with the run commands in a few different ways, and see if you find any issues, even related issues.
