### PR TITLE
improvement(k8s): also delete metadata namespace when cleaning up

### DIFF
--- a/garden-service/src/plugins/kubernetes/init.ts
+++ b/garden-service/src/plugins/kubernetes/init.ts
@@ -7,7 +7,7 @@
  */
 
 import { KubeApi, KubernetesError } from "./api"
-import { getAppNamespace, prepareNamespaces, deleteNamespaces } from "./namespace"
+import { getAppNamespace, prepareNamespaces, deleteNamespaces, getMetadataNamespace } from "./namespace"
 import { KubernetesPluginContext, KubernetesConfig } from "./config"
 import { checkTillerStatus, installTiller } from "./helm/tiller"
 import {
@@ -233,13 +233,14 @@ export async function cleanupEnvironment({ ctx, log }: CleanupEnvironmentParams)
   const k8sCtx = <KubernetesPluginContext>ctx
   const api = await KubeApi.factory(log, k8sCtx.provider)
   const namespace = await getAppNamespace(k8sCtx, log, k8sCtx.provider)
+  const metadataNamespace = await getMetadataNamespace(k8sCtx, log, k8sCtx.provider)
   const entry = log.info({
     section: "kubernetes",
     msg: `Deleting namespace ${namespace} (this may take a while)`,
     status: "active",
   })
 
-  await deleteNamespaces([namespace], api, entry)
+  await deleteNamespaces([namespace, metadataNamespace], api, entry)
 
   return {}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:

We used to keep the metadata namespace around when deleting environments, which was by design at the time but no longer makes sense, and just confuses users.

**Which issue(s) this PR fixes**:

Closes #1266
