### PR TITLE
feat(core): add project outputs and `garden get outputs` command

### DIFF
--- a/docs/module-types/conftest.md
+++ b/docs/module-types/conftest.md
@@ -9,7 +9,7 @@ namespace.
 
 > Note: In many cases, you'll let specific conftest providers (e.g. [`conftest-container`](../providers/conftest-container.md) and [`conftest-kubernetes`](../providers/conftest-kubernetes.md) create this module type automatically, but you may in some cases want or need to manually specify files to test.
 
-See the [conftest docs](https://github.com/instramenta/conftest) for details on how to configure policies.
+See the [conftest docs](https://github.com/instrumenta/conftest) for details on how to configure policies.
 
 ## Reference
 
@@ -126,15 +126,15 @@ files:
 
 The schema version of this module's config (currently not used).
 
-| Type     | Required | Allowed Values | Default          |
-| -------- | -------- | -------------- | ---------------- |
-| `string` | Yes      | "garden.io/v0" | `"garden.io/v0"` |
+| Type     | Allowed Values | Default          | Required |
+| -------- | -------------- | ---------------- | -------- |
+| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
 
 #### `kind`
 
-| Type     | Required | Allowed Values | Default    |
-| -------- | -------- | -------------- | ---------- |
-| `string` | Yes      | "Module"       | `"Module"` |
+| Type     | Allowed Values | Default    | Required |
+| -------- | -------------- | ---------- | -------- |
+| `string` | "Module"       | `"Module"` | Yes      |
 
 #### `type`
 
@@ -187,9 +187,9 @@ module's service or task outputs (i.e. runtime outputs) will fail to resolve whe
 so you need to make sure to provide alternate values for those if you're using them, using conditional
 expressions.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `include`
 
@@ -262,17 +262,17 @@ repositoryUrl: "git+https://github.com/org/repo.git#v2.0"
 
 When false, disables pushing this module to remote registries.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `true`  |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 #### `build`
 
 Specify how to build the module. Note that plugins may define additional keys on this object.
 
-| Type     | Required | Default               |
-| -------- | -------- | --------------------- |
-| `object` | No       | `{"dependencies":[]}` |
+| Type     | Default               | Required |
+| -------- | --------------------- | -------- |
+| `object` | `{"dependencies":[]}` | No       |
 
 #### `build.dependencies[]`
 
@@ -280,9 +280,9 @@ Specify how to build the module. Note that plugins may define additional keys on
 
 A list of modules that must be built before this module is built.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 Example:
 
@@ -309,9 +309,9 @@ Module name to build ahead of this module.
 
 Specify one or more files or directories to copy from the built dependency to this module.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `build.dependencies[].copy[].source`
 
@@ -330,9 +330,9 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
 Defaults to to same as source path.
 
-| Type        | Required | Default |
-| ----------- | -------- | ------- |
-| `posixPath` | No       | `""`    |
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `""`    | No       |
 
 #### `sourceModule`
 
@@ -357,9 +357,9 @@ Defaults to the `policyPath` set in the provider config.
 
 The policy namespace in which to find _deny_ and _warn_ rules.
 
-| Type     | Required | Default  |
+| Type     | Default  | Required |
 | -------- | -------- | -------- |
-| `string` | No       | `"main"` |
+| `string` | `"main"` | No       |
 
 #### `files`
 
@@ -381,9 +381,9 @@ modules.
 
 The build path of the module.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 
@@ -395,9 +395,9 @@ my-variable: ${modules.my-module.buildPath}
 
 The local path of the module.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 
@@ -409,9 +409,9 @@ my-variable: ${modules.my-module.path}
 
 The current version of the module.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 

--- a/docs/module-types/container.md
+++ b/docs/module-types/container.md
@@ -358,15 +358,15 @@ tasks:
 
 The schema version of this module's config (currently not used).
 
-| Type     | Required | Allowed Values | Default          |
-| -------- | -------- | -------------- | ---------------- |
-| `string` | Yes      | "garden.io/v0" | `"garden.io/v0"` |
+| Type     | Allowed Values | Default          | Required |
+| -------- | -------------- | ---------------- | -------- |
+| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
 
 #### `kind`
 
-| Type     | Required | Allowed Values | Default    |
-| -------- | -------- | -------------- | ---------- |
-| `string` | Yes      | "Module"       | `"Module"` |
+| Type     | Allowed Values | Default    | Required |
+| -------- | -------------- | ---------- | -------- |
+| `string` | "Module"       | `"Module"` | Yes      |
 
 #### `type`
 
@@ -419,9 +419,9 @@ module's service or task outputs (i.e. runtime outputs) will fail to resolve whe
 so you need to make sure to provide alternate values for those if you're using them, using conditional
 expressions.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `include`
 
@@ -501,17 +501,17 @@ repositoryUrl: "git+https://github.com/org/repo.git#v2.0"
 
 When false, disables pushing this module to remote registries.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `true`  |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 #### `build`
 
 Specify how to build the module. Note that plugins may define additional keys on this object.
 
-| Type     | Required | Default               |
-| -------- | -------- | --------------------- |
-| `object` | No       | `{"dependencies":[]}` |
+| Type     | Default               | Required |
+| -------- | --------------------- | -------- |
+| `object` | `{"dependencies":[]}` | No       |
 
 #### `build.dependencies[]`
 
@@ -519,9 +519,9 @@ Specify how to build the module. Note that plugins may define additional keys on
 
 A list of modules that must be built before this module is built.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 Example:
 
@@ -548,9 +548,9 @@ Module name to build ahead of this module.
 
 Specify one or more files or directories to copy from the built dependency to this module.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `build.dependencies[].copy[].source`
 
@@ -569,9 +569,9 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
 Defaults to to same as source path.
 
-| Type        | Required | Default |
-| ----------- | -------- | ------- |
-| `posixPath` | No       | `""`    |
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `""`    | No       |
 
 #### `build.targetImage`
 
@@ -589,17 +589,17 @@ For multi-stage Dockerfiles, specify which image to build (see https://docs.dock
 
 Maximum time in seconds to wait for build to finish.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `1200`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `1200`  | No       |
 
 #### `buildArgs`
 
 Specify build arguments to use when building the container image.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `object` | No       | `{}`    |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `object` | `{}`    | No       |
 
 #### `extraFlags`
 
@@ -641,9 +641,9 @@ Specify one or more source files or directories to automatically sync into the r
 
 POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be a relative path if provided. Defaults to the module's top-level directory if no value is provided.
 
-| Type        | Required | Default |
-| ----------- | -------- | ------- |
-| `posixPath` | No       | `"."`   |
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `"."`   | No       |
 
 Example:
 
@@ -704,9 +704,9 @@ POSIX-style name of Dockerfile, relative to module root.
 
 The list of services to deploy from this container module.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `services[].name`
 
@@ -724,9 +724,9 @@ Valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and da
 
 The names of any services that this service depends on at runtime, and the names of any tasks that should be executed before this service is deployed.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[string]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
 
 #### `services[].disabled`
 
@@ -744,9 +744,9 @@ Note however that template strings referencing the service's outputs (i.e. runti
 resolve when the service is disabled, so you need to make sure to provide alternate values for those if
 you're using them, using conditional expressions.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `services[].annotations`
 
@@ -754,9 +754,9 @@ you're using them, using conditional expressions.
 
 Annotations to attach to the service (Note: May not be applicable to all providers).
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `object` | No       | `{}`    |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `object` | `{}`    | No       |
 
 Example:
 
@@ -810,9 +810,9 @@ services:
 
 Whether to run the service as a daemon (to ensure exactly one instance runs per node). May not be supported by all providers.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `services[].ingresses[]`
 
@@ -820,9 +820,9 @@ Whether to run the service as a daemon (to ensure exactly one instance runs per 
 
 List of ingress endpoints that the service exposes.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 Example:
 
@@ -839,9 +839,9 @@ services:
 
 Annotations to attach to the ingress (Note: May not be applicable to all providers)
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `object` | No       | `{}`    |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `object` | `{}`    | No       |
 
 Example:
 
@@ -889,9 +889,9 @@ Otherwise Garden will construct the link URL from the ingress spec.
 
 The path which should be routed to the service.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `string` | No       | `"/"`   |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `string` | `"/"`   | No       |
 
 #### `services[].ingresses[].port`
 
@@ -909,9 +909,9 @@ The name of the container port where the specified paths should be routed.
 
 Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with `GARDEN`) and values must be primitives or references to secrets.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `object` | No       | `{}`    |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `object` | `{}`    | No       |
 
 Example:
 
@@ -970,9 +970,9 @@ The name of the port where the service's health check endpoint should be availab
 
 [services](#services) > [healthCheck](#serviceshealthcheck) > [httpGet](#serviceshealthcheckhttpget) > scheme
 
-| Type     | Required | Default  |
+| Type     | Default  | Required |
 | -------- | -------- | -------- |
-| `string` | No       | `"HTTP"` |
+| `string` | `"HTTP"` | No       |
 
 #### `services[].healthCheck.command[]`
 
@@ -1039,9 +1039,9 @@ services:
 
 Specify resource limits for the service.
 
-| Type     | Required | Default                      |
-| -------- | -------- | ---------------------------- |
-| `object` | No       | `{"cpu":1000,"memory":1024}` |
+| Type     | Default                      | Required |
+| -------- | ---------------------------- | -------- |
+| `object` | `{"cpu":1000,"memory":1024}` | No       |
 
 #### `services[].limits.cpu`
 
@@ -1049,9 +1049,9 @@ Specify resource limits for the service.
 
 The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `1000`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `1000`  | No       |
 
 #### `services[].limits.memory`
 
@@ -1059,9 +1059,9 @@ The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)
 
 The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB)
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `1024`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `1024`  | No       |
 
 #### `services[].ports[]`
 
@@ -1069,9 +1069,9 @@ The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB)
 
 List of ports that the service container exposes.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `services[].ports[].name`
 
@@ -1089,9 +1089,9 @@ The name of the port (used when referencing the port elsewhere in the service co
 
 The protocol of the port.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `string` | No       | `"TCP"` |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `string` | `"TCP"` | No       |
 
 #### `services[].ports[].containerPort`
 
@@ -1172,9 +1172,9 @@ Note: This setting may be overridden or ignored in some cases. For example, when
 
 List of volumes that should be mounted when deploying the container.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `services[].volumes[].name`
 
@@ -1222,9 +1222,9 @@ services:
 
 A list of tests to run in the module.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `tests[].name`
 
@@ -1242,9 +1242,9 @@ The name of the test.
 
 The names of any services that must be running, and the names of any tasks that must be executed, before the test is run.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[string]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
 
 #### `tests[].disabled`
 
@@ -1255,9 +1255,9 @@ enable/disable tests based on, for example, the current environment or other var
 `enabled: \${environment.name != "prod"}`). This is handy when you only want certain tests to run in
 specific environments, e.g. only during CI.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `tests[].timeout`
 
@@ -1265,9 +1265,9 @@ specific environments, e.g. only during CI.
 
 Maximum duration (in seconds) of the test run.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `null`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `null`  | No       |
 
 #### `tests[].args[]`
 
@@ -1332,9 +1332,9 @@ tests:
 
 A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
 
-| Type        | Required | Default |
-| ----------- | -------- | ------- |
-| `posixPath` | No       | `"."`   |
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `"."`   | No       |
 
 Example:
 
@@ -1370,9 +1370,9 @@ tests:
 
 Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with `GARDEN`) and values must be primitives or references to secrets.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `object` | No       | `{}`    |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `object` | `{}`    | No       |
 
 Example:
 
@@ -1391,9 +1391,9 @@ tests:
 
 A list of tasks that can be run from this container module. These can be used as dependencies for services (executed before the service is deployed) or for other tasks.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `tasks[].name`
 
@@ -1421,9 +1421,9 @@ A description of the task.
 
 The names of any tasks that must be executed, and the names of any services that must be running, before this task is executed.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[string]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
 
 #### `tasks[].disabled`
 
@@ -1441,9 +1441,9 @@ Note however that template strings referencing the task's outputs (i.e. runtime 
 resolve when the task is disabled, so you need to make sure to provide alternate values for those if
 you're using them, using conditional expressions.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `tasks[].timeout`
 
@@ -1451,9 +1451,9 @@ you're using them, using conditional expressions.
 
 Maximum duration (in seconds) of the task's execution.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `null`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `null`  | No       |
 
 #### `tasks[].args[]`
 
@@ -1518,9 +1518,9 @@ tasks:
 
 A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
 
-| Type        | Required | Default |
-| ----------- | -------- | ------- |
-| `posixPath` | No       | `"."`   |
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `"."`   | No       |
 
 Example:
 
@@ -1556,9 +1556,9 @@ tasks:
 
 Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with `GARDEN`) and values must be primitives or references to secrets.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `object` | No       | `{}`    |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `object` | `{}`    | No       |
 
 Example:
 
@@ -1585,9 +1585,9 @@ modules.
 
 The build path of the module.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 
@@ -1599,9 +1599,9 @@ my-variable: ${modules.my-module.buildPath}
 
 The local path of the module.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 
@@ -1613,9 +1613,9 @@ my-variable: ${modules.my-module.path}
 
 The current version of the module.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 
