### PR TITLE
fix(container): explicit task & test timeouts

### DIFF
--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -337,9 +337,6 @@ tests:
     # specific environments, e.g. only during CI.
     disabled: false
 
-    # Maximum duration (in seconds) of the test run.
-    timeout: null
-
     # The arguments used to run the test inside the container.
     args:
 
@@ -390,6 +387,9 @@ tests:
         # services at the same time. Refer to the documentation of the module type in question to learn more.
         module:
 
+    # Maximum duration (in seconds) of the test run.
+    timeout: 600
+
 # A list of tasks that can be run from this container module. These can be used as dependencies for services (executed
 # before the service is deployed) or for other tasks.
 tasks:
@@ -415,9 +415,6 @@ tasks:
     # when the task is disabled, so you need to make sure to provide alternate values for those if you're using them,
     # using conditional expressions.
     disabled: false
-
-    # Maximum duration (in seconds) of the task's execution.
-    timeout: null
 
     # The arguments used to run the task inside the container.
     args:
@@ -473,6 +470,9 @@ tasks:
         # the ReadWriteMany access mode, you'll need to make sure it is not configured to be mounted by multiple
         # services at the same time. Refer to the documentation of the module type in question to learn more.
         module:
+
+    # Maximum duration (in seconds) of the task's execution.
+    timeout: 600
 ```
 
 ## Configuration Keys
@@ -1371,16 +1371,6 @@ specific environments, e.g. only during CI.
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
-### `tests[].timeout`
-
-[tests](#tests) > timeout
-
-Maximum duration (in seconds) of the test run.
-
-| Type     | Default | Required |
-| -------- | ------- | -------- |
-| `number` | `null`  | No       |
-
 ### `tests[].args[]`
 
 [tests](#tests) > args
@@ -1567,6 +1557,16 @@ Note: Make sure to pay attention to the supported `accessModes` of the reference
 | -------- | -------- |
 | `string` | No       |
 
+### `tests[].timeout`
+
+[tests](#tests) > timeout
+
+Maximum duration (in seconds) of the test run.
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `600`   | No       |
+
 ### `tasks[]`
 
 A list of tasks that can be run from this container module. These can be used as dependencies for services (executed before the service is deployed) or for other tasks.
@@ -1618,16 +1618,6 @@ Note however that template strings referencing the task's outputs (i.e. runtime 
 | Type      | Default | Required |
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
-
-### `tasks[].timeout`
-
-[tasks](#tasks) > timeout
-
-Maximum duration (in seconds) of the task's execution.
-
-| Type     | Default | Required |
-| -------- | ------- | -------- |
-| `number` | `null`  | No       |
 
 ### `tasks[].args[]`
 
@@ -1824,6 +1814,16 @@ Note: Make sure to pay attention to the supported `accessModes` of the reference
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
+
+### `tasks[].timeout`
+
+[tasks](#tasks) > timeout
+
+Maximum duration (in seconds) of the task's execution.
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `600`   | No       |
 
 
 ## Outputs

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -194,9 +194,6 @@ tasks:
     # using conditional expressions.
     disabled: false
 
-    # Maximum duration (in seconds) of the task's execution.
-    timeout: null
-
     # Set to false if you don't want the task's result to be cached. Use this if the task needs to be run any time
     # your project (or one or more of the task's dependants) is deployed. Otherwise the task is only re-run when its
     # version changes (i.e. the module or one of its dependencies is modified), or when you run `garden run task`.
@@ -219,6 +216,9 @@ tasks:
 
         # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
         target: .
+
+    # Maximum duration (in seconds) of the task's execution.
+    timeout: 600
 
     # The Deployment, DaemonSet or StatefulSet that Garden should use to execute this task. If not specified, the
     # `serviceResource` configured on the module will be used. If neither is specified, an error will be thrown.
@@ -263,9 +263,6 @@ tests:
     # specific environments, e.g. only during CI.
     disabled: false
 
-    # Maximum duration (in seconds) of the test run.
-    timeout: null
-
     # The command/entrypoint used to run the test inside the container.
     command:
 
@@ -283,6 +280,9 @@ tests:
 
         # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
         target: .
+
+    # Maximum duration (in seconds) of the test run.
+    timeout: 600
 
     # The Deployment, DaemonSet or StatefulSet that Garden should use to execute this test suite. If not specified,
     # the `serviceResource` configured on the module will be used. If neither is specified, an error will be thrown.
@@ -746,16 +746,6 @@ Note however that template strings referencing the task's outputs (i.e. runtime 
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
-### `tasks[].timeout`
-
-[tasks](#tasks) > timeout
-
-Maximum duration (in seconds) of the task's execution.
-
-| Type     | Default | Required |
-| -------- | ------- | -------- |
-| `number` | `null`  | No       |
-
 ### `tasks[].cacheResult`
 
 [tasks](#tasks) > cacheResult
@@ -872,6 +862,16 @@ tasks:
   - artifacts:
       - target: "outputs/foo/"
 ```
