### PR TITLE
improvement(k8s): use deploymentRegistry with in-cluster building

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -446,7 +446,7 @@ jobs:
     environment:
       K8S_VERSION: <<parameters.kubernetesVersion>>
       MINIKUBE_VERSION: v1.5.2
-      GARDEN_LOG_LEVEL: silly
+      GARDEN_LOG_LEVEL: debug
       GARDEN_LOGGER_TYPE: basic
     steps:
       - checkout

--- a/docs/providers/kubernetes.md
+++ b/docs/providers/kubernetes.md
@@ -277,6 +277,10 @@ providers:
     context:
 
     # The registry where built containers should be pushed to, and then pulled to the cluster when deploying services.
+    #
+    # Important: If you specify this in combination with `buildMode: cluster-docker` or `buildMode: kaniko`, you must
+    # make sure `imagePullSecrets` includes authentication with the specified deployment registry, that has the
+    # appropriate write privileges (usually full write access to the configured `deploymentRegistry.namespace`).
     deploymentRegistry:
       # The hostname (and optionally port, if not the default port) of the registry.
       hostname:
@@ -1311,6 +1315,8 @@ providers:
 [providers](#providers) > deploymentRegistry
 
 The registry where built containers should be pushed to, and then pulled to the cluster when deploying services.
+
+Important: If you specify this in combination with `buildMode: cluster-docker` or `buildMode: kaniko`, you must make sure `imagePullSecrets` includes authentication with the specified deployment registry, that has the appropriate write privileges (usually full write access to the configured `deploymentRegistry.namespace`).
 
 | Type     | Required |
 | -------- | -------- |

--- a/garden-service/src/plugins/container/config.ts
+++ b/garden-service/src/plugins/container/config.ts
@@ -407,9 +407,10 @@ export const containerRegistryConfigSchema = joi.object().keys({
     .default("_")
     .description("The namespace in the registry where images should be pushed.")
     .example("my-project"),
-}).description(deline`
-    The registry where built containers should be pushed to, and then pulled to the cluster when deploying
-    services.
+}).description(dedent`
+    The registry where built containers should be pushed to, and then pulled to the cluster when deploying services.
+
+    Important: If you specify this in combination with \`buildMode: cluster-docker\` or \`buildMode: kaniko\`, you must make sure \`imagePullSecrets\` includes authentication with the specified deployment registry, that has the appropriate write privileges (usually full write access to the configured \`deploymentRegistry.namespace\`).
   `)
 
 export interface ContainerService extends Service<ContainerModule> {}

--- a/garden-service/src/plugins/kubernetes/constants.ts
+++ b/garden-service/src/plugins/kubernetes/constants.ts
@@ -14,3 +14,4 @@ export const MAX_RUN_RESULT_OUTPUT_LENGTH = 900 * 1024 // max ConfigMap data siz
 
 export const dockerAuthSecretName = "builder-docker-config"
 export const dockerAuthSecretKey = ".dockerconfigjson"
+export const inClusterRegistryHostname = "127.0.0.1:5000"

--- a/garden-service/src/plugins/kubernetes/local/config.ts
+++ b/garden-service/src/plugins/kubernetes/local/config.ts
@@ -131,9 +131,11 @@ export async function configureProvider(params: ConfigureProviderParams<LocalKub
     await configureMicrok8sAddons(log, addons)
 
     // Need to push to the built-in registry
-    config.deploymentRegistry = {
-      hostname: "localhost:32000",
-      namespace,
+    if (config.buildMode === "local-docker") {
+      config.deploymentRegistry = {
+        hostname: "localhost:32000",
+        namespace,
+      }
     }
   }
 

--- a/garden-service/test/data/test-projects/container/garden.yml
+++ b/garden-service/test/data/test-projects/container/garden.yml
@@ -5,7 +5,9 @@ environments:
   - name: cluster-docker
   - name: cluster-docker-buildkit
   - name: cluster-docker-auth
+  - name: cluster-docker-remote-registry
   - name: kaniko
+  - name: kaniko-remote-registry
 providers:
   - name: local-kubernetes
     environments: [local]
@@ -23,5 +25,16 @@ providers:
   - <<: *clusterDocker
     environments: [cluster-docker-auth]
   - <<: *clusterDocker
+    environments: [cluster-docker-remote-registry]
+    deploymentRegistry:
+      hostname: index.docker.io
+      namespace: gardendev
+  - <<: *clusterDocker
     environments: [kaniko]
     buildMode: kaniko
+  - <<: *clusterDocker
+    environments: [kaniko-remote-registry]
+    buildMode: kaniko
+    deploymentRegistry:
+      hostname: index.docker.io
+      namespace: gardendev

--- a/garden-service/test/data/test-projects/container/remote-registry-test/Dockerfile
+++ b/garden-service/test/data/test-projects/container/remote-registry-test/Dockerfile
@@ -1,3 +1,3 @@
 FROM busybox:1.31.1
 
-RUN rm -f /bin/tar
+ADD foo.txt /foo.txt

--- a/garden-service/test/data/test-projects/container/remote-registry-test/garden.yml
+++ b/garden-service/test/data/test-projects/container/remote-registry-test/garden.yml
@@ -1,0 +1,10 @@
+kind: Module
+name: remote-registry-test
+description: Test module for pushing to private registry
+type: container
+services:
+  - name: remote-registry-test
+    command: [sh, -c, "nc -l -p 8080"]
+    ports:
+      - name: http
+        containerPort: 8080

--- a/garden-service/test/integ/src/plugins/kubernetes/container/logs.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/container/logs.ts
@@ -68,6 +68,8 @@ describe("kubernetes", () => {
         tail: -1,
       })
 
+      console.log(entries)
+
       expect(entries[0].msg).to.include("Server running...")
     })
   })

