### PR TITLE
fix(k8s): helm returned deprecated manifest version for tiller

### DIFF
--- a/garden-service/src/plugins/kubernetes/helm/tiller.ts
+++ b/garden-service/src/plugins/kubernetes/helm/tiller.ts
@@ -17,6 +17,7 @@ import { combineStates } from "../../../types/service"
 import { apply } from "../kubectl"
 import { KubernetesProvider, KubernetesPluginContext } from "../config"
 import chalk from "chalk"
+import { convertDeprecatedManifestVersion } from "../util"
 
 const serviceAccountName = "garden-tiller"
 
@@ -84,6 +85,7 @@ async function getTillerResources(
   })
 
   const resources = safeLoadAll(tillerManifests)
+    .map(convertDeprecatedManifestVersion)
 
   return resources
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Helm was returning an out-of-date manifest version for Tiller, which caused issues with Kubernetes 1.16. We patch it by converting the manifest version ourselves.

**Which issue(s) this PR fixes**:

Fixes #1166
