### PR TITLE
improvement: set default include on Helm modules

### DIFF
--- a/garden-service/src/plugins/kubernetes/helm/config.ts
+++ b/garden-service/src/plugins/kubernetes/helm/config.ts
@@ -352,5 +352,10 @@ export async function configureHelmModule({
     "release-name": getReleaseName(moduleConfig),
   }
 
+  // Automatically set the include if not explicitly set
+  if (!moduleConfig.include) {
+    moduleConfig.include = containsSources ? ["*", "charts/**/*", "templates/**/*"] : []
+  }
+
   return { moduleConfig }
 }

--- a/garden-service/test/integ/src/plugins/kubernetes/helm/config.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/helm/config.ts
@@ -46,7 +46,7 @@ describe("validateHelmModule", () => {
       },
       configPath: resolve(ctx.projectRoot, "api", "garden.yml"),
       description: "The API backend for the voting UI",
-      include: undefined,
+      include: ["*", "charts/**/*", "templates/**/*"],
       exclude: undefined,
       name: "api",
       outputs: {
@@ -120,6 +120,19 @@ describe("validateHelmModule", () => {
       type: "helm",
       taskConfigs: [],
     })
+  })
+
+  it("should not set default includes if they have already been explicitly set", async () => {
+    patchModuleConfig("api", { include: ["foo"] })
+    const config = await garden.resolveModuleConfig(garden.log, "api")
+    expect(config.include).to.eql(["foo"])
+  })
+
+  it("should set include to empty if module does not have local chart sources", async () => {
+    // So that Chart.yaml isn't found
+    patchModuleConfig("api", { spec: { chartPath: "invalid-path" } })
+    const config = await garden.resolveModuleConfig(garden.log, "api")
+    expect(config.include).to.eql([])
   })
 
   it("should not return a serviceConfig if skipDeploy=true", async () => {


### PR DESCRIPTION
**What this PR does / why we need it**:

From commit message:

BREAKING CHANGE:

The `include` field on Helm modules now defaults to:

```javascript
["*", "charts/**/*", "templates/**/*"]
```

if not set manually.

Previously, Helm modules would simply include all content under the
module path. If your Helm modules doesn't have `include` set and depends
on content that's not captured with the default include, you will need
to update the relevant `garden.yml` file and set the includes manually.
