### PR TITLE
Standardise errors

### DIFF
--- a/examples/demo-project/garden.yml
+++ b/examples/demo-project/garden.yml
@@ -9,7 +9,8 @@ environments:
     providers:
       - name: kubernetes
         # Replace these values as appropriate
-        context: gke_garden-dev-200012_europe-west1-b_garden-dev-1
+        # context: gke_garden-dev-200012_europe-west1-b_garden-dev-1
+        context: foo
         namespace: ${local.env.USER || local.username}-demo-project
         defaultHostname: ${local.env.USER || local.username}-demo-project.dev-1.sys.garden
         buildMode: cluster-docker

--- a/garden-service/src/build-dir.ts
+++ b/garden-service/src/build-dir.ts
@@ -19,11 +19,11 @@ import {
 import { emptyDir, ensureDir } from "fs-extra"
 import { ConfigurationError } from "./exceptions"
 import { FileCopySpec, Module, getModuleKey } from "./types/module"
-import execa from "execa"
 import { normalizeLocalRsyncPath } from "./util/fs"
 import { LogEntry } from "./logger/log-entry"
 import { ModuleConfig } from "./config/module"
 import { ConfigGraph } from "./config-graph"
+import { exec } from "./util/util"
 
 // FIXME: We don't want to keep special casing this module type so we need to think
 // of a better way around this.
@@ -179,7 +179,7 @@ export class BuildDir {
       log.silly(`File list: ${JSON.stringify(files)}`)
     }
 
-    await execa("rsync", [...syncOpts, sourcePath, destinationPath], { input })
+    await exec("rsync", [...syncOpts, sourcePath, destinationPath], { input })
   }
 }
 

--- a/garden-service/src/commands/get/get-debug-info.ts
+++ b/garden-service/src/commands/get/get-debug-info.ts
@@ -15,10 +15,9 @@ import {
 } from "../base"
 import { findProjectConfig } from "../../config/base"
 import { ensureDir, copy, remove, pathExists, writeFile } from "fs-extra"
-import { getPackageVersion } from "../../util/util"
+import { getPackageVersion, exec } from "../../util/util"
 import { platform, release } from "os"
 import { join, relative, basename, dirname } from "path"
-import execa = require("execa")
 import { LogEntry } from "../../logger/log-entry"
 import { deline } from "../../util/string"
 import { findConfigPathsInPath, getConfigFilePath, defaultDotIgnoreFiles } from "../../util/fs"
