### PR TITLE
fix(container): allow any string as ingress path

### DIFF
--- a/garden-service/src/plugins/container/config.ts
+++ b/garden-service/src/plugins/container/config.ts
@@ -180,7 +180,6 @@ const ingressSchema = joi.object()
       .description("Annotations to attach to the ingress (Note: May not be applicable to all providers)"),
     hostname: ingressHostnameSchema,
     path: joi.string()
-      .uri(<any>{ relativeOnly: true })
       .default("/")
       .description("The path which should be routed to the service."),
     port: joi.string()


### PR DESCRIPTION
**What this PR does / why we need it**:

We were previously validating the path as a valid relative URI, which doesn't work with regexes, which are supported by e.g. nginx for URL rewrites.

**Which issue(s) this PR fixes**:

Closes #1020