### PR TITLE
fix(k8s): ensure sys metadata ns exists for tests

### DIFF
--- a/garden-service/src/plugins/kubernetes/test-results.ts
+++ b/garden-service/src/plugins/kubernetes/test-results.ts
@@ -21,6 +21,7 @@ import * as hasha from "hasha"
 import { gardenAnnotationKey } from "../../util/string"
 import { upsertConfigMap } from "./util"
 import { trimRunOutput } from "./helm/common"
+import { ensureNamespace } from "./namespace"
 
 const testResultNamespace = systemMetadataNamespace
 
@@ -29,6 +30,7 @@ export async function getTestResult(
 ): Promise<TestResult | null> {
   const k8sCtx = <KubernetesPluginContext>ctx
   const api = await KubeApi.factory(log, k8sCtx.provider)
+  await ensureNamespace(api, testResultNamespace)
   const resultKey = getTestResultKey(k8sCtx, module, testName, testVersion)
 
   try {
@@ -83,6 +85,7 @@ export async function storeTestResult(
 ): Promise<TestResult> {
   const k8sCtx = <KubernetesPluginContext>ctx
   const api = await KubeApi.factory(log, k8sCtx.provider)
+  await ensureNamespace(api, testResultNamespace)
 
   const data: TestResult = trimRunOutput(result)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:

When storing or getting test results, ensure that the `garden-system--metadata` namespace exists.

This fixes an issue when using minikube (https://github.com/garden-io/garden/issues/1167), where this namespace wouldn't automatically be created during init, leading to errors when tests were run.

**Which issue(s) this PR fixes**:

Fixes #1167.