### PR TITLE
fix(k8s): ensure get logs handler resolves

### DIFF
--- a/garden-service/src/plugins/kubernetes/logs.ts
+++ b/garden-service/src/plugins/kubernetes/logs.ts
@@ -51,6 +51,10 @@ export async function getPodLogs(params: GetPodLogsParams) {
   const procs = await Bluebird.map(params.pods, pod => getLogs({ ...omit(params, "pods"), pod }))
 
   return new Promise<GetServiceLogsResult>((resolve, reject) => {
+    // Make sure to resolve if no processes get created
+    if (procs.length === 0) {
+      return resolve({})
+    }
     for (const proc of procs) {
       proc.on("error", reject)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In the case of no pods being found for a given service, the `getPodLogs`
promise would never resolve, causing the process to not exit properly.

**Which issue(s) this PR fixes**:

Fixes #1226 