### PR TITLE
fix(cli): add exclude-disabled option to get config command

### DIFF
--- a/dashboard/src/api/api.ts
+++ b/dashboard/src/api/api.ts
@@ -24,7 +24,7 @@ export interface ApiRequest {
 const MAX_LOG_LINES = 5000
 
 export async function fetchConfig() {
-  return apiPost<ConfigDump>("get.config")
+  return apiPost<ConfigDump>("get.config", { "exclude-disabled": true })
 }
 
 export async function fetchGraph() {

--- a/dashboard/src/containers/overview.tsx
+++ b/dashboard/src/containers/overview.tsx
@@ -104,9 +104,9 @@ export default () => {
   }
 
   const moduleProps: ModuleProps[] = Object.values(modules).map((module: Module) => {
-    const serviceEntities = module.services.map((serviceKey) => services[serviceKey]) || []
-    const testEntities = module.tests.map((testKey) => tests[testKey]) || []
-    const taskEntities = module.tasks.map((taskKey) => tasks[taskKey]) || []
+    const serviceEntities = module.services.map((serviceKey) => services[serviceKey]).filter(Boolean)
+    const testEntities = module.tests.map((testKey) => tests[testKey]).filter(Boolean)
+    const taskEntities = module.tasks.map((taskKey) => tasks[taskKey]).filter(Boolean)
 
     return {
       name: module.name,

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -259,7 +259,13 @@ Outputs the fully resolved configuration for this project and environment.
 
 ##### Usage
 
-    garden get config 
+    garden get config [options]
+
+##### Options
+
+| Argument | Alias | Type | Description |
+| -------- | ----- | ---- | ----------- |
+  | `--exclude-disabled` |  | boolean | Exclude disabled module, service, test, and task configs from output.
 
 ### garden get eysi
 

--- a/garden-service/test/unit/src/commands/get/get-config.ts
+++ b/garden-service/test/unit/src/commands/get/get-config.ts
@@ -10,6 +10,7 @@ import { expect } from "chai"
 import { makeTestGardenA, withDefaultGlobalOpts } from "../../../../helpers"
 import { GetConfigCommand } from "../../../../../src/commands/get/get-config"
 import { sortBy } from "lodash"
+import { DEFAULT_API_VERSION } from "../../../../../src/constants"
 
 describe("GetConfigCommand", () => {
   const pluginName = "test-plugin"
@@ -36,6 +37,360 @@ describe("GetConfigCommand", () => {
       providers,
       variables: garden.variables,
       moduleConfigs: sortBy(await garden["resolveModuleConfigs"](log), "name"),
+      projectRoot: garden.projectRoot,
+    }
+
+    expect(config).to.deep.equal(res.result)
+  })
+
+  it("should exclude disabled module configs", async () => {
+    const garden = await makeTestGardenA()
+    const log = garden.log
+    const command = new GetConfigCommand()
+
+    garden.setModuleConfigs([
+      {
+        apiVersion: DEFAULT_API_VERSION,
+        allowPublish: false,
+        build: { dependencies: [] },
+        disabled: true,
+        name: "a-disabled",
+        include: [],
+        outputs: {},
+        path: garden.projectRoot,
+        serviceConfigs: [],
+        taskConfigs: [],
+        spec: {
+          services: [
+            {
+              name: "service",
+              dependencies: [],
+              disabled: false,
+              spec: {},
+            },
+          ],
+        },
+        testConfigs: [],
+        type: "test",
+      },
+      {
+        apiVersion: DEFAULT_API_VERSION,
+        allowPublish: false,
+        build: { dependencies: [] },
+        disabled: false,
+        include: [],
+        name: "b-enabled",
+        outputs: {},
+        path: garden.projectRoot,
+        serviceConfigs: [],
+        taskConfigs: [],
+        spec: {
+          services: [
+            {
+              name: "service",
+              dependencies: [],
+              disabled: false,
+              spec: {},
+            },
+          ],
+        },
+        testConfigs: [],
+        type: "test",
+      },
+    ])
+
+    const res = await command.action({
+      garden,
+      log,
+      headerLog: log,
+      footerLog: log,
+      args: { provider },
+      opts: withDefaultGlobalOpts({ "exclude-disabled": true }),
+    })
+
+    const providers = await garden.resolveProviders()
+
+    // Remove the disabled config, the first one in the array
+    let expectedModuleConfigs = sortBy(await garden["resolveModuleConfigs"](log), "name").slice(1)
+
+    const config = {
+      environmentName: garden.environmentName,
+      providers,
+      variables: garden.variables,
+      moduleConfigs: expectedModuleConfigs,
+      projectRoot: garden.projectRoot,
+    }
+
+    expect(config).to.deep.equal(res.result)
+  })
+
+  it("should exclude disabled service configs", async () => {
+    const garden = await makeTestGardenA()
+    const log = garden.log
+    const command = new GetConfigCommand()
+
+    garden.setModuleConfigs([
+      {
+        apiVersion: DEFAULT_API_VERSION,
+        allowPublish: false,
+        build: { dependencies: [] },
+        disabled: false,
+        name: "enabled",
+        include: [],
+        outputs: {},
+        path: garden.projectRoot,
+        serviceConfigs: [],
+        taskConfigs: [],
+        spec: {
+          services: [
+            {
+              name: "service-disabled",
+              dependencies: [],
+              disabled: true,
+              hotReloadable: false,
+              spec: {},
+            },
+            {
+              name: "service-enabled",
+              dependencies: [],
+              disabled: false,
+              hotReloadable: false,
+              spec: {},
+            },
+          ],
+          tasks: [
+            {
+              name: "task-enabled",
+              dependencies: [],
+              disabled: false,
+            },
+          ],
+        },
+        testConfigs: [],
+        type: "test",
+      },
+    ])
+
+    const res = await command.action({
+      garden,
+      log,
+      headerLog: log,
+      footerLog: log,
+      args: { provider },
+      opts: withDefaultGlobalOpts({ "exclude-disabled": true }),
+    })
+
+    const providers = await garden.resolveProviders()
+
+    const expectedModuleConfigs = await garden["resolveModuleConfigs"](log)
+    // Remove the disabled service
+    expectedModuleConfigs[0].serviceConfigs = [
+      {
+        name: "service-enabled",
+        dependencies: [],
+        disabled: false,
+        sourceModuleName: undefined,
+        spec: {
+          name: "service-enabled",
+          dependencies: [],
+          disabled: false,
+          hotReloadable: false,
+          spec: {},
+          annotations: {},
+          daemon: false,
+          ingresses: [],
+          env: {},
+          limits: {
+            cpu: 1000,
+            memory: 1024,
+          },
+          ports: [],
+          volumes: [],
+        },
+        hotReloadable: false,
+      },
+    ]
+
+    const config = {
+      environmentName: garden.environmentName,
+      providers,
+      variables: garden.variables,
+      moduleConfigs: expectedModuleConfigs,
+      projectRoot: garden.projectRoot,
+    }
+
+    expect(config).to.deep.equal(res.result)
+  })
+
+  it("should exclude disabled task configs", async () => {
+    const garden = await makeTestGardenA()
+    const log = garden.log
+    const command = new GetConfigCommand()
+
+    garden.setModuleConfigs([
+      {
+        apiVersion: DEFAULT_API_VERSION,
+        allowPublish: false,
+        build: { dependencies: [] },
+        disabled: false,
+        name: "enabled",
+        include: [],
+        outputs: {},
+        path: garden.projectRoot,
+        serviceConfigs: [],
+        taskConfigs: [],
+        spec: {
+          services: [
+            {
+              name: "service",
+              dependencies: [],
+              disabled: false,
+              spec: {},
+            },
+          ],
+          tasks: [
+            {
+              name: "task-disabled",
+              dependencies: [],
+              disabled: true,
+            },
+            {
+              name: "task-enabled",
+              dependencies: [],
+              disabled: false,
+            },
+          ],
+        },
+        testConfigs: [],
+        type: "test",
+      },
+    ])
+
+    const res = await command.action({
+      garden,
+      log,
+      headerLog: log,
+      footerLog: log,
+      args: { provider },
+      opts: withDefaultGlobalOpts({ "exclude-disabled": true }),
+    })
+
+    const providers = await garden.resolveProviders()
+
+    const expectedModuleConfigs = await garden["resolveModuleConfigs"](log)
+    // Remove the disabled task
+    expectedModuleConfigs[0].taskConfigs = [
+      {
+        name: "task-enabled",
+        dependencies: [],
+        disabled: false,
+        spec: {
+          name: "task-enabled",
+          dependencies: [],
+          disabled: false,
+          timeout: null,
+          env: {},
+        },
+        timeout: null,
+      },
+    ]
+
+    const config = {
+      environmentName: garden.environmentName,
+      providers,
+      variables: garden.variables,
+      moduleConfigs: expectedModuleConfigs,
+      projectRoot: garden.projectRoot,
+    }
+
+    expect(config).to.deep.equal(res.result)
+  })
+
+  it("should exclude disabled test configs", async () => {
+    const garden = await makeTestGardenA()
+    const log = garden.log
+    const command = new GetConfigCommand()
+
+    garden.setModuleConfigs([
+      {
+        apiVersion: DEFAULT_API_VERSION,
+        allowPublish: false,
+        build: { dependencies: [] },
+        disabled: false,
+        name: "enabled",
+        include: [],
+        outputs: {},
+        path: garden.projectRoot,
+        serviceConfigs: [],
+        taskConfigs: [],
+        spec: {
+          services: [
+            {
+              name: "service",
+              dependencies: [],
+              disabled: false,
+              spec: {},
+            },
+          ],
+          tasks: [
+            {
+              name: "task-enabled",
+              dependencies: [],
+              disabled: false,
+            },
+          ],
+          tests: [
+            {
+              name: "test-enabled",
+              dependencies: [],
+              disabled: false,
+            },
+            {
+              name: "test-disabled",
+              dependencies: [],
+              disabled: true,
+            },
+          ],
+        },
+        testConfigs: [],
+        type: "test",
+      },
+    ])
+
+    const res = await command.action({
+      garden,
+      log,
+      headerLog: log,
+      footerLog: log,
+      args: { provider },
+      opts: withDefaultGlobalOpts({ "exclude-disabled": true }),
+    })
+
+    const providers = await garden.resolveProviders()
+
+    const expectedModuleConfigs = await garden["resolveModuleConfigs"](log)
+    // Remove the disabled task
+    expectedModuleConfigs[0].testConfigs = [
+      {
+        name: "test-enabled",
+        dependencies: [],
+        disabled: false,
+        spec: {
+          name: "test-enabled",
+          dependencies: [],
+          disabled: false,
+          timeout: null,
+          env: {},
+        },
+        timeout: null,
+      },
+    ]
+
+    const config = {
+      environmentName: garden.environmentName,
+      providers,
+      variables: garden.variables,
+      moduleConfigs: expectedModuleConfigs,
       projectRoot: garden.projectRoot,
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `exclude-disabled` option to the `garden get config` command and use it in the dashboard when loading the config. Otherwise, the dashboard fails to render if there are disabled services in the config.

We might want to re-think how we display disabled entities in the dashboard in general but at least this fixes the rendering error. 

We also need to do the same for the `get graph` command although that's more complex since disabled modules may be built if they other modules depend on them.