### PR TITLE
fix(minikube): fix to environment init

### DIFF
--- a/garden-service/src/garden.ts
+++ b/garden-service/src/garden.ts
@@ -297,9 +297,9 @@ export class Garden {
       } catch (error) {
         throw new ConfigurationError(
           `Unable to load plugin "${moduleNameOrLocation}" (could not load module: ${error.message})`, {
-          message: error.message,
-          moduleNameOrLocation,
-        })
+            message: error.message,
+            moduleNameOrLocation,
+          })
       }
 
       try {

--- a/garden-service/src/plugins/kubernetes/init.ts
+++ b/garden-service/src/plugins/kubernetes/init.ts
@@ -69,9 +69,6 @@ export async function getEnvironmentStatus({ ctx, log }: GetEnvironmentStatusPar
   }
 
   if (
-    // No need to continue if we don't need any system services
-    systemServiceNames.length === 0
-    ||
     // Make sure we don't recurse infinitely
     provider.config.namespace === systemNamespace
   ) {
@@ -148,7 +145,7 @@ export async function prepareSystem(
   const systemReady = status.detail && !!status.detail.systemReady && !force
   const systemServiceNames = k8sCtx.provider.config._systemServices
 
-  if (systemServiceNames.length === 0 || systemReady) {
+  if (systemReady) {
     return {}
   }
 
@@ -189,8 +186,8 @@ export async function prepareSystem(
       \`garden --env=${ctx.environmentName} plugins kubernetes cluster-init\`
       to initialize them, or contact a cluster admin to do so, before deploying services to this cluster.
     `, {
-      status,
-    })
+        status,
+      })
   }
 
   // Install Tiller to system namespace


### PR DESCRIPTION
**What this PR does / why we need it**:

Before this fix, the `garden-system--metadata` namespace wasn't being created during environment init when using minikube.

Since test results are stored in this namespace, this would lead to errors when running `garden test`.

**Which issue(s) this PR fixes**:

Fixes #1167.

**Special notes for your reviewer**:

Is this an appropriate change to the init flow, @eysi09 @edvald?

**Does this PR introduce a user-facing change?**:

Nyet.