### PR TITLE
fix(core): missing dep detection in ConfigGraph

### DIFF
--- a/garden-service/src/config-graph.ts
+++ b/garden-service/src/config-graph.ts
@@ -16,11 +16,7 @@ import { TestConfig } from "./config/test"
 import { uniqByName, pickKeys } from "./util/util"
 import { ConfigurationError } from "./exceptions"
 import { deline } from "./util/string"
-import {
-  detectMissingDependencies,
-  handleDependencyErrors,
-  DependencyValidationGraph,
-} from "./util/validate-dependencies"
+import { detectMissingDependencies, DependencyValidationGraph } from "./util/validate-dependencies"
 import { ServiceConfig } from "./config/service"
 import { TaskConfig } from "./config/task"
 import { makeTestTaskName } from "./tasks/helpers"
@@ -167,7 +163,7 @@ export class ConfigGraph {
       }
     }
 
-    const missingDepsError = detectMissingDependencies(Object.values(this.modules))
+    detectMissingDependencies(Object.values(this.modules))
 
     // Add relations between nodes
     for (const module of modules) {
@@ -267,17 +263,11 @@ export class ConfigGraph {
     const validationGraph = DependencyValidationGraph.fromDependencyGraph(this.dependencyGraph)
     const cycles = validationGraph.detectCircularDependencies()
 
-    let circularDepsError
     if (cycles.length > 0) {
       const description = validationGraph.cyclesToString(cycles)
       const errMsg = `\nCircular dependencies detected: \n\n${description}\n`
-      circularDepsError = new ConfigurationError(errMsg, { "circular-dependencies": description })
-    } else {
-      circularDepsError = null
+      throw new ConfigurationError(errMsg, { "circular-dependencies": description })
     }
-
-    // Throw an error if one or both of these errors is non-null.
-    handleDependencyErrors(missingDepsError, circularDepsError)
   }
 
   // Convenience method used in the constructor above.

--- a/garden-service/test/helpers.ts
+++ b/garden-service/test/helpers.ts
@@ -28,7 +28,7 @@ import { Garden, GardenParams, GardenOpts } from "../src/garden"
 import { ModuleConfig } from "../src/config/module"
 import { mapValues, fromPairs } from "lodash"
 import { ModuleVersion } from "../src/vcs/vcs"
-import { GARDEN_SERVICE_ROOT, LOCAL_CONFIG_FILENAME } from "../src/constants"
+import { GARDEN_SERVICE_ROOT, LOCAL_CONFIG_FILENAME, DEFAULT_API_VERSION } from "../src/constants"
 import { EventBus, Events } from "../src/events"
 import { ValueOf, exec, findByName, getNames } from "../src/util/util"
 import { LogEntry } from "../src/logger/log-entry"
@@ -276,7 +276,7 @@ export const testPluginC = createGardenPlugin({
 })
 
 const defaultModuleConfig: ModuleConfig = {
-  apiVersion: "garden.io/v0",
+  apiVersion: DEFAULT_API_VERSION,
   type: "test",
   name: "test",
   path: "bla",

--- a/garden-service/test/unit/src/util/validate-dependencies.ts
+++ b/garden-service/test/unit/src/util/validate-dependencies.ts
@@ -37,8 +37,7 @@ describe("validate-dependencies", () => {
           spec: {},
         },
       ]
-      const err = detectMissingDependencies(moduleConfigs)
-      expect(err).to.be.an.instanceOf(ConfigurationError)
+      expect(() => detectMissingDependencies(moduleConfigs)).to.throw()
     })
 
     it("should return an error when a service dependency is missing", async () => {
@@ -66,8 +65,7 @@ describe("validate-dependencies", () => {
           spec: {},
         },
       ]
-      const err = detectMissingDependencies(moduleConfigs)
-      expect(err).to.be.an.instanceOf(ConfigurationError)
+      expect(() => detectMissingDependencies(moduleConfigs)).to.throw()
     })
 
     it("should return an error when a task dependency is missing", async () => {
@@ -96,8 +94,7 @@ describe("validate-dependencies", () => {
           spec: {},
         },
       ]
-      const err = detectMissingDependencies(moduleConfigs)
-      expect(err).to.be.an.instanceOf(ConfigurationError)
+      expect(() => detectMissingDependencies(moduleConfigs)).to.throw()
     })
 
     it("should return an error when a test dependency is missing", async () => {
@@ -125,8 +122,7 @@ describe("validate-dependencies", () => {
           spec: {},
         },
       ]
-      const err = detectMissingDependencies(moduleConfigs)
-      expect(err).to.be.an.instanceOf(ConfigurationError)
+      expect(() => detectMissingDependencies(moduleConfigs)).to.throw()
     })
 
     it("should return null when no dependencies are missing", async () => {
@@ -146,8 +142,7 @@ describe("validate-dependencies", () => {
           spec: {},
         },
       ]
-      const result = detectMissingDependencies(moduleConfigs)
-      expect(result).to.be.null
+      expect(() => detectMissingDependencies(moduleConfigs))
     })
   })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

Before this fix, we were throwing missing dependency errors in `ConfigGraph`'s constructor after relations were added, which could result in null errors in the case of missing runtime dependencies.

This was fixed by throwing missing dependency errors before adding relations in the constructor.

**Which issue(s) this PR fixes**:

Fixes an issue reported in our community Slack (https://kubernetes.slack.com/archives/CKM7CP8P9/p1586257958248000).