### PR TITLE
fix(cli): do not init Garden class for commands with no project

### DIFF
--- a/garden-service/src/commands/base.ts
+++ b/garden-service/src/commands/base.ts
@@ -248,7 +248,7 @@ export interface PrepareParams<T extends Parameters = {}, U extends Parameters =
 }
 
 export interface CommandParams<T extends Parameters = {}, U extends Parameters = {}> extends PrepareParams<T, U> {
-  garden: Garden
+  garden?: Garden
 }
 
 interface PrepareOutput {

--- a/garden-service/test/unit/src/garden.ts
+++ b/garden-service/test/unit/src/garden.ts
@@ -20,7 +20,6 @@ import {
   testGitUrl,
 } from "../../helpers"
 import { getNames, findByName, deepOmitUndefined } from "../../../src/util/util"
-import { MOCK_CONFIG } from "../../../src/cli/cli"
 import { LinkedSource } from "../../../src/config-store"
 import { ModuleVersion } from "../../../src/vcs/vcs"
 import { getModuleCacheContext } from "../../../src/types/module"
@@ -78,11 +77,6 @@ describe("Garden", () => {
 
       expect((<any>actions).actionHandlers.prepareEnvironment["test-plugin"]).to.be.ok
       expect((<any>actions).actionHandlers.prepareEnvironment["test-plugin-b"]).to.be.ok
-    })
-
-    it("should initialize with MOCK_CONFIG", async () => {
-      const garden = await Garden.factory("./", { config: MOCK_CONFIG })
-      expect(garden).to.be.ok
     })
 
     it("should initialize a project with config files with yaml and yml extensions", async () => {


### PR DESCRIPTION
**What this PR does / why we need it**:

Now we don't initialise the Garden class when running commands with `noProject = true`. We need this because `noProject` commands can fail if the project contains template strings (and presumably for other reasons as well as Garden, e.g. as Garden attempts to resolve providers and configs). 

**Which issue(s) this PR fixes**:

No issue but I noticed this when testing the `migrate` command.
