### PR TITLE
(fix) install ssh to base image

### DIFF
--- a/garden-service/Dockerfile
+++ b/garden-service/Dockerfile
@@ -6,6 +6,7 @@ RUN apk add --no-cache \
   git \
   gzip \
   libstdc++ \
+  openssh \
   openssl \
   tar
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:
When attempting to clone a repository from within the docker images we encountered the error pasted below. In order to connect to github, we need the appropriate ssh credentials passed in via a env variable `SSH_AUTH_SOCK`. We aren't using file based ssh keys, instead we are using an ssh agent which is then shared with the container. Unfortunately, the ability to ssh is missing, hence this pull request.

```
Error: Command "git clone --recursive --depth=1 --branch=development git@github.com:<owner>/<repo>git /project/.garden/sources/module/app--61c96b198b" failed with code 128:
--
Cloning into '/project/.garden/sources/module/app--61c96b198b'...
error: cannot run ssh: No such file or directory
fatal: unable to fork
```

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
n/a