--- a/garden-service/test/integ/src/plugins/kubernetes/container/logs.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/container/logs.ts
@@ -68,8 +68,6 @@ describe("kubernetes", () => {
         tail: -1,
       })
 
-      console.log(entries)
-
       expect(entries[0].msg).to.include("Server running...")
     })
   })

--- a/garden-service/test/integ/src/plugins/kubernetes/util.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/util.ts
@@ -9,7 +9,7 @@
 import { expect } from "chai"
 import { flatten, find, first } from "lodash"
 import stripAnsi from "strip-ansi"
-import { getDataDir, makeTestGarden, TestGarden, expectError } from "../../../../helpers"
+import { TestGarden, expectError } from "../../../../helpers"
 import { ConfigGraph } from "../../../../../src/config-graph"
 import { Provider } from "../../../../../src/config/provider"
 import { DeployTask } from "../../../../../src/tasks/deploy"
@@ -31,6 +31,7 @@ import { buildHelmModule } from "../../../../../src/plugins/kubernetes/helm/buil
 import { HotReloadableResource } from "../../../../../src/plugins/kubernetes/hot-reload"
 import { LogEntry } from "../../../../../src/logger/log-entry"
 import { BuildTask } from "../../../../../src/tasks/build"
+import { getContainerTestGarden } from "./container/container"
 
 describe("util", () => {
   let helmGarden: TestGarden
@@ -72,8 +73,7 @@ describe("util", () => {
   // TODO: Add more test cases
   describe("getWorkloadPods", () => {
     it("should return workload pods", async () => {
-      const root = getDataDir("test-projects", "container")
-      const garden = await makeTestGarden(root)
+      const garden = await getContainerTestGarden("local")
 
       try {
         const graph = await garden.getConfigGraph(garden.log)


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously we would always deploy and use the in-cluster registry
when building in-cluster. Now we allow using the configured
`deploymentRegistry`, which is often preferable (and more scalable)
than using the simpler in-cluster registry.

**Which issue(s) this PR fixes**:

Closes #1034

