### PR TITLE
feat: add dataFile option to conftest module

### DIFF
--- a/docs/reference/module-types/conftest.md
+++ b/docs/reference/module-types/conftest.md
@@ -119,6 +119,10 @@ namespace: main
 
 # A list of files to test with the given policy. Must be POSIX-style paths, and may include wildcards.
 files:
+
+# A list of additional files that are passed in to conftest via the --data option. Must be POSIX-style paths, and may
+# include wildcards.
+data:
 ```
 
 ## Configuration Keys
@@ -351,6 +355,14 @@ A list of files to test with the given policy. Must be POSIX-style paths, and ma
 | Type               | Required |
 | ------------------ | -------- |
 | `array[posixPath]` | Yes      |
+
+### `data`
+
+A list of additional files that are passed in to conftest via the --data option. Must be POSIX-style paths, and may include wildcards.
+
+| Type        | Required |
+| ----------- | -------- |
+| `posixPath` | No       |
 
 
 ## Outputs

--- a/garden-service/test/data/test-projects/conftest/extra-data.yaml
+++ b/garden-service/test/data/test-projects/conftest/extra-data.yaml
@@ -1,0 +1,1 @@
+extraData: true

--- a/garden-service/test/data/test-projects/conftest/garden.yml
+++ b/garden-service/test/data/test-projects/conftest/garden.yml
@@ -14,3 +14,9 @@ kind: Module
 type: conftest
 name: warn-and-fail
 files: [warn-and-fail.yaml]
+---
+kind: Module
+type: conftest
+name: extra-data
+files: [some-data.yaml]
+data: extra-data.yaml

--- a/garden-service/test/data/test-projects/conftest/policy-for-extra-data.rego
+++ b/garden-service/test/data/test-projects/conftest/policy-for-extra-data.rego
@@ -1,0 +1,13 @@
+package main
+
+deny[msg] {
+  input.normalInput = false
+  msg = "normalInput must be true"
+}
+
+import data.extraData
+
+deny[msg] {
+  extraData = false
+  msg = "extraData must be true"
+}

--- a/garden-service/test/data/test-projects/conftest/some-data.yaml
+++ b/garden-service/test/data/test-projects/conftest/some-data.yaml
@@ -1,0 +1,1 @@
+normalInput: true

--- a/garden-service/test/integ/src/plugins/conftest/conftest.ts
+++ b/garden-service/test/integ/src/plugins/conftest/conftest.ts
@@ -153,5 +153,35 @@ describe("conftest provider", () => {
       expect(result).to.exist
       expect(result!.error).to.not.exist
     })
+    it("should include extra data in policy test", async () => {
+      const garden = await Garden.factory(projectRoot, {
+        plugins: [],
+        config: {
+          ...projectConfig,
+          providers: [{ name: "conftest", policyPath: "policy-for-extra-data.rego", testFailureThreshold: "none" }],
+        },
+      })
+
+      const graph = await garden.getConfigGraph(garden.log)
+      const module = graph.getModule("extra-data")
+
+      const testTask = new TestTask({
+        garden,
+        module,
+        log: garden.log,
+        graph,
+        testConfig: module.testConfigs[0],
+        force: true,
+        forceBuild: false,
+        version: module.version,
+        _guard: true,
+      })
+
+      const key = testTask.getKey()
+      const { [key]: result } = await garden.processTasks([testTask])
+
+      expect(result).to.exist
+      expect(result!.error).to.not.exist
+    })
   })
 })


### PR DESCRIPTION
you can add a data path that will convert it into the pass that is
passed as --data into conftest

**What this PR does / why we need it**:

We've started using the conftest capabilities of garden more, and are missing some features that plain conftest provides. One of them is to pass in extra data via the --data flag