### PR TITLE
fix(core): fix watch task logic for sourceModules

### DIFF
--- a/garden-service/src/tasks/helpers.ts
+++ b/garden-service/src/tasks/helpers.ts
@@ -48,7 +48,7 @@ export async function getModuleWatchTasks({
     })
   )
 
-  const serviceNamesForModule = [...module.serviceNames, ...dependantSourceModuleServiceNames]
+  const serviceNamesUsingModule = [...module.serviceNames, ...dependantSourceModuleServiceNames]
 
   /**
    * If a service is deployed with hot reloading enabled, we don't rebuild its module
@@ -60,7 +60,7 @@ export async function getModuleWatchTasks({
    * hotReloadServiceNames and has module as its sourceModule (in which case we
    * also don't add a build task for the dependant's module below).
    */
-  if (intersection(serviceNamesForModule, hotReloadServiceNames).length === 0) {
+  if (intersection(serviceNamesUsingModule, hotReloadServiceNames).length === 0) {
     buildTasks = await BuildTask.factory({
       garden,
       graph,

--- a/garden-service/src/tasks/helpers.ts
+++ b/garden-service/src/tasks/helpers.ts
@@ -7,7 +7,7 @@
  */
 
 import Bluebird from "bluebird"
-import { includes, intersection, flatten, uniqBy } from "lodash"
+import { intersection, flatten, uniqBy } from "lodash"
 import { DeployTask } from "./deploy"
 import { Garden } from "../garden"
 import { Module } from "../types/module"
@@ -74,7 +74,7 @@ export async function getModuleWatchTasks({
 
   const dependantBuildTasks = flatten(
     await Bluebird.map(
-      dependants.build.filter((m) => !m.disabled && !includes(dependantSourceModuleNames, m.name)),
+      dependants.build.filter((m) => !m.disabled && !dependantSourceModuleNames.includes(m.name)),
       (m) =>
         BuildTask.factory({
           garden,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

Before this fix, if a service with a `sourceModule` was deployed with hot reloading enabled, a build task for its source module would be added when its sources change (in addition to the hot reload task).

This was not the desired behavior, and would (e.g. for `helm` modules using a `container` module as a `sourceModule`) result in unnecessary rebuilds of the source module.

**Which issue(s) this PR fixes**:

This issue was reported by a user on our community Slack.