@@ -1623,21 +1623,13 @@ Example:
 my-variable: ${modules.my-module.version}
 ```
 
-#### `${modules.<module-name>.outputs}`
-
-| Type     | Required |
-| -------- | -------- |
-| `object` | Yes      |
-
 #### `${modules.<module-name>.outputs.local-image-name}`
-
-[outputs](#outputs) > local-image-name
 
 The name of the image (without tag/version) that the module uses for local builds and deployments.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 
@@ -1647,13 +1639,11 @@ my-variable: ${modules.my-module.outputs.local-image-name}
 
 #### `${modules.<module-name>.outputs.deployment-image-name}`
 
-[outputs](#outputs) > deployment-image-name
-
 The name of the image (without tag/version) that the module will use during deployment.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 
@@ -1667,19 +1657,11 @@ my-variable: ${modules.my-module.outputs.deployment-image-name}
 The following keys are available via the `${runtime.tasks.<task-name>}` template string key for `container` module tasks.
 Note that these are only resolved when deploying/running dependants of the task, so they are not usable for every field.
 
-#### `${runtime.tasks.<task-name>.outputs}`
-
-| Type     | Required |
-| -------- | -------- |
-| `object` | Yes      |
-
 #### `${runtime.tasks.<task-name>.outputs.log}`
-
-[outputs](#outputs) > log
 
 The full log from the executed task. (Pro-tip: Make it machine readable so it can be parsed by dependant tasks and services!)
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `string` | No       | `""`    |
+| Type     | Default |
+| -------- | ------- |
+| `string` | `""`    |
 

--- a/docs/module-types/exec.md
+++ b/docs/module-types/exec.md
@@ -199,15 +199,15 @@ tests:
 
 The schema version of this module's config (currently not used).
 
-| Type     | Required | Allowed Values | Default          |
-| -------- | -------- | -------------- | ---------------- |
-| `string` | Yes      | "garden.io/v0" | `"garden.io/v0"` |
+| Type     | Allowed Values | Default          | Required |
+| -------- | -------------- | ---------------- | -------- |
+| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
 
 #### `kind`
 
-| Type     | Required | Allowed Values | Default    |
-| -------- | -------- | -------------- | ---------- |
-| `string` | Yes      | "Module"       | `"Module"` |
+| Type     | Allowed Values | Default    | Required |
+| -------- | -------------- | ---------- | -------- |
+| `string` | "Module"       | `"Module"` | Yes      |
 
 #### `type`
 
@@ -260,9 +260,9 @@ module's service or task outputs (i.e. runtime outputs) will fail to resolve whe
 so you need to make sure to provide alternate values for those if you're using them, using conditional
 expressions.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `include`
 
@@ -335,17 +335,17 @@ repositoryUrl: "git+https://github.com/org/repo.git#v2.0"
 
 When false, disables pushing this module to remote registries.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `true`  |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 #### `build`
 
 Specify how to build the module. Note that plugins may define additional keys on this object.
 
-| Type     | Required | Default               |
-| -------- | -------- | --------------------- |
-| `object` | No       | `{"dependencies":[]}` |
+| Type     | Default               | Required |
+| -------- | --------------------- | -------- |
+| `object` | `{"dependencies":[]}` | No       |
 
 #### `build.dependencies[]`
 
@@ -353,9 +353,9 @@ Specify how to build the module. Note that plugins may define additional keys on
 
 A list of modules that must be built before this module is built.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 Example:
 
@@ -382,9 +382,9 @@ Module name to build ahead of this module.
 
 Specify one or more files or directories to copy from the built dependency to this module.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `build.dependencies[].copy[].source`
 
@@ -403,9 +403,9 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
 Defaults to to same as source path.
 
-| Type        | Required | Default |
-| ----------- | -------- | ------- |
-| `posixPath` | No       | `""`    |
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `""`    | No       |
 
 #### `build.command[]`
 
@@ -416,9 +416,9 @@ The command to run to perform the build.
 By default, the command is run inside the Garden build directory (under .garden/build/<module-name>).
 If the top level `local` directive is set to `true`, the command runs in the module source directory instead.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[string]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
 
 Example:
 
@@ -439,25 +439,25 @@ instead of in the Garden build directory (under .garden/build/<module-name>).
 Garden will therefore not stage the build for local exec modules. This means that include/exclude filters
 and ignore files are not applied to local exec modules.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `env`
 
 Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with `GARDEN`) and values must be primitives.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `object` | No       | `{}`    |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `object` | `{}`    | No       |
 
 #### `tasks`
 
 A list of tasks that can be run in this module.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `tasks[].name`
 
@@ -485,9 +485,9 @@ A description of the task.
 
 The names of any tasks that must be executed, and the names of any services that must be running, before this task is executed.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[string]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
 
 #### `tasks[].disabled`
 
@@ -505,9 +505,9 @@ Note however that template strings referencing the task's outputs (i.e. runtime 
 resolve when the task is disabled, so you need to make sure to provide alternate values for those if
 you're using them, using conditional expressions.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `tasks[].timeout`
 
@@ -515,9 +515,9 @@ you're using them, using conditional expressions.
 
 Maximum duration (in seconds) of the task's execution.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `null`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `null`  | No       |
 
 #### `tasks[].artifacts[]`
 
@@ -545,9 +545,9 @@ A POSIX-style path or glob to copy, relative to the build root.
 
 A POSIX-style path to copy the artifact to, relative to the project artifacts directory.
 
-| Type        | Required | Default |
-| ----------- | -------- | ------- |
-| `posixPath` | No       | `"."`   |
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `"."`   | No       |
 
 #### `tasks[].command[]`
 
@@ -568,17 +568,17 @@ If the top level `local` directive is set to `true`, the command runs in the mod
 
 Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with `GARDEN`) and values must be primitives.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `object` | No       | `{}`    |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `object` | `{}`    | No       |
 
 #### `tests`
 
 A list of tests to run in the module.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `tests[].name`
 
@@ -596,9 +596,9 @@ The name of the test.
 
 The names of any services that must be running, and the names of any tasks that must be executed, before the test is run.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[string]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
 
 #### `tests[].disabled`
 
@@ -609,9 +609,9 @@ enable/disable tests based on, for example, the current environment or other var
 `enabled: \${environment.name != "prod"}`). This is handy when you only want certain tests to run in
 specific environments, e.g. only during CI.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `tests[].timeout`
 
@@ -619,9 +619,9 @@ specific environments, e.g. only during CI.
 
 Maximum duration (in seconds) of the test run.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `null`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `null`  | No       |
 
 #### `tests[].command[]`
 
@@ -642,9 +642,9 @@ If the top level `local` directive is set to `true`, the command runs in the mod
 
 Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with `GARDEN`) and values must be primitives.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `object` | No       | `{}`    |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `object` | `{}`    | No       |
 
 #### `tests[].artifacts[]`
 
@@ -672,9 +672,9 @@ A POSIX-style path or glob to copy, relative to the build root.
 
 A POSIX-style path to copy the artifact to, relative to the project artifacts directory.
 
-| Type        | Required | Default |
-| ----------- | -------- | ------- |
-| `posixPath` | No       | `"."`   |
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `"."`   | No       |
 
 
 ### Outputs
@@ -688,9 +688,9 @@ modules.
 
 The build path of the module.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 
@@ -702,9 +702,9 @@ my-variable: ${modules.my-module.buildPath}
 
 The local path of the module.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 
@@ -716,9 +716,9 @@ my-variable: ${modules.my-module.path}
 
 The current version of the module.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 
@@ -732,19 +732,11 @@ my-variable: ${modules.my-module.version}
 The following keys are available via the `${runtime.tasks.<task-name>}` template string key for `exec` module tasks.
 Note that these are only resolved when deploying/running dependants of the task, so they are not usable for every field.
 
-#### `${runtime.tasks.<task-name>.outputs}`
-
-| Type     | Required |
-| -------- | -------- |
-| `object` | Yes      |
-
 #### `${runtime.tasks.<task-name>.outputs.log}`
-
-[outputs](#outputs) > log
 
 The full log from the executed task. (Pro-tip: Make it machine readable so it can be parsed by dependant tasks and services!)
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `string` | No       | `""`    |
+| Type     | Default |
+| -------- | ------- |
+| `string` | `""`    |
 

--- a/docs/module-types/hadolint.md
+++ b/docs/module-types/hadolint.md
@@ -117,15 +117,15 @@ dockerfilePath:
 
 The schema version of this module's config (currently not used).
 
-| Type     | Required | Allowed Values | Default          |
-| -------- | -------- | -------------- | ---------------- |
-| `string` | Yes      | "garden.io/v0" | `"garden.io/v0"` |
+| Type     | Allowed Values | Default          | Required |
+| -------- | -------------- | ---------------- | -------- |
+| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
 
 #### `kind`
 
-| Type     | Required | Allowed Values | Default    |
-| -------- | -------- | -------------- | ---------- |
-| `string` | Yes      | "Module"       | `"Module"` |
+| Type     | Allowed Values | Default    | Required |
+| -------- | -------------- | ---------- | -------- |
+| `string` | "Module"       | `"Module"` | Yes      |
 
 #### `type`
 
@@ -178,9 +178,9 @@ module's service or task outputs (i.e. runtime outputs) will fail to resolve whe
 so you need to make sure to provide alternate values for those if you're using them, using conditional
 expressions.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `include`
 
@@ -253,17 +253,17 @@ repositoryUrl: "git+https://github.com/org/repo.git#v2.0"
 
 When false, disables pushing this module to remote registries.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `true`  |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 #### `build`
 
 Specify how to build the module. Note that plugins may define additional keys on this object.
 
-| Type     | Required | Default               |
-| -------- | -------- | --------------------- |
-| `object` | No       | `{"dependencies":[]}` |
+| Type     | Default               | Required |
+| -------- | --------------------- | -------- |
+| `object` | `{"dependencies":[]}` | No       |
 
 #### `build.dependencies[]`
 
@@ -271,9 +271,9 @@ Specify how to build the module. Note that plugins may define additional keys on
 
 A list of modules that must be built before this module is built.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 Example:
 
@@ -300,9 +300,9 @@ Module name to build ahead of this module.
 
 Specify one or more files or directories to copy from the built dependency to this module.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `build.dependencies[].copy[].source`
 
@@ -321,9 +321,9 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
 Defaults to to same as source path.
 
-| Type        | Required | Default |
-| ----------- | -------- | ------- |
-| `posixPath` | No       | `""`    |
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `""`    | No       |
 
 #### `dockerfilePath`
 
@@ -345,9 +345,9 @@ modules.
 
 The build path of the module.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 
@@ -359,9 +359,9 @@ my-variable: ${modules.my-module.buildPath}
 
 The local path of the module.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 
@@ -373,9 +373,9 @@ my-variable: ${modules.my-module.path}
 
 The current version of the module.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 

--- a/docs/module-types/helm.md
+++ b/docs/module-types/helm.md
@@ -312,15 +312,15 @@ valueFiles: []
 
 The schema version of this module's config (currently not used).
 
-| Type     | Required | Allowed Values | Default          |
-| -------- | -------- | -------------- | ---------------- |
-| `string` | Yes      | "garden.io/v0" | `"garden.io/v0"` |
+| Type     | Allowed Values | Default          | Required |
+| -------- | -------------- | ---------------- | -------- |
+| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
 
 #### `kind`
 
-| Type     | Required | Allowed Values | Default    |
-| -------- | -------- | -------------- | ---------- |
-| `string` | Yes      | "Module"       | `"Module"` |
+| Type     | Allowed Values | Default    | Required |
+| -------- | -------------- | ---------- | -------- |
+| `string` | "Module"       | `"Module"` | Yes      |
 
 #### `type`
 
@@ -373,9 +373,9 @@ module's service or task outputs (i.e. runtime outputs) will fail to resolve whe
 so you need to make sure to provide alternate values for those if you're using them, using conditional
 expressions.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `include`
 
@@ -454,17 +454,17 @@ repositoryUrl: "git+https://github.com/org/repo.git#v2.0"
 
 When false, disables pushing this module to remote registries.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `true`  |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 #### `build`
 
 Specify how to build the module. Note that plugins may define additional keys on this object.
 
-| Type     | Required | Default               |
-| -------- | -------- | --------------------- |
-| `object` | No       | `{"dependencies":[]}` |
+| Type     | Default               | Required |
+| -------- | --------------------- | -------- |
+| `object` | `{"dependencies":[]}` | No       |
 
 #### `build.dependencies[]`
 
@@ -472,9 +472,9 @@ Specify how to build the module. Note that plugins may define additional keys on
 
 A list of modules that must be built before this module is built.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 Example:
 
@@ -501,9 +501,9 @@ Module name to build ahead of this module.
 
 Specify one or more files or directories to copy from the built dependency to this module.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `build.dependencies[].copy[].source`
 
@@ -522,9 +522,9 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
 Defaults to to same as source path.
 
-| Type        | Required | Default |
-| ----------- | -------- | ------- |
-| `posixPath` | No       | `""`    |
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `""`    | No       |
 
 #### `base`
 
@@ -560,17 +560,17 @@ chart: "stable/nginx-ingress"
 
 The path, relative to the module path, to the chart sources (i.e. where the Chart.yaml file is, if any). Not used when `base` is specified.
 
-| Type        | Required | Default |
-| ----------- | -------- | ------- |
-| `posixPath` | No       | `"."`   |
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `"."`   | No       |
 
 #### `dependencies`
 
 List of names of services that should be deployed before this chart.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[string]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
 
 #### `releaseName`
 
@@ -603,9 +603,9 @@ We currently map a Helm chart to a single Garden service, because all the resour
 
 The type of Kubernetes resource to sync files to.
 
-| Type     | Required | Allowed Values                           | Default        |
-| -------- | -------- | ---------------------------------------- | -------------- |
-| `string` | Yes      | "Deployment", "DaemonSet", "StatefulSet" | `"Deployment"` |
+| Type     | Allowed Values                           | Default        | Required |
+| -------- | ---------------------------------------- | -------------- | -------- |
+| `string` | "Deployment", "DaemonSet", "StatefulSet" | `"Deployment"` | Yes      |
 
 #### `serviceResource.name`
 
@@ -672,17 +672,17 @@ serviceResource:
 
 Set this to true if the chart should only be built, but not deployed as a service. Use this, for example, if the chart should only be used as a base for other modules.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `tasks`
 
 The task definitions for this module.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `tasks[].name`
 
@@ -710,9 +710,9 @@ A description of the task.
 
 The names of any tasks that must be executed, and the names of any services that must be running, before this task is executed.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[string]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
 
 #### `tasks[].disabled`
 
@@ -730,9 +730,9 @@ Note however that template strings referencing the task's outputs (i.e. runtime 
 resolve when the task is disabled, so you need to make sure to provide alternate values for those if
 you're using them, using conditional expressions.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `tasks[].timeout`
 
@@ -740,9 +740,9 @@ you're using them, using conditional expressions.
 
 Maximum duration (in seconds) of the task's execution.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `null`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `null`  | No       |
 
 #### `tasks[].resource`
 
@@ -760,9 +760,9 @@ The Deployment, DaemonSet or StatefulSet that Garden should use to execute this 
 
 The type of Kubernetes resource to sync files to.
 
-| Type     | Required | Allowed Values                           | Default        |
-| -------- | -------- | ---------------------------------------- | -------------- |
-| `string` | Yes      | "Deployment", "DaemonSet", "StatefulSet" | `"Deployment"` |
+| Type     | Allowed Values                           | Default        | Required |
+| -------- | ---------------------------------------- | -------------- | -------- |
+| `string` | "Deployment", "DaemonSet", "StatefulSet" | `"Deployment"` | Yes      |
 
 #### `tasks[].resource.name`
 
@@ -871,9 +871,9 @@ tasks:
 
 Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with `GARDEN`) and values must be primitives or references to secrets.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `object` | No       | `{}`    |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `object` | `{}`    | No       |
 
 Example:
 
@@ -894,9 +894,9 @@ tasks:
 
 Specify artifacts to copy out of the container after the task is complete.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `tasks[].artifacts[].source`
 
@@ -922,9 +922,9 @@ tasks:
 
 A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
 
-| Type        | Required | Default |
-| ----------- | -------- | ------- |
-| `posixPath` | No       | `"."`   |
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `"."`   | No       |
 
 Example:
 
@@ -938,9 +938,9 @@ tasks:
 
 The test suite definitions for this module.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `tests[].name`
 
@@ -958,9 +958,9 @@ The name of the test.
 
 The names of any services that must be running, and the names of any tasks that must be executed, before the test is run.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[string]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
 
 #### `tests[].disabled`
 
@@ -971,9 +971,9 @@ enable/disable tests based on, for example, the current environment or other var
 `enabled: \${environment.name != "prod"}`). This is handy when you only want certain tests to run in
 specific environments, e.g. only during CI.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `tests[].timeout`
 
@@ -981,9 +981,9 @@ specific environments, e.g. only during CI.
 
 Maximum duration (in seconds) of the test run.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `null`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `null`  | No       |
 
 #### `tests[].resource`
 
@@ -1001,9 +1001,9 @@ The Deployment, DaemonSet or StatefulSet that Garden should use to execute this 
 
 The type of Kubernetes resource to sync files to.
 
-| Type     | Required | Allowed Values                           | Default        |
-| -------- | -------- | ---------------------------------------- | -------------- |
-| `string` | Yes      | "Deployment", "DaemonSet", "StatefulSet" | `"Deployment"` |
+| Type     | Allowed Values                           | Default        | Required |
+| -------- | ---------------------------------------- | -------------- | -------- |
+| `string` | "Deployment", "DaemonSet", "StatefulSet" | `"Deployment"` | Yes      |
 
 #### `tests[].resource.name`
 
@@ -1112,9 +1112,9 @@ tests:
 
 Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with `GARDEN`) and values must be primitives or references to secrets.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `object` | No       | `{}`    |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `object` | `{}`    | No       |
 
 Example:
 
@@ -1135,9 +1135,9 @@ tests:
 
 Specify artifacts to copy out of the container after the test is complete.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `tests[].artifacts[].source`
 
@@ -1163,9 +1163,9 @@ tests:
 
 A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
 
-| Type        | Required | Default |
-| ----------- | -------- | ------- |
-| `posixPath` | No       | `"."`   |
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `"."`   | No       |
 
 Example:
 
@@ -1179,9 +1179,9 @@ tests:
 
 Time in seconds to wait for Helm to complete any individual Kubernetes operation (like Jobs for hooks).
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `300`   |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `300`   | No       |
 
 #### `version`
 
@@ -1195,9 +1195,9 @@ The chart version to deploy.
 
 Map of values to pass to Helm when rendering the templates. May include arrays and nested objects. When specified, these take precedence over the values in the `values.yaml` file (or the files specified in `valueFiles`).
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `object` | No       | `{}`    |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `object` | `{}`    | No       |
 
 #### `valueFiles`
 
@@ -1211,9 +1211,9 @@ of this list, so they will take precedence over other files listed here.
 Note that the paths here should be relative to the _module_ root, and the files should be contained in
 your module directory.
 
-| Type               | Required | Default |
-| ------------------ | -------- | ------- |
-| `array[posixPath]` | No       | `[]`    |
+| Type               | Default | Required |
+| ------------------ | ------- | -------- |
+| `array[posixPath]` | `[]`    | No       |
 
 
 ### Outputs
@@ -1227,9 +1227,9 @@ modules.
 
 The build path of the module.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 
@@ -1241,9 +1241,9 @@ my-variable: ${modules.my-module.buildPath}
 
 The local path of the module.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 
@@ -1255,9 +1255,9 @@ my-variable: ${modules.my-module.path}
 
 The current version of the module.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 
@@ -1265,19 +1265,11 @@ Example:
 my-variable: ${modules.my-module.version}
 ```
 
-#### `${modules.<module-name>.outputs}`
-
-| Type     | Required |
-| -------- | -------- |
-| `object` | Yes      |
-
 #### `${modules.<module-name>.outputs.release-name}`
-
-[outputs](#outputs) > release-name
 
 The Helm release name of the service.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 

--- a/docs/module-types/kubernetes.md
+++ b/docs/module-types/kubernetes.md
@@ -136,15 +136,15 @@ files: []
 
 The schema version of this module's config (currently not used).
 
-| Type     | Required | Allowed Values | Default          |
-| -------- | -------- | -------------- | ---------------- |
-| `string` | Yes      | "garden.io/v0" | `"garden.io/v0"` |
+| Type     | Allowed Values | Default          | Required |
+| -------- | -------------- | ---------------- | -------- |
+| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
 
 #### `kind`
 
-| Type     | Required | Allowed Values | Default    |
-| -------- | -------- | -------------- | ---------- |
-| `string` | Yes      | "Module"       | `"Module"` |
+| Type     | Allowed Values | Default    | Required |
+| -------- | -------------- | ---------- | -------- |
+| `string` | "Module"       | `"Module"` | Yes      |
 
 #### `type`
 
@@ -197,9 +197,9 @@ module's service or task outputs (i.e. runtime outputs) will fail to resolve whe
 so you need to make sure to provide alternate values for those if you're using them, using conditional
 expressions.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `include`
 
@@ -275,17 +275,17 @@ repositoryUrl: "git+https://github.com/org/repo.git#v2.0"
 
 When false, disables pushing this module to remote registries.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `true`  |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 #### `build`
 
 Specify how to build the module. Note that plugins may define additional keys on this object.
 
-| Type     | Required | Default               |
-| -------- | -------- | --------------------- |
-| `object` | No       | `{"dependencies":[]}` |
+| Type     | Default               | Required |
+| -------- | --------------------- | -------- |
+| `object` | `{"dependencies":[]}` | No       |
 
 #### `build.dependencies[]`
 
@@ -293,9 +293,9 @@ Specify how to build the module. Note that plugins may define additional keys on
 
 A list of modules that must be built before this module is built.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 Example:
 
@@ -322,9 +322,9 @@ Module name to build ahead of this module.
 
 Specify one or more files or directories to copy from the built dependency to this module.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `build.dependencies[].copy[].source`
 
@@ -343,25 +343,25 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
 Defaults to to same as source path.
 
-| Type        | Required | Default |
-| ----------- | -------- | ------- |
-| `posixPath` | No       | `""`    |
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `""`    | No       |
 
 #### `dependencies`
 
 The names of any services that this service depends on at runtime, and the names of any tasks that should be executed before this service is deployed.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[string]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
 
 #### `manifests`
 
 List of Kubernetes resource manifests to deploy. Use this instead of the `files` field if you need to resolve template strings in any of the manifests.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `manifests[].apiVersion`
 
@@ -405,9 +405,9 @@ The name of the resource.
 
 POSIX-style paths to YAML files to load manifests from. Each can contain multiple manifests.
 
-| Type               | Required | Default |
-| ------------------ | -------- | ------- |
-| `array[posixPath]` | No       | `[]`    |
+| Type               | Default | Required |
+| ------------------ | ------- | -------- |
+| `array[posixPath]` | `[]`    | No       |
 
 
 ### Outputs
@@ -421,9 +421,9 @@ modules.
 
 The build path of the module.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 
@@ -435,9 +435,9 @@ my-variable: ${modules.my-module.buildPath}
 
 The local path of the module.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 
@@ -449,9 +449,9 @@ my-variable: ${modules.my-module.path}
 
 The current version of the module.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 

--- a/docs/module-types/maven-container.md
+++ b/docs/module-types/maven-container.md
@@ -369,15 +369,15 @@ mvnOpts: []
 
 The schema version of this module's config (currently not used).
 
-| Type     | Required | Allowed Values | Default          |
-| -------- | -------- | -------------- | ---------------- |
-| `string` | Yes      | "garden.io/v0" | `"garden.io/v0"` |
+| Type     | Allowed Values | Default          | Required |
+| -------- | -------------- | ---------------- | -------- |
+| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
 
 #### `kind`
 
-| Type     | Required | Allowed Values | Default    |
-| -------- | -------- | -------------- | ---------- |
-| `string` | Yes      | "Module"       | `"Module"` |
+| Type     | Allowed Values | Default    | Required |
+| -------- | -------------- | ---------- | -------- |
+| `string` | "Module"       | `"Module"` | Yes      |
 
 #### `type`
 
@@ -430,9 +430,9 @@ module's service or task outputs (i.e. runtime outputs) will fail to resolve whe
 so you need to make sure to provide alternate values for those if you're using them, using conditional
 expressions.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `include`
 
@@ -505,17 +505,17 @@ repositoryUrl: "git+https://github.com/org/repo.git#v2.0"
 
 When false, disables pushing this module to remote registries.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `true`  |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 #### `build`
 
 Specify how to build the module. Note that plugins may define additional keys on this object.
 
-| Type     | Required | Default               |
-| -------- | -------- | --------------------- |
-| `object` | No       | `{"dependencies":[]}` |
+| Type     | Default               | Required |
+| -------- | --------------------- | -------- |
+| `object` | `{"dependencies":[]}` | No       |
 
 #### `build.dependencies[]`
 
@@ -523,9 +523,9 @@ Specify how to build the module. Note that plugins may define additional keys on
 
 A list of modules that must be built before this module is built.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 Example:
 
@@ -552,9 +552,9 @@ Module name to build ahead of this module.
 
 Specify one or more files or directories to copy from the built dependency to this module.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `build.dependencies[].copy[].source`
 
@@ -573,9 +573,9 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
 Defaults to to same as source path.
 
-| Type        | Required | Default |
-| ----------- | -------- | ------- |
-| `posixPath` | No       | `""`    |
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `""`    | No       |
 
 #### `build.targetImage`
 
@@ -593,17 +593,17 @@ For multi-stage Dockerfiles, specify which image to build (see https://docs.dock
 
 Maximum time in seconds to wait for build to finish.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `1200`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `1200`  | No       |
 
 #### `buildArgs`
 
 Specify build arguments to use when building the container image.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `object` | No       | `{}`    |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `object` | `{}`    | No       |
 
 #### `extraFlags`
 
@@ -645,9 +645,9 @@ Specify one or more source files or directories to automatically sync into the r
 
 POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be a relative path if provided. Defaults to the module's top-level directory if no value is provided.
 
-| Type        | Required | Default |
-| ----------- | -------- | ------- |
-| `posixPath` | No       | `"."`   |
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `"."`   | No       |
 
 Example:
 
@@ -708,9 +708,9 @@ POSIX-style name of Dockerfile, relative to module root.
 
 The list of services to deploy from this container module.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `services[].name`
 
@@ -728,9 +728,9 @@ Valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and da
 
 The names of any services that this service depends on at runtime, and the names of any tasks that should be executed before this service is deployed.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[string]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
 
 #### `services[].disabled`
 
@@ -748,9 +748,9 @@ Note however that template strings referencing the service's outputs (i.e. runti
 resolve when the service is disabled, so you need to make sure to provide alternate values for those if
 you're using them, using conditional expressions.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `services[].annotations`
 
@@ -758,9 +758,9 @@ you're using them, using conditional expressions.
 
 Annotations to attach to the service (Note: May not be applicable to all providers).
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `object` | No       | `{}`    |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `object` | `{}`    | No       |
 
 Example:
 
@@ -814,9 +814,9 @@ services:
 
 Whether to run the service as a daemon (to ensure exactly one instance runs per node). May not be supported by all providers.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `services[].ingresses[]`
 
@@ -824,9 +824,9 @@ Whether to run the service as a daemon (to ensure exactly one instance runs per 
 
 List of ingress endpoints that the service exposes.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 Example:
 
@@ -843,9 +843,9 @@ services:
 
 Annotations to attach to the ingress (Note: May not be applicable to all providers)
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `object` | No       | `{}`    |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `object` | `{}`    | No       |
 
 Example:
 
@@ -893,9 +893,9 @@ Otherwise Garden will construct the link URL from the ingress spec.
 
 The path which should be routed to the service.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `string` | No       | `"/"`   |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `string` | `"/"`   | No       |
 
 #### `services[].ingresses[].port`
 
@@ -913,9 +913,9 @@ The name of the container port where the specified paths should be routed.
 
 Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with `GARDEN`) and values must be primitives or references to secrets.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `object` | No       | `{}`    |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `object` | `{}`    | No       |
 
 Example:
 
@@ -974,9 +974,9 @@ The name of the port where the service's health check endpoint should be availab
 
 [services](#services) > [healthCheck](#serviceshealthcheck) > [httpGet](#serviceshealthcheckhttpget) > scheme
 
-| Type     | Required | Default  |
+| Type     | Default  | Required |
 | -------- | -------- | -------- |
-| `string` | No       | `"HTTP"` |
+| `string` | `"HTTP"` | No       |
 
 #### `services[].healthCheck.command[]`
 
@@ -1043,9 +1043,9 @@ services:
 
 Specify resource limits for the service.
 
-| Type     | Required | Default                      |
-| -------- | -------- | ---------------------------- |
-| `object` | No       | `{"cpu":1000,"memory":1024}` |
+| Type     | Default                      | Required |
+| -------- | ---------------------------- | -------- |
+| `object` | `{"cpu":1000,"memory":1024}` | No       |
 
 #### `services[].limits.cpu`
 
@@ -1053,9 +1053,9 @@ Specify resource limits for the service.
 
 The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `1000`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `1000`  | No       |
 
 #### `services[].limits.memory`
 
@@ -1063,9 +1063,9 @@ The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)
 
 The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB)
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `1024`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `1024`  | No       |
 
 #### `services[].ports[]`
 
@@ -1073,9 +1073,9 @@ The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB)
 
 List of ports that the service container exposes.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `services[].ports[].name`
 
