### PR TITLE
feat(k8s): add timeout parameter to helm module type

### DIFF
--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -696,6 +696,14 @@ tests:
           key: some-key
 ```
 
+### `timeout`
+
+Time in seconds to wait for Helm to complete any individual Kubernetes operation (like Jobs for hooks).
+
+| Type     | Required | Default |
+| -------- | -------- | ------- |
+| `number` | No       | `300`   |
+
 ### `version`
 
 The chart version to deploy.
@@ -785,6 +793,7 @@ tests:
       hotReloadArgs:
     args:
     env: {}
+timeout: 300
 version:
 values: {}
 valueFiles: []

--- a/garden-service/src/plugins/kubernetes/helm/config.ts
+++ b/garden-service/src/plugins/kubernetes/helm/config.ts
@@ -29,6 +29,8 @@ import { ContainerModule, ContainerEnvVars, containerEnvVarsSchema, commandExamp
 import { baseBuildSpecSchema } from "../../../config/module"
 import { ConfigureModuleParams, ConfigureModuleResult } from "../../../types/plugin/module/configure"
 
+export const defaultHelmTimeout = 300
+
 // A Helm Module always maps to a single Service
 export type HelmModuleSpec = HelmServiceSpec
 
@@ -140,6 +142,7 @@ export interface HelmServiceSpec extends ServiceSpec {
   skipDeploy: boolean
   tasks: HelmTaskSpec[]
   tests: HelmTestSpec[]
+  timeout: number
   version?: string
   values: DeepPrimitiveMap
   valueFiles: string[]
@@ -205,6 +208,12 @@ export const helmModuleSpecSchema = joi.object().keys({
     .description("The task definitions for this module."),
   tests: joiArray(execTestSchema)
     .description("The test suite definitions for this module."),
+  timeout: joi.number()
+    .integer()
+    .default(defaultHelmTimeout)
+    .description(
+      "Time in seconds to wait for Helm to complete any individual Kubernetes operation (like Jobs for hooks).",
+    ),
   version: joi.string()
     .description("The chart version to deploy."),
   values: joi.object()

--- a/garden-service/src/plugins/openfaas/openfaas.ts
+++ b/garden-service/src/plugins/openfaas/openfaas.ts
@@ -142,6 +142,7 @@ async function configureProvider(
       skipDeploy: false,
       tasks: [],
       tests: [],
+      timeout: 900,
       version: "4.4.0",
       releaseName,
       values: {

--- a/garden-service/test/unit/src/plugins/kubernetes/helm/config.ts
+++ b/garden-service/test/unit/src/plugins/kubernetes/helm/config.ts
@@ -8,6 +8,7 @@ import { deline } from "../../../../../../src/util/string"
 import { ModuleConfig } from "../../../../../../src/config/module"
 import { apply } from "json-merge-patch"
 import { getHelmTestGarden } from "./common"
+import { defaultHelmTimeout } from "../../../../../../src/plugins/kubernetes/helm/config"
 
 describe("validateHelmModule", () => {
   let garden: TestGarden
@@ -77,6 +78,7 @@ describe("validateHelmModule", () => {
             skipDeploy: false,
             tasks: [],
             tests: [],
+            timeout: defaultHelmTimeout,
             values: {
               image: {
                 tag: versionString,
@@ -109,6 +111,7 @@ describe("validateHelmModule", () => {
         skipDeploy: false,
         tasks: [],
         tests: [],
+        timeout: defaultHelmTimeout,
         values: {
           image: {
             tag: versionString,


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously we hard-coded a value of 600 seconds. This simply makes it configurable.

**Which issue(s) this PR fixes**:

Closes #1200
