### PR TITLE
fix(core): improved circular dependency detection

### DIFF
--- a/garden-service/test/unit/src/garden.ts
+++ b/garden-service/test/unit/src/garden.ts
@@ -561,7 +561,8 @@ describe("Garden", () => {
           () => garden.getPlugins(),
           (err) =>
             expect(err.message).to.equal(deline`
-          Found circular dependency between module type bases (defined in plugin(s) 'foo'): foo -> bar -> foo
+          Found circular dependency between module type
+          bases:\n\nfoo (from plugin foo) <- bar (from plugin foo) <- foo (from plugin foo)
           `)
         )
       })
@@ -884,7 +885,7 @@ describe("Garden", () => {
         await expectError(
           () => garden.getPlugins(),
           (err) =>
-            expect(err.message).to.equal("Found a circular dependency between registered plugins: foo -> bar -> foo")
+            expect(err.message).to.equal("Found a circular dependency between registered plugins:\n\nfoo <- bar <- foo")
         )
       })
 
@@ -1252,7 +1253,7 @@ describe("Garden", () => {
             () => garden.getPlugins(),
             (err) =>
               expect(err.message).to.equal(
-                "Found a circular dependency between registered plugins: base-a -> foo -> base-b -> base-a"
+                "Found a circular dependency between registered plugins:\n\nbase-a <- foo <- base-b <- base-a"
               )
           )
         })
@@ -1482,7 +1483,7 @@ describe("Garden", () => {
         () => garden.resolveProviders(),
         (err) =>
           expect(err.message).to.equal(
-            "Found a circular dependency between registered plugins: test-a -> test-b -> test-a"
+            "Found a circular dependency between registered plugins:\n\ntest-a <- test-b <- test-a"
           )
       )
     })
@@ -1510,7 +1511,7 @@ describe("Garden", () => {
       await expectError(
         () => garden.resolveProviders(),
         (err) =>
-          expect(err.message).to.equal("Found a circular dependency between registered plugins: test-a -> test-a")
+          expect(err.message).to.equal("Found a circular dependency between registered plugins:\n\ntest-a <- test-a")
       )
     })
 
@@ -1543,10 +1544,9 @@ describe("Garden", () => {
       await expectError(
         () => garden.resolveProviders(),
         (err) =>
-          expect(err.message).to.equal(
-            "One or more circular dependencies found between providers " +
-              "or their configurations: test-a <- test-b <- test-a"
-          )
+          expect(err.message).to.equal(deline`
+            One or more circular dependencies found between providers or their configurations:\n\ntest-a <- test-b <- test-a
+          `)
       )
     })
 
@@ -1578,10 +1578,10 @@ describe("Garden", () => {
       await expectError(
         () => garden.resolveProviders(),
         (err) =>
-          expect(err.message).to.equal(
-            "One or more circular dependencies found between providers " +
-              "or their configurations: test-b <- test-a <- test-b"
-          )
+          expect(err.message).to.equal(deline`
+            One or more circular dependencies found between providers or their
+            configurations:\n\ntest-a <- test-b <- test-a
+          `)
       )
     })
 

--- a/garden-service/test/unit/src/task-graph.ts
+++ b/garden-service/test/unit/src/task-graph.ts
@@ -14,12 +14,13 @@ import { TaskGraph, TaskResult, TaskResults } from "../../../src/task-graph"
 import { makeTestGarden, freezeTime, dataDir, expectError, TestGarden } from "../../helpers"
 import { Garden } from "../../../src/garden"
 import { deepFilter, defer, sleep, uuidv4 } from "../../../src/util/util"
+import { DependencyValidationGraph } from "../../../src/util/validate-dependencies"
 
 const projectRoot = join(dataDir, "test-project-empty")
 
-type TestTaskCallback = (name: string, result: any) => Promise<void>
+export type TestTaskCallback = (name: string, result: any) => Promise<void>
 
-interface TestTaskOptions {
+export interface TestTaskOptions {
   callback?: TestTaskCallback
   dependencies?: BaseTask[]
   versionString?: string
@@ -27,7 +28,7 @@ interface TestTaskOptions {
   throwError?: boolean
 }
 
-class TestTask extends BaseTask {
+export class TestTask extends BaseTask {
   type: TaskType = "test"
   name: string
   callback: TestTaskCallback | null
@@ -160,8 +161,19 @@ describe("task-graph", () => {
       ])
     })
 
-    it.skip("should throw if tasks have circular dependencies", async () => {
-      throw new Error("TODO")
+    it("should throw if tasks have circular dependencies", async () => {
+      const garden = await getGarden()
+      const graph = new TaskGraph(garden, garden.log)
+      const taskA = new TestTask(garden, "a", false)
+      const taskB = new TestTask(garden, "b", false, { dependencies: [taskA] })
+      const taskC = new TestTask(garden, "c", false, { dependencies: [taskB] })
+      taskA["dependencies"] = [taskC]
+      const errorMsg = "\nCircular task dependencies detected:\n\nb <- a <- c <- b\n"
+
+      await expectError(
+        () => graph.process([taskB]),
+        (err) => expect(err.message).to.eql(errorMsg)
+      )
     })
 
     it("should emit events when processing and completing a task", async () => {
@@ -831,7 +843,8 @@ describe("task-graph", () => {
         const taskC = new TestTask(garden, "c", false)
 
         const tasks = [taskA, taskB, taskC, taskADep1, taskBDep, taskADep2]
-        const taskNodes = await graph.nodesWithDependencies(tasks, false)
+        const validationGraph = new DependencyValidationGraph()
+        const taskNodes = await graph.nodesWithDependencies(tasks, validationGraph, false)
         const batches = graph.partition(taskNodes, { unlimitedConcurrency: false })
         const batchKeys = batches.map((b) => b.nodes.map((n) => n.getKey()))
 
@@ -876,7 +889,8 @@ describe("task-graph", () => {
           taskC,
         ]
 
-        const taskNodes = await graph.nodesWithDependencies(tasks, false)
+        const validationGraph = new DependencyValidationGraph()
+        const taskNodes = await graph.nodesWithDependencies(tasks, validationGraph, false)
         const batches = graph.partition(taskNodes, { unlimitedConcurrency: false })
         const batchKeys = batches.map((b) => b.nodes.map((n) => n.getKey()))
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We now detect circular dependencies in `ConfigGraph` after the graph has been augmented, possibly catching more circular dependencies.

Also added circular task dependency detection to `TaskGraph`.

We also use the new `DependencyValidationGraph` class everywhere we need to detect circular dependencies, e.g. when detecting circular plugin/plugin module dependencies.

**Which issue(s) this PR fixes**:

Some users have run into difficult-to-debug errors that seem to stem from circular config/task dependencies. Hopefully these changes will help quickly diagnose such errors.