### PR TITLE
fix(vcs): no files were found when dotIgnoreFiles was set to empty list

### DIFF
--- a/garden-service/test/unit/src/vcs/git.ts
+++ b/garden-service/test/unit/src/vcs/git.ts
@@ -294,6 +294,23 @@ describe("GitHandler", () => {
       expect(files).to.eql([])
     })
 
+    it("should work without ignore files", async () => {
+      const path = resolve(tmpPath, "foo.txt")
+
+      await createFile(path)
+      await writeFile(path, "my change")
+      await git("add", ".")
+      await git("commit", "-m", "foo")
+
+      const hash = "6e1ab2d7d26c1c66f27fea8c136e13c914e3f137"
+
+      const _handler = new GitHandler(tmpPath, [])
+
+      expect(await _handler.getFiles({ path: tmpPath, log })).to.eql([
+        { path, hash },
+      ])
+    })
+
     it("should correctly handle multiple ignore files", async () => {
       const nameA = "foo.txt"
       const nameB = "boo.txt"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:

If you set `dotIgnoreFiles: []` in your project config, no modules would be found.

**Which issue(s) this PR fixes**:

Just came across this myself.
