### PR TITLE
fix(k8s): hash configuration annotation

### DIFF
--- a/garden-service/src/plugins/kubernetes/util.ts
+++ b/garden-service/src/plugins/kubernetes/util.ts
@@ -12,6 +12,7 @@ import { V1Pod, V1EnvVar } from "@kubernetes/client-node"
 import { apply as jsonMerge } from "json-merge-patch"
 import chalk from "chalk"
 import hasha from "hasha"
+import stableStringify = require("json-stable-stringify")
 
 import { KubernetesResource, KubernetesWorkload, KubernetesPod, KubernetesServerResource } from "./types"
 import { splitLast, serializeValues, findByName } from "../../util/util"
@@ -33,6 +34,14 @@ export const workloadTypes = ["Deployment", "DaemonSet", "ReplicaSet", "Stateful
 
 export function getAnnotation(obj: KubernetesResource, key: string): string | null {
   return get(obj, ["metadata", "annotations", key])
+}
+
+/**
+ * Returns a hash of the manifest. We use this instead of the raw manifest when setting the
+ * "manifest-hash" annotation. This prevents "Too long annotation" errors for long manifests.
+ */
+export async function hashManifest(manifest: KubernetesResource) {
+  return hasha(stableStringify(manifest), { algorithm: "sha256" })
 }
 
 /**

--- a/garden-service/src/util/string.ts
+++ b/garden-service/src/util/string.ts
@@ -23,7 +23,7 @@ export type GardenAnnotationKey =
   | "generated"
   | "helm-migrated"
   | "hot-reload"
-  | "last-applied-configuration"
+  | "manifest-hash"
   | "module"
   | "moduleVersion"
   | "service"


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously we stored the raw manifest under the
garden.io/last-applied-configuration. We now hash it and store it under
garden.io/manifest-hash. This prevents errors when then annotation
string gets too long.

**Which issue(s) this PR fixes**:

Fixes #1496 