### PR TITLE
improvement(watcher): adding/removing many files/dirs more performant

### DIFF
--- a/garden-service/src/bin/add-version-files.ts
+++ b/garden-service/src/bin/add-version-files.ts
@@ -33,7 +33,7 @@ async function addVersionFiles() {
     const versionFilePath = resolve(path, GARDEN_VERSIONFILE_NAME)
 
     const vcsHandler = new GitHandler(garden.gardenDirPath, garden.dotIgnoreFiles)
-    const treeVersion = await vcsHandler.getTreeVersion(config)
+    const treeVersion = await vcsHandler.getTreeVersion(garden.log, config)
 
     console.log(`${config.name} -> ${relative(STATIC_DIR, versionFilePath)}`)
 

--- a/garden-service/src/commands/get/get-debug-info.ts
+++ b/garden-service/src/commands/get/get-debug-info.ts
@@ -72,7 +72,7 @@ export async function collectBasicDebugInfo(root: string, gardenDirPath: string,
   const vcs = new GitHandler(root, config.dotIgnoreFiles || defaultDotIgnoreFiles)
   const include = config.modules && config.modules.include
   const exclude = config.modules && config.modules.exclude
-  const paths = await findConfigPathsInPath(vcs, root, { include, exclude })
+  const paths = await findConfigPathsInPath({ vcs, dir: root, include, exclude, log })
 
   // Copy all the service configuration files
   for (const configPath of paths) {

--- a/garden-service/src/events.ts
+++ b/garden-service/src/events.ts
@@ -68,7 +68,7 @@ export interface Events {
   },
   moduleSourcesChanged: {
     names: string[],
-    pathChanged: string,
+    pathsChanged: string[],
   },
   moduleRemoved: {
   },

--- a/garden-service/src/watch.ts
+++ b/garden-service/src/watch.ts
@@ -7,15 +7,18 @@
  */
 
 import { watch, FSWatcher } from "chokidar"
-import { parse } from "path"
+import { parse, basename } from "path"
 import { pathToCacheContext } from "./cache"
 import { Module } from "./types/module"
 import { Garden } from "./garden"
 import { LogEntry } from "./logger/log-entry"
-import { registerCleanupFunction } from "./util/util"
-import * as Bluebird from "bluebird"
+import { registerCleanupFunction, sleep } from "./util/util"
 import { some } from "lodash"
-import { isConfigFilename } from "./util/fs"
+import { isConfigFilename, matchPath } from "./util/fs"
+import * as Bluebird from "bluebird"
+
+// How long we wait between processing added files and directories
+const DEFAULT_BUFFER_INTERVAL = 500
 
 // IMPORTANT: We must use a single global instance of the watcher, because we may otherwise get
 // segmentation faults on macOS! See https://github.com/fsevents/fsevents/issues/273
@@ -34,164 +37,284 @@ registerCleanupFunction("stop watcher", cleanUpGlobalWatcher)
 
 export type ChangeHandler = (module: Module | null, configChanged: boolean) => Promise<void>
 
+type ChangeType = "added" | "changed" | "removed"
+
+interface ChangedPath {
+  type: "dir" | "file"
+  path: string
+  change: ChangeType
+}
+
 /**
  * Wrapper around the Chokidar file watcher. Emits events on `garden.events` when project files are changed.
  * This needs to be enabled by calling the `.start()` method, and stopped with the `.stop()` method.
  */
 export class Watcher {
   private watcher: FSWatcher
+  private buffer: { [path: string]: ChangedPath }
+  private running: boolean
 
-  constructor(private garden: Garden, private log: LogEntry, paths: string[], modules: Module[]) {
-    log.debug(`Watcher: Watching paths ${paths.join(", ")}`)
-
-    if (watcher === undefined) {
-      watcher = watch(paths, {
-        ignoreInitial: true,
-        persistent: true,
-      })
-    }
-
-    this.watcher = watcher
-
-    this.watcher
-      .on("add", this.makeFileAddedHandler(modules))
-      .on("change", this.makeFileChangedHandler("modified", modules))
-      .on("unlink", this.makeFileChangedHandler("removed", modules))
-      .on("addDir", this.makeDirAddedHandler(modules))
-      .on("unlinkDir", this.makeDirRemovedHandler(modules))
+  constructor(
+    private garden: Garden,
+    private log: LogEntry,
+    private paths: string[],
+    private modules: Module[],
+    private bufferInterval: number = DEFAULT_BUFFER_INTERVAL,
+  ) {
+    this.buffer = {}
+    this.running = false
+    this.start()
   }
 
   stop(): void {
+    this.running = false
+
     if (this.watcher) {
       this.log.debug(`Watcher: Clearing handlers`)
       this.watcher.removeAllListeners()
+      delete this.watcher
     }
   }
 
-  private makeFileAddedHandler(modules: Module[]) {
-    return this.wrapAsync(async (path: string) => {
-      this.log.debug(`Watcher: File ${path} added`)
+  start() {
+    this.log.debug(`Watcher: Watching paths ${this.paths.join(", ")}`)
 
-      const changedModules = await Bluebird.filter(modules, async (m) => {
-        const files = await this.garden.vcs.getFiles(m.path)
-        return some(files, f => f.path === path)
+    if (watcher === undefined) {
+      watcher = watch(this.paths, {
+        ignoreInitial: true,
+        ignorePermissionErrors: true,
+        persistent: true,
+        awaitWriteFinish: {
+          stabilityThreshold: 500,
+          pollInterval: 200,
+        },
       })
-
-      this.sourcesChanged(modules, changedModules, path, "added")
-    })
-  }
-
-  private wrapAsync(listener: (path: string) => Promise<void>) {
-    const _this = this
-
-    return (path: string) => {
-      // Make sure Promise errors are handled appropriately.
-      listener(path)
-        .catch(err => {
-          _this.watcher.emit("error", err)
-        })
-    }
-  }
-
-  private makeFileChangedHandler(type: string, modules: Module[]) {
-    return (path: string) => {
-      this.log.debug(`Watcher: File ${path} ${type}`)
-
-      const changedModules = modules
-        .filter(m => m.version.files.includes(path) || m.configPath === path)
-
-      this.sourcesChanged(modules, changedModules, path, type)
-    }
-  }
-
-  private sourcesChanged(modules: Module[], changedModules: Module[], path: string, type: string) {
-    const parsed = parse(path)
-    const filename = parsed.base
-
-    const isIgnoreFile = this.garden.dotIgnoreFiles.includes(filename)
-
-    if (isIgnoreFile) {
-      // TODO: check to see if the project structure actually changed after the ignore file change
-      this.invalidateCached(modules)
-      this.garden.events.emit("projectConfigChanged", {})
-      return
     }
 
-    if (isConfigFilename(filename)) {
-      this.invalidateCached(modules)
+    this.running = true
 
-      const changedModuleConfigs = changedModules.filter(m => m.configPath === path)
+    if (!this.watcher) {
+      this.watcher = watcher
 
-      if (changedModuleConfigs.length > 0) {
-        const names = changedModuleConfigs.map(m => m.name)
-        this.garden.events.emit("moduleConfigChanged", { names, path })
-      } else if (parsed.dir === this.garden.projectRoot) {
-        this.garden.events.emit("projectConfigChanged", {})
-      } else if (type === "added") {
-        this.garden.events.emit("configAdded", { path })
-      } else {
-        this.garden.events.emit("configRemoved", { path })
+      this.watcher
+        .on("add", this.makeFileAddedHandler())
+        .on("change", this.makeFileChangedHandler())
+        .on("unlink", this.makeFileRemovedHandler())
+        .on("addDir", this.makeDirAddedHandler())
+        .on("unlinkDir", this.makeDirRemovedHandler())
+    }
+
+    this.processBuffer()
+      .catch((err: Error) => {
+        // Log error and restart loop
+        this.watcher.emit("error", err)
+        this.start()
+      })
+  }
+
+  private async processBuffer() {
+    while (this.running) {
+      await sleep(this.bufferInterval)
+
+      const allChanged = Object.values(this.buffer)
+      this.buffer = {}
+
+      if (allChanged.length === 0) {
+        continue
       }
 
-      return
+      const added = allChanged.filter(c => c.change === "added")
+      const removed = allChanged.filter(c => c.change === "removed")
+
+      this.log.silly(`Watcher: Processing ${added.length} added and ${removed.length} removed path(s)`)
+
+      // Check if a config file was added
+      for (const p of added) {
+        if (isConfigFilename(basename(p.path))) {
+          this.invalidateCached(this.modules)
+          this.garden.events.emit("configAdded", { path: p.path })
+
+          // Return because the config change will trigger a reload
+          continue
+        }
+      }
+
+      let modulesRemoved = false
+
+      for (const p of removed) {
+        // Check if project config was removed
+        const { dir, base } = parse(p.path)
+        if (dir === this.garden.projectRoot && isConfigFilename(base)) {
+          this.garden.events.emit("projectConfigChanged", {})
+          continue
+        }
+
+        // Check if any module directory was removed
+        for (const module of this.modules) {
+          if (p.type === "dir" && module.path.startsWith(p.path)) {
+            // at least one module's root dir was removed
+            this.invalidateCached(this.modules)
+            this.garden.events.emit("moduleRemoved", {})
+            modulesRemoved = true
+          }
+        }
+      }
+
+      if (modulesRemoved) {
+        // No need to continue if modules removed (this will trigger a reload)
+        continue
+      }
+
+      // Check if any directories containing config files were added
+      const directoryPaths = added.filter(a => a.type === "dir").map(a => a.path)
+
+      if (directoryPaths.length > 0) {
+        // Check added directories for new config files
+        let dirWithConfigAdded = false
+
+        await Bluebird.map(directoryPaths, async (path) => {
+          const configPaths = await this.garden.scanForConfigs(path)
+
+          if (configPaths.length > 0) {
+            // The added dir contains one or more garden.yml files
+            this.invalidateCached(this.modules)
+            for (const configPath of configPaths) {
+              this.garden.events.emit("configAdded", { path: configPath })
+            }
+            dirWithConfigAdded = true
+          }
+        })
+
+        if (dirWithConfigAdded) {
+          // Return because the config change will trigger a reload
+          continue
+        }
+      }
+
+      // First filter modules by path prefix, and include/exclude filters if applicable
+      const applicableModules = this.modules.filter((m) => {
+        return some(allChanged, p => {
+          return p.path.startsWith(m.path)
+            && (isConfigFilename(basename(p.path)) || matchPath(p.path, m.include, m.exclude))
+        })
+      })
+
+      if (applicableModules.length === 0) {
+        this.log.silly(`Watcher: No applicable modules for ${allChanged.length} changed path(s)`)
+        continue
+      }
+
+      this.log.silly(`Watcher: ${applicableModules.length} applicable modules for ${allChanged.length} changed path(s)`)
+
+      // Match removed files against current file lists
+      removed.length > 0 && this.sourcesChanged(removed)
+
+      // If some modules still apply, update their file lists and match added files against those
+      this.invalidateCached(this.modules)
+      await this.updateModules()
+
+      added.length > 0 && this.sourcesChanged(added)
+    }
+  }
+
+  private async updateModules() {
+    this.log.silly(`Watcher: Updating list of modules`)
+    const graph = await this.garden.getConfigGraph()
+    this.modules = await graph.getModules()
+  }
+
+  private matchModules(paths: ChangedPath[]) {
+    return this.modules
+      .filter(m => some(paths, p =>
+        m.configPath === p.path
+        || (p.type === "file" && m.version.files.includes(p.path))
+        || (p.type === "dir" && p.path.startsWith(m.path)),
+      ))
+  }
+
+  private makeFileAddedHandler() {
+    return (path: string) => {
+      this.buffer[path] = { type: "file", path, change: "added" }
+      this.log.silly(`Watcher: File ${path} added`)
+    }
+  }
+
+  private makeFileRemovedHandler() {
+    return (path: string) => {
+      this.buffer[path] = { type: "file", path, change: "removed" }
+      this.log.silly(`Watcher: File ${path} removed`)
+    }
+  }
+
+  private makeFileChangedHandler() {
+    return (path: string) => {
+      this.log.debug(`Watcher: File ${path} modified`)
+      this.sourcesChanged([{ type: "file", path, change: "changed" }])
+    }
+  }
+
+  private makeDirAddedHandler() {
+    return (path: string) => {
+      this.buffer[path] = { type: "dir", path, change: "added" }
+      this.log.debug(`Watcher: Directory ${path} added to buffer`)
+    }
+  }
+
+  private makeDirRemovedHandler() {
+    return (path: string) => {
+      this.buffer[path] = { type: "dir", path, change: "removed" }
+      this.log.debug(`Watcher: Directory ${path} removed`)
+    }
+  }
+
+  private sourcesChanged(paths: ChangedPath[]) {
+    const changedModules = this.matchModules(paths)
+
+    this.log.silly(`Matched ${changedModules.length} modules`)
+
+    for (const { path, change } of paths) {
+      const parsed = parse(path)
+      const filename = parsed.base
+
+      const isIgnoreFile = this.garden.dotIgnoreFiles.includes(filename)
+
+      if (isIgnoreFile) {
+        // TODO: check to see if the project structure actually changed after the ignore file change
+        this.invalidateCached(this.modules)
+        this.garden.events.emit("projectConfigChanged", {})
+
+        // No need to emit other events if config changed
+        return
+      }
+
+      if (isConfigFilename(filename)) {
+        this.log.silly(`Config file ${path} ${change}`)
+        this.invalidateCached(this.modules)
+
+        if (change === "changed") {
+          const changedModuleConfigs = changedModules.filter(m => m.configPath === path)
+
+          if (changedModuleConfigs.length > 0) {
+            const names = changedModuleConfigs.map(m => m.name)
+            this.garden.events.emit("moduleConfigChanged", { names, path })
+          } else if (parsed.dir === this.garden.projectRoot) {
+            this.garden.events.emit("projectConfigChanged", {})
+          }
+        } else if (change === "added") {
+          this.garden.events.emit("configAdded", { path })
+        } else if (change === "removed") {
+          this.garden.events.emit("configRemoved", { path })
+        }
+
+        // No need to emit other events if config changed
+        return
+      }
     }
 
     if (changedModules.length > 0) {
       const names = changedModules.map(m => m.name)
       this.invalidateCached(changedModules)
-      this.garden.events.emit("moduleSourcesChanged", { names, pathChanged: path })
-    }
-  }
-
-  private makeDirAddedHandler(modules: Module[]) {
-    return this.wrapAsync(async (path: string) => {
-      this.log.debug(`Watcher: Directory ${path} added`)
-
-      const configPaths = await this.garden.scanForConfigs(path)
-
-      if (configPaths.length > 0) {
-        // The added/removed dir contains one or more garden.yml files
-        this.invalidateCached(modules)
-        for (const configPath of configPaths) {
-          this.garden.events.emit("configAdded", { path: configPath })
-        }
-        return
-      }
-
-      // changedModules will only have more than one element when the changed path belongs to >= 2 modules.
-      const changedModules = modules.filter(m => path.startsWith(m.path))
-      const changedModuleNames = changedModules.map(m => m.name)
-
-      if (changedModules.length > 0) {
-        this.invalidateCached(changedModules)
-        this.garden.events.emit("moduleSourcesChanged", { names: changedModuleNames, pathChanged: path })
-      }
-    })
-  }
-
-  private makeDirRemovedHandler(modules: Module[]) {
-    return (path: string) => {
-      this.log.debug(`Watcher: Directory ${path} removed`)
-
-      for (const module of modules) {
-        if (module.path.startsWith(path)) {
-          // at least one module's root dir was removed
-          this.invalidateCached(modules)
-          this.garden.events.emit("moduleRemoved", {})
-          return
-        }
-
-        if (path.startsWith(module.path)) {
-          /*
-           * Removed dir is a subdir of changedModules' root dir.
-           * changedModules will only have more than one element when the changed path belongs to >= 2 modules.
-           */
-          const changedModules = modules.filter(m => path.startsWith(m.path))
-          const changedModuleNames = changedModules.map(m => m.name)
-          this.invalidateCached(changedModules)
-          this.garden.events.emit("moduleSourcesChanged", { names: changedModuleNames, pathChanged: path })
-        }
-      }
+      this.garden.events.emit("moduleSourcesChanged", { names, pathsChanged: paths.map(p => p.path) })
     }
   }
 

--- a/garden-service/test/unit/src/util/fs.ts
+++ b/garden-service/test/unit/src/util/fs.ts
@@ -125,7 +125,11 @@ describe("util", () => {
   describe("findConfigPathsInPath", () => {
     it("should find all garden configs in a directory", async () => {
       const garden = await makeTestGardenA()
-      const files = await findConfigPathsInPath(garden.vcs, garden.projectRoot)
+      const files = await findConfigPathsInPath({
+        vcs: garden.vcs,
+        dir: garden.projectRoot,
+        log: garden.log,
+      })
       expect(files).to.eql([
         join(garden.projectRoot, "garden.yml"),
         join(garden.projectRoot, "module-a", "garden.yml"),
@@ -137,7 +141,12 @@ describe("util", () => {
     it("should respect the include option, if specified", async () => {
       const garden = await makeTestGardenA()
       const include = ["module-a/**/*"]
-      const files = await findConfigPathsInPath(garden.vcs, garden.projectRoot, { include })
+      const files = await findConfigPathsInPath({
+        vcs: garden.vcs,
+        dir: garden.projectRoot,
+        log: garden.log,
+        include,
+      })
       expect(files).to.eql([
         join(garden.projectRoot, "module-a", "garden.yml"),
       ])
@@ -146,7 +155,12 @@ describe("util", () => {
     it("should respect the exclude option, if specified", async () => {
       const garden = await makeTestGardenA()
       const exclude = ["module-a/**/*"]
-      const files = await findConfigPathsInPath(garden.vcs, garden.projectRoot, { exclude })
+      const files = await findConfigPathsInPath({
+        vcs: garden.vcs,
+        dir: garden.projectRoot,
+        log: garden.log,
+        exclude,
+      })
       expect(files).to.eql([
         join(garden.projectRoot, "garden.yml"),
         join(garden.projectRoot, "module-b", "garden.yml"),
@@ -158,7 +172,13 @@ describe("util", () => {
       const garden = await makeTestGardenA()
       const include = ["module*/**/*"]
       const exclude = ["module-a/**/*"]
-      const files = await findConfigPathsInPath(garden.vcs, garden.projectRoot, { include, exclude })
+      const files = await findConfigPathsInPath({
+        vcs: garden.vcs,
+        dir: garden.projectRoot,
+        log: garden.log,
+        include,
+        exclude,
+      })
       expect(files).to.eql([
         join(garden.projectRoot, "module-b", "garden.yml"),
         join(garden.projectRoot, "module-c", "garden.yml"),

--- a/garden-service/test/unit/src/watch.ts
+++ b/garden-service/test/unit/src/watch.ts
@@ -46,8 +46,14 @@ describe("Watcher", () => {
   })
 
   afterEach(async () => {
-    garden.events.clearLog()
     garden["watcher"].stop()
+
+    // Wait for processing to complete
+    while (garden["watcher"].processing) {
+      await sleep(100)
+    }
+
+    garden.events.clearLog()
   })
 
   after(async () => {

--- a/garden-service/test/unit/src/watch.ts
+++ b/garden-service/test/unit/src/watch.ts
@@ -36,11 +36,18 @@ describe("Watcher", () => {
     doubleModulePath = resolve(garden.projectRoot, "double-module")
     includeModulePath = resolve(garden.projectRoot, "with-include")
     moduleContext = pathToCacheContext(modulePath)
-    await garden.startWatcher(await garden.getConfigGraph())
+    await garden.startWatcher(await garden.getConfigGraph(), 10)
   })
 
   beforeEach(async () => {
     garden.events.clearLog()
+    garden["watcher"]["addBuffer"] = {}
+    garden["watcher"].start()
+  })
+
+  afterEach(async () => {
+    garden.events.clearLog()
+    garden["watcher"].stop()
   })
 
   after(async () => {
@@ -84,6 +91,7 @@ describe("Watcher", () => {
   it("should emit a projectConfigChanged changed event when project config is removed", async () => {
     const path = await getConfigFilePath(garden.projectRoot)
     emitEvent(garden, "unlink", path)
+    await waitForEvent("projectConfigChanged")
     expect(garden.events.eventLog).to.eql([
       { name: "projectConfigChanged", payload: {} },
     ])
@@ -110,8 +118,9 @@ describe("Watcher", () => {
   })
 
   it("should emit a configRemoved event when removing a garden.yml file", async () => {
-    const path = await getConfigFilePath(join(garden.projectRoot, "module-b"))
+    const path = await getConfigFilePath(join(garden.projectRoot, "module-a"))
     emitEvent(garden, "unlink", path)
+    await waitForEvent("configRemoved")
     expect(garden.events.eventLog).to.eql([
       { name: "configRemoved", payload: { path } },
     ])
@@ -119,36 +128,36 @@ describe("Watcher", () => {
 
   context("should emit a moduleSourcesChanged event", () => {
     it("containing the module's name when one of its files is changed", async () => {
-      const pathChanged = resolve(modulePath, "foo.txt")
-      emitEvent(garden, "change", pathChanged)
+      const pathsChanged = [resolve(modulePath, "foo.txt")]
+      emitEvent(garden, "change", pathsChanged[0])
       expect(garden.events.eventLog).to.eql([
-        { name: "moduleSourcesChanged", payload: { names: ["module-a"], pathChanged } },
+        { name: "moduleSourcesChanged", payload: { names: ["module-a"], pathsChanged } },
       ])
     })
 
     it("if a file is changed and it matches a module's include list", async () => {
-      const pathChanged = resolve(includeModulePath, "subdir", "foo2.txt")
-      emitEvent(garden, "change", pathChanged)
+      const pathsChanged = [resolve(includeModulePath, "subdir", "foo2.txt")]
+      emitEvent(garden, "change", pathsChanged[0])
       expect(garden.events.eventLog).to.eql([
-        { name: "moduleSourcesChanged", payload: { names: ["with-include"], pathChanged } },
+        { name: "moduleSourcesChanged", payload: { names: ["with-include"], pathsChanged } },
       ])
     })
 
     it("if a file is added to a module", async () => {
-      const pathChanged = resolve(modulePath, "new.txt")
+      const path = resolve(modulePath, "new.txt")
       try {
-        await createFile(pathChanged)
-        expect(await waitForEvent("moduleSourcesChanged")).to.eql({ names: ["module-a"], pathChanged })
+        await createFile(path)
+        expect(await waitForEvent("moduleSourcesChanged")).to.eql({ names: ["module-a"], pathsChanged: [path] })
       } finally {
-        await pathExists(pathChanged) && await remove(pathChanged)
+        await pathExists(path) && await remove(path)
       }
     })
 
     it("containing both modules' names when a source file is changed for two co-located modules", async () => {
-      const pathChanged = resolve(doubleModulePath, "foo.txt")
-      emitEvent(garden, "change", pathChanged)
+      const pathsChanged = [resolve(doubleModulePath, "foo.txt")]
+      emitEvent(garden, "change", pathsChanged[0])
       expect(garden.events.eventLog).to.eql([
-        { name: "moduleSourcesChanged", payload: { names: ["module-b", "module-c"], pathChanged } },
+        { name: "moduleSourcesChanged", payload: { names: ["module-b", "module-c"], pathsChanged } },
       ])
     })
   })
@@ -185,11 +194,11 @@ describe("Watcher", () => {
   })
 
   it("should emit a moduleSourcesChanged event when a directory is added under a module directory", async () => {
-    const pathChanged = resolve(modulePath, "subdir")
-    emitEvent(garden, "addDir", pathChanged)
+    const pathsChanged = [resolve(modulePath, "subdir")]
+    emitEvent(garden, "addDir", pathsChanged[0])
     expect(await waitForEvent("moduleSourcesChanged")).to.eql({
       names: ["module-a"],
-      pathChanged,
+      pathsChanged,
     })
   })
 
@@ -202,16 +211,45 @@ describe("Watcher", () => {
 
   it("should emit a moduleRemoved event if a directory containing a module is removed", async () => {
     emitEvent(garden, "unlinkDir", modulePath)
+    await waitForEvent("moduleRemoved")
     expect(garden.events.eventLog).to.eql([
       { name: "moduleRemoved", payload: {} },
     ])
   })
 
   it("should emit a moduleSourcesChanged event if a directory within a module is removed", async () => {
-    const pathChanged = resolve(modulePath, "subdir")
-    emitEvent(garden, "unlinkDir", pathChanged)
+    const pathsChanged = [resolve(modulePath, "subdir")]
+    emitEvent(garden, "unlinkDir", pathsChanged[0])
+    await waitForEvent("moduleSourcesChanged")
     expect(garden.events.eventLog).to.eql([
-      { name: "moduleSourcesChanged", payload: { names: ["module-a"], pathChanged } },
+      { name: "moduleSourcesChanged", payload: { names: ["module-a"], pathsChanged } },
+    ])
+  })
+
+  it("should emit a moduleSourcesChanged event if a module's file is removed", async () => {
+    const pathsChanged = [resolve(modulePath, "foo.txt")]
+    emitEvent(garden, "unlink", pathsChanged[0])
+    await waitForEvent("moduleSourcesChanged")
+    expect(garden.events.eventLog).to.eql([
+      { name: "moduleSourcesChanged", payload: { names: ["module-a"], pathsChanged } },
+    ])
+  })
+
+  // Note: This is to ensure correct handling of version file lists and cache invalidation
+  it("should correctly handle removing a file and then re-adding it", async () => {
+    const pathsChanged = [resolve(modulePath, "foo.txt")]
+    emitEvent(garden, "unlink", pathsChanged[0])
+    await waitForEvent("moduleSourcesChanged")
+    expect(garden.events.eventLog).to.eql([
+      { name: "moduleSourcesChanged", payload: { names: ["module-a"], pathsChanged } },
+    ])
+
+    garden.events.eventLog = []
+
+    emitEvent(garden, "add", pathsChanged[0])
+    await waitForEvent("moduleSourcesChanged")
+    expect(garden.events.eventLog).to.eql([
+      { name: "moduleSourcesChanged", payload: { names: ["module-a"], pathsChanged } },
     ])
   })
 
@@ -276,10 +314,10 @@ describe("Watcher", () => {
     })
 
     it("should emit a moduleSourcesChanged event when a linked module source is changed", async () => {
-      const pathChanged = resolve(localModuleSourceDir, "module-a", "foo.txt")
-      emitEvent(garden, "change", pathChanged)
+      const pathsChanged = [resolve(localModuleSourceDir, "module-a", "foo.txt")]
+      emitEvent(garden, "change", pathsChanged[0])
       expect(garden.events.eventLog).to.eql([
-        { name: "moduleSourcesChanged", payload: { names: ["module-a"], pathChanged } },
+        { name: "moduleSourcesChanged", payload: { names: ["module-a"], pathsChanged } },
       ])
     })
   })
@@ -345,10 +383,10 @@ describe("Watcher", () => {
     })
 
     it("should emit a moduleSourcesChanged event when a linked project source is changed", async () => {
-      const pathChanged = resolve(localProjectSourceDir, "source-a", "module-a", "foo.txt")
-      emitEvent(garden, "change", pathChanged)
+      const pathsChanged = [resolve(localProjectSourceDir, "source-a", "module-a", "foo.txt")]
+      emitEvent(garden, "change", pathsChanged[0])
       expect(garden.events.eventLog).to.eql([
-        { name: "moduleSourcesChanged", payload: { names: ["module-a"], pathChanged } },
+        { name: "moduleSourcesChanged", payload: { names: ["module-a"], pathsChanged } },
       ])
     })
   })


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, we weren't handling large numbers of added/removed files well. We'd trigger **a lot** of version checks and updates. We now buffer additions of files and directories, and more optimally and consistently handle those changes.

This doesn't exactly fix #1077, which we should look more into, but it does help with many scenarios.

**Special notes for your reviewer**:

Please try to break this! Thrash the file watcher and see what comes up. Whether you find new or old issues, we should reproduce in tests and fix them in this PR.

**Does this PR introduce a user-facing change?**:

Not for everyday use, but this has a significant performance benefit when adding/removing large directories, such as when vendoring dependencies (e.g. `npm install`).