@@ -1093,9 +1093,9 @@ The name of the port (used when referencing the port elsewhere in the service co
 
 The protocol of the port.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `string` | No       | `"TCP"` |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `string` | `"TCP"` | No       |
 
 #### `services[].ports[].containerPort`
 
@@ -1176,9 +1176,9 @@ Note: This setting may be overridden or ignored in some cases. For example, when
 
 List of volumes that should be mounted when deploying the container.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `services[].volumes[].name`
 
@@ -1226,9 +1226,9 @@ services:
 
 A list of tests to run in the module.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `tests[].name`
 
@@ -1246,9 +1246,9 @@ The name of the test.
 
 The names of any services that must be running, and the names of any tasks that must be executed, before the test is run.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[string]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
 
 #### `tests[].disabled`
 
@@ -1259,9 +1259,9 @@ enable/disable tests based on, for example, the current environment or other var
 `enabled: \${environment.name != "prod"}`). This is handy when you only want certain tests to run in
 specific environments, e.g. only during CI.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `tests[].timeout`
 
@@ -1269,9 +1269,9 @@ specific environments, e.g. only during CI.
 
 Maximum duration (in seconds) of the test run.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `null`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `null`  | No       |
 
 #### `tests[].args[]`
 
@@ -1336,9 +1336,9 @@ tests:
 
 A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
 
-| Type        | Required | Default |
-| ----------- | -------- | ------- |
-| `posixPath` | No       | `"."`   |
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `"."`   | No       |
 
 Example:
 
@@ -1374,9 +1374,9 @@ tests:
 
 Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with `GARDEN`) and values must be primitives or references to secrets.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `object` | No       | `{}`    |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `object` | `{}`    | No       |
 
 Example:
 
@@ -1395,9 +1395,9 @@ tests:
 
 A list of tasks that can be run from this container module. These can be used as dependencies for services (executed before the service is deployed) or for other tasks.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `tasks[].name`
 
@@ -1425,9 +1425,9 @@ A description of the task.
 
 The names of any tasks that must be executed, and the names of any services that must be running, before this task is executed.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[string]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
 
 #### `tasks[].disabled`
 
@@ -1445,9 +1445,9 @@ Note however that template strings referencing the task's outputs (i.e. runtime 
 resolve when the task is disabled, so you need to make sure to provide alternate values for those if
 you're using them, using conditional expressions.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `tasks[].timeout`
 
@@ -1455,9 +1455,9 @@ you're using them, using conditional expressions.
 
 Maximum duration (in seconds) of the task's execution.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `null`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `null`  | No       |
 
 #### `tasks[].args[]`
 
@@ -1522,9 +1522,9 @@ tasks:
 
 A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
 
-| Type        | Required | Default |
-| ----------- | -------- | ------- |
-| `posixPath` | No       | `"."`   |
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `"."`   | No       |
 
 Example:
 
@@ -1560,9 +1560,9 @@ tasks:
 
 Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with `GARDEN`) and values must be primitives or references to secrets.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `object` | No       | `{}`    |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `object` | `{}`    | No       |
 
 Example:
 
@@ -1610,17 +1610,17 @@ jarPath: "target/my-module.jar"
 
 The JDK version to use.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `8`     |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `8`     | No       |
 
 #### `mvnOpts`
 
 Options to add to the `mvn package` command when building.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[string]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
 
 
 ### Outputs
@@ -1634,9 +1634,9 @@ modules.
 
 The build path of the module.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 
@@ -1648,9 +1648,9 @@ my-variable: ${modules.my-module.buildPath}
 
 The local path of the module.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 
@@ -1662,9 +1662,9 @@ my-variable: ${modules.my-module.path}
 
 The current version of the module.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 

--- a/docs/module-types/openfaas.md
+++ b/docs/module-types/openfaas.md
@@ -143,15 +143,15 @@ tests:
 
 The schema version of this module's config (currently not used).
 
-| Type     | Required | Allowed Values | Default          |
-| -------- | -------- | -------------- | ---------------- |
-| `string` | Yes      | "garden.io/v0" | `"garden.io/v0"` |
+| Type     | Allowed Values | Default          | Required |
+| -------- | -------------- | ---------------- | -------- |
+| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
 
 #### `kind`
 
-| Type     | Required | Allowed Values | Default    |
-| -------- | -------- | -------------- | ---------- |
-| `string` | Yes      | "Module"       | `"Module"` |
+| Type     | Allowed Values | Default    | Required |
+| -------- | -------------- | ---------- | -------- |
+| `string` | "Module"       | `"Module"` | Yes      |
 
 #### `type`
 
@@ -204,9 +204,9 @@ module's service or task outputs (i.e. runtime outputs) will fail to resolve whe
 so you need to make sure to provide alternate values for those if you're using them, using conditional
 expressions.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `include`
 
@@ -279,17 +279,17 @@ repositoryUrl: "git+https://github.com/org/repo.git#v2.0"
 
 When false, disables pushing this module to remote registries.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `true`  |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 #### `build`
 
 Specify how to build the module. Note that plugins may define additional keys on this object.
 
-| Type     | Required | Default               |
-| -------- | -------- | --------------------- |
-| `object` | No       | `{"dependencies":[]}` |
+| Type     | Default               | Required |
+| -------- | --------------------- | -------- |
+| `object` | `{"dependencies":[]}` | No       |
 
 #### `build.dependencies[]`
 
@@ -297,9 +297,9 @@ Specify how to build the module. Note that plugins may define additional keys on
 
 A list of modules that must be built before this module is built.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 Example:
 
@@ -326,9 +326,9 @@ Module name to build ahead of this module.
 
 Specify one or more files or directories to copy from the built dependency to this module.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `build.dependencies[].copy[].source`
 
@@ -347,33 +347,33 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
 Defaults to to same as source path.
 
-| Type        | Required | Default |
-| ----------- | -------- | ------- |
-| `posixPath` | No       | `""`    |
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `""`    | No       |
 
 #### `dependencies`
 
 The names of services/functions that this function depends on at runtime.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[string]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
 
 #### `env`
 
 Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with `GARDEN`) and values must be primitives.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `object` | No       | `{}`    |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `object` | `{}`    | No       |
 
 #### `handler`
 
 Specify which directory under the module contains the handler file/function.
 
-| Type        | Required | Default |
-| ----------- | -------- | ------- |
-| `posixPath` | No       | `"."`   |
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `"."`   | No       |
 
 #### `image`
 
@@ -395,9 +395,9 @@ The OpenFaaS language template to use to build this function.
 
 A list of tests to run in the module.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `tests[].name`
 
@@ -415,9 +415,9 @@ The name of the test.
 
 The names of any services that must be running, and the names of any tasks that must be executed, before the test is run.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[string]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
 
 #### `tests[].disabled`
 
@@ -428,9 +428,9 @@ enable/disable tests based on, for example, the current environment or other var
 `enabled: \${environment.name != "prod"}`). This is handy when you only want certain tests to run in
 specific environments, e.g. only during CI.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `tests[].timeout`
 
@@ -438,9 +438,9 @@ specific environments, e.g. only during CI.
 
 Maximum duration (in seconds) of the test run.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `null`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `null`  | No       |
 
 #### `tests[].command[]`
 
@@ -458,9 +458,9 @@ The command to run in the module build context in order to test it.
 
 Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with `GARDEN`) and values must be primitives.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `object` | No       | `{}`    |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `object` | `{}`    | No       |
 
 
 ### Outputs
@@ -474,9 +474,9 @@ modules.
 
 The build path of the module.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 
@@ -488,9 +488,9 @@ my-variable: ${modules.my-module.buildPath}
 
 The local path of the module.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 
@@ -502,9 +502,9 @@ my-variable: ${modules.my-module.path}
 
 The current version of the module.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 
