### PR TITLE
fix(tasks): respect force flag in task task

### DIFF
--- a/garden-service/src/tasks/task.ts
+++ b/garden-service/src/tasks/task.ts
@@ -109,14 +109,16 @@ export class TaskTask extends BaseTask { // ... to be renamed soon.
 
     // TODO: Re-enable this logic when we've started providing task graph results to process methods.
 
-    const cachedResult = getRunTaskResults(dependencyResults)[this.task.name]
+    if (!this.force) {
+      const cachedResult = getRunTaskResults(dependencyResults)[this.task.name]
 
-    if (cachedResult && cachedResult.success) {
-      this.log.info({
-        section: task.name,
-      }).setSuccess({ msg: chalk.green("Already run") })
+      if (cachedResult && cachedResult.success) {
+        this.log.info({
+          section: task.name,
+        }).setSuccess({ msg: chalk.green("Already run") })
 
-      return cachedResult
+        return cachedResult
+      }
     }
 
     const log = this.log.info({


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes an issue where the `force` flag was not respected when running task tasks.
