### PR TITLE
docs: ensure check-docs script checks internal header links

### DIFF
--- a/bin/check-docs
+++ b/bin/check-docs
@@ -1,20 +1,35 @@
 #!/bin/bash -e
 
-# Linter before git check so we can lint docs even if they are 'dirty'
-
 # Use "|| true" so we don't exit on empty
 modified_docs=$(git diff --name-status master docs README.md) || true
 modified_examples=$(git diff --name-status master examples | grep "examples.*\README.md$") || true
 
+check_relative_links() {
+  echo $1 | xargs -n 1 ./node_modules/.bin/remark --use validate-links --frail --quiet --no-stdout
+}
+
+check_external_links() {
+  # markdown-link-check is configured to ignore relative links
+  echo $1 | xargs -n 1 ./node_modules/.bin/markdown-link-check --config markdown-link-check-config.json
+}
+
 # Only check links if docs or examples were modified
 if !([ -z "$modified_docs" ] && [ -z "$modified_examples" ]); then
-  # Using xargs to exit 1 if link is broken, see: https://github.com/tcort/markdown-link-check/issues/57
+  docs=$(find docs -name '*.md' -type f)
+  examples=$(find examples -name 'README.md' -type f -not -path "*/.garden/*" -not -path "*/node_modules/*")
+  readme=./README.md
+
   # Check docs
-  find docs -name '*.md' -type f | xargs -n 1 ./node_modules/.bin/markdown-link-check --config markdown-link-check-config.json
+  check_external_links "$docs"
+  check_relative_links "$docs"
+
   # Check examples
-  find examples -name 'README.md' -type f -not -path "*/.garden/*" -not -path "*/node_modules/*" | xargs -n 1 ./node_modules/.bin/markdown-link-check --config markdown-link-check-config.json
+  check_external_links "$examples"
+  check_relative_links "$examples"
+
   # Check README.md
-  find . -name 'README.md' -type f  -maxdepth 1 | xargs -n 1 ./node_modules/.bin/markdown-link-check --config markdown-link-check-config.json
+  check_external_links "$readme"
+  check_relative_links "$readme"
 fi
 
 # Needs to generate clean docs before we can validate they are up to date

