### PR TITLE
improvement: prepareImagePullSecrets() on namespace creation via garden

### DIFF
--- a/docs/guides/in-cluster-building.md
+++ b/docs/guides/in-cluster-building.md
@@ -65,6 +65,13 @@ In this mode, builds are executed as follows:
 
 After enabling this mode (we currently still default to the `local-docker` mode), you will need to run `garden plugins kubernetes cluster-init --env=<env-name>` for each applicable environment, in order to install the required cluster-wide services. Those services include the Docker daemon itself, as well as an image registry, a sync service for receiving build contexts, two persistent volumes, an NFS volume provisioner for one of those volumes, and a couple of small utility services.
 
+Optionally, you can also enable [BuildKit]((https://github.com/moby/buildkit)). In most cases, this should work well and be more performant, but remains optional for now. If you have `cluster-docker` set as your `buildMode` you can enable BuildKit for an environment as follows:
+
+```yaml
+clusterDocker:
+  enableBuildKit: false
+```
+
 Make sure your cluster has enough resources and storage to support the required services, and keep in mind that these
 services are shared across all users of the cluster. Please look at the [resources](../reference/providers/kubernetes.md#providersresources) and [storage](../reference/providers/kubernetes.md#providersstorage) sections in the provider reference for
 details.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:
Preparing imagePullSecrets on app namespace creation in addition to what was already done for `garden-system` namespace and for deployment spec created via garden. This way I can delete and re-create environments + namespaces on local and remote kubernetes, and  don't need to worry with the secrets creation for pulling images from a private registry.

**Which issue(s) this PR fixes**:

Fixes #1774 

**Special notes for your reviewer**:

Below the test scenario:

Snippet of my garden.yaml

```
kind: Project
name: spring-petclinic
environments:
  - name: local
providers:
  - name: local-kubernetes
    environments: ["local"]
    imagePullSecrets:
      - name: docker-reg-cred

---
kind: Module
description: Helm chart for my module
type: helm
include:
  - kube/spring-petclinic-backend/*
  - kube/spring-petclinic-backend/templates/*
name: spring-petclinic-backend
chartPath: ./kube/spring-petclinic-backend
releaseName: spring-petclinic-backend
```

Make sure you have a secret called `docker-reg-cred` in your target testing cluster.
As soon as garden creates the namespace, you should be able to list the secret copied from the `default` namespace.