### PR TITLE
fix(build): fix intermittent concurrency issues when staging build

### DIFF
--- a/garden-service/src/plugins/kubernetes/system.ts
+++ b/garden-service/src/plugins/kubernetes/system.ts
@@ -27,6 +27,7 @@ import { combineStates } from "../../types/service"
 import { KubernetesResource } from "./types"
 import { defaultDotIgnoreFiles } from "../../util/fs"
 import { HelmServiceStatus } from "./helm/status"
+import { LogLevel } from "../../logger/log-node"
 
 const GARDEN_VERSION = getPackageVersion()
 const SYSTEM_NAMESPACE_MIN_VERSION = "0.9.0"
@@ -156,7 +157,10 @@ export async function getSystemServiceStatus({
 
   const actions = await sysGarden.getActionRouter()
 
-  const serviceStatuses = await actions.getServiceStatuses({ log, serviceNames })
+  const serviceStatuses = await actions.getServiceStatuses({
+    log: log.placeholder(LogLevel.verbose, true),
+    serviceNames,
+  })
   const state = combineStates(values(serviceStatuses).map((s) => (s && s.state) || "unknown"))
 
   // Add the Kubernetes dashboard to the Garden dashboard

--- a/garden-service/src/tasks/base.ts
+++ b/garden-service/src/tasks/base.ts
@@ -25,6 +25,7 @@ export type TaskType =
   | "hot-reload"
   | "publish"
   | "resolve-provider"
+  | "stage-build"
   | "task"
   | "test"
 

--- a/garden-service/src/tasks/stage-build.ts
+++ b/garden-service/src/tasks/stage-build.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2018 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import Bluebird from "bluebird"
+import chalk from "chalk"
+import pluralize from "pluralize"
+import { Module, getModuleKey } from "../types/module"
+import { BuildResult } from "../types/plugin/module/build"
+import { BaseTask, TaskType } from "../tasks/base"
+import { Garden } from "../garden"
+import { LogEntry } from "../logger/log-entry"
+
+export interface StageBuildTaskParams {
+  garden: Garden
+  log: LogEntry
+  module: Module
+  force: boolean
+}
+
+export class StageBuildTask extends BaseTask {
+  type: TaskType = "stage-build"
+
+  private module: Module
+
+  constructor({ garden, log, module, force }: StageBuildTaskParams) {
+    super({ garden, log, force, version: module.version })
+    this.module = module
+  }
+
+  async getDependencies() {
+    const dg = await this.garden.getConfigGraph()
+    const deps = (await dg.getDependencies("build", this.getName(), false)).build
+
+    return Bluebird.map(deps, async (m: Module) => {
+      return new StageBuildTask({
+        garden: this.garden,
+        log: this.log,
+        module: m,
+        force: this.force,
+      })
+    })
+  }
+
+  getName() {
+    return getModuleKey(this.module.name, this.module.plugin)
+  }
+
+  getDescription() {
+    return `staging build for ${this.getName()}`
+  }
+
+  async process(): Promise<BuildResult> {
+    let log: LogEntry | undefined = undefined
+
+    if (this.module.version.files.length > 0) {
+      log = this.log.info({
+        section: this.getName(),
+        msg: `Syncing module sources (${pluralize("file", this.module.version.files.length, true)})...`,
+        status: "active",
+      })
+    }
+
+    const graph = await this.garden.getConfigGraph()
+    await this.garden.buildDir.syncFromSrc(this.module, log || this.log)
+    await this.garden.buildDir.syncDependencyProducts(this.module, graph, log || this.log)
+
+    if (log) {
+      log.setSuccess({
+        msg: chalk.green(`Done (took ${log.getDuration(1)} sec)`),
+        append: true,
+      })
+    }
+
+    return {}
+  }
+}

--- a/garden-service/test/unit/src/commands/build.ts
+++ b/garden-service/test/unit/src/commands/build.ts
@@ -23,6 +23,9 @@ describe("commands.build", () => {
       "build.module-a": { fresh: true, buildLog: "A" },
       "build.module-b": { fresh: true, buildLog: "B" },
       "build.module-c": {},
+      "stage-build.module-a": {},
+      "stage-build.module-b": {},
+      "stage-build.module-c": {},
     })
   })
 
