### PR TITLE
fix(k8s): make sure Helm 3 migration is run for project namespaces

### DIFF
--- a/garden-service/src/plugins/kubernetes/init.ts
+++ b/garden-service/src/plugins/kubernetes/init.ts
@@ -196,9 +196,9 @@ export async function prepareEnvironment(params: PrepareEnvironmentParams): Prom
   const k8sCtx = <KubernetesPluginContext>ctx
 
   // Migrate from Helm 2.x and remove Tiller from project namespace, if necessary
-  const systemServiceNames = k8sCtx.provider.config._systemServices
+  const systemNamespace = k8sCtx.provider.config.gardenSystemNamespace
 
-  if (systemServiceNames.length === 0 && status.detail.projectTillerInstalled) {
+  if (k8sCtx.provider.config.namespace !== systemNamespace && status.detail.projectTillerInstalled) {
     const api = await KubeApi.factory(log, k8sCtx.provider)
     const namespace = await getAppNamespace(ctx, log, k8sCtx.provider)
     await migrateToHelm3(k8sCtx, api, namespace, log)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

The Helm 3 migration wasn't being triggered for project namespaces.
