### PR TITLE
fix(k8s): fixed handling of timeouts when artifacts are being copied

### DIFF
--- a/garden-service/src/plugins/kubernetes/container/run.ts
+++ b/garden-service/src/plugins/kubernetes/container/run.ts
@@ -75,7 +75,6 @@ export async function runContainerTask(params: RunTaskParams<ContainerModule>): 
     podName: makePodName("task", module.name, task.name),
     description: `Task '${task.name}' in container module '${module.name}'`,
     timeout: task.spec.timeout || undefined,
-    ignoreError: true, // to ensure results get stored when an error occurs
   })
 
   const result: RunTaskResult = {

--- a/garden-service/src/plugins/kubernetes/container/test.ts
+++ b/garden-service/src/plugins/kubernetes/container/test.ts
@@ -38,7 +38,6 @@ export async function testContainerModule(params: TestModuleParams<ContainerModu
     podName: makePodName("test", module.name, testName),
     description: `Test '${testName}' in container module '${module.name}'`,
     timeout,
-    ignoreError: true, // to ensure results get stored when an error occurs
   })
 
   return storeTestResult({

--- a/garden-service/src/plugins/kubernetes/helm/run.ts
+++ b/garden-service/src/plugins/kubernetes/helm/run.ts
@@ -27,7 +27,6 @@ export async function runHelmModule({
   module,
   args,
   command,
-  ignoreError = true,
   interactive,
   runtimeContext,
   timeout,
@@ -91,7 +90,6 @@ export async function runHelmModule({
   })
 
   return runner.startAndWait({
-    ignoreError,
     interactive,
     log,
     timeout,
@@ -135,7 +133,6 @@ export async function runHelmTask(params: RunTaskParams<HelmModule>): Promise<Ru
     podName: makePodName("task", module.name, task.name),
     description: `Task '${task.name}' in container module '${module.name}'`,
     timeout,
-    ignoreError: true, // to ensure results get stored when an error occurs
   })
 
   const result = {

--- a/garden-service/src/plugins/kubernetes/helm/test.ts
+++ b/garden-service/src/plugins/kubernetes/helm/test.ts
@@ -51,7 +51,6 @@ export async function testHelmModule(params: TestModuleParams<HelmModule>): Prom
     podName: makePodName("test", module.name, testName),
     description: `Test '${testName}' in container module '${module.name}'`,
     timeout,
-    ignoreError: true, // to ensure results get stored when an error occurs
   })
 
   return storeTestResult({

--- a/garden-service/src/plugins/kubernetes/kubernetes-module/run.ts
+++ b/garden-service/src/plugins/kubernetes/kubernetes-module/run.ts
@@ -53,7 +53,6 @@ export async function runKubernetesTask(params: RunTaskParams<KubernetesModule>)
     podName: makePodName("task", module.name, task.name),
     description: `Task '${task.name}' in container module '${module.name}'`,
     timeout,
-    ignoreError: true, // to ensure results get stored when an error occurs
   })
 
   const result = {

--- a/garden-service/src/plugins/kubernetes/kubernetes-module/test.ts
+++ b/garden-service/src/plugins/kubernetes/kubernetes-module/test.ts
@@ -52,7 +52,6 @@ export async function testKubernetesModule(params: TestModuleParams<KubernetesMo
     podName: makePodName("test", module.name, testName),
     description: `Test '${testName}' in container module '${module.name}'`,
     timeout,
-    ignoreError: true, // to ensure results get stored when an error occurs
   })
 
   return storeTestResult({

--- a/garden-service/src/types/plugin/module/runModule.ts
+++ b/garden-service/src/types/plugin/module/runModule.ts
@@ -17,7 +17,6 @@ export interface RunModuleParams<T extends Module = Module> extends PluginModule
   args: string[]
   interactive: boolean
   runtimeContext: RuntimeContext
-  ignoreError?: boolean
   timeout?: number
 }
 

--- a/garden-service/test/helpers.ts
+++ b/garden-service/test/helpers.ts
@@ -218,7 +218,6 @@ export const testPlugin = createGardenPlugin(() => {
               runtimeContext,
               module: task.module,
               args: task.spec.command,
-              ignoreError: false,
               timeout: task.spec.timeout || 9999,
             })
 


### PR DESCRIPTION
**What this PR does / why we need it**:

See the added tests. We weren't handling timeouts correctly or consistently depending on whether artifacts were being copied or not.