### PR TITLE
fix(cli): ensure 'noProject' commands run in invalid projects

### DIFF
--- a/garden-service/src/analytics/analytics.ts
+++ b/garden-service/src/analytics/analytics.ts
@@ -15,7 +15,6 @@ import { globalConfigKeys, AnalyticsGlobalConfig, GlobalConfigStore } from "../c
 import { getPackageVersion } from "../util/util"
 import { SEGMENT_PROD_API_KEY, SEGMENT_DEV_API_KEY } from "../constants"
 import { LogEntry } from "../logger/log-entry"
-import { GitHandler } from "../vcs/git"
 import hasha = require("hasha")
 import uuid from "uuid"
 import { Garden } from "../garden"
@@ -31,13 +30,23 @@ export interface SystemInfo {
   platformVersion: string
 }
 
+// Note that we pluralise the entity names in the count fields (e.g. modulesCount, tasksCount).
+// This is for consistency for when we add fields like modules, tasks, etc.
+interface ProjectMetadata {
+  modulesCount: number
+  tasksCount: number
+  servicesCount: number
+  testsCount: number
+  moduleTypes: string[]
+}
+
 export interface AnalyticsEventProperties {
   projectId: string
   projectName: string
   system: SystemInfo
   isCI: boolean
   sessionId: string
-  projectMetadata: any
+  projectMetadata: ProjectMetadata
 }
 
 export interface AnalyticsCommandEventProperties extends AnalyticsEventProperties {
@@ -112,7 +121,7 @@ export class AnalyticsHandler {
   private isCI = ci.isCI
   private sessionId = uuid.v4()
   protected garden: Garden
-  private projectMetadata
+  private projectMetadata: ProjectMetadata
 
   private constructor(garden: Garden, log: LogEntry) {
     this.segment = new segmentClient(API_KEY, { flushAt: 10, flushInterval: 300 })
@@ -170,19 +179,16 @@ export class AnalyticsHandler {
       ...globalConf.analytics,
     }
 
-    const vcs = new GitHandler(process.cwd(), [])
-    const originName = await vcs.getOriginName(this.log)
+    const originName = await this.garden.vcs.getOriginName(this.log)
     this.projectName = hasha(this.garden.projectName, { algorithm: "sha256" })
     this.projectId = originName ? hasha(originName, { algorithm: "sha256" }) : this.projectName
 
     if (this.globalConfig.firstRun || this.globalConfig.showOptInMessage) {
       if (!this.isCI) {
-        this.log.info(
-          dedent`
-          Thanks for installing Garden! We work hard to provide you with the best experience we can.
-          We collect some anonymized usage data while you use Garden. If you'd like to know more about what we collect
-          or if you'd like to opt out of telemetry, please read more at https://github.com/garden-io/garden/blob/master/README.md#Analytics`
-        )
+        const msg = dedent`
+          Thanks for installing Garden! We work hard to provide you with the best experience we can. We collect some anonymized usage data while you use Garden. If you'd like to know more about what we collect or if you'd like to opt out of telemetry, please read more at https://github.com/garden-io/garden/blob/master/README.md#Analytics
+        `
+        this.log.info({ symbol: "info", msg })
       }
 
       this.globalConfig = {
@@ -249,7 +255,7 @@ export class AnalyticsHandler {
    *
    * eg. number of modules, types of modules, number of tests, etc.
    */
-  private async generateProjectMetadata() {
+  private async generateProjectMetadata(): Promise<ProjectMetadata> {
     const configGraph = await this.garden.getConfigGraph(this.log)
     const modules = await configGraph.getModules()
     const moduleTypes = [...new Set(modules.map((m) => m.type))]
@@ -257,14 +263,14 @@ export class AnalyticsHandler {
     const tasks = await configGraph.getTasks()
     const services = await configGraph.getServices()
     const tests = modules.map((m) => m.testConfigs)
-    const numberOfTests = flatten(tests).length
+    const testsCount = flatten(tests).length
 
     return {
-      numberOfModules: modules.length,
+      modulesCount: modules.length,
       moduleTypes,
-      numberOfTasks: tasks.length,
-      numberOfServices: services.length,
-      numberOfTests,
+      tasksCount: tasks.length,
+      servicesCount: services.length,
+      testsCount,
     }
   }
 

--- a/garden-service/src/commands/migrate.ts
+++ b/garden-service/src/commands/migrate.ts
@@ -142,7 +142,7 @@ export class MigrateCommand extends Command<Args, Opts> {
         await writeFile(path, out)
       } else {
         if (configPaths.length > 1) {
-          log.info(`# Updated config for garden.yml file at path ${path}`)
+          log.info(`# Updated config for garden.yml file at path ${path}:`)
         }
         log.info(out)
       }

--- a/garden-service/src/vcs/vcs.ts
+++ b/garden-service/src/vcs/vcs.ts
@@ -96,6 +96,7 @@ export abstract class VcsHandler {
   abstract async getFiles(params: GetFilesParams): Promise<VcsFile[]>
   abstract async ensureRemoteSource(params: RemoteSourceParams): Promise<string>
   abstract async updateRemoteSource(params: RemoteSourceParams): Promise<void>
+  abstract async getOriginName(log: LogEntry): Promise<string | undefined>
 
   async getTreeVersion(log: LogEntry, moduleConfig: ModuleConfig): Promise<TreeVersion> {
     const configPath = moduleConfig.configPath

--- a/garden-service/test/unit/src/cli/cli.ts
+++ b/garden-service/test/unit/src/cli/cli.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2018 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import { makeDummyGarden } from "../../../../src/cli/cli"
+import { getDataDir } from "../../../helpers"
+
+describe("cli", () => {
+  describe("makeDummyGarden", () => {
+    it("should initialise and resolve config graph in a directory with no project", async () => {
+      const garden = await makeDummyGarden("./foobarbas", {})
+      const dg = await garden.getConfigGraph(garden.log)
+      expect(garden).to.be.ok
+      expect(await dg.getModules()).to.not.throw
+    })
+    it("should initialise and resolve config graph in a project with invalid config", async () => {
+      const root = getDataDir("test-project-invalid-config")
+      const garden = await makeDummyGarden(root, {})
+      const dg = await garden.getConfigGraph(garden.log)
+      expect(garden).to.be.ok
+      expect(await dg.getModules()).to.not.throw
+    })
+    it("should initialise and resolve config graph in a project with template strings", async () => {
+      const root = getDataDir("test-project-templated")
+      const garden = await makeDummyGarden(root, {})
+      const dg = await garden.getConfigGraph(garden.log)
+      expect(garden).to.be.ok
+      expect(await dg.getModules()).to.not.throw
+    })
+  })
+})

--- a/garden-service/test/unit/src/garden.ts
+++ b/garden-service/test/unit/src/garden.ts
@@ -20,7 +20,6 @@ import {
   testGitUrl,
 } from "../../helpers"
 import { getNames, findByName, deepOmitUndefined } from "../../../src/util/util"
-import { MOCK_CONFIG } from "../../../src/cli/cli"
 import { LinkedSource } from "../../../src/config-store"
 import { ModuleVersion } from "../../../src/vcs/vcs"
 import { getModuleCacheContext } from "../../../src/types/module"
@@ -78,11 +77,6 @@ describe("Garden", () => {
 
       expect((<any>actions).actionHandlers.prepareEnvironment["test-plugin"]).to.be.ok
       expect((<any>actions).actionHandlers.prepareEnvironment["test-plugin-b"]).to.be.ok
-    })
-
-    it("should initialize with MOCK_CONFIG", async () => {
-      const garden = await Garden.factory("./", { config: MOCK_CONFIG })
-      expect(garden).to.be.ok
     })
 
     it("should initialize a project with config files with yaml and yml extensions", async () => {

--- a/garden-service/test/unit/src/vcs/vcs.ts
+++ b/garden-service/test/unit/src/vcs/vcs.ts
@@ -33,6 +33,10 @@ class TestVcsHandler extends VcsHandler {
     return []
   }
 
+  async getOriginName() {
+    return undefined
+  }
+
   async getTreeVersion(log: LogEntry, moduleConfig: ModuleConfig) {
     return this.testVersions[moduleConfig.path] || super.getTreeVersion(log, moduleConfig)
   }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a `DummyGarden` class to use for commands that run outside the context of a valid Garden project.

**Which issue(s) this PR fixes**:

Fixes an issue where commands with `noProject=true` fail if the project contains template strings (and presumably for other reasons as well as Garden attempts to resolve providers and configs).