### PR TITLE
feat(workflows): improved log & event streaming

### DIFF
--- a/garden-service/src/enterprise/buffered-event-stream.ts
+++ b/garden-service/src/enterprise/buffered-event-stream.ts
@@ -13,6 +13,8 @@ import { chainMessages } from "../logger/renderers"
 import { got } from "../util/http"
 import { makeAuthHeader } from "./auth"
 
+const workflowUid = process.env.GARDEN_WORKFLOW_UID || null
+
 export type StreamEvent = {
   name: EventName
   payload: Events[EventName]
@@ -148,6 +150,7 @@ export class BufferedEventStream {
   flushEvents(events: StreamEvent[]) {
     const data = {
       events,
+      workflowUid,
       sessionId: this.sessionId,
       projectId: this.projectId,
     }
@@ -160,6 +163,7 @@ export class BufferedEventStream {
   flushLogEntries(logEntries: LogEntryEvent[]) {
     const data = {
       logEntries,
+      workflowUid,
       sessionId: this.sessionId,
       projectId: this.projectId,
     }

--- a/garden-service/src/events.ts
+++ b/garden-service/src/events.ts
@@ -118,6 +118,17 @@ export interface Events extends LoggerEvents {
     completedAt: Date
   }
   watchingForChanges: {}
+
+  // Workflow events
+  workflowStepProcessing: {
+    index: number
+  }
+  workflowStepComplete: {
+    index: number
+  }
+  workflowStepError: {
+    index: number
+  }
 }
 
 export type EventName = keyof Events
@@ -142,4 +153,7 @@ export const eventNames: EventName[] = [
   "taskGraphProcessing",
   "taskGraphComplete",
   "watchingForChanges",
+  "workflowStepProcessing",
+  "workflowStepError",
+  "workflowStepComplete",
 ]

--- a/garden-service/src/garden.ts
+++ b/garden-service/src/garden.ts
@@ -141,7 +141,7 @@ export interface GardenParams {
 
 @Profile()
 export class Garden {
-  public readonly log: LogEntry
+  public log: LogEntry
   private loadedPlugins: GardenPlugin[]
   protected moduleConfigs: ModuleConfigMap
   protected workflowConfigs: WorkflowConfigMap

--- a/garden-service/src/logger/log-entry.ts
+++ b/garden-service/src/logger/log-entry.ts
@@ -8,6 +8,7 @@
 
 import logSymbols from "log-symbols"
 import nodeEmoji from "node-emoji"
+import { cloneDeep, merge } from "lodash"
 
 import { LogNode, LogLevel, CreateNodeParams, PlaceholderOpts } from "./log-node"
 import { Omit } from "../util/util"
@@ -22,6 +23,7 @@ export type TaskLogStatus = "active" | "success" | "error"
 
 export interface LogEntryMetadata {
   task?: TaskMetadata
+  workflowStep?: WorkflowStepMetadata
 }
 
 export interface TaskMetadata {
@@ -31,6 +33,10 @@ export interface TaskMetadata {
   uid: string
   versionString: string
   durationMs?: number
+}
+
+export interface WorkflowStepMetadata {
+  index: number
 }
 
 export const EVENT_LOG_LEVEL = LogLevel.debug
@@ -190,6 +196,7 @@ export class LogEntry extends LogNode {
       ...params,
       indent,
       level,
+      metadata: merge(cloneDeep(this.metadata || {}), params.metadata || {}),
       root: this.root,
       parent: this,
     })
@@ -222,7 +229,12 @@ export class LogEntry extends LogNode {
     return { ...msgState }
   }
 
-  placeholder({ level = LogLevel.info, childEntriesInheritLevel = false, indent = 0 }: PlaceholderOpts = {}): LogEntry {
+  placeholder({
+    level = LogLevel.info,
+    childEntriesInheritLevel = false,
+    indent = 0,
+    metadata,
+  }: PlaceholderOpts = {}): LogEntry {
     // Ensure placeholder child entries align with parent context
     const indentForNode = Math.max((indent || this.indent || 0) - 1, -1)
     return this.addNode({
@@ -230,6 +242,7 @@ export class LogEntry extends LogNode {
       indent: indentForNode,
       childEntriesInheritLevel,
       isPlaceholder: true,
+      metadata,
     })
   }
 

--- a/garden-service/src/logger/log-node.ts
+++ b/garden-service/src/logger/log-node.ts
@@ -9,7 +9,7 @@
 import uniqid from "uniqid"
 import { round } from "lodash"
 
-import { LogEntry, LogEntryParams } from "./log-entry"
+import { LogEntry, LogEntryParams, LogEntryMetadata } from "./log-entry"
 
 export enum LogLevel {
   error = 0,
@@ -29,6 +29,7 @@ export interface PlaceholderOpts {
   level?: number
   childEntriesInheritLevel?: boolean
   indent?: number
+  metadata?: LogEntryMetadata
 }
 
 export function resolveParams(level: LogLevel, params: string | LogEntryParams): CreateNodeParams {

--- a/garden-service/src/logger/logger.ts
+++ b/garden-service/src/logger/logger.ts
@@ -112,9 +112,9 @@ export class Logger extends LogNode {
     return new LogEntry({ ...params, root: this })
   }
 
-  placeholder({ level = LogLevel.info, indent }: PlaceholderOpts = {}): LogEntry {
+  placeholder({ level = LogLevel.info, indent, metadata }: PlaceholderOpts = {}): LogEntry {
     // Ensure placeholder child entries align with parent context
-    return this.addNode({ level, indent: indent || -1, isPlaceholder: true })
+    return this.addNode({ level, indent: indent || -1, isPlaceholder: true, metadata })
   }
 
   onGraphChange(entry: LogEntry) {

--- a/garden-service/test/unit/src/logger/log-entry.ts
+++ b/garden-service/test/unit/src/logger/log-entry.ts
@@ -45,6 +45,31 @@ describe("LogEntry", () => {
     ]
     expect(indents).to.eql([undefined, 1, 2, 3, 2, 3])
   })
+  context("metadata", () => {
+    it("should pass on any metadata to placeholder or child nodes", () => {
+      const ph1 = logger.placeholder({ metadata: { foo: "bar" } })
+      const ph2 = ph1.placeholder()
+      const entry = logger.info({ msg: "hello", metadata: { foo: "bar" } })
+      const ph3 = entry.placeholder()
+      const nested = entry.info("nested")
+      const entry2 = logger.info("hello")
+      const ph4 = entry2.placeholder({ msg: "placeholder", metadata: { foo: "bar" } })
+      expect(ph1.metadata).to.eql({ foo: "bar" })
+      expect(ph2.metadata).to.eql({ foo: "bar" })
+      expect(ph3.metadata).to.eql({ foo: "bar" })
+      expect(ph4.metadata).to.eql({ foo: "bar" }, "ph4")
+      expect(entry.metadata).to.eql({ foo: "bar" })
+      expect(entry2.metadata).to.eql(undefined)
+      expect(nested.metadata).to.eql({ foo: "bar" })
+    })
+
+    it("should not set metadata on parent when creating placeholders or child nodes", () => {
+      const entry = logger.info("hello")
+      const ph = entry.placeholder({ metadata: { foo: "bar" } })
+      expect(entry.metadata).to.eql(undefined)
+      expect(ph.metadata).to.eql({ foo: "bar" })
+    })
+  })
   context("childEntriesInheritLevel is set to true", () => {
     it("should create a log entry whose children inherit the parent level", () => {
       const verbose = logger.verbose({ childEntriesInheritLevel: true })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

Added `workflowStep` metadata to log entries generated by step commands and scripts.

Added step status events, which are emitted when a workflow step starts processing, completes or fails.

Added support for an optional `GARDEN_WORKFLOW_UID` environment variable that is sent along with streamed events & log entries (if it's defined).