### PR TITLE
docs: document GARDEN_DISABLE_ANALYTICS env variable

### DIFF
--- a/docs/misc/telemetry.md
+++ b/docs/misc/telemetry.md
@@ -140,3 +140,9 @@ If you would like to update your analytics settings, please run:
 ```sh
     garden config analytics-enabled true|false
 ```
+
+You can also disable telemetry by setting the environment variable `GARDEN_DISABLE_ANALYTICS`:
+
+```sh
+export GARDEN_DISABLE_ANALYTICS=true
+```


### PR DESCRIPTION
**What this PR does / why we need it**:

This came up on Slack, simple omission from our docs.
