### PR TITLE
perf(analytics): don't wait for event tracks

### DIFF
--- a/garden-service/package-lock.json
+++ b/garden-service/package-lock.json
@@ -2394,9 +2394,9 @@
       }
     },
     "axios-retry": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.1.2.tgz",
-      "integrity": "sha512-+X0mtJ3S0mmia1kTVi1eA3DAC+oWnT2A29g3CpkzcBPMT6vJm+hn/WiV9wPt/KXLHVmg5zev9mWqkPx7bHMovg==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.1.8.tgz",
+      "integrity": "sha512-yPw5Y4Bg6Dgmhm35KaJFtlh23s1TecW0HsUerK4/IS1UKl0gtN2aJqdEKtVomiOS/bDo5w4P3sqgki/M10eF8Q==",
       "requires": {
         "is-retry-allowed": "^1.1.0"
       }
@@ -5239,21 +5239,11 @@
       }
     },
     "follow-redirects": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.7.tgz",
-      "integrity": "sha512-NONJVIFiX7Z8k2WxfqBjtwqMifx7X42ORLFrOZ2LTKGj71G3C0kfdyTqGqr8fx5zSX6Foo/D95dgGWbPUiwnew==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
+      "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
       "requires": {
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
+        "debug": "^3.0.0"
       }
     },
     "for-in": {

--- a/garden-service/src/cli/cli.ts
+++ b/garden-service/src/cli/cli.ts
@@ -354,7 +354,7 @@ export class GardenCli {
           // the file writers depend on the project root.
           await this.initFileWriters(logger, garden.projectRoot, garden.gardenDirPath)
           const analytics = await AnalyticsHandler.init(garden, log)
-          await analytics.trackCommand(command.getFullName())
+          analytics.trackCommand(command.getFullName())
 
           cliContext.details.analytics = analytics
 

--- a/garden-service/src/server/server.ts
+++ b/garden-service/src/server/server.ts
@@ -121,7 +121,7 @@ export class GardenServer {
         this.analytics = await AnalyticsHandler.init(this.garden, this.log)
       }
 
-      await this.analytics.trackApi("POST", ctx.originalUrl, { ...ctx.request.body })
+      this.analytics.trackApi("POST", ctx.originalUrl, { ...ctx.request.body })
 
       const result = await resolveRequest(ctx, this.garden, this.log, commands, ctx.request.body)
       ctx.status = 200

--- a/garden-service/test/unit/src/analytics/analytics.ts
+++ b/garden-service/test/unit/src/analytics/analytics.ts
@@ -1,0 +1,301 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import nock from "nock"
+import { isEqual } from "lodash"
+
+import { makeTestGardenA, TestGarden, enableAnalytics } from "../../../helpers"
+import { AnalyticsHandler } from "../../../../src/analytics/analytics"
+import { DEFAULT_API_VERSION } from "../../../../src/constants"
+
+describe("AnalyticsHandler", () => {
+  const host = "https://api.segment.io"
+  const scope = nock(host)
+  let analytics: AnalyticsHandler
+  let garden: TestGarden
+  let resetAnalyticsConfig: Function
+
+  before(async () => {
+    garden = await makeTestGardenA()
+    resetAnalyticsConfig = await enableAnalytics(garden)
+  })
+
+  beforeEach(async () => {
+    garden = await makeTestGardenA()
+    garden["sessionId"] = "asdf"
+  })
+
+  afterEach(async () => {
+    // Flush so queued events don't leak between tests
+    await analytics.flush()
+    AnalyticsHandler.clearInstance()
+  })
+
+  after(async () => {
+    await resetAnalyticsConfig()
+    nock.cleanAll()
+  })
+
+  describe("trackCommand", () => {
+    it("should return the event with the correct project metadata", async () => {
+      scope.post(`/v1/batch`).reply(200)
+
+      analytics = await AnalyticsHandler.init(garden, garden.log)
+
+      const event = analytics.trackCommand("testCommand")
+
+      expect(event).to.eql({
+        type: "Run Command",
+        properties: {
+          name: "testCommand",
+          projectId: analytics["projectId"],
+          projectName: analytics["projectName"],
+          ciName: analytics["ciName"],
+          system: analytics["systemConfig"],
+          isCI: analytics["isCI"],
+          sessionId: "asdf",
+          projectMetadata: {
+            modulesCount: 3,
+            moduleTypes: ["test"],
+            tasksCount: 3,
+            servicesCount: 3,
+            testsCount: 5,
+          },
+        },
+      })
+    })
+    it("should handle projects with no services, tests, or tasks", async () => {
+      scope.post(`/v1/batch`).reply(200)
+
+      garden.setModuleConfigs([
+        {
+          apiVersion: DEFAULT_API_VERSION,
+          name: "module-a",
+          type: "test",
+          allowPublish: false,
+          build: { dependencies: [] },
+          disabled: false,
+          outputs: {},
+          path: "",
+          serviceConfigs: [],
+          taskConfigs: [],
+          testConfigs: [],
+          spec: {}, // <-------
+        },
+      ])
+      analytics = await AnalyticsHandler.init(garden, garden.log)
+
+      const event = analytics.trackCommand("testCommand")
+
+      expect(event).to.eql({
+        type: "Run Command",
+        properties: {
+          name: "testCommand",
+          projectId: analytics["projectId"],
+          projectName: analytics["projectName"],
+          ciName: analytics["ciName"],
+          system: analytics["systemConfig"],
+          isCI: analytics["isCI"],
+          sessionId: "asdf",
+          projectMetadata: {
+            modulesCount: 1,
+            moduleTypes: ["test"],
+            tasksCount: 0,
+            servicesCount: 0,
+            testsCount: 0,
+          },
+        },
+      })
+    })
+  })
+
+  // NOTE: Segement always flushes on the first event, then queues and flushes subsequent events.
+  // That's why there are usually two mock requests per test below.
+  describe("flush", () => {
+    const getEvents = (body: any) =>
+      body.batch.map((event: any) => ({
+        event: event.event,
+        type: event.type,
+        name: event.properties.name,
+      }))
+
+    context("firstRun=false", () => {
+      it("should track events", async () => {
+        scope
+          .post(`/v1/batch`, (body) => {
+            // Assert that the event batch contains a single "track" event
+            return isEqual(getEvents(body), [
+              {
+                event: "Run Command",
+                type: "track",
+                name: "test-command-A",
+              },
+            ])
+          })
+          .reply(200)
+          .post(`/v1/batch`, (body) => {
+            // Assert that the event batch contains the rest of the "track" events
+            return isEqual(getEvents(body), [
+              {
+                event: "Run Command",
+                type: "track",
+                name: "test-command-B",
+              },
+              {
+                event: "Run Command",
+                type: "track",
+                name: "test-command-C",
+              },
+            ])
+          })
+          .reply(200)
+
+        await garden.globalConfigStore.set(["analytics", "firstRun"], false)
+        analytics = await AnalyticsHandler.init(garden, garden.log)
+
+        analytics.trackCommand("test-command-A")
+        analytics.trackCommand("test-command-B")
+        analytics.trackCommand("test-command-C")
+        await analytics.flush()
+
+        expect(scope.done()).to.not.throw
+      })
+    })
+    context("firstRun=true", () => {
+      it("should identify user", async () => {
+        scope
+          .post(`/v1/batch`, (body) => {
+            const events = body.batch.map((event) => event.type)
+            // Assert that the event batch contains a single "identify" event
+            return isEqual(events, ["identify"])
+          })
+          .reply(200)
+          .post(`/v1/batch`, (body) => {
+            // Assert that the event batch contains the "track" events
+            return isEqual(getEvents(body), [
+              {
+                event: "Run Command",
+                type: "track",
+                name: "test-command-A",
+              },
+              {
+                event: "Run Command",
+                type: "track",
+                name: "test-command-B",
+              },
+              {
+                event: "Run Command",
+                type: "track",
+                name: "test-command-C",
+              },
+            ])
+          })
+          .reply(200)
+
+        await garden.globalConfigStore.set(["analytics", "firstRun"], true)
+        analytics = await AnalyticsHandler.init(garden, garden.log)
+
+        analytics.trackCommand("test-command-A")
+        analytics.trackCommand("test-command-B")
+        analytics.trackCommand("test-command-C")
+        await analytics.flush()
+
+        expect(scope.done()).to.not.throw
+      })
+    })
+    it("should wait for pending events on network delays", async () => {
+      scope
+        .post(`/v1/batch`, (body) => {
+          // Assert that the event batch contains a single "track" event
+          return isEqual(getEvents(body), [
+            {
+              event: "Run Command",
+              type: "track",
+              name: "test-command-A",
+            },
+          ])
+        })
+        .delay(1500)
+        .reply(200)
+
+      await garden.globalConfigStore.set(["analytics", "firstRun"], false)
+      analytics = await AnalyticsHandler.init(garden, garden.log)
+
+      analytics.trackCommand("test-command-A")
+      await analytics.flush()
+
+      expect(analytics["pendingEvents"].size).to.eql(0)
+      expect(scope.done()).to.not.throw
+    })
+    it("should eventually timeout waiting for pending events on network delays", async () => {
+      scope
+        .post(`/v1/batch`, (body) => {
+          // Assert that the event batch contains the first "track" event
+          return isEqual(getEvents(body), [
+            {
+              event: "Run Command",
+              type: "track",
+              name: "test-command-A",
+            },
+          ])
+        })
+        .delay(5000)
+        .reply(200)
+        .post(`/v1/batch`, (body) => {
+          // Assert that the event batch contains the rest of the "track" events
+          return isEqual(getEvents(body), [
+            {
+              event: "Run Command",
+              type: "track",
+              name: "test-command-B",
+            },
+            {
+              event: "Run Command",
+              type: "track",
+              name: "test-command-C",
+            },
+          ])
+        })
+        .reply(200)
+
+      await garden.globalConfigStore.set(["analytics", "firstRun"], false)
+      analytics = await AnalyticsHandler.init(garden, garden.log)
+
+      analytics.trackCommand("test-command-A")
+      analytics.trackCommand("test-command-B")
+      analytics.trackCommand("test-command-C")
+      await analytics.flush()
+
+      const pendingEvents = Array.from(analytics["pendingEvents"].values())
+      expect(pendingEvents).to.eql([
+        {
+          event: "Run Command",
+          userId: pendingEvents[0].userId,
+          properties: {
+            name: "test-command-A",
+            projectId: analytics["projectId"],
+            projectName: analytics["projectName"],
+            ciName: analytics["ciName"],
+            system: analytics["systemConfig"],
+            isCI: analytics["isCI"],
+            sessionId: "asdf",
+            projectMetadata: {
+              modulesCount: 3,
+              moduleTypes: ["test"],
+              tasksCount: 3,
+              servicesCount: 3,
+              testsCount: 5,
+            },
+          },
+        },
+      ])
+      expect(scope.done()).to.not.throw
+    })
+  })
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, we would wait for the `analytics.trackCommand` and `analytics.trackApi` calls to finish. This could cause a delay after Garden is finished resolving the providers and before it executes a given command.

Now we just call the track handlers synchronously and wait for pending events when Garden exits (generally there should be no pending events because the first event is flushed immediately and subsequent events every 300 ms).

It also adds some tests for the `AnalyticsHandler` class and one for the `CLI` class to verify that events are flushed before Garden exits.

**Which issue(s) this PR fixes**:

Partially addresses #1824 

**Special notes for your reviewer**:

- I changed the `generateProjectMetadata` function to only use raw module configs. This way it doesn't have to resolve all the modules which is unneeded overhead.

- The unit tests are to a degree verifying the behaviour of a 3rd party library. That certainly feels like scope creep but I'd rather test this properly and risk not going by the book.

- We talked about forking the `analytics-node` lib to prevent that "flush on first event" issue. That could still lead to dropped events so I instead went for the `waitForPending` approach. The code comments should explain what that's all about. 
