### PR TITLE
feat: production flag

### DIFF
--- a/docs/guides/remote-kubernetes.md
+++ b/docs/guides/remote-kubernetes.md
@@ -131,7 +131,9 @@ you will expose for ingress.
 _How you configure DNS and prepare the certificates will depend on how you manage DNS and certificates in general,
 so we won't cover that in detail here._
 
-Once you have the certificates in hand (the `.crt` and `.key` files), create a
+If you are using cert-manager to manage your TLS certificates you can check out the [cert-manager integration](../guide/cert-manager-integration.md).
+
+If you are manually creating or obtaining the certificates (and you have the `.crt` and `.key` files), create a
 [Secret](https://kubernetes.io/docs/concepts/configuration/secret/) for each cert in the cluster so
 they can be referenced when deploying services:
 
@@ -167,3 +169,13 @@ environments:
         namespace: default
     ...
 ```
+
+## Production flag
+
+You can define a remote environment as `production` by setting the [production flag](../reference/config.md#environmentsproduction).
+
+This will set up some defaults when deploying the container module type:
+
+- Default number of replicas for a service will be 3 (unless specified by the user).
+- A soft AntiAffinity setting will try to schedule pods based over different nodes.
+- RevisionHistoryLimit is set to 10.

--- a/docs/guides/using-helm-charts.md
+++ b/docs/guides/using-helm-charts.md
@@ -300,6 +300,21 @@ sources:
 The base chart can also be any `helm` module (not just "base" charts specifically made for that purpose), so you have
 a lot of flexibility in how you organize your charts.
 
+## Production flag
+
+You can define a remote environment as `production` by setting the [production flag](../reference/config.md#environmentsproduction).
+
+This will set up some defaults when deploying the container module type:
+
+- Default number of replicas for a service will be 3 (unless specified by the user).
+- A soft AntiAffinity setting will try to schedule pods based over different nodes.
+- RevisionHistoryLimit is set to 10.
+
+Ultimately it won't run the following operations even if you specify the \`--force\` option:
+
+- Replace the installed chart with \`--replace\` when force installing a Helm chart module.
+- Force upgrade a Helm release when using the Helm module type.
+
 ## Next steps
 
 Check out the full [helm module reference](../reference/module-types/helm.md) for more details, and the
@@ -308,3 +323,5 @@ Garden's Helm support.
 
 Also check out the [kubernetes-module](https://github.com/garden-io/garden/tree/v0.10.14/examples/kubernetes-module)
 example for a simpler alternative, if you don't need all the features of Helm.
+
+

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -29,6 +29,7 @@ quiet: suppresses all log output, same as --silent.
   | `--log-level` | `-l` | `error` `warn` `info` `verbose` `debug` `silly` `0` `1` `2` `3` `4` `5`  | Set logger level. Values can be either string or numeric and are prioritized from 0 to 5 (highest to lowest) as follows: error: 0, warn: 1, info: 2, verbose: 3, debug: 4, silly: 5.
   | `--output` | `-o` | `json` `yaml`  | Output command result in specified format (note: disables progress logging and interactive functionality).
   | `--emoji` |  | boolean | Enable emoji in output (defaults to true if the environment supports it).
+  | `--yes` | `-y` | boolean | Automatically approve any yes/no prompts during execution.
 
 ### garden build
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -429,6 +429,22 @@ The name of the environment.
 | -------- | -------- |
 | `string` | Yes      |
 
+### `environments[].production`
+
+[environments](#environments) > production
+
+Set environment as production.
+
+Setting this flag to `true` will activate the protection on the `deploy`, `test`, `task`, `build`, `call`, `init` and `dev` commands.
+A protected command will ask for a user confirmation every time is run agains an environment marked as production.
+Run the command with the "--yes" flag to skip the check (e.g. when running Garden in CI).
+
+Note: This flag will affect how certain providers behave. For more details please check the documentation for the providers in use.
+
+| Type      | Required | Default |
+| --------- | -------- | ------- |
+| `boolean` | No       | `false` |
+
 
 ## Project YAML schema
 ```yaml
@@ -463,6 +479,7 @@ environments:
     varfile: garden.<env-name>.env
     variables: {}
     name:
+    production: false
 ```
 
 ## Module configuration keys

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -777,12 +777,12 @@ This allows you to call the service from the outside by the node's IP address an
 
 [services](#services) > replicas
 
-The number of instances of the service to deploy.
+The number of instances of the service to deploy. Defaults to 3 for environments configured with production: true, otherwise 1.
 Note: This setting may be overridden or ignored in some cases. For example, when running with `daemon: true`, with hot-reloading enabled, or if the provider doesn't support multiple replicas.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `1`     |
+| Type     | Required |
+| -------- | -------- |
+| `number` | No       |
 
 ### `services[].volumes[]`
 
@@ -1218,7 +1218,7 @@ services:
         servicePort: <same as containerPort>
         hostPort:
         nodePort:
-    replicas: 1
+    replicas:
     volumes:
       - name:
         containerPath:

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -782,12 +782,12 @@ This allows you to call the service from the outside by the node's IP address an
 
 [services](#services) > replicas
 
-The number of instances of the service to deploy.
+The number of instances of the service to deploy. Defaults to 3 for environments configured with production: true, otherwise 1.
 Note: This setting may be overridden or ignored in some cases. For example, when running with `daemon: true`, with hot-reloading enabled, or if the provider doesn't support multiple replicas.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `1`     |
+| Type     | Required |
+| -------- | -------- |
+| `number` | No       |
 
 ### `services[].volumes[]`
 
@@ -1268,7 +1268,7 @@ services:
         servicePort: <same as containerPort>
         hostPort:
         nodePort:
-    replicas: 1
+    replicas:
     volumes:
       - name:
         containerPath:

--- a/garden-service/src/commands/build.ts
+++ b/garden-service/src/commands/build.ts
@@ -43,6 +43,7 @@ type Opts = typeof buildOptions
 export class BuildCommand extends Command<Args, Opts> {
   name = "build"
   help = "Build your modules."
+  protected = true
 
   description = dedent`
     Builds all or specified modules, taking into account build dependency order.

--- a/garden-service/src/commands/deploy.ts
+++ b/garden-service/src/commands/deploy.ts
@@ -59,6 +59,7 @@ type Opts = typeof deployOpts
 export class DeployCommand extends Command<Args, Opts> {
   name = "deploy"
   help = "Deploy service(s) to your environment."
+  protected = true
 
   description = dedent`
     Deploys all or specified services, taking into account service dependency order.

--- a/garden-service/src/commands/dev.ts
+++ b/garden-service/src/commands/dev.ts
@@ -66,6 +66,7 @@ type Opts = typeof devOpts
 export class DevCommand extends Command<Args, Opts> {
   name = "dev"
   help = "Starts the garden development console."
+  protected = true
 
   // Currently it doesn't make sense to do file watching except in the CLI
   cliOnly = true

--- a/garden-service/src/commands/init.ts
+++ b/garden-service/src/commands/init.ts
@@ -21,6 +21,7 @@ type Opts = typeof initOpts
 export class InitCommand extends Command {
   name = "init"
   help = "Initialize system, environment or other runtime components."
+  protected = true
 
   // This command is generally only used when user input is needed, which will need to happen via the CLI
   cliOnly = true

--- a/garden-service/src/commands/test.ts
+++ b/garden-service/src/commands/test.ts
@@ -60,6 +60,7 @@ type Opts = typeof testOpts
 export class TestCommand extends Command<Args, Opts> {
   name = "test"
   help = "Test all or specified modules."
+  protected = true
 
   description = dedent`
     Runs all or specified tests defined in the project. Also builds modules and dependencies,

--- a/garden-service/src/garden.ts
+++ b/garden-service/src/garden.ts
@@ -98,6 +98,7 @@ export interface GardenParams {
   moduleExcludePatterns?: string[]
   opts: GardenOpts
   plugins: RegisterPluginParam[]
+  production: boolean
   projectName: string
   projectRoot: string
   projectSources?: SourceConfig[]
@@ -126,6 +127,7 @@ export class Garden {
   private actionHelper: ActionRouter
   public readonly events: EventBus
 
+  public readonly production: boolean
   public readonly projectRoot: string
   public readonly projectName: string
   public readonly environmentName: string
@@ -149,6 +151,7 @@ export class Garden {
     this.log = params.log
     this.artifactsPath = params.artifactsPath
     this.opts = params.opts
+    this.production = params.production
     this.projectName = params.projectName
     this.projectRoot = params.projectRoot
     this.projectSources = params.projectSources || []
@@ -225,7 +228,7 @@ export class Garden {
       environmentName = defaultEnvironment
     }
 
-    const { providers, variables } = await pickEnvironment(config, environmentName)
+    const { providers, variables, production } = await pickEnvironment(config, environmentName)
 
     const buildDir = await BuildDir.factory(projectRoot, gardenDirPath)
     const workingCopyId = await getWorkingCopyId(gardenDirPath)
@@ -247,6 +250,7 @@ export class Garden {
       variables,
       projectSources,
       buildDir,
+      production,
       gardenDirPath,
       opts,
       plugins,

--- a/garden-service/src/plugin-context.ts
+++ b/garden-service/src/plugin-context.ts
@@ -22,6 +22,7 @@ type WrappedFromGarden = Pick<
   | "workingCopyId"
   // TODO: remove this from the interface
   | "environmentName"
+  | "production"
 >
 
 export interface CommandInfo {
@@ -62,6 +63,10 @@ export const pluginContextSchema = joi
         The absolute path of the project's Garden dir. This is the directory the contains builds, logs and
         other meta data. A custom path can be set when initialising the Garden class. Defaults to \`.garden\`.
       `),
+    production: joi
+      .boolean()
+      .default(false)
+      .description("Indicate if the current environment is a production environment"),
     projectName: projectNameSchema,
     projectRoot: joi.string().description("The absolute path of the project root."),
     projectSources: projectSourcesSchema,
@@ -78,6 +83,7 @@ export function createPluginContext(garden: Garden, provider: Provider, command?
     projectRoot: garden.projectRoot,
     projectSources: cloneDeep(garden.projectSources),
     provider,
+    production: garden.production,
     workingCopyId: garden.workingCopyId,
   }
 }

--- a/garden-service/src/plugins/container/config.ts
+++ b/garden-service/src/plugins/container/config.ts
@@ -90,7 +90,7 @@ export interface ContainerServiceSpec extends CommonServiceSpec {
   hotReloadArgs?: string[]
   limits: ServiceLimitSpec
   ports: ServicePortSpec[]
-  replicas: number
+  replicas?: number
   volumes: ServiceVolumeSpec[]
 }
 
@@ -375,12 +375,9 @@ const serviceSchema = baseServiceSpecSchema.keys({
   ports: joiArray(portSchema)
     .unique("name")
     .description("List of ports that the service container exposes."),
-  replicas: joi
-    .number()
-    .integer()
-    .min(1)
-    .default(1).description(deline`
+  replicas: joi.number().integer().description(deline`
       The number of instances of the service to deploy.
+      Defaults to 3 for environments configured with production: true, otherwise 1.
 
       Note: This setting may be overridden or ignored in some cases. For example, when running with \`daemon: true\`,
       with hot-reloading enabled, or if the provider doesn't support multiple replicas.

--- a/garden-service/src/plugins/kubernetes/container/logs.ts
+++ b/garden-service/src/plugins/kubernetes/container/logs.ts
@@ -28,6 +28,7 @@ export async function getServiceLogs(params: GetServiceLogsParams<ContainerModul
       runtimeContext: emptyRuntimeContext,
       namespace,
       enableHotReload: false,
+      production: ctx.production,
       log,
     }),
   ]

--- a/garden-service/src/plugins/kubernetes/helm/deployment.ts
+++ b/garden-service/src/plugins/kubernetes/helm/deployment.ts
@@ -74,14 +74,14 @@ export async function deployService({
       "--atomic",
       ...commonArgs,
     ]
-    if (force) {
+    if (force && !ctx.production) {
       installArgs.push("--replace")
     }
     await helm({ ctx: k8sCtx, namespace, log, args: [...installArgs] })
   } else {
     log.silly(`Upgrading Helm release ${releaseName}`)
     const upgradeArgs = ["upgrade", releaseName, chartPath, "--install", ...commonArgs]
-    if (force) {
+    if (force && !ctx.production) {
       upgradeArgs.push("--force")
     }
     await helm({ ctx: k8sCtx, namespace, log, args: [...upgradeArgs] })

--- a/garden-service/src/plugins/kubernetes/hot-reload.ts
+++ b/garden-service/src/plugins/kubernetes/hot-reload.ts
@@ -198,6 +198,7 @@ export async function hotReloadContainer({
     runtimeContext: { envVars: {}, dependencies: [] },
     namespace,
     enableHotReload: true,
+    production: k8sCtx.production,
     log,
   })
   const selector = labelSelectorToString({

--- a/garden-service/src/plugins/kubernetes/kubectl.ts
+++ b/garden-service/src/plugins/kubernetes/kubectl.ts
@@ -21,7 +21,6 @@ export interface ApplyParams {
   manifests: KubernetesResource[]
   namespace?: string
   dryRun?: boolean
-  force?: boolean
   pruneSelector?: string
   validate?: boolean
 }
@@ -33,7 +32,6 @@ export async function apply({
   provider,
   manifests,
   dryRun = false,
-  force = false,
   namespace,
   pruneSelector,
   validate = true,
@@ -54,7 +52,6 @@ export async function apply({
 
   let args = ["apply"]
   dryRun && args.push("--dry-run")
-  force && args.push("--force")
   pruneSelector && args.push("--prune", "--selector", pruneSelector)
   args.push("--output=json", "-f", "-")
   !validate && args.push("--validate=false")

--- a/garden-service/src/plugins/kubernetes/kubernetes-module/handlers.ts
+++ b/garden-service/src/plugins/kubernetes/kubernetes-module/handlers.ts
@@ -81,7 +81,7 @@ async function getServiceStatus({
 }
 
 async function deployService(params: DeployServiceParams<KubernetesModule>): Promise<KubernetesServiceStatus> {
-  const { ctx, force, module, service, log } = params
+  const { ctx, module, service, log } = params
 
   const k8sCtx = <KubernetesPluginContext>ctx
   const api = await KubeApi.factory(log, k8sCtx.provider)
@@ -96,7 +96,7 @@ async function deployService(params: DeployServiceParams<KubernetesModule>): Pro
   const manifests = await getManifests(api, log, module, namespace)
 
   const pruneSelector = getSelector(service)
-  await apply({ log, provider: k8sCtx.provider, manifests, force, pruneSelector })
+  await apply({ log, provider: k8sCtx.provider, manifests, pruneSelector })
 
   await waitForResources({
     ctx: k8sCtx,

--- a/garden-service/test/integ/src/plugins/kubernetes/util.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/util.ts
@@ -50,6 +50,7 @@ describe("util", () => {
         namespace: "container-artifacts",
         enableHotReload: false,
         log: garden.log,
+        production: false,
       })
       await garden.processTasks([deployTask], { throwOnError: true })
 

--- a/garden-service/test/unit/src/config/project.ts
+++ b/garden-service/test/unit/src/config/project.ts
@@ -39,6 +39,7 @@ describe("resolveProjectConfig", () => {
       environments: [
         {
           name: "default",
+          production: false,
           providers: [],
           varfile: defaultEnvVarfilePath("default"),
           variables: {},
@@ -121,6 +122,7 @@ describe("resolveProjectConfig", () => {
         {
           name: "default",
           providers: [],
+          production: false,
           varfile: defaultEnvVarfilePath("default"),
           variables: {
             envVar: "foo",
@@ -197,6 +199,7 @@ describe("resolveProjectConfig", () => {
         {
           name: "default",
           providers: [],
+          production: false,
           varfile: defaultEnvVarfilePath("default"),
           variables: {
             envVar: "foo",
@@ -326,6 +329,7 @@ describe("resolveProjectConfig", () => {
         {
           name: "default",
           providers: [],
+          production: false,
           varfile: defaultEnvVarfilePath("default"),
           variables: {
             envVar: "foo",
@@ -394,6 +398,7 @@ describe("resolveProjectConfig", () => {
         {
           name: "default",
           providers: [],
+          production: false,
           varfile: defaultEnvVarfilePath("default"),
           variables: {
             envVar: "bar",
@@ -462,6 +467,7 @@ describe("pickEnvironment", () => {
 
     expect(await pickEnvironment(config, "default")).to.eql({
       providers: [{ name: "exec" }, { name: "container" }],
+      production: false,
       variables: {},
     })
   })
@@ -486,6 +492,7 @@ describe("pickEnvironment", () => {
 
     expect(await pickEnvironment(config, "default")).to.eql({
       providers: [{ name: "exec" }, { name: "container", newKey: "foo" }, { name: "my-provider", a: "c", b: "b" }],
+      production: false,
       variables: {},
     })
   })
@@ -510,6 +517,7 @@ describe("pickEnvironment", () => {
 
     expect(await pickEnvironment(config, "default")).to.eql({
       providers: [{ name: "exec" }, { name: "container", newKey: "foo" }, { name: "my-provider", b: "b" }],
+      production: false,
       variables: {},
     })
   })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:
Implements a `environments[].production` flag which alters the generated manifests for the container modules and put protections on a subset of garden commands.
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
WIP: Needs refactoring and more tests + the commands protection implementation.
Just putting it out here so we can review it fast.