### PR TITLE
chore(kaniko): bump kaniko version to 0.23

### DIFF
--- a/garden-service/src/plugins/kubernetes/container/build.ts
+++ b/garden-service/src/plugins/kubernetes/container/build.ts
@@ -44,7 +44,7 @@ import chalk = require("chalk")
 import { loadImageToMicrok8s, getMicrok8sImageStatus } from "../local/microk8s"
 import { RunResult } from "../../../types/plugin/base"
 
-const kanikoImage = "gcr.io/kaniko-project/executor:debug-v0.22.0"
+const kanikoImage = "gcr.io/kaniko-project/executor:debug-v0.23.0"
 
 const registryPort = 5000
 
@@ -294,7 +294,6 @@ const remoteBuild: BuildHandler = async (params) => {
   stdout.on("data", (line: Buffer) => {
     statusLine.setState(renderOutputStream(line.toString()))
   })
-
   if (provider.config.buildMode === "cluster-docker") {
     // Prepare the build command
     const dockerfilePath = posix.join(contextPath, dockerfile)


### PR DESCRIPTION
**What this PR does / why we need it**:
Kaniko added some tweaks + tracing ahead of figuring out why sometimes hashing layers takes a very long time

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
