### PR TITLE
ci: use release-service-dist-edge job on merges to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -529,7 +529,7 @@ workflows:
           <<: *only-master
           context: docker
           requires: [build-dist-edge]
-      - release-service-dist:
+      - release-service-dist-edge:
           <<: *only-master
           requires: [build-dist-edge]
 


### PR DESCRIPTION
A previous commit had accidentally changed the job to
release-service-dist. This PR reverts that change.