### PR TITLE
fix(get-service-status): add build dependencies

### DIFF
--- a/garden-service/src/tasks/build.ts
+++ b/garden-service/src/tasks/build.ts
@@ -20,7 +20,6 @@ export interface BuildTaskParams {
   log: LogEntry
   module: Module
   force: boolean
-  fromWatch?: boolean
   hotReloadServiceNames?: string[]
 }
 
@@ -28,13 +27,11 @@ export class BuildTask extends BaseTask {
   type: TaskType = "build"
 
   private module: Module
-  private fromWatch: boolean
   private hotReloadServiceNames: string[]
 
-  constructor({ garden, log, module, force, fromWatch = false, hotReloadServiceNames = [] }: BuildTaskParams) {
+  constructor({ garden, log, module, force, hotReloadServiceNames = [] }: BuildTaskParams) {
     super({ garden, log, force, version: module.version })
     this.module = module
-    this.fromWatch = fromWatch
     this.hotReloadServiceNames = hotReloadServiceNames
   }
 
@@ -48,7 +45,6 @@ export class BuildTask extends BaseTask {
         log: this.log,
         module: m,
         force: this.force,
-        fromWatch: this.fromWatch,
         hotReloadServiceNames: this.hotReloadServiceNames,
       })
     })

--- a/garden-service/src/tasks/deploy.ts
+++ b/garden-service/src/tasks/deploy.ts
@@ -113,7 +113,6 @@ export class DeployTask extends BaseTask {
         log: this.log,
         module: this.service.module,
         force: this.forceBuild,
-        fromWatch: this.fromWatch,
         hotReloadServiceNames: this.hotReloadServiceNames,
       })
 


### PR DESCRIPTION
For GetServiceStatusTask-s, added a dependency on the parent module's build dependencies.

This ensures that any build dependency products have been synced into the module's build directory before any syncs from there take place in GetServiceStatusTask's process method.

Here's a link to the Slack thread where this was raised earlier today: https://kubernetes.slack.com/archives/CKM7CP8P9/p1567645481080200