### PR TITLE
fix: error in test result output schema

### DIFF
--- a/garden-service/src/types/plugin/base.ts
+++ b/garden-service/src/types/plugin/base.ts
@@ -104,8 +104,8 @@ export const runResultSchema = joi.object()
       .required()
       .description("When the module run was completed."),
     log: joi.string()
-      .required()
       .allow("")
+      .default("")
       .description("The output log from the run."),
     output: joi.string()
       .allow("")


### PR DESCRIPTION
This caused breaking errors when retrieving outdated test results.

We may want to release this quickly as a hot patch release, it's
possible this is affecting a number of users.

cc @eysi09 