### PR TITLE
chore(k8s): upgrade kaniko version

### DIFF
--- a/garden-service/src/plugins/kubernetes/container/build.ts
+++ b/garden-service/src/plugins/kubernetes/container/build.ts
@@ -43,7 +43,7 @@ import { dedent } from "../../../util/string"
 import chalk = require("chalk")
 import { loadImageToMicrok8s, getMicrok8sImageStatus } from "../local/microk8s"
 
-const kanikoImage = "gcr.io/kaniko-project/executor:debug-v0.19.0"
+const kanikoImage = "gcr.io/kaniko-project/executor:debug-v0.20.0"
 
 const registryPort = 5000
 


### PR DESCRIPTION
There appears to have been a bug in the v0.20 kaniko version so they released a quick update.

https://github.com/GoogleContainerTools/kaniko/releases/tag/v0.21.0

@edvald,
