### PR TITLE
docs: UPDATED quick-start.md

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -34,7 +34,7 @@ In order to avoid mistakes, Garden will always point to the context specified in
 Also, if your remote cluster hasn't previously been set up for Garden, start by running the following from the project root:
 
 ``` sh
-garden plugins kubernetes cluster-init --env=remote
+garden plugins kubernetes cluster-init
 ```
 
 Now, let's check the environment status by running the following:


### PR DESCRIPTION
It is confusing explaining that the `--env=remote` is only needed when using a remote OR edit the garden.yaml. THEN the first command has the `env` flag stated but none of the following commands do. This confused me for hours. Removing the flag and going start-to-finish now makes a bit more sense.

<!--
Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file. - done
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below) - done
3. Ensure you have added or run the appropriate tests for your PR. - done
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature. - done
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.- done
-->

**What this PR does / why we need it**: Docs update for clearity.

**Which issue(s) this PR fixes**: n/a

@edvald, @thsig, @eysi09, @10ko and @solomonope