### PR TITLE
fix(k8s): play nice with Helm 2 (Tiller) when users still need it

### DIFF
--- a/garden-service/src/config/common.ts
+++ b/garden-service/src/config/common.ts
@@ -14,6 +14,9 @@ import { deline, dedent } from "../util/string"
 
 export type Primitive = string | number | boolean | null
 
+export interface StringMap {
+  [key: string]: string
+}
 export interface PrimitiveMap {
   [key: string]: Primitive
 }

--- a/garden-service/src/plugins/kubernetes/commands/remove-tiller.ts
+++ b/garden-service/src/plugins/kubernetes/commands/remove-tiller.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2018 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { PluginCommand } from "../../../types/plugin/command"
+import chalk from "chalk"
+import { KubernetesPluginContext } from "../config"
+import { getAppNamespace } from "../namespace"
+import { KubeApi } from "../api"
+import { removeTiller } from "../helm/tiller"
+
+export const removeTillerCmd: PluginCommand = {
+  name: "remove-tiller",
+  description: "Remove Tiller from project namespace.",
+
+  title: () => {
+    return `Removing Tiller from project namespace`
+  },
+
+  handler: async ({ ctx, log }) => {
+    const k8sCtx = <KubernetesPluginContext>ctx
+    const api = await KubeApi.factory(log, k8sCtx.provider)
+    const namespace = await getAppNamespace(ctx, log, k8sCtx.provider)
+
+    await removeTiller(k8sCtx, api, namespace, log)
+
+    log.info(chalk.green("\nDone!"))
+
+    return { result: {} }
+  },
+}

--- a/garden-service/src/plugins/kubernetes/init.ts
+++ b/garden-service/src/plugins/kubernetes/init.ts
@@ -17,7 +17,7 @@ import { CleanupEnvironmentParams } from "../../types/plugin/provider/cleanupEnv
 import { millicpuToString, megabytesToString } from "./util"
 import chalk from "chalk"
 import { deline, dedent, gardenAnnotationKey } from "../../util/string"
