### PR TITLE
improvement(k8s): tune probes for build-sync pods

### DIFF
--- a/garden-service/static/kubernetes/system/build-sync/templates/deployment.yaml
+++ b/garden-service/static/kubernetes/system/build-sync/templates/deployment.yaml
@@ -42,12 +42,16 @@ spec:
             - name: rsync
               containerPort: 873
               protocol: TCP
-          livenessProbe:
-            tcpSocket:
-              port: 873
           readinessProbe:
-            tcpSocket:
-              port: 873
+            exec:
+              command: [pidof, rsync]
+            initialDelaySeconds: 5
+            periodSeconds: 2
+          livenessProbe:
+            exec:
+              command: [pidof, rsync]
+            initialDelaySeconds: 20
+            periodSeconds: 20
           volumeMounts:
             - mountPath: /data
               name: garden-build-sync


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:

We've observed Kubernetes killing the rsync pods, and suspect this may
have something to do with the probes.
