### PR TITLE
fix: running task would print undefined

### DIFF
--- a/garden-service/src/commands/run/task.ts
+++ b/garden-service/src/commands/run/task.ts
@@ -64,7 +64,9 @@ export class RunTaskCommand extends Command<Args, Opts> {
 
     if (!result.error) {
       log.info("")
-      log.info(chalk.white(result.output.output))
+      // TODO: The command will need to be updated to stream logs: see https://github.com/garden-io/garden/issues/630.
+      // It's ok with the current providers but the shape might change in the future.
+      log.info(chalk.white(result.output.outputs.log))
       printFooter(footerLog)
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:
The shape of the `TaskResult` output has changed and the logger was printing undefined instead fo the `TaskResult` output
**Which issue(s) this PR fixes**:

Fixes #1137 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
