### PR TITLE
fix(terraform): fix stdin handling in commands

### DIFF
--- a/garden-service/src/plugins/terraform/commands.ts
+++ b/garden-service/src/plugins/terraform/commands.ts
@@ -46,7 +46,7 @@ function makeRootCommand(commandName: string) {
       await tfValidate(log, provider, root, provider.config.variables)
 
       args = [commandName, ...(await prepareVariables(root, provider.config.variables)), ...args]
-      await terraform(provider.config.version).spawnAndWait({ log, args, cwd: root, tty: true })
+      await terraform(provider.config.version).spawnAndWait({ log, args, cwd: root, rawMode: false, tty: true })
 
       return { result: {} }
     },
@@ -73,7 +73,7 @@ function makeModuleCommand(commandName: string) {
       await tfValidate(log, provider, root, provider.config.variables)
 
       args = [commandName, ...(await prepareVariables(root, module.spec.variables)), ...args.slice(1)]
-      await terraform(module.spec.version).spawnAndWait({ log, args, cwd: root, tty: true })
+      await terraform(module.spec.version).spawnAndWait({ log, args, cwd: root, rawMode: false, tty: true })
 
       return { result: {} }
     },

--- a/garden-service/src/util/ext-tools.ts
+++ b/garden-service/src/util/ext-tools.ts
@@ -228,6 +228,7 @@ export interface ExecParams {
 
 export interface SpawnParams extends ExecParams {
   tty?: boolean
+  rawMode?: boolean // Only used if tty = true. See also: https://nodejs.org/api/tty.html#tty_readstream_setrawmode_mode
 }
 
 /**
@@ -316,7 +317,7 @@ export class BinaryCmd extends Library {
     return crossSpawn(path, args, { cwd, env })
   }
 
-  async spawnAndWait({ args, cwd, env, log, ignoreError, stdout, stderr, timeout, tty }: SpawnParams) {
+  async spawnAndWait({ args, cwd, env, log, ignoreError, rawMode, stdout, stderr, timeout, tty }: SpawnParams) {
     const path = await this.getPath(log)
 
     if (!args) {
@@ -332,6 +333,7 @@ export class BinaryCmd extends Library {
       timeout: this.getTimeout(timeout),
       ignoreError,
       env,
+      rawMode,
       stdout,
       stderr,
       tty,

--- a/garden-service/src/util/util.ts
+++ b/garden-service/src/util/util.ts
@@ -190,6 +190,7 @@ export interface SpawnOpts {
   data?: Buffer
   ignoreError?: boolean
   env?: { [key: string]: string | undefined }
+  rawMode?: boolean // Only used if tty = true. See also: https://nodejs.org/api/tty.html#tty_readstream_setrawmode_mode
   stdout?: Writable
   stderr?: Writable
   tty?: boolean
@@ -206,7 +207,7 @@ export interface SpawnOutput {
 
 // TODO Dump output to a log file if it exceeds the MAX_BUFFER_SIZE
 export function spawn(cmd: string, args: string[], opts: SpawnOpts = {}) {
-  const { timeout = 0, cwd, data, ignoreError = false, env, stdout, stderr, tty, wait = true } = opts
+  const { timeout = 0, cwd, data, ignoreError = false, env, rawMode = true, stdout, stderr, tty, wait = true } = opts
 
   const stdio = tty ? "inherit" : "pipe"
   const proc = _spawn(cmd, args, { cwd, env, stdio })
@@ -227,7 +228,9 @@ export function spawn(cmd: string, args: string[], opts: SpawnOpts = {}) {
     }
     _process.stdin.setEncoding("utf8")
     // raw mode is not available if we're running without a TTY
-    _process.stdin.setRawMode && _process.stdin.setRawMode(true)
+    if (rawMode) {
+      _process.stdin.setRawMode && _process.stdin.setRawMode(true)
+    }
   }
 
   // We ensure the output strings never exceed the MAX_BUFFER_SIZE


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

Before this fix, `stdin` was not being handled correctly for the terraform plugin's commands. They were unresponsive to input (including `CTRL-C`), which prevented the commands from being run to completion in some cases.

This was fixed by not setting `setRawMode` to `true` on the child process' `stdin`.

We added the `rawMode` option to `SpawnParams` to facilitate other use cases that need interactive input, but where `rawMode` doesn't play nicely with `stdin` for the underlying child process.

**Which issue(s) this PR fixes**:

Fixes #1709.

**Special notes for your reviewer**:

Is there a decent way to test this for future regressions?

I thought about using the input stream's `write` method (see https://nodejs.org/api/net.html#net_socket_write_data_encoding_callback) for this (e.g. for testing that `CTRL-C` is handled/respected).

Would that be a valid approach, or would it be functionally different from receiving inherited input (and/or be problematic in a CI environment)?

If this approach does make sense, then I'd like to write a couple of unit tests for this too.