### PR TITLE
improvement(openfaas): updated faas-netes and made more configurable

### DIFF
--- a/docs/reference/module-types/openfaas.md
+++ b/docs/reference/module-types/openfaas.md
@@ -4,8 +4,8 @@ title: Openfaas
 
 # `openfaas` reference
 
-Deploy [OpenFaaS](https://www.openfaas.com/) functions using Garden. Requires either the `openfaas` or
-`local-openfaas` provider to be configured.
+Deploy [OpenFaaS](https://www.openfaas.com/) functions using Garden. Requires the `openfaas` provider
+to be configured.
 
 Below is the schema reference. For an introduction to configuring Garden modules, please look at our [Configuration
 guide](../../guides/configuration-files.md).

--- a/docs/reference/providers/local-openfaas.md
+++ b/docs/reference/providers/local-openfaas.md
@@ -52,12 +52,30 @@ providers:
   - name: "openfaas"
 ```
 
+### `providers[].gatewayUrl`
+
+[providers](#providers) > gatewayUrl
+
+The external URL to the function gateway, after installation. This is required if you set `faasNetes.values`
+or `faastNetes.install: false`, so that Garden can know how to reach the gateway.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+Example:
+
+```yaml
+providers:
+  - gatewayUrl: "https://functions.mydomain.com"
+```
+
 ### `providers[].hostname`
 
 [providers](#providers) > hostname
 
-The hostname to configure for the function gateway.
-Defaults to the default hostname of the configured Kubernetes provider.
+The ingress hostname to configure for the function gateway, when `faasNetes.install: true` and not
+overriding `faasNetes.values`. Defaults to the default hostname of the configured Kubernetes provider.
 
 Important: If you have other types of services, this should be different from their ingress hostnames,
 or the other services should not expose paths under /function and /system to avoid routing conflicts.
@@ -73,6 +91,40 @@ providers:
   - hostname: "functions.mydomain.com"
 ```
 
+### `providers[].faasNetes`
+
+[providers](#providers) > faasNetes
+
+| Type     | Required | Default            |
+| -------- | -------- | ------------------ |
+| `object` | No       | `{"install":true}` |
+
+### `providers[].faasNetes.install`
+
+[providers](#providers) > [faasNetes](#providersfaasnetes) > install
+
+Set to false if you'd like to install and configure faas-netes yourself.
+See the [official instructions](https://docs.openfaas.com/deployment/kubernetes/) for details.
+
+| Type      | Required | Default |
+| --------- | -------- | ------- |
+| `boolean` | No       | `true`  |
+
+### `providers[].faasNetes.values`
+
+[providers](#providers) > [faasNetes](#providersfaasnetes) > values
+
+Override the values passed to the faas-netes Helm chart. Ignored if `install: false`.
+See the [chart docs](https://github.com/openfaas/faas-netes/tree/master/chart/openfaas) for the available
+options.
+
+Note that this completely replaces the values Garden assigns by default, including `functionNamespace`,
+ingress configuration etc. so you need to make sure those are correctly configured for your use case.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
 
 ## Complete YAML schema
 
@@ -82,5 +134,9 @@ The values in the schema below are the default values.
 providers:
   - environments:
     name: openfaas
+    gatewayUrl:
     hostname:
+    faasNetes:
+      install: true
+      values:
 ```

--- a/docs/reference/providers/openfaas.md
+++ b/docs/reference/providers/openfaas.md
@@ -52,12 +52,30 @@ providers:
   - name: "openfaas"
 ```
 
+### `providers[].gatewayUrl`
+
+[providers](#providers) > gatewayUrl
+
+The external URL to the function gateway, after installation. This is required if you set `faasNetes.values`
+or `faastNetes.install: false`, so that Garden can know how to reach the gateway.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+Example:
+
+```yaml
+providers:
+  - gatewayUrl: "https://functions.mydomain.com"
+```
+
 ### `providers[].hostname`
 
 [providers](#providers) > hostname
 
-The hostname to configure for the function gateway.
-Defaults to the default hostname of the configured Kubernetes provider.
+The ingress hostname to configure for the function gateway, when `faasNetes.install: true` and not
+overriding `faasNetes.values`. Defaults to the default hostname of the configured Kubernetes provider.
 
 Important: If you have other types of services, this should be different from their ingress hostnames,
 or the other services should not expose paths under /function and /system to avoid routing conflicts.
@@ -73,6 +91,40 @@ providers:
   - hostname: "functions.mydomain.com"
 ```
 
+### `providers[].faasNetes`
+
+[providers](#providers) > faasNetes
+
+| Type     | Required | Default            |
+| -------- | -------- | ------------------ |
+| `object` | No       | `{"install":true}` |
+
+### `providers[].faasNetes.install`
+
+[providers](#providers) > [faasNetes](#providersfaasnetes) > install
+
+Set to false if you'd like to install and configure faas-netes yourself.
+See the [official instructions](https://docs.openfaas.com/deployment/kubernetes/) for details.
+
+| Type      | Required | Default |
+| --------- | -------- | ------- |
+| `boolean` | No       | `true`  |
+
+### `providers[].faasNetes.values`
+
+[providers](#providers) > [faasNetes](#providersfaasnetes) > values
+
+Override the values passed to the faas-netes Helm chart. Ignored if `install: false`.
+See the [chart docs](https://github.com/openfaas/faas-netes/tree/master/chart/openfaas) for the available
+options.
+
+Note that this completely replaces the values Garden assigns by default, including `functionNamespace`,
+ingress configuration etc. so you need to make sure those are correctly configured for your use case.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
 
 ## Complete YAML schema
 
@@ -82,5 +134,9 @@ The values in the schema below are the default values.
 providers:
   - environments:
     name: openfaas
+    gatewayUrl:
     hostname:
+    faasNetes:
+      install: true
+      values:
 ```

--- a/garden-service/src/plugins/openfaas/faas-cli.ts
+++ b/garden-service/src/plugins/openfaas/faas-cli.ts
@@ -12,16 +12,16 @@ export const faasCli = new BinaryCmd({
   name: "faas-cli",
   specs: {
     darwin: {
-      url: "https://github.com/openfaas/faas-cli/releases/download/0.8.21/faas-cli-darwin",
-      sha256: "68d99f789e2e0a763b6f58f075f0118b8828fd43b3ca4eed646961eb6ac352fa",
+      url: "https://github.com/openfaas/faas-cli/releases/download/0.9.5/faas-cli-darwin",
+      sha256: "28beff63ef8234c1c937b14fd63e8c25244432897830650b8f76897fe4e22cbb",
     },
     linux: {
-      url: "https://github.com/openfaas/faas-cli/releases/download/0.8.21/faas-cli",
-      sha256: "b8a5b455f20b14751140cb63277ee4d435e23ed041be1898a0dc2c27ee718046",
+      url: "https://github.com/openfaas/faas-cli/releases/download/0.9.5/faas-cli",
+      sha256: "f4c8014d953f42e0c83628c089aff36aaf306f9f1aea62e5f22c84ab4269d1f7",
     },
     win32: {
-      url: "https://github.com/openfaas/faas-cli/releases/download/0.8.21/faas-cli.exe",
-      sha256: "366e01a364e64f90bec6b8234c2bc5bb87bbd059b187f8afe43c36d22f4d5b84",
+      url: "https://github.com/openfaas/faas-cli/releases/download/0.9.5/faas-cli.exe",
+      sha256: "45d09e4dbff679c32aff8f86cc39e12c3687b6b344a9a20510c6c61f4e141eb5",
     },
   },
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:

Our faas-netes installation was out of date, which caused issues with Kubernetes 1.16. 

Also added some more configurability, which should allow users to make a more proper production-ready setup. See the updated docs for details.

**Which issue(s) this PR fixes**:

Fixes #1306

