### PR TITLE
fix(dashboard): hide ingress view when showing task/test results

### DIFF
--- a/dashboard/src/contexts/ui.tsx
+++ b/dashboard/src/contexts/ui.tsx
@@ -159,6 +159,7 @@ const useUiStateProvider = () => {
       ...uiState,
       overview: {
         ...uiState.overview,
+        selectedIngress: null,
         selectedEntity,
       },
     })


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, the "Show results" button on a task/test card on the Overview page wouldn't work if the "view ingress" component was open. This was because the result pane was hidden under the ingress view. Now we always close the "view ingress" component when opening the results pane.

**Which issue(s) this PR fixes**:

Fixes #915 