### PR TITLE
fix(core): allow unknown in task & test results

### DIFF
--- a/garden-service/src/types/plugin/base.ts
+++ b/garden-service/src/types/plugin/base.ts
@@ -85,36 +85,39 @@ export interface RunResult {
   output?: string
 }
 
-export const runResultSchema = joi.object().keys({
-  moduleName: joi.string().description("The name of the module that was run."),
-  command: joi
-    .array()
-    .items(joi.string())
-    .required()
-    .description("The command that was run in the module."),
-  version: joi.string().description("The string version of the module."),
-  success: joi
-    .boolean()
-    .required()
-    .description("Whether the module was successfully run."),
-  startedAt: joi
-    .date()
-    .required()
-    .description("When the module run was started."),
-  completedAt: joi
-    .date()
-    .required()
-    .description("When the module run was completed."),
-  log: joi
-    .string()
-    .allow("")
-    .default("")
-    .description("The output log from the run."),
-  output: joi
-    .string()
-    .allow("")
-    .description("[DEPRECATED - use `log` instead] The output log from the run."),
-})
+export const runResultSchema = joi
+  .object()
+  .unknown(true)
+  .keys({
+    moduleName: joi.string().description("The name of the module that was run."),
+    command: joi
+      .array()
+      .items(joi.string())
+      .required()
+      .description("The command that was run in the module."),
+    version: joi.string().description("The string version of the module."),
+    success: joi
+      .boolean()
+      .required()
+      .description("Whether the module was successfully run."),
+    startedAt: joi
+      .date()
+      .required()
+      .description("When the module run was started."),
+    completedAt: joi
+      .date()
+      .required()
+      .description("When the module run was completed."),
+    log: joi
+      .string()
+      .allow("")
+      .default("")
+      .description("The output log from the run."),
+    output: joi
+      .string()
+      .allow("")
+      .description("[DEPRECATED - use `log` instead] The output log from the run."),
+  })
 
 export const artifactsPathSchema = joi
   .string()

--- a/garden-service/src/types/plugin/task/getTaskResult.ts
+++ b/garden-service/src/types/plugin/task/getTaskResult.ts
@@ -20,41 +20,44 @@ export interface GetTaskResultParams<T extends Module = Module> extends PluginTa
   taskVersion: ModuleVersion
 }
 
-export const taskResultSchema = joi.object().keys({
-  moduleName: joi.string().description("The name of the module that the task belongs to."),
-  taskName: joi.string().description("The name of the task that was run."),
-  command: joi
-    .array()
-    .items(joi.string())
-    .required()
-    .description("The command that the task ran in the module."),
-  version: joi.string().description("The string version of the task."),
-  success: joi
-    .boolean()
-    .required()
-    .description("Whether the task was successfully run."),
-  startedAt: joi
-    .date()
-    .required()
-    .description("When the task run was started."),
-  completedAt: joi
-    .date()
-    .required()
-    .description("When the task run was completed."),
-  log: joi
-    .string()
-    .required()
-    .allow("")
-    .description("The output log from the run."),
-  output: joi
-    .string()
-    .allow("")
-    .description("[DEPRECATED - use `log` instead] The output log from the run."),
-  outputs: joi
-    .object()
-    .pattern(/.+/, joiPrimitive())
-    .description("A map of primitive values, output from the task."),
-})
+export const taskResultSchema = joi
+  .object()
+  .unknown(true)
+  .keys({
+    moduleName: joi.string().description("The name of the module that the task belongs to."),
+    taskName: joi.string().description("The name of the task that was run."),
+    command: joi
+      .array()
+      .items(joi.string())
+      .required()
+      .description("The command that the task ran in the module."),
+    version: joi.string().description("The string version of the task."),
+    success: joi
+      .boolean()
+      .required()
+      .description("Whether the task was successfully run."),
+    startedAt: joi
+      .date()
+      .required()
+      .description("When the task run was started."),
+    completedAt: joi
+      .date()
+      .required()
+      .description("When the task run was completed."),
+    log: joi
+      .string()
+      .required()
+      .allow("")
+      .description("The output log from the run."),
+    output: joi
+      .string()
+      .allow("")
+      .description("[DEPRECATED - use `log` instead] The output log from the run."),
+    outputs: joi
+      .object()
+      .pattern(/.+/, joiPrimitive())
+      .description("A map of primitive values, output from the task."),
+  })
 
 export const getTaskResult = {
   description: dedent`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

This adds a bit of future-proofing for schema changes to test and task results.

If unknown fields are not allowed in task and test results, new fields stored on results generated by newer versions of the framework may cause errors when read by older versions which do not recognize the new fields.