### PR TITLE
chore(pr-template): remove task list

### DIFF
--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -13,7 +13,7 @@ labels: feature request
 
 ### What should the user be able to do?
 
-<!-- A clear and concise description of your use-case -->
+<!-- A clear and concise description of your use-case. -->
 
 ### Why do they want to do this? What problem does it solve?
 
@@ -25,7 +25,10 @@ labels: feature request
 
 ### How important is this feature for you/your team?
 
-- [ ] Crucial (Garden is unusable for us without it)
-- [ ] High (Not having this feature makes using Garden painful)
-- [ ] Medium (Using Garden without it is mildly inconvenient)
-- [ ] Low (Nice to have someday)
+<!-- Please pick one from the list below. -->
+
+🥀 Crucial, Garden is unusable for us without it
+
+🌵 Not having this feature makes using Garden painful
+
+🌹 It’s a nice to have, but nice things are nice 🙂


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove task list from PR template because GitHub renders it like this:

<img width="166" alt="Screenshot 2020-01-28 at 20 59 42" src="https://user-images.githubusercontent.com/5373776/73300363-2ae8d280-4211-11ea-9414-771493140eda.png">

...which is confusing.