### PR TITLE
fix(config): do not set default include if exclude is set + add tests

### DIFF
--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -51,6 +51,13 @@ description:
 # for details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
+#
+# If neither `include` nor `exclude` is set, and the module has a Dockerfile, Garden
+# will parse the Dockerfile and automatically set `include` to match the files and
+# folders added to the Docker image (via the `COPY` and `ADD` directives in the Dockerfile).
+#
+# If neither `include` nor `exclude` is set, and the module
+# specifies a remote image, Garden automatically sets `include` to `[]`.
 include:
 
 # Specify a list of POSIX-style paths or glob patterns that should be excluded from the module.
@@ -383,6 +390,13 @@ source tree, which use the same format as `.gitignore` files. See the
 [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
+
+If neither `include` nor `exclude` is set, and the module has a Dockerfile, Garden
+will parse the Dockerfile and automatically set `include` to match the files and
+folders added to the Docker image (via the `COPY` and `ADD` directives in the Dockerfile).
+
+If neither `include` nor `exclude` is set, and the module
+specifies a remote image, Garden automatically sets `include` to `[]`.
 
 | Type            | Required |
 | --------------- | -------- |

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -46,6 +46,12 @@ description:
 # for details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
+#
+# If neither `include` nor `exclude` is set, and the module has local chart sources, Garden
+# automatically set `include` to: `["*", "charts/**/*", "templates/**/*"]`.
+#
+# If neither `include` nor `exclude` is set and the module specifies a remote chart, Garden
+# automatically sets `ìnclude` to `[]`.
 include:
 
 # Specify a list of POSIX-style paths or glob patterns that should be excluded from the module.
@@ -359,6 +365,12 @@ source tree, which use the same format as `.gitignore` files. See the
 [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
+
+If neither `include` nor `exclude` is set, and the module has local chart sources, Garden
+automatically set `include` to: `["*", "charts/**/*", "templates/**/*"]`.
+
+If neither `include` nor `exclude` is set and the module specifies a remote chart, Garden
+automatically sets `ìnclude` to `[]`.
 
 | Type            | Required |
 | --------------- | -------- |

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -54,6 +54,9 @@ description:
 # for details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
+#
+# If neither `include` nor `exclude` is set, Garden automatically sets `include` to equal the
+# `files` directive so that only the Kubernetes manifests get included.
 include:
 
 # Specify a list of POSIX-style paths or glob patterns that should be excluded from the module.
@@ -182,6 +185,9 @@ source tree, which use the same format as `.gitignore` files. See the
 [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
+
+If neither `include` nor `exclude` is set, Garden automatically sets `include` to equal the
+`files` directive so that only the Kubernetes manifests get included.
 
 | Type            | Required |
 | --------------- | -------- |

--- a/garden-service/src/config/common.ts
+++ b/garden-service/src/config/common.ts
@@ -14,7 +14,7 @@ import chalk from "chalk"
 import { relative } from "path"
 import { splitLast } from "../util/util"
 import isGitUrl from "is-git-url"
-import { deline } from "../util/string"
+import { deline, dedent } from "../util/string"
 
 export type Primitive = string | number | boolean | null
 
@@ -234,6 +234,30 @@ export const envVarRegex = /^(?!garden)[a-z_][a-z0-9_\.]*$/i
 export const joiIdentifierDescription =
   "valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and dashes, must start with a letter, " +
   "and cannot end with a dash) and must not be longer than 63 characters."
+
+const moduleIncludeDescription = (extraDescription?: string) => {
+  const desc = dedent`
+  Specify a list of POSIX-style paths or globs that should be regarded as the source files for this
+  module. Files that do *not* match these paths or globs are excluded when computing the version of the module,
+  when responding to filesystem watch events, and when staging builds.
+
+  Note that you can also _exclude_ files using the \`exclude\` field or by placing \`.gardenignore\` files in your
+  source tree, which use the same format as \`.gitignore\` files. See the
+  [Configuration Files guide](${includeGuideLink}) for details.
+
+  Also note that specifying an empty list here means _no sources_ should be included.
+  `
+  if (extraDescription) {
+    return desc + "\n\n" + extraDescription
+  }
+  return desc
+}
+
+export const joiModuleIncludeDirective = (extraDescription?: string) =>
+  joi
+    .array()
+    .items(joi.string().posixPath({ allowGlobs: true, subPathOnly: true }))
+    .description(moduleIncludeDescription(extraDescription))
 
 export const joiIdentifier = () =>
   joi

--- a/garden-service/src/config/module.ts
+++ b/garden-service/src/config/module.ts
@@ -6,7 +6,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import dedent = require("dedent")
 import stableStringify = require("json-stable-stringify")
 import { ServiceConfig, ServiceSpec, serviceConfigSchema } from "./service"
 import {
@@ -24,6 +23,7 @@ import { TestConfig, TestSpec, testConfigSchema } from "./test"
 import { TaskConfig, TaskSpec, taskConfigSchema } from "./task"
 import { DEFAULT_API_VERSION } from "../constants"
 import { joiVariables } from "./common"
+import { dedent } from "../util/string"
 
 export interface BuildCopySpec {
   source: string

--- a/garden-service/src/plugins/container/config.ts
+++ b/garden-service/src/plugins/container/config.ts
@@ -18,6 +18,7 @@ import {
   envVarRegex,
   Primitive,
   ArtifactSpec,
+  joiModuleIncludeDirective,
 } from "../../config/common"
 import { Service, ingressHostnameSchema, linkUrlSchema } from "../../types/service"
 import { DEFAULT_PORT_PROTOCOL } from "../../constants"
@@ -539,6 +540,14 @@ export const containerModuleSpecSchema = joi
         Specify the image name for the container. Should be a valid Docker image identifier. If specified and
         the module does not contain a Dockerfile, this image will be used to deploy services for this module.
         If specified and the module does contain a Dockerfile, this identifier is used when pushing the built image.`),
+    include: joiModuleIncludeDirective(dedent`
+      If neither \`include\` nor \`exclude\` is set, and the module has a Dockerfile, Garden
+      will parse the Dockerfile and automatically set \`include\` to match the files and
+      folders added to the Docker image (via the \`COPY\` and \`ADD\` directives in the Dockerfile).
+
+      If neither \`include\` nor \`exclude\` is set, and the module
+      specifies a remote image, Garden automatically sets \`include\` to \`[]\`.
+    `),
     hotReload: hotReloadConfigSchema,
     dockerfile: joi
       .string()

--- a/garden-service/src/plugins/container/container.ts
+++ b/garden-service/src/plugins/container/container.ts
@@ -151,7 +151,7 @@ export async function configureContainerModule({ ctx, log, moduleConfig }: Confi
   }
 
   // Automatically set the include field based on the Dockerfile and config, if not explicitly set
-  if (!moduleConfig.include) {
+  if (!(moduleConfig.include || moduleConfig.exclude)) {
     moduleConfig.include = await containerHelpers.autoResolveIncludes(moduleConfig, log)
   }
 

--- a/garden-service/src/plugins/kubernetes/helm/config.ts
+++ b/garden-service/src/plugins/kubernetes/helm/config.ts
@@ -17,6 +17,7 @@ import {
   DeepPrimitiveMap,
   joi,
   ArtifactSpec,
+  joiModuleIncludeDirective,
 } from "../../../config/common"
 import { Module, FileCopySpec } from "../../../types/module"
 import { containsSource, getReleaseName } from "./common"
@@ -238,6 +239,13 @@ export const helmModuleSpecSchema = joi.object().keys({
       deline`Set this to true if the chart should only be built, but not deployed as a service.
       Use this, for example, if the chart should only be used as a base for other modules.`
     ),
+  include: joiModuleIncludeDirective(dedent`
+    If neither \`include\` nor \`exclude\` is set, and the module has local chart sources, Garden
+    automatically set \`include\` to: \`["*", "charts/**/*", "templates/**/*"]\`.
+
+    If neither \`include\` nor \`exclude\` is set and the module specifies a remote chart, Garden
+    automatically sets \`ìnclude\` to \`[]\`.
+  `),
   tasks: joiArray(taskSchema).description("The task definitions for this module."),
   tests: joiArray(testSchema).description("The test suite definitions for this module."),
   timeout: joi
@@ -353,7 +361,7 @@ export async function configureHelmModule({
   }
 
   // Automatically set the include if not explicitly set
-  if (!moduleConfig.include) {
+  if (!(moduleConfig.include || moduleConfig.exclude)) {
     moduleConfig.include = containsSources ? ["*", "charts/**/*", "templates/**/*"] : []
   }
 

--- a/garden-service/src/plugins/maven-container/maven-container.ts
+++ b/garden-service/src/plugins/maven-container/maven-container.ts
@@ -16,7 +16,7 @@ import {
   ContainerModuleConfig,
   ContainerTaskSpec,
 } from "../container/config"
-import { joiArray, joiProviderName, joi } from "../../config/common"
+import { joiArray, joiProviderName, joi, joiModuleIncludeDirective } from "../../config/common"
 import { Module } from "../../types/module"
 import { resolve } from "path"
 import { RuntimeError, ConfigurationError } from "../../exceptions"
@@ -66,6 +66,7 @@ const mavenKeys = {
     `
     )
     .example("11-jdk"),
+  include: joiModuleIncludeDirective(),
   jarPath: joi
     .string()
     .required()

--- a/garden-service/test/data/test-projects/kubernetes-module/garden.yml
+++ b/garden-service/test/data/test-projects/kubernetes-module/garden.yml
@@ -1,0 +1,4 @@
+kind: Project
+name: kubernetes-module-test
+providers:
+  - name: local-kubernetes

--- a/garden-service/test/data/test-projects/kubernetes-module/module-simple/garden.yml
+++ b/garden-service/test/data/test-projects/kubernetes-module/module-simple/garden.yml
@@ -1,0 +1,26 @@
+kind: Module
+type: kubernetes
+name: module-simple
+description: Simple Kubernetes module with minimum config
+manifests:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: busybox-deployment
+      labels:
+        app: busybox
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: busybox
+      template:
+        metadata:
+          labels:
+            app: busybox
+        spec:
+          containers:
+            - name: busybox
+              image: busybox:1.31.1
+              ports:
+                - containerPort: 80

--- a/garden-service/test/integ/src/plugins/kubernetes/helm/config.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/helm/config.ts
@@ -122,10 +122,16 @@ describe("validateHelmModule", () => {
     })
   })
 
-  it("should not set default includes if they have already been explicitly set", async () => {
+  it("should not set default includes if include has already been explicitly set", async () => {
     patchModuleConfig("api", { include: ["foo"] })
-    const config = await garden.resolveModuleConfig(garden.log, "api")
-    expect(config.include).to.eql(["foo"])
+    const configInclude = await garden.resolveModuleConfig(garden.log, "api")
+    expect(configInclude.include).to.eql(["foo"])
+  })
+
+  it("should not set default includes if exclude has already been explicitly set", async () => {
+    patchModuleConfig("api", { exclude: ["bar"] })
+    const configExclude = await garden.resolveModuleConfig(garden.log, "api")
+    expect(configExclude.include).to.be.undefined
   })
 
   it("should set include to empty if module does not have local chart sources", async () => {

--- a/garden-service/test/integ/src/plugins/kubernetes/kubernetes-module/config.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/kubernetes-module/config.ts
@@ -1,0 +1,174 @@
+import { resolve } from "path"
+import { expect } from "chai"
+import { cloneDeep } from "lodash"
+
+import { TestGarden, dataDir, makeTestGarden } from "../../../../../helpers"
+import { PluginContext } from "../../../../../../src/plugin-context"
+import { ModuleConfig } from "../../../../../../src/config/module"
+import { apply } from "json-merge-patch"
+
+describe("validateKubernetesModule", () => {
+  let garden: TestGarden
+  let ctx: PluginContext
+  let moduleConfigs: { [key: string]: ModuleConfig }
+
+  before(async () => {
+    const projectRoot = resolve(dataDir, "test-projects", "kubernetes-module")
+    garden = await makeTestGarden(projectRoot)
+    const provider = await garden.resolveProvider("local-kubernetes")
+    ctx = garden.getPluginContext(provider)
+    await garden["resolveModuleConfigs"](garden.log)
+    moduleConfigs = cloneDeep((<any>garden).moduleConfigs)
+  })
+
+  afterEach(() => {
+    garden["moduleConfigs"] = cloneDeep(moduleConfigs)
+  })
+
+  function patchModuleConfig(name: string, patch: any) {
+    apply((<any>garden).moduleConfigs[name], patch)
+  }
+
+  it("should validate a Kubernetes module", async () => {
+    const config = await garden.resolveModuleConfig(garden.log, "module-simple")
+
+    expect(config).to.eql({
+      allowPublish: true,
+      apiVersion: "garden.io/v0",
+      build: {
+        dependencies: [],
+      },
+      configPath: resolve(ctx.projectRoot, "module-simple", "garden.yml"),
+      description: "Simple Kubernetes module with minimum config",
+      exclude: undefined,
+      include: [],
+      kind: "Module",
+      name: "module-simple",
+      outputs: {},
+      path: resolve(ctx.projectRoot, "module-simple"),
+      repositoryUrl: undefined,
+      serviceConfigs: [
+        {
+          dependencies: [],
+          hotReloadable: false,
+          name: "module-simple",
+          spec: {
+            build: {
+              dependencies: [],
+            },
+            dependencies: [],
+            files: [],
+            manifests: [
+              {
+                apiVersion: "apps/v1",
+                kind: "Deployment",
+                metadata: {
+                  labels: {
+                    app: "busybox",
+                  },
+                  name: "busybox-deployment",
+                },
+                spec: {
+                  replicas: 1,
+                  selector: {
+                    matchLabels: {
+                      app: "busybox",
+                    },
+                  },
+                  template: {
+                    metadata: {
+                      labels: {
+                        app: "busybox",
+                      },
+                    },
+                    spec: {
+                      containers: [
+                        {
+                          image: "busybox:1.31.1",
+                          name: "busybox",
+                          ports: [
+                            {
+                              containerPort: 80,
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      ],
+      spec: {
+        build: {
+          dependencies: [],
+        },
+        dependencies: [],
+        files: [],
+        manifests: [
+          {
+            apiVersion: "apps/v1",
+            kind: "Deployment",
+            metadata: {
+              labels: {
+                app: "busybox",
+              },
+              name: "busybox-deployment",
+            },
+            spec: {
+              replicas: 1,
+              selector: {
+                matchLabels: {
+                  app: "busybox",
+                },
+              },
+              template: {
+                metadata: {
+                  labels: {
+                    app: "busybox",
+                  },
+                },
+                spec: {
+                  containers: [
+                    {
+                      image: "busybox:1.31.1",
+                      name: "busybox",
+                      ports: [
+                        {
+                          containerPort: 80,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      },
+      taskConfigs: [],
+      testConfigs: [],
+      type: "kubernetes",
+    })
+  })
+
+  it("should set include to equal files if neither include nor exclude has been set", async () => {
+    patchModuleConfig("module-simple", { spec: { files: ["manifest.yaml"] } })
+    const configInclude = await garden.resolveModuleConfig(garden.log, "module-simple")
+    expect(configInclude.include).to.eql(["manifest.yaml"])
+  })
+
+  it("should not set default includes if include has already been explicitly set", async () => {
+    patchModuleConfig("module-simple", { include: ["foo"] })
+    const configInclude = await garden.resolveModuleConfig(garden.log, "module-simple")
+    expect(configInclude.include).to.eql(["foo"])
+  })
+
+  it("should not set default includes if exclude has already been explicitly set", async () => {
+    patchModuleConfig("module-simple", { exclude: ["bar"] })
+    const configExclude = await garden.resolveModuleConfig(garden.log, "module-simple")
+    expect(configExclude.include).to.be.undefined
+  })
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously we would set a default `include` on some module configs if no `include` was specified. Updated to only set a default `include` if neither `include` nor `exclude` is specifically set.

Also updated the description test for the `include` directive and added more tests. 
