### PR TITLE
chore(lint): enforce triple-equals

### DIFF
--- a/dashboard/src/service-worker.ts
+++ b/dashboard/src/service-worker.ts
@@ -68,7 +68,7 @@ function registerValidSW(swUrl, config) {
     .then((registration) => {
       registration.onupdatefound = () => {
         const installingWorker = registration.installing
-        if (installingWorker == null) {
+        if (installingWorker === null) {
           return
         }
         installingWorker.onstatechange = () => {
@@ -112,7 +112,7 @@ function checkValidServiceWorker(swUrl, config) {
     .then((response) => {
       // Ensure service worker exists, and that we really are getting a JS file.
       const contentType = response.headers.get("content-type")
-      if (response.status === 404 || (contentType != null && contentType.indexOf("javascript") === -1)) {
+      if (response.status === 404 || (contentType !== null && contentType.indexOf("javascript") === -1)) {
         // No service worker found. Probably a different app. Reload the page.
         navigator.serviceWorker.ready
           .then((registration) => {

--- a/garden-service/src/plugins/kubernetes/container/deployment.ts
+++ b/garden-service/src/plugins/kubernetes/container/deployment.ts
@@ -145,7 +145,7 @@ export async function deployContainerServiceBlueGreen(
     // Update service (divert traffic from Blue to Green)
 
     // First patch the generated service to point to the new version of the deployment
-    const serviceManifest = find(manifests, (manifest) => manifest.kind == "Service")
+    const serviceManifest = find(manifests, (manifest) => manifest.kind === "Service")
     const patchedServiceManifest = merge(serviceManifest, servicePatchBody)
     // Compare with the deployed Service
     const result = await compareDeployedResources(k8sCtx, api, namespace, [patchedServiceManifest], log)

--- a/garden-service/src/plugins/kubernetes/status/status.ts
+++ b/garden-service/src/plugins/kubernetes/status/status.ts
@@ -353,7 +353,7 @@ export async function compareDeployedResources(
 
     // NOTE: this approach won't fly in the long run, but hopefully we can climb out of this mess when
     //       `kubectl diff` is ready, or server-side apply/diff is ready
-    if (manifest.kind === "DaemonSet" || manifest.kind === "Deployment" || manifest.kind == "StatefulSet") {
+    if (manifest.kind === "DaemonSet" || manifest.kind === "Deployment" || manifest.kind === "StatefulSet") {
       // handle properties that are omitted in the response because they have the default value
       // (another design issue in the K8s API)
       if (manifest.spec.minReadySeconds === 0) {

--- a/package.json
+++ b/package.json
@@ -55,11 +55,11 @@
     "check-package-lock": "git diff --quiet HEAD -- package-lock.json || (echo 'package-lock.json is dirty!' && exit 1)",
     "check-all": "npm run check-docs && npm run check-package-lock && npm run check-licenses && npm run lint",
     "clean": "lerna run clean && git clean -X -f && find . -name \".garden\" -type d -prune -exec rm -rf '{}' '+'",
-    "fix-format": "lerna run fix-format",
+    "fix-format": "lerna run fix-format --no-bail",
     "generate-docs": "lerna run generate-docs",
     "integ": "lerna run integ",
-    "lint": "lerna run lint && gulp check-licenses",
-    "test": "lerna run test"
+    "lint": "lerna run lint --no-bail && gulp check-licenses",
+    "test": "lerna run test --no-bail"
   },
   "husky": {
     "hooks": {

--- a/tslint.base.json
+++ b/tslint.base.json
@@ -49,6 +49,7 @@
       "allow-leading-underscore",
       "allow-pascal-case"
     ],
+    "triple-equals": true,
     "whitespace": [true, "check-branch", "check-operator", "check-separator"]
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Enforce [triple equals](https://palantir.github.io/tslint/rules/triple-equals/) in linter because using `==` can cause subtle bugs. For example:

```javascript
false == 0 // true
```
which we generally don't want.

**Notes for reviewer**

Also added `--no-bail` to `lint`, `test`, and `fix-format` commands so that `lerna` doesn't exit on when the first package errors.