### PR TITLE
feat(core): use service's port when forwarding to localhost if available

### DIFF
--- a/garden-service/src/proxy.ts
+++ b/garden-service/src/proxy.ts
@@ -169,7 +169,7 @@ async function createProxy(garden: Garden, log: LogEntry, service: Service, spec
     })
   })
 
-  const localPort = await getPort()
+  const localPort = await getPort({ port: spec.targetPort })
   const host = `localhost:${localPort}`
   // For convenience, we try to guess a protocol based on the target port, if no URL protocol is specified
   const protocol = spec.urlProtocol || guessProtocol(spec)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR uses the service's port when forwarding to localhost, if it's available, otherwise it uses a random available port. We need it because it's helpful for services to be on the expected localhost ports e.g. 3000 for Create React App, 27017 for MongoDB, 6379 for Redis.

**Which issue(s) this PR fixes**:

Fixes #1428