### PR TITLE
fix(commands): fix regression due to changes to test|task result output

### DIFF
--- a/dashboard/src/api/api.ts
+++ b/dashboard/src/api/api.ts
@@ -9,8 +9,8 @@
 import axios from "axios"
 
 import { GraphOutput } from "garden-service/build/src/commands/get/get-graph"
-import { TaskResultOutput } from "garden-service/build/src/commands/get/get-task-result"
-import { TestResultOutput } from "garden-service/build/src/commands/get/get-test-result"
+import { GetTaskResultCommandResult } from "garden-service/build/src/commands/get/get-task-result"
+import { GetTestResultCommandResult } from "garden-service/build/src/commands/get/get-test-result"
 import { ServiceLogEntry } from "garden-service/build/src/types/plugin/service/getServiceLogs"
 import { CommandResult } from "garden-service/build/src/commands/base"
 import { ConfigDump } from "garden-service/build/src/garden"
@@ -49,7 +49,7 @@ export interface FetchTaskResultParams {
 }
 
 export async function fetchTaskResult(params: FetchTaskResultParams) {
-  return apiPost<TaskResultOutput>("get.task-result", params)
+  return apiPost<GetTaskResultCommandResult>("get.task-result", params)
 }
 
 export interface FetchTestResultParams {
@@ -58,7 +58,7 @@ export interface FetchTestResultParams {
 }
 
 export async function fetchTestResult({ name, moduleName }: FetchTestResultParams) {
-  return apiPost<TestResultOutput>("get.test-result", { name, module: moduleName })
+  return apiPost<GetTestResultCommandResult>("get.test-result", { name, module: moduleName })
 }
 
 async function apiPost<T>(command: string, parameters: {} = {}): Promise<T> {
@@ -73,7 +73,7 @@ async function apiPost<T>(command: string, parameters: {} = {}): Promise<T> {
     throw res.data.errors
   }
 
-  if (!res.data.result) {
+  if (res.data.result === undefined) {
     throw new Error("Empty response from server")
   }
 

--- a/dashboard/src/containers/graph.tsx
+++ b/dashboard/src/containers/graph.tsx
@@ -24,6 +24,7 @@ import { RenderedNode } from "garden-service/build/src/config-graph"
 import { GraphOutput } from "garden-service/build/src/commands/get/get-graph"
 import { loadGraph } from "../api/actions"
 import { useConfig } from "../util/hooks"
+import { getTestKey } from "../util/helpers"
 
 const Wrapper = styled.div`
   padding-left: .75rem;
@@ -40,10 +41,12 @@ export default () => {
   const {
     dispatch,
     store: {
-      entities: { project, modules, services, tests, tasks, graph },
+      entities,
       requestStates,
     },
   } = useApi()
+
+  const { project, modules, services, tests, tasks, graph } = entities
 
   const {
     actions: { selectGraphNode, stackGraphToggleItemsView, clearGraphNodeSelection },
@@ -83,7 +86,8 @@ export default () => {
         taskState = (tasks[node.name] && tasks[node.name].taskState) || taskState
         break
       case "test":
-        taskState = (tests[node.name] && tests[node.name].taskState) || taskState
+        const testKey = getTestKey({ testName: node.name, moduleName: node.moduleName })
+        taskState = (tests[testKey] && tests[testKey].taskState) || taskState
         break
     }
     return { ...node, status: taskState }

--- a/dashboard/src/contexts/api.tsx
+++ b/dashboard/src/contexts/api.tsx
@@ -19,8 +19,8 @@ import { PickFromUnion } from "garden-service/build/src/util/util"
 import { ServiceConfig } from "garden-service/build/src/config/service"
 import { RunStatus } from "garden-service/build/src/commands/get/get-status"
 import { TaskConfig } from "garden-service/build/src/config/task"
-import { TaskResultOutput } from "garden-service/build/src/commands/get/get-task-result"
-import { TestResultOutput } from "garden-service/build/src/commands/get/get-test-result"
+import { GetTaskResultCommandResult } from "garden-service/build/src/commands/get/get-task-result"
+import { GetTestResultCommandResult } from "garden-service/build/src/commands/get/get-test-result"
 import { TestConfig } from "garden-service/build/src/config/test"
 import { EventName } from "garden-service/build/src/events"
 import { EnvironmentStatusMap } from "garden-service/build/src/types/plugin/provider/getEnvironmentStatus"
@@ -52,17 +52,25 @@ export type TaskState = PickFromUnion<SupportedEventName,
   "taskCancelled"
 >
 
+export const taskStates = [
+  "taskComplete",
+  "taskError",
+  "taskPending",
+  "taskProcessing",
+  "taskCancelled",
+]
+
 export interface Test {
   config: TestConfig,
   status: RunStatus,
-  result: TestResultOutput,
+  result: GetTestResultCommandResult,
   taskState: TaskState, // State of the test task for the module
 }
 
 export interface Task {
   config: TaskConfig,
   status: RunStatus,
-  result: TaskResultOutput,
+  result: GetTaskResultCommandResult,
   taskState: TaskState, // State of the task task for the module
 }
 

--- a/dashboard/src/util/helpers.ts
+++ b/dashboard/src/util/helpers.ts
@@ -68,3 +68,10 @@ export function getLinkUrl(ingress: ServiceIngress) {
     pathname: ingress.path,
   }))
 }
+
+/**
+ * Test names are not unique so we construct a unique key from the module name and the test name.
+ */
+export function getTestKey({ testName, moduleName }: { testName: string, moduleName: string }) {
+  return `${moduleName}.${testName}`
+}

--- a/garden-service/test/unit/src/commands/get/get-task-result.ts
+++ b/garden-service/test/unit/src/commands/get/get-task-result.ts
@@ -1,18 +1,59 @@
-import { dataDir, makeTestGarden, expectError, withDefaultGlobalOpts } from "../../../../helpers"
-import { resolve } from "path"
+import { join } from "path"
+import {
+  dataDir,
+  expectError,
+  withDefaultGlobalOpts,
+  configureTestModule,
+} from "../../../../helpers"
 import { GetTaskResultCommand } from "../../../../../src/commands/get/get-task-result"
 import { expect } from "chai"
-import { pick } from "lodash"
+import { PluginFactory } from "../../../../../src/types/plugin/plugin"
+import { LogEntry } from "../../../../../src/logger/log-entry"
+import { Garden } from "../../../../../src/garden"
+import { GetTaskResultParams } from "../../../../../src/types/plugin/task/getTaskResult"
+
+const now = new Date()
+
+const taskResults = {
+  "task-a": {
+    moduleName: "module-a",
+    taskName: "task-a",
+    command: ["foo"],
+    completedAt: now,
+    log: "bla bla",
+    outputs: {
+      log: "bla bla",
+    },
+    success: true,
+    startedAt: now,
+    version: "1234",
+  },
+  "task-c": null,
+}
+
+const testPlugin: PluginFactory = async () => ({
+  moduleActions: {
+    test: {
+      configure: configureTestModule,
+      getTaskResult: async (params: GetTaskResultParams) => taskResults[params.task.name],
+    },
+  },
+})
 
 describe("GetTaskResultCommand", () => {
-  it("should throw error if task not found", async () => {
-    const name = "imaginary-task"
+  let garden: Garden
+  let log: LogEntry
+  const command = new GetTaskResultCommand()
 
-    const garden = await makeTestGarden(
-      resolve(dataDir, "test-project-dependants"),
-    )
-    const log = garden.log
-    const command = new GetTaskResultCommand()
+  before(async () => {
+    const plugins = { "test-plugin": testPlugin }
+    const projectRootB = join(dataDir, "test-project-b")
+    garden = await Garden.factory(projectRootB, { plugins })
+    log = garden.log
+  })
+
+  it("should throw error if task not found", async () => {
+    const name = "banana"
 
     await expectError(
       async () =>
@@ -29,11 +70,7 @@ describe("GetTaskResultCommand", () => {
   })
 
   it("should return the task result", async () => {
-    const name = "task-c"
-
-    const garden = await makeTestGarden(resolve(dataDir, "test-project-a"))
-    const log = garden.log
-    const command = new GetTaskResultCommand()
+    const name = "task-a"
 
     const res = await command.action({
       garden,
@@ -44,6 +81,32 @@ describe("GetTaskResultCommand", () => {
       opts: withDefaultGlobalOpts({}),
     })
 
-    expect(pick(res.result, ["output", "name"])).to.eql({ output: null, name })
+    expect(res.result).to.be.eql({
+      moduleName: "module-a",
+      taskName: "task-a",
+      command: ["foo"],
+      completedAt: now,
+      log: "bla bla",
+      outputs: { log: "bla bla" },
+      success: true,
+      startedAt: now,
+      version: "1234",
+    })
   })
+
+  it("should return result null if task result does not exist", async () => {
+    const name = "task-c"
+
+    const res = await command.action({
+      garden,
+      log,
+      footerLog: log,
+      headerLog: log,
+      args: { name },
+      opts: withDefaultGlobalOpts({}),
+    })
+
+    expect(res.result).to.be.null
+  })
+
 })

--- a/garden-service/test/unit/src/commands/get/get-test-result.ts
+++ b/garden-service/test/unit/src/commands/get/get-test-result.ts
@@ -1,19 +1,58 @@
-import { dataDir, makeTestGarden, expectError, withDefaultGlobalOpts } from "../../../../helpers"
-import { resolve } from "path"
+import {
+  expectError,
+  withDefaultGlobalOpts,
+  configureTestModule,
+  makeTestGardenA,
+} from "../../../../helpers"
 import { GetTestResultCommand } from "../../../../../src/commands/get/get-test-result"
 import { expect } from "chai"
-import { pick } from "lodash"
+import { PluginFactory } from "../../../../../src/types/plugin/plugin"
+import { GetTestResultParams } from "../../../../../src/types/plugin/module/getTestResult"
+import { Garden } from "../../../../../src/garden"
+import { LogEntry } from "../../../../../src/logger/log-entry"
+
+const now = new Date()
+
+const testResults = {
+  unit: {
+    moduleName: "module-a",
+    command: [],
+    completedAt: now,
+    log: "bla bla",
+    outputs: {
+      log: "bla bla",
+    },
+    success: true,
+    startedAt: now,
+    testName: "unit",
+    version: "1234",
+  },
+  integration: null,
+}
+
+const testPlugin: PluginFactory = async () => ({
+  moduleActions: {
+    test: {
+      configure: configureTestModule,
+      getTestResult: async (params: GetTestResultParams) => testResults[params.testName],
+    },
+  },
+})
 
 describe("GetTestResultCommand", () => {
-  it("should throw error if test not found", async () => {
-    const name = "test-run"
-    const module = "test-module"
+  let garden: Garden
+  let log: LogEntry
+  const command = new GetTestResultCommand()
+  const module = "module-a"
 
-    const garden = await makeTestGarden(
-      resolve(dataDir, "test-project-dependants"),
-    )
-    const log = garden.log
-    const command = new GetTestResultCommand()
+  before(async () => {
+    const plugins = { "test-plugin": testPlugin }
+    garden = await makeTestGardenA(plugins)
+    log = garden.log
+  })
+
+  it("should throw error if test not found", async () => {
+    const name = "banana"
 
     await expectError(
       async () =>
@@ -25,17 +64,12 @@ describe("GetTestResultCommand", () => {
           args: { name, module },
           opts: withDefaultGlobalOpts({}),
         }),
-      "parameter",
+      "not-found",
     )
   })
 
   it("should return the test result", async () => {
     const name = "unit"
-    const module = "module-c"
-
-    const garden = await makeTestGarden(resolve(dataDir, "test-project-a"))
-    const log = garden.log
-    const command = new GetTestResultCommand()
 
     const res = await command.action({
       garden,
@@ -46,6 +80,34 @@ describe("GetTestResultCommand", () => {
       opts: withDefaultGlobalOpts({}),
     })
 
-    expect(pick(res.result, ["output", "name", "module"])).to.eql({ output: null, name, module })
+    expect(res.result).to.eql({
+      moduleName: "module-a",
+      command: [],
+      completedAt: now,
+      log: "bla bla",
+      outputs: {
+        log: "bla bla",
+      },
+      success: true,
+      startedAt: now,
+      testName: "unit",
+      version: "1234",
+    })
   })
+
+  it("should return result null if test result does not exist", async () => {
+    const name = "integration"
+
+    const res = await command.action({
+      garden,
+      log,
+      footerLog: log,
+      headerLog: log,
+      args: { name, module },
+      opts: withDefaultGlobalOpts({}),
+    })
+
+    expect(res.result).to.be.null
+  })
+
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a regression due to changes we made to shape of the output of task and test results. This caused the `get-task-result` and `get-test-result` commands to return empty output log. This also caused these not to load in the dashboard.

**Which issue(s) this PR fixes**:

Fixes #1225
Fixes #1224