### PR TITLE
feat(workflows): support referencing outputs from previous steps

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -12,6 +12,8 @@ The commands should be run in a Garden project, and are always scoped to that pr
 Note: You can get a list of commands in the CLI by running `garden -h/--help`,
 and detailed help for each command using `garden <command> -h/--help`
 
+The _Outputs_ sections show the output structure when running the command with `--output yaml`. The same structure is used when `--output json` is used and when querying through the REST API, but in JSON format.
+
 ##### Global options
 
 The following option flags can be used with any of the CLI commands:
@@ -46,22 +48,182 @@ Examples:
     garden build --force    # force rebuild of modules
     garden build --watch    # watch for changes to code
 
-##### Usage
+#### Usage
 
     garden build [modules] [options]
 
-##### Arguments
+#### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `modules` | No | Specify module(s) to build. Use comma as a separator to specify multiple modules.
 
-##### Options
+#### Options
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
   | `--force` |  | boolean | Force rebuild of module(s).
   | `--watch` | `-w` | boolean | Watch for changes in module(s) and auto-build.
+
+#### Outputs
+
+```yaml
+# A map of all modules that were built (or builds scheduled/attempted for) and information about the builds.
+builds:
+  <module name>:
+    # The full log from the build.
+    buildLog:
+
+    # Set to true if the build was fetched from a remote registry.
+    fetched:
+
+    # Set to true if the build was performed, false if it was already built, or fetched from a registry
+    fresh:
+
+    # Additional information, specific to the provider.
+    details:
+
+    # Set to true if the build was not attempted, e.g. if a dependency build failed.
+    aborted:
+
+    # The duration of the build in msec, if applicable.
+    durationMsec:
+
+    # Whether the build was succeessful.
+    success:
+
+    # An error message, if the build failed.
+    error:
+
+    # The version of the module, service, task or test.
+    version:
+
+# A map of all services that were deployed (or deployment scheduled/attempted for) and the service status.
+deployments:
+  <service name>:
+    # When the service was first deployed by the provider.
+    createdAt:
+
+    # Additional detail, specific to the provider.
+    detail:
+
+    # The ID used for the service by the provider (if not the same as the service name).
+    externalId:
+
+    # The provider version of the deployed service (if different from the Garden module version.
+    externalVersion:
+
+    # A list of ports that can be forwarded to from the Garden agent by the provider.
+    forwardablePorts:
+      - # A descriptive name for the port. Should correspond to user-configured ports where applicable.
+        name:
+
+        # The protocol of the port.
+        protocol:
+
+        # The target hostname of the service (only used for informational purposes).
+        targetHostname:
+
+        # The target port on the service.
+        targetPort:
+
+        # The protocol to use for URLs pointing at the port. This can be any valid URI protocol.
+        urlProtocol:
+
+    # List of currently deployed ingress endpoints for the service.
+    ingresses:
+      - # The ingress path that should be matched to route to this service.
+        path:
+
+        # The protocol to use for the ingress.
+        protocol:
+
+        # The hostname where the service can be accessed.
+        hostname:
+
+        # The port number that the service is exposed on internally.
+        # This defaults to the first specified port for the service.
+        port:
+
+    # Latest status message of the service (if any).
+    lastMessage:
+
+    # Latest error status message of the service (if any).
+    lastError:
+
+    # A map of primitive values, output from the service.
+    outputs:
+      # Number, string or boolean
+      <name>:
+
+    # How many replicas of the service are currently running.
+    runningReplicas:
+
+    # The current deployment status of the service.
+    state:
+
+    # When the service was last updated by the provider.
+    updatedAt:
+
+    # Set to true if the build was not attempted, e.g. if a dependency build failed.
+    aborted:
+
+    # The duration of the build in msec, if applicable.
+    durationMsec:
+
+    # Whether the build was succeessful.
+    success:
+
+    # An error message, if the build failed.
+    error:
+
+    # The version of the module, service, task or test.
+    version:
+
+# A map of all tests that were run (or scheduled/attempted) and the test results.
+tests:
+  <test name>:
+    # The name of the module that was run.
+    moduleName:
+
+    # The command that was run in the module.
+    command:
+
+    # When the module run was started.
+    startedAt:
+
+    # When the module run was completed.
+    completedAt:
+
+    # The output log from the run.
+    log:
+
+    # A map of primitive values, output from the test.
+    outputs:
+      # Number, string or boolean
+      <name>:
+
+    # The name of the test that was run.
+    testName:
+
+    # Set to true if the build was not attempted, e.g. if a dependency build failed.
+    aborted:
+
+    # The duration of the build in msec, if applicable.
+    durationMsec:
+
+    # Whether the build was succeessful.
+    success:
+
+    # An error message, if the build failed.
+    error:
+
+    # The version of the module, service, task or test.
+    version:
+
+# A map of all raw graph results. Avoid using this programmatically if you can, and use more structured keys instead.
+graphResults:
+```
 
 ### garden call
 
@@ -77,15 +239,17 @@ Examples:
 
 Note: Currently only supports simple GET requests for HTTP/HTTPS ingresses.
 
-##### Usage
+#### Usage
 
     garden call <serviceAndPath> 
 
-##### Arguments
+#### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `serviceAndPath` | Yes | The name of the service to call followed by the ingress path (e.g. my-container/somepath).
+
+
 
 ### garden config analytics-enabled
 
@@ -105,15 +269,17 @@ Examples:
     garden config analytics-enabled true   # enable analytics
     garden config analytics-enabled false  # disable analytics
 
-##### Usage
+#### Usage
 
     garden config analytics-enabled [enable] 
 
-##### Arguments
+#### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `enable` | No | Enable analytics. Defaults to &quot;true&quot;
+
+
 
 ### garden create project
 
@@ -130,17 +296,18 @@ Examples:
     garden create project --name my-project   # set the project name to my-project
     garden create project --interactive=false # don't prompt for user inputs when creating the config
 
-##### Usage
+#### Usage
 
     garden create project [options]
 
-##### Options
+#### Options
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
   | `--dir` |  | path | Directory to place the project in (defaults to current directory).
   | `--interactive` | `-i` | boolean | Set to false to disable interactive prompts.
   | `--name` |  | string | Name of the project (defaults to current directory name).
+
 
 ### garden create module
 
@@ -156,11 +323,11 @@ Examples:
     garden create module --name my-module     # set the module name to my-module
     garden create module --interactive=false  # don't prompt for user inputs when creating the module
 
-##### Usage
+#### Usage
 
     garden create module [options]
 
-##### Options
+#### Options
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
@@ -168,6 +335,7 @@ Examples:
   | `--interactive` | `-i` | boolean | Set to false to disable interactive prompts.
   | `--name` |  | string | Name of the module (defaults to current directory name).
   | `--type` |  | string | The module type to create. Required if --interactive&#x3D;false.
+
 
 ### garden delete secret
 
@@ -180,16 +348,18 @@ Examples:
     garden delete secret kubernetes somekey
     garden del secret local-kubernetes some-other-key
 
-##### Usage
+#### Usage
 
     garden delete secret <provider> <key> 
 
-##### Arguments
+#### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `provider` | Yes | The name of the provider to remove the secret from.
   | `key` | Yes | The key of the configuration variable. Separate with dots to get a nested key (e.g. key.nested).
+
+
 
 ### garden delete environment
 
@@ -201,9 +371,115 @@ and reset it. When you then run `garden deploy`, the environment will be reconfi
 This can be useful if you find the environment to be in an inconsistent state, or need/want to free up
 resources.
 
-##### Usage
+#### Usage
 
     garden delete environment 
+
+
+#### Outputs
+
+```yaml
+# The status of each provider in the environment.
+providerStatuses:
+  # Description of an environment's status for a provider.
+  <name>:
+    # Set to true if the environment is fully configured for a provider.
+    ready:
+
+    # One or more pages to add to the Garden dashboard.
+    dashboardPages:
+      - # The link title to show in the menu bar (max length 32).
+        title:
+
+        # A description to show when hovering over the link.
+        description:
+
+        # The URL to open in the dashboard pane when clicking the link.
+        url:
+
+        # Set to true if the link should open in a new browser tab/window.
+        newWindow:
+
+    # Use this to include additional information that is specific to the provider.
+    detail:
+
+    # Output variables that modules and other variables can reference.
+    outputs:
+      <name>:
+
+    # Set to true to disable caching of the status.
+    disableCache:
+
+# The status of each service in the environment.
+serviceStatuses:
+  <name>:
+    # When the service was first deployed by the provider.
+    createdAt:
+
+    # Additional detail, specific to the provider.
+    detail:
+
+    # The ID used for the service by the provider (if not the same as the service name).
+    externalId:
+
+    # The provider version of the deployed service (if different from the Garden module version.
+    externalVersion:
+
+    # A list of ports that can be forwarded to from the Garden agent by the provider.
+    forwardablePorts:
+      - # A descriptive name for the port. Should correspond to user-configured ports where applicable.
+        name:
+
+        # The protocol of the port.
+        protocol:
+
+        # The target hostname of the service (only used for informational purposes).
+        targetHostname:
+
+        # The target port on the service.
+        targetPort:
+
+        # The protocol to use for URLs pointing at the port. This can be any valid URI protocol.
+        urlProtocol:
+
+    # List of currently deployed ingress endpoints for the service.
+    ingresses:
+      - # The ingress path that should be matched to route to this service.
+        path:
+
+        # The protocol to use for the ingress.
+        protocol:
+
+        # The hostname where the service can be accessed.
+        hostname:
+
+        # The port number that the service is exposed on internally.
+        # This defaults to the first specified port for the service.
+        port:
+
+    # Latest status message of the service (if any).
+    lastMessage:
+
+    # Latest error status message of the service (if any).
+    lastError:
+
+    # A map of primitive values, output from the service.
+    outputs:
+      # Number, string or boolean
+      <name>:
+
+    # How many replicas of the service are currently running.
+    runningReplicas:
+
+    # The current deployment status of the service.
+    state:
+
+    # When the service was last updated by the provider.
+    updatedAt:
+
+    # The Garden module version of the deployed service.
+    version:
+```
 
 ### garden delete service
 
@@ -217,15 +493,88 @@ Examples:
 
     garden delete service my-service # deletes my-service
 
-##### Usage
+#### Usage
 
     garden delete service <services> 
 
-##### Arguments
+#### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `services` | Yes | The name(s) of the service(s) to delete. Use comma as a separator to specify multiple services.
+
+
+#### Outputs
+
+```yaml
+<name>:
+  # When the service was first deployed by the provider.
+  createdAt:
+
+  # Additional detail, specific to the provider.
+  detail:
+
+  # The ID used for the service by the provider (if not the same as the service name).
+  externalId:
+
+  # The provider version of the deployed service (if different from the Garden module version.
+  externalVersion:
+
+  # A list of ports that can be forwarded to from the Garden agent by the provider.
+  forwardablePorts:
+    - # A descriptive name for the port. Should correspond to user-configured ports where applicable.
+      name:
+
+      # The protocol of the port.
+      protocol:
+
+      # The target hostname of the service (only used for informational purposes).
+      targetHostname:
+
+      # The target port on the service.
+      targetPort:
+
+      # The protocol to use for URLs pointing at the port. This can be any valid URI protocol.
+      urlProtocol:
+
+  # List of currently deployed ingress endpoints for the service.
+  ingresses:
+    - # The ingress path that should be matched to route to this service.
+      path:
+
+      # The protocol to use for the ingress.
+      protocol:
+
+      # The hostname where the service can be accessed.
+      hostname:
+
+      # The port number that the service is exposed on internally.
+      # This defaults to the first specified port for the service.
+      port:
+
+  # Latest status message of the service (if any).
+  lastMessage:
+
+  # Latest error status message of the service (if any).
+  lastError:
+
+  # A map of primitive values, output from the service.
+  outputs:
+    # Number, string or boolean
+    <name>:
+
+  # How many replicas of the service are currently running.
+  runningReplicas:
+
+  # The current deployment status of the service.
+  state:
+
+  # When the service was last updated by the provider.
+  updatedAt:
+
+  # The Garden module version of the deployed service.
+  version:
+```
 
 ### garden deploy
 
@@ -248,17 +597,17 @@ Examples:
     garden deploy --hot=*              # deploys all compatible services with hot reloading enabled
     garden deploy --env stage          # deploy your services to an environment called stage
 
-##### Usage
+#### Usage
 
     garden deploy [services] [options]
 
-##### Arguments
+#### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `services` | No | The name(s) of the service(s) to deploy (skip to deploy all services). Use comma as a separator to specify multiple services.
 
