### PR TITLE
feat(k8s): run a persistent skopeo daemon

### DIFF
--- a/garden-service/src/plugins/kubernetes/constants.ts
+++ b/garden-service/src/plugins/kubernetes/constants.ts
@@ -17,3 +17,9 @@ export const MAX_RUN_RESULT_LOG_LENGTH = 250 * 1024
 export const dockerAuthSecretName = "builder-docker-config"
 export const dockerAuthSecretKey = ".dockerconfigjson"
 export const inClusterRegistryHostname = "127.0.0.1:5000"
+
+export const gardenUtilDaemonDeploymentName = "garden-util-daemon"
+export const dockerDaemonDeploymentName = "garden-docker-daemon"
+
+export const dockerDaemonContainerName = "docker-daemon"
+export const skopeoDaemonContainerName = "util"

--- a/garden-service/src/plugins/kubernetes/kubernetes.ts
+++ b/garden-service/src/plugins/kubernetes/kubernetes.ts
@@ -73,6 +73,8 @@ export async function configureProvider({
         namespace: config.deploymentRegistry?.namespace || projectName,
       }
       config._systemServices.push("docker-registry", "registry-proxy")
+    } else {
+      config._systemServices.push("util")
     }
 
     if (config.buildMode === "cluster-docker") {

--- a/garden-service/static/kubernetes/system/util/Chart.yaml
+++ b/garden-service/static/kubernetes/system/util/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: util
+description: A chart to run a persistent utility containers.
+type: application
+version: 0.1.0
+appVersion: 0.1.0

--- a/garden-service/static/kubernetes/system/util/garden.yml
+++ b/garden-service/static/kubernetes/system/util/garden.yml
@@ -1,0 +1,5 @@
+kind: Module
+name: util
+description: Long lived utility containers.
+type: helm
+releaseName: garden-util-daemon

--- a/garden-service/static/kubernetes/system/util/templates/_helpers.tpl
+++ b/garden-service/static/kubernetes/system/util/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "garden-util.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "garden-util.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "garden-util.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "garden-util.labels" -}}
+helm.sh/chart: {{ include "garden-util.chart" . }}
+{{ include "garden-util.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "garden-util.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "garden-util.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "garden-util.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "garden-util.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/garden-service/static/kubernetes/system/util/templates/deployment.yaml
+++ b/garden-service/static/kubernetes/system/util/templates/deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "garden-util.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "garden-util.name" . }}
+    helm.sh/chart: {{ include "garden-util.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "garden-util.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "garden-util.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      volumes:
+        - name: docker-config
+          secret: 
+            secretName: builder-docker-config
+            items:
+              - key: .dockerconfigjson
+                path: config.json
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/sh", "-ec", "while :; do echo '.'; sleep 5 ; done"]
+          volumeMounts:
+            - name: docker-config
+              mountPath: /root/.docker
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+        - name: proxy
+          image: "gardendev/socat:0.1.0"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - TCP-LISTEN:5000,fork
+            - TCP:{{ .Values.registry.hostname }}:5000
+          ports:
+            - name: proxy
+              containerPort: 5000
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: 5000
+          readinessProbe:
+            tcpSocket:
+              port: 5000
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/garden-service/static/kubernetes/system/util/values.yaml
+++ b/garden-service/static/kubernetes/system/util/values.yaml
@@ -1,0 +1,30 @@
+# Default values for skopeo.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: gardendev/skopeo
+  tag: "1.41.0-1"
+  pullPolicy: IfNotPresent
+
+nameOverride: "garden-util-daemon"
+fullnameOverride: "garden-util-daemon"
+
+resources:
+  limits:
+    cpu: "2"
+    memory: "4Gi"
+  requests:
+    cpu: 200m
+    memory: 256Mi
+
+registry:
+  hostname: garden-docker-registry
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/garden-service/test/integ/src/plugins/kubernetes/container/build.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/container/build.ts
@@ -12,14 +12,18 @@ import { ConfigGraph } from "../../../../../../src/config-graph"
 import {
   k8sBuildContainer,
   k8sGetContainerBuildStatus,
-  getBuilderPodName,
-  execInBuilder,
+  getDeploymentPodName,
+  execInPod,
 } from "../../../../../../src/plugins/kubernetes/container/build"
 import { PluginContext } from "../../../../../../src/plugin-context"
 import { KubernetesProvider } from "../../../../../../src/plugins/kubernetes/config"
 import { expect } from "chai"
 import { getContainerTestGarden } from "./container"
 import { containerHelpers } from "../../../../../../src/plugins/container/helpers"
+import {
+  dockerDaemonDeploymentName,
+  dockerDaemonContainerName,
+} from "../../../../../../src/plugins/kubernetes/constants"
 
 describe("kubernetes build flow", () => {
   let garden: Garden
@@ -156,9 +160,10 @@ describe("kubernetes build flow", () => {
 
       // Clear the image tag from the in-cluster builder
       const remoteId = await containerHelpers.getDeploymentImageId(module, provider.config.deploymentRegistry)
-      const podName = await getBuilderPodName(provider, garden.log)
+      const podName = await getDeploymentPodName(dockerDaemonDeploymentName, provider, garden.log)
+      const containerName = dockerDaemonContainerName
       const args = ["docker", "rmi", remoteId]
-      await execInBuilder({ provider, log: garden.log, args, timeout: 300, podName })
+      await execInPod({ provider, log: garden.log, args, timeout: 300, podName, containerName })
 
       // This should still report the build as ready, because it's in the registry
       const status = await k8sGetContainerBuildStatus({
@@ -214,9 +219,10 @@ describe("kubernetes build flow", () => {
 
       // Clear the image tag from the in-cluster builder
       const remoteId = await containerHelpers.getDeploymentImageId(module, provider.config.deploymentRegistry)
-      const podName = await getBuilderPodName(provider, garden.log)
+      const podName = await getDeploymentPodName(dockerDaemonDeploymentName, provider, garden.log)
+      const containerName = dockerDaemonContainerName
       const args = ["docker", "rmi", remoteId]
-      await execInBuilder({ provider, log: garden.log, args, timeout: 300, podName })
+      await execInPod({ provider, log: garden.log, args, timeout: 300, podName, containerName })
 
       // This should still report the build as ready, because it's in the registry
       const status = await k8sGetContainerBuildStatus({

--- a/garden-service/test/integ/src/plugins/kubernetes/system.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/system.ts
@@ -45,6 +45,7 @@ describe("System services", () => {
       "conftest-ingress-controller",
       "conftest-nfs-provisioner",
       "conftest-registry-proxy",
+      "conftest-util",
     ])
   })
 


### PR DESCRIPTION
This adds a persistent skopeo daemon deployed to the cluster. This is to avoid having to spin up a new skopeo container per build status check for container. We end up seeing some failures randomly in our EKS cluster, most likely to do with failures/timeouts mounting volumes, and this will resolve that issue for us.

@edvald


**Which issue(s) this PR fixes**:

No issue.

**Special notes for your reviewer**:
