### PR TITLE
fix(k8s): intermittent errors with volume mounts in build-sync pods

### DIFF
--- a/garden-service/static/kubernetes/system/build-sync/templates/deployment.yaml
+++ b/garden-service/static/kubernetes/system/build-sync/templates/deployment.yaml
@@ -49,9 +49,11 @@ spec:
             periodSeconds: 2
           livenessProbe:
             exec:
-              command: [pidof, rsync]
+              # The volume mount can go stale (for reasons not fully understood). This checks makes sure the volume
+              # mount works and terminates the container if/when the mount fails.
+              command: [stat, /data]
             initialDelaySeconds: 20
-            periodSeconds: 20
+            periodSeconds: 2
           volumeMounts:
             - mountPath: /data
               name: garden-build-sync


### PR DESCRIPTION
**What this PR does / why we need it**:

When using in-cluster building with the default NFS provisioner, users would very occasionally start getting errors like

```
Failed building backend. Here is the output:
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Command "rsync --recursive --relative --links --perms --times --compress --delete --temp-dir /tmp /root/project/.garden/build/./backend/ rsync://*********:45957/volume/86b9b3e6-91da-4ffe-b43b-e7babfda628e/" failed with code 5:
@ERROR: chdir failed
rsync error: error starting client-server protocol (code 5) at main.c(1675) [sender=3.1.3]
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```

This indicates a failure in the volume mount in the Pod. The liveness probe now checks that the volume mount is still readable (stat otherwise fails).

**Which issue(s) this PR fixes**:

Reported on Slack on a few occasions.
