### PR TITLE
fix(cli): fix janky spinner when initializing providers

### DIFF
--- a/garden-service/src/cli/cli.ts
+++ b/garden-service/src/cli/cli.ts
@@ -152,7 +152,7 @@ export const GLOBAL_OPTIONS = {
 export type GlobalOptions = typeof GLOBAL_OPTIONS
 
 function initLogger({ level, loggerType, emoji }: { level: LogLevel; loggerType: LoggerType; emoji: boolean }) {
-  const writer = getWriterInstance(loggerType)
+  const writer = getWriterInstance(loggerType, level)
   const writers = writer ? [writer] : undefined
   return Logger.initialize({ level, writers, useEmoji: emoji })
 }

--- a/garden-service/src/logger/writers/base.ts
+++ b/garden-service/src/logger/writers/base.ts
@@ -8,8 +8,13 @@
 
 import { LogEntry } from "../log-entry"
 import { Logger } from "../logger"
+import { LogLevel } from "../log-node"
 
 export abstract class Writer {
+  abstract type: string
+
+  constructor(public level: LogLevel = LogLevel.info) {}
+
   abstract render(...args): string | string[] | null
   abstract onGraphChange(entry: LogEntry, logger: Logger): void
   abstract stop(): void

--- a/garden-service/src/logger/writers/basic-terminal-writer.ts
+++ b/garden-service/src/logger/writers/basic-terminal-writer.ts
@@ -12,6 +12,8 @@ import { Logger } from "../logger"
 import { Writer } from "./base"
 
 export class BasicTerminalWriter extends Writer {
+  type = "basic"
+
   render(entry: LogEntry, logger: Logger): string | null {
     return basicRender(entry, logger)
   }

--- a/garden-service/src/logger/writers/fancy-terminal-writer.ts
+++ b/garden-service/src/logger/writers/fancy-terminal-writer.ts
@@ -42,6 +42,8 @@ export interface CustomStream extends NodeJS.WriteStream {
 }
 
 export class FancyTerminalWriter extends Writer {
+  type = "fancy"
+
   private spinners: { [key: string]: Function }
   private intervalID: NodeJS.Timer | null
   private stream: CustomStream
@@ -49,10 +51,8 @@ export class FancyTerminalWriter extends Writer {
   private lastInterceptAt: number | null
   private updatePending: boolean
 
-  public level: LogLevel
-
-  constructor() {
-    super()
+  constructor(level: LogLevel = LogLevel.info) {
+    super(level)
     this.intervalID = null
     this.spinners = {} // Each entry has it's own spinner
     this.prevOutput = []

--- a/garden-service/src/logger/writers/file-writer.ts
+++ b/garden-service/src/logger/writers/file-writer.ts
@@ -48,13 +48,14 @@ export function render(level: LogLevel, entry: LogEntry): string | null {
 }
 
 export class FileWriter extends Writer {
+  type = "file"
+
   private fileLogger: winston.Logger | null
   private logFilePath: string
   private fileTransportOptions: FileTransportOptions
-  public level: LogLevel
 
   constructor(logFilePath: string, config: FileWriterConfig) {
-    super()
+    super(config.level)
 
     const { fileTransportOptions = DEFAULT_FILE_TRANSPORT_OPTIONS, level } = config
     this.level = level

--- a/garden-service/src/logger/writers/json-terminal-writer.ts
+++ b/garden-service/src/logger/writers/json-terminal-writer.ts
@@ -6,7 +6,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { LogLevel } from "../log-node"
 import { LogEntry, LogEntryMetadata } from "../log-entry"
 import { Logger } from "../logger"
 import { Writer } from "./base"
@@ -21,7 +20,7 @@ export interface JsonLogEntry {
 }
 
 export class JsonTerminalWriter extends Writer {
-  public level: LogLevel
+  type = "json"
 
   render(entry: LogEntry, logger: Logger): string | null {
     const level = this.level || logger.level


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:

This avoids triggering the log writers if their level is lower than
the log entry. This was particularly apparent when initializing
providers because that process triggers a lot of verbose+ entries.
