### PR TITLE
fix(k8s): issues with private registry auth and kaniko build status

### DIFF
--- a/garden-service/test/integ/src/plugins/kubernetes/container/build.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/container/build.ts
@@ -278,6 +278,25 @@ describe("kubernetes build flow", () => {
       })
     })
 
+    it("should get the build status from the registry", async () => {
+      const module = await graph.getModule("simple-service")
+      await garden.buildDir.syncFromSrc(module, garden.log)
+
+      await k8sBuildContainer({
+        ctx,
+        log: garden.log,
+        module,
+      })
+
+      const status = await k8sGetContainerBuildStatus({
+        ctx,
+        log: garden.log,
+        module,
+      })
+
+      expect(status.ready).to.be.true
+    })
+
     it("should support pulling from private registries (remote only)", async () => {
       const module = await graph.getModule("private-base")
       await garden.buildDir.syncFromSrc(module, garden.log)
@@ -321,6 +340,25 @@ describe("kubernetes build flow", () => {
         log: garden.log,
         module,
       })
+    })
+
+    it("should get the build status from the registry (remote only)", async () => {
+      const module = await graph.getModule("remote-registry-test")
+      await garden.buildDir.syncFromSrc(module, garden.log)
+
+      await k8sBuildContainer({
+        ctx,
+        log: garden.log,
+        module,
+      })
+
+      const status = await k8sGetContainerBuildStatus({
+        ctx,
+        log: garden.log,
+        module,
+      })
+
+      expect(status.ready).to.be.true
     })
   })
 })

--- a/images/skopeo/Dockerfile
+++ b/images/skopeo/Dockerfile
@@ -1,0 +1,1 @@
+FROM danifernandezs/skopeo:1.41.0-alpine3.10.3

--- a/images/skopeo/garden.yml
+++ b/images/skopeo/garden.yml
@@ -1,0 +1,6 @@
+kind: Module
+type: container
+name: skopeo
+description: Used by the kubernetes provider for interacting with container registries within a cluster
+image: gardendev/skopeo:1.41.0
+dockerfile: Dockerfile


### PR DESCRIPTION
**What this PR does / why we need it**:

We now use skopeo (https://github.com/containers/skopeo) to get build
status when using Kaniko. Previously the build status was reported as not
ready without an error, even when auth was missing or failed.

**Which issue(s) this PR fixes**:

Fixes #1672 

**Special notes for your reviewer**:

cc @mitchfriedman @swist 
