### PR TITLE
fix: failing init if remote is not set

### DIFF
--- a/garden-service/src/analytics/analytics.ts
+++ b/garden-service/src/analytics/analytics.ts
@@ -34,6 +34,7 @@ export interface SystemInfo {
 
 export interface AnalyticsEventProperties {
   projectId: string
+  projectName: string
   system: SystemInfo
   isCI: boolean
   sessionId: string
@@ -107,6 +108,7 @@ export class AnalyticsHandler {
   private globalConfig: AnalyticsGlobalConfig
   private globalConfigStore: GlobalConfigStore
   private projectId = ""
+  private projectName = ""
   private systemConfig: SystemInfo
   private isCI = ci.isCI
   private sessionId = uuid.v4()
@@ -171,7 +173,8 @@ export class AnalyticsHandler {
 
     const vcs = new GitHandler(process.cwd(), [])
     const originName = await vcs.getOriginName(this.log)
-    this.projectId = originName ? hasha(originName, { algorithm: "sha256" }) : "unset"
+    this.projectName = hasha(this.garden.projectName, { algorithm: "sha256" })
+    this.projectId = originName ? hasha(originName, { algorithm: "sha256" }) : this.projectName
 
     if (this.globalConfig.firstRun || this.globalConfig.showOptInMessage) {
       if (!this.isCI) {
@@ -273,6 +276,7 @@ export class AnalyticsHandler {
   private getBasicAnalyticsProperties(): AnalyticsEventProperties {
     return {
       projectId: this.projectId,
+      projectName: this.projectName,
       system: this.systemConfig,
       isCI: this.isCI,
       sessionId: this.sessionId,

--- a/garden-service/src/vcs/git.ts
+++ b/garden-service/src/vcs/git.ts
@@ -389,6 +389,11 @@ export class GitHandler extends VcsHandler {
   async getOriginName(log: LogEntry) {
     const cwd = process.cwd()
     const git = this.gitCli(log, cwd)
-    return (await git("config", "--get", "remote.origin.url"))[0]
+    try {
+      return (await git("config", "--get", "remote.origin.url"))[0]
+    } catch (error) {
+      log.silly(`Trying to retrieve "git remote origin.url" but encountered an error: ${error}`)
+    }
+    return undefined
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:
The `AnalyticsHandler` was wrongly expecting the project to have a `remote.url` set and it was failing when running garden on a local repo. Fixed that.
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
cc @thsig 