### PR TITLE
docs: fix and slightly improve rendering of module template ref docs

### DIFF
--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -1048,7 +1048,7 @@ tasks:
 The following keys are available via the `${modules.<module-name>}` template string key for `container`
 modules.
 
-### `modules.<module-name>.buildPath`
+### `${modules.<module-name>.buildPath}`
 
 The build path of the module.
 
@@ -1059,10 +1059,10 @@ The build path of the module.
 Example:
 
 ```yaml
-buildPath: "/home/me/code/my-project/.garden/build/my-module"
+my-variable: ${modules.my-module.buildPath}
 ```
 
-### `modules.<module-name>.path`
+### `${modules.<module-name>.path}`
 
 The local path of the module.
 
@@ -1073,10 +1073,10 @@ The local path of the module.
 Example:
 
 ```yaml
-path: "/home/me/code/my-project/my-module"
+my-variable: ${modules.my-module.path}
 ```
 
-### `modules.<module-name>.version`
+### `${modules.<module-name>.version}`
 
 The current version of the module.
 
@@ -1087,18 +1087,16 @@ The current version of the module.
 Example:
 
 ```yaml
-version: "v-17ad4cb3fd"
+my-variable: ${modules.my-module.version}
 ```
 
-### `modules.<module-name>.outputs`
-
-The outputs defined by the module.
+### `${modules.<module-name>.outputs}`
 
 | Type     | Required |
 | -------- | -------- |
 | `object` | Yes      |
 
