### PR TITLE
fix(core): fix to dependency logic in dev command

### DIFF
--- a/garden-service/test/data/test-project-a/module-a/garden.yml
+++ b/garden-service/test/data/test-project-a/module-a/garden.yml
@@ -10,6 +10,8 @@ tests:
     command: [echo, OK]
   - name: integration
     command: [echo, OK]
+    dependencies: 
+      - service-a
 tasks:
   - name: task-a
     command: [echo, OK]

--- a/garden-service/test/unit/src/commands/test.ts
+++ b/garden-service/test/unit/src/commands/test.ts
@@ -208,6 +208,8 @@ describe("TestCommand", () => {
     expect(Object.keys(taskResultOutputs(result!)).sort()).to.eql([
       "build.module-a",
       "build.module-b",
+      "deploy.service-a",
+      "get-service-status.service-a",
       "stage-build.module-a",
       "stage-build.module-b",
       "test.module-a.integration",

--- a/garden-service/test/unit/src/config/base.ts
+++ b/garden-service/test/unit/src/config/base.ts
@@ -152,6 +152,7 @@ describe("loadConfig", () => {
             {
               name: "integration",
               command: ["echo", "OK"],
+              dependencies: ["service-a"],
             },
           ],
         },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

Before this fix, if a service was deployed with hot reloading via the dev command, and a test spec had a runtime dependency on that service, the service would initially be deployed without hot reloading enabled.

This would result in subsequent hot reloads for that service failing.

Also added a test case checking for this behavior.