### PR TITLE
chore(ci): don't configure gcloud for minikube tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,11 +360,10 @@ jobs:
     environment:
       K8S_VERSION: <<parameters.kubernetesVersion>>
       MINIKUBE_VERSION: v1.5.2
-      GARDEN_LOG_LEVEL: silly
+      GARDEN_LOG_LEVEL: debug
       GARDEN_LOGGER_TYPE: basic
     steps:
       - checkout
-      - configure_kubectl_context
       - run:
           name: Install system dependencies
           command: |


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:

Configuring gcloud was both unnecessary and caused issues with tests for external PRs
