### PR TITLE
feat(distribution): add container image baked with AWS CLI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,6 +286,21 @@ jobs:
             cd garden-service
             docker build -t ${TAG} -f Dockerfile .
             docker push ${TAG}
+  build-docker-aws:
+    <<: *node-config
+    steps:
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - checkout
+      - *attach-workspace
+      - run:
+          name: Build image and push to registry
+          command: |
+            docker login -u $DOCKER_USER -p $DOCKER_PASS
+            TAG=gardendev/garden-aws:${CIRCLE_SHA1}
+            cd garden-service
+            docker build -t ${TAG} --build-arg TAG=${CIRCLE_SHA1} -f aws.Dockerfile .
+            docker push ${TAG}
   build-docker-gcloud:
     <<: *node-config
     steps:
@@ -549,6 +564,10 @@ workflows:
           <<: *only-internal-prs
           context: docker
           requires: [build]
+      - build-docker-aws:
+          <<: *only-internal-prs
+          context: docker
+          requires: [build-docker]
       - build-docker-gcloud:
           <<: *only-internal-prs
           context: docker

--- a/garden-service/Dockerfile
+++ b/garden-service/Dockerfile
@@ -23,7 +23,8 @@ RUN npm install \
     /usr/lib/node_modules/npm/html/* \
     /usr/lib/node_modules/npm/scripts/*
 
-ADD bin /tmp/bin
+ADD bin/garden /tmp/bin/garden
+ADD bin/garden-debug /tmp/bin/garden-debug
 ADD build /tmp/build
 
 RUN node_modules/.bin/pkg --target node12-alpine-x64 . \

--- a/garden-service/aws.Dockerfile
+++ b/garden-service/aws.Dockerfile
@@ -1,0 +1,6 @@
+ARG TAG=latest
+FROM gardendev/garden:${TAG}
+
+RUN apk add --no-cache python py-pip \
+  && pip install awscli==1.17.9 --upgrade \
+  && apk del py-pip

--- a/garden-service/bin/build-containers.sh
+++ b/garden-service/bin/build-containers.sh
@@ -8,6 +8,7 @@ args=( $@ )
 version=${args[0]:-$(git rev-parse --short HEAD)}
 
 base_tag=gardendev/garden:${version}
+aws_tag=gardendev/garden-aws:${version}
 gcloud_tag=gardendev/garden-gcloud:${version}
 buster_tag=gardendev/garden:${version}-buster
 
@@ -17,6 +18,12 @@ echo "-> Build ${base_tag}"
 docker build -t ${base_tag} -f Dockerfile .
 echo "-> Check ${base_tag}"
 docker run --rm -it ${base_tag} version
+
+echo "-> Build ${aws_tag}"
+docker build -t ${aws_tag} --build-arg TAG=${version} -f aws.Dockerfile .
+echo "-> Check ${aws_tag}"
+docker run --rm -it ${aws_tag} version
+docker run --rm -it --entrypoint=aws ${aws_tag} --version
 
 echo "-> Build ${gcloud_tag}"
 docker build -t ${gcloud_tag} --build-arg TAG=${version} -f gcloud.Dockerfile .

--- a/garden-service/bin/push-containers.sh
+++ b/garden-service/bin/push-containers.sh
@@ -12,5 +12,6 @@ version=${args[0]:-$(git rev-parse --short HEAD)}
 echo "Pushing images"
 
 docker push gardendev/garden:${version}
+docker push gardendev/garden-aws:${version}
 docker push gardendev/garden-gcloud:${version}
 docker push gardendev/garden:${version}-buster


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a `gardendev/garden-aws` image to Docker Hub, that bundles the AWS CLI for convenience and use in CI.
