### PR TITLE
chore(ci): fix flaky microk8s test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -498,9 +498,6 @@ jobs:
             sudo usermod -a -G microk8s circleci
             echo "********* microk8s ready! ************"
 
-            # Allow intra-pod communication
-            sudo iptables -P FORWARD ACCEPT
-
             # Set up kubeconfig and environment
             mkdir -p /home/circleci/.kube
             sudo sh -c 'microk8s.kubectl config view --raw > /home/circleci/.kube/config'


### PR DESCRIPTION
**What this PR does / why we need it**:

The iptables command that I copied from a microk8s example was sometimes causing problems due to some locking issue.
