### PR TITLE
fix(k8s): make helm & k8s tasks respect timeouts

### DIFF
--- a/garden-service/src/constants.ts
+++ b/garden-service/src/constants.ts
@@ -32,6 +32,7 @@ export const DEFAULT_PORT_PROTOCOL = "TCP"
 export const DEFAULT_API_VERSION = "garden.io/v0"
 
 export const DEFAULT_TEST_TIMEOUT = 60 * 1000
+export const DEFAULT_TASK_TIMEOUT = 60 * 1000
 
 export type SupportedPlatform = "linux" | "darwin" | "win32"
 export const SUPPORTED_PLATFORMS: SupportedPlatform[] = ["linux", "darwin", "win32"]

--- a/garden-service/src/plugins/kubernetes/helm/run.ts
+++ b/garden-service/src/plugins/kubernetes/helm/run.ts
@@ -21,6 +21,7 @@ import { prepareEnvVars } from "../util"
 import { V1PodSpec } from "@kubernetes/client-node"
 import { KubeApi } from "../api"
 import { getModuleNamespace } from "../namespace"
+import { DEFAULT_TASK_TIMEOUT } from "../../../constants"
 
 export async function runHelmModule({
   ctx,
@@ -97,7 +98,7 @@ export async function runHelmModule({
 }
 
 export async function runHelmTask(params: RunTaskParams<HelmModule>): Promise<RunTaskResult> {
-  const { ctx, log, module, task, taskVersion, timeout } = params
+  const { ctx, log, module, task, taskVersion } = params
   // TODO: deduplicate this from testHelmModule
   const k8sCtx = <KubernetesPluginContext>ctx
 
@@ -132,7 +133,7 @@ export async function runHelmTask(params: RunTaskParams<HelmModule>): Promise<Ru
     namespace,
     podName: makePodName("task", module.name, task.name),
     description: `Task '${task.name}' in container module '${module.name}'`,
-    timeout,
+    timeout: task.config.timeout || DEFAULT_TASK_TIMEOUT,
   })
 
   const result: RunTaskResult = {

--- a/garden-service/src/plugins/kubernetes/kubernetes-module/run.ts
+++ b/garden-service/src/plugins/kubernetes/kubernetes-module/run.ts
@@ -15,9 +15,10 @@ import { RunTaskParams, RunTaskResult } from "../../../types/plugin/task/runTask
 import { getManifests } from "./common"
 import { KubeApi } from "../api"
 import { getModuleNamespace } from "../namespace"
+import { DEFAULT_TASK_TIMEOUT } from "../../../constants"
 
 export async function runKubernetesTask(params: RunTaskParams<KubernetesModule>): Promise<RunTaskResult> {
-  const { ctx, log, module, task, taskVersion, timeout } = params
+  const { ctx, log, module, task, taskVersion } = params
   const k8sCtx = <KubernetesPluginContext>ctx
   const namespace = await getModuleNamespace({
     ctx: k8sCtx,
@@ -52,7 +53,7 @@ export async function runKubernetesTask(params: RunTaskParams<KubernetesModule>)
     namespace,
     podName: makePodName("task", module.name, task.name),
     description: `Task '${task.name}' in container module '${module.name}'`,
-    timeout,
+    timeout: task.config.timeout || DEFAULT_TASK_TIMEOUT,
   })
 
   const result = {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

Before this fix, the `task.timeout` config field was not being respected for `helm` and `kubernetes` tasks.

We now correctly use the configured value, and fall back to a default, explicit constant for `timeout` when calling `runAndCopy`.

**Which issue(s) this PR fixes**:

Fixes #1837.