### PR TITLE
test: re-enable e2e tests for hot reload & tasks

### DIFF
--- a/examples/tasks/hello/app.js
+++ b/examples/tasks/hello/app.js
@@ -6,6 +6,7 @@ const knex = require("knex")({
     port: 5432,
     database: "postgres",
     user: "postgres",
+    password: "postgres",
   },
   pool: {
     min: 4,

--- a/examples/tasks/postgres/garden.yml
+++ b/examples/tasks/postgres/garden.yml
@@ -1,5 +1,5 @@
 kind: Module
-description: Postgres database for storing voting results
+description: Postgres database for storing user names
 type: helm
 name: postgres
 chart: stable/postgresql

--- a/garden-service/test/e2e/garden.yml
+++ b/garden-service/test/e2e/garden.yml
@@ -9,6 +9,9 @@ environments:
         defaultHostname: dev-1.sys.garden
         buildMode: cluster-docker
         setupIngressController: nginx
+  - name: local
+    providers:
+        - name: local-kubernetes
 
 ---
 
@@ -18,9 +21,9 @@ type: exec
 tests:
   - name: demo-project
     command: [npm, run, e2e-full, --, --project=demo-project, --showlog=true, --env=testing]
-  - name: tasks # Tests for tasks are currently being skipped
+  - name: tasks
     command: [npm, run, e2e-full, --, --project=tasks, --showlog=true, --env=testing]
-  - name: hot-reload # Tests for hot-reload are currently being skipped
+  - name: hot-reload
     command: [npm, run, e2e-full, --, --project=hot-reload, --showlog=true, --env=testing]
   # Disabling until https://github.com/garden-io/garden/issues/1045 is fixed
   # - name: openfaas

--- a/garden-service/test/e2e/src/pre-release.ts
+++ b/garden-service/test/e2e/src/pre-release.ts
@@ -2,12 +2,11 @@ import execa = require("execa")
 import { expect } from "chai"
 import { resolve } from "path"
 import * as mlog from "mocha-logger"
-import replace from "replace-in-file"
+const replace = require("replace-in-file")
 import { examplesDir } from "../../helpers"
 import {
   changeFileStep,
   commandReloadedStep,
-  dashboardUpStep,
   GardenWatch,
   runGarden,
   taskCompletedStep,
@@ -132,12 +131,13 @@ describe("PreReleaseTests", () => {
     * TimeoutError: Knex: Timeout acquiring a connection. The pool is probably full.
     * Are you missing a .transacting(trx) call?
     */
-    describe.skip("tasks", () => {
+    describe("tasks", () => {
       it("calls the hello service to fetch the usernames populated by the ruby migration", async () => {
         /**
          * Verify that the output includes the usernames populated by the ruby-migration task.
          * The users table was created by the node-migration task.
          */
+        await runWithEnv(["deploy"])
         const logEntries = await runWithEnv(["call", "hello"])
         expect(searchLog(logEntries, /John, Paul, George, Ringo/), "expected to find populated usernames in log output")
           .to.eql("passed")
@@ -152,13 +152,13 @@ describe("PreReleaseTests", () => {
     * Got error from Kubernetes API - a container name must be specified for pod node-service-85f48587df-lvjlp,
     * choose one of: [node-service garden-rsync] or one of the init containers: [garden-sync-init]
     */
-    describe.skip("hot-reload", () => {
+    describe("hot-reload", () => {
       it("runs the dev command with hot reloading enabled", async () => {
         const hotReloadProjectPath = resolve(examplesDir, "hot-reload")
         const gardenWatch = watchWithEnv(["dev", "--hot=node-service"])
 
         const testSteps = [
-          dashboardUpStep(),
+          waitingForChangesStep(),
           {
             description: "change 'Node' -> 'Edge' in node-service/app.js",
             action: async () => {


### PR DESCRIPTION
Short and sweet. Just re-enabling a couple of e2e tests that we've been skipping—the one for the `hot-reload` project and the `tasks` project.

Also fixes a bug in the `tasks` project, which was broken prior to this PR.