### PR TITLE
fix(exec): wrong cwd when running `exec` module tests

### DIFF
--- a/garden-service/src/plugins/exec.ts
+++ b/garden-service/src/plugins/exec.ts
@@ -163,7 +163,7 @@ export async function testExecModule({ module, testConfig }: TestModuleParams<Ex
   const result = await execa.shell(
     command.join(" "),
     {
-      cwd: module.path,
+      cwd: module.buildPath,
       env: {
         ...process.env,
         // need to cast the values to strings


### PR DESCRIPTION
**What this PR does / why we need it**:
We were running exec module tests in the source path, and not the build path, which was inconsistent with exec tasks.