### PR TITLE
fix(docker): remove default timeout, fix publish timeouts

### DIFF
--- a/garden-service/src/plugins/container/helpers.ts
+++ b/garden-service/src/plugins/container/helpers.ts
@@ -296,7 +296,7 @@ const helpers = {
     {
       ignoreError = false,
       outputStream,
-      timeout = DEFAULT_BUILD_TIMEOUT,
+      timeout,
     }: { ignoreError?: boolean; outputStream?: Writable; timeout?: number } = {}
   ) {
     // Check if docker is already installed


### PR DESCRIPTION
**What this PR does / why we need it**:

This was causing issues with non-build Docker operations, and was
unnecessary to begin with.

**Which issue(s) this PR fixes**:

Reported on Slack