@@ -115,7 +114,7 @@ export async function collectSystemDiagnostic(gardenDirPath: string, log: LogEnt
   const dockerLog = log.info({ section: "Docker", msg: "collecting info", status: "active" })
   let dockerVersion = ""
   try {
-    dockerVersion = (await execa("docker", ["--version"])).stdout
+    dockerVersion = (await exec("docker", ["--version"])).stdout
     dockerLog.setSuccess({ msg: chalk.green(`Done (took ${log.getDuration(1)} sec)`), append: true })
   } catch (error) {
     log.error("Error encountered while executing docker")

--- a/garden-service/src/commands/get/get-eysi.ts
+++ b/garden-service/src/commands/get/get-eysi.ts
@@ -14,7 +14,7 @@ import dedent = require("dedent")
 import { readFile } from "fs-extra"
 import { STATIC_DIR } from "../../constants"
 import { join } from "path"
-import execa = require("execa")
+import { exec } from "../../util/util"
 
 export class GetEysiCommand extends Command {
   name = "eysi"
@@ -32,7 +32,7 @@ export class GetEysiCommand extends Command {
 
     try {
       // Close enough.
-      await execa("say", ["Hello", ",", "I", "am", "Aysey"])
+      await exec("say", ["Hello", ",", "I", "am", "Aysey"])
     } catch (_) { }
 
     return { result: { eysi } }

--- a/garden-service/src/garden.ts
+++ b/garden-service/src/garden.ts
@@ -496,10 +496,9 @@ export class Garden {
 
       if (failed.length) {
         const messages = failed.map(r => `- ${r!.name}: ${r!.error!.message}`)
+        const names = failed.map(r => r!.name)
         throw new PluginError(
-          `Failed resolving one or more providers:\n${messages.join(
-            "\n",
-          )}`,
+          `Failed resolving one or more providers:\n- ${names.join("\n- ")}`,
           { rawConfigs, taskResults, messages },
         )
       }

--- a/garden-service/src/plugins/kubernetes/container/build.ts
+++ b/garden-service/src/plugins/kubernetes/container/build.ts
@@ -16,7 +16,6 @@ import { BuildModuleParams, BuildResult } from "../../../types/plugin/module/bui
 import { getPods, millicpuToString, megabytesToString } from "../util"
 import { systemNamespace } from "../system"
 import { RSYNC_PORT } from "../constants"
-import execa = require("execa")
 import { posix, resolve } from "path"
 import { KubeApi } from "../api"
 import { kubectl } from "../kubectl"
@@ -31,6 +30,7 @@ import { getPortForward } from "../port-forward"
 import chalk from "chalk"
 import { Writable } from "stream"
 import { LogLevel } from "../../../logger/log-node"
+import { exec } from "../../../util/util"
 
 const dockerDaemonDeploymentName = "garden-docker-daemon"
 const dockerDaemonContainerName = "docker-daemon"
@@ -149,7 +149,7 @@ const remoteBuild: BuildHandler = async (params) => {
 
   // We retry a couple of times, because we may get intermittent connection issues or concurrency issues
   await pRetry(
-    () => execa("rsync", ["-vrpztgo", "--relative", "--delete", src, destination]),
+    () => exec("rsync", ["-vrpztgo", "--relative", "--delete", src, destination]),
     { retries: 3, minTimeout: 500 },
   )
 

--- a/garden-service/src/plugins/kubernetes/hot-reload.ts
+++ b/garden-service/src/plugins/kubernetes/hot-reload.ts
@@ -7,7 +7,6 @@
  */
 
 import Bluebird from "bluebird"
-import execa from "execa"
 import normalizePath = require("normalize-path")
 import { V1Deployment, V1DaemonSet, V1StatefulSet } from "@kubernetes/client-node"
 import { ContainerModule, ContainerHotReloadSpec } from "../container/config"
@@ -29,6 +28,7 @@ import { normalizeLocalRsyncPath } from "../../util/fs"
 import { createWorkloadResource } from "./container/deployment"
 import { kubectl } from "./kubectl"
 import { labelSelectorToString } from "./util"
+import { exec } from "../../util/util"
 
 export const RSYNC_PORT_NAME = "garden-rsync"
 
@@ -291,7 +291,7 @@ export async function syncToService(
 
       log.debug(`Hot-reloading from ${src} to ${destination}`)
 
-      return execa("rsync", ["-vrpztgo", src, destination])
+      return exec("rsync", ["-vrpztgo", src, destination])
     })
 
     const postSyncCommand = hotReloadSpec.postSyncCommand

--- a/garden-service/src/plugins/kubernetes/local/config.ts
+++ b/garden-service/src/plugins/kubernetes/local/config.ts
@@ -7,7 +7,6 @@
  */
 
 import Bluebird from "bluebird"
-import execa from "execa"
 import { KubernetesBaseConfig, kubernetesConfigBase, k8sContextSchema } from "../config"
 import { ConfigureProviderParams } from "../../../types/plugin/provider/configureProvider"
 import { joiProviderName, joi } from "../../../config/common"
@@ -15,6 +14,7 @@ import { getKubeConfig } from "../api"
 import { configureMicrok8sAddons } from "./microk8s"
 import { setMinikubeDockerEnv } from "./minikube"
 import { ContainerRegistryConfig } from "../../container/config"
+import { exec } from "../../../util/util"
 
 // TODO: split this into separate plugins to handle Docker for Mac and Minikube
 
@@ -99,17 +99,17 @@ export async function configureProvider({ config, log, projectName }: ConfigureP
       ["config", "set", "WantUpdateNotification", "false"],
       ["addons", "enable", "dashboard"],
     ]
-    await Bluebird.map(initCmds, async (cmd) => execa("minikube", cmd))
+    await Bluebird.map(initCmds, async (cmd) => exec("minikube", cmd))
 
     if (!defaultHostname) {
       // use the nip.io service to give a hostname to the instance, if none is explicitly configured
-      const { stdout } = await execa("minikube", ["ip"])
+      const { stdout } = await exec("minikube", ["ip"])
       defaultHostname = `${projectName}.${stdout}.nip.io`
     }
 
     if (config.setupIngressController === "nginx") {
       log.debug("Using minikube's ingress addon")
-      await execa("minikube", ["addons", "enable", "ingress"])
+      await exec("minikube", ["addons", "enable", "ingress"])
     }
 
     await setMinikubeDockerEnv()

--- a/garden-service/src/plugins/kubernetes/local/microk8s.ts
+++ b/garden-service/src/plugins/kubernetes/local/microk8s.ts
@@ -6,15 +6,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import execa from "execa"
 import { RuntimeError } from "../../../exceptions"
 import { LogEntry } from "../../../logger/log-entry"
+import { exec } from "../../../util/util"
 
 export async function configureMicrok8sAddons(log: LogEntry, addons: string[]) {
   let status = ""
 
   try {
-    status = (await execa("microk8s.status")).stdout
+    status = (await exec("microk8s.status")).stdout
   } catch {
     // This is caught below.
   }
@@ -29,6 +29,6 @@ export async function configureMicrok8sAddons(log: LogEntry, addons: string[]) {
 
   if (missingAddons.length > 0) {
     log.info({ section: "microk8s", msg: `enabling required addons (${missingAddons.join(", ")})` })
-    await execa("microk8s.enable", missingAddons)
+    await exec("microk8s.enable", missingAddons)
   }
 }

--- a/garden-service/src/plugins/kubernetes/local/minikube.ts
+++ b/garden-service/src/plugins/kubernetes/local/minikube.ts
@@ -7,6 +7,7 @@
  */
 
 import execa from "execa"
+import { exec } from "../../../util/util"
 
 /**
  * Automatically set docker environment variables for minikube
@@ -16,7 +17,7 @@ export async function setMinikubeDockerEnv() {
   let minikubeEnv: string
 
   try {
-    minikubeEnv = (await execa("minikube", ["docker-env", "--shell=bash"])).stdout
+    minikubeEnv = (await exec("minikube", ["docker-env", "--shell=bash"])).stdout
   } catch (err) {
     if ((<execa.ExecaError>err).stderr.includes("driver does not support")) {
       return

--- a/garden-service/src/util/ext-tools.ts
+++ b/garden-service/src/util/ext-tools.ts
@@ -10,9 +10,8 @@ import { platform } from "os"
 import { pathExists, createWriteStream, ensureDir, chmod, remove, move } from "fs-extra"
 import { ConfigurationError, ParameterError, GardenBaseError } from "../exceptions"
 import { join, dirname, basename, sep } from "path"
-import { hashString } from "./util"
+import { hashString, exec } from "./util"
 import Axios from "axios"
-import execa from "execa"
 import tar from "tar"
 import { SupportedPlatform, GARDEN_GLOBAL_PATH } from "../constants"
 import { LogEntry } from "../logger/log-entry"
@@ -269,20 +268,15 @@ export class BinaryCmd extends Library {
 
     log.debug(`Execing '${path} ${args.join(" ")}' in ${cwd}`)
 
-    const proc = execa(path, args, {
+    return exec(path, args, {
       cwd,
       timeout: this.getTimeout(timeout) * 1000,
       env,
       input,
+      outputStream,
       reject: !ignoreError,
     })
 
-    if (outputStream) {
-      proc.stdout && proc.stdout.pipe(outputStream)
-      proc.stderr && proc.stderr.pipe(outputStream)
-    }
-
-    return proc
   }
 
   async stdout(params: ExecParams) {

--- a/garden-service/test/unit/src/garden.ts
+++ b/garden-service/test/unit/src/garden.ts
@@ -1351,10 +1351,15 @@ describe("Garden", () => {
       const garden = await TestGarden.factory(projectRootA, { config: projectConfig, plugins: [test] })
       await expectError(
         () => garden.resolveProviders(),
-        err => expect(err.message).to.equal(
-          "Failed resolving one or more providers:\n" +
-          "- test: Invalid template string \${bla.ble}: Unable to resolve one or more keys.",
-        ),
+        err => {
+          expect(err.message).to.equal(
+            "Failed resolving one or more providers:\n" +
+            "- test",
+          )
+          expect(err.detail.messages[0]).to.equal(
+            "- test: Invalid template string \${bla.ble}: Unable to resolve one or more keys.",
+          )
+        },
       )
     })
 
@@ -1649,10 +1654,15 @@ describe("Garden", () => {
 
       await expectError(
         () => garden.resolveProviders(),
-        err => expect(stripAnsi(err.message)).to.equal(
-          "Failed resolving one or more providers:\n- " +
-          "test: Error validating provider configuration (/garden.yml): key .foo must be a string",
-        ),
+        err => {
+          expect(err.message).to.equal(
+            "Failed resolving one or more providers:\n" +
+            "- test",
+          )
+          expect(stripAnsi(err.detail.messages[0])).to.equal(
+            "- test: Error validating provider configuration (/garden.yml): key .foo must be a string",
+          )
+        },
       )
     })
 
@@ -1690,10 +1700,15 @@ describe("Garden", () => {
 
       await expectError(
         () => garden.resolveProviders(),
-        err => expect(stripAnsi(err.message)).to.equal(
-          "Failed resolving one or more providers:\n- " +
-          "test: Error validating provider configuration (/garden.yml): key .foo must be a string",
-        ),
+        err => {
+          expect(err.message).to.equal(
+            "Failed resolving one or more providers:\n" +
+            "- test",
+          )
+          expect(stripAnsi(err.detail.messages[0])).to.equal(
+            "- test: Error validating provider configuration (/garden.yml): key .foo must be a string",
+          )
+        },
       )
     })
 
@@ -1880,11 +1895,16 @@ describe("Garden", () => {
 
         await expectError(
           () => garden.resolveProviders(),
-          err => expect(stripAnsi(err.message)).to.equal(
-            "Failed resolving one or more providers:\n" +
-            "- test: Error validating provider configuration (base schema from 'base' plugin) " +
-            "(/garden.yml): key .foo must be a string",
-          ),
+          err => {
+            expect(err.message).to.equal(
+              "Failed resolving one or more providers:\n" +
+              "- test",
+            )
+            expect(stripAnsi(err.detail.messages[0])).to.equal(
+              "- test: Error validating provider configuration (base schema from 'base' plugin) " +
+              "(/garden.yml): key .foo must be a string",
+            )
+          },
         )
       })
 
@@ -1927,11 +1947,16 @@ describe("Garden", () => {
 
         await expectError(
           () => garden.resolveProviders(),
-          err => expect(stripAnsi(err.message)).to.equal(
-            "Failed resolving one or more providers:\n" +
-            "- test: Error validating provider configuration (base schema from 'base' plugin) " +
-            "(/garden.yml): key .foo must be a string",
-          ),
+          err => {
+            expect(err.message).to.equal(
+              "Failed resolving one or more providers:\n" +
+              "- test",
+            )
+            expect(stripAnsi(err.detail.messages[0])).to.equal(
+              "- test: Error validating provider configuration (base schema from 'base' plugin) " +
+              "(/garden.yml): key .foo must be a string",
+            )
+          },
         )
       })
     })

--- a/garden-service/test/unit/src/util/util.ts
+++ b/garden-service/test/unit/src/util/util.ts
@@ -1,15 +1,179 @@
 import { expect } from "chai"
+import { describe } from "mocha"
 import {
   pickKeys,
   getEnvVarName,
   deepOmitUndefined,
   deepFilter,
   splitLast,
+  exec,
+  createOutputStream,
+  makeErrorMsg,
+  renderOutputStream,
+  spawn,
 } from "../../../../src/util/util"
 import { expectError } from "../../../helpers"
 import { splitFirst } from "../../../../src/util/util"
+import { getLogger } from "../../../../src/logger/logger"
+import { dedent } from "../../../../src/util/string"
+
+function isLinuxOrDarwin() {
+  return process.platform === "darwin" || process.platform === "linux"
+}
 
 describe("util", () => {
+  describe("makeErrorMsg", () => {
+    it("should return an error message", () => {
+      const msg = makeErrorMsg({
+        code: 1,
+        cmd: "ls",
+        args: ["some-dir"],
+        error: "dir not found",
+        output: "dir not found",
+      })
+      expect(msg).to.equal(dedent`
+        Command "ls some-dir" failed with code 1:
+
+        dir not found
+      `)
+    })
+    it("should ignore emtpy args", () => {
+      const msg = makeErrorMsg({
+        code: 1,
+        cmd: "ls",
+        args: [],
+        error: "dir not found",
+        output: "dir not found",
+      })
+      expect(msg).to.equal(dedent`
+        Command "ls" failed with code 1:
+
+        dir not found
+      `)
+    })
+    it("should include output if it's not the same as the error", () => {
+      const msg = makeErrorMsg({
+        code: 1,
+        cmd: "ls some-dir",
+        args: [],
+        error: "dir not found",
+        output: "dir not found and some more output",
+      })
+      expect(msg).to.equal(dedent`
+        Command "ls some-dir" failed with code 1:
+
+        dir not found
+
+        Here's the full output:
+
+        dir not found and some more output
+      `)
+    })
+    it("should include the last 100 lines of output if output is very long", () => {
+      const output = "All work and no play\n"
+      const outputFull = output.repeat(102)
+      const outputPartial = output.repeat(99) // This makes 100 lines in total
+
+      const msg = makeErrorMsg({
+        code: 1,
+        cmd: "ls some-dir",
+        args: [],
+        error: "dir not found",
+        output: outputFull,
+      })
+      expect(msg).to.equal(dedent`
+        Command "ls some-dir" failed with code 1:
+
+        dir not found
+
+        Here are the last 100 lines of the output:
+
+        ${outputPartial}
+      `)
+    })
+  })
+  describe("exec", () => {
+    before(function() {
+      // These tests depend the underlying OS and are only executed on macOS and linux
+      if (!isLinuxOrDarwin()) {
+        // tslint:disable-next-line: no-invalid-this
+        this.skip()
+      }
+    })
+    it("should successfully execute a command", async () => {
+      const res = await exec("echo", ["hello"])
+      expect(res.stdout).to.equal("hello")
+    })
+    it("should handle command and args in a single string", async () => {
+      const res = await exec("echo hello && echo world", [], { shell: true })
+      expect(res.stdout).to.equal("hello\nworld")
+    })
+    it("should optionally pipe stdout and stderr to an output stream", async () => {
+      const logger = getLogger()
+      const entry = logger.placeholder()
+      const errorEntry = logger.placeholder()
+
+      await exec("echo hello", [], { outputStream: createOutputStream(entry) })
+      // Using "sh -c" to get consistent output between operating systems
+      await exec(`sh -c "echo hello error; exit 1"`, [], {
+        outputStream: createOutputStream(errorEntry), shell: true, reject: false,
+      })
+      expect(entry.getMessageState().msg).to.equal(renderOutputStream("hello"))
+      expect(errorEntry.getMessageState().msg).to.equal(
+        renderOutputStream("hello error"),
+      )
+    })
+    it("should throw a standardised error message on error", async () => {
+      try {
+        // Using "sh -c" to get consistent output between operating systems
+        await exec(`sh -c "echo hello error; exit 1"`, [], { shell: true })
+      } catch (err) {
+        expect(err.message).to.equal(makeErrorMsg({
+          code: 1,
+          cmd: `sh -c "echo hello error; exit 1"`,
+          args: [],
+          output: "hello error",
+          error: "",
+        }))
+      }
+    })
+  })
+
+  describe("spawn", () => {
+    before(function() {
+      // These tests depend on the underlying OS and are only executed on macOS and linux
+      if (!isLinuxOrDarwin()) {
+        // tslint:disable-next-line: no-invalid-this
+        this.skip()
+      }
+    })
+    it("should throw a standardised error message on error", async () => {
+      try {
+        await spawn("ls", ["scottiepippen"])
+      } catch (err) {
+        // We're not using "sh -c" here since the output is not added to stdout|stderr if `tty: true` and
+        // we therefore can't test the entire error message.
+        if (process.platform === "darwin") {
+          expect(err.message).to.equal(makeErrorMsg({
+            code: 1,
+            cmd: "ls scottiepippen",
+            args: [],
+            output: "ls: scottiepippen: No such file or directory",
+            error: "ls: scottiepippen: No such file or directory",
+          }))
+        } else {
+          expect(err.message).to.equal(makeErrorMsg({
+            code: 2,
+            cmd: "ls scottiepippen",
+            args: [],
+            output: "ls: cannot access 'scottiepippen': No such file or directory",
+            error: "ls: cannot access 'scottiepippen': No such file or directory",
+          }))
+        }
+      }
+    })
+  })
+
   describe("getEnvVarName", () => {
     it("should translate the service name to a name appropriate for env variables", async () => {
       expect(getEnvVarName("service-b")).to.equal("SERVICE_B")


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, the error message was not visible when commands were executed via `execa` (see #1282 for an example). Furthermore `execa` and `spawn` would return different looking errors.

The `execa` error message looked like this:

![Screenshot 2019-10-28 at 15 04 45](https://user-images.githubusercontent.com/5373776/67685000-87c7b900-f994-11e9-93b6-8333e4583f0c.png)

Now both `execa` and `spawn` errors look like this:

![Screenshot 2019-10-28 at 15 06 01](https://user-images.githubusercontent.com/5373776/67685010-8f875d80-f994-11e9-8e9b-c09ca6496d9f.png)

In particular, the error itself is visible and the command and error are bold. (EDIT: Text is no longer bold, see comments below).

**Which issue(s) this PR fixes**:

Fixes #1282, #1283 

**Special notes for your reviewer**:

I updated the commit to address an issue that just came up (#1283). I explain the changes in the comments below so that we can compare the different screenshots.

I suggest looking at the final changes as opposed to commit by commit. The tests should also paint a good picture.

Also, I'm flagging this as a draft PR until we squash and merge #1262 as it depends on it.
