### PR TITLE
fix(cli): enable running 'config analytics-enabled' with no project

### DIFF
--- a/garden-service/src/commands/config/config-analytics-enabled.ts
+++ b/garden-service/src/commands/config/config-analytics-enabled.ts
@@ -21,6 +21,7 @@ type Args = typeof configAnalyticsEnabledArgs
 
 export class ConfigAnalyticsEnabled extends Command {
   name = "analytics-enabled"
+  noProject = true
   help = "Update your preferences regarding analytics."
 
   arguments = configAnalyticsEnabledArgs


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables toggling analytics opt-in/opt-out outside of the context of a working project.

**Which issue(s) this PR fixes**:

Fixes #1488 