### PR TITLE
feat: allow disabling result caching for tasks that support it

### DIFF
--- a/docs/module-types/container.md
+++ b/docs/module-types/container.md
@@ -358,17 +358,17 @@ tasks:
     # task is executed.
     dependencies: []
 
-    # Set this to `true` to disable the task. You can use this with conditional template strings to
-    # enable/disable tasks based on, for example, the current environment or other variables (e.g.
-    # `enabled: \${environment.name != "prod"}`). This can be handy when you only want certain tasks to run in
-    # specific environments, e.g. only for development.
+    # Set this to `true` to disable the task. You can use this with conditional template strings to enable/disable
+    # tasks based on, for example, the current environment or other variables (e.g. `enabled: \${environment.name !=
+    # "prod"}`). This can be handy when you only want certain tasks to run in specific environments, e.g. only for
+    # development.
     #
-    # Disabling a task means that it will not be run, and will also be ignored if it is declared as a
-    # runtime dependency for another service, test or task.
+    # Disabling a task means that it will not be run, and will also be ignored if it is declared as a runtime
+    # dependency for another service, test or task.
     #
-    # Note however that template strings referencing the task's outputs (i.e. runtime outputs) will fail to
-    # resolve when the task is disabled, so you need to make sure to provide alternate values for those if
-    # you're using them, using conditional expressions.
+    # Note however that template strings referencing the task's outputs (i.e. runtime outputs) will fail to resolve
+    # when the task is disabled, so you need to make sure to provide alternate values for those if you're using them,
+    # using conditional expressions.
     disabled: false
 
     # Maximum duration (in seconds) of the task's execution.
@@ -386,6 +386,11 @@ tasks:
 
         # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
         target: .
+
+    # Set to false if you don't want the task's result to be cached. Use this if the task needs to be run any time
+    # your project (or one or more of the task's dependants) is deployed. Otherwise the task is only re-run when its
+    # version changes (i.e. the module or one of its dependencies is modified), or when you run `garden run task`.
+    cacheResult: true
 
     # The command/entrypoint used to run the task inside the container.
     command:
