### PR TITLE
fix(k8s): add missing command argument to helm module test schema

### DIFF
--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -664,6 +664,25 @@ tests:
         - my-server.js
 ```
 
+### `tests[].command[]`
+
+[tests](#tests) > command
+
+The command/entrypoint used to run the test inside the container.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
+Example:
+
+```yaml
+tests:
+  - command:
+    - /bin/sh
+    - '-c'
+```
+
 ### `tests[].args[]`
 
 [tests](#tests) > args
@@ -673,6 +692,15 @@ The arguments to pass to the pod used for testing.
 | Type            | Required |
 | --------------- | -------- |
 | `array[string]` | No       |
+
+Example:
+
+```yaml
+tests:
+  - args:
+    - npm
+    - test
+```
 
 ### `tests[].env`
 
@@ -791,6 +819,7 @@ tests:
       containerName:
       containerModule:
       hotReloadArgs:
+    command:
     args:
     env: {}
 timeout: 300

--- a/garden-service/src/plugins/kubernetes/helm/config.ts
+++ b/garden-service/src/plugins/kubernetes/helm/config.ts
@@ -126,8 +126,12 @@ export const execTestSchema = baseTestSpecSchema
         If not specified, the \`serviceResource\` configured on the module will be used. If neither is specified,
         an error will be thrown.`,
       ),
+    command: joi.array().items(joi.string())
+      .description("The command/entrypoint used to run the test inside the container.")
+      .example([commandExample, {}]),
     args: joi.array().items(joi.string())
-      .description("The arguments to pass to the pod used for testing."),
+      .description("The arguments to pass to the pod used for testing.")
+      .example([["npm", "test"], {}]),
     env: containerEnvVarsSchema,
   })
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:

We were already accounting for this in the code, was just missing
from the validation schema.