@@ -44,6 +47,8 @@ describe("commands.build", () => {
     expect(taskResultOutputs(result!)).to.eql({
       "build.module-a": { fresh: true, buildLog: "A" },
       "build.module-b": { fresh: true, buildLog: "B" },
+      "stage-build.module-a": {},
+      "stage-build.module-b": {},
     })
   })
 })

--- a/garden-service/test/unit/src/commands/deploy.ts
+++ b/garden-service/test/unit/src/commands/deploy.ts
@@ -128,6 +128,9 @@ describe("DeployCommand", () => {
     }
 
     expect(taskResultOutputs(result!)).to.eql({
+      "stage-build.module-a": {},
+      "stage-build.module-b": {},
+      "stage-build.module-c": {},
       "build.module-a": { fresh: true, buildLog: "A" },
       "build.module-b": { fresh: true, buildLog: "B" },
       "build.module-c": {},
@@ -197,6 +200,9 @@ describe("DeployCommand", () => {
     }
 
     expect(taskResultOutputs(result!)).to.eql({
+      "stage-build.module-a": {},
+      "stage-build.module-b": {},
+      "stage-build.module-c": {},
       "build.module-a": { fresh: true, buildLog: "A" },
       "build.module-b": { fresh: true, buildLog: "B" },
       "build.module-c": {},

--- a/garden-service/test/unit/src/commands/publish.ts
+++ b/garden-service/test/unit/src/commands/publish.ts
@@ -79,6 +79,8 @@ describe("PublishCommand", () => {
       "publish.module-a": { published: true },
       "publish.module-b": { published: true },
       "publish.module-c": { published: false },
+      "stage-build.module-a": {},
+      "stage-build.module-b": {},
     })
   })
 
@@ -107,6 +109,8 @@ describe("PublishCommand", () => {
       "publish.module-a": { published: true },
       "publish.module-b": { published: true },
       "publish.module-c": { published: false },
+      "stage-build.module-a": {},
+      "stage-build.module-b": {},
     })
   })
 
@@ -132,6 +136,7 @@ describe("PublishCommand", () => {
     expect(taskResultOutputs(result!)).to.eql({
       "build.module-a": { fresh: false },
       "publish.module-a": { published: true },
+      "stage-build.module-a": {},
     })
   })
 
@@ -189,6 +194,7 @@ describe("PublishCommand", () => {
         published: false,
         message: chalk.yellow("No publish handler available for module type test"),
       },
+      "stage-build.module-a": {},
     })
   })
 })

--- a/garden-service/test/unit/src/server/server.ts
+++ b/garden-service/test/unit/src/server/server.ts
@@ -98,6 +98,7 @@ describe("startServer", () => {
           buildLog: "A",
           fresh: true,
         },
+        "stage-build.module-a": {},
       })
     })
   })
@@ -243,6 +244,7 @@ describe("startServer", () => {
               buildLog: "A",
               fresh: true,
             },
+            "stage-build.module-a": {},
           },
         })
         done()

--- a/garden-service/test/unit/src/tasks/helpers.ts
+++ b/garden-service/test/unit/src/tasks/helpers.ts
@@ -58,6 +58,7 @@ describe("TaskHelpers", () => {
           "build.build-dependency",
           "build.good-morning",
           "get-service-status.good-morning",
+          "stage-build.good-morning",
           "task.good-morning-task",
         ].sort()
       )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:

Because both the BuildTask and GetServiceTask need to stage builds,
they could in some cases end up stepping on each other because one
doesn't depend on the other. I resolved that by adding a StageBuildTask
that both depend on.

I also made DeleteService depend on a StageBuildTask to ensure that
sources are synced before attempting to run deleteService handlers,
which had caused a couple of reported issues.

**Which issue(s) this PR fixes**:

Fixes #1189
Fixed #1245 
