### PR TITLE
feat(core): add get remote-sources command

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -331,6 +331,15 @@ Just try it.
 
     garden get eysi 
 
+### garden get remote-sources
+
+Outputs a list of all linked remote sources and modules for this project.
+
+
+##### Usage
+
+    garden get remote-sources 
+
 ### garden get outputs
 
 Resolves and returns the outputs of the project.

--- a/garden-service/src/commands/get/get-remote-sources.ts
+++ b/garden-service/src/commands/get/get-remote-sources.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import chalk from "chalk"
+import { sortBy } from "lodash"
+import { Command, CommandParams, CommandResult } from "../base"
+import { LinkedSource } from "../../config-store"
+import { printHeader } from "../../logger/util"
+import { getLinkedSources } from "../../util/ext-source-util"
+import { renderTable } from "../../util/string"
+
+const getRemoteSourcesArguments = {}
+
+type Args = typeof getRemoteSourcesArguments
+
+export class GetRemoteSourcesCommand extends Command {
+  name = "remote-sources"
+  help = "Outputs a list of all linked remote sources and modules for this project."
+
+  async action({ garden, log, headerLog }: CommandParams<Args>): Promise<CommandResult<LinkedSource[]>> {
+    printHeader(headerLog, "List linked modules and sources", "open_book")
+
+    const linkedProjectSources = sortBy(await getLinkedSources(garden, "project"), (s) => s.name)
+    const linkedModuleSources = sortBy(await getLinkedSources(garden, "module"), (s) => s.name)
+
+    const linkedSources = [...linkedProjectSources, ...linkedModuleSources]
+
+    log.info("")
+
+    if (linkedSources.length === 0) {
+      log.info(chalk.white("No linked sources or modules found for this project."))
+    } else {
+      const linkedSourcesWithType = [
+        ...linkedProjectSources.map((s) => ({ ...s, type: "source" })),
+        ...linkedModuleSources.map((s) => ({ ...s, type: "module" })),
+      ]
+
+      const rows = [
+        [chalk.bold("Name:"), chalk.bold("Type:"), chalk.bold("Path:")],
+        ...linkedSourcesWithType.map((s) => [chalk.cyan.bold(s.name), chalk.cyan.bold(s.type), s.path.trim()]),
+      ]
+
+      log.info(renderTable(rows))
+    }
+
+    return { result: linkedSources }
+  }
+}

--- a/garden-service/src/commands/get/get.ts
+++ b/garden-service/src/commands/get/get.ts
@@ -16,6 +16,7 @@ import { GetTasksCommand } from "./get-tasks"
 import { GetTaskResultCommand } from "./get-task-result"
 import { GetTestResultCommand } from "./get-test-result"
 import { GetDebugInfoCommand } from "./get-debug-info"
+import { GetRemoteSourcesCommand } from "./get-remote-sources"
 import { GetOutputsCommand } from "./get-outputs"
 
 export class GetCommand extends Command {
@@ -26,6 +27,7 @@ export class GetCommand extends Command {
     GetGraphCommand,
     GetConfigCommand,
     GetEysiCommand,
+    GetRemoteSourcesCommand,
     GetOutputsCommand,
     GetSecretCommand,
     GetStatusCommand,

--- a/garden-service/test/unit/src/commands/get/get-remote-sources.ts
+++ b/garden-service/test/unit/src/commands/get/get-remote-sources.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import { join } from "path"
+import {
+  resetLocalConfig,
+  getDataDir,
+  withDefaultGlobalOpts,
+  makeExtModuleSourcesGarden,
+  makeExtProjectSourcesGarden,
+  TestGarden,
+} from "../../../../helpers"
+import { LinkSourceCommand } from "../../../../../src/commands/link/source"
+import { LinkModuleCommand } from "../../../../../src/commands/link/module"
+import { GetRemoteSourcesCommand } from "../../../../../src/commands/get/get-remote-sources"
+
+describe("GetRemoteSourcesCommand", () => {
+  let garden: TestGarden
+
+  afterEach(async () => {
+    await resetLocalConfig(garden.gardenDirPath)
+  })
+
+  it("should list all linked project sources in the project", async () => {
+    garden = await makeExtProjectSourcesGarden()
+    const log = garden.log
+    const sourcesDir = getDataDir("test-project-local-module-sources")
+    const linkSourceCmd = new LinkSourceCommand()
+    const sourceNames = ["source-a", "source-b", "source-c"]
+    for (const sourceName of sourceNames) {
+      await linkSourceCmd.action({
+        garden,
+        log,
+        headerLog: log,
+        footerLog: log,
+        args: { source: sourceName, path: join(sourcesDir, sourceName) },
+        opts: withDefaultGlobalOpts({}),
+      })
+    }
+
+    const getRemoteSourcesCommand = new GetRemoteSourcesCommand()
+    const results = await getRemoteSourcesCommand.action({
+      garden,
+      log,
+      headerLog: log,
+      footerLog: log,
+      args: {},
+      opts: withDefaultGlobalOpts({}),
+    })
+
+    const expected = sourceNames.map((name) => {
+      return { name, path: join(sourcesDir, name) }
+    })
+
+    expect(results.result).to.eql(expected)
+  })
+
+  it("should list all linked modules in the project", async () => {
+    garden = await makeExtModuleSourcesGarden()
+    const log = garden.log
+    const sourcesDir = getDataDir("test-project-local-project-sources")
+    const linkModuleCmd = new LinkModuleCommand()
+    const sourceNames = ["module-a", "module-b", "module-c"]
+    for (const moduleName of sourceNames) {
+      await linkModuleCmd.action({
+        garden,
+        log,
+        headerLog: log,
+        footerLog: log,
+        args: { module: moduleName, path: join(sourcesDir, moduleName) },
+        opts: withDefaultGlobalOpts({}),
+      })
+    }
+
+    const getRemoteSourcesCommand = new GetRemoteSourcesCommand()
+    const results = await getRemoteSourcesCommand.action({
+      garden,
+      log,
+      headerLog: log,
+      footerLog: log,
+      args: {},
+      opts: withDefaultGlobalOpts({}),
+    })
+
+    const expected = sourceNames.map((name) => {
+      return { name, path: join(sourcesDir, name) }
+    })
+
+    expect(results.result).to.eql(expected)
+  })
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

This command renders a list of all linked remote project sources and modules.

This feature was recently requested by a user on our community Slack.