### PR TITLE
fix(Windows): don't always install docker-for-windows

### DIFF
--- a/support/install.ps1
+++ b/support/install.ps1
@@ -107,7 +107,7 @@ CheckChocolatey
 
 # Install choco dependencies
 Write-Host "- Installing Chocolatey dependencies..."
-choco upgrade -y git rsync docker-for-windows
+choco upgrade -y git rsync
 
 [Console]::ResetColor()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevents Windows installer from installing `docker-for-windows` without first asking the user. (As implemented in #885)
