### PR TITLE
chore: hide get|set secret commands for now

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -271,6 +271,12 @@ Get a secret from the environment.
 
 Returns with an error if the provided key could not be found.
 
+>**Note**: The `get|set secret` commands are currently quite limited.
+For Kubernetes secrets, we recommend using kubectl for
+most non-trivial use-cases. Please refer our
+[kubernetes-secrets example](https://github.com/garden-io/garden/tree/master/examples/kubernetes-secrets)
+for more details.
+
 Examples:
 
     garden get secret kubernetes somekey
@@ -679,7 +685,13 @@ These secrets are handled by each provider, and may for example be exposed as en
 variables for services or mounted as files, depending on how the provider is implemented
 and configured.
 
-_Note: The value is currently always stored as a string._
+The value is currently always stored as a string.
+
+>**Note**: The `get|set secret` commands are currently quite limited.
+For Kubernetes secrets, we recommend using kubectl for
+most non-trivial use-cases. Please refer our
+[kubernetes-secrets example](https://github.com/garden-io/garden/tree/master/examples/kubernetes-secrets)
+for more details.
 
 Examples:
 

--- a/garden-service/src/cli/cli.ts
+++ b/garden-service/src/cli/cli.ts
@@ -362,6 +362,7 @@ export class GardenCli {
       setup,
       aliases: command.alias,
       desc: command.help,
+      hidden: command.hidden,
       run: action,
     }
 

--- a/garden-service/src/commands/base.ts
+++ b/garden-service/src/commands/base.ts
@@ -256,6 +256,7 @@ export abstract class Command<T extends Parameters = {}, U extends Parameters = 
 
   cliOnly: boolean = false
   noProject: boolean = false
+  hidden: boolean = false
 
   subCommands: CommandConstructor[] = []
 

--- a/garden-service/src/commands/get/get-secret.ts
+++ b/garden-service/src/commands/get/get-secret.ts
@@ -33,9 +33,16 @@ type GetArgs = typeof getSecretArgs
 export class GetSecretCommand extends Command<GetArgs> {
   name = "secret"
   help = "Get a secret from the environment."
+  hidden = true
 
   description = dedent`
     Returns with an error if the provided key could not be found.
+
+    >**Note**: The \`get|set secret\` commands are currently quite limited.
+    For Kubernetes secrets, we recommend using kubectl for
+    most non-trivial use-cases. Please refer our
+    [kubernetes-secrets example](https://github.com/garden-io/garden/tree/master/examples/kubernetes-secrets)
+    for more details.
 
     Examples:
 

--- a/garden-service/src/commands/set.ts
+++ b/garden-service/src/commands/set.ts
@@ -18,6 +18,7 @@ import { SetSecretResult } from "../types/plugin/provider/setSecret"
 export class SetCommand extends Command {
   name = "set"
   help = "Set or modify data, e.g. secrets."
+  hidden = true
 
   subCommands = [
     SetSecretCommand,
@@ -48,13 +49,20 @@ type SetArgs = typeof setSecretArgs
 export class SetSecretCommand extends Command<typeof setSecretArgs> {
   name = "secret"
   help = "Set a secret value for a provider in an environment."
+  hidden = true
 
   description = dedent`
     These secrets are handled by each provider, and may for example be exposed as environment
     variables for services or mounted as files, depending on how the provider is implemented
     and configured.
 
-    _Note: The value is currently always stored as a string._
+    The value is currently always stored as a string.
+
+    >**Note**: The \`get|set secret\` commands are currently quite limited.
+    For Kubernetes secrets, we recommend using kubectl for
+    most non-trivial use-cases. Please refer our
+    [kubernetes-secrets example](https://github.com/garden-io/garden/tree/master/examples/kubernetes-secrets)
+    for more details.
 
     Examples:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Our current `get|set secret` commands are quite limited and seem to mostly cause confusion. E.g. in the `kubernetes-secrets` example, we recommend that people use kubectl for secrets.

This PR therefore hides the commands from `--help` output and adds an explanation to the docs.

**Which issue(s) this PR fixes**:

Fixes #1094 
