### PR TITLE
chore(examples): remove extra provider key

### DIFF
--- a/examples/demo-project/garden.yml
+++ b/examples/demo-project/garden.yml
@@ -4,7 +4,6 @@ name: demo-project
 environments:
   - name: local
   - name: remote
-    providers:
 providers:
   - name: local-kubernetes
     environments: [local]

--- a/examples/remote-k8s/garden.yml
+++ b/examples/remote-k8s/garden.yml
@@ -6,7 +6,6 @@ environments:
     # you can run garden against this environment by adding "--env remote" to your commands,
     # e.g. garden --env remote deploy
   - name: remote
-    providers:
 providers:
   - name: local-kubernetes
     environments: [local]

--- a/examples/vote/garden.yml
+++ b/examples/vote/garden.yml
@@ -3,7 +3,6 @@ name: vote
 environments:
   - name: local
   - name: remote
-    providers:
   - name: testing
 providers:
   - name: local-kubernetes


### PR DESCRIPTION
...basically a copy/paste error from when we moved the example configs
to the top-level-provider style.