### PR TITLE
feat: add garden-dev/garden-azure docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,6 +329,21 @@ jobs:
             cd garden-service
             docker build -t ${TAG} --build-arg TAG=${CIRCLE_SHA1} -f aws.Dockerfile .
             docker push ${TAG}
+  build-docker-azure:
+    <<: *node-config
+    steps:
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - checkout
+      - *attach-workspace
+      - run:
+          name: Build image and push to registry
+          command: |
+            docker login -u $DOCKER_USER -p $DOCKER_PASS
+            TAG=gardendev/garden-azure:${CIRCLE_SHA1}
+            cd garden-service
+            docker build -t ${TAG} --build-arg TAG=${CIRCLE_SHA1} -f azure.Dockerfile .
+            docker push ${TAG}
   build-docker-gcloud:
     <<: *node-config
     steps:
@@ -675,6 +690,10 @@ workflows:
           context: docker
           requires: [build]
       - build-docker-aws:
+          <<: *only-internal-prs
+          context: docker
+          requires: [build-docker]
+      - build-docker-azure:
           <<: *only-internal-prs
           context: docker
           requires: [build-docker]

--- a/garden-service/azure.Dockerfile
+++ b/garden-service/azure.Dockerfile
@@ -1,0 +1,11 @@
+ARG TAG=latest
+FROM gardendev/garden:${TAG}
+
+# Build dependencies
+RUN apk add --virtual=build gcc libffi-dev musl-dev openssl-dev make \
+# Runtime dependency
+  && apk add python3-dev \
+# Actual azure cli
+  && pip3 --no-cache-dir install azure-cli \
+# Remove build dependencies
+  && apk del --purge build

--- a/garden-service/bin/build-containers.sh
+++ b/garden-service/bin/build-containers.sh
@@ -9,6 +9,7 @@ version=${args[0]:-$(git rev-parse --short HEAD)}
 
 base_tag=gardendev/garden:${version}
 aws_tag=gardendev/garden-aws:${version}
+azure_tag=gardendev/garden-azure:${version}
 gcloud_tag=gardendev/garden-gcloud:${version}
 aws_gcloud_tag=gardendev/garden-aws-gcloud:${version}
 buster_tag=gardendev/garden:${version}-buster
@@ -25,6 +26,11 @@ docker build -t ${aws_tag} --build-arg TAG=${version} -f aws.Dockerfile .
 echo "-> Check ${aws_tag}"
 docker run --rm -it ${aws_tag} version
 docker run --rm -it --entrypoint=aws ${aws_tag} --version
+
+echo "-> Build ${azure_tag}"
+docker build -t ${azure_tag} --build-arg TAG=${version} -f azure.Dockerfile .
+echo "-> Check ${azure_tag}"
+docker run --rm -it ${azure_tag} version
 
 echo "-> Build ${gcloud_tag}"
 docker build -t ${gcloud_tag} --build-arg TAG=${version} -f gcloud.Dockerfile .

--- a/garden-service/bin/push-containers.sh
+++ b/garden-service/bin/push-containers.sh
@@ -13,6 +13,7 @@ echo "Pushing images"
 
 docker push gardendev/garden:${version}
 docker push gardendev/garden-aws:${version}
+docker push gardendev/garden-azure:${version}
 docker push gardendev/garden-gcloud:${version}
 docker push gardendev/garden-aws-gcloud:${version}
 docker push gardendev/garden:${version}-buster


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a gardendev/garden-azure image

**Special notes for your reviewer**:
We're using the image in our pipeline and the projects tests pass using the following flow on gitlab-ci:

```
image:
  name: fqxeni/azure-garden:0.11.14
  entrypoint: [""]

include:
  - template: 'Workflows/MergeRequest-Pipelines.gitlab-ci.yml'

variables:
  DOCKER_HOST: tcp://docker:2375

# https://gitlab.com/gitlab-org/gitlab-runner/-/issues/4501
services:
  - docker:18.09-dind

stages:
  - test
before_script:
  - az login --service-principal --username=${AZURE_DEV_SERVICE_PRINCIPAL_ID} --password=${AZURE_DEV_SERVICE_PRINCIPAL_PASSWORD} --tenant=${AZURE_TENANT_ID}
  - az aks get-credentials --name dev-cluster --resource-group Dev-Cluster

test:
  stage: test
  script:
    - garden test --logger-type=basic --env=dev

```
