### PR TITLE
feat(template): add optional suffix, to allow undefined values

### DIFF
--- a/docs/guides/variables-and-templating.md
+++ b/docs/guides/variables-and-templating.md
@@ -96,6 +96,23 @@ services:
   ...
 ```
 
+### Optional values
+
+In some cases, you may want to provide configuration values only for certain cases, e.g. only for specific environments. By default, an error is thrown when a template string resolves to an undefined value, but you can explicitly allow that by adding a `?` after the template.
+
+Example:
+
+```yaml
+kind: Project
+...
+providers:
+  - name: kubernetes
+    kubeconfig: ${var.kubeconfig}?
+  ...
+```
+
+This is useful when you don't want to provide _any_ value unless one is explicitly set, effectively falling back to whichever the default is for the field in question.
+
 ## Project variables
 
 A common use case for templating is to define variables in the project/environment configuration, and to use template strings to propagate values to modules in the project.

--- a/docs/reference/template-strings.md
+++ b/docs/reference/template-strings.md
@@ -4,7 +4,7 @@ title: Template Strings Reference
 
 # Template string reference
 
-Below you'll find the schema of the keys available when interpolating template strings (see our [Configuration Files](../guides/configuration-files.md) guide for more information and usage examples).
+Below you'll find the schema of the keys available when interpolating template strings (see our [Variables and Templating](../guides/variables-and-templating.md) guide for more information and usage examples).
 
 Note that there are four sections below, since different configuration sections have different keys available to them. Please make sure to refer to the correct section.
 

--- a/garden-service/src/docs/templates/template-strings.hbs
+++ b/garden-service/src/docs/templates/template-strings.hbs
@@ -4,7 +4,7 @@ title: Template Strings Reference
 
 # Template string reference
 
-Below you'll find the schema of the keys available when interpolating template strings (see our [Configuration Files](../guides/configuration-files.md) guide for more information and usage examples).
+Below you'll find the schema of the keys available when interpolating template strings (see our [Variables and Templating](../guides/variables-and-templating.md) guide for more information and usage examples).
 
 Note that there are four sections below, since different configuration sections have different keys available to them. Please make sure to refer to the correct section.
 

--- a/garden-service/src/template-string-parser.pegjs
+++ b/garden-service/src/template-string-parser.pegjs
@@ -13,14 +13,17 @@ TemplateString
   / $(.*) { return text() === "" ? [] : [{ resolved: text() }] }
 
 FormatString
-  = FormatStart e:Expression FormatEnd {
+  = FormatStart e:Expression end:FormatEnd {
     return Promise.resolve(e)
       .then(v => {
         if (v && v._error) {
           return v
         }
 
-        if (v === undefined && !options.allowUndefined) {
+        // Need to provide the optional suffix as a variable because of a parsing bug in pegjs
+        const allowUndefined = options.allowUndefined || end[1] === options.optionalSuffix
+
+        if (options.getValue(v) === undefined && !allowUndefined) {
           const _error = new options.TemplateStringError(v.message || "Unable to resolve one or more keys.", {
             text: text(),
           })
@@ -42,7 +45,8 @@ FormatStart
   = "${" __
 
 FormatEnd
-  = __ "}"
+  = __ "}?"
+  / __ "}"
 
 KeySeparator
   = "."

--- a/garden-service/src/template-string.ts
+++ b/garden-service/src/template-string.ts
@@ -67,6 +67,7 @@ export async function resolveTemplateString(
       ConfigurationError,
       TemplateStringError,
       allowUndefined: opts.allowUndefined,
+      optionalSuffix: "}?",
     })
 
     const outputs: ResolvedClause[] = await Bluebird.map(parsed, async (p: any) => {
@@ -93,12 +94,7 @@ export async function resolveTemplateString(
         .join("")
     }
 
-    if (resolved === undefined && !opts.allowUndefined) {
-      throw new ConfigurationError(`Template string resolves to undefined value.`, {
-        string,
-        resolved,
-      })
-    } else if (resolved !== undefined && !isPrimitive(resolved)) {
+    if (resolved !== undefined && !isPrimitive(resolved)) {
       throw new ConfigurationError(
         `Template string doesn't resolve to a primitive (string, number, boolean or null).`,
         {

--- a/garden-service/test/unit/src/actions.ts
+++ b/garden-service/test/unit/src/actions.ts
@@ -1460,9 +1460,8 @@ describe("ActionRouter", () => {
             },
           }),
         (err) =>
-          expect(err.message).to.equal(
-            "Invalid template string ${runtime.services.service-b.outputs.foo}: " +
-              "Template string resolves to undefined value."
+          expect(stripAnsi(err.message)).to.equal(
+            "Invalid template string ${runtime.services.service-b.outputs.foo}: Could not find key runtime."
           )
       )
     })
@@ -1636,9 +1635,8 @@ describe("ActionRouter", () => {
             },
           }),
         (err) =>
-          expect(err.message).to.equal(
-            "Invalid template string ${runtime.services.service-b.outputs.foo}: " +
-              "Template string resolves to undefined value."
+          expect(stripAnsi(err.message)).to.equal(
+            "Invalid template string ${runtime.services.service-b.outputs.foo}: Could not find key runtime."
           )
       )
     })

--- a/garden-service/test/unit/src/garden.ts
+++ b/garden-service/test/unit/src/garden.ts
@@ -1370,8 +1370,8 @@ describe("Garden", () => {
         () => garden.resolveProviders(),
         (err) => {
           expect(err.message).to.equal("Failed resolving one or more providers:\n" + "- test")
-          expect(err.detail.messages[0]).to.equal(
-            "- test: Invalid template string ${bla.ble}: Template string resolves to undefined value."
+          expect(stripAnsi(err.detail.messages[0])).to.equal(
+            "- test: Invalid template string ${bla.ble}: Could not find key bla."
           )
         }
       )


### PR DESCRIPTION
**What this PR does / why we need it**:

In some cases, you may want to provide configuration values only for
certain cases, e.g. only for specific environments. By default, an
error is thrown when a template string resolves to an undefined value,
but you can explicitly allow that by adding a `?` after the template.

Example:

```yaml
kind: Project
...
providers:
  - name: kubernetes
    kubeconfig: ${var.kubeconfig}?
  ...
```

This is useful when you don't want to provide _any_ value unless one is
explicitly set, effectively falling back to whichever the default is
for the field in question.
