### PR TITLE
improvement(core): delete services in dep order

### DIFF
--- a/garden-service/src/tasks/base.ts
+++ b/garden-service/src/tasks/base.ts
@@ -18,6 +18,7 @@ import { splitLast } from "../util/util"
 
 export type TaskType =
   | "build"
+  | "delete-service"
   | "deploy"
   | "get-service-status"
   | "get-task-result"

--- a/garden-service/src/tasks/delete-service.ts
+++ b/garden-service/src/tasks/delete-service.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2018 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { LogEntry } from "../logger/log-entry"
+import { BaseTask, TaskType } from "./base"
+import { Service, ServiceStatus } from "../types/service"
+import { Garden } from "../garden"
+import { ConfigGraph } from "../config-graph"
+import { TaskResults, TaskResult } from "../task-graph"
+
+export interface DeleteServiceTaskParams {
+  garden: Garden
+  graph: ConfigGraph
+  service: Service
+  log: LogEntry
+  includeDependants?: boolean
+}
+
+export class DeleteServiceTask extends BaseTask {
+  type: TaskType = "delete-service"
+
+  private graph: ConfigGraph
+  private service: Service
+  private includeDependants: boolean
+
+  constructor({ garden, graph, log, service, includeDependants = false }: DeleteServiceTaskParams) {
+    super({ garden, log, force: false, version: service.module.version })
+    this.graph = graph
+    this.service = service
+    this.includeDependants = includeDependants
+  }
+
+  async getDependencies() {
+    if (!this.includeDependants) {
+      return []
+    }
+
+    // Note: We delete in _reverse_ dependency order, so we query for dependants
+    const deps = await this.graph.getDependants("service", this.getName(), false)
+
+    return deps.service.map((service) => {
+      return new DeleteServiceTask({
+        garden: this.garden,
+        graph: this.graph,
+        log: this.log,
+        service,
+        includeDependants: this.includeDependants,
+      })
+    })
+  }
+
+  getName() {
+    return this.service.name
+  }
+
+  getDescription() {
+    return `deleting service '${this.service.name}' (from module '${this.service.module.name}')`
+  }
+
+  async process(): Promise<ServiceStatus> {
+    const actions = await this.garden.getActionRouter()
+    let status: ServiceStatus
+
+    try {
+      status = await actions.deleteService({ log: this.log, service: this.service })
+    } catch (err) {
+      this.log.setError()
+      throw err
+    }
+
+    return status
+  }
+}
+
+export function deletedServiceStatuses(results: TaskResults): { [serviceName: string]: ServiceStatus } {
+  const deleted = <TaskResult[]>Object.values(results).filter((r) => r && r.type === "delete-service")
+  const statuses = {}
+
+  for (const res of deleted) {
+    statuses[res.name] = res.output
+  }
+
+  return statuses
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Short and sweet. The delete environment command now deletes services in dependency order.

That is, a service's _dependants_ are deleted before it itself is deleted.

Added a new task class, `DeleteServiceTask` to accomplish this. The `delete service` and `delete environment` commands now use this task internally instead of calling the action directly.

**Which issue(s) this PR fixes**:

Resolves #1232.

**Special notes for your reviewer**:

Have a look at the `DeleteServiceTask` class (mostly the `getDependencies` method).

Try deploying e.g. the `vote` example, delete a service or two, then delete the environment, see if you approve of the minor tweaks to the log output here.