### PR TITLE
ci: update unbuntu image because missing keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -487,7 +487,7 @@ jobs:
 
   test-microk8s:
     machine:
-      image: 'ubuntu-1604:201903-01'
+      image: 'ubuntu-1604:202004-01'
       docker_layer_caching: true
     parameters:
       kubernetesVersion:
@@ -544,7 +544,7 @@ jobs:
 
   test-minikube:
     machine:
-      image: 'ubuntu-1604:201903-01'
+      image: 'ubuntu-1604:202004-01'
       docker_layer_caching: true
     parameters:
       kubernetesVersion:


### PR DESCRIPTION
**What this PR does / why we need it**:

CI builds were failing because of missing in the Ubuntu image. See also: See: https://discuss.circleci.com/t/keys-missing-in-ubuntu-images/36004

