### PR TITLE
chore(docker): add image that contains gcloud and aws

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,6 +344,22 @@ jobs:
             cd garden-service
             docker build -t ${TAG} --build-arg TAG=${CIRCLE_SHA1} -f gcloud.Dockerfile .
             docker push ${TAG}
+  build-docker-aws-gcloud:
+    <<: *node-config
+    steps:
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - checkout
+      - *attach-workspace
+      - run:
+          name: Build image and push to registry
+          command: |
+            docker login -u $DOCKER_USER -p $DOCKER_PASS
+            TAG=gardendev/garden-aws-gcloud:${CIRCLE_SHA1}
+            cd garden-service
+            docker build -t ${TAG} --build-arg TAG=${CIRCLE_SHA1} -f aws.gcloud.Dockerfile .
+            docker push ${TAG}
+
   build-docker-buster:
     <<: *node-config
     steps:
@@ -662,6 +678,10 @@ workflows:
           <<: *only-internal-prs
           context: docker
           requires: [build-docker]
+      - build-docker-aws-gcloud:
+          <<: *only-internal-prs
+          context: docker
+          requires: [build-docker]    
       - build-docker-buster:
           <<: *only-internal-prs
           context: docker

--- a/garden-service/aws.gcloud.Dockerfile
+++ b/garden-service/aws.gcloud.Dockerfile
@@ -1,0 +1,22 @@
+ARG TAG=latest
+FROM google/cloud-sdk:277.0.0-alpine as gcloud
+
+RUN gcloud components install kubectl
+
+FROM gardendev/garden:${TAG}
+
+ENV CLOUDSDK_PYTHON=python3
+
+COPY --from=gcloud /google-cloud-sdk /google-cloud-sdk
+
+RUN apk add --no-cache python3 \
+  && ln -s /google-cloud-sdk/bin/* /usr/local/bin/ \
+  && chmod +x /usr/local/bin/*
+
+RUN apk add --no-cache python py-pip \
+  && pip install awscli==1.17.9 --upgrade \
+  && apk del py-pip
+
+RUN curl -o aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.15.10/2020-02-22/bin/linux/amd64/aws-iam-authenticator \
+  && chmod +x ./aws-iam-authenticator \
+  && mv ./aws-iam-authenticator /usr/bin/  

--- a/garden-service/bin/build-containers.sh
+++ b/garden-service/bin/build-containers.sh
@@ -10,6 +10,7 @@ version=${args[0]:-$(git rev-parse --short HEAD)}
 base_tag=gardendev/garden:${version}
 aws_tag=gardendev/garden-aws:${version}
 gcloud_tag=gardendev/garden-gcloud:${version}
+aws_gcloud_tag=gardendev/garden-aws-gcloud:${version}
 buster_tag=gardendev/garden:${version}-buster
 
 echo "Building version ${version}"
@@ -29,6 +30,11 @@ echo "-> Build ${gcloud_tag}"
 docker build -t ${gcloud_tag} --build-arg TAG=${version} -f gcloud.Dockerfile .
 echo "-> Check ${gcloud_tag}"
 docker run --rm -it ${gcloud_tag} version
+
+echo "-> Build ${aws_gcloud_tag}"
+docker build -t ${aws_gcloud_tag} --build-arg TAG=${version} -f aws.gcloud.Dockerfile .
+echo "-> Check ${aws_gcloud_tag}"
+docker run --rm -it ${aws_gcloud_tag} version
 
 echo "-> Build ${buster_tag}"
 docker build -t ${buster_tag} -f buster.Dockerfile dist/linux-amd64

--- a/garden-service/bin/push-containers.sh
+++ b/garden-service/bin/push-containers.sh
@@ -14,4 +14,5 @@ echo "Pushing images"
 docker push gardendev/garden:${version}
 docker push gardendev/garden-aws:${version}
 docker push gardendev/garden-gcloud:${version}
+docker push gardendev/garden-aws-gcloud:${version}
 docker push gardendev/garden:${version}-buster


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

**What this PR does / why we need it**:
This PR creates an image that include gcloud, awscli and gardencli in one image
**Which issue(s) this PR fixes**:
It is meant to be used for gardencloud staging deployment
Fixes #

**Special notes for your reviewer**:
