### PR TITLE
fix(commands): ensure get config returns disabled configs (by default)

### DIFF
--- a/bin/test-release.sh
+++ b/bin/test-release.sh
@@ -82,12 +82,18 @@ test_release() {
   echo ""
   ${garden_release} create module
   echo ""
-  echo "→ Running 'garden dev in' demo project - exits after 1 minute"
+  echo "→ Running 'garden dev' in demo project - exits after 1 minute"
   echo ""
   timeout 1m ${garden_release} dev
 
   echo ""
-  echo "→ Running 'garden dev' in vote project - exits after 2 minutes, use the chance to change services and test the dashboard"
+  echo "→ Running 'garden serve' in disabled-configs project - exits after 1 minute. Use the chance to test that the dashboard works."
+  echo "→ The disabled module and test should be flagged appropriately on the Overview, and Stack Graph pages."
+  echo ""
+  timeout 1m ${garden_release} serve
+
+  echo ""
+  echo "→ Running 'garden dev' in vote project - exits after 2 minutes. Use the chance to change services and test the dashboard."
   echo "→ Try e.g. to change the status in the POST method in this file: ${garden_root}/examples/vote/api/app.py"
   echo "→ It should break the integ test"
   echo ""
@@ -96,7 +102,7 @@ test_release() {
   timeout 2m ${garden_release} dev
 
   echo ""
-  echo "→ Running 'garden deploy --hot=node-service' in hot-reload project - exits after 1 minute, use the chance to test if hot-reload works"
+  echo "→ Running 'garden deploy --hot=node-service' in hot-reload project - exits after 1 minute. Use the chance to test if hot-reload works"
   echo "→ Try e.g. to update this file: ${garden_root}/examples/hot-reload/node-service/app.js"
   echo ""
   cd ..

--- a/examples/disabled-configs/README.md
+++ b/examples/disabled-configs/README.md
@@ -1,0 +1,29 @@
+# Disabled configs example project
+
+A simple variation on the [demo-project](https://github.com/garden-io/garden/blob/master/examples/demo-project/README.md) where the `backend` module, and the `integ` test in the `frontend` module, are disabled for the `local` environment.
+
+The `backend` config then looks like this:
+
+```yaml
+# in backend/garden.yml
+kind: Module
+name: backend
+type: container
+disabled: ${environment.name == local}
+# ...
+```
+
+And the `frontend` config like this:
+
+```yaml
+# in frontend/garden.yml
+kind: Module
+name: frontend
+type: container
+# ...
+tests:
+  - name: integ
+    args: [npm, run, integ]
+    disabled: ${environment.name == local}
+# ...
+```

--- a/examples/disabled-configs/backend/.dockerignore
+++ b/examples/disabled-configs/backend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+Dockerfile
+garden.yml
+app.yaml

--- a/examples/disabled-configs/backend/.gitignore
+++ b/examples/disabled-configs/backend/.gitignore
@@ -1,0 +1,27 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+.vscode/settings.json
+webserver/*server*

--- a/examples/disabled-configs/backend/Dockerfile
+++ b/examples/disabled-configs/backend/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.8.3-alpine
+
+ENV PORT=8080
+EXPOSE ${PORT}
+WORKDIR /app
+
+COPY main.go .
+
+RUN go build -o main .
+
+ENTRYPOINT ["./main"]

--- a/examples/disabled-configs/backend/garden.yml
+++ b/examples/disabled-configs/backend/garden.yml
@@ -1,0 +1,18 @@
+kind: Module
+name: backend
+description: Backend service container
+type: container
+disabled: ${environment.name == local}
+services:
+  - name: backend
+    ports:
+      - name: http
+        containerPort: 8080
+        # Maps service:80 -> container:8080
+        servicePort: 80
+    ingresses:
+      - path: /hello-backend
+        port: http
+tasks:
+  - name: test
+    command: ["sh", "-c", "echo task output"]

--- a/examples/disabled-configs/backend/main.go
+++ b/examples/disabled-configs/backend/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, "Hello from Go!")
+}
+
+func main() {
+	http.HandleFunc("/hello-backend", handler)
+	fmt.Println("Server running...")
+
+	http.ListenAndServe(":8080", nil)
+}

--- a/examples/disabled-configs/frontend/.dockerignore
+++ b/examples/disabled-configs/frontend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+Dockerfile
+garden.yml
+app.yaml

--- a/examples/disabled-configs/frontend/Dockerfile
+++ b/examples/disabled-configs/frontend/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:9-alpine
+
+ENV PORT=8080
+EXPOSE ${PORT}
+WORKDIR /app
+
+COPY package.json /app
+RUN npm install
+
+COPY . /app
+
+CMD ["npm", "start"]

--- a/examples/disabled-configs/frontend/app.js
+++ b/examples/disabled-configs/frontend/app.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const request = require('request-promise')
+const app = express();
+
+const backendServiceEndpoint = `http://backend/hello-backend`
+
+app.get('/hello-frontend', (req, res) => res.send('Hello from the frontend!'));
+
+app.get('/call-backend', (req, res) => {
+  // Query the backend and return the response
+  request.get(backendServiceEndpoint)
+    .then(message => {
+      message = `Backend says: '${message}'`
+      res.json({
+        message,
+      })
+    })
+    .catch(err => {
+      res.statusCode = 500
+      res.json({
+        error: err,
+        message: "Unable to reach service at " + backendServiceEndpoint,
+      })
+    });
+});
+
+module.exports = { app }

--- a/examples/disabled-configs/frontend/garden.yml
+++ b/examples/disabled-configs/frontend/garden.yml
@@ -1,0 +1,28 @@
+kind: Module
+name: frontend
+description: Frontend service container
+type: container
+services:
+  - name: frontend
+    ports:
+      - name: http
+        containerPort: 8080
+    healthCheck:
+      httpGet:
+        path: /hello-frontend
+        port: http
+    ingresses:
+      - path: /hello-frontend
+        port: http
+      - path: /call-backend
+        port: http
+    dependencies:
+      - backend
+tests:
+  - name: unit
+    args: [npm, test]
+  - name: integ
+    args: [npm, run, integ]
+    disabled: ${environment.name == local}
+    dependencies:
+      - frontend

--- a/examples/disabled-configs/frontend/main.js
+++ b/examples/disabled-configs/frontend/main.js
@@ -1,0 +1,3 @@
+const { app } = require('./app');
+
+app.listen(process.env.PORT, '0.0.0.0', () => console.log('Frontend service started'));

--- a/examples/disabled-configs/frontend/package.json
+++ b/examples/disabled-configs/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "description": "Simple Node.js docker service",
+  "main": "main.js",
+  "scripts": {
+    "start": "node main.js",
+    "test": "echo OK",
+    "integ": "node_modules/mocha/bin/mocha test/integ.js"
+  },
+  "author": "garden.io <info@garden.io>",
+  "license": "ISC",
+  "dependencies": {
+    "express": "^4.16.2",
+    "request": "^2.83.0",
+    "request-promise": "^4.2.2"
+  },
+  "devDependencies": {
+    "mocha": "^5.1.1",
+    "supertest": "^3.0.0"
+  }
+}

--- a/examples/disabled-configs/frontend/test/integ.js
+++ b/examples/disabled-configs/frontend/test/integ.js
@@ -1,0 +1,17 @@
+const supertest = require("supertest")
+const { app } = require("../app")
+
+describe('GET /call-backend', () => {
+  const agent = supertest.agent(app)
+
+  it('should respond with a message from the backend service', (done) => {
+    agent
+      .get("/call-backend")
+      .expect(200, { message: "Backend says: 'Hello from Go!'" })
+      .end((err) => {
+        if (err) return done(err)
+        done()
+      })
+  })
+})
+

--- a/examples/disabled-configs/garden.yml
+++ b/examples/disabled-configs/garden.yml
@@ -1,0 +1,16 @@
+kind: Project
+name: disabled-configs
+# defaultEnvironment: "remote" # Uncomment if you'd like the remote environment to be the default for this project.
+environments:
+  - name: local
+  - name: remote
+providers:
+  - name: local-kubernetes
+    environments: [local]
+  - name: kubernetes
+    environments: [remote]
+    # Replace these values as appropriate
+    context: gke_garden-dev-200012_europe-west1-b_garden-dev-1
+    namespace: disabled-configs-testing-${local.env.USER || local.username}
+    defaultHostname: ${local.env.USER || local.username}-disabled-configs.dev-1.sys.garden
+    buildMode: cluster-docker

--- a/garden-service/src/commands/get/get-config.ts
+++ b/garden-service/src/commands/get/get-config.ts
@@ -23,20 +23,19 @@ export class GetConfigCommand extends Command<{}, Opts> {
   options = options
 
   async action({ garden, log, opts }: CommandParams<{}, Opts>): Promise<CommandResult<ConfigDump>> {
-    const config = await garden.dumpConfig(log)
+    const config = await garden.dumpConfig(log, !opts["exclude-disabled"])
 
+    // Also filter out service, task, and test configs
     if (opts["exclude-disabled"]) {
-      const filteredModuleConfigs = config.moduleConfigs
-        .filter((moduleConfig) => !moduleConfig.disabled)
-        .map((moduleConfig) => {
-          const filteredConfig = {
-            ...moduleConfig,
-            serviceConfigs: moduleConfig.serviceConfigs.filter((c) => !c.disabled),
-            taskConfigs: moduleConfig.taskConfigs.filter((c) => !c.disabled),
-            testConfigs: moduleConfig.testConfigs.filter((c) => !c.disabled),
-          }
-          return filteredConfig
-        })
+      const filteredModuleConfigs = config.moduleConfigs.map((moduleConfig) => {
+        const filteredConfig = {
+          ...moduleConfig,
+          serviceConfigs: moduleConfig.serviceConfigs.filter((c) => !c.disabled),
+          taskConfigs: moduleConfig.taskConfigs.filter((c) => !c.disabled),
+          testConfigs: moduleConfig.testConfigs.filter((c) => !c.disabled),
+        }
+        return filteredConfig
+      })
 
       config.moduleConfigs = filteredModuleConfigs
     }

--- a/garden-service/src/garden.ts
+++ b/garden-service/src/garden.ts
@@ -1033,9 +1033,9 @@ export class Garden {
   /**
    * This dumps the full project configuration including all modules.
    */
-  public async dumpConfig(log: LogEntry): Promise<ConfigDump> {
+  public async dumpConfig(log: LogEntry, includeDisabled: boolean = false): Promise<ConfigDump> {
     const graph = await this.getConfigGraph(log)
-    const modules = graph.getModules()
+    const modules = graph.getModules({ includeDisabled })
 
     return {
       environmentName: this.environmentName,

--- a/garden-service/test/helpers.ts
+++ b/garden-service/test/helpers.ts
@@ -351,12 +351,22 @@ export class TestGarden extends Garden {
   }
 
   /**
-   * Returns modules that are registered in this context, fully resolved and configured.
+   * Returns modules that are registered in this context, fully resolved and configured. Optionally includes
+   * disabled modules.
+   *
    * Scans for modules in the project root and remote/linked sources if it hasn't already been done.
    */
-  async resolveModules({ log, runtimeContext }: { log: LogEntry; runtimeContext?: RuntimeContext }): Promise<Module[]> {
+  async resolveModules({
+    log,
+    runtimeContext,
+    includeDisabled = false,
+  }: {
+    log: LogEntry
+    runtimeContext?: RuntimeContext
+    includeDisabled?: boolean
+  }): Promise<Module[]> {
     const graph = await this.getConfigGraph(log, runtimeContext)
-    return graph.getModules()
+    return graph.getModules({ includeDisabled })
   }
 
   /**

--- a/garden-service/test/unit/src/commands/get/get-config.ts
+++ b/garden-service/test/unit/src/commands/get/get-config.ts
@@ -40,7 +40,7 @@ describe("GetConfigCommand", () => {
     expect(config).to.deep.equal(res.result)
   })
 
-  it("should exclude disabled module configs", async () => {
+  it("should include disabled module configs", async () => {
     const garden = await makeTestGardenA()
     const log = garden.log
     const command = new GetConfigCommand()
@@ -102,12 +102,14 @@ describe("GetConfigCommand", () => {
       headerLog: log,
       footerLog: log,
       args: {},
-      opts: withDefaultGlobalOpts({ "exclude-disabled": true }),
+      opts: withDefaultGlobalOpts({ "exclude-disabled": false }),
     })
 
     const providers = await garden.resolveProviders()
 
-    const expectedModuleConfigs = sortBy(await garden.resolveModules({ log }), "name").map((m) => m._config)
+    const expectedModuleConfigs = sortBy(await garden.resolveModules({ log, includeDisabled: true }), "name").map(
+      (m) => m._config
+    )
 
     const config = {
       environmentName: garden.environmentName,
@@ -117,11 +119,11 @@ describe("GetConfigCommand", () => {
       projectRoot: garden.projectRoot,
     }
 
-    expect(expectedModuleConfigs.length).to.equal(1)
+    expect(expectedModuleConfigs.length).to.equal(2)
     expect(config).to.deep.equal(res.result)
   })
 
-  it("should exclude disabled service configs", async () => {
+  it("should include disabled service configs", async () => {
     const garden = await makeTestGardenA()
     const log = garden.log
     const command = new GetConfigCommand()
@@ -174,39 +176,12 @@ describe("GetConfigCommand", () => {
       headerLog: log,
       footerLog: log,
       args: {},
-      opts: withDefaultGlobalOpts({ "exclude-disabled": true }),
+      opts: withDefaultGlobalOpts({ "exclude-disabled": false }),
     })
 
     const providers = await garden.resolveProviders()
 
-    const expectedModuleConfigs = (await garden.resolveModules({ log })).map((m) => m._config)
-    // Remove the disabled service
-    expectedModuleConfigs[0].serviceConfigs = [
-      {
-        name: "service-enabled",
-        dependencies: [],
-        disabled: false,
-        sourceModuleName: undefined,
-        spec: {
-          name: "service-enabled",
-          dependencies: [],
-          disabled: false,
-          hotReloadable: false,
-          spec: {},
-          annotations: {},
-          daemon: false,
-          ingresses: [],
-          env: {},
-          limits: {
-            cpu: 1000,
-            memory: 1024,
-          },
-          ports: [],
-          volumes: [],
-        },
-        hotReloadable: false,
-      },
-    ]
+    const expectedModuleConfigs = (await garden.resolveModules({ log, includeDisabled: true })).map((m) => m._config)
 
     const config = {
       environmentName: garden.environmentName,
@@ -219,7 +194,7 @@ describe("GetConfigCommand", () => {
     expect(config).to.deep.equal(res.result)
   })
 
-  it("should exclude disabled task configs", async () => {
+  it("should include disabled task configs", async () => {
     const garden = await makeTestGardenA()
     const log = garden.log
     const command = new GetConfigCommand()
@@ -269,31 +244,12 @@ describe("GetConfigCommand", () => {
       headerLog: log,
       footerLog: log,
       args: {},
-      opts: withDefaultGlobalOpts({ "exclude-disabled": true }),
+      opts: withDefaultGlobalOpts({ "exclude-disabled": false }),
     })
 
     const providers = await garden.resolveProviders()
 
-    const expectedModuleConfigs = (await garden.resolveModules({ log })).map((m) => m._config)
-    // Remove the disabled task
-    expectedModuleConfigs[0].taskConfigs = [
-      {
-        name: "task-enabled",
-        cacheResult: true,
-        dependencies: [],
-        disabled: false,
-        spec: {
-          name: "task-enabled",
-          cacheResult: true,
-          dependencies: [],
-          disabled: false,
-          timeout: null,
-          env: {},
-          volumes: [],
-        },
-        timeout: null,
-      },
-    ]
+    const expectedModuleConfigs = (await garden.resolveModules({ log, includeDisabled: true })).map((m) => m._config)
 
     const config = {
       environmentName: garden.environmentName,
@@ -306,7 +262,7 @@ describe("GetConfigCommand", () => {
     expect(res.result).to.deep.equal(config)
   })
 
-  it("should exclude disabled test configs", async () => {
+  it("should include disabled test configs", async () => {
     const garden = await makeTestGardenA()
     const log = garden.log
     const command = new GetConfigCommand()
@@ -363,29 +319,12 @@ describe("GetConfigCommand", () => {
       headerLog: log,
       footerLog: log,
       args: {},
-      opts: withDefaultGlobalOpts({ "exclude-disabled": true }),
+      opts: withDefaultGlobalOpts({ "exclude-disabled": false }),
     })
 
     const providers = await garden.resolveProviders()
 
-    const expectedModuleConfigs = (await garden.resolveModules({ log })).map((m) => m._config)
-    // Remove the disabled task
-    expectedModuleConfigs[0].testConfigs = [
-      {
-        name: "test-enabled",
-        dependencies: [],
-        disabled: false,
-        spec: {
-          name: "test-enabled",
-          dependencies: [],
-          disabled: false,
-          timeout: null,
-          env: {},
-          volumes: [],
-        },
-        timeout: null,
-      },
-    ]
+    const expectedModuleConfigs = (await garden.resolveModules({ log, includeDisabled: true })).map((m) => m._config)
 
     const config = {
       environmentName: garden.environmentName,
@@ -396,5 +335,365 @@ describe("GetConfigCommand", () => {
     }
 
     expect(res.result).to.deep.equal(config)
+  })
+
+  context("--exclude-disabled", () => {
+    it("should exclude disabled module configs", async () => {
+      const garden = await makeTestGardenA()
+      const log = garden.log
+      const command = new GetConfigCommand()
+
+      garden.setModuleConfigs([
+        {
+          apiVersion: DEFAULT_API_VERSION,
+          allowPublish: false,
+          build: { dependencies: [] },
+          disabled: true,
+          name: "a-disabled",
+          include: [],
+          outputs: {},
+          path: garden.projectRoot,
+          serviceConfigs: [],
+          taskConfigs: [],
+          spec: {
+            services: [
+              {
+                name: "service-a",
+                dependencies: [],
+                disabled: false,
+                spec: {},
+              },
+            ],
+          },
+          testConfigs: [],
+          type: "test",
+        },
+        {
+          apiVersion: DEFAULT_API_VERSION,
+          allowPublish: false,
+          build: { dependencies: [] },
+          disabled: false,
+          include: [],
+          name: "b-enabled",
+          outputs: {},
+          path: garden.projectRoot,
+          serviceConfigs: [],
+          taskConfigs: [],
+          spec: {
+            services: [
+              {
+                name: "service-b",
+                dependencies: [],
+                disabled: false,
+                spec: {},
+              },
+            ],
+          },
+          testConfigs: [],
+          type: "test",
+        },
+      ])
+
+      const res = await command.action({
+        garden,
+        log,
+        headerLog: log,
+        footerLog: log,
+        args: {},
+        opts: withDefaultGlobalOpts({ "exclude-disabled": true }),
+      })
+
+      const providers = await garden.resolveProviders()
+
+      const expectedModuleConfigs = sortBy(await garden.resolveModules({ log }), "name").map((m) => m._config)
+
+      const config = {
+        environmentName: garden.environmentName,
+        providers,
+        variables: garden.variables,
+        moduleConfigs: expectedModuleConfigs,
+        projectRoot: garden.projectRoot,
+      }
+
+      expect(expectedModuleConfigs.length).to.equal(1)
+      expect(config).to.deep.equal(res.result)
+    })
+
+    it("should exclude disabled service configs", async () => {
+      const garden = await makeTestGardenA()
+      const log = garden.log
+      const command = new GetConfigCommand()
+
+      garden.setModuleConfigs([
+        {
+          apiVersion: DEFAULT_API_VERSION,
+          allowPublish: false,
+          build: { dependencies: [] },
+          disabled: false,
+          name: "enabled",
+          include: [],
+          outputs: {},
+          path: garden.projectRoot,
+          serviceConfigs: [],
+          taskConfigs: [],
+          spec: {
+            services: [
+              {
+                name: "service-disabled",
+                dependencies: [],
+                disabled: true,
+                hotReloadable: false,
+                spec: {},
+              },
+              {
+                name: "service-enabled",
+                dependencies: [],
+                disabled: false,
+                hotReloadable: false,
+                spec: {},
+              },
+            ],
+            tasks: [
+              {
+                name: "task-enabled",
+                dependencies: [],
+                disabled: false,
+              },
+            ],
+          },
+          testConfigs: [],
+          type: "test",
+        },
+      ])
+
+      const res = await command.action({
+        garden,
+        log,
+        headerLog: log,
+        footerLog: log,
+        args: {},
+        opts: withDefaultGlobalOpts({ "exclude-disabled": true }),
+      })
+
+      const providers = await garden.resolveProviders()
+
+      const expectedModuleConfigs = (await garden.resolveModules({ log })).map((m) => m._config)
+      // Remove the disabled service
+      expectedModuleConfigs[0].serviceConfigs = [
+        {
+          name: "service-enabled",
+          dependencies: [],
+          disabled: false,
+          sourceModuleName: undefined,
+          spec: {
+            name: "service-enabled",
+            dependencies: [],
+            disabled: false,
+            hotReloadable: false,
+            spec: {},
+            annotations: {},
+            daemon: false,
+            ingresses: [],
+            env: {},
+            limits: {
+              cpu: 1000,
+              memory: 1024,
+            },
+            ports: [],
+            volumes: [],
+          },
+          hotReloadable: false,
+        },
+      ]
+
+      const config = {
+        environmentName: garden.environmentName,
+        providers,
+        variables: garden.variables,
+        moduleConfigs: expectedModuleConfigs,
+        projectRoot: garden.projectRoot,
+      }
+
+      expect(config).to.deep.equal(res.result)
+    })
+
+    it("should exclude disabled task configs", async () => {
+      const garden = await makeTestGardenA()
+      const log = garden.log
+      const command = new GetConfigCommand()
+
+      garden.setModuleConfigs([
+        {
+          apiVersion: DEFAULT_API_VERSION,
+          allowPublish: false,
+          build: { dependencies: [] },
+          disabled: false,
+          name: "enabled",
+          include: [],
+          outputs: {},
+          path: garden.projectRoot,
+          serviceConfigs: [],
+          taskConfigs: [],
+          spec: {
+            services: [
+              {
+                name: "service",
+                dependencies: [],
+                disabled: false,
+                spec: {},
+              },
+            ],
+            tasks: [
+              {
+                name: "task-disabled",
+                dependencies: [],
+                disabled: true,
+              },
+              {
+                name: "task-enabled",
+                dependencies: [],
+                disabled: false,
+              },
+            ],
+          },
+          testConfigs: [],
+          type: "test",
+        },
+      ])
+
+      const res = await command.action({
+        garden,
+        log,
+        headerLog: log,
+        footerLog: log,
+        args: {},
+        opts: withDefaultGlobalOpts({ "exclude-disabled": true }),
+      })
+
+      const providers = await garden.resolveProviders()
+
+      const expectedModuleConfigs = (await garden.resolveModules({ log })).map((m) => m._config)
+      // Remove the disabled task
+      expectedModuleConfigs[0].taskConfigs = [
+        {
+          name: "task-enabled",
+          cacheResult: true,
+          dependencies: [],
+          disabled: false,
+          spec: {
+            name: "task-enabled",
+            cacheResult: true,
+            dependencies: [],
+            disabled: false,
+            timeout: null,
+            env: {},
+            volumes: [],
+          },
+          timeout: null,
+        },
+      ]
+
+      const config = {
+        environmentName: garden.environmentName,
+        providers,
+        variables: garden.variables,
+        moduleConfigs: expectedModuleConfigs,
+        projectRoot: garden.projectRoot,
+      }
+
+      expect(res.result).to.deep.equal(config)
+    })
+
+    it("should exclude disabled test configs", async () => {
+      const garden = await makeTestGardenA()
+      const log = garden.log
+      const command = new GetConfigCommand()
+
+      garden.setModuleConfigs([
+        {
+          apiVersion: DEFAULT_API_VERSION,
+          allowPublish: false,
+          build: { dependencies: [] },
+          disabled: false,
+          name: "enabled",
+          include: [],
+          outputs: {},
+          path: garden.projectRoot,
+          serviceConfigs: [],
+          taskConfigs: [],
+          spec: {
+            services: [
+              {
+                name: "service",
+                dependencies: [],
+                disabled: false,
+                spec: {},
+              },
+            ],
+            tasks: [
+              {
+                name: "task-enabled",
+                dependencies: [],
+                disabled: false,
+              },
+            ],
+            tests: [
+              {
+                name: "test-enabled",
+                dependencies: [],
+                disabled: false,
+              },
+              {
+                name: "test-disabled",
+                dependencies: [],
+                disabled: true,
+              },
+            ],
+          },
+          testConfigs: [],
+          type: "test",
+        },
+      ])
+
+      const res = await command.action({
+        garden,
+        log,
+        headerLog: log,
+        footerLog: log,
+        args: {},
+        opts: withDefaultGlobalOpts({ "exclude-disabled": true }),
+      })
+
+      const providers = await garden.resolveProviders()
+
+      const expectedModuleConfigs = (await garden.resolveModules({ log })).map((m) => m._config)
+      // Remove the disabled task
+      expectedModuleConfigs[0].testConfigs = [
+        {
+          name: "test-enabled",
+          dependencies: [],
+          disabled: false,
+          spec: {
+            name: "test-enabled",
+            dependencies: [],
+            disabled: false,
+            timeout: null,
+            env: {},
+            volumes: [],
+          },
+          timeout: null,
+        },
+      ]
+
+      const config = {
+        environmentName: garden.environmentName,
+        providers,
+        variables: garden.variables,
+        moduleConfigs: expectedModuleConfigs,
+        projectRoot: garden.projectRoot,
+      }
+
+      expect(res.result).to.deep.equal(config)
+    })
   })
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

Due to a regression, the `get config` command was no longer returning disabled module configs. This caused issues with the dashboard.

This PR ensures that `get config` returns disabled configs by default and adds tests.

EDIT: Also added a `disabled-configs` example project and a manual release test.  

**Which issue(s) this PR fixes**:

Addresses the same problem as this PR: #1803 

**Special notes for your reviewer**:
