### PR TITLE
docs: mention cluster-init step

### DIFF
--- a/docs/basics/quick-start.md
+++ b/docs/basics/quick-start.md
@@ -15,7 +15,21 @@ git clone https://github.com/garden-io/garden.git
 cd garden/examples/demo-project
 ```
 
-First, let's check the environment status by running the following from the project root:
+If you'd like to use a remote Kubernetes cluster, include the option `--env=remote` when invoking the `garden` commands below, or uncomment the line
+
+```sh
+defaultEnvironment: remote
+```
+
+in the project `garden.yml`.
+
+Also, if your remote cluster hasn't previously been set up for Garden, start by running the following from the project root:
+
+``` sh
+garden plugins kubernetes cluster-init --env=remote
+```
+
+Now, let's check the environment status by running the following:
 
 ```sh
 garden get status

--- a/docs/examples/demo-project.md
+++ b/docs/examples/demo-project.md
@@ -138,9 +138,23 @@ The [services](../using-garden/configuration-files.md#Services) field is specifi
 
 ## Deploying
 
-With this configuration, Garden can now deploy our service to a local Kubernetes cluster. If this is your first time deploying this project, Garden will start by initializing the environment.
+With this configuration, Garden can now deploy our service to a local Kubernetes cluster.
 
-To deploy, run:
+If you'd like to use a remote Kubernetes cluster, include the option `--env=remote` when invoking the `garden` commands below, or uncomment the line
+
+```sh
+defaultEnvironment: remote
+```
+
+in the project `garden.yml`.
+
+Also, if your remote cluster hasn't previously been set up for Garden, start by running the following from the project root:
+
+``` sh
+garden plugins kubernetes cluster-init --env=remote
+```
+
+The first time you deploy this project, Garden will start by initializing the environment. To deploy, run:
 
 ```sh
 garden deploy

--- a/examples/demo-project/garden.yml
+++ b/examples/demo-project/garden.yml
@@ -1,5 +1,6 @@
 kind: Project
 name: demo-project
+# defaultEnvironment: "remote" # Uncomment if you'd like the remote environment to be the default for this project.
 environments:
   - name: local
     providers:


### PR DESCRIPTION
Added mentions of the `cluster-init` step for remote clusters to the _Quick Start_ and _Demo Project_ guides.