### PR TITLE
fix(k8s): don't include any hooks when checking resource statuses

### DIFF
--- a/garden-service/src/plugins/kubernetes/helm/common.ts
+++ b/garden-service/src/plugins/kubernetes/helm/common.ts
@@ -68,8 +68,14 @@ export async function getChartResources(ctx: PluginContext, module: Module, log:
 
   const resources = objects
     .filter(obj => {
+      // Don't try to check status of hooks
       const helmHook = getAnnotation(obj, "helm.sh/hook")
-      if (helmHook && helmHook.startsWith("test-")) {
+      if (helmHook) {
+        return false
+      }
+
+      // Ephemeral objects should also not be checked
+      if (obj.kind === "Pod" || obj.kind === "Job") {
         return false
       }
 

--- a/garden-service/test/unit/src/plugins/kubernetes/helm/common.ts
+++ b/garden-service/test/unit/src/plugins/kubernetes/helm/common.ts
@@ -462,7 +462,7 @@ describe("Helm common functions", () => {
       expect(await getChartResources(ctx, module, log)).to.not.throw
     })
 
-    it("should filter out test pods", async () => {
+    it("should filter out resources with hooks", async () => {
       const module = await graph.getModule("chart-with-test-pod")
       const resources = await getChartResources(ctx, module, log)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously we were only filtering out _test_ hooks, but we should in fact filter all of them out. Also filtered out ephemeral objects (Pod and Job) since they shouldn't be expected to persist.

**Which issue(s) this PR fixes**:

Fixes #1205
