### PR TITLE
fix(dashboard): make sure we can display disabled modules

### DIFF
--- a/dashboard/src/api/actions.ts
+++ b/dashboard/src/api/actions.ts
@@ -115,6 +115,10 @@ function processConfigInitResult(entities: Entities, config: ConfigDump) {
         tests: cfg.testConfigs.map((test) => `${cfg.name}.${test.name}`),
         tasks: cfg.taskConfigs.map((task) => task.name),
         taskState: "taskComplete",
+        config: {
+          ...cfg,
+          moduleDisabled: cfg.disabled,
+        },
       }
       draft.modules[cfg.name] = module
 

--- a/dashboard/src/contexts/api.tsx
+++ b/dashboard/src/contexts/api.tsx
@@ -81,6 +81,7 @@ export type ModuleEntity = Pick<
   tasks: string[]
   tests: string[]
   taskState: TaskState // State of the build task for the module
+  config: ModuleConfig
 }
 
 export interface ServiceEntity {


### PR DESCRIPTION
Turns out that if module is disabled, `modules[node.name]`
is undefined (perhaps because it got filtered out). Since
we don't care about disabled modules other than saying:
"here's the name and it's disabled", I have fixed the
method for getting the entity from API response and made
it more defensive in general case (better to miss results
than to display react exception :))

**Which issue(s) this PR fixes**:

Fixes (As described above)

**Special notes for your reviewer**:

I am not sure if `getTestKey` is still needed. It worked fine without it, but my eyballs could have been deceiving me.