### PR TITLE
fix(k8s): if the output is json, stringify it

### DIFF
--- a/garden-service/src/plugins/kubernetes/status/pod.ts
+++ b/garden-service/src/plugins/kubernetes/status/pod.ts
@@ -113,6 +113,10 @@ export async function getPodLogs({
       }
     }
 
+    if (typeof(log) === "object") {
+      log = JSON.stringify(log)
+    }
+
     // the API returns undefined if no logs have been output, for some reason
     return { containerName, log: log || "" }
   })

--- a/garden-service/src/plugins/kubernetes/status/pod.ts
+++ b/garden-service/src/plugins/kubernetes/status/pod.ts
@@ -113,7 +113,7 @@ export async function getPodLogs({
       }
     }
 
-    if (typeof(log) === "object") {
+    if (typeof log === "object") {
       log = JSON.stringify(log)
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

I spotted this issue with a task that ran the AWS CLI to create DynamoDB tables. The output of the command is in JSON. When the output is JSON it comes into garden as an object, which doesn't have a trim method. You can see this in [run.ts](https://github.com/garden-io/garden/blob/master/garden-service/src/plugins/kubernetes/run.ts#L341).

You can recreate this issue by having a task output JSON, ala.

``` bash
#!/usr/bin/env bash

# Forced for the sake of the test.
echo '{"hello": "world"}'
exit 0
```
_setup.sh_

``` yaml
kind: Module
name: database-tables
description: Create database tables
type: container
tasks:
 - name: db-migrate-default
   command: ["bash", "/project/setup.sh"]
   dependencies:
     - database-default
```
_garden.yml_

and then a docker file that just copies over the setup.sh file.

**Which issue(s) this PR fixes**:

Internal issue at the company I work for

**Special notes for your reviewer**:

