### PR TITLE
fix: force anlytics events queue flush

### DIFF
--- a/garden-service/src/cli/cli.ts
+++ b/garden-service/src/cli/cli.ts
@@ -177,7 +177,7 @@ export interface ParseResults {
 
 interface SywacParseResults extends ParseResults {
   output: string
-  details: { logger: Logger; result?: CommandResult }
+  details: { logger: Logger; result?: CommandResult; analytics?: AnalyticsHandler }
 }
 
 export class GardenCli {
@@ -324,6 +324,8 @@ export class GardenCli {
           const analytics = await AnalyticsHandler.init(garden, log)
           analytics.trackCommand(command.getFullName())
 
+          cliContext.details.analytics = analytics
+
           // tslint:disable-next-line: no-floating-promises
           checkForUpdates(garden.globalConfigStore, headerLog)
 
@@ -409,6 +411,12 @@ export class GardenCli {
         level: LogLevel.info,
         writers: [new BasicTerminalWriter()],
       })
+    }
+
+    // Flushes the Analytics events queue in case there are some remaining events.
+    const { analytics } = details
+    if (analytics) {
+      await analytics.flush()
     }
 
     // --help or --version options were called so we log the cli output and exit


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:
This PR introduces a flush of the Analytics events queue before we return.
This is needed because we have been experiencing missing events an more often than not, the queue is not flushed before the end of the cli execution.


**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
This way of handling this specific case will go away once we swith to stateful analytics events (sqlite + sending events batch).