### PR TITLE
improvement(core): don't respect .gitignore files by default

### DIFF
--- a/docs/guides/configuration-files.md
+++ b/docs/guides/configuration-files.md
@@ -381,7 +381,11 @@ Note that the module `include` and `exclude` fields have no effect on which path
 
 #### .ignore files
 
-By default, Garden respects `.gitignore` and `.gardenignore` files and excludes any patterns matched in those files.
+{% hint style="warning" %}
+Prior to Garden 0.12.0, `.gitignore` files were also respected by default. The default is now to only respect `.gardenignore` files. See below how you can revert to the previous behavior.
+{% endhint %}
+
+By default, Garden respects `.gardenignore` files and excludes any patterns matched in those files. You can place the ignore files anywhere in your repository, much like `.gitignore` files, and they will follow the same semantics.
 
 You can use those to exclude files and directories across the project, _both from being scanned for Garden modules and when selecting source files for individual module_. For example, you might put this `.gardenignore` file in your project root directory:
 
@@ -391,16 +395,16 @@ public
 *.log
 ```
 
-This would cause Garden to ignore `node_modules` and `public` directories across your project/repo, and all `.log` files. You can place the ignore files anywhere in your repository, much like `.gitignore` files, and they will follow the same semantics.
+This would cause Garden to ignore `node_modules` and `public` directories across your project/repo, and all `.log` files.
 
 Note that _these take precedence over both `modules.include` fields in your project config, and `include` fields in your module configs_. If a path is matched by one of the ignore files, the path will not be included in your project or modules.
 
-You can override which filenames to use as ".ignore" files using the `dotIgnoreFiles` field in your project configuration. For example, you might choose to only use `.gardenignore` files and not exclude paths based on your `.gitignore` files:
+You can override which filenames to use as ".ignore" files using the `dotIgnoreFiles` field in your project configuration. For example, you might choose to also respect `.gitignore` files (this was the default behavior prior to Garden 0.12.0):
 
 ```yaml
 kind: Project
 name: my-project
-dotIgnoreFiles: [.gardenignore]
+dotIgnoreFiles: [.gardenignore, .gitignore]
 ```
 
 #### Git submodules

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -94,14 +94,14 @@ providers:
 defaultEnvironment: ''
 
 # Specify a list of filenames that should be used as ".ignore" files across the project, using the same syntax and
-# semantics as `.gitignore` files. By default, patterns matched in `.gitignore` and `.gardenignore` files, found
-# anywhere in the project, are ignored when scanning for modules and module sources.
+# semantics as `.gitignore` files. By default, patterns matched in `.gardenignore` files, found anywhere in the
+# project, are ignored when scanning for modules and module sources (Note: prior to version 0.12.0, `.gitignore` files
+# were also used by default).
 # Note that these take precedence over the project `module.include` field, and module `include` fields, so any paths
 # matched by the .ignore files will be ignored even if they are explicitly specified in those fields.
 # See the [Configuration Files
 # guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 dotIgnoreFiles:
-  - .gitignore
   - .gardenignore
 
 # Control where to scan for modules in the project.
@@ -429,20 +429,20 @@ defaultEnvironment: "dev"
 
 ### `dotIgnoreFiles[]`
 
-Specify a list of filenames that should be used as ".ignore" files across the project, using the same syntax and semantics as `.gitignore` files. By default, patterns matched in `.gitignore` and `.gardenignore` files, found anywhere in the project, are ignored when scanning for modules and module sources.
+Specify a list of filenames that should be used as ".ignore" files across the project, using the same syntax and semantics as `.gitignore` files. By default, patterns matched in `.gardenignore` files, found anywhere in the project, are ignored when scanning for modules and module sources (Note: prior to version 0.12.0, `.gitignore` files were also used by default).
 Note that these take precedence over the project `module.include` field, and module `include` fields, so any paths matched by the .ignore files will be ignored even if they are explicitly specified in those fields.
 See the [Configuration Files guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
 
-| Type               | Default                          | Required |
-| ------------------ | -------------------------------- | -------- |
-| `array[posixPath]` | `[".gitignore",".gardenignore"]` | No       |
+| Type               | Default             | Required |
+| ------------------ | ------------------- | -------- |
+| `array[posixPath]` | `[".gardenignore"]` | No       |
 
 Example:
 
 ```yaml
 dotIgnoreFiles:
   - .gardenignore
