### PR TITLE
chore(ci): enable docker layer caching for minikube tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,6 +353,7 @@ jobs:
   test-minikube:
     machine:
       image: 'ubuntu-1604:201903-01'
+      docker_layer_caching: true
     parameters:
       kubernetesVersion:
         description: The Kubernetes version to run


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:

Since we use VM-less minikube, the layer caching should actually be helpful in terms of performance.

