### PR TITLE
improvement(terraform): support v0.12.26 and remove old versions

### DIFF
--- a/docs/reference/providers/terraform.md
+++ b/docs/reference/providers/terraform.md
@@ -43,7 +43,7 @@ providers:
     variables:
 
     # The version of Terraform to use.
-    version: 0.12.24
+    version: 0.12.26
 ```
 ## Configuration Keys
 
@@ -132,5 +132,5 @@ The version of Terraform to use.
 
 | Type     | Default     | Required |
 | -------- | ----------- | -------- |
-| `string` | `"0.12.24"` | No       |
+| `string` | `"0.12.26"` | No       |
 

--- a/garden-service/src/plugins/terraform/cli.ts
+++ b/garden-service/src/plugins/terraform/cli.ts
@@ -25,16 +25,16 @@ export function terraform(provider: TerraformProvider) {
 }
 
 export const terraformCliSpecs: { [version: string]: PluginToolSpec } = {
-  "0.11.14": {
-    name: "terraform-0-11-14",
-    description: "The terraform CLI, v0.11.14",
+  "0.12.26": {
+    name: "terraform-0-12-26",
+    description: "The terraform CLI, v0.12.26",
     type: "binary",
     builds: [
       {
         platform: "darwin",
         architecture: "amd64",
-        url: "https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_darwin_amd64.zip",
-        sha256: "829bdba148afbd61eab4aafbc6087838f0333d8876624fe2ebc023920cfc2ad5",
+        url: "https://releases.hashicorp.com/terraform/0.12.26/terraform_0.12.26_darwin_amd64.zip",
+        sha256: "79fb293324012bc981006e1527267987666dd80cff80b11f93fb0ab2e321c450",
         extract: {
           format: "zip",
           targetPath: "terraform",
@@ -43,8 +43,8 @@ export const terraformCliSpecs: { [version: string]: PluginToolSpec } = {
       {
         platform: "linux",
         architecture: "amd64",
-        url: "https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip",
-        sha256: "9b9a4492738c69077b079e595f5b2a9ef1bc4e8fb5596610f69a6f322a8af8dd",
+        url: "https://releases.hashicorp.com/terraform/0.12.26/terraform_0.12.26_linux_amd64.zip",
+        sha256: "607bc802b1c6c2a5e62cc48640f38aaa64bef1501b46f0ae4829feb51594b257",
         extract: {
           format: "zip",
           targetPath: "terraform",
@@ -53,119 +53,8 @@ export const terraformCliSpecs: { [version: string]: PluginToolSpec } = {
       {
         platform: "windows",
         architecture: "amd64",
-        url: "https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_windows_amd64.zip",
-        sha256: "bfec66e2ad079a1fab6101c19617a82ef79357dc1b92ddca80901bb8d5312dc0",
-        extract: {
-          format: "zip",
-          targetPath: "terraform.exe",
-        },
-      },
-    ],
-  },
-  "0.12.7": {
-    name: "terraform-0-12-7",
-    description: "The terraform CLI, v0.12.7",
-    type: "binary",
-    builds: [
-      {
-        platform: "darwin",
-        architecture: "amd64",
-        url: "https://releases.hashicorp.com/terraform/0.12.7/terraform_0.12.7_darwin_amd64.zip",
-        sha256: "5cb59cdc4a8c4ebdfc0b8715936110e707d869c59603d27020e33b2be2e50f21",
-        extract: {
-          format: "zip",
-          targetPath: "terraform",
-        },
-      },
-      {
-        platform: "linux",
-        architecture: "amd64",
-        url: "https://releases.hashicorp.com/terraform/0.12.7/terraform_0.12.7_linux_amd64.zip",
-        sha256: "a0fa11217325f76bf1b4f53b0f7a6efb1be1826826ef8024f2f45e60187925e7",
-        extract: {
-          format: "zip",
-          targetPath: "terraform",
-        },
-      },
-      {
-        platform: "windows",
-        architecture: "amd64",
-        url: "https://releases.hashicorp.com/terraform/0.12.7/terraform_0.12.7_windows_amd64.zip",
-        sha256: "ce5b0eae0b443cbbb7c592d1b48bad6c8a3c5298932d35a4ebcba800c3488e4e",
-        extract: {
-          format: "zip",
-          targetPath: "terraform.exe",
-        },
-      },
-    ],
-  },
-  "0.12.21": {
-    name: "terraform-0-12-21",
-    description: "The terraform CLI, v0.12.21",
-    type: "binary",
-    builds: [
-      {
-        platform: "darwin",
-        architecture: "amd64",
-        url: "https://releases.hashicorp.com/terraform/0.12.21/terraform_0.12.21_darwin_amd64.zip",
-        sha256: "f89b620e59439fccc80950bbcbd37a069101cbef7029029a12227eee831e463f",
-        extract: {
-          format: "zip",
-          targetPath: "terraform",
-        },
-      },
-      {
-        platform: "linux",
-        architecture: "amd64",
-        url: "https://releases.hashicorp.com/terraform/0.12.21/terraform_0.12.21_linux_amd64.zip",
-        sha256: "ca0d0796c79d14ee73a3d45649dab5e531f0768ee98da71b31e423e3278e9aa9",
-        extract: {
-          format: "zip",
-          targetPath: "terraform",
-        },
-      },
-      {
-        platform: "windows",
-        architecture: "amd64",
-        url: "https://releases.hashicorp.com/terraform/0.12.21/terraform_0.12.21_windows_amd64.zip",
-        sha256: "254e5f870efe9d86a3f211a1b9c3c01325fc380e428f54542b7750d8bfd62bb1",
-        extract: {
-          format: "zip",
-          targetPath: "terraform.exe",
-        },
-      },
-    ],
-  },
-  "0.12.24": {
-    name: "terraform-0-12-24",
-    description: "The terraform CLI, v0.12.24",
-    type: "binary",
-    builds: [
-      {
-        platform: "darwin",
-        architecture: "amd64",
-        url: "https://releases.hashicorp.com/terraform/0.12.24/terraform_0.12.24_darwin_amd64.zip",
-        sha256: "72482000a5e25c33e88e95d70208304acfd09bf855a7ede110da032089d13b4f",
-        extract: {
-          format: "zip",
-          targetPath: "terraform",
-        },
-      },
-      {
-        platform: "linux",
-        architecture: "amd64",
-        url: "https://releases.hashicorp.com/terraform/0.12.24/terraform_0.12.24_linux_amd64.zip",
-        sha256: "602d2529aafdaa0f605c06adb7c72cfb585d8aa19b3f4d8d189b42589e27bf11",
-        extract: {
-          format: "zip",
-          targetPath: "terraform",
-        },
-      },
-      {
-        platform: "windows",
-        architecture: "amd64",
-        url: "https://releases.hashicorp.com/terraform/0.12.24/terraform_0.12.24_windows_amd64.zip",
-        sha256: "fd1679999d4555639f7074ad0a86d1a627a6da5e52dacdb77d3ecbcd1b5bca0a",
+        url: "https://releases.hashicorp.com/terraform/0.12.26/terraform_0.12.26_windows_amd64.zip",
+        sha256: "f232bf25dc32e618fbb692b98857d10a84e16e531e9ce5e87e060c1369bde092",
         extract: {
           format: "zip",
           targetPath: "terraform.exe",


### PR DESCRIPTION
**What this PR does / why we need it**:

We had been collecting a bunch of Terraform versions over time. Now that we fetch them automatically, they're basically clutter, so the 0.12 breaking release is a good moment to remove them.

BREAKING CHANGE:

All Terraform versions below 0.12.26 have now been removed and are no
longer supported. If you have explicitly set a Terraform version in your
`terraform` provider config, you need to update that to `"0.12.26"` or 
remove the field.
