### PR TITLE
refactor(container): revert build logs log level to debug

### DIFF
--- a/garden-service/src/plugins/container/build.ts
+++ b/garden-service/src/plugins/container/build.ts
@@ -64,7 +64,7 @@ export async function buildContainerModule({ module, log }: BuildModuleParams<Co
   }
 
   // Stream log to a status line
-  const outputStream = createOutputStream(log.placeholder(LogLevel.info))
+  const outputStream = createOutputStream(log.placeholder(LogLevel.debug))
   const timeout = module.spec.build.timeout
   const buildLog = await containerHelpers.dockerCli(module, [...cmdOpts, buildPath], { outputStream, timeout })
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Turns out logging build logs (introduced in #1143) can get really noisy if we don't
truncate the output somehow. I tried truncating it with the `cliTruncate`
function but it messed up the terminal cursor position and by extension
the entire log output. Putting this on ice for now.

