### PR TITLE
fix(k8s): in-cluster registry updates would hang with RWO volumes

### DIFF
--- a/garden-service/src/plugins/kubernetes/commands/cleanup-cluster-registry.ts
+++ b/garden-service/src/plugins/kubernetes/commands/cleanup-cluster-registry.ts
@@ -393,7 +393,7 @@ async function cleanupBuildSyncVolume(provider: KubernetesProvider, log: LogEntr
     provider,
     log,
     args: deleteArgs,
-    timeout: 30,
+    timeout: 300,
     podName,
   })
 

--- a/garden-service/src/plugins/openfaas/openfaas.ts
+++ b/garden-service/src/plugins/openfaas/openfaas.ts
@@ -268,7 +268,7 @@ async function deployService(params: DeployServiceParams<OpenFaasModule>): Promi
       const now = new Date().getTime()
 
       // Retry a few times in case faas-netes is still initializing
-      if (err.stderr?.includes("failed to deploy with status code: 503") && now - start < faasNetesInitTimeout * 1000) {
+      if (err.all?.includes("failed to deploy with status code: 503") && now - start < faasNetesInitTimeout * 1000) {
         await sleep(retryWait)
         continue
       } else {

--- a/garden-service/src/util/util.ts
+++ b/garden-service/src/util/util.ts
@@ -143,7 +143,7 @@ interface ExecOpts extends execa.Options {
  */
 export async function exec(cmd: string, args: string[], opts: ExecOpts = {}) {
   // Ensure buffer is always set to true so that we can read the error output
-  opts = { ...opts, buffer: true }
+  opts = { ...opts, buffer: true, all: true }
   const proc = execa(cmd, args, omit(opts, ["stdout", "stderr"]))
 
   opts.stdout && proc.stdout && proc.stdout.pipe(opts.stdout)

--- a/garden-service/static/kubernetes/system/docker-registry/garden.yml
+++ b/garden-service/static/kubernetes/system/docker-registry/garden.yml
@@ -6,6 +6,9 @@ chart: stable/docker-registry
 releaseName: garden-docker-registry
 version: 1.8.3
 values:
+  # This is to avoid a multi-attach error when updating
+  updateStrategy:
+    type: Recreate
   resources:
     limits:
       cpu: ${var.registry-limits-cpu}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:

We need to terminate the registry pods instead of attempting to launch
another instance before terminating the other.
