### PR TITLE
chore: Bump kaniko version to 0.19.0

### DIFF
--- a/garden-service/src/plugins/kubernetes/container/build.ts
+++ b/garden-service/src/plugins/kubernetes/container/build.ts
@@ -35,8 +35,10 @@ import chalk = require("chalk")
 
 const dockerDaemonDeploymentName = "garden-docker-daemon"
 const dockerDaemonContainerName = "docker-daemon"
-const kanikoImage = "gcr.io/kaniko-project/executor:debug-v0.17.1"
+
+const kanikoImage = "gcr.io/kaniko-project/executor:debug-v0.19.0"
 const skopeoImage = "gardendev/skopeo:1.41.0-1"
+
 const registryPort = 5000
 
 export const buildSyncDeploymentName = "garden-build-sync"


### PR DESCRIPTION
This fixes a few hairy things around dockerfiles not
being handled isomorphically to docker daemon.

We have had a few issues since 0.17 release and 
had figured out a few workarounds, but this claims
to fix those issues proper. Means our future modules
will require less oversight