### PR TITLE
docs: fix markdown list in cert-manager guide

### DIFF
--- a/docs/guides/cert-manager-integration.md
+++ b/docs/guides/cert-manager-integration.md
@@ -89,10 +89,10 @@ When you set `managedBy: cert-manager` on a certificate specified in the `tlsCer
 
 The above configuration will trigger the following workflow:
 
-1) cert-manager will create a ClusterIssuer in your cluster which will generate your certificate. Each certificate gets an associated ClusterIssuer, which will take care of performing the issue challenge.
-2) Garden will then create a Certificate resource to request the TLS certificate.
-3) cert-manager will then automatically create an Ingress to solve the HTTP-01 ACME challenge.
-4) Once the challenge is solved the TLS certificate will be stored as a Secret using the name/namespace specified above (e.g. `cert-manager-example/tls-secret-for-certificate`).
+1. cert-manager will create a ClusterIssuer in your cluster which will generate your certificate. Each certificate gets an associated ClusterIssuer, which will take care of performing the issue challenge.
+2. Garden will then create a Certificate resource to request the TLS certificate.
+3. cert-manager will then automatically create an Ingress to solve the HTTP-01 ACME challenge.
+4. Once the challenge is solved the TLS certificate will be stored as a Secret using the name/namespace specified above (e.g. `cert-manager-example/tls-secret-for-certificate`).
 
 All the steps above will happen at system startup/init. All your services will be built/tested/deployed after all the secrets have been populated.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:
The Guide for the cert-manager integration has a list which was syntacticly wrong in the markdonw file and rendered wrongly: `1) bla-bla` vs `1. bla-bla`. 