### PR TITLE
fix(k8s): ensure rendered helm chart contain runtime values

### DIFF
--- a/garden-service/src/plugins/kubernetes/helm/common.ts
+++ b/garden-service/src/plugins/kubernetes/helm/common.ts
@@ -27,6 +27,7 @@ import { KubernetesPluginContext } from "../config"
 import { RunResult } from "../../../types/plugin/base"
 import { MAX_RUN_RESULT_LOG_LENGTH } from "../constants"
 import { dumpYaml } from "../../../util/util"
+import { getReleaseStatus } from "./status"
 
 const gardenValuesFilename = "garden-values.yml"
 
@@ -109,20 +110,32 @@ export async function renderTemplates(ctx: KubernetesPluginContext, module: Modu
     skipCreate: true,
   })
 
-  return helm({
+  const releaseStatus = await getReleaseStatus(ctx, module, releaseName, log, hotReload)
+  // Use `install|upgrade --dry-run` since `template` doesn't render values that need to be retrieved from the cluster.
+  const cmd = releaseStatus.state === "missing" ? "install" : "upgrade"
+
+  const res = await helm({
     ctx,
     log,
     namespace,
     args: [
-      "template",
+      cmd,
       releaseName,
+      chartPath,
+      "--dry-run",
       "--namespace",
       namespace,
-      "--dependency-update",
+      // Set output to JSON so that we can get just the manifests. The default output contains notes and additional data
+      "--output",
+      "json",
+      "--timeout",
+      module.spec.timeout.toString(10) + "s",
       ...(await getValueArgs(module, hotReload)),
-      chartPath,
     ],
   })
+
+  const manifest = JSON.parse(res).manifest as string
+  return manifest
 }
 
 /**

--- a/garden-service/src/plugins/kubernetes/helm/helm-cli.ts
+++ b/garden-service/src/plugins/kubernetes/helm/helm-cli.ts
@@ -111,6 +111,7 @@ export async function helm({
   args,
   version = 3,
   env = {},
+  cwd,
 }: {
   ctx: KubernetesPluginContext
   namespace?: string
@@ -118,6 +119,7 @@ export async function helm({
   args: string[]
   version?: 2 | 3
   env?: { [key: string]: string }
+  cwd?: string
 }) {
   const opts = ["--kube-context", ctx.provider.config.context]
 
@@ -151,5 +153,6 @@ export async function helm({
     env: envVars,
     // Helm itself will time out pretty reliably, so we shouldn't time out early on our side.
     timeout: 3600,
+    cwd,
   })
 }

--- a/garden-service/test/data/test-projects/conftest-kubernetes/helm/garden.yml
+++ b/garden-service/test/data/test-projects/conftest-kubernetes/helm/garden.yml
@@ -2,8 +2,9 @@ kind: Module
 description: Test Helm chart
 type: helm
 name: helm
-chart: stable/postgresql
-version: 8.6.4
+chart: postgresql
+repo: https://charts.bitnami.com/bitnami
+version: "8.10.5"
 dependencies: [kubernetes]
 values:
   foo: ${runtime.services.kubernetes.outputs}

--- a/garden-service/test/data/test-projects/conftest-kubernetes/helm/garden.yml
+++ b/garden-service/test/data/test-projects/conftest-kubernetes/helm/garden.yml
@@ -3,7 +3,7 @@ description: Test Helm chart
 type: helm
 name: helm
 chart: stable/postgresql
-version: 3.9.2
+version: 8.6.4
 dependencies: [kubernetes]
 values:
   foo: ${runtime.services.kubernetes.outputs}

--- a/garden-service/test/data/test-projects/helm/postgres/garden.yml
+++ b/garden-service/test/data/test-projects/helm/postgres/garden.yml
@@ -2,8 +2,9 @@ kind: Module
 description: Postgres database for storing voting results
 type: helm
 name: postgres
-chart: stable/postgresql
-version: 3.9.2
+chart: postgresql
+repo: https://charts.bitnami.com/bitnami
+version: "8.10.5"
 serviceResource:
   kind: StatefulSet
   name: postgres


### PR DESCRIPTION
What this PR does / why we need it:

The helm template command doesn't render values that need to be
retrieved from the cluster. We therefore use helm install|upgrade --dry-run instead.

Which issue(s) this PR fixes:

Fixes #1795

Reviewer notes:

Actually, I closed the prior issue prematurely @eysi09. This remains separate from the other fix I'll follow up with.