### PR TITLE
fix(k8s): helm status check now compares Garden version

### DIFF
--- a/garden-service/src/plugins/kubernetes/helm/build.ts
+++ b/garden-service/src/plugins/kubernetes/helm/build.ts
@@ -46,6 +46,13 @@ export async function buildHelmModule({ ctx, module, log }: BuildModuleParams<He
   // Merge with the base module's values, if applicable
   const specValues = baseModule ? jsonMerge(baseModule.spec.values, module.spec.values) : module.spec.values
 
+  // Add Garden metadata
+  specValues[".garden"] = {
+    moduleName: module.name,
+    projectName: ctx.projectName,
+    version: module.version.versionString,
+  }
+
   const valuesPath = getGardenValuesPath(chartPath)
   log.silly(`Writing chart values to ${valuesPath}`)
   await dumpYaml(valuesPath, specValues)

--- a/garden-service/src/plugins/kubernetes/helm/deployment.ts
+++ b/garden-service/src/plugins/kubernetes/helm/deployment.ts
@@ -53,7 +53,7 @@ export async function deployService({
   const chartPath = await getChartPath(module)
   const namespace = await getAppNamespace(k8sCtx, log, provider)
   const releaseName = getReleaseName(module)
-  const releaseStatus = await getReleaseStatus(k8sCtx, releaseName, log)
+  const releaseStatus = await getReleaseStatus(k8sCtx, module, releaseName, log)
 
   const commonArgs = [
     "--namespace",


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:

Turns out `helm status` doesn't do any meaningful comparison checks
on its own (in hindsight I really don't why I thought it did), so
updates to `helm` modules would get ignored without the `--force` flag.

We can rely on our version hash for comparison, however, since it
includes hashes of all the templates and the config passed to the
template.

**Special notes for your reviewer**:

Perhaps try messing with the `vote-helm` project, triggering reloads etc., and see if everything happens as expected.
