### PR TITLE
chore: add alpine back to release bins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,6 +155,9 @@ commands:
         type: string
         default: ""
     steps:
+      # We need Docker for building the Alpine package
+      - setup_remote_docker:
+          docker_layer_caching: true
       - checkout
       - npm_install
       - run: sudo apt-get update && sudo apt-get -y install rsync


### PR DESCRIPTION
**What this PR does / why we need it**:

We stopped releasing an Alpine bin because of issues with building it locally, instead we built it in a container and released the image. However, we never removed it from the install script, an issue that a user recently bumped into (#1730).

This PR re-enables it by building the container image and copying the Alpine bin and deps from out of the container. 

**Which issue(s) this PR fixes**:

Fixes #1730

**Special notes for your reviewer**:

N/A