### PR TITLE
fix(k8s): error when retrieving older test results from cache

### DIFF
--- a/garden-service/src/plugins/kubernetes/container/test.ts
+++ b/garden-service/src/plugins/kubernetes/container/test.ts
@@ -56,5 +56,15 @@ export async function testContainerModule(
     timeout,
   })
 
-  return storeTestResult({ ctx, log, module, testName, testVersion, result })
+  return storeTestResult({
+    ctx,
+    log,
+    module,
+    testName,
+    testVersion,
+    result: {
+      testName,
+      ...result,
+    },
+  })
 }

--- a/garden-service/src/plugins/kubernetes/helm/test.ts
+++ b/garden-service/src/plugins/kubernetes/helm/test.ts
@@ -71,6 +71,9 @@ export async function testHelmModule(
     module,
     testName,
     testVersion,
-    result,
+    result: {
+      testName,
+      ...result,
+    },
   })
 }

--- a/garden-service/src/plugins/kubernetes/task-results.ts
+++ b/garden-service/src/plugins/kubernetes/task-results.ts
@@ -36,16 +36,12 @@ export async function getTaskResult(
     const result: any = deserializeValues(res.data!)
 
     // Backwards compatibility for modified result schema
-    if (result.output) {
-      result.log = result.output
-    }
-
     if (!result.outputs) {
       result.outputs = {}
     }
 
-    if (!result.outputs.stdout) {
-      result.outputs.log = result.log
+    if (!result.outputs.log) {
+      result.outputs.log = result.log || ""
     }
 
     if (result.version.versionString) {
@@ -89,14 +85,7 @@ export async function storeTaskResult(
   const api = await KubeApi.factory(log, provider)
   const namespace = await getMetadataNamespace(ctx, log, provider)
 
-  result = trimRunOutput(result)
-
-  const data: RunTaskResult = {
-    ...result,
-    outputs: {
-      log: result.log,
-    },
-  }
+  const data = trimRunOutput(result)
 
   await upsertConfigMap({
     api,

--- a/garden-service/src/types/plugin/task/runTask.ts
+++ b/garden-service/src/types/plugin/task/runTask.ts
@@ -22,14 +22,7 @@ export interface RunTaskParams<T extends Module = Module> extends PluginTaskActi
 }
 
 export interface RunTaskResult extends RunResult {
-  moduleName: string
   taskName: string
-  command: string[]
-  version: string
-  success: boolean
-  startedAt: Date
-  completedAt: Date
-  log: string
   outputs: PrimitiveMap
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

If users had cached test results, we weren't properly converting the old schema when reading the results. This would not have affected users on previous versions, this issue only affected the current master.