### PR TITLE
feat(workflows): allow writing files ahead of workflow execution

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -5,12 +5,15 @@ title: Config Files
 
 # garden.yml reference
 
-Below is the schema reference for the [Project](#project-configuration-keys) and [Module](#module-configuration-keys) `garden.yml` configuration files. For an introduction to configuring a Garden project,
-please look at our [configuration guide](../guides/configuration-files.md).
+Below is the schema reference for the [Project](#project-configuration-keys), [Module](#module-configuration-keys) and [Workflow](#workflow-configuration-keys) `garden.yml` configuration files. For an introduction to configuring a Garden project, please look at our [configuration guide](../guides/configuration-files.md).
 
-The reference is divided into four sections. The [first section](#project-yaml-schema) contains the project level YAML schema, and the [second section](#project-configuration-keys) describes each individual schema key for the project level configuration.
-
-The [third section](#module-yaml-schema) contains the module level YAML schema, and the [fourth section](#module-configuration-keys) describes each individual schema key for the module level configuration.
+The reference is divided into a few sections:
+* [Project YAML schema](#project-yaml-schema) contains the Project config YAML schema
+* [Project configuration keys](#project-configuration-keys) describes each individual schema key for Project configuration files.
+* [Module YAML schema](#module-yaml-schema) contains the Module config YAML schema
+* [Module configuration keys](#module-configuration-keys) describes each individual schema key for Module configuration files.
+* [Workflow YAML schema](#workflow-yaml-schema) contains the Workflow config YAML schema
+* [Workflow configuration keys](#module-configuration-keys) describes each individual schema key for Workflow configuration files.
 
 Note that individual providers, e.g. `kubernetes`, add their own project level configuration keys. The provider types are listed on the [Providers page](../reference/providers/README.md).
 
@@ -911,9 +914,333 @@ Defaults to to same as source path.
 
 ## Workflow YAML schema
 ```yaml
+# The schema version of this workflow's config (currently not used).
+apiVersion: garden.io/v0
 
+kind: Workflow
+
+# The name of this workflow.
+name:
+
+# A description of the workflow.
+description:
+
+# A list of files to write before starting the workflow.
+#
+# This is useful to e.g. create files required for provider authentication, and can be created from data stored in
+# secrets or templated strings.
+#
+# Note that you cannot reference provider configuration in template strings within this field, since they are resolved
+# after these files are generated. This means you can reference the files specified here in your provider
+# configurations.
+files:
+  - # POSIX-style path to write the file to, relative to the project root. If the path contains one or more
+    # directories, they are created automatically if necessary.
+    # If any of those directories conflict with existing file paths, or if the file path conflicts with an existing
+    # directory path, an error will be thrown.
+    # Any existing file with the same path will be overwritten.
+    path:
+
+    # The file data as a string.
+    data:
+
+    # The name of a Garden secret to copy the file data from (Garden Enterprise only).
+    secretName:
+
+# The number of hours to keep the workflow pod running after completion.
+keepAliveHours: 48
+
+limits:
+  # The maximum amount of CPU the workflow pod can use, in millicpus (i.e. 1000 = 1 CPU)
+  cpu: 1000
+
+  # The maximum amount of RAM the workflow pod can use, in megabytes (i.e. 1024 = 1 GB)
+  memory: 1024
+
+# The steps the workflow should run. At least one step is required. Steps are run sequentially. If a step fails,
+# subsequent steps are skipped.
+steps:
+  - # The Garden command this step should run.
+    #
+    # Supported commands:
+    #
+    # `[delete, environment]`
+    #
+    # `[delete, service]`
+    #
+    # `[deploy]`
+    #
+    # `[get, outputs]`
+    #
+    # `[publish]`
+    #
+    # `[run, task]`
+    #
+    # `[run, test]`
+    #
+    # `[test]`
+    command:
+
+    # A description of the workflow step.
+    description:
+
+# A list of triggers that determine when the workflow should be run, and which environment should be used (Garden
+# Enterprise only).
+triggers:
+  - # The environment name (from your project configuration) to use for the workflow when matched by this trigger.
+    environment:
+
+    # A list of GitHub events that should trigger this workflow.
+    events:
+
+    # If specified, only run the workflow for branches matching one of these filters.
+    branches:
+
+    # If specified, only run the workflow for tags matching one of these filters.
+    tags:
+
+    # If specified, do not run the workflow for branches matching one of these filters.
+    ignoreBranches:
+
+    # If specified, do not run the workflow for tags matching one of these filters.
+    ignoreTags:
 ```
 
 ## Workflow configuration keys
 
+
+### `apiVersion`
+
+The schema version of this workflow's config (currently not used).
+
+| Type     | Allowed Values | Default          | Required |
+| -------- | -------------- | ---------------- | -------- |
+| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+
+### `kind`
+
+| Type     | Allowed Values | Default      | Required |
+| -------- | -------------- | ------------ | -------- |
+| `string` | "Workflow"     | `"Workflow"` | Yes      |
+
+### `name`
+
+The name of this workflow.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | Yes      |
+
+Example:
+
+```yaml
+name: "my-workflow"
+```
+
+### `description`
+
+A description of the workflow.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `files[]`
+
+A list of files to write before starting the workflow.
+
+This is useful to e.g. create files required for provider authentication, and can be created from data stored in secrets or templated strings.
+
+Note that you cannot reference provider configuration in template strings within this field, since they are resolved after these files are generated. This means you can reference the files specified here in your provider configurations.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[object]` | No       |
+
+### `files[].path`
+
+[files](#files) > path
+
+POSIX-style path to write the file to, relative to the project root. If the path contains one or more directories, they are created automatically if necessary.
+If any of those directories conflict with existing file paths, or if the file path conflicts with an existing directory path, an error will be thrown.
+Any existing file with the same path will be overwritten.
+
+| Type        | Required |
+| ----------- | -------- |
+| `posixPath` | No       |
+
+Example:
+
+```yaml
+files:
+  - path: ".auth/kubeconfig.yaml"
+```
+
+### `files[].data`
+
+[files](#files) > data
+
+The file data as a string.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `files[].secretName`
+
+[files](#files) > secretName
+
+The name of a Garden secret to copy the file data from (Garden Enterprise only).
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `keepAliveHours`
+
+The number of hours to keep the workflow pod running after completion.
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `48`    | No       |
+
+### `limits`
+
+| Type     | Default                      | Required |
+| -------- | ---------------------------- | -------- |
+| `object` | `{"cpu":1000,"memory":1024}` | No       |
+
+### `limits.cpu`
+
+[limits](#limits) > cpu
+
+The maximum amount of CPU the workflow pod can use, in millicpus (i.e. 1000 = 1 CPU)
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `1000`  | No       |
+
+### `limits.memory`
+
+[limits](#limits) > memory
+
+The maximum amount of RAM the workflow pod can use, in megabytes (i.e. 1024 = 1 GB)
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `1024`  | No       |
+
+### `steps[]`
+
+The steps the workflow should run. At least one step is required. Steps are run sequentially. If a step fails, subsequent steps are skipped.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[object]` | Yes      |
+
+### `steps[].command[]`
+
+[steps](#steps) > command
+
+The Garden command this step should run.
+
+Supported commands:
+
+`[delete, environment]`
+
+`[delete, service]`
+
+`[deploy]`
+
+`[get, outputs]`
+
+`[publish]`
+
+`[run, task]`
+
+`[run, test]`
+
+`[test]`
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | Yes      |
+
+### `steps[].description`
+
+[steps](#steps) > description
+
+A description of the workflow step.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `triggers[]`
+
+A list of triggers that determine when the workflow should be run, and which environment should be used (Garden Enterprise only).
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[object]` | No       |
+
+### `triggers[].environment`
+
+[triggers](#triggers) > environment
+
+The environment name (from your project configuration) to use for the workflow when matched by this trigger.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | Yes      |
+
+### `triggers[].events[]`
+
+[triggers](#triggers) > events
+
+A list of GitHub events that should trigger this workflow.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
+### `triggers[].branches[]`
+
+[triggers](#triggers) > branches
+
+If specified, only run the workflow for branches matching one of these filters.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
+### `triggers[].tags[]`
+
+[triggers](#triggers) > tags
+
+If specified, only run the workflow for tags matching one of these filters.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
+### `triggers[].ignoreBranches[]`
+
+[triggers](#triggers) > ignoreBranches
+
+If specified, do not run the workflow for branches matching one of these filters.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
+### `triggers[].ignoreTags[]`
+
+[triggers](#triggers) > ignoreTags
+
+If specified, do not run the workflow for tags matching one of these filters.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
 

--- a/garden-service/src/commands/run/workflow.ts
+++ b/garden-service/src/commands/run/workflow.ts
@@ -12,9 +12,15 @@ import { printHeader, getTerminalWidth, formatGardenError } from "../../logger/u
 import { StringParameter, Command, CommandParams, CommandResult, parseCliArgs } from "../base"
 import { dedent, wordWrap, deline } from "../../util/string"
 import { Garden } from "../../garden"
-import { getStepCommandConfigs } from "../../config/workflow"
+import { getStepCommandConfigs, WorkflowFileSpec } from "../../config/workflow"
 import { LogEntry } from "../../logger/log-entry"
 import { GardenError } from "../../exceptions"
+import { WorkflowConfigContext } from "../../config/config-context"
+import { resolveTemplateStrings } from "../../template-string"
+import { ConfigurationError, FilesystemError } from "../../exceptions"
+import { posix, join } from "path"
+import { ensureDir, writeFile } from "fs-extra"
+import Bluebird from "bluebird"
 
 const runWorkflowArgs = {
   workflow: new StringParameter({
@@ -41,6 +47,15 @@ export class RunWorkflowCommand extends Command<Args, {}> {
   arguments = runWorkflowArgs
 
   async action({ garden, log, headerLog, args, opts }: CommandParams<Args, {}>): Promise<CommandResult<null>> {
+    // Partially resolve the workflow config, and prepare any configured files before continuing
+    const rawWorkflow = garden.getRawWorkflowConfig(args.workflow)
+    const templateContext = new WorkflowConfigContext(garden, {}, garden.variables, garden.secrets)
+    const files = resolveTemplateStrings(rawWorkflow.files || [], templateContext)
+
+    // Write all the configured files for the workflow
+    await Bluebird.map(files, (file) => writeWorkflowFile(garden, file))
+
+    // Fully resolve the config
     const workflow = await garden.getWorkflowConfig(args.workflow)
     const steps = workflow.steps
 
@@ -177,5 +192,37 @@ export function logErrors(
   for (const error of errors) {
     log.error("")
     log.error(formatGardenError(error))
+  }
+}
+
+async function writeWorkflowFile(garden: Garden, file: WorkflowFileSpec) {
+  let data: string
+
+  if (file.data !== undefined) {
+    data = file.data
+  } else if (file.secretName) {
+    data = garden.secrets[file.secretName]
+
+    if (data === undefined) {
+      throw new ConfigurationError(
+        `File '${file.path}' requires secret '${file.secretName}' which could not be found.`,
+        {
+          file,
+          availableSecrets: Object.keys(garden.secrets),
+        }
+      )
+    }
+  } else {
+    throw new ConfigurationError(`File '${file.path}' specifies neither string data nor a secret name.`, { file })
+  }
+
+  const fullPath = join(garden.projectRoot, ...file.path.split(posix.sep))
+  const parsedPath = posix.parse(fullPath)
+
+  try {
+    await ensureDir(parsedPath.dir)
+    await writeFile(fullPath, data)
+  } catch (error) {
+    throw new FilesystemError(`Unable to write file '${file.path}': ${error.message}`, { error, file })
   }
 }

--- a/garden-service/src/config/common.ts
+++ b/garden-service/src/config/common.ts
@@ -40,6 +40,7 @@ export const enumToArray = (Enum) => Object.values(Enum).filter((k) => typeof k 
 interface MetadataKeys {
   internal?: boolean
   deprecated?: boolean
+  enterprise?: boolean
   extendable?: boolean
   experimental?: boolean
   keyPlaceholder?: string
@@ -361,6 +362,7 @@ export const identifierRegex = /^(?![0-9]+$)(?!.*-$)(?!-)[a-z0-9-]{1,63}$/
 export const userIdentifierRegex = /^(?!garden)(?=.{1,63}$)[a-z][a-z0-9]*(-[a-z0-9]+)*$/
 export const envVarRegex = /^(?!garden)[a-z_][a-z0-9_\.]*$/i
 export const gitUrlRegex = /(?:git|ssh|https?|git@[-\w.]+):(\/\/)?(.*?)(\/?|\#[-\d\w._\/]+?)$/
+export const variableNameRegex = /[a-zA-Z][a-zA-Z0-9_\-]+/i
 
 export const joiIdentifierDescription =
   "valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and dashes, must start with a letter, " +
@@ -426,13 +428,12 @@ export const joiIdentifierMap = (valueSchema: Joi.Schema) =>
 export const joiVariablesDescription =
   "Keys may contain letters and numbers. Any values are permitted, including arrays and objects of any nesting."
 
+export const joiVariableName = () => joi.string().regex(variableNameRegex)
+
 export const joiVariables = () =>
   joi
     .object()
-    .pattern(
-      /[a-zA-Z][a-zA-Z0-9_\-]+/i,
-      joi.alternatives(joiPrimitive(), joi.link("..."), joi.array().items(joi.link("...")))
-    )
+    .pattern(variableNameRegex, joi.alternatives(joiPrimitive(), joi.link("..."), joi.array().items(joi.link("..."))))
     .default(() => ({}))
     .unknown(false)
     .description("Key/value map. " + joiVariablesDescription)

--- a/garden-service/src/docs/config.ts
+++ b/garden-service/src/docs/config.ts
@@ -19,6 +19,7 @@ import { STATIC_DIR } from "../constants"
 import { indent, renderMarkdownTable, convertMarkdownLinks, NormalizedSchemaDescription } from "./common"
 import { normalizeJoiSchemaDescription, JoiDescription } from "./joi-schema"
 import { safeDumpYaml } from "../util/util"
+import { workflowConfigSchema } from "../config/workflow"
 
 export const TEMPLATES_DIR = resolve(STATIC_DIR, "docs", "templates")
 const partialTemplatePath = resolve(TEMPLATES_DIR, "config-partial.hbs")
@@ -418,6 +419,9 @@ export function renderBaseConfigReference() {
   const baseTemplatePath = resolve(TEMPLATES_DIR, "base-config.hbs")
   const { markdownReference: projectMarkdownReference, yaml: projectYaml } = renderProjectConfigReference()
   const { markdownReference: moduleMarkdownReference, yaml: moduleYaml } = renderConfigReference(baseModuleSpecSchema())
+  const { markdownReference: workflowMarkdownReference, yaml: workflowYaml } = renderConfigReference(
+    workflowConfigSchema()
+  )
 
   const template = handlebars.compile(readFileSync(baseTemplatePath).toString())
   return template({
@@ -425,5 +429,7 @@ export function renderBaseConfigReference() {
     projectYaml,
     moduleMarkdownReference,
     moduleYaml,
+    workflowMarkdownReference,
+    workflowYaml,
   })
 }

--- a/garden-service/src/garden.ts
+++ b/garden-service/src/garden.ts
@@ -636,18 +636,25 @@ export class Garden {
     return keyBy(providers, "name")
   }
 
+  getRawWorkflowConfig(name: string) {
+    return this.getRawWorkflowConfigs([name])[0]
+  }
+
+  getRawWorkflowConfigs(names?: string[]) {
+    if (names) {
+      return Object.values(pickKeys(this.workflowConfigs, names, "workflow"))
+    } else {
+      return Object.values(this.workflowConfigs)
+    }
+  }
+
   async getWorkflowConfig(name: string): Promise<WorkflowConfig> {
     return (await this.getWorkflowConfigs([name]))[0]
   }
 
   async getWorkflowConfigs(names?: string[]): Promise<WorkflowConfig[]> {
     const providers = await this.resolveProviders()
-
-    if (!names) {
-      names = Object.keys(this.workflowConfigs)
-    }
-
-    const configs = Object.values(pickKeys(this.workflowConfigs, names, "workflow"))
+    const configs = this.getRawWorkflowConfigs(names)
     return configs.map((config) => resolveWorkflowConfig(this, providers, config))
   }
 

--- a/garden-service/static/docs/templates/base-config.hbs
+++ b/garden-service/static/docs/templates/base-config.hbs
@@ -5,12 +5,15 @@ title: Config Files
 
 # garden.yml reference
 
-Below is the schema reference for the [Project](#project-configuration-keys) and [Module](#module-configuration-keys) `garden.yml` configuration files. For an introduction to configuring a Garden project,
-please look at our [configuration guide](../guides/configuration-files.md).
+Below is the schema reference for the [Project](#project-configuration-keys), [Module](#module-configuration-keys) and [Workflow](#workflow-configuration-keys) `garden.yml` configuration files. For an introduction to configuring a Garden project, please look at our [configuration guide](../guides/configuration-files.md).
 
-The reference is divided into four sections. The [first section](#project-yaml-schema) contains the project level YAML schema, and the [second section](#project-configuration-keys) describes each individual schema key for the project level configuration.
-
-The [third section](#module-yaml-schema) contains the module level YAML schema, and the [fourth section](#module-configuration-keys) describes each individual schema key for the module level configuration.
+The reference is divided into a few sections:
+* [Project YAML schema](#project-yaml-schema) contains the Project config YAML schema
+* [Project configuration keys](#project-configuration-keys) describes each individual schema key for Project configuration files.
+* [Module YAML schema](#module-yaml-schema) contains the Module config YAML schema
+* [Module configuration keys](#module-configuration-keys) describes each individual schema key for Module configuration files.
+* [Workflow YAML schema](#workflow-yaml-schema) contains the Workflow config YAML schema
+* [Workflow configuration keys](#module-configuration-keys) describes each individual schema key for Workflow configuration files.
 
 Note that individual providers, e.g. `kubernetes`, add their own project level configuration keys. The provider types are listed on the [Providers page](../reference/providers/README.md).
 

--- a/garden-service/test/unit/src/commands/run/workflow.ts
+++ b/garden-service/test/unit/src/commands/run/workflow.ts
@@ -9,27 +9,35 @@
 import execa from "execa"
 import tmp from "tmp-promise"
 import { expect } from "chai"
-import { TestGarden, makeTestGardenA, withDefaultGlobalOpts } from "../../../../helpers"
+import { TestGarden, makeTestGardenA, withDefaultGlobalOpts, expectError } from "../../../../helpers"
 import { DEFAULT_API_VERSION } from "../../../../../src/constants"
 import { RunWorkflowCommand } from "../../../../../src/commands/run/workflow"
 import { createGardenPlugin } from "../../../../../src/types/plugin/plugin"
 import { joi } from "../../../../../src/config/common"
 import { RunTaskParams } from "../../../../../src/types/plugin/task/runTask"
 import { ProjectConfig } from "../../../../../src/config/project"
+import { join } from "path"
+import { remove, readFile, pathExists } from "fs-extra"
+import { defaultDotIgnoreFiles } from "../../../../../src/util/fs"
 
 describe("RunWorkflowCommand", () => {
   const cmd = new RunWorkflowCommand()
+  let garden: TestGarden
+  let defaultParams: any
 
-  it("should run a workflow", async () => {
-    const garden = await makeTestGardenA()
+  before(async () => {
+    garden = await makeTestGardenA()
     const log = garden.log
-    const defaultParams = {
+    defaultParams = {
       garden,
       log,
       headerLog: log,
       footerLog: log,
       opts: withDefaultGlobalOpts({}),
     }
+  })
+
+  it("should run a workflow", async () => {
     garden.setWorkflowConfigs([
       {
         apiVersion: DEFAULT_API_VERSION,
@@ -126,16 +134,9 @@ describe("RunWorkflowCommand", () => {
       variables: {},
     }
 
-    const garden = await TestGarden.factory(tmpDir.path, { config: projectConfig, plugins: [testPlugin] })
+    const _garden = await TestGarden.factory(tmpDir.path, { config: projectConfig, plugins: [testPlugin] })
     const log = garden.log
-    const defaultParams = {
-      garden,
-      log,
-      headerLog: log,
-      footerLog: log,
-      opts: withDefaultGlobalOpts({}),
-    }
-    garden.setModuleConfigs([
+    _garden.setModuleConfigs([
       {
         apiVersion: DEFAULT_API_VERSION,
         name: "test",
@@ -168,7 +169,7 @@ describe("RunWorkflowCommand", () => {
         spec: {},
       },
     ])
-    garden.setWorkflowConfigs([
+    _garden.setWorkflowConfigs([
       {
         apiVersion: DEFAULT_API_VERSION,
         name: "workflow-a",
@@ -178,7 +179,139 @@ describe("RunWorkflowCommand", () => {
       },
     ])
 
-    await cmd.action({ ...defaultParams, args: { workflow: "workflow-a" } })
+    await cmd.action({
+      garden: _garden,
+      log,
+      headerLog: log,
+      footerLog: log,
+      opts: withDefaultGlobalOpts({}),
+      args: { workflow: "workflow-a" },
+    })
     expect(testModuleLog.length).to.eql(0)
+  })
+
+  it("should write a file with string data ahead of the run, before resolving providers", async () => {
+    // Make a test plugin that expects a certain file to exist when resolving
+    const filePath = join(garden.projectRoot, ".garden", "test.txt")
+    await remove(filePath)
+
+    const test = createGardenPlugin({
+      name: "test",
+      handlers: {
+        configureProvider: async ({ config }) => {
+          expect(await pathExists(filePath)).to.be.true
+          return { config }
+        },
+      },
+    })
+
+    const projectConfig: ProjectConfig = {
+      apiVersion: "garden.io/v0",
+      kind: "Project",
+      name: "test",
+      path: garden.projectRoot,
+      defaultEnvironment: "default",
+      dotIgnoreFiles: defaultDotIgnoreFiles,
+      environments: [{ name: "default", variables: {} }],
+      providers: [{ name: "test" }],
+      variables: {},
+    }
+
+    const _garden = await TestGarden.factory(garden.projectRoot, { config: projectConfig, plugins: [test] })
+
+    _garden.setWorkflowConfigs([
+      {
+        apiVersion: DEFAULT_API_VERSION,
+        name: "workflow-a",
+        kind: "Workflow",
+        path: garden.projectRoot,
+        files: [{ path: ".garden/test.txt", data: "test" }],
+        steps: [{ command: ["get", "outputs"] }],
+      },
+    ])
+
+    await cmd.action({ ...defaultParams, args: { workflow: "workflow-a" } })
+  })
+
+  it("should write a file with data from a secret", async () => {
+    garden.secrets.test = "super secret value"
+    garden.setWorkflowConfigs([
+      {
+        apiVersion: DEFAULT_API_VERSION,
+        name: "workflow-a",
+        kind: "Workflow",
+        path: garden.projectRoot,
+        files: [{ path: ".garden/test.txt", secretName: "test" }],
+        steps: [{ command: ["get", "outputs"] }],
+      },
+    ])
+
+    const filePath = join(garden.projectRoot, ".garden", "test.txt")
+    await remove(filePath)
+
+    await cmd.action({ ...defaultParams, args: { workflow: "workflow-a" } })
+
+    const data = await readFile(filePath)
+    expect(data.toString()).to.equal(garden.secrets.test)
+  })
+
+  it("should throw if a file references a secret that doesn't exist", async () => {
+    garden.setWorkflowConfigs([
+      {
+        apiVersion: DEFAULT_API_VERSION,
+        name: "workflow-a",
+        kind: "Workflow",
+        path: garden.projectRoot,
+        files: [{ path: ".garden/test.txt", secretName: "missing" }],
+        steps: [{ command: ["get", "outputs"] }],
+      },
+    ])
+
+    await expectError(
+      () => cmd.action({ ...defaultParams, args: { workflow: "workflow-a" } }),
+      (err) =>
+        expect(err.message).to.equal("File '.garden/test.txt' requires secret 'missing' which could not be found.")
+    )
+  })
+
+  it("should throw if attempting to write a file with a directory path that contains an existing file", async () => {
+    garden.setWorkflowConfigs([
+      {
+        apiVersion: DEFAULT_API_VERSION,
+        name: "workflow-a",
+        kind: "Workflow",
+        path: garden.projectRoot,
+        files: [{ path: "garden.yml/foo.txt", data: "foo" }],
+        steps: [{ command: ["get", "outputs"] }],
+      },
+    ])
+
+    await expectError(
+      () => cmd.action({ ...defaultParams, args: { workflow: "workflow-a" } }),
+      (err) =>
+        expect(err.message.startsWith("Unable to write file 'garden.yml/foo.txt': EEXIST: file already exists, mkdir"))
+          .to.be.true
+    )
+  })
+
+  it("should throw if attempting to write a file to an existing directory path", async () => {
+    garden.setWorkflowConfigs([
+      {
+        apiVersion: DEFAULT_API_VERSION,
+        name: "workflow-a",
+        kind: "Workflow",
+        path: garden.projectRoot,
+        files: [{ path: ".garden", data: "foo" }],
+        steps: [{ command: ["get", "outputs"] }],
+      },
+    ])
+
+    await expectError(
+      () => cmd.action({ ...defaultParams, args: { workflow: "workflow-a" } }),
+      (err) =>
+        expect(err.message).to.equal(
+          `Unable to write file '.garden': EISDIR: illegal operation on a directory, open '${garden.gardenDirPath}'`
+        )
+    )
   })
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

This allows writing files from either string data, or referencing secrets when using Garden Enterprise, ahead of running workflows. 

The files are resolved and written before resolving providers, so they can reference the files. A common use case would e.g. be to write authentication files like kubeconfigs, which providers can then use.