-  - .customignore
+  - .gitignore
 ```
 
 ### `modules`

--- a/examples/ambassador/go-service/.gardenignore
+++ b/examples/ambassador/go-service/.gardenignore
@@ -1,0 +1,27 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+.vscode/settings.json
+webserver/*server*

--- a/examples/ambassador/node-service/.gardenignore
+++ b/examples/ambassador/node-service/.gardenignore
@@ -1,0 +1,15 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/

--- a/examples/base-image/backend/.gardenignore
+++ b/examples/base-image/backend/.gardenignore
@@ -1,0 +1,27 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+.vscode/settings.json
+webserver/*server*

--- a/examples/build-dependencies/backend/.gardenignore
+++ b/examples/build-dependencies/backend/.gardenignore
@@ -1,0 +1,27 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+.vscode/settings.json
+webserver/*server*

--- a/examples/build-dependencies/frontend/.gardenignore
+++ b/examples/build-dependencies/frontend/.gardenignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/demo-project-start/backend/.gardenignore
+++ b/examples/demo-project-start/backend/.gardenignore
@@ -1,0 +1,27 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+.vscode/settings.json
+webserver/*server*

--- a/examples/demo-project-start/frontend/.gardenignore
+++ b/examples/demo-project-start/frontend/.gardenignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/demo-project-start/frontend/.gitignore
+++ b/examples/demo-project-start/frontend/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/demo-project/backend/.gardenignore
+++ b/examples/demo-project/backend/.gardenignore
@@ -1,0 +1,27 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+.vscode/settings.json
+webserver/*server*

--- a/examples/demo-project/frontend/.gardenignore
+++ b/examples/demo-project/frontend/.gardenignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/deployment-strategies/backend/.gardenignore
+++ b/examples/deployment-strategies/backend/.gardenignore
@@ -1,0 +1,27 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+.vscode/settings.json
+webserver/*server*

--- a/examples/deployment-strategies/frontend/.gardenignore
+++ b/examples/deployment-strategies/frontend/.gardenignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/deployment-strategies/frontend/.gitignore
+++ b/examples/deployment-strategies/frontend/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/disabled-configs/backend/.gardenignore
+++ b/examples/disabled-configs/backend/.gardenignore
@@ -1,0 +1,27 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+.vscode/settings.json
+webserver/*server*

--- a/examples/disabled-configs/frontend/.gardenignore
+++ b/examples/disabled-configs/frontend/.gardenignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/disabled-configs/frontend/.gitignore
+++ b/examples/disabled-configs/frontend/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/gatsby-hot-reload/.gardenignore
+++ b/examples/gatsby-hot-reload/.gardenignore
@@ -1,0 +1,8 @@
+# Project dependencies
+.cache
+node_modules
+yarn-error.log
+
+# Build directory
+/public
+.DS_Store

--- a/examples/hadolint/backend/.gardenignore
+++ b/examples/hadolint/backend/.gardenignore
@@ -1,0 +1,27 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+.vscode/settings.json
+webserver/*server*

--- a/examples/hadolint/frontend/.gardenignore
+++ b/examples/hadolint/frontend/.gardenignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/hadolint/frontend/.gitignore
+++ b/examples/hadolint/frontend/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/hot-reload-post-sync-command/node-service/.gardenignore
+++ b/examples/hot-reload-post-sync-command/node-service/.gardenignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/hot-reload-post-sync-command/node-service/.gitignore
+++ b/examples/hot-reload-post-sync-command/node-service/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/hot-reload/node-service/.gardenignore
+++ b/examples/hot-reload/node-service/.gardenignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/hot-reload/node-service/.gitignore
+++ b/examples/hot-reload/node-service/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/kaniko/backend/.gardenignore
+++ b/examples/kaniko/backend/.gardenignore
@@ -1,0 +1,27 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+.vscode/settings.json
+webserver/*server*

--- a/examples/kaniko/frontend/.gardenignore
+++ b/examples/kaniko/frontend/.gardenignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/kaniko/frontend/.gitignore
+++ b/examples/kaniko/frontend/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/kubernetes-secrets/backend/.gardenignore
+++ b/examples/kubernetes-secrets/backend/.gardenignore
@@ -1,0 +1,27 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+.vscode/settings.json
+webserver/*server*

--- a/examples/kubernetes-secrets/frontend/.gardenignore
+++ b/examples/kubernetes-secrets/frontend/.gardenignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/kubernetes-secrets/frontend/.gitignore
+++ b/examples/kubernetes-secrets/frontend/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/local-exec/backend/.gardenignore
+++ b/examples/local-exec/backend/.gardenignore
@@ -1,0 +1,27 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+.vscode/settings.json
+webserver/*server*

--- a/examples/local-tls/services/go-service/.gardenignore
+++ b/examples/local-tls/services/go-service/.gardenignore
@@ -1,0 +1,27 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+.vscode/settings.json
+webserver/*server*

--- a/examples/local-tls/services/node-service/.gardenignore
+++ b/examples/local-tls/services/node-service/.gardenignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/local-tls/services/node-service/.gitignore
+++ b/examples/local-tls/services/node-service/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/multiple-modules/node-service/.gardenignore
+++ b/examples/multiple-modules/node-service/.gardenignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/multiple-modules/node-service/.gitignore
+++ b/examples/multiple-modules/node-service/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/openfaas/libraries/hello-npm-package/.gardenignore
+++ b/examples/openfaas/libraries/hello-npm-package/.gardenignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/openfaas/libraries/hello-npm-package/.gitignore
+++ b/examples/openfaas/libraries/hello-npm-package/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/openfaas/services/hello-container/.gardenignore
+++ b/examples/openfaas/services/hello-container/.gardenignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/openfaas/services/hello-container/.gitignore
+++ b/examples/openfaas/services/hello-container/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/openfaas/services/hello-function/.gardenignore
+++ b/examples/openfaas/services/hello-function/.gardenignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/openfaas/services/hello-function/.gitignore
+++ b/examples/openfaas/services/hello-function/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/project-variables/backend/.gardenignore
+++ b/examples/project-variables/backend/.gardenignore
@@ -1,0 +1,27 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+.vscode/settings.json
+webserver/*server*

--- a/examples/project-variables/frontend/.gardenignore
+++ b/examples/project-variables/frontend/.gardenignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/project-variables/frontend/.gitignore
+++ b/examples/project-variables/frontend/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/remote-k8s/services/go-service/.gardenignore
+++ b/examples/remote-k8s/services/go-service/.gardenignore
@@ -1,0 +1,27 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+.vscode/settings.json
+webserver/*server*

--- a/examples/remote-k8s/services/node-service/.gardenignore
+++ b/examples/remote-k8s/services/node-service/.gardenignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/remote-k8s/services/node-service/.gitignore
+++ b/examples/remote-k8s/services/node-service/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/tasks/hello/.gardenignore
+++ b/examples/tasks/hello/.gardenignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/tasks/hello/.gitignore
+++ b/examples/tasks/hello/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/terraform-gke/backend/.gardenignore
+++ b/examples/terraform-gke/backend/.gardenignore
@@ -1,0 +1,27 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+.vscode/settings.json
+webserver/*server*

--- a/examples/terraform-gke/frontend/.gardenignore
+++ b/examples/terraform-gke/frontend/.gardenignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/terraform-gke/frontend/.gitignore
+++ b/examples/terraform-gke/frontend/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/vote-helm/result-image/.gardenignore
+++ b/examples/vote-helm/result-image/.gardenignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/vote-helm/result-image/.gitignore
+++ b/examples/vote-helm/result-image/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/vote-helm/vote-image/.gardenignore
+++ b/examples/vote-helm/vote-image/.gardenignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/vote/result/.dockerignore
+++ b/examples/vote/result/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+Dockerfile
+garden.yml
+app.yaml

--- a/examples/vote/result/.gardenignore
+++ b/examples/vote/result/.gardenignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/vote/result/.gitignore
+++ b/examples/vote/result/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/vote/vote/.gardenignore
+++ b/examples/vote/vote/.gardenignore
@@ -1,0 +1,1 @@
+node_modules

--- a/garden-service/src/config/project.ts
+++ b/garden-service/src/config/project.ts
@@ -345,18 +345,14 @@ export const projectDocsSchema = () =>
         .default(defaultDotIgnoreFiles)
         .description(
           deline`
