### PR TITLE
feat: added securityContext for production flag

### DIFF
--- a/docs/guides/remote-kubernetes.md
+++ b/docs/guides/remote-kubernetes.md
@@ -180,7 +180,8 @@ The flag is also given to each provider, which may modify behavior accordingly. 
 
 1. Set the default number of replicas for `container` services to 3 (unless specified by the user).
 2. Set a soft AntiAffinity setting on `container` deployments to try to schedule Pods in a single Deployment across many nodes.
-3. Increase the `RevisionHistoryLimit` on workloads to 10.
-4. By default, running `garden deploy --force` will propagate the `--force` flag to `helm upgrade`, and set the `--replace` flag on `helm install` when deploying `helm` modules. This may be okay while developing but risky in production, so the `production` flag prevents both of those.
+3. Set a restricted `securityContext` for Pods (runAsUser: 1000, runAsGroup: 3000, fsGroup: 2000).
+4. Increase the `RevisionHistoryLimit` on workloads to 10.
+5. By default, running `garden deploy --force` will propagate the `--force` flag to `helm upgrade`, and set the `--replace` flag on `helm install` when deploying `helm` modules. This may be okay while developing but risky in production, so the `production` flag prevents both of those.
 
 We would highly appreciate feedback on other configuration settings that should be altered when `production: true`. Please send us feedback via [GitHub issues](https://github.com/garden-io/garden/issues) or reach out on our Slack channel!

--- a/garden-service/src/plugins/kubernetes/container/deployment.ts
+++ b/garden-service/src/plugins/kubernetes/container/deployment.ts
@@ -296,6 +296,9 @@ export async function createWorkloadResource({
       },
     },
     imagePullPolicy: "IfNotPresent",
+    securityContext: {
+      allowPrivilegeEscalation: false,
+    },
   }
 
   if (service.spec.command && service.spec.command.length > 0) {
@@ -395,7 +398,14 @@ export async function createWorkloadResource({
       },
     }
 
+    const securityContext = {
+      runAsUser: 1000,
+      runAsGroup: 3000,
+      fsGroup: 2000,
+    }
+
     deployment.spec.template.spec.affinity = affinity
+    deployment.spec.template.spec.securityContext = securityContext
   }
 
   if (enableHotReload) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:
This adds a `securityContext` field in the pod definition when using the `container` module and the `production` flag.
Furthermore the `pod.containers[].securityContext.allowPrivilegeEscalation` is now by default set to `false`.

**Which issue(s) this PR fixes**:
none

**Special notes for your reviewer**:
