### PR TITLE
fix(core): make test task deps hot-reload aware

### DIFF
--- a/garden-service/src/commands/dev.ts
+++ b/garden-service/src/commands/dev.ts
@@ -204,6 +204,7 @@ export class DevCommand extends Command<DevCommandArgs, DevCommandOpts> {
                   module: m,
                   graph: updatedGraph,
                   filterNames,
+                  hotReloadServiceNames,
                 })
               )
             )

--- a/garden-service/test/unit/src/tasks/test.ts
+++ b/garden-service/test/unit/src/tasks/test.ts
@@ -8,7 +8,7 @@
 
 import { expect } from "chai"
 import { resolve } from "path"
-import { TestTask } from "../../../../src/tasks/test"
+import { TestTask, getTestTasks } from "../../../../src/tasks/test"
 import td from "testdouble"
 import { Garden } from "../../../../src/garden"
 import { dataDir, makeTestGarden } from "../../../helpers"
@@ -94,6 +94,26 @@ describe("TestTask", () => {
       const deps = await task.getDependencies()
 
       expect(deps.map((d) => d.getKey())).to.eql(["build.module-a", "deploy.service-b", "task.task-a"])
+    })
+  })
+
+  describe("getTestTasks", () => {
+    it("should not return test tasks with deploy dependencies on services deployed with hot reloading", async () => {
+      const moduleA = await graph.getModule("module-a")
+
+      const tasks = await getTestTasks({
+        garden,
+        log,
+        graph,
+        module: moduleA,
+        hotReloadServiceNames: ["service-b"],
+      })
+
+      const testTask = tasks[0]
+      const deps = await testTask.getDependencies()
+
+      expect(tasks.length).to.eql(1)
+      expect(deps.map((d) => d.getKey())).to.eql(["build.module-a", "task.task-a"])
     })
   })
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

Before this fix, the `getDependencies` method of `TestTask` returned deploy tasks without the hot reload flag set appropriately.

This meant that repeated hot reloads of services with test dependants would fail (because the test dependant would redeploy the service without hot reloading enabled) when using the dev command.

**Which issue(s) this PR fixes**:

Fixes #1552.

**Special notes for your reviewer**:

Do we think this needs additional test cases? Or is this fine as is?