### PR TITLE
fix(k8s): tasks and tests would sometimes return empty logs

### DIFF
--- a/garden-service/src/plugins/kubernetes/api.ts
+++ b/garden-service/src/plugins/kubernetes/api.ts
@@ -441,10 +441,12 @@ export class KubeApi {
           if (typeof output.then === "function") {
             return (
               output
-                // return the result body direcly
+                // return the result body directly if applicable
                 .then((res: any) => {
-                  if (isPlainObject(res) && res["body"] !== undefined) {
+                  if (isPlainObject(res) && res.hasOwnProperty("body")) {
                     return res["body"]
+                  } else {
+                    return res
                   }
                 })
                 // the API errors are not properly formed Error objects

--- a/garden-service/src/plugins/kubernetes/status/pod.ts
+++ b/garden-service/src/plugins/kubernetes/status/pod.ts
@@ -57,51 +57,88 @@ export function checkWorkloadPodStatus(
   return { state: combineStates(pods.map(checkPodStatus)), resource }
 }
 
+export async function getPodLogs({
+  api,
+  namespace,
+  podName,
+  containerNames,
+  byteLimit,
+  lineLimit,
+}: {
+  api: KubeApi
+  namespace: string
+  podName: string
+  containerNames?: string[]
+  byteLimit?: number
+  lineLimit?: number
+}) {
+  let podRes: V1Pod
+
+  try {
+    podRes = await api.core.readNamespacedPod(podName, namespace)
+  } catch (err) {
+    if (err.code === 404) {
+      return []
+    } else {
+      throw err
+    }
+  }
+
+  let podContainers = podRes.spec!.containers.map((c) => c.name).filter((n) => !n.match(/garden-/))
+
+  if (containerNames) {
+    podContainers = podContainers.filter((name) => containerNames.includes(name))
+  }
+
+  return Bluebird.map(podContainers, async (containerName) => {
+    let log = ""
+
+    try {
+      log = await api.core.readNamespacedPodLog(
+        podName,
+        namespace,
+        containerName,
+        false, // follow
+        byteLimit,
+        undefined, // pretty
+        false, // previous
+        undefined, // sinceSeconds
+        lineLimit
+      )
+    } catch (err) {
+      if (err instanceof KubernetesError && err.message.includes("waiting to start")) {
+        log = ""
+      } else {
+        throw err
+      }
+    }
+
+    // the API returns undefined if no logs have been output, for some reason
+    return { containerName, log: log || "" }
+  })
+}
+
 /**
  * Get a formatted list of log tails for each of the specified pods. Used for debugging and error logs.
  */
-export async function getPodLogs(api: KubeApi, namespace: string, podNames: string[]): Promise<string> {
-  const allLogs = await Bluebird.map(podNames, async (name) => {
-    let containerName: string | undefined
-
-    try {
-      const podRes = await api.core.readNamespacedPod(name, namespace)
-      const containerNames = podRes.spec.containers.map((c) => c.name)
-      if (containerNames.length > 1) {
-        containerName = containerNames.filter((n) => !n.match(/garden-/))[0] || containerNames[0]
-      } else {
-        containerName = containerNames[0]
-      }
-    } catch (err) {
-      if (err.code === 404) {
-        return ""
-      } else {
-        throw err
-      }
-    }
-
-    // Putting 5000 bytes as a length limit in addition to the line limit, just as a precaution in case someone
-    // accidentally logs a binary file or something.
-    try {
-      const log = await api.core.readNamespacedPodLog(
-        name,
-        namespace,
-        containerName,
-        false,
-        5000,
-        undefined,
-        false,
-        undefined,
-        podLogLines
-      )
-      return log ? chalk.blueBright(`\n****** ${name} ******\n`) + log : ""
-    } catch (err) {
-      if (err instanceof KubernetesError && err.message.includes("waiting to start")) {
-        return ""
-      } else {
-        throw err
-      }
+export async function getFormattedPodLogs(api: KubeApi, namespace: string, podNames: string[]): Promise<string> {
+  const allLogs = await Bluebird.map(podNames, async (podName) => {
+    return {
+      podName,
+      // Putting 5000 bytes as a length limit in addition to the line limit, just as a precaution in case someone
+      // accidentally logs a binary file or something.
+      containers: await getPodLogs({ api, namespace, podName, byteLimit: 5000, lineLimit: podLogLines }),
     }
   })
-  return allLogs.filter((l) => l !== "").join("\n\n")
+
+  return allLogs
+    .map(({ podName, containers }) => {
+      return (
+        chalk.blueBright(`\n****** ${podName} ******\n`) +
+        containers.map(({ containerName, log }) => {
+          return chalk.gray(`------ ${containerName} ------`) + (log || "<no logs>")
+        })
+      )
+    })
+    .join("\n\n")
 }

--- a/garden-service/src/plugins/kubernetes/status/workload.ts
+++ b/garden-service/src/plugins/kubernetes/status/workload.ts
@@ -21,7 +21,7 @@ import {
 } from "@kubernetes/client-node"
 import dedent = require("dedent")
 import { getCurrentWorkloadPods } from "../util"
-import { getPodLogs, podLogLines } from "./pod"
+import { getFormattedPodLogs, podLogLines } from "./pod"
 import { ResourceStatus, StatusHandlerParams } from "./status"
 import { getResourceEvents } from "./events"
 
@@ -83,7 +83,7 @@ export async function checkWorkloadStatus({ api, namespace, resource }: StatusHa
 
     // Attach pod logs for debug output
     const podNames = (await getPods()).map((pod) => pod.metadata.name)
-    const podLogs = (await getPodLogs(api, namespace, podNames)) || undefined
+    const podLogs = (await getFormattedPodLogs(api, namespace, podNames)) || undefined
 
     if (podLogs) {
       logs += chalk.white("\n\n━━━ Pod logs ━━━\n")

--- a/garden-service/test/data/test-projects/container/missing-sh/garden.yml
+++ b/garden-service/test/data/test-projects/container/missing-sh/garden.yml
@@ -4,11 +4,11 @@ description: Test module for attempting to copy artifacts without sh present in 
 type: container
 tasks:
   - name: missing-sh-task
-    command: [sh, -c, "touch /task-a.txt"]
+    command: [sh, -c, "touch /task-a.txt && echo ok"]
     artifacts:
       - source: /task-a.txt
 tests:
   - name: missing-sh-test
-    command: [sh, -c, "touch /test-a.txt"]
+    command: [sh, -c, "touch /test-a.txt && echo ok"]
     artifacts:
       - source: /test-a.txt

--- a/garden-service/test/data/test-projects/container/missing-tar/garden.yml
+++ b/garden-service/test/data/test-projects/container/missing-tar/garden.yml
@@ -4,11 +4,11 @@ description: Test module for attempting to copy artifacts without tar binary in 
 type: container
 tasks:
   - name: missing-tar-task
-    command: [sh, -c, "touch /task-a.txt"]
+    command: [sh, -c, "touch /task-a.txt && echo ok"]
     artifacts:
       - source: /task-a.txt
 tests:
   - name: missing-tar-test
-    command: [sh, -c, "touch /test-a.txt"]
+    command: [sh, -c, "touch /test-a.txt && echo ok"]
     artifacts:
       - source: /test-a.txt

--- a/garden-service/test/data/test-projects/container/simple/garden.yml
+++ b/garden-service/test/data/test-projects/container/simple/garden.yml
@@ -13,19 +13,19 @@ tasks:
   - name: echo-task
     command: [sh, -c, "echo ok"]
   - name: artifacts-task
-    command: [sh, -c, "touch /task.txt"]
+    command: [sh, -c, "touch /task.txt && echo ok"]
     artifacts:
       - source: /task.txt
       - source: /task.txt
         target: subdir
   - name: globs-task
-    command: [sh, -c, "touch /task.txt && mkdir -p /tasks && touch /tasks/output.txt"]
+    command: [sh, -c, "touch /task.txt && mkdir -p /tasks && touch /tasks/output.txt && echo ok"]
     artifacts:
       - source: /task.*
         target: subdir
       - source: /tasks/*
   - name: dir-task
-    command: [sh, -c, "mkdir -p /report && touch /report/output.txt"]
+    command: [sh, -c, "mkdir -p /report && touch /report/output.txt && echo ok"]
     artifacts:
       - source: /report/*
         target: my-task-report
@@ -33,13 +33,13 @@ tests:
   - name: echo-test
     command: [sh, -c, "echo ok"]
   - name: artifacts-test
-    command: [sh, -c, "touch /test.txt"]
+    command: [sh, -c, "touch /test.txt && echo ok"]
     artifacts:
       - source: /test.txt
       - source: /test.txt
         target: subdir
   - name: globs-test
-    command: [sh, -c, "touch /test.txt && mkdir -p /tests && touch /tests/output.txt"]
+    command: [sh, -c, "touch /test.txt && mkdir -p /tests && touch /tests/output.txt && echo ok"]
     artifacts:
       - source: /test.*
         target: subdir

--- a/garden-service/test/data/test-projects/helm/artifacts/garden.yml
+++ b/garden-service/test/data/test-projects/helm/artifacts/garden.yml
@@ -12,13 +12,13 @@ tasks:
   - name: echo-task
     command: [sh, -c, "echo ok"]
   - name: artifacts-task
-    command: [sh, -c, "touch /task.txt"]
+    command: [sh, -c, "touch /task.txt && echo ok"]
     artifacts:
       - source: /task.txt
       - source: /task.txt
         target: subdir
   - name: globs-task
-    command: [sh, -c, "touch /task.txt && mkdir -p /tasks && touch /tasks/output.txt"]
+    command: [sh, -c, "touch /task.txt && mkdir -p /tasks && touch /tasks/output.txt && echo ok"]
     artifacts:
       - source: /task.*
         target: subdir
@@ -27,13 +27,13 @@ tests:
   - name: echo-test
     command: [sh, -c, "echo ok"]
   - name: artifacts-test
-    command: [sh, -c, "touch /test.txt"]
+    command: [sh, -c, "touch /test.txt && echo ok"]
     artifacts:
       - source: /test.txt
       - source: /test.txt
         target: subdir
   - name: globs-test
-    command: [sh, -c, "touch /test.txt && mkdir -p /tests && touch /tests/output.txt"]
+    command: [sh, -c, "touch /test.txt && mkdir -p /tests && touch /tests/output.txt && echo ok"]
     artifacts:
       - source: /test.*
         target: subdir

--- a/garden-service/test/data/test-projects/kubernetes-module/artifacts/garden.yml
+++ b/garden-service/test/data/test-projects/kubernetes-module/artifacts/garden.yml
@@ -28,13 +28,13 @@ serviceResource:
   name: busybox-deployment
 tasks:
   - name: artifacts-task
-    command: [sh, -c, "touch /task.txt"]
+    command: [sh, -c, "touch /task.txt && echo ok"]
     artifacts:
       - source: /task.txt
       - source: /task.txt
         target: subdir
   - name: globs-task
-    command: [sh, -c, "touch /task.txt && mkdir -p /tasks && touch /tasks/output.txt"]
+    command: [sh, -c, "touch /task.txt && mkdir -p /tasks && touch /tasks/output.txt && echo ok"]
     artifacts:
       - source: /task.*
         target: subdir
@@ -43,13 +43,13 @@ tests:
   - name: echo-test
     command: [sh, -c, "echo ok"]
   - name: artifacts-test
-    command: [sh, -c, "touch /test.txt"]
+    command: [sh, -c, "touch /test.txt && echo ok"]
     artifacts:
       - source: /test.txt
       - source: /test.txt
         target: subdir
   - name: globs-test
-    command: [sh, -c, "touch /test.txt && mkdir -p /tests && touch /tests/output.txt"]
+    command: [sh, -c, "touch /test.txt && mkdir -p /tests && touch /tests/output.txt && echo ok"]
     artifacts:
       - source: /test.*
         target: subdir

--- a/garden-service/test/integ/src/plugins/kubernetes/container/container.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/container/container.ts
@@ -18,33 +18,29 @@ import { findByName } from "../../../../../../src/util/util"
 import { deline } from "../../../../../../src/util/string"
 import { TaskTask } from "../../../../../../src/tasks/task"
 import { runAndCopy } from "../../../../../../src/plugins/kubernetes/run"
-import { Provider } from "../../../../../../src/config/provider"
 import { containerHelpers } from "../../../../../../src/plugins/container/helpers"
 import { runContainerService } from "../../../../../../src/plugins/kubernetes/container/run"
 import { prepareRuntimeContext } from "../../../../../../src/runtime-context"
+import { KubeApi } from "../../../../../../src/plugins/kubernetes/api"
+import { KubernetesProvider } from "../../../../../../src/plugins/kubernetes/config"
+import { makePodName } from "../../../../../../src/plugins/kubernetes/util"
 
 describe("kubernetes container module handlers", () => {
   let garden: Garden
   let graph: ConfigGraph
-  let provider: Provider
-  let result: any
+  let provider: KubernetesProvider
+  let namespace: string
 
   before(async () => {
     const root = getDataDir("test-projects", "container")
     garden = await makeTestGarden(root)
     graph = await garden.getConfigGraph(garden.log)
-    provider = await garden.resolveProvider("local-kubernetes")
+    provider = <KubernetesProvider>await garden.resolveProvider("local-kubernetes")
+    namespace = garden.projectName
   })
 
   after(async () => {
     await garden.close()
-  })
-
-  // Adding logs to try to debug flaky tests
-  // TODO: remove this
-  afterEach(() => {
-    // tslint:disable-next-line: no-console
-    console.log(result)
   })
 
   describe("runAndCopy", () => {
@@ -62,19 +58,45 @@ describe("kubernetes container module handlers", () => {
       const module = await graph.getModule("simple")
       const image = await containerHelpers.getDeploymentImageId(module, provider.config.deploymentRegistry)
 
-      result = await runAndCopy({
+      const result = await runAndCopy({
         ctx: garden.getPluginContext(provider),
         log: garden.log,
         command: ["sh", "-c", "echo ok"],
         args: [],
         interactive: false,
         module,
-        namespace: provider.config.namespace,
+        namespace,
         runtimeContext: { envVars: {}, dependencies: [] },
         image,
       })
 
       expect(result.log.trim()).to.equal("ok")
+    })
+
+    it("should clean up the created container", async () => {
+      const module = await graph.getModule("simple")
+      const image = await containerHelpers.getDeploymentImageId(module, provider.config.deploymentRegistry)
+      const podName = makePodName("test", module.name)
+
+      await runAndCopy({
+        ctx: garden.getPluginContext(provider),
+        log: garden.log,
+        command: ["sh", "-c", "echo ok"],
+        args: [],
+        interactive: false,
+        module,
+        namespace: garden.projectName,
+        podName,
+        runtimeContext: { envVars: {}, dependencies: [] },
+        image,
+      })
+
+      const api = await KubeApi.factory(garden.log, provider)
+
+      await expectError(
+        () => api.core.readNamespacedPod(podName, namespace),
+        (err) => expect(err.code).to.equal(404)
+      )
     })
 
     context("artifacts are specified", () => {
@@ -83,6 +105,31 @@ describe("kubernetes container module handlers", () => {
         const module = task.module
         const image = await containerHelpers.getDeploymentImageId(module, provider.config.deploymentRegistry)
 
+        const result = await runAndCopy({
+          ctx: garden.getPluginContext(provider),
+          log: garden.log,
+          command: task.spec.command,
+          args: [],
+          interactive: false,
+          module,
+          namespace,
+          runtimeContext: { envVars: {}, dependencies: [] },
+          artifacts: task.spec.artifacts,
+          artifactsPath: tmpDir.path,
+          image,
+        })
+
+        expect(result.log.trim()).to.equal("ok")
+        expect(await pathExists(join(tmpDir.path, "task.txt"))).to.be.true
+        expect(await pathExists(join(tmpDir.path, "subdir", "task.txt"))).to.be.true
+      })
+
+      it("should clean up the created Pod", async () => {
+        const task = await graph.getTask("artifacts-task")
+        const module = task.module
+        const image = await containerHelpers.getDeploymentImageId(module, provider.config.deploymentRegistry)
+        const podName = makePodName("test", module.name)
+
         await runAndCopy({
           ctx: garden.getPluginContext(provider),
           log: garden.log,
@@ -90,15 +137,20 @@ describe("kubernetes container module handlers", () => {
           args: [],
           interactive: false,
           module,
-          namespace: provider.config.namespace,
+          namespace,
+          podName,
           runtimeContext: { envVars: {}, dependencies: [] },
           artifacts: task.spec.artifacts,
           artifactsPath: tmpDir.path,
           image,
         })
 
-        expect(await pathExists(join(tmpDir.path, "task.txt"))).to.be.true
-        expect(await pathExists(join(tmpDir.path, "subdir", "task.txt"))).to.be.true
+        const api = await KubeApi.factory(garden.log, provider)
+
+        await expectError(
+          () => api.core.readNamespacedPod(podName, namespace),
+          (err) => expect(err.code).to.equal(404)
+        )
       })
 
       it("should handle globs when copying artifacts out of the container", async () => {
@@ -113,7 +165,7 @@ describe("kubernetes container module handlers", () => {
           args: [],
           interactive: false,
           module,
-          namespace: provider.config.namespace,
+          namespace,
           runtimeContext: { envVars: {}, dependencies: [] },
           artifacts: task.spec.artifacts,
           artifactsPath: tmpDir.path,
@@ -136,7 +188,7 @@ describe("kubernetes container module handlers", () => {
           args: [],
           interactive: false,
           module,
-          namespace: provider.config.namespace,
+          namespace,
           runtimeContext: { envVars: {}, dependencies: [] },
           artifacts: task.spec.artifacts,
           artifactsPath: tmpDir.path,
@@ -168,7 +220,7 @@ describe("kubernetes container module handlers", () => {
               args: [],
               interactive: false,
               module,
-              namespace: provider.config.namespace,
+              namespace,
               runtimeContext: { envVars: {}, dependencies: [] },
               artifacts: task.spec.artifacts,
               artifactsPath: tmpDir.path,
@@ -208,7 +260,7 @@ describe("kubernetes container module handlers", () => {
               args: [],
               interactive: false,
               module,
-              namespace: provider.config.namespace,
+              namespace,
               runtimeContext: { envVars: {}, dependencies: [] },
               artifacts: task.spec.artifacts,
               artifactsPath: tmpDir.path,
@@ -240,7 +292,7 @@ describe("kubernetes container module handlers", () => {
               args: [],
               interactive: false,
               module,
-              namespace: provider.config.namespace,
+              namespace,
               runtimeContext: { envVars: {}, dependencies: [] },
               artifacts: task.spec.artifacts,
               artifactsPath: tmpDir.path,
@@ -277,7 +329,7 @@ describe("kubernetes container module handlers", () => {
         taskResults: {},
       })
 
-      result = await runContainerService({
+      const result = await runContainerService({
         ctx: garden.getPluginContext(provider),
         log: garden.log,
         service,
@@ -311,7 +363,7 @@ describe("kubernetes container module handlers", () => {
         taskResults: {},
       })
 
-      result = await runContainerService({
+      const result = await runContainerService({
         ctx: garden.getPluginContext(provider),
         log: garden.log,
         service,
@@ -338,7 +390,7 @@ describe("kubernetes container module handlers", () => {
         version: task.module.version,
       })
 
-      result = await garden.processTasks([testTask], { throwOnError: true })
+      const result = await garden.processTasks([testTask], { throwOnError: true })
 
       const key = "task.echo-task"
       expect(result).to.have.property(key)
@@ -367,7 +419,7 @@ describe("kubernetes container module handlers", () => {
       const actions = await garden.getActionRouter()
 
       // We also verify that, despite the task failing, its result was still saved.
-      result = await actions.getTaskResult({
+      const result = await actions.getTaskResult({
         log: garden.log,
         task,
         taskVersion: task.module.version,
@@ -432,7 +484,7 @@ describe("kubernetes container module handlers", () => {
           version: task.module.version,
         })
 
-        result = await garden.processTasks([testTask])
+        const result = await garden.processTasks([testTask])
 
         const key = "task.missing-sh-task"
 
@@ -458,7 +510,7 @@ describe("kubernetes container module handlers", () => {
           version: task.module.version,
         })
 
-        result = await garden.processTasks([testTask])
+        const result = await garden.processTasks([testTask])
 
         const key = "task.missing-tar-task"
 
@@ -489,7 +541,7 @@ describe("kubernetes container module handlers", () => {
         _guard: true,
       })
 
-      result = await garden.processTasks([testTask], { throwOnError: true })
+      const result = await garden.processTasks([testTask], { throwOnError: true })
 
       const key = "test.simple.echo-test"
       expect(result).to.have.property(key)
@@ -522,7 +574,7 @@ describe("kubernetes container module handlers", () => {
       const actions = await garden.getActionRouter()
 
       // We also verify that, despite the test failing, its result was still saved.
-      result = await actions.getTestResult({
+      const result = await actions.getTestResult({
         log: garden.log,
         module,
         testName: testConfig.name,
@@ -594,7 +646,7 @@ describe("kubernetes container module handlers", () => {
           _guard: true,
         })
 
-        result = await garden.processTasks([testTask])
+        const result = await garden.processTasks([testTask])
 
         const key = "test.missing-sh.missing-sh-test"
         expect(result).to.have.property(key)
@@ -621,7 +673,7 @@ describe("kubernetes container module handlers", () => {
           _guard: true,
         })
 
-        result = await garden.processTasks([testTask])
+        const result = await garden.processTasks([testTask])
 
         const key = "test.missing-tar.missing-tar-test"
         expect(result).to.have.property(key)


### PR DESCRIPTION
**What this PR does / why we need it**:

This was due to kubectl sometimes failing to attach to Pods. We now
explicitly fetch the logs, with a bit of trickery to be able to do so
when copying artifacts out of the container after running the test/task
command.

This should also address the flaky integ tests we've been seeing in
minikube.