### PR TITLE
fix(k8s): fix issues with helm 2to3 migration

### DIFF
--- a/garden-service/src/util/util.ts
+++ b/garden-service/src/util/util.ts
@@ -442,6 +442,7 @@ export async function loadYamlFile(path: string): Promise<any> {
 
 export interface ObjectWithName {
   name: string
+  [key: string]: any
 }
 
 export function getNames<T extends ObjectWithName>(array: T[]) {


### PR DESCRIPTION
**What this PR does / why we need it**:

The 2to3 plugin doesn't support multiple files in KUBECONFIG, and does
not support/respect the --kube-context parameter at all.
