### PR TITLE
fix: allow dots in env variable names

### DIFF
--- a/garden-service/src/config/common.ts
+++ b/garden-service/src/config/common.ts
@@ -168,7 +168,7 @@ export const absolutePathRegex = /^\/.*/ // Note: Only checks for the leading sl
 // from https://stackoverflow.com/a/12311250/3290965
 export const identifierRegex = /^(?![0-9]+$)(?!.*-$)(?!-)[a-z0-9-]{1,63}$/
 export const userIdentifierRegex = /^(?!garden)(?=.{1,63}$)[a-z][a-z0-9]*(-[a-z0-9]+)*$/
-export const envVarRegex = /^(?!garden)[a-z_][a-z0-9_]*$/i
+export const envVarRegex = /^(?!garden)[a-z_][a-z0-9_\.]*$/i
 
 export const joiIdentifierDescription =
   "valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and dashes, must start with a letter, " +

--- a/garden-service/test/unit/src/config/common.ts
+++ b/garden-service/test/unit/src/config/common.ts
@@ -36,6 +36,7 @@ describe("envVarRegex", () => {
       "_2134",
       "a_b_c",
       "A_B_C_",
+      "some.var", // This is not strictly valid POSIX, but a bunch of Java services use this style
     ]
     for (const tc of testCases) {
       const result = envVarRegex.test(tc)


### PR DESCRIPTION
This is to accommodate Java services that expect this format
(e.g. "some.var"). It's not expressly permitted in POSIX but is
apparently commonly used, so I see no reason to disallow it.
