### PR TITLE
fix(k8s): automatic include for helm modules should include chartPath

### DIFF
--- a/garden-service/src/plugins/kubernetes/helm/config.ts
+++ b/garden-service/src/plugins/kubernetes/helm/config.ts
@@ -32,6 +32,7 @@ import {
   KubernetesTaskSpec,
   namespaceSchema,
 } from "../config"
+import { posix } from "path"
 
 export const defaultHelmTimeout = 300
 
@@ -219,7 +220,7 @@ export const helmModuleSpecSchema = () =>
 export async function configureHelmModule({
   moduleConfig,
 }: ConfigureModuleParams<HelmModule>): Promise<ConfigureModuleResult<HelmModule>> {
-  const { base, dependencies, serviceResource, skipDeploy, tasks, tests } = moduleConfig.spec
+  const { base, chartPath, dependencies, serviceResource, skipDeploy, tasks, tests } = moduleConfig.spec
 
   const sourceModuleName = serviceResource ? serviceResource.containerModule : undefined
 
@@ -296,6 +297,8 @@ export async function configureHelmModule({
     moduleConfig.include = containsSources
       ? ["*", "charts/**/*", "templates/**/*", ...valueFiles]
       : ["*.yaml", "*.yml", ...valueFiles]
+
+    moduleConfig.include = moduleConfig.include.map((path) => posix.join(chartPath, path))
   }
 
   return { moduleConfig }

--- a/garden-service/test/integ/src/plugins/kubernetes/helm/config.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/helm/config.ts
@@ -149,7 +149,7 @@ describe("configureHelmModule", () => {
     // So that Chart.yaml isn't found
     patchModuleConfig("api", { spec: { chartPath: "invalid-path" } })
     const config = await garden.resolveModule("api")
-    expect(config.include).to.eql(["*.yaml", "*.yml"])
+    expect(config.include).to.eql(["invalid-path/*.yaml", "invalid-path/*.yml"])
   })
 
   it("should not return a serviceConfig if skipDeploy=true", async () => {


### PR DESCRIPTION
**What this PR does / why we need it**:

Automatic includes weren't factoring in the configured `chartPath` (if any), which could cause errors when using that field.

**Which issue(s) this PR fixes**:

I just noticed this, rather incidentally.
