### PR TITLE
fix(config): throw error on base module schema validation errors

### DIFF
--- a/garden-service/test/data/test-project-invalid-config/missing-kind/garden.yml
+++ b/garden-service/test/data/test-project-invalid-config/missing-kind/garden.yml
@@ -1,0 +1,2 @@
+type: foo
+name: bla

--- a/garden-service/test/data/test-project-invalid-config/missing-name/garden.yml
+++ b/garden-service/test/data/test-project-invalid-config/missing-name/garden.yml
@@ -1,0 +1,2 @@
+kind: Module
+type: foo

--- a/garden-service/test/data/test-project-invalid-config/missing-type/garden.yml
+++ b/garden-service/test/data/test-project-invalid-config/missing-type/garden.yml
@@ -1,0 +1,2 @@
+kind: Module
+name: foo

--- a/garden-service/test/unit/src/config/base.ts
+++ b/garden-service/test/unit/src/config/base.ts
@@ -3,6 +3,7 @@ import { loadConfig, findProjectConfig } from "../../../../src/config/base"
 import { resolve } from "path"
 import { dataDir, expectError, getDataDir } from "../../../helpers"
 import { DEFAULT_API_VERSION } from "../../../../src/constants"
+import stripAnsi = require("strip-ansi")
 
 const projectPathA = resolve(dataDir, "test-project-a")
 const modulePathA = resolve(projectPathA, "module-a")
@@ -28,6 +29,40 @@ describe("loadConfig", () => {
       async () => await loadConfig(projectPath, resolve(projectPath, "invalid-syntax-module")),
       (err) => {
         expect(err.message).to.match(/Could not parse/)
+      }
+    )
+  })
+
+  it("should throw if a config doesn't specify a kind", async () => {
+    const projectPath = resolve(dataDir, "test-project-invalid-config")
+    await expectError(
+      async () => await loadConfig(projectPath, resolve(projectPath, "missing-kind")),
+      (err) => {
+        expect(err.message).to.equal("Missing `kind` field in config at missing-kind/garden.yml")
+      }
+    )
+  })
+
+  it("should throw if a module config doesn't specify a type", async () => {
+    const projectPath = resolve(dataDir, "test-project-invalid-config")
+    await expectError(
+      async () => await loadConfig(projectPath, resolve(projectPath, "missing-type")),
+      (err) => {
+        expect(stripAnsi(err.message)).to.equal(
+          "Error validating module (missing-type/garden.yml): key .type is required"
+        )
+      }
+    )
+  })
+
+  it("should throw if a module config doesn't specify a name", async () => {
+    const projectPath = resolve(dataDir, "test-project-invalid-config")
+    await expectError(
+      async () => await loadConfig(projectPath, resolve(projectPath, "missing-name")),
+      (err) => {
+        expect(stripAnsi(err.message)).to.equal(
+          "Error validating module (missing-name/garden.yml): key .name is required"
+        )
       }
     )
   })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:

We previously ignored configs that did not have `kind` set, and threw
some confusing errors when e.g. `type` or `name` were missing.

**Which issue(s) this PR fixes**:

Fixes #1280