+
+### `tasks[].timeout`
+
+[tasks](#tasks) > timeout
+
+Maximum duration (in seconds) of the task's execution.
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `600`   | No       |
 
 ### `tasks[].resource`
 
@@ -997,16 +997,6 @@ specific environments, e.g. only during CI.
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
-### `tests[].timeout`
-
-[tests](#tests) > timeout
-
-Maximum duration (in seconds) of the test run.
-
-| Type     | Default | Required |
-| -------- | ------- | -------- |
-| `number` | `null`  | No       |
-
 ### `tests[].command[]`
 
 [tests](#tests) > command
@@ -1113,6 +1103,16 @@ tests:
   - artifacts:
       - target: "outputs/foo/"
 ```
+
+### `tests[].timeout`
+
+[tests](#tests) > timeout
+
+Maximum duration (in seconds) of the test run.
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `600`   | No       |
 
 ### `tests[].resource`
 

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -173,9 +173,6 @@ tasks:
     # using conditional expressions.
     disabled: false
 
-    # Maximum duration (in seconds) of the task's execution.
-    timeout: null
-
     # The Deployment, DaemonSet or StatefulSet that Garden should use to execute this task. If not specified, the
     # `serviceResource` configured on the module will be used. If neither is specified, an error will be thrown.
     resource:
@@ -213,6 +210,9 @@ tasks:
         # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
         target: .
 
+    # Maximum duration (in seconds) of the task's execution.
+    timeout: 600
+
 tests:
   - # The name of the test.
     name:
@@ -226,9 +226,6 @@ tests:
     # `enabled: \${environment.name != "prod"}`). This is handy when you only want certain tests to run in
     # specific environments, e.g. only during CI.
     disabled: false
-
-    # Maximum duration (in seconds) of the test run.
-    timeout: null
 
     # The Deployment, DaemonSet or StatefulSet that Garden should use to execute this test suite. If not specified,
     # the `serviceResource` configured on the module will be used. If neither is specified, an error will be thrown.
@@ -261,6 +258,9 @@ tests:
 
         # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
         target: .
+
+    # Maximum duration (in seconds) of the test run.
+    timeout: 600
 ```
 
 ## Configuration Keys
@@ -620,16 +620,6 @@ Note however that template strings referencing the task's outputs (i.e. runtime 
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
-### `tasks[].timeout`
-
-[tasks](#tasks) > timeout
-
-Maximum duration (in seconds) of the task's execution.
-
-| Type     | Default | Required |
-| -------- | ------- | -------- |
-| `number` | `null`  | No       |
-
 ### `tasks[].resource`
 
 [tasks](#tasks) > resource
@@ -787,6 +777,16 @@ tasks:
       - target: "outputs/foo/"
 ```
 
+### `tasks[].timeout`
+
+[tasks](#tasks) > timeout
+
+Maximum duration (in seconds) of the task's execution.
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `600`   | No       |
+
 ### `tests[]`
 
 | Type            | Default | Required |
@@ -825,16 +825,6 @@ specific environments, e.g. only during CI.
 | Type      | Default | Required |
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
-
-### `tests[].timeout`
-
-[tests](#tests) > timeout
-
-Maximum duration (in seconds) of the test run.
-
-| Type     | Default | Required |
-| -------- | ------- | -------- |
-| `number` | `null`  | No       |
 
 ### `tests[].resource`
 
@@ -982,6 +972,16 @@ tests:
   - artifacts:
       - target: "outputs/foo/"
 ```
+
+### `tests[].timeout`
+
+[tests](#tests) > timeout
+
+Maximum duration (in seconds) of the test run.
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `600`   | No       |
 
 
 ## Outputs

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -335,9 +335,6 @@ tests:
     # specific environments, e.g. only during CI.
     disabled: false
 
-    # Maximum duration (in seconds) of the test run.
-    timeout: null
-
     # The arguments used to run the test inside the container.
     args:
 
@@ -388,6 +385,9 @@ tests:
         # services at the same time. Refer to the documentation of the module type in question to learn more.
         module:
 
+    # Maximum duration (in seconds) of the test run.
+    timeout: 600
+
 # A list of tasks that can be run from this container module. These can be used as dependencies for services (executed
 # before the service is deployed) or for other tasks.
 tasks:
@@ -413,9 +413,6 @@ tasks:
     # when the task is disabled, so you need to make sure to provide alternate values for those if you're using them,
     # using conditional expressions.
     disabled: false
-
-    # Maximum duration (in seconds) of the task's execution.
-    timeout: null
 
     # The arguments used to run the task inside the container.
     args:
@@ -471,6 +468,9 @@ tasks:
         # the ReadWriteMany access mode, you'll need to make sure it is not configured to be mounted by multiple
         # services at the same time. Refer to the documentation of the module type in question to learn more.
         module:
+
+    # Maximum duration (in seconds) of the task's execution.
+    timeout: 600
 
 # Set this to override the default OpenJDK container image version. Make sure the image version matches the
 # configured `jdkVersion`. Ignored if you provide your own Dockerfile.
@@ -1379,16 +1379,6 @@ specific environments, e.g. only during CI.
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
-### `tests[].timeout`
-
-[tests](#tests) > timeout
-
-Maximum duration (in seconds) of the test run.
-
-| Type     | Default | Required |
-| -------- | ------- | -------- |
-| `number` | `null`  | No       |
-
 ### `tests[].args[]`
 
 [tests](#tests) > args
@@ -1575,6 +1565,16 @@ Note: Make sure to pay attention to the supported `accessModes` of the reference
 | -------- | -------- |
 | `string` | No       |
 
+### `tests[].timeout`
+
+[tests](#tests) > timeout
+
+Maximum duration (in seconds) of the test run.
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `600`   | No       |
+
 ### `tasks[]`
 
 A list of tasks that can be run from this container module. These can be used as dependencies for services (executed before the service is deployed) or for other tasks.
@@ -1626,16 +1626,6 @@ Note however that template strings referencing the task's outputs (i.e. runtime 
 | Type      | Default | Required |
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
-
-### `tasks[].timeout`
-
-[tasks](#tasks) > timeout
-
-Maximum duration (in seconds) of the task's execution.
-
-| Type     | Default | Required |
-| -------- | ------- | -------- |
-| `number` | `null`  | No       |
 
 ### `tasks[].args[]`
 
@@ -1832,6 +1822,16 @@ Note: Make sure to pay attention to the supported `accessModes` of the reference
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
+
+### `tasks[].timeout`
+
+[tasks](#tasks) > timeout
+
+Maximum duration (in seconds) of the task's execution.
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `600`   | No       |
 
 ### `imageVersion`
 

--- a/garden-service/src/config/task.ts
+++ b/garden-service/src/config/task.ts
@@ -55,14 +55,16 @@ export const baseTaskSpecSchema = () =>
         Note however that template strings referencing the task's outputs (i.e. runtime outputs) will fail to resolve when the task is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
         `
         ),
-      timeout: joi
-        .number()
-        .optional()
-        .allow(null)
-        .default(null)
-        .description("Maximum duration (in seconds) of the task's execution."),
+      timeout: baseTaskTimeoutSchema,
     })
     .description("Required configuration for module tasks.")
+
+export const baseTaskTimeoutSchema = joi
+  .number()
+  .optional()
+  .allow(null)
+  .default(null)
+  .description("Maximum duration (in seconds) of the task's execution.")
 
 export interface TaskConfig<T extends TaskSpec = TaskSpec> extends BaseTaskSpec {
   cacheResult: boolean

--- a/garden-service/src/config/test.ts
+++ b/garden-service/src/config/test.ts
@@ -36,12 +36,14 @@ export const baseTestSpecSchema = () =>
         specific environments, e.g. only during CI.
       `
       ),
-    timeout: joi
-      .number()
-      .allow(null)
-      .default(null)
-      .description("Maximum duration (in seconds) of the test run."),
+    timeout: baseTestTimeoutSchema,
   })
+
+export const baseTestTimeoutSchema = joi
+  .number()
+  .allow(null)
+  .default(null)
+  .description("Maximum duration (in seconds) of the test run.")
 
 export interface TestConfig<T extends {} = {}> extends BaseTestSpec {
   // Plugins can add custom fields that are kept here

--- a/garden-service/src/plugins/container/config.ts
+++ b/garden-service/src/plugins/container/config.ts
@@ -25,11 +25,14 @@ import { Service, ingressHostnameSchema, linkUrlSchema } from "../../types/servi
 import { DEFAULT_PORT_PROTOCOL } from "../../constants"
 import { ModuleSpec, ModuleConfig, baseBuildSpecSchema, BaseBuildSpec } from "../../config/module"
 import { CommonServiceSpec, ServiceConfig, baseServiceSpecSchema } from "../../config/service"
-import { baseTaskSpecSchema, BaseTaskSpec, cacheResultSchema } from "../../config/task"
-import { baseTestSpecSchema, BaseTestSpec } from "../../config/test"
+import { baseTaskSpecSchema, BaseTaskSpec, cacheResultSchema, baseTaskTimeoutSchema } from "../../config/task"
+import { baseTestSpecSchema, BaseTestSpec, baseTestTimeoutSchema } from "../../config/test"
 import { joiStringMap } from "../../config/common"
 import { dedent } from "../../util/string"
 import { getModuleTypeUrl } from "../../docs/common"
+
+export const defaultContainerTestTimeoutSeconds = 60 * 10
+export const defaultContainerTaskTimeoutSeconds = 60 * 10
 
 export const defaultContainerLimits: ServiceLimitSpec = {
   cpu: 1000, // = 1000 millicpu = 1 CPU
@@ -507,6 +510,7 @@ export const containerTestSchema = () =>
       .example(commandExample),
     env: containerEnvVarsSchema(),
     volumes: getContainerVolumesSchema("test"),
+    timeout: baseTestTimeoutSchema.default(defaultContainerTestTimeoutSeconds),
   })
 
 export interface ContainerTaskSpec extends BaseTaskSpec {
@@ -535,6 +539,7 @@ export const containerTaskSchema = () =>
         .example(commandExample),
       env: containerEnvVarsSchema(),
       volumes: getContainerVolumesSchema("task"),
+      timeout: baseTaskTimeoutSchema.default(defaultContainerTaskTimeoutSeconds),
     })
     .description("A task that can be run in the container.")
 

--- a/garden-service/src/plugins/kubernetes/config.ts
+++ b/garden-service/src/plugins/kubernetes/config.ts
@@ -17,13 +17,15 @@ import {
   containerEnvVarsSchema,
   containerArtifactSchema,
   ContainerEnvVars,
+  defaultContainerTaskTimeoutSeconds,
+  defaultContainerTestTimeoutSeconds,
 } from "../container/config"
 import { PluginContext } from "../../plugin-context"
 import { deline } from "../../util/string"
 import { defaultSystemNamespace } from "./system"
 import { hotReloadableKinds, HotReloadableKind } from "./hot-reload"
-import { baseTaskSpecSchema, BaseTaskSpec, cacheResultSchema } from "../../config/task"
-import { baseTestSpecSchema, BaseTestSpec } from "../../config/test"
+import { baseTaskSpecSchema, BaseTaskSpec, cacheResultSchema, baseTaskTimeoutSchema } from "../../config/task"
+import { baseTestSpecSchema, BaseTestSpec, baseTestTimeoutSchema } from "../../config/test"
 import { ArtifactSpec } from "../../config/validation"
 import { V1Toleration } from "@kubernetes/client-node"
 
@@ -633,6 +635,7 @@ export const kubernetesTaskSchema = () =>
       artifacts: joiArray(containerArtifactSchema()).description(
         "Specify artifacts to copy out of the container after the task is complete."
       ),
+      timeout: baseTaskTimeoutSchema.default(defaultContainerTaskTimeoutSeconds),
     })
     .description("The task definitions for this module.")
 
@@ -658,6 +661,7 @@ export const kubernetesTestSchema = () =>
       artifacts: joiArray(containerArtifactSchema()).description(
         "Specify artifacts to copy out of the container after the test is complete."
       ),
+      timeout: baseTestTimeoutSchema.default(defaultContainerTestTimeoutSeconds),
     })
     .description("The test suite definitions for this module.")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

Before this fix, tasks and tests for `container`, `helm`, `kubernetes` and `maven-container` modules implicitly used a default timeout of 600 seconds, but the reference docs listed the default timeout as `null`, which has confused some users.

Here, we make default test and task timeouts explicit for these module types (while leaving the default timeouts for the base test and task specs, used e.g. by the `exec` module type, as `null`).