@@ -512,19 +512,11 @@ Example:
 my-variable: ${modules.my-module.version}
 ```
 
-#### `${modules.<module-name>.outputs}`
-
-| Type     | Required |
-| -------- | -------- |
-| `object` | Yes      |
-
 #### `${modules.<module-name>.outputs.endpoint}`
-
-[outputs](#outputs) > endpoint
 
 The full URL to query this service _from within_ the cluster.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 

--- a/docs/module-types/terraform.md
+++ b/docs/module-types/terraform.md
@@ -142,15 +142,15 @@ version: 0.12.7
 
 The schema version of this module's config (currently not used).
 
-| Type     | Required | Allowed Values | Default          |
-| -------- | -------- | -------------- | ---------------- |
-| `string` | Yes      | "garden.io/v0" | `"garden.io/v0"` |
+| Type     | Allowed Values | Default          | Required |
+| -------- | -------------- | ---------------- | -------- |
+| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
 
 #### `kind`
 
-| Type     | Required | Allowed Values | Default    |
-| -------- | -------- | -------------- | ---------- |
-| `string` | Yes      | "Module"       | `"Module"` |
+| Type     | Allowed Values | Default    | Required |
+| -------- | -------------- | ---------- | -------- |
+| `string` | "Module"       | `"Module"` | Yes      |
 
 #### `type`
 
@@ -203,9 +203,9 @@ module's service or task outputs (i.e. runtime outputs) will fail to resolve whe
 so you need to make sure to provide alternate values for those if you're using them, using conditional
 expressions.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `include`
 
@@ -278,17 +278,17 @@ repositoryUrl: "git+https://github.com/org/repo.git#v2.0"
 
 When false, disables pushing this module to remote registries.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `true`  |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 #### `build`
 
 Specify how to build the module. Note that plugins may define additional keys on this object.
 
-| Type     | Required | Default               |
-| -------- | -------- | --------------------- |
-| `object` | No       | `{"dependencies":[]}` |
+| Type     | Default               | Required |
+| -------- | --------------------- | -------- |
+| `object` | `{"dependencies":[]}` | No       |
 
 #### `build.dependencies[]`
 
@@ -296,9 +296,9 @@ Specify how to build the module. Note that plugins may define additional keys on
 
 A list of modules that must be built before this module is built.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 Example:
 
@@ -325,9 +325,9 @@ Module name to build ahead of this module.
 
 Specify one or more files or directories to copy from the built dependency to this module.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `build.dependencies[].copy[].source`
 
@@ -346,34 +346,34 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
 Defaults to to same as source path.
 
-| Type        | Required | Default |
-| ----------- | -------- | ------- |
-| `posixPath` | No       | `""`    |
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `""`    | No       |
 
 #### `autoApply`
 
 If set to true, Garden will automatically run `terraform apply -auto-approve` when the stack is not up-to-date. Otherwise, a warning is logged if the stack is out-of-date, and an error thrown if it is missing entirely.
 Defaults to the value set in the provider config.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `null`  |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `null`  | No       |
 
 #### `dependencies`
 
 The names of any services that this service depends on at runtime, and the names of any tasks that should be executed before this service is deployed.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[string]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
 
 #### `root`
 
 Specify the path to the working directory root—i.e. where your Terraform files are—relative to the module root.
 
-| Type        | Required | Default |
-| ----------- | -------- | ------- |
-| `posixPath` | No       | `"."`   |
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `"."`   | No       |
 
 #### `variables`
 
@@ -388,9 +388,9 @@ If you specified `variables` in the `terraform` provider config, those will be 
 
 The version of Terraform to use. Defaults to the version set in the provider config.
 
-| Type     | Required | Default    |
-| -------- | -------- | ---------- |
-| `string` | No       | `"0.12.7"` |
+| Type     | Default    | Required |
+| -------- | ---------- | -------- |
+| `string` | `"0.12.7"` | No       |
 
 
 ### Outputs
@@ -404,9 +404,9 @@ modules.
 
 The build path of the module.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 
@@ -418,9 +418,9 @@ my-variable: ${modules.my-module.buildPath}
 
 The local path of the module.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 
@@ -432,9 +432,9 @@ my-variable: ${modules.my-module.path}
 
 The current version of the module.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 Example:
 
@@ -448,11 +448,17 @@ my-variable: ${modules.my-module.version}
 The following keys are available via the `${runtime.services.<service-name>}` template string key for `terraform` module services.
 Note that these are only resolved when deploying/running dependants of the service, so they are not usable for every field.
 
-#### `${runtime.services.<service-name>.outputs}`
+#### `${runtime.services.<service-name>.outputs.*}`
 
 A map of all the outputs defined in the Terraform stack.
 
-| Type     | Required |
-| -------- | -------- |
-| `object` | Yes      |
+| Type     |
+| -------- |
+| `object` |
+
+#### `${runtime.services.<service-name>.outputs.<name>}`
+
+| Type  |
+| ----- |
+| `any` |
 

--- a/docs/providers/conftest-container.md
+++ b/docs/providers/conftest-container.md
@@ -41,9 +41,9 @@ providers:
 
 #### `providers`
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `providers[].name`
 
@@ -87,9 +87,9 @@ providers:
 
 Path to the default policy directory or rego file to use for `conftest` modules.
 
-| Type        | Required | Default      |
-| ----------- | -------- | ------------ |
-| `posixPath` | No       | `"./policy"` |
+| Type        | Default      | Required |
+| ----------- | ------------ | -------- |
+| `posixPath` | `"./policy"` | No       |
 
 #### `providers[].namespace`
 
@@ -108,7 +108,7 @@ Default policy namespace to use for `conftest` modules.
 Set this to `"warn"` if you'd like tests to be marked as failed if one or more _warn_ rules are matched.
 Set to `"none"` to always mark the tests as successful.
 
-| Type     | Required | Default   |
-| -------- | -------- | --------- |
-| `string` | No       | `"error"` |
+| Type     | Default   | Required |
+| -------- | --------- | -------- |
+| `string` | `"error"` | No       |
 

--- a/docs/providers/conftest-kubernetes.md
+++ b/docs/providers/conftest-kubernetes.md
@@ -43,9 +43,9 @@ providers:
 
 #### `providers`
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `providers[].name`
 
@@ -89,9 +89,9 @@ providers:
 
 Path to the default policy directory or rego file to use for `conftest` modules.
 
-| Type        | Required | Default      |
-| ----------- | -------- | ------------ |
-| `posixPath` | No       | `"./policy"` |
+| Type        | Default      | Required |
+| ----------- | ------------ | -------- |
+| `posixPath` | `"./policy"` | No       |
 
 #### `providers[].namespace`
 
@@ -110,7 +110,7 @@ Default policy namespace to use for `conftest` modules.
 Set this to `"warn"` if you'd like tests to be marked as failed if one or more _warn_ rules are matched.
 Set to `"none"` to always mark the tests as successful.
 
-| Type     | Required | Default   |
-| -------- | -------- | --------- |
-| `string` | No       | `"error"` |
+| Type     | Default   | Required |
+| -------- | --------- | -------- |
+| `string` | `"error"` | No       |
 

--- a/docs/providers/conftest.md
+++ b/docs/providers/conftest.md
@@ -50,9 +50,9 @@ providers:
 
 #### `providers`
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `providers[].name`
 
@@ -96,9 +96,9 @@ providers:
 
 Path to the default policy directory or rego file to use for `conftest` modules.
 
-| Type        | Required | Default      |
-| ----------- | -------- | ------------ |
-| `posixPath` | No       | `"./policy"` |
+| Type        | Default      | Required |
+| ----------- | ------------ | -------- |
+| `posixPath` | `"./policy"` | No       |
 
 #### `providers[].namespace`
 
@@ -117,7 +117,7 @@ Default policy namespace to use for `conftest` modules.
 Set this to `"warn"` if you'd like tests to be marked as failed if one or more _warn_ rules are matched.
 Set to `"none"` to always mark the tests as successful.
 
-| Type     | Required | Default   |
-| -------- | -------- | --------- |
-| `string` | No       | `"error"` |
+| Type     | Default   | Required |
+| -------- | --------- | -------- |
+| `string` | `"error"` | No       |
 

--- a/docs/providers/hadolint.md
+++ b/docs/providers/hadolint.md
@@ -44,9 +44,9 @@ providers:
 
 #### `providers`
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `providers[].name`
 
@@ -91,9 +91,9 @@ providers:
 By default, the provider automatically creates a `hadolint` module for every `container` module in your
 project. Set this to `false` to disable this behavior.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `true`  |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 #### `providers[].testFailureThreshold`
 
@@ -102,7 +102,7 @@ project. Set this to `false` to disable this behavior.
 Set this to `"warning"` if you'd like tests to be marked as failed if one or more warnings are returned.
 Set to `"none"` to always mark the tests as successful.
 
-| Type     | Required | Default   |
-| -------- | -------- | --------- |
-| `string` | No       | `"error"` |
+| Type     | Default   | Required |
+| -------- | --------- | -------- |
+| `string` | `"error"` | No       |
 

--- a/docs/providers/kubernetes.md
+++ b/docs/providers/kubernetes.md
@@ -282,9 +282,9 @@ providers:
 
 #### `providers`
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `providers[].environments[]`
 
@@ -325,9 +325,9 @@ to build. The former uses a normal Docker daemon in the cluster. Because this ha
 this is less secure than Kaniko, but in turn it is generally faster. See the
 [Kaniko docs](https://github.com/GoogleContainerTools/kaniko) for more information on Kaniko.
 
-| Type     | Required | Default          |
-| -------- | -------- | ---------------- |
-| `string` | No       | `"local-docker"` |
+| Type     | Default          | Required |
+| -------- | ---------------- | -------- |
+| `string` | `"local-docker"` | No       |
 
 #### `providers[].clusterDocker`
 
@@ -345,9 +345,9 @@ Configuration options for the `cluster-docker` build mode.
 
 Enable [BuildKit](https://github.com/moby/buildkit) support. This should in most cases work well and be more performant, but we're opting to keep it optional until it's enabled by default in Docker.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `providers[].defaultHostname`
 
@@ -384,9 +384,9 @@ Defines the strategy for deploying the project services.
 Default is "rolling update" and there is experimental support for "blue/green" deployment.
 The feature only supports modules of type `container`: other types will just deploy using the default strategy.
 
-| Type     | Required | Default     |
-| -------- | -------- | ----------- |
-| `string` | No       | `"rolling"` |
+| Type     | Default     | Required |
+| -------- | ----------- | -------- |
+| `string` | `"rolling"` | No       |
 
 #### `providers[].forceSsl`
 
@@ -394,9 +394,9 @@ The feature only supports modules of type `container`: other types will just dep
 
 Require SSL on all `container` module services. If set to true, an error is raised when no certificate is available for a configured hostname on a `container` module.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `providers[].imagePullSecrets[]`
 
@@ -406,9 +406,9 @@ References to `docker-registry` secrets to use for authenticating with remote re
 images. This is necessary if you reference private images in your module configuration, and is required
 when configuring a remote Kubernetes environment with buildMode=local.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `providers[].imagePullSecrets[].name`
 
@@ -434,9 +434,9 @@ providers:
 
 The namespace where the secret is stored. If necessary, the secret may be copied to the appropriate namespace before use.
 
-| Type     | Required | Default     |
-| -------- | -------- | ----------- |
-| `string` | No       | `"default"` |
+| Type     | Default     | Required |
+| -------- | ----------- | -------- |
+| `string` | `"default"` | No       |
 
 #### `providers[].resources`
 
@@ -444,9 +444,9 @@ The namespace where the secret is stored. If necessary, the secret may be copied
 
 Resource requests and limits for the in-cluster builder, container registry and code sync service. (which are automatically installed and used when `buildMode` is `cluster-docker` or `kaniko`).
 
-| Type     | Required | Default                                                                                                                                                                                                                                                    |
-| -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `object` | No       | `{"builder":{"limits":{"cpu":4000,"memory":8192},"requests":{"cpu":200,"memory":512}},"registry":{"limits":{"cpu":2000,"memory":4096},"requests":{"cpu":200,"memory":512}},"sync":{"limits":{"cpu":500,"memory":512},"requests":{"cpu":100,"memory":64}}}` |
+| Type     | Default                                                                                                                                                                                                                                                    | Required |
+| -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `object` | `{"builder":{"limits":{"cpu":4000,"memory":8192},"requests":{"cpu":200,"memory":512}},"registry":{"limits":{"cpu":2000,"memory":4096},"requests":{"cpu":200,"memory":512}},"sync":{"limits":{"cpu":500,"memory":512},"requests":{"cpu":100,"memory":64}}}` | No       |
 
 #### `providers[].resources.builder`
 
@@ -461,17 +461,17 @@ in how many concurrent builds you expect and how heavy your builds tend to be.
 When `buildMode` is `kaniko`, this refers to _each instance_ of Kaniko, so you'd generally use lower
 limits/requests, but you should evaluate based on your needs.
 
-| Type     | Required | Default                                                                     |
-| -------- | -------- | --------------------------------------------------------------------------- |
-| `object` | No       | `{"limits":{"cpu":4000,"memory":8192},"requests":{"cpu":200,"memory":512}}` |
+| Type     | Default                                                                     | Required |
+| -------- | --------------------------------------------------------------------------- | -------- |
+| `object` | `{"limits":{"cpu":4000,"memory":8192},"requests":{"cpu":200,"memory":512}}` | No       |
 
 #### `providers[].resources.builder.limits`
 
 [providers](#providers) > [resources](#providersresources) > [builder](#providersresourcesbuilder) > limits
 
-| Type     | Required | Default                      |
-| -------- | -------- | ---------------------------- |
-| `object` | No       | `{"cpu":4000,"memory":8192}` |
+| Type     | Default                      | Required |
+| -------- | ---------------------------- | -------- |
+| `object` | `{"cpu":4000,"memory":8192}` | No       |
 
 #### `providers[].resources.builder.limits.cpu`
 
@@ -479,9 +479,9 @@ limits/requests, but you should evaluate based on your needs.
 
 CPU limit in millicpu.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `4000`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `4000`  | No       |
 
 Example:
 
@@ -502,9 +502,9 @@ providers:
 
 Memory limit in megabytes.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `8192`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `8192`  | No       |
 
 Example:
 
@@ -523,9 +523,9 @@ providers:
 
 [providers](#providers) > [resources](#providersresources) > [builder](#providersresourcesbuilder) > requests
 
-| Type     | Required | Default                    |
-| -------- | -------- | -------------------------- |
-| `object` | No       | `{"cpu":200,"memory":512}` |
+| Type     | Default                    | Required |
+| -------- | -------------------------- | -------- |
+| `object` | `{"cpu":200,"memory":512}` | No       |
 
 #### `providers[].resources.builder.requests.cpu`
 
@@ -533,9 +533,9 @@ providers:
 
 CPU request in millicpu.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `200`   |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `200`   | No       |
 
 Example:
 
@@ -556,9 +556,9 @@ providers:
 
 Memory request in megabytes.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `512`   |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `512`   | No       |
 
 Example:
 
@@ -583,17 +583,17 @@ so that they are available to all the nodes in your cluster.
 This is shared across all users and builds, so it should be resourced accordingly, factoring
 in how many concurrent builds you expect and how large your images tend to be.
 
-| Type     | Required | Default                                                                     |
-| -------- | -------- | --------------------------------------------------------------------------- |
-| `object` | No       | `{"limits":{"cpu":2000,"memory":4096},"requests":{"cpu":200,"memory":512}}` |
+| Type     | Default                                                                     | Required |
+| -------- | --------------------------------------------------------------------------- | -------- |
+| `object` | `{"limits":{"cpu":2000,"memory":4096},"requests":{"cpu":200,"memory":512}}` | No       |
 
 #### `providers[].resources.registry.limits`
 
 [providers](#providers) > [resources](#providersresources) > [registry](#providersresourcesregistry) > limits
 
-| Type     | Required | Default                      |
-| -------- | -------- | ---------------------------- |
-| `object` | No       | `{"cpu":2000,"memory":4096}` |
+| Type     | Default                      | Required |
+| -------- | ---------------------------- | -------- |
+| `object` | `{"cpu":2000,"memory":4096}` | No       |
 
 #### `providers[].resources.registry.limits.cpu`
 
@@ -601,9 +601,9 @@ in how many concurrent builds you expect and how large your images tend to be.
 
 CPU limit in millicpu.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `2000`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `2000`  | No       |
 
 Example:
 
@@ -624,9 +624,9 @@ providers:
 
 Memory limit in megabytes.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `4096`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `4096`  | No       |
 
 Example:
 
@@ -645,9 +645,9 @@ providers:
 
 [providers](#providers) > [resources](#providersresources) > [registry](#providersresourcesregistry) > requests
 
-| Type     | Required | Default                    |
-| -------- | -------- | -------------------------- |
-| `object` | No       | `{"cpu":200,"memory":512}` |
+| Type     | Default                    | Required |
+| -------- | -------------------------- | -------- |
+| `object` | `{"cpu":200,"memory":512}` | No       |
 
 #### `providers[].resources.registry.requests.cpu`
 
@@ -655,9 +655,9 @@ providers:
 
 CPU request in millicpu.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `200`   |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `200`   | No       |
 
 Example:
 
@@ -678,9 +678,9 @@ providers:
 
 Memory request in megabytes.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `512`   |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `512`   | No       |
 
 Example:
 
@@ -703,17 +703,17 @@ Resource requests and limits for the code sync service, which we use to sync bui
 ahead of building images. This generally is not resource intensive, but you might want to adjust the
 defaults if you have many concurrent users.
 
-| Type     | Required | Default                                                                  |
-| -------- | -------- | ------------------------------------------------------------------------ |
-| `object` | No       | `{"limits":{"cpu":500,"memory":512},"requests":{"cpu":100,"memory":64}}` |
+| Type     | Default                                                                  | Required |
+| -------- | ------------------------------------------------------------------------ | -------- |
+| `object` | `{"limits":{"cpu":500,"memory":512},"requests":{"cpu":100,"memory":64}}` | No       |
 
 #### `providers[].resources.sync.limits`
 
 [providers](#providers) > [resources](#providersresources) > [sync](#providersresourcessync) > limits
 
-| Type     | Required | Default                    |
-| -------- | -------- | -------------------------- |
-| `object` | No       | `{"cpu":500,"memory":512}` |
+| Type     | Default                    | Required |
+| -------- | -------------------------- | -------- |
+| `object` | `{"cpu":500,"memory":512}` | No       |
 
 #### `providers[].resources.sync.limits.cpu`
 
@@ -721,9 +721,9 @@ defaults if you have many concurrent users.
 
 CPU limit in millicpu.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `500`   |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `500`   | No       |
 
 Example:
 
@@ -744,9 +744,9 @@ providers:
 
 Memory limit in megabytes.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `512`   |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `512`   | No       |
 
 Example:
 
@@ -765,9 +765,9 @@ providers:
 
 [providers](#providers) > [resources](#providersresources) > [sync](#providersresourcessync) > requests
 
-| Type     | Required | Default                   |
-| -------- | -------- | ------------------------- |
-| `object` | No       | `{"cpu":100,"memory":64}` |
+| Type     | Default                   | Required |
+| -------- | ------------------------- | -------- |
+| `object` | `{"cpu":100,"memory":64}` | No       |
 
 #### `providers[].resources.sync.requests.cpu`
 
@@ -775,9 +775,9 @@ providers:
 
 CPU request in millicpu.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `100`   |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `100`   | No       |
 
 Example:
 
@@ -798,9 +798,9 @@ providers:
 
 Memory request in megabytes.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `64`    |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `64`    | No       |
 
 Example:
 
@@ -825,9 +825,9 @@ Storage parameters to set for the in-cluster builder, container registry and cod
 These are all shared cluster-wide across all users and builds, so they should be resourced accordingly,
 factoring in how many concurrent builds you expect and how large your images and build contexts tend to be.
 
-| Type     | Required | Default                                                                                                                                                              |
-| -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `object` | No       | `{"builder":{"size":20480,"storageClass":null},"nfs":{"storageClass":null},"registry":{"size":20480,"storageClass":null},"sync":{"size":10240,"storageClass":null}}` |
+| Type     | Default                                                                                                                                                              | Required |
+| -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `object` | `{"builder":{"size":20480,"storageClass":null},"nfs":{"storageClass":null},"registry":{"size":20480,"storageClass":null},"sync":{"size":10240,"storageClass":null}}` | No       |
 
 #### `providers[].storage.builder`
 
@@ -837,9 +837,9 @@ Storage parameters for the data volume for the in-cluster Docker Daemon.
 
 Only applies when `buildMode` is set to `cluster-docker`, ignored otherwise.
 
-| Type     | Required | Default                              |
-| -------- | -------- | ------------------------------------ |
-| `object` | No       | `{"size":20480,"storageClass":null}` |
+| Type     | Default                              | Required |
+| -------- | ------------------------------------ | -------- |
+| `object` | `{"size":20480,"storageClass":null}` | No       |
 
 #### `providers[].storage.builder.size`
 
@@ -847,9 +847,9 @@ Only applies when `buildMode` is set to `cluster-docker`, ignored otherwise.
 
 Volume size in megabytes.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `20480` |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `20480` | No       |
 
 #### `providers[].storage.builder.storageClass`
 
@@ -857,9 +857,9 @@ Volume size in megabytes.
 
 Storage class to use for the volume.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `string` | No       | `null`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `string` | `null`  | No       |
 
 #### `providers[].storage.nfs`
 
@@ -870,9 +870,9 @@ you specify a `storageClass` for the sync volume. See the below `sync` parameter
 
 Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored otherwise.
 
-| Type     | Required | Default                 |
-| -------- | -------- | ----------------------- |
-| `object` | No       | `{"storageClass":null}` |
+| Type     | Default                 | Required |
+| -------- | ----------------------- | -------- |
+| `object` | `{"storageClass":null}` | No       |
 
 #### `providers[].storage.nfs.storageClass`
 
@@ -880,9 +880,9 @@ Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored ot
 
 Storage class to use as backing storage for NFS .
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `string` | No       | `null`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `string` | `null`  | No       |
 
 #### `providers[].storage.registry`
 
@@ -893,9 +893,9 @@ are available to all the nodes in your cluster.
 
 Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored otherwise.
 
-| Type     | Required | Default                              |
-| -------- | -------- | ------------------------------------ |
-| `object` | No       | `{"size":20480,"storageClass":null}` |
+| Type     | Default                              | Required |
+| -------- | ------------------------------------ | -------- |
+| `object` | `{"size":20480,"storageClass":null}` | No       |
 
 #### `providers[].storage.registry.size`
 
@@ -903,9 +903,9 @@ Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored ot
 
 Volume size in megabytes.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `20480` |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `20480` | No       |
 
 #### `providers[].storage.registry.storageClass`
 
@@ -913,9 +913,9 @@ Volume size in megabytes.
 
 Storage class to use for the volume.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `string` | No       | `null`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `string` | `null`  | No       |
 
 #### `providers[].storage.sync`
 
@@ -930,9 +930,9 @@ NFS volume for the sync data volume.
 
 Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored otherwise.
 
-| Type     | Required | Default                              |
-| -------- | -------- | ------------------------------------ |
-| `object` | No       | `{"size":10240,"storageClass":null}` |
+| Type     | Default                              | Required |
+| -------- | ------------------------------------ | -------- |
+| `object` | `{"size":10240,"storageClass":null}` | No       |
 
 #### `providers[].storage.sync.size`
 
@@ -940,9 +940,9 @@ Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored ot
 
 Volume size in megabytes.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `10240` |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `10240` | No       |
 
 #### `providers[].storage.sync.storageClass`
 
@@ -950,9 +950,9 @@ Volume size in megabytes.
 
 Storage class to use for the volume.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `string` | No       | `null`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `string` | `null`  | No       |
 
 #### `providers[].tlsCertificates[]`
 
@@ -960,9 +960,9 @@ Storage class to use for the volume.
 
 One or more certificates to use for ingress.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `providers[].tlsCertificates[].name`
 
@@ -1049,9 +1049,9 @@ providers:
 
 The namespace where the secret is stored. If necessary, the secret may be copied to the appropriate namespace before use.
 
-| Type     | Required | Default     |
-| -------- | -------- | ----------- |
-| `string` | No       | `"default"` |
+| Type     | Default     | Required |
+| -------- | ----------- | -------- |
+| `string` | `"default"` | No       |
 
 #### `providers[].tlsCertificates[].managedBy`
 
@@ -1091,9 +1091,9 @@ cert-manager configuration, for creating and managing TLS certificates. See the
 Automatically install `cert-manager` on initialization. See the
 [cert-manager integration guide](https://docs.garden.io/guides/cert-manager-integration) for details.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `providers[].certManager.email`
 
@@ -1120,9 +1120,9 @@ providers:
 
 The type of issuer for the certificate (only ACME is supported for now).
 
-| Type     | Required | Default  |
+| Type     | Default  | Required |
 | -------- | -------- | -------- |
-| `string` | No       | `"acme"` |
+| `string` | `"acme"` | No       |
 
 Example:
 
@@ -1139,9 +1139,9 @@ providers:
 
 Specify which ACME server to request certificates from. Currently Let's Encrypt staging and prod servers are supported.
 
-| Type     | Required | Default                 |
-| -------- | -------- | ----------------------- |
-| `string` | No       | `"letsencrypt-staging"` |
+| Type     | Default                 | Required |
+| -------- | ----------------------- | -------- |
+| `string` | `"letsencrypt-staging"` | No       |
 
 Example:
 
@@ -1158,9 +1158,9 @@ providers:
 
 The type of ACME challenge used to validate hostnames and generate the certificates (only HTTP-01 is supported for now).
 
-| Type     | Required | Default     |
-| -------- | -------- | ----------- |
-| `string` | No       | `"HTTP-01"` |
+| Type     | Default     | Required |
+| -------- | ----------- | -------- |
+| `string` | `"HTTP-01"` | No       |
 
 Example:
 
@@ -1181,9 +1181,9 @@ The registry-proxy is a DaemonSet that proxies connections to the docker registr
 Use this only if you're doing in-cluster building and the nodes in your cluster
 have [taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/).
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `providers[].registryProxyTolerations[].effect`
 
@@ -1215,9 +1215,9 @@ If the key is empty, operator must be "Exists"; this combination means to match 
 "Equal". "Exists" is equivalent to wildcard for value, so that a pod can tolerate all taints of a
 particular category.
 
-| Type     | Required | Default   |
-| -------- | -------- | --------- |
-| `string` | No       | `"Equal"` |
+| Type     | Default   | Required |
+| -------- | --------- | -------- |
+| `string` | `"Equal"` | No       |
 
 #### `providers[].registryProxyTolerations[].tolerationSeconds`
 
@@ -1249,9 +1249,9 @@ otherwise just a regular string.
 
 The name of the provider plugin to use.
 
-| Type     | Required | Default        |
-| -------- | -------- | -------------- |
-| `string` | Yes      | `"kubernetes"` |
+| Type     | Default        | Required |
+| -------- | -------------- | -------- |
+| `string` | `"kubernetes"` | Yes      |
 
 Example:
 
@@ -1322,9 +1322,9 @@ The port where the registry listens on, if not the default.
 
 The namespace in the registry where images should be pushed.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `string` | No       | `"_"`   |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `string` | `"_"`   | No       |
 
 Example:
 
@@ -1352,9 +1352,9 @@ when deploying `container` services. Use this if you have multiple ingress contr
 
 The external HTTP port of the cluster's ingress controller.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `80`    |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `80`    | No       |
 
 #### `providers[].ingressHttpsPort`
 
@@ -1362,9 +1362,9 @@ The external HTTP port of the cluster's ingress controller.
 
 The external HTTPS port of the cluster's ingress controller.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `443`   |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `443`   | No       |
 
 #### `providers[].kubeconfig`
 
@@ -1392,47 +1392,35 @@ Specify which namespace to deploy services to (defaults to <project name>). Note
 
 Set this to `nginx` to install/enable the NGINX ingress controller.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `string` | No       | `false` |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `string` | `false` | No       |
 
 
 ### Outputs
 
 The following keys are available via the `${providers.<provider-name>}` template string key for `kubernetes` providers.
 
-#### `${providers.<provider-name>.outputs}`
-
-| Type     | Required |
-| -------- | -------- |
-| `object` | Yes      |
-
 #### `${providers.<provider-name>.outputs.app-namespace}`
-
-[outputs](#outputs) > app-namespace
 
 The primary namespace used for resource deployments.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 #### `${providers.<provider-name>.outputs.default-hostname}`
 
-[outputs](#outputs) > default-hostname
-
 The default hostname configured on the provider.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | No       |
+| Type     |
+| -------- |
+| `string` |
 
 #### `${providers.<provider-name>.outputs.metadata-namespace}`
 
-[outputs](#outputs) > metadata-namespace
-
 The namespace used for Garden metadata.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |

--- a/docs/providers/local-kubernetes.md
+++ b/docs/providers/local-kubernetes.md
@@ -261,9 +261,9 @@ providers:
 
 #### `providers`
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `providers[].environments[]`
 
@@ -304,9 +304,9 @@ to build. The former uses a normal Docker daemon in the cluster. Because this ha
 this is less secure than Kaniko, but in turn it is generally faster. See the
 [Kaniko docs](https://github.com/GoogleContainerTools/kaniko) for more information on Kaniko.
 
-| Type     | Required | Default          |
-| -------- | -------- | ---------------- |
-| `string` | No       | `"local-docker"` |
+| Type     | Default          | Required |
+| -------- | ---------------- | -------- |
+| `string` | `"local-docker"` | No       |
 
 #### `providers[].clusterDocker`
 
@@ -324,9 +324,9 @@ Configuration options for the `cluster-docker` build mode.
 
 Enable [BuildKit](https://github.com/moby/buildkit) support. This should in most cases work well and be more performant, but we're opting to keep it optional until it's enabled by default in Docker.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `providers[].defaultHostname`
 
@@ -363,9 +363,9 @@ Defines the strategy for deploying the project services.
 Default is "rolling update" and there is experimental support for "blue/green" deployment.
 The feature only supports modules of type `container`: other types will just deploy using the default strategy.
 
-| Type     | Required | Default     |
-| -------- | -------- | ----------- |
-| `string` | No       | `"rolling"` |
+| Type     | Default     | Required |
+| -------- | ----------- | -------- |
+| `string` | `"rolling"` | No       |
 
 #### `providers[].forceSsl`
 
@@ -373,9 +373,9 @@ The feature only supports modules of type `container`: other types will just dep
 
 Require SSL on all `container` module services. If set to true, an error is raised when no certificate is available for a configured hostname on a `container` module.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `providers[].imagePullSecrets[]`
 
@@ -385,9 +385,9 @@ References to `docker-registry` secrets to use for authenticating with remote re
 images. This is necessary if you reference private images in your module configuration, and is required
 when configuring a remote Kubernetes environment with buildMode=local.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `providers[].imagePullSecrets[].name`
 
@@ -413,9 +413,9 @@ providers:
 
 The namespace where the secret is stored. If necessary, the secret may be copied to the appropriate namespace before use.
 
-| Type     | Required | Default     |
-| -------- | -------- | ----------- |
-| `string` | No       | `"default"` |
+| Type     | Default     | Required |
+| -------- | ----------- | -------- |
+| `string` | `"default"` | No       |
 
 #### `providers[].resources`
 
@@ -423,9 +423,9 @@ The namespace where the secret is stored. If necessary, the secret may be copied
 
 Resource requests and limits for the in-cluster builder, container registry and code sync service. (which are automatically installed and used when `buildMode` is `cluster-docker` or `kaniko`).
 
-| Type     | Required | Default                                                                                                                                                                                                                                                    |
-| -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `object` | No       | `{"builder":{"limits":{"cpu":4000,"memory":8192},"requests":{"cpu":200,"memory":512}},"registry":{"limits":{"cpu":2000,"memory":4096},"requests":{"cpu":200,"memory":512}},"sync":{"limits":{"cpu":500,"memory":512},"requests":{"cpu":100,"memory":64}}}` |
+| Type     | Default                                                                                                                                                                                                                                                    | Required |
+| -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `object` | `{"builder":{"limits":{"cpu":4000,"memory":8192},"requests":{"cpu":200,"memory":512}},"registry":{"limits":{"cpu":2000,"memory":4096},"requests":{"cpu":200,"memory":512}},"sync":{"limits":{"cpu":500,"memory":512},"requests":{"cpu":100,"memory":64}}}` | No       |
 
 #### `providers[].resources.builder`
 
@@ -440,17 +440,17 @@ in how many concurrent builds you expect and how heavy your builds tend to be.
 When `buildMode` is `kaniko`, this refers to _each instance_ of Kaniko, so you'd generally use lower
 limits/requests, but you should evaluate based on your needs.
 
-| Type     | Required | Default                                                                     |
-| -------- | -------- | --------------------------------------------------------------------------- |
-| `object` | No       | `{"limits":{"cpu":4000,"memory":8192},"requests":{"cpu":200,"memory":512}}` |
+| Type     | Default                                                                     | Required |
+| -------- | --------------------------------------------------------------------------- | -------- |
+| `object` | `{"limits":{"cpu":4000,"memory":8192},"requests":{"cpu":200,"memory":512}}` | No       |
 
 #### `providers[].resources.builder.limits`
 
 [providers](#providers) > [resources](#providersresources) > [builder](#providersresourcesbuilder) > limits
 
-| Type     | Required | Default                      |
-| -------- | -------- | ---------------------------- |
-| `object` | No       | `{"cpu":4000,"memory":8192}` |
+| Type     | Default                      | Required |
+| -------- | ---------------------------- | -------- |
+| `object` | `{"cpu":4000,"memory":8192}` | No       |
 
 #### `providers[].resources.builder.limits.cpu`
 
@@ -458,9 +458,9 @@ limits/requests, but you should evaluate based on your needs.
 
 CPU limit in millicpu.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `4000`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `4000`  | No       |
 
 Example:
 
@@ -481,9 +481,9 @@ providers:
 
 Memory limit in megabytes.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `8192`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `8192`  | No       |
 
 Example:
 
@@ -502,9 +502,9 @@ providers:
 
 [providers](#providers) > [resources](#providersresources) > [builder](#providersresourcesbuilder) > requests
 
-| Type     | Required | Default                    |
-| -------- | -------- | -------------------------- |
-| `object` | No       | `{"cpu":200,"memory":512}` |
+| Type     | Default                    | Required |
+| -------- | -------------------------- | -------- |
+| `object` | `{"cpu":200,"memory":512}` | No       |
 
 #### `providers[].resources.builder.requests.cpu`
 
@@ -512,9 +512,9 @@ providers:
 
 CPU request in millicpu.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `200`   |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `200`   | No       |
 
 Example:
 
@@ -535,9 +535,9 @@ providers:
 
 Memory request in megabytes.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `512`   |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `512`   | No       |
 
 Example:
 
@@ -562,17 +562,17 @@ so that they are available to all the nodes in your cluster.
 This is shared across all users and builds, so it should be resourced accordingly, factoring
 in how many concurrent builds you expect and how large your images tend to be.
 
-| Type     | Required | Default                                                                     |
-| -------- | -------- | --------------------------------------------------------------------------- |
-| `object` | No       | `{"limits":{"cpu":2000,"memory":4096},"requests":{"cpu":200,"memory":512}}` |
+| Type     | Default                                                                     | Required |
+| -------- | --------------------------------------------------------------------------- | -------- |
+| `object` | `{"limits":{"cpu":2000,"memory":4096},"requests":{"cpu":200,"memory":512}}` | No       |
 
 #### `providers[].resources.registry.limits`
 
 [providers](#providers) > [resources](#providersresources) > [registry](#providersresourcesregistry) > limits
 
-| Type     | Required | Default                      |
-| -------- | -------- | ---------------------------- |
-| `object` | No       | `{"cpu":2000,"memory":4096}` |
+| Type     | Default                      | Required |
+| -------- | ---------------------------- | -------- |
+| `object` | `{"cpu":2000,"memory":4096}` | No       |
 
 #### `providers[].resources.registry.limits.cpu`
 
@@ -580,9 +580,9 @@ in how many concurrent builds you expect and how large your images tend to be.
 
 CPU limit in millicpu.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `2000`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `2000`  | No       |
 
 Example:
 
@@ -603,9 +603,9 @@ providers:
 
 Memory limit in megabytes.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `4096`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `4096`  | No       |
 
 Example:
 
@@ -624,9 +624,9 @@ providers:
 
 [providers](#providers) > [resources](#providersresources) > [registry](#providersresourcesregistry) > requests
 
-| Type     | Required | Default                    |
-| -------- | -------- | -------------------------- |
-| `object` | No       | `{"cpu":200,"memory":512}` |
+| Type     | Default                    | Required |
+| -------- | -------------------------- | -------- |
+| `object` | `{"cpu":200,"memory":512}` | No       |
 
 #### `providers[].resources.registry.requests.cpu`
 
@@ -634,9 +634,9 @@ providers:
 
 CPU request in millicpu.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `200`   |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `200`   | No       |
 
 Example:
 
@@ -657,9 +657,9 @@ providers:
 
 Memory request in megabytes.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `512`   |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `512`   | No       |
 
 Example:
 
@@ -682,17 +682,17 @@ Resource requests and limits for the code sync service, which we use to sync bui
 ahead of building images. This generally is not resource intensive, but you might want to adjust the
 defaults if you have many concurrent users.
 
-| Type     | Required | Default                                                                  |
-| -------- | -------- | ------------------------------------------------------------------------ |
-| `object` | No       | `{"limits":{"cpu":500,"memory":512},"requests":{"cpu":100,"memory":64}}` |
+| Type     | Default                                                                  | Required |
+| -------- | ------------------------------------------------------------------------ | -------- |
+| `object` | `{"limits":{"cpu":500,"memory":512},"requests":{"cpu":100,"memory":64}}` | No       |
 
 #### `providers[].resources.sync.limits`
 
 [providers](#providers) > [resources](#providersresources) > [sync](#providersresourcessync) > limits
 
-| Type     | Required | Default                    |
-| -------- | -------- | -------------------------- |
-| `object` | No       | `{"cpu":500,"memory":512}` |
+| Type     | Default                    | Required |
+| -------- | -------------------------- | -------- |
+| `object` | `{"cpu":500,"memory":512}` | No       |
 
 #### `providers[].resources.sync.limits.cpu`
 
@@ -700,9 +700,9 @@ defaults if you have many concurrent users.
 
 CPU limit in millicpu.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `500`   |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `500`   | No       |
 
 Example:
 
@@ -723,9 +723,9 @@ providers:
 
 Memory limit in megabytes.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `512`   |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `512`   | No       |
 
 Example:
 
@@ -744,9 +744,9 @@ providers:
 
 [providers](#providers) > [resources](#providersresources) > [sync](#providersresourcessync) > requests
 
-| Type     | Required | Default                   |
-| -------- | -------- | ------------------------- |
-| `object` | No       | `{"cpu":100,"memory":64}` |
+| Type     | Default                   | Required |
+| -------- | ------------------------- | -------- |
+| `object` | `{"cpu":100,"memory":64}` | No       |
 
 #### `providers[].resources.sync.requests.cpu`
 
@@ -754,9 +754,9 @@ providers:
 
 CPU request in millicpu.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `100`   |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `100`   | No       |
 
 Example:
 
@@ -777,9 +777,9 @@ providers:
 
 Memory request in megabytes.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `64`    |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `64`    | No       |
 
 Example:
 
@@ -804,9 +804,9 @@ Storage parameters to set for the in-cluster builder, container registry and cod
 These are all shared cluster-wide across all users and builds, so they should be resourced accordingly,
 factoring in how many concurrent builds you expect and how large your images and build contexts tend to be.
 
-| Type     | Required | Default                                                                                                                                                              |
-| -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `object` | No       | `{"builder":{"size":20480,"storageClass":null},"nfs":{"storageClass":null},"registry":{"size":20480,"storageClass":null},"sync":{"size":10240,"storageClass":null}}` |
+| Type     | Default                                                                                                                                                              | Required |
+| -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `object` | `{"builder":{"size":20480,"storageClass":null},"nfs":{"storageClass":null},"registry":{"size":20480,"storageClass":null},"sync":{"size":10240,"storageClass":null}}` | No       |
 
 #### `providers[].storage.builder`
 
@@ -816,9 +816,9 @@ Storage parameters for the data volume for the in-cluster Docker Daemon.
 
 Only applies when `buildMode` is set to `cluster-docker`, ignored otherwise.
 
-| Type     | Required | Default                              |
-| -------- | -------- | ------------------------------------ |
-| `object` | No       | `{"size":20480,"storageClass":null}` |
+| Type     | Default                              | Required |
+| -------- | ------------------------------------ | -------- |
+| `object` | `{"size":20480,"storageClass":null}` | No       |
 
 #### `providers[].storage.builder.size`
 
@@ -826,9 +826,9 @@ Only applies when `buildMode` is set to `cluster-docker`, ignored otherwise.
 
 Volume size in megabytes.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `20480` |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `20480` | No       |
 
 #### `providers[].storage.builder.storageClass`
 
@@ -836,9 +836,9 @@ Volume size in megabytes.
 
 Storage class to use for the volume.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `string` | No       | `null`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `string` | `null`  | No       |
 
 #### `providers[].storage.nfs`
 
@@ -849,9 +849,9 @@ you specify a `storageClass` for the sync volume. See the below `sync` parameter
 
 Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored otherwise.
 
-| Type     | Required | Default                 |
-| -------- | -------- | ----------------------- |
-| `object` | No       | `{"storageClass":null}` |
+| Type     | Default                 | Required |
+| -------- | ----------------------- | -------- |
+| `object` | `{"storageClass":null}` | No       |
 
 #### `providers[].storage.nfs.storageClass`
 
@@ -859,9 +859,9 @@ Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored ot
 
 Storage class to use as backing storage for NFS .
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `string` | No       | `null`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `string` | `null`  | No       |
 
 #### `providers[].storage.registry`
 
@@ -872,9 +872,9 @@ are available to all the nodes in your cluster.
 
 Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored otherwise.
 
-| Type     | Required | Default                              |
-| -------- | -------- | ------------------------------------ |
-| `object` | No       | `{"size":20480,"storageClass":null}` |
+| Type     | Default                              | Required |
+| -------- | ------------------------------------ | -------- |
+| `object` | `{"size":20480,"storageClass":null}` | No       |
 
 #### `providers[].storage.registry.size`
 
@@ -882,9 +882,9 @@ Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored ot
 
 Volume size in megabytes.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `20480` |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `20480` | No       |
 
 #### `providers[].storage.registry.storageClass`
 
@@ -892,9 +892,9 @@ Volume size in megabytes.
 
 Storage class to use for the volume.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `string` | No       | `null`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `string` | `null`  | No       |
 
 #### `providers[].storage.sync`
 
@@ -909,9 +909,9 @@ NFS volume for the sync data volume.
 
 Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored otherwise.
 
-| Type     | Required | Default                              |
-| -------- | -------- | ------------------------------------ |
-| `object` | No       | `{"size":10240,"storageClass":null}` |
+| Type     | Default                              | Required |
+| -------- | ------------------------------------ | -------- |
+| `object` | `{"size":10240,"storageClass":null}` | No       |
 
 #### `providers[].storage.sync.size`
 
@@ -919,9 +919,9 @@ Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored ot
 
 Volume size in megabytes.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `number` | No       | `10240` |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `10240` | No       |
 
 #### `providers[].storage.sync.storageClass`
 
@@ -929,9 +929,9 @@ Volume size in megabytes.
 
 Storage class to use for the volume.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `string` | No       | `null`  |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `string` | `null`  | No       |
 
 #### `providers[].tlsCertificates[]`
 
@@ -939,9 +939,9 @@ Storage class to use for the volume.
 
 One or more certificates to use for ingress.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `providers[].tlsCertificates[].name`
 
@@ -1028,9 +1028,9 @@ providers:
 
 The namespace where the secret is stored. If necessary, the secret may be copied to the appropriate namespace before use.
 
-| Type     | Required | Default     |
-| -------- | -------- | ----------- |
-| `string` | No       | `"default"` |
+| Type     | Default     | Required |
+| -------- | ----------- | -------- |
+| `string` | `"default"` | No       |
 
 #### `providers[].tlsCertificates[].managedBy`
 
@@ -1070,9 +1070,9 @@ cert-manager configuration, for creating and managing TLS certificates. See the
 Automatically install `cert-manager` on initialization. See the
 [cert-manager integration guide](https://docs.garden.io/guides/cert-manager-integration) for details.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `providers[].certManager.email`
 
@@ -1099,9 +1099,9 @@ providers:
 
 The type of issuer for the certificate (only ACME is supported for now).
 
-| Type     | Required | Default  |
+| Type     | Default  | Required |
 | -------- | -------- | -------- |
-| `string` | No       | `"acme"` |
+| `string` | `"acme"` | No       |
 
 Example:
 
@@ -1118,9 +1118,9 @@ providers:
 
 Specify which ACME server to request certificates from. Currently Let's Encrypt staging and prod servers are supported.
 
-| Type     | Required | Default                 |
-| -------- | -------- | ----------------------- |
-| `string` | No       | `"letsencrypt-staging"` |
+| Type     | Default                 | Required |
+| -------- | ----------------------- | -------- |
+| `string` | `"letsencrypt-staging"` | No       |
 
 Example:
 
@@ -1137,9 +1137,9 @@ providers:
 
 The type of ACME challenge used to validate hostnames and generate the certificates (only HTTP-01 is supported for now).
 
-| Type     | Required | Default     |
-| -------- | -------- | ----------- |
-| `string` | No       | `"HTTP-01"` |
+| Type     | Default     | Required |
+| -------- | ----------- | -------- |
+| `string` | `"HTTP-01"` | No       |
 
 Example:
 
@@ -1160,9 +1160,9 @@ The registry-proxy is a DaemonSet that proxies connections to the docker registr
 Use this only if you're doing in-cluster building and the nodes in your cluster
 have [taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/).
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `providers[].registryProxyTolerations[].effect`
 
@@ -1194,9 +1194,9 @@ If the key is empty, operator must be "Exists"; this combination means to match 
 "Equal". "Exists" is equivalent to wildcard for value, so that a pod can tolerate all taints of a
 particular category.
 
-| Type     | Required | Default   |
-| -------- | -------- | --------- |
-| `string` | No       | `"Equal"` |
+| Type     | Default   | Required |
+| -------- | --------- | -------- |
+| `string` | `"Equal"` | No       |
 
 #### `providers[].registryProxyTolerations[].tolerationSeconds`
 
@@ -1228,9 +1228,9 @@ otherwise just a regular string.
 
 The name of the provider plugin to use.
 
-| Type     | Required | Default              |
-| -------- | -------- | -------------------- |
-| `string` | Yes      | `"local-kubernetes"` |
+| Type     | Default              | Required |
+| -------- | -------------------- | -------- |
+| `string` | `"local-kubernetes"` | Yes      |
 
 Example:
 
@@ -1272,47 +1272,35 @@ Specify which namespace to deploy services to (defaults to the project name). No
 
 Set this to null or false to skip installing/enabling the `nginx` ingress controller.
 
-| Type     | Required | Default   |
-| -------- | -------- | --------- |
-| `string` | No       | `"nginx"` |
+| Type     | Default   | Required |
+| -------- | --------- | -------- |
+| `string` | `"nginx"` | No       |
 
 
 ### Outputs
 
 The following keys are available via the `${providers.<provider-name>}` template string key for `local-kubernetes` providers.
 
-#### `${providers.<provider-name>.outputs}`
-
-| Type     | Required |
-| -------- | -------- |
-| `object` | Yes      |
-
 #### `${providers.<provider-name>.outputs.app-namespace}`
-
-[outputs](#outputs) > app-namespace
 
 The primary namespace used for resource deployments.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |
 
 #### `${providers.<provider-name>.outputs.default-hostname}`
 
-[outputs](#outputs) > default-hostname
-
 The default hostname configured on the provider.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | No       |
+| Type     |
+| -------- |
+| `string` |
 
 #### `${providers.<provider-name>.outputs.metadata-namespace}`
 
-[outputs](#outputs) > metadata-namespace
-
 The namespace used for Garden metadata.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
+| Type     |
+| -------- |
+| `string` |

--- a/docs/providers/maven-container.md
+++ b/docs/providers/maven-container.md
@@ -32,9 +32,9 @@ providers:
 
 #### `providers`
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `providers[].name`
 

--- a/docs/providers/openfaas.md
+++ b/docs/providers/openfaas.md
@@ -57,9 +57,9 @@ providers:
 
 #### `providers`
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `providers[].environments[]`
 
@@ -86,9 +86,9 @@ providers:
 
 The name of the provider plugin to use.
 
-| Type     | Required | Default      |
-| -------- | -------- | ------------ |
-| `string` | Yes      | `"openfaas"` |
+| Type     | Default      | Required |
+| -------- | ------------ | -------- |
+| `string` | `"openfaas"` | Yes      |
 
 Example:
 
@@ -140,9 +140,9 @@ providers:
 
 [providers](#providers) > faasNetes
 
-| Type     | Required | Default            |
-| -------- | -------- | ------------------ |
-| `object` | No       | `{"install":true}` |
+| Type     | Default            | Required |
+| -------- | ------------------ | -------- |
+| `object` | `{"install":true}` | No       |
 
 #### `providers[].faasNetes.install`
 
@@ -151,9 +151,9 @@ providers:
 Set to false if you'd like to install and configure faas-netes yourself.
 See the [official instructions](https://docs.openfaas.com/deployment/kubernetes/) for details.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `true`  |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 #### `providers[].faasNetes.values`
 

--- a/docs/providers/terraform.md
+++ b/docs/providers/terraform.md
@@ -42,9 +42,9 @@ providers:
 
 #### `providers`
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `providers[].name`
 
@@ -88,9 +88,9 @@ providers:
 
 If set to true, Garden will automatically run `terraform apply -auto-approve` when a stack is not up-to-date. Otherwise, a warning is logged if the stack is out-of-date, and an error thrown if it is missing entirely.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `providers[].initRoot`
 
@@ -121,7 +121,7 @@ A map of variables to use when applying Terraform stacks. You can define these h
 
 The version of Terraform to use.
 
-| Type     | Required | Default    |
-| -------- | -------- | ---------- |
-| `string` | No       | `"0.12.7"` |
+| Type     | Default    | Required |
+| -------- | ---------- | -------- |
+| `string` | `"0.12.7"` | No       |
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -271,6 +271,23 @@ Just try it.
 
     garden get eysi 
 
+### garden get outputs
+
+Resolves and returns the outputs of the project.
+
+Resolves and returns the outputs of the project. If necessary, this may involve deploying services and/or running
+tasks referenced by the outputs in the project configuration.
+
+Examples:
+
+    garden get outputs                 # resolve and print the outputs from the project
+    garden get outputs --env=prod      # resolve and print the outputs from the project for the prod environment
+    garden get outputs --output=json   # resolve and return the project outputs in JSON format
+
+##### Usage
+
+    garden get outputs 
+
 ### garden get secret
 
 Get a secret from the environment.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -83,6 +83,23 @@ modules:
   # guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
   exclude:
 
+# A list of output values that the project should export. These are exported by the `garden outputs` command,
+# as well as when referencing a project as a sub-project within another project.
+#
+# You may use any template strings to specify the values, including references to provider outputs, module
+# outputs and runtime outputs. For a full reference, see the
+# [Output configuration context](../reference/template-strings.md#output-configuration-context) section in the
+# Template String Reference.
+#
+# Note that if any runtime outputs are referenced, the referenced services and tasks will be deployed and run
+# if necessary when resolving the outputs.
+outputs:
+  # The name of the output value.
+  - name:
+    # The value for the output. Must be a primitive (string, number, boolean or null). May also be any valid template
+    # string.
+    value:
+
 # A list of providers that should be used for this project, and their configuration. Please refer to individual
 # plugins/providers for details on how to configure them.
 providers:
@@ -154,15 +171,15 @@ environments:
 
 The schema version of this project's config (currently not used).
 
-| Type     | Required | Allowed Values | Default          |
-| -------- | -------- | -------------- | ---------------- |
-| `string` | Yes      | "garden.io/v0" | `"garden.io/v0"` |
+| Type     | Allowed Values | Default          | Required |
+| -------- | -------------- | ---------------- | -------- |
+| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
 
 #### `kind`
 
-| Type     | Required | Allowed Values | Default     |
-| -------- | -------- | -------------- | ----------- |
-| `string` | Yes      | "Project"      | `"Project"` |
+| Type     | Allowed Values | Default     | Required |
+| -------- | -------------- | ----------- | -------- |
+| `string` | "Project"      | `"Project"` | Yes      |
 
 #### `name`
 
@@ -182,9 +199,9 @@ name: "my-sweet-project"
 
 The default environment to use when calling commands without the `--env` parameter. Defaults to the first configured environment.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `string` | No       | `""`    |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `string` | `""`    | No       |
 
 #### `dotIgnoreFiles`
 
@@ -192,9 +209,9 @@ Specify a list of filenames that should be used as ".ignore" files across the pr
 Note that these take precedence over the project `module.include` field, and module `include` fields, so any paths matched by the .ignore files will be ignored even if they are explicitly specified in those fields.
 See the [Configuration Files guide] (https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 
-| Type               | Required | Default                          |
-| ------------------ | -------- | -------------------------------- |
-| `array[posixPath]` | No       | `[".gitignore",".gardenignore"]` |
+| Type               | Default                          | Required |
+| ------------------ | -------------------------------- | -------- |
+| `array[posixPath]` | `[".gitignore",".gardenignore"]` | No       |
 
 #### `modules`
 
@@ -271,13 +288,51 @@ modules:
     - tmp/**/*
 ```
 
