### PR TITLE
chore(ci): reduce container size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ orbs:
         environment:
           <<: *shared-env-config
           GARDEN_TASK_CONCURRENCY_LIMIT: "10"
-    resource_class: large
+    resource_class: medium
 
   # Configuration for release jobs
   release-config: &release-config


### PR DESCRIPTION
The larger container size doesn't appear to give us much in the way of performance, so this'll save a bit of money.