### PR TITLE
chore(build-script): remove node_modules and package files from dist dir

### DIFF
--- a/garden-service/bin/build-pkg.sh
+++ b/garden-service/bin/build-pkg.sh
@@ -95,3 +95,8 @@ cp ../lib/fsevents/node-v64-darwin-x64/fsevents.node macos-amd64/fsevents.node
 
 echo "    -> tar"
 tar -czf garden-${version}-macos-amd64.tar.gz macos-amd64
+
+echo "-> removing node_modules and package files..."
+rm -rf node_modules
+rm package.json
+rm package-lock.json


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes node_modules and package.json files from `dist` dir after building the package. If they're not removed, they get uploaded with the zip files when creating a release.  