+#### `outputs`
+
+A list of output values that the project should export. These are exported by the `garden outputs` command,
+as well as when referencing a project as a sub-project within another project.
+
+You may use any template strings to specify the values, including references to provider outputs, module
+outputs and runtime outputs. For a full reference, see the
+[Output configuration context](../reference/template-strings.md#output-configuration-context) section in the
+Template String Reference.
+
+Note that if any runtime outputs are referenced, the referenced services and tasks will be deployed and run
+if necessary when resolving the outputs.
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
+
+#### `outputs[].name`
+
+[outputs](#outputs) > name
+
+The name of the output value.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | Yes      |
+
+#### `outputs[].value`
+
+[outputs](#outputs) > value
+
+The value for the output. Must be a primitive (string, number, boolean or null). May also be any valid template
+string.
+
+| Type                        | Required |
+| --------------------------- | -------- |
+| `number | string | boolean` | Yes      |
+
 #### `providers`
 
 A list of providers that should be used for this project, and their configuration. Please refer to individual plugins/providers for details on how to configure them.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `providers[].name`
 
@@ -319,9 +374,9 @@ providers:
 
 A list of remote sources to import into project.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `sources[].name`
 
@@ -362,17 +417,17 @@ If you do override the default value and the file doesn't exist, an error will b
 _Note that in many cases it is advisable to only use environment-specific var files, instead of combining
 multiple ones. See the `environments[].varfile` field for this option._
 
-| Type        | Required | Default        |
-| ----------- | -------- | -------------- |
-| `posixPath` | No       | `"garden.env"` |
+| Type        | Default        | Required |
+| ----------- | -------------- | -------- |
+| `posixPath` | `"garden.env"` | No       |
 
 #### `variables`
 
 Variables to configure for all environments.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `object` | No       | `{}`    |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `object` | `{}`    | No       |
 
 #### `environments`
 
@@ -386,9 +441,9 @@ Variables to configure for all environments.
 
 DEPRECATED - Please use the top-level `providers` field instead, and if needed use the `environments` key on the provider configurations to limit them to specific environments.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `environments[].providers[].name`
 
@@ -449,9 +504,9 @@ we simply ignore it. If you do override the default value and the file doesn't e
 
 A key/value map of variables that modules can reference when using this environment. These take precedence over variables defined in the top-level `variables` field.
 
-| Type     | Required | Default |
-| -------- | -------- | ------- |
-| `object` | No       | `{}`    |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `object` | `{}`    | No       |
 
 #### `environments[].name`
 
@@ -477,9 +532,9 @@ Run the command with the "--yes" flag to skip the check (e.g. when running Garde
 This flag is also passed on to every provider, and may affect how certain providers behave.
 For more details please check the documentation for the providers in use.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 
 ## Module YAML schema
@@ -571,15 +626,15 @@ build:
 
 The schema version of this module's config (currently not used).
 
-| Type     | Required | Allowed Values | Default          |
-| -------- | -------- | -------------- | ---------------- |
-| `string` | Yes      | "garden.io/v0" | `"garden.io/v0"` |
+| Type     | Allowed Values | Default          | Required |
+| -------- | -------------- | ---------------- | -------- |
+| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
 
 #### `kind`
 
-| Type     | Required | Allowed Values | Default    |
-| -------- | -------- | -------------- | ---------- |
-| `string` | Yes      | "Module"       | `"Module"` |
+| Type     | Allowed Values | Default    | Required |
+| -------- | -------------- | ---------- | -------- |
+| `string` | "Module"       | `"Module"` | Yes      |
 
 #### `type`
 
@@ -632,9 +687,9 @@ module's service or task outputs (i.e. runtime outputs) will fail to resolve whe
 so you need to make sure to provide alternate values for those if you're using them, using conditional
 expressions.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `false` |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 #### `include`
 
@@ -707,17 +762,17 @@ repositoryUrl: "git+https://github.com/org/repo.git#v2.0"
 
 When false, disables pushing this module to remote registries.
 
-| Type      | Required | Default |
-| --------- | -------- | ------- |
-| `boolean` | No       | `true`  |
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 #### `build`
 
 Specify how to build the module. Note that plugins may define additional keys on this object.
 
-| Type     | Required | Default               |
-| -------- | -------- | --------------------- |
-| `object` | No       | `{"dependencies":[]}` |
+| Type     | Default               | Required |
+| -------- | --------------------- | -------- |
+| `object` | `{"dependencies":[]}` | No       |
 
 #### `build.dependencies[]`
 
@@ -725,9 +780,9 @@ Specify how to build the module. Note that plugins may define additional keys on
 
 A list of modules that must be built before this module is built.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 Example:
 
@@ -754,9 +809,9 @@ Module name to build ahead of this module.
 
 Specify one or more files or directories to copy from the built dependency to this module.
 
-| Type            | Required | Default |
-| --------------- | -------- | ------- |
-| `array[object]` | No       | `[]`    |
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
 
 #### `build.dependencies[].copy[].source`
 
@@ -775,8 +830,8 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
 Defaults to to same as source path.
 
-| Type        | Required | Default |
-| ----------- | -------- | ------- |
-| `posixPath` | No       | `""`    |
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `""`    | No       |
 
 

--- a/docs/reference/template-strings.md
+++ b/docs/reference/template-strings.md
@@ -4,292 +4,964 @@ title: Template Strings Reference
 
 # Template string reference
 
-Below you'll find the schema of the keys available when interpolating template strings (see our
-[Configuration Files](../guides/configuration-files.md) guide for more information and usage examples).
+Below you'll find the schema of the keys available when interpolating template strings (see our [Configuration Files](../guides/configuration-files.md) guide for more information and usage examples).
 
-Note that there are three sections below, since Project configs and Module configs have different keys available to
-them, and since additional keys are available under `providers` in Project configs.
-Please make sure to refer to the correct section.
-
-Modules can reference `outputs` defined by other modules, via the `${modules.<module-name>.outputs}` key, as well
-as service and task outputs via the `${runtime.services.<service-name>.outputs}` and
-`${runtime.tasks.<task-name>.outputs}`.
-For details on which outputs are available for a given module type, please refer to the
-[reference](https://docs.garden.io/module-types) docs for the module type in question, and look for the
-_Outputs_ section.
+Note that there are four sections below, since different configuration sections have different keys available to them. Please make sure to refer to the correct section.
 
 ## Project configuration context
 
-The following keys are available in any template strings within project definitions in `garden.yml` config files
-(see the [Provider](#provider-configuration-context) section below for additional keys available when configuring
-`providers`):
+The following keys are available in any template strings within project definitions in `garden.yml` config files (see the [Provider](#provider-configuration-context) section below for additional keys available when configuring `providers`):
+
+
+#### `${local.*}`
+
+Context variables that are specific to the currently running environment/machine.
+
+| Type     |
+| -------- |
+| `object` |
+
+#### `${local.artifactsPath}`
+
+The absolute path to the directory where exported artifacts from test and task runs are stored.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
 
 ```yaml
-# Context variables that are specific to the currently running environment/machine.
-#
-# Type: object
-#
-local:
-  # The absolute path to the directory where exported artifacts from test and task runs are stored.
-  #
-  # Type: string
-  #
-  # Example: "/home/me/my-project/.garden/artifacts"
-  #
-  artifactsPath:
-
-  # A map of all local environment variables (see https://nodejs.org/api/process.html#process_process_env).
-  #
-  # Type: object
-  #
-  env:
-
-  # A string indicating the platform that the framework is running on (see
-  # https://nodejs.org/api/process.html#process_process_platform)
-  #
-  # Type: string
-  #
-  # Example: "posix"
-  #
-  platform:
-
-  # The current username (as resolved by https://github.com/sindresorhus/username)
-  #
-  # Type: string
-  #
-  # Example: "tenzing_norgay"
-  #
-  username:
+my-variable: ${local.artifactsPath}
 ```
+
+#### `${local.env.*}`
+
+A map of all local environment variables (see https://nodejs.org/api/process.html#process_process_env).
+
+| Type     |
+| -------- |
+| `object` |
+
+#### `${local.env.<env-var-name>}`
+
+The environment variable value.
+
+| Type     |
+| -------- |
+| `string` |
+
+#### `${local.platform}`
+
+A string indicating the platform that the framework is running on (see https://nodejs.org/api/process.html#process_process_platform)
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.platform}
+```
+
+#### `${local.username}`
+
+The current username (as resolved by https://github.com/sindresorhus/username)
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.username}
+```
+
 
 ## Provider configuration context
 
-The following keys are available in template strings under the `providers` key (or `environments[].providers)
-in `garden.yml` project config files:
+The following keys are available in template strings under the `providers` key (or `environments[].providers) in project configs.
+
+Providers can also reference outputs defined by other providers, via the `${providers.<provider-name>.outputs}` key. For details on which outputs are available for a given provider, please refer to the [reference](https://docs.garden.io/providers) docs for the provider in question, and look for the _Outputs_ section.
+
+
+#### `${local.*}`
+
+Context variables that are specific to the currently running environment/machine.
+
+| Type     |
+| -------- |
+| `object` |
+
+#### `${local.artifactsPath}`
+
+The absolute path to the directory where exported artifacts from test and task runs are stored.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
 
 ```yaml
-# Context variables that are specific to the currently running environment/machine.
-#
-# Type: object
-#
-local:
-  # The absolute path to the directory where exported artifacts from test and task runs are stored.
-  #
-  # Type: string
-  #
-  # Example: "/home/me/my-project/.garden/artifacts"
-  #
-  artifactsPath:
-
-  # A map of all local environment variables (see https://nodejs.org/api/process.html#process_process_env).
-  #
-  # Type: object
-  #
-  env:
-
-  # A string indicating the platform that the framework is running on (see
-  # https://nodejs.org/api/process.html#process_process_platform)
-  #
-  # Type: string
-  #
-  # Example: "posix"
-  #
-  platform:
-
-  # The current username (as resolved by https://github.com/sindresorhus/username)
-  #
-  # Type: string
-  #
-  # Example: "tenzing_norgay"
-  #
-  username:
-
-# Information about the environment that Garden is running against.
-#
-# Type: object
-#
-environment:
-  # The name of the environment Garden is running against.
-  #
-  # Type: string
-  #
-  # Example: "local"
-  #
-  name:
-
-# Information about the Garden project.
-#
-# Type: object
-#
-project:
-  # The name of the Garden project.
-  #
-  # Type: string
-  #
-  # Example: "my-project"
-  #
-  name:
-
-# Retrieve information about providers that are defined in the project.
-#
-# Type: object
-#
-# Example:
-#   kubernetes:
-#     config:
-#       clusterHostname: my-cluster.example.com
-#
-providers: {}
-
-# A map of all variables defined in the project configuration.
-#
-# Type: object
-#
-# Example:
-#   team-name: bananaramallama
-#   some-service-endpoint: 'https://someservice.com/api/v2'
-#
-variables: {}
-
-# Alias for the variables field.
-#
-# Type: object
-#
-var: {}
+my-variable: ${local.artifactsPath}
 ```
+
+#### `${local.env.*}`
+
+A map of all local environment variables (see https://nodejs.org/api/process.html#process_process_env).
+
+| Type     |
+| -------- |
+| `object` |
+
+#### `${local.env.<env-var-name>}`
+
+The environment variable value.
+
+| Type     |
+| -------- |
+| `string` |
+
+#### `${local.platform}`
+
+A string indicating the platform that the framework is running on (see https://nodejs.org/api/process.html#process_process_platform)
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.platform}
+```
+
+#### `${local.username}`
+
+The current username (as resolved by https://github.com/sindresorhus/username)
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.username}
+```
+
+#### `${environment.*}`
+
+Information about the environment that Garden is running against.
+
+| Type     |
+| -------- |
+| `object` |
+
+#### `${environment.name}`
+
+The name of the environment Garden is running against.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${environment.name}
+```
+
+#### `${project.*}`
+
+Information about the Garden project.
+
+| Type     |
+| -------- |
+| `object` |
+
+#### `${project.name}`
+
+The name of the Garden project.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${project.name}
+```
+
+#### `${providers.*}`
+
+Retrieve information about providers that are defined in the project.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+#### `${providers.<provider-name>.config.*}`
+
+The resolved configuration for the provider.
+
+| Type     |
+| -------- |
+| `object` |
+
+Example:
+
+```yaml
+providers:
+  {}
+  <provider-name>:
+    ...
+    config:
+        clusterHostname: my-cluster.example.com
+```
+
+#### `${providers.<provider-name>.config.<config-key>}`
+
+The provider config key value. Refer to individual [provider references](../providers/README.md) for details.
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
+#### `${providers.<provider-name>.outputs.*}`
+
+The outputs defined by the provider (see individual plugin docs for details).
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+Example:
+
+```yaml
+providers:
+  {}
+  <provider-name>:
+    ...
+    outputs:
+        cluster-ip: 1.2.3.4
+```
+
+#### `${providers.<provider-name>.outputs.<output-key>}`
+
+The provider output value. Refer to individual [provider references](../providers/README.md) for details.
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
+#### `${variables.*}`
+
+A map of all variables defined in the project configuration.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+#### `${variables.<variable-name>}`
+
+The value of the variable.
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
+#### `${var.*}`
+
+Alias for the variables field.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+#### `${var.<name>}`
+
+Number, string or boolean
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
 
 ## Module configuration context
 
-The following keys are available in template strings with module definitions in `garden.yml` config files:
+The below keys are available in template strings in module configs. These include all the keys from the sections above.
+
+Modules can reference outputs defined by providers, via the `${providers.<provider-name>.outputs}` key. For details on which outputs are available for a given provider, please refer to the [reference](https://docs.garden.io/providers) docs for the provider in question, and look for the _Outputs_ section.
+
+Modules can also reference outputs defined by other modules, via the `${modules.<module-name>.outputs}` key, as well as service and task outputs via the `${runtime.services.<service-name>.outputs}` and `${runtime.tasks.<task-name>.outputs}` keys.
+For details on which outputs are available for a given module type, please refer to the [reference](https://docs.garden.io/module-types) docs for the module type in question, and look for the _Outputs_ section.
+
+
+#### `${local.*}`
+
+Context variables that are specific to the currently running environment/machine.
+
+| Type     |
+| -------- |
+| `object` |
+
+#### `${local.artifactsPath}`
+
+The absolute path to the directory where exported artifacts from test and task runs are stored.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
 
 ```yaml
-# Context variables that are specific to the currently running environment/machine.
-#
-# Type: object
-#
-local:
-  # The absolute path to the directory where exported artifacts from test and task runs are stored.
-  #
-  # Type: string
-  #
-  # Example: "/home/me/my-project/.garden/artifacts"
-  #
-  artifactsPath:
-
-  # A map of all local environment variables (see https://nodejs.org/api/process.html#process_process_env).
-  #
-  # Type: object
-  #
-  env:
-
-  # A string indicating the platform that the framework is running on (see
-  # https://nodejs.org/api/process.html#process_process_platform)
-  #
-  # Type: string
-  #
-  # Example: "posix"
-  #
-  platform:
-
-  # The current username (as resolved by https://github.com/sindresorhus/username)
-  #
-  # Type: string
-  #
-  # Example: "tenzing_norgay"
-  #
-  username:
-
-# Information about the environment that Garden is running against.
-#
-# Type: object
-#
-environment:
-  # The name of the environment Garden is running against.
-  #
-  # Type: string
-  #
-  # Example: "local"
-  #
-  name:
-
-# Information about the Garden project.
-#
-# Type: object
-#
-project:
-  # The name of the Garden project.
-  #
-  # Type: string
-  #
-  # Example: "my-project"
-  #
-  name:
-
-# Retrieve information about providers that are defined in the project.
-#
-# Type: object
-#
-# Example:
-#   kubernetes:
-#     config:
-#       clusterHostname: my-cluster.example.com
-#
-providers: {}
-
-# A map of all variables defined in the project configuration.
-#
-# Type: object
-#
-# Example:
-#   team-name: bananaramallama
-#   some-service-endpoint: 'https://someservice.com/api/v2'
-#
-variables: {}
-
-# Alias for the variables field.
-#
-# Type: object
-#
-var: {}
-
-# Retrieve information about modules that are defined in the project.
-#
-# Type: object
-#
-# Example:
-#   my-module:
-#     buildPath: /home/me/code/my-project/.garden/build/my-module
-#     path: /home/me/code/my-project/my-module
-#     outputs: {}
-#     version: v-17ad4cb3fd
-#
-modules: {}
-
-# Runtime outputs and information from services and tasks (only resolved at runtime when deploying services and
-# running tasks).
-#
-# Type: object
-#
-runtime:
-  # Runtime information from the services that the service/task being run depends on.
-  #
-  # Type: object
-  #
-  # Example:
-  #   my-service:
-  #     outputs:
-  #       some-key: some value
-  #
-  services: {}
-
-  # Runtime information from the tasks that the service/task being run depends on.
-  #
-  # Type: object
-  #
-  # Example:
-  #   my-task:
-  #     outputs:
-  #       some-key: some value
-  #
-  tasks: {}
+my-variable: ${local.artifactsPath}
 ```
+
+#### `${local.env.*}`
+
+A map of all local environment variables (see https://nodejs.org/api/process.html#process_process_env).
+
+| Type     |
+| -------- |
+| `object` |
+
+#### `${local.env.<env-var-name>}`
+
+The environment variable value.
+
+| Type     |
+| -------- |
+| `string` |
+
+#### `${local.platform}`
+
+A string indicating the platform that the framework is running on (see https://nodejs.org/api/process.html#process_process_platform)
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.platform}
+```
+
+#### `${local.username}`
+
+The current username (as resolved by https://github.com/sindresorhus/username)
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.username}
+```
+
+#### `${environment.*}`
+
+Information about the environment that Garden is running against.
+
+| Type     |
+| -------- |
+| `object` |
+
+#### `${environment.name}`
+
+The name of the environment Garden is running against.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${environment.name}
+```
+
+#### `${project.*}`
+
+Information about the Garden project.
+
+| Type     |
+| -------- |
+| `object` |
+
+#### `${project.name}`
+
+The name of the Garden project.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${project.name}
+```
+
+#### `${providers.*}`
+
+Retrieve information about providers that are defined in the project.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+#### `${providers.<provider-name>.config.*}`
+
+The resolved configuration for the provider.
+
+| Type     |
+| -------- |
+| `object` |
+
+Example:
+
+```yaml
+providers:
+  {}
+  <provider-name>:
+    ...
+    config:
+        clusterHostname: my-cluster.example.com
+```
+
+#### `${providers.<provider-name>.config.<config-key>}`
+
+The provider config key value. Refer to individual [provider references](../providers/README.md) for details.
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
+#### `${providers.<provider-name>.outputs.*}`
+
+The outputs defined by the provider (see individual plugin docs for details).
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+Example:
+
+```yaml
+providers:
+  {}
+  <provider-name>:
+    ...
+    outputs:
+        cluster-ip: 1.2.3.4
+```
+
+#### `${providers.<provider-name>.outputs.<output-key>}`
+
+The provider output value. Refer to individual [provider references](../providers/README.md) for details.
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
+#### `${variables.*}`
+
+A map of all variables defined in the project configuration.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+#### `${variables.<variable-name>}`
+
+The value of the variable.
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
+#### `${var.*}`
+
+Alias for the variables field.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+#### `${var.<name>}`
+
+Number, string or boolean
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
+#### `${modules.*}`
+
+Retrieve information about modules that are defined in the project.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+#### `${modules.<module-name>.buildPath}`
+
+The build path of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${modules.<module-name>.buildPath}
+```
+
+#### `${modules.<module-name>.outputs.*}`
+
+The outputs defined by the module (see individual module type [references](https://docs.garden.io/module-types) for details).
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+#### `${modules.<module-name>.outputs.<output-name>}`
+
+The module output value. Refer to individual [module type references](../module-types/README.md) for details.
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
+#### `${modules.<module-name>.path}`
+
+The local path of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${modules.<module-name>.path}
+```
+
+#### `${modules.<module-name>.version}`
+
+The current version of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${modules.<module-name>.version}
+```
+
+#### `${runtime.*}`
+
+Runtime outputs and information from services and tasks (only resolved at runtime when deploying services and running tasks).
+
+| Type     |
+| -------- |
+| `object` |
+
+#### `${runtime.services.*}`
+
+Runtime information from the services that the service/task being run depends on.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+#### `${runtime.services.<service-name>.outputs.*}`
+
+The runtime outputs defined by the service (see individual module type [references](https://docs.garden.io/module-types) for details).
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+#### `${runtime.services.<service-name>.outputs.<output-name>}`
+
+The service output value. Refer to individual [module type references](../module-types/README.md) for details.
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
+#### `${runtime.tasks.*}`
+
+Runtime information from the tasks that the service/task being run depends on.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+#### `${runtime.tasks.<task-name>.outputs.*}`
+
+The runtime outputs defined by the task (see individual module type [references](https://docs.garden.io/module-types) for details).
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+#### `${runtime.tasks.<task-name>.outputs.<output-name>}`
+
+The task output value. Refer to individual [module type references](../module-types/README.md) for details.
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
+
+## Output configuration context
+
+The below keys are available in template strings for _project outputs_, specified in `outputs[].value` keys in project config files. These include all the keys from the sections above.
+
+Output values can reference outputs defined by providers, via the `${providers.<provider-name>.outputs}` key. For details on which outputs are available for a given provider, please refer to the [reference](https://docs.garden.io/providers) docs for the provider in question, and look for the _Outputs_ section.
+
+Output values may also reference outputs defined by modules, via the `${modules.<module-name>.outputs}` key, as well as service and task outputs via the `${runtime.services.<service-name>.outputs}` and `${runtime.tasks.<task-name>.outputs}` keys.
+For details on which outputs are available for a given module type, please refer to the [reference](https://docs.garden.io/module-types) docs for the module type in question, and look for the _Outputs_ section.
+
+
+#### `${local.*}`
+
+Context variables that are specific to the currently running environment/machine.
+
+| Type     |
+| -------- |
+| `object` |
+
+#### `${local.artifactsPath}`
+
+The absolute path to the directory where exported artifacts from test and task runs are stored.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.artifactsPath}
+```
+
+#### `${local.env.*}`
+
+A map of all local environment variables (see https://nodejs.org/api/process.html#process_process_env).
+
+| Type     |
+| -------- |
+| `object` |
+
+#### `${local.env.<env-var-name>}`
+
+The environment variable value.
+
+| Type     |
+| -------- |
+| `string` |
+
+#### `${local.platform}`
+
+A string indicating the platform that the framework is running on (see https://nodejs.org/api/process.html#process_process_platform)
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.platform}
+```
+
+#### `${local.username}`
+
+The current username (as resolved by https://github.com/sindresorhus/username)
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.username}
+```
+
+#### `${environment.*}`
+
+Information about the environment that Garden is running against.
+
+| Type     |
+| -------- |
+| `object` |
+
+#### `${environment.name}`
+
+The name of the environment Garden is running against.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${environment.name}
+```
+
+#### `${project.*}`
+
+Information about the Garden project.
+
+| Type     |
+| -------- |
+| `object` |
+
+#### `${project.name}`
+
+The name of the Garden project.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${project.name}
+```
+
+#### `${providers.*}`
+
+Retrieve information about providers that are defined in the project.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+#### `${providers.<provider-name>.config.*}`
+
+The resolved configuration for the provider.
+
+| Type     |
+| -------- |
+| `object` |
+
+Example:
+
+```yaml
+providers:
+  {}
+  <provider-name>:
+    ...
+    config:
+        clusterHostname: my-cluster.example.com
+```
+
+#### `${providers.<provider-name>.config.<config-key>}`
+
+The provider config key value. Refer to individual [provider references](../providers/README.md) for details.
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
+#### `${providers.<provider-name>.outputs.*}`
+
+The outputs defined by the provider (see individual plugin docs for details).
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+Example:
+
+```yaml
+providers:
+  {}
+  <provider-name>:
+    ...
+    outputs:
+        cluster-ip: 1.2.3.4
+```
+
+#### `${providers.<provider-name>.outputs.<output-key>}`
+
+The provider output value. Refer to individual [provider references](../providers/README.md) for details.
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
+#### `${variables.*}`
+
+A map of all variables defined in the project configuration.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+#### `${variables.<variable-name>}`
+
+The value of the variable.
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
+#### `${var.*}`
+
+Alias for the variables field.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+#### `${var.<name>}`
+
+Number, string or boolean
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
+#### `${modules.*}`
+
+Retrieve information about modules that are defined in the project.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+#### `${modules.<module-name>.buildPath}`
+
+The build path of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${modules.<module-name>.buildPath}
+```
+
+#### `${modules.<module-name>.outputs.*}`
+
+The outputs defined by the module (see individual module type [references](https://docs.garden.io/module-types) for details).
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+#### `${modules.<module-name>.outputs.<output-name>}`
+
+The module output value. Refer to individual [module type references](../module-types/README.md) for details.
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
+#### `${modules.<module-name>.path}`
+
+The local path of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${modules.<module-name>.path}
+```
+
+#### `${modules.<module-name>.version}`
+
+The current version of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${modules.<module-name>.version}
+```
+
+#### `${runtime.*}`
+
+Runtime outputs and information from services and tasks (only resolved at runtime when deploying services and running tasks).
+
+| Type     |
+| -------- |
+| `object` |
+
+#### `${runtime.services.*}`
+
+Runtime information from the services that the service/task being run depends on.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+#### `${runtime.services.<service-name>.outputs.*}`
+
+The runtime outputs defined by the service (see individual module type [references](https://docs.garden.io/module-types) for details).
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+#### `${runtime.services.<service-name>.outputs.<output-name>}`
+
+The service output value. Refer to individual [module type references](../module-types/README.md) for details.
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
+#### `${runtime.tasks.*}`
+
+Runtime information from the tasks that the service/task being run depends on.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+#### `${runtime.tasks.<task-name>.outputs.*}`
+
+The runtime outputs defined by the task (see individual module type [references](https://docs.garden.io/module-types) for details).
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+#### `${runtime.tasks.<task-name>.outputs.<output-name>}`
+
+The task output value. Refer to individual [module type references](../module-types/README.md) for details.
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+

--- a/examples/demo-project/backend/garden.yml
+++ b/examples/demo-project/backend/garden.yml
@@ -12,3 +12,6 @@ services:
     ingresses:
       - path: /hello-backend
         port: http
+tasks:
+  - name: test
+    command: ["sh", "-c", "echo task output"]

--- a/examples/demo-project/garden.yml
+++ b/examples/demo-project/garden.yml
@@ -14,3 +14,10 @@ providers:
     namespace: demo-project-testing-${local.env.USER || local.username}
     defaultHostname: ${local.env.USER || local.username}-demo-project.dev-1.sys.garden
     buildMode: cluster-docker
+outputs:
+  - name: namespace
+    value: ${providers.local-kubernetes.outputs.app-namespace}
+  - name: backend-image
+    value: ${modules.backend.outputs.deployment-image-name}
+  - name: task-output
+    value: ${runtime.tasks.test.outputs.log}

--- a/examples/hadolint/README.md
+++ b/examples/hadolint/README.md
@@ -1,6 +1,6 @@
 # hadolint project
 
-A simple variation on the [demo-project](../demo-project/README.md) that adds the [hadolint provider](https://docs.garden.io/providers/hadolint.md). This generates an additional Dockerfile linting test for each `container` module in your project that contains a Dockerfile.
+A simple variation on the [demo-project](../demo-project/README.md) that adds the [hadolint provider](https://docs.garden.io/providers/hadolint). This generates an additional Dockerfile linting test for each `container` module in your project that contains a Dockerfile.
 
 To test it, run `garden dev` in this directory, and wait for the initial processing to complete. Notice the two tests that are added and run by the `hadolint` provider.
 

--- a/garden-service/src/commands/get/get-outputs.ts
+++ b/garden-service/src/commands/get/get-outputs.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Command, CommandResult, CommandParams, PrepareParams } from "../base"
+import { printHeader } from "../../logger/util"
+import { fromPairs } from "lodash"
+import { PrimitiveMap } from "../../config/common"
+import { renderTable, dedent } from "../../util/string"
+import chalk from "chalk"
+import { resolveProjectOutputs } from "../../outputs"
+
+export class GetOutputsCommand extends Command {
+  name = "outputs"
+  help = "Resolves and returns the outputs of the project."
+
+  description = dedent`
+    Resolves and returns the outputs of the project. If necessary, this may involve deploying services and/or running
+    tasks referenced by the outputs in the project configuration.
+
+    Examples:
+
+        garden get outputs                 # resolve and print the outputs from the project
+        garden get outputs --env=prod      # resolve and print the outputs from the project for the prod environment
+        garden get outputs --output=json   # resolve and return the project outputs in JSON format
+  `
+
+  async prepare({ headerLog }: PrepareParams) {
+    printHeader(headerLog, "Resolving project outputs", "notebook")
+    return { persistent: false }
+  }
+
+  async action({ garden, log }: CommandParams): Promise<CommandResult<PrimitiveMap>> {
+    const outputs = await resolveProjectOutputs(garden, log)
+
+    const rows = [
+      { [chalk.bold("Name:")]: [chalk.bold("Value:")] },
+      ...outputs.map((o) => ({ [chalk.cyan.bold(o.name)]: [o.value?.toString().trim()] })),
+    ]
+    log.info("")
+    log.info(chalk.white.bold("Outputs:"))
+    log.info(renderTable(rows))
+
+    return { result: fromPairs(outputs.map((o) => [o.name, o.value])) }
+  }
+}

--- a/garden-service/src/commands/get/get.ts
+++ b/garden-service/src/commands/get/get.ts
@@ -16,6 +16,7 @@ import { GetTasksCommand } from "./get-tasks"
 import { GetTaskResultCommand } from "./get-task-result"
 import { GetTestResultCommand } from "./get-test-result"
 import { GetDebugInfoCommand } from "./get-debug-info"
+import { GetOutputsCommand } from "./get-outputs"
 
 export class GetCommand extends Command {
   name = "get"
@@ -25,6 +26,7 @@ export class GetCommand extends Command {
     GetGraphCommand,
     GetConfigCommand,
     GetEysiCommand,
+    GetOutputsCommand,
     GetSecretCommand,
     GetStatusCommand,
     GetTasksCommand,

--- a/garden-service/src/commands/run/module.ts
+++ b/garden-service/src/commands/run/module.ts
@@ -99,7 +99,7 @@ export class RunModuleCommand extends Command<Args, Opts> {
       garden,
       graph,
       dependencies,
-      module,
+      version: module.version,
       serviceStatuses: {},
       taskResults: {},
     })

--- a/garden-service/src/commands/run/service.ts
+++ b/garden-service/src/commands/run/service.ts
@@ -95,7 +95,7 @@ export class RunServiceCommand extends Command<Args, Opts> {
       garden,
       graph,
       dependencies,
-      module,
+      version: module.version,
       serviceStatuses,
       taskResults,
     })

--- a/garden-service/src/commands/run/test.ts
+++ b/garden-service/src/commands/run/test.ts
@@ -120,7 +120,7 @@ export class RunTestCommand extends Command<Args, Opts> {
       garden,
       graph,
       dependencies,
-      module,
+      version: module.version,
       serviceStatuses,
       taskResults,
     })

--- a/garden-service/src/config/common.ts
+++ b/garden-service/src/config/common.ts
@@ -37,6 +37,7 @@ interface MetadataKeys {
   deprecated?: boolean
   extendable?: boolean
   experimental?: boolean
+  keyPlaceholder?: string
 }
 
 // Unfortunately we need to explicitly extend each type (just extending the AnySchema doesn't work).

--- a/garden-service/src/docs/template-strings.ts
+++ b/garden-service/src/docs/template-strings.ts
@@ -7,8 +7,13 @@
  */
 
 import { resolve } from "path"
-import { renderSchemaDescriptionYaml, normalizeSchemaDescriptions, TEMPLATES_DIR, Description } from "./config"
-import { ProjectConfigContext, ModuleConfigContext, ProviderConfigContext } from "../config/config-context"
+import { TEMPLATES_DIR, renderTemplateStringReference } from "./config"
+import {
+  ProjectConfigContext,
+  ModuleConfigContext,
+  ProviderConfigContext,
+  OutputConfigContext,
+} from "../config/config-context"
 import { readFileSync, writeFileSync } from "fs"
 import handlebars from "handlebars"
 import { GARDEN_SERVICE_ROOT } from "../constants"
@@ -17,24 +22,25 @@ export function writeTemplateStringReferenceDocs(docsRoot: string) {
   const referenceDir = resolve(docsRoot, "reference")
   const outputPath = resolve(referenceDir, "template-strings.md")
 
-  const projectDescriptions = normalizeSchemaDescriptions(ProjectConfigContext.getSchema().describe() as Description)
-  const projectContext = renderSchemaDescriptionYaml(projectDescriptions, {
-    renderRequired: false,
+  const projectContext = renderTemplateStringReference({
+    schema: ProjectConfigContext.getSchema().required(),
   })
 
-  const providerDescriptions = normalizeSchemaDescriptions(ProviderConfigContext.getSchema().describe() as Description)
-  const providerContext = renderSchemaDescriptionYaml(providerDescriptions, {
-    renderRequired: false,
+  const providerContext = renderTemplateStringReference({
+    schema: ProviderConfigContext.getSchema().required(),
   })
 
-  const moduleDescriptions = normalizeSchemaDescriptions(ModuleConfigContext.getSchema().describe() as Description)
-  const moduleContext = renderSchemaDescriptionYaml(moduleDescriptions, {
-    renderRequired: false,
+  const moduleContext = renderTemplateStringReference({
+    schema: ModuleConfigContext.getSchema().required(),
+  })
+
+  const outputContext = renderTemplateStringReference({
+    schema: OutputConfigContext.getSchema().required(),
   })
 
   const templatePath = resolve(TEMPLATES_DIR, "template-strings.hbs")
   const template = handlebars.compile(readFileSync(templatePath).toString())
-  const markdown = template({ projectContext, providerContext, moduleContext })
+  const markdown = template({ projectContext, providerContext, moduleContext, outputContext })
 
   writeFileSync(outputPath, markdown)
 }

--- a/garden-service/src/docs/templates/template-strings.hbs
+++ b/garden-service/src/docs/templates/template-strings.hbs
@@ -4,43 +4,42 @@ title: Template Strings Reference
 
 # Template string reference
 
-Below you'll find the schema of the keys available when interpolating template strings (see our
-[Configuration Files](../guides/configuration-files.md) guide for more information and usage examples).
+Below you'll find the schema of the keys available when interpolating template strings (see our [Configuration Files](../guides/configuration-files.md) guide for more information and usage examples).
 
-Note that there are three sections below, since Project configs and Module configs have different keys available to
-them, and since additional keys are available under `providers` in Project configs.
-Please make sure to refer to the correct section.
-
-Modules can reference `outputs` defined by other modules, via the `${modules.<module-name>.outputs}` key, as well
-as service and task outputs via the `${runtime.services.<service-name>.outputs}` and
-`${runtime.tasks.<task-name>.outputs}`.
-For details on which outputs are available for a given module type, please refer to the
-[reference](https://docs.garden.io/module-types) docs for the module type in question, and look for the
-_Outputs_ section.
+Note that there are four sections below, since different configuration sections have different keys available to them. Please make sure to refer to the correct section.
 
 ## Project configuration context
 
-The following keys are available in any template strings within project definitions in `garden.yml` config files
-(see the [Provider](#provider-configuration-context) section below for additional keys available when configuring
-`providers`):
+The following keys are available in any template strings within project definitions in `garden.yml` config files (see the [Provider](#provider-configuration-context) section below for additional keys available when configuring `providers`):
 
-```yaml
 {{{projectContext}}}
-```
 
 ## Provider configuration context
 
-The following keys are available in template strings under the `providers` key (or `environments[].providers)
-in `garden.yml` project config files:
+The following keys are available in template strings under the `providers` key (or `environments[].providers) in project configs.
 
-```yaml
+Providers can also reference outputs defined by other providers, via the `${providers.<provider-name>.outputs}` key. For details on which outputs are available for a given provider, please refer to the [reference](https://docs.garden.io/providers) docs for the provider in question, and look for the _Outputs_ section.
+
 {{{providerContext}}}
-```
 
 ## Module configuration context
 
-The following keys are available in template strings with module definitions in `garden.yml` config files:
+The below keys are available in template strings in module configs. These include all the keys from the sections above.
 
-```yaml
+Modules can reference outputs defined by providers, via the `${providers.<provider-name>.outputs}` key. For details on which outputs are available for a given provider, please refer to the [reference](https://docs.garden.io/providers) docs for the provider in question, and look for the _Outputs_ section.
+
+Modules can also reference outputs defined by other modules, via the `${modules.<module-name>.outputs}` key, as well as service and task outputs via the `${runtime.services.<service-name>.outputs}` and `${runtime.tasks.<task-name>.outputs}` keys.
+For details on which outputs are available for a given module type, please refer to the [reference](https://docs.garden.io/module-types) docs for the module type in question, and look for the _Outputs_ section.
+
 {{{moduleContext}}}
-```
+
+## Output configuration context
+
+The below keys are available in template strings for _project outputs_, specified in `outputs[].value` keys in project config files. These include all the keys from the sections above.
+
+Output values can reference outputs defined by providers, via the `${providers.<provider-name>.outputs}` key. For details on which outputs are available for a given provider, please refer to the [reference](https://docs.garden.io/providers) docs for the provider in question, and look for the _Outputs_ section.
+
+Output values may also reference outputs defined by modules, via the `${modules.<module-name>.outputs}` key, as well as service and task outputs via the `${runtime.services.<service-name>.outputs}` and `${runtime.tasks.<task-name>.outputs}` keys.
+For details on which outputs are available for a given module type, please refer to the [reference](https://docs.garden.io/module-types) docs for the module type in question, and look for the _Outputs_ section.
+
+{{{outputContext}}}

--- a/garden-service/src/outputs.ts
+++ b/garden-service/src/outputs.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Garden } from "./garden"
+import { collectTemplateReferences, resolveTemplateStrings } from "./template-string"
+import { OutputConfigContext } from "./config/config-context"
+import { emptyRuntimeContext, prepareRuntimeContext } from "./runtime-context"
+import { DeployTask } from "./tasks/deploy"
+import { TaskTask } from "./tasks/task"
+import { TaskResults } from "./task-graph"
+import { getServiceStatuses, getRunTaskResults } from "./tasks/base"
+import { LogEntry } from "./logger/log-entry"
+import { OutputSpec } from "./config/project"
+
+/**
+ * Resolves all declared project outputs. If necessary, this will resolve providers and modules, and ensure services
+ * and tasks have been deployed and run, so that relevant template strings can be fully resolved.
+ */
+export async function resolveProjectOutputs(garden: Garden, log: LogEntry): Promise<OutputSpec[]> {
+  if (garden.rawOutputs.length === 0) {
+    return []
+  }
+
+  // Check for template references to figure out what needs to be resolved
+  let needProviders: string[] = []
+  let needModules: string[] = []
+  let needServices: string[] = []
+  let needTasks: string[] = []
+
+  const templateRefs = await collectTemplateReferences(garden.rawOutputs)
+
+  if (templateRefs.length === 0) {
+    // Nothing to resolve
+    return garden.rawOutputs
+  }
+
+  for (const ref of templateRefs) {
+    if (!ref[1]) {
+      continue
+    }
+    if (ref[0] === "providers") {
+      needProviders.push(ref[1])
+    } else if (ref[0] === "modules") {
+      needModules.push(ref[1])
+    } else if (ref[0] === "runtime" && ref[2]) {
+      if (ref[1] === "services") {
+        needServices.push(ref[2])
+      } else if (ref[1] === "tasks") {
+        needTasks.push(ref[2])
+      }
+    }
+  }
+
+  const allRefs = [...needProviders, ...needModules, ...needServices, ...needTasks]
+
+  if (allRefs.length === 0) {
+    // No need to resolve any entities
+    return resolveTemplateStrings(
+      garden.rawOutputs,
+      new OutputConfigContext(garden, [], garden.variables, [], emptyRuntimeContext)
+    )
+  }
+
+  // Make sure all referenced services and tasks are ready and collect their outputs for the runtime context
+  const graph = await garden.getConfigGraph(log)
+  const services = await graph.getServices({ names: needServices })
+  const tasks = await graph.getTasks({ names: needTasks })
+
+  const graphTasks = [
+    ...services.map(
+      (service) =>
+        new DeployTask({
+          force: false,
+          forceBuild: false,
+          garden,
+          graph,
+          log,
+          service,
+        })
+    ),
+    ...(await Promise.all(
+      tasks.map((task) =>
+        TaskTask.factory({
+          force: false,
+          forceBuild: false,
+          garden,
+          graph,
+          log,
+          task,
+        })
+      )
+    )),
+  ]
+
+  const dependencyResults: TaskResults = graphTasks.length > 0 ? await garden.processTasks(graphTasks) : {}
+
+  const serviceStatuses = getServiceStatuses(dependencyResults)
+  const taskResults = getRunTaskResults(dependencyResults)
+
+  const runtimeContext = await prepareRuntimeContext({
+    garden,
+    graph,
+    dependencies: {
+      build: [],
+      deploy: services,
+      run: tasks,
+      test: [],
+    },
+    version: garden.version,
+    serviceStatuses,
+    taskResults,
+  })
+
+  const configContext = await garden.getOutputConfigContext(runtimeContext)
+
+  return resolveTemplateStrings(garden.rawOutputs, configContext)
+}

--- a/garden-service/src/plugins/conftest/conftest.ts
+++ b/garden-service/src/plugins/conftest/conftest.ts
@@ -89,7 +89,7 @@ export const gardenPlugin = createGardenPlugin({
 
         > Note: In many cases, you'll let specific conftest providers (e.g. [\`conftest-container\`](../providers/conftest-container.md) and [\`conftest-kubernetes\`](../providers/conftest-kubernetes.md) create this module type automatically, but you may in some cases want or need to manually specify files to test.
 
-        See the [conftest docs](https://github.com/instramenta/conftest) for details on how to configure policies.
+        See the [conftest docs](https://github.com/instrumenta/conftest) for details on how to configure policies.
       `,
       schema: joi.object().keys({
         build: baseBuildSpecSchema,

--- a/garden-service/src/plugins/kubernetes/run.ts
+++ b/garden-service/src/plugins/kubernetes/run.ts
@@ -459,7 +459,9 @@ export class PodRunner extends PodRunnerParams {
   /**
    * Executes a command in the running Pod. Must be called after `start()`.
    */
-  async exec({ log, command, container, ignoreError, stdout, stderr, timeout }: ExecParams) {
+  async exec(params: ExecParams) {
+    const { log, command, container, ignoreError, stdout, stderr, timeout } = params
+
     if (!this.proc) {
       throw new PodRunnerError(`Attempting to exec a command in Pod before starting it`, { command })
     }

--- a/garden-service/src/runtime-context.ts
+++ b/garden-service/src/runtime-context.ts
@@ -8,8 +8,7 @@
 
 import { getEnvVarName, uniqByName } from "./util/util"
 import { PrimitiveMap, joiEnvVars, joiPrimitive, joi, joiIdentifier } from "./config/common"
-import { Module } from "./types/module"
-import { moduleVersionSchema } from "./vcs/vcs"
+import { moduleVersionSchema, ModuleVersion } from "./vcs/vcs"
 import { Garden } from "./garden"
 import { ConfigGraph, DependencyRelations } from "./config-graph"
 import { ServiceStatus } from "./types/service"
@@ -65,10 +64,10 @@ export const runtimeContextSchema = joi
 interface PrepareRuntimeContextParams {
   garden: Garden
   graph: ConfigGraph
-  module: Module
   dependencies: DependencyRelations
   serviceStatuses: { [name: string]: ServiceStatus }
   taskResults: { [name: string]: RunTaskResult }
+  version: ModuleVersion
 }
 
 /**
@@ -81,12 +80,12 @@ interface PrepareRuntimeContextParams {
  */
 export async function prepareRuntimeContext({
   garden,
-  module,
   dependencies,
   serviceStatuses,
   taskResults,
+  version,
 }: PrepareRuntimeContextParams): Promise<RuntimeContext> {
-  const { versionString } = module.version
+  const { versionString } = version
   const envVars = {
     GARDEN_VERSION: versionString,
   }

--- a/garden-service/src/tasks/deploy.ts
+++ b/garden-service/src/tasks/deploy.ts
@@ -166,7 +166,7 @@ export class DeployTask extends BaseTask {
       garden: this.garden,
       graph: this.graph,
       dependencies,
-      module: this.service.module,
+      version: this.version,
       serviceStatuses,
       taskResults,
     })

--- a/garden-service/src/tasks/get-service-status.ts
+++ b/garden-service/src/tasks/get-service-status.ts
@@ -103,7 +103,7 @@ export class GetServiceStatusTask extends BaseTask {
       garden: this.garden,
       graph: this.graph,
       dependencies,
-      module: this.service.module,
+      version: this.version,
       serviceStatuses,
       taskResults,
     })

--- a/garden-service/src/tasks/task.ts
+++ b/garden-service/src/tasks/task.ts
@@ -144,7 +144,7 @@ export class TaskTask extends BaseTask {
       garden: this.garden,
       graph: this.graph,
       dependencies,
-      module: this.task.module,
+      version: this.task.module.version,
       serviceStatuses,
       taskResults,
     })

--- a/garden-service/src/tasks/test.ts
+++ b/garden-service/src/tasks/test.ts
@@ -160,7 +160,7 @@ export class TestTask extends BaseTask {
       garden: this.garden,
       graph: this.graph,
       dependencies,
-      module: this.module,
+      version: this.module.version,
       serviceStatuses,
       taskResults,
     })

--- a/garden-service/src/util/string.ts
+++ b/garden-service/src/util/string.ts
@@ -9,6 +9,7 @@
 import _dedent = require("dedent")
 import _deline = require("deline")
 import _urlJoin = require("proper-url-join")
+import CliTable from "cli-table3"
 
 // Exporting these here for convenience and ease of imports (otherwise we need to require modules instead of using
 // the import syntax, and it for some reason doesn't play nice with IDEs).
@@ -91,4 +92,35 @@ export function randomString(length = 8) {
  */
 export function splitLines(s: string) {
   return s.split(/\r?\n/)
+}
+
+const defaultTableConfig: CliTable.TableConstructorOptions = {
+  // chars: {
+  //   "top": "",
+  //   "top-mid": "",
+  //   "top-left": "",
+  //   "top-right": "",
+  //   "bottom": "",
+  //   "bottom-mid": "",
+  //   "bottom-left": "",
+  //   "bottom-right": "",
+  //   "left": "",
+  //   "left-mid": "",
+  //   "mid": " ",
+  //   "mid-mid": "",
+  //   "right": "",
+  //   "right-mid": "",
+  //   "middle": "",
+  // },
+  wordWrap: true,
+  // truncate: " ",
+}
+
+type TableRow = CliTable.CrossTableRow | CliTable.HorizontalTableRow | CliTable.VerticalTableRow
+
+export function renderTable(rows: TableRow[], opts?: CliTable.TableConstructorOptions) {
+  const table = new CliTable({ ...defaultTableConfig, ...(opts || {}) })
+  // The typings here are a complete mess
+  table.push(...(<any>rows))
+  return table.toString()
 }

--- a/garden-service/src/util/util.ts
+++ b/garden-service/src/util/util.ts
@@ -36,6 +36,7 @@ export type PickFromUnion<T, U extends T> = U
 export type ValueOf<T> = T[keyof T]
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 export type Diff<T, U> = T extends U ? never : T
+export type Mutable<T> = { -readonly [K in keyof T]: T[K] }
 export type Nullable<T> = { [P in keyof T]: T[P] | null }
 // From: https://stackoverflow.com/a/49936686/5629940
 export type DeepPartial<T> = {

--- a/garden-service/test/integ/src/plugins/kubernetes/container/container.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/container/container.ts
@@ -265,7 +265,7 @@ describe("kubernetes container module handlers", () => {
           run: [],
           test: [],
         },
-        module: service.module,
+        version: service.module.version,
         serviceStatuses: {},
         taskResults: {},
       })
@@ -299,7 +299,7 @@ describe("kubernetes container module handlers", () => {
           run: [],
           test: [],
         },
-        module: service.module,
+        version: service.module.version,
         serviceStatuses: {},
         taskResults: {},
       })

--- a/garden-service/test/unit/src/actions.ts
+++ b/garden-service/test/unit/src/actions.ts
@@ -80,7 +80,7 @@ describe("ActionRouter", () => {
         run: [],
         test: [],
       },
-      module,
+      version: module.version,
       serviceStatuses: {},
       taskResults: {},
     })
@@ -1388,7 +1388,7 @@ describe("ActionRouter", () => {
           run: [],
           test: [],
         },
-        module: serviceA.module,
+        version: serviceA.module.version,
         serviceStatuses: {
           "service-b": {
             state: "ready",
@@ -1439,7 +1439,7 @@ describe("ActionRouter", () => {
           run: [],
           test: [],
         },
-        module: serviceA.module,
+        version: serviceA.module.version,
         serviceStatuses: {},
         taskResults: {},
       })
@@ -1551,7 +1551,7 @@ describe("ActionRouter", () => {
           run: [],
           test: [],
         },
-        module: taskA.module,
+        version: taskA.module.version,
         serviceStatuses: {
           "service-b": {
             state: "ready",
@@ -1613,7 +1613,7 @@ describe("ActionRouter", () => {
           run: [],
           test: [],
         },
-        module: taskA.module,
+        version: taskA.module.version,
         // Omitting the service-b outputs here
         serviceStatuses: {},
         taskResults: {},

--- a/garden-service/test/unit/src/commands/get/get-outputs.ts
+++ b/garden-service/test/unit/src/commands/get/get-outputs.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import tmp from "tmp-promise"
+import { withDefaultGlobalOpts, TestGarden } from "../../../../helpers"
+import { GetOutputsCommand } from "../../../../../src/commands/get/get-outputs"
+import { ProjectConfig } from "../../../../../src/config/project"
+import { DEFAULT_API_VERSION } from "../../../../../src/constants"
+import { createGardenPlugin } from "../../../../../src/types/plugin/plugin"
+import { exec } from "../../../../../src/util/util"
+
+describe("GetOutputsCommand", () => {
+  const pluginName = "test-plugin"
+  const provider = pluginName
+  let tmpDir: tmp.DirectoryResult
+  let projectConfig: ProjectConfig
+
+  before(async () => {
+    tmpDir = await tmp.dir({ unsafeCleanup: true })
+
+    await exec("git", ["init"], { cwd: tmpDir.path })
+
+    projectConfig = {
+      apiVersion: DEFAULT_API_VERSION,
+      kind: "Project",
+      name: "test",
+      path: tmpDir.path,
+      defaultEnvironment: "default",
+      dotIgnoreFiles: [],
+      environments: [{ name: "default", variables: {} }],
+      providers: [{ name: "test" }],
+      variables: {},
+    }
+  })
+
+  it("should resolve and return defined project outputs", async () => {
+    const plugin = createGardenPlugin({
+      name: "test",
+      handlers: {
+        async getEnvironmentStatus() {
+          return { ready: true, outputs: { test: "test-value" } }
+        },
+      },
+    })
+
+    projectConfig.outputs = [{ name: "test", value: "${providers.test.outputs.test}" }]
+
+    const garden = await TestGarden.factory(tmpDir.path, {
+      plugins: [plugin],
+      config: projectConfig,
+    })
+
+    const log = garden.log
+    const command = new GetOutputsCommand()
+
+    const res = await command.action({
+      garden,
+      log,
+      headerLog: log,
+      footerLog: log,
+      args: { provider },
+      opts: withDefaultGlobalOpts({}),
+    })
+
+    expect(res.result).to.eql({
+      test: "test-value",
+    })
+  })
+})

--- a/garden-service/test/unit/src/config/config-context.ts
+++ b/garden-service/test/unit/src/config/config-context.ts
@@ -321,7 +321,7 @@ describe("ModuleConfigContext", () => {
           run: [taskB],
           test: [],
         },
-        module: serviceA.module,
+        version: serviceA.module.version,
         serviceStatuses: {
           "service-b": {
             state: "ready",

--- a/garden-service/test/unit/src/config/project.ts
+++ b/garden-service/test/unit/src/config/project.ts
@@ -34,6 +34,7 @@ describe("resolveProjectConfig", () => {
       defaultEnvironment: "default",
       dotIgnoreFiles: defaultDotIgnoreFiles,
       environments: [{ name: "default", variables: {} }],
+      outputs: [],
       providers: [{ name: "some-provider" }],
       variables: {},
     }
@@ -62,6 +63,7 @@ describe("resolveProjectConfig", () => {
       defaultEnvironment: "local",
       dotIgnoreFiles: defaultDotIgnoreFiles,
       environments: [],
+      outputs: [],
       providers: [{ name: "some-provider" }],
       variables: {},
     }
@@ -118,6 +120,7 @@ describe("resolveProjectConfig", () => {
           },
         },
       ],
+      outputs: [],
       sources: [
         {
           name: "foo",
@@ -178,6 +181,7 @@ describe("resolveProjectConfig", () => {
           },
         },
       ],
+      outputs: [],
       providers: [
         {
           name: "provider-a",
@@ -206,6 +210,7 @@ describe("resolveProjectConfig", () => {
       defaultEnvironment: "",
       dotIgnoreFiles: defaultDotIgnoreFiles,
       environments: [],
+      outputs: [],
       providers: [{ name: "some-provider" }],
       variables: {},
     }
@@ -228,6 +233,7 @@ describe("resolveProjectConfig", () => {
       defaultEnvironment: "",
       dotIgnoreFiles: defaultDotIgnoreFiles,
       environments: [],
+      outputs: [],
       providers: [{ name: "some-provider" }],
       variables: {},
     }
@@ -257,6 +263,7 @@ describe("resolveProjectConfig", () => {
           },
         },
       ],
+      outputs: [],
       providers: [
         {
           name: "provider-a",
@@ -284,6 +291,7 @@ describe("resolveProjectConfig", () => {
           },
         },
       ],
+      outputs: [],
       providers: [
         {
           name: "provider-a",
@@ -322,6 +330,7 @@ describe("resolveProjectConfig", () => {
           },
         },
       ],
+      outputs: [],
       providers: [
         {
           name: "provider-a",
@@ -344,6 +353,7 @@ describe("resolveProjectConfig", () => {
           },
         },
       ],
+      outputs: [],
       providers: [
         {
           name: "provider-a",

--- a/garden-service/test/unit/src/docs/config.ts
+++ b/garden-service/test/unit/src/docs/config.ts
@@ -296,17 +296,17 @@ describe("config", () => {
 
         key b
 
-        | Type     | Required | Allowed Values |
-        | -------- | -------- | -------------- |
-        | \`string\` | Yes      | "b"            |
+        | Type     | Allowed Values | Required |
+        | -------- | -------------- | -------- |
+        | \`string\` | "b"            | Yes      |
 
         #### \`testArray\`
 
         test array
 
-        | Type            | Required | Default |
-        | --------------- | -------- | ------- |
-        | \`array[number]\` | No       | \`[]\`    |\n
+        | Type            | Default | Required |
+        | --------------- | ------- | -------- |
+        | \`array[number]\` | \`[]\`    | No       |\n
       `)
     })
     it("should return the correct yaml", () => {

--- a/garden-service/test/unit/src/outputs.ts
+++ b/garden-service/test/unit/src/outputs.ts
@@ -1,0 +1,251 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import tmp from "tmp-promise"
+import { TestGarden } from "../../helpers"
+import { resolveProjectOutputs } from "../../../src/outputs"
+import { expect } from "chai"
+import { realpath } from "fs-extra"
+import { createGardenPlugin } from "../../../src/types/plugin/plugin"
+import { ProjectConfig } from "../../../src/config/project"
+import { DEFAULT_API_VERSION } from "../../../src/constants"
+import { exec } from "../../../src/util/util"
+import { ServiceState } from "../../../src/types/service"
+import { RunTaskResult } from "../../../src/types/plugin/task/runTask"
+
+describe("resolveProjectOutputs", () => {
+  let tmpDir: tmp.DirectoryResult
+  let tmpPath: string
+  let projectConfig: ProjectConfig
+
+  beforeEach(async () => {
+    tmpDir = await tmp.dir({ unsafeCleanup: true })
+    tmpPath = await realpath(tmpDir.path)
+    await exec("git", ["init"], { cwd: tmpPath })
+    projectConfig = {
+      apiVersion: DEFAULT_API_VERSION,
+      kind: "Project",
+      name: "test",
+      path: tmpPath,
+      defaultEnvironment: "default",
+      dotIgnoreFiles: [],
+      environments: [{ name: "default", variables: {} }],
+      providers: [{ name: "test" }],
+      variables: {},
+    }
+  })
+
+  afterEach(async () => {
+    await tmpDir.cleanup()
+  })
+
+  it("should return immediately if there are no outputs specified", async () => {
+    const garden = await TestGarden.factory(tmpPath, {
+      config: projectConfig,
+    })
+    const outputs = await resolveProjectOutputs(garden, garden.log)
+    expect(outputs).to.eql([])
+  })
+
+  it("should resolve provider output template references", async () => {
+    const plugin = createGardenPlugin({
+      name: "test",
+      handlers: {
+        async getEnvironmentStatus() {
+          return { ready: true, outputs: { test: "test-value" } }
+        },
+      },
+    })
+
+    projectConfig.outputs = [{ name: "test", value: "${providers.test.outputs.test}" }]
+
+    const garden = await TestGarden.factory(tmpPath, {
+      plugins: [plugin],
+      config: projectConfig,
+    })
+
+    const outputs = await resolveProjectOutputs(garden, garden.log)
+    expect(outputs).to.eql([{ name: "test", value: "test-value" }])
+  })
+
+  it("should resolve module output template references", async () => {
+    const plugin = createGardenPlugin({
+      name: "test",
+      handlers: {
+        async getEnvironmentStatus() {
+          return { ready: true, outputs: { test: "test-value" } }
+        },
+      },
+      createModuleTypes: [
+        {
+          name: "test",
+          docs: "test",
+          handlers: {},
+        },
+      ],
+    })
+
+    projectConfig.outputs = [{ name: "test", value: "${modules.test.outputs.test}" }]
+
+    const garden = await TestGarden.factory(tmpPath, {
+      plugins: [plugin],
+      config: projectConfig,
+    })
+
+    garden.setModuleConfigs([
+      {
+        apiVersion: DEFAULT_API_VERSION,
+        allowPublish: false,
+        build: { dependencies: [] },
+        disabled: false,
+        name: "test",
+        outputs: {
+          test: "test-value",
+        },
+        path: tmpPath,
+        serviceConfigs: [],
+        taskConfigs: [],
+        spec: {},
+        testConfigs: [],
+        type: "test",
+      },
+    ])
+
+    const outputs = await resolveProjectOutputs(garden, garden.log)
+    expect(outputs).to.eql([{ name: "test", value: "test-value" }])
+  })
+
+  it("should resolve service runtime output references", async () => {
+    const status = { state: <ServiceState>"ready", outputs: { test: "test-value" }, detail: {} }
+    const plugin = createGardenPlugin({
+      name: "test",
+      handlers: {},
+      createModuleTypes: [
+        {
+          name: "test",
+          docs: "test",
+          handlers: {
+            async getServiceStatus() {
+              return status
+            },
+            async deployService() {
+              return status
+            },
+          },
+        },
+      ],
+    })
+
+    projectConfig.outputs = [{ name: "test", value: "${runtime.services.test.outputs.test}" }]
+
+    const garden = await TestGarden.factory(tmpPath, {
+      plugins: [plugin],
+      config: projectConfig,
+    })
+
+    garden.setModuleConfigs([
+      {
+        apiVersion: DEFAULT_API_VERSION,
+        allowPublish: false,
+        build: { dependencies: [] },
+        disabled: false,
+        name: "test",
+        outputs: {
+          test: "test-value",
+        },
+        path: tmpPath,
+        serviceConfigs: [
+          {
+            name: "test",
+            dependencies: [],
+            disabled: false,
+            hotReloadable: false,
+            spec: {},
+          },
+        ],
+        taskConfigs: [],
+        spec: {},
+        testConfigs: [],
+        type: "test",
+      },
+    ])
+
+    const outputs = await resolveProjectOutputs(garden, garden.log)
+    expect(outputs).to.eql([{ name: "test", value: "test-value" }])
+  })
+
+  it("should resolve task runtime output references", async () => {
+    const result: RunTaskResult = {
+      command: ["whatever"],
+      completedAt: new Date(),
+      log: "hello",
+      moduleName: "test",
+      outputs: { log: "hello" },
+      startedAt: new Date(),
+      success: true,
+      taskName: "test",
+      version: "abcdef",
+    }
+
+    const plugin = createGardenPlugin({
+      name: "test",
+      handlers: {},
+      createModuleTypes: [
+        {
+          name: "test",
+          docs: "test",
+          handlers: {
+            async getTaskResult() {
+              return result
+            },
+            async runTask() {
+              return result
+            },
+          },
+        },
+      ],
+    })
+
+    projectConfig.outputs = [{ name: "test", value: "${runtime.tasks.test.outputs.log}" }]
+
+    const garden = await TestGarden.factory(tmpPath, {
+      plugins: [plugin],
+      config: projectConfig,
+    })
+
+    garden.setModuleConfigs([
+      {
+        apiVersion: DEFAULT_API_VERSION,
+        allowPublish: false,
+        build: { dependencies: [] },
+        disabled: false,
+        name: "test",
+        outputs: {
+          test: "test-value",
+        },
+        path: tmpPath,
+        serviceConfigs: [],
+        taskConfigs: [
+          {
+            name: "test",
+            dependencies: [],
+            disabled: false,
+            spec: {},
+            timeout: null,
+          },
+        ],
+        spec: {},
+        testConfigs: [],
+        type: "test",
+      },
+    ])
+
+    const outputs = await resolveProjectOutputs(garden, garden.log)
+    expect(outputs).to.eql([{ name: "test", value: "hello" }])
+  })
+})

--- a/garden-service/test/unit/src/runtime-context.ts
+++ b/garden-service/test/unit/src/runtime-context.ts
@@ -27,7 +27,7 @@ describe("prepareRuntimeContext", () => {
     const runtimeContext = await prepareRuntimeContext({
       garden,
       graph,
-      module,
+      version: module.version,
       dependencies: {
         build: [],
         deploy: [],
@@ -49,7 +49,7 @@ describe("prepareRuntimeContext", () => {
     const runtimeContext = await prepareRuntimeContext({
       garden,
       graph,
-      module,
+      version: module.version,
       dependencies: {
         build: [],
         deploy: [],
@@ -72,7 +72,7 @@ describe("prepareRuntimeContext", () => {
     const runtimeContext = await prepareRuntimeContext({
       garden,
       graph,
-      module,
+      version: module.version,
       dependencies: {
         build: [moduleB],
         deploy: [],
@@ -107,7 +107,7 @@ describe("prepareRuntimeContext", () => {
     const runtimeContext = await prepareRuntimeContext({
       garden,
       graph,
-      module,
+      version: module.version,
       dependencies: {
         build: [],
         deploy: [serviceB],
@@ -148,7 +148,7 @@ describe("prepareRuntimeContext", () => {
     const runtimeContext = await prepareRuntimeContext({
       garden,
       graph,
-      module,
+      version: module.version,
       dependencies: {
         build: [],
         deploy: [],
@@ -195,7 +195,7 @@ describe("prepareRuntimeContext", () => {
     const runtimeContext = await prepareRuntimeContext({
       garden,
       graph,
-      module,
+      version: module.version,
       dependencies: {
         build: [],
         deploy: [serviceB],
@@ -218,7 +218,7 @@ describe("prepareRuntimeContext", () => {
     const runtimeContext = await prepareRuntimeContext({
       garden,
       graph,
-      module,
+      version: module.version,
       dependencies: {
         build: [],
         deploy: [serviceB],


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds a facility for projects to export values, that can be viewed with the CLI and programmatically used by scripts. This is a foundational component of #1477.
