### PR TITLE
improvement(config): add linkUrl field

### DIFF
--- a/dashboard/src/components/ingresses.tsx
+++ b/dashboard/src/components/ingresses.tsx
@@ -10,9 +10,7 @@ import React from "react"
 import styled from "@emotion/styled"
 import { ExternalLink } from "./links"
 import { ServiceIngress } from "garden-service/build/src/types/service"
-import { truncateMiddle } from "../util/helpers"
-import normalizeUrl from "normalize-url"
-import { format } from "url"
+import { truncateMiddle, getLinkUrl } from "../util/helpers"
 import { useUiState } from "../contexts/ui"
 
 const Ingresses = styled.div`
@@ -42,15 +40,6 @@ const LinkContainer = styled.div`
   }
 `
 
-const getIngressUrl = (ingress: ServiceIngress) => {
-  return normalizeUrl(format({
-    protocol: ingress.protocol,
-    hostname: ingress.hostname,
-    port: ingress.port,
-    pathname: ingress.path,
-  }))
-}
-
 interface IngressesProp {
   ingresses: ServiceIngress[] | undefined
 }
@@ -70,7 +59,7 @@ export default ({ ingresses }: IngressesProp) => {
   return (
     <Ingresses>
       {(ingresses || []).map((ingress) => {
-        const url = getIngressUrl(ingress)
+        const url = getLinkUrl(ingress)
         return (
           <LinkContainer key={ingress.path}>
             <div className="visible-lg-block">

--- a/dashboard/src/components/view-ingress.tsx
+++ b/dashboard/src/components/view-ingress.tsx
@@ -10,9 +10,7 @@ import React from "react"
 import styled from "@emotion/styled"
 import { ExternalLink } from "./links"
 import { ServiceIngress } from "garden-service/build/src/types/service"
-import { truncateMiddle } from "../util/helpers"
-import normalizeUrl from "normalize-url"
-import { format } from "url"
+import { truncateMiddle, getLinkUrl } from "../util/helpers"
 import { useUiState } from "../contexts/ui"
 import { ActionIcon } from "./action-icon"
 
@@ -58,15 +56,6 @@ const Frame = styled.iframe`
   width: 100%;
 `
 
-const getIngressUrl = (ingress: ServiceIngress) => {
-  return normalizeUrl(format({
-    protocol: ingress.protocol,
-    hostname: ingress.hostname,
-    port: ingress.port,
-    pathname: ingress.path,
-  }))
-}
-
 interface ViewIngressProp {
   ingress: ServiceIngress,
   height?: string,
@@ -80,7 +69,7 @@ export default ({ ingress, height, width }: ViewIngressProp) => {
     selectIngress(null)
   }
 
-  const url = getIngressUrl(ingress)
+  const url = getLinkUrl(ingress)
 
   return (
     <ViewIngress>

--- a/dashboard/src/util/helpers.ts
+++ b/dashboard/src/util/helpers.ts
@@ -6,8 +6,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import normalizeUrl from "normalize-url"
+import { format } from "url"
 import { flatten } from "lodash"
 import { ModuleConfig } from "garden-service/build/src/config/module"
+import { ServiceIngress } from "garden-service/build/src/types/service"
 
 export function getServiceNames(moduleConfigs: ModuleConfig[]) {
   return flatten(moduleConfigs.map(m => m.serviceConfigs.map(s => s.name)))
@@ -48,4 +51,20 @@ export const truncateMiddle = (str: string, resLength: number = 35) => {
   }
 
   return str
+}
+
+/**
+ * Returns the link URL or falls back to constructing the URL from the ingress spec
+ */
+export function getLinkUrl(ingress: ServiceIngress) {
+  if (ingress.linkUrl) {
+    return ingress.linkUrl
+  }
+
+  return normalizeUrl(format({
+    protocol: ingress.protocol,
+    hostname: ingress.hostname,
+    port: ingress.port,
+    pathname: ingress.path,
+  }))
 }

--- a/dashboard/src/util/hooks.tsx
+++ b/dashboard/src/util/hooks.tsx
@@ -30,4 +30,4 @@ export const useConfig = (dispatch: ApiDispatch, requestState: RequestState) => 
  * See e.g. here: https://github.com/facebook/react/issues/15865.
  * Here's the suggested solution: https://github.com/facebook/create-react-app/issues/6880#issuecomment-488158024
  */
-export const useMountEffect = (fun: () => void) => useEffect(fun, [])
+export const useMountEffect = (fn: () => void) => useEffect(fn, [])

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -481,6 +481,22 @@ Note that if you're developing locally you may need to add this hostname to your
 | -------- | -------- |
 | `string` | No       |
 
+### `services[].ingresses[].linkUrl`
+
+[services](#services) > [ingresses](#services[].ingresses[]) > linkUrl
+
+The link URL for the ingress to show in the console and on the dashboard.
+Also used when calling the service with the `call` command.
+
+Use this if the actual URL is different from what's specified in the ingress,
+e.g. because there's a load balancer in front of the service that rewrites the paths.
+
+Otherwise Garden will construct the link URL from the ingress spec.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
 ### `services[].ingresses[].path`
 
 [services](#services) > [ingresses](#services[].ingresses[]) > path
@@ -1046,6 +1062,7 @@ services:
     ingresses:
       - annotations: {}
         hostname:
+        linkUrl:
         path: /
         port:
     env: {}

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -486,6 +486,22 @@ Note that if you're developing locally you may need to add this hostname to your
 | -------- | -------- |
 | `string` | No       |
 
+### `services[].ingresses[].linkUrl`
+
+[services](#services) > [ingresses](#services[].ingresses[]) > linkUrl
+
+The link URL for the ingress to show in the console and on the dashboard.
+Also used when calling the service with the `call` command.
+
+Use this if the actual URL is different from what's specified in the ingress,
+e.g. because there's a load balancer in front of the service that rewrites the paths.
+
+Otherwise Garden will construct the link URL from the ingress spec.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
 ### `services[].ingresses[].path`
 
 [services](#services) > [ingresses](#services[].ingresses[]) > path
@@ -1081,6 +1097,7 @@ services:
     ingresses:
       - annotations: {}
         hostname:
+        linkUrl:
         path: /
         port:
     env: {}

--- a/garden-service/src/plugins/container/config.ts
+++ b/garden-service/src/plugins/container/config.ts
@@ -18,7 +18,7 @@ import {
   envVarRegex,
   Primitive,
 } from "../../config/common"
-import { Service, ingressHostnameSchema } from "../../types/service"
+import { Service, ingressHostnameSchema, linkUrlSchema } from "../../types/service"
 import { DEFAULT_PORT_PROTOCOL } from "../../constants"
 import { ModuleSpec, ModuleConfig, baseBuildSpecSchema, BaseBuildSpec } from "../../config/module"
 import { CommonServiceSpec, ServiceConfig, baseServiceSpecSchema } from "../../config/service"
@@ -33,6 +33,7 @@ export const defaultContainerLimits: ServiceLimitSpec = {
 
 export interface ContainerIngressSpec {
   annotations: Annotations
+  linkUrl?: string
   hostname?: string
   path: string
   port: string
@@ -185,6 +186,7 @@ const ingressSchema = joi.object()
     annotations: annotationsSchema
       .description("Annotations to attach to the ingress (Note: May not be applicable to all providers)"),
     hostname: ingressHostnameSchema,
+    linkUrl: linkUrlSchema,
     path: joi.string()
       .default("/")
       .description("The path which should be routed to the service."),

--- a/garden-service/src/plugins/kubernetes/container/ingress.ts
+++ b/garden-service/src/plugins/kubernetes/container/ingress.ts
@@ -125,6 +125,7 @@ export async function getIngresses(
       hostname: ingress.hostname,
       path: ingress.path,
       port: ingress.port,
+      linkUrl: ingress.linkUrl,
       protocol: ingress.protocol,
     }))
 }

--- a/garden-service/src/tasks/deploy.ts
+++ b/garden-service/src/tasks/deploy.ts
@@ -11,7 +11,7 @@ import chalk from "chalk"
 import { includes } from "lodash"
 import { LogEntry } from "../logger/log-entry"
 import { BaseTask, TaskType, getServiceStatuses, getRunTaskResults } from "./base"
-import { Service, ServiceStatus, getIngressUrl } from "../types/service"
+import { Service, ServiceStatus, getLinkUrl } from "../types/service"
 import { Garden } from "../garden"
 import { TaskTask, getTaskVersion } from "./task"
 import { BuildTask } from "./build"
@@ -188,7 +188,7 @@ export class DeployTask extends BaseTask {
     }
 
     for (const ingress of status.ingresses || []) {
-      log.info(chalk.gray("→ Ingress: ") + chalk.underline.gray(getIngressUrl(ingress)))
+      log.info(chalk.gray("→ Ingress: ") + chalk.underline.gray(getLinkUrl(ingress)))
     }
 
     if (this.garden.persistent) {


### PR DESCRIPTION
EDIT: Depends on #1234. Please review and merge that first. (This is because that one contains fixes that I hoped resolved the build error we were seeing. They don't. See comment below).

**What this PR does / why we need it**:

Allows the user to set the display URL for a service ingress that Garden prints in the console, displays in the Dashboard, and uses for the `call` command.

We need this because the URL is different from what Garden constructs from the ingress spec, e.g. because the user has a load balancer in front of the services that re-writes paths or secures them.

**Which issue(s) this PR fixes**:

Closes #1185 

**Special notes for your reviewer**:

We've debated the name for the field and might still want to change it. Here are some contenders:

- `ingressUrl`
- `linkUrl`
- `actualUrl`

Basically, the opposite of the inferred URL (cc @thsig).