### PR TITLE
fix(k8s): use configured ingress ports when installing nginx

### DIFF
--- a/garden-service/src/plugins/kubernetes/init.ts
+++ b/garden-service/src/plugins/kubernetes/init.ts
@@ -423,6 +423,9 @@ export function getKubernetesSystemVariables(config: KubernetesConfig) {
     "builder-storage-size": megabytesToString(config.storage.builder.size!),
     "builder-storage-class": config.storage.builder.storageClass,
 
+    "ingress-http-port": config.ingressHttpPort,
+    "ingress-https-port": config.ingressHttpsPort,
+
     // We only use NFS for the build-sync volume, so we allocate the space we need for that plus 1GB for margin.
     "nfs-storage-size": megabytesToString(config.storage.sync.size! + 1024),
     "nfs-storage-class": config.storage.nfs.storageClass,

--- a/garden-service/static/kubernetes/system/ingress-controller/garden.yml
+++ b/garden-service/static/kubernetes/system/ingress-controller/garden.yml
@@ -18,6 +18,9 @@ values:
         maxUnavailable: 1
     daemonset:
       useHostPort: true
+      hostPorts:
+        http: ${var.ingress-http-port}
+        https: ${var.ingress-https-port}
     service:
       omitClusterIP: true
     minReadySeconds: 1


### PR DESCRIPTION
**What this PR does / why we need it**:

This was a simple omission. We should of course pass configured ports
to the nginx Helm chart when we're installing it.
