### PR TITLE
fix(container): extraFlags weren't used when building in-cluster

### DIFF
--- a/garden-service/src/plugins/container/build.ts
+++ b/garden-service/src/plugins/container/build.ts
@@ -59,8 +59,6 @@ export async function buildContainerModule({ module, log }: BuildModuleParams<Co
 
   const cmdOpts = ["build", "-t", identifier, ...getDockerBuildFlags(module)]
 
-  cmdOpts.push(...(module.spec.extraFlags || []))
-
   if (module.spec.dockerfile) {
     cmdOpts.push("--file", containerHelpers.getDockerfileBuildPath(module))
   }
@@ -93,6 +91,8 @@ export function getDockerBuildFlags(module: ContainerModule) {
   if (module.spec.build.targetImage) {
     args.push("--target", module.spec.build.targetImage)
   }
+
+  args.push(...(module.spec.extraFlags || []))
 
   return args
 }

--- a/garden-service/test/unit/src/plugins/container/container.ts
+++ b/garden-service/test/unit/src/plugins/container/container.ts
@@ -28,6 +28,7 @@ import {
   minDockerVersion,
   DEFAULT_BUILD_TIMEOUT,
 } from "../../../../../src/plugins/container/helpers"
+import { getDockerBuildFlags } from "../../../../../src/plugins/container/build"
 
 describe("plugins.container", () => {
   const projectRoot = resolve(dataDir, "test-project-container")
@@ -986,6 +987,43 @@ describe("plugins.container", () => {
           expect(err.message).to.equal("Docker server needs to be version 17.07.0 or newer (got 17.06)")
         }
       )
+    })
+  })
+
+  describe("getDockerBuildFlags", () => {
+    it("should include extraFlags", async () => {
+      const module = await getTestModule({
+        allowPublish: false,
+        build: {
+          dependencies: [],
+        },
+        disabled: false,
+        apiVersion: "garden.io/v0",
+        name: "module-a",
+        outputs: {},
+        path: modulePath,
+        type: "container",
+
+        spec: {
+          build: {
+            dependencies: [],
+            timeout: DEFAULT_BUILD_TIMEOUT,
+          },
+          buildArgs: {},
+          extraFlags: ["--cache-from", "some-image:latest"],
+          services: [],
+          tasks: [],
+          tests: [],
+        },
+
+        serviceConfigs: [],
+        taskConfigs: [],
+        testConfigs: [],
+      })
+
+      const args = getDockerBuildFlags(module)
+
+      expect(args).to.eql(["--cache-from", "some-image:latest"])
     })
   })
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

We were only applying the `extraFlags` field for local builds. This moves it into a shared function that's used for all build modes.

**Which issue(s) this PR fixes**:

Reported by @elliott-davis on Slack. Thanks :)