-        Specify a list of filenames that should be used as ".ignore" files across the project, using the same syntax and
-        semantics as \`.gitignore\` files. By default, patterns matched in \`.gitignore\` and \`.gardenignore\`
-        files, found anywhere in the project, are ignored when scanning for modules and module sources.
+        Specify a list of filenames that should be used as ".ignore" files across the project, using the same syntax and semantics as \`.gitignore\` files. By default, patterns matched in \`.gardenignore\` files, found anywhere in the project, are ignored when scanning for modules and module sources (Note: prior to version 0.12.0, \`.gitignore\` files were also used by default).
 
-        Note that these take precedence over the project \`module.include\` field, and module \`include\` fields,
-        so any paths matched by the .ignore files will be ignored even if they are explicitly specified in those fields.
+        Note that these take precedence over the project \`module.include\` field, and module \`include\` fields, so any paths matched by the .ignore files will be ignored even if they are explicitly specified in those fields.
 
-        See the [Configuration Files guide](${DOCS_BASE_URL}/guides/configuration-files#including-excluding-files-and-directories)
-        for details.
+        See the [Configuration Files guide](${DOCS_BASE_URL}/guides/configuration-files#including-excluding-files-and-directories) for details.
       `
         )
-        .example([".gardenignore", ".customignore"]),
+        .example([".gardenignore", ".gitignore"]),
       modules: projectModulesSchema().description("Control where to scan for modules in the project."),
       outputs: joiArray(projectOutputSchema())
         .unique("name")

