### PR TITLE
improvement(k8s): default in-cluster registry namespace to project name

### DIFF
--- a/garden-service/src/plugins/kubernetes/kubernetes.ts
+++ b/garden-service/src/plugins/kubernetes/kubernetes.ts
@@ -67,7 +67,9 @@ export async function configureProvider({
       // to make sure every node in the cluster can resolve the image from the registry we deploy in-cluster.
       config.deploymentRegistry = {
         hostname: inClusterRegistryHostname,
-        namespace: config.namespace,
+        // Default to use the project name as the namespace in the in-cluster registry, if none is explicitly
+        // configured. This allows users to share builds for a project.
+        namespace: config.deploymentRegistry?.namespace || projectName,
       }
       config._systemServices.push("docker-registry", "registry-proxy")
     }

--- a/garden-service/test/helpers.ts
+++ b/garden-service/test/helpers.ts
@@ -30,7 +30,7 @@ import { mapValues, fromPairs } from "lodash"
 import { ModuleVersion } from "../src/vcs/vcs"
 import { GARDEN_SERVICE_ROOT, LOCAL_CONFIG_FILENAME } from "../src/constants"
 import { EventBus, Events } from "../src/events"
-import { ValueOf } from "../src/util/util"
+import { ValueOf, exec } from "../src/util/util"
 import { LogEntry } from "../src/logger/log-entry"
 import timekeeper = require("timekeeper")
 import { GLOBAL_OPTIONS, GlobalOptions } from "../src/cli/cli"
@@ -507,10 +507,15 @@ export type TempDirectory = tmp.DirectoryResult
 /**
  * Create a temp directory. Make sure to clean it up after use using the `cleanup()` method on the returned object.
  */
-export async function makeTempDir(): Promise<TempDirectory> {
+export async function makeTempDir({ git = false } = {}): Promise<TempDirectory> {
   const tmpDir = await tmp.dir({ unsafeCleanup: true })
   // Fully resolve path so that we don't get path mismatches in tests
   tmpDir.path = await realpath(tmpDir.path)
+
+  if (git) {
+    await exec("git", ["init"], { cwd: tmpDir.path })
+  }
+
   return tmpDir
 }
 

--- a/garden-service/test/unit/src/plugins/kubernetes/kubernetes.ts
+++ b/garden-service/test/unit/src/plugins/kubernetes/kubernetes.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { configureProvider } from "../../../../../src/plugins/kubernetes/kubernetes"
+import { KubernetesConfig, defaultResources, defaultStorage } from "../../../../../src/plugins/kubernetes/config"
+import { defaultSystemNamespace } from "../../../../../src/plugins/kubernetes/system"
+import { makeDummyGarden } from "../../../../../src/cli/cli"
+import { expect } from "chai"
+import { TempDirectory, makeTempDir } from "../../../../helpers"
+
+describe("kubernetes configureProvider", () => {
+  const basicConfig: KubernetesConfig = {
+    name: "kubernetes",
+    buildMode: "local-docker",
+    context: "my-cluster",
+    defaultHostname: "my.domain.com",
+    forceSsl: false,
+    gardenSystemNamespace: defaultSystemNamespace,
+    imagePullSecrets: [],
+    ingressClass: "nginx",
+    ingressHttpPort: 80,
+    ingressHttpsPort: 443,
+    resources: defaultResources,
+    storage: defaultStorage,
+    registryProxyTolerations: [],
+    tlsCertificates: [],
+    _systemServices: [],
+  }
+
+  let tmpDir: TempDirectory
+
+  beforeEach(async () => {
+    tmpDir = await makeTempDir({ git: true })
+  })
+
+  afterEach(async () => {
+    await tmpDir.cleanup()
+  })
+
+  context("cluster-docker mode", () => {
+    it("should set a default deploymentRegistry with projectName as namespace", async () => {
+      const garden = await makeDummyGarden(tmpDir.path)
+      const config: KubernetesConfig = {
+        ...basicConfig,
+        buildMode: "cluster-docker",
+      }
+
+      const result = await configureProvider({
+        projectName: garden.projectName,
+        projectRoot: garden.projectRoot,
+        config,
+        log: garden.log,
+        dependencies: [],
+        configStore: garden.configStore,
+      })
+
+      expect(result.config.deploymentRegistry).to.eql({
+        hostname: "127.0.0.1:5000",
+        namespace: garden.projectName,
+      })
+    })
+
+    it("should allow overriding the deploymentRegistry namespace for the in-cluster registry", async () => {
+      const garden = await makeDummyGarden(tmpDir.path)
+      const config: KubernetesConfig = {
+        ...basicConfig,
+        buildMode: "cluster-docker",
+        deploymentRegistry: {
+          hostname: "127.0.0.1:5000",
+          namespace: "my-namespace",
+        },
+      }
+
+      const result = await configureProvider({
+        projectName: garden.projectName,
+        projectRoot: garden.projectRoot,
+        config,
+        log: garden.log,
+        dependencies: [],
+        configStore: garden.configStore,
+      })
+
+      expect(result.config.deploymentRegistry).to.eql({
+        hostname: "127.0.0.1:5000",
+        namespace: "my-namespace",
+      })
+    })
+  })
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

This means that by default builds are shared between users when sharing
a cluster. Image _layers_ were anyway shared, but this change will
accelerate builds and tests through reducing the number of steps
involved when all layers already exist.

Co-authored-by: swist <me@swistofon.pl>

**Which issue(s) this PR fixes**:

Closes #1649 

cc @swist
