### PR TITLE
Minikube fixes

### DIFF
--- a/garden-service/src/plugins/kubernetes/local/minikube.ts
+++ b/garden-service/src/plugins/kubernetes/local/minikube.ts
@@ -18,7 +18,7 @@ export async function setMinikubeDockerEnv() {
   try {
     minikubeEnv = await execa.stdout("minikube", ["docker-env", "--shell=bash"])
   } catch (err) {
-    if (err.contains("driver does not support")) {
+    if ((<execa.ExecaError>err).stderr.includes("driver does not support")) {
       return
     }
     throw err


### PR DESCRIPTION
**What this PR does / why we need it**:

Contains fixes to two issues I ran into while trying to run Garden on minikube in CI. 

One issue was that Garden just hangs while trying to deploy the `kubernetes-dashboard` helm chart. Minikube already has a `dashboard` addon so now we just use that. This does mean that the link to the K8s dashboard is no longer visible on the Garden dashboard for minikube users.

I'll add a separate issue for that since it's a higher priority to be able to deploy a project to begin with.