### PR TITLE
fix(terraform): ensure correct init root is validate + add logs

### DIFF
--- a/garden-service/src/plugins/terraform/module.ts
+++ b/garden-service/src/plugins/terraform/module.ts
@@ -66,7 +66,7 @@ export async function configureTerraformModule({ ctx, moduleConfig }: ConfigureM
   // Make sure the configured root path exists
   const root = moduleConfig.spec.root
   if (root) {
-    const absRoot = join(ctx.projectRoot, root)
+    const absRoot = join(moduleConfig.path, root)
     const exists = await pathExists(absRoot)
 
     if (!exists) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Terraform would error if you had a `terraform` module that was not in the project root and that had the `init` field set.

Also added some logs to the `getStackStatus` function. 