-##### Options
+#### Options
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
@@ -266,6 +615,166 @@ Examples:
   | `--force-build` |  | boolean | Force rebuild of module(s).
   | `--watch` | `-w` | boolean | Watch for changes in module(s) and auto-deploy.
   | `--hot-reload` | `-hot` | array:string | The name(s) of the service(s) to deploy with hot reloading enabled. Use comma as a separator to specify multiple services. Use * to deploy all services with hot reloading enabled (ignores services belonging to modules that don&#x27;t support or haven&#x27;t configured hot reloading). When this option is used, the command is run in watch mode (i.e. implicitly assumes the --watch/-w flag).
+
+#### Outputs
+
+```yaml
+# A map of all modules that were built (or builds scheduled/attempted for) and information about the builds.
+builds:
+  <module name>:
+    # The full log from the build.
+    buildLog:
+
+    # Set to true if the build was fetched from a remote registry.
+    fetched:
+
+    # Set to true if the build was performed, false if it was already built, or fetched from a registry
+    fresh:
+
+    # Additional information, specific to the provider.
+    details:
+
+    # Set to true if the build was not attempted, e.g. if a dependency build failed.
+    aborted:
+
+    # The duration of the build in msec, if applicable.
+    durationMsec:
+
+    # Whether the build was succeessful.
+    success:
+
+    # An error message, if the build failed.
+    error:
+
+    # The version of the module, service, task or test.
+    version:
+
+# A map of all services that were deployed (or deployment scheduled/attempted for) and the service status.
+deployments:
+  <service name>:
+    # When the service was first deployed by the provider.
+    createdAt:
+
+    # Additional detail, specific to the provider.
+    detail:
+
+    # The ID used for the service by the provider (if not the same as the service name).
+    externalId:
+
+    # The provider version of the deployed service (if different from the Garden module version.
+    externalVersion:
+
+    # A list of ports that can be forwarded to from the Garden agent by the provider.
+    forwardablePorts:
+      - # A descriptive name for the port. Should correspond to user-configured ports where applicable.
+        name:
+
+        # The protocol of the port.
+        protocol:
+
+        # The target hostname of the service (only used for informational purposes).
+        targetHostname:
+
+        # The target port on the service.
+        targetPort:
+
+        # The protocol to use for URLs pointing at the port. This can be any valid URI protocol.
+        urlProtocol:
+
+    # List of currently deployed ingress endpoints for the service.
+    ingresses:
+      - # The ingress path that should be matched to route to this service.
+        path:
+
+        # The protocol to use for the ingress.
+        protocol:
+
+        # The hostname where the service can be accessed.
+        hostname:
+
+        # The port number that the service is exposed on internally.
+        # This defaults to the first specified port for the service.
+        port:
+
+    # Latest status message of the service (if any).
+    lastMessage:
+
+    # Latest error status message of the service (if any).
+    lastError:
+
+    # A map of primitive values, output from the service.
+    outputs:
+      # Number, string or boolean
+      <name>:
+
+    # How many replicas of the service are currently running.
+    runningReplicas:
+
+    # The current deployment status of the service.
+    state:
+
+    # When the service was last updated by the provider.
+    updatedAt:
+
+    # Set to true if the build was not attempted, e.g. if a dependency build failed.
+    aborted:
+
+    # The duration of the build in msec, if applicable.
+    durationMsec:
+
+    # Whether the build was succeessful.
+    success:
+
+    # An error message, if the build failed.
+    error:
+
+    # The version of the module, service, task or test.
+    version:
+
+# A map of all tests that were run (or scheduled/attempted) and the test results.
+tests:
+  <test name>:
+    # The name of the module that was run.
+    moduleName:
+
+    # The command that was run in the module.
+    command:
+
+    # When the module run was started.
+    startedAt:
+
+    # When the module run was completed.
+    completedAt:
+
+    # The output log from the run.
+    log:
+
+    # A map of primitive values, output from the test.
+    outputs:
+      # Number, string or boolean
+      <name>:
+
+    # The name of the test that was run.
+    testName:
+
+    # Set to true if the build was not attempted, e.g. if a dependency build failed.
+    aborted:
+
+    # The duration of the build in msec, if applicable.
+    durationMsec:
+
+    # Whether the build was succeessful.
+    success:
+
+    # An error message, if the build failed.
+    error:
+
+    # The version of the module, service, task or test.
+    version:
+
+# A map of all raw graph results. Avoid using this programmatically if you can, and use more structured keys instead.
+graphResults:
+```
 
 ### garden dev
 
@@ -284,17 +793,18 @@ Examples:
     garden dev --name integ                   # run all tests with the name 'integ' in the project
     garden test --name integ*                 # run all tests with the name starting with 'integ' in the project
 
-##### Usage
+#### Usage
 
     garden dev [options]
 
-##### Options
+#### Options
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
   | `--hot-reload` | `-hot` | array:string | The name(s) of the service(s) to deploy with hot reloading enabled. Use comma as a separator to specify multiple services. Use * to deploy all services with hot reloading enabled (ignores services belonging to modules that don&#x27;t support or haven&#x27;t configured hot reloading).
   | `--skip-tests` |  | boolean | Disable running the tests.
   | `--test-names` | `-tn` | array:string | Filter the tests to run by test name across all modules (leave unset to run all tests). Accepts glob patterns (e.g. integ* would run both &#x27;integ&#x27; and &#x27;integration&#x27;).
+
 
 ### garden exec
 
@@ -309,46 +819,634 @@ Examples:
 
      garden exec my-service /bin/sh   # runs a shell in the my-service container
 
-##### Usage
+#### Usage
 
     garden exec <service> <command> [options]
 
-##### Arguments
+#### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `service` | Yes | The service to exec the command in.
   | `command` | Yes | The command to run.
 
-##### Options
+#### Options
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
   | `--interactive` |  | boolean | Set to false to skip interactive mode and just output the command result
+
+#### Outputs
+
+```yaml
+# The exit code of the command executed in the service container.
+code:
+
+# The output of the executed command.
+output:
+
+# The stdout output of the executed command (if available).
+stdout:
+
+# The stderr output of the executed command (if available).
+stderr:
+```
 
 ### garden get graph
 
 Outputs the dependency relationships specified in this project&#x27;s garden.yml files.
 
 
-##### Usage
+#### Usage
 
     garden get graph 
+
+
 
 ### garden get config
 
 Outputs the fully resolved configuration for this project and environment.
 
 
-##### Usage
+#### Usage
 
     garden get config [options]
 
-##### Options
+#### Options
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
   | `--exclude-disabled` |  | boolean | Exclude disabled module, service, test, and task configs from output.
+
+#### Outputs
+
+```yaml
+allEnvironmentNames:
+
+# The name of the environment.
+environmentName:
+
+# The namespace of the current environment (if applicable).
+namespace:
+
+# A list of all configured providers in the environment.
+providers:
+  - # The name of the provider plugin to use.
+    name:
+
+    # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
+    # disables the provider. To use a provider in all environments, omit this field.
+    environments:
+
+    # Map of all the providers that this provider depends on.
+    dependencies:
+      <name>:
+
+    config:
+      # The name of the provider plugin to use.
+      name:
+
+      # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
+      # disables the provider. To use a provider in all environments, omit this field.
+      environments:
+
+    moduleConfigs:
+      - # The schema version of this module's config (currently not used).
+        apiVersion:
+
+        kind:
+
+        # The type of this module.
+        type:
+
+        # The name of this module.
+        name:
+
+        # A description of the module.
+        description:
+
+        # Set this to `true` to disable the module. You can use this with conditional template strings to disable
+        # modules based on, for example, the current environment or other variables (e.g. `disabled:
+        # \${environment.name == "prod"}`). This can be handy when you only need certain modules for specific
+        # environments, e.g. only for development.
+        #
+        # Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It
+        # also means that the module is not built _unless_ it is declared as a build dependency by another enabled
+        # module (in which case building this module is necessary for the dependant to be built).
+        #
+        # If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden
+        # will automatically ignore those dependency declarations. Note however that template strings referencing the
+        # module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so
+        # you need to make sure to provide alternate values for those if you're using them, using conditional
+        # expressions.
+        disabled:
+
+        # Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module.
+        # Files that do *not* match these paths or globs are excluded when computing the version of the module, when
+        # responding to filesystem watch events, and when staging builds.
+        #
+        # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
+        # source tree, which use the same format as `.gitignore` files. See the [Configuration Files
+        # guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for
+        # details.
+        #
+        # Also note that specifying an empty list here means _no sources_ should be included.
+        include:
+
+        # Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that
+        # match these paths or globs are excluded when computing the version of the module, when responding to
+        # filesystem watch events, and when staging builds.
+        #
+        # Note that you can also explicitly _include_ files using the `include` field. If you also specify the
+        # `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the
+        # [Configuration Files
+        # guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for
+        # details.
+        #
+        # Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files
+        # and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you
+        # have large directories that should not be watched for changes.
+        exclude:
+
+        # A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a
+        # specific branch or tag, with the format: <git remote url>#<branch|tag>
+        #
+        # Garden will import the repository source code into this module, but read the module's config from the local
+        # garden.yml file.
+        repositoryUrl:
+
+        # When false, disables pushing this module to remote registries.
+        allowPublish:
+
+        # Specify how to build the module. Note that plugins may define additional keys on this object.
+        build:
+          # A list of modules that must be built before this module is built.
+          dependencies:
+            - # Module name to build ahead of this module.
+              name:
+
+              # Specify one or more files or directories to copy from the built dependency to this module.
+              copy:
+                - # POSIX-style path or filename of the directory or file(s) to copy to the target.
+                  source:
+
+                  # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
+                  # Defaults to to same as source path.
+                  target:
+
+        # The outputs defined by the module (referenceable in other module configs).
+        outputs:
+          <name>:
+
+        # The filesystem path of the module.
+        path:
+
+        # The filesystem path of the module config file.
+        configPath:
+
+        # List of services configured by this module.
+        serviceConfigs:
+          - # Valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and dashes, must start with a
+            # letter, and cannot end with a dash), cannot contain consecutive dashes or start with `garden`, or be
+            # longer than 63 characters.
+            name:
+
+            # The names of any services that this service depends on at runtime, and the names of any tasks that
+            # should be executed before this service is deployed.
+            dependencies:
+
+            # Set this to `true` to disable the service. You can use this with conditional template strings to
+            # enable/disable services based on, for example, the current environment or other variables (e.g.
+            # `enabled: \${environment.name != "prod"}`). This can be handy when you only need certain services for
+            # specific environments, e.g. only for development.
+            #
+            # Disabling a service means that it will not be deployed, and will also be ignored if it is declared as a
+            # runtime dependency for another service, test or task.
+            #
+            # Note however that template strings referencing the service's outputs (i.e. runtime outputs) will fail to
+            # resolve when the service is disabled, so you need to make sure to provide alternate values for those if
+            # you're using them, using conditional expressions.
+            disabled:
+
+            # Set this to true if the module and service configuration supports hot reloading.
+            hotReloadable:
+
+            # The `validate` module action should populate this, if the service's code sources are contained in a
+            # separate module from the parent module. For example, when the service belongs to a module that contains
+            # manifests (e.g. a Helm chart), but the actual code lives in a different module (e.g. a container
+            # module).
+            sourceModuleName:
+
+            # The service's specification, as defined by its provider plugin.
+            spec:
+
+        # List of tasks configured by this module.
+        taskConfigs:
+          - # The name of the task.
+            name:
+
+            # A description of the task.
+            description:
+
+            # The names of any tasks that must be executed, and the names of any services that must be running, before
+            # this task is executed.
+            dependencies:
+
+            # Set this to `true` to disable the task. You can use this with conditional template strings to
+            # enable/disable tasks based on, for example, the current environment or other variables (e.g. `enabled:
+            # \${environment.name != "prod"}`). This can be handy when you only want certain tasks to run in specific
+            # environments, e.g. only for development.
+            #
+            # Disabling a task means that it will not be run, and will also be ignored if it is declared as a runtime
+            # dependency for another service, test or task.
+            #
+            # Note however that template strings referencing the task's outputs (i.e. runtime outputs) will fail to
+            # resolve when the task is disabled, so you need to make sure to provide alternate values for those if
+            # you're using them, using conditional expressions.
+            disabled:
+
+            # Maximum duration (in seconds) of the task's execution.
+            timeout:
+
+            # Set to false if you don't want the task's result to be cached. Use this if the task needs to be run any
+            # time your project (or one or more of the task's dependants) is deployed. Otherwise the task is only
+            # re-run when its version changes (i.e. the module or one of its dependencies is modified), or when you
+            # run `garden run task`.
+            cacheResult:
+
+            # The task's specification, as defined by its provider plugin.
+            spec:
+
+        # List of tests configured by this module.
+        testConfigs:
+          - # The name of the test.
+            name:
+
+            # The names of any services that must be running, and the names of any tasks that must be executed, before
+            # the test is run.
+            dependencies:
+
+            # Set this to `true` to disable the test. You can use this with conditional template strings to
+            # enable/disable tests based on, for example, the current environment or other variables (e.g.
+            # `enabled: \${environment.name != "prod"}`). This is handy when you only want certain tests to run in
+            # specific environments, e.g. only during CI.
+            disabled:
+
+            # Maximum duration (in seconds) of the test run.
+            timeout:
+
+            # The configuration for the test, as specified by its module's provider.
+            spec:
+
+        # The module spec, as defined by the provider plugin.
+        spec:
+
+    # Description of an environment's status for a provider.
+    status:
+      # Set to true if the environment is fully configured for a provider.
+      ready:
+
+      # One or more pages to add to the Garden dashboard.
+      dashboardPages:
+        - # The link title to show in the menu bar (max length 32).
+          title:
+
+          # A description to show when hovering over the link.
+          description:
+
+          # The URL to open in the dashboard pane when clicking the link.
+          url:
+
+          # Set to true if the link should open in a new browser tab/window.
+          newWindow:
+
+      # Use this to include additional information that is specific to the provider.
+      detail:
+
+      # Output variables that modules and other variables can reference.
+      outputs:
+        <name>:
+
+      # Set to true to disable caching of the status.
+      disableCache:
+
+# All configured variables in the environment.
+variables:
+  <name>:
+
+# All module configs in the project.
+moduleConfigs:
+  - # The schema version of this module's config (currently not used).
+    apiVersion:
+
+    kind:
+
+    # The type of this module.
+    type:
+
+    # The name of this module.
+    name:
+
+    # A description of the module.
+    description:
+
+    # Set this to `true` to disable the module. You can use this with conditional template strings to disable modules
+    # based on, for example, the current environment or other variables (e.g. `disabled: \${environment.name ==
+    # "prod"}`). This can be handy when you only need certain modules for specific environments, e.g. only for
+    # development.
+    #
+    # Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also
+    # means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in
+    # which case building this module is necessary for the dependant to be built).
+    #
+    # If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden
+    # will automatically ignore those dependency declarations. Note however that template strings referencing the
+    # module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you
+    # need to make sure to provide alternate values for those if you're using them, using conditional expressions.
+    disabled:
+
+    # Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files
+    # that do *not* match these paths or globs are excluded when computing the version of the module, when responding
+    # to filesystem watch events, and when staging builds.
+    #
+    # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
+    # source tree, which use the same format as `.gitignore` files. See the [Configuration Files
+    # guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories) for details.
+    #
+    # Also note that specifying an empty list here means _no sources_ should be included.
+    include:
+
+    # Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match
+    # these paths or globs are excluded when computing the version of the module, when responding to filesystem watch
+    # events, and when staging builds.
+    #
+    # Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
+    # field, the files/patterns specified here are filtered from the files matched by `include`. See the
+    # [Configuration Files
+    # guide](https://docs.garden.io/guides/configuration-files#including-excluding-files-and-directories)for details.
+    #
+    # Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files and
+    # directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have large
+    # directories that should not be watched for changes.
+    exclude:
+
+    # A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific
+    # branch or tag, with the format: <git remote url>#<branch|tag>
+    #
+    # Garden will import the repository source code into this module, but read the module's config from the local
+    # garden.yml file.
+    repositoryUrl:
+
+    # When false, disables pushing this module to remote registries.
+    allowPublish:
+
+    # Specify how to build the module. Note that plugins may define additional keys on this object.
+    build:
+      # A list of modules that must be built before this module is built.
+      dependencies:
+        - # Module name to build ahead of this module.
+          name:
+
+          # Specify one or more files or directories to copy from the built dependency to this module.
+          copy:
+            - # POSIX-style path or filename of the directory or file(s) to copy to the target.
+              source:
+
+              # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
+              # Defaults to to same as source path.
+              target:
+
+    # The outputs defined by the module (referenceable in other module configs).
+    outputs:
+      <name>:
+
+    # The filesystem path of the module.
+    path:
+
+    # The filesystem path of the module config file.
+    configPath:
+
+    # List of services configured by this module.
+    serviceConfigs:
+      - # Valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and dashes, must start with a
+        # letter, and cannot end with a dash), cannot contain consecutive dashes or start with `garden`, or be longer
+        # than 63 characters.
+        name:
+
+        # The names of any services that this service depends on at runtime, and the names of any tasks that should be
+        # executed before this service is deployed.
+        dependencies:
+
+        # Set this to `true` to disable the service. You can use this with conditional template strings to
+        # enable/disable services based on, for example, the current environment or other variables (e.g. `enabled:
+        # \${environment.name != "prod"}`). This can be handy when you only need certain services for specific
+        # environments, e.g. only for development.
+        #
+        # Disabling a service means that it will not be deployed, and will also be ignored if it is declared as a
+        # runtime dependency for another service, test or task.
+        #
+        # Note however that template strings referencing the service's outputs (i.e. runtime outputs) will fail to
+        # resolve when the service is disabled, so you need to make sure to provide alternate values for those if
+        # you're using them, using conditional expressions.
+        disabled:
+
+        # Set this to true if the module and service configuration supports hot reloading.
+        hotReloadable:
+
+        # The `validate` module action should populate this, if the service's code sources are contained in a separate
+        # module from the parent module. For example, when the service belongs to a module that contains manifests
+        # (e.g. a Helm chart), but the actual code lives in a different module (e.g. a container module).
+        sourceModuleName:
+
+        # The service's specification, as defined by its provider plugin.
+        spec:
+
+    # List of tasks configured by this module.
+    taskConfigs:
+      - # The name of the task.
+        name:
+
+        # A description of the task.
+        description:
+
+        # The names of any tasks that must be executed, and the names of any services that must be running, before
+        # this task is executed.
+        dependencies:
+
+        # Set this to `true` to disable the task. You can use this with conditional template strings to enable/disable
+        # tasks based on, for example, the current environment or other variables (e.g. `enabled: \${environment.name
+        # != "prod"}`). This can be handy when you only want certain tasks to run in specific environments, e.g. only
+        # for development.
+        #
+        # Disabling a task means that it will not be run, and will also be ignored if it is declared as a runtime
+        # dependency for another service, test or task.
+        #
+        # Note however that template strings referencing the task's outputs (i.e. runtime outputs) will fail to
+        # resolve when the task is disabled, so you need to make sure to provide alternate values for those if you're
+        # using them, using conditional expressions.
+        disabled:
+
+        # Maximum duration (in seconds) of the task's execution.
+        timeout:
+
+        # Set to false if you don't want the task's result to be cached. Use this if the task needs to be run any time
+        # your project (or one or more of the task's dependants) is deployed. Otherwise the task is only re-run when
+        # its version changes (i.e. the module or one of its dependencies is modified), or when you run `garden run
+        # task`.
+        cacheResult:
+
+        # The task's specification, as defined by its provider plugin.
+        spec:
+
+    # List of tests configured by this module.
+    testConfigs:
+      - # The name of the test.
+        name:
+
+        # The names of any services that must be running, and the names of any tasks that must be executed, before the
+        # test is run.
+        dependencies:
+
+        # Set this to `true` to disable the test. You can use this with conditional template strings to
+        # enable/disable tests based on, for example, the current environment or other variables (e.g.
+        # `enabled: \${environment.name != "prod"}`). This is handy when you only want certain tests to run in
+        # specific environments, e.g. only during CI.
+        disabled:
+
+        # Maximum duration (in seconds) of the test run.
+        timeout:
+
+        # The configuration for the test, as specified by its module's provider.
+        spec:
+
+    # The module spec, as defined by the provider plugin.
+    spec:
+
+# All workflow configs in the project.
+workflowConfigs:
+  - # The schema version of this workflow's config (currently not used).
+    apiVersion:
+
+    kind:
+
+    # The name of this workflow.
+    name:
+
+    # A description of the workflow.
+    description:
+
+    # A list of files to write before starting the workflow.
+    #
+    # This is useful to e.g. create files required for provider authentication, and can be created from data stored in
+    # secrets or templated strings.
+    #
+    # Note that you cannot reference provider configuration in template strings within this field, since they are
+    # resolved after these files are generated. This means you can reference the files specified here in your provider
+    # configurations.
+    files:
+      - # POSIX-style path to write the file to, relative to the project root (or absolute). If the path contains one
+        # or more directories, they are created automatically if necessary.
+        # If any of those directories conflict with existing file paths, or if the file path conflicts with an
+        # existing directory path, an error will be thrown.
+        # **Any existing file with the same path will be overwritten, so be careful not to accidentally accidentally
+        # overwrite files unrelated to your workflow.**
+        path:
+
+        # The file data as a string.
+        data:
+
+        # The name of a Garden secret to copy the file data from (Garden Enterprise only).
+        secretName:
+
+    # The number of hours to keep the workflow pod running after completion.
+    keepAliveHours:
+
+    limits:
+      # The maximum amount of CPU the workflow pod can use, in millicpus (i.e. 1000 = 1 CPU)
+      cpu:
+
+      # The maximum amount of RAM the workflow pod can use, in megabytes (i.e. 1024 = 1 GB)
+      memory:
+
+    # The steps the workflow should run. At least one step is required. Steps are run sequentially. If a step fails,
+    # subsequent steps are skipped.
+    steps:
+      - # An identifier to assign to this step. If none is specified, this defaults to "step-<number of step>", where
+        # <number of step> is the sequential number of the step (first step being number 1).
+        #
+        # This identifier is useful when referencing command outputs in following steps. For example, if you set this
+        # to "my-step", following steps can reference the \${steps.my-step.outputs.*} key in the `script` or `command`
+        # fields.
+        name:
+
+        # A Garden command this step should run, followed by any required or optional arguments and flags.
+        # Arguments and options for the commands may be templated, including references to previous steps, but for now
+        # the commands themselves (as listed below) must be hard-coded.
+        #
+        # Supported commands:
+        #
+        # `[build]`
+        # `[delete, environment]`
+        # `[delete, service]`
+        # `[deploy]`
+        # `[exec]`
+        # `[get, config]`
+        # `[get, outputs]`
+        # `[get, status]`
+        # `[get, task-result]`
+        # `[get, test-result]`
+        # `[link, module]`
+        # `[link, source]`
+        # `[publish]`
+        # `[run, task]`
+        # `[run, test]`
+        # `[test]`
+        # `[update-remote, all]`
+        # `[update-remote, modules]`
+        # `[update-remote, sources]`
+        #
+        #
+        command:
+
+        # A description of the workflow step.
+        description:
+
+        # A bash script to run. Note that the host running the workflow must have bash installed and on path. It is
+        # considered to have run successfully if it returns an exit code of 0. Any other exit code signals an error,
+        # and the remainder of the workflow is aborted.
+        # The script may include template strings, including references to previous steps.
+        script:
+
+    # A list of triggers that determine when the workflow should be run, and which environment should be used (Garden
+    # Enterprise only).
+    triggers:
+      - # The environment name (from your project configuration) to use for the workflow when matched by this trigger.
+        environment:
+
+        # A list of GitHub events that should trigger this workflow.
+        events:
+
+        # If specified, only run the workflow for branches matching one of these filters.
+        branches:
+
+        # If specified, only run the workflow for tags matching one of these filters.
+        tags:
+
+        # If specified, do not run the workflow for branches matching one of these filters.
+        ignoreBranches:
+
+        # If specified, do not run the workflow for tags matching one of these filters.
+        ignoreTags:
+
+# The name of the project.
+projectName:
+
+# The local path to the project root.
+projectRoot:
+
+# The project ID (Garden Enterprise only).
+projectId:
+```
 
 ### garden get eysi
 
@@ -356,18 +1454,22 @@ Meet our CTO.
 
 Just try it.
 
-##### Usage
+#### Usage
 
     garden get eysi 
+
+
 
 ### garden get linked-repos
 
 Outputs a list of all linked remote sources and modules for this project.
 
 
-##### Usage
+#### Usage
 
     garden get linked-repos 
+
+
 
 ### garden get outputs
 
@@ -382,64 +1484,276 @@ Examples:
     garden get outputs --env=prod      # resolve and print the outputs from the project for the prod environment
     garden get outputs --output=json   # resolve and return the project outputs in JSON format
 
-##### Usage
+#### Usage
 
     garden get outputs 
+
+
+#### Outputs
+
+```yaml
+<name>:
+```
 
 ### garden get status
 
 Outputs the full status of your environment.
 
 
-##### Usage
+#### Usage
 
     garden get status 
+
+
+#### Outputs
+
+```yaml
+# A map of statuses for each configured provider.
+providers:
+  # Description of an environment's status for a provider.
+  <name>:
+    # Set to true if the environment is fully configured for a provider.
+    ready:
+
+    # One or more pages to add to the Garden dashboard.
+    dashboardPages:
+      - # The link title to show in the menu bar (max length 32).
+        title:
+
+        # A description to show when hovering over the link.
+        description:
+
+        # The URL to open in the dashboard pane when clicking the link.
+        url:
+
+        # Set to true if the link should open in a new browser tab/window.
+        newWindow:
+
+    # Use this to include additional information that is specific to the provider.
+    detail:
+
+    # Output variables that modules and other variables can reference.
+    outputs:
+      <name>:
+
+    # Set to true to disable caching of the status.
+    disableCache:
+
+# A map of statuses for each configured service.
+services:
+  <name>:
+    # When the service was first deployed by the provider.
+    createdAt:
+
+    # Additional detail, specific to the provider.
+    detail:
+
+    # The ID used for the service by the provider (if not the same as the service name).
+    externalId:
+
+    # The provider version of the deployed service (if different from the Garden module version.
+    externalVersion:
+
+    # A list of ports that can be forwarded to from the Garden agent by the provider.
+    forwardablePorts:
+      - # A descriptive name for the port. Should correspond to user-configured ports where applicable.
+        name:
+
+        # The protocol of the port.
+        protocol:
+
+        # The target hostname of the service (only used for informational purposes).
+        targetHostname:
+
+        # The target port on the service.
+        targetPort:
+
+        # The protocol to use for URLs pointing at the port. This can be any valid URI protocol.
+        urlProtocol:
+
+    # List of currently deployed ingress endpoints for the service.
+    ingresses:
+      - # The ingress path that should be matched to route to this service.
+        path:
+
+        # The protocol to use for the ingress.
+        protocol:
+
+        # The hostname where the service can be accessed.
+        hostname:
+
+        # The port number that the service is exposed on internally.
+        # This defaults to the first specified port for the service.
+        port:
+
+    # Latest status message of the service (if any).
+    lastMessage:
+
+    # Latest error status message of the service (if any).
+    lastError:
+
+    # A map of primitive values, output from the service.
+    outputs:
+      # Number, string or boolean
+      <name>:
+
+    # How many replicas of the service are currently running.
+    runningReplicas:
+
+    # The current deployment status of the service.
+    state:
+
+    # When the service was last updated by the provider.
+    updatedAt:
+
+    # The Garden module version of the deployed service.
+    version:
+
+# A map of statuses for each configured task.
+tasks:
+  <name>:
+    state:
+
+    # When the last run was started (if applicable).
+    startedAt:
+
+    # When the last run completed (if applicable).
+    completedAt:
+
+# A map of statuses for each configured test.
+tests:
+  <name>:
+    state:
+
+    # When the last run was started (if applicable).
+    startedAt:
+
+    # When the last run completed (if applicable).
+    completedAt:
+```
 
 ### garden get tasks
 
 Lists the tasks defined in your project&#x27;s modules.
 
 
-##### Usage
+#### Usage
 
     garden get tasks [tasks] 
 
-##### Arguments
+#### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `tasks` | No | Specify task(s) to list. Use comma as a separator to specify multiple tasks.
+
+
 
 ### garden get task-result
 
 Outputs the latest execution result of a provided task.
 
 
-##### Usage
+#### Usage
 
     garden get task-result <name> 
 
-##### Arguments
+#### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `name` | Yes | The name of the task
+
+
+#### Outputs
+
+```yaml
+# The name of the module that the task belongs to.
+moduleName:
+
+# The name of the task that was run.
+taskName:
+
+# The command that the task ran in the module.
+command:
+
+# The string version of the task.
+version:
+
+# Whether the task was successfully run.
+success:
+
+# When the task run was started.
+startedAt:
+
+# When the task run was completed.
+completedAt:
+
+# The output log from the run.
+log:
+
+# A map of primitive values, output from the task.
+outputs:
+  # Number, string or boolean
+  <name>:
+
+# Local file paths to any exported artifacts from the task run.
+artifacts:
+```
 
 ### garden get test-result
 
 Outputs the latest execution result of a provided test.
 
 
-##### Usage
+#### Usage
 
     garden get test-result <module> <name> 
 
-##### Arguments
+#### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `module` | Yes | Module name of where the test runs.
   | `name` | Yes | Test name.
+
+
+#### Outputs
+
+```yaml
+# The name of the module that was run.
+moduleName:
+
+# The command that was run in the module.
+command:
+
+# Whether the module was successfully run.
+success:
+
+# When the module run was started.
+startedAt:
+
+# When the module run was completed.
+completedAt:
+
+# The output log from the run.
+log:
+
+# A map of primitive values, output from the test.
+outputs:
+  # Number, string or boolean
+  <name>:
+
+# The name of the test that was run.
+testName:
+
+# The test run's version, as a string. In addition to the parent module's version, this also factors in the module
+# versions of the test's runtime dependencies (if any).
+version:
+
+# Local file paths to any exported artifacts from the test run.
+artifacts:
+```
 
 ### garden get debug-info
 
@@ -451,17 +1765,18 @@ garden get debug-info                    # create a zip file at the root of the 
 garden get debug-info --format yaml      # output provider info as YAML files (default is JSON)
 garden get debug-info --include-project  # include provider info for the project namespace (disabled by default)
 
-##### Usage
+#### Usage
 
     garden get debug-info [options]
 
-##### Options
+#### Options
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
   | `--format` |  | `json` `yaml`  | The output format for plugin-generated debug info.
   | `--include-project` |  | boolean | Include project-specific information from configured providers.
 Note that this may include sensitive data, depending on the provider and your configuration.
+
 
 ### garden link source
 
@@ -475,16 +1790,29 @@ Examples:
 
     garden link source my-source path/to/my-source # links my-source to its local version at the given path
 
-##### Usage
+#### Usage
 
     garden link source <source> <path> 
 
-##### Arguments
+#### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `source` | Yes | Name of the source to link as declared in the project config.
   | `path` | Yes | Path to the local directory that containes the source.
+
+
+#### Outputs
+
+```yaml
+# A list of all locally linked external sources.
+sources:
+  - # The name of the linked source.
+    name:
+
+    # The local directory path of the linked repo clone.
+    path:
+```
 
 ### garden link module
 
@@ -498,16 +1826,29 @@ Examples:
 
     garden link module my-module path/to/my-module # links my-module to its local version at the given path
 
-##### Usage
+#### Usage
 
     garden link module <module> <path> 
 
-##### Arguments
+#### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `module` | Yes | Name of the module to link.
   | `path` | Yes | Path to the local directory that containes the module.
+
+
+#### Outputs
+
+```yaml
+# A list of all locally linked external modules.
+sources:
+  - # The name of the linked module.
+    name:
+
+    # The local directory path of the linked repo clone.
+    path:
+```
 
 ### garden logs
 
@@ -521,22 +1862,23 @@ Examples:
     garden logs my-service    # prints latest logs for my-service
     garden logs -t            # keeps running and streams all incoming logs to the console
 
-##### Usage
+#### Usage
 
     garden logs [services] [options]
 
-##### Arguments
+#### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `services` | No | The name(s) of the service(s) to log (skip to log all services). Use comma as a separator to specify multiple services.
 
-##### Options
+#### Options
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
   | `--follow` | `-f` | boolean | Continuously stream new logs from the service(s).
   | `--tail` | `-t` | number | Number of lines to show for each service. Defaults to -1, showing all log lines.
+
 
 ### garden migrate
 
@@ -555,21 +1897,22 @@ Examples:
     garden migrate --write      # scans all garden.yml files and overwrites them with the updated versions.
     garden migrate ./garden.yml # scans the provided garden.yml file and prints the updated version.
 
-##### Usage
+#### Usage
 
     garden migrate [configPaths] [options]
 
-##### Arguments
+#### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `configPaths` | No | Specify the path to a &#x60;garden.yml&#x60; file to convert. Use comma as a separator to specify multiple files.
 
-##### Options
+#### Options
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
   | `--write` |  | boolean | Update the &#x60;garden.yml&#x60; in place.
+
 
 ### garden options
 
@@ -577,9 +1920,11 @@ Print global options.
 
 Prints all global options (options that can be applied to any command).
 
-##### Usage
+#### Usage
 
     garden options 
+
+
 
 ### garden plugins
 
@@ -600,16 +1945,18 @@ Examples:
     # List all the commands from the `kubernetes` plugin.
     garden plugins kubernetes
 
-##### Usage
+#### Usage
 
     garden plugins [plugin] [command] 
 
-##### Arguments
+#### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `plugin` | No | The name of the plugin, whose command you wish to run.
   | `command` | No | The name of the command to run.
+
+
 
 ### garden publish
 
@@ -625,22 +1972,206 @@ Examples:
     garden publish --force-build  # force re-build of modules before publishing artifacts
     garden publish --allow-dirty  # allow publishing dirty builds (which by default triggers error)
 
-##### Usage
+#### Usage
 
     garden publish [modules] [options]
 
-##### Arguments
+#### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `modules` | No | The name(s) of the module(s) to publish (skip to publish all modules). Use comma as a separator to specify multiple modules.
 
-##### Options
+#### Options
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
   | `--force-build` |  | boolean | Force rebuild of module(s) before publishing.
   | `--allow-dirty` |  | boolean | Allow publishing dirty builds (with untracked/uncommitted changes).
+
+#### Outputs
+
+```yaml
+# A map of all modules that were built (or builds scheduled/attempted for) and information about the builds.
+builds:
+  <module name>:
+    # The full log from the build.
+    buildLog:
+
+    # Set to true if the build was fetched from a remote registry.
+    fetched:
+
+    # Set to true if the build was performed, false if it was already built, or fetched from a registry
+    fresh:
+
+    # Additional information, specific to the provider.
+    details:
+
+    # Set to true if the build was not attempted, e.g. if a dependency build failed.
+    aborted:
+
+    # The duration of the build in msec, if applicable.
+    durationMsec:
+
+    # Whether the build was succeessful.
+    success:
+
+    # An error message, if the build failed.
+    error:
+
+    # The version of the module, service, task or test.
+    version:
+
+# A map of all services that were deployed (or deployment scheduled/attempted for) and the service status.
+deployments:
+  <service name>:
+    # When the service was first deployed by the provider.
+    createdAt:
+
+    # Additional detail, specific to the provider.
+    detail:
+
+    # The ID used for the service by the provider (if not the same as the service name).
+    externalId:
+
+    # The provider version of the deployed service (if different from the Garden module version.
+    externalVersion:
+
+    # A list of ports that can be forwarded to from the Garden agent by the provider.
+    forwardablePorts:
+      - # A descriptive name for the port. Should correspond to user-configured ports where applicable.
+        name:
+
+        # The protocol of the port.
+        protocol:
+
+        # The target hostname of the service (only used for informational purposes).
+        targetHostname:
+
+        # The target port on the service.
+        targetPort:
+
+        # The protocol to use for URLs pointing at the port. This can be any valid URI protocol.
+        urlProtocol:
+
+    # List of currently deployed ingress endpoints for the service.
+    ingresses:
+      - # The ingress path that should be matched to route to this service.
+        path:
+
+        # The protocol to use for the ingress.
+        protocol:
+
+        # The hostname where the service can be accessed.
+        hostname:
+
+        # The port number that the service is exposed on internally.
+        # This defaults to the first specified port for the service.
+        port:
+
+    # Latest status message of the service (if any).
+    lastMessage:
+
+    # Latest error status message of the service (if any).
+    lastError:
+
+    # A map of primitive values, output from the service.
+    outputs:
+      # Number, string or boolean
+      <name>:
+
+    # How many replicas of the service are currently running.
+    runningReplicas:
+
+    # The current deployment status of the service.
+    state:
+
+    # When the service was last updated by the provider.
+    updatedAt:
+
+    # Set to true if the build was not attempted, e.g. if a dependency build failed.
+    aborted:
+
+    # The duration of the build in msec, if applicable.
+    durationMsec:
+
+    # Whether the build was succeessful.
+    success:
+
+    # An error message, if the build failed.
+    error:
+
+    # The version of the module, service, task or test.
+    version:
+
+# A map of all tests that were run (or scheduled/attempted) and the test results.
+tests:
+  <test name>:
+    # The name of the module that was run.
+    moduleName:
+
+    # The command that was run in the module.
+    command:
+
+    # When the module run was started.
+    startedAt:
+
+    # When the module run was completed.
+    completedAt:
+
+    # The output log from the run.
+    log:
+
+    # A map of primitive values, output from the test.
+    outputs:
+      # Number, string or boolean
+      <name>:
+
+    # The name of the test that was run.
+    testName:
+
+    # Set to true if the build was not attempted, e.g. if a dependency build failed.
+    aborted:
+
+    # The duration of the build in msec, if applicable.
+    durationMsec:
+
+    # Whether the build was succeessful.
+    success:
+
+    # An error message, if the build failed.
+    error:
+
+    # The version of the module, service, task or test.
+    version:
+
+# A map of all raw graph results. Avoid using this programmatically if you can, and use more structured keys instead.
+graphResults:
+
+# A map of all modules that were published (or scheduled/attempted for publishing) and the results.
+published:
+  <name>:
+    # Set to true if the module was published.
+    published:
+
+    # Optional result message from the provider.
+    message:
+
+    # Set to true if the build was not attempted, e.g. if a dependency build failed.
+    aborted:
+
+    # The duration of the build in msec, if applicable.
+    durationMsec:
+
+    # Whether the build was succeessful.
+    success:
+
+    # An error message, if the build failed.
+    error:
+
+    # The version of the module, service, task or test.
+    version:
+```
 
 ### garden run module
 
@@ -654,24 +2185,25 @@ Examples:
     garden run module my-container /bin/sh                           # run an interactive shell in a new my-container container
     garden run module my-container --interactive=false /some/script  # execute a script in my-container and return the output
 
-##### Usage
+#### Usage
 
     garden run module <module> [arguments] [options]
 
-##### Arguments
+#### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `module` | Yes | The name of the module to run.
   | `arguments` | No | The arguments to run the module with. Example: &#x27;npm run my-script&#x27;.
 
-##### Options
+#### Options
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
   | `--interactive` |  | boolean | Set to false to skip interactive mode and just output the command result.
   | `--force-build` |  | boolean | Force rebuild of module before running.
   | `--command` | `-c` | array:string | The base command (a.k.a. entrypoint) to run in the module. For container modules, for example, this overrides the image&#x27;s default command/entrypoint. This option may not be relevant for all module types. Example: &#x27;/bin/sh -c&#x27;.
+
 
 ### garden run service
 
@@ -683,22 +2215,23 @@ Examples:
 
     garden run service my-service   # run an ad-hoc instance of a my-service and attach to it
 
-##### Usage
+#### Usage
 
     garden run service <service> [options]
 
-##### Arguments
+#### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `service` | Yes | The service to run.
 
-##### Options
+#### Options
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
   | `--force` |  | boolean | Run the service even if it&#x27;s disabled for the environment.
   | `--force-build` |  | boolean | Force rebuild of module.
+
 
 ### garden run task
 
@@ -710,22 +2243,69 @@ Examples:
 
     garden run task my-db-migration   # run my-migration
 
-##### Usage
+#### Usage
 
     garden run task <task> [options]
 
-##### Arguments
+#### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `task` | Yes | The name of the task to run.
 
-##### Options
+#### Options
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
   | `--force` |  | boolean | Run the task even if it&#x27;s disabled for the environment.
   | `--force-build` |  | boolean | Force rebuild of module before running.
+
+#### Outputs
+
+```yaml
+# The result of the task.
+result:
+  # The name of the module that the task belongs to.
+  moduleName:
+
+  # The name of the task that was run.
+  taskName:
+
+  # The command that the task ran in the module.
+  command:
+
+  # When the task run was started.
+  startedAt:
+
+  # When the task run was completed.
+  completedAt:
+
+  # The output log from the run.
+  log:
+
+  # A map of primitive values, output from the task.
+  outputs:
+    # Number, string or boolean
+    <name>:
+
+  # Set to true if the build was not attempted, e.g. if a dependency build failed.
+  aborted:
+
+  # The duration of the build in msec, if applicable.
+  durationMsec:
+
+  # Whether the build was succeessful.
+  success:
+
+  # An error message, if the build failed.
+  error:
+
+  # The version of the module, service, task or test.
+  version:
+
+# A map of all raw graph results. Avoid using this programmatically if you can, and use more structured keys instead.
+graphResults:
+```
 
 ### garden run test
 
@@ -738,18 +2318,18 @@ Examples:
     garden run test my-module integ                      # run the test named 'integ' in my-module
     garden run test my-module integ --interactive=false  # do not attach to the test run, just output results when completed
 
-##### Usage
+#### Usage
 
     garden run test <module> <test> [options]
 
-##### Arguments
+#### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `module` | Yes | The name of the module to run.
   | `test` | Yes | The name of the test to run in the module.
 
-##### Options
+#### Options
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
@@ -757,14 +2337,63 @@ Examples:
   | `--force` |  | boolean | Run the test even if it&#x27;s disabled for the environment.
   | `--force-build` |  | boolean | Force rebuild of module before running.
 
+#### Outputs
+
+```yaml
+# The result of the test.
+result:
+  # The name of the module that was run.
+  moduleName:
+
+  # The command that was run in the module.
+  command:
+
+  # When the module run was started.
+  startedAt:
+
+  # When the module run was completed.
+  completedAt:
+
+  # The output log from the run.
+  log:
+
+  # A map of primitive values, output from the test.
+  outputs:
+    # Number, string or boolean
+    <name>:
+
+  # The name of the test that was run.
+  testName:
+
+  # Set to true if the build was not attempted, e.g. if a dependency build failed.
+  aborted:
+
+  # The duration of the build in msec, if applicable.
+  durationMsec:
+
+  # Whether the build was succeessful.
+  success:
+
+  # An error message, if the build failed.
+  error:
+
+  # The version of the module, service, task or test.
+  version:
+
+# A map of all raw graph results. Avoid using this programmatically if you can, and use more structured keys instead.
+graphResults:
+```
+
 ### garden scan
 
 Scans your project and outputs an overview of all modules.
 
 
-##### Usage
+#### Usage
 
     garden scan 
+
+
 
 ### garden serve
 
@@ -774,15 +2403,16 @@ Starts the Garden HTTP API service - **Experimental**
 
 Starts an HTTP server that exposes Garden commands and events.
 
-##### Usage
+#### Usage
 
     garden serve [options]
 
-##### Options
+#### Options
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
   | `--port` |  | number | The port number for the Garden service to listen on.
+
 
 ### garden test
 
@@ -803,17 +2433,17 @@ Examples:
     garden test --force       # force tests to be re-run, even if they've already run successfully
     garden test --watch       # watch for changes to code
 
-##### Usage
+#### Usage
 
     garden test [modules] [options]
 
-##### Arguments
+#### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `modules` | No | The name(s) of the module(s) to test (skip to test all modules). Use comma as a separator to specify multiple modules.
 
-##### Options
+#### Options
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
@@ -821,6 +2451,166 @@ Examples:
   | `--force` | `-f` | boolean | Force re-test of module(s).
   | `--force-build` |  | boolean | Force rebuild of module(s).
   | `--watch` | `-w` | boolean | Watch for changes in module(s) and auto-test.
+
+#### Outputs
+
+```yaml
+# A map of all modules that were built (or builds scheduled/attempted for) and information about the builds.
+builds:
+  <module name>:
+    # The full log from the build.
+    buildLog:
+
+    # Set to true if the build was fetched from a remote registry.
+    fetched:
+
+    # Set to true if the build was performed, false if it was already built, or fetched from a registry
+    fresh:
+
+    # Additional information, specific to the provider.
+    details:
+
+    # Set to true if the build was not attempted, e.g. if a dependency build failed.
+    aborted:
+
+    # The duration of the build in msec, if applicable.
+    durationMsec:
+
+    # Whether the build was succeessful.
+    success:
+
+    # An error message, if the build failed.
+    error:
+
+    # The version of the module, service, task or test.
+    version:
+
+# A map of all services that were deployed (or deployment scheduled/attempted for) and the service status.
+deployments:
+  <service name>:
+    # When the service was first deployed by the provider.
+    createdAt:
+
+    # Additional detail, specific to the provider.
+    detail:
+
+    # The ID used for the service by the provider (if not the same as the service name).
+    externalId:
+
+    # The provider version of the deployed service (if different from the Garden module version.
+    externalVersion:
+
+    # A list of ports that can be forwarded to from the Garden agent by the provider.
+    forwardablePorts:
+      - # A descriptive name for the port. Should correspond to user-configured ports where applicable.
+        name:
+
+        # The protocol of the port.
+        protocol:
+
+        # The target hostname of the service (only used for informational purposes).
+        targetHostname:
+
+        # The target port on the service.
+        targetPort:
+
+        # The protocol to use for URLs pointing at the port. This can be any valid URI protocol.
+        urlProtocol:
+
+    # List of currently deployed ingress endpoints for the service.
+    ingresses:
+      - # The ingress path that should be matched to route to this service.
+        path:
+
+        # The protocol to use for the ingress.
+        protocol:
+
+        # The hostname where the service can be accessed.
+        hostname:
+
+        # The port number that the service is exposed on internally.
+        # This defaults to the first specified port for the service.
+        port:
+
+    # Latest status message of the service (if any).
+    lastMessage:
+
+    # Latest error status message of the service (if any).
+    lastError:
+
+    # A map of primitive values, output from the service.
+    outputs:
+      # Number, string or boolean
+      <name>:
+
+    # How many replicas of the service are currently running.
+    runningReplicas:
+
+    # The current deployment status of the service.
+    state:
+
+    # When the service was last updated by the provider.
+    updatedAt:
+
+    # Set to true if the build was not attempted, e.g. if a dependency build failed.
+    aborted:
+
+    # The duration of the build in msec, if applicable.
+    durationMsec:
+
+    # Whether the build was succeessful.
+    success:
+
+    # An error message, if the build failed.
+    error:
+
+    # The version of the module, service, task or test.
+    version:
+
+# A map of all tests that were run (or scheduled/attempted) and the test results.
+tests:
+  <test name>:
+    # The name of the module that was run.
+    moduleName:
+
+    # The command that was run in the module.
+    command:
+
+    # When the module run was started.
+    startedAt:
+
+    # When the module run was completed.
+    completedAt:
+
+    # The output log from the run.
+    log:
+
+    # A map of primitive values, output from the test.
+    outputs:
+      # Number, string or boolean
+      <name>:
+
+    # The name of the test that was run.
+    testName:
+
+    # Set to true if the build was not attempted, e.g. if a dependency build failed.
+    aborted:
+
+    # The duration of the build in msec, if applicable.
+    durationMsec:
+
+    # Whether the build was succeessful.
+    success:
+
+    # An error message, if the build failed.
+    error:
+
+    # The version of the module, service, task or test.
+    version:
+
+# A map of all raw graph results. Avoid using this programmatically if you can, and use more structured keys instead.
+graphResults:
+```
 
 ### garden tools
 
@@ -848,21 +2638,22 @@ Examples:
     # List all available tools.
     garden tools
 
-##### Usage
+#### Usage
 
     garden tools [tool] [options]
 
-##### Arguments
+#### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `tool` | No | The name of the tool to run.
 
-##### Options
+#### Options
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
   | `--get-path` |  | boolean | If specified, we print the path to the binary or library instead of running it.
+
 
 ### garden unlink source
 
@@ -876,21 +2667,22 @@ Examples:
     garden unlink source my-source  # unlinks my-source
     garden unlink source --all      # unlinks all sources
 
-##### Usage
+#### Usage
 
     garden unlink source [sources] [options]
 
-##### Arguments
+#### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `sources` | No | The name(s) of the source(s) to unlink. Use comma as a separator to specify multiple sources.
 
-##### Options
+#### Options
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
   | `--all` | `-a` | boolean | Unlink all sources.
+
 
 ### garden unlink module
 
@@ -904,21 +2696,22 @@ Examples:
     garden unlink module my-module  # unlinks my-module
     garden unlink module --all      # unlink all modules
 
-##### Usage
+#### Usage
 
     garden unlink module [modules] [options]
 
-##### Arguments
+#### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `modules` | No | The name(s) of the module(s) to unlink. Use comma as a separator to specify multiple modules.
 
-##### Options
+#### Options
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
   | `--all` | `-a` | boolean | Unlink all modules.
+
 
 ### garden update-remote sources
 
@@ -931,15 +2724,29 @@ Examples:
     garden update-remote sources            # update all remote sources
     garden update-remote sources my-source  # update remote source my-source
 
-##### Usage
+#### Usage
 
     garden update-remote sources [sources] 
 
-##### Arguments
+#### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `sources` | No | The name(s) of the remote source(s) to update. Use comma as a separator to specify multiple sources.
+
+
+#### Outputs
+
+```yaml
+# A list of all configured external project sources.
+sources:
+  - # The name of the source to import
+    name:
+
+    # A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific
+    # branch or tag, with the format: <git remote url>#<branch|tag>
+    repositoryUrl:
+```
 
 ### garden update-remote modules
 
@@ -953,15 +2760,29 @@ Examples:
     garden update-remote modules            # update all remote modules in the project
     garden update-remote modules my-module  # update remote module my-module
 
-##### Usage
+#### Usage
 
     garden update-remote modules [modules] 
 
-##### Arguments
+#### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `modules` | No | The name(s) of the remote module(s) to update. Use comma as a separator to specify multiple modules.
+
+
+#### Outputs
+
+```yaml
+# A list of all external module sources in the project.
+sources:
+  - # The name of the module.
+    name:
+
+    # A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific
+    # branch or tag, with the format: <git remote url>#<branch|tag>
+    repositoryUrl:
+```
 
 ### garden update-remote all
 
@@ -971,9 +2792,32 @@ Examples:
 
     garden update-remote all # update all remote sources and modules in the project
 
-##### Usage
+#### Usage
 
     garden update-remote all 
+
+
+#### Outputs
+
+```yaml
+# A list of all configured external project sources.
+projectSources:
+  - # The name of the source to import
+    name:
+
+    # A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific
+    # branch or tag, with the format: <git remote url>#<branch|tag>
+    repositoryUrl:
+
+# A list of all external module sources in the project.
+moduleSources:
+  - # The name of the module.
+    name:
+
+    # A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific
+    # branch or tag, with the format: <git remote url>#<branch|tag>
+    repositoryUrl:
+```
 
 ### garden util fetch-tools
 
@@ -988,15 +2832,16 @@ Examples:
     garden util fetch-tools        # fetch for just the current project/env
     garden util fetch-tools --all  # fetch for all registered providers
 
-##### Usage
+#### Usage
 
     garden util fetch-tools [options]
 
-##### Options
+#### Options
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
   | `--all` |  | boolean | Fetch all tools for registered plugins, instead of just ones in the current env/project.
+
 
 ### garden validate
 
@@ -1004,7 +2849,9 @@ Check your garden configuration for errors.
 
 Throws an error and exits with code 1 if something's not right in your garden.yml files.
 
-##### Usage
+#### Usage
 
     garden validate 
+
+
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -388,7 +388,7 @@ Examples:
 
 ### garden get status
 
-Outputs the status of your environment.
+Outputs the full status of your environment.
 
 
 ##### Usage
@@ -735,8 +735,8 @@ This can be useful for debugging tests, particularly integration/end-to-end test
 
 Examples:
 
-    garden run test my-module integ                     # run the test named 'integ' in my-module
-    garden run test my-module integ --interactive=false # do not attach to the test run, just output results when completed
+    garden run test my-module integ                      # run the test named 'integ' in my-module
+    garden run test my-module integ --interactive=false  # do not attach to the test run, just output results when completed
 
 ##### Usage
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -961,25 +961,41 @@ limits:
 # The steps the workflow should run. At least one step is required. Steps are run sequentially. If a step fails,
 # subsequent steps are skipped.
 steps:
-  - # A Garden command this step should run.
+  - # An identifier to assign to this step. If none is specified, this defaults to "step-<number of step>", where
+    # <number of step> is the sequential number of the step (first step being number 1).
+    #
+    # This identifier is useful when referencing command outputs in following steps. For example, if you set this
+    # to "my-step", following steps can reference the \${steps.my-step.outputs.*} key in the `script` or `command`
+    # fields.
+    name:
+
+    # A Garden command this step should run, followed by any required or optional arguments and flags.
+    # Arguments and options for the commands may be templated, including references to previous steps, but for now
+    # the commands themselves (as listed below) must be hard-coded.
     #
     # Supported commands:
     #
+    # `[build]`
     # `[delete, environment]`
-    #
     # `[delete, service]`
-    #
     # `[deploy]`
-    #
+    # `[exec]`
+    # `[get, config]`
     # `[get, outputs]`
-    #
+    # `[get, status]`
+    # `[get, task-result]`
+    # `[get, test-result]`
+    # `[link, module]`
+    # `[link, source]`
     # `[publish]`
-    #
     # `[run, task]`
-    #
     # `[run, test]`
-    #
     # `[test]`
+    # `[update-remote, all]`
+    # `[update-remote, modules]`
+    # `[update-remote, sources]`
+    #
+    #
     command:
 
     # A description of the workflow step.
@@ -988,6 +1004,7 @@ steps:
     # A bash script to run. Note that the host running the workflow must have bash installed and on path. It is
     # considered to have run successfully if it returns an exit code of 0. Any other exit code signals an error, and
     # the remainder of the workflow is aborted.
+    # The script may include template strings, including references to previous steps.
     script:
 
 # A list of triggers that determine when the workflow should be run, and which environment should be used (Garden
@@ -1145,33 +1162,66 @@ The steps the workflow should run. At least one step is required. Steps are run 
 | --------------- | -------- |
 | `array[object]` | Yes      |
 
+### `steps[].name`
+
+[steps](#steps) > name
+
+An identifier to assign to this step. If none is specified, this defaults to "step-<number of step>", where
+<number of step> is the sequential number of the step (first step being number 1).
+
+This identifier is useful when referencing command outputs in following steps. For example, if you set this
+to "my-step", following steps can reference the \${steps.my-step.outputs.*} key in the `script` or `command`
+fields.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
 ### `steps[].command[]`
 
 [steps](#steps) > command
 
-A Garden command this step should run.
+A Garden command this step should run, followed by any required or optional arguments and flags.
+Arguments and options for the commands may be templated, including references to previous steps, but for now
+the commands themselves (as listed below) must be hard-coded.
 
 Supported commands:
 
+`[build]`
 `[delete, environment]`
-
 `[delete, service]`
-
 `[deploy]`
-
+`[exec]`
+`[get, config]`
 `[get, outputs]`
-
+`[get, status]`
+`[get, task-result]`
+`[get, test-result]`
+`[link, module]`
+`[link, source]`
 `[publish]`
-
 `[run, task]`
-
 `[run, test]`
-
 `[test]`
+`[update-remote, all]`
+`[update-remote, modules]`
+`[update-remote, sources]`
+
+
 
 | Type            | Required |
 | --------------- | -------- |
 | `array[string]` | No       |
+
+Example:
+
+```yaml
+steps:
+  - command:
+      - run
+      - task
+      - my-task
+```
 
 ### `steps[].description`
 
@@ -1188,6 +1238,7 @@ A description of the workflow step.
 [steps](#steps) > script
 
 A bash script to run. Note that the host running the workflow must have bash installed and on path. It is considered to have run successfully if it returns an exit code of 0. Any other exit code signals an error, and the remainder of the workflow is aborted.
+The script may include template strings, including references to previous steps.
 
 | Type     | Required |
 | -------- | -------- |

--- a/docs/reference/module-types/terraform.md
+++ b/docs/reference/module-types/terraform.md
@@ -445,3 +445,9 @@ A map of all the outputs defined in the Terraform stack.
 | -------- |
 | `object` |
 
+### `${runtime.services.<service-name>.outputs.<name>}`
+
+| Type  |
+| ----- |
+| `any` |
+

--- a/docs/reference/template-strings.md
+++ b/docs/reference/template-strings.md
@@ -232,14 +232,6 @@ Example:
 my-variable: ${environment.namespace}
 ```
 
-### `${providers.*}`
-
-Retrieve information about providers that are defined in the project.
-
-| Type     | Default |
-| -------- | ------- |
-| `object` | `{}`    |
-
 ### `${variables.*}`
 
 A map of all variables defined in the project configuration.
@@ -251,6 +243,14 @@ A map of all variables defined in the project configuration.
 ### `${var.*}`
 
 Alias for the variables field.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${providers.*}`
+
+Retrieve information about providers that are defined in the project.
 
 | Type     | Default |
 | -------- | ------- |
@@ -397,14 +397,6 @@ Example:
 my-variable: ${environment.namespace}
 ```
 
-### `${providers.*}`
-
-Retrieve information about providers that are defined in the project.
-
-| Type     | Default |
-| -------- | ------- |
-| `object` | `{}`    |
-
 ### `${variables.*}`
 
 A map of all variables defined in the project configuration.
@@ -416,6 +408,14 @@ A map of all variables defined in the project configuration.
 ### `${var.*}`
 
 Alias for the variables field.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${providers.*}`
+
+Retrieve information about providers that are defined in the project.
 
 | Type     | Default |
 | -------- | ------- |
@@ -594,14 +594,6 @@ Example:
 my-variable: ${environment.namespace}
 ```
 
-### `${providers.*}`
-
-Retrieve information about providers that are defined in the project.
-
-| Type     | Default |
-| -------- | ------- |
-| `object` | `{}`    |
-
 ### `${variables.*}`
 
 A map of all variables defined in the project configuration.
@@ -613,6 +605,14 @@ A map of all variables defined in the project configuration.
 ### `${var.*}`
 
 Alias for the variables field.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${providers.*}`
+
+Retrieve information about providers that are defined in the project.
 
 | Type     | Default |
 | -------- | ------- |
@@ -645,6 +645,170 @@ Runtime information from the services that the service/task being run depends on
 ### `${runtime.tasks.*}`
 
 Runtime information from the tasks that the service/task being run depends on.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+
+## Workflow configuration context
+
+The below keys are available in template strings for Workflow configurations.
+
+Note that the `{steps.*}` key is only available for the `steps[].command` and `steps[].script` fields in Workflow configs, and may only reference previous steps in the same workflow. See below for more details.
+
+
+### `${local.*}`
+
+Context variables that are specific to the currently running environment/machine.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${local.artifactsPath}`
+
+The absolute path to the directory where exported artifacts from test and task runs are stored.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.artifactsPath}
+```
+
+### `${local.env.*}`
+
+A map of all local environment variables (see https://nodejs.org/api/process.html#process_process_env).
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${local.platform}`
+
+A string indicating the platform that the framework is running on (see https://nodejs.org/api/process.html#process_process_platform)
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.platform}
+```
+
+### `${local.username}`
+
+The current username (as resolved by https://github.com/sindresorhus/username)
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.username}
+```
+
+### `${project.*}`
+
+Information about the Garden project.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${project.name}`
+
+The name of the Garden project.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${project.name}
+```
+
+### `${environment.*}`
+
+Information about the environment that Garden is running against.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${environment.name}`
+
+The name of the environment Garden is running against, excluding the namespace.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${environment.name}
+```
+
+### `${environment.fullName}`
+
+The full name of the environment Garden is running against, including the namespace.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${environment.fullName}
+```
+
+### `${environment.namespace}`
+
+The currently active namespace (if any).
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${environment.namespace}
+```
+
+### `${variables.*}`
+
+A map of all variables defined in the project configuration.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${var.*}`
+
+Alias for the variables field.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${steps.*}`
+
+Reference previous steps in a workflow. Only available in the `steps[].command` and `steps[].script` fields.
+The name of the step should be the explicitly set `name` of the other step, or if one is not set, use
+`step-<n>`, where <n> is the sequential number of the step (starting from 1).
 
 | Type     | Default |
 | -------- | ------- |

--- a/docs/reference/template-strings.md
+++ b/docs/reference/template-strings.md
@@ -44,6 +44,14 @@ A map of all local environment variables (see https://nodejs.org/api/process.htm
 | -------- |
 | `object` |
 
+### `${local.env.<env-var-name>}`
+
+The environment variable value.
+
+| Type     |
+| -------- |
+| `string` |
+
 ### `${local.platform}`
 
 A string indicating the platform that the framework is running on (see https://nodejs.org/api/process.html#process_process_platform)
@@ -132,6 +140,14 @@ A map of all local environment variables (see https://nodejs.org/api/process.htm
 | -------- |
 | `object` |
 
+### `${local.env.<env-var-name>}`
+
+The environment variable value.
+
+| Type     |
+| -------- |
+| `string` |
+
 ### `${local.platform}`
 
 A string indicating the platform that the framework is running on (see https://nodejs.org/api/process.html#process_process_platform)
@@ -240,6 +256,12 @@ A map of all variables defined in the project configuration.
 | -------- | ------- |
 | `object` | `{}`    |
 
+### `${variables.<variable-name>}`
+
+| Type                                             |
+| ------------------------------------------------ |
+| `number | string | boolean | link | array[link]` |
+
 ### `${var.*}`
 
 Alias for the variables field.
@@ -248,6 +270,14 @@ Alias for the variables field.
 | -------- | ------- |
 | `object` | `{}`    |
 
+### `${var.<name>}`
+
+Number, string or boolean
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
 ### `${providers.*}`
 
 Retrieve information about providers that are defined in the project.
@@ -255,6 +285,38 @@ Retrieve information about providers that are defined in the project.
 | Type     | Default |
 | -------- | ------- |
 | `object` | `{}`    |
+
+### `${providers.<provider-name>.config.*}`
+
+The resolved configuration for the provider.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${providers.<provider-name>.config.<config-key>}`
+
+The provider config key value. Refer to individual [provider references](https://docs.garden.io/reference/providers) for details.
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
+### `${providers.<provider-name>.outputs.*}`
+
+The outputs defined by the provider (see individual plugin docs for details).
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${providers.<provider-name>.outputs.<output-key>}`
+
+The provider output value. Refer to individual [provider references](https://docs.garden.io/reference/providers) for details.
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
 
 
 ## Module configuration context
@@ -297,6 +359,14 @@ A map of all local environment variables (see https://nodejs.org/api/process.htm
 | -------- |
 | `object` |
 
+### `${local.env.<env-var-name>}`
+
+The environment variable value.
+
+| Type     |
+| -------- |
+| `string` |
+
 ### `${local.platform}`
 
 A string indicating the platform that the framework is running on (see https://nodejs.org/api/process.html#process_process_platform)
@@ -405,6 +475,12 @@ A map of all variables defined in the project configuration.
 | -------- | ------- |
 | `object` | `{}`    |
 
+### `${variables.<variable-name>}`
+
+| Type                                             |
+| ------------------------------------------------ |
+| `number | string | boolean | link | array[link]` |
+
 ### `${var.*}`
 
 Alias for the variables field.
@@ -412,6 +488,14 @@ Alias for the variables field.
 | Type     | Default |
 | -------- | ------- |
 | `object` | `{}`    |
+
+### `${var.<name>}`
+
+Number, string or boolean
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
 
 ### `${providers.*}`
 
@@ -421,6 +505,38 @@ Retrieve information about providers that are defined in the project.
 | -------- | ------- |
 | `object` | `{}`    |
 
+### `${providers.<provider-name>.config.*}`
+
+The resolved configuration for the provider.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${providers.<provider-name>.config.<config-key>}`
+
+The provider config key value. Refer to individual [provider references](https://docs.garden.io/reference/providers) for details.
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
+### `${providers.<provider-name>.outputs.*}`
+
+The outputs defined by the provider (see individual plugin docs for details).
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${providers.<provider-name>.outputs.<output-key>}`
+
+The provider output value. Refer to individual [provider references](https://docs.garden.io/reference/providers) for details.
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
 ### `${modules.*}`
 
 Retrieve information about modules that are defined in the project.
@@ -428,6 +544,64 @@ Retrieve information about modules that are defined in the project.
 | Type     | Default |
 | -------- | ------- |
 | `object` | `{}`    |
+
+### `${modules.<module-name>.buildPath}`
+
+The build path of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${modules.<module-name>.buildPath}
+```
+
+### `${modules.<module-name>.outputs.*}`
+
+The outputs defined by the module (see individual module type [references](https://docs.garden.io/reference/module-types) for details).
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${modules.<module-name>.outputs.<output-name>}`
+
+The module output value. Refer to individual [module type references](https://docs.garden.io/reference/module-types) for details.
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
+### `${modules.<module-name>.path}`
+
+The local path of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${modules.<module-name>.path}
+```
+
+### `${modules.<module-name>.version}`
+
+The current version of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${modules.<module-name>.version}
+```
 
 ### `${runtime.*}`
 
@@ -445,6 +619,22 @@ Runtime information from the services that the service/task being run depends on
 | -------- | ------- |
 | `object` | `{}`    |
 
+### `${runtime.services.<service-name>.outputs.*}`
+
+The runtime outputs defined by the service (see individual module type [references](https://docs.garden.io/reference/module-types) for details).
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${runtime.services.<service-name>.outputs.<output-name>}`
+
+The service output value. Refer to individual [module type references](https://docs.garden.io/reference/module-types) for details.
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
 ### `${runtime.tasks.*}`
 
 Runtime information from the tasks that the service/task being run depends on.
@@ -452,6 +642,22 @@ Runtime information from the tasks that the service/task being run depends on.
 | Type     | Default |
 | -------- | ------- |
 | `object` | `{}`    |
+
+### `${runtime.tasks.<task-name>.outputs.*}`
+
+The runtime outputs defined by the task (see individual module type [references](https://docs.garden.io/reference/module-types) for details).
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${runtime.tasks.<task-name>.outputs.<output-name>}`
+
+The task output value. Refer to individual [module type references](https://docs.garden.io/reference/module-types) for details.
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
 
 
 ## Output configuration context
@@ -494,6 +700,14 @@ A map of all local environment variables (see https://nodejs.org/api/process.htm
 | -------- |
 | `object` |
 
+### `${local.env.<env-var-name>}`
+
+The environment variable value.
+
+| Type     |
+| -------- |
+| `string` |
+
 ### `${local.platform}`
 
 A string indicating the platform that the framework is running on (see https://nodejs.org/api/process.html#process_process_platform)
@@ -602,6 +816,12 @@ A map of all variables defined in the project configuration.
 | -------- | ------- |
 | `object` | `{}`    |
 
+### `${variables.<variable-name>}`
+
+| Type                                             |
+| ------------------------------------------------ |
+| `number | string | boolean | link | array[link]` |
+
 ### `${var.*}`
 
 Alias for the variables field.
@@ -609,6 +829,14 @@ Alias for the variables field.
 | Type     | Default |
 | -------- | ------- |
 | `object` | `{}`    |
+
+### `${var.<name>}`
+
+Number, string or boolean
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
 
 ### `${providers.*}`
 
@@ -618,6 +846,38 @@ Retrieve information about providers that are defined in the project.
 | -------- | ------- |
 | `object` | `{}`    |
 
+### `${providers.<provider-name>.config.*}`
+
+The resolved configuration for the provider.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${providers.<provider-name>.config.<config-key>}`
+
+The provider config key value. Refer to individual [provider references](https://docs.garden.io/reference/providers) for details.
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
+### `${providers.<provider-name>.outputs.*}`
+
+The outputs defined by the provider (see individual plugin docs for details).
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${providers.<provider-name>.outputs.<output-key>}`
+
+The provider output value. Refer to individual [provider references](https://docs.garden.io/reference/providers) for details.
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
 ### `${modules.*}`
 
 Retrieve information about modules that are defined in the project.
@@ -625,6 +885,64 @@ Retrieve information about modules that are defined in the project.
 | Type     | Default |
 | -------- | ------- |
 | `object` | `{}`    |
+
+### `${modules.<module-name>.buildPath}`
+
+The build path of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${modules.<module-name>.buildPath}
+```
+
+### `${modules.<module-name>.outputs.*}`
+
+The outputs defined by the module (see individual module type [references](https://docs.garden.io/reference/module-types) for details).
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${modules.<module-name>.outputs.<output-name>}`
+
+The module output value. Refer to individual [module type references](https://docs.garden.io/reference/module-types) for details.
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
+### `${modules.<module-name>.path}`
+
+The local path of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${modules.<module-name>.path}
+```
+
+### `${modules.<module-name>.version}`
+
+The current version of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${modules.<module-name>.version}
+```
 
 ### `${runtime.*}`
 
@@ -642,6 +960,22 @@ Runtime information from the services that the service/task being run depends on
 | -------- | ------- |
 | `object` | `{}`    |
 
+### `${runtime.services.<service-name>.outputs.*}`
+
+The runtime outputs defined by the service (see individual module type [references](https://docs.garden.io/reference/module-types) for details).
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${runtime.services.<service-name>.outputs.<output-name>}`
+
+The service output value. Refer to individual [module type references](https://docs.garden.io/reference/module-types) for details.
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
 ### `${runtime.tasks.*}`
 
 Runtime information from the tasks that the service/task being run depends on.
@@ -649,6 +983,22 @@ Runtime information from the tasks that the service/task being run depends on.
 | Type     | Default |
 | -------- | ------- |
 | `object` | `{}`    |
+
+### `${runtime.tasks.<task-name>.outputs.*}`
+
+The runtime outputs defined by the task (see individual module type [references](https://docs.garden.io/reference/module-types) for details).
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${runtime.tasks.<task-name>.outputs.<output-name>}`
+
+The task output value. Refer to individual [module type references](https://docs.garden.io/reference/module-types) for details.
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
 
 
 ## Workflow configuration context
@@ -688,6 +1038,14 @@ A map of all local environment variables (see https://nodejs.org/api/process.htm
 | -------- |
 | `object` |
 
+### `${local.env.<env-var-name>}`
+
+The environment variable value.
+
+| Type     |
+| -------- |
+| `string` |
+
 ### `${local.platform}`
 
 A string indicating the platform that the framework is running on (see https://nodejs.org/api/process.html#process_process_platform)
@@ -796,6 +1154,12 @@ A map of all variables defined in the project configuration.
 | -------- | ------- |
 | `object` | `{}`    |
 
+### `${variables.<variable-name>}`
+
+| Type                                             |
+| ------------------------------------------------ |
+| `number | string | boolean | link | array[link]` |
+
 ### `${var.*}`
 
 Alias for the variables field.
@@ -803,6 +1167,14 @@ Alias for the variables field.
 | Type     | Default |
 | -------- | ------- |
 | `object` | `{}`    |
+
+### `${var.<name>}`
+
+Number, string or boolean
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
 
 ### `${steps.*}`
 
@@ -813,4 +1185,28 @@ The name of the step should be the explicitly set `name` of the other step, or i
 | Type     | Default |
 | -------- | ------- |
 | `object` | `{}`    |
+
+### `${steps.<step-name>.log}`
+
+The full output log from the step.
+
+| Type     |
+| -------- |
+| `string` |
+
+### `${steps.<step-name>.outputs.*}`
+
+The outputs returned by the step, as a mapping. Script steps will always have `stdout` and `stderr` keys.
+Command steps return different keys, including potentially nested maps and arrays. Please refer to each command
+for its output schema.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${steps.<step-name>.outputs.<output-key>}`
+
+| Type                                             |
+| ------------------------------------------------ |
+| `number | string | boolean | link | array[link]` |
 

--- a/garden-service/src/actions.ts
+++ b/garden-service/src/actions.ts
@@ -798,8 +798,6 @@ export class ActionRouter implements TypeGuard {
       const configContext = new ModuleConfigContext({
         garden: this.garden,
         resolvedProviders: providers,
-        variables: this.garden.variables,
-        secrets: this.garden.secrets,
         dependencyConfigs: modules,
         dependencyVersions: fromPairs(modules.map((m) => [m.name, m.version])),
         runtimeContext,
@@ -860,8 +858,6 @@ export class ActionRouter implements TypeGuard {
       const configContext = new ModuleConfigContext({
         garden: this.garden,
         resolvedProviders: providers,
-        variables: this.garden.variables,
-        secrets: this.garden.secrets,
         dependencyConfigs: modules,
         dependencyVersions: fromPairs(modules.map((m) => [m.name, m.version])),
         runtimeContext,

--- a/garden-service/src/cli/cli.ts
+++ b/garden-service/src/cli/cli.ts
@@ -24,7 +24,7 @@ import {
   StringParameter,
 } from "../commands/base"
 import { GardenError, PluginError, toGardenError } from "../exceptions"
-import { Garden, GardenOpts } from "../garden"
+import { Garden, GardenOpts, DummyGarden } from "../garden"
 import { getLogger, Logger, LoggerType, LOGGER_TYPES, getWriterInstance } from "../logger/logger"
 import { LogLevel } from "../logger/log-node"
 import { BasicTerminalWriter } from "../logger/writers/basic-terminal-writer"
@@ -67,18 +67,6 @@ const OUTPUT_RENDERERS = {
 }
 
 const GLOBAL_OPTIONS_GROUP_NAME = "Global options"
-
-/**
- * Dummy Garden class that doesn't scan for modules nor resolves providers.
- * Used by commands that have noProject=true. That is, commands that need
- * to run outside of valid Garden projects.
- */
-export class DummyGarden extends Garden {
-  async resolveProviders() {
-    return {}
-  }
-  async scanAndAddConfigs() {}
-}
 
 export async function makeDummyGarden(root: string, gardenOpts: GardenOpts = {}) {
   const environments = gardenOpts.environmentName

--- a/garden-service/src/commands/build.ts
+++ b/garden-service/src/commands/build.ts
@@ -15,8 +15,9 @@ import {
   handleProcessResults,
   StringsParameter,
   PrepareParams,
+  ProcessCommandResult,
+  processCommandResultSchema,
 } from "./base"
-import { TaskResults } from "../task-graph"
 import dedent from "dedent"
 import { processModules } from "../process"
 import { printHeader } from "../logger/util"
@@ -45,7 +46,9 @@ type Opts = typeof buildOpts
 export class BuildCommand extends Command<Args, Opts> {
   name = "build"
   help = "Build your modules."
+
   protected = true
+  workflows = true
 
   description = dedent`
     Builds all or specified modules, taking into account build dependency order.
@@ -61,6 +64,8 @@ export class BuildCommand extends Command<Args, Opts> {
 
   arguments = buildArgs
   options = buildOpts
+
+  outputsSchema = () => processCommandResultSchema()
 
   private server: GardenServer
   private isPersistent = (opts) => !!opts.watch
@@ -83,7 +88,7 @@ export class BuildCommand extends Command<Args, Opts> {
     footerLog,
     args,
     opts,
-  }: CommandParams<Args, Opts>): Promise<CommandResult<TaskResults>> {
+  }: CommandParams<Args, Opts>): Promise<CommandResult<ProcessCommandResult>> {
     if (!this.isPersistent(opts)) {
       printHeader(headerLog, "Build", "hammer")
     }

--- a/garden-service/src/commands/exec.ts
+++ b/garden-service/src/commands/exec.ts
@@ -8,7 +8,7 @@
 
 import chalk from "chalk"
 import { LoggerType } from "../logger/logger"
-import { ExecInServiceResult } from "../types/plugin/service/execInService"
+import { ExecInServiceResult, execInServiceResultSchema } from "../types/plugin/service/execInService"
 import { printHeader } from "../logger/util"
 import { Command, CommandResult, CommandParams, StringParameter, BooleanParameter, StringsParameter } from "./base"
 import dedent = require("dedent")
@@ -41,6 +41,8 @@ export class ExecCommand extends Command<Args> {
   name = "exec"
   help = "Executes a command (such as an interactive shell) in a running service."
 
+  workflows = true
+
   description = dedent`
     Finds an active container for a deployed service and executes the given command within the container.
     Supports interactive shells.
@@ -54,6 +56,8 @@ export class ExecCommand extends Command<Args> {
 
   arguments = execArgs
   options = execOpts
+
+  outputsSchema = () => execInServiceResultSchema()
 
   getLoggerType(): LoggerType {
     return "basic"

--- a/garden-service/src/commands/get/get-config.ts
+++ b/garden-service/src/commands/get/get-config.ts
@@ -9,7 +9,7 @@
 import { Command, CommandResult, CommandParams, BooleanParameter } from "../base"
 import { ConfigDump } from "../../garden"
 import { environmentNameSchema } from "../../config/project"
-import { joiIdentifier, joiIdentifierMap, joiVariables, joiArray, joi } from "../../config/common"
+import { joiIdentifier, joiVariables, joiArray, joi } from "../../config/common"
 import { providerSchemaWithoutTools } from "../../config/provider"
 import { moduleConfigSchema } from "../../config/module"
 import { workflowConfigSchema } from "../../config/workflow"
@@ -30,6 +30,7 @@ export class GetConfigCommand extends Command<{}, Opts> {
 
   outputsSchema = () =>
     joi.object().keys({
+      allEnvironmentNames: joiArray(environmentNameSchema()).required(),
       environmentName: environmentNameSchema().required(),
       namespace: joiIdentifier().description("The namespace of the current environment (if applicable)."),
       providers: joiArray(providerSchemaWithoutTools()).description(
@@ -41,6 +42,7 @@ export class GetConfigCommand extends Command<{}, Opts> {
         .array()
         .items(workflowConfigSchema())
         .description("All workflow configs in the project."),
+      projectName: joi.string().description("The name of the project."),
       projectRoot: joi.string().description("The local path to the project root."),
       projectId: joi.string().description("The project ID (Garden Enterprise only)."),
     })

--- a/garden-service/src/commands/get/get-outputs.ts
+++ b/garden-service/src/commands/get/get-outputs.ts
@@ -9,7 +9,7 @@
 import { Command, CommandResult, CommandParams, PrepareParams } from "../base"
 import { printHeader } from "../../logger/util"
 import { fromPairs } from "lodash"
-import { PrimitiveMap } from "../../config/common"
+import { PrimitiveMap, joiVariables } from "../../config/common"
 import { renderTable, dedent } from "../../util/string"
 import chalk from "chalk"
 import { resolveProjectOutputs } from "../../outputs"
@@ -17,6 +17,8 @@ import { resolveProjectOutputs } from "../../outputs"
 export class GetOutputsCommand extends Command {
   name = "outputs"
   help = "Resolves and returns the outputs of the project."
+
+  workflows = true
 
   description = dedent`
     Resolves and returns the outputs of the project. If necessary, this may involve deploying services and/or running
@@ -28,6 +30,8 @@ export class GetOutputsCommand extends Command {
         garden get outputs --env=prod      # resolve and print the outputs from the project for the prod environment
         garden get outputs --output=json   # resolve and return the project outputs in JSON format
   `
+
+  outputsSchema = () => joiVariables().description("A map of all the defined project outputs, fully resolved.")
 
   async prepare({ headerLog }: PrepareParams) {
     printHeader(headerLog, "Resolving project outputs", "notebook")

--- a/garden-service/src/commands/get/get-status.ts
+++ b/garden-service/src/commands/get/get-status.ts
@@ -45,7 +45,7 @@ const runStatusSchema = () =>
       .allow("outdated", "succeeded", "failed", "not-implemented")
       .required(),
     startedAt: joi.date().description("When the last run was started (if applicable)."),
-    completedAT: joi.date().description("When the last run completed (if applicable)."),
+    completedAt: joi.date().description("When the last run completed (if applicable)."),
   })
 
 // Value is "completed" if the test/task has been run for the current version.

--- a/garden-service/src/commands/get/get-task-result.ts
+++ b/garden-service/src/commands/get/get-task-result.ts
@@ -13,6 +13,8 @@ import { getTaskVersion } from "../../tasks/task"
 import { RunTaskResult } from "../../types/plugin/task/runTask"
 import chalk from "chalk"
 import { getArtifactFileList, getArtifactKey } from "../../util/artifacts"
+import { taskResultSchema } from "../../types/plugin/task/getTaskResult"
+import { joiArray, joi } from "../../config/common"
 
 const getTaskResultArgs = {
   name: new StringParameter({
@@ -33,7 +35,16 @@ export class GetTaskResultCommand extends Command<Args> {
   name = "task-result"
   help = "Outputs the latest execution result of a provided task."
 
+  workflows = true
+
   arguments = getTaskResultArgs
+
+  outputsSchema = () =>
+    taskResultSchema()
+      .keys({
+        artifacts: joiArray(joi.string()).description("Local file paths to any exported artifacts from the task run."),
+      })
+      .description("The output from the task. May also return null if no task result is found.")
 
   async action({
     garden,

--- a/garden-service/src/commands/get/get-test-result.ts
+++ b/garden-service/src/commands/get/get-test-result.ts
@@ -8,12 +8,13 @@
 
 import { Command, CommandResult, CommandParams, StringParameter } from "../base"
 import { NotFoundError } from "../../exceptions"
-import { TestResult } from "../../types/plugin/module/getTestResult"
+import { TestResult, testResultSchema } from "../../types/plugin/module/getTestResult"
 import { getTestVersion } from "../../tasks/test"
 import { findByName, getNames } from "../../util/util"
 import { printHeader } from "../../logger/util"
 import chalk from "chalk"
 import { getArtifactFileList, getArtifactKey } from "../../util/artifacts"
+import { joi, joiArray } from "../../config/common"
 
 const getTestResultArgs = {
   module: new StringParameter({
@@ -38,7 +39,16 @@ export class GetTestResultCommand extends Command<Args> {
   name = "test-result"
   help = "Outputs the latest execution result of a provided test."
 
+  workflows = true
+
   arguments = getTestResultArgs
+
+  outputsSchema = () =>
+    testResultSchema()
+      .keys({
+        artifacts: joiArray(joi.string()).description("Local file paths to any exported artifacts from the test run."),
+      })
+      .description("The result from the test. May also return null if no test result is found.")
 
   async action({
     garden,

--- a/garden-service/src/commands/link/module.ts
+++ b/garden-service/src/commands/link/module.ts
@@ -15,6 +15,8 @@ import { Command, CommandResult, StringParameter, PathParameter, CommandParams }
 import { LinkedSource } from "../../config-store"
 import { printHeader } from "../../logger/util"
 import { addLinkedSources, hasRemoteSource } from "../../util/ext-source-util"
+import { joiArray } from "../../config/common"
+import { linkedModuleSchema } from "../../config/project"
 
 const linkModuleArguments = {
   module: new StringParameter({
@@ -33,6 +35,10 @@ export class LinkModuleCommand extends Command<Args> {
   name = "module"
   help = "Link a module to a local directory."
   arguments = linkModuleArguments
+
+  workflows = true
+
+  outputsSchema = () => joiArray(linkedModuleSchema()).description("A list of all locally linked external modules.")
 
   description = dedent`
     After linking a remote module, Garden will read the source from the module's local directory instead of from

--- a/garden-service/src/commands/link/module.ts
+++ b/garden-service/src/commands/link/module.ts
@@ -15,7 +15,7 @@ import { Command, CommandResult, StringParameter, PathParameter, CommandParams }
 import { LinkedSource } from "../../config-store"
 import { printHeader } from "../../logger/util"
 import { addLinkedSources, hasRemoteSource } from "../../util/ext-source-util"
-import { joiArray } from "../../config/common"
+import { joiArray, joi } from "../../config/common"
 import { linkedModuleSchema } from "../../config/project"
 
 const linkModuleArguments = {
@@ -31,6 +31,10 @@ const linkModuleArguments = {
 
 type Args = typeof linkModuleArguments
 
+interface Output {
+  sources: LinkedSource[]
+}
+
 export class LinkModuleCommand extends Command<Args> {
   name = "module"
   help = "Link a module to a local directory."
@@ -38,7 +42,10 @@ export class LinkModuleCommand extends Command<Args> {
 
   workflows = true
 
-  outputsSchema = () => joiArray(linkedModuleSchema()).description("A list of all locally linked external modules.")
+  outputsSchema = () =>
+    joi.object().keys({
+      sources: joiArray(linkedModuleSchema()).description("A list of all locally linked external modules."),
+    })
 
   description = dedent`
     After linking a remote module, Garden will read the source from the module's local directory instead of from
@@ -50,7 +57,7 @@ export class LinkModuleCommand extends Command<Args> {
         garden link module my-module path/to/my-module # links my-module to its local version at the given path
   `
 
-  async action({ garden, log, headerLog, args }: CommandParams<Args>): Promise<CommandResult<LinkedSource[]>> {
+  async action({ garden, log, headerLog, args }: CommandParams<Args>): Promise<CommandResult<Output>> {
     printHeader(headerLog, "Link module", "link")
 
     const sourceType = "module"
@@ -85,6 +92,6 @@ export class LinkModuleCommand extends Command<Args> {
 
     log.info(`Linked module ${moduleName}`)
 
-    return { result: linkedModuleSources }
+    return { result: { sources: linkedModuleSources } }
   }
 }

--- a/garden-service/src/commands/link/source.ts
+++ b/garden-service/src/commands/link/source.ts
@@ -16,7 +16,7 @@ import { addLinkedSources } from "../../util/ext-source-util"
 import { LinkedSource } from "../../config-store"
 import { CommandParams } from "../base"
 import { printHeader } from "../../logger/util"
-import { joiArray } from "../../config/common"
+import { joiArray, joi } from "../../config/common"
 import { linkedSourceSchema } from "../../config/project"
 
 const linkSourceArguments = {
@@ -32,6 +32,10 @@ const linkSourceArguments = {
 
 type Args = typeof linkSourceArguments
 
+interface Output {
+  sources: LinkedSource[]
+}
+
 export class LinkSourceCommand extends Command<Args> {
   name = "source"
   help = "Link a remote source to a local directory."
@@ -39,7 +43,10 @@ export class LinkSourceCommand extends Command<Args> {
 
   workflows = true
 
-  outputsSchema = () => joiArray(linkedSourceSchema()).description("A list of all locally linked external sources.")
+  outputsSchema = () =>
+    joi.object().keys({
+      sources: joiArray(linkedSourceSchema()).description("A list of all locally linked external sources."),
+    })
 
   description = dedent`
     After linking a remote source, Garden will read it from its local directory instead of
@@ -51,7 +58,7 @@ export class LinkSourceCommand extends Command<Args> {
         garden link source my-source path/to/my-source # links my-source to its local version at the given path
   `
 
-  async action({ garden, log, headerLog, args }: CommandParams<Args>): Promise<CommandResult<LinkedSource[]>> {
+  async action({ garden, log, headerLog, args }: CommandParams<Args>): Promise<CommandResult<Output>> {
     printHeader(headerLog, "Link source", "link")
 
     const sourceType = "project"
@@ -82,6 +89,6 @@ export class LinkSourceCommand extends Command<Args> {
 
     log.info(`Linked source ${sourceName}`)
 
-    return { result: linkedProjectSources }
+    return { result: { sources: linkedProjectSources } }
   }
 }

--- a/garden-service/src/commands/link/source.ts
+++ b/garden-service/src/commands/link/source.ts
@@ -16,6 +16,8 @@ import { addLinkedSources } from "../../util/ext-source-util"
 import { LinkedSource } from "../../config-store"
 import { CommandParams } from "../base"
 import { printHeader } from "../../logger/util"
+import { joiArray } from "../../config/common"
+import { linkedSourceSchema } from "../../config/project"
 
 const linkSourceArguments = {
   source: new StringParameter({
@@ -34,6 +36,10 @@ export class LinkSourceCommand extends Command<Args> {
   name = "source"
   help = "Link a remote source to a local directory."
   arguments = linkSourceArguments
+
+  workflows = true
+
+  outputsSchema = () => joiArray(linkedSourceSchema()).description("A list of all locally linked external sources.")
 
   description = dedent`
     After linking a remote source, Garden will read it from its local directory instead of

--- a/garden-service/src/commands/run/workflow.ts
+++ b/garden-service/src/commands/run/workflow.ts
@@ -63,7 +63,7 @@ export class RunWorkflowCommand extends Command<Args, {}> {
     const outerLog = log.placeholder()
     // Partially resolve the workflow config, and prepare any configured files before continuing
     const rawWorkflow = garden.getRawWorkflowConfig(args.workflow)
-    const templateContext = new WorkflowConfigContext(garden, garden.variables, garden.secrets)
+    const templateContext = new WorkflowConfigContext(garden)
     const files = resolveTemplateStrings(rawWorkflow.files || [], templateContext)
 
     // Write all the configured files for the workflow

--- a/garden-service/src/commands/test.ts
+++ b/garden-service/src/commands/test.ts
@@ -19,8 +19,9 @@ import {
   StringOption,
   StringsParameter,
   PrepareParams,
+  ProcessCommandResult,
+  processCommandResultSchema,
 } from "./base"
-import { TaskResults } from "../task-graph"
 import { processModules } from "../process"
 import { Module } from "../types/module"
 import { getTestTasks } from "../tasks/test"
@@ -60,7 +61,9 @@ type Opts = typeof testOpts
 export class TestCommand extends Command<Args, Opts> {
   name = "test"
   help = "Test all or specified modules."
+
   protected = true
+  workflows = true
 
   description = dedent`
     Runs all or specified tests defined in the project. Also builds modules and dependencies,
@@ -81,6 +84,8 @@ export class TestCommand extends Command<Args, Opts> {
 
   arguments = testArgs
   options = testOpts
+
+  outputsSchema = () => processCommandResultSchema()
 
   private server: GardenServer
   private isPersistent = (opts) => !!opts.watch
@@ -103,7 +108,7 @@ export class TestCommand extends Command<Args, Opts> {
     footerLog,
     args,
     opts,
-  }: CommandParams<Args, Opts>): Promise<CommandResult<TaskResults>> {
+  }: CommandParams<Args, Opts>): Promise<CommandResult<ProcessCommandResult>> {
     if (!this.isPersistent(opts)) {
       printHeader(headerLog, `Running tests`, "thermometer")
     }

--- a/garden-service/src/commands/tools.ts
+++ b/garden-service/src/commands/tools.ts
@@ -10,7 +10,7 @@ import chalk from "chalk"
 import { max, omit, sortBy } from "lodash"
 import { dedent, renderTable, tablePresets } from "../util/string"
 import { LogEntry } from "../logger/log-entry"
-import { Garden } from "../garden"
+import { Garden, DummyGarden } from "../garden"
 import { Command, CommandParams, StringOption, BooleanParameter } from "./base"
 import { getTerminalWidth } from "../logger/util"
 import { LoggerType } from "../logger/logger"
@@ -18,7 +18,6 @@ import { ParameterError } from "../exceptions"
 import { uniqByName, exec } from "../util/util"
 import { PluginTool } from "../util/ext-tools"
 import { findProjectConfig } from "../config/base"
-import { DummyGarden } from "../cli/cli"
 
 const toolsArgs = {
   tool: new StringOption({

--- a/garden-service/src/commands/update-remote/all.ts
+++ b/garden-service/src/commands/update-remote/all.ts
@@ -11,8 +11,9 @@ import dedent = require("dedent")
 import { Command, CommandResult, CommandParams } from "../base"
 import { updateRemoteSources } from "./sources"
 import { updateRemoteModules } from "./modules"
-import { SourceConfig } from "../../config/project"
+import { SourceConfig, projectSourceSchema, moduleSourceSchema } from "../../config/project"
 import { printHeader } from "../../logger/util"
+import { joi, joiArray } from "../../config/common"
 
 export interface UpdateRemoteAllResult {
   projectSources: SourceConfig[]
@@ -22,6 +23,16 @@ export interface UpdateRemoteAllResult {
 export class UpdateRemoteAllCommand extends Command {
   name = "all"
   help = "Update all remote sources and modules."
+
+  workflows = true
+
+  outputsSchema = () =>
+    joi.object().keys({
+      projectSources: joiArray(projectSourceSchema()).description("A list of all configured external project sources."),
+      moduleSources: joiArray(moduleSourceSchema()).description(
+        "A list of all external module sources in the project."
+      ),
+    })
 
   description = dedent`
     Examples:

--- a/garden-service/src/commands/update-remote/all.ts
+++ b/garden-service/src/commands/update-remote/all.ts
@@ -56,8 +56,8 @@ export class UpdateRemoteAllCommand extends Command {
 
     return {
       result: {
-        projectSources: projectSources!,
-        moduleSources: moduleSources!,
+        projectSources: projectSources!.sources,
+        moduleSources: moduleSources!.sources,
       },
     }
   }

--- a/garden-service/src/commands/update-remote/sources.ts
+++ b/garden-service/src/commands/update-remote/sources.ts
@@ -13,10 +13,11 @@ import chalk from "chalk"
 import { Command, StringsParameter, CommandResult, CommandParams, ParameterValues } from "../base"
 import { ParameterError } from "../../exceptions"
 import { pruneRemoteSources } from "./helpers"
-import { SourceConfig } from "../../config/project"
+import { SourceConfig, projectSourceSchema } from "../../config/project"
 import { printHeader } from "../../logger/util"
 import { Garden } from "../../garden"
 import { LogEntry } from "../../logger/log-entry"
+import { joiArray } from "../../config/common"
 
 const updateRemoteSourcesArguments = {
   sources: new StringsParameter({
@@ -30,6 +31,11 @@ export class UpdateRemoteSourcesCommand extends Command<Args> {
   name = "sources"
   help = "Update remote sources."
   arguments = updateRemoteSourcesArguments
+
+  workflows = true
+
+  outputsSchema = () =>
+    joiArray(projectSourceSchema()).description("A list of all configured external project sources.")
 
   description = dedent`
     Updates the remote sources declared in the project level \`garden.yml\` config file.

--- a/garden-service/src/commands/util.ts
+++ b/garden-service/src/commands/util.ts
@@ -11,12 +11,11 @@ import { RuntimeError } from "../exceptions"
 import dedent from "dedent"
 import { GardenPlugin } from "../types/plugin/plugin"
 import { findProjectConfig } from "../config/base"
-import { Garden } from "../garden"
+import { Garden, DummyGarden } from "../garden"
 import Bluebird from "bluebird"
 import { PluginTool } from "../util/ext-tools"
 import { fromPairs, omit, uniqBy } from "lodash"
 import { printHeader, printFooter } from "../logger/util"
-import { DummyGarden } from "../cli/cli"
 
 export class UtilCommand extends Command {
   name = "util"

--- a/garden-service/src/config-store.ts
+++ b/garden-service/src/config-store.ts
@@ -11,11 +11,12 @@ import { join } from "path"
 import { ensureFile, readFile } from "fs-extra"
 import { get, isPlainObject, unset } from "lodash"
 
-import { Primitive, joiArray, joiUserIdentifier, joiPrimitive, joi } from "./config/common"
+import { Primitive, joiArray, joiPrimitive, joi } from "./config/common"
 import { validateSchema } from "./config/validation"
 import { LocalConfigError } from "./exceptions"
 import { dumpYaml } from "./util/util"
 import { LOCAL_CONFIG_FILENAME, GLOBAL_CONFIG_FILENAME, GARDEN_GLOBAL_PATH } from "./constants"
+import { linkedSourceSchema } from "./config/project"
 
 export type ConfigValue = Primitive | Primitive[] | Object[] | Object
 
@@ -174,15 +175,6 @@ export interface LocalConfig {
   linkedProjectSources?: LinkedSource[]
   analytics: AnalyticsLocalConfig
 }
-
-const linkedSourceSchema = () =>
-  joi
-    .object()
-    .keys({
-      name: joiUserIdentifier(),
-      path: joi.string(),
-    })
-    .meta({ internal: true })
 
 const analyticsLocalConfigSchema = () =>
   joi

--- a/garden-service/src/config/project.ts
+++ b/garden-service/src/config/project.ts
@@ -155,6 +155,15 @@ export interface SourceConfig {
   repositoryUrl: string
 }
 
+export const moduleSourceSchema = () =>
+  joi.object().keys({
+    name: joiUserIdentifier()
+      .required()
+      .description("The name of the module.")
+      .example("my-external-module"),
+    repositoryUrl: joiRepositoryUrl().required(),
+  })
+
 export const projectSourceSchema = () =>
   joi.object().keys({
     name: joiUserIdentifier()
@@ -168,6 +177,18 @@ export const projectSourcesSchema = () =>
   joiArray(projectSourceSchema())
     .unique("name")
     .description("A list of remote sources to import into project.")
+
+export const linkedSourceSchema = () =>
+  joi.object().keys({
+    name: joiUserIdentifier().description("The name of the linked source."),
+    path: joi.string().description("The local directory path of the linked repo clone."),
+  })
+
+export const linkedModuleSchema = () =>
+  joi.object().keys({
+    name: joiUserIdentifier().description("The name of the linked module."),
+    path: joi.string().description("The local directory path of the linked repo clone."),
+  })
 
 export interface OutputSpec {
   name: string

--- a/garden-service/src/config/provider.ts
+++ b/garden-service/src/config/provider.ts
@@ -58,15 +58,19 @@ export interface Provider<T extends ProviderConfig = ProviderConfig> {
   tools: PluginTools
 }
 
+export const providerSchemaWithoutTools = () =>
+  providerFixedFieldsSchema().keys({
+    dependencies: joiIdentifierMap(joi.link("..."))
+      .description("Map of all the providers that this provider depends on.")
+      .required(),
+    config: providerConfigBaseSchema().required(),
+    moduleConfigs: joiArray(moduleConfigSchema().optional()),
+    status: environmentStatusSchema(),
+  })
+
 export const providerSchema = () =>
-  providerFixedFieldsSchema()
+  providerSchemaWithoutTools()
     .keys({
-      dependencies: joiIdentifierMap(joi.link("..."))
-        .description("Map of all the providers that this provider depends on.")
-        .required(),
-      config: providerConfigBaseSchema().required(),
-      moduleConfigs: joiArray(moduleConfigSchema().optional()),
-      status: environmentStatusSchema(),
       tools: joiIdentifierMap(joi.object())
         .required()
         .description("Map of tools defined by the provider."),

--- a/garden-service/src/config/workflow.ts
+++ b/garden-service/src/config/workflow.ts
@@ -249,7 +249,6 @@ export interface WorkflowConfigMap {
 
 export function resolveWorkflowConfig(garden: Garden, config: WorkflowConfig) {
   const log = garden.log
-  const { variables, secrets } = garden
   const context = new WorkflowConfigContext(garden)
   log.silly(`Resolving template strings for workflow ${config.name}`)
   let resolvedConfig = resolveTemplateStrings(cloneDeep(config), context, { allowPartial: true })

--- a/garden-service/src/config/workflow.ts
+++ b/garden-service/src/config/workflow.ts
@@ -250,7 +250,7 @@ export interface WorkflowConfigMap {
 export function resolveWorkflowConfig(garden: Garden, config: WorkflowConfig) {
   const log = garden.log
   const { variables, secrets } = garden
-  const context = new WorkflowConfigContext(garden, variables, secrets)
+  const context = new WorkflowConfigContext(garden)
   log.silly(`Resolving template strings for workflow ${config.name}`)
   let resolvedConfig = resolveTemplateStrings(cloneDeep(config), context, { allowPartial: true })
   log.silly(`Validating config for workflow ${config.name}`)

--- a/garden-service/src/docs/config.ts
+++ b/garden-service/src/docs/config.ts
@@ -16,7 +16,13 @@ import { baseModuleSpecSchema } from "../config/module"
 import handlebars = require("handlebars")
 import { joi } from "../config/common"
 import { STATIC_DIR } from "../constants"
-import { indent, renderMarkdownTable, convertMarkdownLinks, NormalizedSchemaDescription } from "./common"
+import {
+  indent,
+  renderMarkdownTable,
+  convertMarkdownLinks,
+  NormalizedSchemaDescription,
+  NormalizeOptions,
+} from "./common"
 import { normalizeJoiSchemaDescription, JoiDescription } from "./joi-schema"
 import { safeDumpYaml } from "../util/util"
 import { workflowConfigSchema } from "../config/workflow"
@@ -322,6 +328,7 @@ export function renderSchemaDescriptionYaml(
 
 interface RenderConfigOpts {
   titlePrefix?: string
+  normalizeOpts?: NormalizeOptions
   yamlOpts?: RenderYamlOpts
 }
 
@@ -330,8 +337,11 @@ interface RenderConfigOpts {
  * The config reference contains a list of keys and their description in Markdown
  * and a YAML schema.
  */
-export function renderConfigReference(configSchema: Joi.ObjectSchema, { yamlOpts = {} }: RenderConfigOpts = {}) {
-  const normalizedDescriptions = normalizeJoiSchemaDescription(configSchema.describe() as JoiDescription)
+export function renderConfigReference(
+  configSchema: Joi.ObjectSchema,
+  { normalizeOpts = {}, yamlOpts = {} }: RenderConfigOpts = {}
+) {
+  const normalizedDescriptions = normalizeJoiSchemaDescription(configSchema.describe() as JoiDescription, normalizeOpts)
 
   const yaml = renderSchemaDescriptionYaml(normalizedDescriptions, { renderBasicDescription: true, ...yamlOpts })
   const keys = normalizedDescriptions.map((d) => makeMarkdownDescription(d))

--- a/garden-service/src/docs/template-strings.ts
+++ b/garden-service/src/docs/template-strings.ts
@@ -13,6 +13,7 @@ import {
   ModuleConfigContext,
   ProviderConfigContext,
   OutputConfigContext,
+  WorkflowStepConfigContext,
 } from "../config/config-context"
 import { readFileSync, writeFileSync } from "fs"
 import handlebars from "handlebars"
@@ -38,9 +39,13 @@ export function writeTemplateStringReferenceDocs(docsRoot: string) {
     schema: OutputConfigContext.getSchema().required(),
   })
 
+  const workflowContext = renderTemplateStringReference({
+    schema: WorkflowStepConfigContext.getSchema().required(),
+  })
+
   const templatePath = resolve(TEMPLATES_DIR, "template-strings.hbs")
   const template = handlebars.compile(readFileSync(templatePath).toString())
-  const markdown = template({ projectContext, providerContext, moduleContext, outputContext })
+  const markdown = template({ projectContext, providerContext, moduleContext, outputContext, workflowContext })
 
   writeFileSync(outputPath, markdown)
 }

--- a/garden-service/src/events.ts
+++ b/garden-service/src/events.ts
@@ -8,7 +8,7 @@
 
 import { EventEmitter2 } from "eventemitter2"
 import { ModuleVersion } from "./vcs/vcs"
-import { TaskResult } from "./task-graph"
+import { GraphResult } from "./task-graph"
 import { LogEntryEvent } from "./enterprise/buffered-event-stream"
 
 /**
@@ -102,8 +102,8 @@ export interface Events extends LoggerEvents {
     name: string
     version: ModuleVersion
   }
-  taskComplete: TaskResult
-  taskError: TaskResult
+  taskComplete: GraphResult
+  taskError: GraphResult
   taskCancelled: {
     cancelledAt: Date
     batchId: string

--- a/garden-service/src/garden.ts
+++ b/garden-service/src/garden.ts
@@ -697,8 +697,6 @@ export class Garden {
     return new OutputConfigContext({
       garden: this,
       resolvedProviders: providers,
-      variables: this.variables,
-      secrets: this.secrets,
       modules,
       runtimeContext,
     })
@@ -792,8 +790,6 @@ export class Garden {
       const configContext = new ModuleConfigContext({
         garden: this,
         resolvedProviders: keyBy(providers, "name"),
-        variables: this.variables,
-        secrets: this.secrets,
         dependencyConfigs: resolvedModules,
         dependencyVersions: fromPairs(resolvedModules.map((m) => [m.name, m.version])),
         runtimeContext,

--- a/garden-service/src/outputs.ts
+++ b/garden-service/src/outputs.ts
@@ -65,8 +65,6 @@ export async function resolveProjectOutputs(garden: Garden, log: LogEntry): Prom
       new OutputConfigContext({
         garden,
         resolvedProviders: {},
-        variables: garden.variables,
-        secrets: garden.secrets,
         modules: [],
         runtimeContext: emptyRuntimeContext,
       })

--- a/garden-service/src/outputs.ts
+++ b/garden-service/src/outputs.ts
@@ -12,7 +12,7 @@ import { OutputConfigContext } from "./config/config-context"
 import { emptyRuntimeContext, prepareRuntimeContext } from "./runtime-context"
 import { DeployTask } from "./tasks/deploy"
 import { TaskTask } from "./tasks/task"
-import { TaskResults } from "./task-graph"
+import { GraphResults } from "./task-graph"
 import { getServiceStatuses, getRunTaskResults } from "./tasks/base"
 import { LogEntry } from "./logger/log-entry"
 import { OutputSpec } from "./config/project"
@@ -105,7 +105,7 @@ export async function resolveProjectOutputs(garden: Garden, log: LogEntry): Prom
     )),
   ]
 
-  const dependencyResults: TaskResults = graphTasks.length > 0 ? await garden.processTasks(graphTasks) : {}
+  const dependencyResults: GraphResults = graphTasks.length > 0 ? await garden.processTasks(graphTasks) : {}
 
   const serviceStatuses = getServiceStatuses(dependencyResults)
   const taskResults = getRunTaskResults(dependencyResults)

--- a/garden-service/src/process.ts
+++ b/garden-service/src/process.ts
@@ -12,7 +12,7 @@ import { keyBy, flatten } from "lodash"
 
 import { Module } from "./types/module"
 import { BaseTask } from "./tasks/base"
-import { TaskResults } from "./task-graph"
+import { GraphResults } from "./task-graph"
 import { isModuleLinked } from "./util/ext-source-util"
 import { Garden } from "./garden"
 import { LogEntry } from "./logger/log-entry"
@@ -40,7 +40,7 @@ export interface ProcessModulesParams extends ProcessParams {
 }
 
 export interface ProcessResults {
-  taskResults: TaskResults
+  taskResults: GraphResults
   restartRequired?: boolean
 }
 

--- a/garden-service/src/tasks/base.ts
+++ b/garden-service/src/tasks/base.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { TaskResults } from "../task-graph"
+import { GraphResults } from "../task-graph"
 import { ModuleVersion } from "../vcs/vcs"
 import { v1 as uuidv1 } from "uuid"
 import { Garden } from "../garden"
@@ -89,10 +89,10 @@ export abstract class BaseTask {
 
   abstract getDescription(): string
 
-  abstract async process(dependencyResults: TaskResults): Promise<any>
+  abstract async process(dependencyResults: GraphResults): Promise<any>
 }
 
-export function getServiceStatuses(dependencyResults: TaskResults): { [name: string]: ServiceStatus } {
+export function getServiceStatuses(dependencyResults: GraphResults): { [name: string]: ServiceStatus } {
   const getServiceStatusResults = pickBy(dependencyResults, (r) => r && r.type === "get-service-status")
   const deployResults = pickBy(dependencyResults, (r) => r && r.type === "deploy")
   // DeployTask results take precedence over GetServiceStatusTask results, because status changes after deployment
@@ -101,7 +101,7 @@ export function getServiceStatuses(dependencyResults: TaskResults): { [name: str
   return mapKeys(statuses, (_, key) => splitLast(key, ".")[1])
 }
 
-export function getRunTaskResults(dependencyResults: TaskResults): { [name: string]: RunTaskResult } {
+export function getRunTaskResults(dependencyResults: GraphResults): { [name: string]: RunTaskResult } {
   const storedResults = pickBy(dependencyResults, (r) => r && r.type === "get-task-result")
   const runResults = pickBy(dependencyResults, (r) => r && r.type === "task")
   // TaskTask results take precedence over GetTaskResultTask results

--- a/garden-service/src/tasks/delete-service.ts
+++ b/garden-service/src/tasks/delete-service.ts
@@ -11,7 +11,7 @@ import { BaseTask, TaskType } from "./base"
 import { Service, ServiceStatus } from "../types/service"
 import { Garden } from "../garden"
 import { ConfigGraph } from "../config-graph"
-import { TaskResults, TaskResult } from "../task-graph"
+import { GraphResults, GraphResult } from "../task-graph"
 import { StageBuildTask } from "./stage-build"
 
 export interface DeleteServiceTaskParams {
@@ -88,8 +88,8 @@ export class DeleteServiceTask extends BaseTask {
   }
 }
 
-export function deletedServiceStatuses(results: TaskResults): { [serviceName: string]: ServiceStatus } {
-  const deleted = <TaskResult[]>Object.values(results).filter((r) => r && r.type === "delete-service")
+export function deletedServiceStatuses(results: GraphResults): { [serviceName: string]: ServiceStatus } {
+  const deleted = <GraphResult[]>Object.values(results).filter((r) => r && r.type === "delete-service")
   const statuses = {}
 
   for (const res of deleted) {

--- a/garden-service/src/tasks/deploy.ts
+++ b/garden-service/src/tasks/deploy.ts
@@ -17,7 +17,7 @@ import { TaskTask, getTaskVersion } from "./task"
 import { BuildTask } from "./build"
 import { ConfigGraph } from "../config-graph"
 import { startPortProxies } from "../proxy"
-import { TaskResults } from "../task-graph"
+import { GraphResults } from "../task-graph"
 import { prepareRuntimeContext } from "../runtime-context"
 import { GetServiceStatusTask } from "./get-service-status"
 import { GetTaskResultTask } from "./get-task-result"
@@ -151,7 +151,7 @@ export class DeployTask extends BaseTask {
     return `deploying service '${this.service.name}' (from module '${this.service.module.name}')`
   }
 
-  async process(dependencyResults: TaskResults): Promise<ServiceStatus> {
+  async process(dependencyResults: GraphResults): Promise<ServiceStatus> {
     let version = this.version
     const hotReload = includes(this.hotReloadServiceNames, this.service.name)
 

--- a/garden-service/src/tasks/get-service-status.ts
+++ b/garden-service/src/tasks/get-service-status.ts
@@ -12,7 +12,7 @@ import { BaseTask, TaskType, getServiceStatuses, getRunTaskResults } from "./bas
 import { Service, ServiceStatus } from "../types/service"
 import { Garden } from "../garden"
 import { ConfigGraph } from "../config-graph"
-import { TaskResults } from "../task-graph"
+import { GraphResults } from "../task-graph"
 import { prepareRuntimeContext } from "../runtime-context"
 import { getTaskVersion } from "./task"
 import Bluebird from "bluebird"
@@ -79,7 +79,7 @@ export class GetServiceStatusTask extends BaseTask {
     return `getting status for service '${this.service.name}' (from module '${this.service.module.name}')`
   }
 
-  async process(dependencyResults: TaskResults): Promise<ServiceStatus> {
+  async process(dependencyResults: GraphResults): Promise<ServiceStatus> {
     const log = this.log.placeholder()
 
     const hotReload = includes(this.hotReloadServiceNames, this.service.name)

--- a/garden-service/src/tasks/resolve-module.ts
+++ b/garden-service/src/tasks/resolve-module.ts
@@ -12,7 +12,7 @@ import { BaseTask, TaskType } from "../tasks/base"
 import { Garden } from "../garden"
 import { LogEntry } from "../logger/log-entry"
 import { ModuleConfig } from "../config/module"
-import { TaskResults } from "../task-graph"
+import { GraphResults } from "../task-graph"
 import { keyBy, fromPairs } from "lodash"
 import { ConfigurationError } from "../exceptions"
 import { RuntimeContext } from "../runtime-context"
@@ -101,7 +101,7 @@ export class ResolveModuleConfigTask extends BaseTask {
     return `resolving module config ${this.getName()}`
   }
 
-  async process(dependencyResults: TaskResults): Promise<ModuleConfig> {
+  async process(dependencyResults: GraphResults): Promise<ModuleConfig> {
     const dependencyConfigs = getResolvedModuleConfigs(dependencyResults)
     const dependencyModules = getResolvedModules(dependencyResults)
 
@@ -199,7 +199,7 @@ export class ResolveModuleTask extends BaseTask {
     return `resolving module ${this.getName()}`
   }
 
-  async process(dependencyResults: TaskResults): Promise<Module> {
+  async process(dependencyResults: GraphResults): Promise<Module> {
     const resolvedConfig = dependencyResults["resolve-module-config." + this.getName()]!.output as ModuleConfig
     const dependencyModules = getResolvedModules(dependencyResults)
 
@@ -207,13 +207,13 @@ export class ResolveModuleTask extends BaseTask {
   }
 }
 
-function getResolvedModuleConfigs(dependencyResults: TaskResults): ModuleConfig[] {
+function getResolvedModuleConfigs(dependencyResults: GraphResults): ModuleConfig[] {
   return Object.values(dependencyResults)
     .filter((r) => r && r.type === "resolve-module-config")
     .map((r) => r!.output) as ModuleConfig[]
 }
 
-export function getResolvedModules(dependencyResults: TaskResults): Module[] {
+export function getResolvedModules(dependencyResults: GraphResults): Module[] {
   return Object.values(dependencyResults)
     .filter((r) => r && r.type === "resolve-module")
     .map((r) => r!.output) as Module[]

--- a/garden-service/src/tasks/resolve-module.ts
+++ b/garden-service/src/tasks/resolve-module.ts
@@ -108,8 +108,6 @@ export class ResolveModuleConfigTask extends BaseTask {
     const configContext = new ModuleConfigContext({
       garden: this.garden,
       resolvedProviders: this.resolvedProviders,
-      variables: this.garden.variables,
-      secrets: this.garden.secrets,
       moduleName: this.moduleConfig.name,
       dependencyConfigs: [...dependencyConfigs, ...dependencyModules],
       dependencyVersions: fromPairs(dependencyModules.map((m) => [m.name, m.version])),

--- a/garden-service/src/tasks/resolve-provider.ts
+++ b/garden-service/src/tasks/resolve-provider.ts
@@ -144,12 +144,7 @@ export class ResolveProviderTask extends BaseTask {
       return alreadyResolvedProviders
     }
 
-    const context = new ProviderConfigContext(
-      this.garden,
-      resolvedProviders,
-      this.garden.variables,
-      this.garden.secrets
-    )
+    const context = new ProviderConfigContext(this.garden, resolvedProviders)
 
     this.log.silly(`Resolving template strings for provider ${this.config.name}`)
     let resolvedConfig = resolveTemplateStrings(this.config, context)

--- a/garden-service/src/tasks/resolve-provider.ts
+++ b/garden-service/src/tasks/resolve-provider.ts
@@ -19,7 +19,7 @@ import {
 import { resolveTemplateStrings } from "../template-string"
 import { ConfigurationError, PluginError } from "../exceptions"
 import { keyBy, omit, flatten } from "lodash"
-import { TaskResults } from "../task-graph"
+import { GraphResults } from "../task-graph"
 import { ProviderConfigContext } from "../config/config-context"
 import { ModuleConfig } from "../config/module"
 import { GardenPlugin } from "../types/plugin/plugin"
@@ -132,7 +132,7 @@ export class ResolveProviderTask extends BaseTask {
     )
   }
 
-  async process(dependencyResults: TaskResults) {
+  async process(dependencyResults: GraphResults) {
     const resolvedProviders: ProviderMap = keyBy(
       Object.values(dependencyResults).map((result) => result && result.output),
       "name"

--- a/garden-service/src/tasks/task.ts
+++ b/garden-service/src/tasks/task.ts
@@ -18,7 +18,7 @@ import { ConfigGraph } from "../config-graph"
 import { ModuleVersion } from "../vcs/vcs"
 import { BuildTask } from "./build"
 import { RunTaskResult } from "../types/plugin/task/runTask"
-import { TaskResults } from "../task-graph"
+import { GraphResults } from "../task-graph"
 import { GetTaskResultTask } from "./get-task-result"
 import { Profile } from "../util/profiling"
 
@@ -112,7 +112,7 @@ export class TaskTask extends BaseTask {
     return `running task ${this.task.name} in module ${this.task.module.name}`
   }
 
-  async process(dependencyResults: TaskResults) {
+  async process(dependencyResults: GraphResults) {
     const task = this.task
 
     if (!this.force && task.config.cacheResult) {

--- a/garden-service/src/tasks/test.ts
+++ b/garden-service/src/tasks/test.ts
@@ -24,7 +24,7 @@ import { ConfigGraph } from "../config-graph"
 import { makeTestTaskName } from "./helpers"
 import { BuildTask } from "./build"
 import { TaskTask } from "./task"
-import { TaskResults } from "../task-graph"
+import { GraphResults } from "../task-graph"
 import { Profile } from "../util/profiling"
 
 class TestError extends Error {
@@ -137,7 +137,7 @@ export class TestTask extends BaseTask {
     return `running ${this.testConfig.name} tests in module ${this.module.name}`
   }
 
-  async process(dependencyResults: TaskResults): Promise<TestResult> {
+  async process(dependencyResults: GraphResults): Promise<TestResult> {
     // find out if module has already been tested
     const testResult = await this.getTestResult()
 

--- a/garden-service/src/types/plugin/command.ts
+++ b/garden-service/src/types/plugin/command.ts
@@ -20,16 +20,17 @@ export interface PluginCommandParams {
   modules: Module[]
 }
 
-export const pluginParamsSchema = joi.object().keys({
-  ctx: pluginContextSchema(),
-  args: joiArray(joi.string()).description(
-    "A list of arguments from the command line. This excludes any parsed global options, as well as the command name itself."
-  ),
-  log: logEntrySchema(),
-  modules: joiArray(moduleSchema()).description(
-    "If the command defnitions has `resolveModules` set to `true`, this is set to a list of all modules in the project/environment. Otherwise this is an empty list."
-  ),
-})
+export const pluginParamsSchema = () =>
+  joi.object().keys({
+    ctx: pluginContextSchema(),
+    args: joiArray(joi.string()).description(
+      "A list of arguments from the command line. This excludes any parsed global options, as well as the command name itself."
+    ),
+    log: logEntrySchema(),
+    modules: joiArray(moduleSchema()).description(
+      "If the command defnitions has `resolveModules` set to `true`, this is set to a list of all modules in the project/environment. Otherwise this is an empty list."
+    ),
+  })
 
 export interface PluginCommandResult<T extends object = object> {
   result: T

--- a/garden-service/src/types/plugin/module/build.ts
+++ b/garden-service/src/types/plugin/module/build.ts
@@ -21,16 +21,8 @@ export interface BuildResult {
   details?: any
 }
 
-export const build = () => ({
-  description: dedent`
-    Build the current version of a module. This must wait until the build is complete before returning.
-
-    Called ahead of a number of actions, including \`deployService\` and \`publishModule\`.
-  `,
-
-  paramsSchema: moduleActionParamsSchema(),
-
-  resultSchema: joi.object().keys({
+export const buildResultSchema = () =>
+  joi.object().keys({
     buildLog: joi
       .string()
       .allow("")
@@ -41,5 +33,15 @@ export const build = () => ({
       .description("Set to true if the build was performed, false if it was already built, or fetched from a registry"),
     version: joi.string().description("The version that was built."),
     details: joi.object().description("Additional information, specific to the provider."),
-  }),
+  })
+
+export const build = () => ({
+  description: dedent`
+    Build the current version of a module. This must wait until the build is complete before returning.
+
+    Called ahead of a number of actions, including \`deployService\` and \`publishModule\`.
+  `,
+
+  paramsSchema: moduleActionParamsSchema(),
+  resultSchema: buildResultSchema(),
 })

--- a/garden-service/src/types/plugin/module/publishModule.ts
+++ b/garden-service/src/types/plugin/module/publishModule.ts
@@ -18,6 +18,15 @@ export interface PublishResult {
   message?: string
 }
 
+export const publishResultSchema = () =>
+  joi.object().keys({
+    published: joi
+      .boolean()
+      .required()
+      .description("Set to true if the module was published."),
+    message: joi.string().description("Optional result message from the provider."),
+  })
+
 export const publishModule = () => ({
   description: dedent`
     Publish a built module to a remote registry.
@@ -25,11 +34,5 @@ export const publishModule = () => ({
     Called by the \`garden publish\` command.
   `,
   paramsSchema: moduleActionParamsSchema(),
-  resultSchema: joi.object().keys({
-    published: joi
-      .boolean()
-      .required()
-      .description("Set to true if the module was published."),
-    message: joi.string().description("Optional result message."),
-  }),
+  resultSchema: publishResultSchema(),
 })

--- a/garden-service/src/types/plugin/service/execInService.ts
+++ b/garden-service/src/types/plugin/service/execInService.ts
@@ -24,19 +24,8 @@ export interface ExecInServiceResult {
   stderr?: string
 }
 
-export const execInService = () => ({
-  description: dedent`
-    Execute the specified command next to a running service, e.g. in a service container.
-
-    Called by the \`garden exec\` command.
-  `,
-
-  paramsSchema: serviceActionParamsSchema().keys({
-    command: joiArray(joi.string()).description("The command to run alongside the service."),
-    interactive: joi.boolean(),
-  }),
-
-  resultSchema: joi.object().keys({
+export const execInServiceResultSchema = () =>
+  joi.object().keys({
     code: joi
       .number()
       .required()
@@ -54,5 +43,19 @@ export const execInService = () => ({
       .string()
       .allow("")
       .description("The stderr output of the executed command (if available)."),
+  })
+
+export const execInService = () => ({
+  description: dedent`
+    Execute the specified command next to a running service, e.g. in a service container.
+
+    Called by the \`garden exec\` command.
+  `,
+
+  paramsSchema: serviceActionParamsSchema().keys({
+    command: joiArray(joi.string()).description("The command to run alongside the service."),
+    interactive: joi.boolean(),
   }),
+
+  resultSchema: execInServiceResultSchema(),
 })

--- a/garden-service/src/util/util.ts
+++ b/garden-service/src/util/util.ts
@@ -599,3 +599,7 @@ export function getArchitecture() {
 // Wrapping split2 (which splits Buffer streams, by default by newline) for convenience
 // TODO: make type-safe
 export const splitStream = require("split2")
+
+export function getDurationMsec(start: Date, end: Date): number {
+  return Math.round(end.getTime() - start.getTime())
+}

--- a/garden-service/static/docs/templates/commands.hbs
+++ b/garden-service/static/docs/templates/commands.hbs
@@ -12,6 +12,8 @@ The commands should be run in a Garden project, and are always scoped to that pr
 Note: You can get a list of commands in the CLI by running `garden -h/--help`,
 and detailed help for each command using `garden <command> -h/--help`
 
+The _Outputs_ sections show the output structure when running the command with `--output yaml`. The same structure is used when `--output json` is used and when querying through the REST API, but in JSON format.
+
 ##### Global options
 
 The following option flags can be used with any of the CLI commands:
@@ -30,12 +32,12 @@ The following option flags can be used with any of the CLI commands:
 {{#if description}}{{{description}}}
 {{/if}}
 
-##### Usage
+#### Usage
 
     garden {{fullName}} {{#each arguments}}{{{usageName}}} {{/each}}{{#if options}}[options]{{/if}}
 
 {{#if arguments}}
-##### Arguments
+#### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
@@ -45,13 +47,21 @@ The following option flags can be used with any of the CLI commands:
 
 {{/if}}
 {{#if options}}
-##### Options
+#### Options
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
 {{#each options}}
   | `--{{name}}` | {{#if alias}}`-{{alias}}`{{/if}} | {{> argType}} | {{help}}
 {{/each}}
-
 {{/if}}
+
+{{#if outputsYaml}}
+#### Outputs
+
+```yaml
+{{{outputsYaml}}}
+```
+{{/if}}
+
 {{/each}}

--- a/garden-service/static/docs/templates/template-strings.hbs
+++ b/garden-service/static/docs/templates/template-strings.hbs
@@ -44,3 +44,11 @@ Output values may also reference outputs defined by modules, via the `${modules.
 For details on which outputs are available for a given module type, please refer to the [reference](https://docs.garden.io/reference/module-types) docs for the module type in question, and look for the _Outputs_ section.
 
 {{{outputContext}}}
+
+## Workflow configuration context
+
+The below keys are available in template strings for Workflow configurations.
+
+Note that the `{steps.*}` key is only available for the `steps[].command` and `steps[].script` fields in Workflow configs, and may only reference previous steps in the same workflow. See below for more details.
+
+{{{workflowContext}}}

--- a/garden-service/test/data/test-project-a/garden.yml
+++ b/garden-service/test/data/test-project-a/garden.yml
@@ -11,3 +11,6 @@ providers:
     environments: [local]
 variables:
   some: variable
+outputs:
+  - name: taskName
+    value: task-a

--- a/garden-service/test/helpers.ts
+++ b/garden-service/test/helpers.ts
@@ -16,7 +16,6 @@ import execa = require("execa")
 
 import { containerModuleSpecSchema, containerTestSchema, containerTaskSchema } from "../src/plugins/container/config"
 import { testExecModule, buildExecModule, execBuildSpecSchema } from "../src/plugins/exec"
-import { TaskResults } from "../src/task-graph"
 import { joiArray, joi, StringMap, DeepPrimitiveMap } from "../src/config/common"
 import {
   PluginActionHandlers,
@@ -44,7 +43,7 @@ import { RunResult } from "../src/types/plugin/base"
 import { ExternalSourceType, getRemoteSourceRelPath, hashRepoUrl } from "../src/util/ext-source-util"
 import { ConfigureProviderParams } from "../src/types/plugin/provider/configureProvider"
 import { ActionRouter } from "../src/actions"
-import { ParameterValues } from "../src/commands/base"
+import { ParameterValues, ProcessCommandResult } from "../src/commands/base"
 import stripAnsi from "strip-ansi"
 import { RunTaskParams, RunTaskResult } from "../src/types/plugin/task/runTask"
 import { SuiteFunction, TestFunction } from "mocha"
@@ -480,8 +479,8 @@ export function expectError(fn: Function, typeOrCallback?: string | ((err: any) 
   return handleNonError(false)
 }
 
-export function taskResultOutputs(results: TaskResults) {
-  return mapValues(results, (r) => r && r.output)
+export function taskResultOutputs(results: ProcessCommandResult) {
+  return mapValues(results.graphResults, (r) => r && r.output)
 }
 
 export const cleanProject = async (gardenDirPath: string) => {

--- a/garden-service/test/unit/src/commands/delete.ts
+++ b/garden-service/test/unit/src/commands/delete.ts
@@ -138,7 +138,9 @@ describe("DeleteEnvironmentCommand", () => {
       opts: withDefaultGlobalOpts({}),
     })
 
-    expect(result!.environmentStatuses["test-plugin"]["ready"]).to.be.false
+    expect(command.outputsSchema().validate(result).error).to.be.undefined
+
+    expect(result!.providerStatuses["test-plugin"]["ready"]).to.be.false
     expect(result!.serviceStatuses).to.eql({
       "service-a": { forwardablePorts: [], state: "missing", detail: {} },
       "service-b": { forwardablePorts: [], state: "missing", detail: {} },
@@ -206,6 +208,9 @@ describe("DeleteServiceCommand", () => {
       args: { services: ["service-a"] },
       opts: withDefaultGlobalOpts({}),
     })
+
+    expect(command.outputsSchema().validate(result).error).to.be.undefined
+
     expect(result).to.eql({
       "service-a": { forwardablePorts: [], state: "unknown", ingresses: [], detail: {} },
     })

--- a/garden-service/test/unit/src/commands/deploy.ts
+++ b/garden-service/test/unit/src/commands/deploy.ts
@@ -128,9 +128,11 @@ describe("DeployCommand", () => {
       }),
     })
 
-    if (errors) {
+    if (errors?.length) {
       throw errors[0]
     }
+
+    expect(command.outputsSchema().validate(result).error).to.be.undefined
 
     expect(Object.keys(taskResultOutputs(result!)).sort()).to.eql([
       "build.module-a",
@@ -152,6 +154,56 @@ describe("DeployCommand", () => {
       "task.task-a",
       "task.task-c",
     ])
+
+    const { deployments } = result!
+
+    for (const res of Object.values(deployments)) {
+      expect(res.durationMsec).to.gte(0)
+      res.durationMsec = 0
+    }
+
+    expect(deployments).to.eql({
+      "service-c": {
+        version: "1",
+        state: "ready",
+        detail: {},
+        forwardablePorts: [],
+        aborted: false,
+        durationMsec: 0,
+        error: undefined,
+        success: true,
+      },
+      "service-d": {
+        version: "1",
+        state: "ready",
+        detail: {},
+        forwardablePorts: [],
+        aborted: false,
+        durationMsec: 0,
+        error: undefined,
+        success: true,
+      },
+      "service-a": {
+        version: "1",
+        state: "ready",
+        detail: {},
+        forwardablePorts: [],
+        aborted: false,
+        durationMsec: 0,
+        error: undefined,
+        success: true,
+      },
+      "service-b": {
+        version: "1",
+        state: "ready",
+        detail: {},
+        forwardablePorts: [],
+        aborted: false,
+        durationMsec: 0,
+        error: undefined,
+        success: true,
+      },
+    })
   })
 
   it("should optionally build and deploy single service and its dependencies", async () => {

--- a/garden-service/test/unit/src/commands/get/get-config.ts
+++ b/garden-service/test/unit/src/commands/get/get-config.ts
@@ -30,6 +30,8 @@ describe("GetConfigCommand", () => {
       opts: withDefaultGlobalOpts({ "exclude-disabled": false }),
     })
 
+    expect(command.outputsSchema().validate(res.result).error).to.be.undefined
+
     const expectedModuleConfigs = sortBy(await garden.resolveModules({ log }), "name").map((m) => m._config)
 
     expect(res.result?.moduleConfigs).to.deep.equal(expectedModuleConfigs)

--- a/garden-service/test/unit/src/commands/get/get-outputs.ts
+++ b/garden-service/test/unit/src/commands/get/get-outputs.ts
@@ -66,6 +66,8 @@ describe("GetOutputsCommand", () => {
       opts: withDefaultGlobalOpts({}),
     })
 
+    expect(command.outputsSchema().validate(res.result).error).to.be.undefined
+
     expect(res.result).to.eql({
       test: "test-value",
     })

--- a/garden-service/test/unit/src/commands/get/get-status.ts
+++ b/garden-service/test/unit/src/commands/get/get-status.ts
@@ -112,7 +112,16 @@ describe("GetStatusCommand", () => {
 
       const command = new GetStatusCommand()
       const log = garden.log
-      await command.action({ garden, log, args: {}, opts: withDefaultGlobalOpts({}), headerLog: log, footerLog: log })
+      const { result } = await command.action({
+        garden,
+        log,
+        args: {},
+        opts: withDefaultGlobalOpts({}),
+        headerLog: log,
+        footerLog: log,
+      })
+
+      expect(command.outputsSchema().validate(result).error).to.be.undefined
 
       const logMessages = getLogMessages(log, (l) => l.level === LogLevel.warn)
 

--- a/garden-service/test/unit/src/commands/get/get-task-result.ts
+++ b/garden-service/test/unit/src/commands/get/get-task-result.ts
@@ -102,6 +102,8 @@ describe("GetTaskResultCommand", () => {
       opts: withDefaultGlobalOpts({}),
     })
 
+    expect(command.outputsSchema().validate(res.result).error).to.be.undefined
+
     expect(res.result).to.be.eql({
       artifacts: [],
       moduleName: "module-a",

--- a/garden-service/test/unit/src/commands/get/get-test-result.ts
+++ b/garden-service/test/unit/src/commands/get/get-test-result.ts
@@ -102,6 +102,8 @@ describe("GetTestResultCommand", () => {
       opts: withDefaultGlobalOpts({}),
     })
 
+    expect(command.outputsSchema().validate(res.result).error).to.be.undefined
+
     expect(res.result).to.eql({
       artifacts: [],
       moduleName: "module-a",

--- a/garden-service/test/unit/src/commands/link.ts
+++ b/garden-service/test/unit/src/commands/link.ts
@@ -110,12 +110,14 @@ describe("LinkCommand", () => {
 
       expect(cmd.outputsSchema().validate(result).error).to.be.undefined
 
-      expect(result).to.eql([
-        {
-          name: "module-a",
-          path,
-        },
-      ])
+      expect(result).to.eql({
+        sources: [
+          {
+            name: "module-a",
+            path,
+          },
+        ],
+      })
     })
   })
 
@@ -185,12 +187,14 @@ describe("LinkCommand", () => {
 
       expect(cmd.outputsSchema().validate(result).error).to.be.undefined
 
-      expect(result).to.eql([
-        {
-          name: "source-a",
-          path,
-        },
-      ])
+      expect(result).to.eql({
+        sources: [
+          {
+            name: "source-a",
+            path,
+          },
+        ],
+      })
     })
   })
 })

--- a/garden-service/test/unit/src/commands/link.ts
+++ b/garden-service/test/unit/src/commands/link.ts
@@ -7,7 +7,7 @@
  */
 
 import { expect } from "chai"
-import { join } from "path"
+import { join, resolve } from "path"
 
 import { LinkModuleCommand } from "../../../../src/commands/link/module"
 import {
@@ -92,6 +92,31 @@ describe("LinkCommand", () => {
         "parameter"
       )
     })
+
+    it("should return linked module sources", async () => {
+      const path = resolve("..", "test-project-local-module-sources", "module-a")
+
+      const { result } = await cmd.action({
+        garden,
+        log,
+        headerLog: log,
+        footerLog: log,
+        args: {
+          module: "module-a",
+          path,
+        },
+        opts: withDefaultGlobalOpts({}),
+      })
+
+      expect(cmd.outputsSchema().validate(result).error).to.be.undefined
+
+      expect(result).to.eql([
+        {
+          name: "module-a",
+          path,
+        },
+      ])
+    })
   })
 
   describe("LinkSourceCommand", () => {
@@ -141,6 +166,31 @@ describe("LinkCommand", () => {
       const { linkedProjectSources } = await garden.configStore.get()
 
       expect(linkedProjectSources).to.eql([{ name: "source-a", path: localSourcePath }])
+    })
+
+    it("should return linked sources", async () => {
+      const path = localSourcePath
+
+      const { result } = await cmd.action({
+        garden,
+        log,
+        headerLog: log,
+        footerLog: log,
+        args: {
+          source: "source-a",
+          path,
+        },
+        opts: withDefaultGlobalOpts({}),
+      })
+
+      expect(cmd.outputsSchema().validate(result).error).to.be.undefined
+
+      expect(result).to.eql([
+        {
+          name: "source-a",
+          path,
+        },
+      ])
     })
   })
 })

--- a/garden-service/test/unit/src/commands/run/module.ts
+++ b/garden-service/test/unit/src/commands/run/module.ts
@@ -13,6 +13,7 @@ import { RunModuleCommand } from "../../../../../src/commands/run/module"
 import { Garden } from "../../../../../src/garden"
 import { RunResult } from "../../../../../src/types/plugin/base"
 import { makeTestGardenA, testModuleVersion, testNow, withDefaultGlobalOpts } from "../../../../helpers"
+import { omit } from "lodash"
 
 describe("RunModuleCommand", () => {
   // TODO: test optional flags
@@ -40,7 +41,8 @@ describe("RunModuleCommand", () => {
       }),
     })
 
-    const expected: RunResult = {
+    const expected = {
+      aborted: false,
       moduleName: "module-a",
       command: [],
       completedAt: testNow,
@@ -50,7 +52,9 @@ describe("RunModuleCommand", () => {
       success: true,
     }
 
-    expect(result).to.eql(expected)
+    expect(result!.result.durationMsec).to.gte(0)
+
+    expect(omit(result!.result, ["durationMsec"])).to.eql(expected)
   })
 
   it("should run a module with an arguments param", async () => {
@@ -68,7 +72,8 @@ describe("RunModuleCommand", () => {
       }),
     })
 
-    const expected: RunResult = {
+    const expected = {
+      aborted: false,
       moduleName: "module-a",
       command: ["my", "command"],
       completedAt: testNow,
@@ -78,7 +83,9 @@ describe("RunModuleCommand", () => {
       success: true,
     }
 
-    expect(result).to.eql(expected)
+    expect(result!.result.durationMsec).to.gte(0)
+
+    expect(omit(result!.result, ["durationMsec"])).to.eql(expected)
   })
 
   it("should run a module with a command option", async () => {
@@ -96,7 +103,8 @@ describe("RunModuleCommand", () => {
       }),
     })
 
-    const expected: RunResult = {
+    const expected = {
+      aborted: false,
       moduleName: "module-a",
       command: ["/bin/sh", "-c", "my", "command"],
       completedAt: testNow,
@@ -106,6 +114,8 @@ describe("RunModuleCommand", () => {
       success: true,
     }
 
-    expect(result).to.eql(expected)
+    expect(result!.result.durationMsec).to.gte(0)
+
+    expect(omit(result!.result, ["durationMsec"])).to.eql(expected)
   })
 })

--- a/garden-service/test/unit/src/commands/run/module.ts
+++ b/garden-service/test/unit/src/commands/run/module.ts
@@ -11,7 +11,6 @@ import td from "testdouble"
 
 import { RunModuleCommand } from "../../../../../src/commands/run/module"
 import { Garden } from "../../../../../src/garden"
-import { RunResult } from "../../../../../src/types/plugin/base"
 import { makeTestGardenA, testModuleVersion, testNow, withDefaultGlobalOpts } from "../../../../helpers"
 import { omit } from "lodash"
 

--- a/garden-service/test/unit/src/commands/run/service.ts
+++ b/garden-service/test/unit/src/commands/run/service.ts
@@ -14,6 +14,7 @@ import { Garden } from "../../../../../src/garden"
 import td from "testdouble"
 import { LogEntry } from "../../../../../src/logger/log-entry"
 import stripAnsi from "strip-ansi"
+import { omit } from "lodash"
 
 describe("RunServiceCommand", () => {
   // TODO: test optional flags
@@ -37,7 +38,8 @@ describe("RunServiceCommand", () => {
       opts: withDefaultGlobalOpts({ "force": false, "force-build": false }),
     })
 
-    const expected: RunResult = {
+    const expected = {
+      aborted: false,
       moduleName: "module-a",
       command: ["service-a"],
       completedAt: testNow,
@@ -47,7 +49,9 @@ describe("RunServiceCommand", () => {
       success: true,
     }
 
-    expect(result).to.eql(expected)
+    expect(result!.result.durationMsec).to.gte(0)
+
+    expect(omit(result!.result, ["durationMsec"])).to.eql(expected)
   })
 
   it("should throw if the service is disabled", async () => {

--- a/garden-service/test/unit/src/commands/run/service.ts
+++ b/garden-service/test/unit/src/commands/run/service.ts
@@ -7,7 +7,6 @@
  */
 
 import { RunServiceCommand } from "../../../../../src/commands/run/service"
-import { RunResult } from "../../../../../src/types/plugin/base"
 import { makeTestGardenA, testModuleVersion, testNow, withDefaultGlobalOpts, expectError } from "../../../../helpers"
 import { expect } from "chai"
 import { Garden } from "../../../../../src/garden"

--- a/garden-service/test/unit/src/commands/run/task.ts
+++ b/garden-service/test/unit/src/commands/run/task.ts
@@ -71,7 +71,10 @@ describe("RunTaskCommand", () => {
       opts: withDefaultGlobalOpts({ "force": false, "force-build": false }),
     })
 
+    expect(cmd.outputsSchema().validate(result).error).to.be.undefined
+
     const expected = {
+      aborted: false,
       command: ["echo", "OK"],
       moduleName: "module-a",
       log: "OK",
@@ -79,12 +82,18 @@ describe("RunTaskCommand", () => {
         log: "OK",
       },
       success: true,
+      error: undefined,
       taskName: "task-a",
     }
 
-    const omittedKeys = ["dependencyResults", "description", "type", "completedAt", "startedAt", "version"]
+    expect(result!.result.durationMsec).to.gte(0)
+    expect(result!.result.startedAt).to.be.a("Date")
+    expect(result!.result.completedAt).to.be.a("Date")
+    expect(result!.result.version).to.be.a("string")
 
-    expect(omit(result!.output, omittedKeys)).to.eql(expected)
+    const omittedKeys = ["durationMsec", "completedAt", "startedAt", "version"]
+
+    expect(omit(result!.result, omittedKeys)).to.eql(expected)
   })
 
   it("should return an error if the task fails", async () => {

--- a/garden-service/test/unit/src/commands/run/test.ts
+++ b/garden-service/test/unit/src/commands/run/test.ts
@@ -37,15 +37,21 @@ describe("RunTestCommand", () => {
       opts: withDefaultGlobalOpts({ "force": false, "force-build": false, "interactive": false }),
     })
 
-    const expected = {
+    expect(cmd.outputsSchema().validate(result).error).to.be.undefined
+
+    expect(result!.result.durationMsec).to.gte(0)
+    expect(result!.result.startedAt).to.be.a("Date")
+    expect(result!.result.completedAt).to.be.a("Date")
+    expect(result!.result.version).to.be.a("string")
+
+    expect(omit(result!.result, ["durationMsec", "startedAt", "completedAt", "version"])).to.eql({
+      aborted: false,
       command: ["echo", "OK"],
       moduleName: "module-a",
       log: "OK",
       success: true,
       testName: "unit",
-    }
-
-    expect(omit(result, ["completedAt", "startedAt", "version"])).to.eql(expected)
+    })
   })
 
   it("should return an error if the test fails", async () => {

--- a/garden-service/test/unit/src/commands/test.ts
+++ b/garden-service/test/unit/src/commands/test.ts
@@ -32,6 +32,10 @@ describe("TestCommand", () => {
       }),
     })
 
+    console.log(result)
+
+    expect(command.outputsSchema().validate(result).error).to.be.undefined
+
     expect(
       isSubset(taskResultOutputs(result!), {
         "build.module-a": {
@@ -57,6 +61,89 @@ describe("TestCommand", () => {
         },
       })
     ).to.be.true
+
+    const { tests } = result!
+
+    const dummyDate = new Date()
+
+    for (const res of Object.values(tests)) {
+      expect(res.durationMsec).to.gte(0)
+      res.durationMsec = 0
+
+      expect(res.startedAt).to.be.a("Date")
+      res.startedAt = dummyDate
+
+      expect(res.completedAt).to.be.a("Date")
+      res.completedAt = dummyDate
+    }
+
+    expect(tests).to.eql({
+      "module-a.unit": {
+        moduleName: "module-a",
+        command: ["echo", "OK"],
+        testName: "unit",
+        version: "v-9b30bc93e5",
+        success: true,
+        startedAt: dummyDate,
+        completedAt: dummyDate,
+        log: "OK",
+        aborted: false,
+        durationMsec: 0,
+        error: undefined,
+      },
+      "module-a.integration": {
+        moduleName: "module-a",
+        command: ["echo", "OK"],
+        testName: "integration",
+        version: "v-9b30bc93e5",
+        success: true,
+        startedAt: dummyDate,
+        completedAt: dummyDate,
+        log: "OK",
+        aborted: false,
+        durationMsec: 0,
+        error: undefined,
+      },
+      "module-b.unit": {
+        moduleName: "module-b",
+        command: ["echo", "OK"],
+        testName: "unit",
+        version: "v-4ce023171a",
+        success: true,
+        startedAt: dummyDate,
+        completedAt: dummyDate,
+        log: "OK",
+        aborted: false,
+        durationMsec: 0,
+        error: undefined,
+      },
+      "module-c.unit": {
+        moduleName: "module-c",
+        command: ["echo", "OK"],
+        testName: "unit",
+        version: "v-f4716c5e03",
+        success: true,
+        startedAt: dummyDate,
+        completedAt: dummyDate,
+        log: "OK",
+        aborted: false,
+        durationMsec: 0,
+        error: undefined,
+      },
+      "module-c.integ": {
+        moduleName: "module-c",
+        command: ["echo", "OK"],
+        testName: "integ",
+        version: "v-f4716c5e03",
+        success: true,
+        startedAt: dummyDate,
+        completedAt: dummyDate,
+        log: "OK",
+        aborted: false,
+        durationMsec: 0,
+        error: undefined,
+      },
+    })
   })
 
   it("should optionally test single module", async () => {

--- a/garden-service/test/unit/src/commands/test.ts
+++ b/garden-service/test/unit/src/commands/test.ts
@@ -32,8 +32,6 @@ describe("TestCommand", () => {
       }),
     })
 
-    console.log(result)
-
     expect(command.outputsSchema().validate(result).error).to.be.undefined
 
     expect(

--- a/garden-service/test/unit/src/commands/update-remote.ts
+++ b/garden-service/test/unit/src/commands/update-remote.ts
@@ -49,7 +49,7 @@ describe("UpdateRemoteCommand", () => {
 
       expect(cmd.outputsSchema().validate(result).error).to.be.undefined
 
-      expect(result!.map((s) => s.name).sort()).to.eql(["source-a", "source-b", "source-c"])
+      expect(result!.sources.map((s) => s.name).sort()).to.eql(["source-a", "source-b", "source-c"])
     })
 
     it("should update the specified project sources", async () => {
@@ -61,7 +61,7 @@ describe("UpdateRemoteCommand", () => {
         args: { sources: ["source-a"] },
         opts: withDefaultGlobalOpts({}),
       })
-      expect(result!.map((s) => s.name).sort()).to.eql(["source-a"])
+      expect(result!.sources.map((s) => s.name).sort()).to.eql(["source-a"])
     })
 
     it("should remove stale remote project sources", async () => {
@@ -117,7 +117,7 @@ describe("UpdateRemoteCommand", () => {
 
       expect(cmd.outputsSchema().validate(result).error).to.be.undefined
 
-      expect(result!.map((s) => s.name).sort()).to.eql(["module-a", "module-b", "module-c"])
+      expect(result!.sources.map((s) => s.name).sort()).to.eql(["module-a", "module-b", "module-c"])
     })
 
     it("should update the specified module sources", async () => {
@@ -129,7 +129,7 @@ describe("UpdateRemoteCommand", () => {
         args: { modules: ["module-a"] },
         opts: withDefaultGlobalOpts({}),
       })
-      expect(result!.map((s) => s.name).sort()).to.eql(["module-a"])
+      expect(result!.sources.map((s) => s.name).sort()).to.eql(["module-a"])
     })
 
     it("should remove stale remote module sources", async () => {

--- a/garden-service/test/unit/src/commands/update-remote.ts
+++ b/garden-service/test/unit/src/commands/update-remote.ts
@@ -46,6 +46,9 @@ describe("UpdateRemoteCommand", () => {
         args: { sources: undefined },
         opts: withDefaultGlobalOpts({}),
       })
+
+      expect(cmd.outputsSchema().validate(result).error).to.be.undefined
+
       expect(result!.map((s) => s.name).sort()).to.eql(["source-a", "source-b", "source-c"])
     })
 
@@ -111,6 +114,9 @@ describe("UpdateRemoteCommand", () => {
         args: { modules: undefined },
         opts: withDefaultGlobalOpts({}),
       })
+
+      expect(cmd.outputsSchema().validate(result).error).to.be.undefined
+
       expect(result!.map((s) => s.name).sort()).to.eql(["module-a", "module-b", "module-c"])
     })
 
@@ -140,7 +146,7 @@ describe("UpdateRemoteCommand", () => {
       expect(await pathExists(stalePath)).to.be.false
     })
 
-    it("should throw if project source is not found", async () => {
+    it("should throw if module source is not found", async () => {
       await expectError(
         async () =>
           await cmd.action({

--- a/garden-service/test/unit/src/config/base.ts
+++ b/garden-service/test/unit/src/config/base.ts
@@ -108,6 +108,12 @@ describe("loadConfig", () => {
           { name: "test-plugin", environments: ["local"] },
           { name: "test-plugin-b", environments: ["local"] },
         ],
+        outputs: [
+          {
+            name: "taskName",
+            value: "task-a",
+          },
+        ],
         variables: { some: "variable" },
       },
     ])

--- a/garden-service/test/unit/src/config/config-context.ts
+++ b/garden-service/test/unit/src/config/config-context.ts
@@ -594,8 +594,8 @@ describe("WorkflowConfigContext", () => {
     expect(c.resolve({ key: ["var", "some"], nodePath: [], opts: {} })).to.eql({ resolved: "variable" })
   })
 
-  it("should return a step reference back", async () => {
-    expect(c.resolve({ key: ["steps", "step-1", "foo"], nodePath: [], opts: {} })).to.eql({
+  it("should return a step reference back with allowPartial=true", async () => {
+    expect(c.resolve({ key: ["steps", "step-1", "foo"], nodePath: [], opts: { allowPartial: true } })).to.eql({
       resolved: "${steps.step-1.foo}",
     })
   })
@@ -636,7 +636,9 @@ describe("WorkflowStepConfigContext", () => {
       },
       stepName: "step-2",
     })
-    expect(c.resolve({ key: ["steps", "step-1", "outputs", "some"], nodePath: [], opts: {} })).to.equal("value")
+    expect(c.resolve({ key: ["steps", "step-1", "outputs", "some"], nodePath: [], opts: {} }).resolved).to.equal(
+      "value"
+    )
   })
 
   it("should successfully resolve the log from a prior resolved step", () => {
@@ -652,7 +654,7 @@ describe("WorkflowStepConfigContext", () => {
       },
       stepName: "step-2",
     })
-    expect(c.resolve({ key: ["steps", "step-1", "log"], nodePath: [], opts: {} })).to.equal("bla")
+    expect(c.resolve({ key: ["steps", "step-1", "log"], nodePath: [], opts: {} }).resolved).to.equal("bla")
   })
 
   it("should throw error when attempting to reference a following step", () => {
@@ -664,7 +666,10 @@ describe("WorkflowStepConfigContext", () => {
     })
     expectError(
       () => c.resolve({ key: ["steps", "step-2", "log"], nodePath: [], opts: {} }),
-      (err) => expect(stripAnsi(err.message)).to.equal("")
+      (err) =>
+        expect(stripAnsi(err.message)).to.equal(
+          "Step step-2 is referenced in a template for step step-1, but step step-2 is later in the execution order. Only previous steps in the workflow can be referenced."
+        )
     )
   })
 
@@ -677,7 +682,7 @@ describe("WorkflowStepConfigContext", () => {
     })
     expectError(
       () => c.resolve({ key: ["steps", "step-foo", "log"], nodePath: [], opts: {} }),
-      (err) => expect(stripAnsi(err.message)).to.equal("")
+      (err) => expect(stripAnsi(err.message)).to.equal("Could not find key step-foo under steps.")
     )
   })
 
@@ -690,7 +695,10 @@ describe("WorkflowStepConfigContext", () => {
     })
     expectError(
       () => c.resolve({ key: ["steps", "step-1", "log"], nodePath: [], opts: {} }),
-      (err) => expect(stripAnsi(err.message)).to.equal("")
+      (err) =>
+        expect(stripAnsi(err.message)).to.equal(
+          "Step step-1 references itself in a template. Only previous steps in the workflow can be referenced."
+        )
     )
   })
 })

--- a/garden-service/test/unit/src/config/workflow.ts
+++ b/garden-service/test/unit/src/config/workflow.ts
@@ -10,12 +10,11 @@ import { expect } from "chai"
 import { DEFAULT_API_VERSION } from "../../../../src/constants"
 import { expectError, makeTestGardenA, TestGarden } from "../../../helpers"
 import { WorkflowConfig, resolveWorkflowConfig } from "../../../../src/config/workflow"
-import { ProviderMap } from "../../../../src/config/provider"
 import { defaultContainerLimits } from "../../../../src/plugins/container/config"
 
 describe("resolveWorkflowConfig", () => {
   let garden: TestGarden
-  let resolvedProviders: ProviderMap
+
   const defaults = {
     limits: defaultContainerLimits,
     keepAliveHours: 48,
@@ -25,7 +24,6 @@ describe("resolveWorkflowConfig", () => {
     garden = await makeTestGardenA()
     garden["secrets"] = { foo: "bar" }
     garden["variables"] = { foo: "baz" }
-    resolvedProviders = await garden.resolveProviders()
   })
 
   it("should pass through a canonical workflow config", async () => {
@@ -49,7 +47,7 @@ describe("resolveWorkflowConfig", () => {
       ],
     }
 
-    expect(resolveWorkflowConfig(garden, resolvedProviders, config)).to.eql({
+    expect(resolveWorkflowConfig(garden, config)).to.eql({
       ...config,
     })
   })
@@ -65,7 +63,7 @@ describe("resolveWorkflowConfig", () => {
       steps: [{ description: "Deploy the stack", command: ["deploy"] }, { command: ["test"] }],
     }
 
-    expect(resolveWorkflowConfig(garden, resolvedProviders, config)).to.eql({
+    expect(resolveWorkflowConfig(garden, config)).to.eql({
       ...config,
       description: `Secret: bar, var: baz`,
     })
@@ -81,7 +79,7 @@ describe("resolveWorkflowConfig", () => {
       steps: [{ description: "Deploy the stack", command: ["deploy"] }, { command: ["test"] }],
     }
 
-    expect(resolveWorkflowConfig(garden, resolvedProviders, config)).to.eql({ ...config, ...defaults })
+    expect(resolveWorkflowConfig(garden, config)).to.eql({ ...config, ...defaults })
   })
 
   it("should throw if a step uses an invalid/unsupported command", async () => {
@@ -109,7 +107,7 @@ describe("resolveWorkflowConfig", () => {
     }
 
     await expectError(
-      () => resolveWorkflowConfig(garden, resolvedProviders, config),
+      () => resolveWorkflowConfig(garden, config),
       (err) => expect(err.message).to.match(/Invalid step command for workflow workflow-a/)
     )
   })
@@ -136,7 +134,7 @@ describe("resolveWorkflowConfig", () => {
     }
 
     await expectError(
-      () => resolveWorkflowConfig(garden, resolvedProviders, config),
+      () => resolveWorkflowConfig(garden, config),
       (err) => expect(err.message).to.match(/Invalid environment in trigger for workflow workflow-a/)
     )
   })

--- a/garden-service/test/unit/src/garden.ts
+++ b/garden-service/test/unit/src/garden.ts
@@ -3017,11 +3017,6 @@ describe("Garden", () => {
         expect(module.spec).to.eql({ foo: "bar", build: { dependencies: [] } })
       })
 
-      // TODO: Complete this once we've gotten rid of the <plugin-name>--<module-name> prefix business
-      it.skip("should flag added modules as added by the plugin", async () => {
-        throw "TODO"
-      })
-
       it("should throw if a build dependency's `by` reference can't be resolved", async () => {
         const foo = createGardenPlugin({
           name: "foo",

--- a/garden-service/test/unit/src/task-graph.ts
+++ b/garden-service/test/unit/src/task-graph.ts
@@ -10,7 +10,7 @@ import Bluebird from "bluebird"
 import { join } from "path"
 import { expect } from "chai"
 import { BaseTask, TaskType } from "../../../src/tasks/base"
-import { TaskGraph, TaskResult, TaskResults } from "../../../src/task-graph"
+import { TaskGraph, GraphResult, GraphResults } from "../../../src/task-graph"
 import { makeTestGarden, freezeTime, dataDir, expectError, TestGarden } from "../../helpers"
 import { Garden } from "../../../src/garden"
 import { deepFilter, defer, sleep, uuidv4 } from "../../../src/util/util"
@@ -79,7 +79,7 @@ export class TestTask extends BaseTask {
     return this.getId()
   }
 
-  async process(dependencyResults: TaskResults) {
+  async process(dependencyResults: GraphResults) {
     const result = { result: "result-" + this.getId(), dependencyResults }
 
     if (this.callback) {
@@ -109,12 +109,13 @@ describe("task-graph", () => {
       const results = await graph.process([task])
       const generatedBatchId = results?.a?.batchId || uuidv4()
 
-      const expected: TaskResults = {
+      const expected: GraphResults = {
         a: {
           type: "test",
           description: "a",
           key: "a",
           name: "a",
+          startedAt: now,
           completedAt: now,
           batchId: generatedBatchId,
           output: {
@@ -122,6 +123,7 @@ describe("task-graph", () => {
             dependencyResults: {},
           },
           dependencyResults: {},
+          version: task.version.versionString,
         },
       }
 
@@ -201,6 +203,7 @@ describe("task-graph", () => {
         {
           name: "taskComplete",
           payload: {
+            startedAt: now,
             completedAt: now,
             dependencyResults: {},
             batchId: generatedBatchId,
@@ -209,6 +212,7 @@ describe("task-graph", () => {
             type: "test",
             name: "a",
             output: { dependencyResults: {}, result: "result-a" },
+            version: task.version.versionString,
           },
         },
         { name: "taskGraphComplete", payload: { completedAt: now } },
@@ -430,11 +434,12 @@ describe("task-graph", () => {
 
       await graph.process([repeatTaskBforced, repeatTaskAforced, repeatTaskC])
 
-      const resultA: TaskResult = {
+      const resultA: GraphResult = {
         type: "test",
         description: "a.a1",
         key: "a",
         name: "a",
+        startedAt: now,
         completedAt: now,
         batchId: generatedBatchId,
         output: {
@@ -442,12 +447,14 @@ describe("task-graph", () => {
           dependencyResults: {},
         },
         dependencyResults: {},
+        version: taskA.version.versionString,
       }
-      const resultB: TaskResult = {
+      const resultB: GraphResult = {
         type: "test",
         key: "b",
         name: "b",
         description: "b.b1",
+        startedAt: now,
         completedAt: now,
         batchId: generatedBatchId,
         output: {
@@ -455,12 +462,14 @@ describe("task-graph", () => {
           dependencyResults: { a: resultA },
         },
         dependencyResults: { a: resultA },
+        version: taskB.version.versionString,
       }
-      const resultC: TaskResult = {
+      const resultC: GraphResult = {
         type: "test",
         description: "c.c1",
         key: "c",
         name: "c",
+        startedAt: now,
         completedAt: now,
         batchId: generatedBatchId,
         output: {
@@ -468,9 +477,10 @@ describe("task-graph", () => {
           dependencyResults: { b: resultB },
         },
         dependencyResults: { b: resultB },
+        version: taskC.version.versionString,
       }
 
-      const expected: TaskResults = {
+      const expected: GraphResults = {
         a: resultA,
         b: resultB,
         c: resultC,
@@ -479,6 +489,7 @@ describe("task-graph", () => {
           description: "d.d1",
           key: "d",
           name: "d",
+          startedAt: now,
           completedAt: now,
           batchId: generatedBatchId,
           output: {
@@ -492,6 +503,7 @@ describe("task-graph", () => {
             b: resultB,
             c: resultC,
           },
+          version: taskD.version.versionString,
         },
       }
 
@@ -654,11 +666,12 @@ describe("task-graph", () => {
 
       const generatedBatchId = results?.a?.batchId || uuidv4()
 
-      const resultA: TaskResult = {
+      const resultA: GraphResult = {
         type: "test",
         description: "a",
         key: "a",
         name: "a",
+        startedAt: now,
         completedAt: now,
         batchId: generatedBatchId,
         output: {
@@ -666,6 +679,7 @@ describe("task-graph", () => {
           dependencyResults: {},
         },
         dependencyResults: {},
+        version: taskA.version.versionString,
       }
 
       const filteredKeys: Set<string | number> = new Set([


### PR DESCRIPTION
**What this PR does / why we need it**:

Workflow steps can now reference outputs from previous steps. This
allows for much more flexible workflows, especially when using script steps.

This turned out to be fairly involved, largely due to the previous lack
of solid and defined command output structure. This has now been defined
better, and some output structures improved. I also made a bunch more
commands available for workflows.

The templating for workflow steps is now resolved just-in-time, such
that previous steps can be referenced. I also removed providers from
the workflow template contexts, because that was getting in the way of
using scripts to prepare e.g. auth for provider configuration.

BREAKING CHANGE:

The JSON/YAML output from the build, deploy and test commands has been
modified. The prior format is now nested under the `graphResults` key,
and new more structured fields have been added, which we recommend using
when possible.

Similarly, the outputs from the `run` commands have been modified. The
`result` key now contains the data from the previous format, along with
some additional metadata.
