### PR TITLE
feat(core): improved task graph concurrency

### DIFF
--- a/garden-service/src/events.ts
+++ b/garden-service/src/events.ts
@@ -62,6 +62,10 @@ export type Events = {
   configRemoved: {
     path: string
   }
+  internalError: {
+    timestamp: Date
+    error: Error
+  }
   projectConfigChanged: {}
   moduleConfigChanged: {
     names: string[]

--- a/garden-service/src/garden.ts
+++ b/garden-service/src/garden.ts
@@ -506,9 +506,7 @@ export class Garden {
       })
 
       // Process as many providers in parallel as possible
-      const taskResults = await this.processTasks(tasks, {
-        concurrencyLimit: tasks.length,
-      })
+      const taskResults = await this.processTasks(tasks, { unlimitedConcurrency: true })
 
       const failed = Object.values(taskResults).filter((r) => r && r.error)
 

--- a/garden-service/test/helpers.ts
+++ b/garden-service/test/helpers.ts
@@ -373,22 +373,6 @@ export function stubModuleAction<T extends keyof ModuleAndRuntimeActionHandlers<
   return td.replace(actions["moduleActionHandlers"][actionType][moduleType], pluginName, handler)
 }
 
-/**
- * Returns a promise that can be "manually" resolved/rejected by calling resolver/rejecter.
- *
- * This is useful e.g. when testing async control flows where concurrent long-running operations need to be simulated.
- */
-export function defer() {
-  let outerResolve
-  let outerReject
-  const promise = new Promise((res, rej) => {
-    outerResolve = res
-    outerReject = rej
-  })
-
-  return { promise, resolver: outerResolve, rejecter: outerReject }
-}
-
 export async function expectError(fn: Function, typeOrCallback?: string | ((err: any) => void)) {
   try {
     await fn()

--- a/garden-service/test/unit/src/util/util.ts
+++ b/garden-service/test/unit/src/util/util.ts
@@ -8,6 +8,7 @@
 
 import { expect } from "chai"
 import { describe } from "mocha"
+import { includes } from "lodash"
 import {
   pickKeys,
   getEnvVarName,
@@ -19,6 +20,7 @@ import {
   makeErrorMsg,
   renderOutputStream,
   spawn,
+  relationshipClasses,
 } from "../../../../src/util/util"
 import { expectError } from "../../../helpers"
 import { splitFirst } from "../../../../src/util/util"
@@ -324,6 +326,22 @@ describe("util", () => {
 
     it("should return the whole string as last element when no delimiter is found in string", () => {
       expect(splitLast("foo", ":")).to.eql(["", "foo"])
+    })
+  })
+
+  describe("relationshipClasses", () => {
+    it("should correctly partition related items", () => {
+      const items = ["ab", "b", "c", "a", "cd"]
+      const isRelated = (s1: string, s2: string) => includes(s1, s2) || includes(s2, s1)
+      expect(relationshipClasses(items, isRelated)).to.eql([
+        ["ab", "b", "a"],
+        ["c", "cd"],
+      ])
+    })
+
+    it("should return a single partition when only one item is passed", () => {
+      const isRelated = (s1: string, s2: string) => s1[0] === s2[0]
+      expect(relationshipClasses(["a"], isRelated)).to.eql([["a"]])
     })
   })
 })

--- a/package.json
+++ b/package.json
@@ -67,5 +67,6 @@
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
       "pre-push": "npm run check-all && npm test"
     }
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit adds batch-based concurrency to the task graph.

When `TaskGraph`'s process method is called, the requested tasks are grouped into batches that share one or more keys (including dependencies). These batches are then queued.

In each iteration of the task graph's main loop, any pending batches that share no keys with currently in-progress batches are added to the graph.

This enables e.g. hot reload tasks to be run concurrently with build and test tasks for their underlying modules, which was one of the primary motivators behind this change.

Also replaced the `concurrencyLimit` option for `TaskGraph`'s `processTasks` method with an `unlimitedConcurrency` option. This is useful e.g. when resolving providers.

Task nodes from batches with unlimited concurrency are processed regardless of normally available task graph concurrency.

**Which issue(s) this PR fixes**:

Fixes #505.
