### PR TITLE
fix: include aws-iam-authenticator in AWS specific container

### DIFF
--- a/garden-service/aws.Dockerfile
+++ b/garden-service/aws.Dockerfile
@@ -4,3 +4,7 @@ FROM gardendev/garden:${TAG}
 RUN apk add --no-cache python py-pip \
   && pip install awscli==1.17.9 --upgrade \
   && apk del py-pip
+
+RUN curl -o aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.15.10/2020-02-22/bin/linux/amd64/aws-iam-authenticator \
+  && chmod +x ./aws-iam-authenticator \
+  && mv ./aws-iam-authenticator /usr/bin/


### PR DESCRIPTION
When running the Garden CLI on some clusters on AWS, the `aws-iam-authenticator` executable is required to look up credentials for ECR

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

When deploying to an EKS cluster on AWS using the `ecr-login` method of authentication (`{ "credHelpers": { "<aws_account_id>.dkr.ecr.<region>.amazonaws.com": "ecr-login" } }` and `https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#registry-secret-existing-credentials`), Garden will call out to `aws-iam-authenticator` executable. This executable it not on the current container, and this PR installs it.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
