### PR TITLE
fix(vcs): include submodules with remote sources

### DIFF
--- a/garden-service/src/vcs/git.ts
+++ b/garden-service/src/vcs/git.ts
@@ -152,7 +152,8 @@ export class GitHandler extends VcsHandler {
     log: LogEntry, remoteSourcesPath: string, repositoryUrl: string, hash: string, absPath: string,
   ) {
     const git = this.gitCli(log, remoteSourcesPath)
-    return git("clone", "--depth=1", `--branch=${hash}`, repositoryUrl, absPath)
+    // Use `--recursive` to include submodules
+    return git("clone", "--recursive", "--depth=1", `--branch=${hash}`, repositoryUrl, absPath)
   }
 
   // TODO Better auth handling
@@ -202,6 +203,8 @@ export class GitHandler extends VcsHandler {
       try {
         await git("fetch", "--depth=1", "origin", hash)
         await git("reset", "--hard", `origin/${hash}`)
+        // Update submodules if applicable (no-op if no submodules in repo)
+        await git("submodule", "update", "--recursive")
       } catch (err) {
         entry.setError()
         throw new RuntimeError(`Updating remote ${sourceType} failed with error: \n\n${err}`, {

--- a/garden-service/test/e2e/src/pre-release.ts
+++ b/garden-service/test/e2e/src/pre-release.ts
@@ -223,6 +223,11 @@ describe("PreReleaseTests", () => {
 
   if (project === "remote-sources") {
     describe("remote sources", () => {
+      it("runs the update-remote command", async () => {
+        const logEntries = await runWithEnv(["update-remote", "all"])
+        const res = searchLog(logEntries, /Source already up to date/)
+        expect(res, "expected to find 'Source already up to date' in log output").to.eql("passed")
+      })
       it("calls the result service to get a 200 OK response including the HTML for the result page", async () => {
         const logEntries = await runWithEnv(["call", "result"])
         expect(searchLog(logEntries, /200 OK/), "expected to find '200 OK' in log output").to.eql("passed")


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously we didn't initialise submodules for remote sources.

**Which issue(s) this PR fixes**:

Fixes #463