### PR TITLE
improvement(k8s): update socat image used for registry proxies

### DIFF
--- a/garden-service/src/plugins/kubernetes/container/build.ts
+++ b/garden-service/src/plugins/kubernetes/container/build.ts
@@ -642,7 +642,7 @@ function isLocalHostname(hostname: string) {
 function getSocatContainer(registryHostname: string) {
   return {
     name: "proxy",
-    image: "basi/socat:v0.1.0",
+    image: "gardendev/socat:0.1.0",
     command: ["/bin/sh", "-c", `socat TCP-LISTEN:5000,fork TCP:${registryHostname}:5000 || exit 0`],
     ports: [
       {

--- a/garden-service/static/kubernetes/system/docker-daemon/templates/deployment.yaml
+++ b/garden-service/static/kubernetes/system/docker-daemon/templates/deployment.yaml
@@ -65,13 +65,11 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
         - name: proxy
-          image: "basi/socat:v0.1.0"
+          image: "gardendev/socat:0.1.0"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command:
-            - /bin/sh
-            - -c
-            - |
-              socat TCP-LISTEN:5000,fork TCP:{{ .Values.registry.hostname }}:5000
+          args:
+            - TCP-LISTEN:5000,fork
+            - TCP:{{ .Values.registry.hostname }}:5000
           ports:
             - name: proxy
               containerPort: 5000

--- a/garden-service/static/kubernetes/system/registry-proxy/values.yaml
+++ b/garden-service/static/kubernetes/system/registry-proxy/values.yaml
@@ -3,8 +3,8 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: basi/socat
-  tag: v0.1.0
+  repository: envoyproxy/envoy-alpine
+  tag: v1.11.0
   pullPolicy: IfNotPresent
 
 nameOverride: garden-registry-proxy

--- a/images/socat/Dockerfile
+++ b/images/socat/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.11.3
+
+RUN apk add --no-cache socat
+
+ENTRYPOINT ["socat"]

--- a/images/socat/garden.yml
+++ b/images/socat/garden.yml
@@ -1,0 +1,6 @@
+kind: Module
+type: container
+name: socat
+description: The socat image, used for proxy sidecars
+image: gardendev/socat:0.1.0
+dockerfile: Dockerfile


### PR DESCRIPTION
**What this PR does / why we need it**:

We've gotten reports of the socat proxy segfaulting on EKS 1.15. This is an experiment to see if this fixes that issue.
