### PR TITLE
fix(k8s): provider init errors weren't handled properly

### DIFF
--- a/garden-service/src/plugins/kubernetes/system.ts
+++ b/garden-service/src/plugins/kubernetes/system.ts
@@ -7,7 +7,6 @@
  */
 
 import { join } from "path"
-import { values } from "lodash"
 import { V1Namespace } from "@kubernetes/client-node"
 import semver from "semver"
 
@@ -159,7 +158,7 @@ export async function getSystemServiceStatus({ sysGarden, log, serviceNames }: G
     log: log.placeholder(LogLevel.verbose, true),
     serviceNames,
   })
-  const state = combineStates(values(serviceStatuses).map((s) => (s && s.state) || "unknown"))
+  const state = combineStates(Object.values(serviceStatuses).map((s) => (s && s.state) || "unknown"))
 
   return {
     state,
@@ -202,7 +201,7 @@ export async function prepareSystemServices({
       forceBuild: force,
     })
 
-    const failed = values(results.taskResults)
+    const failed = Object.values(results)
       .filter((r) => r && r.error)
       .map((r) => r!)
     const errors = failed.map((r) => r.error)


### PR DESCRIPTION
Just noticed this while looking into something else. Turns out the `values` lodash function isn't type-safe, so we missed a change during refactoring, and we shouldn't be using that anyway.