### PR TITLE
fix(commands): don't use default port in serve cmd

### DIFF
--- a/garden-service/src/commands/serve.ts
+++ b/garden-service/src/commands/serve.ts
@@ -11,14 +11,13 @@ import { LoggerType } from "../logger/logger"
 import { IntegerParameter, PrepareParams } from "./base"
 import { Command, CommandResult, CommandParams } from "./base"
 import { sleep } from "../util/util"
-import { DEFAULT_PORT, GardenServer, startServer } from "../server/server"
+import { GardenServer, startServer } from "../server/server"
 
 const serveArgs = {}
 
 const serveOpts = {
   port: new IntegerParameter({
     help: `The port number for the Garden service to listen on.`,
-    defaultValue: DEFAULT_PORT,
   }),
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

Before this commit, the `garden serve` command would use `DEFAULT_PORT` as the default value for its `port` option.

If another command was already running and serving on `DEFAULT_PORT` when `garden serve` was called, this would result in an error.

This was fixed by deferring to the standard random port selection logic we use for other commands by skipping the default value for this command option.

**Which issue(s) this PR fixes**:

Fixes #1657.