### PR TITLE
fix(sync): issue with build staging sync procedure on Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -389,6 +389,9 @@ jobs:
           name: Override build ID
           command: $env:CIRCLE_BUILD_NUM = "$env:CIRCLE_BUILD_NUM-win"
       - run:
+          name: Build demo-project
+          command: .\garden-service\dist\windows-amd64\garden.exe build --root .\examples\demo-project\ --logger-type basic --env testing
+      - run:
           name: Deploy demo-project
           command: .\garden-service\dist\windows-amd64\garden.exe deploy --root .\examples\demo-project\ --logger-type basic --env testing
       - run:

--- a/garden-service/src/build-dir.ts
+++ b/garden-service/src/build-dir.ts
@@ -161,6 +161,13 @@ export class BuildDir {
     // --exclude is required for modules where the module and project are in the same directory
     const syncOpts = ["-rptgo", `--exclude=${this.buildDirPath}`, "--ignore-missing-args"]
 
+    // We have noticed occasional issues with the default rsync behavior of creating temp files when copying
+    // when using Windows/cwRsync. This workaround appears to do the trick, but is less optimal so we don't apply
+    // it for other platforms.
+    if (process.platform === "win32") {
+      syncOpts.push("--inplace")
+    }
+
     let logMsg =
       `Syncing ${module.version.files.length} files from ` +
       `${relative(this.projectRoot, sourcePath)} to ${relative(this.projectRoot, destinationPath)}`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:

We found rsync rename errors during testing on Windows. This is a workaround, that we only apply on Windows.
