### PR TITLE
Fix run command exit codes

### DIFF
--- a/docs/misc/faq.md
+++ b/docs/misc/faq.md
@@ -167,6 +167,16 @@ garden run task <task-name>
 
 This will run the task even if the result is cached.
 
+### What's the difference between `garden test` and `garden run test`
+
+The `garden test` command can run all your tests, or a subset of your tests, and has a `--watch` flag. It won't re-run tests that are cached unless the `--force` flag is set and it won't print the output unless the test fails. [See here](https://docs.garden.io/reference/commands#garden-test) for the synopsis and examples.
+
+The `garden run test` command runs **a single test in interactive mode** regardless of whether or not it's cached. Interactive mode means that the output is streamed to the screen immediately and you can interact with it if applicable.
+
+Note that due to a [known limitation](https://github.com/garden-io/garden/issues/1739), Garden can't copy artifacts for tests in interactive mode. You can disable it by setting `--interactive false`. [See here](https://docs.garden.io/reference/commands#garden-run-test) for the full synopsis.
+
+We plan on making `--interactive=false` the default with our next major release.
+
 ## Secrets
 
 ### How do I pass secrets to container modules?

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -732,8 +732,8 @@ This can be useful for debugging tests, particularly integration/end-to-end test
 
 Examples:
 
-    garden run test my-module integ            # run the test named 'integ' in my-module
-    garden run test my-module integ --i=false  # do not attach to the test run, just output results when completed
+    garden run test my-module integ                     # run the test named 'integ' in my-module
+    garden run test my-module integ --interactive=false # do not attach to the test run, just output results when completed
 
 ##### Usage
 
@@ -750,7 +750,7 @@ Examples:
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
-  | `--interactive` |  | boolean | Set to false to skip interactive mode and just output the command result.
+  | `--interactive` | `-i` | boolean | Set to false to skip interactive mode and just output the command result. Note that Garden won&#x27;t retrieve artifacts if set to true (the default).
   | `--force` |  | boolean | Run the test even if it&#x27;s disabled for the environment.
   | `--force-build` |  | boolean | Force rebuild of module before running.
 

--- a/garden-service/package-lock.json
+++ b/garden-service/package-lock.json
@@ -5600,8 +5600,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -5622,14 +5621,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -5644,20 +5641,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -5774,8 +5768,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -5787,7 +5780,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -5802,7 +5794,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -5810,14 +5801,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -5836,7 +5825,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -5917,8 +5905,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -5930,7 +5917,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -6016,8 +6002,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -6053,7 +6038,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -6073,7 +6057,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -6117,14 +6100,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },

--- a/garden-service/src/cli/cli.ts
+++ b/garden-service/src/cli/cli.ts
@@ -66,7 +66,6 @@ const OUTPUT_RENDERERS = {
 }
 
 const GLOBAL_OPTIONS_GROUP_NAME = "Global options"
-const DEFAULT_CLI_LOGGER_TYPE = "fancy"
 
 /**
  * Dummy Garden class that doesn't scan for modules nor resolves providers.
@@ -285,7 +284,7 @@ export class GardenCli {
         output,
       } = parsedOpts
 
-      let loggerType = loggerTypeOpt || command.loggerType || DEFAULT_CLI_LOGGER_TYPE
+      let loggerType = loggerTypeOpt || command.getLoggerType({ opts: parsedOpts, args: parsedArgs })
 
       if (silent || output) {
         loggerType = "quiet"

--- a/garden-service/src/commands/base.ts
+++ b/garden-service/src/commands/base.ts
@@ -18,10 +18,11 @@ import { GardenError, InternalError, ParameterError, RuntimeError } from "../exc
 import { Garden } from "../garden"
 import { LogEntry } from "../logger/log-entry"
 import { LoggerType } from "../logger/logger"
-import { printFooter } from "../logger/util"
+import { printFooter, renderMessageWithDivider } from "../logger/util"
 import { ProcessResults } from "../process"
-import { TaskResults } from "../task-graph"
+import { TaskResults, TaskResult } from "../task-graph"
 import { RunResult } from "../types/plugin/base"
+import { capitalize } from "lodash"
 
 export interface ParameterConstructor<T> {
   help: string
@@ -241,12 +242,12 @@ export interface CommandResult<T = any> {
 export interface CommandParamsBase<T extends Parameters = {}, U extends Parameters = {}> {
   args: ParameterValues<T> & { _?: string[] }
   opts: ParameterValues<GlobalOptions & U>
-  log: LogEntry
 }
 
 export interface PrepareParams<T extends Parameters = {}, U extends Parameters = {}> extends CommandParamsBase<T, U> {
   headerLog: LogEntry
   footerLog: LogEntry
+  log: LogEntry
 }
 
 export interface CommandParams<T extends Parameters = {}, U extends Parameters = {}> extends PrepareParams<T, U> {
@@ -264,7 +265,6 @@ export abstract class Command<T extends Parameters = {}, U extends Parameters = 
 
   description?: string
   alias?: string
-  loggerType?: LoggerType
 
   arguments?: T
   options?: U
@@ -303,6 +303,10 @@ export abstract class Command<T extends Parameters = {}, U extends Parameters = 
 
   getSubCommands(): Command[] {
     return this.subCommands.map((cls) => new cls(this))
+  }
+
+  getLoggerType(_: CommandParamsBase<T, U>): LoggerType {
+    return "fancy"
   }
 
   describe() {
@@ -372,21 +376,92 @@ export abstract class Command<T extends Parameters = {}, U extends Parameters = 
   }
 }
 
-export async function handleActionResult(action: string, result: RunResult): Promise<CommandResult<RunResult>> {
+export function printResult({
+  log,
+  result,
+  success,
+  actionDescription,
+}: {
+  log: LogEntry
+  result: string
+  success: boolean
+  actionDescription: string
+}) {
+  const prefix = success
+    ? `${capitalize(actionDescription)} output:`
+    : `${capitalize(actionDescription)} failed with error:`
+  const msg = renderMessageWithDivider(prefix, result, !success)
+  success ? log.info(chalk.white(msg)) : log.error(msg)
+}
+
+/**
+ * Handles the command result and logging for commands the return a result of type RunResult. E.g.
+ * the `run test` and `run service` commands.
+ */
+export async function handleRunResult({
+  log,
+  actionDescription,
+  result,
+  interactive,
+}: {
+  log: LogEntry
+  actionDescription: string
+  result: RunResult
+  interactive: boolean
+}): Promise<CommandResult<RunResult>> {
+  if (!interactive && result.log) {
+    printResult({ log, result: result.log, success: result.success, actionDescription })
+  }
+
   if (!result.success) {
-    return {
-      errors: [
-        new RuntimeError(`${action} failed!`, {
-          result,
-        }),
-      ],
-    }
+    const error = new RuntimeError(`${capitalize(actionDescription)} failed!`, {
+      result,
+    })
+    return { errors: [error] }
+  }
+
+  if (!interactive) {
+    printFooter(log)
   }
 
   return { result }
 }
 
-export async function handleTaskResults(
+/**
+ * Handles the command result and logging for commands the return a result of type TaskResult. E.g.
+ * the `run task` command.
+ */
+export async function handleTaskResult({
+  log,
+  actionDescription,
+  result,
+}: {
+  log: LogEntry
+  actionDescription: string
+  result: TaskResult
+}): Promise<CommandResult<TaskResult>> {
+  // If there's an error, the task graph prints it
+  if (!result.error && result.output.log) {
+    printResult({ log, result: result.output.log, success: true, actionDescription })
+  }
+
+  if (result.error) {
+    const error = new RuntimeError(`${capitalize(actionDescription)} failed!`, {
+      result,
+    })
+    return { errors: [error] }
+  }
+
+  printFooter(log)
+
+  return { result }
+}
+
+/**
+ * Handles the command result and logging for commands the return results of type ProcessResults.
+ * This applies to commands that can run in watch mode.
+ */
+export async function handleProcessResults(
   log: LogEntry,
   taskType: string,
   results: ProcessResults

--- a/garden-service/src/commands/build.ts
+++ b/garden-service/src/commands/build.ts
@@ -12,7 +12,7 @@ import {
   Command,
   CommandResult,
   CommandParams,
-  handleTaskResults,
+  handleProcessResults,
   StringsParameter,
   PrepareParams,
 } from "./base"
@@ -109,6 +109,6 @@ export class BuildCommand extends Command<Args, Opts> {
       },
     })
 
-    return handleTaskResults(footerLog, "build", results)
+    return handleProcessResults(footerLog, "build", results)
   }
 }