--- a/garden-service/src/util/fs.ts
+++ b/garden-service/src/util/fs.ts
@@ -24,7 +24,7 @@ import { uuidv4 } from "./util"
 
 const VALID_CONFIG_FILENAMES = ["garden.yml", "garden.yaml"]
 const metadataFilename = "metadata.json"
-export const defaultDotIgnoreFiles = [".gitignore", ".gardenignore"]
+export const defaultDotIgnoreFiles = [".gardenignore"]
 export const fixedExcludes = [".git", ".gitmodules", ".garden/**/*", "debug-info*/**"]
 
 /*

--- a/garden-service/test/unit/src/commands/create/create-project.ts
+++ b/garden-service/test/unit/src/commands/create/create-project.ts
@@ -80,6 +80,25 @@ describe("CreateProjectCommand", () => {
     expect((await readFile(ignoreFilePath)).toString()).to.equal(ignoreContent)
   })
 
+  it("should copy existing .gitignore to .gardenignore if it exists", async () => {
+    const ignoreContent = "node_modules/\n"
+    await writeFile(join(tmp.path, ".gitignore"), ignoreContent)
+
+    const { result } = await command.action({
+      garden,
+      footerLog: garden.log,
+      headerLog: garden.log,
+      log: garden.log,
+      args: {},
+      opts: withDefaultGlobalOpts({ dir: tmp.path, interactive: false, name: undefined }),
+    })
+    const { ignoreFileCreated, ignoreFilePath } = result!
+
+    expect(ignoreFileCreated).to.be.true
+    expect(await pathExists(ignoreFilePath)).to.be.true
+    expect((await readFile(ignoreFilePath)).toString()).to.equal(ignoreContent)
+  })
+
   it("should optionally set a project name", async () => {
     const { result } = await command.action({
       garden,


### PR DESCRIPTION
**What this PR does / why we need it**:

The previous default behavior has been known to cause confusion, and
sometimes makes it difficult to correctly control which files should
be used for build contexts. We now default to only respect
`.gardenignore` files.

You can override the default behavior by explicitly setting the
`dotIgnoreFiles` field in your project configuration.

The `garden create project` command now also copies a .gitignore file
next to the project config file, if one is found, and instructs the
user accordingly.

I also added a bunch of .gardenignore files (and sometimes missing
.gitignore files) to our examples.

BREAKING CHANGE:

Garden no longer respects `.gitignore` files by default now. If you'd
like to retain the previous default behavior, you can explicitly set
`dotIgnoreFiles: [.gitignore, .gardenignore]` in your project configs.
If you already have `dotIgnoreFiles` set in your config, no change is
necessary.