@@ -1445,17 +1450,11 @@ The names of any tasks that must be executed, and the names of any services that
 
 [tasks](#tasks) > disabled
 
-Set this to `true` to disable the task. You can use this with conditional template strings to
-enable/disable tasks based on, for example, the current environment or other variables (e.g.
-`enabled: \${environment.name != "prod"}`). This can be handy when you only want certain tasks to run in
-specific environments, e.g. only for development.
+Set this to `true` to disable the task. You can use this with conditional template strings to enable/disable tasks based on, for example, the current environment or other variables (e.g. `enabled: \${environment.name != "prod"}`). This can be handy when you only want certain tasks to run in specific environments, e.g. only for development.
 
-Disabling a task means that it will not be run, and will also be ignored if it is declared as a
-runtime dependency for another service, test or task.
+Disabling a task means that it will not be run, and will also be ignored if it is declared as a runtime dependency for another service, test or task.
 
-Note however that template strings referencing the task's outputs (i.e. runtime outputs) will fail to
-resolve when the task is disabled, so you need to make sure to provide alternate values for those if
-you're using them, using conditional expressions.
+Note however that template strings referencing the task's outputs (i.e. runtime outputs) will fail to resolve when the task is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |
@@ -1546,6 +1545,16 @@ tasks:
       - source: /report/**/*
       - target: "outputs/foo/"
 ```
+
+### `tasks[].cacheResult`
+
+[tasks](#tasks) > cacheResult
+
+Set to false if you don't want the task's result to be cached. Use this if the task needs to be run any time your project (or one or more of the task's dependants) is deployed. Otherwise the task is only re-run when its version changes (i.e. the module or one of its dependencies is modified), or when you run `garden run task`.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 ### `tasks[].command[]`
 

--- a/docs/module-types/exec.md
+++ b/docs/module-types/exec.md
@@ -138,17 +138,17 @@ tasks:
     # task is executed.
     dependencies: []
 
-    # Set this to `true` to disable the task. You can use this with conditional template strings to
-    # enable/disable tasks based on, for example, the current environment or other variables (e.g.
-    # `enabled: \${environment.name != "prod"}`). This can be handy when you only want certain tasks to run in
-    # specific environments, e.g. only for development.
+    # Set this to `true` to disable the task. You can use this with conditional template strings to enable/disable
+    # tasks based on, for example, the current environment or other variables (e.g. `enabled: \${environment.name !=
+    # "prod"}`). This can be handy when you only want certain tasks to run in specific environments, e.g. only for
+    # development.
     #
-    # Disabling a task means that it will not be run, and will also be ignored if it is declared as a
-    # runtime dependency for another service, test or task.
+    # Disabling a task means that it will not be run, and will also be ignored if it is declared as a runtime
+    # dependency for another service, test or task.
     #
-    # Note however that template strings referencing the task's outputs (i.e. runtime outputs) will fail to
-    # resolve when the task is disabled, so you need to make sure to provide alternate values for those if
-    # you're using them, using conditional expressions.
+    # Note however that template strings referencing the task's outputs (i.e. runtime outputs) will fail to resolve
+    # when the task is disabled, so you need to make sure to provide alternate values for those if you're using them,
+    # using conditional expressions.
     disabled: false
 
     # Maximum duration (in seconds) of the task's execution.
@@ -491,17 +491,11 @@ The names of any tasks that must be executed, and the names of any services that
 
 [tasks](#tasks) > disabled
 
-Set this to `true` to disable the task. You can use this with conditional template strings to
-enable/disable tasks based on, for example, the current environment or other variables (e.g.
-`enabled: \${environment.name != "prod"}`). This can be handy when you only want certain tasks to run in
-specific environments, e.g. only for development.
+Set this to `true` to disable the task. You can use this with conditional template strings to enable/disable tasks based on, for example, the current environment or other variables (e.g. `enabled: \${environment.name != "prod"}`). This can be handy when you only want certain tasks to run in specific environments, e.g. only for development.
 
-Disabling a task means that it will not be run, and will also be ignored if it is declared as a
-runtime dependency for another service, test or task.
+Disabling a task means that it will not be run, and will also be ignored if it is declared as a runtime dependency for another service, test or task.
 
-Note however that template strings referencing the task's outputs (i.e. runtime outputs) will fail to
-resolve when the task is disabled, so you need to make sure to provide alternate values for those if
-you're using them, using conditional expressions.
+Note however that template strings referencing the task's outputs (i.e. runtime outputs) will fail to resolve when the task is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |

--- a/docs/module-types/helm.md
+++ b/docs/module-types/helm.md
@@ -181,21 +181,26 @@ tasks:
     # task is executed.
     dependencies: []
 
-    # Set this to `true` to disable the task. You can use this with conditional template strings to
-    # enable/disable tasks based on, for example, the current environment or other variables (e.g.
-    # `enabled: \${environment.name != "prod"}`). This can be handy when you only want certain tasks to run in
-    # specific environments, e.g. only for development.
+    # Set this to `true` to disable the task. You can use this with conditional template strings to enable/disable
+    # tasks based on, for example, the current environment or other variables (e.g. `enabled: \${environment.name !=
+    # "prod"}`). This can be handy when you only want certain tasks to run in specific environments, e.g. only for
+    # development.
     #
-    # Disabling a task means that it will not be run, and will also be ignored if it is declared as a
-    # runtime dependency for another service, test or task.
+    # Disabling a task means that it will not be run, and will also be ignored if it is declared as a runtime
+    # dependency for another service, test or task.
     #
-    # Note however that template strings referencing the task's outputs (i.e. runtime outputs) will fail to
-    # resolve when the task is disabled, so you need to make sure to provide alternate values for those if
-    # you're using them, using conditional expressions.
+    # Note however that template strings referencing the task's outputs (i.e. runtime outputs) will fail to resolve
+    # when the task is disabled, so you need to make sure to provide alternate values for those if you're using them,
+    # using conditional expressions.
     disabled: false
 
     # Maximum duration (in seconds) of the task's execution.
     timeout: null
+
+    # Set to false if you don't want the task's result to be cached. Use this if the task needs to be run any time
+    # your project (or one or more of the task's dependants) is deployed. Otherwise the task is only re-run when its
+    # version changes (i.e. the module or one of its dependencies is modified), or when you run `garden run task`.
+    cacheResult: true
 
     # The command/entrypoint used to run the task inside the container.
     command:
@@ -731,17 +736,11 @@ The names of any tasks that must be executed, and the names of any services that
 
 [tasks](#tasks) > disabled
 
-Set this to `true` to disable the task. You can use this with conditional template strings to
-enable/disable tasks based on, for example, the current environment or other variables (e.g.
-`enabled: \${environment.name != "prod"}`). This can be handy when you only want certain tasks to run in
-specific environments, e.g. only for development.
+Set this to `true` to disable the task. You can use this with conditional template strings to enable/disable tasks based on, for example, the current environment or other variables (e.g. `enabled: \${environment.name != "prod"}`). This can be handy when you only want certain tasks to run in specific environments, e.g. only for development.
 
-Disabling a task means that it will not be run, and will also be ignored if it is declared as a
-runtime dependency for another service, test or task.
+Disabling a task means that it will not be run, and will also be ignored if it is declared as a runtime dependency for another service, test or task.
 
-Note however that template strings referencing the task's outputs (i.e. runtime outputs) will fail to
-resolve when the task is disabled, so you need to make sure to provide alternate values for those if
-you're using them, using conditional expressions.
+Note however that template strings referencing the task's outputs (i.e. runtime outputs) will fail to resolve when the task is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |
@@ -756,6 +755,16 @@ Maximum duration (in seconds) of the task's execution.
 | Type     | Default | Required |
 | -------- | ------- | -------- |
 | `number` | `null`  | No       |
+
+### `tasks[].cacheResult`
+
+[tasks](#tasks) > cacheResult
+
+Set to false if you don't want the task's result to be cached. Use this if the task needs to be run any time your project (or one or more of the task's dependants) is deployed. Otherwise the task is only re-run when its version changes (i.e. the module or one of its dependencies is modified), or when you run `garden run task`.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 ### `tasks[].command[]`
 

--- a/docs/module-types/kubernetes.md
+++ b/docs/module-types/kubernetes.md
@@ -161,17 +161,17 @@ tasks:
     # task is executed.
     dependencies: []
 
-    # Set this to `true` to disable the task. You can use this with conditional template strings to
-    # enable/disable tasks based on, for example, the current environment or other variables (e.g.
-    # `enabled: \${environment.name != "prod"}`). This can be handy when you only want certain tasks to run in
-    # specific environments, e.g. only for development.
+    # Set this to `true` to disable the task. You can use this with conditional template strings to enable/disable
+    # tasks based on, for example, the current environment or other variables (e.g. `enabled: \${environment.name !=
+    # "prod"}`). This can be handy when you only want certain tasks to run in specific environments, e.g. only for
+    # development.
     #
-    # Disabling a task means that it will not be run, and will also be ignored if it is declared as a
-    # runtime dependency for another service, test or task.
+    # Disabling a task means that it will not be run, and will also be ignored if it is declared as a runtime
+    # dependency for another service, test or task.
     #
-    # Note however that template strings referencing the task's outputs (i.e. runtime outputs) will fail to
-    # resolve when the task is disabled, so you need to make sure to provide alternate values for those if
-    # you're using them, using conditional expressions.
+    # Note however that template strings referencing the task's outputs (i.e. runtime outputs) will fail to resolve
+    # when the task is disabled, so you need to make sure to provide alternate values for those if you're using them,
+    # using conditional expressions.
     disabled: false
 
     # Maximum duration (in seconds) of the task's execution.
@@ -190,6 +190,11 @@ tasks:
       # The name of a container in the target. Specify this if the target contains more than one container and the
       # main container is not the first container in the spec.
       containerName:
+
+    # Set to false if you don't want the task's result to be cached. Use this if the task needs to be run any time
+    # your project (or one or more of the task's dependants) is deployed. Otherwise the task is only re-run when its
+    # version changes (i.e. the module or one of its dependencies is modified), or when you run `garden run task`.
+    cacheResult: true
 
     # The command/entrypoint used to run the task inside the container.
     command:
@@ -606,17 +611,11 @@ The names of any tasks that must be executed, and the names of any services that
 
 [tasks](#tasks) > disabled
 
-Set this to `true` to disable the task. You can use this with conditional template strings to
-enable/disable tasks based on, for example, the current environment or other variables (e.g.
-`enabled: \${environment.name != "prod"}`). This can be handy when you only want certain tasks to run in
-specific environments, e.g. only for development.
+Set this to `true` to disable the task. You can use this with conditional template strings to enable/disable tasks based on, for example, the current environment or other variables (e.g. `enabled: \${environment.name != "prod"}`). This can be handy when you only want certain tasks to run in specific environments, e.g. only for development.
 
-Disabling a task means that it will not be run, and will also be ignored if it is declared as a
-runtime dependency for another service, test or task.
+Disabling a task means that it will not be run, and will also be ignored if it is declared as a runtime dependency for another service, test or task.
 
-Note however that template strings referencing the task's outputs (i.e. runtime outputs) will fail to
-resolve when the task is disabled, so you need to make sure to provide alternate values for those if
-you're using them, using conditional expressions.
+Note however that template strings referencing the task's outputs (i.e. runtime outputs) will fail to resolve when the task is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |
@@ -671,6 +670,16 @@ The name of a container in the target. Specify this if the target contains more 
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
+
+### `tasks[].cacheResult`
+
+[tasks](#tasks) > cacheResult
+
+Set to false if you don't want the task's result to be cached. Use this if the task needs to be run any time your project (or one or more of the task's dependants) is deployed. Otherwise the task is only re-run when its version changes (i.e. the module or one of its dependencies is modified), or when you run `garden run task`.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 ### `tasks[].command[]`
 

--- a/docs/module-types/maven-container.md
+++ b/docs/module-types/maven-container.md
@@ -356,17 +356,17 @@ tasks:
     # task is executed.
     dependencies: []
 
-    # Set this to `true` to disable the task. You can use this with conditional template strings to
-    # enable/disable tasks based on, for example, the current environment or other variables (e.g.
-    # `enabled: \${environment.name != "prod"}`). This can be handy when you only want certain tasks to run in
-    # specific environments, e.g. only for development.
+    # Set this to `true` to disable the task. You can use this with conditional template strings to enable/disable
+    # tasks based on, for example, the current environment or other variables (e.g. `enabled: \${environment.name !=
+    # "prod"}`). This can be handy when you only want certain tasks to run in specific environments, e.g. only for
+    # development.
     #
-    # Disabling a task means that it will not be run, and will also be ignored if it is declared as a
-    # runtime dependency for another service, test or task.
+    # Disabling a task means that it will not be run, and will also be ignored if it is declared as a runtime
+    # dependency for another service, test or task.
     #
-    # Note however that template strings referencing the task's outputs (i.e. runtime outputs) will fail to
-    # resolve when the task is disabled, so you need to make sure to provide alternate values for those if
-    # you're using them, using conditional expressions.
+    # Note however that template strings referencing the task's outputs (i.e. runtime outputs) will fail to resolve
+    # when the task is disabled, so you need to make sure to provide alternate values for those if you're using them,
+    # using conditional expressions.
     disabled: false
 
     # Maximum duration (in seconds) of the task's execution.
@@ -384,6 +384,11 @@ tasks:
 
         # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
         target: .
+
+    # Set to false if you don't want the task's result to be cached. Use this if the task needs to be run any time
+    # your project (or one or more of the task's dependants) is deployed. Otherwise the task is only re-run when its
+    # version changes (i.e. the module or one of its dependencies is modified), or when you run `garden run task`.
+    cacheResult: true
 
     # The command/entrypoint used to run the task inside the container.
     command:
@@ -1453,17 +1458,11 @@ The names of any tasks that must be executed, and the names of any services that
 
 [tasks](#tasks) > disabled
 
-Set this to `true` to disable the task. You can use this with conditional template strings to
-enable/disable tasks based on, for example, the current environment or other variables (e.g.
-`enabled: \${environment.name != "prod"}`). This can be handy when you only want certain tasks to run in
-specific environments, e.g. only for development.
+Set this to `true` to disable the task. You can use this with conditional template strings to enable/disable tasks based on, for example, the current environment or other variables (e.g. `enabled: \${environment.name != "prod"}`). This can be handy when you only want certain tasks to run in specific environments, e.g. only for development.
 
-Disabling a task means that it will not be run, and will also be ignored if it is declared as a
-runtime dependency for another service, test or task.
+Disabling a task means that it will not be run, and will also be ignored if it is declared as a runtime dependency for another service, test or task.
 
-Note however that template strings referencing the task's outputs (i.e. runtime outputs) will fail to
-resolve when the task is disabled, so you need to make sure to provide alternate values for those if
-you're using them, using conditional expressions.
+Note however that template strings referencing the task's outputs (i.e. runtime outputs) will fail to resolve when the task is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
 
 | Type      | Default | Required |
 | --------- | ------- | -------- |
@@ -1554,6 +1553,16 @@ tasks:
       - source: /report/**/*
       - target: "outputs/foo/"
 ```
+
+### `tasks[].cacheResult`
+
+[tasks](#tasks) > cacheResult
+
+Set to false if you don't want the task's result to be cached. Use this if the task needs to be run any time your project (or one or more of the task's dependants) is deployed. Otherwise the task is only re-run when its version changes (i.e. the module or one of its dependencies is modified), or when you run `garden run task`.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 ### `tasks[].command[]`
 

--- a/garden-service/src/config/task.ts
+++ b/garden-service/src/config/task.ts
@@ -19,6 +19,15 @@ export interface BaseTaskSpec extends TaskSpec {
   timeout: number | null
 }
 
+export const cacheResultSchema = joi
+  .boolean()
+  .default(true)
+  .description(
+    dedent`
+    Set to false if you don't want the task's result to be cached. Use this if the task needs to be run any time your project (or one or more of the task's dependants) is deployed. Otherwise the task is only re-run when its version changes (i.e. the module or one of its dependencies is modified), or when you run \`garden run task\`.
+    `
+  )
+
 export const baseTaskSpecSchema = joi
   .object()
   .keys({
@@ -30,25 +39,18 @@ export const baseTaskSpecSchema = joi
       .optional()
       .description("A description of the task."),
     dependencies: joiArray(joi.string()).description(deline`
-        The names of any tasks that must be executed, and the names of any
-        services that must be running, before this task is executed.
+        The names of any tasks that must be executed, and the names of any services that must be running, before this task is executed.
       `),
     disabled: joi
       .boolean()
       .default(false)
       .description(
         dedent`
-          Set this to \`true\` to disable the task. You can use this with conditional template strings to
-          enable/disable tasks based on, for example, the current environment or other variables (e.g.
-          \`enabled: \${environment.name != "prod"}\`). This can be handy when you only want certain tasks to run in
-          specific environments, e.g. only for development.
+        Set this to \`true\` to disable the task. You can use this with conditional template strings to enable/disable tasks based on, for example, the current environment or other variables (e.g. \`enabled: \${environment.name != "prod"}\`). This can be handy when you only want certain tasks to run in specific environments, e.g. only for development.
 
-          Disabling a task means that it will not be run, and will also be ignored if it is declared as a
-          runtime dependency for another service, test or task.
+        Disabling a task means that it will not be run, and will also be ignored if it is declared as a runtime dependency for another service, test or task.
 
-          Note however that template strings referencing the task's outputs (i.e. runtime outputs) will fail to
-          resolve when the task is disabled, so you need to make sure to provide alternate values for those if
-          you're using them, using conditional expressions.
+        Note however that template strings referencing the task's outputs (i.e. runtime outputs) will fail to resolve when the task is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
         `
       ),
     timeout: joi
@@ -61,12 +63,14 @@ export const baseTaskSpecSchema = joi
   .description("Required configuration for module tasks.")
 
 export interface TaskConfig<T extends TaskSpec = TaskSpec> extends BaseTaskSpec {
+  cacheResult: boolean
   // Plugins can add custom fields that are kept here
   spec: T
 }
 
 export const taskConfigSchema = baseTaskSpecSchema
   .keys({
+    cacheResult: cacheResultSchema,
     spec: joi
       .object()
       .meta({ extendable: true })

--- a/garden-service/src/plugins/container/config.ts
+++ b/garden-service/src/plugins/container/config.ts
@@ -24,7 +24,7 @@ import { Service, ingressHostnameSchema, linkUrlSchema } from "../../types/servi
 import { DEFAULT_PORT_PROTOCOL } from "../../constants"
 import { ModuleSpec, ModuleConfig, baseBuildSpecSchema, BaseBuildSpec } from "../../config/module"
 import { CommonServiceSpec, ServiceConfig, baseServiceSpecSchema } from "../../config/service"
-import { baseTaskSpecSchema, BaseTaskSpec } from "../../config/task"
+import { baseTaskSpecSchema, BaseTaskSpec, cacheResultSchema } from "../../config/task"
 import { baseTestSpecSchema, BaseTestSpec } from "../../config/test"
 import { joiStringMap } from "../../config/common"
 import { dedent } from "../../util/string"
@@ -470,6 +470,7 @@ export const containerTestSchema = baseTestSpecSchema.keys({
 export interface ContainerTaskSpec extends BaseTaskSpec {
   args: string[]
   artifacts: ArtifactSpec[]
+  cacheResult: boolean
   command?: string[]
   env: ContainerEnvVars
 }
@@ -482,6 +483,7 @@ export const containerTaskSchema = baseTaskSpecSchema
       .description("The arguments used to run the task inside the container.")
       .example(["rake", "db:migrate"]),
     artifacts: artifactsSchema,
+    cacheResult: cacheResultSchema,
     command: joi
       .array()
       .items(joi.string())

--- a/garden-service/src/plugins/container/container.ts
+++ b/garden-service/src/plugins/container/container.ts
@@ -140,6 +140,7 @@ export async function configureContainerModule({ ctx, log, moduleConfig }: Confi
 
   moduleConfig.taskConfigs = moduleConfig.spec.tasks.map((t) => ({
     name: t.name,
+    cacheResult: t.cacheResult,
     dependencies: t.dependencies,
     disabled: t.disabled,
     spec: t,

--- a/garden-service/src/plugins/exec.ts
+++ b/garden-service/src/plugins/exec.ts
@@ -188,6 +188,7 @@ export async function configureExecModule({
 
   moduleConfig.taskConfigs = moduleConfig.spec.tasks.map((t) => ({
     name: t.name,
+    cacheResult: false,
     dependencies: t.dependencies,
     disabled: t.disabled,
     timeout: t.timeout,

--- a/garden-service/src/plugins/kubernetes/config.ts
+++ b/garden-service/src/plugins/kubernetes/config.ts
@@ -22,7 +22,7 @@ import { PluginContext } from "../../plugin-context"
 import { deline } from "../../util/string"
 import { defaultSystemNamespace } from "./system"
 import { hotReloadableKinds, HotReloadableKind } from "./hot-reload"
-import { baseTaskSpecSchema, BaseTaskSpec } from "../../config/task"
+import { baseTaskSpecSchema, BaseTaskSpec, cacheResultSchema } from "../../config/task"
 import { baseTestSpecSchema, BaseTestSpec } from "../../config/test"
 import { ArtifactSpec } from "../../config/validation"
 
@@ -572,6 +572,7 @@ export interface ServiceResourceSpec {
 export interface KubernetesTaskSpec extends BaseTaskSpec {
   args: string[]
   artifacts: ArtifactSpec[]
+  cacheResult: boolean
   command?: string[]
   env: ContainerEnvVars
   resource: ServiceResourceSpec
@@ -609,6 +610,7 @@ export const kubernetesTaskSchema = baseTaskSpecSchema
         If not specified, the \`serviceResource\` configured on the module will be used. If neither is specified,
         an error will be thrown.`
     ),
+    cacheResult: cacheResultSchema,
     command: joi
       .array()
       .items(joi.string())

--- a/garden-service/src/plugins/kubernetes/container/run.ts
+++ b/garden-service/src/plugins/kubernetes/container/run.ts
@@ -85,12 +85,16 @@ export async function runContainerTask(params: RunTaskParams<ContainerModule>): 
     },
   }
 
-  return storeTaskResult({
-    ctx,
-    log,
-    module,
-    result,
-    taskVersion,
-    taskName: task.name,
-  })
+  if (task.config.cacheResult) {
+    await storeTaskResult({
+      ctx,
+      log,
+      module,
+      result,
+      taskVersion,
+      taskName: task.name,
+    })
+  }
+
+  return result
 }

--- a/garden-service/src/plugins/kubernetes/helm/config.ts
+++ b/garden-service/src/plugins/kubernetes/helm/config.ts
@@ -273,6 +273,7 @@ export async function configureHelmModule({
 
     return {
       name: spec.name,
+      cacheResult: spec.cacheResult,
       dependencies: spec.dependencies,
       disabled: moduleConfig.disabled,
       timeout: spec.timeout,

--- a/garden-service/src/plugins/kubernetes/helm/run.ts
+++ b/garden-service/src/plugins/kubernetes/helm/run.ts
@@ -143,14 +143,16 @@ export async function runHelmTask(params: RunTaskParams<HelmModule>): Promise<Ru
     },
   }
 
-  await storeTaskResult({
-    ctx,
-    log,
-    module,
-    result,
-    taskVersion,
-    taskName: task.name,
-  })
+  if (task.config.cacheResult) {
+    await storeTaskResult({
+      ctx,
+      log,
+      module,
+      result,
+      taskVersion,
+      taskName: task.name,
+    })
+  }
 
   return result
 }

--- a/garden-service/src/plugins/kubernetes/kubernetes-module/config.ts
+++ b/garden-service/src/plugins/kubernetes/kubernetes-module/config.ts
@@ -113,6 +113,7 @@ export async function configureKubernetesModule({
 
   moduleConfig.taskConfigs = moduleConfig.spec.tasks.map((t) => ({
     name: t.name,
+    cacheResult: t.cacheResult,
     dependencies: t.dependencies,
     disabled: t.disabled,
     spec: t,

--- a/garden-service/src/plugins/kubernetes/kubernetes-module/run.ts
+++ b/garden-service/src/plugins/kubernetes/kubernetes-module/run.ts
@@ -63,14 +63,16 @@ export async function runKubernetesTask(params: RunTaskParams<KubernetesModule>)
     },
   }
 
-  await storeTaskResult({
-    ctx,
-    log,
-    module,
-    result,
-    taskVersion,
-    taskName: task.name,
-  })
+  if (task.config.cacheResult) {
+    await storeTaskResult({
+      ctx,
+      log,
+      module,
+      result,
+      taskVersion,
+      taskName: task.name,
+    })
+  }
 
   return result
 }

--- a/garden-service/src/task-graph.ts
+++ b/garden-service/src/task-graph.ts
@@ -154,6 +154,10 @@ export class TaskGraph {
     })
   }
 
+  clearCache() {
+    this.resultCache = new ResultCache()
+  }
+
   /**
    * Rebuilds the dependency relationships between the TaskNodes in this.index, and updates this.roots accordingly.
    */

--- a/garden-service/src/tasks/task.ts
+++ b/garden-service/src/tasks/task.ts
@@ -113,9 +113,7 @@ export class TaskTask extends BaseTask {
   async process(dependencyResults: TaskResults) {
     const task = this.task
 
-    // TODO: Re-enable this logic when we've started providing task graph results to process methods.
-
-    if (!this.force) {
+    if (!this.force && task.config.cacheResult) {
       const cachedResult = getRunTaskResults(dependencyResults)[this.task.name]
 
       if (cachedResult && cachedResult.success) {

--- a/garden-service/test/integ/src/plugins/kubernetes/helm/run.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/helm/run.ts
@@ -14,6 +14,7 @@ import { getHelmTestGarden } from "./common"
 import { TaskTask } from "../../../../../../src/tasks/task"
 import { emptyDir, pathExists } from "fs-extra"
 import { join } from "path"
+import { clearTaskResult } from "../../../../../../src/plugins/kubernetes/task-results"
 
 describe("runHelmTask", () => {
   let garden: TestGarden
@@ -27,8 +28,9 @@ describe("runHelmTask", () => {
     graph = await garden.getConfigGraph(garden.log)
   })
 
-  it("should run a basic task", async () => {
+  it("should run a basic task and store its result", async () => {
     const task = await graph.getTask("echo-task")
+    const version = task.module.version
 
     const testTask = new TaskTask({
       garden,
@@ -37,10 +39,16 @@ describe("runHelmTask", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
-      version: task.module.version,
+      version,
     })
 
     const key = testTask.getKey()
+
+    // Clear any existing task result
+    const provider = await garden.resolveProvider("local-kubernetes")
+    const ctx = garden.getPluginContext(provider)
+    await clearTaskResult({ ctx, log: garden.log, module: task.module, task, taskVersion: version })
+
     const { [key]: result } = await garden.processTasks([testTask], { throwOnError: true })
 
     expect(result).to.exist
@@ -48,6 +56,49 @@ describe("runHelmTask", () => {
     expect(result!.output.log.trim()).to.equal("ok")
     expect(result!.output).to.have.property("outputs")
     expect(result!.output.outputs.log.trim()).to.equal("ok")
+
+    // We also verify that, despite the task failing, its result was still saved.
+    const actions = await garden.getActionRouter()
+    const storedResult = await actions.getTaskResult({
+      log: garden.log,
+      task,
+      taskVersion: task.module.version,
+    })
+
+    expect(storedResult).to.exist
+  })
+
+  it("should not store task results if cacheResult=false", async () => {
+    const task = await graph.getTask("echo-task")
+    const version = task.module.version
+    task.config.cacheResult = false
+
+    const testTask = new TaskTask({
+      garden,
+      graph,
+      task,
+      log: garden.log,
+      force: true,
+      forceBuild: false,
+      version,
+    })
+
+    // Clear any existing task result
+    const provider = await garden.resolveProvider("local-kubernetes")
+    const ctx = garden.getPluginContext(provider)
+    await clearTaskResult({ ctx, log: garden.log, module: task.module, task, taskVersion: version })
+
+    await garden.processTasks([testTask], { throwOnError: true })
+
+    // We also verify that, despite the task failing, its result was still saved.
+    const actions = await garden.getActionRouter()
+    const storedResult = await actions.getTaskResult({
+      log: garden.log,
+      task,
+      taskVersion: task.module.version,
+    })
+
+    expect(storedResult).to.not.exist
   })
 
   it("should run a task in a different namespace, if configured", async () => {

--- a/garden-service/test/integ/src/plugins/kubernetes/kubernetes-module/config.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/kubernetes-module/config.ts
@@ -49,6 +49,7 @@ describe("validateKubernetesModule", () => {
       {
         name: "echo-task",
         command: ["sh", "-c", "echo ok"],
+        cacheResult: true,
         dependencies: [],
         disabled: false,
         timeout: null,
@@ -196,6 +197,7 @@ describe("validateKubernetesModule", () => {
       taskConfigs: [
         {
           name: "echo-task",
+          cacheResult: true,
           dependencies: [],
           disabled: false,
           spec: taskSpecs[0],

--- a/garden-service/test/unit/src/commands/get/get-config.ts
+++ b/garden-service/test/unit/src/commands/get/get-config.ts
@@ -282,10 +282,12 @@ describe("GetConfigCommand", () => {
     expectedModuleConfigs[0].taskConfigs = [
       {
         name: "task-enabled",
+        cacheResult: true,
         dependencies: [],
         disabled: false,
         spec: {
           name: "task-enabled",
+          cacheResult: true,
           dependencies: [],
           disabled: false,
           timeout: null,

--- a/garden-service/test/unit/src/garden.ts
+++ b/garden-service/test/unit/src/garden.ts
@@ -3149,9 +3149,9 @@ describe("Garden", () => {
     })
 
     context("test against fixed version hashes", async () => {
-      const moduleAVersionString = "v-58abca9921"
-      const moduleBVersionString = "v-f25bb29260"
-      const moduleCVersionString = "v-b4f769e846"
+      const moduleAVersionString = "v-0ef068b6a4"
+      const moduleBVersionString = "v-53b030b72a"
+      const moduleCVersionString = "v-a362160029"
 
       it("should return the same module versions between runtimes", async () => {
         const projectRoot = getDataDir("test-projects", "fixed-version-hashes-1")

--- a/garden-service/test/unit/src/outputs.ts
+++ b/garden-service/test/unit/src/outputs.ts
@@ -233,6 +233,7 @@ describe("resolveProjectOutputs", () => {
         taskConfigs: [
           {
             name: "test",
+            cacheResult: true,
             dependencies: [],
             disabled: false,
             spec: {},

--- a/garden-service/test/unit/src/plugins/container/container.ts
+++ b/garden-service/test/unit/src/plugins/container/container.ts
@@ -161,6 +161,7 @@ describe("plugins.container", () => {
               name: "task-a",
               args: ["echo", "OK"],
               artifacts: [],
+              cacheResult: true,
               dependencies: [],
               disabled: false,
               env: {
@@ -245,6 +246,7 @@ describe("plugins.container", () => {
                 name: "task-a",
                 args: ["echo", "OK"],
                 artifacts: [],
+                cacheResult: true,
                 dependencies: [],
                 disabled: false,
                 env: {
@@ -303,12 +305,14 @@ describe("plugins.container", () => {
           ],
           taskConfigs: [
             {
+              cacheResult: true,
               dependencies: [],
               disabled: false,
               name: "task-a",
               spec: {
                 args: ["echo", "OK"],
                 artifacts: [],
+                cacheResult: true,
                 dependencies: [],
                 disabled: false,
                 env: {
@@ -390,6 +394,7 @@ describe("plugins.container", () => {
               name: "task-a",
               args: ["echo"],
               artifacts: [],
+              cacheResult: true,
               dependencies: [],
               disabled: false,
               env: {},
@@ -464,6 +469,7 @@ describe("plugins.container", () => {
               name: "task-a",
               args: ["echo"],
               artifacts: [],
+              cacheResult: true,
               dependencies: [],
               disabled: false,
               env: {},
@@ -525,6 +531,7 @@ describe("plugins.container", () => {
               name: "task-a",
               args: ["echo"],
               artifacts: [],
+              cacheResult: true,
               dependencies: [],
               disabled: false,
               env: {},

--- a/garden-service/test/unit/src/plugins/exec.ts
+++ b/garden-service/test/unit/src/plugins/exec.ts
@@ -53,6 +53,7 @@ describe("exec plugin", () => {
     expect(moduleA.taskConfigs).to.eql([
       {
         name: "banana",
+        cacheResult: false,
         dependencies: ["orange"],
         disabled: false,
         timeout: null,
@@ -67,6 +68,7 @@ describe("exec plugin", () => {
       },
       {
         name: "orange",
+        cacheResult: false,
         dependencies: [],
         disabled: false,
         timeout: 999,
@@ -163,6 +165,7 @@ describe("exec plugin", () => {
     expect(moduleLocal.taskConfigs).to.eql([
       {
         name: "pwd",
+        cacheResult: false,
         dependencies: [],
         disabled: false,
         timeout: null,

--- a/garden-service/test/unit/src/tasks/deploy.ts
+++ b/garden-service/test/unit/src/tasks/deploy.ts
@@ -117,6 +117,7 @@ describe("DeployTask", () => {
           taskConfigs: [
             {
               name: "test-task",
+              cacheResult: true,
               dependencies: [],
               disabled: false,
               spec: {

--- a/garden-service/test/unit/src/tasks/get-service-status.ts
+++ b/garden-service/test/unit/src/tasks/get-service-status.ts
@@ -110,6 +110,7 @@ describe("GetServiceStatusTask", () => {
           taskConfigs: [
             {
               name: "test-task",
+              cacheResult: true,
               dependencies: [],
               disabled: false,
               spec: {

--- a/garden-service/test/unit/src/tasks/task.ts
+++ b/garden-service/test/unit/src/tasks/task.ts
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import tmp from "tmp-promise"
+import { expect } from "chai"
+import { TestGarden } from "../../../helpers"
+import { ProjectConfig } from "../../../../src/config/project"
+import { DEFAULT_API_VERSION } from "../../../../src/constants"
+import execa from "execa"
+import { createGardenPlugin } from "../../../../src/types/plugin/plugin"
+import { joi } from "../../../../src/config/common"
+import { RunTaskParams, RunTaskResult } from "../../../../src/types/plugin/task/runTask"
+import { TaskTask } from "../../../../src/tasks/task"
+import { Task } from "../../../../src/types/task"
+import { GetTaskResultParams } from "../../../../src/types/plugin/task/getTaskResult"
+
+describe("TaskTask", () => {
+  let tmpDir: tmp.DirectoryResult
+  let config: ProjectConfig
+
+  before(async () => {
+    tmpDir = await tmp.dir({ unsafeCleanup: true })
+
+    await execa("git", ["init"], { cwd: tmpDir.path })
+
+    config = {
+      apiVersion: DEFAULT_API_VERSION,
+      kind: "Project",
+      name: "test",
+      path: tmpDir.path,
+      defaultEnvironment: "default",
+      dotIgnoreFiles: [],
+      environments: [{ name: "default", variables: {} }],
+      providers: [{ name: "test" }],
+      variables: {},
+    }
+  })
+
+  after(async () => {
+    await tmpDir.cleanup()
+  })
+
+  describe("process", () => {
+    let cache: { [key: string]: RunTaskResult } = {}
+
+    beforeEach(() => {
+      cache = {}
+    })
+
+    const getKey = (task: Task) => {
+      return `${task.name}-${task.module.version.versionString}`
+    }
+
+    const testPlugin = createGardenPlugin({
+      name: "test",
+      createModuleTypes: [
+        {
+          name: "test",
+          docs: "test",
+          serviceOutputsSchema: joi.object().keys({ log: joi.string() }),
+          handlers: {
+            build: async () => ({}),
+            runTask: async ({ task }: RunTaskParams) => {
+              const log = new Date().getTime().toString()
+
+              const result = {
+                taskName: task.name,
+                moduleName: task.module.name,
+                success: true,
+                outputs: { log },
+                command: [],
+                log,
+                startedAt: new Date(),
+                completedAt: new Date(),
+                version: task.module.version.versionString,
+              }
+
+              cache[getKey(task)] = result
+
+              return result
+            },
+            getTaskResult: async ({ task }: GetTaskResultParams) => {
+              return cache[getKey(task)] || null
+            },
+          },
+        },
+      ],
+    })
+
+    it("should cache results when cacheResult=true", async () => {
+      const garden = await TestGarden.factory(tmpDir.path, { config, plugins: [testPlugin] })
+
+      garden.setModuleConfigs([
+        {
+          apiVersion: DEFAULT_API_VERSION,
+          name: "test",
+          type: "test",
+          allowPublish: false,
+          disabled: false,
+          build: { dependencies: [] },
+          outputs: {},
+          path: tmpDir.path,
+          serviceConfigs: [],
+          taskConfigs: [
+            {
+              name: "test",
+              cacheResult: true,
+              dependencies: [],
+              disabled: false,
+              spec: {},
+              timeout: 10,
+            },
+          ],
+          testConfigs: [],
+          spec: {},
+        },
+      ])
+
+      let graph = await garden.getConfigGraph(garden.log)
+      let taskTask = await TaskTask.factory({
+        garden,
+        graph,
+        task: await graph.getTask("test"),
+        force: false,
+        forceBuild: false,
+        log: garden.log,
+      })
+
+      let result = await garden.processTasks([taskTask], { throwOnError: true })
+      const logA = result[taskTask.getKey()]!.output.outputs.log
+
+      garden["taskGraph"].clearCache()
+
+      result = await garden.processTasks([taskTask], { throwOnError: true })
+      const logB = result[taskTask.getKey()]!.output.outputs.log
+
+      // Expect the same log from the second run
+      expect(logA).to.equal(logB)
+    })
+
+    it("should not cache results when cacheResult=false", async () => {
+      const garden = await TestGarden.factory(tmpDir.path, { config, plugins: [testPlugin] })
+
+      garden.setModuleConfigs([
+        {
+          apiVersion: DEFAULT_API_VERSION,
+          name: "test",
+          type: "test",
+          allowPublish: false,
+          disabled: false,
+          build: { dependencies: [] },
+          outputs: {},
+          path: tmpDir.path,
+          serviceConfigs: [],
+          taskConfigs: [
+            {
+              name: "test",
+              cacheResult: false,
+              dependencies: [],
+              disabled: false,
+              spec: {},
+              timeout: 10,
+            },
+          ],
+          testConfigs: [],
+          spec: {},
+        },
+      ])
+
+      let graph = await garden.getConfigGraph(garden.log)
+      let taskTask = await TaskTask.factory({
+        garden,
+        graph,
+        task: await graph.getTask("test"),
+        force: false,
+        forceBuild: false,
+        log: garden.log,
+      })
+
+      let result = await garden.processTasks([taskTask], { throwOnError: true })
+      const logA = result[taskTask.getKey()]!.output.outputs.log
+
+      garden["taskGraph"].clearCache()
+
+      result = await garden.processTasks([taskTask], { throwOnError: true })
+      const logB = result[taskTask.getKey()]!.output.outputs.log
+
+      // Expect a different log from the second run
+      expect(logA).to.not.equal(logB)
+    })
+  })
+})

--- a/garden-service/test/unit/src/types/task.ts
+++ b/garden-service/test/unit/src/types/task.ts
@@ -15,6 +15,7 @@ describe("taskFromConfig", () => {
   it("should propagate the disabled flag from the config", async () => {
     const config: TaskConfig = {
       name: "test",
+      cacheResult: true,
       dependencies: [],
       disabled: true,
       spec: {},
@@ -32,6 +33,7 @@ describe("taskFromConfig", () => {
   it("should set disabled=true if the module is disabled", async () => {
     const config: TaskConfig = {
       name: "test",
+      cacheResult: true,
       dependencies: [],
       disabled: false,
       spec: {},

--- a/garden-service/test/unit/src/vcs/vcs.ts
+++ b/garden-service/test/unit/src/vcs/vcs.ts
@@ -285,7 +285,7 @@ describe("VcsHandler", () => {
         const garden = await makeTestGarden(projectRoot)
         const config = await garden.resolveModuleConfig(garden.log, "module-a")
 
-        const fixedVersionString = "v-748612a7c4"
+        const fixedVersionString = "v-64e51cdd17"
         expect(getVersionString(config, [namedVersionA, namedVersionB, namedVersionC])).to.eql(fixedVersionString)
 
         delete process.env.TEST_ENV_VAR


### PR DESCRIPTION
**What this PR does / why we need it**:

Certain tasks should be run every time their dependants are run/deployed, rather than getting cached results and passing those down the graph. The `cacheResult` flag allows users to control this behavior.

We had previously talked about a more elaborate multi-value argument for controlling this, but with the `disabled` flag implemented a simple boolean should suffice.
