### PR TITLE
fix(k8s): hostPath is now relative to module source path

### DIFF
--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -813,9 +813,23 @@ The path where the volume should be mounted in the container.
 
 [services](#services) > [volumes](#servicesvolumes) > hostPath
 
+_NOTE: Usage of hostPath is generally discouraged, since it doesn't work reliably across different platforms
+and providers. Some providers may not support it at all._
+
+A local path or path on the node that's running the container, to mount in the container, relative to the
+module source path (or absolute).
+
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
+
+Example:
+
+```yaml
+services:
+  - volumes:
+      - hostPath: "/some/dir"
+```
 
 ### `tests`
 

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -818,9 +818,23 @@ The path where the volume should be mounted in the container.
 
 [services](#services) > [volumes](#servicesvolumes) > hostPath
 
+_NOTE: Usage of hostPath is generally discouraged, since it doesn't work reliably across different platforms
+and providers. Some providers may not support it at all._
+
+A local path or path on the node that's running the container, to mount in the container, relative to the
+module source path (or absolute).
+
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
+
+Example:
+
+```yaml
+services:
+  - volumes:
+      - hostPath: "/some/dir"
+```
 
 ### `tests`
 

--- a/garden-service/src/plugins/container/config.ts
+++ b/garden-service/src/plugins/container/config.ts
@@ -25,6 +25,7 @@ import { CommonServiceSpec, ServiceConfig, baseServiceSpecSchema } from "../../c
 import { baseTaskSpecSchema, BaseTaskSpec } from "../../config/task"
 import { baseTestSpecSchema, BaseTestSpec } from "../../config/test"
 import { joiStringMap } from "../../config/common"
+import { dedent } from "../../util/string"
 
 export const defaultContainerLimits: ServiceLimitSpec = {
   cpu: 1000,     // = 1000 millicpu = 1 CPU
@@ -285,10 +286,19 @@ const volumeSchema = joi.object()
       .required()
       .description("The name of the allocated volume."),
     containerPath: joi.string()
+      .posixPath()
       .required()
       .description("The path where the volume should be mounted in the container."),
     hostPath: joi.string()
-      .meta({ deprecated: true }),
+      .posixPath()
+      .description(dedent`
+        _NOTE: Usage of hostPath is generally discouraged, since it doesn't work reliably across different platforms
+        and providers. Some providers may not support it at all._
+
+        A local path or path on the node that's running the container, to mount in the container, relative to the
+        module source path (or absolute).
+      `)
+      .example("/some/dir"),
   })
 
 const serviceSchema = baseServiceSpecSchema

--- a/garden-service/src/plugins/kubernetes/container/deployment.ts
+++ b/garden-service/src/plugins/kubernetes/container/deployment.ts
@@ -30,6 +30,7 @@ import { DeleteServiceParams } from "../../../types/plugin/service/deleteService
 import { millicpuToString, kilobytesToString, prepareEnvVars, workloadTypes } from "../util"
 import { gardenAnnotationKey } from "../../../util/string"
 import { RuntimeContext } from "../../../runtime-context"
+import { resolve } from "path"
 
 export const DEFAULT_CPU_REQUEST = "10m"
 export const DEFAULT_MEMORY_REQUEST = "64Mi"
@@ -288,7 +289,7 @@ export async function createWorkloadResource(
   }
 
   if (spec.volumes && spec.volumes.length) {
-    configureVolumes(deployment, container, spec)
+    configureVolumes(service.module, deployment, container, spec)
   }
 
   const ports = spec.ports
@@ -467,7 +468,7 @@ function configureHealthCheck(container, spec): void {
 
 }
 
-function configureVolumes(deployment, container, spec): void {
+function configureVolumes(module: ContainerModule, deployment, container, spec): void {
   const volumes: any[] = []
   const volumeMounts: any[] = []
 
@@ -492,12 +493,12 @@ function configureVolumes(deployment, container, spec): void {
       volumes.push({
         name: volumeName,
         hostPath: {
-          path: volume.hostPath,
+          path: resolve(module.path, volume.hostPath),
         },
       })
       volumeMounts.push({
         name: volumeName,
-        mountPath: volume.containerPath || volume.hostPath,
+        mountPath: volume.containerPath,
       })
     } else {
       throw new Error("Unsupported volume type: " + volumeType)

--- a/garden-service/src/plugins/local/local-docker-swarm.ts
+++ b/garden-service/src/plugins/local/local-docker-swarm.ts
@@ -20,6 +20,7 @@ import { DeployServiceParams } from "../../types/plugin/service/deployService"
 import { ExecInServiceParams } from "../../types/plugin/service/execInService"
 import { GetServiceStatusParams } from "../../types/plugin/service/getServiceStatus"
 import { EnvironmentStatus } from "../../types/plugin/provider/getEnvironmentStatus"
+import { resolve } from "path"
 
 // should this be configurable and/or global across providers?
 const DEPLOY_TIMEOUT = 30
@@ -64,7 +65,7 @@ export const gardenPlugin = createGardenPlugin({
           if (v.hostPath) {
             return {
               Type: "bind",
-              Source: v.hostPath,
+              Source: resolve(module.path, v.hostPath),
               Target: v.containerPath,
             }
           } else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:

Previously we implicitly expected an absolute path. Now we explicitly
make it relative to the module path, but also support absolute paths.

Also added some docs, warning against the usage of hostPath.
