### PR TITLE
feat(hot-reload): added post-sync callback option

### DIFF
--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -294,6 +294,26 @@ hotReload:
     - target: "/app/src"
 ```
 
+### `hotReload.sync[].callback[]`
+
+[hotReload](#hotreload) > [sync](#hotreload.sync[]) > callback
+
+A optional command to run inside the container after syncing. Applies only to files belonging to this source/target pair.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
+Example:
+
+```yaml
+hotReload:
+  ...
+  sync:
+    - callback:
+      - rebuild-static-assets.sh
+```
+
 ### `dockerfile`
 
 POSIX-style name of Dockerfile, relative to module root.
@@ -976,6 +996,7 @@ hotReload:
   sync:
     - source: .
       target:
+      callback:
 dockerfile:
 services:
   - name:

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -299,6 +299,26 @@ hotReload:
     - target: "/app/src"
 ```
 
+### `hotReload.sync[].callback[]`
+
+[hotReload](#hotreload) > [sync](#hotreload.sync[]) > callback
+
+A optional command to run inside the container after syncing. Applies only to files belonging to this source/target pair.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
+Example:
+
+```yaml
+hotReload:
+  ...
+  sync:
+    - callback:
+      - rebuild-static-assets.sh
+```
+
 ### `dockerfile`
 
 POSIX-style name of Dockerfile, relative to module root.
@@ -1011,6 +1031,7 @@ hotReload:
   sync:
     - source: .
       target:
+      callback:
 dockerfile:
 services:
   - name:

--- a/garden-service/src/plugins/container/config.ts
+++ b/garden-service/src/plugins/container/config.ts
@@ -109,10 +109,20 @@ const hotReloadSyncSchema = joi.object()
         POSIX-style absolute path to sync the directory to inside the container. The root path (i.e. "/") is
         not allowed.`)
       .example("/app/src"),
+    callback: joi.array().items(joi.string())
+      .optional()
+      .description(deline`
+        A optional command to run inside the container after syncing. Applies only to files belonging to this
+        source/target pair.`)
+      .example([["rebuild-static-assets.sh"], {}]),
   })
 
+export interface HotReloadSyncPairSpec extends FileCopySpec {
+  callback?: string[]
+}
+
 export interface ContainerHotReloadSpec {
-  sync: FileCopySpec[]
+  sync: HotReloadSyncPairSpec[]
 }
 
 const hotReloadConfigSchema = joi.object()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:

Adds a new config option to hot reload sync specs: `callback`.

This is a command that is run inside the container after a hot reload
sync takes place for the source/target pair in question.

**Which issue(s) this PR fixes**:

Doesn't fix any issues, but implements a feature that's been requested by several users.

**Special notes for your reviewer**:

If we could think of a more instructive/straightforward example use case of this than the `rebuild-static-assets.sh` I added to the Joi spec, that would be good. When requested by users, the use cases so far have been relatively nontrivial and/or specific to their setup/stack (things like clearing caches or running custom scripts).

Any thoughts on this?