### PR TITLE
feat(core): add event and log streaming

### DIFF
--- a/garden-service/src/analytics/analytics.ts
+++ b/garden-service/src/analytics/analytics.ts
@@ -20,6 +20,7 @@ import { Events, EventName } from "../events"
 import { AnalyticsType } from "./analytics-types"
 import dedent from "dedent"
 import { getGitHubUrl } from "../docs/common"
+import { InternalError } from "../exceptions"
 
 const API_KEY = process.env.ANALYTICS_DEV ? SEGMENT_DEV_API_KEY : SEGMENT_PROD_API_KEY
 
@@ -134,14 +135,18 @@ export class AnalyticsHandler {
   private ciName = ci.name
   private systemConfig: SystemInfo
   private isCI = ci.isCI
-  private sessionId = uuidv4()
+  private sessionId: string
   protected garden: Garden
   private projectMetadata: ProjectMetadata
 
   private constructor(garden: Garden, log: LogEntry) {
+    if (!garden.sessionId) {
+      throw new InternalError(`Garden instance with null sessionId passed to AnalyticsHandler constructor.`, {})
+    }
     this.segment = new segmentClient(API_KEY, { flushAt: 20, flushInterval: 300 })
     this.log = log
     this.garden = garden
+    this.sessionId = garden.sessionId
     this.globalConfigStore = new GlobalConfigStore()
     this.analyticsConfig = {
       userId: "",

--- a/garden-service/src/cloud/auth.ts
+++ b/garden-service/src/cloud/auth.ts
@@ -19,6 +19,8 @@ import { LogEntry } from "../logger/log-entry"
 import { got } from "../util/http"
 import { RuntimeError } from "../exceptions"
 
+export const makeAuthHeader = (clientAuthToken: string) => ({ "x-access-auth-token": clientAuthToken })
+
 // TODO: Add error handling and tests for all of this
 
 /**
@@ -65,7 +67,7 @@ async function checkClientAuthToken(token: string, platformUrl: string, log: Log
     await got({
       method: "get",
       url: `${platformUrl}/token/verify`,
-      headers: { "x-access-auth-token": token },
+      headers: makeAuthHeader(token),
     })
     valid = true
   } catch (err) {

--- a/garden-service/src/cloud/buffered-event-stream.ts
+++ b/garden-service/src/cloud/buffered-event-stream.ts
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { registerCleanupFunction } from "../util/util"
+import { Events, EventName, EventBus, eventNames } from "../events"
+import { LogEntryMetadata, LogEntry } from "../logger/log-entry"
+import { chainMessages } from "../logger/renderers"
+import { got } from "../util/http"
+import { makeAuthHeader } from "./auth"
+
+export type StreamEvent = {
+  name: EventName
+  payload: Events[EventName]
+  timestamp: Date
+}
+
+export interface LogEntryEvent {
+  key: string
+  parentKey: string | null
+  revision: number
+  msg: string | string[]
+  timestamp: Date
+  data?: any
+  section?: string
+  metadata?: LogEntryMetadata
+}
+
+export function formatForEventStream(entry: LogEntry): LogEntryEvent {
+  const { section, data } = entry.getMessageState()
+  const { key, revision } = entry
+  const parentKey = entry.parent ? entry.parent.key : null
+  const metadata = entry.getMetadata()
+  const msg = chainMessages(entry.getMessageStates() || [])
+  const timestamp = new Date()
+  return { key, parentKey, revision, msg, data, metadata, section, timestamp }
+}
+
+export const FLUSH_INTERVAL_MSEC = 1000
+export const MAX_BATCH_SIZE = 100
+
+/**
+ * Buffers events and log entries and periodically POSTs them to the platform.
+ *
+ * Subscribes to logger events once, in the constructor.
+ *
+ * Subscribes to Garden events via the connect method, since we need to subscribe to the event bus of
+ * new Garden instances (and unsubscribe from events from the previously connected Garden instance, if
+ * any) e.g. when config changes during a watch-mode command.
+ */
+export class BufferedEventStream {
+  private log: LogEntry
+  private eventBus: EventBus
+  public sessionId: string
+  private platformUrl: string
+  private clientAuthToken: string
+  private projectName: string
+
+  /**
+   * We maintain this map to facilitate unsubscribing from a previously connected event bus
+   * when a new event bus is connected.
+   */
+  private gardenEventListeners: { [eventName: string]: (payload: any) => void }
+
+  private intervalId: NodeJS.Timer | null
+  private bufferedEvents: StreamEvent[]
+  private bufferedLogEntries: LogEntryEvent[]
+
+  constructor(log: LogEntry, sessionId: string) {
+    this.sessionId = sessionId
+    this.log = log
+    this.log.root.events.onAny((_name: string, payload: LogEntryEvent) => {
+      this.streamLogEntry(payload)
+    })
+    this.bufferedEvents = []
+    this.bufferedLogEntries = []
+  }
+
+  // TODO: Replace projectName with projectId once we've figured out the flow for that.
+  connect(eventBus: EventBus, clientAuthToken: string, platformUrl: string, projectName: string) {
+    this.clientAuthToken = clientAuthToken
+    this.platformUrl = platformUrl
+    this.projectName = projectName
+
+    if (!this.intervalId) {
+      this.startInterval()
+    }
+
+    if (this.eventBus) {
+      // We unsubscribe from the old event bus' events.
+      this.unsubscribeFromGardenEvents(this.eventBus)
+    }
+
+    this.eventBus = eventBus
+    this.subscribeToGardenEvents(this.eventBus)
+  }
+
+  subscribeToGardenEvents(eventBus: EventBus) {
+    // We maintain this map to facilitate unsubscribing from events when the Garden instance is closed.
+    const gardenEventListeners = {}
+    for (const gardenEventName of eventNames) {
+      const listener = (payload: LogEntryEvent) => this.streamEvent(gardenEventName, payload)
+      gardenEventListeners[gardenEventName] = listener
+      eventBus.on(gardenEventName, listener)
+    }
+    this.gardenEventListeners = gardenEventListeners
+  }
+
+  unsubscribeFromGardenEvents(eventBus: EventBus) {
+    for (const [gardenEventName, listener] of Object.entries(this.gardenEventListeners)) {
+      eventBus.removeListener(gardenEventName, listener)
+    }
+  }
+
+  startInterval() {
+    this.intervalId = setInterval(() => {
+      this.flushBuffered({ flushAll: false })
+    }, FLUSH_INTERVAL_MSEC)
+
+    registerCleanupFunction("flushAllBufferedEventsAndLogEntries", () => {
+      this.close()
+    })
+  }
+
+  close() {
+    if (this.intervalId) {
+      clearInterval(this.intervalId)
+      this.intervalId = null
+    }
+    this.flushBuffered({ flushAll: true })
+  }
+
+  streamEvent<T extends EventName>(name: T, payload: Events[T]) {
+    this.bufferedEvents.push({
+      name,
+      payload,
+      timestamp: new Date(),
+    })
+  }
+
+  streamLogEntry(logEntry: LogEntryEvent) {
+    this.bufferedLogEntries.push(logEntry)
+  }
+
+  flushEvents(events: StreamEvent[]) {
+    const data = {
+      events,
+      sessionId: this.sessionId,
+      projectName: this.projectName,
+    }
+    const headers = makeAuthHeader(this.clientAuthToken)
+    got.post(`${this.platformUrl}/events`, { json: data, headers }).catch((err) => {
+      this.log.error(err)
+    })
+  }
+
+  flushLogEntries(logEntries: LogEntryEvent[]) {
+    const data = {
+      logEntries,
+      sessionId: this.sessionId,
+      projectName: this.projectName,
+    }
+    const headers = makeAuthHeader(this.clientAuthToken)
+    got.post(`${this.platformUrl}/log-entries`, { json: data, headers }).catch((err) => {
+      this.log.error(err)
+    })
+  }
+
+  flushBuffered({ flushAll = false }) {
+    const eventsToFlush = this.bufferedEvents.splice(0, flushAll ? this.bufferedEvents.length : MAX_BATCH_SIZE)
+
+    if (eventsToFlush.length > 0) {
+      this.flushEvents(eventsToFlush)
+    }
+
+    const logEntryFlushCount = flushAll ? this.bufferedLogEntries.length : MAX_BATCH_SIZE - eventsToFlush.length
+    const logEntriesToFlush = this.bufferedLogEntries.splice(0, logEntryFlushCount)
+
+    if (logEntriesToFlush.length > 0) {
+      this.flushLogEntries(logEntriesToFlush)
+    }
+  }
+}

--- a/garden-service/src/commands/login.ts
+++ b/garden-service/src/commands/login.ts
@@ -9,7 +9,7 @@
 import { Command, CommandParams, CommandResult } from "./base"
 import { printHeader } from "../logger/util"
 import dedent = require("dedent")
-import { login } from "../platform/auth"
+import { login } from "../cloud/auth"
 
 export class LoginCommand extends Command {
   name = "login"

--- a/garden-service/src/commands/logout.ts
+++ b/garden-service/src/commands/logout.ts
@@ -9,7 +9,7 @@
 import { Command, CommandParams, CommandResult } from "./base"
 import { printHeader } from "../logger/util"
 import dedent = require("dedent")
-import { clearAuthToken } from "../platform/auth"
+import { clearAuthToken } from "../cloud/auth"
 
 export class LogOutCommand extends Command {
   name = "logout"

--- a/garden-service/src/db/base-entity.ts
+++ b/garden-service/src/db/base-entity.ts
@@ -45,7 +45,6 @@ export class GardenEntity extends BaseEntity {
   /**
    * Helper method to avoid circular import issues.
    */
-
   static getConnection() {
     return getConnection()
   }

--- a/garden-service/src/events.ts
+++ b/garden-service/src/events.ts
@@ -7,9 +7,9 @@
  */
 
 import { EventEmitter2 } from "eventemitter2"
-import { LogEntry } from "./logger/log-entry"
 import { ModuleVersion } from "./vcs/vcs"
 import { TaskResult } from "./task-graph"
+import { LogEntryEvent } from "./cloud/buffered-event-stream"
 
 /**
  * This simple class serves as the central event bus for a Garden instance. Its function
@@ -18,7 +18,7 @@ import { TaskResult } from "./task-graph"
  * See below for the event interfaces.
  */
 export class EventBus extends EventEmitter2 {
-  constructor(private log: LogEntry) {
+  constructor() {
     super({
       wildcard: false,
       newListener: false,
@@ -27,7 +27,6 @@ export class EventBus extends EventEmitter2 {
   }
 
   emit<T extends EventName>(name: T, payload: Events[T]) {
-    this.log.silly(`Emit event '${name}'`)
     return super.emit(name, payload)
   }
 
@@ -47,9 +46,19 @@ export class EventBus extends EventEmitter2 {
 }
 
 /**
- * The supported events and their interfaces.
+ * Supported logger events and their interfaces.
  */
-export type Events = {
+export interface LoggerEvents {
+  _test: any
+  logEntry: LogEntryEvent
+}
+
+export type LoggerEventName = keyof LoggerEvents
+
+/**
+ * Supported Garden events and their interfaces.
+ */
+export interface Events extends LoggerEvents {
   // Internal test/control events
   _exit: {}
   _restart: {}
@@ -108,8 +117,29 @@ export type Events = {
   taskGraphComplete: {
     completedAt: Date
   }
-
   watchingForChanges: {}
 }
 
 export type EventName = keyof Events
+
+// Note: Does not include logger events.
+export const eventNames: EventName[] = [
+  "_exit",
+  "_restart",
+  "_test",
+  "configAdded",
+  "configRemoved",
+  "internalError",
+  "projectConfigChanged",
+  "moduleConfigChanged",
+  "moduleSourcesChanged",
+  "moduleRemoved",
+  "taskPending",
+  "taskProcessing",
+  "taskComplete",
+  "taskError",
+  "taskCancelled",
+  "taskGraphProcessing",
+  "taskGraphComplete",
+  "watchingForChanges",
+]

--- a/garden-service/src/garden.ts
+++ b/garden-service/src/garden.ts
@@ -61,7 +61,7 @@ import { deline, naturalList } from "./util/string"
 import { ensureConnected } from "./db/connection"
 import { DependencyValidationGraph } from "./util/validate-dependencies"
 import { Profile } from "./util/profiling"
-import { readAuthToken, login } from "./platform/auth"
+import { readAuthToken, login } from "./cloud/auth"
 import { ResolveModuleTask, getResolvedModules } from "./tasks/resolve-module"
 import username from "username"
 
@@ -220,7 +220,7 @@ export class Garden {
     this.resolvedProviders = {}
 
     this.taskGraph = new TaskGraph(this, this.log)
-    this.events = new EventBus(this.log)
+    this.events = new EventBus()
 
     // Register plugins
     for (const plugin of [...builtinPlugins, ...params.plugins]) {
@@ -336,6 +336,7 @@ export class Garden {
    * Clean up before shutting down.
    */
   async close() {
+    this.events.removeAllListeners()
     this.watcher && (await this.watcher.stop())
   }
 

--- a/garden-service/src/logger/writers/json-terminal-writer.ts
+++ b/garden-service/src/logger/writers/json-terminal-writer.ts
@@ -15,7 +15,6 @@ export interface JsonLogEntry {
   msg: string
   data?: any
   section?: string
-  durationMs?: number
   metadata?: LogEntryMetadata
 }
 

--- a/garden-service/src/process.ts
+++ b/garden-service/src/process.ts
@@ -211,6 +211,7 @@ async function validateConfigChange(
   try {
     const nextGarden = await Garden.factory(garden.projectRoot, garden.opts)
     await nextGarden.getConfigGraph(log)
+    await nextGarden.close()
   } catch (error) {
     if (error instanceof ConfigurationError) {
       const msg = dedent`

--- a/garden-service/test/helpers.ts
+++ b/garden-service/test/helpers.ts
@@ -320,8 +320,8 @@ interface EventLogEntry {
 class TestEventBus extends EventBus {
   public eventLog: EventLogEntry[]
 
-  constructor(log: LogEntry) {
-    super(log)
+  constructor() {
+    super()
     this.eventLog = []
   }
 
@@ -342,7 +342,7 @@ export class TestGarden extends Garden {
 
   constructor(params: GardenParams) {
     super(params)
-    this.events = new TestEventBus(this.log)
+    this.events = new TestEventBus()
   }
 
   setModuleConfigs(moduleConfigs: ModuleConfig[]) {

--- a/garden-service/test/unit/src/events.ts
+++ b/garden-service/test/unit/src/events.ts
@@ -8,13 +8,12 @@
 
 import { EventBus } from "../../../src/events"
 import { expect } from "chai"
-import { getLogger } from "../../../src/logger/logger"
 
 describe("EventBus", () => {
   let events: EventBus
 
   beforeEach(() => {
-    events = new EventBus(getLogger().placeholder())
+    events = new EventBus()
   })
 
   it("should send+receive events", (done) => {

--- a/garden-service/test/unit/src/platform/auth.ts
+++ b/garden-service/test/unit/src/platform/auth.ts
@@ -10,9 +10,9 @@ import Bluebird from "bluebird"
 import { expect } from "chai"
 import { ClientAuthToken } from "../../../../src/db/entities/client-auth-token"
 import { makeTestGardenA } from "../../../helpers"
-import { saveAuthToken, readAuthToken, clearAuthToken } from "../../../../src/platform/auth"
+import { saveAuthToken, readAuthToken, clearAuthToken } from "../../../../src/cloud/auth"
 
-async function cleanupAuthTokens() {
+export async function cleanupAuthTokens() {
   await ClientAuthToken.createQueryBuilder()
     .delete()
     .execute()

--- a/garden-service/test/unit/src/platform/buffered-event-stream.ts
+++ b/garden-service/test/unit/src/platform/buffered-event-stream.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import { StreamEvent, LogEntryEvent, BufferedEventStream } from "../../../../src/cloud/buffered-event-stream"
+import { getLogger } from "../../../../src/logger/logger"
+import { EventBus } from "../../../../src/events"
+
+describe("BufferedEventStream", () => {
+  it("should flush events and log entries emitted by a connected event emitter", async () => {
+    const flushedEvents: StreamEvent[] = []
+    const flushedLogEntries: LogEntryEvent[] = []
+
+    const log = getLogger().placeholder()
+
+    const bufferedEventStream = new BufferedEventStream(log, "dummy-session-id")
+
+    bufferedEventStream["flushEvents"] = (events: StreamEvent[]) => {
+      flushedEvents.push(...events)
+    }
+    bufferedEventStream["flushLogEntries"] = (logEntries: LogEntryEvent[]) => {
+      flushedLogEntries.push(...logEntries)
+    }
+
+    const eventBus = new EventBus()
+    bufferedEventStream.connect(eventBus, "dummy-client-token", "dummy-platform_url", "myproject")
+
+    eventBus.emit("_test", {})
+    log.root.events.emit("_test", {})
+
+    bufferedEventStream.flushBuffered({ flushAll: true })
+
+    expect(flushedEvents.length).to.eql(1)
+    expect(flushedLogEntries.length).to.eql(1)
+  })
+
+  it("should only flush events or log entries emitted by the last connected event emitter", async () => {
+    const flushedEvents: StreamEvent[] = []
+    const flushedLogEntries: LogEntryEvent[] = []
+
+    const log = getLogger().placeholder()
+
+    const bufferedEventStream = new BufferedEventStream(log, "dummy-session-id")
+
+    bufferedEventStream["flushEvents"] = (events: StreamEvent[]) => {
+      flushedEvents.push(...events)
+    }
+    bufferedEventStream["flushLogEntries"] = (logEntries: LogEntryEvent[]) => {
+      flushedLogEntries.push(...logEntries)
+    }
+
+    const oldEventBus = new EventBus()
+    bufferedEventStream.connect(oldEventBus, "dummy-client-token", "dummy-platform_url", "myproject")
+    const newEventBus = new EventBus()
+    bufferedEventStream.connect(newEventBus, "dummy-client-token", "dummy-platform_url", "myproject")
+
+    log.root.events.emit("_test", {})
+    oldEventBus.emit("_test", {})
+
+    bufferedEventStream.flushBuffered({ flushAll: true })
+
+    expect(flushedEvents.length).to.eql(0)
+    expect(flushedLogEntries.length).to.eql(1)
+
+    newEventBus.emit("_test", {})
+    bufferedEventStream.flushBuffered({ flushAll: true })
+
+    expect(flushedEvents.length).to.eql(1)
+  })
+})


### PR DESCRIPTION
* Added an event bus to `Logger`, which emits events when log entries are created or updated.

* Added the `BufferedEventStream` class. This is used for batching and streaming events from the Logger and the active Garden instance to the platform when the user is logged in. Later, we can use this class for streaming to the dashboard as well.