### PR TITLE
Fix logs

### DIFF
--- a/garden-service/src/logger/log-entry.ts
+++ b/garden-service/src/logger/log-entry.ts
@@ -68,10 +68,10 @@ export interface LogEntryConstructor extends LogEntryParams {
 }
 
 function resolveParams(params?: string | UpdateLogEntryParams): UpdateLogEntryParams {
-  if (!params) {
-    return {}
-  } else if (typeof params === "string") {
+  if (typeof params === "string") {
     return { msg: params }
+  } else if (!params) {
+    return {}
   } else {
     return params
   }

--- a/garden-service/src/plugins/kubernetes/container/exec.ts
+++ b/garden-service/src/plugins/kubernetes/container/exec.ts
@@ -16,7 +16,7 @@ import { getContainerServiceStatus } from "./status"
 import { KubernetesPluginContext, KubernetesProvider } from "../config"
 import { ExecInServiceParams } from "../../../types/plugin/service/execInService"
 import { LogEntry } from "../../../logger/log-entry"
-import { getWorkloadPods } from "../util"
+import { getCurrentWorkloadPods } from "../util"
 import { KubernetesWorkload } from "../types"
 
 export async function execInService(params: ExecInServiceParams<ContainerModule>) {
@@ -61,7 +61,7 @@ export async function execInWorkload({
   interactive: boolean
 }) {
   const api = await KubeApi.factory(log, provider)
-  const pods = await getWorkloadPods(api, namespace, workload)
+  const pods = await getCurrentWorkloadPods(api, namespace, workload)
 
   const pod = pods[0]
 

--- a/garden-service/src/plugins/kubernetes/status/workload.ts
+++ b/garden-service/src/plugins/kubernetes/status/workload.ts
@@ -20,7 +20,7 @@ import {
   V1Event,
 } from "@kubernetes/client-node"
 import dedent = require("dedent")
-import { getWorkloadPods } from "../util"
+import { getCurrentWorkloadPods } from "../util"
 import { getPodLogs, podLogLines } from "./pod"
 import { ResourceStatus, StatusHandlerParams } from "./status"
 import { getResourceEvents } from "./events"
@@ -48,7 +48,7 @@ export async function checkWorkloadStatus({ api, namespace, resource }: StatusHa
 
   const getPods = async () => {
     if (!_pods) {
-      _pods = await getWorkloadPods(api, namespace, workload)
+      _pods = await getCurrentWorkloadPods(api, namespace, workload)
     }
     return _pods
   }

--- a/garden-service/test/data/test-projects/container/simple-service/Dockerfile
+++ b/garden-service/test/data/test-projects/container/simple-service/Dockerfile
@@ -1,0 +1,7 @@
+FROM busybox
+
+COPY main .
+
+ENTRYPOINT ./main
+
+EXPOSE 8080

--- a/garden-service/test/data/test-projects/container/simple-service/garden.yml
+++ b/garden-service/test/data/test-projects/container/simple-service/garden.yml
@@ -1,0 +1,9 @@
+kind: Module
+name: simple-service
+description: Test module for a simple service
+type: container
+services:
+  - name: simple-service
+    ports:
+      - name: http
+        containerPort: 8080

--- a/garden-service/test/data/test-projects/container/simple-service/main.go
+++ b/garden-service/test/data/test-projects/container/simple-service/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, "Hello from Go!")
+}
+
+func main() {
+	http.HandleFunc("/hello-backend", handler)
+	fmt.Println("Server running...")
+
+	http.ListenAndServe(":8080", nil)
+}

--- a/garden-service/test/integ/src/plugins/kubernetes/container/logs.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/container/logs.ts
@@ -1,0 +1,66 @@
+import { expect } from "chai"
+import { Garden } from "../../../../../../src/garden"
+import { getDataDir, makeTestGarden } from "../../../../../helpers"
+import { ConfigGraph } from "../../../../../../src/config-graph"
+import { Provider } from "../../../../../../src/config/provider"
+import { DeployTask } from "../../../../../../src/tasks/deploy"
+import { getServiceLogs } from "../../../../../../src/plugins/kubernetes/container/logs"
+import { Stream } from "ts-stream"
+import { ServiceLogEntry } from "../../../../../../src/types/plugin/service/getServiceLogs"
+import { PluginContext } from "../../../../../../src/plugin-context"
+
+describe("kubernetes", () => {
+  describe("getServiceLogs", () => {
+    let garden: Garden
+    let graph: ConfigGraph
+    let provider: Provider
+    let ctx: PluginContext
+
+    before(async () => {
+      const root = getDataDir("test-projects", "container")
+      garden = await makeTestGarden(root)
+      graph = await garden.getConfigGraph()
+      provider = await garden.resolveProvider("local-kubernetes")
+      ctx = garden.getPluginContext(provider)
+    })
+
+    after(async () => {
+      await garden.close()
+    })
+
+    it("should write service logs to stream", async () => {
+      const module = await graph.getModule("simple-service")
+      const service = await graph.getService("simple-service")
+
+      const entries: ServiceLogEntry[] = []
+
+      const deployTask = new DeployTask({
+        force: true,
+        forceBuild: true,
+        garden,
+        graph,
+        log: garden.log,
+        service,
+      })
+
+      await garden.processTasks([deployTask], { throwOnError: true })
+      const stream = new Stream<ServiceLogEntry>()
+
+      void stream.forEach((entry) => {
+        entries.push(entry)
+      })
+
+      await getServiceLogs({
+        ctx,
+        module,
+        service,
+        log: garden.log,
+        stream,
+        follow: false,
+        tail: -1,
+      })
+
+      expect(entries[0].msg).to.include("Server running...")
+    })
+  })
+})

--- a/garden-service/test/integ/src/plugins/kubernetes/util.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/util.ts
@@ -1,0 +1,61 @@
+import { expect } from "chai"
+import { flatten } from "lodash"
+import { Garden } from "../../../../../src/garden"
+import { getDataDir, makeTestGarden } from "../../../../helpers"
+import { ConfigGraph } from "../../../../../src/config-graph"
+import { Provider } from "../../../../../src/config/provider"
+import { DeployTask } from "../../../../../src/tasks/deploy"
+import { KubeApi } from "../../../../../src/plugins/kubernetes/api"
+import { KubernetesConfig } from "../../../../../src/plugins/kubernetes/config"
+import { getWorkloadPods } from "../../../../../src/plugins/kubernetes/util"
+import { createWorkloadResource } from "../../../../../src/plugins/kubernetes/container/deployment"
+import { emptyRuntimeContext } from "../../../../../src/runtime-context"
+
+describe("util", () => {
+  // TODO: Add more test cases
+  describe("getWorkloadPods", () => {
+    let garden: Garden
+    let graph: ConfigGraph
+    let provider: Provider<KubernetesConfig>
+    let api: KubeApi
+
+    before(async () => {
+      const root = getDataDir("test-projects", "container")
+      garden = await makeTestGarden(root)
+      graph = await garden.getConfigGraph()
+      provider = (await garden.resolveProvider("local-kubernetes")) as Provider<KubernetesConfig>
+      api = await KubeApi.factory(garden.log, provider)
+    })
+
+    after(async () => {
+      await garden.close()
+    })
+
+    it("should return workload pods", async () => {
+      const service = await graph.getService("simple-service")
+
+      const deployTask = new DeployTask({
+        force: false,
+        forceBuild: false,
+        garden,
+        graph,
+        log: garden.log,
+        service,
+      })
+
+      const resource = await createWorkloadResource({
+        provider,
+        service,
+        runtimeContext: emptyRuntimeContext,
+        namespace: "container-artifacts",
+        enableHotReload: false,
+        log: garden.log,
+      })
+      await garden.processTasks([deployTask], { throwOnError: true })
+
+      const pods = await getWorkloadPods(api, "container-artifacts", resource)
+      const services = flatten(pods.map((pod) => pod.spec.containers.map((container) => container.name)))
+      expect(services).to.eql(["simple-service"])
+    })
+  })
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes an issue where Garden wouldn't find pods because the version in
the cluster didn't match the version Garden expected after a hot reload
event. This would e.g. cause issues for the 'logs' and 'exec' commands.

**Which issue(s) this PR fixes**:

Fixes #1246 (and an undocumented issue where `garden exec my-module <cmd>` wouldn't work after a hot reload event). 