### PR TITLE
fix(windows): normalize path for sync temp directory

### DIFF
--- a/garden-service/src/build-dir.ts
+++ b/garden-service/src/build-dir.ts
@@ -162,7 +162,13 @@ export class BuildDir {
     destinationPath = stripWildcard(destinationPath)
 
     // --exclude is required for modules where the module and project are in the same directory
-    const syncOpts = ["-rptgo", `--exclude=${this.buildDirPath}`, "--ignore-missing-args", "--temp-dir", tmpDir]
+    const syncOpts = [
+      "-rptgo",
+      `--exclude=${this.buildDirPath}`,
+      "--ignore-missing-args",
+      "--temp-dir",
+      normalizeLocalRsyncPath(tmpDir),
+    ]
 
     let logMsg =
       `Syncing ${module.version.files.length} files from ` +


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:

Forgot to normalize the path we use for the local build sync temp directory, so we got permission errors in testing.
