### PR TITLE
fix(workflows): abort if step cmd returns errors

### DIFF
--- a/garden-service/test/unit/src/commands/run/workflow.ts
+++ b/garden-service/test/unit/src/commands/run/workflow.ts
@@ -6,30 +6,30 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import execa from "execa"
+import tmp from "tmp-promise"
+import { expect } from "chai"
 import { TestGarden, makeTestGardenA, withDefaultGlobalOpts } from "../../../../helpers"
-import { LogEntry } from "../../../../../src/logger/log-entry"
 import { DEFAULT_API_VERSION } from "../../../../../src/constants"
 import { RunWorkflowCommand } from "../../../../../src/commands/run/workflow"
+import { createGardenPlugin } from "../../../../../src/types/plugin/plugin"
+import { joi } from "../../../../../src/config/common"
+import { RunTaskParams } from "../../../../../src/types/plugin/task/runTask"
+import { ProjectConfig } from "../../../../../src/config/project"
 
 describe("RunWorkflowCommand", () => {
   const cmd = new RunWorkflowCommand()
-  let garden: TestGarden
-  let log: LogEntry
-  let defaultParams
 
-  before(async () => {
-    garden = await makeTestGardenA()
-    log = garden.log
-    defaultParams = {
+  it("should run a workflow", async () => {
+    const garden = await makeTestGardenA()
+    const log = garden.log
+    const defaultParams = {
       garden,
       log,
       headerLog: log,
       footerLog: log,
       opts: withDefaultGlobalOpts({}),
     }
-  })
-
-  it("should run a workflow", async () => {
     garden.setWorkflowConfigs([
       {
         apiVersion: DEFAULT_API_VERSION,
@@ -50,5 +50,135 @@ describe("RunWorkflowCommand", () => {
     ])
 
     await cmd.action({ ...defaultParams, args: { workflow: "workflow-a" } })
+  })
+
+  it("should abort subsequent steps if a command returns an error", async () => {
+    const testModuleLog: string[] = []
+    // This plugin always returns errors when a task is run.
+    const testPlugin = createGardenPlugin({
+      name: "test",
+      createModuleTypes: [
+        {
+          name: "test",
+          docs: "test",
+          serviceOutputsSchema: joi.object().keys({ log: joi.string() }),
+          handlers: {
+            build: async () => ({}),
+            runTask: async ({ task }: RunTaskParams) => {
+              const result = {
+                taskName: task.name,
+                moduleName: task.module.name,
+                success: false,
+                outputs: { log: "" },
+                command: [],
+                errors: [
+                  {
+                    type: "task",
+                    message: "Task failed",
+                    detail: {},
+                  },
+                ],
+                log: "",
+                startedAt: new Date(),
+                completedAt: new Date(),
+                version: task.module.version.versionString,
+              }
+
+              return result
+            },
+            testModule: async ({}) => {
+              testModuleLog.push("tests have been run") // <--------
+              const now = new Date()
+              return {
+                moduleName: "",
+                command: [],
+                completedAt: now,
+                log: "",
+                outputs: {
+                  log: "",
+                },
+                success: true,
+                startedAt: now,
+                testName: "some-test",
+                version: "123",
+              }
+            },
+            getTaskResult: async ({}) => {
+              return null
+            },
+          },
+        },
+      ],
+    })
+
+    const tmpDir = await tmp.dir({ unsafeCleanup: true })
+    await execa("git", ["init"], { cwd: tmpDir.path })
+
+    const projectConfig: ProjectConfig = {
+      apiVersion: DEFAULT_API_VERSION,
+      kind: "Project",
+      name: "test",
+      path: tmpDir.path,
+      defaultEnvironment: "default",
+      dotIgnoreFiles: [],
+      environments: [{ name: "default", variables: {} }],
+      providers: [{ name: "test" }],
+      variables: {},
+    }
+
+    const garden = await TestGarden.factory(tmpDir.path, { config: projectConfig, plugins: [testPlugin] })
+    const log = garden.log
+    const defaultParams = {
+      garden,
+      log,
+      headerLog: log,
+      footerLog: log,
+      opts: withDefaultGlobalOpts({}),
+    }
+    garden.setModuleConfigs([
+      {
+        apiVersion: DEFAULT_API_VERSION,
+        name: "test",
+        type: "test",
+        allowPublish: false,
+        disabled: false,
+        build: { dependencies: [] },
+        outputs: {},
+        path: tmpDir.path,
+        serviceConfigs: [],
+        taskConfigs: [
+          {
+            name: "some-task",
+            cacheResult: true,
+            dependencies: [],
+            disabled: false,
+            spec: {},
+            timeout: 10,
+          },
+        ],
+        testConfigs: [
+          {
+            name: "unit",
+            dependencies: [],
+            disabled: false,
+            spec: {},
+            timeout: 10,
+          },
+        ],
+        spec: {},
+      },
+    ])
+    garden.setWorkflowConfigs([
+      {
+        apiVersion: DEFAULT_API_VERSION,
+        name: "workflow-a",
+        kind: "Workflow",
+        path: garden.projectRoot,
+        steps: [{ command: ["run", "task", "some-task"] }, { command: ["test"] }],
+      },
+    ])
+
+    await cmd.action({ ...defaultParams, args: { workflow: "workflow-a" } })
+    expect(testModuleLog.length).to.eql(0)
   })
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

This fixes an oversight in the initial implementation, where succeeding steps were only aborted if the step threw an exception, but not if it had an an error in its command result.

We now abort subsequent steps if a step command has errors in its result, and log the error details directly in the log (since looking into `error.log` is an undesirable extra step e.g. in a CI context).