### PR TITLE
fix(cmd): better error messages in get task-result

### DIFF
--- a/garden-service/src/actions.ts
+++ b/garden-service/src/actions.ts
@@ -495,11 +495,11 @@ export class ActionRouter implements TypeGuard {
     }
   }
 
-  async getTaskResult(params: TaskActionRouterParams<GetTaskResultParams>): Promise<RunTaskResult | null> {
+  async getTaskResult(params: TaskActionRouterParams<GetTaskResultParams>): Promise<RunTaskResult | null | undefined> {
     const { result } = await this.callTaskHandler({
       params,
       actionType: "getTaskResult",
-      defaultHandler: async () => null,
+      defaultHandler: async () => undefined,
     })
     result && this.validateTaskOutputs(params.task, result)
     return result

--- a/garden-service/src/commands/get/get-status.ts
+++ b/garden-service/src/commands/get/get-status.ts
@@ -21,7 +21,7 @@ import { deline } from "../../util/string"
 import { EnvironmentStatusMap } from "../../types/plugin/provider/getEnvironmentStatus"
 import { ServiceStatus } from "../../types/service"
 
-export type RunState = "outdated" | "succeeded" | "failed"
+export type RunState = "outdated" | "succeeded" | "failed" | "not-implemented"
 
 export interface RunStatus {
   state: RunState
@@ -129,7 +129,7 @@ async function getTaskStatuses(garden: Garden, configGraph: ConfigGraph, log: Lo
   )
 }
 
-function runStatus<R extends RunResult>(result: R | null): RunStatus {
+function runStatus<R extends RunResult>(result: R | null | undefined): RunStatus {
   if (result) {
     const { startedAt, completedAt } = result
     return {
@@ -138,6 +138,6 @@ function runStatus<R extends RunResult>(result: R | null): RunStatus {
       state: result.success ? "succeeded" : "failed",
     }
   } else {
-    return { state: "outdated" }
+    return { state: result === null ? "outdated" : "not-implemented" }
   }
 }

--- a/garden-service/src/commands/get/get-task-result.ts
+++ b/garden-service/src/commands/get/get-task-result.ts
@@ -70,10 +70,16 @@ export class GetTaskResultCommand extends Command<Args> {
 
     printHeader(headerLog, `Task result for task ${chalk.cyan(taskName)}`, "rocket")
 
-    if (result === null) {
+    log.info("")
+
+    if (taskResult === null) {
       log.info(`Could not find results for task '${taskName}'`)
     } else {
-      log.info({ data: result })
+      if (taskResult === undefined) {
+        log.error(`Module type ${task.module.type} for task ${taskName} does not support storing/getting task results.`)
+      } else {
+        log.info({ data: result })
+      }
     }
 
     return { result }

--- a/garden-service/src/tasks/get-task-result.ts
+++ b/garden-service/src/tasks/get-task-result.ts
@@ -42,7 +42,7 @@ export class GetTaskResultTask extends BaseTask {
     return `getting task result '${this.task.name}' (from module '${this.task.module.name}')`
   }
 
-  async process(): Promise<RunTaskResult | null> {
+  async process(): Promise<RunTaskResult | null | undefined> {
     const log = this.log.info({
       section: this.task.name,
       msg: "Checking result...",
@@ -50,7 +50,8 @@ export class GetTaskResultTask extends BaseTask {
     })
     const actions = await this.garden.getActionRouter()
 
-    let result: RunTaskResult | null
+    // The default handler (for plugins that don't implement getTaskResult) returns undefined.
+    let result: RunTaskResult | null | undefined
     try {
       result = await actions.getTaskResult({
         task: this.task,

--- a/garden-service/src/types/plugin/plugin.ts
+++ b/garden-service/src/types/plugin/plugin.ts
@@ -243,7 +243,7 @@ export type TaskActionParams<T extends Module = Module> = {
 
 export interface TaskActionOutputs {
   runTask: RunTaskResult
-  getTaskResult: RunTaskResult | null
+  getTaskResult: RunTaskResult | null | undefined
 }
 
 const taskActionDescriptions: { [P in TaskActionName]: () => PluginActionDescription } = {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

When the `get task-result` command is run for a task whose module type doesn't implement the getTaskResult handler, we now display a more helpful error message.

**Which issue(s) this PR fixes**:

Some users have been confused by the error messages displayed when running `garden get task-result` in `exec` modules, which don't currently support storing/reading task results.

**Special notes for your reviewer**:

Is this approach of using `undefined` as a return value for the default handler (to discriminate between "real" `null` values returned by plugin handlers that actually implement this behavior) a good way to go? Seemed simple and intuitive to me, at any rate.