### PR TITLE
feat(core): allow custom local db path

### DIFF
--- a/garden-service/src/db/connection.ts
+++ b/garden-service/src/db/connection.ts
@@ -6,11 +6,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { Connection, getConnectionManager, ConnectionOptions } from "typeorm"
 import { join } from "path"
+import { Connection, getConnectionManager, ConnectionOptions } from "typeorm"
 import { GARDEN_GLOBAL_PATH } from "../constants"
 
 let connection: Connection
+
+const databasePath = join(process.env.GARDEN_DB_DIR || GARDEN_GLOBAL_PATH, "db")
 
 // Note: This function needs to be synchronous to work with the typeorm Active Record pattern (see ./base-entity.ts)
 export function getConnection(): Connection {
@@ -20,7 +22,7 @@ export function getConnection(): Connection {
     // Prepare the connection (the ormconfig.json in the static dir is only used for the typeorm CLI during dev)
     const options: ConnectionOptions = {
       type: "sqlite",
-      database: join(GARDEN_GLOBAL_PATH, "db"),
+      database: databasePath,
       // IMPORTANT: All entities and migrations need to be manually referenced here because of how we
       // package the garden binary
       entities: [LocalAddress, ClientAuthToken],


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

A custom path to Garden's config DB can now be set via the `GARDEN_CONFIG_DB_PATH` variable.

**Special notes for your reviewer**:

There are no tests for this functionality (since I couldn't think of a way to test this automatically without getting into a lot of gymnastics).

But the semantics are very simple, and any errors should be obvious to the user during usage.