### PR TITLE
chore(analytics): changed color to warning + retrocompatibility

### DIFF
--- a/garden-service/src/analytics/analytics.ts
+++ b/garden-service/src/analytics/analytics.ts
@@ -15,7 +15,6 @@ import { globalConfigKeys, AnalyticsGlobalConfig, GlobalConfigStore } from "../c
 import { getPackageVersion } from "../util/util"
 import { SEGMENT_PROD_API_KEY, SEGMENT_DEV_API_KEY } from "../constants"
 import { LogEntry } from "../logger/log-entry"
-import { printWarningMessage } from "../logger/util"
 import { GitHandler } from "../vcs/git"
 import hasha = require("hasha")
 import uuid from "uuid"
@@ -178,8 +177,7 @@ export class AnalyticsHandler {
 
     if (this.globalConfig.firstRun || this.globalConfig.showOptInMessage) {
       if (!this.isCI) {
-        printWarningMessage(
-          this.log,
+        this.log.info(
           dedent`
           Thanks for installing Garden! We work hard to provide you with the best experience we can.
           We collect some anonymized usage data while you use Garden. If you'd like to know more about what we collect
@@ -307,7 +305,7 @@ export class AnalyticsHandler {
   private track(event: AnalyticsEvent) {
     if (this.segment && this.hasOptedIn()) {
       const segmentEvent: SegmentEvent = {
-        userId: this.globalConfig.userId,
+        userId: this.globalConfig.userId || "unknown",
         event: event.type,
         properties: {
           ...this.getBasicAnalyticsProperties(),

--- a/garden-service/src/config-store.ts
+++ b/garden-service/src/config-store.ts
@@ -249,11 +249,13 @@ export class LocalConfigStore extends ConfigStore<LocalConfig> {
  *                                           *
  **********************************************/
 
-export interface AnalyticsGlobalConfig {
-  userId: string
-  optedIn: boolean
-  firstRun: boolean
-  showOptInMessage: boolean
+export type AnalyticsGlobalConfig = {
+  userId?: string
+  optedIn?: boolean
+  firstRun?: boolean
+  showOptInMessage?: boolean
+} & {
+  [key: string]: any
 }
 
 export interface VersionCheckGlobalConfig {
@@ -275,6 +277,7 @@ const analyticsGlobalConfigSchema = joi
     firstRun: joi.boolean().optional(),
     showOptInMessage: joi.boolean().optional(),
   })
+  .unknown(true)
   .meta({ internal: true })
 
 const versionCheckGlobalConfigSchema = joi


### PR DESCRIPTION
Tiny PR to address some small issues:

- Change the color of the message informing the users of the automatic opt-in
from yellow (warning) to gray (info).
- Allow unknown keys in the GlobalConfig to prevent errors in future versions
when changing the type keys.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
