### PR TITLE
improvement(logger): store all message states

### DIFF
--- a/garden-service/src/commands/logs.ts
+++ b/garden-service/src/commands/logs.ts
@@ -85,10 +85,7 @@ export class LogsCommand extends Command<Args, Opts> {
         } catch { }
       }
 
-      log.info({
-        section: entry.serviceName,
-        msg: [timestamp, chalk.white(entry.msg)],
-      })
+      log.info({ section: entry.serviceName, msg: `${timestamp} → ${chalk.white(entry.msg)}` })
 
       if (!follow) {
         result.push(entry)
@@ -98,7 +95,7 @@ export class LogsCommand extends Command<Args, Opts> {
     const actions = await garden.getActionHelper()
 
     await Bluebird.map(services, async (service: Service<any>) => {
-      const voidLog = log.placeholder(LogLevel.silly, { childEntriesInheritLevel: true })
+      const voidLog = log.placeholder(LogLevel.silly, true)
       const runtimeContext = await getServiceRuntimeContext(garden, graph, service)
       const status = await actions.getServiceStatus({ log: voidLog, service, hotReload: false, runtimeContext })
 

--- a/garden-service/src/logger/log-node.ts
+++ b/garden-service/src/logger/log-node.ts
@@ -9,7 +9,7 @@
 import * as uniqid from "uniqid"
 import { round } from "lodash"
 
-import { LogEntry, CreateParam } from "./log-entry"
+import { LogEntry, LogEntryParams } from "./log-entry"
 
 export enum LogLevel {
   error = 0,
@@ -18,6 +18,18 @@ export enum LogLevel {
   verbose = 3,
   debug = 4,
   silly = 5,
+}
+
+export interface CreateNodeParams extends LogEntryParams {
+  level: LogLevel
+  isPlaceholder?: boolean
+}
+
+export function resolveParams(level: LogLevel, params: string | LogEntryParams): CreateNodeParams {
+  if (typeof params === "string") {
+    return { msg: params, level }
+  }
+  return { ...params, level }
 }
 
 export abstract class LogNode {
@@ -35,44 +47,44 @@ export abstract class LogNode {
     this.children = []
   }
 
-  protected abstract createNode(level: LogLevel, param: CreateParam): LogEntry
+  protected abstract createNode(params: CreateNodeParams): LogEntry
   protected abstract onGraphChange(node: LogEntry): void
 
   /**
    * A placeholder entry is an empty entry whose children should be aligned with the parent context.
    * Useful for setting a placeholder in the middle of the log that can later be populated.
    */
-  abstract placeholder(level: LogLevel, param?: CreateParam): LogEntry
+  abstract placeholder(level: LogLevel, childEntriesInheritLevel?: boolean): LogEntry
 
-  protected appendNode(level: LogLevel, param: CreateParam): LogEntry {
-    const node = this.createNode(level, param)
+  protected addNode(params: CreateNodeParams): LogEntry {
+    const node = this.createNode(params)
     this.children.push(node)
     this.onGraphChange(node)
     return node
   }
 
-  silly(param: CreateParam): LogEntry {
-    return this.appendNode(LogLevel.silly, param)
+  silly(params: string | LogEntryParams): LogEntry {
+    return this.addNode(resolveParams(LogLevel.silly, params))
   }
 
-  debug(param: CreateParam): LogEntry {
-    return this.appendNode(LogLevel.debug, param)
+  debug(params: string | LogEntryParams): LogEntry {
+    return this.addNode(resolveParams(LogLevel.debug, params))
   }
 
-  verbose(param: CreateParam): LogEntry {
-    return this.appendNode(LogLevel.verbose, param)
+  verbose(params: string | LogEntryParams): LogEntry {
+    return this.addNode(resolveParams(LogLevel.verbose, params))
   }
 
-  info(param: CreateParam): LogEntry {
-    return this.appendNode(LogLevel.info, param)
+  info(params: string | LogEntryParams): LogEntry {
+    return this.addNode(resolveParams(LogLevel.info, params))
   }
 
-  warn(param: CreateParam): LogEntry {
-    return this.appendNode(LogLevel.warn, param)
+  warn(params: string | LogEntryParams): LogEntry {
+    return this.addNode(resolveParams(LogLevel.warn, params))
   }
 
-  error(param: CreateParam): LogEntry {
-    return this.appendNode(LogLevel.error, param)
+  error(params: string | LogEntryParams): LogEntry {
+    return this.addNode(resolveParams(LogLevel.error, params))
   }
 
   /**

--- a/garden-service/src/logger/logger.ts
+++ b/garden-service/src/logger/logger.ts
@@ -6,8 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { LogNode } from "./log-node"
-import { LogEntry, CreateOpts, resolveParam } from "./log-entry"
+import { LogNode, CreateNodeParams } from "./log-node"
+import { LogEntry } from "./log-entry"
 import { getChildEntries, findLogNode } from "./util"
 import { Writer } from "./writers/base"
 import { InternalError, ParameterError } from "../exceptions"
@@ -119,13 +119,13 @@ export class Logger extends LogNode {
     this.useEmoji = config.useEmoji === false ? false : true
   }
 
-  protected createNode(level: LogLevel, opts: CreateOpts): LogEntry {
-    return new LogEntry({ level, root: this, opts: resolveParam(opts) })
+  protected createNode(params: CreateNodeParams): LogEntry {
+    return new LogEntry({ ...params, root: this })
   }
 
   placeholder(level: LogLevel = LogLevel.info): LogEntry {
     // Ensure placeholder child entries align with parent context
-    return this.appendNode(level, { indent: - 1 })
+    return this.addNode({ level, indent: - 1, isPlaceholder: true })
   }
 
   onGraphChange(entry: LogEntry) {
@@ -133,11 +133,11 @@ export class Logger extends LogNode {
   }
 
   getLogEntries(): LogEntry[] {
-    return getChildEntries(this).filter(entry => !entry.fromStdStream())
+    return getChildEntries(this).filter(entry => !entry.fromStdStream)
   }
 
   filterBySection(section: string): LogEntry[] {
-    return getChildEntries(this).filter(entry => entry.opts.section === section)
+    return getChildEntries(this).filter(entry => entry.getMessageState().section === section)
   }
 
   findById(id: string): LogEntry | void {

--- a/garden-service/src/logger/util.ts
+++ b/garden-service/src/logger/util.ts
@@ -10,13 +10,13 @@ import * as nodeEmoji from "node-emoji"
 import chalk from "chalk"
 import * as CircularJSON from "circular-json"
 import { LogNode } from "./log-node"
-import { LogEntry, CreateOpts, EmojiName } from "./log-entry"
+import { LogEntry, LogEntryParams, EmojiName } from "./log-entry"
 
 export interface Node {
   children: any[]
 }
 
-export type LogOptsResolvers = { [K in keyof CreateOpts]?: Function }
+export type LogOptsResolvers = { [K in keyof LogEntryParams]?: Function }
 
 export type ProcessNode<T extends Node = Node> = (node: T) => boolean
 

--- a/garden-service/src/logger/writers/basic-terminal-writer.ts
+++ b/garden-service/src/logger/writers/basic-terminal-writer.ts
@@ -19,8 +19,11 @@ export class BasicTerminalWriter extends Writer {
     const level = this.level || logger.level
     if (level >= entry.level) {
       // Use info symbol for active entries because basic logger doesn't have a spinner
-      if (entry.opts.status === "active" && !entry.opts.symbol) {
-        entry.opts.symbol = "info"
+      const msgState = entry.getMessageState()
+      if (msgState.status === "active" && !msgState.symbol) {
+        msgState.symbol = "info"
+        // We know that entry.messages isn't empty if the status is defined
+        entry.getMessageStates()![entry.getMessageStates()!.length - 1] = msgState
       }
       return formatForTerminal(entry)
     }

--- a/garden-service/src/logger/writers/fancy-terminal-writer.ts
+++ b/garden-service/src/logger/writers/fancy-terminal-writer.ts
@@ -140,7 +140,7 @@ export class FancyTerminalWriter extends Writer {
     this.updatePending = false
 
     // Suspend processing and write immediately if a lot of data is being intercepted, e.g. when user is typing in input
-    if (log.fromStdStream() && !didWrite) {
+    if (log.fromStdStream && !didWrite) {
       const now = Date.now()
       const throttleProcessing = this.lastInterceptAt && (now - this.lastInterceptAt) < THROTTLE_MS
       this.lastInterceptAt = now
@@ -195,7 +195,7 @@ export class FancyTerminalWriter extends Writer {
         let spinnerX
         let spinnerCoords: Coords | undefined
 
-        if (entry.opts.status === "active") {
+        if (entry.getMessageState().status === "active") {
           spinnerX = leftPad(entry).length
           spinnerFrame = this.tickSpinner(entry.key)
           spinnerCoords = [spinnerX, currentLineNumber]
@@ -204,11 +204,7 @@ export class FancyTerminalWriter extends Writer {
         }
 
         const text = [entry]
-          .map(e => (
-            e.fromStdStream()
-              ? renderMsg(e)
-              : formatForTerminal(e)
-          ))
+          .map(e => e.fromStdStream ? renderMsg(e) : formatForTerminal(e))
           .map(str => (
             spinnerFrame
               ? `${str.slice(0, spinnerX)}${spinnerStyle(spinnerFrame)} ${str.slice(spinnerX)}`

--- a/garden-service/src/server/commands.ts
+++ b/garden-service/src/server/commands.ts
@@ -67,7 +67,7 @@ export async function resolveRequest(
   const command = commandSpec.command
 
   // We generally don't want actions to log anything in the server.
-  const cmdLog = log.placeholder(LogLevel.silly, { childEntriesInheritLevel: true })
+  const cmdLog = log.placeholder(LogLevel.silly, true)
 
   const cmdArgs = mapParams(ctx, request.parameters, command.arguments)
   const optParams = extend({ ...GLOBAL_OPTIONS, ...command.options })

--- a/garden-service/test/run-garden.ts
+++ b/garden-service/test/run-garden.ts
@@ -9,7 +9,7 @@ import { JsonLogEntry } from "../src/logger/writers/json-terminal-writer"
 import { ParameterError } from "../src/exceptions"
 import { dedent, deline } from "../src/util/string"
 import { GARDEN_SERVICE_ROOT } from "../src/constants"
-import { UpdateOpts } from "../src/logger/log-entry"
+import { UpdateLogEntryParams } from "../src/logger/log-entry"
 import chalk from "chalk"
 
 export const gardenBinPath = parsedArgs.binPath || resolve(GARDEN_SERVICE_ROOT, "bin", "garden")
@@ -87,7 +87,7 @@ export function commandReloadedStep(): WatchTestStep {
   }
 }
 
-function stringifyJsonLog(entries: UpdateOpts[]) {
+function stringifyJsonLog(entries: UpdateLogEntryParams[]) {
   return entries
     .map(l => {
       const msg = chalk.white(<string>l.msg || "")

--- a/garden-service/test/unit/src/logger/logger.ts
+++ b/garden-service/test/unit/src/logger/logger.ts
@@ -15,7 +15,7 @@ describe("Logger", () => {
       logger.info({ msg: "0" })
       logger.info({ msg: "a1", id: "a" })
       logger.info({ msg: "a2", id: "a" })
-      expect(logger.findById("a")["opts"]["msg"]).to.eql("a1")
+      expect(logger.findById("a")["messageStates"][0]["msg"]).to.eql("a1")
       expect(logger.findById("z")).to.be.undefined
     })
   })


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, when calling `log.setState()`, `log.setSuccess()` etc, we would just overwrite the log message fields. This made it impossible to tell precisely when individual updates took place. Now we instead keep track of all updates in the `messageStates` field of the `LogEntry`. 

This way, we can look at a single entry, see when it was created, when it was updated, and when it completed.

This is e.g. useful for our own internal e2e tests to determine when tasks complete (cc @thsig ). Going forward, this will also allow us to completely replay an entire Garden run (e.g. at a different verbosity) without actually re-running Garden.