### PR TITLE
feat(core): add projectId to get config cmd output

### DIFF
--- a/garden-service/src/garden.ts
+++ b/garden-service/src/garden.ts
@@ -190,6 +190,7 @@ export class Garden {
     this.rawOutputs = params.outputs
     this.production = params.production
     this.projectName = params.projectName
+    this.projectId = params.projectId
     this.projectRoot = params.projectRoot
     this.projectSources = params.projectSources || []
     this.providerConfigs = params.providerConfigs
@@ -1092,6 +1093,7 @@ export class Garden {
         "name"
       ),
       projectRoot: this.projectRoot,
+      projectId: this.projectId,
     }
   }
 
@@ -1104,4 +1106,5 @@ export interface ConfigDump {
   variables: DeepPrimitiveMap
   moduleConfigs: ModuleConfig[]
   projectRoot: string
+  projectId: string | null
 }

--- a/garden-service/test/data/test-project-a/garden.yml
+++ b/garden-service/test/data/test-project-a/garden.yml
@@ -1,5 +1,6 @@
 kind: Project
 name: test-project-a
+id: test-project-id
 environments:
   - name: local
   - name: other

--- a/garden-service/test/unit/src/commands/get/get-config.ts
+++ b/garden-service/test/unit/src/commands/get/get-config.ts
@@ -35,6 +35,7 @@ describe("GetConfigCommand", () => {
       variables: garden.variables,
       moduleConfigs: sortBy(await garden.resolveModules({ log }), "name").map((m) => m._config),
       projectRoot: garden.projectRoot,
+      projectId: "test-project-id",
     }
 
     expect(config).to.deep.equal(res.result)
@@ -117,6 +118,7 @@ describe("GetConfigCommand", () => {
       variables: garden.variables,
       moduleConfigs: expectedModuleConfigs,
       projectRoot: garden.projectRoot,
+      projectId: "test-project-id",
     }
 
     expect(expectedModuleConfigs.length).to.equal(2)
@@ -189,6 +191,7 @@ describe("GetConfigCommand", () => {
       variables: garden.variables,
       moduleConfigs: expectedModuleConfigs,
       projectRoot: garden.projectRoot,
+      projectId: "test-project-id",
     }
 
     expect(config).to.deep.equal(res.result)
@@ -257,6 +260,7 @@ describe("GetConfigCommand", () => {
       variables: garden.variables,
       moduleConfigs: expectedModuleConfigs,
       projectRoot: garden.projectRoot,
+      projectId: "test-project-id",
     }
 
     expect(res.result).to.deep.equal(config)
@@ -332,6 +336,7 @@ describe("GetConfigCommand", () => {
       variables: garden.variables,
       moduleConfigs: expectedModuleConfigs,
       projectRoot: garden.projectRoot,
+      projectId: "test-project-id",
     }
 
     expect(res.result).to.deep.equal(config)
@@ -413,6 +418,7 @@ describe("GetConfigCommand", () => {
         variables: garden.variables,
         moduleConfigs: expectedModuleConfigs,
         projectRoot: garden.projectRoot,
+        projectId: "test-project-id",
       }
 
       expect(expectedModuleConfigs.length).to.equal(1)
@@ -512,6 +518,7 @@ describe("GetConfigCommand", () => {
         variables: garden.variables,
         moduleConfigs: expectedModuleConfigs,
         projectRoot: garden.projectRoot,
+        projectId: "test-project-id",
       }
 
       expect(config).to.deep.equal(res.result)
@@ -599,6 +606,7 @@ describe("GetConfigCommand", () => {
         variables: garden.variables,
         moduleConfigs: expectedModuleConfigs,
         projectRoot: garden.projectRoot,
+        projectId: "test-project-id",
       }
 
       expect(res.result).to.deep.equal(config)
@@ -691,6 +699,7 @@ describe("GetConfigCommand", () => {
         variables: garden.variables,
         moduleConfigs: expectedModuleConfigs,
         projectRoot: garden.projectRoot,
+        projectId: "test-project-id",
       }
 
       expect(res.result).to.deep.equal(config)

--- a/garden-service/test/unit/src/config/base.ts
+++ b/garden-service/test/unit/src/config/base.ts
@@ -95,6 +95,7 @@ describe("loadConfig", () => {
         path: projectPathA,
         configPath,
         name: "test-project-a",
+        id: "test-project-id",
         environments: [
           {
             name: "local",


### PR DESCRIPTION
**What this PR does / why we need it**:

This is useful for scanning for workflows in repos with several projects.
