### PR TITLE
chore(ci): store dist artifacts after CI runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,9 @@ commands:
           root: ./
           paths:
             - garden-service/dist/
+      - store_artifacts:
+          path: garden-service/dist
+          destination: dist
 #
 # Jobs section
 #


### PR DESCRIPTION
**What this PR does / why we need it**:

It's handy to be able to get dist builds after any CI build. Now we can fetch them from CircleCI.
