### PR TITLE
fix(k8s): allow user to configure own storageClass for build-sync volume

### DIFF
--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -539,7 +539,7 @@ Only applies when `buildMode` is set to `cluster-docker`, ignored otherwise.
 
 [providers](#providers) > [storage](#providers[].storage) > [builder](#providers[].storage.builder) > size
 
-Volume size for the registry in megabytes.
+Volume size in megabytes.
 
 | Type     | Required | Default |
 | -------- | -------- | ------- |
@@ -572,7 +572,7 @@ Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored ot
 
 [providers](#providers) > [storage](#providers[].storage) > [registry](#providers[].storage.registry) > size
 
-Volume size for the registry in megabytes.
+Volume size in megabytes.
 
 | Type     | Required | Default |
 | -------- | -------- | ------- |
@@ -595,6 +595,10 @@ Storage class to use for the volume.
 Storage parameters for the code sync volume, which build contexts are synced to ahead of running
 in-cluster builds.
 
+Important: The storage class configured here has to support _ReadWriteMany_ access.
+If you don't specify a storage class, Garden creates an NFS provisioner and provisions an ephemeral
+NFS volume for the sync data volume.
+
 Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored otherwise.
 
 | Type     | Required | Default                              |
@@ -605,7 +609,7 @@ Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored ot
 
 [providers](#providers) > [storage](#providers[].storage) > [sync](#providers[].storage.sync) > size
 
-Volume size for the registry in megabytes.
+Volume size in megabytes.
 
 | Type     | Required | Default |
 | -------- | -------- | ------- |

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -539,7 +539,7 @@ Only applies when `buildMode` is set to `cluster-docker`, ignored otherwise.
 
 [providers](#providers) > [storage](#providers[].storage) > [builder](#providers[].storage.builder) > size
 
-Volume size for the registry in megabytes.
+Volume size in megabytes.
 
 | Type     | Required | Default |
 | -------- | -------- | ------- |
@@ -572,7 +572,7 @@ Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored ot
 
 [providers](#providers) > [storage](#providers[].storage) > [registry](#providers[].storage.registry) > size
 
-Volume size for the registry in megabytes.
+Volume size in megabytes.
 
 | Type     | Required | Default |
 | -------- | -------- | ------- |
@@ -595,6 +595,10 @@ Storage class to use for the volume.
 Storage parameters for the code sync volume, which build contexts are synced to ahead of running
 in-cluster builds.
 
+Important: The storage class configured here has to support _ReadWriteMany_ access.
+If you don't specify a storage class, Garden creates an NFS provisioner and provisions an ephemeral
+NFS volume for the sync data volume.
+
 Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored otherwise.
 
 | Type     | Required | Default                              |
@@ -605,7 +609,7 @@ Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored ot
 
 [providers](#providers) > [storage](#providers[].storage) > [sync](#providers[].storage.sync) > size
 
-Volume size for the registry in megabytes.
+Volume size in megabytes.
 
 | Type     | Required | Default |
 | -------- | -------- | ------- |

--- a/garden-service/src/plugins/kubernetes/config.ts
+++ b/garden-service/src/plugins/kubernetes/config.ts
@@ -168,7 +168,7 @@ const storageSchema = (defaults: KubernetesStorageSpec) => joi.object()
     size: joi.number()
       .integer()
       .default(defaults.size)
-      .description("Volume size for the registry in megabytes."),
+      .description("Volume size in megabytes."),
     storageClass: joi.string()
       .allow(null)
       .default(null)
@@ -307,6 +307,10 @@ export const kubernetesConfigBase = providerConfigBaseSchema
           .description(dedent`
             Storage parameters for the code sync volume, which build contexts are synced to ahead of running
             in-cluster builds.
+
+            Important: The storage class configured here has to support _ReadWriteMany_ access.
+            If you don't specify a storage class, Garden creates an NFS provisioner and provisions an ephemeral
+            NFS volume for the sync data volume.
 
             Only applies when \`buildMode\` is set to \`cluster-docker\` or \`kaniko\`, ignored otherwise.
           `),

--- a/garden-service/src/plugins/kubernetes/init.ts
+++ b/garden-service/src/plugins/kubernetes/init.ts
@@ -25,6 +25,8 @@ import chalk from "chalk"
 import { deline } from "../../util/string"
 import { combineStates, ServiceStatusMap } from "../../types/service"
 
+const nfsStorageClass = "garden-system-nfs"
+
 /**
  * Performs the following actions to check environment status:
  *   1. Checks Tiller status in the project namespace
@@ -254,7 +256,7 @@ export function getKubernetesSystemVariables(config: KubernetesConfig) {
     "sync-requests-cpu": millicpuToString(config.resources.sync.requests.cpu),
     "sync-requests-memory": megabytesToString(config.resources.sync.requests.memory),
     "sync-storage-size": megabytesToString(config.storage.sync.size),
-    "sync-storage-class": config.storage.sync.storageClass,
+    "sync-storage-class": config.storage.sync.storageClass || nfsStorageClass,
   }
 }
 

--- a/garden-service/src/plugins/kubernetes/kubernetes.ts
+++ b/garden-service/src/plugins/kubernetes/kubernetes.ts
@@ -51,10 +51,15 @@ export async function configureProvider({ projectName, config }: ConfigureProvid
     }
 
     // Deploy build services on init
-    config._systemServices.push("build-sync", "docker-registry", "registry-proxy", "nfs-provisioner")
+    config._systemServices.push("build-sync", "docker-registry", "registry-proxy")
 
     if (config.buildMode === "cluster-docker") {
       config._systemServices.push("docker-daemon")
+    }
+
+    // Set up an NFS provisioner if the user doesn't explicitly set a storage class for the shared sync volume
+    if (!config.storage.sync.storageClass) {
+      config._systemServices.push("nfs-provisioner")
     }
 
   } else if (config.name !== "local-kubernetes" && !config.deploymentRegistry) {

--- a/garden-service/static/kubernetes/system/build-sync/garden.yml
+++ b/garden-service/static/kubernetes/system/build-sync/garden.yml
@@ -15,4 +15,4 @@ values:
       memory: ${var.sync-requests-memory}
   storage:
     request: ${var.sync-storage-size}
-    storageClass: garden-system-nfs
+    storageClass: ${var.sync-storage-class}

--- a/garden-service/static/kubernetes/system/nfs-provisioner/garden.yml
+++ b/garden-service/static/kubernetes/system/nfs-provisioner/garden.yml
@@ -9,7 +9,6 @@ values:
   nameOverride: garden-nfs-provisioner
   fullnameOverride: garden-nfs-provisioner
   persistence:
-    enable: true
-    size: 50Gi
+    enabled: false
   storageClass:
     name: garden-system-nfs


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, the `storage.sync.storageClass` parameter was silently
ignored. We now respect the parameter, and skip installing the NFS
provisioner if a storageClass is specified for the volume.

**Which issue(s) this PR fixes**:

Fixes #1120