### PR TITLE
feat(k8s): add `clusterDocker.enableBuildKit` option

### DIFF
--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -59,6 +59,26 @@ this is less secure than Kaniko, but in turn it is generally faster. See the
 | -------- | -------- | ---------------- |
 | `string` | No       | `"local-docker"` |
 
+### `providers[].clusterDocker`
+
+[providers](#providers) > clusterDocker
+
+Configuration options for the `cluster-docker` build mode.
+
+| Type     | Required | Default |
+| -------- | -------- | ------- |
+| `object` | No       | `"{}"`  |
+
+### `providers[].clusterDocker.enableBuildKit`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > enableBuildKit
+
+Enable [BuildKit](https://github.com/moby/buildkit) support. This should in most cases work well and be more performant, but we're opting to keep it optional until it's enabled by default in Docker.
+
+| Type      | Required | Default |
+| --------- | -------- | ------- |
+| `boolean` | No       | `false` |
+
 ### `providers[].defaultHostname`
 
 [providers](#providers) > defaultHostname
@@ -1116,6 +1136,8 @@ The values in the schema below are the default values.
 providers:
   - environments:
     buildMode: local-docker
+    clusterDocker:
+      enableBuildKit: false
     defaultHostname:
     defaultUsername:
     deploymentStrategy: rolling

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -59,6 +59,26 @@ this is less secure than Kaniko, but in turn it is generally faster. See the
 | -------- | -------- | ---------------- |
 | `string` | No       | `"local-docker"` |
 
+### `providers[].clusterDocker`
+
+[providers](#providers) > clusterDocker
+
+Configuration options for the `cluster-docker` build mode.
+
+| Type     | Required | Default |
+| -------- | -------- | ------- |
+| `object` | No       | `"{}"`  |
+
+### `providers[].clusterDocker.enableBuildKit`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > enableBuildKit
+
+Enable [BuildKit](https://github.com/moby/buildkit) support. This should in most cases work well and be more performant, but we're opting to keep it optional until it's enabled by default in Docker.
+
+| Type      | Required | Default |
+| --------- | -------- | ------- |
+| `boolean` | No       | `false` |
+
 ### `providers[].defaultHostname`
 
 [providers](#providers) > defaultHostname
@@ -1017,6 +1037,8 @@ The values in the schema below are the default values.
 providers:
   - environments:
     buildMode: local-docker
+    clusterDocker:
+      enableBuildKit: false
     defaultHostname:
     defaultUsername:
     deploymentStrategy: rolling

--- a/examples/demo-project/garden.yml
+++ b/examples/demo-project/garden.yml
@@ -20,3 +20,5 @@ environments:
         namespace: demo-project-testing-${local.env.CIRCLE_BUILD_NUM || local.username}
         defaultHostname: demo-project-testing.dev-1.sys.garden
         buildMode: cluster-docker
+        clusterDocker:
+          enableBuildKit: true

--- a/examples/vote/garden.yml
+++ b/examples/vote/garden.yml
@@ -19,3 +19,5 @@ environments:
         namespace: vote-testing-${local.env.CIRCLE_BUILD_NUM || local.username}
         defaultHostname: vote-testing.dev-1.sys.garden
         buildMode: cluster-docker
+        clusterDocker:
+          enableBuildKit: true

--- a/garden-service/static/kubernetes/system/docker-daemon/templates/deployment.yaml
+++ b/garden-service/static/kubernetes/system/docker-daemon/templates/deployment.yaml
@@ -41,16 +41,20 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: docker
-              containerPort: 2375
+              containerPort: 2376
               protocol: TCP
           securityContext:
             privileged: true
-          livenessProbe:
-            tcpSocket:
-              port: 2375
           readinessProbe:
             tcpSocket:
-              port: 2375
+              port: 2376
+            initialDelaySeconds: 10
+            periodSeconds: 2
+          livenessProbe:
+            tcpSocket:
+              port: 2376
+            initialDelaySeconds: 20
+            periodSeconds: 20
           volumeMounts:
             - name: garden-docker-data
               mountPath: /var/lib/docker

--- a/garden-service/static/kubernetes/system/docker-daemon/values.yaml
+++ b/garden-service/static/kubernetes/system/docker-daemon/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: docker
-  tag: 18.09.3-dind
+  tag: 19.03.4-dind
   pullPolicy: IfNotPresent
 
 nameOverride: "garden-docker-daemon"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:

This allows the user to use BuildKit, which in many cases offers
better performance than the standard builder, and will eventually
supplant the current default implementation.

Also updated the in-cluster docker daemon to 19.03.4, which addresses a bunch of BuildKit related issues.
