### PR TITLE
fix(server): re-use Garden instance when running commands for API calls

### DIFF
--- a/garden-service/src/server/commands.ts
+++ b/garden-service/src/server/commands.ts
@@ -66,10 +66,6 @@ export async function resolveRequest(
   // Prepare arguments for command action.
   const command = commandSpec.command
 
-  // TODO: Creating a new Garden instance is not ideal,
-  //       need to revisit once we've refactored the TaskGraph and config resolution.
-  const cmdGarden = await Garden.factory(garden.projectRoot, garden.opts)
-
   // We generally don't want actions to log anything in the server.
   const cmdLog = log.placeholder(LogLevel.silly, { childEntriesInheritLevel: true })
 
@@ -78,7 +74,7 @@ export async function resolveRequest(
   const cmdOpts = mapParams(ctx, request.parameters, optParams)
 
   return command.action({
-    garden: cmdGarden,
+    garden,
     log: cmdLog,
     headerLog: cmdLog,
     footerLog: cmdLog,

--- a/garden-service/test/unit/src/server/server.ts
+++ b/garden-service/test/unit/src/server/server.ts
@@ -194,6 +194,10 @@ describe("startServer", () => {
     it("should correctly map arguments and options to commands", (done) => {
       const id = uuid.v4()
       onMessage((req) => {
+        // Ignore other events such as taskPending and taskProcessing and wait for the command result
+        if ((<any>req).type !== "commandResult") {
+          return
+        }
         const taskResult = taskResultOutputs((<any>req).result)
         const result = {
           ...req,


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously we were creating a new Garden instance for every command that needed to be executed when receiving API calls from the Dashboard. This was because of the way we were resolving modules in the past.

Recent changes to how we resolve providers made this very slow so now we're just using the Garden instance already available to the server instead of creating a new one. This should be fine now, thanks to improvements we've made to the task graph and module resolutions. 