### PR TITLE
Task graph cache fixes and changes to DeployTask dependency logic tor task dependencies

### DIFF
--- a/garden-service/src/task-graph.ts
+++ b/garden-service/src/task-graph.ts
@@ -195,7 +195,7 @@ export class TaskGraph {
     } else {
       const result = this.resultCache.get(node.getKey(), node.getVersion())
       if (result) {
-        this.garden.events.emit("taskComplete", result)
+        this.garden.events.emit(result.error ? "taskError" : "taskComplete", result)
       }
     }
   }
@@ -733,12 +733,12 @@ class ResultCache {
 
   get(key: string, versionString: string): TaskResult | null {
     const r = this.cache[key]
-    return r && r.versionString === versionString && !r.result.error ? r.result : null
+    return r && r.versionString === versionString ? r.result : null
   }
 
   getNewest(key: string): TaskResult | null {
     const r = this.cache[key]
-    return r && !r.result.error ? r.result : null
+    return r ? r.result : null
   }
 
   // Returns newest cached results, if any, for keys

--- a/garden-service/src/tasks/deploy.ts
+++ b/garden-service/src/tasks/deploy.ts
@@ -124,7 +124,7 @@ export class DeployTask extends BaseTask {
           garden: this.garden,
           log: this.log,
           graph: this.graph,
-          force: this.force,
+          force: false,
           forceBuild: this.forceBuild,
         })
       })


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces two changes:

1. After this change, a task will not be re-run if it has force = false and another task with the same key and version has already thrown an error while running (and thus had its result cached in the graph's `ResultCache`).

    This means that we treat task results as cached regardless of whether the task succeeded or not: The semantic is that a task with `force = false` should always succeed with the same result (or fail) for a given key + version.

    When this is not the case, `force = true` should be used.

    This prevents e.g. time-consuming tasks from repeatedly running and failing in the same fashion when repeatedly added to the task graph following watch changes.

2. `DeployTask`'s `getDependencies` method now always returns task dependencies initialized with `force = false`.

    The underlying semantic is that unless the task dependency's module sources have changed, there's no need to re-run them when force-deploying the dependant service.

    I.e. the decision whether to run or not run the task dependency is delegated to the `TaskTask` in the normal way.

**Which issue(s) this PR fixes**:

Fixes a couple of issues that came up during development (but weren't formally reported).
