### PR TITLE
fix(k8s): ensure Garden can upgrade garden-nginx release

### DIFF
--- a/garden-service/src/plugins/kubernetes/init.ts
+++ b/garden-service/src/plugins/kubernetes/init.ts
@@ -201,7 +201,7 @@ export async function prepareEnvironment(params: PrepareEnvironmentParams): Prom
   if (k8sCtx.provider.config.namespace !== systemNamespace && status.detail.projectTillerInstalled) {
     const api = await KubeApi.factory(log, k8sCtx.provider)
     const namespace = await getAppNamespace(ctx, log, k8sCtx.provider)
-    await migrateToHelm3(k8sCtx, api, namespace, log)
+    await migrateToHelm3({ ctx: k8sCtx, api, namespace, log })
   }
 
   // Prepare system services
@@ -288,7 +288,7 @@ export async function prepareSystem({
 
   // Migrate from Helm 2.x and remove Tiller from system namespace, if necessary
   if (status.detail.systemTillerInstalled) {
-    await migrateToHelm3(sysCtx, sysApi, systemNamespace, log)
+    await migrateToHelm3({ ctx: sysCtx, api: sysApi, namespace: systemNamespace, sysGarden, log })
   }
 
   // Set auth secret for in-cluster builder


### PR DESCRIPTION
**What this PR does / why we need it**:

Without it, `garden deploy` fails with the following error after migrating to Helm 3:

```
   ✖ ingress-controller        → Deploying version v-deb87c8a3a...
Failed resolving provider local-kubernetes. Here is the output:
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
local-kubernetes — an error occurred when configuring environment:
Error: Command "/Users/eysi/.garden/tools/helm3/dd4668d875bedaf5/darwin-amd64/helm --kube-context docker-for-desktop --namespace garden
-system upgrade garden-nginx /Users/eysi/code/garden-io/garden/examples/demo-project/.garden/kubernetes.garden/build/ingress-controller
/nginx-ingress --install --atomic --namespace garden-system --timeout 300s --values /Users/eysi/code/garden-io/garden/examples/demo-pro
ject/.garden/kubernetes.garden/build/ingress-controller/nginx-ingress/garden-values.yml" failed with code 1:
Error: UPGRADE FAILED: rendered manifests contain a new resource that already exists. Unable to continue with update: existing resource
 conflict: kind: DaemonSet, namespace: garden-system, name: garden-nginx-nginx-ingress-controller
Error: UPGRADE FAILED: rendered manifests contain a new resource that already exists. Unable to continue with update: existing resource
 conflict: kind: DaemonSet, namespace: garden-system, name: garden-nginx-nginx-ingress-controller
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Failed resolving one or more providers:
- local-kubernetes
```

**Special notes for your reviewer**:

* I'm duplicating some of the `deployHelmService` logic in the `migrateToHelm3` function since it's non-trivial to refactor the `deployService` handler to except the Helm version.
* This only runs if the release has status  "DEPLOYED". I'm assuming that's enough.
* I'm passing `sysGarden` to `migrateToHelm3` because getting it via the plugin context will mess with the build path. 