--- a/docs/examples/demo-project.md
+++ b/docs/examples/demo-project.md
@@ -7,7 +7,7 @@ In what follows you'll learn how to:
 * [Configure the project](#project-wide-configuration)
 * [Configure individual modules](#module-configuration)
 * [Deploy the project locally](#deploying)
-* [Have the services communicate with one another](#inter-service-communication)
+* [Have the services communicate with one another](#communication-between-services)
 * [Manage service dependencies](#dependencies)
 * [Test services](#testing)
 
@@ -76,7 +76,7 @@ Above, we've specified the name of our project and configured it to use the `loc
 
 ## Module configuration
 
-Now, let's turn to our services. Services live inside [modules](../reference/glossary.md#Module), and each module has its own `garden.yml` configuration file. You can read more about the difference between services and modules [here](../basics/stack-graph.md#structure).
+Now, let's turn to our services. Services live inside [modules](../reference/glossary.md#Module), and each module has its own `garden.yml` configuration file. You can read more about the difference between services and modules [here](../basics/stack-graph.md#structure-and-terminology).
 
 We'll start with the module for the `frontend`:
 

--- a/docs/examples/using-garden-in-ci.md
+++ b/docs/examples/using-garden-in-ci.md
@@ -9,7 +9,7 @@ In this guide we'll demonstrate how Garden can fit into your continuous integrat
 
 To use Garden in your CI pipeline you need the following:
 
-1. A Garden project, [configured to deploy to a remote cluster](#configure-garden-for-remote-environments).
+1. A Garden project, [configured to deploy to a remote cluster](#configure-remote-environments).
 2. A [Kubectl context](#configure-the-kubectl-context) on the CI agent that's configured for the remote cluster.
 
 For the purposes of this example we'll be using [CircleCI](https://circleci.com) and deploying to a Google Kubernetes Engine (GKE) cluster. However, the instructions below can easily be applied to other CI platforms and cloud providers.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -4,7 +4,7 @@ title: Config Files Reference
 
 # garden.yml reference
 
-Below is the schema reference for the [Project](#project-configuration) and [Module](#module-configuration) `garden.yml` configuration files. For an introduction to configuring a Garden project,
+Below is the schema reference for the [Project](#project-configuration-keys) and [Module](#module-configuration-keys) `garden.yml` configuration files. For an introduction to configuring a Garden project,
 please look at our [configuration guide](../using-garden/configuration-files.md).
 
 The reference is divided into four sections. The [first section](#project-configuration-keys) lists and describes the available schema keys for the project level configuration, and the [second section](#project-yaml-schema) contains the project level YAML schema.
@@ -94,7 +94,7 @@ DEPRECATED - Please use the top-level `providers` field instead, and if needed u
 
 ### `environmentDefaults.providers[].name`
 
-[environmentDefaults](#environmentdefaults) > [providers](#environmentdefaults.providers[]) > name
+[environmentDefaults](#environmentdefaults) > [providers](#environmentdefaultsproviders) > name
 
 The name of the provider plugin to use.
 
@@ -115,7 +115,7 @@ environmentDefaults:
 
 ### `environmentDefaults.providers[].environments[]`
 
-[environmentDefaults](#environmentdefaults) > [providers](#environmentdefaults.providers[]) > environments
+[environmentDefaults](#environmentdefaults) > [providers](#environmentdefaultsproviders) > environments
 
 If specified, this provider will only be used in the listed environments. Note that an empty array effectively disables the provider. To use a provider in all environments, omit this field.
 
@@ -334,7 +334,7 @@ DEPRECATED - Please use the top-level `providers` field instead, and if needed u
 
 ### `environments[].providers[].name`
 
-[environments](#environments) > [providers](#environments[].providers[]) > name
+[environments](#environments) > [providers](#environmentsproviders) > name
 
 The name of the provider plugin to use.
 
@@ -352,7 +352,7 @@ environments:
 
 ### `environments[].providers[].environments[]`
 
-[environments](#environments) > [providers](#environments[].providers[]) > environments
+[environments](#environments) > [providers](#environmentsproviders) > environments
 
 If specified, this provider will only be used in the listed environments. Note that an empty array effectively disables the provider. To use a provider in all environments, omit this field.
 
@@ -592,7 +592,7 @@ build:
 
 ### `build.dependencies[].name`
 
-[build](#build) > [dependencies](#build.dependencies[]) > name
+[build](#build) > [dependencies](#builddependencies) > name
 
 Module name to build ahead of this module.
 
@@ -602,7 +602,7 @@ Module name to build ahead of this module.
 
 ### `build.dependencies[].copy[]`
 
-[build](#build) > [dependencies](#build.dependencies[]) > copy
+[build](#build) > [dependencies](#builddependencies) > copy
 
 Specify one or more files or directories to copy from the built dependency to this module.
 
@@ -612,7 +612,7 @@ Specify one or more files or directories to copy from the built dependency to th
 
 ### `build.dependencies[].copy[].source`
 
-[build](#build) > [dependencies](#build.dependencies[]) > [copy](#build.dependencies[].copy[]) > source
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > source
 
 POSIX-style path or filename of the directory or file(s) to copy to the target.
 
@@ -622,7 +622,7 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 
 ### `build.dependencies[].copy[].target`
 
-[build](#build) > [dependencies](#build.dependencies[]) > [copy](#build.dependencies[].copy[]) > target
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > target
 
 POSIX-style path or filename to copy the directory or file(s).
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -34,7 +34,7 @@ For a comprehensive list of providers available in Garden, check out the [Refere
 
 #### Service
 The unit of deployment in Garden. Services are defined in their parent [module](#module)'s `garden.yml`, each
-exposing [one or more ingress endpoints](./config.md#container).
+exposing [one or more ingress endpoints](./module-types/container.md#servicesingresses).
 
 Services may depend on services defined in other modules, in which case those services will be deployed first, and
 their deployment output made available to the requiring service's deploy step.

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -169,7 +169,7 @@ build:
 
 ### `build.dependencies[].name`
 
-[build](#build) > [dependencies](#build.dependencies[]) > name
+[build](#build) > [dependencies](#builddependencies) > name
 
 Module name to build ahead of this module.
 
@@ -179,7 +179,7 @@ Module name to build ahead of this module.
 
 ### `build.dependencies[].copy[]`
 
-[build](#build) > [dependencies](#build.dependencies[]) > copy
+[build](#build) > [dependencies](#builddependencies) > copy
 
 Specify one or more files or directories to copy from the built dependency to this module.
 
@@ -189,7 +189,7 @@ Specify one or more files or directories to copy from the built dependency to th
 
 ### `build.dependencies[].copy[].source`
 
-[build](#build) > [dependencies](#build.dependencies[]) > [copy](#build.dependencies[].copy[]) > source
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > source
 
 POSIX-style path or filename of the directory or file(s) to copy to the target.
 
@@ -199,7 +199,7 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 
 ### `build.dependencies[].copy[].target`
 
-[build](#build) > [dependencies](#build.dependencies[]) > [copy](#build.dependencies[].copy[]) > target
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > target
 
 POSIX-style path or filename to copy the directory or file(s).
 
@@ -271,7 +271,7 @@ Specify one or more source files or directories to automatically sync into the r
 
 ### `hotReload.sync[].source`
 
-[hotReload](#hotreload) > [sync](#hotreload.sync[]) > source
+[hotReload](#hotreload) > [sync](#hotreloadsync) > source
 
 POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be a relative path if provided. Defaults to the module's top-level directory if no value is provided.
 
@@ -290,7 +290,7 @@ hotReload:
 
 ### `hotReload.sync[].target`
 
-[hotReload](#hotreload) > [sync](#hotreload.sync[]) > target
+[hotReload](#hotreload) > [sync](#hotreloadsync) > target
 
 POSIX-style absolute path to sync the directory to inside the container. The root path (i.e. "/") is not allowed.
 
@@ -449,7 +449,7 @@ services:
 
 ### `services[].ingresses[].annotations`
 
-[services](#services) > [ingresses](#services[].ingresses[]) > annotations
+[services](#services) > [ingresses](#servicesingresses) > annotations
 
 Annotations to attach to the ingress (Note: May not be applicable to all providers)
 
@@ -470,7 +470,7 @@ services:
 
 ### `services[].ingresses[].hostname`
 
-[services](#services) > [ingresses](#services[].ingresses[]) > hostname
+[services](#services) > [ingresses](#servicesingresses) > hostname
 
 The hostname that should route to this service. Defaults to the default hostname
 configured in the provider configuration.
@@ -483,7 +483,7 @@ Note that if you're developing locally you may need to add this hostname to your
 
 ### `services[].ingresses[].linkUrl`
 
-[services](#services) > [ingresses](#services[].ingresses[]) > linkUrl
+[services](#services) > [ingresses](#servicesingresses) > linkUrl
 
 The link URL for the ingress to show in the console and on the dashboard.
 Also used when calling the service with the `call` command.
@@ -499,7 +499,7 @@ Otherwise Garden will construct the link URL from the ingress spec.
 
 ### `services[].ingresses[].path`
 
-[services](#services) > [ingresses](#services[].ingresses[]) > path
+[services](#services) > [ingresses](#servicesingresses) > path
 
 The path which should be routed to the service.
 
@@ -509,7 +509,7 @@ The path which should be routed to the service.
 
 ### `services[].ingresses[].port`
 
-[services](#services) > [ingresses](#services[].ingresses[]) > port
+[services](#services) > [ingresses](#servicesingresses) > port
 
 The name of the container port where the specified paths should be routed.
 
@@ -551,7 +551,7 @@ Specify how the service's health should be checked after deploying.
 
 ### `services[].healthCheck.httpGet`
 
-[services](#services) > [healthCheck](#services[].healthcheck) > httpGet
+[services](#services) > [healthCheck](#serviceshealthcheck) > httpGet
 
 Set this to check the service's health by making an HTTP request.
 
@@ -561,7 +561,7 @@ Set this to check the service's health by making an HTTP request.
 
 ### `services[].healthCheck.httpGet.path`
 
-[services](#services) > [healthCheck](#services[].healthcheck) > [httpGet](#services[].healthcheck.httpget) > path
+[services](#services) > [healthCheck](#serviceshealthcheck) > [httpGet](#serviceshealthcheckhttpget) > path
 
 The path of the service's health check endpoint.
 
@@ -571,7 +571,7 @@ The path of the service's health check endpoint.
 
 ### `services[].healthCheck.httpGet.port`
 
-[services](#services) > [healthCheck](#services[].healthcheck) > [httpGet](#services[].healthcheck.httpget) > port
+[services](#services) > [healthCheck](#serviceshealthcheck) > [httpGet](#serviceshealthcheckhttpget) > port
 
 The name of the port where the service's health check endpoint should be available.
 
@@ -581,7 +581,7 @@ The name of the port where the service's health check endpoint should be availab
 
 ### `services[].healthCheck.httpGet.scheme`
 
-[services](#services) > [healthCheck](#services[].healthcheck) > [httpGet](#services[].healthcheck.httpget) > scheme
+[services](#services) > [healthCheck](#serviceshealthcheck) > [httpGet](#serviceshealthcheckhttpget) > scheme
 
 | Type     | Required | Default  |
 | -------- | -------- | -------- |
@@ -589,7 +589,7 @@ The name of the port where the service's health check endpoint should be availab
 
 ### `services[].healthCheck.command[]`
 
-[services](#services) > [healthCheck](#services[].healthcheck) > command
+[services](#services) > [healthCheck](#serviceshealthcheck) > command
 
 Set this to check the service's health by running a command in its container.
 
@@ -599,7 +599,7 @@ Set this to check the service's health by running a command in its container.
 
 ### `services[].healthCheck.tcpPort`
 
-[services](#services) > [healthCheck](#services[].healthcheck) > tcpPort
+[services](#services) > [healthCheck](#serviceshealthcheck) > tcpPort
 
 Set this to check the service's health by checking if this TCP port is accepting connections.
 
@@ -658,7 +658,7 @@ Specify resource limits for the service.
 
 ### `services[].limits.cpu`
 
-[services](#services) > [limits](#services[].limits) > cpu
+[services](#services) > [limits](#serviceslimits) > cpu
 
 The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)
 
@@ -668,7 +668,7 @@ The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)
 
 ### `services[].limits.memory`
 
-[services](#services) > [limits](#services[].limits) > memory
+[services](#services) > [limits](#serviceslimits) > memory
 
 The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB)
 
@@ -688,7 +688,7 @@ List of ports that the service container exposes.
 
 ### `services[].ports[].name`
 
-[services](#services) > [ports](#services[].ports[]) > name
+[services](#services) > [ports](#servicesports) > name
 
 The name of the port (used when referencing the port elsewhere in the service configuration).
 
@@ -698,7 +698,7 @@ The name of the port (used when referencing the port elsewhere in the service co
 
 ### `services[].ports[].protocol`
 
-[services](#services) > [ports](#services[].ports[]) > protocol
+[services](#services) > [ports](#servicesports) > protocol
 
 The protocol of the port.
 
@@ -708,7 +708,7 @@ The protocol of the port.
 
 ### `services[].ports[].containerPort`
 
-[services](#services) > [ports](#services[].ports[]) > containerPort
+[services](#services) > [ports](#servicesports) > containerPort
 
 The port exposed on the container by the running process. This will also be the default value for `servicePort`.
 This is the port you would expose in your Dockerfile and that your process listens on. This is commonly a non-priviledged port like 8080 for security reasons.
@@ -729,7 +729,7 @@ services:
 
 ### `services[].ports[].servicePort`
 
-[services](#services) > [ports](#services[].ports[]) > servicePort
+[services](#services) > [ports](#servicesports) > servicePort
 
 The port exposed on the service. Defaults to `containerPort` if not specified.
 This is the port you use when calling a service from another service within the cluster. For example, if your service name is my-service and the service port is 8090, you would call it with: http://my-service:8090/some-endpoint.
@@ -751,7 +751,7 @@ services:
 
 ### `services[].ports[].hostPort`
 
-[services](#services) > [ports](#services[].ports[]) > hostPort
+[services](#services) > [ports](#servicesports) > hostPort
 
 | Type     | Required |
 | -------- | -------- |
@@ -759,7 +759,7 @@ services:
 
 ### `services[].ports[].nodePort`
 
-[services](#services) > [ports](#services[].ports[]) > nodePort
+[services](#services) > [ports](#servicesports) > nodePort
 
 Set this to expose the service on the specified port on the host node (may not be supported by all providers). Set to `true` to have the cluster pick a port automatically, which is most often advisable if the cluster is shared by multiple users.
 This allows you to call the service from the outside by the node's IP address and the port number set in this field.
@@ -791,7 +791,7 @@ List of volumes that should be mounted when deploying the container.
 
 ### `services[].volumes[].name`
 
-[services](#services) > [volumes](#services[].volumes[]) > name
+[services](#services) > [volumes](#servicesvolumes) > name
 
 The name of the allocated volume.
 
@@ -801,7 +801,7 @@ The name of the allocated volume.
 
 ### `services[].volumes[].containerPath`
 
-[services](#services) > [volumes](#services[].volumes[]) > containerPath
+[services](#services) > [volumes](#servicesvolumes) > containerPath
 
 The path where the volume should be mounted in the container.
 
@@ -811,7 +811,7 @@ The path where the volume should be mounted in the container.
 
 ### `services[].volumes[].hostPath`
 
-[services](#services) > [volumes](#services[].volumes[]) > hostPath
+[services](#services) > [volumes](#servicesvolumes) > hostPath
 
 | Type     | Required |
 | -------- | -------- |

--- a/docs/reference/module-types/exec.md
+++ b/docs/reference/module-types/exec.md
@@ -164,7 +164,7 @@ build:
 
 ### `build.dependencies[].name`
 
-[build](#build) > [dependencies](#build.dependencies[]) > name
+[build](#build) > [dependencies](#builddependencies) > name
 
 Module name to build ahead of this module.
 
@@ -174,7 +174,7 @@ Module name to build ahead of this module.
 
 ### `build.dependencies[].copy[]`
 
-[build](#build) > [dependencies](#build.dependencies[]) > copy
+[build](#build) > [dependencies](#builddependencies) > copy
 
 Specify one or more files or directories to copy from the built dependency to this module.
 
@@ -184,7 +184,7 @@ Specify one or more files or directories to copy from the built dependency to th
 
 ### `build.dependencies[].copy[].source`
 
-[build](#build) > [dependencies](#build.dependencies[]) > [copy](#build.dependencies[].copy[]) > source
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > source
 
 POSIX-style path or filename of the directory or file(s) to copy to the target.
 
@@ -194,7 +194,7 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 
 ### `build.dependencies[].copy[].target`
 
-[build](#build) > [dependencies](#build.dependencies[]) > [copy](#build.dependencies[].copy[]) > target
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > target
 
 POSIX-style path or filename to copy the directory or file(s).
 

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -164,7 +164,7 @@ build:
 
 ### `build.dependencies[].name`
 
-[build](#build) > [dependencies](#build.dependencies[]) > name
+[build](#build) > [dependencies](#builddependencies) > name
 
 Module name to build ahead of this module.
 
@@ -174,7 +174,7 @@ Module name to build ahead of this module.
 
 ### `build.dependencies[].copy[]`
 
-[build](#build) > [dependencies](#build.dependencies[]) > copy
+[build](#build) > [dependencies](#builddependencies) > copy
 
 Specify one or more files or directories to copy from the built dependency to this module.
 
@@ -184,7 +184,7 @@ Specify one or more files or directories to copy from the built dependency to th
 
 ### `build.dependencies[].copy[].source`
 
-[build](#build) > [dependencies](#build.dependencies[]) > [copy](#build.dependencies[].copy[]) > source
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > source
 
 POSIX-style path or filename of the directory or file(s) to copy to the target.
 
@@ -194,7 +194,7 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 
 ### `build.dependencies[].copy[].target`
 
-[build](#build) > [dependencies](#build.dependencies[]) > [copy](#build.dependencies[].copy[]) > target
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > target
 
 POSIX-style path or filename to copy the directory or file(s).
 
@@ -412,7 +412,7 @@ The Deployment, DaemonSet or StatefulSet that Garden should use to execute this 
 
 ### `tasks[].resource.kind`
 
-[tasks](#tasks) > [resource](#tasks[].resource) > kind
+[tasks](#tasks) > [resource](#tasksresource) > kind
 
 The type of Kubernetes resource to sync files to.
 
@@ -422,7 +422,7 @@ The type of Kubernetes resource to sync files to.
 
 ### `tasks[].resource.name`
 
-[tasks](#tasks) > [resource](#tasks[].resource) > name
+[tasks](#tasks) > [resource](#tasksresource) > name
 
 The name of the resource to sync to. If the chart contains a single resource of the specified Kind, this can be omitted.
 This can include a Helm template string, e.g. '{{ template "my-chart.fullname" . }}'. This allows you to easily match the dynamic names given by Helm. In most cases you should copy this directly from the template in question in order to match it. Note that you may need to add single quotes around the string for the YAML to be parsed correctly.
@@ -433,7 +433,7 @@ This can include a Helm template string, e.g. '{{ template "my-chart.fullname" .
 
 ### `tasks[].resource.containerName`
 
-[tasks](#tasks) > [resource](#tasks[].resource) > containerName
+[tasks](#tasks) > [resource](#tasksresource) > containerName
 
 The name of a container in the target. Specify this if the target contains more than one container and the main container is not the first container in the spec.
 
@@ -443,7 +443,7 @@ The name of a container in the target. Specify this if the target contains more 
 
 ### `tasks[].resource.containerModule`
 
-[tasks](#tasks) > [resource](#tasks[].resource) > containerModule
+[tasks](#tasks) > [resource](#tasksresource) > containerModule
 
 The Garden module that contains the sources for the container. This needs to be specified under `serviceResource` in order to enable hot-reloading for the chart, but is not necessary for tasks and tests.
 Must be a `container` module, and for hot-reloading to work you must specify the `hotReload` field on the container module.
@@ -464,7 +464,7 @@ tasks:
 
 ### `tasks[].resource.hotReloadArgs[]`
 
-[tasks](#tasks) > [resource](#tasks[].resource) > hotReloadArgs
+[tasks](#tasks) > [resource](#tasksresource) > hotReloadArgs
 
 If specified, overrides the arguments for the main container when running in hot-reload mode.
 
@@ -593,7 +593,7 @@ The Deployment, DaemonSet or StatefulSet that Garden should use to execute this 
 
 ### `tests[].resource.kind`
 
-[tests](#tests) > [resource](#tests[].resource) > kind
+[tests](#tests) > [resource](#testsresource) > kind
 
 The type of Kubernetes resource to sync files to.
 
@@ -603,7 +603,7 @@ The type of Kubernetes resource to sync files to.
 
 ### `tests[].resource.name`
 
-[tests](#tests) > [resource](#tests[].resource) > name
+[tests](#tests) > [resource](#testsresource) > name
 
 The name of the resource to sync to. If the chart contains a single resource of the specified Kind, this can be omitted.
 This can include a Helm template string, e.g. '{{ template "my-chart.fullname" . }}'. This allows you to easily match the dynamic names given by Helm. In most cases you should copy this directly from the template in question in order to match it. Note that you may need to add single quotes around the string for the YAML to be parsed correctly.
@@ -614,7 +614,7 @@ This can include a Helm template string, e.g. '{{ template "my-chart.fullname" .
 
 ### `tests[].resource.containerName`
 
-[tests](#tests) > [resource](#tests[].resource) > containerName
+[tests](#tests) > [resource](#testsresource) > containerName
 
 The name of a container in the target. Specify this if the target contains more than one container and the main container is not the first container in the spec.
 
@@ -624,7 +624,7 @@ The name of a container in the target. Specify this if the target contains more 
 
 ### `tests[].resource.containerModule`
 
-[tests](#tests) > [resource](#tests[].resource) > containerModule
+[tests](#tests) > [resource](#testsresource) > containerModule
 
 The Garden module that contains the sources for the container. This needs to be specified under `serviceResource` in order to enable hot-reloading for the chart, but is not necessary for tasks and tests.
 Must be a `container` module, and for hot-reloading to work you must specify the `hotReload` field on the container module.
@@ -645,7 +645,7 @@ tests:
 
 ### `tests[].resource.hotReloadArgs[]`
 
-[tests](#tests) > [resource](#tests[].resource) > hotReloadArgs
+[tests](#tests) > [resource](#testsresource) > hotReloadArgs
 
 If specified, overrides the arguments for the main container when running in hot-reload mode.
 

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -172,7 +172,7 @@ build:
 
 ### `build.dependencies[].name`
 
-[build](#build) > [dependencies](#build.dependencies[]) > name
+[build](#build) > [dependencies](#builddependencies) > name
 
 Module name to build ahead of this module.
 
@@ -182,7 +182,7 @@ Module name to build ahead of this module.
 
 ### `build.dependencies[].copy[]`
 
-[build](#build) > [dependencies](#build.dependencies[]) > copy
+[build](#build) > [dependencies](#builddependencies) > copy
 
 Specify one or more files or directories to copy from the built dependency to this module.
 
@@ -192,7 +192,7 @@ Specify one or more files or directories to copy from the built dependency to th
 
 ### `build.dependencies[].copy[].source`
 
-[build](#build) > [dependencies](#build.dependencies[]) > [copy](#build.dependencies[].copy[]) > source
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > source
 
 POSIX-style path or filename of the directory or file(s) to copy to the target.
 
@@ -202,7 +202,7 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 
 ### `build.dependencies[].copy[].target`
 
-[build](#build) > [dependencies](#build.dependencies[]) > [copy](#build.dependencies[].copy[]) > target
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > target
 
 POSIX-style path or filename to copy the directory or file(s).
 
@@ -256,7 +256,7 @@ The kind of the resource.
 
 ### `manifests[].metadata.name`
 
-[manifests](#manifests) > [metadata](#manifests[].metadata) > name
+[manifests](#manifests) > [metadata](#manifestsmetadata) > name
 
 The name of the resource.
 

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -174,7 +174,7 @@ build:
 
 ### `build.dependencies[].name`
 
-[build](#build) > [dependencies](#build.dependencies[]) > name
+[build](#build) > [dependencies](#builddependencies) > name
 
 Module name to build ahead of this module.
 
@@ -184,7 +184,7 @@ Module name to build ahead of this module.
 
 ### `build.dependencies[].copy[]`
 
-[build](#build) > [dependencies](#build.dependencies[]) > copy
+[build](#build) > [dependencies](#builddependencies) > copy
 
 Specify one or more files or directories to copy from the built dependency to this module.
 
@@ -194,7 +194,7 @@ Specify one or more files or directories to copy from the built dependency to th
 
 ### `build.dependencies[].copy[].source`
 
-[build](#build) > [dependencies](#build.dependencies[]) > [copy](#build.dependencies[].copy[]) > source
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > source
 
 POSIX-style path or filename of the directory or file(s) to copy to the target.
 
@@ -204,7 +204,7 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 
 ### `build.dependencies[].copy[].target`
 
-[build](#build) > [dependencies](#build.dependencies[]) > [copy](#build.dependencies[].copy[]) > target
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > target
 
 POSIX-style path or filename to copy the directory or file(s).
 
@@ -276,7 +276,7 @@ Specify one or more source files or directories to automatically sync into the r
 
 ### `hotReload.sync[].source`
 
-[hotReload](#hotreload) > [sync](#hotreload.sync[]) > source
+[hotReload](#hotreload) > [sync](#hotreloadsync) > source
 
 POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be a relative path if provided. Defaults to the module's top-level directory if no value is provided.
 
@@ -295,7 +295,7 @@ hotReload:
 
 ### `hotReload.sync[].target`
 
-[hotReload](#hotreload) > [sync](#hotreload.sync[]) > target
+[hotReload](#hotreload) > [sync](#hotreloadsync) > target
 
 POSIX-style absolute path to sync the directory to inside the container. The root path (i.e. "/") is not allowed.
 
@@ -454,7 +454,7 @@ services:
 
 ### `services[].ingresses[].annotations`
 
-[services](#services) > [ingresses](#services[].ingresses[]) > annotations
+[services](#services) > [ingresses](#servicesingresses) > annotations
 
 Annotations to attach to the ingress (Note: May not be applicable to all providers)
 
@@ -475,7 +475,7 @@ services:
 
 ### `services[].ingresses[].hostname`
 
-[services](#services) > [ingresses](#services[].ingresses[]) > hostname
+[services](#services) > [ingresses](#servicesingresses) > hostname
 
 The hostname that should route to this service. Defaults to the default hostname
 configured in the provider configuration.
@@ -488,7 +488,7 @@ Note that if you're developing locally you may need to add this hostname to your
 
 ### `services[].ingresses[].linkUrl`
 
-[services](#services) > [ingresses](#services[].ingresses[]) > linkUrl
+[services](#services) > [ingresses](#servicesingresses) > linkUrl
 
 The link URL for the ingress to show in the console and on the dashboard.
 Also used when calling the service with the `call` command.
@@ -504,7 +504,7 @@ Otherwise Garden will construct the link URL from the ingress spec.
 
 ### `services[].ingresses[].path`
 
-[services](#services) > [ingresses](#services[].ingresses[]) > path
+[services](#services) > [ingresses](#servicesingresses) > path
 
 The path which should be routed to the service.
 
@@ -514,7 +514,7 @@ The path which should be routed to the service.
 
 ### `services[].ingresses[].port`
 
-[services](#services) > [ingresses](#services[].ingresses[]) > port
+[services](#services) > [ingresses](#servicesingresses) > port
 
 The name of the container port where the specified paths should be routed.
 
@@ -556,7 +556,7 @@ Specify how the service's health should be checked after deploying.
 
 ### `services[].healthCheck.httpGet`
 
-[services](#services) > [healthCheck](#services[].healthcheck) > httpGet
+[services](#services) > [healthCheck](#serviceshealthcheck) > httpGet
 
 Set this to check the service's health by making an HTTP request.
 
@@ -566,7 +566,7 @@ Set this to check the service's health by making an HTTP request.
 
 ### `services[].healthCheck.httpGet.path`
 
-[services](#services) > [healthCheck](#services[].healthcheck) > [httpGet](#services[].healthcheck.httpget) > path
+[services](#services) > [healthCheck](#serviceshealthcheck) > [httpGet](#serviceshealthcheckhttpget) > path
 
 The path of the service's health check endpoint.
 
@@ -576,7 +576,7 @@ The path of the service's health check endpoint.
 
 ### `services[].healthCheck.httpGet.port`
 
-[services](#services) > [healthCheck](#services[].healthcheck) > [httpGet](#services[].healthcheck.httpget) > port
+[services](#services) > [healthCheck](#serviceshealthcheck) > [httpGet](#serviceshealthcheckhttpget) > port
 
 The name of the port where the service's health check endpoint should be available.
 
@@ -586,7 +586,7 @@ The name of the port where the service's health check endpoint should be availab
 
 ### `services[].healthCheck.httpGet.scheme`
 
-[services](#services) > [healthCheck](#services[].healthcheck) > [httpGet](#services[].healthcheck.httpget) > scheme
+[services](#services) > [healthCheck](#serviceshealthcheck) > [httpGet](#serviceshealthcheckhttpget) > scheme
 
 | Type     | Required | Default  |
 | -------- | -------- | -------- |
@@ -594,7 +594,7 @@ The name of the port where the service's health check endpoint should be availab
 
 ### `services[].healthCheck.command[]`
 
-[services](#services) > [healthCheck](#services[].healthcheck) > command
+[services](#services) > [healthCheck](#serviceshealthcheck) > command
 
 Set this to check the service's health by running a command in its container.
 
@@ -604,7 +604,7 @@ Set this to check the service's health by running a command in its container.
 
 ### `services[].healthCheck.tcpPort`
 
-[services](#services) > [healthCheck](#services[].healthcheck) > tcpPort
+[services](#services) > [healthCheck](#serviceshealthcheck) > tcpPort
 
 Set this to check the service's health by checking if this TCP port is accepting connections.
 
@@ -663,7 +663,7 @@ Specify resource limits for the service.
 
 ### `services[].limits.cpu`
 
-[services](#services) > [limits](#services[].limits) > cpu
+[services](#services) > [limits](#serviceslimits) > cpu
 
 The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)
 
@@ -673,7 +673,7 @@ The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)
 
 ### `services[].limits.memory`
 
-[services](#services) > [limits](#services[].limits) > memory
+[services](#services) > [limits](#serviceslimits) > memory
 
 The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB)
 
@@ -693,7 +693,7 @@ List of ports that the service container exposes.
 
 ### `services[].ports[].name`
 
-[services](#services) > [ports](#services[].ports[]) > name
+[services](#services) > [ports](#servicesports) > name
 
 The name of the port (used when referencing the port elsewhere in the service configuration).
 
@@ -703,7 +703,7 @@ The name of the port (used when referencing the port elsewhere in the service co
 
 ### `services[].ports[].protocol`
 
-[services](#services) > [ports](#services[].ports[]) > protocol
+[services](#services) > [ports](#servicesports) > protocol
 
 The protocol of the port.
 
@@ -713,7 +713,7 @@ The protocol of the port.
 
 ### `services[].ports[].containerPort`
 
-[services](#services) > [ports](#services[].ports[]) > containerPort
+[services](#services) > [ports](#servicesports) > containerPort
 
 The port exposed on the container by the running process. This will also be the default value for `servicePort`.
 This is the port you would expose in your Dockerfile and that your process listens on. This is commonly a non-priviledged port like 8080 for security reasons.
@@ -734,7 +734,7 @@ services:
 
 ### `services[].ports[].servicePort`
 
-[services](#services) > [ports](#services[].ports[]) > servicePort
+[services](#services) > [ports](#servicesports) > servicePort
 
 The port exposed on the service. Defaults to `containerPort` if not specified.
 This is the port you use when calling a service from another service within the cluster. For example, if your service name is my-service and the service port is 8090, you would call it with: http://my-service:8090/some-endpoint.
@@ -756,7 +756,7 @@ services:
 
 ### `services[].ports[].hostPort`
 
-[services](#services) > [ports](#services[].ports[]) > hostPort
+[services](#services) > [ports](#servicesports) > hostPort
 
 | Type     | Required |
 | -------- | -------- |
@@ -764,7 +764,7 @@ services:
 
 ### `services[].ports[].nodePort`
 
-[services](#services) > [ports](#services[].ports[]) > nodePort
+[services](#services) > [ports](#servicesports) > nodePort
 
 Set this to expose the service on the specified port on the host node (may not be supported by all providers). Set to `true` to have the cluster pick a port automatically, which is most often advisable if the cluster is shared by multiple users.
 This allows you to call the service from the outside by the node's IP address and the port number set in this field.
@@ -796,7 +796,7 @@ List of volumes that should be mounted when deploying the container.
 
 ### `services[].volumes[].name`
 
-[services](#services) > [volumes](#services[].volumes[]) > name
+[services](#services) > [volumes](#servicesvolumes) > name
 
 The name of the allocated volume.
 
@@ -806,7 +806,7 @@ The name of the allocated volume.
 
 ### `services[].volumes[].containerPath`
 
-[services](#services) > [volumes](#services[].volumes[]) > containerPath
+[services](#services) > [volumes](#servicesvolumes) > containerPath
 
 The path where the volume should be mounted in the container.
 
@@ -816,7 +816,7 @@ The path where the volume should be mounted in the container.
 
 ### `services[].volumes[].hostPath`
 
-[services](#services) > [volumes](#services[].volumes[]) > hostPath
+[services](#services) > [volumes](#servicesvolumes) > hostPath
 
 | Type     | Required |
 | -------- | -------- |

--- a/docs/reference/module-types/openfaas.md
+++ b/docs/reference/module-types/openfaas.md
@@ -164,7 +164,7 @@ build:
 
 ### `build.dependencies[].name`
 
-[build](#build) > [dependencies](#build.dependencies[]) > name
+[build](#build) > [dependencies](#builddependencies) > name
 
 Module name to build ahead of this module.
 
@@ -174,7 +174,7 @@ Module name to build ahead of this module.
 
 ### `build.dependencies[].copy[]`
 
-[build](#build) > [dependencies](#build.dependencies[]) > copy
+[build](#build) > [dependencies](#builddependencies) > copy
 
 Specify one or more files or directories to copy from the built dependency to this module.
 
@@ -184,7 +184,7 @@ Specify one or more files or directories to copy from the built dependency to th
 
 ### `build.dependencies[].copy[].source`
 
-[build](#build) > [dependencies](#build.dependencies[]) > [copy](#build.dependencies[].copy[]) > source
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > source
 
 POSIX-style path or filename of the directory or file(s) to copy to the target.
 
@@ -194,7 +194,7 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 
 ### `build.dependencies[].copy[].target`
 
-[build](#build) > [dependencies](#build.dependencies[]) > [copy](#build.dependencies[].copy[]) > target
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > target
 
 POSIX-style path or filename to copy the directory or file(s).
 

--- a/docs/reference/module-types/terraform.md
+++ b/docs/reference/module-types/terraform.md
@@ -178,7 +178,7 @@ build:
 
 ### `build.dependencies[].name`
 
-[build](#build) > [dependencies](#build.dependencies[]) > name
+[build](#build) > [dependencies](#builddependencies) > name
 
 Module name to build ahead of this module.
 
@@ -188,7 +188,7 @@ Module name to build ahead of this module.
 
 ### `build.dependencies[].copy[]`
 
-[build](#build) > [dependencies](#build.dependencies[]) > copy
+[build](#build) > [dependencies](#builddependencies) > copy
 
 Specify one or more files or directories to copy from the built dependency to this module.
 
@@ -198,7 +198,7 @@ Specify one or more files or directories to copy from the built dependency to th
 
 ### `build.dependencies[].copy[].source`
 
-[build](#build) > [dependencies](#build.dependencies[]) > [copy](#build.dependencies[].copy[]) > source
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > source
 
 POSIX-style path or filename of the directory or file(s) to copy to the target.
 
@@ -208,7 +208,7 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 
 ### `build.dependencies[].copy[].target`
 
-[build](#build) > [dependencies](#build.dependencies[]) > [copy](#build.dependencies[].copy[]) > target
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > target
 
 POSIX-style path or filename to copy the directory or file(s).
 

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -123,7 +123,7 @@ when configuring a remote Kubernetes environment with buildMode=local.
 
 ### `providers[].imagePullSecrets[].name`
 
-[providers](#providers) > [imagePullSecrets](#providers[].imagepullsecrets[]) > name
+[providers](#providers) > [imagePullSecrets](#providersimagepullsecrets) > name
 
 The name of the Kubernetes secret.
 
@@ -141,7 +141,7 @@ providers:
 
 ### `providers[].imagePullSecrets[].namespace`
 
-[providers](#providers) > [imagePullSecrets](#providers[].imagepullsecrets[]) > namespace
+[providers](#providers) > [imagePullSecrets](#providersimagepullsecrets) > namespace
 
 The namespace where the secret is stored. If necessary, the secret may be copied to the appropriate namespace before use.
 
@@ -161,7 +161,7 @@ Resource requests and limits for the in-cluster builder, container registry and 
 
 ### `providers[].resources.builder`
 
-[providers](#providers) > [resources](#providers[].resources) > builder
+[providers](#providers) > [resources](#providersresources) > builder
 
 Resource requests and limits for the in-cluster builder.
 
@@ -178,7 +178,7 @@ limits/requests, but you should evaluate based on your needs.
 
 ### `providers[].resources.builder.limits`
 
-[providers](#providers) > [resources](#providers[].resources) > [builder](#providers[].resources.builder) > limits
+[providers](#providers) > [resources](#providersresources) > [builder](#providersresourcesbuilder) > limits
 
 | Type     | Required | Default                      |
 | -------- | -------- | ---------------------------- |
@@ -186,7 +186,7 @@ limits/requests, but you should evaluate based on your needs.
 
 ### `providers[].resources.builder.limits.cpu`
 
-[providers](#providers) > [resources](#providers[].resources) > [builder](#providers[].resources.builder) > [limits](#providers[].resources.builder.limits) > cpu
+[providers](#providers) > [resources](#providersresources) > [builder](#providersresourcesbuilder) > [limits](#providersresourcesbuilderlimits) > cpu
 
 CPU limit in millicpu.
 
@@ -209,7 +209,7 @@ providers:
 
 ### `providers[].resources.builder.limits.memory`
 
-[providers](#providers) > [resources](#providers[].resources) > [builder](#providers[].resources.builder) > [limits](#providers[].resources.builder.limits) > memory
+[providers](#providers) > [resources](#providersresources) > [builder](#providersresourcesbuilder) > [limits](#providersresourcesbuilderlimits) > memory
 
 Memory limit in megabytes.
 
@@ -232,7 +232,7 @@ providers:
 
 ### `providers[].resources.builder.requests`
 
-[providers](#providers) > [resources](#providers[].resources) > [builder](#providers[].resources.builder) > requests
+[providers](#providers) > [resources](#providersresources) > [builder](#providersresourcesbuilder) > requests
 
 | Type     | Required | Default                    |
 | -------- | -------- | -------------------------- |
@@ -240,7 +240,7 @@ providers:
 
 ### `providers[].resources.builder.requests.cpu`
 
-[providers](#providers) > [resources](#providers[].resources) > [builder](#providers[].resources.builder) > [requests](#providers[].resources.builder.requests) > cpu
+[providers](#providers) > [resources](#providersresources) > [builder](#providersresourcesbuilder) > [requests](#providersresourcesbuilderrequests) > cpu
 
 CPU request in millicpu.
 
@@ -263,7 +263,7 @@ providers:
 
 ### `providers[].resources.builder.requests.memory`
 
-[providers](#providers) > [resources](#providers[].resources) > [builder](#providers[].resources.builder) > [requests](#providers[].resources.builder.requests) > memory
+[providers](#providers) > [resources](#providersresources) > [builder](#providersresourcesbuilder) > [requests](#providersresourcesbuilderrequests) > memory
 
 Memory request in megabytes.
 
@@ -286,7 +286,7 @@ providers:
 
 ### `providers[].resources.registry`
 
-[providers](#providers) > [resources](#providers[].resources) > registry
+[providers](#providers) > [resources](#providersresources) > registry
 
 Resource requests and limits for the in-cluster image registry. Built images are pushed to this registry,
 so that they are available to all the nodes in your cluster.
@@ -300,7 +300,7 @@ in how many concurrent builds you expect and how large your images tend to be.
 
 ### `providers[].resources.registry.limits`
 
-[providers](#providers) > [resources](#providers[].resources) > [registry](#providers[].resources.registry) > limits
+[providers](#providers) > [resources](#providersresources) > [registry](#providersresourcesregistry) > limits
 
 | Type     | Required | Default                      |
 | -------- | -------- | ---------------------------- |
@@ -308,7 +308,7 @@ in how many concurrent builds you expect and how large your images tend to be.
 
 ### `providers[].resources.registry.limits.cpu`
 
-[providers](#providers) > [resources](#providers[].resources) > [registry](#providers[].resources.registry) > [limits](#providers[].resources.registry.limits) > cpu
+[providers](#providers) > [resources](#providersresources) > [registry](#providersresourcesregistry) > [limits](#providersresourcesregistrylimits) > cpu
 
 CPU limit in millicpu.
 
@@ -331,7 +331,7 @@ providers:
 
 ### `providers[].resources.registry.limits.memory`
 
-[providers](#providers) > [resources](#providers[].resources) > [registry](#providers[].resources.registry) > [limits](#providers[].resources.registry.limits) > memory
+[providers](#providers) > [resources](#providersresources) > [registry](#providersresourcesregistry) > [limits](#providersresourcesregistrylimits) > memory
 
 Memory limit in megabytes.
 
@@ -354,7 +354,7 @@ providers:
 
 ### `providers[].resources.registry.requests`
 
-[providers](#providers) > [resources](#providers[].resources) > [registry](#providers[].resources.registry) > requests
+[providers](#providers) > [resources](#providersresources) > [registry](#providersresourcesregistry) > requests
 
 | Type     | Required | Default                    |
 | -------- | -------- | -------------------------- |
@@ -362,7 +362,7 @@ providers:
 
 ### `providers[].resources.registry.requests.cpu`
 
-[providers](#providers) > [resources](#providers[].resources) > [registry](#providers[].resources.registry) > [requests](#providers[].resources.registry.requests) > cpu
+[providers](#providers) > [resources](#providersresources) > [registry](#providersresourcesregistry) > [requests](#providersresourcesregistryrequests) > cpu
 
 CPU request in millicpu.
 
@@ -385,7 +385,7 @@ providers:
 
 ### `providers[].resources.registry.requests.memory`
 
-[providers](#providers) > [resources](#providers[].resources) > [registry](#providers[].resources.registry) > [requests](#providers[].resources.registry.requests) > memory
+[providers](#providers) > [resources](#providersresources) > [registry](#providersresourcesregistry) > [requests](#providersresourcesregistryrequests) > memory
 
 Memory request in megabytes.
 
@@ -408,7 +408,7 @@ providers:
 
 ### `providers[].resources.sync`
 
-[providers](#providers) > [resources](#providers[].resources) > sync
+[providers](#providers) > [resources](#providersresources) > sync
 
 Resource requests and limits for the code sync service, which we use to sync build contexts to the cluster
 ahead of building images. This generally is not resource intensive, but you might want to adjust the
@@ -420,7 +420,7 @@ defaults if you have many concurrent users.
 
 ### `providers[].resources.sync.limits`
 
-[providers](#providers) > [resources](#providers[].resources) > [sync](#providers[].resources.sync) > limits
+[providers](#providers) > [resources](#providersresources) > [sync](#providersresourcessync) > limits
 
 | Type     | Required | Default                    |
 | -------- | -------- | -------------------------- |
@@ -428,7 +428,7 @@ defaults if you have many concurrent users.
 
 ### `providers[].resources.sync.limits.cpu`
 
-[providers](#providers) > [resources](#providers[].resources) > [sync](#providers[].resources.sync) > [limits](#providers[].resources.sync.limits) > cpu
+[providers](#providers) > [resources](#providersresources) > [sync](#providersresourcessync) > [limits](#providersresourcessynclimits) > cpu
 
 CPU limit in millicpu.
 
@@ -451,7 +451,7 @@ providers:
 
 ### `providers[].resources.sync.limits.memory`
 
-[providers](#providers) > [resources](#providers[].resources) > [sync](#providers[].resources.sync) > [limits](#providers[].resources.sync.limits) > memory
+[providers](#providers) > [resources](#providersresources) > [sync](#providersresourcessync) > [limits](#providersresourcessynclimits) > memory
 
 Memory limit in megabytes.
 
@@ -474,7 +474,7 @@ providers:
 
 ### `providers[].resources.sync.requests`
 
-[providers](#providers) > [resources](#providers[].resources) > [sync](#providers[].resources.sync) > requests
+[providers](#providers) > [resources](#providersresources) > [sync](#providersresourcessync) > requests
 
 | Type     | Required | Default                   |
 | -------- | -------- | ------------------------- |
@@ -482,7 +482,7 @@ providers:
 
 ### `providers[].resources.sync.requests.cpu`
 
-[providers](#providers) > [resources](#providers[].resources) > [sync](#providers[].resources.sync) > [requests](#providers[].resources.sync.requests) > cpu
+[providers](#providers) > [resources](#providersresources) > [sync](#providersresourcessync) > [requests](#providersresourcessyncrequests) > cpu
 
 CPU request in millicpu.
 
@@ -505,7 +505,7 @@ providers:
 
 ### `providers[].resources.sync.requests.memory`
 
-[providers](#providers) > [resources](#providers[].resources) > [sync](#providers[].resources.sync) > [requests](#providers[].resources.sync.requests) > memory
+[providers](#providers) > [resources](#providersresources) > [sync](#providersresourcessync) > [requests](#providersresourcessyncrequests) > memory
 
 Memory request in megabytes.
 
@@ -542,7 +542,7 @@ factoring in how many concurrent builds you expect and how large your images and
 
 ### `providers[].storage.builder`
 
-[providers](#providers) > [storage](#providers[].storage) > builder
+[providers](#providers) > [storage](#providersstorage) > builder
 
 Storage parameters for the data volume for the in-cluster Docker Daemon.
 
@@ -554,7 +554,7 @@ Only applies when `buildMode` is set to `cluster-docker`, ignored otherwise.
 
 ### `providers[].storage.builder.size`
 
-[providers](#providers) > [storage](#providers[].storage) > [builder](#providers[].storage.builder) > size
+[providers](#providers) > [storage](#providersstorage) > [builder](#providersstoragebuilder) > size
 
 Volume size in megabytes.
 
@@ -564,7 +564,7 @@ Volume size in megabytes.
 
 ### `providers[].storage.builder.storageClass`
 
-[providers](#providers) > [storage](#providers[].storage) > [builder](#providers[].storage.builder) > storageClass
+[providers](#providers) > [storage](#providersstorage) > [builder](#providersstoragebuilder) > storageClass
 
 Storage class to use for the volume.
 
@@ -574,7 +574,7 @@ Storage class to use for the volume.
 
 ### `providers[].storage.registry`
 
-[providers](#providers) > [storage](#providers[].storage) > registry
+[providers](#providers) > [storage](#providersstorage) > registry
 
 Storage parameters for the in-cluster Docker registry volume. Built images are stored here, so that they
 are available to all the nodes in your cluster.
@@ -587,7 +587,7 @@ Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored ot
 
 ### `providers[].storage.registry.size`
 
-[providers](#providers) > [storage](#providers[].storage) > [registry](#providers[].storage.registry) > size
+[providers](#providers) > [storage](#providersstorage) > [registry](#providersstorageregistry) > size
 
 Volume size in megabytes.
 
@@ -597,7 +597,7 @@ Volume size in megabytes.
 
 ### `providers[].storage.registry.storageClass`
 
-[providers](#providers) > [storage](#providers[].storage) > [registry](#providers[].storage.registry) > storageClass
+[providers](#providers) > [storage](#providersstorage) > [registry](#providersstorageregistry) > storageClass
 
 Storage class to use for the volume.
 
@@ -607,7 +607,7 @@ Storage class to use for the volume.
 
 ### `providers[].storage.sync`
 
-[providers](#providers) > [storage](#providers[].storage) > sync
+[providers](#providers) > [storage](#providersstorage) > sync
 
 Storage parameters for the code sync volume, which build contexts are synced to ahead of running
 in-cluster builds.
@@ -624,7 +624,7 @@ Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored ot
 
 ### `providers[].storage.sync.size`
 
-[providers](#providers) > [storage](#providers[].storage) > [sync](#providers[].storage.sync) > size
+[providers](#providers) > [storage](#providersstorage) > [sync](#providersstoragesync) > size
 
 Volume size in megabytes.
 
@@ -634,7 +634,7 @@ Volume size in megabytes.
 
 ### `providers[].storage.sync.storageClass`
 
-[providers](#providers) > [storage](#providers[].storage) > [sync](#providers[].storage.sync) > storageClass
+[providers](#providers) > [storage](#providersstorage) > [sync](#providersstoragesync) > storageClass
 
 Storage class to use for the volume.
 
@@ -654,7 +654,7 @@ One or more certificates to use for ingress.
 
 ### `providers[].tlsCertificates[].name`
 
-[providers](#providers) > [tlsCertificates](#providers[].tlscertificates[]) > name
+[providers](#providers) > [tlsCertificates](#providerstlscertificates) > name
 
 A unique identifier for this certificate.
 
@@ -672,7 +672,7 @@ providers:
 
 ### `providers[].tlsCertificates[].hostnames[]`
 
-[providers](#providers) > [tlsCertificates](#providers[].tlscertificates[]) > hostnames
+[providers](#providers) > [tlsCertificates](#providerstlscertificates) > hostnames
 
 A list of hostnames that this certificate should be used for. If you don't specify these, they will be automatically read from the certificate.
 
@@ -691,7 +691,7 @@ providers:
 
 ### `providers[].tlsCertificates[].secretRef`
 
-[providers](#providers) > [tlsCertificates](#providers[].tlscertificates[]) > secretRef
+[providers](#providers) > [tlsCertificates](#providerstlscertificates) > secretRef
 
 A reference to the Kubernetes secret that contains the TLS certificate and key for the domain.
 
@@ -711,7 +711,7 @@ providers:
 
 ### `providers[].tlsCertificates[].secretRef.name`
 
-[providers](#providers) > [tlsCertificates](#providers[].tlscertificates[]) > [secretRef](#providers[].tlscertificates[].secretref) > name
+[providers](#providers) > [tlsCertificates](#providerstlscertificates) > [secretRef](#providerstlscertificatessecretref) > name
 
 The name of the Kubernetes secret.
 
@@ -733,7 +733,7 @@ providers:
 
 ### `providers[].tlsCertificates[].secretRef.namespace`
 
-[providers](#providers) > [tlsCertificates](#providers[].tlscertificates[]) > [secretRef](#providers[].tlscertificates[].secretref) > namespace
+[providers](#providers) > [tlsCertificates](#providerstlscertificates) > [secretRef](#providerstlscertificatessecretref) > namespace
 
 The namespace where the secret is stored. If necessary, the secret may be copied to the appropriate namespace before use.
 
@@ -787,7 +787,7 @@ The registry where built containers should be pushed to, and then pulled to the 
 
 ### `providers[].deploymentRegistry.hostname`
 
-[providers](#providers) > [deploymentRegistry](#providers[].deploymentregistry) > hostname
+[providers](#providers) > [deploymentRegistry](#providersdeploymentregistry) > hostname
 
 The hostname (and optionally port, if not the default port) of the registry.
 
@@ -806,7 +806,7 @@ providers:
 
 ### `providers[].deploymentRegistry.port`
 
-[providers](#providers) > [deploymentRegistry](#providers[].deploymentregistry) > port
+[providers](#providers) > [deploymentRegistry](#providersdeploymentregistry) > port
 
 The port where the registry listens on, if not the default.
 
@@ -816,7 +816,7 @@ The port where the registry listens on, if not the default.
 
 ### `providers[].deploymentRegistry.namespace`
 
-[providers](#providers) > [deploymentRegistry](#providers[].deploymentregistry) > namespace
+[providers](#providers) > [deploymentRegistry](#providersdeploymentregistry) > namespace
 
 The namespace in the registry where images should be pushed.
 

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -123,7 +123,7 @@ when configuring a remote Kubernetes environment with buildMode=local.
 
 ### `providers[].imagePullSecrets[].name`
 
-[providers](#providers) > [imagePullSecrets](#providers[].imagepullsecrets[]) > name
+[providers](#providers) > [imagePullSecrets](#providersimagepullsecrets) > name
 
 The name of the Kubernetes secret.
 
@@ -141,7 +141,7 @@ providers:
 
 ### `providers[].imagePullSecrets[].namespace`
 
-[providers](#providers) > [imagePullSecrets](#providers[].imagepullsecrets[]) > namespace
+[providers](#providers) > [imagePullSecrets](#providersimagepullsecrets) > namespace
 
 The namespace where the secret is stored. If necessary, the secret may be copied to the appropriate namespace before use.
 
@@ -161,7 +161,7 @@ Resource requests and limits for the in-cluster builder, container registry and 
 
 ### `providers[].resources.builder`
 
-[providers](#providers) > [resources](#providers[].resources) > builder
+[providers](#providers) > [resources](#providersresources) > builder
 
 Resource requests and limits for the in-cluster builder.
 
@@ -178,7 +178,7 @@ limits/requests, but you should evaluate based on your needs.
 
 ### `providers[].resources.builder.limits`
 
-[providers](#providers) > [resources](#providers[].resources) > [builder](#providers[].resources.builder) > limits
+[providers](#providers) > [resources](#providersresources) > [builder](#providersresourcesbuilder) > limits
 
 | Type     | Required | Default                      |
 | -------- | -------- | ---------------------------- |
@@ -186,7 +186,7 @@ limits/requests, but you should evaluate based on your needs.
 
 ### `providers[].resources.builder.limits.cpu`
 
-[providers](#providers) > [resources](#providers[].resources) > [builder](#providers[].resources.builder) > [limits](#providers[].resources.builder.limits) > cpu
+[providers](#providers) > [resources](#providersresources) > [builder](#providersresourcesbuilder) > [limits](#providersresourcesbuilderlimits) > cpu
 
 CPU limit in millicpu.
 
@@ -209,7 +209,7 @@ providers:
 
 ### `providers[].resources.builder.limits.memory`
 
-[providers](#providers) > [resources](#providers[].resources) > [builder](#providers[].resources.builder) > [limits](#providers[].resources.builder.limits) > memory
+[providers](#providers) > [resources](#providersresources) > [builder](#providersresourcesbuilder) > [limits](#providersresourcesbuilderlimits) > memory
 
 Memory limit in megabytes.
 
@@ -232,7 +232,7 @@ providers:
 
 ### `providers[].resources.builder.requests`
 
-[providers](#providers) > [resources](#providers[].resources) > [builder](#providers[].resources.builder) > requests
+[providers](#providers) > [resources](#providersresources) > [builder](#providersresourcesbuilder) > requests
 
 | Type     | Required | Default                    |
 | -------- | -------- | -------------------------- |
@@ -240,7 +240,7 @@ providers:
 
 ### `providers[].resources.builder.requests.cpu`
 
-[providers](#providers) > [resources](#providers[].resources) > [builder](#providers[].resources.builder) > [requests](#providers[].resources.builder.requests) > cpu
+[providers](#providers) > [resources](#providersresources) > [builder](#providersresourcesbuilder) > [requests](#providersresourcesbuilderrequests) > cpu
 
 CPU request in millicpu.
 
@@ -263,7 +263,7 @@ providers:
 
 ### `providers[].resources.builder.requests.memory`
 
-[providers](#providers) > [resources](#providers[].resources) > [builder](#providers[].resources.builder) > [requests](#providers[].resources.builder.requests) > memory
+[providers](#providers) > [resources](#providersresources) > [builder](#providersresourcesbuilder) > [requests](#providersresourcesbuilderrequests) > memory
 
 Memory request in megabytes.
 
@@ -286,7 +286,7 @@ providers:
 
 ### `providers[].resources.registry`
 
-[providers](#providers) > [resources](#providers[].resources) > registry
+[providers](#providers) > [resources](#providersresources) > registry
 
 Resource requests and limits for the in-cluster image registry. Built images are pushed to this registry,
 so that they are available to all the nodes in your cluster.
@@ -300,7 +300,7 @@ in how many concurrent builds you expect and how large your images tend to be.
 
 ### `providers[].resources.registry.limits`
 
-[providers](#providers) > [resources](#providers[].resources) > [registry](#providers[].resources.registry) > limits
+[providers](#providers) > [resources](#providersresources) > [registry](#providersresourcesregistry) > limits
 
 | Type     | Required | Default                      |
 | -------- | -------- | ---------------------------- |
@@ -308,7 +308,7 @@ in how many concurrent builds you expect and how large your images tend to be.
 
 ### `providers[].resources.registry.limits.cpu`
 
-[providers](#providers) > [resources](#providers[].resources) > [registry](#providers[].resources.registry) > [limits](#providers[].resources.registry.limits) > cpu
+[providers](#providers) > [resources](#providersresources) > [registry](#providersresourcesregistry) > [limits](#providersresourcesregistrylimits) > cpu
 
 CPU limit in millicpu.
 
@@ -331,7 +331,7 @@ providers:
 
 ### `providers[].resources.registry.limits.memory`
 
-[providers](#providers) > [resources](#providers[].resources) > [registry](#providers[].resources.registry) > [limits](#providers[].resources.registry.limits) > memory
+[providers](#providers) > [resources](#providersresources) > [registry](#providersresourcesregistry) > [limits](#providersresourcesregistrylimits) > memory
 
 Memory limit in megabytes.
 
@@ -354,7 +354,7 @@ providers:
 
 ### `providers[].resources.registry.requests`
 
-[providers](#providers) > [resources](#providers[].resources) > [registry](#providers[].resources.registry) > requests
+[providers](#providers) > [resources](#providersresources) > [registry](#providersresourcesregistry) > requests
 
 | Type     | Required | Default                    |
 | -------- | -------- | -------------------------- |
@@ -362,7 +362,7 @@ providers:
 
 ### `providers[].resources.registry.requests.cpu`
 
-[providers](#providers) > [resources](#providers[].resources) > [registry](#providers[].resources.registry) > [requests](#providers[].resources.registry.requests) > cpu
+[providers](#providers) > [resources](#providersresources) > [registry](#providersresourcesregistry) > [requests](#providersresourcesregistryrequests) > cpu
 
 CPU request in millicpu.
 
@@ -385,7 +385,7 @@ providers:
 
 ### `providers[].resources.registry.requests.memory`
 
-[providers](#providers) > [resources](#providers[].resources) > [registry](#providers[].resources.registry) > [requests](#providers[].resources.registry.requests) > memory
+[providers](#providers) > [resources](#providersresources) > [registry](#providersresourcesregistry) > [requests](#providersresourcesregistryrequests) > memory
 
 Memory request in megabytes.
 
@@ -408,7 +408,7 @@ providers:
 
 ### `providers[].resources.sync`
 
-[providers](#providers) > [resources](#providers[].resources) > sync
+[providers](#providers) > [resources](#providersresources) > sync
 
 Resource requests and limits for the code sync service, which we use to sync build contexts to the cluster
 ahead of building images. This generally is not resource intensive, but you might want to adjust the
@@ -420,7 +420,7 @@ defaults if you have many concurrent users.
 
 ### `providers[].resources.sync.limits`
 
-[providers](#providers) > [resources](#providers[].resources) > [sync](#providers[].resources.sync) > limits
+[providers](#providers) > [resources](#providersresources) > [sync](#providersresourcessync) > limits
 
 | Type     | Required | Default                    |
 | -------- | -------- | -------------------------- |
@@ -428,7 +428,7 @@ defaults if you have many concurrent users.
 
 ### `providers[].resources.sync.limits.cpu`
 
-[providers](#providers) > [resources](#providers[].resources) > [sync](#providers[].resources.sync) > [limits](#providers[].resources.sync.limits) > cpu
+[providers](#providers) > [resources](#providersresources) > [sync](#providersresourcessync) > [limits](#providersresourcessynclimits) > cpu
 
 CPU limit in millicpu.
 
@@ -451,7 +451,7 @@ providers:
 
 ### `providers[].resources.sync.limits.memory`
 
-[providers](#providers) > [resources](#providers[].resources) > [sync](#providers[].resources.sync) > [limits](#providers[].resources.sync.limits) > memory
+[providers](#providers) > [resources](#providersresources) > [sync](#providersresourcessync) > [limits](#providersresourcessynclimits) > memory
 
 Memory limit in megabytes.
 
@@ -474,7 +474,7 @@ providers:
 
 ### `providers[].resources.sync.requests`
 
-[providers](#providers) > [resources](#providers[].resources) > [sync](#providers[].resources.sync) > requests
+[providers](#providers) > [resources](#providersresources) > [sync](#providersresourcessync) > requests
 
 | Type     | Required | Default                   |
 | -------- | -------- | ------------------------- |
@@ -482,7 +482,7 @@ providers:
 
 ### `providers[].resources.sync.requests.cpu`
 
-[providers](#providers) > [resources](#providers[].resources) > [sync](#providers[].resources.sync) > [requests](#providers[].resources.sync.requests) > cpu
+[providers](#providers) > [resources](#providersresources) > [sync](#providersresourcessync) > [requests](#providersresourcessyncrequests) > cpu
 
 CPU request in millicpu.
 
@@ -505,7 +505,7 @@ providers:
 
 ### `providers[].resources.sync.requests.memory`
 
-[providers](#providers) > [resources](#providers[].resources) > [sync](#providers[].resources.sync) > [requests](#providers[].resources.sync.requests) > memory
+[providers](#providers) > [resources](#providersresources) > [sync](#providersresourcessync) > [requests](#providersresourcessyncrequests) > memory
 
 Memory request in megabytes.
 
@@ -542,7 +542,7 @@ factoring in how many concurrent builds you expect and how large your images and
 
 ### `providers[].storage.builder`
 
-[providers](#providers) > [storage](#providers[].storage) > builder
+[providers](#providers) > [storage](#providersstorage) > builder
 
 Storage parameters for the data volume for the in-cluster Docker Daemon.
 
@@ -554,7 +554,7 @@ Only applies when `buildMode` is set to `cluster-docker`, ignored otherwise.
 
 ### `providers[].storage.builder.size`
 
-[providers](#providers) > [storage](#providers[].storage) > [builder](#providers[].storage.builder) > size
+[providers](#providers) > [storage](#providersstorage) > [builder](#providersstoragebuilder) > size
 
 Volume size in megabytes.
 
@@ -564,7 +564,7 @@ Volume size in megabytes.
 
 ### `providers[].storage.builder.storageClass`
 
-[providers](#providers) > [storage](#providers[].storage) > [builder](#providers[].storage.builder) > storageClass
+[providers](#providers) > [storage](#providersstorage) > [builder](#providersstoragebuilder) > storageClass
 
 Storage class to use for the volume.
 
@@ -574,7 +574,7 @@ Storage class to use for the volume.
 
 ### `providers[].storage.registry`
 
-[providers](#providers) > [storage](#providers[].storage) > registry
+[providers](#providers) > [storage](#providersstorage) > registry
 
 Storage parameters for the in-cluster Docker registry volume. Built images are stored here, so that they
 are available to all the nodes in your cluster.
@@ -587,7 +587,7 @@ Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored ot
 
 ### `providers[].storage.registry.size`
 
-[providers](#providers) > [storage](#providers[].storage) > [registry](#providers[].storage.registry) > size
+[providers](#providers) > [storage](#providersstorage) > [registry](#providersstorageregistry) > size
 
 Volume size in megabytes.
 
@@ -597,7 +597,7 @@ Volume size in megabytes.
 
 ### `providers[].storage.registry.storageClass`
 
-[providers](#providers) > [storage](#providers[].storage) > [registry](#providers[].storage.registry) > storageClass
+[providers](#providers) > [storage](#providersstorage) > [registry](#providersstorageregistry) > storageClass
 
 Storage class to use for the volume.
 
@@ -607,7 +607,7 @@ Storage class to use for the volume.
 
 ### `providers[].storage.sync`
 
-[providers](#providers) > [storage](#providers[].storage) > sync
+[providers](#providers) > [storage](#providersstorage) > sync
 
 Storage parameters for the code sync volume, which build contexts are synced to ahead of running
 in-cluster builds.
@@ -624,7 +624,7 @@ Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored ot
 
 ### `providers[].storage.sync.size`
 
-[providers](#providers) > [storage](#providers[].storage) > [sync](#providers[].storage.sync) > size
+[providers](#providers) > [storage](#providersstorage) > [sync](#providersstoragesync) > size
 
 Volume size in megabytes.
 
@@ -634,7 +634,7 @@ Volume size in megabytes.
 
 ### `providers[].storage.sync.storageClass`
 
-[providers](#providers) > [storage](#providers[].storage) > [sync](#providers[].storage.sync) > storageClass
+[providers](#providers) > [storage](#providersstorage) > [sync](#providersstoragesync) > storageClass
 
 Storage class to use for the volume.
 
@@ -654,7 +654,7 @@ One or more certificates to use for ingress.
 
 ### `providers[].tlsCertificates[].name`
 
-[providers](#providers) > [tlsCertificates](#providers[].tlscertificates[]) > name
+[providers](#providers) > [tlsCertificates](#providerstlscertificates) > name
 
 A unique identifier for this certificate.
 
@@ -672,7 +672,7 @@ providers:
 
 ### `providers[].tlsCertificates[].hostnames[]`
 
-[providers](#providers) > [tlsCertificates](#providers[].tlscertificates[]) > hostnames
+[providers](#providers) > [tlsCertificates](#providerstlscertificates) > hostnames
 
 A list of hostnames that this certificate should be used for. If you don't specify these, they will be automatically read from the certificate.
 
@@ -691,7 +691,7 @@ providers:
 
 ### `providers[].tlsCertificates[].secretRef`
 
-[providers](#providers) > [tlsCertificates](#providers[].tlscertificates[]) > secretRef
+[providers](#providers) > [tlsCertificates](#providerstlscertificates) > secretRef
 
 A reference to the Kubernetes secret that contains the TLS certificate and key for the domain.
 
@@ -711,7 +711,7 @@ providers:
 
 ### `providers[].tlsCertificates[].secretRef.name`
 
-[providers](#providers) > [tlsCertificates](#providers[].tlscertificates[]) > [secretRef](#providers[].tlscertificates[].secretref) > name
+[providers](#providers) > [tlsCertificates](#providerstlscertificates) > [secretRef](#providerstlscertificatessecretref) > name
 
 The name of the Kubernetes secret.
 
@@ -733,7 +733,7 @@ providers:
 
 ### `providers[].tlsCertificates[].secretRef.namespace`
 
-[providers](#providers) > [tlsCertificates](#providers[].tlscertificates[]) > [secretRef](#providers[].tlscertificates[].secretref) > namespace
+[providers](#providers) > [tlsCertificates](#providerstlscertificates) > [secretRef](#providerstlscertificatessecretref) > namespace
 
 The namespace where the secret is stored. If necessary, the secret may be copied to the appropriate namespace before use.
 

--- a/docs/using-garden/configuration-files.md
+++ b/docs/using-garden/configuration-files.md
@@ -47,7 +47,7 @@ then available for substitution in any string value in any module's `garden.yml`
 
 For example, assuming the above project configuration, `"foo-${var.my-variable}-bar"` would evaluate to
 `"foo-hello-variable-bar"` when used as a string value in a module's `garden.yml`. See
-[Template strings](#template-strings) below for more on templating your configuration files.
+[Template strings](./variables-and-templating.md#template-string-basics) below for more on templating your configuration files.
 
 ## Module Configuration
 
@@ -105,7 +105,7 @@ depending on which provider is responsible for that module.
 
 Regardless of the implementation, a module's build process is executed with its working directory set to a copy of the
 module's top-level directory, located at `[project-root]/.garden/build/[module-name]`. This internal directory is
-referred to as the module's [build directory](../reference/glossary.md#build-directory).
+referred to as the module's build directory.
 
 The `.garden` directory should not be modified by users, since this may lead to unexpected errors when the Garden CLI
 tools are used in the project.

--- a/docs/using-garden/container-modules.md
+++ b/docs/using-garden/container-modules.md
@@ -19,7 +19,7 @@ type: container
 name: my-container
 ```
 
-If you have a `Dockerfile` next to this file, this is enough to tell Garden to build it. You can also specify `dockerfile: <path-to-Dockerfile>` if you need to override the Dockerfile name. You might also want to explictly [include or exclude](./configuration-files.md#including-excluding-files-and-directories) files in the build context.
+If you have a `Dockerfile` next to this file, this is enough to tell Garden to build it. You can also specify `dockerfile: <path-to-Dockerfile>` if you need to override the Dockerfile name. You might also want to explicitly [include or exclude](./configuration-files.md#includingexcluding-files-and-directories) files in the build context.
 
 ## Using remote images
 
@@ -105,7 +105,7 @@ services:
 ...
 ```
 
-`env` is a simple mapping of "name: value". Above we see a simple example with a string value, but you'll also commonly use [template strings](./configuration-files.md#template-strings) to interpolate variables to be consumed by the container service.
+`env` is a simple mapping of "name: value". Above we see a simple example with a string value, but you'll also commonly use [template strings](./variables-and-templating.md#template-string-basics) to interpolate variables to be consumed by the container service.
 
 #### Secrets
 
@@ -197,7 +197,7 @@ See the [reference](../reference/module-types/container.md#tasks) for all the co
 
 ## Referencing from other modules
 
-Modules can reference outputs from each other using [template strings](./configuration-files.md#template-strings). `container` modules are, for instance, often referenced by other module types such as `helm` module types. For example:
+Modules can reference outputs from each other using [template strings](./variables-and-templating.md#template-string-basics). `container` modules are, for instance, often referenced by other module types such as `helm` module types. For example:
 
 ```yaml
 kind: Module

--- a/docs/using-garden/in-cluster-building.md
+++ b/docs/using-garden/in-cluster-building.md
@@ -32,8 +32,8 @@ Specifically, the clusters need the following:
 - Support for `PersistentVolumeClaim`s and enough disk space for layer caches and the in-cluster image registry.
 
 You can—_and should_—adjust the allocated resources and storage in the provider configuration, under
-[resources](../reference/providers/kubernetes.md#providers[].resources) and
-[storage](../reference/providers/kubernetes.md#providers[].storage). See the individual modes below as well for more
+[resources](../reference/providers/kubernetes.md#providersresources) and
+[storage](../reference/providers/kubernetes.md#providersstorage). See the individual modes below as well for more
 information on how to allocate resources appropriately.
 
 ## Build modes
@@ -74,8 +74,8 @@ and a couple of small utility services.
 
 Make sure your cluster has enough resources and storage to support the required services, and keep in mind that these
 services are shared across all users of the cluster. Please look at the
-[resources](../reference/providers/kubernetes.md#providers[].resources) and
-[storage](../reference/providers/kubernetes.md#providers[].storage) sections in the provider reference for
+[resources](../reference/providers/kubernetes.md#providersresources) and
+[storage](../reference/providers/kubernetes.md#providersstorage) sections in the provider reference for
 details.
 
 ### Kaniko
@@ -94,7 +94,7 @@ The trade-off is generally in performance, at least for the moment, partly becau
 cache layers. There are also some known issues and incompatibilities, so your mileage may vary.
 
 Note the difference in how resources for the builder are allocated. See the
-[builder resources](../reference/providers/kubernetes.md#providers[].resources.builder) reference for details.
+[builder resources](../reference/providers/kubernetes.md#providersresourcesbuilder) reference for details.
 
 ### Local Docker
 

--- a/docs/using-garden/remote-kubernetes.md
+++ b/docs/using-garden/remote-kubernetes.md
@@ -124,7 +124,7 @@ to your registry's documentation on how to do that (for Docker Hub you simply ru
 
 ### Ingress, TLS and DNS
 
-By default, Garden will not install an ingress controller for remote environments. This can be toggled by setting the [`setupIngressController` flag](../reference/providers/kubernetes.md#providers[].setupingresscontroller) to `nginx`. Alternatively, you can set up your own ingress controller, e.g. using [Traefik](https://traefik.io/), [Ambassador](https://www.getambassador.io/) or [Istio](https://istio.io/).  You can find examples for [using Garden with Ambassador](https://github.com/garden-io/garden/tree/v0.10.12/examples/ambassador) and [with Istio](https://github.com/garden-io/garden/tree/v0.10.12/examples/istio) in our [examples directory](https://github.com/garden-io/garden/tree/v0.10.12/examples).
+By default, Garden will not install an ingress controller for remote environments. This can be toggled by setting the [`setupIngressController` flag](../reference/providers/kubernetes.md#providerssetupingresscontroller) to `nginx`. Alternatively, you can set up your own ingress controller, e.g. using [Traefik](https://traefik.io/), [Ambassador](https://www.getambassador.io/) or [Istio](https://istio.io/).  You can find examples for [using Garden with Ambassador](https://github.com/garden-io/garden/tree/v0.10.12/examples/ambassador) and [with Istio](https://github.com/garden-io/garden/tree/v0.10.12/examples/istio) in our [examples directory](https://github.com/garden-io/garden/tree/v0.10.12/examples).
 
 You'll also need to point one or more DNS entries to your cluster, and configure a TLS certificate for the hostnames
 you will expose for ingress.

--- a/docs/using-garden/terraform.md
+++ b/docs/using-garden/terraform.md
@@ -59,7 +59,7 @@ Notice also that we're providing an output value from the stack to the `kubernet
 
 ## Terraform modules
 
-You can also define `terraform` modules as part of your project, which act much like other Garden modules. A `terraform` module maps to a single _service_, that you can define as a runtime dependency for any of your other services and tasks. You can also reference the stack outputs of a `terraform` module using [runtime output template strings](./configuration-files.md#runtime-outputs). For example:
+You can also define `terraform` modules as part of your project, which act much like other Garden modules. A `terraform` module maps to a single _service_, that you can define as a runtime dependency for any of your other services and tasks. You can also reference the stack outputs of a `terraform` module using [runtime output template strings](./variables-and-templating.md#runtime-outputs). For example:
 
 ```yaml
 kind: Module

--- a/docs/using-garden/using-helm-charts.md
+++ b/docs/using-garden/using-helm-charts.md
@@ -4,7 +4,7 @@ The [Helm](https://helm.sh/) package manager is one of the most commonly used to
 
 In this guide we'll be using the [vote-helm](https://github.com/garden-io/garden/tree/v0.10.12/examples/vote-helm) project. If you prefer to just check out a complete example, the project itself is also a good resource.
 
-You may also want to check out the full [helm module reference](../reference/config.md#helm).
+You may also want to check out the full [helm module reference](../reference/module-types/helm.md).
 
 _Note: If you only need a way to deploy some Kubernetes manifests and don't need all the features of Helm, you can_
 _use the simpler `kubernetes` module type instead. Check out the_
@@ -302,7 +302,7 @@ a lot of flexibility in how you organize your charts.
 
 ## Next steps
 
-Check out the full [helm module reference](../reference/config.md#helm) for more details, and the
+Check out the full [helm module reference](../reference/module-types/helm.md) for more details, and the
 [vote-helm](https://github.com/garden-io/garden-example-vote-helm) example project for a full project that showcases
 Garden's Helm support.
 

--- a/docs/using-garden/using-remote-sources.md
+++ b/docs/using-garden/using-remote-sources.md
@@ -107,7 +107,7 @@ repositoryUrl: file:///my/local/project/path#master
 
 As usual, the URL must point to a specific branch or tag.
 
-Local paths work just the same remote URLs and you'll still need to [link the repository](#linking-remote-sources/modules-to-local-code) if you want to edit it locally.
+Local paths work just the same remote URLs and you'll still need to [link the repository](#linking-remote-sourcesmodules-to-local-code) if you want to edit it locally.
 
 In general we don't recommend using local paths except for testing purposes. The `garden.yml` files should be checked into your version control system and therefore shouldn't contain anything specific to a particular user's setup.
 

--- a/docs/using-garden/variables-and-templating.md
+++ b/docs/using-garden/variables-and-templating.md
@@ -100,7 +100,7 @@ services:
 
 A common use case for templating is to define variables in the project/environment configuration, and to use template strings to propagate values to modules in the project.
 
-You can define them in your project configuration using the [`variables` key](../reference/config.md#variables), as well as the [`environment[].variables` key](../reference/config.md#environment-variables) for environment-specific values. You might, for example, define project defaults using the `variables` key, and then provide environment-specific overrides in the `environment[].variables` key for each environment.
+You can define them in your project configuration using the [`variables` key](../reference/config.md#variables), as well as the [`environment[].variables` key](../reference/config.md#environmentsvariables) for environment-specific values. You might, for example, define project defaults using the `variables` key, and then provide environment-specific overrides in the `environment[].variables` key for each environment.
 
 The variables can then be configured via `${var.<key>}` template string keys. For example:
 

--- a/garden-service/src/docs/config.ts
+++ b/garden-service/src/docs/config.ts
@@ -221,8 +221,11 @@ function renderMarkdownTitle(description: NormalizedDescription, prefix = "") {
   return prefix + title
 }
 
-function renderMarkdownLink(description: NormalizedDescription) {
-  const path = renderMarkdownTitle(description).replace(/\s+/g, "-").toLowerCase()
+export function renderMarkdownLink(description: NormalizedDescription) {
+  const path = renderMarkdownTitle(description)
+    .replace(/\s+/g, "-") // Replace " " with "-""
+    .replace(/(\.)|(\[\])/g, "") // Replace "." and "[]" with ""
+    .toLowerCase()
   return `[${description.name}](#${path})`
 }
 

--- a/garden-service/src/docs/templates/base-config.hbs
+++ b/garden-service/src/docs/templates/base-config.hbs
@@ -4,7 +4,7 @@ title: Config Files Reference
 
 # garden.yml reference
 
-Below is the schema reference for the [Project](#project-configuration) and [Module](#module-configuration) `garden.yml` configuration files. For an introduction to configuring a Garden project,
+Below is the schema reference for the [Project](#project-configuration-keys) and [Module](#module-configuration-keys) `garden.yml` configuration files. For an introduction to configuring a Garden project,
 please look at our [configuration guide](../using-garden/configuration-files.md).
 
 The reference is divided into four sections. The [first section](#project-configuration-keys) lists and describes the available schema keys for the project level configuration, and the [second section](#project-yaml-schema) contains the project level YAML schema.

--- a/garden-service/test/unit/src/docs/config.ts
+++ b/garden-service/test/unit/src/docs/config.ts
@@ -3,6 +3,8 @@ import {
   getDefaultValue,
   normalizeDescriptions,
   renderConfigReference,
+  NormalizedDescription,
+  renderMarkdownLink,
 } from "../../../../src/docs/config"
 import { expect } from "chai"
 import dedent = require("dedent")
@@ -232,4 +234,54 @@ describe("config", () => {
     })
   })
 
+  describe("renderMarkdownLink", () => {
+    it("should return a markdown link with a name and relative path", () => {
+      const happy: NormalizedDescription = {
+        name: "happy",
+        level: 0,
+        required: false,
+        hasChildren: true,
+        formattedName: "happy",
+        formattedType: "string",
+      }
+      const families: NormalizedDescription = {
+        name: "families",
+        level: 0,
+        required: false,
+        hasChildren: true,
+        formattedName: "families[]",
+        formattedType: "array",
+        parent: happy,
+      }
+      const are: NormalizedDescription = {
+        name: "happy",
+        level: 0,
+        required: false,
+        hasChildren: true,
+        formattedName: "are",
+        formattedType: "string",
+        parent: families,
+      }
+      const all: NormalizedDescription = {
+        name: "all",
+        level: 0,
+        required: false,
+        hasChildren: true,
+        formattedName: "all[]",
+        formattedType: "array",
+        parent: are,
+      }
+      const alike: NormalizedDescription = {
+        name: "alike",
+        level: 0,
+        required: false,
+        hasChildren: false,
+        formattedName: "alike",
+        formattedType: "string",
+        parent: all,
+      }
+
+      expect(renderMarkdownLink(alike)).to.equal(`[alike](#happyfamiliesareallalike)`)
+    })
+  })
 })

--- a/markdown-link-check-config.json
+++ b/markdown-link-check-config.json
@@ -1,10 +1,20 @@
 {
   "ignorePatterns": [
     {
-      "pattern": "local.app.garden"
+      "pattern": "local.app.garden",
+      "reason": "Ignore example URL"
     },
     {
-      "pattern": "my-service"
+      "pattern": "^http://my-service",
+      "reason": "Ignore example URL"
+    },
+    {
+      "pattern": "^[^\/]+\/[^\/].*$|^\/[^\/].*$",
+      "reason": "Ignore relative paths. Those are handled by another tool due to: https://github.com/tcort/markdown-link-check/issues/65"
+    },
+    {
+      "pattern": "^#",
+      "reason": "Ignore relative paths. Those are handled by another tool due to: https://github.com/tcort/markdown-link-check/issues/65"
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1747,6 +1747,12 @@
         "universal-user-agent": "^4.0.0"
       }
     },
+    "@sindresorhus/is": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+      "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+      "dev": true
+    },
     "@snyk/cli-interface": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@snyk/cli-interface/-/cli-interface-2.1.0.tgz",
@@ -1784,6 +1790,15 @@
       "resolved": "https://registry.npmjs.org/@snyk/gemfile/-/gemfile-1.2.0.tgz",
       "integrity": "sha512-nI7ELxukf7pT4/VraL4iabtNNMz8mUo7EXlqCFld8O5z6mIMLX9llps24iPpaIZOwArkY3FWA+4t+ixyvtTSIA==",
       "dev": true
+    },
+    "@szmarczak/http-timer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+      "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
+      "dev": true,
+      "requires": {
+        "defer-to-connect": "^1.0.1"
+      }
     },
     "@types/agent-base": {
       "version": "4.2.0",
@@ -1891,6 +1906,12 @@
       "integrity": "sha512-G1Ggy7/9Nsa1Jt2yiBR2riEuyK2DFNnqow6R7cromXPMNynackRY1vqFTLz/gwnef1LHokbXThcPhqMRjUbkpQ==",
       "dev": true
     },
+    "@types/unist": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
+      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
+      "dev": true
+    },
     "@types/xml2js": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.3.tgz",
@@ -1950,6 +1971,24 @@
       "dev": true,
       "requires": {
         "humanize-ms": "^1.2.1"
+      }
+    },
+    "aggregate-error": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "dev": true,
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+          "dev": true
+        }
       }
     },
     "ajv": {
@@ -2426,6 +2465,12 @@
         "now-and-later": "^2.0.0"
       }
     },
+    "bail": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.4.tgz",
+      "integrity": "sha512-S8vuDB4w6YpRhICUDET3guPlQpaJl7od94tpZ0Fvnyp+MKW/HyDTcRDck+29C9g+d/qQHnddRH3+94kZdrW0Ww==",
+      "dev": true
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -2738,6 +2783,50 @@
         "unset-value": "^1.0.0"
       }
     },
+    "cacheable-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+      "dev": true,
+      "requires": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^3.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^1.0.2"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "http-cache-semantics": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
+          "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==",
+          "dev": true
+        },
+        "lowercase-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+          "dev": true
+        },
+        "normalize-url": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+          "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+          "dev": true
+        }
+      }
+    },
     "call-me-maybe": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
@@ -2805,6 +2894,12 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
+    "ccount": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.4.tgz",
+      "integrity": "sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w==",
+      "dev": true
+    },
     "chalk": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
@@ -2836,11 +2931,83 @@
         }
       }
     },
+    "character-entities": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.3.tgz",
+      "integrity": "sha512-yB4oYSAa9yLcGyTbB4ItFwHw43QHdH129IJ5R+WvxOkWlyFnR5FAaBNnUq4mcxsTVZGh28bHoeTHMKXH1wZf3w==",
+      "dev": true
+    },
+    "character-entities-html4": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.3.tgz",
+      "integrity": "sha512-SwnyZ7jQBCRHELk9zf2CN5AnGEc2nA+uKMZLHvcqhpPprjkYhiLn0DywMHgN5ttFZuITMATbh68M6VIVKwJbcg==",
+      "dev": true
+    },
+    "character-entities-legacy": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.3.tgz",
+      "integrity": "sha512-YAxUpPoPwxYFsslbdKkhrGnXAtXoHNgYjlBM3WMXkWGTl5RsY3QmOyhwAgL8Nxm9l5LBThXGawxKPn68y6/fww==",
+      "dev": true
+    },
+    "character-reference-invalid": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.3.tgz",
+      "integrity": "sha512-VOq6PRzQBam/8Jm6XBGk2fNEnHXAdGd6go0rtd4weAGECBamHDwwCQSOT12TACIYUZegUXnV6xBXqUssijtxIg==",
+      "dev": true
+    },
     "chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "check-links": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/check-links/-/check-links-1.1.8.tgz",
+      "integrity": "sha512-lxt1EeQ1CVkmiZzPfbPufperYK0t7MvhdLs3zlRH9areA6NVT1tcGymAdJONolNWQBdCFU/sek59RpeLmVHCnw==",
+      "dev": true,
+      "requires": {
+        "got": "^9.6.0",
+        "is-relative-url": "^2.0.0",
+        "p-map": "^2.0.0",
+        "p-memoize": "^2.1.0"
+      },
+      "dependencies": {
+        "got": {
+          "version": "9.6.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+          "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+          "dev": true,
+          "requires": {
+            "@sindresorhus/is": "^0.14.0",
+            "@szmarczak/http-timer": "^1.1.2",
+            "cacheable-request": "^6.0.0",
+            "decompress-response": "^3.3.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^4.1.0",
+            "lowercase-keys": "^1.0.1",
+            "mimic-response": "^1.0.1",
+            "p-cancelable": "^1.0.0",
+            "to-readable-stream": "^1.0.0",
+            "url-parse-lax": "^3.0.0"
+          }
+        },
+        "prepend-http": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+          "dev": true
+        },
+        "url-parse-lax": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+          "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+          "dev": true,
+          "requires": {
+            "prepend-http": "^2.0.0"
+          }
+        }
+      }
     },
     "chokidar": {
       "version": "2.1.6",
@@ -3540,6 +3707,12 @@
         }
       }
     },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true
+    },
     "cli-boxes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
@@ -3607,6 +3780,15 @@
         }
       }
     },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
     "clone-stats": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
@@ -3660,6 +3842,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "collapse-white-space": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.5.tgz",
+      "integrity": "sha512-703bOOmytCYAX9cXYqoikYIx6twmFCXsnzRQheBcTG3nzKYBR4P/+wkYeH+Mvj7qUz8zZDtdyzbxfnEi/kYzRQ==",
       "dev": true
     },
     "collection-map": {
@@ -4429,6 +4617,15 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -4486,6 +4683,12 @@
           "dev": true
         }
       }
+    },
+    "defer-to-connect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.0.2.tgz",
+      "integrity": "sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw==",
+      "dev": true
     },
     "define-properties": {
       "version": "1.1.3",
@@ -4621,6 +4824,24 @@
       "dev": true,
       "requires": {
         "path-type": "^3.0.0"
+      }
+    },
+    "dns-packet": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.2.1.tgz",
+      "integrity": "sha512-JHj2yJeKOqlxzeuYpN1d56GfhzivAxavNwHj9co3qptECel27B1rLY5PifJAvubsInX5pGLDjAHuCfCUc2Zv/w==",
+      "dev": true,
+      "requires": {
+        "ip": "^1.1.5"
+      }
+    },
+    "dns-socket": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dns-socket/-/dns-socket-4.2.0.tgz",
+      "integrity": "sha512-4XuD3z28jht3jvHbiom6fAipgG5LkjYeDLrX5OH8cbl0AtzTyUUAxGckcW8T7z0pLfBBV5qOiuC4wUEohk6FrQ==",
+      "dev": true,
+      "requires": {
+        "dns-packet": "^5.1.2"
       }
     },
     "dockerfile-ast": {
@@ -5293,6 +5514,15 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fault": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.3.tgz",
+      "integrity": "sha512-sfFuP4X0hzrbGKjAUNXYvNqsZ5F6ohx/dZ9I0KQud/aiZNwg263r5L9yGB0clvXHCkzXh5W3t7RSHchggYIFmA==",
+      "dev": true,
+      "requires": {
+        "format": "^0.2.2"
+      }
+    },
     "figgy-pudding": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
@@ -5422,6 +5652,12 @@
         }
       }
     },
+    "fn-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
+      "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
+      "dev": true
+    },
     "follow-redirects": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
@@ -5473,6 +5709,12 @@
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
+    },
+    "format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=",
+      "dev": true
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -6003,6 +6245,23 @@
       "dev": true,
       "requires": {
         "ini": "^1.3.2"
+      }
+    },
+    "github-slugger": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.2.1.tgz",
+      "integrity": "sha512-SsZUjg/P03KPzQBt7OxJPasGw6NRO5uOgiZ5RGXVud5iSIZ0eNZeNp5rTwCxtavrRUa/A77j8mePVc5lEvk0KQ==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": ">=6.0.0 <=6.1.1"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.1.tgz",
+          "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4=",
+          "dev": true
+        }
       }
     },
     "glob": {
@@ -7042,6 +7301,12 @@
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
       "dev": true
     },
+    "ip-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.1.0.tgz",
+      "integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA==",
+      "dev": true
+    },
     "is-absolute": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
@@ -7076,6 +7341,28 @@
             "is-buffer": "^1.1.5"
           }
         }
+      }
+    },
+    "is-alphabetical": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.3.tgz",
+      "integrity": "sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA==",
+      "dev": true
+    },
+    "is-alphanumeric": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz",
+      "integrity": "sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ=",
+      "dev": true
+    },
+    "is-alphanumerical": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz",
+      "integrity": "sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==",
+      "dev": true,
+      "requires": {
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
       }
     },
     "is-arrayish": {
@@ -7140,6 +7427,12 @@
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
+    "is-decimal": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.3.tgz",
+      "integrity": "sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ==",
+      "dev": true
+    },
     "is-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
@@ -7163,6 +7456,12 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
+    },
+    "is-empty": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-empty/-/is-empty-1.2.0.tgz",
+      "integrity": "sha1-3pu1snhzigWgsJpX4ftNSjQan2s=",
       "dev": true
     },
     "is-extendable": {
@@ -7204,6 +7503,18 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-hexadecimal": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz",
+      "integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA==",
+      "dev": true
+    },
+    "is-hidden": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-hidden/-/is-hidden-1.1.2.tgz",
+      "integrity": "sha512-kytBeNVW2QTIqZdJBDKIjP+EkUTzDT07rsc111w/gxqR6wK3ODkOswcpxgED6HU6t7fEhOxqojVZ2a2kU9rj+A==",
+      "dev": true
+    },
     "is-installed-globally": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
@@ -7212,6 +7523,15 @@
       "requires": {
         "global-dirs": "^0.1.0",
         "is-path-inside": "^1.0.0"
+      }
+    },
+    "is-ip": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
+      "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+      "dev": true,
+      "requires": {
+        "ip-regex": "^4.0.0"
       }
     },
     "is-negated-glob": {
@@ -7251,6 +7571,60 @@
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
+    },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "dev": true
+    },
+    "is-online": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/is-online/-/is-online-8.2.0.tgz",
+      "integrity": "sha512-dvTrzRlziHPdl+uazMK+9ypLlwOA3szkaGfAWqI/MKuUutgNxOFBl2gfu2BTkV8C7A2YcYHNlVcsxHzZik3wUQ==",
+      "dev": true,
+      "requires": {
+        "got": "^9.6.0",
+        "p-any": "^2.0.0",
+        "p-timeout": "^3.0.0",
+        "public-ip": "^3.0.0"
+      },
+      "dependencies": {
+        "got": {
+          "version": "9.6.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+          "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+          "dev": true,
+          "requires": {
+            "@sindresorhus/is": "^0.14.0",
+            "@szmarczak/http-timer": "^1.1.2",
+            "cacheable-request": "^6.0.0",
+            "decompress-response": "^3.3.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^4.1.0",
+            "lowercase-keys": "^1.0.1",
+            "mimic-response": "^1.0.1",
+            "p-cancelable": "^1.0.0",
+            "to-readable-stream": "^1.0.0",
+            "url-parse-lax": "^3.0.0"
+          }
+        },
+        "prepend-http": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+          "dev": true
+        },
+        "url-parse-lax": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+          "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+          "dev": true,
+          "requires": {
+            "prepend-http": "^2.0.0"
+          }
+        }
+      }
     },
     "is-path-inside": {
       "version": "1.0.1",
@@ -7381,10 +7755,22 @@
       "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
       "dev": true
     },
+    "is-whitespace-character": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz",
+      "integrity": "sha512-SNPgMLz9JzPccD3nPctcj8sZlX9DAMJSKH8bP7Z6bohCwuNgX8xbWr1eTAYXX9Vpi/aSn8Y1akL9WgM3t43YNQ==",
+      "dev": true
+    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "is-word-character": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.3.tgz",
+      "integrity": "sha512-0wfcrFgOOOBdgRNT9H33xe6Zi6yhX/uoc4U8NBZGeQQB0ctU1dnlNTyL9JM2646bHDTpsDm1Brb3VPoCIMrd/A==",
       "dev": true
     },
     "is-wsl": {
@@ -7448,6 +7834,12 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
     },
+    "json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+      "dev": true
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -7477,6 +7869,15 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
+    },
+    "json5": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+      "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.0"
+      }
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -7548,6 +7949,15 @@
       "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.0.0.tgz",
       "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
       "dev": true
+    },
+    "keyv": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
+      "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+      "dev": true,
+      "requires": {
+        "json-buffer": "3.0.0"
+      }
     },
     "kind-of": {
       "version": "6.0.2",
@@ -7632,6 +8042,12 @@
         "npmlog": "^4.1.2"
       }
     },
+    "levenshtein-edit-distance": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/levenshtein-edit-distance/-/levenshtein-edit-distance-1.0.0.tgz",
+      "integrity": "sha1-iVuvR4zOi1waDSfkXXwdl4pmHkk=",
+      "dev": true
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -7711,6 +8127,16 @@
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         }
+      }
+    },
+    "load-plugin": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/load-plugin/-/load-plugin-2.3.1.tgz",
+      "integrity": "sha512-dYB1lbwqHgPTrruy9glukCu8Ya9vzj6TMfouCtj2H/GuJ+8syioisgKTBPxnCi6m8K8jINKfTOxOHngFkUYqHw==",
+      "dev": true,
+      "requires": {
+        "npm-prefix": "^1.2.0",
+        "resolve-from": "^5.0.0"
       }
     },
     "locate-path": {
@@ -7906,6 +8332,12 @@
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
+    "longest-streak": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.3.tgz",
+      "integrity": "sha512-9lz5IVdpwsKLMzQi0MQ+oD9EA0mIGcWYP7jXMTZVXP8D42PwuAk+M/HBFYQoxt1G5OR8m7aSIgb1UymfWGBWEw==",
+      "dev": true
+    },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -8028,6 +8460,18 @@
         "object-visit": "^1.0.0"
       }
     },
+    "markdown-escapes": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.3.tgz",
+      "integrity": "sha512-XUi5HJhhV5R74k8/0H2oCbCiYf/u4cO/rX8tnGkRvrqhsr5BRNU6Mg0yt/8UIx1iIS8220BNJsDb7XnILhLepw==",
+      "dev": true
+    },
+    "markdown-extensions": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-1.1.1.tgz",
+      "integrity": "sha512-WWC0ZuMzCyDHYCasEGs4IPvLyTGftYwh6wIEOULOF0HXcqZlhwRzrK0w2VUlxWA98xnvb/jszw4ZSkJ6ADpM6Q==",
+      "dev": true
+    },
     "markdown-link-check": {
       "version": "3.7.3",
       "resolved": "https://registry.npmjs.org/markdown-link-check/-/markdown-link-check-3.7.3.tgz",
@@ -8090,6 +8534,12 @@
         "marked": "^0.6.2"
       }
     },
+    "markdown-table": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
+      "integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==",
+      "dev": true
+    },
     "marked": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.3.tgz",
@@ -8130,6 +8580,21 @@
           }
         }
       }
+    },
+    "mdast-util-compact": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.3.tgz",
+      "integrity": "sha512-nRiU5GpNy62rZppDKbLwhhtw5DXoFMqw9UNZFmlPsNaQCZ//WLjGKUwWMdJrUH+Se7UvtO2gXtAMe0g/N+eI5w==",
+      "dev": true,
+      "requires": {
+        "unist-util-visit": "^1.1.0"
+      }
+    },
+    "mdast-util-to-string": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.0.6.tgz",
+      "integrity": "sha512-868pp48gUPmZIhfKrLbaDneuzGiw3OTDjHc5M1kAepR2CWBJ+HpEsm252K4aXdiP5coVZaJPOqGtVU6Po8xnXg==",
+      "dev": true
     },
     "mem": {
       "version": "4.1.0",
@@ -8211,6 +8676,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
+    },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "dev": true
     },
     "minimatch": {
@@ -8762,6 +9233,17 @@
         }
       }
     },
+    "npm-prefix": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/npm-prefix/-/npm-prefix-1.2.0.tgz",
+      "integrity": "sha1-5hlFX3B0ulTMZtbQ033Z8b5ry8A=",
+      "dev": true,
+      "requires": {
+        "rc": "^1.1.0",
+        "shellsubstitute": "^1.1.0",
+        "untildify": "^2.1.0"
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -9045,6 +9527,31 @@
         "os-tmpdir": "^1.0.0"
       }
     },
+    "p-any": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-any/-/p-any-2.1.0.tgz",
+      "integrity": "sha512-JAERcaMBLYKMq+voYw36+x5Dgh47+/o7yuv2oQYuSSUml4YeqJEFznBrY2UeEkoSHqBua6hz518n/PsowTYLLg==",
+      "dev": true,
+      "requires": {
+        "p-cancelable": "^2.0.0",
+        "p-some": "^4.0.0",
+        "type-fest": "^0.3.0"
+      },
+      "dependencies": {
+        "p-cancelable": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
+          "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==",
+          "dev": true
+        }
+      }
+    },
+    "p-cancelable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+      "dev": true
+    },
     "p-defer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
@@ -9096,6 +9603,16 @@
         "p-reduce": "^1.0.0"
       }
     },
+    "p-memoize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-memoize/-/p-memoize-2.1.0.tgz",
+      "integrity": "sha512-c6+a2iV4JyX0r4+i2IBJYO0r6LZAT2fg/tcB6GQbv1uzZsfsmKT7Ej5DRT1G6Wi7XUJSV2ZiP9+YEtluvhCmkg==",
+      "dev": true,
+      "requires": {
+        "mem": "^4.0.0",
+        "mimic-fn": "^1.0.0"
+      }
+    },
     "p-pipe": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/p-pipe/-/p-pipe-1.2.0.tgz",
@@ -9116,6 +9633,33 @@
       "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
       "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
       "dev": true
+    },
+    "p-some": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-some/-/p-some-4.1.0.tgz",
+      "integrity": "sha512-MF/HIbq6GeBqTrTIl5OJubzkGU+qfFhAFi0gnTAK6rgEIJIknEiABHOTtQu4e6JiXjIwuMPMUFQzyHh5QjCl1g==",
+      "dev": true,
+      "requires": {
+        "aggregate-error": "^3.0.0",
+        "p-cancelable": "^2.0.0"
+      },
+      "dependencies": {
+        "p-cancelable": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
+          "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==",
+          "dev": true
+        }
+      }
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dev": true,
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
     },
     "p-try": {
       "version": "1.0.0",
@@ -9222,6 +9766,20 @@
       "dev": true,
       "requires": {
         "callsites": "^3.0.0"
+      }
+    },
+    "parse-entities": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+      "dev": true,
+      "requires": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
       }
     },
     "parse-filepath": {
@@ -9358,6 +9916,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
+      "integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==",
       "dev": true
     },
     "pify": {
@@ -9520,6 +10084,15 @@
         "read": "1"
       }
     },
+    "propose": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/propose/-/propose-0.0.5.tgz",
+      "integrity": "sha1-SKBl2ex9TIZn9AULFcSi2F28pWs=",
+      "dev": true,
+      "requires": {
+        "levenshtein-edit-distance": "^1.0.0"
+      }
+    },
     "proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -9601,6 +10174,53 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
       "integrity": "sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA==",
       "dev": true
+    },
+    "public-ip": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/public-ip/-/public-ip-3.2.0.tgz",
+      "integrity": "sha512-DBq4o955zhrhESG4z6GkLN9mtY9NT/JOjEV8pvnYy3bjVQOQF0J5lJNwWLbEWwNstyNFJlY7JxCPFq4bdXSabw==",
+      "dev": true,
+      "requires": {
+        "dns-socket": "^4.2.0",
+        "got": "^9.6.0",
+        "is-ip": "^3.1.0"
+      },
+      "dependencies": {
+        "got": {
+          "version": "9.6.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+          "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+          "dev": true,
+          "requires": {
+            "@sindresorhus/is": "^0.14.0",
+            "@szmarczak/http-timer": "^1.1.2",
+            "cacheable-request": "^6.0.0",
+            "decompress-response": "^3.3.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^4.1.0",
+            "lowercase-keys": "^1.0.1",
+            "mimic-response": "^1.0.1",
+            "p-cancelable": "^1.0.0",
+            "to-readable-stream": "^1.0.0",
+            "url-parse-lax": "^3.0.0"
+          }
+        },
+        "prepend-http": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+          "dev": true
+        },
+        "url-parse-lax": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+          "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+          "dev": true,
+          "requires": {
+            "prepend-http": "^2.0.0"
+          }
+        }
+      }
     },
     "pump": {
       "version": "3.0.0",
@@ -9844,6 +10464,130 @@
       "dev": true,
       "requires": {
         "rc": "^1.0.1"
+      }
+    },
+    "remark": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/remark/-/remark-11.0.1.tgz",
+      "integrity": "sha512-Fl2AvN+yU6sOBAjUz3xNC5iEvLkXV8PZicLOOLifjU8uKGusNvhHfGRCfETsqyvRHZ24JXqEyDY4hRLhoUd30A==",
+      "dev": true,
+      "requires": {
+        "remark-parse": "^7.0.0",
+        "remark-stringify": "^7.0.0",
+        "unified": "^8.2.0"
+      }
+    },
+    "remark-cli": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/remark-cli/-/remark-cli-7.0.0.tgz",
+      "integrity": "sha512-gYomWviFnZsiRimG+Jdb4LQ9c8uSOcGmPTmzlvxImt0gvzabqlp1kaqndxTx4kYLsWGqwhQRO+M9iyqHDkoDlA==",
+      "dev": true,
+      "requires": {
+        "markdown-extensions": "^1.1.0",
+        "remark": "^11.0.0",
+        "unified-args": "^7.0.0"
+      }
+    },
+    "remark-lint-no-dead-urls": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-dead-urls/-/remark-lint-no-dead-urls-0.5.0.tgz",
+      "integrity": "sha512-wMr1+7Sh5rRGF9hmF9iyajRNQfA2BnADc9myYjpRxsYozRDj6p2ddVwBh76loUKwCZ64sLRKamyhMDwQ0NIdYA==",
+      "dev": true,
+      "requires": {
+        "check-links": "^1.1.7",
+        "is-online": "^8.2.0",
+        "unified-lint-rule": "^1.0.4",
+        "unist-util-visit": "^2.0.0"
+      },
+      "dependencies": {
+        "unist-util-is": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.0.tgz",
+          "integrity": "sha512-E5JLUKRQlAYiJmN2PVBdSz01R3rUKRSM00X+0DB/yLqxdLu6wZZkRdTIsxDp9X+bkxh8Eq+O2YYRbZvLZtQT1A==",
+          "dev": true
+        },
+        "unist-util-visit": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.0.tgz",
+          "integrity": "sha512-kiTpWKsF54u/78L/UU/i7lxrnqGiEWBgqCpaIZBYP0gwUC+Akq0Ajm4U8JiNIoQNfAioBdsyarnOcTEAb9mLeQ==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^4.0.0",
+            "unist-util-visit-parents": "^3.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.0.0.tgz",
+          "integrity": "sha512-H3K8d81S4V3XVXVwLvrLGk+R5VILryfUotD06/R/rLsTsPLGjkn6gIP8qEEVITcuIySNYj0ocJLsePjm9F/Vcg==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.3",
+            "unist-util-is": "^4.0.0"
+          }
+        }
+      }
+    },
+    "remark-parse": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-7.0.1.tgz",
+      "integrity": "sha512-WOZLa545jYXtSy+txza6ACudKWByQac4S2DmGk+tAGO/3XnVTOxwyCIxB7nTcLlk8Aayhcuf3cV1WV6U6L7/DQ==",
+      "dev": true,
+      "requires": {
+        "collapse-white-space": "^1.0.2",
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-whitespace-character": "^1.0.0",
+        "is-word-character": "^1.0.0",
+        "markdown-escapes": "^1.0.0",
+        "parse-entities": "^1.1.0",
+        "repeat-string": "^1.5.4",
+        "state-toggle": "^1.0.0",
+        "trim": "0.0.1",
+        "trim-trailing-lines": "^1.0.0",
+        "unherit": "^1.0.4",
+        "unist-util-remove-position": "^1.0.0",
+        "vfile-location": "^2.0.0",
+        "xtend": "^4.0.1"
+      }
+    },
+    "remark-stringify": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-7.0.3.tgz",
+      "integrity": "sha512-+jgmjNjm2kR7y2Ns1BATXRlFr+iQ7sDcpSgytfU77nkw7UCd5yJNArSxB3MU3Uul7HuyYNTCjetoGfy8xLia1A==",
+      "dev": true,
+      "requires": {
+        "ccount": "^1.0.0",
+        "is-alphanumeric": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-whitespace-character": "^1.0.0",
+        "longest-streak": "^2.0.1",
+        "markdown-escapes": "^1.0.0",
+        "markdown-table": "^1.1.0",
+        "mdast-util-compact": "^1.0.0",
+        "parse-entities": "^1.0.2",
+        "repeat-string": "^1.5.4",
+        "state-toggle": "^1.0.0",
+        "stringify-entities": "^2.0.0",
+        "unherit": "^1.0.4",
+        "xtend": "^4.0.1"
+      }
+    },
+    "remark-validate-links": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/remark-validate-links/-/remark-validate-links-9.0.1.tgz",
+      "integrity": "sha512-+ZW2xzqDEujM+oPkutHm5LiTkMXeE7ldzruwi1xYVYq5xOE+zbPf0UMpc14ek2yn10T9Vvc+xLF5njZILqyAFw==",
+      "dev": true,
+      "requires": {
+        "github-slugger": "^1.2.0",
+        "hosted-git-info": "^2.5.0",
+        "mdast-util-to-string": "^1.0.4",
+        "propose": "0.0.5",
+        "to-vfile": "^6.0.0",
+        "trough": "^1.0.0",
+        "unist-util-visit": "^1.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "remove-bom-buffer": {
@@ -10230,6 +10974,15 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
+    "responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "dev": true,
+      "requires": {
+        "lowercase-keys": "^1.0.0"
+      }
+    },
     "restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
@@ -10460,6 +11213,12 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
+    "shellsubstitute": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shellsubstitute/-/shellsubstitute-1.2.0.tgz",
+      "integrity": "sha1-5PcCpQxRiw9v6YRRiQ1wWvKba3A=",
+      "dev": true
+    },
     "shx": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.2.tgz",
@@ -10506,6 +11265,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
       "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true
+    },
+    "sliced": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
+      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E=",
       "dev": true
     },
     "slide": {
@@ -11435,6 +12200,12 @@
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "dev": true
     },
+    "state-toggle": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.2.tgz",
+      "integrity": "sha512-8LpelPGR0qQM4PnfLiplOQNJcIN1/r2Gy0xKB2zKnIW2YzPMt2sR4I/+gtPjhN7Svh9kw+zqEg2SFwpBO9iNiw==",
+      "dev": true
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -11511,6 +12282,19 @@
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "stringify-entities": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-2.0.0.tgz",
+      "integrity": "sha512-fqqhZzXyAM6pGD9lky/GOPq6V4X0SeTAFBl0iXb/BzOegl40gpf/bV3QQP7zULNYvjr6+Dx8SCaDULjVoOru0A==",
+      "dev": true,
+      "requires": {
+        "character-entities-html4": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.2",
+        "is-hexadecimal": "^1.0.0"
       }
     },
     "strip-ansi": {
@@ -11700,6 +12484,12 @@
       "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
       "dev": true
     },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
     "then-fs": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/then-fs/-/then-fs-2.0.0.tgz",
@@ -11810,6 +12600,12 @@
         }
       }
     },
+    "to-readable-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
+      "dev": true
+    },
     "to-regex": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
@@ -11839,6 +12635,24 @@
       "dev": true,
       "requires": {
         "through2": "^2.0.3"
+      }
+    },
+    "to-vfile": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/to-vfile/-/to-vfile-6.0.0.tgz",
+      "integrity": "sha512-i9fwXXSsHLu7mzgixc1WjgnqSe6pGpjnzCYoFmrASvEueLfyKf09QAe+XQYu8OAJ62aFqHpe2EKXojeRVvEzqA==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "^2.0.0",
+        "vfile": "^4.0.0"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "dev": true
+        }
       }
     },
     "toidentifier": {
@@ -11886,6 +12700,12 @@
       "integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==",
       "dev": true
     },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+      "dev": true
+    },
     "trim-newlines": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
@@ -11896,6 +12716,18 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
       "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
+      "dev": true
+    },
+    "trim-trailing-lines": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz",
+      "integrity": "sha512-MUjYItdrqqj2zpcHFTkMa9WAv4JHTI6gnRQGPFLrt5L9a6tRMiDnIqYl8JBvu2d2Tc3lWJKQwlGCp0K8AvCM+Q==",
+      "dev": true
+    },
+    "trough": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.4.tgz",
+      "integrity": "sha512-tdzBRDGWcI1OpPVmChbdSKhvSVurznZ8X36AYURAcl+0o2ldlCY2XPzyXNNxwJwwyIU+rIglTCG4kxtNKBQH7Q==",
       "dev": true
     },
     "ts-node": {
@@ -12107,6 +12939,235 @@
       "integrity": "sha1-XkvaMI5KiirlhPm5pDWaSZglzFA=",
       "dev": true
     },
+    "unherit": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.2.tgz",
+      "integrity": "sha512-W3tMnpaMG7ZY6xe/moK04U9fBhi6wEiCYHUW5Mop/wQHf12+79EQGwxYejNdhEz2mkqkBlGwm7pxmgBKMVUj0w==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "xtend": "^4.0.1"
+      }
+    },
+    "unified": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-8.4.1.tgz",
+      "integrity": "sha512-YPj/uIIZSO7mMIZQj/5Z3hDl4lshWYRQGs5TgUCjHTVdklUWH+O94mK5Cy77SEcmEUwGhnUcudMuH/zIwporqw==",
+      "dev": true,
+      "requires": {
+        "bail": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^2.0.0",
+        "trough": "^1.0.0",
+        "vfile": "^4.0.0"
+      },
+      "dependencies": {
+        "is-plain-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.0.0.tgz",
+          "integrity": "sha512-EYisGhpgSCwspmIuRHGjROWTon2Xp8Z7U03Wubk/bTL5TTRC5R1rGVgyjzBrk9+ULdH6cRD06KRcw/xfqhVYKQ==",
+          "dev": true
+        }
+      }
+    },
+    "unified-args": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/unified-args/-/unified-args-7.1.0.tgz",
+      "integrity": "sha512-soi9Rn7l5c1g0RfElSCHMwaxeiclSI0EsS3uZmMPUOfwMeeeZjLpNmHAowV9iSlQh59iiZhSMyQu9lB8WnIz5g==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "chalk": "^2.0.0",
+        "chokidar": "^3.0.0",
+        "fault": "^1.0.2",
+        "json5": "^2.0.0",
+        "minimist": "^1.2.0",
+        "text-table": "^0.2.0",
+        "unified-engine": "^7.0.0"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+          "dev": true,
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "binary-extensions": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+          "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+          "dev": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "chokidar": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.2.1.tgz",
+          "integrity": "sha512-/j5PPkb5Feyps9e+jo07jUZGvkB5Aj953NrI4s8xSVScrAo/RHeILrtdb4uzR7N6aaFFxxJ+gt8mA8HfNpw76w==",
+          "dev": true,
+          "requires": {
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.1.0",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.1.3"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "fsevents": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.0.tgz",
+          "integrity": "sha512-+iXhW3LuDQsno8dOIrCIT/CBjeBWuP7PXe8w9shnj9Lebny/Gx1ZjVBYwexLz36Ri2jKuXMNpV6CYNh8lHHgrQ==",
+          "dev": true,
+          "optional": true
+        },
+        "glob-parent": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+          "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "is-binary-path": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+          "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+          "dev": true,
+          "requires": {
+            "binary-extensions": "^2.0.0"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "dev": true
+        },
+        "readdirp": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.1.3.tgz",
+          "integrity": "sha512-ZOsfTGkjO2kqeR5Mzr5RYDbTGYneSkdNKX2fOX2P5jF7vMrd/GNnIAUtDldeHHumHUCQ3V05YfWUdxMPAsRu9Q==",
+          "dev": true,
+          "requires": {
+            "picomatch": "^2.0.4"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
+    "unified-engine": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/unified-engine/-/unified-engine-7.0.0.tgz",
+      "integrity": "sha512-zH/MvcISpWg3JZtCoY/GYBw1WnVHkhnPoMBWpmuvAifCPSS9mzT9EbtimesJp6t2nnr/ojI0mg3TmkO1CjIwVA==",
+      "dev": true,
+      "requires": {
+        "concat-stream": "^2.0.0",
+        "debug": "^4.0.0",
+        "fault": "^1.0.0",
+        "figures": "^3.0.0",
+        "fn-name": "^2.0.1",
+        "glob": "^7.0.3",
+        "ignore": "^5.0.0",
+        "is-empty": "^1.0.0",
+        "is-hidden": "^1.0.1",
+        "is-object": "^1.0.1",
+        "js-yaml": "^3.6.1",
+        "load-plugin": "^2.0.0",
+        "parse-json": "^4.0.0",
+        "to-vfile": "^6.0.0",
+        "trough": "^1.0.0",
+        "unist-util-inspect": "^4.1.2",
+        "vfile-reporter": "^6.0.0",
+        "vfile-statistics": "^1.1.0",
+        "x-is-string": "^0.1.0",
+        "xtend": "^4.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "figures": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-3.0.0.tgz",
+          "integrity": "sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "ignore": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "unified-lint-rule": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unified-lint-rule/-/unified-lint-rule-1.0.4.tgz",
+      "integrity": "sha512-q9wY6S+d38xRAuWQVOMjBQYi7zGyKkY23ciNafB8JFVmDroyKjtytXHCg94JnhBCXrNqpfojo3+8D+gmF4zxJQ==",
+      "dev": true,
+      "requires": {
+        "wrapped": "^1.0.1"
+      }
+    },
     "union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -12154,6 +13215,57 @@
       "dev": true,
       "requires": {
         "crypto-random-string": "^1.0.0"
+      }
+    },
+    "unist-util-inspect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/unist-util-inspect/-/unist-util-inspect-4.1.4.tgz",
+      "integrity": "sha512-7xxyvKiZ1SC9vL5qrMqKub1T31gRHfau4242F69CcaOrXt//5PmRVOmDZ36UAEgiT+tZWzmQmbNZn+mVtnR9HQ==",
+      "dev": true,
+      "requires": {
+        "is-empty": "^1.0.0"
+      }
+    },
+    "unist-util-is": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
+      "dev": true
+    },
+    "unist-util-remove-position": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.3.tgz",
+      "integrity": "sha512-CtszTlOjP2sBGYc2zcKA/CvNdTdEs3ozbiJ63IPBxh8iZg42SCCb8m04f8z2+V1aSk5a7BxbZKEdoDjadmBkWA==",
+      "dev": true,
+      "requires": {
+        "unist-util-visit": "^1.1.0"
+      }
+    },
+    "unist-util-stringify-position": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.1.tgz",
+      "integrity": "sha512-Zqlf6+FRI39Bah8Q6ZnNGrEHUhwJOkHde2MHVk96lLyftfJJckaPslKgzhVcviXj8KcE9UJM9F+a4JEiBUTYgA==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.2"
+      }
+    },
+    "unist-util-visit": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+      "dev": true,
+      "requires": {
+        "unist-util-visit-parents": "^2.0.0"
+      }
+    },
+    "unist-util-visit-parents": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+      "dev": true,
+      "requires": {
+        "unist-util-is": "^3.0.0"
       }
     },
     "universal-user-agent": {
@@ -12215,6 +13327,15 @@
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
           "dev": true
         }
+      }
+    },
+    "untildify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
+      "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0"
       }
     },
     "unzip-response": {
@@ -12369,6 +13490,118 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
+    },
+    "vfile": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.0.1.tgz",
+      "integrity": "sha512-lRHFCuC4SQBFr7Uq91oJDJxlnftoTLQ7eKIpMdubhYcVMho4781a8MWXLy3qZrZ0/STD1kRiKc0cQOHm4OkPeA==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "replace-ext": "1.0.0",
+        "unist-util-stringify-position": "^2.0.0",
+        "vfile-message": "^2.0.0"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "dev": true
+        }
+      }
+    },
+    "vfile-location": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.5.tgz",
+      "integrity": "sha512-Pa1ey0OzYBkLPxPZI3d9E+S4BmvfVwNAAXrrqGbwTVXWaX2p9kM1zZ+n35UtVM06shmWKH4RPRN8KI80qE3wNQ==",
+      "dev": true
+    },
+    "vfile-message": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.1.tgz",
+      "integrity": "sha512-KtasSV+uVU7RWhUn4Lw+wW1Zl/nW8JWx7JCPps10Y9JRRIDeDXf8wfBLoOSsJLyo27DqMyAi54C6Jf/d6Kr2Bw==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.2",
+        "unist-util-stringify-position": "^2.0.0"
+      }
+    },
+    "vfile-reporter": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vfile-reporter/-/vfile-reporter-6.0.0.tgz",
+      "integrity": "sha512-8Is0XxFxWJUhPJdOg3CyZTqd3ICCWg6r304PuBl818ZG91h4FMS3Q+lrOPS+cs5/DZK3H0+AkJdH0J8JEwKtDA==",
+      "dev": true,
+      "requires": {
+        "repeat-string": "^1.5.0",
+        "string-width": "^4.0.0",
+        "supports-color": "^6.0.0",
+        "unist-util-stringify-position": "^2.0.0",
+        "vfile-sort": "^2.1.2",
+        "vfile-statistics": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
+          "integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^5.2.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "vfile-sort": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/vfile-sort/-/vfile-sort-2.2.1.tgz",
+      "integrity": "sha512-5dt7xEhC44h0uRQKhbM2JAe0z/naHphIZlMOygtMBM9Nn0pZdaX5fshhwWit9wvsuP8t/wp43nTDRRErO1WK8g==",
+      "dev": true
+    },
+    "vfile-statistics": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vfile-statistics/-/vfile-statistics-1.1.3.tgz",
+      "integrity": "sha512-CstaK/ebTz1W3Qp41Bt9Lj/2DmumFsCwC2sKahDNSPh0mPh7/UyMLCoU8ZBX34CRU0d61B4W41yIFsV0NKMZeA==",
+      "dev": true
     },
     "vinyl": {
       "version": "2.2.0",
@@ -12621,6 +13854,24 @@
         "strip-ansi": "^3.0.1"
       }
     },
+    "wrapped": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wrapped/-/wrapped-1.0.1.tgz",
+      "integrity": "sha1-x4PZ2Aeyc+mwHoUWgKk4yHyQckI=",
+      "dev": true,
+      "requires": {
+        "co": "3.1.0",
+        "sliced": "^1.0.1"
+      },
+      "dependencies": {
+        "co": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
+          "integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g=",
+          "dev": true
+        }
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -12707,6 +13958,12 @@
           }
         }
       }
+    },
+    "x-is-string": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
+      "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
+      "dev": true
     },
     "xdg-basedir": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "lerna": "^3.16.4",
     "lodash": "^4.17.15",
     "markdown-link-check": "^3.7.3",
+    "remark-cli": "^7.0.0",
+    "remark-validate-links": "^9.0.1",
     "replace-in-file": "^4.1.3",
     "semver": "^6.3.0",
     "shx": "^0.3.2",


### PR DESCRIPTION
**What this PR does / why we need it**:

`markdown-check-link` doesn't check internal header links. This is a
known issue (https://github.com/tcort/markdown-link-check/issues/65).

We therefore add a new tool to check for internal links and limit
markdown-check-link to external links.

The new tool is from the remark family of markdown tools and expects
anchor links to not include any special characters so we also had to
make appropriate changes to the docs generator functions.

Finally, this commit fixes broken links discovered because of these
fixes.

**Which issue(s) this PR fixes**:

Fixes #1249 
