### PR TITLE
fix(core): fix empty runtimeContext check

### DIFF
--- a/garden-service/src/actions.ts
+++ b/garden-service/src/actions.ts
@@ -772,7 +772,11 @@ export class ActionRouter implements TypeGuard {
     })
 
     // Resolve ${runtime.*} template strings if needed.
-    if (runtimeContext && (await getRuntimeTemplateReferences(module)).length > 0) {
+    const runtimeContextIsEmpty = runtimeContext
+      ? Object.keys(runtimeContext.envVars).length === 0 && runtimeContext.dependencies.length === 0
+      : true
+
+    if (!runtimeContextIsEmpty && (await getRuntimeTemplateReferences(module)).length > 0) {
       log.silly(`Resolving runtime template strings for service '${service.name}'`)
       const configContext = await this.garden.getModuleConfigContext(runtimeContext)
       const graph = await this.garden.getConfigGraph(log, { configContext })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or ran the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09,  @ellenkorbes, @10ko.
-->

**What this PR does / why we need it**:

Before this fix, calls to service action handlers for services with runtime dependencies in template variables would fail if an empty `runtimeContext` was passed to the handler, even if the service handler in question doesn't need environment variables (e.g. `getServiceStatus` and `getServiceLogs`).

**Which issue(s) this PR fixes**:

Fixes #1408.