### PR TITLE
feat: allow specifying tolerations for registry-proxy

### DIFF
--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -764,6 +764,78 @@ The namespace where the secret is stored. If necessary, the secret may be copied
 | -------- | -------- | ----------- |
 | `string` | No       | `"default"` |
 
+### `providers[].registryProxyTolerations[]`
+
+[providers](#providers) > registryProxyTolerations
+
+For setting tolerations on the registry-proxy when using in-cluster building.
+The registry-proxy is a DaemonSet that proxies connections to the docker registry service on each node.
+
+Use this only if you're doing in-cluster building and the nodes in your cluster
+have [taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/).
+
+| Type            | Required | Default |
+| --------------- | -------- | ------- |
+| `array[object]` | No       | `[]`    |
+
+### `providers[].registryProxyTolerations[].effect`
+
+[providers](#providers) > [registryProxyTolerations](#providersregistryproxytolerations) > effect
+
+"Effect" indicates the taint effect to match. Empty means match all taint effects. When specified,
+allowed values are "NoSchedule", "PreferNoSchedule" and "NoExecute".
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].registryProxyTolerations[].key`
+
+[providers](#providers) > [registryProxyTolerations](#providersregistryproxytolerations) > key
+
+"Key" is the taint key that the toleration applies to. Empty means match all taint keys.
+If the key is empty, operator must be "Exists"; this combination means to match all values and all keys.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].registryProxyTolerations[].operator`
+
+[providers](#providers) > [registryProxyTolerations](#providersregistryproxytolerations) > operator
+
+"Operator" represents a key's relationship to the value. Valid operators are "Exists" and "Equal". Defaults to
+"Equal". "Exists" is equivalent to wildcard for value, so that a pod can tolerate all taints of a
+particular category.
+
+| Type     | Required | Default   |
+| -------- | -------- | --------- |
+| `string` | No       | `"Equal"` |
+
+### `providers[].registryProxyTolerations[].tolerationSeconds`
+
+[providers](#providers) > [registryProxyTolerations](#providersregistryproxytolerations) > tolerationSeconds
+
+"TolerationSeconds" represents the period of time the toleration (which must be of effect "NoExecute",
+otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate
+the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately)
+by the system.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].registryProxyTolerations[].value`
+
+[providers](#providers) > [registryProxyTolerations](#providersregistryproxytolerations) > value
+
+"Value" is the taint value the toleration matches to. If the operator is "Exists", the value should be empty,
+otherwise just a regular string.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
 ### `providers[].name`
 
 [providers](#providers) > name
@@ -973,6 +1045,12 @@ providers:
         secretRef:
           name:
           namespace: default
+    registryProxyTolerations:
+      - effect:
+        key:
+        operator: Equal
+        tolerationSeconds:
+        value:
     name: kubernetes
     context:
     deploymentRegistry:

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -764,6 +764,78 @@ The namespace where the secret is stored. If necessary, the secret may be copied
 | -------- | -------- | ----------- |
 | `string` | No       | `"default"` |
 
+### `providers[].registryProxyTolerations[]`
+
+[providers](#providers) > registryProxyTolerations
+
+For setting tolerations on the registry-proxy when using in-cluster building.
+The registry-proxy is a DaemonSet that proxies connections to the docker registry service on each node.
+
+Use this only if you're doing in-cluster building and the nodes in your cluster
+have [taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/).
+
+| Type            | Required | Default |
+| --------------- | -------- | ------- |
+| `array[object]` | No       | `[]`    |
+
+### `providers[].registryProxyTolerations[].effect`
+
+[providers](#providers) > [registryProxyTolerations](#providersregistryproxytolerations) > effect
+
+"Effect" indicates the taint effect to match. Empty means match all taint effects. When specified,
+allowed values are "NoSchedule", "PreferNoSchedule" and "NoExecute".
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].registryProxyTolerations[].key`
+
+[providers](#providers) > [registryProxyTolerations](#providersregistryproxytolerations) > key
+
+"Key" is the taint key that the toleration applies to. Empty means match all taint keys.
+If the key is empty, operator must be "Exists"; this combination means to match all values and all keys.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].registryProxyTolerations[].operator`
+
+[providers](#providers) > [registryProxyTolerations](#providersregistryproxytolerations) > operator
+
+"Operator" represents a key's relationship to the value. Valid operators are "Exists" and "Equal". Defaults to
+"Equal". "Exists" is equivalent to wildcard for value, so that a pod can tolerate all taints of a
+particular category.
+
+| Type     | Required | Default   |
+| -------- | -------- | --------- |
+| `string` | No       | `"Equal"` |
+
+### `providers[].registryProxyTolerations[].tolerationSeconds`
+
+[providers](#providers) > [registryProxyTolerations](#providersregistryproxytolerations) > tolerationSeconds
+
+"TolerationSeconds" represents the period of time the toleration (which must be of effect "NoExecute",
+otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate
+the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately)
+by the system.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].registryProxyTolerations[].value`
+
+[providers](#providers) > [registryProxyTolerations](#providersregistryproxytolerations) > value
+
+"Value" is the taint value the toleration matches to. If the operator is "Exists", the value should be empty,
+otherwise just a regular string.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
 ### `providers[].name`
 
 [providers](#providers) > name
@@ -874,6 +946,12 @@ providers:
         secretRef:
           name:
           namespace: default
+    registryProxyTolerations:
+      - effect:
+        key:
+        operator: Equal
+        tolerationSeconds:
+        value:
     name: local-kubernetes
     context:
     namespace:

--- a/garden-service/src/plugins/kubernetes/init.ts
+++ b/garden-service/src/plugins/kubernetes/init.ts
@@ -279,6 +279,10 @@ export function getKubernetesSystemVariables(config: KubernetesConfig) {
     "sync-storage-size": megabytesToString(config.storage.sync.size!),
     "sync-storage-class": syncStorageClass,
     "sync-volume-name": `garden-sync-${syncStorageClass}`,
+
+    // Stringifying the tolerations since variable values should be primitives.
+    // Helm handles the decoding automatically.
+    "registry-proxy-tolerations": JSON.stringify(config.registryProxyTolerations),
   }
 }
 

--- a/garden-service/src/plugins/kubernetes/local/config.ts
+++ b/garden-service/src/plugins/kubernetes/local/config.ts
@@ -161,6 +161,7 @@ export async function configureProvider({ config, log, projectName }: ConfigureP
     storage: config.storage,
     setupIngressController: config.setupIngressController,
     tlsCertificates: config.tlsCertificates,
+    registryProxyTolerations: config.registryProxyTolerations,
     _systemServices,
   }
 

--- a/garden-service/static/kubernetes/system/registry-proxy/garden.yml
+++ b/garden-service/static/kubernetes/system/registry-proxy/garden.yml
@@ -4,6 +4,7 @@ name: registry-proxy
 description: DaemonSet that proxies connections to the docker registry service on each node
 releaseName: garden-registry-proxy
 values:
+  tolerations: ${var.registry-proxy-tolerations}
   registry:
     hostname: ${var.registry-hostname || "foo"}
     # tlsSecretName: ${variables.registry-tls-secret-name}

--- a/garden-service/static/kubernetes/system/registry-proxy/templates/daemonset.yaml
+++ b/garden-service/static/kubernetes/system/registry-proxy/templates/daemonset.yaml
@@ -47,15 +47,17 @@ spec:
         - name: envoy-yaml
           configMap:
             name: {{ include "registry-proxy.fullname" . }}-envoy
+    # We expose the tolerations directive to the user.
+    {{- with .Values.tolerations }}
+      # Note that we're not using the toYAML function here because the tolerations are JSON stringified (by Garden)
+      tolerations:
+        {{- . | nindent 8 }}
+    {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     {{- with .Values.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
-      tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/garden-service/test/unit/src/plugins/kubernetes/container/ingress.ts
+++ b/garden-service/test/unit/src/plugins/kubernetes/container/ingress.ts
@@ -48,6 +48,7 @@ const basicConfig: KubernetesConfig = {
   ingressHttpsPort: 443,
   resources: defaultResources,
   storage: defaultStorage,
+  registryProxyTolerations: [],
   tlsCertificates: [],
   _systemServices: [],
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables users to set tolerations for the registry-proxy DaemonSet. From the docs:

> For setting tolerations on the registry-proxy when using in-cluster building.
The registry-proxy is a DaemonSet that proxies connections to the docker registry service on each node.
>
> Use this only if you're doing in-cluster building and the nodes in your cluster
have [taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/).

**Which issue(s) this PR fixes**:

Fixes #1279

**Special notes for your reviewer**:

The description for the individual toleration fields and the validation rules are derived from the [K8s API reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#toleration-v1-core).