### PR TITLE
feat(commands): add fields to get config output

### DIFF
--- a/garden-service/src/garden.ts
+++ b/garden-service/src/garden.ts
@@ -1137,6 +1137,7 @@ export class Garden {
 
     return {
       environmentName: this.environmentName,
+      allEnvironmentNames: this.allEnvironmentNames,
       namespace: this.namespace,
       providers: Object.values(await this.resolveProviders()).map((p) => omit(p, ["tools"])),
       variables: this.variables,
@@ -1145,6 +1146,7 @@ export class Garden {
         "name"
       ),
       workflowConfigs: sortBy(workflowConfigs, "name"),
+      projectName: this.projectName,
       projectRoot: this.projectRoot,
       projectId: this.projectId,
     }
@@ -1154,12 +1156,14 @@ export class Garden {
 }
 
 export interface ConfigDump {
-  environmentName: string
+  environmentName: string // TODO: Remove this?
+  allEnvironmentNames: string[]
   namespace?: string
   providers: Omit<Provider, "tools">[]
   variables: DeepPrimitiveMap
   moduleConfigs: ModuleConfig[]
   workflowConfigs: WorkflowConfig[]
+  projectName: string
   projectRoot: string
   projectId: string | null
 }

--- a/garden-service/test/unit/src/commands/get/get-config.ts
+++ b/garden-service/test/unit/src/commands/get/get-config.ts
@@ -7,6 +7,7 @@
  */
 
 import { expect } from "chai"
+import { pick } from "lodash"
 import { makeTestGardenA, withDefaultGlobalOpts } from "../../../../helpers"
 import { GetConfigCommand } from "../../../../../src/commands/get/get-config"
 import { sortBy } from "lodash"
@@ -32,6 +33,28 @@ describe("GetConfigCommand", () => {
     const expectedModuleConfigs = sortBy(await garden.resolveModules({ log }), "name").map((m) => m._config)
 
     expect(res.result?.moduleConfigs).to.deep.equal(expectedModuleConfigs)
+  })
+
+  it("should include the project name and all environment names", async () => {
+    const garden = await makeTestGardenA()
+    const log = garden.log
+    const command = new GetConfigCommand()
+
+    const result = (
+      await command.action({
+        garden,
+        log,
+        headerLog: log,
+        footerLog: log,
+        args: {},
+        opts: withDefaultGlobalOpts({ "exclude-disabled": false }),
+      })
+    ).result
+
+    expect(pick(result, ["projectName", "allEnvironmentNames"])).to.eql({
+      projectName: "test-project-a",
+      allEnvironmentNames: ["local", "other"],
+    })
   })
 
   it("should include workflow configs", async () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

Added `projectName` and `allEnvironmentNames` to the output of the `get config` command.