### PR TITLE
fix(k8s): don't truncate container build logs

### DIFF
--- a/garden-service/src/plugins/kubernetes/container/build.ts
+++ b/garden-service/src/plugins/kubernetes/container/build.ts
@@ -27,10 +27,9 @@ import { getRegistryHostname } from "../init"
 import { getManifestFromRegistry } from "./util"
 import { normalizeLocalRsyncPath } from "../../../util/fs"
 import { getPortForward } from "../port-forward"
-import chalk from "chalk"
 import { Writable } from "stream"
 import { LogLevel } from "../../../logger/log-node"
-import { exec } from "../../../util/util"
+import { exec, renderOutputStream } from "../../../util/util"
 
 const dockerDaemonDeploymentName = "garden-docker-daemon"
 const dockerDaemonContainerName = "docker-daemon"
@@ -187,7 +186,7 @@ const remoteBuild: BuildHandler = async (params) => {
 
   stdout.on("error", () => {})
   stdout.on("data", (line: Buffer) => {
-    statusLine.setState(chalk.gray("  → " + line.toString().slice(0, 80)))
+    statusLine.setState(renderOutputStream(line.toString()))
   })
 
   if (provider.config.buildMode === "cluster-docker") {

--- a/garden-service/src/util/util.ts
+++ b/garden-service/src/util/util.ts
@@ -78,7 +78,7 @@ export async function sleep(msec) {
  * Extracting to a separate function so that we can test output streams
  */
 export function renderOutputStream(msg: string) {
-  return chalk.gray("  → " + msg.toString().slice(0, 80))
+  return chalk.gray("  → " + msg)
 }
 
 /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:

The truncate was previously added to improve appearance in the fancy
logger, but we no longer use the fancy logger for verbose+ log levels.

**Which issue(s) this PR fixes**:

Fixes #1357 
