### PR TITLE
Do not set in-cluster registry namespace to be the K8S namespace

### DIFF
--- a/garden-service/src/plugins/kubernetes/kubernetes.ts
+++ b/garden-service/src/plugins/kubernetes/kubernetes.ts
@@ -67,7 +67,7 @@ export async function configureProvider({
       // to make sure every node in the cluster can resolve the image from the registry we deploy in-cluster.
       config.deploymentRegistry = {
         hostname: inClusterRegistryHostname,
-        namespace: config.namespace,
+        namespace: (config.deploymentRegistry && config.deploymentRegistry.namespace) || config.namespace,
       }
       config._systemServices.push("docker-registry", "registry-proxy")
     }


### PR DESCRIPTION
We would like to share builds across namespaces, but instead we
see that each namespace gets its own repository in the in-cluster
registry. Hopefully this should push everything to its own org
as it won't get overriden by k8s namespace from root k8s provider
config?


