### PR TITLE
fix: bubble exec error

### DIFF
--- a/garden-service/src/plugins/kubernetes/container/build.ts
+++ b/garden-service/src/plugins/kubernetes/container/build.ts
@@ -92,7 +92,7 @@ const getRemoteBuildStatus: BuildStatusHandler = async (params) => {
   const pushArgs = ["/bin/sh", "-c", "DOCKER_CLI_EXPERIMENTAL=enabled docker " + args.join(" ")]
 
   const podName = await getBuilderPodName(provider, log)
-  const res = await execInBuilder({ provider, log, args: pushArgs, timeout: 300, podName, ignoreError: true })
+  const res = await execInBuilder({ provider, log, args: pushArgs, timeout: 300, podName, ignoreError: false })
 
   return { ready: res.exitCode === 0 }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

When attempting to inspect an image to see if it exists, if there is an auth issue (or any other issue), this silently fails the build continues. It's probably best to blow up with the exception so the user can deal with it.

**Which issue(s) this PR fixes**:

No issue filed for this, just a slack discussion [here](https://kubernetes.slack.com/archives/CKM7CP8P9/p1583679776335800?thread_ts=1583603497.309500&cid=CKM7CP8P9)

An example error looks like:
```
Failed building packages. Here is the output:
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Command "/Users/foo/.garden/tools/kubectl/b57d7033ebdf2a5a/kubectl --context=storks-develop --namespace=garden-system exec -i garden-docker-daemon-fc9bb476d-qwvjq -c docker-daemon -- /bin/sh -c DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect <ECR_HOST>/garden/packages:v-version_number" failed with code 1:

Get https://<ECR_HOST>/garden/packages/manifests/v-version_number: no basic auth credentials
command terminated with exit code 1
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

✖ tasks                     → Failed task build.packages.39163c00-615e-11ea-bf40-7d0637cbb4ee
ℹ Remaining tasks 0
ℹ Remaining tasks 0
1 build task(s) failed!
```

@edvald 