--- a/garden-service/src/commands/create/create-module.ts
+++ b/garden-service/src/commands/create/create-module.ts
@@ -78,7 +78,6 @@ export class CreateModuleCommand extends Command<CreateModuleArgs, CreateModuleO
   help = "Create a new Garden module."
   noProject = true
   cliOnly = true
-  loggerType = <LoggerType>"basic"
 
   description = dedent`
     Creates a new Garden module configuration. The generated config includes some default values, as well as the
@@ -94,6 +93,10 @@ export class CreateModuleCommand extends Command<CreateModuleArgs, CreateModuleO
 
   arguments = createModuleArgs
   options = createModuleOpts
+
+  getLoggerType(): LoggerType {
+    return "basic"
+  }
 
   async prepare({ headerLog }: PrepareParams<CreateModuleArgs, CreateModuleOpts>) {
     printHeader(headerLog, "Create new module", "pencil2")

--- a/garden-service/src/commands/create/create-project.ts
+++ b/garden-service/src/commands/create/create-project.ts
@@ -71,7 +71,6 @@ export class CreateProjectCommand extends Command<CreateProjectArgs, CreateProje
   help = "Create a new Garden project."
   noProject = true
   cliOnly = true
-  loggerType = <LoggerType>"basic"
 
   description = dedent`
     Creates a new Garden project configuration. The generated config includes some default values, as well as the
@@ -88,6 +87,10 @@ export class CreateProjectCommand extends Command<CreateProjectArgs, CreateProje
 
   arguments = createProjectArgs
   options = createProjectOpts
+
+  getLoggerType(): LoggerType {
+    return "basic"
+  }
 
   async prepare({ headerLog }: PrepareParams<CreateProjectArgs, CreateProjectOpts>) {
     printHeader(headerLog, "Create new project", "pencil2")

--- a/garden-service/src/commands/deploy.ts
+++ b/garden-service/src/commands/deploy.ts
@@ -14,7 +14,7 @@ import {
   Command,
   CommandParams,
   CommandResult,
-  handleTaskResults,
+  handleProcessResults,
   StringsParameter,
   PrepareParams,
 } from "./base"
@@ -176,6 +176,6 @@ export class DeployCommand extends Command<Args, Opts> {
       },
     })
 
-    return handleTaskResults(footerLog, "deploy", results)
+    return handleProcessResults(footerLog, "deploy", results)
   }
 }

