### PR TITLE
feat(cli): add `garden create project/module` commands

### DIFF
--- a/docs/module-types/conftest.md
+++ b/docs/module-types/conftest.md
@@ -7,7 +7,7 @@ title: conftest
 Creates a test that runs `conftest` on the specified files, with the specified (or default) policy and
 namespace.
 
-> Note: In many cases, you'll let specific conftest providers (e.g. [`conftest-container`](../providers/conftest-container.md) and [`conftest-kubernetes`](../providers/conftest-kubernetes.md) create this module type automatically, but you may in some cases want or need to manually specify files to test.
+> Note: In many cases, you'll let specific conftest providers (e.g. [`conftest-container`](https://docs.garden.io/providers/conftest-container) and [`conftest-kubernetes`](https://docs.garden.io/providers/conftest-kubernetes) create this module type automatically, but you may in some cases want or need to manually specify files to test.
 
 See the [conftest docs](https://github.com/instrumenta/conftest) for details on how to configure policies.
 
@@ -36,55 +36,53 @@ type:
 # The name of this module.
 name:
 
+# A description of the module.
 description:
 
-# Set this to `true` to disable the module. You can use this with conditional template strings to
-# disable modules based on, for example, the current environment or other variables (e.g.
-# `disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for
-# specific environments, e.g. only for development.
+# Set this to `true` to disable the module. You can use this with conditional template strings to disable modules
+# based on, for example, the current environment or other variables (e.g. `disabled: \${environment.name == "prod"}`).
+# This can be handy when you only need certain modules for specific environments, e.g. only for development.
 #
-# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run.
-# It also means that the module is not built _unless_ it is declared as a build dependency by another enabled
-# module (in which case building this module is necessary for the dependant to be built).
+# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also
+# means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which
+# case building this module is necessary for the dependant to be built).
 #
-# If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden
-# will automatically ignore those dependency declarations. Note however that template strings referencing the
-# module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled,
-# so you need to make sure to provide alternate values for those if you're using them, using conditional
-# expressions.
+# If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will
+# automatically ignore those dependency declarations. Note however that template strings referencing the module's
+# service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make
+# sure to provide alternate values for those if you're using them, using conditional expressions.
 disabled: false
 
-# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this
-# module. Files that do *not* match these paths or globs are excluded when computing the version of the module,
-# when responding to filesystem watch events, and when staging builds.
+# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that
+# do *not* match these paths or globs are excluded when computing the version of the module, when responding to
+# filesystem watch events, and when staging builds.
 #
-# Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
-# source tree, which use the same format as `.gitignore` files. See the
-# [Configuration Files
+# Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
+# tree, which use the same format as `.gitignore` files. See the [Configuration Files
 # guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
 include:
 
-# Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that
-# match these paths or globs are excluded when computing the version of the module, when responding to filesystem
-# watch events, and when staging builds.
+# Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these
+# paths or globs are excluded when computing the version of the module, when responding to filesystem watch events,
+# and when staging builds.
 #
-# Note that you can also explicitly _include_ files using the `include` field. If you also specify the
-# `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the
-# [Configuration Files
-# guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
+# Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
+# field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration
+# Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for
+# details.
 #
-# Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files
-# and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have
-# large directories that should not be watched for changes.
+# Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files and
+# directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have large
+# directories that should not be watched for changes.
 exclude:
 
 # A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific
 # branch or tag, with the format: <git remote url>#<branch|tag>
 #
-# Garden will import the repository source code into this module, but read the module's
-# config from the local garden.yml file.
+# Garden will import the repository source code into this module, but read the module's config from the local
+# garden.yml file.
 repositoryUrl:
 
 # When false, disables pushing this module to remote registries.
@@ -94,12 +92,14 @@ allowPublish: true
 build:
   # A list of modules that must be built before this module is built.
   dependencies:
-    # Module name to build ahead of this module.
-    - name:
+    - # Module name to build ahead of this module.
+      name:
+
       # Specify one or more files or directories to copy from the built dependency to this module.
       copy:
-        # POSIX-style path or filename of the directory or file(s) to copy to the target.
-        - source:
+        - # POSIX-style path or filename of the directory or file(s) to copy to the target.
+          source:
+
           # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
           # Defaults to to same as source path.
           target: ''
@@ -166,40 +166,29 @@ name: "my-sweet-module"
 
 #### `description`
 
+A description of the module.
+
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
 
 #### `disabled`
 
-Set this to `true` to disable the module. You can use this with conditional template strings to
-disable modules based on, for example, the current environment or other variables (e.g.
-`disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for
-specific environments, e.g. only for development.
+Set this to `true` to disable the module. You can use this with conditional template strings to disable modules based on, for example, the current environment or other variables (e.g. `disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for specific environments, e.g. only for development.
 
-Disabling a module means that any services, tasks and tests contained in it will not be deployed or run.
-It also means that the module is not built _unless_ it is declared as a build dependency by another enabled
-module (in which case building this module is necessary for the dependant to be built).
+Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which case building this module is necessary for the dependant to be built).
 
-If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden
-will automatically ignore those dependency declarations. Note however that template strings referencing the
-module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled,
-so you need to make sure to provide alternate values for those if you're using them, using conditional
-expressions.
+If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will automatically ignore those dependency declarations. Note however that template strings referencing the module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
-#### `include`
+#### `include[]`
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this
-module. Files that do *not* match these paths or globs are excluded when computing the version of the module,
-when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
-source tree, which use the same format as `.gitignore` files. See the
-[Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
 
@@ -215,19 +204,13 @@ include:
   - my-app.js
 ```
 
-#### `exclude`
+#### `exclude[]`
 
-Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that
-match these paths or globs are excluded when computing the version of the module, when responding to filesystem
-watch events, and when staging builds.
+Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the
-`include` field, the files/patterns specified here are filtered from the files matched by `include`. See the
-[Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
 
-Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files
-and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have
-large directories that should not be watched for changes.
+Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have large directories that should not be watched for changes.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -245,8 +228,7 @@ exclude:
 
 A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific branch or tag, with the format: <git remote url>#<branch|tag>
 
-Garden will import the repository source code into this module, but read the module's
-config from the local garden.yml file.
+Garden will import the repository source code into this module, but read the module's config from the local garden.yml file.
 
 | Type              | Required |
 | ----------------- | -------- |
@@ -361,7 +343,7 @@ The policy namespace in which to find _deny_ and _warn_ rules.
 | -------- | -------- | -------- |
 | `string` | `"main"` | No       |
 
-#### `files`
+#### `files[]`
 
 A list of files to test with the given policy. Must be POSIX-style paths, and may include wildcards.
 

--- a/docs/module-types/container.md
+++ b/docs/module-types/container.md
@@ -54,8 +54,8 @@ description:
 # sure to provide alternate values for those if you're using them, using conditional expressions.
 disabled: false
 
-# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this   module. Files
-# that do *not* match these paths or globs are excluded when computing the version of the module, when responding to
+# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that
+# do *not* match these paths or globs are excluded when computing the version of the module, when responding to
 # filesystem watch events, and when staging builds.
 #
 # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
@@ -460,7 +460,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 #### `include[]`
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this   module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
 Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 

--- a/docs/module-types/container.md
+++ b/docs/module-types/container.md
@@ -10,7 +10,7 @@ You may also optionally specify services to deploy, tasks or tests to run inside
 Note that the runtime services have somewhat limited features in this module type. For example, you cannot
 specify replicas for redundancy, and various platform-specific options are not included. For those, look at
 other module types like [helm](https://docs.garden.io/module-types/helm) or
-[kubernetes](https://github.com/garden-io/garden/blob/master/docs/module-types/kubernetes.md).
+[kubernetes](https://docs.garden.io/module-types/kubernetes).
 
 ## Reference
 
@@ -37,31 +37,29 @@ type:
 # The name of this module.
 name:
 
+# A description of the module.
 description:
 
-# Set this to `true` to disable the module. You can use this with conditional template strings to
-# disable modules based on, for example, the current environment or other variables (e.g.
-# `disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for
-# specific environments, e.g. only for development.
+# Set this to `true` to disable the module. You can use this with conditional template strings to disable modules
+# based on, for example, the current environment or other variables (e.g. `disabled: \${environment.name == "prod"}`).
+# This can be handy when you only need certain modules for specific environments, e.g. only for development.
 #
-# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run.
-# It also means that the module is not built _unless_ it is declared as a build dependency by another enabled
-# module (in which case building this module is necessary for the dependant to be built).
+# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also
+# means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which
+# case building this module is necessary for the dependant to be built).
 #
-# If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden
-# will automatically ignore those dependency declarations. Note however that template strings referencing the
-# module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled,
-# so you need to make sure to provide alternate values for those if you're using them, using conditional
-# expressions.
+# If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will
+# automatically ignore those dependency declarations. Note however that template strings referencing the module's
+# service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make
+# sure to provide alternate values for those if you're using them, using conditional expressions.
 disabled: false
 
-# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this
-# module. Files that do *not* match these paths or globs are excluded when computing the version of the module,
-# when responding to filesystem watch events, and when staging builds.
+# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this   module. Files
+# that do *not* match these paths or globs are excluded when computing the version of the module, when responding to
+# filesystem watch events, and when staging builds.
 #
-# Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
-# source tree, which use the same format as `.gitignore` files. See the
-# [Configuration Files
+# Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
+# tree, which use the same format as `.gitignore` files. See the [Configuration Files
 # guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
@@ -74,25 +72,25 @@ disabled: false
 # specifies a remote image, Garden automatically sets `include` to `[]`.
 include:
 
-# Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that
-# match these paths or globs are excluded when computing the version of the module, when responding to filesystem
-# watch events, and when staging builds.
+# Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these
+# paths or globs are excluded when computing the version of the module, when responding to filesystem watch events,
+# and when staging builds.
 #
-# Note that you can also explicitly _include_ files using the `include` field. If you also specify the
-# `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the
-# [Configuration Files
-# guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
+# Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
+# field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration
+# Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for
+# details.
 #
-# Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files
-# and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have
-# large directories that should not be watched for changes.
+# Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files and
+# directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have large
+# directories that should not be watched for changes.
 exclude:
 
 # A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific
 # branch or tag, with the format: <git remote url>#<branch|tag>
 #
-# Garden will import the repository source code into this module, but read the module's
-# config from the local garden.yml file.
+# Garden will import the repository source code into this module, but read the module's config from the local
+# garden.yml file.
 repositoryUrl:
 
 # When false, disables pushing this module to remote registries.
@@ -102,12 +100,14 @@ allowPublish: true
 build:
   # A list of modules that must be built before this module is built.
   dependencies:
-    # Module name to build ahead of this module.
-    - name:
+    - # Module name to build ahead of this module.
+      name:
+
       # Specify one or more files or directories to copy from the built dependency to this module.
       copy:
-        # POSIX-style path or filename of the directory or file(s) to copy to the target.
-        - source:
+        - # POSIX-style path or filename of the directory or file(s) to copy to the target.
+          source:
+
           # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
           # Defaults to to same as source path.
           target: ''
@@ -137,9 +137,10 @@ image:
 hotReload:
   # Specify one or more source files or directories to automatically sync into the running container.
   sync:
-    # POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be
-    # a relative path if provided. Defaults to the module's top-level directory if no value is provided.
-    - source: .
+    - # POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be
+      # a relative path if provided. Defaults to the module's top-level directory if no value is provided.
+      source: .
+
       # POSIX-style absolute path to sync the directory to inside the container. The root path (i.e. "/") is not
       # allowed.
       target:
@@ -150,60 +151,73 @@ hotReload:
 # POSIX-style name of Dockerfile, relative to module root.
 dockerfile:
 
-# The list of services to deploy from this container module.
+# A list of services to deploy from this container module.
 services:
-  # Valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and dashes, must start with a letter,
-  # and cannot end with a dash), cannot contain consecutive dashes or start with `garden`, or be longer than 63
-  # characters.
-  - name:
+  - # Valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and dashes, must start with a letter,
+    # and cannot end with a dash), cannot contain consecutive dashes or start with `garden`, or be longer than 63
+    # characters.
+    name:
+
     # The names of any services that this service depends on at runtime, and the names of any tasks that should be
     # executed before this service is deployed.
     dependencies: []
-    # Set this to `true` to disable the service. You can use this with conditional template strings to
-    # enable/disable services based on, for example, the current environment or other variables (e.g.
-    # `enabled: \${environment.name != "prod"}`). This can be handy when you only need certain services for
-    # specific environments, e.g. only for development.
+
+    # Set this to `true` to disable the service. You can use this with conditional template strings to enable/disable
+    # services based on, for example, the current environment or other variables (e.g. `enabled: \${environment.name
+    # != "prod"}`). This can be handy when you only need certain services for specific environments, e.g. only for
+    # development.
     #
-    # Disabling a service means that it will not be deployed, and will also be ignored if it is declared as a
-    # runtime dependency for another service, test or task.
+    # Disabling a service means that it will not be deployed, and will also be ignored if it is declared as a runtime
+    # dependency for another service, test or task.
     #
-    # Note however that template strings referencing the service's outputs (i.e. runtime outputs) will fail to
-    # resolve when the service is disabled, so you need to make sure to provide alternate values for those if
-    # you're using them, using conditional expressions.
+    # Note however that template strings referencing the service's outputs (i.e. runtime outputs) will fail to resolve
+    # when the service is disabled, so you need to make sure to provide alternate values for those if you're using
+    # them, using conditional expressions.
     disabled: false
+
     # Annotations to attach to the service (Note: May not be applicable to all providers).
     annotations: {}
+
     # The command/entrypoint to run the container with when starting the service.
     command:
+
     # The arguments to run the container with when starting the service.
     args:
+
     # Whether to run the service as a daemon (to ensure exactly one instance runs per node). May not be supported by
     # all providers.
     daemon: false
+
     # List of ingress endpoints that the service exposes.
     ingresses:
-      # Annotations to attach to the ingress (Note: May not be applicable to all providers)
-      - annotations: {}
-        # The hostname that should route to this service. Defaults to the default hostname
-        # configured in the provider configuration.
+      - # Annotations to attach to the ingress (Note: May not be applicable to all providers)
+        annotations: {}
+
+        # The hostname that should route to this service. Defaults to the default hostname configured in the provider
+        # configuration.
         #
         # Note that if you're developing locally you may need to add this hostname to your hosts file.
         hostname:
-        # The link URL for the ingress to show in the console and on the dashboard.
-        # Also used when calling the service with the `call` command.
+
+        # The link URL for the ingress to show in the console and on the dashboard. Also used when calling the service
+        # with the `call` command.
         #
-        # Use this if the actual URL is different from what's specified in the ingress,
-        # e.g. because there's a load balancer in front of the service that rewrites the paths.
+        # Use this if the actual URL is different from what's specified in the ingress, e.g. because there's a load
+        # balancer in front of the service that rewrites the paths.
         #
         # Otherwise Garden will construct the link URL from the ingress spec.
         linkUrl:
+
         # The path which should be routed to the service.
         path: /
+
         # The name of the container port where the specified paths should be routed.
         port:
+
     # Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with
     # `GARDEN`) and values must be primitives or references to secrets.
     env: {}
+
     # Specify how the service's health should be checked after deploying.
     healthCheck:
       # Set this to check the service's health by making an HTTP request.
@@ -221,12 +235,15 @@ services:
 
       # Set this to check the service's health by checking if this TCP port is accepting connections.
       tcpPort:
+
     # If this module uses the `hotReload` field, the container will be run with this command/entrypoint when the
     # service is deployed with hot reloading enabled.
     hotReloadCommand:
+
     # If this module uses the `hotReload` field, the container will be run with these arguments when the service is
     # deployed with hot reloading enabled.
     hotReloadArgs:
+
     # Specify resource limits for the service.
     limits:
       # The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)
@@ -234,12 +251,15 @@ services:
 
       # The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB)
       memory: 1024
+
     # List of ports that the service container exposes.
     ports:
-      # The name of the port (used when referencing the port elsewhere in the service configuration).
-      - name:
+      - # The name of the port (used when referencing the port elsewhere in the service configuration).
+        name:
+
         # The protocol of the port.
         protocol: TCP
+
         # The port exposed on the container by the running process. This will also be the default value for
         # `servicePort`.
         # This is the port you would expose in your Dockerfile and that your process listens on. This is commonly a
@@ -247,6 +267,7 @@ services:
         # The service port maps to the container port:
         # `servicePort:80 -> containerPort:8080 -> process:8080`
         containerPort:
+
         # The port exposed on the service. Defaults to `containerPort` if not specified.
         # This is the port you use when calling a service from another service within the cluster. For example, if
         # your service name is my-service and the service port is 8090, you would call it with:
@@ -256,24 +277,28 @@ services:
         # The service port maps to the container port:
         # `servicePort:80 -> containerPort:8080 -> process:8080`
         servicePort:
-        hostPort:
+
         # Set this to expose the service on the specified port on the host node (may not be supported by all
         # providers). Set to `true` to have the cluster pick a port automatically, which is most often advisable if
         # the cluster is shared by multiple users.
         # This allows you to call the service from the outside by the node's IP address and the port number set in
         # this field.
         nodePort:
+
     # The number of instances of the service to deploy. Defaults to 3 for environments configured with `production:
     # true`, otherwise 1.
     # Note: This setting may be overridden or ignored in some cases. For example, when running with `daemon: true`,
     # with hot-reloading enabled, or if the provider doesn't support multiple replicas.
     replicas:
+
     # List of volumes that should be mounted when deploying the container.
     volumes:
-      # The name of the allocated volume.
-      - name:
+      - # The name of the allocated volume.
+        name:
+
         # The path where the volume should be mounted in the container.
         containerPath:
+
         # _NOTE: Usage of hostPath is generally discouraged, since it doesn't work reliably across different platforms
         # and providers. Some providers may not support it at all._
         #
@@ -283,30 +308,38 @@ services:
 
 # A list of tests to run in the module.
 tests:
-  # The name of the test.
-  - name:
+  - # The name of the test.
+    name:
+
     # The names of any services that must be running, and the names of any tasks that must be executed, before the
     # test is run.
     dependencies: []
+
     # Set this to `true` to disable the test. You can use this with conditional template strings to
     # enable/disable tests based on, for example, the current environment or other variables (e.g.
     # `enabled: \${environment.name != "prod"}`). This is handy when you only want certain tests to run in
     # specific environments, e.g. only during CI.
     disabled: false
+
     # Maximum duration (in seconds) of the test run.
     timeout: null
+
     # The arguments used to run the test inside the container.
     args:
+
     # Specify artifacts to copy out of the container after the run.
     # Note: Depending on the provider, this may require the container image to include `sh` `tar`, in order to enable
     # the file transfer.
     artifacts:
-      # A POSIX-style path or glob to copy. Must be an absolute path. May contain wildcards.
-      - source:
+      - # A POSIX-style path or glob to copy. Must be an absolute path. May contain wildcards.
+        source:
+
         # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
         target: .
+
     # The command/entrypoint used to run the test inside the container.
     command:
+
     # Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with
     # `GARDEN`) and values must be primitives or references to secrets.
     env: {}
@@ -314,13 +347,16 @@ tests:
 # A list of tasks that can be run from this container module. These can be used as dependencies for services (executed
 # before the service is deployed) or for other tasks.
 tasks:
-  # The name of the task.
-  - name:
+  - # The name of the task.
+    name:
+
     # A description of the task.
     description:
+
     # The names of any tasks that must be executed, and the names of any services that must be running, before this
     # task is executed.
     dependencies: []
+
     # Set this to `true` to disable the task. You can use this with conditional template strings to
     # enable/disable tasks based on, for example, the current environment or other variables (e.g.
     # `enabled: \${environment.name != "prod"}`). This can be handy when you only want certain tasks to run in
@@ -333,20 +369,26 @@ tasks:
     # resolve when the task is disabled, so you need to make sure to provide alternate values for those if
     # you're using them, using conditional expressions.
     disabled: false
+
     # Maximum duration (in seconds) of the task's execution.
     timeout: null
+
     # The arguments used to run the task inside the container.
     args:
+
     # Specify artifacts to copy out of the container after the run.
     # Note: Depending on the provider, this may require the container image to include `sh` `tar`, in order to enable
     # the file transfer.
     artifacts:
-      # A POSIX-style path or glob to copy. Must be an absolute path. May contain wildcards.
-      - source:
+      - # A POSIX-style path or glob to copy. Must be an absolute path. May contain wildcards.
+        source:
+
         # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
         target: .
+
     # The command/entrypoint used to run the task inside the container.
     command:
+
     # Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with
     # `GARDEN`) and values must be primitives or references to secrets.
     env: {}
@@ -398,40 +440,29 @@ name: "my-sweet-module"
 
 #### `description`
 
+A description of the module.
+
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
 
 #### `disabled`
 
-Set this to `true` to disable the module. You can use this with conditional template strings to
-disable modules based on, for example, the current environment or other variables (e.g.
-`disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for
-specific environments, e.g. only for development.
+Set this to `true` to disable the module. You can use this with conditional template strings to disable modules based on, for example, the current environment or other variables (e.g. `disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for specific environments, e.g. only for development.
 
-Disabling a module means that any services, tasks and tests contained in it will not be deployed or run.
-It also means that the module is not built _unless_ it is declared as a build dependency by another enabled
-module (in which case building this module is necessary for the dependant to be built).
+Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which case building this module is necessary for the dependant to be built).
 
-If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden
-will automatically ignore those dependency declarations. Note however that template strings referencing the
-module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled,
-so you need to make sure to provide alternate values for those if you're using them, using conditional
-expressions.
+If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will automatically ignore those dependency declarations. Note however that template strings referencing the module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
-#### `include`
+#### `include[]`
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this
-module. Files that do *not* match these paths or globs are excluded when computing the version of the module,
-when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this   module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
-source tree, which use the same format as `.gitignore` files. See the
-[Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
 
@@ -454,19 +485,13 @@ include:
   - my-app.js
 ```
 
-#### `exclude`
+#### `exclude[]`
 
-Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that
-match these paths or globs are excluded when computing the version of the module, when responding to filesystem
-watch events, and when staging builds.
+Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the
-`include` field, the files/patterns specified here are filtered from the files matched by `include`. See the
-[Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
 
-Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files
-and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have
-large directories that should not be watched for changes.
+Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have large directories that should not be watched for changes.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -484,8 +509,7 @@ exclude:
 
 A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific branch or tag, with the format: <git remote url>#<branch|tag>
 
-Garden will import the repository source code into this module, but read the module's
-config from the local garden.yml file.
+Garden will import the repository source code into this module, but read the module's config from the local garden.yml file.
 
 | Type              | Required |
 | ----------------- | -------- |
@@ -601,7 +625,7 @@ Specify build arguments to use when building the container image.
 | -------- | ------- | -------- |
 | `object` | `{}`    | No       |
 
-#### `extraFlags`
+#### `extraFlags[]`
 
 Specify extra flags to use when building the container image. Note that arguments may not be portable across implementations.
 
@@ -700,9 +724,9 @@ POSIX-style name of Dockerfile, relative to module root.
 | ----------- | -------- |
 | `posixPath` | No       |
 
-#### `services`
+#### `services[]`
 
-The list of services to deploy from this container module.
+A list of services to deploy from this container module.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
@@ -732,17 +756,11 @@ The names of any services that this service depends on at runtime, and the names
 
 [services](#services) > disabled
 
-Set this to `true` to disable the service. You can use this with conditional template strings to
-enable/disable services based on, for example, the current environment or other variables (e.g.
-`enabled: \${environment.name != "prod"}`). This can be handy when you only need certain services for
-specific environments, e.g. only for development.
+Set this to `true` to disable the service. You can use this with conditional template strings to enable/disable services based on, for example, the current environment or other variables (e.g. `enabled: \${environment.name != "prod"}`). This can be handy when you only need certain services for specific environments, e.g. only for development.
 
-Disabling a service means that it will not be deployed, and will also be ignored if it is declared as a
-runtime dependency for another service, test or task.
+Disabling a service means that it will not be deployed, and will also be ignored if it is declared as a runtime dependency for another service, test or task.
 
-Note however that template strings referencing the service's outputs (i.e. runtime outputs) will fail to
-resolve when the service is disabled, so you need to make sure to provide alternate values for those if
-you're using them, using conditional expressions.
+Note however that template strings referencing the service's outputs (i.e. runtime outputs) will fail to resolve when the service is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |
@@ -763,7 +781,7 @@ Example:
 ```yaml
 services:
   - annotations:
-      nginx.ingress.kubernetes.io/proxy-body-size: '0'
+        nginx.ingress.kubernetes.io/proxy-body-size: '0'
 ```
 
 #### `services[].command[]`
@@ -781,8 +799,8 @@ Example:
 ```yaml
 services:
   - command:
-    - /bin/sh
-    - '-c'
+      - /bin/sh
+      - '-c'
 ```
 
 #### `services[].args[]`
@@ -800,8 +818,8 @@ Example:
 ```yaml
 services:
   - args:
-    - npm
-    - start
+      - npm
+      - start
 ```
 
 #### `services[].daemon`
@@ -829,8 +847,8 @@ Example:
 ```yaml
 services:
   - ingresses:
-    - path: /api
-      port: http
+      - path: /api
+        port: http
 ```
 
 #### `services[].ingresses[].annotations`
@@ -848,18 +866,17 @@ Example:
 ```yaml
 services:
   - ingresses:
-    - path: /api
-      port: http
+      - path: /api
+        port: http
       - annotations:
-          nginx.ingress.kubernetes.io/proxy-body-size: '0'
+            nginx.ingress.kubernetes.io/proxy-body-size: '0'
 ```
 
 #### `services[].ingresses[].hostname`
 
 [services](#services) > [ingresses](#servicesingresses) > hostname
 
-The hostname that should route to this service. Defaults to the default hostname
-configured in the provider configuration.
+The hostname that should route to this service. Defaults to the default hostname configured in the provider configuration.
 
 Note that if you're developing locally you may need to add this hostname to your hosts file.
 
@@ -871,11 +888,9 @@ Note that if you're developing locally you may need to add this hostname to your
 
 [services](#services) > [ingresses](#servicesingresses) > linkUrl
 
-The link URL for the ingress to show in the console and on the dashboard.
-Also used when calling the service with the `call` command.
+The link URL for the ingress to show in the console and on the dashboard. Also used when calling the service with the `call` command.
 
-Use this if the actual URL is different from what's specified in the ingress,
-e.g. because there's a load balancer in front of the service that rewrites the paths.
+Use this if the actual URL is different from what's specified in the ingress, e.g. because there's a load balancer in front of the service that rewrites the paths.
 
 Otherwise Garden will construct the link URL from the ingress spec.
 
@@ -918,12 +933,12 @@ Example:
 ```yaml
 services:
   - env:
-      - MY_VAR: some-value
-        MY_SECRET_VAR:
-          secretRef:
-            name: my-secret
-            key: some-key
-      - {}
+        - MY_VAR: some-value
+          MY_SECRET_VAR:
+            secretRef:
+              name: my-secret
+              key: some-key
+        - {}
 ```
 
 #### `services[].healthCheck`
@@ -1009,8 +1024,8 @@ Example:
 ```yaml
 services:
   - hotReloadCommand:
-    - /bin/sh
-    - '-c'
+      - /bin/sh
+      - '-c'
 ```
 
 #### `services[].hotReloadArgs[]`
@@ -1028,9 +1043,9 @@ Example:
 ```yaml
 services:
   - hotReloadArgs:
-    - npm
-    - run
-    - dev
+      - npm
+      - run
+      - dev
 ```
 
 #### `services[].limits`
@@ -1218,7 +1233,7 @@ services:
       - hostPath: "/some/dir"
 ```
 
-#### `tests`
+#### `tests[]`
 
 A list of tests to run in the module.
 
@@ -1284,8 +1299,8 @@ Example:
 ```yaml
 tests:
   - args:
-    - npm
-    - test
+      - npm
+      - test
 ```
 
 #### `tests[].artifacts[]`
@@ -1304,7 +1319,7 @@ Example:
 ```yaml
 tests:
   - artifacts:
-    - source: /report/**/*
+      - source: /report/**/*
 ```
 
 #### `tests[].artifacts[].source`
@@ -1322,7 +1337,7 @@ Example:
 ```yaml
 tests:
   - artifacts:
-    - source: /report/**/*
+      - source: /report/**/*
       - source: "/output/**/*"
 ```
 
@@ -1341,7 +1356,7 @@ Example:
 ```yaml
 tests:
   - artifacts:
-    - source: /report/**/*
+      - source: /report/**/*
       - target: "outputs/foo/"
 ```
 
@@ -1360,8 +1375,8 @@ Example:
 ```yaml
 tests:
   - command:
-    - /bin/sh
-    - '-c'
+      - /bin/sh
+      - '-c'
 ```
 
 #### `tests[].env`
@@ -1379,15 +1394,15 @@ Example:
 ```yaml
 tests:
   - env:
-      - MY_VAR: some-value
-        MY_SECRET_VAR:
-          secretRef:
-            name: my-secret
-            key: some-key
-      - {}
+        - MY_VAR: some-value
+          MY_SECRET_VAR:
+            secretRef:
+              name: my-secret
+              key: some-key
+        - {}
 ```
 
-#### `tasks`
+#### `tasks[]`
 
 A list of tasks that can be run from this container module. These can be used as dependencies for services (executed before the service is deployed) or for other tasks.
 
@@ -1470,8 +1485,8 @@ Example:
 ```yaml
 tasks:
   - args:
-    - rake
-    - 'db:migrate'
+      - rake
+      - 'db:migrate'
 ```
 
 #### `tasks[].artifacts[]`
@@ -1490,7 +1505,7 @@ Example:
 ```yaml
 tasks:
   - artifacts:
-    - source: /report/**/*
+      - source: /report/**/*
 ```
 
 #### `tasks[].artifacts[].source`
@@ -1508,7 +1523,7 @@ Example:
 ```yaml
 tasks:
   - artifacts:
-    - source: /report/**/*
+      - source: /report/**/*
       - source: "/output/**/*"
 ```
 
@@ -1527,7 +1542,7 @@ Example:
 ```yaml
 tasks:
   - artifacts:
-    - source: /report/**/*
+      - source: /report/**/*
       - target: "outputs/foo/"
 ```
 
@@ -1546,8 +1561,8 @@ Example:
 ```yaml
 tasks:
   - command:
-    - /bin/sh
-    - '-c'
+      - /bin/sh
+      - '-c'
 ```
 
 #### `tasks[].env`
@@ -1565,12 +1580,12 @@ Example:
 ```yaml
 tasks:
   - env:
-      - MY_VAR: some-value
-        MY_SECRET_VAR:
-          secretRef:
-            name: my-secret
-            key: some-key
-      - {}
+        - MY_VAR: some-value
+          MY_SECRET_VAR:
+            secretRef:
+              name: my-secret
+              key: some-key
+        - {}
 ```
 
 

--- a/docs/module-types/exec.md
+++ b/docs/module-types/exec.md
@@ -40,55 +40,53 @@ type:
 # The name of this module.
 name:
 
+# A description of the module.
 description:
 
-# Set this to `true` to disable the module. You can use this with conditional template strings to
-# disable modules based on, for example, the current environment or other variables (e.g.
-# `disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for
-# specific environments, e.g. only for development.
+# Set this to `true` to disable the module. You can use this with conditional template strings to disable modules
+# based on, for example, the current environment or other variables (e.g. `disabled: \${environment.name == "prod"}`).
+# This can be handy when you only need certain modules for specific environments, e.g. only for development.
 #
-# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run.
-# It also means that the module is not built _unless_ it is declared as a build dependency by another enabled
-# module (in which case building this module is necessary for the dependant to be built).
+# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also
+# means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which
+# case building this module is necessary for the dependant to be built).
 #
-# If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden
-# will automatically ignore those dependency declarations. Note however that template strings referencing the
-# module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled,
-# so you need to make sure to provide alternate values for those if you're using them, using conditional
-# expressions.
+# If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will
+# automatically ignore those dependency declarations. Note however that template strings referencing the module's
+# service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make
+# sure to provide alternate values for those if you're using them, using conditional expressions.
 disabled: false
 
-# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this
-# module. Files that do *not* match these paths or globs are excluded when computing the version of the module,
-# when responding to filesystem watch events, and when staging builds.
+# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that
+# do *not* match these paths or globs are excluded when computing the version of the module, when responding to
+# filesystem watch events, and when staging builds.
 #
-# Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
-# source tree, which use the same format as `.gitignore` files. See the
-# [Configuration Files
+# Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
+# tree, which use the same format as `.gitignore` files. See the [Configuration Files
 # guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
 include:
 
-# Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that
-# match these paths or globs are excluded when computing the version of the module, when responding to filesystem
-# watch events, and when staging builds.
+# Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these
+# paths or globs are excluded when computing the version of the module, when responding to filesystem watch events,
+# and when staging builds.
 #
-# Note that you can also explicitly _include_ files using the `include` field. If you also specify the
-# `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the
-# [Configuration Files
-# guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
+# Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
+# field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration
+# Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for
+# details.
 #
-# Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files
-# and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have
-# large directories that should not be watched for changes.
+# Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files and
+# directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have large
+# directories that should not be watched for changes.
 exclude:
 
 # A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific
 # branch or tag, with the format: <git remote url>#<branch|tag>
 #
-# Garden will import the repository source code into this module, but read the module's
-# config from the local garden.yml file.
+# Garden will import the repository source code into this module, but read the module's config from the local
+# garden.yml file.
 repositoryUrl:
 
 # When false, disables pushing this module to remote registries.
@@ -98,12 +96,14 @@ allowPublish: true
 build:
   # A list of modules that must be built before this module is built.
   dependencies:
-    # Module name to build ahead of this module.
-    - name:
+    - # Module name to build ahead of this module.
+      name:
+
       # Specify one or more files or directories to copy from the built dependency to this module.
       copy:
-        # POSIX-style path or filename of the directory or file(s) to copy to the target.
-        - source:
+        - # POSIX-style path or filename of the directory or file(s) to copy to the target.
+          source:
+
           # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
           # Defaults to to same as source path.
           target: ''
@@ -127,13 +127,16 @@ env: {}
 
 # A list of tasks that can be run in this module.
 tasks:
-  # The name of the task.
-  - name:
+  - # The name of the task.
+    name:
+
     # A description of the task.
     description:
+
     # The names of any tasks that must be executed, and the names of any services that must be running, before this
     # task is executed.
     dependencies: []
+
     # Set this to `true` to disable the task. You can use this with conditional template strings to
     # enable/disable tasks based on, for example, the current environment or other variables (e.g.
     # `enabled: \${environment.name != "prod"}`). This can be handy when you only want certain tasks to run in
@@ -146,49 +149,61 @@ tasks:
     # resolve when the task is disabled, so you need to make sure to provide alternate values for those if
     # you're using them, using conditional expressions.
     disabled: false
+
     # Maximum duration (in seconds) of the task's execution.
     timeout: null
+
     # A list of artifacts to copy after the task run.
     artifacts:
-      # A POSIX-style path or glob to copy, relative to the build root.
-      - source:
+      - # A POSIX-style path or glob to copy, relative to the build root.
+        source:
+
         # A POSIX-style path to copy the artifact to, relative to the project artifacts directory.
         target: .
+
     # The command to run.
     #
     # By default, the command is run inside the Garden build directory (under .garden/build/<module-name>).
     # If the top level `local` directive is set to `true`, the command runs in the module source directory instead.
     command:
+
     # Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with
     # `GARDEN`) and values must be primitives.
     env: {}
 
 # A list of tests to run in the module.
 tests:
-  # The name of the test.
-  - name:
+  - # The name of the test.
+    name:
+
     # The names of any services that must be running, and the names of any tasks that must be executed, before the
     # test is run.
     dependencies: []
+
     # Set this to `true` to disable the test. You can use this with conditional template strings to
     # enable/disable tests based on, for example, the current environment or other variables (e.g.
     # `enabled: \${environment.name != "prod"}`). This is handy when you only want certain tests to run in
     # specific environments, e.g. only during CI.
     disabled: false
+
     # Maximum duration (in seconds) of the test run.
     timeout: null
+
     # The command to run to test the module.
     #
     # By default, the command is run inside the Garden build directory (under .garden/build/<module-name>).
     # If the top level `local` directive is set to `true`, the command runs in the module source directory instead.
     command:
+
     # Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with
     # `GARDEN`) and values must be primitives.
     env: {}
+
     # A list of artifacts to copy after the test run.
     artifacts:
-      # A POSIX-style path or glob to copy, relative to the build root.
-      - source:
+      - # A POSIX-style path or glob to copy, relative to the build root.
+        source:
+
         # A POSIX-style path to copy the artifact to, relative to the project artifacts directory.
         target: .
 ```
@@ -239,40 +254,29 @@ name: "my-sweet-module"
 
 #### `description`
 
+A description of the module.
+
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
 
 #### `disabled`
 
-Set this to `true` to disable the module. You can use this with conditional template strings to
-disable modules based on, for example, the current environment or other variables (e.g.
-`disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for
-specific environments, e.g. only for development.
+Set this to `true` to disable the module. You can use this with conditional template strings to disable modules based on, for example, the current environment or other variables (e.g. `disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for specific environments, e.g. only for development.
 
-Disabling a module means that any services, tasks and tests contained in it will not be deployed or run.
-It also means that the module is not built _unless_ it is declared as a build dependency by another enabled
-module (in which case building this module is necessary for the dependant to be built).
+Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which case building this module is necessary for the dependant to be built).
 
-If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden
-will automatically ignore those dependency declarations. Note however that template strings referencing the
-module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled,
-so you need to make sure to provide alternate values for those if you're using them, using conditional
-expressions.
+If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will automatically ignore those dependency declarations. Note however that template strings referencing the module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
-#### `include`
+#### `include[]`
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this
-module. Files that do *not* match these paths or globs are excluded when computing the version of the module,
-when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
-source tree, which use the same format as `.gitignore` files. See the
-[Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
 
@@ -288,19 +292,13 @@ include:
   - my-app.js
 ```
 
-#### `exclude`
+#### `exclude[]`
 
-Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that
-match these paths or globs are excluded when computing the version of the module, when responding to filesystem
-watch events, and when staging builds.
+Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the
-`include` field, the files/patterns specified here are filtered from the files matched by `include`. See the
-[Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
 
-Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files
-and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have
-large directories that should not be watched for changes.
+Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have large directories that should not be watched for changes.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -318,8 +316,7 @@ exclude:
 
 A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific branch or tag, with the format: <git remote url>#<branch|tag>
 
-Garden will import the repository source code into this module, but read the module's
-config from the local garden.yml file.
+Garden will import the repository source code into this module, but read the module's config from the local garden.yml file.
 
 | Type              | Required |
 | ----------------- | -------- |
@@ -451,7 +448,7 @@ Key/value map of environment variables. Keys must be valid POSIX environment var
 | -------- | ------- | -------- |
 | `object` | `{}`    | No       |
 
-#### `tasks`
+#### `tasks[]`
 
 A list of tasks that can be run in this module.
 
@@ -572,7 +569,7 @@ Key/value map of environment variables. Keys must be valid POSIX environment var
 | -------- | ------- | -------- |
 | `object` | `{}`    | No       |
 
-#### `tests`
+#### `tests[]`
 
 A list of tests to run in the module.
 

--- a/docs/module-types/hadolint.md
+++ b/docs/module-types/hadolint.md
@@ -6,7 +6,7 @@ title: hadolint
 
 Runs `hadolint` on the specified Dockerfile.
 
-> Note: In most cases, you'll let the [provider](../providers/hadolint.md) create this module type automatically, but you may in some cases want or need to manually specify a Dockerfile to lint.
+> Note: In most cases, you'll let the [provider](https://docs.garden.io/providers/hadolint) create this module type automatically, but you may in some cases want or need to manually specify a Dockerfile to lint.
 
 To configure `hadolint`, you can use `.hadolint.yaml` config files. For each test, we first look for one in
 the module root. If none is found there, we check the project root, and if none is there we fall back to default
@@ -39,55 +39,53 @@ type:
 # The name of this module.
 name:
 
+# A description of the module.
 description:
 
-# Set this to `true` to disable the module. You can use this with conditional template strings to
-# disable modules based on, for example, the current environment or other variables (e.g.
-# `disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for
-# specific environments, e.g. only for development.
+# Set this to `true` to disable the module. You can use this with conditional template strings to disable modules
+# based on, for example, the current environment or other variables (e.g. `disabled: \${environment.name == "prod"}`).
+# This can be handy when you only need certain modules for specific environments, e.g. only for development.
 #
-# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run.
-# It also means that the module is not built _unless_ it is declared as a build dependency by another enabled
-# module (in which case building this module is necessary for the dependant to be built).
+# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also
+# means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which
+# case building this module is necessary for the dependant to be built).
 #
-# If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden
-# will automatically ignore those dependency declarations. Note however that template strings referencing the
-# module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled,
-# so you need to make sure to provide alternate values for those if you're using them, using conditional
-# expressions.
+# If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will
+# automatically ignore those dependency declarations. Note however that template strings referencing the module's
+# service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make
+# sure to provide alternate values for those if you're using them, using conditional expressions.
 disabled: false
 
-# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this
-# module. Files that do *not* match these paths or globs are excluded when computing the version of the module,
-# when responding to filesystem watch events, and when staging builds.
+# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that
+# do *not* match these paths or globs are excluded when computing the version of the module, when responding to
+# filesystem watch events, and when staging builds.
 #
-# Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
-# source tree, which use the same format as `.gitignore` files. See the
-# [Configuration Files
+# Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
+# tree, which use the same format as `.gitignore` files. See the [Configuration Files
 # guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
 include:
 
-# Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that
-# match these paths or globs are excluded when computing the version of the module, when responding to filesystem
-# watch events, and when staging builds.
+# Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these
+# paths or globs are excluded when computing the version of the module, when responding to filesystem watch events,
+# and when staging builds.
 #
-# Note that you can also explicitly _include_ files using the `include` field. If you also specify the
-# `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the
-# [Configuration Files
-# guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
+# Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
+# field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration
+# Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for
+# details.
 #
-# Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files
-# and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have
-# large directories that should not be watched for changes.
+# Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files and
+# directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have large
+# directories that should not be watched for changes.
 exclude:
 
 # A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific
 # branch or tag, with the format: <git remote url>#<branch|tag>
 #
-# Garden will import the repository source code into this module, but read the module's
-# config from the local garden.yml file.
+# Garden will import the repository source code into this module, but read the module's config from the local
+# garden.yml file.
 repositoryUrl:
 
 # When false, disables pushing this module to remote registries.
@@ -97,12 +95,14 @@ allowPublish: true
 build:
   # A list of modules that must be built before this module is built.
   dependencies:
-    # Module name to build ahead of this module.
-    - name:
+    - # Module name to build ahead of this module.
+      name:
+
       # Specify one or more files or directories to copy from the built dependency to this module.
       copy:
-        # POSIX-style path or filename of the directory or file(s) to copy to the target.
-        - source:
+        - # POSIX-style path or filename of the directory or file(s) to copy to the target.
+          source:
+
           # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
           # Defaults to to same as source path.
           target: ''
@@ -157,40 +157,29 @@ name: "my-sweet-module"
 
 #### `description`
 
+A description of the module.
+
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
 
 #### `disabled`
 
-Set this to `true` to disable the module. You can use this with conditional template strings to
-disable modules based on, for example, the current environment or other variables (e.g.
-`disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for
-specific environments, e.g. only for development.
+Set this to `true` to disable the module. You can use this with conditional template strings to disable modules based on, for example, the current environment or other variables (e.g. `disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for specific environments, e.g. only for development.
 
-Disabling a module means that any services, tasks and tests contained in it will not be deployed or run.
-It also means that the module is not built _unless_ it is declared as a build dependency by another enabled
-module (in which case building this module is necessary for the dependant to be built).
+Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which case building this module is necessary for the dependant to be built).
 
-If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden
-will automatically ignore those dependency declarations. Note however that template strings referencing the
-module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled,
-so you need to make sure to provide alternate values for those if you're using them, using conditional
-expressions.
+If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will automatically ignore those dependency declarations. Note however that template strings referencing the module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
-#### `include`
+#### `include[]`
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this
-module. Files that do *not* match these paths or globs are excluded when computing the version of the module,
-when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
-source tree, which use the same format as `.gitignore` files. See the
-[Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
 
@@ -206,19 +195,13 @@ include:
   - my-app.js
 ```
 
-#### `exclude`
+#### `exclude[]`
 
-Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that
-match these paths or globs are excluded when computing the version of the module, when responding to filesystem
-watch events, and when staging builds.
+Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the
-`include` field, the files/patterns specified here are filtered from the files matched by `include`. See the
-[Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
 
-Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files
-and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have
-large directories that should not be watched for changes.
+Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have large directories that should not be watched for changes.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -236,8 +219,7 @@ exclude:
 
 A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific branch or tag, with the format: <git remote url>#<branch|tag>
 
-Garden will import the repository source code into this module, but read the module's
-config from the local garden.yml file.
+Garden will import the repository source code into this module, but read the module's config from the local garden.yml file.
 
 | Type              | Required |
 | ----------------- | -------- |

--- a/docs/module-types/helm.md
+++ b/docs/module-types/helm.md
@@ -5,7 +5,7 @@ title: helm
 # `helm` Module Type
 
 Specify a Helm chart (either in your repository or remote from a registry) to deploy.
-Refer to the [Helm guide](../guides/using-helm-charts.md) for usage instructions.
+Refer to the [Helm guide](https://docs.garden.io/guides/using-helm-charts) for usage instructions.
 
 ## Reference
 
@@ -32,31 +32,29 @@ type:
 # The name of this module.
 name:
 
+# A description of the module.
 description:
 
-# Set this to `true` to disable the module. You can use this with conditional template strings to
-# disable modules based on, for example, the current environment or other variables (e.g.
-# `disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for
-# specific environments, e.g. only for development.
+# Set this to `true` to disable the module. You can use this with conditional template strings to disable modules
+# based on, for example, the current environment or other variables (e.g. `disabled: \${environment.name == "prod"}`).
+# This can be handy when you only need certain modules for specific environments, e.g. only for development.
 #
-# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run.
-# It also means that the module is not built _unless_ it is declared as a build dependency by another enabled
-# module (in which case building this module is necessary for the dependant to be built).
+# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also
+# means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which
+# case building this module is necessary for the dependant to be built).
 #
-# If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden
-# will automatically ignore those dependency declarations. Note however that template strings referencing the
-# module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled,
-# so you need to make sure to provide alternate values for those if you're using them, using conditional
-# expressions.
+# If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will
+# automatically ignore those dependency declarations. Note however that template strings referencing the module's
+# service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make
+# sure to provide alternate values for those if you're using them, using conditional expressions.
 disabled: false
 
-# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this
-# module. Files that do *not* match these paths or globs are excluded when computing the version of the module,
-# when responding to filesystem watch events, and when staging builds.
+# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this   module. Files
+# that do *not* match these paths or globs are excluded when computing the version of the module, when responding to
+# filesystem watch events, and when staging builds.
 #
-# Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
-# source tree, which use the same format as `.gitignore` files. See the
-# [Configuration Files
+# Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
+# tree, which use the same format as `.gitignore` files. See the [Configuration Files
 # guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
@@ -68,25 +66,25 @@ disabled: false
 # automatically sets `ìnclude` to `[]`.
 include:
 
-# Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that
-# match these paths or globs are excluded when computing the version of the module, when responding to filesystem
-# watch events, and when staging builds.
+# Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these
+# paths or globs are excluded when computing the version of the module, when responding to filesystem watch events,
+# and when staging builds.
 #
-# Note that you can also explicitly _include_ files using the `include` field. If you also specify the
-# `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the
-# [Configuration Files
-# guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
+# Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
+# field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration
+# Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for
+# details.
 #
-# Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files
-# and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have
-# large directories that should not be watched for changes.
+# Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files and
+# directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have large
+# directories that should not be watched for changes.
 exclude:
 
 # A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific
 # branch or tag, with the format: <git remote url>#<branch|tag>
 #
-# Garden will import the repository source code into this module, but read the module's
-# config from the local garden.yml file.
+# Garden will import the repository source code into this module, but read the module's config from the local
+# garden.yml file.
 repositoryUrl:
 
 # When false, disables pushing this module to remote registries.
@@ -96,12 +94,14 @@ allowPublish: true
 build:
   # A list of modules that must be built before this module is built.
   dependencies:
-    # Module name to build ahead of this module.
-    - name:
+    - # Module name to build ahead of this module.
+      name:
+
       # Specify one or more files or directories to copy from the built dependency to this module.
       copy:
-        # POSIX-style path or filename of the directory or file(s) to copy to the target.
-        - source:
+        - # POSIX-style path or filename of the directory or file(s) to copy to the target.
+          source:
+
           # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
           # Defaults to to same as source path.
           target: ''
@@ -170,13 +170,16 @@ skipDeploy: false
 
 # The task definitions for this module.
 tasks:
-  # The name of the task.
-  - name:
+  - # The name of the task.
+    name:
+
     # A description of the task.
     description:
+
     # The names of any tasks that must be executed, and the names of any services that must be running, before this
     # task is executed.
     dependencies: []
+
     # Set this to `true` to disable the task. You can use this with conditional template strings to
     # enable/disable tasks based on, for example, the current environment or other variables (e.g.
     # `enabled: \${environment.name != "prod"}`). This can be handy when you only want certain tasks to run in
@@ -189,21 +192,28 @@ tasks:
     # resolve when the task is disabled, so you need to make sure to provide alternate values for those if
     # you're using them, using conditional expressions.
     disabled: false
+
     # Maximum duration (in seconds) of the task's execution.
     timeout: null
+
     # The command/entrypoint used to run the task inside the container.
     command:
+
     # The arguments to pass to the container used for execution.
     args:
+
     # Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with
     # `GARDEN`) and values must be primitives or references to secrets.
     env: {}
+
     # Specify artifacts to copy out of the container after the task is complete.
     artifacts:
-      # A POSIX-style path or glob to copy. Must be an absolute path. May contain wildcards.
-      - source:
+      - # A POSIX-style path or glob to copy. Must be an absolute path. May contain wildcards.
+        source:
+
         # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
         target: .
+
     # The Deployment, DaemonSet or StatefulSet that Garden should use to execute this task. If not specified, the
     # `serviceResource` configured on the module will be used. If neither is specified, an error will be thrown.
     resource:
@@ -234,31 +244,40 @@ tasks:
 
 # The test suite definitions for this module.
 tests:
-  # The name of the test.
-  - name:
+  - # The name of the test.
+    name:
+
     # The names of any services that must be running, and the names of any tasks that must be executed, before the
     # test is run.
     dependencies: []
+
     # Set this to `true` to disable the test. You can use this with conditional template strings to
     # enable/disable tests based on, for example, the current environment or other variables (e.g.
     # `enabled: \${environment.name != "prod"}`). This is handy when you only want certain tests to run in
     # specific environments, e.g. only during CI.
     disabled: false
+
     # Maximum duration (in seconds) of the test run.
     timeout: null
+
     # The command/entrypoint used to run the test inside the container.
     command:
+
     # The arguments to pass to the container used for testing.
     args:
+
     # Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with
     # `GARDEN`) and values must be primitives or references to secrets.
     env: {}
+
     # Specify artifacts to copy out of the container after the test is complete.
     artifacts:
-      # A POSIX-style path or glob to copy. Must be an absolute path. May contain wildcards.
-      - source:
+      - # A POSIX-style path or glob to copy. Must be an absolute path. May contain wildcards.
+        source:
+
         # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
         target: .
+
     # The Deployment, DaemonSet or StatefulSet that Garden should use to execute this test suite. If not specified,
     # the `serviceResource` configured on the module will be used. If neither is specified, an error will be thrown.
     resource:
@@ -355,40 +374,29 @@ name: "my-sweet-module"
 
 #### `description`
 
+A description of the module.
+
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
 
 #### `disabled`
 
-Set this to `true` to disable the module. You can use this with conditional template strings to
-disable modules based on, for example, the current environment or other variables (e.g.
-`disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for
-specific environments, e.g. only for development.
+Set this to `true` to disable the module. You can use this with conditional template strings to disable modules based on, for example, the current environment or other variables (e.g. `disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for specific environments, e.g. only for development.
 
-Disabling a module means that any services, tasks and tests contained in it will not be deployed or run.
-It also means that the module is not built _unless_ it is declared as a build dependency by another enabled
-module (in which case building this module is necessary for the dependant to be built).
+Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which case building this module is necessary for the dependant to be built).
 
-If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden
-will automatically ignore those dependency declarations. Note however that template strings referencing the
-module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled,
-so you need to make sure to provide alternate values for those if you're using them, using conditional
-expressions.
+If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will automatically ignore those dependency declarations. Note however that template strings referencing the module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
-#### `include`
+#### `include[]`
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this
-module. Files that do *not* match these paths or globs are excluded when computing the version of the module,
-when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this   module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
-source tree, which use the same format as `.gitignore` files. See the
-[Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
 
@@ -410,19 +418,13 @@ include:
   - my-app.js
 ```
 
-#### `exclude`
+#### `exclude[]`
 
-Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that
-match these paths or globs are excluded when computing the version of the module, when responding to filesystem
-watch events, and when staging builds.
+Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the
-`include` field, the files/patterns specified here are filtered from the files matched by `include`. See the
-[Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
 
-Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files
-and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have
-large directories that should not be watched for changes.
+Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have large directories that should not be watched for changes.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -440,8 +442,7 @@ exclude:
 
 A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific branch or tag, with the format: <git remote url>#<branch|tag>
 
-Garden will import the repository source code into this module, but read the module's
-config from the local garden.yml file.
+Garden will import the repository source code into this module, but read the module's config from the local garden.yml file.
 
 | Type              | Required |
 | ----------------- | -------- |
@@ -567,7 +568,7 @@ The path, relative to the module path, to the chart sources (i.e. where the Char
 | ----------- | ------- | -------- |
 | `posixPath` | `"."`   | No       |
 
-#### `dependencies`
+#### `dependencies[]`
 
 List of names of services that should be deployed before this chart.
 
@@ -687,7 +688,7 @@ Set this to true if the chart should only be built, but not deployed as a servic
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
-#### `tasks`
+#### `tasks[]`
 
 The task definitions for this module.
 
@@ -770,8 +771,8 @@ Example:
 ```yaml
 tasks:
   - command:
-    - /bin/sh
-    - '-c'
+      - /bin/sh
+      - '-c'
 ```
 
 #### `tasks[].args[]`
@@ -789,8 +790,8 @@ Example:
 ```yaml
 tasks:
   - args:
-    - rake
-    - 'db:migrate'
+      - rake
+      - 'db:migrate'
 ```
 
 #### `tasks[].env`
@@ -808,12 +809,12 @@ Example:
 ```yaml
 tasks:
   - env:
-      - MY_VAR: some-value
-        MY_SECRET_VAR:
-          secretRef:
-            name: my-secret
-            key: some-key
-      - {}
+        - MY_VAR: some-value
+          MY_SECRET_VAR:
+            secretRef:
+              name: my-secret
+              key: some-key
+        - {}
 ```
 
 #### `tasks[].artifacts[]`
@@ -945,7 +946,7 @@ tasks:
         - my-server.js
 ```
 
-#### `tests`
+#### `tests[]`
 
 The test suite definitions for this module.
 
@@ -1011,8 +1012,8 @@ Example:
 ```yaml
 tests:
   - command:
-    - /bin/sh
-    - '-c'
+      - /bin/sh
+      - '-c'
 ```
 
 #### `tests[].args[]`
@@ -1030,8 +1031,8 @@ Example:
 ```yaml
 tests:
   - args:
-    - npm
-    - test
+      - npm
+      - test
 ```
 
 #### `tests[].env`
@@ -1049,12 +1050,12 @@ Example:
 ```yaml
 tests:
   - env:
-      - MY_VAR: some-value
-        MY_SECRET_VAR:
-          secretRef:
-            name: my-secret
-            key: some-key
-      - {}
+        - MY_VAR: some-value
+          MY_SECRET_VAR:
+            secretRef:
+              name: my-secret
+              key: some-key
+        - {}
 ```
 
 #### `tests[].artifacts[]`
@@ -1210,7 +1211,7 @@ Map of values to pass to Helm when rendering the templates. May include arrays a
 | -------- | ------- | -------- |
 | `object` | `{}`    | No       |
 
-#### `valueFiles`
+#### `valueFiles[]`
 
 Specify value files to use when rendering the Helm chart. These will take precedence over the `values.yaml` file
 bundled in the Helm chart, and should be specified in ascending order of precedence. Meaning, the last file in

--- a/docs/module-types/helm.md
+++ b/docs/module-types/helm.md
@@ -49,8 +49,8 @@ description:
 # sure to provide alternate values for those if you're using them, using conditional expressions.
 disabled: false
 
-# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this   module. Files
-# that do *not* match these paths or globs are excluded when computing the version of the module, when responding to
+# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that
+# do *not* match these paths or globs are excluded when computing the version of the module, when responding to
 # filesystem watch events, and when staging builds.
 #
 # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
@@ -394,7 +394,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 #### `include[]`
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this   module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
 Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 

--- a/docs/module-types/kubernetes.md
+++ b/docs/module-types/kubernetes.md
@@ -57,8 +57,8 @@ description:
 # sure to provide alternate values for those if you're using them, using conditional expressions.
 disabled: false
 
-# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this   module. Files
-# that do *not* match these paths or globs are excluded when computing the version of the module, when responding to
+# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that
+# do *not* match these paths or globs are excluded when computing the version of the module, when responding to
 # filesystem watch events, and when staging builds.
 #
 # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
@@ -324,7 +324,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 #### `include[]`
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this   module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
 Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 

--- a/docs/module-types/kubernetes.md
+++ b/docs/module-types/kubernetes.md
@@ -10,10 +10,10 @@ You can either (or both) specify the manifests as part of the `garden.yml` confi
 one or more files with existing manifests.
 
 Note that if you include the manifests in the `garden.yml` file, you can use
-[template strings](../guides/variables-and-templating.md) to interpolate values into the manifests.
+[template strings](https://docs.garden.io/guides/variables-and-templating) to interpolate values into the manifests.
 
 If you need more advanced templating features you can use the
-[helm](./helm.md) module type.
+[helm](https://docs.garden.io/module-types/helm) module type.
 
 ## Reference
 
@@ -40,31 +40,29 @@ type:
 # The name of this module.
 name:
 
+# A description of the module.
 description:
 
-# Set this to `true` to disable the module. You can use this with conditional template strings to
-# disable modules based on, for example, the current environment or other variables (e.g.
-# `disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for
-# specific environments, e.g. only for development.
+# Set this to `true` to disable the module. You can use this with conditional template strings to disable modules
+# based on, for example, the current environment or other variables (e.g. `disabled: \${environment.name == "prod"}`).
+# This can be handy when you only need certain modules for specific environments, e.g. only for development.
 #
-# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run.
-# It also means that the module is not built _unless_ it is declared as a build dependency by another enabled
-# module (in which case building this module is necessary for the dependant to be built).
+# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also
+# means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which
+# case building this module is necessary for the dependant to be built).
 #
-# If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden
-# will automatically ignore those dependency declarations. Note however that template strings referencing the
-# module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled,
-# so you need to make sure to provide alternate values for those if you're using them, using conditional
-# expressions.
+# If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will
+# automatically ignore those dependency declarations. Note however that template strings referencing the module's
+# service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make
+# sure to provide alternate values for those if you're using them, using conditional expressions.
 disabled: false
 
-# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this
-# module. Files that do *not* match these paths or globs are excluded when computing the version of the module,
-# when responding to filesystem watch events, and when staging builds.
+# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this   module. Files
+# that do *not* match these paths or globs are excluded when computing the version of the module, when responding to
+# filesystem watch events, and when staging builds.
 #
-# Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
-# source tree, which use the same format as `.gitignore` files. See the
-# [Configuration Files
+# Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
+# tree, which use the same format as `.gitignore` files. See the [Configuration Files
 # guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
@@ -73,25 +71,25 @@ disabled: false
 # `files` directive so that only the Kubernetes manifests get included.
 include:
 
-# Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that
-# match these paths or globs are excluded when computing the version of the module, when responding to filesystem
-# watch events, and when staging builds.
+# Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these
+# paths or globs are excluded when computing the version of the module, when responding to filesystem watch events,
+# and when staging builds.
 #
-# Note that you can also explicitly _include_ files using the `include` field. If you also specify the
-# `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the
-# [Configuration Files
-# guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
+# Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
+# field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration
+# Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for
+# details.
 #
-# Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files
-# and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have
-# large directories that should not be watched for changes.
+# Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files and
+# directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have large
+# directories that should not be watched for changes.
 exclude:
 
 # A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific
 # branch or tag, with the format: <git remote url>#<branch|tag>
 #
-# Garden will import the repository source code into this module, but read the module's
-# config from the local garden.yml file.
+# Garden will import the repository source code into this module, but read the module's config from the local
+# garden.yml file.
 repositoryUrl:
 
 # When false, disables pushing this module to remote registries.
@@ -101,12 +99,14 @@ allowPublish: true
 build:
   # A list of modules that must be built before this module is built.
   dependencies:
-    # Module name to build ahead of this module.
-    - name:
+    - # Module name to build ahead of this module.
+      name:
+
       # Specify one or more files or directories to copy from the built dependency to this module.
       copy:
-        # POSIX-style path or filename of the directory or file(s) to copy to the target.
-        - source:
+        - # POSIX-style path or filename of the directory or file(s) to copy to the target.
+          source:
+
           # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
           # Defaults to to same as source path.
           target: ''
@@ -118,10 +118,12 @@ dependencies: []
 # List of Kubernetes resource manifests to deploy. Use this instead of the `files` field if you need to resolve
 # template strings in any of the manifests.
 manifests:
-  # The API version of the resource.
-  - apiVersion:
+  - # The API version of the resource.
+    apiVersion:
+
     # The kind of the resource.
     kind:
+
     metadata:
       # The name of the resource.
       name:
@@ -148,13 +150,16 @@ serviceResource:
   containerName:
 
 tasks:
-  # The name of the task.
-  - name:
+  - # The name of the task.
+    name:
+
     # A description of the task.
     description:
+
     # The names of any tasks that must be executed, and the names of any services that must be running, before this
     # task is executed.
     dependencies: []
+
     # Set this to `true` to disable the task. You can use this with conditional template strings to
     # enable/disable tasks based on, for example, the current environment or other variables (e.g.
     # `enabled: \${environment.name != "prod"}`). This can be handy when you only want certain tasks to run in
@@ -167,8 +172,10 @@ tasks:
     # resolve when the task is disabled, so you need to make sure to provide alternate values for those if
     # you're using them, using conditional expressions.
     disabled: false
+
     # Maximum duration (in seconds) of the task's execution.
     timeout: null
+
     # The Deployment, DaemonSet or StatefulSet that Garden should use to execute this task. If not specified, the
     # `serviceResource` configured on the module will be used. If neither is specified, an error will be thrown.
     resource:
@@ -182,33 +189,42 @@ tasks:
       # The name of a container in the target. Specify this if the target contains more than one container and the
       # main container is not the first container in the spec.
       containerName:
+
     # The command/entrypoint used to run the task inside the container.
     command:
+
     # The arguments to pass to the container used for execution.
     args:
+
     # Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with
     # `GARDEN`) and values must be primitives or references to secrets.
     env: {}
+
     # Specify artifacts to copy out of the container after the task is complete.
     artifacts:
-      # A POSIX-style path or glob to copy. Must be an absolute path. May contain wildcards.
-      - source:
+      - # A POSIX-style path or glob to copy. Must be an absolute path. May contain wildcards.
+        source:
+
         # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
         target: .
 
 tests:
-  # The name of the test.
-  - name:
+  - # The name of the test.
+    name:
+
     # The names of any services that must be running, and the names of any tasks that must be executed, before the
     # test is run.
     dependencies: []
+
     # Set this to `true` to disable the test. You can use this with conditional template strings to
     # enable/disable tests based on, for example, the current environment or other variables (e.g.
     # `enabled: \${environment.name != "prod"}`). This is handy when you only want certain tests to run in
     # specific environments, e.g. only during CI.
     disabled: false
+
     # Maximum duration (in seconds) of the test run.
     timeout: null
+
     # The Deployment, DaemonSet or StatefulSet that Garden should use to execute this test suite. If not specified,
     # the `serviceResource` configured on the module will be used. If neither is specified, an error will be thrown.
     resource:
@@ -222,17 +238,22 @@ tests:
       # The name of a container in the target. Specify this if the target contains more than one container and the
       # main container is not the first container in the spec.
       containerName:
+
     # The command/entrypoint used to run the test inside the container.
     command:
+
     # The arguments to pass to the container used for testing.
     args:
+
     # Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with
     # `GARDEN`) and values must be primitives or references to secrets.
     env: {}
+
     # Specify artifacts to copy out of the container after the test is complete.
     artifacts:
-      # A POSIX-style path or glob to copy. Must be an absolute path. May contain wildcards.
-      - source:
+      - # A POSIX-style path or glob to copy. Must be an absolute path. May contain wildcards.
+        source:
+
         # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
         target: .
 ```
@@ -283,40 +304,29 @@ name: "my-sweet-module"
 
 #### `description`
 
+A description of the module.
+
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
 
 #### `disabled`
 
-Set this to `true` to disable the module. You can use this with conditional template strings to
-disable modules based on, for example, the current environment or other variables (e.g.
-`disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for
-specific environments, e.g. only for development.
+Set this to `true` to disable the module. You can use this with conditional template strings to disable modules based on, for example, the current environment or other variables (e.g. `disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for specific environments, e.g. only for development.
 
-Disabling a module means that any services, tasks and tests contained in it will not be deployed or run.
-It also means that the module is not built _unless_ it is declared as a build dependency by another enabled
-module (in which case building this module is necessary for the dependant to be built).
+Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which case building this module is necessary for the dependant to be built).
 
-If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden
-will automatically ignore those dependency declarations. Note however that template strings referencing the
-module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled,
-so you need to make sure to provide alternate values for those if you're using them, using conditional
-expressions.
+If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will automatically ignore those dependency declarations. Note however that template strings referencing the module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
-#### `include`
+#### `include[]`
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this
-module. Files that do *not* match these paths or globs are excluded when computing the version of the module,
-when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this   module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
-source tree, which use the same format as `.gitignore` files. See the
-[Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
 
@@ -335,19 +345,13 @@ include:
   - my-app.js
 ```
 
-#### `exclude`
+#### `exclude[]`
 
-Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that
-match these paths or globs are excluded when computing the version of the module, when responding to filesystem
-watch events, and when staging builds.
+Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the
-`include` field, the files/patterns specified here are filtered from the files matched by `include`. See the
-[Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
 
-Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files
-and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have
-large directories that should not be watched for changes.
+Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have large directories that should not be watched for changes.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -365,8 +369,7 @@ exclude:
 
 A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific branch or tag, with the format: <git remote url>#<branch|tag>
 
-Garden will import the repository source code into this module, but read the module's
-config from the local garden.yml file.
+Garden will import the repository source code into this module, but read the module's config from the local garden.yml file.
 
 | Type              | Required |
 | ----------------- | -------- |
@@ -454,7 +457,7 @@ Defaults to to same as source path.
 | ----------- | ------- | -------- |
 | `posixPath` | `""`    | No       |
 
-#### `dependencies`
+#### `dependencies[]`
 
 The names of any services that this service depends on at runtime, and the names of any tasks that should be executed before this service is deployed.
 
@@ -462,7 +465,7 @@ The names of any services that this service depends on at runtime, and the names
 | --------------- | ------- | -------- |
 | `array[string]` | `[]`    | No       |
 
-#### `manifests`
+#### `manifests[]`
 
 List of Kubernetes resource manifests to deploy. Use this instead of the `files` field if you need to resolve template strings in any of the manifests.
 
@@ -508,7 +511,7 @@ The name of the resource.
 | -------- | -------- |
 | `string` | Yes      |
 
-#### `files`
+#### `files[]`
 
 POSIX-style paths to YAML files to load manifests from. Each can contain multiple manifests.
 
@@ -562,7 +565,7 @@ The name of a container in the target. Specify this if the target contains more 
 | -------- | -------- |
 | `string` | No       |
 
-#### `tasks`
+#### `tasks[]`
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
@@ -683,8 +686,8 @@ Example:
 ```yaml
 tasks:
   - command:
-    - /bin/sh
-    - '-c'
+      - /bin/sh
+      - '-c'
 ```
 
 #### `tasks[].args[]`
@@ -702,8 +705,8 @@ Example:
 ```yaml
 tasks:
   - args:
-    - rake
-    - 'db:migrate'
+      - rake
+      - 'db:migrate'
 ```
 
 #### `tasks[].env`
@@ -721,12 +724,12 @@ Example:
 ```yaml
 tasks:
   - env:
-      - MY_VAR: some-value
-        MY_SECRET_VAR:
-          secretRef:
-            name: my-secret
-            key: some-key
-      - {}
+        - MY_VAR: some-value
+          MY_SECRET_VAR:
+            secretRef:
+              name: my-secret
+              key: some-key
+        - {}
 ```
 
 #### `tasks[].artifacts[]`
@@ -775,7 +778,7 @@ tasks:
       - target: "outputs/foo/"
 ```
 
-#### `tests`
+#### `tests[]`
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
@@ -879,8 +882,8 @@ Example:
 ```yaml
 tests:
   - command:
-    - /bin/sh
-    - '-c'
+      - /bin/sh
+      - '-c'
 ```
 
 #### `tests[].args[]`
@@ -898,8 +901,8 @@ Example:
 ```yaml
 tests:
   - args:
-    - npm
-    - test
+      - npm
+      - test
 ```
 
 #### `tests[].env`
@@ -917,12 +920,12 @@ Example:
 ```yaml
 tests:
   - env:
-      - MY_VAR: some-value
-        MY_SECRET_VAR:
-          secretRef:
-            name: my-secret
-            key: some-key
-      - {}
+        - MY_VAR: some-value
+          MY_SECRET_VAR:
+            secretRef:
+              name: my-secret
+              key: some-key
+        - {}
 ```
 
 #### `tests[].artifacts[]`

--- a/docs/module-types/maven-container.md
+++ b/docs/module-types/maven-container.md
@@ -59,8 +59,8 @@ description:
 # sure to provide alternate values for those if you're using them, using conditional expressions.
 disabled: false
 
-# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this   module. Files
-# that do *not* match these paths or globs are excluded when computing the version of the module, when responding to
+# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that
+# do *not* match these paths or globs are excluded when computing the version of the module, when responding to
 # filesystem watch events, and when staging builds.
 #
 # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
@@ -475,7 +475,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 #### `include[]`
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this   module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
 Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 

--- a/docs/module-types/maven-container.md
+++ b/docs/module-types/maven-container.md
@@ -42,55 +42,53 @@ type:
 # The name of this module.
 name:
 
+# A description of the module.
 description:
 
-# Set this to `true` to disable the module. You can use this with conditional template strings to
-# disable modules based on, for example, the current environment or other variables (e.g.
-# `disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for
-# specific environments, e.g. only for development.
+# Set this to `true` to disable the module. You can use this with conditional template strings to disable modules
+# based on, for example, the current environment or other variables (e.g. `disabled: \${environment.name == "prod"}`).
+# This can be handy when you only need certain modules for specific environments, e.g. only for development.
 #
-# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run.
-# It also means that the module is not built _unless_ it is declared as a build dependency by another enabled
-# module (in which case building this module is necessary for the dependant to be built).
+# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also
+# means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which
+# case building this module is necessary for the dependant to be built).
 #
-# If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden
-# will automatically ignore those dependency declarations. Note however that template strings referencing the
-# module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled,
-# so you need to make sure to provide alternate values for those if you're using them, using conditional
-# expressions.
+# If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will
+# automatically ignore those dependency declarations. Note however that template strings referencing the module's
+# service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make
+# sure to provide alternate values for those if you're using them, using conditional expressions.
 disabled: false
 
-# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this
-# module. Files that do *not* match these paths or globs are excluded when computing the version of the module,
-# when responding to filesystem watch events, and when staging builds.
+# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this   module. Files
+# that do *not* match these paths or globs are excluded when computing the version of the module, when responding to
+# filesystem watch events, and when staging builds.
 #
-# Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
-# source tree, which use the same format as `.gitignore` files. See the
-# [Configuration Files
+# Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
+# tree, which use the same format as `.gitignore` files. See the [Configuration Files
 # guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
 include:
 
-# Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that
-# match these paths or globs are excluded when computing the version of the module, when responding to filesystem
-# watch events, and when staging builds.
+# Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these
+# paths or globs are excluded when computing the version of the module, when responding to filesystem watch events,
+# and when staging builds.
 #
-# Note that you can also explicitly _include_ files using the `include` field. If you also specify the
-# `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the
-# [Configuration Files
-# guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
+# Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
+# field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration
+# Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for
+# details.
 #
-# Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files
-# and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have
-# large directories that should not be watched for changes.
+# Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files and
+# directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have large
+# directories that should not be watched for changes.
 exclude:
 
 # A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific
 # branch or tag, with the format: <git remote url>#<branch|tag>
 #
-# Garden will import the repository source code into this module, but read the module's
-# config from the local garden.yml file.
+# Garden will import the repository source code into this module, but read the module's config from the local
+# garden.yml file.
 repositoryUrl:
 
 # When false, disables pushing this module to remote registries.
@@ -100,12 +98,14 @@ allowPublish: true
 build:
   # A list of modules that must be built before this module is built.
   dependencies:
-    # Module name to build ahead of this module.
-    - name:
+    - # Module name to build ahead of this module.
+      name:
+
       # Specify one or more files or directories to copy from the built dependency to this module.
       copy:
-        # POSIX-style path or filename of the directory or file(s) to copy to the target.
-        - source:
+        - # POSIX-style path or filename of the directory or file(s) to copy to the target.
+          source:
+
           # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
           # Defaults to to same as source path.
           target: ''
@@ -135,9 +135,10 @@ image:
 hotReload:
   # Specify one or more source files or directories to automatically sync into the running container.
   sync:
-    # POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be
-    # a relative path if provided. Defaults to the module's top-level directory if no value is provided.
-    - source: .
+    - # POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be
+      # a relative path if provided. Defaults to the module's top-level directory if no value is provided.
+      source: .
+
       # POSIX-style absolute path to sync the directory to inside the container. The root path (i.e. "/") is not
       # allowed.
       target:
@@ -148,60 +149,73 @@ hotReload:
 # POSIX-style name of Dockerfile, relative to module root.
 dockerfile:
 
-# The list of services to deploy from this container module.
+# A list of services to deploy from this container module.
 services:
-  # Valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and dashes, must start with a letter,
-  # and cannot end with a dash), cannot contain consecutive dashes or start with `garden`, or be longer than 63
-  # characters.
-  - name:
+  - # Valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and dashes, must start with a letter,
+    # and cannot end with a dash), cannot contain consecutive dashes or start with `garden`, or be longer than 63
+    # characters.
+    name:
+
     # The names of any services that this service depends on at runtime, and the names of any tasks that should be
     # executed before this service is deployed.
     dependencies: []
-    # Set this to `true` to disable the service. You can use this with conditional template strings to
-    # enable/disable services based on, for example, the current environment or other variables (e.g.
-    # `enabled: \${environment.name != "prod"}`). This can be handy when you only need certain services for
-    # specific environments, e.g. only for development.
+
+    # Set this to `true` to disable the service. You can use this with conditional template strings to enable/disable
+    # services based on, for example, the current environment or other variables (e.g. `enabled: \${environment.name
+    # != "prod"}`). This can be handy when you only need certain services for specific environments, e.g. only for
+    # development.
     #
-    # Disabling a service means that it will not be deployed, and will also be ignored if it is declared as a
-    # runtime dependency for another service, test or task.
+    # Disabling a service means that it will not be deployed, and will also be ignored if it is declared as a runtime
+    # dependency for another service, test or task.
     #
-    # Note however that template strings referencing the service's outputs (i.e. runtime outputs) will fail to
-    # resolve when the service is disabled, so you need to make sure to provide alternate values for those if
-    # you're using them, using conditional expressions.
+    # Note however that template strings referencing the service's outputs (i.e. runtime outputs) will fail to resolve
+    # when the service is disabled, so you need to make sure to provide alternate values for those if you're using
+    # them, using conditional expressions.
     disabled: false
+
     # Annotations to attach to the service (Note: May not be applicable to all providers).
     annotations: {}
+
     # The command/entrypoint to run the container with when starting the service.
     command:
+
     # The arguments to run the container with when starting the service.
     args:
+
     # Whether to run the service as a daemon (to ensure exactly one instance runs per node). May not be supported by
     # all providers.
     daemon: false
+
     # List of ingress endpoints that the service exposes.
     ingresses:
-      # Annotations to attach to the ingress (Note: May not be applicable to all providers)
-      - annotations: {}
-        # The hostname that should route to this service. Defaults to the default hostname
-        # configured in the provider configuration.
+      - # Annotations to attach to the ingress (Note: May not be applicable to all providers)
+        annotations: {}
+
+        # The hostname that should route to this service. Defaults to the default hostname configured in the provider
+        # configuration.
         #
         # Note that if you're developing locally you may need to add this hostname to your hosts file.
         hostname:
-        # The link URL for the ingress to show in the console and on the dashboard.
-        # Also used when calling the service with the `call` command.
+
+        # The link URL for the ingress to show in the console and on the dashboard. Also used when calling the service
+        # with the `call` command.
         #
-        # Use this if the actual URL is different from what's specified in the ingress,
-        # e.g. because there's a load balancer in front of the service that rewrites the paths.
+        # Use this if the actual URL is different from what's specified in the ingress, e.g. because there's a load
+        # balancer in front of the service that rewrites the paths.
         #
         # Otherwise Garden will construct the link URL from the ingress spec.
         linkUrl:
+
         # The path which should be routed to the service.
         path: /
+
         # The name of the container port where the specified paths should be routed.
         port:
+
     # Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with
     # `GARDEN`) and values must be primitives or references to secrets.
     env: {}
+
     # Specify how the service's health should be checked after deploying.
     healthCheck:
       # Set this to check the service's health by making an HTTP request.
@@ -219,12 +233,15 @@ services:
 
       # Set this to check the service's health by checking if this TCP port is accepting connections.
       tcpPort:
+
     # If this module uses the `hotReload` field, the container will be run with this command/entrypoint when the
     # service is deployed with hot reloading enabled.
     hotReloadCommand:
+
     # If this module uses the `hotReload` field, the container will be run with these arguments when the service is
     # deployed with hot reloading enabled.
     hotReloadArgs:
+
     # Specify resource limits for the service.
     limits:
       # The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)
@@ -232,12 +249,15 @@ services:
 
       # The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB)
       memory: 1024
+
     # List of ports that the service container exposes.
     ports:
-      # The name of the port (used when referencing the port elsewhere in the service configuration).
-      - name:
+      - # The name of the port (used when referencing the port elsewhere in the service configuration).
+        name:
+
         # The protocol of the port.
         protocol: TCP
+
         # The port exposed on the container by the running process. This will also be the default value for
         # `servicePort`.
         # This is the port you would expose in your Dockerfile and that your process listens on. This is commonly a
@@ -245,6 +265,7 @@ services:
         # The service port maps to the container port:
         # `servicePort:80 -> containerPort:8080 -> process:8080`
         containerPort:
+
         # The port exposed on the service. Defaults to `containerPort` if not specified.
         # This is the port you use when calling a service from another service within the cluster. For example, if
         # your service name is my-service and the service port is 8090, you would call it with:
@@ -254,24 +275,28 @@ services:
         # The service port maps to the container port:
         # `servicePort:80 -> containerPort:8080 -> process:8080`
         servicePort:
-        hostPort:
+
         # Set this to expose the service on the specified port on the host node (may not be supported by all
         # providers). Set to `true` to have the cluster pick a port automatically, which is most often advisable if
         # the cluster is shared by multiple users.
         # This allows you to call the service from the outside by the node's IP address and the port number set in
         # this field.
         nodePort:
+
     # The number of instances of the service to deploy. Defaults to 3 for environments configured with `production:
     # true`, otherwise 1.
     # Note: This setting may be overridden or ignored in some cases. For example, when running with `daemon: true`,
     # with hot-reloading enabled, or if the provider doesn't support multiple replicas.
     replicas:
+
     # List of volumes that should be mounted when deploying the container.
     volumes:
-      # The name of the allocated volume.
-      - name:
+      - # The name of the allocated volume.
+        name:
+
         # The path where the volume should be mounted in the container.
         containerPath:
+
         # _NOTE: Usage of hostPath is generally discouraged, since it doesn't work reliably across different platforms
         # and providers. Some providers may not support it at all._
         #
@@ -281,30 +306,38 @@ services:
 
 # A list of tests to run in the module.
 tests:
-  # The name of the test.
-  - name:
+  - # The name of the test.
+    name:
+
     # The names of any services that must be running, and the names of any tasks that must be executed, before the
     # test is run.
     dependencies: []
+
     # Set this to `true` to disable the test. You can use this with conditional template strings to
     # enable/disable tests based on, for example, the current environment or other variables (e.g.
     # `enabled: \${environment.name != "prod"}`). This is handy when you only want certain tests to run in
     # specific environments, e.g. only during CI.
     disabled: false
+
     # Maximum duration (in seconds) of the test run.
     timeout: null
+
     # The arguments used to run the test inside the container.
     args:
+
     # Specify artifacts to copy out of the container after the run.
     # Note: Depending on the provider, this may require the container image to include `sh` `tar`, in order to enable
     # the file transfer.
     artifacts:
-      # A POSIX-style path or glob to copy. Must be an absolute path. May contain wildcards.
-      - source:
+      - # A POSIX-style path or glob to copy. Must be an absolute path. May contain wildcards.
+        source:
+
         # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
         target: .
+
     # The command/entrypoint used to run the test inside the container.
     command:
+
     # Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with
     # `GARDEN`) and values must be primitives or references to secrets.
     env: {}
@@ -312,13 +345,16 @@ tests:
 # A list of tasks that can be run from this container module. These can be used as dependencies for services (executed
 # before the service is deployed) or for other tasks.
 tasks:
-  # The name of the task.
-  - name:
+  - # The name of the task.
+    name:
+
     # A description of the task.
     description:
+
     # The names of any tasks that must be executed, and the names of any services that must be running, before this
     # task is executed.
     dependencies: []
+
     # Set this to `true` to disable the task. You can use this with conditional template strings to
     # enable/disable tasks based on, for example, the current environment or other variables (e.g.
     # `enabled: \${environment.name != "prod"}`). This can be handy when you only want certain tasks to run in
@@ -331,20 +367,26 @@ tasks:
     # resolve when the task is disabled, so you need to make sure to provide alternate values for those if
     # you're using them, using conditional expressions.
     disabled: false
+
     # Maximum duration (in seconds) of the task's execution.
     timeout: null
+
     # The arguments used to run the task inside the container.
     args:
+
     # Specify artifacts to copy out of the container after the run.
     # Note: Depending on the provider, this may require the container image to include `sh` `tar`, in order to enable
     # the file transfer.
     artifacts:
-      # A POSIX-style path or glob to copy. Must be an absolute path. May contain wildcards.
-      - source:
+      - # A POSIX-style path or glob to copy. Must be an absolute path. May contain wildcards.
+        source:
+
         # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
         target: .
+
     # The command/entrypoint used to run the task inside the container.
     command:
+
     # Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with
     # `GARDEN`) and values must be primitives or references to secrets.
     env: {}
@@ -413,40 +455,29 @@ name: "my-sweet-module"
 
 #### `description`
 
+A description of the module.
+
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
 
 #### `disabled`
 
-Set this to `true` to disable the module. You can use this with conditional template strings to
-disable modules based on, for example, the current environment or other variables (e.g.
-`disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for
-specific environments, e.g. only for development.
+Set this to `true` to disable the module. You can use this with conditional template strings to disable modules based on, for example, the current environment or other variables (e.g. `disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for specific environments, e.g. only for development.
 
-Disabling a module means that any services, tasks and tests contained in it will not be deployed or run.
-It also means that the module is not built _unless_ it is declared as a build dependency by another enabled
-module (in which case building this module is necessary for the dependant to be built).
+Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which case building this module is necessary for the dependant to be built).
 
-If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden
-will automatically ignore those dependency declarations. Note however that template strings referencing the
-module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled,
-so you need to make sure to provide alternate values for those if you're using them, using conditional
-expressions.
+If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will automatically ignore those dependency declarations. Note however that template strings referencing the module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
-#### `include`
+#### `include[]`
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this
-module. Files that do *not* match these paths or globs are excluded when computing the version of the module,
-when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this   module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
-source tree, which use the same format as `.gitignore` files. See the
-[Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
 
@@ -462,19 +493,13 @@ include:
   - my-app.js
 ```
 
-#### `exclude`
+#### `exclude[]`
 
-Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that
-match these paths or globs are excluded when computing the version of the module, when responding to filesystem
-watch events, and when staging builds.
+Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the
-`include` field, the files/patterns specified here are filtered from the files matched by `include`. See the
-[Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
 
-Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files
-and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have
-large directories that should not be watched for changes.
+Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have large directories that should not be watched for changes.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -492,8 +517,7 @@ exclude:
 
 A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific branch or tag, with the format: <git remote url>#<branch|tag>
 
-Garden will import the repository source code into this module, but read the module's
-config from the local garden.yml file.
+Garden will import the repository source code into this module, but read the module's config from the local garden.yml file.
 
 | Type              | Required |
 | ----------------- | -------- |
@@ -609,7 +633,7 @@ Specify build arguments to use when building the container image.
 | -------- | ------- | -------- |
 | `object` | `{}`    | No       |
 
-#### `extraFlags`
+#### `extraFlags[]`
 
 Specify extra flags to use when building the container image. Note that arguments may not be portable across implementations.
 
@@ -708,9 +732,9 @@ POSIX-style name of Dockerfile, relative to module root.
 | ----------- | -------- |
 | `posixPath` | No       |
 
-#### `services`
+#### `services[]`
 
-The list of services to deploy from this container module.
+A list of services to deploy from this container module.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
@@ -740,17 +764,11 @@ The names of any services that this service depends on at runtime, and the names
 
 [services](#services) > disabled
 
-Set this to `true` to disable the service. You can use this with conditional template strings to
-enable/disable services based on, for example, the current environment or other variables (e.g.
-`enabled: \${environment.name != "prod"}`). This can be handy when you only need certain services for
-specific environments, e.g. only for development.
+Set this to `true` to disable the service. You can use this with conditional template strings to enable/disable services based on, for example, the current environment or other variables (e.g. `enabled: \${environment.name != "prod"}`). This can be handy when you only need certain services for specific environments, e.g. only for development.
 
-Disabling a service means that it will not be deployed, and will also be ignored if it is declared as a
-runtime dependency for another service, test or task.
+Disabling a service means that it will not be deployed, and will also be ignored if it is declared as a runtime dependency for another service, test or task.
 
-Note however that template strings referencing the service's outputs (i.e. runtime outputs) will fail to
-resolve when the service is disabled, so you need to make sure to provide alternate values for those if
-you're using them, using conditional expressions.
+Note however that template strings referencing the service's outputs (i.e. runtime outputs) will fail to resolve when the service is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |
@@ -771,7 +789,7 @@ Example:
 ```yaml
 services:
   - annotations:
-      nginx.ingress.kubernetes.io/proxy-body-size: '0'
+        nginx.ingress.kubernetes.io/proxy-body-size: '0'
 ```
 
 #### `services[].command[]`
@@ -789,8 +807,8 @@ Example:
 ```yaml
 services:
   - command:
-    - /bin/sh
-    - '-c'
+      - /bin/sh
+      - '-c'
 ```
 
 #### `services[].args[]`
@@ -808,8 +826,8 @@ Example:
 ```yaml
 services:
   - args:
-    - npm
-    - start
+      - npm
+      - start
 ```
 
 #### `services[].daemon`
@@ -837,8 +855,8 @@ Example:
 ```yaml
 services:
   - ingresses:
-    - path: /api
-      port: http
+      - path: /api
+        port: http
 ```
 
 #### `services[].ingresses[].annotations`
@@ -856,18 +874,17 @@ Example:
 ```yaml
 services:
   - ingresses:
-    - path: /api
-      port: http
+      - path: /api
+        port: http
       - annotations:
-          nginx.ingress.kubernetes.io/proxy-body-size: '0'
+            nginx.ingress.kubernetes.io/proxy-body-size: '0'
 ```
 
 #### `services[].ingresses[].hostname`
 
 [services](#services) > [ingresses](#servicesingresses) > hostname
 
-The hostname that should route to this service. Defaults to the default hostname
-configured in the provider configuration.
+The hostname that should route to this service. Defaults to the default hostname configured in the provider configuration.
 
 Note that if you're developing locally you may need to add this hostname to your hosts file.
 
@@ -879,11 +896,9 @@ Note that if you're developing locally you may need to add this hostname to your
 
 [services](#services) > [ingresses](#servicesingresses) > linkUrl
 
-The link URL for the ingress to show in the console and on the dashboard.
-Also used when calling the service with the `call` command.
+The link URL for the ingress to show in the console and on the dashboard. Also used when calling the service with the `call` command.
 
-Use this if the actual URL is different from what's specified in the ingress,
-e.g. because there's a load balancer in front of the service that rewrites the paths.
+Use this if the actual URL is different from what's specified in the ingress, e.g. because there's a load balancer in front of the service that rewrites the paths.
 
 Otherwise Garden will construct the link URL from the ingress spec.
 
@@ -926,12 +941,12 @@ Example:
 ```yaml
 services:
   - env:
-      - MY_VAR: some-value
-        MY_SECRET_VAR:
-          secretRef:
-            name: my-secret
-            key: some-key
-      - {}
+        - MY_VAR: some-value
+          MY_SECRET_VAR:
+            secretRef:
+              name: my-secret
+              key: some-key
+        - {}
 ```
 
 #### `services[].healthCheck`
@@ -1017,8 +1032,8 @@ Example:
 ```yaml
 services:
   - hotReloadCommand:
-    - /bin/sh
-    - '-c'
+      - /bin/sh
+      - '-c'
 ```
 
 #### `services[].hotReloadArgs[]`
@@ -1036,9 +1051,9 @@ Example:
 ```yaml
 services:
   - hotReloadArgs:
-    - npm
-    - run
-    - dev
+      - npm
+      - run
+      - dev
 ```
 
 #### `services[].limits`
@@ -1226,7 +1241,7 @@ services:
       - hostPath: "/some/dir"
 ```
 
-#### `tests`
+#### `tests[]`
 
 A list of tests to run in the module.
 
@@ -1292,8 +1307,8 @@ Example:
 ```yaml
 tests:
   - args:
-    - npm
-    - test
+      - npm
+      - test
 ```
 
 #### `tests[].artifacts[]`
@@ -1312,7 +1327,7 @@ Example:
 ```yaml
 tests:
   - artifacts:
-    - source: /report/**/*
+      - source: /report/**/*
 ```
 
 #### `tests[].artifacts[].source`
@@ -1330,7 +1345,7 @@ Example:
 ```yaml
 tests:
   - artifacts:
-    - source: /report/**/*
+      - source: /report/**/*
       - source: "/output/**/*"
 ```
 
@@ -1349,7 +1364,7 @@ Example:
 ```yaml
 tests:
   - artifacts:
-    - source: /report/**/*
+      - source: /report/**/*
       - target: "outputs/foo/"
 ```
 
@@ -1368,8 +1383,8 @@ Example:
 ```yaml
 tests:
   - command:
-    - /bin/sh
-    - '-c'
+      - /bin/sh
+      - '-c'
 ```
 
 #### `tests[].env`
@@ -1387,15 +1402,15 @@ Example:
 ```yaml
 tests:
   - env:
-      - MY_VAR: some-value
-        MY_SECRET_VAR:
-          secretRef:
-            name: my-secret
-            key: some-key
-      - {}
+        - MY_VAR: some-value
+          MY_SECRET_VAR:
+            secretRef:
+              name: my-secret
+              key: some-key
+        - {}
 ```
 
-#### `tasks`
+#### `tasks[]`
 
 A list of tasks that can be run from this container module. These can be used as dependencies for services (executed before the service is deployed) or for other tasks.
 
@@ -1478,8 +1493,8 @@ Example:
 ```yaml
 tasks:
   - args:
-    - rake
-    - 'db:migrate'
+      - rake
+      - 'db:migrate'
 ```
 
 #### `tasks[].artifacts[]`
@@ -1498,7 +1513,7 @@ Example:
 ```yaml
 tasks:
   - artifacts:
-    - source: /report/**/*
+      - source: /report/**/*
 ```
 
 #### `tasks[].artifacts[].source`
@@ -1516,7 +1531,7 @@ Example:
 ```yaml
 tasks:
   - artifacts:
-    - source: /report/**/*
+      - source: /report/**/*
       - source: "/output/**/*"
 ```
 
@@ -1535,7 +1550,7 @@ Example:
 ```yaml
 tasks:
   - artifacts:
-    - source: /report/**/*
+      - source: /report/**/*
       - target: "outputs/foo/"
 ```
 
@@ -1554,8 +1569,8 @@ Example:
 ```yaml
 tasks:
   - command:
-    - /bin/sh
-    - '-c'
+      - /bin/sh
+      - '-c'
 ```
 
 #### `tasks[].env`
@@ -1573,12 +1588,12 @@ Example:
 ```yaml
 tasks:
   - env:
-      - MY_VAR: some-value
-        MY_SECRET_VAR:
-          secretRef:
-            name: my-secret
-            key: some-key
-      - {}
+        - MY_VAR: some-value
+          MY_SECRET_VAR:
+            secretRef:
+              name: my-secret
+              key: some-key
+        - {}
 ```
 
 #### `imageVersion`
@@ -1618,7 +1633,7 @@ The JDK version to use.
 | -------- | ------- | -------- |
 | `number` | `8`     | No       |
 
-#### `mvnOpts`
+#### `mvnOpts[]`
 
 Options to add to the `mvn package` command when building.
 

--- a/docs/module-types/openfaas.md
+++ b/docs/module-types/openfaas.md
@@ -32,55 +32,53 @@ type:
 # The name of this module.
 name:
 
+# A description of the module.
 description:
 
-# Set this to `true` to disable the module. You can use this with conditional template strings to
-# disable modules based on, for example, the current environment or other variables (e.g.
-# `disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for
-# specific environments, e.g. only for development.
+# Set this to `true` to disable the module. You can use this with conditional template strings to disable modules
+# based on, for example, the current environment or other variables (e.g. `disabled: \${environment.name == "prod"}`).
+# This can be handy when you only need certain modules for specific environments, e.g. only for development.
 #
-# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run.
-# It also means that the module is not built _unless_ it is declared as a build dependency by another enabled
-# module (in which case building this module is necessary for the dependant to be built).
+# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also
+# means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which
+# case building this module is necessary for the dependant to be built).
 #
-# If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden
-# will automatically ignore those dependency declarations. Note however that template strings referencing the
-# module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled,
-# so you need to make sure to provide alternate values for those if you're using them, using conditional
-# expressions.
+# If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will
+# automatically ignore those dependency declarations. Note however that template strings referencing the module's
+# service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make
+# sure to provide alternate values for those if you're using them, using conditional expressions.
 disabled: false
 
-# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this
-# module. Files that do *not* match these paths or globs are excluded when computing the version of the module,
-# when responding to filesystem watch events, and when staging builds.
+# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that
+# do *not* match these paths or globs are excluded when computing the version of the module, when responding to
+# filesystem watch events, and when staging builds.
 #
-# Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
-# source tree, which use the same format as `.gitignore` files. See the
-# [Configuration Files
+# Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
+# tree, which use the same format as `.gitignore` files. See the [Configuration Files
 # guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
 include:
 
-# Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that
-# match these paths or globs are excluded when computing the version of the module, when responding to filesystem
-# watch events, and when staging builds.
+# Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these
+# paths or globs are excluded when computing the version of the module, when responding to filesystem watch events,
+# and when staging builds.
 #
-# Note that you can also explicitly _include_ files using the `include` field. If you also specify the
-# `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the
-# [Configuration Files
-# guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
+# Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
+# field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration
+# Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for
+# details.
 #
-# Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files
-# and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have
-# large directories that should not be watched for changes.
+# Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files and
+# directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have large
+# directories that should not be watched for changes.
 exclude:
 
 # A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific
 # branch or tag, with the format: <git remote url>#<branch|tag>
 #
-# Garden will import the repository source code into this module, but read the module's
-# config from the local garden.yml file.
+# Garden will import the repository source code into this module, but read the module's config from the local
+# garden.yml file.
 repositoryUrl:
 
 # When false, disables pushing this module to remote registries.
@@ -90,12 +88,14 @@ allowPublish: true
 build:
   # A list of modules that must be built before this module is built.
   dependencies:
-    # Module name to build ahead of this module.
-    - name:
+    - # Module name to build ahead of this module.
+      name:
+
       # Specify one or more files or directories to copy from the built dependency to this module.
       copy:
-        # POSIX-style path or filename of the directory or file(s) to copy to the target.
-        - source:
+        - # POSIX-style path or filename of the directory or file(s) to copy to the target.
+          source:
+
           # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
           # Defaults to to same as source path.
           target: ''
@@ -118,20 +118,25 @@ lang:
 
 # A list of tests to run in the module.
 tests:
-  # The name of the test.
-  - name:
+  - # The name of the test.
+    name:
+
     # The names of any services that must be running, and the names of any tasks that must be executed, before the
     # test is run.
     dependencies: []
+
     # Set this to `true` to disable the test. You can use this with conditional template strings to
     # enable/disable tests based on, for example, the current environment or other variables (e.g.
     # `enabled: \${environment.name != "prod"}`). This is handy when you only want certain tests to run in
     # specific environments, e.g. only during CI.
     disabled: false
+
     # Maximum duration (in seconds) of the test run.
     timeout: null
+
     # The command to run in the module build context in order to test it.
     command:
+
     # Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with
     # `GARDEN`) and values must be primitives.
     env: {}
@@ -183,40 +188,29 @@ name: "my-sweet-module"
 
 #### `description`
 
+A description of the module.
+
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
 
 #### `disabled`
 
-Set this to `true` to disable the module. You can use this with conditional template strings to
-disable modules based on, for example, the current environment or other variables (e.g.
-`disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for
-specific environments, e.g. only for development.
+Set this to `true` to disable the module. You can use this with conditional template strings to disable modules based on, for example, the current environment or other variables (e.g. `disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for specific environments, e.g. only for development.
 
-Disabling a module means that any services, tasks and tests contained in it will not be deployed or run.
-It also means that the module is not built _unless_ it is declared as a build dependency by another enabled
-module (in which case building this module is necessary for the dependant to be built).
+Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which case building this module is necessary for the dependant to be built).
 
-If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden
-will automatically ignore those dependency declarations. Note however that template strings referencing the
-module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled,
-so you need to make sure to provide alternate values for those if you're using them, using conditional
-expressions.
+If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will automatically ignore those dependency declarations. Note however that template strings referencing the module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
-#### `include`
+#### `include[]`
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this
-module. Files that do *not* match these paths or globs are excluded when computing the version of the module,
-when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
-source tree, which use the same format as `.gitignore` files. See the
-[Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
 
@@ -232,19 +226,13 @@ include:
   - my-app.js
 ```
 
-#### `exclude`
+#### `exclude[]`
 
-Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that
-match these paths or globs are excluded when computing the version of the module, when responding to filesystem
-watch events, and when staging builds.
+Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the
-`include` field, the files/patterns specified here are filtered from the files matched by `include`. See the
-[Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
 
-Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files
-and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have
-large directories that should not be watched for changes.
+Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have large directories that should not be watched for changes.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -262,8 +250,7 @@ exclude:
 
 A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific branch or tag, with the format: <git remote url>#<branch|tag>
 
-Garden will import the repository source code into this module, but read the module's
-config from the local garden.yml file.
+Garden will import the repository source code into this module, but read the module's config from the local garden.yml file.
 
 | Type              | Required |
 | ----------------- | -------- |
@@ -351,7 +338,7 @@ Defaults to to same as source path.
 | ----------- | ------- | -------- |
 | `posixPath` | `""`    | No       |
 
-#### `dependencies`
+#### `dependencies[]`
 
 The names of services/functions that this function depends on at runtime.
 
@@ -391,7 +378,7 @@ The OpenFaaS language template to use to build this function.
 | -------- | -------- |
 | `string` | Yes      |
 
-#### `tests`
+#### `tests[]`
 
 A list of tests to run in the module.
 

--- a/docs/module-types/terraform.md
+++ b/docs/module-types/terraform.md
@@ -18,7 +18,7 @@ configurations, e.g. if you spin up an environment with the Terraform provider, 
 that to configure another provider or other modules via `\${providers.terraform.outputs.<key>}` template
 strings.
 
-See the [Terraform guide](../guides/terraform.md) for a high-level introduction to the `terraform`
+See the [Terraform guide](https://docs.garden.io/guides/terraform) for a high-level introduction to the `terraform`
 provider.
 
 ## Reference
@@ -46,55 +46,53 @@ type:
 # The name of this module.
 name:
 
+# A description of the module.
 description:
 
-# Set this to `true` to disable the module. You can use this with conditional template strings to
-# disable modules based on, for example, the current environment or other variables (e.g.
-# `disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for
-# specific environments, e.g. only for development.
+# Set this to `true` to disable the module. You can use this with conditional template strings to disable modules
+# based on, for example, the current environment or other variables (e.g. `disabled: \${environment.name == "prod"}`).
+# This can be handy when you only need certain modules for specific environments, e.g. only for development.
 #
-# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run.
-# It also means that the module is not built _unless_ it is declared as a build dependency by another enabled
-# module (in which case building this module is necessary for the dependant to be built).
+# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also
+# means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which
+# case building this module is necessary for the dependant to be built).
 #
-# If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden
-# will automatically ignore those dependency declarations. Note however that template strings referencing the
-# module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled,
-# so you need to make sure to provide alternate values for those if you're using them, using conditional
-# expressions.
+# If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will
+# automatically ignore those dependency declarations. Note however that template strings referencing the module's
+# service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make
+# sure to provide alternate values for those if you're using them, using conditional expressions.
 disabled: false
 
-# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this
-# module. Files that do *not* match these paths or globs are excluded when computing the version of the module,
-# when responding to filesystem watch events, and when staging builds.
+# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that
+# do *not* match these paths or globs are excluded when computing the version of the module, when responding to
+# filesystem watch events, and when staging builds.
 #
-# Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
-# source tree, which use the same format as `.gitignore` files. See the
-# [Configuration Files
+# Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
+# tree, which use the same format as `.gitignore` files. See the [Configuration Files
 # guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
 include:
 
-# Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that
-# match these paths or globs are excluded when computing the version of the module, when responding to filesystem
-# watch events, and when staging builds.
+# Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these
+# paths or globs are excluded when computing the version of the module, when responding to filesystem watch events,
+# and when staging builds.
 #
-# Note that you can also explicitly _include_ files using the `include` field. If you also specify the
-# `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the
-# [Configuration Files
-# guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
+# Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
+# field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration
+# Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for
+# details.
 #
-# Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files
-# and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have
-# large directories that should not be watched for changes.
+# Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files and
+# directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have large
+# directories that should not be watched for changes.
 exclude:
 
 # A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific
 # branch or tag, with the format: <git remote url>#<branch|tag>
 #
-# Garden will import the repository source code into this module, but read the module's
-# config from the local garden.yml file.
+# Garden will import the repository source code into this module, but read the module's config from the local
+# garden.yml file.
 repositoryUrl:
 
 # When false, disables pushing this module to remote registries.
@@ -104,12 +102,14 @@ allowPublish: true
 build:
   # A list of modules that must be built before this module is built.
   dependencies:
-    # Module name to build ahead of this module.
-    - name:
+    - # Module name to build ahead of this module.
+      name:
+
       # Specify one or more files or directories to copy from the built dependency to this module.
       copy:
-        # POSIX-style path or filename of the directory or file(s) to copy to the target.
-        - source:
+        - # POSIX-style path or filename of the directory or file(s) to copy to the target.
+          source:
+
           # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
           # Defaults to to same as source path.
           target: ''
@@ -182,40 +182,29 @@ name: "my-sweet-module"
 
 #### `description`
 
+A description of the module.
+
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
 
 #### `disabled`
 
-Set this to `true` to disable the module. You can use this with conditional template strings to
-disable modules based on, for example, the current environment or other variables (e.g.
-`disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for
-specific environments, e.g. only for development.
+Set this to `true` to disable the module. You can use this with conditional template strings to disable modules based on, for example, the current environment or other variables (e.g. `disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for specific environments, e.g. only for development.
 
-Disabling a module means that any services, tasks and tests contained in it will not be deployed or run.
-It also means that the module is not built _unless_ it is declared as a build dependency by another enabled
-module (in which case building this module is necessary for the dependant to be built).
+Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which case building this module is necessary for the dependant to be built).
 
-If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden
-will automatically ignore those dependency declarations. Note however that template strings referencing the
-module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled,
-so you need to make sure to provide alternate values for those if you're using them, using conditional
-expressions.
+If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will automatically ignore those dependency declarations. Note however that template strings referencing the module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
-#### `include`
+#### `include[]`
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this
-module. Files that do *not* match these paths or globs are excluded when computing the version of the module,
-when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
-source tree, which use the same format as `.gitignore` files. See the
-[Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
 
@@ -231,19 +220,13 @@ include:
   - my-app.js
 ```
 
-#### `exclude`
+#### `exclude[]`
 
-Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that
-match these paths or globs are excluded when computing the version of the module, when responding to filesystem
-watch events, and when staging builds.
+Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the
-`include` field, the files/patterns specified here are filtered from the files matched by `include`. See the
-[Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
 
-Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files
-and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have
-large directories that should not be watched for changes.
+Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have large directories that should not be watched for changes.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -261,8 +244,7 @@ exclude:
 
 A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific branch or tag, with the format: <git remote url>#<branch|tag>
 
-Garden will import the repository source code into this module, but read the module's
-config from the local garden.yml file.
+Garden will import the repository source code into this module, but read the module's config from the local garden.yml file.
 
 | Type              | Required |
 | ----------------- | -------- |
@@ -359,7 +341,7 @@ Defaults to the value set in the provider config.
 | --------- | ------- | -------- |
 | `boolean` | `null`  | No       |
 
-#### `dependencies`
+#### `dependencies[]`
 
 The names of any services that this service depends on at runtime, and the names of any tasks that should be executed before this service is deployed.
 

--- a/docs/providers/conftest-container.md
+++ b/docs/providers/conftest-container.md
@@ -4,7 +4,7 @@ title: conftest-container
 
 # `conftest-container` Provider
 
-This provider automatically generates [conftest modules](../module-types/conftest.md) for `container` modules
+This provider automatically generates [conftest modules](https://docs.garden.io/module-types/conftest) for `container` modules
 in your project. A `conftest` module is created for each `container` module that includes a Dockerfile that
 can be validated.
 
@@ -24,22 +24,26 @@ The values in the schema below are the default values.
 
 ```yaml
 providers:
-  # The name of the provider plugin to use.
-  - name:
+  - # The name of the provider plugin to use.
+    name:
+
     # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
+
     # Path to the default policy directory or rego file to use for `conftest` modules.
     policyPath: ./policy
+
     # Default policy namespace to use for `conftest` modules.
     namespace:
+
     # Set this to `"warn"` if you'd like tests to be marked as failed if one or more _warn_ rules are matched.
     # Set to `"none"` to always mark the tests as successful.
     testFailureThreshold: error
 ```
 ### Configuration Keys
 
-#### `providers`
+#### `providers[]`
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
@@ -77,8 +81,8 @@ Example:
 ```yaml
 providers:
   - environments:
-    - dev
-    - stage
+      - dev
+      - stage
 ```
 
 #### `providers[].policyPath`

--- a/docs/providers/conftest-kubernetes.md
+++ b/docs/providers/conftest-kubernetes.md
@@ -4,7 +4,7 @@ title: conftest-kubernetes
 
 # `conftest-kubernetes` Provider
 
-This provider automatically generates [conftest modules](../module-types/conftest.md) for `kubernetes` and
+This provider automatically generates [conftest modules](https://docs.garden.io/module-types/conftest) for `kubernetes` and
 `helm` modules in your project. A `conftest` module is created for each of those module types.
 
 Simply add this provider to your project configuration, and configure your policies. Check out the below
@@ -26,22 +26,26 @@ The values in the schema below are the default values.
 
 ```yaml
 providers:
-  # The name of the provider plugin to use.
-  - name:
+  - # The name of the provider plugin to use.
+    name:
+
     # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
+
     # Path to the default policy directory or rego file to use for `conftest` modules.
     policyPath: ./policy
+
     # Default policy namespace to use for `conftest` modules.
     namespace:
+
     # Set this to `"warn"` if you'd like tests to be marked as failed if one or more _warn_ rules are matched.
     # Set to `"none"` to always mark the tests as successful.
     testFailureThreshold: error
 ```
 ### Configuration Keys
 
-#### `providers`
+#### `providers[]`
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
@@ -79,8 +83,8 @@ Example:
 ```yaml
 providers:
   - environments:
-    - dev
-    - stage
+      - dev
+      - stage
 ```
 
 #### `providers[].policyPath`

--- a/docs/providers/conftest.md
+++ b/docs/providers/conftest.md
@@ -10,14 +10,14 @@ The provider creates a module type of the same name, which allows you to specify
 Each module then creates a Garden test that becomes part of your Stack Graph.
 
 Note that, in many cases, you'll actually want to use more specific providers that can automatically configure your
-`conftest` modules, e.g. the [`conftest-container`](./conftest-container.md) and/or
-[`conftest-kubernetes`](./conftest-kubernetes.md) providers. See the
+`conftest` modules, e.g. the [`conftest-container`](https://docs.garden.io/providers/conftest-container) and/or
+[`conftest-kubernetes`](https://docs.garden.io/providers/conftest-kubernetes) providers. See the
 [conftest example project](https://github.com/garden-io/garden/tree/master/examples/conftest) for a simple usage
 example of the latter.
 
 If those don't match your needs, you can use this provider directly and manually configure your `conftest`
 modules. Simply add this provider to your project configuration, and see the
-[conftest module documentation](../module-types/conftest.md) for a detailed reference. Also, check out the below
+[conftest module documentation](https://docs.garden.io/module-types/conftest) for a detailed reference. Also, check out the below
 [reference](#reference) for how to configure default policies, default namespaces, and test failure thresholds for
 all `conftest` modules.
 
@@ -33,22 +33,26 @@ The values in the schema below are the default values.
 
 ```yaml
 providers:
-  # The name of the provider plugin to use.
-  - name:
+  - # The name of the provider plugin to use.
+    name:
+
     # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
+
     # Path to the default policy directory or rego file to use for `conftest` modules.
     policyPath: ./policy
+
     # Default policy namespace to use for `conftest` modules.
     namespace:
+
     # Set this to `"warn"` if you'd like tests to be marked as failed if one or more _warn_ rules are matched.
     # Set to `"none"` to always mark the tests as successful.
     testFailureThreshold: error
 ```
 ### Configuration Keys
 
-#### `providers`
+#### `providers[]`
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
@@ -86,8 +90,8 @@ Example:
 ```yaml
 providers:
   - environments:
-    - dev
-    - stage
+      - dev
+      - stage
 ```
 
 #### `providers[].policyPath`

--- a/docs/providers/hadolint.md
+++ b/docs/providers/hadolint.md
@@ -4,7 +4,7 @@ title: hadolint
 
 # `hadolint` Provider
 
-This provider creates a [`hadolint`](../module-types/hadolint.md) module type, and (by default) generates one
+This provider creates a [`hadolint`](https://docs.garden.io/module-types/hadolint) module type, and (by default) generates one
 such module for each `container` module that contains a Dockerfile in your project. Each module creates a single
 test that runs [hadolint](https://github.com/hadolint/hadolint) against the Dockerfile in question, in order to
 ensure that the Dockerfile is valid and follows best practices.
@@ -28,21 +28,24 @@ The values in the schema below are the default values.
 
 ```yaml
 providers:
-  # The name of the provider plugin to use.
-  - name:
+  - # The name of the provider plugin to use.
+    name:
+
     # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
+
     # By default, the provider automatically creates a `hadolint` module for every `container` module in your
     # project. Set this to `false` to disable this behavior.
     autoInject: true
+
     # Set this to `"warning"` if you'd like tests to be marked as failed if one or more warnings are returned.
     # Set to `"none"` to always mark the tests as successful.
     testFailureThreshold: error
 ```
 ### Configuration Keys
 
-#### `providers`
+#### `providers[]`
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
@@ -80,8 +83,8 @@ Example:
 ```yaml
 providers:
   - environments:
-    - dev
-    - stage
+      - dev
+      - stage
 ```
 
 #### `providers[].autoInject`

--- a/docs/providers/kubernetes.md
+++ b/docs/providers/kubernetes.md
@@ -4,16 +4,16 @@ title: kubernetes
 
 # `kubernetes` Provider
 
-The `kubernetes` provider allows you to deploy [`container` modules](../module-types/container.md) to
-Kubernetes clusters, and adds the [`helm`](../module-types/helm.md) and
-[`kubernetes`](../module-types/kubernetes.md) module types.
+The `kubernetes` provider allows you to deploy [`container` modules](https://docs.garden.io/module-types/container) to
+Kubernetes clusters, and adds the [`helm`](https://docs.garden.io/module-types/helm) and
+[`kubernetes`](https://docs.garden.io/module-types/kubernetes) module types.
 
-For usage information, please refer to the [guides section](../guides/README.md). A good place to start is
-the [Remote Kubernetes guide](../guides/remote-kubernetes.md) guide if you're connecting to remote clusters.
-The [demo-project](../examples/demo-project.md) example project and guide are also helpful as an introduction.
+For usage information, please refer to the [guides section]https://docs.garden.io/guides). A good place to start is
+the [Remote Kubernetes guide](https://docs.garden.io/guides/remote-kubernetes) guide if you're connecting to remote clusters.
+The [demo-project](https://docs.garden.io/examples/demo-project) example project and guide are also helpful as an introduction.
 
 Note that if you're using a local Kubernetes cluster (e.g. minikube or Docker Desktop), the
-[local-kubernetes provider](./local-kubernetes.md) simplifies (and automates) the configuration and setup quite a
+[local-kubernetes provider](https://docs.garden.io/providers/local-kubernetes) simplifies (and automates) the configuration and setup quite a
 bit.
 
 ## Reference
@@ -28,9 +28,10 @@ The values in the schema below are the default values.
 
 ```yaml
 providers:
-  # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
-  # disables the provider. To use a provider in all environments, omit this field.
-  - environments:
+  - # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
+    # disables the provider. To use a provider in all environments, omit this field.
+    environments:
+
     # Choose the mechanism for building container images before deploying. By default it uses the local Docker
     # daemon, but you can set it to `cluster-docker` or `kaniko` to sync files to a remote Docker daemon,
     # installed in the cluster, and build container images there. This removes the need to run Docker or
@@ -47,31 +48,39 @@ providers:
     # this is less secure than Kaniko, but in turn it is generally faster. See the
     # [Kaniko docs](https://github.com/GoogleContainerTools/kaniko) for more information on Kaniko.
     buildMode: local-docker
+
     # Configuration options for the `cluster-docker` build mode.
     clusterDocker:
       # Enable [BuildKit](https://github.com/moby/buildkit) support. This should in most cases work well and be more
       # performant, but we're opting to keep it optional until it's enabled by default in Docker.
       enableBuildKit: false
+
     # A default hostname to use when no hostname is explicitly configured for a service.
     defaultHostname:
+
     # Set a default username (used for namespacing within a cluster).
     defaultUsername:
+
     # Defines the strategy for deploying the project services.
     # Default is "rolling update" and there is experimental support for "blue/green" deployment.
     # The feature only supports modules of type `container`: other types will just deploy using the default strategy.
     deploymentStrategy: rolling
+
     # Require SSL on all `container` module services. If set to true, an error is raised when no certificate is
     # available for a configured hostname on a `container` module.
     forceSsl: false
+
     # References to `docker-registry` secrets to use for authenticating with remote registries when pulling
     # images. This is necessary if you reference private images in your module configuration, and is required
     # when configuring a remote Kubernetes environment with buildMode=local.
     imagePullSecrets:
-      # The name of the Kubernetes secret.
-      - name:
+      - # The name of the Kubernetes secret.
+        name:
+
         # The namespace where the secret is stored. If necessary, the secret may be copied to the appropriate
         # namespace before use.
         namespace: default
+
     # Resource requests and limits for the in-cluster builder, container registry and code sync service. (which are
     # automatically installed and used when `buildMode` is `cluster-docker` or `kaniko`).
     resources:
@@ -135,6 +144,7 @@ providers:
 
           # Memory request in megabytes.
           memory: 64
+
     # Storage parameters to set for the in-cluster builder, container registry and code sync persistent volumes
     # (which are automatically installed and used when `buildMode` is `cluster-docker` or `kaniko`).
     #
@@ -184,13 +194,16 @@ providers:
 
         # Storage class to use for the volume.
         storageClass: null
+
     # One or more certificates to use for ingress.
     tlsCertificates:
-      # A unique identifier for this certificate.
-      - name:
+      - # A unique identifier for this certificate.
+        name:
+
         # A list of hostnames that this certificate should be used for. If you don't specify these, they will be
         # automatically read from the certificate.
         hostnames:
+
         # A reference to the Kubernetes secret that contains the TLS certificate and key for the domain.
         secretRef:
           # The name of the Kubernetes secret.
@@ -199,10 +212,12 @@ providers:
           # The namespace where the secret is stored. If necessary, the secret may be copied to the appropriate
           # namespace before use.
           namespace: default
+
         # Set to `cert-manager` to configure [cert-manager](https://github.com/jetstack/cert-manager) to manage this
         # certificate. See our
         # [cert-manager integration guide](https://docs.garden.io/guides/cert-manager-integration) for details.
         managedBy:
+
     # cert-manager configuration, for creating and managing TLS certificates. See the
     # [cert-manager guide](https://docs.garden.io/guides/cert-manager-integration) for details.
     certManager:
@@ -223,36 +238,44 @@ providers:
       # The type of ACME challenge used to validate hostnames and generate the certificates (only HTTP-01 is supported
       # for now).
       acmeChallengeType: HTTP-01
+
     # For setting tolerations on the registry-proxy when using in-cluster building.
     # The registry-proxy is a DaemonSet that proxies connections to the docker registry service on each node.
     #
     # Use this only if you're doing in-cluster building and the nodes in your cluster
     # have [taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/).
     registryProxyTolerations:
-      # "Effect" indicates the taint effect to match. Empty means match all taint effects. When specified,
-      # allowed values are "NoSchedule", "PreferNoSchedule" and "NoExecute".
-      - effect:
+      - # "Effect" indicates the taint effect to match. Empty means match all taint effects. When specified,
+        # allowed values are "NoSchedule", "PreferNoSchedule" and "NoExecute".
+        effect:
+
         # "Key" is the taint key that the toleration applies to. Empty means match all taint keys.
         # If the key is empty, operator must be "Exists"; this combination means to match all values and all keys.
         key:
+
         # "Operator" represents a key's relationship to the value. Valid operators are "Exists" and "Equal". Defaults
         # to
         # "Equal". "Exists" is equivalent to wildcard for value, so that a pod can tolerate all taints of a
         # particular category.
         operator: Equal
+
         # "TolerationSeconds" represents the period of time the toleration (which must be of effect "NoExecute",
         # otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate
         # the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately)
         # by the system.
         tolerationSeconds:
+
         # "Value" is the taint value the toleration matches to. If the operator is "Exists", the value should be
         # empty,
         # otherwise just a regular string.
         value:
+
     # The name of the provider plugin to use.
     name: kubernetes
+
     # The kubectl context to use to connect to the Kubernetes cluster.
     context:
+
     # The registry where built containers should be pushed to, and then pulled to the cluster when deploying services.
     deploymentRegistry:
       # The hostname (and optionally port, if not the default port) of the registry.
@@ -263,24 +286,30 @@ providers:
 
       # The namespace in the registry where images should be pushed.
       namespace: _
+
     # The ingress class to use on configured Ingresses (via the `kubernetes.io/ingress.class` annotation)
     # when deploying `container` services. Use this if you have multiple ingress controllers in your cluster.
     ingressClass:
+
     # The external HTTP port of the cluster's ingress controller.
     ingressHttpPort: 80
+
     # The external HTTPS port of the cluster's ingress controller.
     ingressHttpsPort: 443
+
     # Path to kubeconfig file to use instead of the system default. Must be a POSIX-style path.
     kubeconfig:
+
     # Specify which namespace to deploy services to (defaults to <project name>). Note that the framework generates
     # other namespaces as well with this name as a prefix.
     namespace:
+
     # Set this to `nginx` to install/enable the NGINX ingress controller.
     setupIngressController: false
 ```
 ### Configuration Keys
 
-#### `providers`
+#### `providers[]`
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
@@ -301,8 +330,8 @@ Example:
 ```yaml
 providers:
   - environments:
-    - dev
-    - stage
+      - dev
+      - stage
 ```
 
 #### `providers[].buildMode`
@@ -998,7 +1027,7 @@ Example:
 providers:
   - tlsCertificates:
       - hostnames:
-        - www.mydomain.com
+          - www.mydomain.com
 ```
 
 #### `providers[].tlsCertificates[].secretRef`
@@ -1017,8 +1046,8 @@ Example:
 providers:
   - tlsCertificates:
       - secretRef:
-          name: my-tls-secret
-          namespace: default
+            name: my-tls-secret
+            namespace: default
 ```
 
 #### `providers[].tlsCertificates[].secretRef.name`
@@ -1037,8 +1066,8 @@ Example:
 providers:
   - tlsCertificates:
       - secretRef:
-          name: my-tls-secret
-          namespace: default
+            name: my-tls-secret
+            namespace: default
           ...
           name: "my-secret"
 ```

--- a/docs/providers/local-kubernetes.md
+++ b/docs/providers/local-kubernetes.md
@@ -4,15 +4,15 @@ title: local-kubernetes
 
 # `local-kubernetes` Provider
 
-The `local-kubernetes` provider is a specialized version of the [`kubernetes` provider](./kubernetes.md) that
+The `local-kubernetes` provider is a specialized version of the [`kubernetes` provider](https://docs.garden.io/providers/kubernetes) that
 automates and simplifies working with local Kubernetes clusters.
 
-For general Kubernetes usage information, please refer to the [guides section](../guides/README.md). For local
-clusters a good place to start is the [Local Kubernetes guide](../guides/local-kubernetes.md) guide.
-The [demo-project](../examples/demo-project.md) example project and guide are also helpful as an introduction.
+For general Kubernetes usage information, please refer to the [guides section](https://docs.garden.io/guides). For local
+clusters a good place to start is the [Local Kubernetes guide](https://docs.garden.io/guides/local-kubernetes) guide.
+The [demo-project](https://docs.garden.io/examples/demo-project) example project and guide are also helpful as an introduction.
 
-If you're working with a remote Kubernetes cluster, please refer to the [`kubernetes` provider](./kubernetes.md)
-docs, and the [Remote Kubernetes guide](../guides/remote-kubernetes.md) guide.
+If you're working with a remote Kubernetes cluster, please refer to the [`kubernetes` provider](https://docs.garden.io/providers/kubernetes)
+docs, and the [Remote Kubernetes guide](https://docs.garden.io/guides/remote-kubernetes) guide.
 
 ## Reference
 
@@ -26,9 +26,10 @@ The values in the schema below are the default values.
 
 ```yaml
 providers:
-  # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
-  # disables the provider. To use a provider in all environments, omit this field.
-  - environments:
+  - # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
+    # disables the provider. To use a provider in all environments, omit this field.
+    environments:
+
     # Choose the mechanism for building container images before deploying. By default it uses the local Docker
     # daemon, but you can set it to `cluster-docker` or `kaniko` to sync files to a remote Docker daemon,
     # installed in the cluster, and build container images there. This removes the need to run Docker or
@@ -45,31 +46,39 @@ providers:
     # this is less secure than Kaniko, but in turn it is generally faster. See the
     # [Kaniko docs](https://github.com/GoogleContainerTools/kaniko) for more information on Kaniko.
     buildMode: local-docker
+
     # Configuration options for the `cluster-docker` build mode.
     clusterDocker:
       # Enable [BuildKit](https://github.com/moby/buildkit) support. This should in most cases work well and be more
       # performant, but we're opting to keep it optional until it's enabled by default in Docker.
       enableBuildKit: false
+
     # A default hostname to use when no hostname is explicitly configured for a service.
     defaultHostname:
+
     # Set a default username (used for namespacing within a cluster).
     defaultUsername:
+
     # Defines the strategy for deploying the project services.
     # Default is "rolling update" and there is experimental support for "blue/green" deployment.
     # The feature only supports modules of type `container`: other types will just deploy using the default strategy.
     deploymentStrategy: rolling
+
     # Require SSL on all `container` module services. If set to true, an error is raised when no certificate is
     # available for a configured hostname on a `container` module.
     forceSsl: false
+
     # References to `docker-registry` secrets to use for authenticating with remote registries when pulling
     # images. This is necessary if you reference private images in your module configuration, and is required
     # when configuring a remote Kubernetes environment with buildMode=local.
     imagePullSecrets:
-      # The name of the Kubernetes secret.
-      - name:
+      - # The name of the Kubernetes secret.
+        name:
+
         # The namespace where the secret is stored. If necessary, the secret may be copied to the appropriate
         # namespace before use.
         namespace: default
+
     # Resource requests and limits for the in-cluster builder, container registry and code sync service. (which are
     # automatically installed and used when `buildMode` is `cluster-docker` or `kaniko`).
     resources:
@@ -133,6 +142,7 @@ providers:
 
           # Memory request in megabytes.
           memory: 64
+
     # Storage parameters to set for the in-cluster builder, container registry and code sync persistent volumes
     # (which are automatically installed and used when `buildMode` is `cluster-docker` or `kaniko`).
     #
@@ -182,13 +192,16 @@ providers:
 
         # Storage class to use for the volume.
         storageClass: null
+
     # One or more certificates to use for ingress.
     tlsCertificates:
-      # A unique identifier for this certificate.
-      - name:
+      - # A unique identifier for this certificate.
+        name:
+
         # A list of hostnames that this certificate should be used for. If you don't specify these, they will be
         # automatically read from the certificate.
         hostnames:
+
         # A reference to the Kubernetes secret that contains the TLS certificate and key for the domain.
         secretRef:
           # The name of the Kubernetes secret.
@@ -197,10 +210,12 @@ providers:
           # The namespace where the secret is stored. If necessary, the secret may be copied to the appropriate
           # namespace before use.
           namespace: default
+
         # Set to `cert-manager` to configure [cert-manager](https://github.com/jetstack/cert-manager) to manage this
         # certificate. See our
         # [cert-manager integration guide](https://docs.garden.io/guides/cert-manager-integration) for details.
         managedBy:
+
     # cert-manager configuration, for creating and managing TLS certificates. See the
     # [cert-manager guide](https://docs.garden.io/guides/cert-manager-integration) for details.
     certManager:
@@ -221,45 +236,54 @@ providers:
       # The type of ACME challenge used to validate hostnames and generate the certificates (only HTTP-01 is supported
       # for now).
       acmeChallengeType: HTTP-01
+
     # For setting tolerations on the registry-proxy when using in-cluster building.
     # The registry-proxy is a DaemonSet that proxies connections to the docker registry service on each node.
     #
     # Use this only if you're doing in-cluster building and the nodes in your cluster
     # have [taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/).
     registryProxyTolerations:
-      # "Effect" indicates the taint effect to match. Empty means match all taint effects. When specified,
-      # allowed values are "NoSchedule", "PreferNoSchedule" and "NoExecute".
-      - effect:
+      - # "Effect" indicates the taint effect to match. Empty means match all taint effects. When specified,
+        # allowed values are "NoSchedule", "PreferNoSchedule" and "NoExecute".
+        effect:
+
         # "Key" is the taint key that the toleration applies to. Empty means match all taint keys.
         # If the key is empty, operator must be "Exists"; this combination means to match all values and all keys.
         key:
+
         # "Operator" represents a key's relationship to the value. Valid operators are "Exists" and "Equal". Defaults
         # to
         # "Equal". "Exists" is equivalent to wildcard for value, so that a pod can tolerate all taints of a
         # particular category.
         operator: Equal
+
         # "TolerationSeconds" represents the period of time the toleration (which must be of effect "NoExecute",
         # otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate
         # the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately)
         # by the system.
         tolerationSeconds:
+
         # "Value" is the taint value the toleration matches to. If the operator is "Exists", the value should be
         # empty,
         # otherwise just a regular string.
         value:
+
     # The name of the provider plugin to use.
     name: local-kubernetes
+
     # The kubectl context to use to connect to the Kubernetes cluster.
     context:
+
     # Specify which namespace to deploy services to (defaults to the project name). Note that the framework generates
     # other namespaces as well with this name as a prefix.
     namespace:
+
     # Set this to null or false to skip installing/enabling the `nginx` ingress controller.
     setupIngressController: nginx
 ```
 ### Configuration Keys
 
-#### `providers`
+#### `providers[]`
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
@@ -280,8 +304,8 @@ Example:
 ```yaml
 providers:
   - environments:
-    - dev
-    - stage
+      - dev
+      - stage
 ```
 
 #### `providers[].buildMode`
@@ -977,7 +1001,7 @@ Example:
 providers:
   - tlsCertificates:
       - hostnames:
-        - www.mydomain.com
+          - www.mydomain.com
 ```
 
 #### `providers[].tlsCertificates[].secretRef`
@@ -996,8 +1020,8 @@ Example:
 providers:
   - tlsCertificates:
       - secretRef:
-          name: my-tls-secret
-          namespace: default
+            name: my-tls-secret
+            namespace: default
 ```
 
 #### `providers[].tlsCertificates[].secretRef.name`
@@ -1016,8 +1040,8 @@ Example:
 providers:
   - tlsCertificates:
       - secretRef:
-          name: my-tls-secret
-          namespace: default
+            name: my-tls-secret
+            namespace: default
           ...
           name: "my-secret"
 ```

--- a/docs/providers/maven-container.md
+++ b/docs/providers/maven-container.md
@@ -4,11 +4,11 @@ title: maven-container
 
 # `maven-container` Provider
 
-Adds the [maven-container module type](../module-types/maven-container.md), which is a specialized version of the
+Adds the [maven-container module type](https://docs.garden.io/module-types/maven-container), which is a specialized version of the
 `container` module type that has special semantics for building JAR files using Maven.
 
 To use it, simply add the provider to your provider configuration, and refer to the
-[maven-container module docs](../module-types/maven-container.md) for details on how to configure the modules.
+[maven-container module docs](https://docs.garden.io/module-types/maven-container) for details on how to configure the modules.
 
 ## Reference
 
@@ -22,15 +22,16 @@ The values in the schema below are the default values.
 
 ```yaml
 providers:
-  # The name of the provider plugin to use.
-  - name:
+  - # The name of the provider plugin to use.
+    name:
+
     # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
 ```
 ### Configuration Keys
 
-#### `providers`
+#### `providers[]`
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
@@ -68,7 +69,7 @@ Example:
 ```yaml
 providers:
   - environments:
-    - dev
-    - stage
+      - dev
+      - stage
 ```
 

--- a/docs/providers/openfaas.md
+++ b/docs/providers/openfaas.md
@@ -5,11 +5,11 @@ title: openfaas
 # `openfaas` Provider
 
 This provider adds support for [OpenFaaS](https://www.openfaas.com/). It adds the
-[`openfaas` module type](../module-types/openfaas.md) and (by default) installs the `faas-netes` runtime to
+[`openfaas` module type](https://docs.garden.io/module-types/openfaas) and (by default) installs the `faas-netes` runtime to
 the project namespace. Each `openfaas` module maps to a single OpenFaaS function.
 
 See the [reference](#reference) below for configuration options for `faas-netes`, and the
-[module type docs](../module-types/openfaas.md) for how to configure the individual functions.
+[module type docs](https://docs.garden.io/module-types/openfaas) for how to configure the individual functions.
 
 Also see the [openfaas example project](https://github.com/garden-io/garden/tree/master/examples/openfaas) for a
 simple usage example.
@@ -26,20 +26,24 @@ The values in the schema below are the default values.
 
 ```yaml
 providers:
-  # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
-  # disables the provider. To use a provider in all environments, omit this field.
-  - environments:
+  - # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
+    # disables the provider. To use a provider in all environments, omit this field.
+    environments:
+
     # The name of the provider plugin to use.
     name: openfaas
+
     # The external URL to the function gateway, after installation. This is required if you set `faasNetes.values`
     # or `faastNetes.install: false`, so that Garden can know how to reach the gateway.
     gatewayUrl:
+
     # The ingress hostname to configure for the function gateway, when `faasNetes.install: true` and not
     # overriding `faasNetes.values`. Defaults to the default hostname of the configured Kubernetes provider.
     #
     # Important: If you have other types of services, this should be different from their ingress hostnames,
     # or the other services should not expose paths under /function and /system to avoid routing conflicts.
     hostname:
+
     faasNetes:
       # Set to false if you'd like to install and configure faas-netes yourself.
       # See the [official instructions](https://docs.openfaas.com/deployment/kubernetes/) for details.
@@ -55,7 +59,7 @@ providers:
 ```
 ### Configuration Keys
 
-#### `providers`
+#### `providers[]`
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
@@ -76,8 +80,8 @@ Example:
 ```yaml
 providers:
   - environments:
-    - dev
-    - stage
+      - dev
+      - stage
 ```
 
 #### `providers[].name`

--- a/docs/providers/terraform.md
+++ b/docs/providers/terraform.md
@@ -5,7 +5,7 @@ title: terraform
 # `terraform` Provider
 
 This provider allows you to integrate Terraform stacks into your Garden project.
-See the [Terraform guide](../guides/terraform.md) for details and usage information.
+See the [Terraform guide](https://docs.garden.io/guides/terraform) for details and usage information.
 
 ## Reference
 
@@ -19,28 +19,33 @@ The values in the schema below are the default values.
 
 ```yaml
 providers:
-  # The name of the provider plugin to use.
-  - name:
+  - # The name of the provider plugin to use.
+    name:
+
     # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
+
     # If set to true, Garden will automatically run `terraform apply -auto-approve` when a stack is not up-to-date.
     # Otherwise, a warning is logged if the stack is out-of-date, and an error thrown if it is missing entirely.
     autoApply: false
+
     # Specify the path to a Terraform config directory, that should be resolved when initializing the provider.
     # This is useful when other providers need to be able to reference the outputs from the stack.
     #
-    # See the [Terraform guide](../guides/terraform.md) for more information.
+    # See the [Terraform guide](https://docs.garden.io/guides/terraform) for more information.
     initRoot:
+
     # A map of variables to use when applying Terraform stacks. You can define these here, in individual `terraform`
     # module configs, or you can place a `terraform.tfvars` file in each working directory.
     variables:
+
     # The version of Terraform to use.
     version: 0.12.7
 ```
 ### Configuration Keys
 
-#### `providers`
+#### `providers[]`
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
@@ -78,8 +83,8 @@ Example:
 ```yaml
 providers:
   - environments:
-    - dev
-    - stage
+      - dev
+      - stage
 ```
 
 #### `providers[].autoApply`
@@ -99,7 +104,7 @@ If set to true, Garden will automatically run `terraform apply -auto-approve` wh
 Specify the path to a Terraform config directory, that should be resolved when initializing the provider.
 This is useful when other providers need to be able to reference the outputs from the stack.
 
-See the [Terraform guide](../guides/terraform.md) for more information.
+See the [Terraform guide](https://docs.garden.io/guides/terraform) for more information.
 
 | Type        | Required |
 | ----------- | -------- |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -86,6 +86,60 @@ Note: Currently only supports simple GET requests for HTTP/HTTPS ingresses.
 | -------- | -------- | ----------- |
   | `serviceAndPath` | Yes | The name of the service to call followed by the ingress path (e.g. my-container/somepath).
 
+### garden create project
+
+Create a new Garden project.
+
+Creates a new Garden project configuration. The generated config includes some default values, as well as the
+schema of the config in the form of commentented-out fields. Also creates a default (blank) .gardenignore file
+in the same path.
+
+Examples:
+
+    garden create project                     # create a Garden project config in the current directory
+    garden create project --dir some-dir      # create a Garden project config in the ./some-dir directory
+    garden create project --name my-project   # set the project name to my-project
+    garden create project --interactive=false # don't prompt for user inputs when creating the config
+
+##### Usage
+
+    garden create project [options]
+
+##### Options
+
+| Argument | Alias | Type | Description |
+| -------- | ----- | ---- | ----------- |
+  | `--dir` |  | path | Directory to place the project in (defaults to current directory).
+  | `--interactive` | `-i` | boolean | Set to false to disable interactive prompts.
+  | `--name` |  | string | Name of the project (defaults to current directory name).
+
+### garden create module
+
+Create a new Garden module.
+
+Creates a new Garden module configuration. The generated config includes some default values, as well as the
+schema of the config in the form of commentented-out fields.
+
+Examples:
+
+    garden create module                      # create a Garden module config in the current directory
+    garden create module --dir some-dir       # create a Garden module config in the ./some-dir directory
+    garden create module --name my-module     # set the module name to my-module
+    garden create module --interactive=false  # don't prompt for user inputs when creating the module
+
+##### Usage
+
+    garden create module [options]
+
+##### Options
+
+| Argument | Alias | Type | Description |
+| -------- | ----- | ---- | ----------- |
+  | `--dir` |  | path | Directory to place the module in (defaults to current directory).
+  | `--interactive` | `-i` | boolean | Set to false to disable interactive prompts.
+  | `--name` |  | string | Name of the module (defaults to current directory name).
+  | `--type` |  | string | The module type to create. Required if --interactive&#x3D;false.
+
 ### garden delete secret
 
 Delete a secret from the environment.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -23,13 +23,49 @@ Please refer to those for more details on provider and module configuration.
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this project's config (currently not used).
-apiVersion: garden.io/v0
-
+# Indicate what kind of config this is.
 kind: Project
 
 # The name of the project.
 name:
+
+# A list of environments to configure for the project.
+environments:
+  - # The name of the environment.
+    name:
+
+    # Flag the environment as a production environment.
+    #
+    # Setting this flag to `true` will activate the protection on the `deploy`, `test`, `task`, `build`,
+    # and `dev` commands. A protected command will ask for a user confirmation every time is run agains
+    # an environment marked as production.
+    # Run the command with the "--yes" flag to skip the check (e.g. when running Garden in CI).
+    #
+    # This flag is also passed on to every provider, and may affect how certain providers behave.
+    # For more details please check the documentation for the providers in use.
+    production: false
+
+    # Specify a path (relative to the project root) to a file containing variables, that we apply on top of the
+    # _environment-specific_ `variables` field. The file should be in a standard "dotenv" format, specified
+    # [here](https://github.com/motdotla/dotenv#rules).
+    #
+    # If you don't set the field and the `garden.<env-name>.env` file does not exist,
+    # we simply ignore it. If you do override the default value and the file doesn't exist, an error will be thrown.
+    varfile:
+
+    # A key/value map of variables that modules can reference when using this environment. These take precedence over
+    # variables defined in the top-level `variables` field.
+    variables: {}
+
+# A list of providers that should be used for this project, and their configuration. Please refer to individual
+# plugins/providers for details on how to configure them.
+providers:
+  - # The name of the provider plugin to use.
+    name:
+
+    # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
+    # disables the provider. To use a provider in all environments, omit this field.
+    environments:
 
 # The default environment to use when calling commands without the `--env` parameter. Defaults to the first configured
 # environment.
@@ -40,42 +76,37 @@ defaultEnvironment: ''
 # anywhere in the project, are ignored when scanning for modules and module sources.
 # Note that these take precedence over the project `module.include` field, and module `include` fields, so any paths
 # matched by the .ignore files will be ignored even if they are explicitly specified in those fields.
-# See the [Configuration Files guide]
-# (https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
+# See the [Configuration Files
+# guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 dotIgnoreFiles:
   - .gitignore
   - .gardenignore
 
+# Control where to scan for modules in the project.
 modules:
   # Specify a list of POSIX-style paths or globs that should be scanned for Garden modules.
   #
-  # Note that you can also _exclude_ path using the `exclude` field or by placing `.gardenignore` files in your
-  # source tree, which use the same format as `.gitignore` files. See the
-  # [Configuration Files
+  # Note that you can also _exclude_ path using the `exclude` field or by placing `.gardenignore` files in your source
+  # tree, which use the same format as `.gitignore` files. See the [Configuration Files
   # guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
   #
-  # Unlike the `exclude` field, the paths/globs specified here have _no effect_ on which files and directories
-  # Garden watches for changes. Use the `exclude` field to affect those, if you have large directories that
-  # should not be watched for changes.
+  # Unlike the `exclude` field, the paths/globs specified here have _no effect_ on which files and directories Garden
+  # watches for changes. Use the `exclude` field to affect those, if you have large directories that should not be
+  # watched for changes.
   #
   # Also note that specifying an empty list here means _no paths_ should be included.
   include:
 
   # Specify a list of POSIX-style paths or glob patterns that should be excluded when scanning for modules.
   #
-  # The filters here also affect which files and directories are watched for changes. So if you have a large number
-  # of directories in your project that should not be watched, you should specify them here.
+  # The filters here also affect which files and directories are watched for changes. So if you have a large number of
+  # directories in your project that should not be watched, you should specify them here.
   #
-  # For example, you might want to exclude large vendor directories in your project from being scanned and
-  # watched:
+  # For example, you might want to exclude large vendor directories in your project from being scanned and watched, by
+  # setting `exclude: [node_modules/**/*, vendor/**/*]`.
   #
-  # modules:
-  #   exclude:
-  #     - node_modules/**/*
-  #     - vendor/**/*
-  #
-  # Note that you can also explicitly _include_ files using the `include` field. If you also specify the
-  # `include` field, the paths/patterns specified here are filtered from the files matched by `include`.
+  # Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
+  # field, the paths/patterns specified here are filtered from the files matched by `include`.
   #
   # The `include` field does _not_ affect which files are watched.
   #
@@ -83,36 +114,29 @@ modules:
   # guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
   exclude:
 
-# A list of output values that the project should export. These are exported by the `garden get outputs` command,
-# as well as when referencing a project as a sub-project within another project.
+# A list of output values that the project should export. These are exported by the `garden get outputs` command, as
+# well as when referencing a project as a sub-project within another project.
 #
 # You may use any template strings to specify the values, including references to provider outputs, module
-# outputs and runtime outputs. For a full reference, see the
-# [Output configuration context](../reference/template-strings.md#output-configuration-context) section in the
-# Template String Reference.
+# outputs and runtime outputs. For a full reference, see the [Output configuration
+# context](https://docs.garden.io/reference/template-strings#output-configuration-context) section in the Template
+# String Reference.
 #
-# Note that if any runtime outputs are referenced, the referenced services and tasks will be deployed and run
-# if necessary when resolving the outputs.
+# Note that if any runtime outputs are referenced, the referenced services and tasks will be deployed and run if
+# necessary when resolving the outputs.
 outputs:
-  # The name of the output value.
-  - name:
+  - # The name of the output value.
+    name:
+
     # The value for the output. Must be a primitive (string, number, boolean or null). May also be any valid template
     # string.
     value:
 
-# A list of providers that should be used for this project, and their configuration. Please refer to individual
-# plugins/providers for details on how to configure them.
-providers:
-  # The name of the provider plugin to use.
-  - name:
-    # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
-    # disables the provider. To use a provider in all environments, omit this field.
-    environments:
-
 # A list of remote sources to import into project.
 sources:
-  # The name of the source to import
-  - name:
+  - # The name of the source to import
+    name:
+
     # A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific
     # branch or tag, with the format: <git remote url>#<branch|tag>
     repositoryUrl:
@@ -130,52 +154,14 @@ varfile: garden.env
 
 # Variables to configure for all environments.
 variables: {}
-
-environments:
-  # DEPRECATED - Please use the top-level `providers` field instead, and if needed use the `environments` key on the
-  # provider configurations to limit them to specific environments.
-  - providers:
-      # The name of the provider plugin to use.
-      - name:
-        # If specified, this provider will only be used in the listed environments. Note that an empty array
-        # effectively disables the provider. To use a provider in all environments, omit this field.
-        environments:
-    # Specify a path (relative to the project root) to a file containing variables, that we apply on top of the
-    # _environment-specific_ `variables` field. The file should be in a standard "dotenv" format, specified
-    # [here](https://github.com/motdotla/dotenv#rules).
-    #
-    # If you don't set the field and the `garden.<env-name>.env` file does not exist,
-    # we simply ignore it. If you do override the default value and the file doesn't exist, an error will be thrown.
-    varfile:
-    # A key/value map of variables that modules can reference when using this environment. These take precedence over
-    # variables defined in the top-level `variables` field.
-    variables: {}
-    # The name of the environment.
-    name:
-    # Flag the environment as a production environment.
-    #
-    # Setting this flag to `true` will activate the protection on the `deploy`, `test`, `task`, `build`,
-    # and `dev` commands. A protected command will ask for a user confirmation every time is run agains
-    # an environment marked as production.
-    # Run the command with the "--yes" flag to skip the check (e.g. when running Garden in CI).
-    #
-    # This flag is also passed on to every provider, and may affect how certain providers behave.
-    # For more details please check the documentation for the providers in use.
-    production: false
 ```
 
 ## Project configuration keys
 
 
-#### `apiVersion`
-
-The schema version of this project's config (currently not used).
-
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
-
 #### `kind`
+
+Indicate what kind of config this is.
 
 | Type     | Allowed Values | Default     | Required |
 | -------- | -------------- | ----------- | -------- |
@@ -195,138 +181,131 @@ Example:
 name: "my-sweet-project"
 ```
 
-#### `defaultEnvironment`
+#### `environments[]`
 
-The default environment to use when calling commands without the `--env` parameter. Defaults to the first configured environment.
+A list of environments to configure for the project.
 
-| Type     | Default | Required |
-| -------- | ------- | -------- |
-| `string` | `""`    | No       |
+| Type            | Required |
+| --------------- | -------- |
+| `array[object]` | No       |
 
-#### `dotIgnoreFiles`
+#### `environments[].name`
 
-Specify a list of filenames that should be used as ".ignore" files across the project, using the same syntax and semantics as `.gitignore` files. By default, patterns matched in `.gitignore` and `.gardenignore` files, found anywhere in the project, are ignored when scanning for modules and module sources.
-Note that these take precedence over the project `module.include` field, and module `include` fields, so any paths matched by the .ignore files will be ignored even if they are explicitly specified in those fields.
-See the [Configuration Files guide] (https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
+[environments](#environments) > name
 
-| Type               | Default                          | Required |
-| ------------------ | -------------------------------- | -------- |
-| `array[posixPath]` | `[".gitignore",".gardenignore"]` | No       |
-
-#### `modules`
-
-| Type     | Required |
-| -------- | -------- |
-| `object` | No       |
-
-#### `modules.include[]`
-
-[modules](#modules) > include
-
-Specify a list of POSIX-style paths or globs that should be scanned for Garden modules.
-
-Note that you can also _exclude_ path using the `exclude` field or by placing `.gardenignore` files in your
-source tree, which use the same format as `.gitignore` files. See the
-[Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
-
-Unlike the `exclude` field, the paths/globs specified here have _no effect_ on which files and directories
-Garden watches for changes. Use the `exclude` field to affect those, if you have large directories that
-should not be watched for changes.
-
-Also note that specifying an empty list here means _no paths_ should be included.
-
-| Type               | Required |
-| ------------------ | -------- |
-| `array[posixPath]` | No       |
-
-Example:
-
-```yaml
-modules:
-  ...
-  include:
-    - modules/**/*
-```
-
-#### `modules.exclude[]`
-
-[modules](#modules) > exclude
-
-Specify a list of POSIX-style paths or glob patterns that should be excluded when scanning for modules.
-
-The filters here also affect which files and directories are watched for changes. So if you have a large number
-of directories in your project that should not be watched, you should specify them here.
-
-For example, you might want to exclude large vendor directories in your project from being scanned and
-watched:
-
-```yaml
-modules:
-  exclude:
-    - node_modules/**/*
-    - vendor/**/*
-```
-
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the
-`include` field, the paths/patterns specified here are filtered from the files matched by `include`.
-
-The `include` field does _not_ affect which files are watched.
-
-See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
-
-| Type               | Required |
-| ------------------ | -------- |
-| `array[posixPath]` | No       |
-
-Example:
-
-```yaml
-modules:
-  ...
-  exclude:
-    - public/**/*
-    - tmp/**/*
-```
-
-#### `outputs`
-
-A list of output values that the project should export. These are exported by the `garden get outputs` command,
-as well as when referencing a project as a sub-project within another project.
-
-You may use any template strings to specify the values, including references to provider outputs, module
-outputs and runtime outputs. For a full reference, see the
-[Output configuration context](../reference/template-strings.md#output-configuration-context) section in the
-Template String Reference.
-
-Note that if any runtime outputs are referenced, the referenced services and tasks will be deployed and run
-if necessary when resolving the outputs.
-
-| Type            | Default | Required |
-| --------------- | ------- | -------- |
-| `array[object]` | `[]`    | No       |
-
-#### `outputs[].name`
-
-[outputs](#outputs) > name
-
-The name of the output value.
+The name of the environment.
 
 | Type     | Required |
 | -------- | -------- |
 | `string` | Yes      |
 
-#### `outputs[].value`
+Example:
 
-[outputs](#outputs) > value
+```yaml
+environments:
+  - name: "dev"
+```
 
-The value for the output. Must be a primitive (string, number, boolean or null). May also be any valid template
-string.
+#### `environments[].production`
 
-| Type                        | Required |
-| --------------------------- | -------- |
-| `number | string | boolean` | Yes      |
+[environments](#environments) > production
 
-#### `providers`
+Flag the environment as a production environment.
+
+Setting this flag to `true` will activate the protection on the `deploy`, `test`, `task`, `build`,
+and `dev` commands. A protected command will ask for a user confirmation every time is run agains
+an environment marked as production.
+Run the command with the "--yes" flag to skip the check (e.g. when running Garden in CI).
+
+This flag is also passed on to every provider, and may affect how certain providers behave.
+For more details please check the documentation for the providers in use.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
+
+Example:
+
+```yaml
+environments:
+  - production: true
+```
+
+#### `environments[].providers[]`
+
+[environments](#environments) > providers
+
+DEPRECATED - Please use the top-level `providers` field instead, and if needed use the `environments` key on the provider configurations to limit them to specific environments.
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
+
+#### `environments[].providers[].name`
+
+[environments](#environments) > [providers](#environmentsproviders) > name
+
+The name of the provider plugin to use.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | Yes      |
+
+Example:
+
+```yaml
+environments:
+```
+
+#### `environments[].providers[].environments[]`
+
+[environments](#environments) > [providers](#environmentsproviders) > environments
+
+If specified, this provider will only be used in the listed environments. Note that an empty array effectively disables the provider. To use a provider in all environments, omit this field.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
+Example:
+
+```yaml
+environments:
+```
+
+#### `environments[].varfile`
+
+[environments](#environments) > varfile
+
+Specify a path (relative to the project root) to a file containing variables, that we apply on top of the
+_environment-specific_ `variables` field. The file should be in a standard "dotenv" format, specified
+[here](https://github.com/motdotla/dotenv#rules).
+
+If you don't set the field and the `garden.<env-name>.env` file does not exist,
+we simply ignore it. If you do override the default value and the file doesn't exist, an error will be thrown.
+
+| Type        | Required |
+| ----------- | -------- |
+| `posixPath` | No       |
+
+Example:
+
+```yaml
+environments:
+  - varfile: "custom.env"
+```
+
+#### `environments[].variables`
+
+[environments](#environments) > variables
+
+A key/value map of variables that modules can reference when using this environment. These take precedence over variables defined in the top-level `variables` field.
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `object` | `{}`    | No       |
+
+#### `providers[]`
 
 A list of providers that should be used for this project, and their configuration. Please refer to individual plugins/providers for details on how to configure them.
 
@@ -366,11 +345,154 @@ Example:
 ```yaml
 providers:
   - environments:
-    - dev
-    - stage
+      - dev
+      - stage
 ```
 
-#### `sources`
+#### `defaultEnvironment`
+
+The default environment to use when calling commands without the `--env` parameter. Defaults to the first configured environment.
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `string` | `""`    | No       |
+
+Example:
+
+```yaml
+defaultEnvironment: "dev"
+```
+
+#### `dotIgnoreFiles[]`
+
+Specify a list of filenames that should be used as ".ignore" files across the project, using the same syntax and semantics as `.gitignore` files. By default, patterns matched in `.gitignore` and `.gardenignore` files, found anywhere in the project, are ignored when scanning for modules and module sources.
+Note that these take precedence over the project `module.include` field, and module `include` fields, so any paths matched by the .ignore files will be ignored even if they are explicitly specified in those fields.
+See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
+
+| Type               | Default                          | Required |
+| ------------------ | -------------------------------- | -------- |
+| `array[posixPath]` | `[".gitignore",".gardenignore"]` | No       |
+
+Example:
+
+```yaml
+dotIgnoreFiles:
+  - .gardenignore
+  - .customignore
+```
+
+#### `modules`
+
+Control where to scan for modules in the project.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+#### `modules.include[]`
+
+[modules](#modules) > include
+
+Specify a list of POSIX-style paths or globs that should be scanned for Garden modules.
+
+Note that you can also _exclude_ path using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
+
+Unlike the `exclude` field, the paths/globs specified here have _no effect_ on which files and directories Garden watches for changes. Use the `exclude` field to affect those, if you have large directories that should not be watched for changes.
+
+Also note that specifying an empty list here means _no paths_ should be included.
+
+| Type               | Required |
+| ------------------ | -------- |
+| `array[posixPath]` | No       |
+
+Example:
+
+```yaml
+modules:
+  ...
+  include:
+    - modules/**/*
+```
+
+#### `modules.exclude[]`
+
+[modules](#modules) > exclude
+
+Specify a list of POSIX-style paths or glob patterns that should be excluded when scanning for modules.
+
+The filters here also affect which files and directories are watched for changes. So if you have a large number of directories in your project that should not be watched, you should specify them here.
+
+For example, you might want to exclude large vendor directories in your project from being scanned and watched, by setting `exclude: [node_modules/**/*, vendor/**/*]`.
+
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the paths/patterns specified here are filtered from the files matched by `include`.
+
+The `include` field does _not_ affect which files are watched.
+
+See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
+
+| Type               | Required |
+| ------------------ | -------- |
+| `array[posixPath]` | No       |
+
+Example:
+
+```yaml
+modules:
+  ...
+  exclude:
+    - public/**/*
+    - tmp/**/*
+```
+
+#### `outputs[]`
+
+A list of output values that the project should export. These are exported by the `garden get outputs` command, as well as when referencing a project as a sub-project within another project.
+
+You may use any template strings to specify the values, including references to provider outputs, module
+outputs and runtime outputs. For a full reference, see the [Output configuration context](https://docs.garden.io/reference/template-strings#output-configuration-context) section in the Template String Reference.
+
+Note that if any runtime outputs are referenced, the referenced services and tasks will be deployed and run if necessary when resolving the outputs.
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
+
+#### `outputs[].name`
+
+[outputs](#outputs) > name
+
+The name of the output value.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | Yes      |
+
+Example:
+
+```yaml
+outputs:
+  - name: "my-output-key"
+```
+
+#### `outputs[].value`
+
+[outputs](#outputs) > value
+
+The value for the output. Must be a primitive (string, number, boolean or null). May also be any valid template
+string.
+
+| Type                        | Required |
+| --------------------------- | -------- |
+| `number | string | boolean` | Yes      |
+
+Example:
+
+```yaml
+outputs:
+  - value: "${modules.my-module.outputs.some-output}"
+```
+
+#### `sources[]`
 
 A list of remote sources to import into project.
 
@@ -387,6 +509,13 @@ The name of the source to import
 | Type     | Required |
 | -------- | -------- |
 | `string` | Yes      |
+
+Example:
+
+```yaml
+sources:
+  - name: "my-external-repo"
+```
 
 #### `sources[].repositoryUrl`
 
@@ -421,6 +550,12 @@ multiple ones. See the `environments[].varfile` field for this option._
 | ----------- | -------------- | -------- |
 | `posixPath` | `"garden.env"` | No       |
 
+Example:
+
+```yaml
+varfile: "custom.env"
+```
+
 #### `variables`
 
 Variables to configure for all environments.
@@ -428,113 +563,6 @@ Variables to configure for all environments.
 | Type     | Default | Required |
 | -------- | ------- | -------- |
 | `object` | `{}`    | No       |
-
-#### `environments`
-
-| Type            | Required |
-| --------------- | -------- |
-| `array[object]` | No       |
-
-#### `environments[].providers[]`
-
-[environments](#environments) > providers
-
-DEPRECATED - Please use the top-level `providers` field instead, and if needed use the `environments` key on the provider configurations to limit them to specific environments.
-
-| Type            | Default | Required |
-| --------------- | ------- | -------- |
-| `array[object]` | `[]`    | No       |
-
-#### `environments[].providers[].name`
-
-[environments](#environments) > [providers](#environmentsproviders) > name
-
-The name of the provider plugin to use.
-
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
-
-Example:
-
-```yaml
-environments:
-  - providers:
-      - name: "local-kubernetes"
-```
-
-#### `environments[].providers[].environments[]`
-
-[environments](#environments) > [providers](#environmentsproviders) > environments
-
-If specified, this provider will only be used in the listed environments. Note that an empty array effectively disables the provider. To use a provider in all environments, omit this field.
-
-| Type            | Required |
-| --------------- | -------- |
-| `array[string]` | No       |
-
-Example:
-
-```yaml
-environments:
-  - providers:
-      - environments:
-        - dev
-        - stage
-```
-
-#### `environments[].varfile`
-
-[environments](#environments) > varfile
-
-Specify a path (relative to the project root) to a file containing variables, that we apply on top of the
-_environment-specific_ `variables` field. The file should be in a standard "dotenv" format, specified
-[here](https://github.com/motdotla/dotenv#rules).
-
-If you don't set the field and the `garden.<env-name>.env` file does not exist,
-we simply ignore it. If you do override the default value and the file doesn't exist, an error will be thrown.
-
-| Type        | Required |
-| ----------- | -------- |
-| `posixPath` | No       |
-
-#### `environments[].variables`
-
-[environments](#environments) > variables
-
-A key/value map of variables that modules can reference when using this environment. These take precedence over variables defined in the top-level `variables` field.
-
-| Type     | Default | Required |
-| -------- | ------- | -------- |
-| `object` | `{}`    | No       |
-
-#### `environments[].name`
-
-[environments](#environments) > name
-
-The name of the environment.
-
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
-
-#### `environments[].production`
-
-[environments](#environments) > production
-
-Flag the environment as a production environment.
-
-Setting this flag to `true` will activate the protection on the `deploy`, `test`, `task`, `build`,
-and `dev` commands. A protected command will ask for a user confirmation every time is run agains
-an environment marked as production.
-Run the command with the "--yes" flag to skip the check (e.g. when running Garden in CI).
-
-This flag is also passed on to every provider, and may affect how certain providers behave.
-For more details please check the documentation for the providers in use.
-
-| Type      | Default | Required |
-| --------- | ------- | -------- |
-| `boolean` | `false` | No       |
 
 
 ## Module YAML schema
@@ -550,55 +578,53 @@ type:
 # The name of this module.
 name:
 
+# A description of the module.
 description:
 
-# Set this to `true` to disable the module. You can use this with conditional template strings to
-# disable modules based on, for example, the current environment or other variables (e.g.
-# `disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for
-# specific environments, e.g. only for development.
+# Set this to `true` to disable the module. You can use this with conditional template strings to disable modules
+# based on, for example, the current environment or other variables (e.g. `disabled: \${environment.name == "prod"}`).
+# This can be handy when you only need certain modules for specific environments, e.g. only for development.
 #
-# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run.
-# It also means that the module is not built _unless_ it is declared as a build dependency by another enabled
-# module (in which case building this module is necessary for the dependant to be built).
+# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also
+# means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which
+# case building this module is necessary for the dependant to be built).
 #
-# If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden
-# will automatically ignore those dependency declarations. Note however that template strings referencing the
-# module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled,
-# so you need to make sure to provide alternate values for those if you're using them, using conditional
-# expressions.
+# If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will
+# automatically ignore those dependency declarations. Note however that template strings referencing the module's
+# service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make
+# sure to provide alternate values for those if you're using them, using conditional expressions.
 disabled: false
 
-# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this
-# module. Files that do *not* match these paths or globs are excluded when computing the version of the module,
-# when responding to filesystem watch events, and when staging builds.
+# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that
+# do *not* match these paths or globs are excluded when computing the version of the module, when responding to
+# filesystem watch events, and when staging builds.
 #
-# Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
-# source tree, which use the same format as `.gitignore` files. See the
-# [Configuration Files
+# Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
+# tree, which use the same format as `.gitignore` files. See the [Configuration Files
 # guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 #
 # Also note that specifying an empty list here means _no sources_ should be included.
 include:
 
-# Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that
-# match these paths or globs are excluded when computing the version of the module, when responding to filesystem
-# watch events, and when staging builds.
+# Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these
+# paths or globs are excluded when computing the version of the module, when responding to filesystem watch events,
+# and when staging builds.
 #
-# Note that you can also explicitly _include_ files using the `include` field. If you also specify the
-# `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the
-# [Configuration Files
-# guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
+# Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
+# field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration
+# Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for
+# details.
 #
-# Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files
-# and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have
-# large directories that should not be watched for changes.
+# Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files and
+# directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have large
+# directories that should not be watched for changes.
 exclude:
 
 # A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific
 # branch or tag, with the format: <git remote url>#<branch|tag>
 #
-# Garden will import the repository source code into this module, but read the module's
-# config from the local garden.yml file.
+# Garden will import the repository source code into this module, but read the module's config from the local
+# garden.yml file.
 repositoryUrl:
 
 # When false, disables pushing this module to remote registries.
@@ -608,12 +634,14 @@ allowPublish: true
 build:
   # A list of modules that must be built before this module is built.
   dependencies:
-    # Module name to build ahead of this module.
-    - name:
+    - # Module name to build ahead of this module.
+      name:
+
       # Specify one or more files or directories to copy from the built dependency to this module.
       copy:
-        # POSIX-style path or filename of the directory or file(s) to copy to the target.
-        - source:
+        - # POSIX-style path or filename of the directory or file(s) to copy to the target.
+          source:
+
           # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
           # Defaults to to same as source path.
           target: ''
@@ -666,40 +694,29 @@ name: "my-sweet-module"
 
 #### `description`
 
+A description of the module.
+
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
 
 #### `disabled`
 
-Set this to `true` to disable the module. You can use this with conditional template strings to
-disable modules based on, for example, the current environment or other variables (e.g.
-`disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for
-specific environments, e.g. only for development.
+Set this to `true` to disable the module. You can use this with conditional template strings to disable modules based on, for example, the current environment or other variables (e.g. `disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for specific environments, e.g. only for development.
 
-Disabling a module means that any services, tasks and tests contained in it will not be deployed or run.
-It also means that the module is not built _unless_ it is declared as a build dependency by another enabled
-module (in which case building this module is necessary for the dependant to be built).
+Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which case building this module is necessary for the dependant to be built).
 
-If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden
-will automatically ignore those dependency declarations. Note however that template strings referencing the
-module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled,
-so you need to make sure to provide alternate values for those if you're using them, using conditional
-expressions.
+If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will automatically ignore those dependency declarations. Note however that template strings referencing the module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
-#### `include`
+#### `include[]`
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this
-module. Files that do *not* match these paths or globs are excluded when computing the version of the module,
-when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
-source tree, which use the same format as `.gitignore` files. See the
-[Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 
 Also note that specifying an empty list here means _no sources_ should be included.
 
@@ -715,19 +732,13 @@ include:
   - my-app.js
 ```
 
-#### `exclude`
+#### `exclude[]`
 
-Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that
-match these paths or globs are excluded when computing the version of the module, when responding to filesystem
-watch events, and when staging builds.
+Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-Note that you can also explicitly _include_ files using the `include` field. If you also specify the
-`include` field, the files/patterns specified here are filtered from the files matched by `include`. See the
-[Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
 
-Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files
-and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have
-large directories that should not be watched for changes.
+Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have large directories that should not be watched for changes.
 
 | Type               | Required |
 | ------------------ | -------- |
@@ -745,8 +756,7 @@ exclude:
 
 A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific branch or tag, with the format: <git remote url>#<branch|tag>
 
-Garden will import the repository source code into this module, but read the module's
-config from the local garden.yml file.
+Garden will import the repository source code into this module, but read the module's config from the local garden.yml file.
 
 | Type              | Required |
 | ----------------- | -------- |

--- a/docs/reference/template-strings.md
+++ b/docs/reference/template-strings.md
@@ -213,20 +213,9 @@ The resolved configuration for the provider.
 | -------- |
 | `object` |
 
-Example:
-
-```yaml
-providers:
-  {}
-  <provider-name>:
-    ...
-    config:
-        clusterHostname: my-cluster.example.com
-```
-
 #### `${providers.<provider-name>.config.<config-key>}`
 
-The provider config key value. Refer to individual [provider references](../providers/README.md) for details.
+The provider config key value. Refer to individual [provider references](https://docs.garden.io/providers) for details.
 
 | Type                        |
 | --------------------------- |
@@ -240,20 +229,9 @@ The outputs defined by the provider (see individual plugin docs for details).
 | -------- | ------- |
 | `object` | `{}`    |
 
-Example:
-
-```yaml
-providers:
-  {}
-  <provider-name>:
-    ...
-    outputs:
-        cluster-ip: 1.2.3.4
-```
-
 #### `${providers.<provider-name>.outputs.<output-key>}`
 
-The provider output value. Refer to individual [provider references](../providers/README.md) for details.
+The provider output value. Refer to individual [provider references](https://docs.garden.io/providers) for details.
 
 | Type                        |
 | --------------------------- |
@@ -428,20 +406,9 @@ The resolved configuration for the provider.
 | -------- |
 | `object` |
 
-Example:
-
-```yaml
-providers:
-  {}
-  <provider-name>:
-    ...
-    config:
-        clusterHostname: my-cluster.example.com
-```
-
 #### `${providers.<provider-name>.config.<config-key>}`
 
-The provider config key value. Refer to individual [provider references](../providers/README.md) for details.
+The provider config key value. Refer to individual [provider references](https://docs.garden.io/providers) for details.
 
 | Type                        |
 | --------------------------- |
@@ -455,20 +422,9 @@ The outputs defined by the provider (see individual plugin docs for details).
 | -------- | ------- |
 | `object` | `{}`    |
 
-Example:
-
-```yaml
-providers:
-  {}
-  <provider-name>:
-    ...
-    outputs:
-        cluster-ip: 1.2.3.4
-```
-
 #### `${providers.<provider-name>.outputs.<output-key>}`
 
-The provider output value. Refer to individual [provider references](../providers/README.md) for details.
+The provider output value. Refer to individual [provider references](https://docs.garden.io/providers) for details.
 
 | Type                        |
 | --------------------------- |
@@ -538,7 +494,7 @@ The outputs defined by the module (see individual module type [references](https
 
 #### `${modules.<module-name>.outputs.<output-name>}`
 
-The module output value. Refer to individual [module type references](../module-types/README.md) for details.
+The module output value. Refer to individual [module type references](https://docs.garden.io/module-types) for details.
 
 | Type                        |
 | --------------------------- |
@@ -598,7 +554,7 @@ The runtime outputs defined by the service (see individual module type [referenc
 
 #### `${runtime.services.<service-name>.outputs.<output-name>}`
 
-The service output value. Refer to individual [module type references](../module-types/README.md) for details.
+The service output value. Refer to individual [module type references](https://docs.garden.io/module-types) for details.
 
 | Type                        |
 | --------------------------- |
@@ -622,7 +578,7 @@ The runtime outputs defined by the task (see individual module type [references]
 
 #### `${runtime.tasks.<task-name>.outputs.<output-name>}`
 
-The task output value. Refer to individual [module type references](../module-types/README.md) for details.
+The task output value. Refer to individual [module type references](https://docs.garden.io/module-types) for details.
 
 | Type                        |
 | --------------------------- |
@@ -765,20 +721,9 @@ The resolved configuration for the provider.
 | -------- |
 | `object` |
 
-Example:
-
-```yaml
-providers:
-  {}
-  <provider-name>:
-    ...
-    config:
-        clusterHostname: my-cluster.example.com
-```
-
 #### `${providers.<provider-name>.config.<config-key>}`
 
-The provider config key value. Refer to individual [provider references](../providers/README.md) for details.
+The provider config key value. Refer to individual [provider references](https://docs.garden.io/providers) for details.
 
 | Type                        |
 | --------------------------- |
@@ -792,20 +737,9 @@ The outputs defined by the provider (see individual plugin docs for details).
 | -------- | ------- |
 | `object` | `{}`    |
 
-Example:
-
-```yaml
-providers:
-  {}
-  <provider-name>:
-    ...
-    outputs:
-        cluster-ip: 1.2.3.4
-```
-
 #### `${providers.<provider-name>.outputs.<output-key>}`
 
-The provider output value. Refer to individual [provider references](../providers/README.md) for details.
+The provider output value. Refer to individual [provider references](https://docs.garden.io/providers) for details.
 
 | Type                        |
 | --------------------------- |
@@ -875,7 +809,7 @@ The outputs defined by the module (see individual module type [references](https
 
 #### `${modules.<module-name>.outputs.<output-name>}`
 
-The module output value. Refer to individual [module type references](../module-types/README.md) for details.
+The module output value. Refer to individual [module type references](https://docs.garden.io/module-types) for details.
 
 | Type                        |
 | --------------------------- |
@@ -935,7 +869,7 @@ The runtime outputs defined by the service (see individual module type [referenc
 
 #### `${runtime.services.<service-name>.outputs.<output-name>}`
 
-The service output value. Refer to individual [module type references](../module-types/README.md) for details.
+The service output value. Refer to individual [module type references](https://docs.garden.io/module-types) for details.
 
 | Type                        |
 | --------------------------- |
@@ -959,7 +893,7 @@ The runtime outputs defined by the task (see individual module type [references]
 
 #### `${runtime.tasks.<task-name>.outputs.<output-name>}`
 
-The task output value. Refer to individual [module type references](../module-types/README.md) for details.
+The task output value. Refer to individual [module type references](https://docs.garden.io/module-types) for details.
 
 | Type                        |
 | --------------------------- |

--- a/docs/using-garden/creating-a-project.md
+++ b/docs/using-garden/creating-a-project.md
@@ -5,7 +5,7 @@ title: Creating a Project
 
 # Creating a Project
 
-The first step to using Garden is to create a project. You do this by adding a `garden.yml` file in the root directory of your project.
+The first step to using Garden is to create a project. You can use the `garden create project` helper command, or manually create a `garden.yml` file in the root directory of your project:
 
 ```yaml
 # garden.yml - located in the top-level directory of your project
@@ -17,6 +17,8 @@ providers:
   - name: local-kubernetes
     environments: ["local"]
 ```
+
+The helper command has the benefit of including all the possible fields you can configure, and their documentation, so you can quickly scan through the available options and uncomment as needed.
 
 ## How it Works
 

--- a/garden-service/src/actions.ts
+++ b/garden-service/src/actions.ts
@@ -719,7 +719,7 @@ export class ActionRouter implements TypeGuard {
     return result
   }
 
-  private async callModuleHandler<T extends keyof Omit<ModuleActionHandlers, "configure">>({
+  private async callModuleHandler<T extends keyof Omit<ModuleActionHandlers, "configure" | "suggestModules">>({
     params,
     actionType,
     defaultHandler,

--- a/garden-service/src/cli/cli.ts
+++ b/garden-service/src/cli/cli.ts
@@ -79,7 +79,7 @@ class DummyGarden extends Garden {
   async scanModules() {}
 }
 
-export async function makeDummyGarden(root: string, gardenOpts: GardenOpts) {
+export async function makeDummyGarden(root: string, gardenOpts: GardenOpts = {}) {
   const config: ProjectConfig = {
     path: root,
     apiVersion: DEFAULT_API_VERSION,

--- a/garden-service/src/commands/commands.ts
+++ b/garden-service/src/commands/commands.ts
@@ -9,6 +9,7 @@
 import { Command } from "./base"
 import { BuildCommand } from "./build"
 import { CallCommand } from "./call"
+import { CreateCommand } from "./create/create"
 import { DeleteCommand } from "./delete"
 import { DeployCommand } from "./deploy"
 import { DevCommand } from "./dev"
@@ -33,6 +34,7 @@ import { PluginsCommand } from "./plugins"
 export const coreCommands: Command[] = [
   new BuildCommand(),
   new CallCommand(),
+  new CreateCommand(),
   new DeleteCommand(),
   new DeployCommand(),
   new DevCommand(),

--- a/garden-service/src/commands/create/create-module.ts
+++ b/garden-service/src/commands/create/create-module.ts
@@ -56,7 +56,6 @@ const createModuleOpts = {
   type: new StringOption({
     help: "The module type to create. Required if --interactive=false.",
   }),
-  // TODO: add type option
 }
 
 type CreateModuleArgs = typeof createModuleArgs

--- a/garden-service/src/commands/create/create-module.ts
+++ b/garden-service/src/commands/create/create-module.ts
@@ -1,0 +1,252 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import chalk from "chalk"
+import dedent from "dedent"
+import { pathExists } from "fs-extra"
+import inquirer from "inquirer"
+import {
+  Command,
+  CommandResult,
+  CommandParams,
+  PrepareParams,
+  PathParameter,
+  BooleanParameter,
+  StringOption,
+} from "../base"
+import { printHeader } from "../../logger/util"
+import { getConfigFilePath, isDirectory } from "../../util/fs"
+import { loadConfig, findProjectConfig } from "../../config/base"
+import { resolve, basename, relative } from "path"
+import { GardenBaseError, ParameterError } from "../../exceptions"
+import { getModuleTypes } from "../../plugins"
+import { addConfig } from "./helpers"
+import { supportedPlugins } from "../../plugins/plugins"
+import { baseModuleSpecSchema } from "../../config/module"
+import { renderConfigReference } from "../../docs/config"
+import { DOCS_BASE_URL } from "../../constants"
+import { flatten } from "lodash"
+import { fixedPlugins } from "../../config/project"
+import { deline, wordWrap } from "../../util/string"
+import { joi } from "../../config/common"
+import { LoggerType } from "../../logger/logger"
+
+const createModuleArgs = {}
+const createModuleOpts = {
+  dir: new PathParameter({
+    help: "Directory to place the module in (defaults to current directory).",
+    defaultValue: ".",
+  }),
+  interactive: new BooleanParameter({
+    alias: "i",
+    help: "Set to false to disable interactive prompts.",
+    defaultValue: true,
+  }),
+  name: new StringOption({
+    help: "Name of the module (defaults to current directory name).",
+  }),
+  type: new StringOption({
+    help: "The module type to create. Required if --interactive=false.",
+  }),
+  // TODO: add type option
+}
+
+type CreateModuleArgs = typeof createModuleArgs
+type CreateModuleOpts = typeof createModuleOpts
+
+interface CreateModuleResult {
+  configPath: string
+  name: string
+  type: string
+}
+
+// TODO: move to common
+class CreateError extends GardenBaseError {
+  type: "create"
+}
+
+export class CreateModuleCommand extends Command<CreateModuleArgs, CreateModuleOpts> {
+  name = "module"
+  help = "Create a new Garden module."
+  noProject = true
+  cliOnly = true
+  loggerType = <LoggerType>"basic"
+
+  description = dedent`
+    Creates a new Garden module configuration. The generated config includes some default values, as well as the
+    schema of the config in the form of commentented-out fields.
+
+    Examples:
+
+        garden create module                      # create a Garden module config in the current directory
+        garden create module --dir some-dir       # create a Garden module config in the ./some-dir directory
+        garden create module --name my-module     # set the module name to my-module
+        garden create module --interactive=false  # don't prompt for user inputs when creating the module
+  `
+
+  arguments = createModuleArgs
+  options = createModuleOpts
+
+  async prepare({ headerLog }: PrepareParams<CreateModuleArgs, CreateModuleOpts>) {
+    printHeader(headerLog, "Create new module", "pencil2")
+    return { persistent: false }
+  }
+
+  async action({
+    opts,
+    log,
+  }: CommandParams<CreateModuleArgs, CreateModuleOpts>): Promise<CommandResult<CreateModuleResult>> {
+    const configDir = resolve(process.cwd(), opts.dir)
+
+    if (!(await isDirectory(configDir))) {
+      throw new ParameterError(`${configDir} is not a directory`, { configDir })
+    }
+
+    const configPath = await getConfigFilePath(configDir)
+
+    let name = opts.name || basename(configDir)
+    let type = opts.type
+
+    const allModuleTypes = getModuleTypes(supportedPlugins)
+
+    // TODO: query providers to get suggestions/detected module types/configs
+
+    if (opts.interactive && (!opts.name || !opts.type)) {
+      log.root.stop()
+
+      if (!opts.type) {
+        const answer = await inquirer.prompt({
+          name: "type",
+          message: "Select a module type:",
+          type: "list",
+          choices: Object.keys(allModuleTypes),
+          pageSize: 20,
+        })
+        type = answer.type
+      }
+
+      if (!opts.name) {
+        const answer = await inquirer.prompt({
+          name: "name",
+          message: "Set the module name:",
+          type: "input",
+          default: name,
+        })
+        name = answer.name
+      }
+
+      log.info("")
+    }
+
+    if (!type) {
+      throw new ParameterError(`Must specify --type if --interactive=false`, {})
+    }
+
+    // Throw if module with same name already exists
+    if (await pathExists(configPath)) {
+      const configs = await loadConfig(configDir, configDir)
+
+      if (configs.filter((c) => c.kind === "Module" && c.name === name).length > 0) {
+        throw new CreateError(
+          chalk.red(
+            `A Garden module named ${chalk.white.bold(name)} already exists in ${chalk.white.bold(configPath)}`
+          ),
+          {
+            configDir,
+            configPath,
+          }
+        )
+      }
+    }
+
+    const definition = allModuleTypes[type]
+
+    if (!definition) {
+      throw new ParameterError(`Could not find module type ${chalk.white.bold(type)}`, {
+        availableTypes: Object.keys(allModuleTypes),
+      })
+    }
+
+    const schema = (definition.schema ? baseModuleSpecSchema.concat(definition.schema) : baseModuleSpecSchema).keys({
+      // Hide this from docs until we actually use it
+      apiVersion: joi.string().meta({ internal: true }),
+    })
+
+    const { yaml } = renderConfigReference(schema, {
+      yamlOpts: {
+        commentOutEmpty: true,
+        filterMarkdown: true,
+        renderBasicDescription: true,
+        renderFullDescription: false,
+        renderValue: "preferExample",
+        // TODO: get more values from provider suggestion, if applicable
+        presetValues: {
+          kind: "Module",
+          name,
+          type,
+        },
+      },
+    })
+
+    await addConfig(configPath, yaml)
+
+    log.info(chalk.green(`-> Created new module config in ${chalk.bold.white(relative(process.cwd(), configPath))}`))
+    log.info("")
+
+    // Warn if module type is defined by provider that isn't configured OR if not in a project, ask to make sure
+    // it is configured in the project that will use the module.
+    const projectConfig = await findProjectConfig(configDir)
+    const pluginName = definition.pluginName
+
+    if (!fixedPlugins.includes(pluginName)) {
+      if (projectConfig) {
+        const allProviders = flatten([
+          projectConfig.providers,
+          ...projectConfig.environments.map((e) => e.providers || []),
+        ])
+
+        if (!allProviders.map((p) => p.name).includes(definition.pluginName)) {
+          log.warn(
+            chalk.yellow(deline`
+              Module type ${chalk.white.bold(type)} is defined by the ${chalk.white.bold(pluginName)} provider,
+              which is not configured in your project. Please make sure it is configured before using the new module.
+            `)
+          )
+        }
+      } else {
+        log.info(deline`
+          Module type ${chalk.white.bold(type)} is defined by the ${chalk.white.bold(pluginName)} provider.
+          Please make sure it is configured in your project before using the new module.
+        `)
+      }
+    }
+
+    // This is to avoid `prettier` messing with the string formatting...
+    const moduleTypeUrl = chalk.cyan.underline(`${DOCS_BASE_URL}/module-types/${type}`)
+    const providerUrl = chalk.cyan.underline(`${DOCS_BASE_URL}/providers/${pluginName}`)
+    const configFilesUrl = chalk.cyan.underline(`${DOCS_BASE_URL}/guides/configuration-files`)
+    const formattedType = chalk.bold(type)
+    const formattedPluginName = chalk.bold(pluginName)
+
+    log.info({
+      symbol: "info",
+      msg: wordWrap(
+        dedent`
+        We recommend reviewing the generated config, uncommenting fields that you'd like to configure, and cleaning up any commented fields that you don't need to use.
+
+        For more information about ${formattedType} modules, please check out ${moduleTypeUrl}, and the ${formattedPluginName} docs at ${providerUrl}. For general information about Garden configuration files, take a look at ${configFilesUrl}.
+        `,
+        120
+      ),
+    })
+
+    log.info("")
+
+    return { result: { configPath, name, type } }
+  }
+}

--- a/garden-service/src/commands/create/create-project.ts
+++ b/garden-service/src/commands/create/create-project.ts
@@ -174,7 +174,7 @@ export class CreateProjectCommand extends Command<CreateProjectArgs, CreateProje
       symbol: "info",
       msg: wordWrap(
         dedent`
-        We recommend reviewing the generated config, uncommenting fields that you'd like to configure, and cleaning up any commented fields that you don't need to use. Also make sure to update the ${formattedIgnoreName} file with any files you'd like to exclude from the Garden projects.
+        We recommend reviewing the generated config, uncommenting fields that you'd like to configure, and cleaning up any commented fields that you don't need to use. Also make sure to update the ${formattedIgnoreName} file with any files you'd like to exclude from the Garden project.
 
         For more information about Garden configuration files, please check out ${configFilesUrl}, and for a detailed reference, take a look at ${referenceUrl}.
         `,

--- a/garden-service/src/commands/create/create-project.ts
+++ b/garden-service/src/commands/create/create-project.ts
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import chalk from "chalk"
+import dedent from "dedent"
+import { pathExists, writeFile } from "fs-extra"
+import inquirer from "inquirer"
+import {
+  Command,
+  CommandResult,
+  CommandParams,
+  PrepareParams,
+  PathParameter,
+  BooleanParameter,
+  StringOption,
+} from "../base"
+import { printHeader } from "../../logger/util"
+import { getConfigFilePath, isDirectory } from "../../util/fs"
+import { loadConfig } from "../../config/base"
+import { resolve, basename, relative } from "path"
+import { GardenBaseError, ParameterError } from "../../exceptions"
+import { renderProjectConfigReference } from "../../docs/config"
+import { addConfig } from "./helpers"
+import { wordWrap } from "../../util/string"
+import { LoggerType } from "../../logger/logger"
+
+const ignorefileName = ".gardenignore"
+const defaultIgnorefile = dedent`
+# Add paths here that you would like Garden to ignore when building modules and computing versions,
+# using the same syntax as .gitignore files.
+# For more info, see https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories
+`
+
+const createProjectArgs = {}
+const createProjectOpts = {
+  dir: new PathParameter({
+    help: "Directory to place the project in (defaults to current directory).",
+    defaultValue: ".",
+  }),
+  interactive: new BooleanParameter({
+    alias: "i",
+    help: "Set to false to disable interactive prompts.",
+    defaultValue: true,
+  }),
+  name: new StringOption({
+    help: "Name of the project (defaults to current directory name).",
+  }),
+}
+
+type CreateProjectArgs = typeof createProjectArgs
+type CreateProjectOpts = typeof createProjectOpts
+
+interface CreateProjectResult {
+  configPath: string
+  ignoreFileCreated: boolean
+  ignoreFilePath: string
+  name: string
+}
+
+class CreateError extends GardenBaseError {
+  type: "create"
+}
+
+export class CreateProjectCommand extends Command<CreateProjectArgs, CreateProjectOpts> {
+  name = "project"
+  help = "Create a new Garden project."
+  noProject = true
+  cliOnly = true
+  loggerType = <LoggerType>"basic"
+
+  description = dedent`
+    Creates a new Garden project configuration. The generated config includes some default values, as well as the
+    schema of the config in the form of commentented-out fields. Also creates a default (blank) .gardenignore file
+    in the same path.
+
+    Examples:
+
+        garden create project                     # create a Garden project config in the current directory
+        garden create project --dir some-dir      # create a Garden project config in the ./some-dir directory
+        garden create project --name my-project   # set the project name to my-project
+        garden create project --interactive=false # don't prompt for user inputs when creating the config
+  `
+
+  arguments = createProjectArgs
+  options = createProjectOpts
+
+  async prepare({ headerLog }: PrepareParams<CreateProjectArgs, CreateProjectOpts>) {
+    printHeader(headerLog, "Create new project", "pencil2")
+    return { persistent: false }
+  }
+
+  async action({
+    opts,
+    log,
+  }: CommandParams<CreateProjectArgs, CreateProjectOpts>): Promise<CommandResult<CreateProjectResult>> {
+    const configDir = resolve(process.cwd(), opts.dir)
+
+    if (!(await isDirectory(configDir))) {
+      throw new ParameterError(`${configDir} is not a directory`, { configDir })
+    }
+
+    const configPath = await getConfigFilePath(configDir)
+
+    // Throw if a project config already exists in the config path
+    if (await pathExists(configPath)) {
+      const configs = await loadConfig(configDir, configDir)
+
+      if (configs.filter((c) => c.kind === "Project").length > 0) {
+        throw new CreateError(`A Garden project already exists in ${configPath}`, { configDir, configPath })
+      }
+    }
+
+    let name = opts.name || basename(configDir)
+
+    if (opts.interactive && !opts.name) {
+      log.root.stop()
+
+      const answer = await inquirer.prompt({
+        name: "name",
+        message: "Project name:",
+        type: "input",
+        default: name,
+      })
+
+      name = answer.name
+
+      log.info("")
+    }
+
+    const { yaml } = renderProjectConfigReference({
+      yamlOpts: {
+        commentOutEmpty: true,
+        filterMarkdown: true,
+        renderBasicDescription: true,
+        renderFullDescription: false,
+        renderValue: "preferExample",
+        presetValues: {
+          kind: "Project",
+          name,
+          environments: [{ name: "default" }],
+          providers: [{ name: "local-kubernetes" }],
+        },
+      },
+    })
+
+    await addConfig(configPath, yaml)
+
+    log.info(chalk.green(`-> Created new project config in ${chalk.bold.white(relative(process.cwd(), configPath))}`))
+
+    const ignoreFilePath = resolve(configDir, ignorefileName)
+    let ignoreFileCreated = false
+
+    if (!(await pathExists(ignoreFilePath))) {
+      await writeFile(ignoreFilePath, defaultIgnorefile + "\n")
+      log.info(
+        chalk.green(`-> Created .gardenignore file at ${chalk.bold.white(relative(process.cwd(), ignoreFilePath))}`)
+      )
+      ignoreFileCreated = true
+    }
+
+    log.info("")
+
+    // This is to avoid `prettier` messing with the string formatting...
+    const formattedIgnoreName = chalk.bold.white(".gardenignore")
+    const configFilesUrl = chalk.cyan.underline("https://docs.garden.io/guides/configuration-files")
+    const referenceUrl = chalk.cyan.underline("https://docs.garden.io/reference/config")
+
+    log.info({
+      symbol: "info",
+      msg: wordWrap(
+        dedent`
+        We recommend reviewing the generated config, uncommenting fields that you'd like to configure, and cleaning up any commented fields that you don't need to use. Also make sure to update the ${formattedIgnoreName} file with any files you'd like to exclude from the Garden projects.
+
+        For more information about Garden configuration files, please check out ${configFilesUrl}, and for a detailed reference, take a look at ${referenceUrl}.
+        `,
+        120
+      ),
+    })
+
+    log.info("")
+
+    return { result: { configPath, ignoreFileCreated, ignoreFilePath, name } }
+  }
+}

--- a/garden-service/src/commands/create/create.ts
+++ b/garden-service/src/commands/create/create.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Command } from "../base"
+import { CreateProjectCommand } from "./create-project"
+import { CreateModuleCommand } from "./create-module"
+
+export class CreateCommand extends Command {
+  name = "create"
+  help = "Create new project or module."
+
+  subCommands = [CreateProjectCommand, CreateModuleCommand]
+
+  async action() {
+    return {}
+  }
+}

--- a/garden-service/src/commands/create/helpers.ts
+++ b/garden-service/src/commands/create/helpers.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { pathExists, readFile, writeFile } from "fs-extra"
+
+export async function addConfig(configPath: string, yaml: string) {
+  let output = yaml
+
+  if (await pathExists(configPath)) {
+    const currentConfigFile = await readFile(configPath)
+    output = currentConfigFile.toString()
+    if (!output.endsWith("---")) {
+      output += "\n\n---\n\n"
+    }
+    output += yaml
+  }
+
+  await writeFile(configPath, output + "\n")
+}

--- a/garden-service/src/config/common.ts
+++ b/garden-service/src/config/common.ts
@@ -262,7 +262,7 @@ export const joiIdentifierDescription =
 
 const moduleIncludeDescription = (extraDescription?: string) => {
   const desc = dedent`
-  Specify a list of POSIX-style paths or globs that should be regarded as the source files for this   module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
+  Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
   Note that you can also _exclude_ files using the \`exclude\` field or by placing \`.gardenignore\` files in your source tree, which use the same format as \`.gitignore\` files. See the [Configuration Files guide](${includeGuideLink}) for details.
 

--- a/garden-service/src/config/common.ts
+++ b/garden-service/src/config/common.ts
@@ -262,13 +262,9 @@ export const joiIdentifierDescription =
 
 const moduleIncludeDescription = (extraDescription?: string) => {
   const desc = dedent`
-  Specify a list of POSIX-style paths or globs that should be regarded as the source files for this
-  module. Files that do *not* match these paths or globs are excluded when computing the version of the module,
-  when responding to filesystem watch events, and when staging builds.
+  Specify a list of POSIX-style paths or globs that should be regarded as the source files for this   module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-  Note that you can also _exclude_ files using the \`exclude\` field or by placing \`.gardenignore\` files in your
-  source tree, which use the same format as \`.gitignore\` files. See the
-  [Configuration Files guide](${includeGuideLink}) for details.
+  Note that you can also _exclude_ files using the \`exclude\` field or by placing \`.gardenignore\` files in your source tree, which use the same format as \`.gitignore\` files. See the [Configuration Files guide](${includeGuideLink}) for details.
 
   Also note that specifying an empty list here means _no sources_ should be included.
   `
@@ -310,9 +306,7 @@ export const joiUserIdentifier = () =>
     .regex(userIdentifierRegex)
     .description(
       deline`
-        Valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and dashes, must start
-        with a letter, and cannot end with a dash), cannot contain consecutive dashes or start with \`garden\`,
-        or be longer than 63 characters.
+        Valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and dashes, must start with a letter, and cannot end with a dash), cannot contain consecutive dashes or start with \`garden\`, or be longer than 63 characters.
       `
     )
 

--- a/garden-service/src/config/config-context.ts
+++ b/garden-service/src/config/config-context.ts
@@ -7,6 +7,7 @@
  */
 
 import Joi from "@hapi/joi"
+import chalk from "chalk"
 import username from "username"
 import { isString } from "lodash"
 import { PrimitiveMap, joiIdentifierMap, joiStringMap, joiPrimitive } from "./common"
@@ -20,7 +21,7 @@ import { joi } from "../config/common"
 import { KeyedSet } from "../util/keyed-set"
 import { RuntimeContext } from "../runtime-context"
 import { deline } from "../util/string"
-import chalk = require("chalk")
+import { DOCS_BASE_URL } from "../constants"
 
 export type ContextKey = string[]
 
@@ -301,7 +302,7 @@ class ProviderContext extends ConfigContext {
         /.*/,
         joiPrimitive().description(
           deline`
-          The provider config key value. Refer to individual [provider references](../providers/README.md) for details.
+          The provider config key value. Refer to individual [provider references](${DOCS_BASE_URL}/providers) for details.
           `
         )
       )
@@ -315,7 +316,7 @@ class ProviderContext extends ConfigContext {
     joiIdentifierMap(
       joiPrimitive().description(
         deline`
-        The provider output value. Refer to individual [provider references](../providers/README.md) for details.
+        The provider output value. Refer to individual [provider references](${DOCS_BASE_URL}/providers) for details.
         `
       )
     )
@@ -389,7 +390,7 @@ export class ModuleContext extends ConfigContext {
     joiIdentifierMap(
       joiPrimitive().description(
         deline`
-        The module output value. Refer to individual [module type references](../module-types/README.md) for details.
+        The module output value. Refer to individual [module type references](${DOCS_BASE_URL}/module-types) for details.
         `
       )
     )
@@ -434,7 +435,7 @@ export class ServiceRuntimeContext extends ConfigContext {
     joiIdentifierMap(
       joiPrimitive().description(
         deline`
-        The service output value. Refer to individual [module type references](../module-types/README.md) for details.
+        The service output value. Refer to individual [module type references](${DOCS_BASE_URL}/module-types) for details.
         `
       )
     )
@@ -465,7 +466,7 @@ export class TaskRuntimeContext extends ServiceRuntimeContext {
     joiIdentifierMap(
       joiPrimitive().description(
         deline`
-        The task output value. Refer to individual [module type references](../module-types/README.md) for details.
+        The task output value. Refer to individual [module type references](${DOCS_BASE_URL}/module-types) for details.
         `
       )
     )

--- a/garden-service/src/config/module.ts
+++ b/garden-service/src/config/module.ts
@@ -83,9 +83,10 @@ export interface AddModuleSpec {
   exclude?: string[]
   include?: string[]
   name: string
-  path: string
+  path?: string
   repositoryUrl?: string
   type: string
+  [key: string]: any
 }
 
 export interface BaseModuleSpec extends AddModuleSpec {

--- a/garden-service/src/config/module.ts
+++ b/garden-service/src/config/module.ts
@@ -134,26 +134,17 @@ export const coreModuleSpecSchema = joi
 
 // These fields may be resolved later in the process, and allow for usage of template strings
 export const baseModuleSpecSchema = coreModuleSpecSchema.keys({
-  description: joi.string(),
+  description: joi.string().description("A description of the module."),
   disabled: joi
     .boolean()
     .default(false)
     .description(
       dedent`
-        Set this to \`true\` to disable the module. You can use this with conditional template strings to
-        disable modules based on, for example, the current environment or other variables (e.g.
-        \`disabled: \${environment.name == "prod"}\`). This can be handy when you only need certain modules for
-        specific environments, e.g. only for development.
+        Set this to \`true\` to disable the module. You can use this with conditional template strings to disable modules based on, for example, the current environment or other variables (e.g. \`disabled: \${environment.name == "prod"}\`). This can be handy when you only need certain modules for specific environments, e.g. only for development.
 
-        Disabling a module means that any services, tasks and tests contained in it will not be deployed or run.
-        It also means that the module is not built _unless_ it is declared as a build dependency by another enabled
-        module (in which case building this module is necessary for the dependant to be built).
+        Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which case building this module is necessary for the dependant to be built).
 
-        If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden
-        will automatically ignore those dependency declarations. Note however that template strings referencing the
-        module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled,
-        so you need to make sure to provide alternate values for those if you're using them, using conditional
-        expressions.
+        If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will automatically ignore those dependency declarations. Note however that template strings referencing the module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
       `
     ),
   include: joi
@@ -165,13 +156,10 @@ export const baseModuleSpecSchema = coreModuleSpecSchema.keys({
         .subPathOnly()
     )
     .description(
-      dedent`Specify a list of POSIX-style paths or globs that should be regarded as the source files for this
-        module. Files that do *not* match these paths or globs are excluded when computing the version of the module,
-        when responding to filesystem watch events, and when staging builds.
+      dedent`
+        Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-        Note that you can also _exclude_ files using the \`exclude\` field or by placing \`.gardenignore\` files in your
-        source tree, which use the same format as \`.gitignore\` files. See the
-        [Configuration Files guide](${includeGuideLink}) for details.
+        Note that you can also _exclude_ files using the \`exclude\` field or by placing \`.gardenignore\` files in your source tree, which use the same format as \`.gitignore\` files. See the [Configuration Files guide](${includeGuideLink}) for details.
 
         Also note that specifying an empty list here means _no sources_ should be included.`
     )
@@ -185,25 +173,20 @@ export const baseModuleSpecSchema = coreModuleSpecSchema.keys({
         .subPathOnly()
     )
     .description(
-      dedent`Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that
-        match these paths or globs are excluded when computing the version of the module, when responding to filesystem
-        watch events, and when staging builds.
+      dedent`
+        Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
-        Note that you can also explicitly _include_ files using the \`include\` field. If you also specify the
-        \`include\` field, the files/patterns specified here are filtered from the files matched by \`include\`. See the
-        [Configuration Files guide](${includeGuideLink})for details.
+        Note that you can also explicitly _include_ files using the \`include\` field. If you also specify the \`include\` field, the files/patterns specified here are filtered from the files matched by \`include\`. See the [Configuration Files guide](${includeGuideLink})for details.
 
-        Unlike the \`modules.exclude\` field in the project config, the filters here have _no effect_ on which files
-        and directories are watched for changes. Use the project \`modules.exclude\` field to affect those, if you have
-        large directories that should not be watched for changes.
+        Unlike the \`modules.exclude\` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project \`modules.exclude\` field to affect those, if you have large directories that should not be watched for changes.
         `
     )
     .example(["tmp/**/*", "*.log"]),
   repositoryUrl: joiRepositoryUrl().description(
-    dedent`${(<any>joiRepositoryUrl().describe().flags).description}
+    dedent`
+      ${(<any>joiRepositoryUrl().describe().flags).description}
 
-        Garden will import the repository source code into this module, but read the module's
-        config from the local garden.yml file.`
+      Garden will import the repository source code into this module, but read the module's config from the local garden.yml file.`
   ),
   allowPublish: joi
     .boolean()

--- a/garden-service/src/config/service.ts
+++ b/garden-service/src/config/service.ts
@@ -36,17 +36,11 @@ export const baseServiceSpecSchema = joi
       .default(false)
       .description(
         dedent`
-          Set this to \`true\` to disable the service. You can use this with conditional template strings to
-          enable/disable services based on, for example, the current environment or other variables (e.g.
-          \`enabled: \${environment.name != "prod"}\`). This can be handy when you only need certain services for
-          specific environments, e.g. only for development.
+          Set this to \`true\` to disable the service. You can use this with conditional template strings to enable/disable services based on, for example, the current environment or other variables (e.g. \`enabled: \${environment.name != "prod"}\`). This can be handy when you only need certain services for specific environments, e.g. only for development.
 
-          Disabling a service means that it will not be deployed, and will also be ignored if it is declared as a
-          runtime dependency for another service, test or task.
+          Disabling a service means that it will not be deployed, and will also be ignored if it is declared as a runtime dependency for another service, test or task.
 
-          Note however that template strings referencing the service's outputs (i.e. runtime outputs) will fail to
-          resolve when the service is disabled, so you need to make sure to provide alternate values for those if
-          you're using them, using conditional expressions.
+          Note however that template strings referencing the service's outputs (i.e. runtime outputs) will fail to resolve when the service is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
         `
       ),
   })
@@ -69,9 +63,7 @@ export const serviceConfigSchema = baseServiceSpecSchema
       .default(false)
       .description("Set this to true if the module and service configuration supports hot reloading."),
     sourceModuleName: joiIdentifier().optional().description(deline`
-        The \`validate\` module action should populate this, if the service's code sources are contained in a
-        separate module from the parent module. For example, when the service belongs to a module that contains
-        manifests (e.g. a Helm chart), but the actual code lives in a different module (e.g. a container module).
+        The \`validate\` module action should populate this, if the service's code sources are contained in a separate module from the parent module. For example, when the service belongs to a module that contains manifests (e.g. a Helm chart), but the actual code lives in a different module (e.g. a container module).
       `),
     spec: joi
       .object()

--- a/garden-service/src/constants.ts
+++ b/garden-service/src/constants.ts
@@ -39,4 +39,5 @@ export const SUPPORTED_PLATFORMS: SupportedPlatform[] = ["linux", "darwin", "win
 export const SEGMENT_DEV_API_KEY = "D3DUZ3lBSDO3krnuIO7eYDdtlDAjooKW"
 export const SEGMENT_PROD_API_KEY = "b6ovUD9A0YjQqT3ZWetWUbuZ9OmGxKMa"
 
+export const DOCS_BASE_URL = "https://docs.garden.io"
 export const VERSION_CHECK_URL = "https://get.garden.io/version"

--- a/garden-service/src/docs/generate.ts
+++ b/garden-service/src/docs/generate.ts
@@ -8,9 +8,15 @@
 
 import { resolve } from "path"
 import { writeCommandReferenceDocs } from "./commands"
-import { writeConfigReferenceDocs } from "./config"
+import { renderBaseConfigReference } from "./config"
 import { writeTemplateStringReferenceDocs } from "./template-strings"
 import { writeTableOfContents } from "./table-of-contents"
+import { Garden } from "../garden"
+import { defaultDotIgnoreFiles } from "../util/fs"
+import { keyBy, startCase } from "lodash"
+import { writeFileSync } from "fs-extra"
+import { renderModuleTypeReference, moduleTypes } from "./module-type"
+import { renderProviderReference } from "./provider"
 
 export async function generateDocs(targetDir: string) {
   // tslint:disable: no-console
@@ -24,4 +30,81 @@ export async function generateDocs(targetDir: string) {
   writeTemplateStringReferenceDocs(docsRoot)
   console.log("Generating table of contents...")
   await writeTableOfContents(docsRoot, "README.md")
+}
+
+export async function writeConfigReferenceDocs(docsRoot: string) {
+  // tslint:disable: no-console
+  const referenceDir = resolve(docsRoot, "reference")
+  const configPath = resolve(referenceDir, "config.md")
+
+  const garden = await Garden.factory(__dirname, {
+    config: {
+      path: __dirname,
+      apiVersion: "garden.io/v0",
+      kind: "Project",
+      name: "generate-docs",
+      defaultEnvironment: "default",
+      dotIgnoreFiles: defaultDotIgnoreFiles,
+      variables: {},
+      environments: [
+        {
+          name: "default",
+          variables: {},
+        },
+      ],
+      providers: [
+        { name: "conftest" },
+        { name: "conftest-container" },
+        { name: "conftest-kubernetes" },
+        { name: "hadolint" },
+        { name: "kubernetes" },
+        { name: "local-kubernetes" },
+        { name: "maven-container" },
+        { name: "openfaas" },
+        { name: "terraform" },
+      ],
+    },
+  })
+
+  const providerDir = resolve(docsRoot, "providers")
+  const plugins = await garden.getPlugins()
+  const pluginsByName = keyBy(plugins, "name")
+  const providersReadme = ["---", "order: 6", "title: Providers", "---", "", "# Providers", ""]
+
+  for (const plugin of plugins) {
+    const name = plugin.name
+
+    // Currently nothing to document for these
+    if (name === "container" || name === "exec") {
+      continue
+    }
+
+    const path = resolve(providerDir, `${name}.md`)
+    console.log("->", path)
+    writeFileSync(path, renderProviderReference(name, plugin, pluginsByName))
+
+    providersReadme.push(`* [${name}](./${name}.md)`)
+  }
+  writeFileSync(resolve(providerDir, `README.md`), providersReadme.join("\n"))
+
+  // Render module types
+  const moduleTypeDir = resolve(docsRoot, "module-types")
+  const readme = ["---", "order: 7", "title: Module Types", "---", "", "# Module Types", ""]
+  const moduleTypeDefinitions = await garden.getModuleTypes()
+
+  for (const { name } of moduleTypes) {
+    const path = resolve(moduleTypeDir, `${name}.md`)
+    const desc = moduleTypeDefinitions[name]
+
+    console.log("->", path)
+    writeFileSync(path, renderModuleTypeReference(name, moduleTypeDefinitions))
+
+    readme.push(`* [${desc.title || startCase(name.replace("-", " "))}](./${name}.md)`)
+  }
+
+  writeFileSync(resolve(moduleTypeDir, `README.md`), readme.join("\n"))
+
+  // Render base config docs
+  console.log("->", configPath)
+  writeFileSync(configPath, renderBaseConfigReference())
 }

--- a/garden-service/src/docs/module-type.ts
+++ b/garden-service/src/docs/module-type.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import Joi = require("@hapi/joi")
+import { readFileSync } from "fs"
+import { resolve } from "path"
+import { baseModuleSpecSchema } from "../config/module"
+import handlebars = require("handlebars")
+import { joi } from "../config/common"
+import { ModuleContext, ServiceRuntimeContext, TaskRuntimeContext } from "../config/config-context"
+import { ModuleTypeDefinition } from "../types/plugin/plugin"
+import { renderConfigReference, renderTemplateStringReference, TEMPLATES_DIR } from "./config"
+
+const populateModuleSchema = (schema: Joi.ObjectSchema) => baseModuleSpecSchema.concat(schema)
+
+export const moduleTypes = [
+  { name: "exec" },
+  { name: "container" },
+  { name: "conftest", pluginName: "conftest" },
+  { name: "hadolint" },
+  { name: "helm", pluginName: "local-kubernetes" },
+  { name: "kubernetes", pluginName: "local-kubernetes" },
+  { name: "maven-container" },
+  { name: "openfaas", pluginName: "local-kubernetes" },
+  { name: "terraform" },
+]
+
+/**
+ * Generates the module types reference from the module-type.hbs template.
+ * The reference includes the rendered output from the config-partial.hbs template.
+ */
+export function renderModuleTypeReference(name: string, definitions: { [name: string]: ModuleTypeDefinition }) {
+  const desc = definitions[name]
+  let { schema, docs } = desc
+
+  if (!schema) {
+    schema = joi
+      .object()
+      .keys({})
+      .unknown(false)
+  }
+
+  const moduleTemplatePath = resolve(TEMPLATES_DIR, "module-type.hbs")
+  const { markdownReference, yaml } = renderConfigReference(populateModuleSchema(schema))
+
+  // Get each schema from the module definitions, or the nearest base schema
+  const getOutputsSchema = (
+    spec: ModuleTypeDefinition,
+    type: "moduleOutputsSchema" | "serviceOutputsSchema" | "taskOutputsSchema"
+  ): Joi.ObjectSchema => {
+    const outputsSchema = desc[type]
+
+    if (outputsSchema) {
+      return outputsSchema
+    } else if (spec.base) {
+      return getOutputsSchema(definitions[spec.base], type)
+    } else {
+      return joi.object()
+    }
+  }
+
+  const moduleOutputsReference = renderTemplateStringReference({
+    schema: ModuleContext.getSchema().keys({
+      outputs: getOutputsSchema(desc, "moduleOutputsSchema").required(),
+    }),
+    prefix: "modules",
+    placeholder: "<module-name>",
+    exampleName: "my-module",
+  })
+
+  const serviceOutputsReference = renderTemplateStringReference({
+    schema: ServiceRuntimeContext.getSchema().keys({
+      outputs: getOutputsSchema(desc, "serviceOutputsSchema").required(),
+    }),
+    prefix: "runtime.services",
+    placeholder: "<service-name>",
+    exampleName: "my-service",
+  })
+
+  const taskOutputsReference = renderTemplateStringReference({
+    schema: TaskRuntimeContext.getSchema().keys({
+      outputs: getOutputsSchema(desc, "taskOutputsSchema").required(),
+    }),
+    prefix: "runtime.tasks",
+    placeholder: "<task-name>",
+    exampleName: "my-tasks",
+  })
+
+  const frontmatterTitle = name
+  const template = handlebars.compile(readFileSync(moduleTemplatePath).toString())
+  return template({
+    frontmatterTitle,
+    name,
+    docs,
+    markdownReference,
+    yaml,
+    hasOutputs: moduleOutputsReference || serviceOutputsReference || taskOutputsReference,
+    moduleOutputsReference,
+    serviceOutputsReference,
+    taskOutputsReference,
+  })
+}

--- a/garden-service/src/docs/provider.ts
+++ b/garden-service/src/docs/provider.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import Joi from "@hapi/joi"
+import { readFileSync } from "fs"
+import { resolve } from "path"
+import handlebars = require("handlebars")
+import { joiArray, joi } from "../config/common"
+import { providerConfigBaseSchema } from "../config/provider"
+import { GardenPlugin, PluginMap } from "../types/plugin/plugin"
+import { getPluginBases } from "../plugins"
+import { renderTemplateStringReference, renderConfigReference, TEMPLATES_DIR } from "./config"
+
+const populateProviderSchema = (schema: Joi.ObjectSchema) =>
+  joi.object().keys({
+    providers: joiArray(schema),
+  })
+
+/**
+ * Generates the provider reference from the provider.hbs template.
+ * The reference includes the rendered output from the config-partial.hbs template.
+ */
+export function renderProviderReference(name: string, plugin: GardenPlugin, allPlugins: PluginMap) {
+  let configSchema = plugin.configSchema
+
+  // If the plugin doesn't specify its own config schema, we need to walk through its bases to get a schema to document
+  if (!configSchema) {
+    for (const base of getPluginBases(plugin, allPlugins)) {
+      if (base.configSchema) {
+        configSchema = base.configSchema
+        break
+      }
+    }
+  }
+
+  const schema = populateProviderSchema(configSchema || providerConfigBaseSchema)
+  const docs = plugin.docs || ""
+
+  const moduleOutputsSchema = plugin.outputsSchema
+
+  const providerTemplatePath = resolve(TEMPLATES_DIR, "provider.hbs")
+  const { markdownReference, yaml } = renderConfigReference(schema)
+
+  const moduleOutputsReference =
+    moduleOutputsSchema &&
+    renderTemplateStringReference({
+      schema: joi.object().keys({
+        outputs: moduleOutputsSchema.required(),
+      }),
+      prefix: "providers",
+      placeholder: "<provider-name>",
+      exampleName: "my-provider",
+    })
+
+  const template = handlebars.compile(readFileSync(providerTemplatePath).toString())
+  const frontmatterTitle = name
+  return template({ name, docs, frontmatterTitle, markdownReference, yaml, moduleOutputsReference })
+}

--- a/garden-service/src/docs/util.ts
+++ b/garden-service/src/docs/util.ts
@@ -24,3 +24,10 @@ export function renderMarkdownTable(data: { [heading: string]: string }) {
 
   return [head, divider, values].join("\n")
 }
+
+/**
+ * Converts all markdown-formatted links in the given text to just normal links in parentheses after the link text.
+ */
+export function convertMarkdownLinks(text: string) {
+  return text.replace(/\[([\w\s]+)\]\((.*)\)/g, "$1 ($2)")
+}

--- a/garden-service/src/exceptions.ts
+++ b/garden-service/src/exceptions.ts
@@ -47,6 +47,10 @@ export class CommandError extends GardenBaseError {
   type = "command"
 }
 
+export class FilesystemError extends GardenBaseError {
+  type = "filesystem"
+}
+
 export class LocalConfigError extends GardenBaseError {
   type = "local-config"
 }

--- a/garden-service/src/garden.ts
+++ b/garden-service/src/garden.ts
@@ -634,7 +634,8 @@ export class Garden {
 
       // Resolve module configs from specs and add to the list
       await Bluebird.map(addModules || [], async (spec) => {
-        const moduleConfig = prepareModuleResource(spec, spec.path, spec.path, this.projectRoot)
+        const path = spec.path || this.projectRoot
+        const moduleConfig = prepareModuleResource(spec, path, path, this.projectRoot)
         moduleConfigs.push(await resolveModuleConfig(this, moduleConfig, opts))
         graph = undefined
       })

--- a/garden-service/src/garden.ts
+++ b/garden-service/src/garden.ts
@@ -8,7 +8,7 @@
 
 import Bluebird from "bluebird"
 import { parse, relative, resolve, dirname } from "path"
-import { flatten, isString, sortBy, fromPairs, keyBy, some } from "lodash"
+import { flatten, isString, sortBy, fromPairs, keyBy } from "lodash"
 const AsyncLock = require("async-lock")
 
 import { TreeCache } from "./cache"
@@ -56,7 +56,7 @@ import { detectCycles, cyclesToString, Dependency } from "./util/validate-depend
 import chalk from "chalk"
 import { RuntimeContext } from "./runtime-context"
 import { ensureDir } from "fs-extra"
-import { loadPlugins, getDependencyOrder } from "./plugins"
+import { loadPlugins, getDependencyOrder, getModuleTypes } from "./plugins"
 import { deline, naturalList } from "./util/string"
 import dedent from "dedent"
 import { ensureConnected } from "./db/connection"
@@ -412,17 +412,7 @@ export class Garden {
     const configNames = keyBy(this.getRawProviderConfigs(), "name")
     const configuredPlugins = plugins.filter((p) => configNames[p.name])
 
-    const definitions = flatten(configuredPlugins.map((p) => p.createModuleTypes))
-    const extensions = flatten(configuredPlugins.map((p) => p.extendModuleTypes))
-
-    return keyBy(
-      definitions.map((definition) => {
-        const typeExtensions = extensions.filter((e) => e.name === definition.name)
-        const needsBuild = !!definition.handlers.build || some(typeExtensions, (e) => !!e.handlers.build)
-        return { ...definition, needsBuild }
-      }),
-      "name"
-    )
+    return getModuleTypes(configuredPlugins)
   }
 
   getRawProviderConfigs() {

--- a/garden-service/src/plugin-context.ts
+++ b/garden-service/src/plugin-context.ts
@@ -66,7 +66,8 @@ export const pluginContextSchema = joi
     production: joi
       .boolean()
       .default(false)
-      .description("Indicate if the current environment is a production environment"),
+      .description("Indicate if the current environment is a production environment")
+      .example(true),
     projectName: projectNameSchema,
     projectRoot: joi.string().description("The absolute path of the project root."),
     projectSources: projectSourcesSchema,

--- a/garden-service/src/plugin-context.ts
+++ b/garden-service/src/plugin-context.ts
@@ -66,7 +66,7 @@ export const pluginContextSchema = joi
     production: joi
       .boolean()
       .default(false)
-      .description("Indicate if the current environment is a production environment")
+      .description("Indicate if the current environment is a production environment.")
       .example(true),
     projectName: projectNameSchema,
     projectRoot: joi.string().description("The absolute path of the project root."),

--- a/garden-service/src/plugins.ts
+++ b/garden-service/src/plugins.ts
@@ -7,7 +7,14 @@
  */
 
 import { DepGraph } from "dependency-graph"
-import { PluginMap, GardenPlugin, ModuleTypeDefinition, ModuleTypeExtension, pluginSchema } from "./types/plugin/plugin"
+import {
+  PluginMap,
+  GardenPlugin,
+  ModuleTypeDefinition,
+  ModuleTypeExtension,
+  pluginSchema,
+  ModuleTypeMap,
+} from "./types/plugin/plugin"
 import { ProviderConfig } from "./config/provider"
 import { ConfigurationError, PluginError, RuntimeError } from "./exceptions"
 import { uniq, mapValues, fromPairs, flatten, keyBy, some } from "lodash"
@@ -289,8 +296,8 @@ export function getPluginDependencies(plugin: GardenPlugin, loadedPlugins: Plugi
 /**
  * Returns all the module types defined in the given list of plugins.
  */
-export function getModuleTypes(plugins: GardenPlugin[]) {
-  const definitions = flatten(plugins.map((p) => p.createModuleTypes.map((d) => ({ ...d, pluginName: p.name }))))
+export function getModuleTypes(plugins: GardenPlugin[]): ModuleTypeMap {
+  const definitions = flatten(plugins.map((p) => p.createModuleTypes.map((spec) => ({ ...spec, plugin: p }))))
   const extensions = flatten(plugins.map((p) => p.extendModuleTypes))
 
   return keyBy(

--- a/garden-service/src/plugins/conftest/conftest-container.ts
+++ b/garden-service/src/plugins/conftest/conftest-container.ts
@@ -12,6 +12,7 @@ import { createGardenPlugin } from "../../types/plugin/plugin"
 import { containerHelpers } from "../container/helpers"
 import { ConftestProvider } from "./conftest"
 import { dedent } from "../../util/string"
+import { DOCS_BASE_URL } from "../../constants"
 
 /**
  * Auto-generates a conftest module for each container module in your project
@@ -21,7 +22,7 @@ export const gardenPlugin = createGardenPlugin({
   base: "conftest",
   dependencies: ["container"],
   docs: dedent`
-    This provider automatically generates [conftest modules](../module-types/conftest.md) for \`container\` modules
+    This provider automatically generates [conftest modules](${DOCS_BASE_URL}/module-types/conftest) for \`container\` modules
     in your project. A \`conftest\` module is created for each \`container\` module that includes a Dockerfile that
     can be validated.
 

--- a/garden-service/src/plugins/conftest/conftest-kubernetes.ts
+++ b/garden-service/src/plugins/conftest/conftest-kubernetes.ts
@@ -11,6 +11,7 @@ import { createGardenPlugin } from "../../types/plugin/plugin"
 import { ConftestProvider } from "./conftest"
 import { relative, resolve } from "path"
 import { dedent } from "../../util/string"
+import { DOCS_BASE_URL } from "../../constants"
 
 /**
  * Auto-generates a conftest module for each helm and kubernetes module in your project
@@ -20,7 +21,7 @@ export const gardenPlugin = createGardenPlugin({
   base: "conftest",
   dependencies: ["kubernetes"],
   docs: dedent`
-    This provider automatically generates [conftest modules](../module-types/conftest.md) for \`kubernetes\` and
+    This provider automatically generates [conftest modules](${DOCS_BASE_URL}/module-types/conftest) for \`kubernetes\` and
     \`helm\` modules in your project. A \`conftest\` module is created for each of those module types.
 
     Simply add this provider to your project configuration, and configure your policies. Check out the below

--- a/garden-service/src/plugins/conftest/conftest.ts
+++ b/garden-service/src/plugins/conftest/conftest.ts
@@ -18,6 +18,7 @@ import chalk from "chalk"
 import { baseBuildSpecSchema } from "../../config/module"
 import { matchGlobs, listDirectory } from "../../util/fs"
 import { PluginError } from "../../exceptions"
+import { DOCS_BASE_URL } from "../../constants"
 
 interface ConftestProviderConfig extends ProviderConfig {
   policyPath: string
@@ -67,14 +68,14 @@ export const gardenPlugin = createGardenPlugin({
     Each module then creates a Garden test that becomes part of your Stack Graph.
 
     Note that, in many cases, you'll actually want to use more specific providers that can automatically configure your
-    \`conftest\` modules, e.g. the [\`conftest-container\`](./conftest-container.md) and/or
-    [\`conftest-kubernetes\`](./conftest-kubernetes.md) providers. See the
+    \`conftest\` modules, e.g. the [\`conftest-container\`](${DOCS_BASE_URL}/providers/conftest-container) and/or
+    [\`conftest-kubernetes\`](${DOCS_BASE_URL}/providers/conftest-kubernetes) providers. See the
     [conftest example project](https://github.com/garden-io/garden/tree/master/examples/conftest) for a simple usage
     example of the latter.
 
     If those don't match your needs, you can use this provider directly and manually configure your \`conftest\`
     modules. Simply add this provider to your project configuration, and see the
-    [conftest module documentation](../module-types/conftest.md) for a detailed reference. Also, check out the below
+    [conftest module documentation](${DOCS_BASE_URL}/module-types/conftest) for a detailed reference. Also, check out the below
     [reference](#reference) for how to configure default policies, default namespaces, and test failure thresholds for
     all \`conftest\` modules.
   `,
@@ -87,7 +88,7 @@ export const gardenPlugin = createGardenPlugin({
         Creates a test that runs \`conftest\` on the specified files, with the specified (or default) policy and
         namespace.
 
-        > Note: In many cases, you'll let specific conftest providers (e.g. [\`conftest-container\`](../providers/conftest-container.md) and [\`conftest-kubernetes\`](../providers/conftest-kubernetes.md) create this module type automatically, but you may in some cases want or need to manually specify files to test.
+        > Note: In many cases, you'll let specific conftest providers (e.g. [\`conftest-container\`](${DOCS_BASE_URL}/providers/conftest-container) and [\`conftest-kubernetes\`](${DOCS_BASE_URL}/providers/conftest-kubernetes) create this module type automatically, but you may in some cases want or need to manually specify files to test.
 
         See the [conftest docs](https://github.com/instrumenta/conftest) for details on how to configure policies.
       `,

--- a/garden-service/src/plugins/container/config.ts
+++ b/garden-service/src/plugins/container/config.ts
@@ -555,7 +555,7 @@ export const containerModuleSpecSchema = joi
       .description("POSIX-style name of Dockerfile, relative to module root."),
     services: joiArray(serviceSchema)
       .unique("name")
-      .description("The list of services to deploy from this container module."),
+      .description("A list of services to deploy from this container module."),
     tests: joiArray(containerTestSchema).description("A list of tests to run in the module."),
     // We use the user-facing term "tasks" as the key here, instead of "tasks".
     tasks: joiArray(containerTaskSchema).description(deline`

--- a/garden-service/src/plugins/container/container.ts
+++ b/garden-service/src/plugins/container/container.ts
@@ -19,6 +19,7 @@ import { ConfigureModuleParams } from "../../types/plugin/module/configure"
 import { HotReloadServiceParams } from "../../types/plugin/service/hotReloadService"
 import { joi } from "../../config/common"
 import { publishContainerModule } from "./publish"
+import { DOCS_BASE_URL } from "../../constants"
 
 export const containerModuleOutputsSchema = joi.object().keys({
   "local-image-name": joi
@@ -172,8 +173,8 @@ export const gardenPlugin = createGardenPlugin({
 
         Note that the runtime services have somewhat limited features in this module type. For example, you cannot
         specify replicas for redundancy, and various platform-specific options are not included. For those, look at
-        other module types like [helm](https://docs.garden.io/module-types/helm) or
-        [kubernetes](https://github.com/garden-io/garden/blob/master/docs/module-types/kubernetes.md).
+        other module types like [helm](${DOCS_BASE_URL}/module-types/helm) or
+        [kubernetes](${DOCS_BASE_URL}/module-types/kubernetes).
       `,
       moduleOutputsSchema: containerModuleOutputsSchema,
       schema: containerModuleSpecSchema,

--- a/garden-service/src/plugins/hadolint/hadolint.ts
+++ b/garden-service/src/plugins/hadolint/hadolint.ts
@@ -16,7 +16,7 @@ import { dedent, splitLines, naturalList } from "../../util/string"
 import { TestModuleParams } from "../../types/plugin/module/testModule"
 import { Module } from "../../types/module"
 import { BinaryCmd } from "../../util/ext-tools"
-import { STATIC_DIR } from "../../constants"
+import { STATIC_DIR, DOCS_BASE_URL } from "../../constants"
 import { padStart, padEnd } from "lodash"
 import chalk from "chalk"
 import { ConfigurationError } from "../../exceptions"
@@ -67,7 +67,7 @@ export const gardenPlugin = createGardenPlugin({
   name: "hadolint",
   dependencies: ["container"],
   docs: dedent`
-    This provider creates a [\`hadolint\`](../module-types/hadolint.md) module type, and (by default) generates one
+    This provider creates a [\`hadolint\`](${DOCS_BASE_URL}/module-types/hadolint) module type, and (by default) generates one
     such module for each \`container\` module that contains a Dockerfile in your project. Each module creates a single
     test that runs [hadolint](https://github.com/hadolint/hadolint) against the Dockerfile in question, in order to
     ensure that the Dockerfile is valid and follows best practices.
@@ -136,7 +136,7 @@ export const gardenPlugin = createGardenPlugin({
       docs: dedent`
         Runs \`hadolint\` on the specified Dockerfile.
 
-        > Note: In most cases, you'll let the [provider](../providers/hadolint.md) create this module type automatically, but you may in some cases want or need to manually specify a Dockerfile to lint.
+        > Note: In most cases, you'll let the [provider](${DOCS_BASE_URL}/providers/hadolint) create this module type automatically, but you may in some cases want or need to manually specify a Dockerfile to lint.
 
         To configure \`hadolint\`, you can use \`.hadolint.yaml\` config files. For each test, we first look for one in
         the module root. If none is found there, we check the project root, and if none is there we fall back to default

--- a/garden-service/src/plugins/kubernetes/helm/handlers.ts
+++ b/garden-service/src/plugins/kubernetes/helm/handlers.ts
@@ -21,6 +21,10 @@ import { getTaskResult } from "../task-results"
 import { GetPortForwardParams } from "../../../types/plugin/service/getPortForward"
 import { KubernetesPluginContext } from "../config"
 import { getModuleNamespace } from "../namespace"
+import { join } from "path"
+import { pathExists } from "fs-extra"
+import chalk = require("chalk")
+import { SuggestModulesParams, SuggestModulesResult } from "../../../types/plugin/module/suggestModules"
 
 export const helmHandlers: Partial<ModuleAndRuntimeActionHandlers<HelmModule>> = {
   build: buildHelmModule,
@@ -49,5 +53,24 @@ export const helmHandlers: Partial<ModuleAndRuntimeActionHandlers<HelmModule>> =
   // TODO: add publishModule handler
   runModule: runHelmModule,
   runTask: runHelmTask,
+  suggestModules: async ({ name, path }: SuggestModulesParams): Promise<SuggestModulesResult> => {
+    const chartPath = join(path, "Chart.yaml")
+    if (await pathExists(chartPath)) {
+      return {
+        suggestions: [
+          {
+            description: `based on found ${chalk.white("Chart.yaml")}`,
+            module: {
+              type: "helm",
+              name,
+              chartPath: ".",
+            },
+          },
+        ],
+      }
+    } else {
+      return { suggestions: [] }
+    }
+  },
   testModule: testHelmModule,
 }

--- a/garden-service/src/plugins/kubernetes/kubernetes.ts
+++ b/garden-service/src/plugins/kubernetes/kubernetes.ts
@@ -34,6 +34,7 @@ import chalk from "chalk"
 import pluralize from "pluralize"
 import { getSystemMetadataNamespaceName } from "./system"
 import { removeTillerCmd } from "./commands/remove-tiller"
+import { DOCS_BASE_URL } from "../../constants"
 
 export async function configureProvider({
   projectName,
@@ -167,16 +168,16 @@ export const gardenPlugin = createGardenPlugin({
   name: "kubernetes",
   dependencies: ["container"],
   docs: dedent`
-    The \`kubernetes\` provider allows you to deploy [\`container\` modules](../module-types/container.md) to
-    Kubernetes clusters, and adds the [\`helm\`](../module-types/helm.md) and
-    [\`kubernetes\`](../module-types/kubernetes.md) module types.
+    The \`kubernetes\` provider allows you to deploy [\`container\` modules](${DOCS_BASE_URL}/module-types/container) to
+    Kubernetes clusters, and adds the [\`helm\`](${DOCS_BASE_URL}/module-types/helm) and
+    [\`kubernetes\`](${DOCS_BASE_URL}/module-types/kubernetes) module types.
 
-    For usage information, please refer to the [guides section](../guides/README.md). A good place to start is
-    the [Remote Kubernetes guide](../guides/remote-kubernetes.md) guide if you're connecting to remote clusters.
-    The [demo-project](../examples/demo-project.md) example project and guide are also helpful as an introduction.
+    For usage information, please refer to the [guides section]${DOCS_BASE_URL}/guides). A good place to start is
+    the [Remote Kubernetes guide](${DOCS_BASE_URL}/guides/remote-kubernetes) guide if you're connecting to remote clusters.
+    The [demo-project](${DOCS_BASE_URL}/examples/demo-project) example project and guide are also helpful as an introduction.
 
     Note that if you're using a local Kubernetes cluster (e.g. minikube or Docker Desktop), the
-    [local-kubernetes provider](./local-kubernetes.md) simplifies (and automates) the configuration and setup quite a
+    [local-kubernetes provider](${DOCS_BASE_URL}/providers/local-kubernetes) simplifies (and automates) the configuration and setup quite a
     bit.
   `,
   configSchema,
@@ -197,7 +198,7 @@ export const gardenPlugin = createGardenPlugin({
       name: "helm",
       docs: dedent`
         Specify a Helm chart (either in your repository or remote from a registry) to deploy.
-        Refer to the [Helm guide](../guides/using-helm-charts.md) for usage instructions.
+        Refer to the [Helm guide](${DOCS_BASE_URL}/guides/using-helm-charts) for usage instructions.
       `,
       moduleOutputsSchema: helmModuleOutputsSchema,
       schema: helmModuleSpecSchema,
@@ -212,10 +213,10 @@ export const gardenPlugin = createGardenPlugin({
         one or more files with existing manifests.
 
         Note that if you include the manifests in the \`garden.yml\` file, you can use
-        [template strings](../guides/variables-and-templating.md) to interpolate values into the manifests.
+        [template strings](${DOCS_BASE_URL}/guides/variables-and-templating) to interpolate values into the manifests.
 
         If you need more advanced templating features you can use the
-        [helm](./helm.md) module type.
+        [helm](${DOCS_BASE_URL}/module-types/helm) module type.
       `,
       moduleOutputsSchema: joi.object().keys({}),
       schema: kubernetesModuleSpecSchema,

--- a/garden-service/src/plugins/kubernetes/local/local.ts
+++ b/garden-service/src/plugins/kubernetes/local/local.ts
@@ -9,20 +9,21 @@
 import { configureProvider, configSchema } from "./config"
 import { createGardenPlugin } from "../../../types/plugin/plugin"
 import { dedent } from "../../../util/string"
+import { DOCS_BASE_URL } from "../../../constants"
 
 export const gardenPlugin = createGardenPlugin({
   name: "local-kubernetes",
   base: "kubernetes",
   docs: dedent`
-    The \`local-kubernetes\` provider is a specialized version of the [\`kubernetes\` provider](./kubernetes.md) that
+    The \`local-kubernetes\` provider is a specialized version of the [\`kubernetes\` provider](${DOCS_BASE_URL}/providers/kubernetes) that
     automates and simplifies working with local Kubernetes clusters.
 
-    For general Kubernetes usage information, please refer to the [guides section](../guides/README.md). For local
-    clusters a good place to start is the [Local Kubernetes guide](../guides/local-kubernetes.md) guide.
-    The [demo-project](../examples/demo-project.md) example project and guide are also helpful as an introduction.
+    For general Kubernetes usage information, please refer to the [guides section](${DOCS_BASE_URL}/guides). For local
+    clusters a good place to start is the [Local Kubernetes guide](${DOCS_BASE_URL}/guides/local-kubernetes) guide.
+    The [demo-project](${DOCS_BASE_URL}/examples/demo-project) example project and guide are also helpful as an introduction.
 
-    If you're working with a remote Kubernetes cluster, please refer to the [\`kubernetes\` provider](./kubernetes.md)
-    docs, and the [Remote Kubernetes guide](../guides/remote-kubernetes.md) guide.
+    If you're working with a remote Kubernetes cluster, please refer to the [\`kubernetes\` provider](${DOCS_BASE_URL}/providers/kubernetes)
+    docs, and the [Remote Kubernetes guide](${DOCS_BASE_URL}/guides/remote-kubernetes) guide.
   `,
   configSchema,
   handlers: {

--- a/garden-service/src/plugins/maven-container/maven-container.ts
+++ b/garden-service/src/plugins/maven-container/maven-container.ts
@@ -21,7 +21,7 @@ import { Module } from "../../types/module"
 import { resolve } from "path"
 import { RuntimeError, ConfigurationError } from "../../exceptions"
 import { containerHelpers } from "../container/helpers"
-import { STATIC_DIR } from "../../constants"
+import { STATIC_DIR, DOCS_BASE_URL } from "../../constants"
 import { xml2json } from "xml-js"
 import { containerModuleSpecSchema } from "../container/config"
 import { providerConfigBaseSchema } from "../../config/provider"
@@ -101,11 +101,11 @@ export const gardenPlugin = createGardenPlugin({
   dependencies: ["container"],
 
   docs: dedent`
-    Adds the [maven-container module type](../module-types/maven-container.md), which is a specialized version of the
+    Adds the [maven-container module type](${DOCS_BASE_URL}/module-types/maven-container), which is a specialized version of the
     \`container\` module type that has special semantics for building JAR files using Maven.
 
     To use it, simply add the provider to your provider configuration, and refer to the
-    [maven-container module docs](../module-types/maven-container.md) for details on how to configure the modules.
+    [maven-container module docs](${DOCS_BASE_URL}/module-types/maven-container) for details on how to configure the modules.
   `,
 
   createModuleTypes: [

--- a/garden-service/src/plugins/openfaas/openfaas.ts
+++ b/garden-service/src/plugins/openfaas/openfaas.ts
@@ -23,7 +23,7 @@ import { GetServiceStatusParams } from "../../types/plugin/service/getServiceSta
 import { GetServiceLogsParams } from "../../types/plugin/service/getServiceLogs"
 import { DeleteServiceParams } from "../../types/plugin/service/deleteService"
 import { HelmModuleConfig } from "../kubernetes/helm/config"
-import { DEFAULT_API_VERSION, STATIC_DIR } from "../../constants"
+import { DEFAULT_API_VERSION, STATIC_DIR, DOCS_BASE_URL } from "../../constants"
 import { ExecModuleConfig } from "../exec"
 import { ConfigureProviderParams, ConfigureProviderResult } from "../../types/plugin/provider/configureProvider"
 import { KubernetesDeployment } from "../kubernetes/types"
@@ -56,11 +56,11 @@ export const gardenPlugin = createGardenPlugin({
   dependencies: ["kubernetes"],
   docs: dedent`
     This provider adds support for [OpenFaaS](https://www.openfaas.com/). It adds the
-    [\`openfaas\` module type](../module-types/openfaas.md) and (by default) installs the \`faas-netes\` runtime to
+    [\`openfaas\` module type](${DOCS_BASE_URL}/module-types/openfaas) and (by default) installs the \`faas-netes\` runtime to
     the project namespace. Each \`openfaas\` module maps to a single OpenFaaS function.
 
     See the [reference](#reference) below for configuration options for \`faas-netes\`, and the
-    [module type docs](../module-types/openfaas.md) for how to configure the individual functions.
+    [module type docs](${DOCS_BASE_URL}/module-types/openfaas) for how to configure the individual functions.
 
     Also see the [openfaas example project](https://github.com/garden-io/garden/tree/master/examples/openfaas) for a
     simple usage example.

--- a/garden-service/src/plugins/plugins.ts
+++ b/garden-service/src/plugins/plugins.ts
@@ -7,21 +7,26 @@
  */
 
 // These plugins are always registered
-export const builtinPlugins = [
+export const supportedPlugins = [
   require("./conftest/conftest"),
   require("./conftest/conftest-container"),
   require("./conftest/conftest-kubernetes"),
   require("./container/container"),
   require("./exec"),
-  require("./google/google-app-engine"),
-  require("./google/google-cloud-functions"),
   require("./hadolint/hadolint"),
-  require("./local/local-google-cloud-functions"),
   require("./kubernetes/kubernetes"),
   require("./kubernetes/local/local"),
   require("./maven-container/maven-container"),
-  require("./npm-package"),
-  require("./google/google-app-engine"),
   require("./openfaas/openfaas"),
   require("./terraform/terraform"),
 ].map((m) => m.gardenPlugin)
+
+// These plugins are always registered
+export const builtinPlugins = supportedPlugins.concat(
+  [
+    require("./google/google-app-engine"),
+    require("./google/google-cloud-functions"),
+    require("./local/local-google-cloud-functions"),
+    require("./npm-package"),
+  ].map((m) => m.gardenPlugin)
+)

--- a/garden-service/src/plugins/terraform/terraform.ts
+++ b/garden-service/src/plugins/terraform/terraform.ts
@@ -18,6 +18,7 @@ import { ConfigureProviderParams, ConfigureProviderResult } from "../../types/pl
 import { ConfigurationError } from "../../exceptions"
 import { variablesSchema, TerraformBaseSpec } from "./common"
 import { schema, configureTerraformModule, getTerraformStatus, deployTerraform } from "./module"
+import { DOCS_BASE_URL } from "../../constants"
 
 type TerraformProviderConfig = ProviderConfig &
   TerraformBaseSpec & {
@@ -37,7 +38,7 @@ const configSchema = providerConfigBaseSchema
         Specify the path to a Terraform config directory, that should be resolved when initializing the provider.
         This is useful when other providers need to be able to reference the outputs from the stack.
 
-        See the [Terraform guide](../guides/terraform.md) for more information.
+        See the [Terraform guide](${DOCS_BASE_URL}/guides/terraform) for more information.
       `),
     // When you provide variables directly in \`terraform\` modules, those variables will
     // extend the ones specified here, and take precedence if the keys overlap.
@@ -59,7 +60,7 @@ export const gardenPlugin = createGardenPlugin({
   name: "terraform",
   docs: dedent`
     This provider allows you to integrate Terraform stacks into your Garden project.
-    See the [Terraform guide](../guides/terraform.md) for details and usage information.
+    See the [Terraform guide](${DOCS_BASE_URL}/guides/terraform) for details and usage information.
   `,
   configSchema,
   handlers: {
@@ -85,7 +86,7 @@ export const gardenPlugin = createGardenPlugin({
       that to configure another provider or other modules via \`\${providers.terraform.outputs.<key>}\` template
       strings.
 
-      See the [Terraform guide](../guides/terraform.md) for a high-level introduction to the \`terraform\`
+      See the [Terraform guide](${DOCS_BASE_URL}/guides/terraform) for a high-level introduction to the \`terraform\`
       provider.
     `,
       serviceOutputsSchema: joi

--- a/garden-service/src/types/plugin/module/suggestModules.ts
+++ b/garden-service/src/types/plugin/module/suggestModules.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { dedent } from "../../../util/string"
+import { AddModuleSpec } from "../../../config/module"
+import { joi, joiArray } from "../../../config/common"
+import { addModuleSchema } from "../provider/augmentGraph"
+import { LogEntry } from "../../../logger/log-entry"
+import { ActionHandlerParamsBase } from "../plugin"
+
+export const maxDescriptionLength = 48
+
+export interface SuggestModulesParams extends ActionHandlerParamsBase {
+  log: LogEntry
+  name: string
+  path: string
+}
+
+export interface ModuleSuggestion {
+  description: string
+  module: AddModuleSpec
+}
+
+export interface SuggestModulesResult {
+  suggestions: ModuleSuggestion[]
+}
+
+const suggestionSchema = joi.object().keys({
+  description: joi.string().description(
+    dedent`
+    A short description (anything longer than ${maxDescriptionLength} chars will be truncated) of the module being suggested. If specified, this is shown in the list of suggested modules in the \`garden create module\` command, to help distinguish between multiple candidates and explain why the suggestion was made.
+    `
+  ),
+  module: addModuleSchema.required().description(
+    dedent`
+    The module to suggest. This should be a module spec in the same format as a normal module specified in a \`garden.yml\` config file.
+    `
+  ),
+})
+
+export const suggestModules = {
+  description: dedent`
+    Given a directory path, return a list of suggested modules (if applicable).
+
+    This is used by the \`garden create module\` command, to ease transition of existing projects to Garden, and to automate some of the parameters when defining modules.
+  `,
+
+  paramsSchema: joi.object().keys({
+    path: joi
+      .string()
+      .required()
+      .description("The absolute path to the directory where the module is being created."),
+  }),
+
+  resultSchema: joi.object().keys({
+    suggestions: joiArray(suggestionSchema).description("A list of modules to suggest for the given path."),
+  }),
+}

--- a/garden-service/src/types/plugin/plugin.ts
+++ b/garden-service/src/types/plugin/plugin.ts
@@ -41,6 +41,7 @@ import { pluginCommandSchema, PluginCommand } from "./command"
 import { getPortForward, GetPortForwardParams, GetPortForwardResult } from "./service/getPortForward"
 import { StopPortForwardParams, stopPortForward } from "./service/stopPortForward"
 import { AugmentGraphResult, AugmentGraphParams, augmentGraph } from "./provider/augmentGraph"
+import { suggestModules, SuggestModulesParams, SuggestModulesResult } from "./module/suggestModules"
 
 export interface ActionHandlerParamsBase {
   base?: ActionHandler<any, any>
@@ -231,6 +232,7 @@ export const taskActionDescriptions: { [P in TaskActionName]: PluginActionDescri
 
 interface _ModuleActionParams<T extends Module = Module> {
   configure: ConfigureModuleParams<T>
+  suggestModules: SuggestModulesParams
   getBuildStatus: GetBuildStatusParams<T>
   build: BuildModuleParams<T>
   publish: PublishModuleParams<T>
@@ -248,6 +250,7 @@ export type ModuleActionParams<T extends Module = Module> = {
 
 export interface ModuleActionOutputs extends ServiceActionOutputs {
   configure: ConfigureModuleResult
+  suggestModules: SuggestModulesResult
   getBuildStatus: BuildStatus
   build: BuildResult
   publish: PublishResult
@@ -260,6 +263,7 @@ const _moduleActionDescriptions: {
   [P in ModuleActionName | ServiceActionName | TaskActionName]: PluginActionDescription
 } = {
   configure,
+  suggestModules,
   getBuildStatus,
   build,
   publish: publishModule,
@@ -298,6 +302,7 @@ export interface ModuleTypeDefinition extends ModuleTypeExtension {
 }
 
 export interface ModuleType extends ModuleTypeDefinition {
+  plugin: GardenPlugin
   needsBuild: boolean
 }
 

--- a/garden-service/src/types/plugin/provider/augmentGraph.ts
+++ b/garden-service/src/types/plugin/provider/augmentGraph.ts
@@ -9,7 +9,7 @@
 import { PluginActionParamsBase, actionParamsSchema } from "../base"
 import { dedent } from "../../../util/string"
 import { joi, joiArray, joiIdentifier } from "../../../config/common"
-import { baseModuleSpecSchema, AddModuleSpec, modulePathSchema } from "../../../config/module"
+import { baseModuleSpecSchema, AddModuleSpec } from "../../../config/module"
 import { Provider, providerSchema } from "../../../config/provider"
 import { Module, moduleSchema } from "../../module"
 
@@ -29,9 +29,7 @@ export interface AugmentGraphResult {
   addModules?: AddModuleSpec[]
 }
 
-const addModuleSchema = baseModuleSpecSchema.keys({
-  path: modulePathSchema,
-})
+export const addModuleSchema = baseModuleSpecSchema
 
 export const augmentGraph = {
   description: dedent`
@@ -111,7 +109,7 @@ export const augmentGraph = {
         dedent`
           Add modules (of any defined kind) to the stack graph. Each should be a module spec in the same format as
           a normal module specified in a \`garden.yml\` config file (which will later be passed to the appropriate
-          \`configure\` handler(s) for the module type), with the addition of \`path\` being required.
+          \`configure\` handler(s) for the module type).
 
           The added modules can be referenced in \`addBuildDependencies\`, and their services/tasks can be referenced
           in \`addRuntimeDependencies\`.

--- a/garden-service/src/types/service.ts
+++ b/garden-service/src/types/service.ts
@@ -104,18 +104,15 @@ export interface ServiceIngress extends ServiceIngressSpec {
 }
 
 export const ingressHostnameSchema = joi.string().hostname().description(dedent`
-    The hostname that should route to this service. Defaults to the default hostname
-    configured in the provider configuration.
+    The hostname that should route to this service. Defaults to the default hostname configured in the provider configuration.
 
     Note that if you're developing locally you may need to add this hostname to your hosts file.
   `)
 
 export const linkUrlSchema = joi.string().uri().description(dedent`
-    The link URL for the ingress to show in the console and on the dashboard.
-    Also used when calling the service with the \`call\` command.
+    The link URL for the ingress to show in the console and on the dashboard. Also used when calling the service with the \`call\` command.
 
-    Use this if the actual URL is different from what's specified in the ingress,
-    e.g. because there's a load balancer in front of the service that rewrites the paths.
+    Use this if the actual URL is different from what's specified in the ingress, e.g. because there's a load balancer in front of the service that rewrites the paths.
 
     Otherwise Garden will construct the link URL from the ingress spec.
   `)

--- a/garden-service/src/util/fs.ts
+++ b/garden-service/src/util/fs.ts
@@ -10,12 +10,12 @@ import klaw = require("klaw")
 import glob from "glob"
 import _spawn from "cross-spawn"
 import Bluebird from "bluebird"
-import { pathExists, readFile, writeFile } from "fs-extra"
+import { pathExists, readFile, writeFile, lstat } from "fs-extra"
 import minimatch = require("minimatch")
 import { some } from "lodash"
 import uuid from "uuid"
 import { join, basename, win32, posix } from "path"
-import { ValidationError } from "../exceptions"
+import { ValidationError, FilesystemError } from "../exceptions"
 import { platform } from "os"
 import { VcsHandler } from "../vcs/vcs"
 import { LogEntry } from "../logger/log-entry"
@@ -236,4 +236,17 @@ export async function getWorkingCopyId(gardenDirPath: string) {
   }
 
   return metadata.workingCopyId
+}
+
+/**
+ * Returns true if the given path is a directory, otherwise false. Throws if the path does not exist.
+ */
+export async function isDirectory(path: string) {
+  if (!(await pathExists(path))) {
+    throw new FilesystemError(`Path ${path} does not exist`, { path })
+  }
+
+  const stat = await lstat(path)
+
+  return stat.isDirectory()
 }

--- a/garden-service/src/util/fs.ts
+++ b/garden-service/src/util/fs.ts
@@ -180,9 +180,11 @@ export function normalizeLocalRsyncPath(path: string) {
 /**
  * Return a list of all files in directory at `path`
  */
-export async function listDirectory(path: string): Promise<string[]> {
+export async function listDirectory(path: string, { recursive = true } = {}): Promise<string[]> {
+  const pattern = recursive ? "**/*" : "*"
+
   return new Promise((resolve, reject) => {
-    glob("**/*", { cwd: path, dot: true }, (err, files) => {
+    glob(pattern, { cwd: path, dot: true }, (err, files) => {
       if (err) {
         reject(err)
       } else {

--- a/garden-service/src/util/string.ts
+++ b/garden-service/src/util/string.ts
@@ -10,6 +10,8 @@ import _dedent = require("dedent")
 import _deline = require("deline")
 import _urlJoin = require("proper-url-join")
 import CliTable from "cli-table3"
+import { getTerminalWidth } from "../logger/util"
+import wrapAnsi from "wrap-ansi"
 
 // Exporting these here for convenience and ease of imports (otherwise we need to require modules instead of using
 // the import syntax, and it for some reason doesn't play nice with IDEs).
@@ -123,4 +125,17 @@ export function renderTable(rows: TableRow[], opts?: CliTable.TableConstructorOp
   // The typings here are a complete mess
   table.push(...(<any>rows))
   return table.toString()
+}
+
+/**
+ * Line wraps the given text.
+ *
+ * @param text the text to wrap
+ * @param maxWidth the maximum width in characters (the terminal width is used if smaller)
+ * @param opts options passed to the `linewrap` library
+ */
+export function wordWrap(text: string, maxWidth: number, opts: any = {}) {
+  const termWidth = getTerminalWidth()
+  const width = maxWidth > termWidth ? termWidth : maxWidth
+  return wrapAnsi(text, width, opts)
 }

--- a/garden-service/src/util/string.ts
+++ b/garden-service/src/util/string.ts
@@ -10,6 +10,7 @@ import _dedent = require("dedent")
 import _deline = require("deline")
 import _urlJoin = require("proper-url-join")
 import CliTable from "cli-table3"
+import cliTruncate from "cli-truncate"
 import { getTerminalWidth } from "../logger/util"
 import wrapAnsi from "wrap-ansi"
 
@@ -132,10 +133,21 @@ export function renderTable(rows: TableRow[], opts?: CliTable.TableConstructorOp
  *
  * @param text the text to wrap
  * @param maxWidth the maximum width in characters (the terminal width is used if smaller)
- * @param opts options passed to the `linewrap` library
+ * @param opts options passed to the `wrapAnsi` library
  */
 export function wordWrap(text: string, maxWidth: number, opts: any = {}) {
   const termWidth = getTerminalWidth()
   const width = maxWidth > termWidth ? termWidth : maxWidth
   return wrapAnsi(text, width, opts)
+}
+
+/**
+ * Truncates the given text, if necessary. Handles ANSI color codes correctly.
+ *
+ * @param text the text to truncate
+ * @param length maximum length of the output text
+ * @param opts options passed to `cli-truncate`
+ */
+export function truncate(text: string, length: number, opts: cliTruncate.Options = {}) {
+  return cliTruncate(text, length, opts)
 }

--- a/garden-service/test/unit/src/actions.ts
+++ b/garden-service/test/unit/src/actions.ts
@@ -1775,6 +1775,10 @@ const testPlugin = createGardenPlugin({
           }
         },
 
+        suggestModules: async () => {
+          return { suggestions: [] }
+        },
+
         getBuildStatus: async (params) => {
           validateSchema(params, moduleActionDescriptions.getBuildStatus.paramsSchema)
           return { ready: true }

--- a/garden-service/test/unit/src/commands/create/create-module.ts
+++ b/garden-service/test/unit/src/commands/create/create-module.ts
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import { withDefaultGlobalOpts, TempDirectory, makeTempDir, expectError } from "../../../../helpers"
+import { CreateModuleCommand } from "../../../../../src/commands/create/create-module"
+import { makeDummyGarden } from "../../../../../src/cli/cli"
+import { Garden } from "../../../../../src/garden"
+import { basename, join } from "path"
+import { pathExists, readFile, writeFile, mkdirp } from "fs-extra"
+import { safeLoadAll, safeDump } from "js-yaml"
+import { exec } from "../../../../../src/util/util"
+import stripAnsi = require("strip-ansi")
+
+describe("CreateModuleCommand", () => {
+  const command = new CreateModuleCommand()
+  let tmp: TempDirectory
+  let garden: Garden
+
+  beforeEach(async () => {
+    tmp = await makeTempDir()
+    await exec("git", ["init"], { cwd: tmp.path })
+    garden = await makeDummyGarden(tmp.path)
+  })
+
+  afterEach(async () => {
+    await tmp?.cleanup()
+  })
+
+  it("should create a module config", async () => {
+    const dir = join(tmp.path, "test")
+    await mkdirp(dir)
+
+    const { result } = await command.action({
+      garden,
+      footerLog: garden.log,
+      headerLog: garden.log,
+      log: garden.log,
+      args: {},
+      opts: withDefaultGlobalOpts({ dir, interactive: false, name: undefined, type: "exec" }),
+    })
+    const { name, configPath } = result!
+
+    expect(name).to.equal(basename("test"))
+    expect(configPath).to.equal(join(dir, "garden.yml"))
+    expect(await pathExists(configPath)).to.be.true
+
+    const parsed = safeLoadAll((await readFile(configPath)).toString())
+
+    expect(parsed).to.eql([
+      {
+        kind: "Module",
+        name,
+        type: "exec",
+      },
+    ])
+  })
+
+  it("should optionally set a module name", async () => {
+    const { result } = await command.action({
+      garden,
+      footerLog: garden.log,
+      headerLog: garden.log,
+      log: garden.log,
+      args: {},
+      opts: withDefaultGlobalOpts({ dir: tmp.path, interactive: false, name: "test", type: "exec" }),
+    })
+    const { name, configPath } = result!
+
+    expect(name).to.equal("test")
+    const parsed = safeLoadAll((await readFile(configPath)).toString())
+    expect(parsed).to.eql([
+      {
+        kind: "Module",
+        name: "test",
+        type: "exec",
+      },
+    ])
+  })
+
+  it("should add to an existing garden.yml if one exists", async () => {
+    const existing = {
+      kind: "Module",
+      type: "foo",
+      name: "foo",
+    }
+    await writeFile(join(tmp.path, "garden.yml"), safeDump(existing))
+
+    const { result } = await command.action({
+      garden,
+      footerLog: garden.log,
+      headerLog: garden.log,
+      log: garden.log,
+      args: {},
+      opts: withDefaultGlobalOpts({ dir: tmp.path, interactive: false, name: "test", type: "exec" }),
+    })
+    const { name, configPath } = result!
+
+    const parsed = safeLoadAll((await readFile(configPath)).toString())
+    expect(parsed).to.eql([
+      existing,
+      {
+        kind: "Module",
+        name,
+        type: "exec",
+      },
+    ])
+  })
+
+  it("should throw if a module with the same name is already in the directory", async () => {
+    const existing = {
+      kind: "Module",
+      name: "test",
+      type: "exec",
+    }
+    const configPath = join(tmp.path, "garden.yml")
+    await writeFile(configPath, safeDump(existing))
+
+    await expectError(
+      () =>
+        command.action({
+          garden,
+          footerLog: garden.log,
+          headerLog: garden.log,
+          log: garden.log,
+          args: {},
+          opts: withDefaultGlobalOpts({ dir: tmp.path, interactive: false, name: "test", type: "exec" }),
+        }),
+      (err) => expect(stripAnsi(err.message)).to.equal("A Garden module named test already exists in " + configPath)
+    )
+  })
+
+  it("should throw if target directory doesn't exist", async () => {
+    const dir = join(tmp.path, "bla")
+    await expectError(
+      () =>
+        command.action({
+          garden,
+          footerLog: garden.log,
+          headerLog: garden.log,
+          log: garden.log,
+          args: {},
+          opts: withDefaultGlobalOpts({ dir, interactive: false, name: "test", type: "exec" }),
+        }),
+      (err) => expect(err.message).to.equal(`Path ${dir} does not exist`)
+    )
+  })
+
+  it("should throw if the module type doesn't exist", async () => {
+    await expectError(
+      () =>
+        command.action({
+          garden,
+          footerLog: garden.log,
+          headerLog: garden.log,
+          log: garden.log,
+          args: {},
+          opts: withDefaultGlobalOpts({ dir: tmp.path, interactive: false, name: undefined, type: "foo" }),
+        }),
+      (err) => expect(stripAnsi(err.message)).to.equal("Could not find module type foo")
+    )
+  })
+})

--- a/garden-service/test/unit/src/commands/create/create-project.ts
+++ b/garden-service/test/unit/src/commands/create/create-project.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import { withDefaultGlobalOpts, TempDirectory, makeTempDir, expectError } from "../../../../helpers"
+import { CreateProjectCommand } from "../../../../../src/commands/create/create-project"
+import { makeDummyGarden } from "../../../../../src/cli/cli"
+import { Garden } from "../../../../../src/garden"
+import { basename, join } from "path"
+import { pathExists, readFile, writeFile } from "fs-extra"
+import { safeLoadAll, safeDump } from "js-yaml"
+import { exec } from "../../../../../src/util/util"
+
+describe("CreateProjectCommand", () => {
+  const command = new CreateProjectCommand()
+  let tmp: TempDirectory
+  let garden: Garden
+
+  beforeEach(async () => {
+    tmp = await makeTempDir()
+    await exec("git", ["init"], { cwd: tmp.path })
+    garden = await makeDummyGarden(tmp.path)
+  })
+
+  afterEach(async () => {
+    await tmp?.cleanup()
+  })
+
+  it("should create a project config and a .gardenignore", async () => {
+    const { result } = await command.action({
+      garden,
+      footerLog: garden.log,
+      headerLog: garden.log,
+      log: garden.log,
+      args: {},
+      opts: withDefaultGlobalOpts({ dir: tmp.path, interactive: false, name: undefined }),
+    })
+    const { name, configPath, ignoreFileCreated, ignoreFilePath } = result!
+
+    expect(name).to.equal(basename(tmp.path))
+    expect(ignoreFileCreated).to.be.true
+    expect(configPath).to.equal(join(tmp.path, "garden.yml"))
+    expect(ignoreFilePath).to.equal(join(tmp.path, ".gardenignore"))
+    expect(await pathExists(configPath)).to.be.true
+    expect(await pathExists(ignoreFilePath)).to.be.true
+
+    const parsed = safeLoadAll((await readFile(configPath)).toString())
+
+    expect(parsed).to.eql([
+      {
+        kind: "Project",
+        name,
+        environments: [{ name: "default" }],
+        providers: [{ name: "local-kubernetes" }],
+      },
+    ])
+  })
+
+  it("should leave existing .gardenignore if one already exists", async () => {
+    const ignoreContent = "node_modules/\n"
+    await writeFile(join(tmp.path, ".gardenignore"), ignoreContent)
+
+    const { result } = await command.action({
+      garden,
+      footerLog: garden.log,
+      headerLog: garden.log,
+      log: garden.log,
+      args: {},
+      opts: withDefaultGlobalOpts({ dir: tmp.path, interactive: false, name: undefined }),
+    })
+    const { ignoreFileCreated, ignoreFilePath } = result!
+
+    expect(ignoreFileCreated).to.be.false
+    expect(await pathExists(ignoreFilePath)).to.be.true
+    expect((await readFile(ignoreFilePath)).toString()).to.equal(ignoreContent)
+  })
+
+  it("should optionally set a project name", async () => {
+    const { result } = await command.action({
+      garden,
+      footerLog: garden.log,
+      headerLog: garden.log,
+      log: garden.log,
+      args: {},
+      opts: withDefaultGlobalOpts({ dir: tmp.path, interactive: false, name: "foo" }),
+    })
+    const { name, configPath } = result!
+
+    expect(name).to.equal("foo")
+    const parsed = safeLoadAll((await readFile(configPath)).toString())
+    expect(parsed).to.eql([
+      {
+        kind: "Project",
+        name: "foo",
+        environments: [{ name: "default" }],
+        providers: [{ name: "local-kubernetes" }],
+      },
+    ])
+  })
+
+  it("should add to an existing garden.yml if one exists", async () => {
+    const existing = {
+      kind: "Module",
+      type: "foo",
+      name: "foo",
+    }
+    await writeFile(join(tmp.path, "garden.yml"), safeDump(existing))
+
+    const { result } = await command.action({
+      garden,
+      footerLog: garden.log,
+      headerLog: garden.log,
+      log: garden.log,
+      args: {},
+      opts: withDefaultGlobalOpts({ dir: tmp.path, interactive: false, name: undefined }),
+    })
+    const { name, configPath } = result!
+
+    const parsed = safeLoadAll((await readFile(configPath)).toString())
+    expect(parsed).to.eql([
+      existing,
+      {
+        kind: "Project",
+        name,
+        environments: [{ name: "default" }],
+        providers: [{ name: "local-kubernetes" }],
+      },
+    ])
+  })
+
+  it("should throw if a project is already in the directory", async () => {
+    const existing = {
+      kind: "Project",
+      name: "foo",
+    }
+    const configPath = join(tmp.path, "garden.yml")
+    await writeFile(configPath, safeDump(existing))
+
+    await expectError(
+      () =>
+        command.action({
+          garden,
+          footerLog: garden.log,
+          headerLog: garden.log,
+          log: garden.log,
+          args: {},
+          opts: withDefaultGlobalOpts({ dir: tmp.path, interactive: false, name: undefined }),
+        }),
+      (err) => expect(err.message).to.equal("A Garden project already exists in " + configPath)
+    )
+  })
+
+  it("should throw if target directory doesn't exist", async () => {
+    const dir = join(tmp.path, "bla")
+    await expectError(
+      () =>
+        command.action({
+          garden,
+          footerLog: garden.log,
+          headerLog: garden.log,
+          log: garden.log,
+          args: {},
+          opts: withDefaultGlobalOpts({ dir, interactive: false, name: undefined }),
+        }),
+      (err) => expect(err.message).to.equal(`Path ${dir} does not exist`)
+    )
+  })
+})

--- a/garden-service/test/unit/src/commands/dev.ts
+++ b/garden-service/test/unit/src/commands/dev.ts
@@ -70,6 +70,9 @@ describe("DevCommand", () => {
     const args = {}
     const opts = withDefaultGlobalOpts({
       "force-build": false,
+      "hot-reload": undefined,
+      "skip-tests": false,
+      "test-names": undefined,
     })
 
     const { promise, completedTasks } = await completeFirstTasks(garden, args, opts)
@@ -112,6 +115,9 @@ describe("DevCommand", () => {
     const args = {}
     const opts = withDefaultGlobalOpts({
       "force-build": false,
+      "hot-reload": undefined,
+      "skip-tests": false,
+      "test-names": undefined,
     })
 
     const { promise, completedTasks } = await completeFirstTasks(garden, args, opts)
@@ -130,6 +136,9 @@ describe("DevCommand", () => {
     const args = {}
     const opts = withDefaultGlobalOpts({
       "force-build": false,
+      "hot-reload": undefined,
+      "skip-tests": false,
+      "test-names": undefined,
     })
 
     const { promise, completedTasks } = await completeFirstTasks(garden, args, opts)
@@ -148,6 +157,9 @@ describe("DevCommand", () => {
     const args = {}
     const opts = withDefaultGlobalOpts({
       "force-build": false,
+      "hot-reload": undefined,
+      "skip-tests": false,
+      "test-names": undefined,
     })
 
     const { promise, completedTasks } = await completeFirstTasks(garden, args, opts)
@@ -166,6 +178,9 @@ describe("DevCommand", () => {
     const args = {}
     const opts = withDefaultGlobalOpts({
       "force-build": false,
+      "hot-reload": undefined,
+      "skip-tests": false,
+      "test-names": undefined,
     })
 
     const { promise, completedTasks } = await completeFirstTasks(garden, args, opts)
@@ -184,6 +199,9 @@ describe("DevCommand", () => {
     const args = {}
     const opts = withDefaultGlobalOpts({
       "force-build": false,
+      "hot-reload": undefined,
+      "skip-tests": false,
+      "test-names": undefined,
     })
 
     const { promise, completedTasks } = await completeFirstTasks(garden, args, opts)
@@ -202,6 +220,9 @@ describe("DevCommand", () => {
     const args = {}
     const opts = withDefaultGlobalOpts({
       "force-build": false,
+      "hot-reload": undefined,
+      "skip-tests": false,
+      "test-names": undefined,
     })
 
     const { promise, completedTasks } = await completeFirstTasks(garden, args, opts)

--- a/garden-service/test/unit/src/commands/get/get-config.ts
+++ b/garden-service/test/unit/src/commands/get/get-config.ts
@@ -27,7 +27,7 @@ describe("GetConfigCommand", () => {
       headerLog: log,
       footerLog: log,
       args: { provider },
-      opts: withDefaultGlobalOpts({}),
+      opts: withDefaultGlobalOpts({ "exclude-disabled": false }),
     })
 
     const providers = await garden.resolveProviders()

--- a/garden-service/test/unit/src/commands/get/get-debug-info.ts
+++ b/garden-service/test/unit/src/commands/get/get-debug-info.ts
@@ -67,7 +67,7 @@ describe("GetDebugInfoCommand", () => {
         headerLog: log,
         footerLog: log,
         args: {},
-        opts: withDefaultGlobalOpts({ format: "json" }),
+        opts: withDefaultGlobalOpts({ "format": "json", "include-project": false }),
       })
 
       expect(res.result).to.eql(0)

--- a/garden-service/test/unit/src/commands/migrate.ts
+++ b/garden-service/test/unit/src/commands/migrate.ts
@@ -51,6 +51,7 @@ describe("commands", () => {
           args: { configPaths: [] },
           opts: withDefaultGlobalOpts({
             root: projectPath,
+            write: false,
           }),
         })
         result = res.result!
@@ -297,6 +298,7 @@ describe("commands", () => {
             args: { configPaths: ["./project-varfile/garden.yml"] },
             opts: withDefaultGlobalOpts({
               root: projectPathErrors,
+              write: false,
             }),
           }),
         (err) => {
@@ -341,6 +343,7 @@ describe("commands", () => {
           args: { configPaths: ["./garden.yml"] },
           opts: withDefaultGlobalOpts({
             root: projectPath,
+            write: false,
           }),
         })
         const specs = res.result!.updatedConfigs[0].specs

--- a/garden-service/test/unit/src/commands/run/module.ts
+++ b/garden-service/test/unit/src/commands/run/module.ts
@@ -33,6 +33,7 @@ describe("RunModuleCommand", () => {
       footerLog: log,
       args: { module: "module-a", arguments: [] },
       opts: withDefaultGlobalOpts({
+        "command": undefined,
         "interactive": false,
         "force-build": false,
       }),
@@ -60,6 +61,7 @@ describe("RunModuleCommand", () => {
       footerLog: log,
       args: { module: "module-a", arguments: ["my", "command"] },
       opts: withDefaultGlobalOpts({
+        "command": undefined,
         "interactive": false,
         "force-build": false,
       }),

--- a/garden-service/test/unit/src/commands/run/task.ts
+++ b/garden-service/test/unit/src/commands/run/task.ts
@@ -25,7 +25,7 @@ describe("RunTaskCommand", () => {
       headerLog: log,
       footerLog: log,
       args: { task: "task-a" },
-      opts: withDefaultGlobalOpts({ "force-build": false }),
+      opts: withDefaultGlobalOpts({ "force": false, "force-build": false, "interactive": false }),
     })
 
     const expected = {

--- a/garden-service/test/unit/src/commands/run/test.ts
+++ b/garden-service/test/unit/src/commands/run/test.ts
@@ -25,7 +25,7 @@ describe("RunTestCommand", () => {
       headerLog: log,
       footerLog: log,
       args: { test: "unit", module: "module-a" },
-      opts: withDefaultGlobalOpts({ "force-build": false }),
+      opts: withDefaultGlobalOpts({ "force": false, "force-build": false, "interactive": false }),
     })
 
     const expected = {
@@ -54,7 +54,7 @@ describe("RunTestCommand", () => {
           headerLog: log,
           footerLog: log,
           args: { module: "module-a", test: "unit" },
-          opts: withDefaultGlobalOpts({ "force": false, "force-build": false }),
+          opts: withDefaultGlobalOpts({ "force": false, "force-build": false, "interactive": false }),
         }),
       (err) =>
         expect(stripAnsi(err.message)).to.equal(
@@ -77,7 +77,7 @@ describe("RunTestCommand", () => {
       headerLog: log,
       footerLog: log,
       args: { module: "module-a", test: "unit" },
-      opts: withDefaultGlobalOpts({ "force": true, "force-build": false }),
+      opts: withDefaultGlobalOpts({ "force": true, "force-build": false, "interactive": false }),
     })
 
     expect(errors).to.not.exist

--- a/garden-service/test/unit/src/commands/test.ts
+++ b/garden-service/test/unit/src/commands/test.ts
@@ -158,6 +158,7 @@ describe("TestCommand", () => {
       footerLog: log,
       args: { modules: ["module-c"] },
       opts: withDefaultGlobalOpts({
+        "name": undefined,
         "force": true,
         "force-build": false,
         "watch": false,
@@ -193,6 +194,7 @@ describe("TestCommand", () => {
       footerLog: log,
       args: { modules: undefined },
       opts: withDefaultGlobalOpts({
+        "name": undefined,
         "force": true,
         "force-build": false,
         "watch": false,

--- a/garden-service/test/unit/src/docs/util.ts
+++ b/garden-service/test/unit/src/docs/util.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { dedent } from "../../../../src/util/string"
+import { expect } from "chai"
+import { convertMarkdownLinks } from "../../../../src/docs/util"
+
+describe("convertMarkdownLinks", () => {
+  it("should convert all markdown links in the given text to plain links", () => {
+    const text = dedent`
+    For a full reference, see the [Output configuration context](https://docs.garden.io/reference/template-strings#output-configuration-context) section in the Template String Reference.
+
+    See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
+    `
+
+    expect(convertMarkdownLinks(text)).to.equal(dedent`
+    For a full reference, see the Output configuration context (https://docs.garden.io/reference/template-strings#output-configuration-context) section in the Template String Reference.
+
+    See the Configuration Files guide (https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
+    `)
+  })
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

See the docs and CLI help texts for details. The generated configs
contain the full project/module config schema (minus deprecated fields),
so users can easily uncomment and/or remove fields depending on their
needs.

Providers are asked to suggest modules, and I implemented that for
`container`, `helm` and `terraform` modules.

This required a bit of refactoring in our docs generation code, so a
bunch of the line changes relate to that. Also needed to make all links
in field descriptions absolute, and tweak the line breaks and formatting
for readability.
