### PR TITLE
improvement(template): allow template expression in nested strings

### DIFF
--- a/garden-service/src/template-string-parser.pegjs
+++ b/garden-service/src/template-string-parser.pegjs
@@ -65,8 +65,15 @@ Suffix
 // ---- expressions -----
 // Reduced and adapted from: https://github.com/pegjs/pegjs/blob/master/examples/javascript.pegjs
 PrimaryExpression
-  = v:Literal {
+  = v:NonStringLiteral {
     return v
+  }
+  / v:StringLiteral {
+    // Allow nested template strings in literals
+    return options.resolveNested(v)
+      .catch(_error => {
+        return { _error }
+      })
   }
   / key:Key {
     return options.getKey(key, { allowUndefined: true })
@@ -278,10 +285,13 @@ Keyword
   = TypeofToken
 
 Literal
+  = NonStringLiteral
+  / StringLiteral
+
+NonStringLiteral
   = NullLiteral
   / BooleanLiteral
   / NumericLiteral
-  / StringLiteral
 
 NullLiteral
   = NullToken { return null }

--- a/garden-service/src/template-string.ts
+++ b/garden-service/src/template-string.ts
@@ -60,6 +60,7 @@ export async function resolveTemplateString(
         return context.resolve({ key, nodePath: [], opts: { ...opts, ...(resolveOpts || {}) } })
       },
       getValue,
+      resolveNested: (nested: string) => resolveTemplateString(nested, context, opts),
       // Some utilities to pass to the parser
       buildBinaryExpression,
       buildLogicalExpression,

--- a/garden-service/src/util/string.ts
+++ b/garden-service/src/util/string.ts
@@ -56,8 +56,10 @@ export function tailString(str: string, maxLength: number, nextLine = false) {
   if (overflow > 0) {
     if (nextLine) {
       const lineBreakIdx = str.indexOf("\n", overflow)
-      if (lineBreakIdx) {
+      if (lineBreakIdx >= 0) {
         return str.substr(lineBreakIdx + 1)
+      } else {
+        return str.substr(overflow)
       }
     }
     return str.substr(overflow)

--- a/garden-service/test/unit/src/template-string.ts
+++ b/garden-service/test/unit/src/template-string.ts
@@ -481,14 +481,13 @@ describe("resolveTemplateString", async () => {
     expect(res).to.equal(true)
   })
 
-  // FIXME: We should support this
-  // it("should handle a ternary expression with nested expressions", async () => {
-  //   const res = await resolveTemplateString(
-  //     "${foo == 'bar' ? '=${foo}' : b}",
-  //     new TestContext({ foo: "bar", a: true, b: false }),
-  //   )
-  //   expect(res).to.equal("=bar")
-  // })
+  it("should handle a ternary expression with template key values", async () => {
+    const res = await resolveTemplateString(
+      "${foo == 'bar' ? '=${foo}' : b}",
+      new TestContext({ foo: "bar", a: true, b: false })
+    )
+    expect(res).to.equal("=bar")
+  })
 
   it("should handle an expression in parentheses", async () => {
     const res = await resolveTemplateString("${foo || (a > 5)}", new TestContext({ foo: false, a: 10 }))

--- a/garden-service/test/unit/src/util/string.ts
+++ b/garden-service/test/unit/src/util/string.ts
@@ -24,4 +24,9 @@ describe("tailString", () => {
     const str = "1234567\n890"
     expect(tailString(str, 5, true)).to.equal("890")
   })
+
+  it("should trim the last line if it is longer than maxLength and nextLine=true", () => {
+    const str = "123\n4567890"
+    expect(tailString(str, 5, true)).to.equal("67890")
+  })
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously it was not possible to include template strings in literals
within template strings, e.g. nested in a conditional. This could
cause problems if you need to template values differently based on
context (e.g. differently by environments).

You can now make expressions like

`${environment.name == "local" ? "something-${var.local-var}" : "other-${remote-var}"}`

**Special notes for your reviewer**:

Maybe try and break this somehow, see if you can think of any potential funky edge cases.
