### PR TITLE
fix(core): allow referencing disabled providers in template strings

### DIFF
--- a/garden-service/src/config/provider.ts
+++ b/garden-service/src/config/provider.ts
@@ -100,11 +100,15 @@ export function providerFromConfig(
  * as well as implicit dependencies based on template strings.
  */
 export async function getAllProviderDependencyNames(plugin: GardenPlugin, config: ProviderConfig) {
-  // Declared dependencies from config
-  const deps: string[] = [...(plugin.dependencies || [])]
+  return uniq([...(plugin.dependencies || []), ...(await getProviderTemplateReferences(config))]).sort()
+}
 
-  // Implicit dependencies from template strings
+/**
+ * Given a provider config, return implicit dependencies based on template strings.
+ */
+export async function getProviderTemplateReferences(config: ProviderConfig) {
   const references = await collectTemplateReferences(config)
+  const deps: string[] = []
 
   for (const key of references) {
     if (key[0] === "providers") {


### PR DESCRIPTION
Previously, referencing a disabled provider (i.e. one that is not
enabled for the current environment) in a template string in a provider
config would always throw an error.  Now the template reference 
returns undefined instead, so you can use those in conditionals.

Example:

```yaml
kind: Project
environments:
  - name: dev
  - name: prod
providers:
  - name: terraform
    environments: [prod]
  - name: kubernetes:
    context: ${providers.terraform.outputs.kubecontext || 'default'}
```