-import { combineStates, ServiceStatusMap } from "../../types/service"
+import { combineStates, ServiceStatusMap, ServiceState } from "../../types/service"
 import {
   setupCertManager,
   checkCertManagerStatus,
@@ -32,6 +32,7 @@ import { dockerAuthSecretName, dockerAuthSecretKey } from "./constants"
 import { V1Secret } from "@kubernetes/client-node"
 import { KubernetesResource } from "./types"
 import { compareDeployedResources } from "./status/status"
+import { PrimitiveMap } from "../../config/common"
 
 // Note: We need to increment a version number here if we ever make breaking changes to the NFS provisioner StatefulSet
 const nfsStorageClassVersion = 2
@@ -42,6 +43,25 @@ See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-
 a registry auth secret.
 `
 
+interface KubernetesProviderOutputs extends PrimitiveMap {
+  "app-namespace": string
+  "metadata-namespace": string
+  "default-hostname": string | null
+}
+
+interface KubernetesEnvironmentDetail {
+  projectHelmMigrated: boolean
+  projectTillerInstalled: boolean
+  serviceStatuses: ServiceStatusMap
+  systemReady: boolean
+  systemServiceState: ServiceState
+  systemTillerInstalled: boolean
+  systemCertManagerReady: boolean
+  systemManagedCertificatesReady: boolean
+}
+
+type KubernetesEnvironmentStatus = EnvironmentStatus<KubernetesProviderOutputs, KubernetesEnvironmentDetail>
+
 /**
  * Performs the following actions to check environment status:
  *   1. Checks Tiller status in the project namespace
@@ -50,38 +70,46 @@ a registry auth secret.
  *
  * Returns ready === true if all the above are ready.
  */
-export async function getEnvironmentStatus({ ctx, log }: GetEnvironmentStatusParams): Promise<EnvironmentStatus> {
+export async function getEnvironmentStatus({
+  ctx,
+  log,
+}: GetEnvironmentStatusParams): Promise<KubernetesEnvironmentStatus> {
   const k8sCtx = <KubernetesPluginContext>ctx
   const provider = k8sCtx.provider
   const api = await KubeApi.factory(log, provider)
 
-  let projectReady = true
+  let projectHelmMigrated = true
   let projectTillerInstalled = false
 
   const namespaces = await prepareNamespaces({ ctx, log })
 
   // Check Tiller status in project namespace
   if ((await checkTillerStatus(k8sCtx, api, namespaces["app-namespace"], log)) !== "missing") {
-    projectReady = false
     projectTillerInstalled = true
+
+    // Check if Helm 2->3 migration has been performed
+    const projectNamespace = await api.core.readNamespace(namespaces["app-namespace"])
+    if (projectNamespace.metadata.annotations?.[gardenAnnotationKey("helm-migrated")] !== "true") {
+      projectHelmMigrated = false
+    }
   }
 
   const systemServiceNames = k8sCtx.provider.config._systemServices
   const systemNamespace = ctx.provider.config.gardenSystemNamespace
 
-  const detail = {
-    projectReady,
+  const detail: KubernetesEnvironmentDetail = {
+    projectHelmMigrated,
     projectTillerInstalled,
     serviceStatuses: {},
     systemReady: true,
-    systemServiceState: "unknown",
+    systemServiceState: <ServiceState>"unknown",
     systemTillerInstalled: false,
     systemCertManagerReady: true,
     systemManagedCertificatesReady: true,
   }
 
-  const result: EnvironmentStatus = {
-    ready: projectReady,
+  const result: KubernetesEnvironmentStatus = {
+    ready: true,
     detail,
     dashboardPages: [],
     outputs: {
@@ -109,8 +137,6 @@ export async function getEnvironmentStatus({ ctx, log }: GetEnvironmentStatusPar
   const sysTillerStatus = await checkTillerStatus(sysCtx, sysApi, systemNamespace, log)
 
   if (sysTillerStatus !== "missing") {
-    result.ready = false
-    detail.systemReady = false
     detail.systemTillerInstalled = true
   }
 
@@ -191,17 +217,23 @@ export async function getEnvironmentStatus({ ctx, log }: GetEnvironmentStatusPar
  *  2. Installs Tiller in system namespace (if provider has system services)
  *  3. Deploys system services (if provider has system services)
  */
-export async function prepareEnvironment(params: PrepareEnvironmentParams): Promise<PrepareEnvironmentResult> {
+export async function prepareEnvironment(
+  params: PrepareEnvironmentParams<KubernetesEnvironmentStatus>
+): Promise<PrepareEnvironmentResult> {
   const { ctx, log, status } = params
   const k8sCtx = <KubernetesPluginContext>ctx
 
   // Migrate from Helm 2.x and remove Tiller from project namespace, if necessary
   const systemNamespace = k8sCtx.provider.config.gardenSystemNamespace
 
-  if (k8sCtx.provider.config.namespace !== systemNamespace && status.detail.projectTillerInstalled) {
+  if (
+    k8sCtx.provider.config.namespace !== systemNamespace &&
+    status.detail!.projectTillerInstalled &&
+    !status.detail!.projectHelmMigrated
+  ) {
     const api = await KubeApi.factory(log, k8sCtx.provider)
     const namespace = await getAppNamespace(ctx, log, k8sCtx.provider)
-    await migrateToHelm3({ ctx: k8sCtx, api, namespace, log })
+    await migrateToHelm3({ ctx: k8sCtx, api, namespace, log, cleanup: false })
   }
 
   // Prepare system services
@@ -218,7 +250,7 @@ export async function prepareSystem({
   force,
   status,
   clusterInit,
-}: PrepareEnvironmentParams & { clusterInit: boolean }) {
+}: PrepareEnvironmentParams<KubernetesEnvironmentStatus> & { clusterInit: boolean }) {
   const k8sCtx = <KubernetesPluginContext>ctx
   const provider = k8sCtx.provider
   const variables = getKubernetesSystemVariables(provider.config)
@@ -287,14 +319,14 @@ export async function prepareSystem({
   await sysGarden.clearBuilds()
 
   // Migrate from Helm 2.x and remove Tiller from system namespace, if necessary
-  if (status.detail.systemTillerInstalled) {
-    await migrateToHelm3({ ctx: sysCtx, api: sysApi, namespace: systemNamespace, sysGarden, log })
+  if (status.detail!.systemTillerInstalled) {
+    await migrateToHelm3({ ctx: sysCtx, api: sysApi, namespace: systemNamespace, sysGarden, log, cleanup: true })
   }
 
   // Set auth secret for in-cluster builder
   if (provider.config.buildMode !== "local-docker") {
     const authSecret = await prepareDockerAuth(sysApi, sysProvider)
-    await sysApi.upsert("Secret", systemNamespace, authSecret, log)
+    await sysApi.upsert({ kind: "Secret", namespace: systemNamespace, obj: authSecret, log })
   }
 
   // We need to install the NFS provisioner separately, so that we can optionally install it

--- a/garden-service/src/plugins/kubernetes/kubernetes.ts
+++ b/garden-service/src/plugins/kubernetes/kubernetes.ts
@@ -33,6 +33,7 @@ import { isNumber } from "util"
 import chalk from "chalk"
 import pluralize from "pluralize"
 import { getSystemMetadataNamespaceName } from "./system"
+import { removeTillerCmd } from "./commands/remove-tiller"
 
 export async function configureProvider({
   projectName,
@@ -167,7 +168,7 @@ export const gardenPlugin = createGardenPlugin({
   dependencies: ["container"],
   configSchema,
   outputsSchema,
-  commands: [cleanupClusterRegistry, clusterInit, uninstallGardenServices],
+  commands: [cleanupClusterRegistry, clusterInit, removeTillerCmd, uninstallGardenServices],
   handlers: {
     configureProvider,
     getEnvironmentStatus,

--- a/garden-service/src/plugins/kubernetes/local/kind.ts
+++ b/garden-service/src/plugins/kubernetes/local/kind.ts
@@ -55,7 +55,7 @@ async function isKindContext(log: LogEntry, provider: KubernetesProvider): Promi
     },
   }
   try {
-    await kubeApi.readBySpec("kube-system", manifest, log)
+    await kubeApi.readBySpec({ namespace: "kube-system", manifest, log })
     return true
   } catch (err) {
     log.debug(`An attempt to get kindnet deamonset failed with ${err}`)

--- a/garden-service/src/plugins/kubernetes/secrets.ts
+++ b/garden-service/src/plugins/kubernetes/secrets.ts
@@ -120,5 +120,5 @@ export async function ensureSecret(api: KubeApi, secretRef: ProviderSecretRef, t
     namespace: targetNamespace,
   }
 
-  await api.upsert("Secret", targetNamespace, secret, log)
+  await api.upsert({ kind: "Secret", namespace: targetNamespace, obj: secret, log })
 }

--- a/garden-service/src/plugins/kubernetes/status/status.ts
+++ b/garden-service/src/plugins/kubernetes/status/status.ts
@@ -134,7 +134,7 @@ export async function checkResourceStatus(
   let resourceVersion: number | undefined
 
   try {
-    resource = await api.readBySpec(namespace, manifest, log)
+    resource = await api.readBySpec({ namespace, manifest, log })
     resourceVersion = parseInt(resource.metadata.resourceVersion!, 10)
   } catch (err) {
     if (err.code === 404) {
@@ -397,7 +397,7 @@ async function getDeployedResource(
   const namespace = resource.metadata.namespace || (await getAppNamespace(ctx, log, provider))
 
   try {
-    const res = await api.readBySpec(namespace, resource, log)
+    const res = await api.readBySpec({ namespace, manifest: resource, log })
     return <KubernetesResource>res
   } catch (err) {
     if (err.code === 404) {

--- a/garden-service/src/types/plugin/provider/getEnvironmentStatus.ts
+++ b/garden-service/src/types/plugin/provider/getEnvironmentStatus.ts
@@ -8,16 +8,15 @@
 
 import { PluginActionParamsBase, actionParamsSchema } from "../base"
 import { dedent } from "../../../util/string"
-import { PrimitiveMap } from "../../../config/common"
 import { DashboardPage, environmentStatusSchema } from "../../../config/status"
 
 export interface GetEnvironmentStatusParams extends PluginActionParamsBase {}
 
-export interface EnvironmentStatus<T extends PrimitiveMap = PrimitiveMap> {
+export interface EnvironmentStatus<O extends {} = any, D extends {} = any> {
   ready: boolean
   dashboardPages?: DashboardPage[]
-  detail?: any
-  outputs: T
+  detail?: D
+  outputs: O
 }
 
 export const defaultEnvironmentStatus: EnvironmentStatus = {

--- a/garden-service/src/types/plugin/provider/prepareEnvironment.ts
+++ b/garden-service/src/types/plugin/provider/prepareEnvironment.ts
@@ -12,8 +12,9 @@ import { dedent } from "../../../util/string"
 import { joi } from "../../../config/common"
 import { environmentStatusSchema } from "../../../config/status"
 
-export interface PrepareEnvironmentParams extends PluginActionParamsBase {
-  status: EnvironmentStatus
+export interface PrepareEnvironmentParams<T extends EnvironmentStatus = EnvironmentStatus>
+  extends PluginActionParamsBase {
+  status: T
   force: boolean
 }
 

--- a/garden-service/src/util/string.ts
+++ b/garden-service/src/util/string.ts
@@ -20,8 +20,9 @@ const gardenAnnotationPrefix = "garden.io/"
 
 export type GardenAnnotationKey =
   | "generated"
-  | "last-applied-configuration"
+  | "helm-migrated"
   | "hot-reload"
+  | "last-applied-configuration"
   | "module"
   | "moduleVersion"
   | "service"

--- a/garden-service/test/integ/src/plugins/kubernetes/api.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/api.ts
@@ -1,0 +1,59 @@
+import { Garden } from "../../../../../src/garden"
+import { Provider } from "../../../../../src/config/provider"
+import { KubernetesConfig } from "../../../../../src/plugins/kubernetes/config"
+import { KubeApi } from "../../../../../src/plugins/kubernetes/api"
+import { getDataDir, makeTestGarden } from "../../../../helpers"
+import { getAppNamespace } from "../../../../../src/plugins/kubernetes/namespace"
+import { randomString } from "../../../../../src/util/string"
+import { V1ConfigMap } from "@kubernetes/client-node"
+import { KubernetesResource } from "../../../../../src/plugins/kubernetes/types"
+import { expect } from "chai"
+
+describe("KubeApi", () => {
+  let garden: Garden
+  let provider: Provider<KubernetesConfig>
+  let api: KubeApi
+
+  before(async () => {
+    const root = getDataDir("test-projects", "container")
+    garden = await makeTestGarden(root)
+    provider = (await garden.resolveProvider("local-kubernetes")) as Provider<KubernetesConfig>
+    api = await KubeApi.factory(garden.log, provider)
+  })
+
+  after(async () => {
+    await garden.close()
+  })
+
+  describe("replace", () => {
+    it("should replace an existing resource in the cluster", async () => {
+      const ctx = garden.getPluginContext(provider)
+      const namespace = await getAppNamespace(ctx, garden.log, provider)
+      const name = randomString()
+
+      const configMap: KubernetesResource<V1ConfigMap> = {
+        apiVersion: "v1",
+        kind: "ConfigMap",
+        metadata: {
+          name,
+          namespace,
+        },
+        data: {
+          something: "whatever",
+        },
+      }
+
+      await api.core.createNamespacedConfigMap(namespace, configMap)
+
+      try {
+        configMap.data!.other = "thing"
+        await api.replace({ log: garden.log, resource: configMap })
+
+        const updated = await api.core.readNamespacedConfigMap(name, namespace)
+        expect(updated.data?.other).to.equal("thing")
+      } finally {
+        await api.deleteBySpec({ namespace, manifest: configMap, log: garden.log })
+      }
+    })
+  })
+})

--- a/garden-service/test/integ/src/plugins/kubernetes/container/build.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/container/build.ts
@@ -34,7 +34,7 @@ describe("k8sBuildContainer", () => {
         (await decryptSecretFile(resolve(GARDEN_SERVICE_ROOT, "..", "secrets", "test-docker-auth.json"))).toString()
       )
       const api = await KubeApi.factory(garden.log, provider)
-      await api.upsert("Secret", "default", authSecret, garden.log)
+      await api.upsert({ kind: "Secret", namespace: "default", obj: authSecret, log: garden.log })
     }
 
     garden = await makeTestGarden(root, { environmentName })

--- a/garden-service/test/unit/src/plugins/kubernetes/container/ingress.ts
+++ b/garden-service/test/unit/src/plugins/kubernetes/container/ingress.ts
@@ -597,7 +597,7 @@ describe("createIngressResources", () => {
     const api = await getKubeApi(singleTlsProvider)
     const ingresses = await createIngressResources(api, singleTlsProvider, namespace, service, garden.log)
 
-    td.verify(api.upsert("Secret", namespace, myDomainCertSecret, garden.log))
+    td.verify(api.upsert({ kind: "Secret", namespace, obj: myDomainCertSecret, log: garden.log }))
 
     expect(ingresses).to.eql([
       {
@@ -758,7 +758,7 @@ describe("createIngressResources", () => {
     const api = await getKubeApi(multiTlsProvider)
     const ingresses = await createIngressResources(api, multiTlsProvider, namespace, service, garden.log)
 
-    td.verify(api.upsert("Secret", namespace, wildcardDomainCertSecret, garden.log))
+    td.verify(api.upsert({ kind: "Secret", namespace, obj: wildcardDomainCertSecret, log: garden.log }))
 
     expect(ingresses).to.eql([
       {
@@ -829,7 +829,7 @@ describe("createIngressResources", () => {
     td.when(api.core.readNamespacedSecret("foo", "default")).thenResolve(myDomainCertSecret)
     const ingresses = await createIngressResources(api, provider, namespace, service, garden.log)
 
-    td.verify(api.upsert("Secret", namespace, myDomainCertSecret, garden.log))
+    td.verify(api.upsert({ kind: "Secret", namespace, obj: myDomainCertSecret, log: garden.log }))
 
     expect(ingresses).to.eql([
       {


### PR DESCRIPTION
**What this PR does / why we need it**:

Users may need Tiller for non-Garden related reasons. We now no longer
automatically remove Tiller from project namespaces (but we do for
garden-system), and instead provide a command to do the cleanup and a
prompt for the user to run it.

**Special notes for your reviewer**:

NOTE: We need to update the 0.11 release notes to reflect this!
