### PR TITLE
improvement(k8s): add default tolerations to system services

### DIFF
--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -238,6 +238,12 @@ providers:
       # for now).
       acmeChallengeType: HTTP-01
 
+    # Exposes the `nodeSelector` field on the PodSpec of system services. This allows you to constrain
+    # the system services to only run on particular nodes. [See
+    # here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) for the official Kubernetes guide to
+    # assigning Pods to nodes.
+    systemNodeSelector: {}
+
     # For setting tolerations on the registry-proxy when using in-cluster building.
     # The registry-proxy is a DaemonSet that proxies connections to the docker registry service on each node.
     #
@@ -1202,6 +1208,25 @@ providers:
   - certManager:
       ...
       acmeChallengeType: "HTTP-01"
+```
+
+### `providers[].systemNodeSelector`
+
+[providers](#providers) > systemNodeSelector
+
+Exposes the `nodeSelector` field on the PodSpec of system services. This allows you to constrain
+the system services to only run on particular nodes. [See here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) for the official Kubernetes guide to assigning Pods to nodes.
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `object` | `{}`    | No       |
+
+Example:
+
+```yaml
+providers:
+  - systemNodeSelector:
+        disktype: ssd
 ```
 
 ### `providers[].registryProxyTolerations[]`

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -234,6 +234,12 @@ providers:
       # for now).
       acmeChallengeType: HTTP-01
 
+    # Exposes the `nodeSelector` field on the PodSpec of system services. This allows you to constrain
+    # the system services to only run on particular nodes. [See
+    # here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) for the official Kubernetes guide to
+    # assigning Pods to nodes.
+    systemNodeSelector: {}
+
     # For setting tolerations on the registry-proxy when using in-cluster building.
     # The registry-proxy is a DaemonSet that proxies connections to the docker registry service on each node.
     #
@@ -1170,6 +1176,25 @@ providers:
   - certManager:
       ...
       acmeChallengeType: "HTTP-01"
+```
+
+### `providers[].systemNodeSelector`
+
+[providers](#providers) > systemNodeSelector
+
+Exposes the `nodeSelector` field on the PodSpec of system services. This allows you to constrain
+the system services to only run on particular nodes. [See here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) for the official Kubernetes guide to assigning Pods to nodes.
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `object` | `{}`    | No       |
+
+Example:
+
+```yaml
+providers:
+  - systemNodeSelector:
+        disktype: ssd
 ```
 
 ### `providers[].registryProxyTolerations[]`

--- a/garden-service/package-lock.json
+++ b/garden-service/package-lock.json
@@ -5600,8 +5600,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -5622,14 +5621,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -5644,20 +5641,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -5774,8 +5768,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -5787,7 +5780,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -5802,7 +5794,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -5810,14 +5801,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -5836,7 +5825,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -5917,8 +5905,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -5930,7 +5917,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -6016,8 +6002,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -6053,7 +6038,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -6073,7 +6057,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -6117,14 +6100,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -11380,8 +11361,7 @@
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
     },
     "slice-ansi": {
       "version": "3.0.0",

--- a/garden-service/package.json
+++ b/garden-service/package.json
@@ -107,6 +107,7 @@
     "recursive-readdir": "^2.2.2",
     "request": "^2.88.2",
     "request-promise": "^4.2.5",
+    "slash": "^3.0.0",
     "source-map-support": "^0.5.16",
     "split": "^1.0.1",
     "split2": "^3.1.1",

--- a/garden-service/src/plugins/conftest/conftest-kubernetes.ts
+++ b/garden-service/src/plugins/conftest/conftest-kubernetes.ts
@@ -7,6 +7,7 @@
  */
 
 import Bluebird from "bluebird"
+import slash from "slash"
 import { createGardenPlugin } from "../../types/plugin/plugin"
 import { ConftestProvider } from "./conftest"
 import { relative, resolve } from "path"
@@ -65,7 +66,8 @@ export const gardenPlugin = createGardenPlugin({
             ? [".rendered.yaml"]
             : module.include || ["*.yaml", "**/*.yaml", "*.yml", "**/*.yml"]
 
-          const policyPath = relative(module.path, resolve(ctx.projectRoot, provider.config.policyPath))
+          // Make sure the policy path is valid POSIX on Windows
+          const policyPath = slash(relative(module.path, resolve(ctx.projectRoot, provider.config.policyPath)))
 
           return {
             kind: "Module",

--- a/garden-service/src/plugins/conftest/conftest.ts
+++ b/garden-service/src/plugins/conftest/conftest.ts
@@ -20,7 +20,7 @@ import { matchGlobs, listDirectory } from "../../util/fs"
 import { PluginError } from "../../exceptions"
 import { getModuleTypeUrl, getGitHubUrl, getProviderUrl } from "../../docs/common"
 
-interface ConftestProviderConfig extends ProviderConfig {
+export interface ConftestProviderConfig extends ProviderConfig {
   policyPath: string
   namespace?: string
   testFailureThreshold: "deny" | "warn" | "none"

--- a/garden-service/src/plugins/conftest/conftest.ts
+++ b/garden-service/src/plugins/conftest/conftest.ts
@@ -19,6 +19,7 @@ import { baseBuildSpecSchema } from "../../config/module"
 import { matchGlobs, listDirectory } from "../../util/fs"
 import { PluginError } from "../../exceptions"
 import { getModuleTypeUrl, getGitHubUrl, getProviderUrl } from "../../docs/common"
+import slash from "slash"
 
 export interface ConftestProviderConfig extends ProviderConfig {
   policyPath: string
@@ -135,7 +136,8 @@ export const gardenPlugin = createGardenPlugin({
           const provider = ctx.provider as ConftestProvider
 
           const defaultPolicyPath = relative(module.path, resolve(ctx.projectRoot, provider.config.policyPath))
-          const policyPath = resolve(module.path, module.spec.policyPath || defaultPolicyPath)
+          // Make sure the policy path is valid POSIX on Windows
+          const policyPath = slash(resolve(module.path, module.spec.policyPath || defaultPolicyPath))
           const namespace = module.spec.namespace || provider.config.namespace
 
           const buildPath = module.spec.sourceModule

--- a/garden-service/src/plugins/kubernetes/config.ts
+++ b/garden-service/src/plugins/kubernetes/config.ts
@@ -25,6 +25,7 @@ import { hotReloadableKinds, HotReloadableKind } from "./hot-reload"
 import { baseTaskSpecSchema, BaseTaskSpec, cacheResultSchema } from "../../config/task"
 import { baseTestSpecSchema, BaseTestSpec } from "../../config/test"
 import { ArtifactSpec } from "../../config/validation"
+import { V1Toleration } from "@kubernetes/client-node"
 
 export interface ProviderSecretRef {
   name: string
@@ -80,14 +81,6 @@ interface KubernetesStorage {
   sync: KubernetesStorageSpec
 }
 
-export interface Toleration {
-  effect?: "NoSchedule" | "PreferNoSchedule" | "NoExecute"
-  key?: string
-  operator: "Exists" | "Equal"
-  tolerationSeconds?: number
-  value?: string
-}
-
 export type ContainerBuildMode = "local-docker" | "cluster-docker" | "kaniko"
 
 export type DefaultDeploymentStrategy = "rolling"
@@ -110,7 +103,7 @@ export interface KubernetesConfig extends ProviderConfig {
   ingressClass?: string
   kubeconfig?: string
   namespace?: string
-  registryProxyTolerations: Toleration[]
+  registryProxyTolerations: V1Toleration[]
   resources: KubernetesResources
   storage: KubernetesStorage
   gardenSystemNamespace: string

--- a/garden-service/src/plugins/kubernetes/config.ts
+++ b/garden-service/src/plugins/kubernetes/config.ts
@@ -8,7 +8,7 @@
 
 import dedent = require("dedent")
 
-import { joiArray, joiIdentifier, joiProviderName, joi } from "../../config/common"
+import { joiArray, joiIdentifier, joiProviderName, joi, joiStringMap } from "../../config/common"
 import { Provider, providerConfigBaseSchema, ProviderConfig } from "../../config/provider"
 import {
   containerRegistryConfigSchema,
@@ -104,6 +104,7 @@ export interface KubernetesConfig extends ProviderConfig {
   kubeconfig?: string
   namespace?: string
   registryProxyTolerations: V1Toleration[]
+  systemNodeSelector: { [key: string]: string }
   resources: KubernetesResources
   storage: KubernetesStorage
   gardenSystemNamespace: string
@@ -484,6 +485,15 @@ export const kubernetesConfigBase = providerConfigBaseSchema().keys({
     }).description(dedent`cert-manager configuration, for creating and managing TLS certificates. See the
         [cert-manager guide](https://docs.garden.io/advanced/cert-manager-integration) for details.`),
   _systemServices: joiArray(joiIdentifier()).meta({ internal: true }),
+  systemNodeSelector: joiStringMap(joi.string())
+    .description(
+      dedent`
+      Exposes the \`nodeSelector\` field on the PodSpec of system services. This allows you to constrain
+      the system services to only run on particular nodes. [See here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) for the official Kubernetes guide to assigning Pods to nodes.
+    `
+    )
+    .example({ disktype: "ssd" })
+    .default(() => ({})),
   registryProxyTolerations: joiArray(
     joi.object().keys({
       effect: joi.string().allow("NoSchedule", "PreferNoSchedule", "NoExecute").description(dedent`

--- a/garden-service/src/plugins/kubernetes/init.ts
+++ b/garden-service/src/plugins/kubernetes/init.ts
@@ -34,7 +34,7 @@ import { ConfigurationError } from "../../exceptions"
 import Bluebird from "bluebird"
 import { readSecret } from "./secrets"
 import { dockerAuthSecretName, dockerAuthSecretKey } from "./constants"
-import { V1Secret } from "@kubernetes/client-node"
+import { V1Secret, V1Toleration } from "@kubernetes/client-node"
 import { KubernetesResource } from "./types"
 import { compareDeployedResources } from "./status/status"
 import { PrimitiveMap } from "../../config/common"
@@ -418,6 +418,15 @@ export function getKubernetesSystemVariables(config: KubernetesConfig) {
   const nfsStorageClass = getNfsStorageClass(config)
   const syncStorageClass = config.storage.sync.storageClass || nfsStorageClass
   const systemNamespace = config.gardenSystemNamespace
+  const systemTolerations: V1Toleration[] = [
+    {
+      key: "garden-system",
+      operator: "Equal",
+      value: "true",
+      effect: "NoSchedule",
+    },
+  ]
+  const registryProxyTolerations = config.registryProxyTolerations || systemTolerations
 
   return {
     "namespace": systemNamespace,
@@ -454,9 +463,8 @@ export function getKubernetesSystemVariables(config: KubernetesConfig) {
     "sync-storage-class": syncStorageClass,
     "sync-volume-name": `garden-sync-${syncStorageClass}`,
 
-    // Stringifying the tolerations since variable values should be primitives.
-    // Helm handles the decoding automatically.
-    "registry-proxy-tolerations": JSON.stringify(config.registryProxyTolerations),
+    "registry-proxy-tolerations": <PrimitiveMap[]>registryProxyTolerations,
+    "system-tolerations": <PrimitiveMap[]>systemTolerations,
   }
 }
 

--- a/garden-service/src/plugins/kubernetes/init.ts
+++ b/garden-service/src/plugins/kubernetes/init.ts
@@ -465,6 +465,7 @@ export function getKubernetesSystemVariables(config: KubernetesConfig) {
 
     "registry-proxy-tolerations": <PrimitiveMap[]>registryProxyTolerations,
     "system-tolerations": <PrimitiveMap[]>systemTolerations,
+    "system-node-selector": config.systemNodeSelector,
   }
 }
 

--- a/garden-service/src/plugins/kubernetes/system.ts
+++ b/garden-service/src/plugins/kubernetes/system.ts
@@ -21,11 +21,12 @@ import { deline, gardenAnnotationKey } from "../../util/string"
 import { deleteNamespaces } from "./namespace"
 import { PluginError } from "../../exceptions"
 import { DashboardPage } from "../../config/status"
-import { PrimitiveMap } from "../../config/common"
+import { DeepPrimitiveMap } from "../../config/common"
 import { combineStates } from "../../types/service"
 import { KubernetesResource } from "./types"
 import { defaultDotIgnoreFiles } from "../../util/fs"
 import { LogLevel } from "../../logger/log-node"
+import { ConftestProviderConfig } from "../conftest/conftest"
 
 const GARDEN_VERSION = getPackageVersion()
 const SYSTEM_NAMESPACE_MIN_VERSION = "0.9.0"
@@ -46,10 +47,17 @@ export function getSystemMetadataNamespaceName(config: KubernetesConfig) {
  */
 export async function getSystemGarden(
   ctx: KubernetesPluginContext,
-  variables: PrimitiveMap,
+  variables: DeepPrimitiveMap,
   log: LogEntry
 ): Promise<Garden> {
   const systemNamespace = await getSystemNamespace(ctx.provider, log)
+
+  const conftest: ConftestProviderConfig = {
+    environments: ["default"],
+    name: "conftest-kubernetes",
+    policyPath: "./policy",
+    testFailureThreshold: "warn",
+  }
 
   const sysProvider: KubernetesConfig = {
     ...ctx.provider.config,
@@ -71,7 +79,7 @@ export async function getSystemGarden(
       defaultEnvironment: "default",
       dotIgnoreFiles: defaultDotIgnoreFiles,
       environments: [{ name: "default", variables: {} }],
-      providers: [sysProvider],
+      providers: [sysProvider, conftest],
       variables,
     },
     commandInfo: ctx.command,

--- a/garden-service/src/plugins/kubernetes/system.ts
+++ b/garden-service/src/plugins/kubernetes/system.ts
@@ -55,7 +55,7 @@ export async function getSystemGarden(
   const conftest: ConftestProviderConfig = {
     environments: ["default"],
     name: "conftest-kubernetes",
-    policyPath: "./policy",
+    policyPath: "policy",
     testFailureThreshold: "warn",
   }
 

--- a/garden-service/src/runtime-context.ts
+++ b/garden-service/src/runtime-context.ts
@@ -14,6 +14,7 @@ import { ConfigGraph, DependencyRelations } from "./config-graph"
 import { ServiceStatus } from "./types/service"
 import { RunTaskResult } from "./types/plugin/task/runTask"
 import { joiArray } from "./config/common"
+import { isPrimitive } from "util"
 
 interface RuntimeDependency {
   moduleName: string
@@ -92,9 +93,13 @@ export async function prepareRuntimeContext({
     GARDEN_VERSION: versionString,
   }
 
+  // DEPRECATED: Remove in v0.12
   for (const [key, value] of Object.entries(garden.variables)) {
-    const envVarName = `GARDEN_VARIABLES_${getEnvVarName(key)}`
-    envVars[envVarName] = value
+    // Only store primitive values, objects and arrays cause issues further down.
+    if (isPrimitive(value)) {
+      const envVarName = `GARDEN_VARIABLES_${getEnvVarName(key)}`
+      envVars[envVarName] = value
+    }
   }
 
   const result: RuntimeContext = {

--- a/garden-service/static/kubernetes/system/build-sync/garden.yml
+++ b/garden-service/static/kubernetes/system/build-sync/garden.yml
@@ -21,3 +21,4 @@ values:
   pvc:
     name: ${var.sync-volume-name}
   tolerations: ${var.system-tolerations}
+  nodeSelector: ${var.system-node-selector}

--- a/garden-service/static/kubernetes/system/build-sync/garden.yml
+++ b/garden-service/static/kubernetes/system/build-sync/garden.yml
@@ -20,3 +20,4 @@ values:
     storageClass: ${var.sync-storage-class}
   pvc:
     name: ${var.sync-volume-name}
+  tolerations: ${var.system-tolerations}

--- a/garden-service/static/kubernetes/system/docker-daemon/garden.yml
+++ b/garden-service/static/kubernetes/system/docker-daemon/garden.yml
@@ -24,3 +24,4 @@ values:
     volume:
       name: ${var.sync-volume-name}
   tolerations: ${var.system-tolerations}
+  nodeSelector: ${var.system-node-selector}

--- a/garden-service/static/kubernetes/system/docker-daemon/garden.yml
+++ b/garden-service/static/kubernetes/system/docker-daemon/garden.yml
@@ -23,3 +23,4 @@ values:
   buildSync:
     volume:
       name: ${var.sync-volume-name}
+  tolerations: ${var.system-tolerations}

--- a/garden-service/static/kubernetes/system/docker-registry/garden.yml
+++ b/garden-service/static/kubernetes/system/docker-registry/garden.yml
@@ -26,3 +26,4 @@ values:
     size: ${var.registry-storage-size}
     storageClass: ${var.registry-storage-class}
     deleteEnabled: true
+  tolerations: ${var.system-tolerations}

--- a/garden-service/static/kubernetes/system/docker-registry/garden.yml
+++ b/garden-service/static/kubernetes/system/docker-registry/garden.yml
@@ -27,3 +27,4 @@ values:
     storageClass: ${var.registry-storage-class}
     deleteEnabled: true
   tolerations: ${var.system-tolerations}
+  nodeSelector: ${var.system-node-selector}

--- a/garden-service/static/kubernetes/system/ingress-controller/garden.yml
+++ b/garden-service/static/kubernetes/system/ingress-controller/garden.yml
@@ -25,5 +25,6 @@ values:
       omitClusterIP: true
     minReadySeconds: 1
     tolerations: ${var.system-tolerations}
+    nodeSelector: ${var.system-node-selector}
   defaultBackend:
     enabled: false

--- a/garden-service/static/kubernetes/system/ingress-controller/garden.yml
+++ b/garden-service/static/kubernetes/system/ingress-controller/garden.yml
@@ -24,5 +24,6 @@ values:
     service:
       omitClusterIP: true
     minReadySeconds: 1
+    tolerations: ${var.system-tolerations}
   defaultBackend:
     enabled: false

--- a/garden-service/static/kubernetes/system/nfs-provisioner/garden.yml
+++ b/garden-service/static/kubernetes/system/nfs-provisioner/garden.yml
@@ -13,3 +13,4 @@ values:
   storageClass:
     name: ${var.sync-storage-class}
   tolerations: ${var.system-tolerations}
+  nodeSelector: ${var.system-node-selector}

--- a/garden-service/static/kubernetes/system/nfs-provisioner/garden.yml
+++ b/garden-service/static/kubernetes/system/nfs-provisioner/garden.yml
@@ -12,3 +12,4 @@ values:
     storageClass: ${var.nfs-storage-class}
   storageClass:
     name: ${var.sync-storage-class}
+  tolerations: ${var.system-tolerations}

--- a/garden-service/static/kubernetes/system/policy/base_test.rego
+++ b/garden-service/static/kubernetes/system/policy/base_test.rego
@@ -1,0 +1,31 @@
+package main
+
+empty(value) {
+  count(value) == 0
+}
+
+no_violations {
+  empty(deny)
+}
+
+no_warnings {
+  empty(warn)
+}
+
+test_deployment_without_security_context {
+  deny["Containers must not run as root in Deployment sample"] with input as {"kind": "Deployment", "metadata": { "name": "sample" }}
+}
+
+test_deployment_with_security_context {
+  no_violations with input as {"kind": "Deployment", "metadata": {"name": "sample"}, "spec": {
+    "selector": { "matchLabels": { "app": "something", "release": "something" }},
+    "template": { "spec": { "securityContext": { "runAsNonRoot": true  }}}}}
+}
+
+test_services_not_denied {
+  no_violations with input as {"kind": "Service", "metadata": { "name": "sample" }}
+}
+
+test_services_issue_warning {
+  warn["Found service sample but services are not allowed"] with input as {"kind": "Service", "metadata": { "name": "sample" }}
+}

--- a/garden-service/static/kubernetes/system/policy/deny.rego
+++ b/garden-service/static/kubernetes/system/policy/deny.rego
@@ -1,0 +1,18 @@
+package main
+
+import data.kubernetes
+
+name = input.metadata.name
+
+deny[msg] {
+  kubernetes.is_deployment
+  toleration := {
+    "key": "garden-system",
+    "operator": "Equal",
+    "value": "true",
+    "effect": "NoSchedule",
+  }
+  input.spec.template.spec.tolerations[_] != toleration
+
+  msg = sprintf("Deployment %s is missing toleration of kind %v", [name, toleration])
+}

--- a/garden-service/static/kubernetes/system/policy/kubernetes.rego
+++ b/garden-service/static/kubernetes/system/policy/kubernetes.rego
@@ -1,0 +1,9 @@
+package kubernetes
+
+is_service {
+  input.kind = "Service"
+}
+
+is_deployment {
+  input.kind = "Deployment"
+}

--- a/garden-service/static/kubernetes/system/policy/labels.rego
+++ b/garden-service/static/kubernetes/system/policy/labels.rego
@@ -1,0 +1,21 @@
+package main
+
+import data.kubernetes
+
+name = input.metadata.name
+
+# TODO: Re-enable this policy (or some version thereof)
+# labels {
+#     input.metadata.labels["app.kubernetes.io/name"]
+#     input.metadata.labels["app.kubernetes.io/instance"]
+#     input.metadata.labels["app.kubernetes.io/version"]
+#     input.metadata.labels["app.kubernetes.io/component"]
+#     input.metadata.labels["app.kubernetes.io/part-of"]
+#     input.metadata.labels["app.kubernetes.io/managed-by"]
+# }
+#
+# deny[msg] {
+#   kubernetes.is_deployment
+#   not labels
+#   msg = sprintf("%s must include Kubernetes recommended labels: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels ", [name])
+# }

--- a/garden-service/static/kubernetes/system/policy/warn.rego
+++ b/garden-service/static/kubernetes/system/policy/warn.rego
@@ -1,0 +1,6 @@
+package main
+
+import data.kubernetes
+
+name = input.metadata.name
+

--- a/garden-service/static/kubernetes/system/registry-proxy/templates/daemonset.yaml
+++ b/garden-service/static/kubernetes/system/registry-proxy/templates/daemonset.yaml
@@ -51,7 +51,7 @@ spec:
     {{- with .Values.tolerations }}
       # Note that we're not using the toYAML function here because the tolerations are JSON stringified (by Garden)
       tolerations:
-        {{- . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
     {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/garden-service/test/integ/src/plugins/kubernetes/system.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/system.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Garden } from "../../../../../src/garden"
+import { Provider } from "../../../../../src/config/provider"
+import { KubernetesConfig, KubernetesPluginContext } from "../../../../../src/plugins/kubernetes/config"
+import { getDataDir, makeTestGarden } from "../../../../helpers"
+import { expect } from "chai"
+import { TestTask } from "../../../../../src/tasks/test"
+import { getSystemGarden } from "../../../../../src/plugins/kubernetes/system"
+import { getKubernetesSystemVariables } from "../../../../../src/plugins/kubernetes/init"
+import Bluebird = require("bluebird")
+
+describe("System services", () => {
+  let garden: Garden
+  let provider: Provider<KubernetesConfig>
+
+  before(async () => {
+    const root = getDataDir("test-projects", "container")
+    garden = await makeTestGarden(root)
+    provider = (await garden.resolveProvider("local-kubernetes")) as Provider<KubernetesConfig>
+  })
+
+  after(async () => {
+    await garden.close()
+  })
+
+  it("should use conftest to check whether system services have a valid config", async () => {
+    const ctx = <KubernetesPluginContext>garden.getPluginContext(provider)
+    const variables = getKubernetesSystemVariables(provider.config)
+    const systemGarden = await getSystemGarden(ctx, variables, garden.log)
+    const graph = await systemGarden.getConfigGraph(garden.log)
+    const modules = (await graph.getModules()).filter((module) => module.name.startsWith("conftest-"))
+
+    await Bluebird.map(modules, async (module) => {
+      const testTask = new TestTask({
+        garden: systemGarden,
+        module,
+        log: garden.log,
+        graph,
+        testConfig: module.testConfigs[0] || {},
+        force: true,
+        forceBuild: true,
+        version: module.version,
+        _guard: true,
+      })
+      const key = testTask.getKey()
+      const result = await systemGarden.processTasks([testTask])
+      expect(result[key]).to.exist
+      expect(result[key]?.error).to.not.exist
+    })
+  })
+})

--- a/garden-service/test/integ/src/plugins/kubernetes/system.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/system.ts
@@ -35,6 +35,24 @@ describe("System services", () => {
     const variables = getKubernetesSystemVariables(provider.config)
     const systemGarden = await getSystemGarden(ctx, variables, garden.log)
     const graph = await systemGarden.getConfigGraph(garden.log)
+    const conftestModuleNames = (await graph.getModules())
+      .filter((module) => module.name.startsWith("conftest-"))
+      .map((m) => m.name)
+    expect(conftestModuleNames.sort()).to.eql([
+      "conftest-build-sync",
+      "conftest-docker-daemon",
+      "conftest-docker-registry",
+      "conftest-ingress-controller",
+      "conftest-nfs-provisioner",
+      "conftest-registry-proxy",
+    ])
+  })
+
+  it("should check whether system modules pass the conftest test", async () => {
+    const ctx = <KubernetesPluginContext>garden.getPluginContext(provider)
+    const variables = getKubernetesSystemVariables(provider.config)
+    const systemGarden = await getSystemGarden(ctx, variables, garden.log)
+    const graph = await systemGarden.getConfigGraph(garden.log)
     const modules = (await graph.getModules()).filter((module) => module.name.startsWith("conftest-"))
 
     await Bluebird.map(modules, async (module) => {

--- a/garden-service/test/unit/src/plugins/kubernetes/container/ingress.ts
+++ b/garden-service/test/unit/src/plugins/kubernetes/container/ingress.ts
@@ -60,6 +60,7 @@ const basicConfig: KubernetesConfig = {
   ingressHttpsPort: 443,
   resources: defaultResources,
   storage: defaultStorage,
+  systemNodeSelector: {},
   registryProxyTolerations: [],
   tlsCertificates: [],
   _systemServices: [],

--- a/garden-service/test/unit/src/plugins/kubernetes/init.ts
+++ b/garden-service/test/unit/src/plugins/kubernetes/init.ts
@@ -53,6 +53,7 @@ const basicConfig: KubernetesConfig = {
   ingressHttpsPort: 443,
   resources: defaultResources,
   storage: defaultStorage,
+  systemNodeSelector: {},
   registryProxyTolerations: [],
   tlsCertificates: [],
   _systemServices: [],

--- a/garden-service/test/unit/src/plugins/kubernetes/kubernetes.ts
+++ b/garden-service/test/unit/src/plugins/kubernetes/kubernetes.ts
@@ -27,6 +27,7 @@ describe("kubernetes configureProvider", () => {
     ingressHttpsPort: 443,
     resources: defaultResources,
     storage: defaultStorage,
+    systemNodeSelector: {},
     registryProxyTolerations: [],
     tlsCertificates: [],
     _systemServices: [],


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds default tolerations and expose the `nodeSelector` field on some Garden system services, namely:

* `build-sync`
* `docker-daemon`
* `docker-registry`
* `ingress-controller`
* `nfs-provisioner`

The tolerations have the following spec:

```yaml
tolerations:
  - key: "garden-system"
    operator: "Equal"
    value: "true"
    effect: "NoSchedule"
```

**Which issue(s) this PR fixes**:

Fixes #1600 

**Special notes for your reviewer**:

We use the `conftest` plugin to test whether system services have the right policies. Dog fooding ftw. 

**Note that this does not apply to `cert-manager` and `default-backend`. **