### PR TITLE
Docs: Openfaas reference states wrong module type

### DIFF
--- a/docs/reference/module-types/openfaas.md
+++ b/docs/reference/module-types/openfaas.md
@@ -41,7 +41,7 @@ The type of this module.
 Example:
 
 ```yaml
-type: "container"
+type: "openfaas"
 ```
 
 ### `name`


### PR DESCRIPTION
Openfaas module reference documentation states wrong module type `container` should be `openfaas`

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:

Simple documentation typo/error fix

**Which issue(s) this PR fixes**:

Fixes # N/A

**Special notes for your reviewer**:
