### PR TITLE
feat(container): output build log while building with debug log level

### DIFF
--- a/garden-service/src/plugins/container/helpers.ts
+++ b/garden-service/src/plugins/container/helpers.ts
@@ -12,6 +12,7 @@ import { ConfigurationError, RuntimeError } from "../../exceptions"
 import { splitFirst, spawn, splitLast } from "../../util/util"
 import { ModuleConfig } from "../../config/module"
 import { ContainerModule, ContainerRegistryConfig, defaultTag, defaultNamespace, ContainerModuleConfig } from "./config"
+import { Writable } from "stream"
 
 export const DEFAULT_BUILD_TIMEOUT = 600
 export const minDockerVersion = "17.07.0"
@@ -251,14 +252,14 @@ const helpers = {
 
   async dockerCli(
     module: ContainerModule, args: string[],
-    { timeout = DEFAULT_BUILD_TIMEOUT }: { timeout?: number } = {},
+    { outputStream, timeout = DEFAULT_BUILD_TIMEOUT }: { outputStream?: Writable, timeout?: number } = {},
   ) {
     await helpers.checkDockerVersion()
 
     const cwd = module.buildPath
 
     try {
-      const res = await spawn("docker", args, { cwd, timeout })
+      const res = await spawn("docker", args, { cwd, outputStream, timeout })
       return res.output || ""
     } catch (err) {
       throw new RuntimeError(

--- a/garden-service/src/plugins/kubernetes/run.ts
+++ b/garden-service/src/plugins/kubernetes/run.ts
@@ -13,6 +13,7 @@ import { LogEntry } from "../../logger/log-entry"
 import { V1PodSpec } from "@kubernetes/client-node"
 import { PluginError } from "../../exceptions"
 import { KubernetesProvider } from "./config"
+import { Writable } from "stream"
 
 interface RunPodParams {
   provider: KubernetesProvider,
@@ -24,6 +25,7 @@ interface RunPodParams {
   namespace: string,
   annotations?: { [key: string]: string }
   spec: V1PodSpec,
+  outputStream?: Writable,
   podName?: string,
   timeout?: number,
 }
@@ -39,6 +41,7 @@ export async function runPod(
     namespace,
     annotations,
     spec,
+    outputStream,
     podName,
     timeout,
   }: RunPodParams,
@@ -98,6 +101,7 @@ export async function runPod(
     namespace,
     ignoreError,
     args: kubecmd,
+    outputStream,
     timeout,
     tty: interactive,
   })

--- a/garden-service/test/unit/src/plugins/container/container.ts
+++ b/garden-service/test/unit/src/plugins/container/container.ts
@@ -540,7 +540,7 @@ describe("plugins.container", () => {
       })
 
       const cmdArgs = ["build", "-t", "some/image", module.buildPath]
-      td.verify(dockerCli(module, cmdArgs, { timeout: DEFAULT_BUILD_TIMEOUT }))
+      td.verify(dockerCli(module, cmdArgs), { ignoreExtraArgs: true })
     })
 
     it("should set build target image parameter if configured", async () => {
@@ -564,7 +564,7 @@ describe("plugins.container", () => {
       })
 
       const cmdArgs = ["build", "-t", "some/image", "--target", "foo", module.buildPath]
-      td.verify(dockerCli(module, cmdArgs, { timeout: DEFAULT_BUILD_TIMEOUT }))
+      td.verify(dockerCli(module, cmdArgs), { ignoreExtraArgs: true })
     })
 
     it("should build image using the user specified Dockerfile path", async () => {
@@ -596,7 +596,7 @@ describe("plugins.container", () => {
         join(module.buildPath, relDockerfilePath),
         module.buildPath,
       ]
-      td.verify(dockerCli(module, cmdArgs, { timeout: DEFAULT_BUILD_TIMEOUT }))
+      td.verify(dockerCli(module, cmdArgs), { ignoreExtraArgs: true })
     })
   })
 


### PR DESCRIPTION
When using the fancy logger we only show one line at a time, but you
could use the basic logger to get the full log.

This should be helpful when debugging docker builds.

Closes #852