-### `modules.<module-name>.outputs.local-image-name`
+### `${modules.<module-name>.outputs.local-image-name}`
 
 [outputs](#outputs) > local-image-name
 
@@ -1111,12 +1109,10 @@ The name of the image (without tag/version) that the module uses for local build
 Example:
 
 ```yaml
-outputs:
-  ...
-  local-image-name: "my-module"
+my-variable: ${modules.my-module.outputs.local-image-name}
 ```
 
-### `modules.<module-name>.outputs.deployment-image-name`
+### `${modules.<module-name>.outputs.deployment-image-name}`
 
 [outputs](#outputs) > deployment-image-name
 
@@ -1129,9 +1125,7 @@ The name of the image (without tag/version) that the module will use during depl
 Example:
 
 ```yaml
-outputs:
-  ...
-  deployment-image-name: "my-deployment-registry.io/my-org/my-module"
+my-variable: ${modules.my-module.outputs.deployment-image-name}
 ```
 
 
@@ -1140,7 +1134,15 @@ outputs:
 The following keys are available via the `${runtime.tasks.<task-name>}` template string key for `container` module tasks.
 Note that these are only resolved when deploying/running dependants of the task, so they are not usable for every field.
 
-### `runtime.tasks.<task-name>.outputs.log`
+### `${runtime.tasks.<task-name>.outputs}`
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | Yes      |
+
+### `${runtime.tasks.<task-name>.outputs.log}`
+
+[outputs](#outputs) > log
 
 The full log from the executed task. (Pro-tip: Make it machine readable so it can be parsed by dependant tasks and services!)
 

--- a/docs/reference/module-types/exec.md
+++ b/docs/reference/module-types/exec.md
@@ -384,7 +384,7 @@ tests:
 The following keys are available via the `${modules.<module-name>}` template string key for `exec`
 modules.
 
-### `modules.<module-name>.buildPath`
+### `${modules.<module-name>.buildPath}`
 
 The build path of the module.
 
@@ -395,10 +395,10 @@ The build path of the module.
 Example:
 
 ```yaml
-buildPath: "/home/me/code/my-project/.garden/build/my-module"
+my-variable: ${modules.my-module.buildPath}
 ```
 
-### `modules.<module-name>.path`
+### `${modules.<module-name>.path}`
 
 The local path of the module.
 
@@ -409,10 +409,10 @@ The local path of the module.
 Example:
 
 ```yaml
-path: "/home/me/code/my-project/my-module"
+my-variable: ${modules.my-module.path}
 ```
 
-### `modules.<module-name>.version`
+### `${modules.<module-name>.version}`
 
 The current version of the module.
 
@@ -423,16 +423,8 @@ The current version of the module.
 Example:
 
 ```yaml
-version: "v-17ad4cb3fd"
+my-variable: ${modules.my-module.version}
 ```
-
-### `modules.<module-name>.outputs`
-
-The outputs defined by the module.
-
-| Type     | Required |
-| -------- | -------- |
-| `object` | Yes      |
 
 
 ### Task outputs
@@ -440,7 +432,15 @@ The outputs defined by the module.
 The following keys are available via the `${runtime.tasks.<task-name>}` template string key for `exec` module tasks.
 Note that these are only resolved when deploying/running dependants of the task, so they are not usable for every field.
 
-### `runtime.tasks.<task-name>.outputs.log`
+### `${runtime.tasks.<task-name>.outputs}`
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | Yes      |
+
+### `${runtime.tasks.<task-name>.outputs.log}`
+
+[outputs](#outputs) > log
 
 The full log from the executed task. (Pro-tip: Make it machine readable so it can be parsed by dependant tasks and services!)
 

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -793,7 +793,7 @@ valueFiles: []
 The following keys are available via the `${modules.<module-name>}` template string key for `helm`
 modules.
 
-### `modules.<module-name>.buildPath`
+### `${modules.<module-name>.buildPath}`
 
 The build path of the module.
 
@@ -804,10 +804,10 @@ The build path of the module.
 Example:
 
 ```yaml
-buildPath: "/home/me/code/my-project/.garden/build/my-module"
+my-variable: ${modules.my-module.buildPath}
 ```
 
-### `modules.<module-name>.path`
+### `${modules.<module-name>.path}`
 
 The local path of the module.
 
@@ -818,10 +818,10 @@ The local path of the module.
 Example:
 
 ```yaml
-path: "/home/me/code/my-project/my-module"
+my-variable: ${modules.my-module.path}
 ```
 
-### `modules.<module-name>.version`
+### `${modules.<module-name>.version}`
 
 The current version of the module.
 
@@ -832,18 +832,16 @@ The current version of the module.
 Example:
 
 ```yaml
-version: "v-17ad4cb3fd"
+my-variable: ${modules.my-module.version}
 ```
 
-### `modules.<module-name>.outputs`
-
-The outputs defined by the module.
+### `${modules.<module-name>.outputs}`
 
 | Type     | Required |
 | -------- | -------- |
 | `object` | Yes      |
 
-### `modules.<module-name>.outputs.release-name`
+### `${modules.<module-name>.outputs.release-name}`
 
 [outputs](#outputs) > release-name
 

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -302,7 +302,7 @@ files: []
 The following keys are available via the `${modules.<module-name>}` template string key for `kubernetes`
 modules.
 
-### `modules.<module-name>.buildPath`
+### `${modules.<module-name>.buildPath}`
 
 The build path of the module.
 
@@ -313,10 +313,10 @@ The build path of the module.
 Example:
 
 ```yaml
-buildPath: "/home/me/code/my-project/.garden/build/my-module"
+my-variable: ${modules.my-module.buildPath}
 ```
 
-### `modules.<module-name>.path`
+### `${modules.<module-name>.path}`
 
 The local path of the module.
 
@@ -327,10 +327,10 @@ The local path of the module.
 Example:
 
 ```yaml
-path: "/home/me/code/my-project/my-module"
+my-variable: ${modules.my-module.path}
 ```
 
-### `modules.<module-name>.version`
+### `${modules.<module-name>.version}`
 
 The current version of the module.
 
@@ -341,14 +341,6 @@ The current version of the module.
 Example:
 
 ```yaml
-version: "v-17ad4cb3fd"
+my-variable: ${modules.my-module.version}
 ```
-
-### `modules.<module-name>.outputs`
-
-The outputs defined by the module.
-
-| Type     | Required |
-| -------- | -------- |
-| `object` | Yes      |
 

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -1086,7 +1086,7 @@ mvnOpts: []
 The following keys are available via the `${modules.<module-name>}` template string key for `maven-container`
 modules.
 
-### `modules.<module-name>.buildPath`
+### `${modules.<module-name>.buildPath}`
 
 The build path of the module.
 
@@ -1097,10 +1097,10 @@ The build path of the module.
 Example:
 
 ```yaml
-buildPath: "/home/me/code/my-project/.garden/build/my-module"
+my-variable: ${modules.my-module.buildPath}
 ```
 
-### `modules.<module-name>.path`
+### `${modules.<module-name>.path}`
 
 The local path of the module.
 
@@ -1111,10 +1111,10 @@ The local path of the module.
 Example:
 
 ```yaml
-path: "/home/me/code/my-project/my-module"
+my-variable: ${modules.my-module.path}
 ```
 
-### `modules.<module-name>.version`
+### `${modules.<module-name>.version}`
 
 The current version of the module.
 
@@ -1125,18 +1125,16 @@ The current version of the module.
 Example:
 
 ```yaml
-version: "v-17ad4cb3fd"
+my-variable: ${modules.my-module.version}
 ```
 
-### `modules.<module-name>.outputs`
-
-The outputs defined by the module.
+### `${modules.<module-name>.outputs}`
 
 | Type     | Required |
 | -------- | -------- |
 | `object` | Yes      |
 
-### `modules.<module-name>.outputs.local-image-name`
+### `${modules.<module-name>.outputs.local-image-name}`
 
 [outputs](#outputs) > local-image-name
 
@@ -1149,12 +1147,10 @@ The name of the image (without tag/version) that the module uses for local build
 Example:
 
 ```yaml
-outputs:
-  ...
-  local-image-name: "my-module"
+my-variable: ${modules.my-module.outputs.local-image-name}
 ```
 
-### `modules.<module-name>.outputs.deployment-image-name`
+### `${modules.<module-name>.outputs.deployment-image-name}`
 
 [outputs](#outputs) > deployment-image-name
 
@@ -1167,8 +1163,6 @@ The name of the image (without tag/version) that the module will use during depl
 Example:
 
 ```yaml
-outputs:
-  ...
-  deployment-image-name: "my-deployment-registry.io/my-org/my-module"
+my-variable: ${modules.my-module.outputs.deployment-image-name}
 ```
 

--- a/docs/reference/module-types/openfaas.md
+++ b/docs/reference/module-types/openfaas.md
@@ -334,7 +334,7 @@ tests:
 The following keys are available via the `${modules.<module-name>}` template string key for `openfaas`
 modules.
 
-### `modules.<module-name>.buildPath`
+### `${modules.<module-name>.buildPath}`
 
 The build path of the module.
 
@@ -345,10 +345,10 @@ The build path of the module.
 Example:
 
 ```yaml
-buildPath: "/home/me/code/my-project/.garden/build/my-module"
+my-variable: ${modules.my-module.buildPath}
 ```
 
-### `modules.<module-name>.path`
+### `${modules.<module-name>.path}`
 
 The local path of the module.
 
@@ -359,10 +359,10 @@ The local path of the module.
 Example:
 
 ```yaml
-path: "/home/me/code/my-project/my-module"
+my-variable: ${modules.my-module.path}
 ```
 
-### `modules.<module-name>.version`
+### `${modules.<module-name>.version}`
 
 The current version of the module.
 
@@ -373,18 +373,16 @@ The current version of the module.
 Example:
 
 ```yaml
-version: "v-17ad4cb3fd"
+my-variable: ${modules.my-module.version}
 ```
 
-### `modules.<module-name>.outputs`
-
-The outputs defined by the module.
+### `${modules.<module-name>.outputs}`
 
 | Type     | Required |
 | -------- | -------- |
 | `object` | Yes      |
 
-### `modules.<module-name>.outputs.endpoint`
+### `${modules.<module-name>.outputs.endpoint}`
 
 [outputs](#outputs) > endpoint
 

--- a/docs/reference/module-types/terraform.md
+++ b/docs/reference/module-types/terraform.md
@@ -286,7 +286,7 @@ version: 0.12.7
 The following keys are available via the `${modules.<module-name>}` template string key for `terraform`
 modules.
 
-### `modules.<module-name>.buildPath`
+### `${modules.<module-name>.buildPath}`
 
 The build path of the module.
 
@@ -297,10 +297,10 @@ The build path of the module.
 Example:
 
 ```yaml
-buildPath: "/home/me/code/my-project/.garden/build/my-module"
+my-variable: ${modules.my-module.buildPath}
 ```
 
-### `modules.<module-name>.path`
+### `${modules.<module-name>.path}`
 
 The local path of the module.
 
@@ -311,10 +311,10 @@ The local path of the module.
 Example:
 
 ```yaml
-path: "/home/me/code/my-project/my-module"
+my-variable: ${modules.my-module.path}
 ```
 
-### `modules.<module-name>.version`
+### `${modules.<module-name>.version}`
 
 The current version of the module.
 
@@ -325,12 +325,18 @@ The current version of the module.
 Example:
 
 ```yaml
-version: "v-17ad4cb3fd"
+my-variable: ${modules.my-module.version}
 ```
 
-### `modules.<module-name>.outputs`
 
-The outputs defined by the module.
+### Service outputs
+
+The following keys are available via the `${runtime.services.<service-name>}` template string key for `terraform` module services.
+Note that these are only resolved when deploying/running dependants of the service, so they are not usable for every field.
+
+### `${runtime.services.<service-name>.outputs}`
+
+A map of all the outputs defined in the Terraform stack.
 
 | Type     | Required |
 | -------- | -------- |

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -948,7 +948,15 @@ providers:
 
 The following keys are available via the `${providers.<provider-name>}` template string key for `kubernetes` providers.
 
-### `providers.<provider-name>.app-namespace`
+### `${providers.<provider-name>.outputs}`
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | Yes      |
+
+### `${providers.<provider-name>.outputs.app-namespace}`
+
+[outputs](#outputs) > app-namespace
 
 The primary namespace used for resource deployments.
 
@@ -956,7 +964,9 @@ The primary namespace used for resource deployments.
 | -------- | -------- |
 | `string` | Yes      |
 
-### `providers.<provider-name>.default-hostname`
+### `${providers.<provider-name>.outputs.default-hostname}`
+
+[outputs](#outputs) > default-hostname
 
 The default hostname configured on the provider.
 
@@ -964,7 +974,9 @@ The default hostname configured on the provider.
 | -------- | -------- |
 | `string` | No       |
 
-### `providers.<provider-name>.metadata-namespace`
+### `${providers.<provider-name>.outputs.metadata-namespace}`
+
+[outputs](#outputs) > metadata-namespace
 
 The namespace used for Garden metadata.
 

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -841,7 +841,15 @@ providers:
 
 The following keys are available via the `${providers.<provider-name>}` template string key for `local-kubernetes` providers.
 
-### `providers.<provider-name>.app-namespace`
+### `${providers.<provider-name>.outputs}`
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | Yes      |
+
+### `${providers.<provider-name>.outputs.app-namespace}`
+
+[outputs](#outputs) > app-namespace
 
 The primary namespace used for resource deployments.
 
@@ -849,7 +857,9 @@ The primary namespace used for resource deployments.
 | -------- | -------- |
 | `string` | Yes      |
 
-### `providers.<provider-name>.default-hostname`
+### `${providers.<provider-name>.outputs.default-hostname}`
+
+[outputs](#outputs) > default-hostname
 
 The default hostname configured on the provider.
 
@@ -857,7 +867,9 @@ The default hostname configured on the provider.
 | -------- | -------- |
 | `string` | No       |
 
-### `providers.<provider-name>.metadata-namespace`
+### `${providers.<provider-name>.outputs.metadata-namespace}`
+
+[outputs](#outputs) > metadata-namespace
 
 The namespace used for Garden metadata.
 

--- a/garden-service/src/config/config-context.ts
+++ b/garden-service/src/config/config-context.ts
@@ -368,7 +368,7 @@ const exampleModule = {
   version: exampleVersion,
 }
 
-class ServiceRuntimeContext extends ConfigContext {
+export class ServiceRuntimeContext extends ConfigContext {
   @schema(
     joiIdentifierMap(joiPrimitive())
       .required()
@@ -393,7 +393,7 @@ class ServiceRuntimeContext extends ConfigContext {
   }
 }
 
-class TaskRuntimeContext extends ServiceRuntimeContext {
+export class TaskRuntimeContext extends ServiceRuntimeContext {
   @schema(
     joiIdentifierMap(joiPrimitive())
       .required()

--- a/garden-service/src/plugins/terraform/module.ts
+++ b/garden-service/src/plugins/terraform/module.ts
@@ -86,7 +86,7 @@ export async function describeTerraformModuleType({ }: DescribeModuleTypeParams)
       provider.
     `,
     serviceOutputsSchema: joi.object()
-      .unknown(true)
+      .pattern(/.+/, joi.any())
       .description("A map of all the outputs defined in the Terraform stack."),
     schema,
   }


### PR DESCRIPTION
**What this PR does / why we need it**:

We weren't rendering certain schemas properly, this fixes that and also slightly improves rendering of template string output references for module types and providers.
