### PR TITLE
fix(k8s): artifact logs

### DIFF
--- a/garden-service/src/plugins/kubernetes/run.ts
+++ b/garden-service/src/plugins/kubernetes/run.ts
@@ -122,7 +122,7 @@ export async function runAndCopy({
 
     // We start the container with a named pipe and tail that, to get the logs from the actual command
     // we plan on running. Then we sleep, so that we can copy files out of the container.
-    spec.containers[0].command = ["sh", "-c", "mkfifo /tmp/output && tail -f /tmp/output && sleep 86400"]
+    spec.containers[0].command = ["sh", "-c", "mkfifo /tmp/output && cat /tmp/output && sleep 86400"]
   } else {
     if (args) {
       spec.containers[0].args = args

--- a/garden-service/test/integ/src/plugins/kubernetes/container/container.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/container/container.ts
@@ -338,7 +338,7 @@ describe("kubernetes container module handlers", () => {
           timeout: 3,
         })
 
-        expect(result.log.trim()).to.equal("Command timed out.")
+        expect(result.log.trim()).to.equal("Command timed out. Here are the logs until the timeout occurred:\n\nbanana")
         expect(result.success).to.be.false
       })
 


### PR DESCRIPTION
Use cat instead of tail -f. For some reason, cat works with multiple tests and tail -f doesn't.

To replicate:

1. Make a garden file with a single test + artifacts.
2. Make that test fail. See the correct log output of > 10 lines.
3. Add a second test (can succeed/fail, have artifacts or not, doesn't matter).
4. Run the tests again, and see the truncated log output for the original failing test.

@edvald 