--- a/garden-service/src/commands/dev.ts
+++ b/garden-service/src/commands/dev.ts
@@ -21,7 +21,7 @@ import {
   CommandResult,
   CommandParams,
   StringsParameter,
-  handleTaskResults,
+  handleProcessResults,
   PrepareParams,
   BooleanParameter,
 } from "./base"
@@ -164,7 +164,7 @@ export class DevCommand extends Command<DevCommandArgs, DevCommandOpts> {
       },
     })
 
-    return handleTaskResults(footerLog, "dev", results)
+    return handleProcessResults(footerLog, "dev", results)
   }
 }
 

--- a/garden-service/src/commands/exec.ts
+++ b/garden-service/src/commands/exec.ts
@@ -54,7 +54,10 @@ export class ExecCommand extends Command<Args> {
 
   arguments = runArgs
   options = runOpts
-  loggerType: LoggerType = "basic"
+
+  getLoggerType(): LoggerType {
+    return "basic"
+  }
 
   async action({
     garden,

--- a/garden-service/src/commands/logs.ts
+++ b/garden-service/src/commands/logs.ts
@@ -60,7 +60,10 @@ export class LogsCommand extends Command<Args, Opts> {
 
   arguments = logsArgs
   options = logsOpts
-  loggerType: LoggerType = "basic"
+
+  getLoggerType(): LoggerType {
+    return "basic"
+  }
 
   async action({ garden, log, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<ServiceLogEntry[]>> {
     const { follow, tail } = opts

--- a/garden-service/src/commands/migrate.ts
+++ b/garden-service/src/commands/migrate.ts
@@ -45,7 +45,6 @@ export interface MigrateCommandResult {
 export class MigrateCommand extends Command<Args, Opts> {
   name = "migrate"
   noProject = true
-  loggerType: LoggerType = "basic"
   arguments = migrateArguments
   options = migrateOptions
   help = "Migrate `garden.yml` configuration files to version v0.11.x"
@@ -65,6 +64,10 @@ export class MigrateCommand extends Command<Args, Opts> {
         garden migrate ./garden.yml # scans the provided garden.yml file and prints the updated version.
 
   `
+
+  getLoggerType(): LoggerType {
+    return "basic"
+  }
 
   async action({ log, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<MigrateCommandResult>> {
     // opts.root defaults to current directory

--- a/garden-service/src/commands/plugins.ts
+++ b/garden-service/src/commands/plugins.ts
@@ -38,7 +38,6 @@ export class PluginsCommand extends Command<Args> {
 
   // FIXME: We need this while we're still resolving providers in the AnalyticsHandler
   noProject = true
-  loggerType = <LoggerType>"basic"
 
   description = dedent`
     Execute a command defined by a plugin in your project.
@@ -58,6 +57,10 @@ export class PluginsCommand extends Command<Args> {
   `
 
   arguments = pluginArgs
+
+  getLoggerType(): LoggerType {
+    return "basic"
+  }
 
   async action({ garden: dummyGarden, log, args }: CommandParams<Args>): Promise<CommandResult> {
     // FIXME: We need this while we're still resolving providers in the AnalyticsHandler

--- a/garden-service/src/commands/publish.ts
+++ b/garden-service/src/commands/publish.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { BooleanParameter, Command, CommandParams, CommandResult, handleTaskResults, StringsParameter } from "./base"
+import { BooleanParameter, Command, CommandParams, CommandResult, handleProcessResults, StringsParameter } from "./base"
 import { Module } from "../types/module"
 import { PublishTask } from "../tasks/publish"
 import { TaskResults } from "../task-graph"
@@ -69,7 +69,7 @@ export class PublishCommand extends Command<Args, Opts> {
 
     const results = await publishModules(garden, log, modules, !!opts["force-build"], !!opts["allow-dirty"])
 
-    return handleTaskResults(footerLog, "publish", { taskResults: results })
+    return handleProcessResults(footerLog, "publish", { taskResults: results })
   }
 }
 

--- a/garden-service/src/commands/run/module.ts
+++ b/garden-service/src/commands/run/module.ts
@@ -18,7 +18,7 @@ import {
   Command,
   CommandParams,
   CommandResult,
-  handleActionResult,
+  handleRunResult,
   StringParameter,
   StringsParameter,
 } from "../base"
@@ -103,6 +103,7 @@ export class RunModuleCommand extends Command<Args, Opts> {
     await garden.processTasks(buildTasks)
 
     const dependencies = await graph.getDependencies({ nodeType: "build", name: module.name, recursive: false })
+    const interactive = opts.interactive
 
     const runtimeContext = await prepareRuntimeContext({
       garden,
@@ -117,16 +118,20 @@ export class RunModuleCommand extends Command<Args, Opts> {
 
     log.info("")
 
+    if (interactive) {
+      log.root.stop()
+    }
+
     const result = await actions.runModule({
       log,
       module,
       command: opts.command,
       args: args.arguments || [],
       runtimeContext,
-      interactive: opts.interactive,
-      timeout: opts.interactive ? 999999 : undefined,
+      interactive,
+      timeout: interactive ? 999999 : undefined,
     })
 
-    return handleActionResult(`Module ${module.name}`, result)
+    return handleRunResult({ log, actionDescription: "run module", result, interactive })
   }
 }

--- a/garden-service/src/commands/run/service.ts
+++ b/garden-service/src/commands/run/service.ts
@@ -16,7 +16,7 @@ import { getRunTaskResults, getServiceStatuses } from "../../tasks/base"
 import { DeployTask } from "../../tasks/deploy"
 import { RunResult } from "../../types/plugin/base"
 import { deline } from "../../util/string"
-import { BooleanParameter, Command, CommandParams, CommandResult, handleActionResult, StringParameter } from "../base"
+import { BooleanParameter, Command, CommandParams, CommandResult, handleRunResult, StringParameter } from "../base"
 import { printRuntimeContext } from "./run"
 
 const runArgs = {
@@ -91,6 +91,7 @@ export class RunServiceCommand extends Command<Args, Opts> {
     const dependencies = await graph.getDependencies({ nodeType: "deploy", name: serviceName, recursive: false })
     const serviceStatuses = getServiceStatuses(dependencyResults)
     const taskResults = getRunTaskResults(dependencyResults)
+    const interactive = true
 
     const runtimeContext = await prepareRuntimeContext({
       garden,
@@ -103,14 +104,18 @@ export class RunServiceCommand extends Command<Args, Opts> {
 
     printRuntimeContext(log, runtimeContext)
 
+    if (interactive) {
+      log.root.stop()
+    }
+
     const result = await actions.runService({
       log,
       service,
       runtimeContext,
-      interactive: true,
+      interactive,
       timeout: 999999,
     })
 
-    return handleActionResult(`Service ${service.name} in module ${module.name}`, result)
+    return handleRunResult({ log, actionDescription: "run service", result, interactive })
   }
 }

--- a/garden-service/src/commands/run/task.ts
+++ b/garden-service/src/commands/run/task.ts
@@ -7,10 +7,10 @@
  */
 
 import chalk from "chalk"
-import { BooleanParameter, Command, CommandParams, StringParameter, CommandResult } from "../base"
+import { BooleanParameter, Command, CommandParams, StringParameter, CommandResult, handleTaskResult } from "../base"
 import { TaskTask } from "../../tasks/task"
 import { TaskResult } from "../../task-graph"
-import { printHeader, printFooter } from "../../logger/util"
+import { printHeader } from "../../logger/util"
 import { CommandError } from "../../exceptions"
 import { dedent, deline } from "../../util/string"
 
@@ -53,7 +53,6 @@ export class RunTaskCommand extends Command<Args, Opts> {
     garden,
     log,
     headerLog,
-    footerLog,
     args,
     opts,
   }: CommandParams<Args, Opts>): Promise<CommandResult<TaskResult | null>> {
@@ -78,14 +77,6 @@ export class RunTaskCommand extends Command<Args, Opts> {
     const taskTask = await TaskTask.factory({ garden, graph, task, log, force: true, forceBuild: opts["force-build"] })
     const result = (await garden.processTasks([taskTask]))[taskTask.getKey()]
 
-    if (result && !result.error) {
-      log.info("")
-      // TODO: The command will need to be updated to stream logs: see https://github.com/garden-io/garden/issues/630.
-      // It's ok with the current providers but the shape might change in the future.
-      log.info(chalk.white(result.output.log.trim()))
-      printFooter(footerLog)
-    }
-
-    return { result }
+    return handleTaskResult({ log, actionDescription: "task", result: result! })
   }
 }

--- a/garden-service/src/commands/serve.ts
+++ b/garden-service/src/commands/serve.ts
@@ -29,7 +29,6 @@ export class ServeCommand extends Command<Args, Opts> {
   help = "Starts the Garden HTTP API service - **Experimental**"
 
   cliOnly = true
-  loggerType: LoggerType = "basic"
 
   description = dedent`
     **Experimental**
@@ -41,6 +40,10 @@ export class ServeCommand extends Command<Args, Opts> {
   options = serveOpts
 
   private server: GardenServer
+
+  getLoggerType(): LoggerType {
+    return "basic"
+  }
 
   async prepare({ footerLog, opts }: PrepareParams<Args, Opts>) {
     this.server = await startServer(footerLog, opts.port)

--- a/garden-service/src/commands/test.ts
+++ b/garden-service/src/commands/test.ts
@@ -15,7 +15,7 @@ import {
   Command,
   CommandParams,
   CommandResult,
-  handleTaskResults,
+  handleProcessResults,
   StringOption,
   StringsParameter,
   PrepareParams,
@@ -152,6 +152,6 @@ export class TestCommand extends Command<Args, Opts> {
       },
     })
 
-    return handleTaskResults(footerLog, "test", results)
+    return handleProcessResults(footerLog, "test", results)
   }
 }

--- a/garden-service/src/logger/util.ts
+++ b/garden-service/src/logger/util.ts
@@ -13,6 +13,9 @@ import { LogNode, LogLevel } from "./log-node"
 import { LogEntry, LogEntryParams, EmojiName } from "./log-entry"
 import { isBuffer } from "util"
 import { deepMap } from "../util/util"
+import { padEnd } from "lodash"
+import { dedent } from "../util/string"
+import hasAnsi from "has-ansi"
 
 export interface Node {
   children: any[]
@@ -202,6 +205,20 @@ export function printFooter(log: LogEntry) {
 
 export function printWarningMessage(log: LogEntry, text: string) {
   return log.info({ emoji: "warning", msg: chalk.bold.yellow(text) })
+}
+
+export function renderDivider() {
+  return padEnd("", 80, "━")
+}
+
+export function renderMessageWithDivider(prefix: string, msg: string, isError: boolean) {
+  const color = isError ? chalk.red : chalk.white
+  return dedent`
+  \n${color.bold(prefix)}
+  ${color.bold(renderDivider())}
+  ${hasAnsi(msg) ? msg : color(msg)}
+  ${color.bold(renderDivider())}
+  `
 }
 
 /**

--- a/garden-service/src/plugins/exec.ts
+++ b/garden-service/src/plugins/exec.ts
@@ -279,6 +279,7 @@ export async function runExecTask(params: RunTaskParams<ExecModule>): Promise<Ru
 
   let completedAt: Date
   let outputLog: string
+  let success = true
 
   if (command && command.length) {
     const commandResult = await exec(command.join(" "), [], {
@@ -288,11 +289,14 @@ export async function runExecTask(params: RunTaskParams<ExecModule>): Promise<Ru
         ...mapValues(module.spec.env, (v) => v.toString()),
         ...mapValues(task.spec.env, (v) => v.toString()),
       },
+      // We handle the error at the command level
+      reject: false,
       shell: true,
     })
 
     completedAt = new Date()
     outputLog = (commandResult.stdout + commandResult.stderr).trim()
+    success = commandResult.exitCode === 0
   } else {
     completedAt = startedAt
     outputLog = ""
@@ -305,8 +309,7 @@ export async function runExecTask(params: RunTaskParams<ExecModule>): Promise<Ru
     taskName: task.name,
     command,
     version: module.version.versionString,
-    // the exec call throws on error so we can assume success if we made it this far
-    success: true,
+    success,
     log: outputLog,
     outputs: {
       log: outputLog,

--- a/garden-service/src/plugins/kubernetes/run.ts
+++ b/garden-service/src/plugins/kubernetes/run.ts
@@ -245,7 +245,7 @@ export async function runAndCopy({
         result = await runner.exec({
           // Pipe the output from the command to the /tmp/output pipe, including stderr. Some shell voodoo happening
           // here, but this was the only working approach I could find after a lot of trial and error.
-          command: ["sh", "-c", `echo $(${cmd}) >>/tmp/output 2>&1`],
+          command: ["sh", "-c", `exec >/tmp/output; ${cmd}`],
           container: mainContainerName,
           ignoreError: true,
           log,

--- a/garden-service/src/process.ts
+++ b/garden-service/src/process.ts
@@ -8,7 +8,7 @@
 
 import Bluebird from "bluebird"
 import chalk from "chalk"
-import { padEnd, keyBy, flatten } from "lodash"
+import { keyBy, flatten } from "lodash"
 
 import { Module } from "./types/module"
 import { BaseTask } from "./tasks/base"
@@ -20,7 +20,7 @@ import { ConfigGraph } from "./config-graph"
 import { dedent } from "./util/string"
 import { ConfigurationError } from "./exceptions"
 import { uniqByName } from "./util/util"
-import { printEmoji } from "./logger/util"
+import { printEmoji, renderDivider } from "./logger/util"
 
 export type ProcessHandler = (graph: ConfigGraph, module: Module) => Promise<BaseTask[]>
 
@@ -63,10 +63,9 @@ export async function processModules({
     .map((msg) => "  " + msg) // indent list
 
   if (linkedModulesMsg.length > 0) {
-    const divider = padEnd("", 80, "—")
-    log.info(divider)
+    log.info(renderDivider())
     log.info(chalk.gray(`Following modules are linked to a local path:\n${linkedModulesMsg.join("\n")}`))
-    log.info(divider)
+    log.info(renderDivider())
   }
 
   if (watch && !!footerLog) {

--- a/garden-service/src/task-graph.ts
+++ b/garden-service/src/task-graph.ts
@@ -9,8 +9,7 @@
 import Bluebird from "bluebird"
 import chalk from "chalk"
 import yaml from "js-yaml"
-import hasAnsi = require("has-ansi")
-import { every, flatten, intersection, merge, padEnd, union, uniqWith, without } from "lodash"
+import { every, flatten, intersection, merge, union, uniqWith, without } from "lodash"
 import { BaseTask, TaskDefinitionError, TaskType } from "./tasks/base"
 
 import { LogEntry, LogEntryMetadata, TaskLogStatus } from "./logger/log-entry"
@@ -21,6 +20,7 @@ import { defer, relationshipClasses, uuidv4 } from "./util/util"
 import { renderError } from "./logger/renderers"
 import { DependencyValidationGraph } from "./util/validate-dependencies"
 import { Profile } from "./util/profiling"
+import { renderMessageWithDivider } from "./logger/util"
 
 class TaskGraphError extends GardenBaseError {
   type = "task-graph"
@@ -577,14 +577,10 @@ export class TaskGraph {
   }
 
   private logError(err: Error, errMessagePrefix: string) {
-    const divider = padEnd("", 80, "━")
     const error = toGardenError(err)
     const errorMessage = error.message.trim()
 
-    const msg =
-      chalk.red.bold(`\n${errMessagePrefix}\n${divider}\n`) +
-      (hasAnsi(errorMessage) ? errorMessage : chalk.red(errorMessage)) +
-      chalk.red.bold(`\n${divider}\n`)
+    const msg = renderMessageWithDivider(errMessagePrefix, errorMessage, true)
 
     const entry = this.log.error({ msg, error })
     this.log.silly({ msg: renderError(entry) })

--- a/garden-service/test/data/test-project-fails/module/garden.yml
+++ b/garden-service/test/data/test-project-fails/module/garden.yml
@@ -3,7 +3,7 @@ name: module
 type: test
 tests:
   - name: unit
-    command: [exit, "10"]
+    command: ["echo test-error && exit 10"]
 tasks:
   - name: task
-    command: [exit, "10"]
+    command: ["echo task-error && exit 10"]

--- a/garden-service/test/data/test-projects/container/simple/garden.yml
+++ b/garden-service/test/data/test-projects/container/simple/garden.yml
@@ -18,6 +18,12 @@ tasks:
       - source: /task.txt
       - source: /task.txt
         target: subdir
+  - name: artifacts-task-fail
+    command: [sh, -c, "touch /test.txt && exit 1"]
+    artifacts:
+      - source: /test.txt
+      - source: /test.txt
+        target: subdir
   - name: globs-task
     command: [sh, -c, "touch /task.txt && mkdir -p /tasks && touch /tasks/output.txt && echo ok"]
     artifacts:
@@ -34,6 +40,12 @@ tests:
     command: [sh, -c, "echo ok"]
   - name: artifacts-test
     command: [sh, -c, "touch /test.txt && echo ok"]
+    artifacts:
+      - source: /test.txt
+      - source: /test.txt
+        target: subdir
+  - name: artifacts-test-fail
+    command: [sh, -c, "touch /test.txt && exit 1"]
     artifacts:
       - source: /test.txt
       - source: /test.txt

--- a/garden-service/test/data/test-projects/helm/artifacts/garden.yml
+++ b/garden-service/test/data/test-projects/helm/artifacts/garden.yml
@@ -17,6 +17,12 @@ tasks:
       - source: /task.txt
       - source: /task.txt
         target: subdir
+  - name: artifacts-task-fail
+    command: [sh, -c, "touch /test.txt && exit 1"]
+    artifacts:
+      - source: /test.txt
+      - source: /test.txt
+        target: subdir
   - name: globs-task
     command: [sh, -c, "touch /task.txt && mkdir -p /tasks && touch /tasks/output.txt && echo ok"]
     artifacts:
@@ -28,6 +34,12 @@ tests:
     command: [sh, -c, "echo ok"]
   - name: artifacts-test
     command: [sh, -c, "touch /test.txt && echo ok"]
+    artifacts:
+      - source: /test.txt
+      - source: /test.txt
+        target: subdir
+  - name: artifacts-test-fail
+    command: [sh, -c, "touch /test.txt && exit 1"]
     artifacts:
       - source: /test.txt
       - source: /test.txt

--- a/garden-service/test/data/test-projects/kubernetes-module/artifacts/garden.yml
+++ b/garden-service/test/data/test-projects/kubernetes-module/artifacts/garden.yml
@@ -33,6 +33,12 @@ tasks:
       - source: /task.txt
       - source: /task.txt
         target: subdir
+  - name: artifacts-task-fail
+    command: [sh, -c, "touch /test.txt && exit 1"]
+    artifacts:
+      - source: /test.txt
+      - source: /test.txt
+        target: subdir
   - name: globs-task
     command: [sh, -c, "touch /task.txt && mkdir -p /tasks && touch /tasks/output.txt && echo ok"]
     artifacts:
@@ -44,6 +50,12 @@ tests:
     command: [sh, -c, "echo ok"]
   - name: artifacts-test
     command: [sh, -c, "touch /test.txt && echo ok"]
+    artifacts:
+      - source: /test.txt
+      - source: /test.txt
+        target: subdir
+  - name: artifacts-test-fail
+    command: [sh, -c, "touch /test.txt && exit 1"]
     artifacts:
       - source: /test.txt
       - source: /test.txt

--- a/garden-service/test/helpers.ts
+++ b/garden-service/test/helpers.ts
@@ -40,13 +40,13 @@ import { SetSecretParams } from "../src/types/plugin/provider/setSecret"
 import { GetSecretParams } from "../src/types/plugin/provider/getSecret"
 import { DeleteSecretParams } from "../src/types/plugin/provider/deleteSecret"
 import { RunServiceParams } from "../src/types/plugin/service/runService"
-import { RunTaskParams, RunTaskResult } from "../src/types/plugin/task/runTask"
 import { RunResult } from "../src/types/plugin/base"
 import { ExternalSourceType, getRemoteSourceRelPath, hashRepoUrl } from "../src/util/ext-source-util"
 import { ConfigureProviderParams } from "../src/types/plugin/provider/configureProvider"
 import { ActionRouter } from "../src/actions"
 import { ParameterValues } from "../src/commands/base"
 import stripAnsi from "strip-ansi"
+import { RunTaskParams, RunTaskResult } from "../src/types/plugin/task/runTask"
 
 export const dataDir = resolve(GARDEN_SERVICE_ROOT, "test", "data")
 export const examplesDir = resolve(GARDEN_SERVICE_ROOT, "..", "examples")

--- a/garden-service/test/integ/src/plugins/kubernetes/container/container.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/container/container.ts
@@ -623,6 +623,31 @@ describe("kubernetes container module handlers", () => {
         expect(await pathExists(join(garden.artifactsPath, "subdir", "test.txt"))).to.be.true
       })
 
+      it("should fail if an error occurs, but copy the artifacts out of the container", async () => {
+        const module = await graph.getModule("simple")
+
+        const testTask = new TestTask({
+          garden,
+          graph,
+          module,
+          testConfig: findByName(module.testConfigs, "artifacts-test-fail")!,
+          log: garden.log,
+          force: true,
+          forceBuild: false,
+          version: module.version,
+          _guard: true,
+        })
+
+        await emptyDir(garden.artifactsPath)
+
+        const results = await garden.processTasks([testTask], { throwOnError: false })
+
+        expect(results[testTask.getKey()]!.error).to.exist
+
+        expect(await pathExists(join(garden.artifactsPath, "test.txt"))).to.be.true
+        expect(await pathExists(join(garden.artifactsPath, "subdir", "test.txt"))).to.be.true
+      })
+
       it("should handle globs when copying artifacts out of the container", async () => {
         const module = await graph.getModule("simple")
 

--- a/garden-service/test/integ/src/plugins/kubernetes/container/run.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/container/run.ts
@@ -160,6 +160,28 @@ describe("runContainerTask", () => {
       expect(await pathExists(join(garden.artifactsPath, "subdir", "task.txt"))).to.be.true
     })
 
+    it("should fail if an error occurs, but copy the artifacts out of the container", async () => {
+      const task = await graph.getTask("artifacts-task-fail")
+
+      const testTask = new TaskTask({
+        garden,
+        graph,
+        task,
+        log: garden.log,
+        force: true,
+        forceBuild: false,
+        version: task.module.version,
+      })
+      await emptyDir(garden.artifactsPath)
+
+      const results = await garden.processTasks([testTask], { throwOnError: false })
+
+      expect(results[testTask.getKey()]!.error).to.exist
+
+      expect(await pathExists(join(garden.artifactsPath, "test.txt"))).to.be.true
+      expect(await pathExists(join(garden.artifactsPath, "subdir", "test.txt"))).to.be.true
+    })
+
     it("should handle globs when copying artifacts out of the container", async () => {
       const task = await graph.getTask("globs-task")
 

--- a/garden-service/test/integ/src/plugins/kubernetes/helm/run.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/helm/run.ts
@@ -177,6 +177,28 @@ describe("runHelmTask", () => {
       expect(await pathExists(join(garden.artifactsPath, "subdir", "task.txt"))).to.be.true
     })
 
+    it("should fail if an error occurs, but copy the artifacts out of the container", async () => {
+      const task = await graph.getTask("artifacts-task-fail")
+
+      const testTask = new TaskTask({
+        garden,
+        graph,
+        task,
+        log: garden.log,
+        force: true,
+        forceBuild: false,
+        version: task.module.version,
+      })
+      await emptyDir(garden.artifactsPath)
+
+      const results = await garden.processTasks([testTask], { throwOnError: false })
+
+      expect(results[testTask.getKey()]!.error).to.exist
+
+      expect(await pathExists(join(garden.artifactsPath, "test.txt"))).to.be.true
+      expect(await pathExists(join(garden.artifactsPath, "subdir", "test.txt"))).to.be.true
+    })
+
     it("should handle globs when copying artifacts out of the container", async () => {
       const task = await graph.getTask("globs-task")
 

--- a/garden-service/test/integ/src/plugins/kubernetes/helm/test.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/helm/test.ts
@@ -128,6 +128,31 @@ describe("testHelmModule", () => {
       expect(await pathExists(join(garden.artifactsPath, "subdir", "test.txt"))).to.be.true
     })
 
+    it("should fail if an error occurs, but copy the artifacts out of the container", async () => {
+      const module = await graph.getModule("artifacts")
+
+      const testTask = new TestTask({
+        garden,
+        graph,
+        module,
+        testConfig: findByName(module.testConfigs, "artifacts-test-fail")!,
+        log: garden.log,
+        force: true,
+        forceBuild: false,
+        version: module.version,
+        _guard: true,
+      })
+
+      await emptyDir(garden.artifactsPath)
+
+      const results = await garden.processTasks([testTask], { throwOnError: false })
+
+      expect(results[testTask.getKey()]!.error).to.exist
+
+      expect(await pathExists(join(garden.artifactsPath, "test.txt"))).to.be.true
+      expect(await pathExists(join(garden.artifactsPath, "subdir", "test.txt"))).to.be.true
+    })
+
     it("should handle globs when copying artifacts out of the container", async () => {
       const module = await graph.getModule("artifacts")
 

--- a/garden-service/test/integ/src/plugins/kubernetes/kubernetes-module/run.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/kubernetes-module/run.ts
@@ -176,6 +176,28 @@ describe("runKubernetesTask", () => {
       expect(await pathExists(join(garden.artifactsPath, "subdir", "task.txt"))).to.be.true
     })
 
+    it("should fail if an error occurs, but copy the artifacts out of the container", async () => {
+      const task = await graph.getTask("artifacts-task-fail")
+
+      const testTask = new TaskTask({
+        garden,
+        graph,
+        task,
+        log: garden.log,
+        force: true,
+        forceBuild: false,
+        version: task.module.version,
+      })
+      await emptyDir(garden.artifactsPath)
+
+      const results = await garden.processTasks([testTask], { throwOnError: false })
+
+      expect(results[testTask.getKey()]!.error).to.exist
+
+      expect(await pathExists(join(garden.artifactsPath, "test.txt"))).to.be.true
+      expect(await pathExists(join(garden.artifactsPath, "subdir", "test.txt"))).to.be.true
+    })
+
     it("should handle globs when copying artifacts out of the container", async () => {
       const task = await graph.getTask("globs-task")
 

--- a/garden-service/test/integ/src/plugins/kubernetes/kubernetes-module/test.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/kubernetes-module/test.ts
@@ -128,6 +128,31 @@ describe("testKubernetesModule", () => {
       expect(await pathExists(join(garden.artifactsPath, "subdir", "test.txt"))).to.be.true
     })
 
+    it("should fail if an error occurs, but copy the artifacts out of the container", async () => {
+      const module = await graph.getModule("artifacts")
+
+      const testTask = new TestTask({
+        garden,
+        graph,
+        module,
+        testConfig: findByName(module.testConfigs, "artifacts-test-fail")!,
+        log: garden.log,
+        force: true,
+        forceBuild: false,
+        version: module.version,
+        _guard: true,
+      })
+
+      await emptyDir(garden.artifactsPath)
+
+      const results = await garden.processTasks([testTask], { throwOnError: false })
+
+      expect(results[testTask.getKey()]!.error).to.exist
+
+      expect(await pathExists(join(garden.artifactsPath, "test.txt"))).to.be.true
+      expect(await pathExists(join(garden.artifactsPath, "subdir", "test.txt"))).to.be.true
+    })
+
     it("should handle globs when copying artifacts out of the container", async () => {
       const module = await graph.getModule("artifacts")
 

--- a/garden-service/test/unit/src/commands/run/test.ts
+++ b/garden-service/test/unit/src/commands/run/test.ts
@@ -9,8 +9,17 @@
 import stripAnsi from "strip-ansi"
 import { expect } from "chai"
 import { omit } from "lodash"
-import { makeTestGardenA, makeTestGardenTasksFails, withDefaultGlobalOpts, expectError } from "../../../../helpers"
+import {
+  makeTestGardenA,
+  makeTestGardenTasksFails,
+  withDefaultGlobalOpts,
+  expectError,
+  getLogMessages,
+} from "../../../../helpers"
 import { RunTestCommand } from "../../../../../src/commands/run/test"
+import { LogLevel } from "../../../../../src/logger/log-node"
+import { dedent } from "../../../../../src/util/string"
+import { renderDivider } from "../../../../../src/logger/util"
 
 describe("RunTestCommand", () => {
   const cmd = new RunTestCommand()
@@ -97,5 +106,86 @@ describe("RunTestCommand", () => {
     })
 
     expect(errors).to.not.exist
+  })
+
+  it("should log the result if interactive=false", async () => {
+    const garden = await makeTestGardenA()
+    const log = garden.log
+
+    await cmd.action({
+      garden,
+      log,
+      headerLog: log,
+      footerLog: log,
+      args: { test: "unit", module: "module-a" },
+      opts: withDefaultGlobalOpts({ "force": false, "force-build": false, "interactive": false }),
+    })
+
+    const logOutput = getLogMessages(log, (entry) => entry.level === LogLevel.info).join("\n")
+
+    expect(logOutput).to.include(dedent`
+    \nTest output:
+    ${renderDivider()}
+    OK
+    ${renderDivider()}
+
+    Done! ✔️
+    `)
+  })
+
+  it("should not log the result if interactive=true", async () => {
+    const garden = await makeTestGardenA()
+    const log = garden.log
+
+    await cmd.action({
+      garden,
+      log,
+      headerLog: log,
+      footerLog: log,
+      args: { test: "unit", module: "module-a" },
+      opts: withDefaultGlobalOpts({ "force": false, "force-build": false, "interactive": true }),
+    })
+
+    const logOutput = getLogMessages(log, (entry) => entry.level === LogLevel.info).join("\n")
+    expect(logOutput).to.not.include("Run test result:")
+  })
+
+  it("should log the error if interactive=false", async () => {
+    const garden = await makeTestGardenTasksFails()
+    const log = garden.log
+
+    await cmd.action({
+      garden,
+      log,
+      headerLog: log,
+      footerLog: log,
+      args: { test: "unit", module: "module" },
+      opts: withDefaultGlobalOpts({ "force": false, "force-build": false, "interactive": false }),
+    })
+
+    const logOutput = getLogMessages(log, (entry) => entry.level === LogLevel.error).join("\n")
+    expect(logOutput).to.include(dedent`
+    \nTest failed with error:
+    ${renderDivider()}
+    test-error
+    ${renderDivider()}
+    `)
+  })
+
+  it("should not log the error if interactive=true", async () => {
+    const garden = await makeTestGardenTasksFails()
+    const log = garden.log
+
+    await cmd.action({
+      garden,
+      log,
+      headerLog: log,
+      footerLog: log,
+      args: { test: "unit", module: "module" },
+      opts: withDefaultGlobalOpts({ "force": false, "force-build": false, "interactive": true }),
+    })
+
+    const logOutput = getLogMessages(log, (entry) => entry.level === LogLevel.error).join("\n")
+    expect(logOutput).to.not.include("test-error")
   })
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

The first commit fixes an issue with `garden run test` returning exit code 0 if the test fails and artifacts are copied.

As I was working on that, I noticed that `garden run task` would return the wrong exit code for local tasks, and some other inconsistencies in how the outputs were printed. The second commit addresses that.

**Which issue(s) this PR fixes**:

This came up in a conversation on the community Slack.

**Special notes for your reviewer**:

I turned the `loggerType` static property into a function so that commands can dynamically decide what the logger type should be. For example, commands with `--interactive=true` should use the basic logger. 

Here are screenshots from how the outputs look now:

<img width="737" alt="Screenshot 2020-03-26 at 14 41 21" src="https://user-images.githubusercontent.com/5373776/77653965-af857200-6f70-11ea-8057-62ee7320737d.png">

<img width="734" alt="Screenshot 2020-03-26 at 14 41 46" src="https://user-images.githubusercontent.com/5373776/77653992-b7451680-6f70-11ea-82a4-9110233f1fb1.png">

<img width="735" alt="Screenshot 2020-03-26 at 14 42 17" src="https://user-images.githubusercontent.com/5373776/77654017-be6c2480-6f70-11ea-8f66-63d8ee4a9bbe.png">


