### PR TITLE
Add buildkit documentation / update kubernetes provider documentation

### DIFF
--- a/docs/guides/in-cluster-building.md
+++ b/docs/guides/in-cluster-building.md
@@ -68,6 +68,13 @@ In this mode, builds are executed as follows:
 
 After enabling this mode (we currently still default to the `local-docker` mode), you will need to run `garden plugins kubernetes cluster-init --env=<env-name>` for each applicable environment, in order to install the required cluster-wide services. Those services include the Docker daemon itself, as well as an image registry, a sync service for receiving build contexts, two persistent volumes, an NFS volume provisioner for one of those volumes, and a couple of small utility services.
 
+Optionally, you can also enable [BuildKit]((https://github.com/moby/buildkit)). In most cases, this should work well and be more performant, but remains optional for now. If you have `cluster-docker` set as your `buildMode` you can enable BuildKit for an environment as follows:
+
+```yaml
+clusterDocker:
+  enableBuildKit: false
+```
+
 Make sure your cluster has enough resources and storage to support the required services, and keep in mind that these
 services are shared across all users of the cluster. Please look at the
 [resources](../providers/kubernetes.md#providersresources) and


### PR DESCRIPTION
**What this PR does / why we need it**:
BuildKit currently isn't documented in our in-cluster building guide.

The Kubernetes provider documentation has `local-docker` set as the build-mode. Assuming most users are using this provider for remote clusters, it makes more sense to change this to `cluster-docker`. 