### PR TITLE
fix(k8s): ensure system namespace exists before using it

### DIFF
--- a/garden-service/src/plugins/kubernetes/commands/cluster-init.ts
+++ b/garden-service/src/plugins/kubernetes/commands/cluster-init.ts
@@ -11,6 +11,7 @@ import { prepareSystem, getEnvironmentStatus } from "../init"
 import chalk from "chalk"
 import { helm } from "../helm/helm-cli"
 import { KubernetesPluginContext, KubernetesProvider } from "../config"
+import { getSystemNamespace } from "../namespace"
 
 export const clusterInit: PluginCommand = {
   name: "cluster-init",
@@ -41,11 +42,12 @@ export const clusterInit: PluginCommand = {
 
     log.info("Cleaning up old resources...")
 
+    const systemNamespace = await getSystemNamespace(provider, log)
     try {
       await helm({
         ctx: k8sCtx,
         log,
-        namespace: provider.config.gardenSystemNamespace,
+        namespace: systemNamespace,
         args: ["delete", "--purge", "garden-nfs-provisioner"],
       })
     } catch (_) {}

--- a/garden-service/src/plugins/kubernetes/container/util.ts
+++ b/garden-service/src/plugins/kubernetes/container/util.ts
@@ -12,10 +12,10 @@ import { getPortForward } from "../port-forward"
 import { CLUSTER_REGISTRY_DEPLOYMENT_NAME, CLUSTER_REGISTRY_PORT } from "../constants"
 import { containerHelpers } from "../../container/helpers"
 import { PluginError } from "../../../exceptions"
-import { PluginContext } from "../../../plugin-context"
 import { LogEntry } from "../../../logger/log-entry"
 import { KubernetesPluginContext } from "../config"
 import axios, { AxiosRequestConfig } from "axios"
+import { getSystemNamespace } from "../namespace"
 
 export async function queryRegistry(
   ctx: KubernetesPluginContext,
@@ -30,8 +30,8 @@ export async function queryRegistry(
   return axios({ url, ...opts })
 }
 
-export async function getRegistryPortForward(ctx: PluginContext, log: LogEntry) {
-  const systemNamespace = ctx.provider.config.gardenSystemNamespace
+export async function getRegistryPortForward(ctx: KubernetesPluginContext, log: LogEntry) {
+  const systemNamespace = await getSystemNamespace(ctx.provider, log)
 
   return getPortForward({
     ctx,

--- a/garden-service/src/plugins/kubernetes/kubernetes.ts
+++ b/garden-service/src/plugins/kubernetes/kubernetes.ts
@@ -10,7 +10,7 @@ import Bluebird from "bluebird"
 
 import { createGardenPlugin } from "../../types/plugin/plugin"
 import { helmHandlers } from "./helm/handlers"
-import { getAppNamespace, getMetadataNamespace } from "./namespace"
+import { getAppNamespace, getMetadataNamespace, getSystemNamespace } from "./namespace"
 import { getSecret, setSecret, deleteSecret } from "./secrets"
 import { getEnvironmentStatus, prepareEnvironment, cleanupEnvironment } from "./init"
 import { containerHandlers } from "./container/handlers"
@@ -126,7 +126,7 @@ export async function debugInfo({ ctx, log, includeProject }: GetDebugInfoParams
   const provider = k8sCtx.provider
   const entry = log.info({ section: ctx.provider.name, msg: "collecting provider configuration", status: "active" })
 
-  const systemNamespace = ctx.provider.config.gardenSystemNamespace
+  const systemNamespace = await getSystemNamespace(provider, log)
   const systemMetadataNamespace = getSystemMetadataNamespaceName(provider.config)
 
   const namespacesList = [systemNamespace, systemMetadataNamespace]

--- a/garden-service/src/plugins/kubernetes/namespace.ts
+++ b/garden-service/src/plugins/kubernetes/namespace.ts
@@ -88,6 +88,15 @@ export async function getNamespace({
   return namespace
 }
 
+export async function getSystemNamespace(provider: KubernetesProvider, log: LogEntry): Promise<string> {
+  const namespace = provider.config.gardenSystemNamespace
+
+  const api = await KubeApi.factory(log, provider)
+  await ensureNamespace(api, namespace)
+
+  return namespace
+}
+
 export async function getAppNamespace(ctx: PluginContext, log: LogEntry, provider: KubernetesProvider) {
   return getNamespace({
     log,

--- a/garden-service/src/plugins/kubernetes/system.ts
+++ b/garden-service/src/plugins/kubernetes/system.ts
@@ -16,7 +16,7 @@ import { Garden } from "../../garden"
 import { KubernetesPluginContext, KubernetesConfig } from "./config"
 import { LogEntry } from "../../logger/log-entry"
 import { KubeApi } from "./api"
-import { createNamespace } from "./namespace"
+import { createNamespace, getSystemNamespace } from "./namespace"
 import { getPackageVersion } from "../../util/util"
 import { deline, gardenAnnotationKey } from "../../util/string"
 import { deleteNamespaces } from "./namespace"
@@ -50,7 +50,7 @@ export async function getSystemGarden(
   variables: PrimitiveMap,
   log: LogEntry
 ): Promise<Garden> {
-  const systemNamespace = ctx.provider.config.gardenSystemNamespace
+  const systemNamespace = await getSystemNamespace(ctx.provider, log)
 
   const sysProvider: KubernetesConfig = {
     ...ctx.provider.config,

--- a/garden-service/src/plugins/kubernetes/test-results.ts
+++ b/garden-service/src/plugins/kubernetes/test-results.ts
@@ -21,6 +21,7 @@ import hasha from "hasha"
 import { gardenAnnotationKey } from "../../util/string"
 import { upsertConfigMap } from "./util"
 import { trimRunOutput } from "./helm/common"
+import { getSystemNamespace } from "./namespace"
 
 export async function getTestResult({
   ctx,
@@ -31,7 +32,7 @@ export async function getTestResult({
 }: GetTestResultParams<ContainerModule | HelmModule | KubernetesModule>): Promise<TestResult | null> {
   const k8sCtx = <KubernetesPluginContext>ctx
   const api = await KubeApi.factory(log, k8sCtx.provider)
-  const testResultNamespace = k8sCtx.provider.config.gardenSystemNamespace
+  const testResultNamespace = await getSystemNamespace(k8sCtx.provider, log)
 
   const resultKey = getTestResultKey(k8sCtx, module, testName, testVersion)
 
@@ -92,7 +93,7 @@ export async function storeTestResult({
 }: StoreTestResultParams): Promise<TestResult> {
   const k8sCtx = <KubernetesPluginContext>ctx
   const api = await KubeApi.factory(log, k8sCtx.provider)
-  const testResultNamespace = k8sCtx.provider.config.gardenSystemNamespace
+  const testResultNamespace = await getSystemNamespace(k8sCtx.provider, log)
 
   const data: TestResult = trimRunOutput(result)
 

--- a/garden-service/src/plugins/kubernetes/util.ts
+++ b/garden-service/src/plugins/kubernetes/util.ts
@@ -27,6 +27,7 @@ import { HelmModule } from "./helm/config"
 import { KubernetesModule } from "./kubernetes-module/config"
 import { getChartPath, renderHelmTemplateString } from "./helm/common"
 import { HotReloadableResource } from "./hot-reload"
+import { getSystemNamespace } from "./namespace"
 
 const STATIC_LABEL_REGEX = /[0-9]/g
 export const workloadTypes = ["Deployment", "DaemonSet", "ReplicaSet", "StatefulSet"]
@@ -383,7 +384,7 @@ export function convertDeprecatedManifestVersion(manifest: KubernetesResource): 
 
 export async function getRunningPodInDeployment(deploymentName: string, provider: KubernetesProvider, log: LogEntry) {
   const api = await KubeApi.factory(log, provider)
-  const systemNamespace = provider.config.gardenSystemNamespace
+  const systemNamespace = await getSystemNamespace(provider, log)
 
   const status = await api.apps.readNamespacedDeployment(deploymentName, systemNamespace)
   const pods = await getPods(api, systemNamespace, status.spec.selector.matchLabels)


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, we would just read the system namespace from the provider config and then execute commands in it without ensuring that it exists. Usually the system namespace gets created during the prepare/init environment flow but not if the project doesn't have any system services.

Now we instead ensure that the namespace exists before passing it off to commands that use it. 

**Which issue(s) this PR fixes**:

Fixes #1464 