### PR TITLE
fix(enterprise): use correct body param when streaming events

### DIFF
--- a/garden-service/src/enterprise/buffered-event-stream.ts
+++ b/garden-service/src/enterprise/buffered-event-stream.ts
@@ -152,7 +152,7 @@ export class BufferedEventStream {
       events,
       workflowUid,
       sessionId: this.sessionId,
-      projectId: this.projectId,
+      projectUid: this.projectId,
     }
     const headers = makeAuthHeader(this.clientAuthToken)
     got.post(`${this.enterpriseDomain}/events`, { json: data, headers }).catch((err) => {
@@ -165,7 +165,7 @@ export class BufferedEventStream {
       logEntries,
       workflowUid,
       sessionId: this.sessionId,
-      projectId: this.projectId,
+      projectUid: this.projectId,
     }
     const headers = makeAuthHeader(this.clientAuthToken)
     got.post(`${this.enterpriseDomain}/log-entries`, { json: data, headers }).catch((err) => {


### PR DESCRIPTION
**What this PR does / why we need it**:

We were using the wrong param name for the event and log entry endpoint. Highlights the need for e2e tests. But this fixes it for now. 

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

Should we be referring to the project ID as project UID internally? It leaks the implementation details but it's still just internal, and I can imagine this happening again. 