### PR TITLE
chore: use our own rsync image

### DIFF
--- a/garden-service/src/plugins/kubernetes/hot-reload.ts
+++ b/garden-service/src/plugins/kubernetes/hot-reload.ts
@@ -114,7 +114,7 @@ export function configureHotReload({
 
   const rsyncContainer = {
     name: "garden-rsync",
-    image: "eugenmayer/rsync",
+    image: "gardendev/rsync:0.1",
     imagePullPolicy: "IfNotPresent",
     env: [
       // This makes sure the server is accessible on any IP address, because CIDRs can be different across clusters.

--- a/garden-service/static/kubernetes/system/build-sync/templates/deployment.yaml
+++ b/garden-service/static/kubernetes/system/build-sync/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
             claimName: garden-build-sync
       containers:
         - name: sync
-          image: "eugenmayer/rsync:latest"
+          image: "gardendev/rsync:0.1"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: rsync

--- a/garden-service/test/unit/src/plugins/kubernetes/hot-reload.ts
+++ b/garden-service/test/unit/src/plugins/kubernetes/hot-reload.ts
@@ -72,7 +72,7 @@ describe("configureHotReload", () => {
               },
               {
                 name: "garden-rsync",
-                image: "eugenmayer/rsync",
+                image: "gardendev/rsync:0.1",
                 imagePullPolicy: "IfNotPresent",
                 env: [
                   {


### PR DESCRIPTION
This is mostly a security issue. We want to control the code we use,
instead of using a mutable tag maintained by a stranger. The code
is unchanged though, so this should have no effect for users.

Closes #666 👹