### PR TITLE
fix(core): use fresh statuses in get status cmd

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -35,7 +35,7 @@ to start the `garden-service` API server. Then run:
 
 ```sh
 cd dashboard
-npm dev
+npm run dev
 ```
 
 to start the dashboard development server. The `start` command returns a link to the development version of the dashboard. The default is `http://localhost:3000`.

--- a/garden-service/src/actions.ts
+++ b/garden-service/src/actions.ts
@@ -538,7 +538,7 @@ export class ActionRouter implements TypeGuard {
     const tasks = services.map(
       (service) =>
         new GetServiceStatusTask({
-          force: false,
+          force: true,
           garden: this.garden,
           graph,
           log,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

Before this fix, the `get status` command was using `force: false` for its `GetServiceStatus` tasks, which resulted in the overview tab of the dashboard displaying stale service statuses.

After this fix, refreshing the dashboard once all services are deployed will show their statuses as `"ready"`, which is the expected/correct behavior.

**Which issue(s) this PR fixes**:

Fixes #1265
