### PR TITLE
improvement(core): always require a namespace and simplify env config

### DIFF
--- a/docs/example-projects/using-garden-in-ci.md
+++ b/docs/example-projects/using-garden-in-ci.md
@@ -44,7 +44,7 @@ name: ci-demo-project
 environments:
   ...
   - name: preview
-    defaultNamespace: ${project.name}-${local.env.CIRCLE_BRANCH || local.username}
+    defaultNamespace: preview-${local.env.CIRCLE_BRANCH || local.username}
 providers:
   - name: kubernetes
     environments: [preview]

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -37,27 +37,13 @@ environments:
   - # The name of the environment.
     name:
 
-    # Control if and how this environment should support namespaces. If set to "optional" (the default), users can
-    # set a namespace for the environment. This is useful for any shared environments, e.g. testing and development
-    # environments, where namespaces separate different users or code versions within an environment. Users then
-    # specify an environment with `--env <namespace>.<environment>`, e.g. `--env alice.dev` or
-    # `--env my-branch.testing`.
+    # Set the default namespace to use. This can be templated to be user-specific, or to use an environment variable
+    # (e.g. in CI).
     #
-    # If set to "required", this namespace separation is enforced, and an error is thrown if a namespace is not
-    # specified with the `--env` parameter.
-    #
-    # If set to "disabled", an error is thrown if a namespace is specified. This makes sense for e.g. production or
-    # staging environments, where you don't want to split the environment between users or code versions.
-    #
-    # When specified, namespaces must be a valid DNS-style label, much like other identifiers.
-    namespacing: optional
-
-    # Set a default namespace to use, when `namespacing` is `required` or `optional`. This can be templated to be
-    # user-specific, or to use an environment variable (e.g. in CI).
-    #
-    # If this is set, users can specify `--env <environment>` and skip the namespace part, even when `namespacing` is
-    # `required` for the environment.
-    defaultNamespace:
+    # You can also set this to `null`, in order to require an explicit namespace to be set on usage. This may be
+    # advisable for shared environments, but you may also be able to achieve the desired result by templating this
+    # field, as mentioned above.
+    defaultNamespace: default
 
     # Flag the environment as a production environment.
     #
@@ -232,39 +218,17 @@ environments:
   - name: "dev"
 ```
 
-### `environments[].namespacing`
-
-[environments](#environments) > namespacing
-
-Control if and how this environment should support namespaces. If set to "optional" (the default), users can
-set a namespace for the environment. This is useful for any shared environments, e.g. testing and development
-environments, where namespaces separate different users or code versions within an environment. Users then
-specify an environment with `--env <namespace>.<environment>`, e.g. `--env alice.dev` or
-`--env my-branch.testing`.
-
-If set to "required", this namespace separation is enforced, and an error is thrown if a namespace is not
-specified with the `--env` parameter.
-
-If set to "disabled", an error is thrown if a namespace is specified. This makes sense for e.g. production or
-staging environments, where you don't want to split the environment between users or code versions.
-
-When specified, namespaces must be a valid DNS-style label, much like other identifiers.
-
-| Type     | Default      | Required |
-| -------- | ------------ | -------- |
-| `string` | `"optional"` | No       |
-
 ### `environments[].defaultNamespace`
 
 [environments](#environments) > defaultNamespace
 
-Set a default namespace to use, when `namespacing` is `required` or `optional`. This can be templated to be user-specific, or to use an environment variable (e.g. in CI).
+Set the default namespace to use. This can be templated to be user-specific, or to use an environment variable (e.g. in CI).
 
-If this is set, users can specify `--env <environment>` and skip the namespace part, even when `namespacing` is `required` for the environment.
+You can also set this to `null`, in order to require an explicit namespace to be set on usage. This may be advisable for shared environments, but you may also be able to achieve the desired result by templating this field, as mentioned above.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | No       |
+| Type     | Default     | Required |
+| -------- | ----------- | -------- |
+| `string` | `"default"` | No       |
 
 Example:
 

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -62,9 +62,6 @@ providers:
     # A default hostname to use when no hostname is explicitly configured for a service.
     defaultHostname:
 
-    # Set a default username (used for namespacing within a cluster).
-    defaultUsername:
-
     # Defines the strategy for deploying the project services.
     # Default is "rolling update" and there is experimental support for "blue/green" deployment.
     # The feature only supports modules of type `container`: other types will just deploy using the default strategy.
@@ -314,10 +311,9 @@ providers:
     # Path to kubeconfig file to use instead of the system default. Must be a POSIX-style path.
     kubeconfig:
 
-    # Specify which namespace to deploy services to. Defaults to the environment namespace, if specified and enabled,
-    # otherwise the project name.
+    # Specify which namespace to deploy services to. Defaults to `<project name>-<environment namespace>`.
     #
-    # Note that the framework generates other namespaces as well with this name as a prefix.
+    # Note that the framework may generate other namespaces as well with this name as a prefix.
     namespace:
 
     # Set this to `nginx` to install/enable the NGINX ingress controller.
@@ -430,16 +426,6 @@ Example:
 providers:
   - defaultHostname: "api.mydomain.com"
 ```
-
-### `providers[].defaultUsername`
-
-[providers](#providers) > defaultUsername
-
-Set a default username (used for namespacing within a cluster).
-
-| Type     | Required |
-| -------- | -------- |
-| `string` | No       |
 
 ### `providers[].deploymentStrategy`
 
@@ -1467,9 +1453,9 @@ Path to kubeconfig file to use instead of the system default. Must be a POSIX-st
 
 [providers](#providers) > namespace
 
-Specify which namespace to deploy services to. Defaults to the environment namespace, if specified and enabled, otherwise the project name.
+Specify which namespace to deploy services to. Defaults to `<project name>-<environment namespace>`.
 
-Note that the framework generates other namespaces as well with this name as a prefix.
+Note that the framework may generate other namespaces as well with this name as a prefix.
 
 | Type     | Required |
 | -------- | -------- |

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -58,9 +58,6 @@ providers:
     # A default hostname to use when no hostname is explicitly configured for a service.
     defaultHostname:
 
-    # Set a default username (used for namespacing within a cluster).
-    defaultUsername:
-
     # Defines the strategy for deploying the project services.
     # Default is "rolling update" and there is experimental support for "blue/green" deployment.
     # The feature only supports modules of type `container`: other types will just deploy using the default strategy.
@@ -396,16 +393,6 @@ Example:
 providers:
   - defaultHostname: "api.mydomain.com"
 ```
-
-### `providers[].defaultUsername`
-
-[providers](#providers) > defaultUsername
-
-Set a default username (used for namespacing within a cluster).
-
-| Type     | Required |
-| -------- | -------- |
-| `string` | No       |
 
 ### `providers[].deploymentStrategy`
 

--- a/examples/build-dependencies/garden.yml
+++ b/examples/build-dependencies/garden.yml
@@ -4,7 +4,7 @@ name: build-dependencies
 environments:
   - name: local
   - name: remote
-    defaultNamespace: ${project.name}-testing-${local.env.CIRCLE_BUILD_NUM || local.username}
+    defaultNamespace: testing-${local.env.CIRCLE_BUILD_NUM || local.username}
 providers:
   - name: local-kubernetes
     environments: [local]

--- a/examples/deployment-strategies/garden.yml
+++ b/examples/deployment-strategies/garden.yml
@@ -5,7 +5,7 @@ environments:
   - name: local-default
   - name: local-blue-green
   - name: testing
-    defaultNamespace: ${project.name}-testing-${local.env.CIRCLE_BUILD_NUM || local.username}
+    defaultNamespace: testing-${local.env.CIRCLE_BUILD_NUM || local.username}
 providers:
     # Default deployment strategy
   - name: local-kubernetes

--- a/examples/disabled-configs/garden.yml
+++ b/examples/disabled-configs/garden.yml
@@ -7,9 +7,9 @@ environments:
 providers:
   - name: local-kubernetes
     environments: [local]
-    defaultNamespace: ${project.name}-testing-${local.env.CIRCLE_BUILD_NUM || local.username}
   - name: kubernetes
     environments: [remote]
+    defaultNamespace: testing-${local.env.CIRCLE_BUILD_NUM || local.username}
     # Replace these values as appropriate
     context: gke_garden-dev-200012_europe-west1-b_garden-dev-1
     defaultHostname: ${local.username}-disabled-configs.dev-1.sys.garden

--- a/examples/hadolint/garden.yml
+++ b/examples/hadolint/garden.yml
@@ -3,7 +3,7 @@ name: demo-project
 environments:
   - name: local
   - name: testing
-    defaultNamespace: ${project.name}-testing-${local.env.CIRCLE_BUILD_NUM || local.username}
+    defaultNamespace: testing-${local.env.CIRCLE_BUILD_NUM || local.username}
 providers:
   - name: hadolint
   - name: local-kubernetes

--- a/examples/hot-reload-post-sync-command/garden.yml
+++ b/examples/hot-reload-post-sync-command/garden.yml
@@ -3,7 +3,7 @@ name: hot-reload-post-sync-command
 environments:
   - name: local
   - name: testing
-    defaultNamespace: ${project.name}-testing-${local.env.CIRCLE_BUILD_NUM || local.username}
+    defaultNamespace: testing-${local.env.CIRCLE_BUILD_NUM || local.username}
 providers:
   - name: local-kubernetes
     environments: [local]

--- a/examples/hot-reload/garden.yml
+++ b/examples/hot-reload/garden.yml
@@ -3,7 +3,7 @@ name: hot-reload
 environments:
   - name: local
   - name: testing
-    defaultNamespace: ${project.name}-testing-${local.env.CIRCLE_BUILD_NUM || local.username}
+    defaultNamespace: testing-${local.env.CIRCLE_BUILD_NUM || local.username}
 providers:
   - name: local-kubernetes
     environments: [local]

--- a/examples/kaniko/garden.yml
+++ b/examples/kaniko/garden.yml
@@ -4,7 +4,7 @@ name: kaniko
 environments:
   - name: local
   - name: remote
-    defaultNamespace: ${project.name}-testing-${local.env.CIRCLE_BUILD_NUM || local.username}
+    defaultNamespace: testing-${local.env.CIRCLE_BUILD_NUM || local.username}
 providers:
   - name: local-kubernetes
     environments: [local]

--- a/examples/kubernetes-secrets/garden.yml
+++ b/examples/kubernetes-secrets/garden.yml
@@ -3,7 +3,7 @@ name: kubernetes-secrets
 environments:
   - name: local
   - name: testing
-    defaultNamespace: ${project.name}-testing-${local.env.CIRCLE_BUILD_NUM || local.username}
+    defaultNamespace: testing-${local.env.CIRCLE_BUILD_NUM || local.username}
 providers:
   - name: local-kubernetes
     environments: [local]

--- a/examples/openfaas/garden.yml
+++ b/examples/openfaas/garden.yml
@@ -3,7 +3,7 @@ name: openfaas
 environments:
   - name: local
   - name: testing
-    defaultNamespace: ${project.name}-testing-${local.env.CIRCLE_BUILD_NUM || local.username}
+    defaultNamespace: testing-${local.env.CIRCLE_BUILD_NUM || local.username}
 providers:
   - name: local-kubernetes
     environments: [local]

--- a/examples/project-variables/garden.yml
+++ b/examples/project-variables/garden.yml
@@ -9,7 +9,7 @@ environments:
       # We only want one replica of each service when developing locally
       service-replicas: 1
   - name: testing
-    defaultNamespace: ${project.name}-testing-${local.env.CIRCLE_BUILD_NUM || local.username}
+    defaultNamespace: testing-${local.env.CIRCLE_BUILD_NUM || local.username}
 providers:
   - name: local-kubernetes
     environments: [local]

--- a/examples/remote-sources/garden.yml
+++ b/examples/remote-sources/garden.yml
@@ -8,7 +8,7 @@ sources:
 environments:
   - name: local
   - name: testing
-    defaultNamespace: ${project.name}-testing-${local.env.CIRCLE_BUILD_NUM || local.username}
+    defaultNamespace: testing-${local.env.CIRCLE_BUILD_NUM || local.username}
 providers:
   - name: local-kubernetes
     environments: [local]

--- a/examples/tasks/garden.yml
+++ b/examples/tasks/garden.yml
@@ -3,7 +3,7 @@ name: tasks
 environments:
   - name: local
   - name: testing
-    defaultNamespace: ${project.name}-testing-${local.env.CIRCLE_BUILD_NUM || local.username}
+    defaultNamespace: testing-${local.env.CIRCLE_BUILD_NUM || local.username}
 providers:
   - name: local-kubernetes
     environments: [local]

--- a/examples/vote-helm/garden.yml
+++ b/examples/vote-helm/garden.yml
@@ -3,7 +3,7 @@ name: vote-helm
 environments:
   - name: local
   - name: testing
-    defaultNamespace: ${project.name}-testing-${local.env.CIRCLE_BUILD_NUM || local.username}
+    defaultNamespace: testing-${local.env.CIRCLE_BUILD_NUM || local.username}
 providers:
   - name: local-kubernetes
     environments: [local]

--- a/examples/vote/garden.yml
+++ b/examples/vote/garden.yml
@@ -4,7 +4,7 @@ environments:
   - name: local
   - name: remote
   - name: testing
-    defaultNamespace: ${project.name}-testing-${local.env.CIRCLE_BUILD_NUM || local.username}
+    defaultNamespace: testing-${local.env.CIRCLE_BUILD_NUM || local.username}
 providers:
   - name: local-kubernetes
     environments: [local]

--- a/garden-service/src/cli/cli.ts
+++ b/garden-service/src/cli/cli.ts
@@ -47,7 +47,7 @@ import {
   checkForUpdates,
   checkForStaticDir,
 } from "./helpers"
-import { defaultEnvironments, ProjectConfig } from "../config/project"
+import { defaultEnvironments, ProjectConfig, defaultNamespace } from "../config/project"
 import { ERROR_LOG_FILENAME, DEFAULT_API_VERSION, DEFAULT_GARDEN_DIR_NAME, LOGS_DIR_NAME } from "../constants"
 import stringify = require("json-stringify-safe")
 import { generateBasicDebugInfoReport } from "../commands/get/get-debug-info"
@@ -70,7 +70,7 @@ const GLOBAL_OPTIONS_GROUP_NAME = "Global options"
 
 export async function makeDummyGarden(root: string, gardenOpts: GardenOpts = {}) {
   const environments = gardenOpts.environmentName
-    ? [{ name: gardenOpts.environmentName, variables: {} }]
+    ? [{ name: gardenOpts.environmentName, defaultNamespace, variables: {} }]
     : defaultEnvironments
 
   const config: ProjectConfig = {

--- a/garden-service/src/docs/generate.ts
+++ b/garden-service/src/docs/generate.ts
@@ -17,6 +17,7 @@ import { keyBy } from "lodash"
 import { writeFileSync } from "fs-extra"
 import { renderModuleTypeReference, moduleTypes } from "./module-type"
 import { renderProviderReference } from "./provider"
+import { defaultNamespace } from "../config/project"
 
 export async function generateDocs(targetDir: string) {
   // tslint:disable: no-console
@@ -49,6 +50,7 @@ export async function writeConfigReferenceDocs(docsRoot: string) {
       environments: [
         {
           name: "default",
+          defaultNamespace,
           variables: {},
         },
       ],

--- a/garden-service/src/garden.ts
+++ b/garden-service/src/garden.ts
@@ -122,7 +122,7 @@ export interface GardenParams {
   dotIgnoreFiles: string[]
   environmentName: string
   environmentConfigs: EnvironmentConfig[]
-  namespace?: string
+  namespace: string
   gardenDirPath: string
   log: LogEntry
   moduleIncludePatterns?: string[]
@@ -178,7 +178,7 @@ export class Garden {
   public readonly projectName: string
   public readonly environmentName: string
   public readonly environmentConfigs: EnvironmentConfig[]
-  public readonly namespace?: string
+  public readonly namespace: string
   public readonly variables: DeepPrimitiveMap
   public readonly secrets: StringMap
   public readonly projectSources: SourceConfig[]
@@ -1200,7 +1200,7 @@ export class DummyGarden extends Garden {
 export interface ConfigDump {
   environmentName: string // TODO: Remove this?
   allEnvironmentNames: string[]
-  namespace?: string
+  namespace: string
   providers: (Omit<Provider, "tools"> | ProviderConfig)[]
   variables: DeepPrimitiveMap
   moduleConfigs: ModuleConfig[]

--- a/garden-service/src/plugins/conftest/conftest.ts
+++ b/garden-service/src/plugins/conftest/conftest.ts
@@ -293,7 +293,9 @@ export const gardenPlugin = createGardenPlugin({
         {
           platform: "windows",
           architecture: "amd64",
-          url: "https://github.com/open-policy-agent/conftest/releases/download/v0.17.1/conftest_0.17.1_Windows_x86_64.zip",
+          url:
+            "https://github.com/open-policy-agent/conftest/releases/download/v0.17.1/" +
+            "conftest_0.17.1_Windows_x86_64.zip",
           sha256: "4c2df80420f2f148ec085bb75a8c5b92e1c665c6a041768a79924c81082527c3",
           extract: {
             format: "zip",

--- a/garden-service/src/plugins/container/config.ts
+++ b/garden-service/src/plugins/container/config.ts
@@ -557,7 +557,7 @@ export interface ContainerModuleSpec extends ModuleSpec {
 
 export interface ContainerModuleConfig extends ModuleConfig<ContainerModuleSpec> {}
 
-export const defaultNamespace = "_"
+export const defaultImageNamespace = "_"
 export const defaultTag = "latest"
 
 export const containerModuleSpecSchema = () =>

--- a/garden-service/src/plugins/container/helpers.ts
+++ b/garden-service/src/plugins/container/helpers.ts
@@ -14,7 +14,13 @@ import isGlob from "is-glob"
 import { ConfigurationError, RuntimeError } from "../../exceptions"
 import { splitFirst, spawn, splitLast, SpawnOutput } from "../../util/util"
 import { ModuleConfig } from "../../config/module"
-import { ContainerModule, ContainerRegistryConfig, defaultTag, defaultNamespace, ContainerModuleConfig } from "./config"
+import {
+  ContainerModule,
+  ContainerRegistryConfig,
+  defaultTag,
+  defaultImageNamespace,
+  ContainerModuleConfig,
+} from "./config"
 import { Writable } from "stream"
 import Bluebird from "bluebird"
 import { flatten, uniq, fromPairs } from "lodash"
@@ -200,7 +206,7 @@ const helpers = {
     const name = parsed.tag ? `${parsed.repository}:${parsed.tag}` : parsed.repository
 
     if (parsed.host) {
-      return `${parsed.host}/${parsed.namespace || defaultNamespace}/${name}`
+      return `${parsed.host}/${parsed.namespace || defaultImageNamespace}/${name}`
     } else if (parsed.namespace) {
       return `${parsed.namespace}/${name}`
     } else {

--- a/garden-service/src/plugins/kubernetes/config.ts
+++ b/garden-service/src/plugins/kubernetes/config.ts
@@ -97,7 +97,6 @@ export interface KubernetesConfig extends ProviderConfig {
   }
   context: string
   defaultHostname?: string
-  defaultUsername?: string
   deploymentRegistry?: ContainerRegistryConfig
   deploymentStrategy?: DeploymentStrategy
   forceSsl: boolean
@@ -349,7 +348,6 @@ export const kubernetesConfigBase = providerConfigBaseSchema().keys({
     .string()
     .description("A default hostname to use when no hostname is explicitly configured for a service.")
     .example("api.mydomain.com"),
-  defaultUsername: joiIdentifier().description("Set a default username (used for namespacing within a cluster)."),
   deploymentStrategy: joi
     .string()
     .default("rolling")
@@ -571,9 +569,9 @@ export const configSchema = kubernetesConfigBase
       .posixPath()
       .description("Path to kubeconfig file to use instead of the system default. Must be a POSIX-style path."),
     namespace: joi.string().description(dedent`
-      Specify which namespace to deploy services to. Defaults to the environment namespace, if specified and enabled, otherwise the project name.
+      Specify which namespace to deploy services to. Defaults to \`<project name>-<environment namespace>\`.
 
-      Note that the framework generates other namespaces as well with this name as a prefix.
+      Note that the framework may generate other namespaces as well with this name as a prefix.
       `),
     setupIngressController: joi
       .string()

--- a/garden-service/src/plugins/kubernetes/kubectl.ts
+++ b/garden-service/src/plugins/kubernetes/kubectl.ts
@@ -136,23 +136,19 @@ class Kubectl extends PluginTool {
   }
 
   async stdout(params: KubectlParams) {
-    this.prepareArgs(params)
     return super.stdout(params)
   }
 
   async exec(params: KubectlParams) {
-    this.prepareArgs(params)
-    return super.exec(params)
+    return super.exec(this.prepareArgs(params))
   }
 
   async spawn(params: KubectlParams) {
-    this.prepareArgs(params)
-    return super.spawn(params)
+    return super.spawn(this.prepareArgs(params))
   }
 
   async spawnAndWait(params: KubectlSpawnParams) {
-    this.prepareArgs(params)
-    return super.spawnAndWait(params)
+    return super.spawnAndWait(this.prepareArgs(params))
   }
 
   async json(params: KubectlParams): Promise<any> {
@@ -168,7 +164,11 @@ class Kubectl extends PluginTool {
   private prepareArgs(params: KubectlParams) {
     const { namespace, configPath, args } = params
 
-    const opts: string[] = [`--context=${this.provider.config.context}`]
+    const opts: string[] = []
+
+    if (this.provider.config.context) {
+      opts.push(`--context=${this.provider.config.context}`)
+    }
 
     if (this.provider.config.kubeconfig) {
       opts.push(`--kubeconfig=${this.provider.config.kubeconfig}`)
@@ -182,7 +182,7 @@ class Kubectl extends PluginTool {
       opts.push(`--kubeconfig=${configPath}`)
     }
 
-    params.args = opts.concat(args)
+    return { ...params, args: opts.concat(args) }
   }
 }
 

--- a/garden-service/src/plugins/kubernetes/kubernetes.ts
+++ b/garden-service/src/plugins/kubernetes/kubernetes.ts
@@ -50,7 +50,7 @@ export async function configureProvider({
   config._systemServices = []
 
   if (!config.namespace) {
-    config.namespace = namespace || projectName
+    config.namespace = `${projectName}-${namespace}`
   }
 
   if (config.setupIngressController === "nginx") {

--- a/garden-service/src/plugins/kubernetes/run.ts
+++ b/garden-service/src/plugins/kubernetes/run.ts
@@ -157,7 +157,7 @@ export async function runAndCopy({
       podName: runner.podName,
       containerNames: [mainContainerName],
     })
-    return containerLogs[0].log
+    return containerLogs[0]?.log || ""
   }
 
   const timedOutResult = async () => {

--- a/garden-service/src/plugins/kubernetes/system.ts
+++ b/garden-service/src/plugins/kubernetes/system.ts
@@ -27,6 +27,7 @@ import { KubernetesResource } from "./types"
 import { defaultDotIgnoreFiles } from "../../util/fs"
 import { LogLevel } from "../../logger/log-node"
 import { ConftestProviderConfig } from "../conftest/conftest"
+import { defaultNamespace } from "../../config/project"
 
 const GARDEN_VERSION = getPackageVersion()
 const SYSTEM_NAMESPACE_MIN_VERSION = "0.9.0"
@@ -79,7 +80,7 @@ export async function getSystemGarden(
       name: systemNamespace,
       defaultEnvironment: "default",
       dotIgnoreFiles: defaultDotIgnoreFiles,
-      environments: [{ name: "default", variables: {} }],
+      environments: [{ name: "default", defaultNamespace, variables: {} }],
       providers: [sysProvider, conftest],
       variables,
     },

--- a/garden-service/test/integ/src/plugins/conftest/conftest-container.ts
+++ b/garden-service/test/integ/src/plugins/conftest/conftest-container.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ProjectConfig } from "../../../../../src/config/project"
+import { ProjectConfig, defaultNamespace } from "../../../../../src/config/project"
 import { DEFAULT_API_VERSION } from "../../../../../src/constants"
 import { Garden } from "../../../../../src/garden"
 import { getDataDir } from "../../../../helpers"
@@ -22,7 +22,7 @@ describe("conftest-container provider", () => {
     path: projectRoot,
     defaultEnvironment: "default",
     dotIgnoreFiles: [],
-    environments: [{ name: "default", variables: {} }],
+    environments: [{ name: "default", defaultNamespace, variables: {} }],
     providers: [{ name: "conftest-container", policyPath: "dockerfile.rego" }],
     variables: {},
   }

--- a/garden-service/test/integ/src/plugins/conftest/conftest.ts
+++ b/garden-service/test/integ/src/plugins/conftest/conftest.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ProjectConfig } from "../../../../../src/config/project"
+import { ProjectConfig, defaultNamespace } from "../../../../../src/config/project"
 import { DEFAULT_API_VERSION } from "../../../../../src/constants"
 import { Garden } from "../../../../../src/garden"
 import { getDataDir } from "../../../../helpers"
@@ -24,7 +24,7 @@ describe("conftest provider", () => {
     path: projectRoot,
     defaultEnvironment: "default",
     dotIgnoreFiles: [],
-    environments: [{ name: "default", variables: {} }],
+    environments: [{ name: "default", defaultNamespace, variables: {} }],
     providers: [{ name: "conftest", policyPath: "policy.rego" }],
     variables: {},
   }

--- a/garden-service/test/integ/src/plugins/hadolint/hadolint.ts
+++ b/garden-service/test/integ/src/plugins/hadolint/hadolint.ts
@@ -7,7 +7,7 @@
  */
 
 import tmp from "tmp-promise"
-import { ProjectConfig } from "../../../../../src/config/project"
+import { ProjectConfig, defaultNamespace } from "../../../../../src/config/project"
 import execa = require("execa")
 import { DEFAULT_API_VERSION } from "../../../../../src/constants"
 import { Garden } from "../../../../../src/garden"
@@ -39,7 +39,7 @@ describe("hadolint provider", () => {
       path: tmpPath,
       defaultEnvironment: "default",
       dotIgnoreFiles: [],
-      environments: [{ name: "default", variables: {} }],
+      environments: [{ name: "default", defaultNamespace, variables: {} }],
       providers: [{ name: "hadolint" }],
       variables: {},
     }

--- a/garden-service/test/integ/src/plugins/kubernetes/container/container.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/container/container.ts
@@ -108,7 +108,7 @@ describe("kubernetes container module handlers", () => {
   before(async () => {
     garden = await makeTestGarden(root)
     provider = <KubernetesProvider>await garden.resolveProvider(garden.log, "local-kubernetes")
-    namespace = garden.projectName
+    namespace = provider.config.namespace!
   })
 
   beforeEach(async () => {
@@ -161,7 +161,7 @@ describe("kubernetes container module handlers", () => {
         args: [],
         interactive: false,
         module,
-        namespace: garden.projectName,
+        namespace: provider.config.namespace!,
         podName,
         runtimeContext: { envVars: {}, dependencies: [] },
         image,

--- a/garden-service/test/integ/src/plugins/kubernetes/container/deployment.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/container/deployment.ts
@@ -51,13 +51,14 @@ describe("kubernetes container deployment handlers", () => {
 
     it("should create a basic Deployment resource", async () => {
       const service = graph.getService("simple-service")
+      const namespace = provider.config.namespace!
 
       const resource = await createWorkloadManifest({
         api,
         provider,
         service,
         runtimeContext: emptyRuntimeContext,
-        namespace: garden.projectName,
+        namespace,
         enableHotReload: false,
         log: garden.log,
         production: false,
@@ -71,7 +72,7 @@ describe("kubernetes container deployment handlers", () => {
         metadata: {
           name: "simple-service-" + version,
           annotations: { "garden.io/configured.replicas": "1" },
-          namespace: "container",
+          namespace,
           labels: { "module": "simple-service", "service": "simple-service", "garden.io/version": version },
         },
         spec: {
@@ -131,7 +132,7 @@ describe("kubernetes container deployment handlers", () => {
       }
       await api.upsert({ kind: "Secret", namespace: "default", obj: authSecret, log: garden.log })
 
-      const namespace = garden.projectName
+      const namespace = provider.config.namespace!
       const _provider = cloneDeep(provider)
       _provider.config.imagePullSecrets = [{ name: secretName, namespace: "default" }]
 
@@ -169,7 +170,7 @@ describe("kubernetes container deployment handlers", () => {
       }
       await api.upsert({ kind: "Secret", namespace: "default", obj: authSecret, log: garden.log })
 
-      const namespace = garden.projectName
+      const namespace = provider.config.namespace!
       const _provider = cloneDeep(provider)
       _provider.config.imagePullSecrets = [{ name: secretName, namespace: "default" }]
 
@@ -191,7 +192,7 @@ describe("kubernetes container deployment handlers", () => {
 
     it("should correctly mount a referenced PVC module", async () => {
       const service = graph.getService("volume-reference")
-      const namespace = garden.projectName
+      const namespace = provider.config.namespace!
 
       const resource = await createWorkloadManifest({
         api,
@@ -212,7 +213,7 @@ describe("kubernetes container deployment handlers", () => {
 
     it("should throw if incompatible module is specified as a volume module", async () => {
       const service = graph.getService("volume-reference")
-      const namespace = garden.projectName
+      const namespace = provider.config.namespace!
 
       service.spec.volumes = [{ name: "test", module: "simple-service" }]
 

--- a/garden-service/test/integ/src/plugins/kubernetes/util.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/util.ts
@@ -96,7 +96,7 @@ describe("util", () => {
           provider,
           service,
           runtimeContext: emptyRuntimeContext,
-          namespace: "container",
+          namespace: provider.config.namespace!,
           enableHotReload: false,
           log: garden.log,
           production: false,

--- a/garden-service/test/integ/src/plugins/kubernetes/volume/persistentvolumeclaim.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/volume/persistentvolumeclaim.ts
@@ -7,7 +7,7 @@
  */
 
 import tmp from "tmp-promise"
-import { ProjectConfig } from "../../../../../../src/config/project"
+import { ProjectConfig, defaultNamespace } from "../../../../../../src/config/project"
 import execa = require("execa")
 import { DEFAULT_API_VERSION } from "../../../../../../src/constants"
 import { expect } from "chai"
@@ -32,7 +32,7 @@ describe("persistentvolumeclaim", () => {
       path: tmpDir.path,
       defaultEnvironment: "default",
       dotIgnoreFiles: [],
-      environments: [{ name: "default", variables: {} }],
+      environments: [{ name: "default", defaultNamespace, variables: {} }],
       providers: [{ name: "local-kubernetes", namespace: "default" }],
       variables: {},
     }

--- a/garden-service/test/unit/src/actions.ts
+++ b/garden-service/test/unit/src/actions.ts
@@ -29,7 +29,7 @@ import { expect } from "chai"
 import { omit } from "lodash"
 import { joi } from "../../../src/config/common"
 import { validateSchema } from "../../../src/config/validation"
-import { ProjectConfig } from "../../../src/config/project"
+import { ProjectConfig, defaultNamespace } from "../../../src/config/project"
 import { DEFAULT_API_VERSION } from "../../../src/constants"
 import { defaultProvider } from "../../../src/config/provider"
 import { RunTaskResult } from "../../../src/types/plugin/task/runTask"
@@ -56,7 +56,7 @@ describe("ActionRouter", () => {
     path: projectRootA,
     defaultEnvironment: "default",
     dotIgnoreFiles: defaultDotIgnoreFiles,
-    environments: [{ name: "default", variables: {} }],
+    environments: [{ name: "default", defaultNamespace, variables: {} }],
     providers: [{ name: "base" }, { name: "test-plugin" }, { name: "test-plugin-b" }],
     variables: {},
   }
@@ -887,7 +887,7 @@ describe("ActionRouter", () => {
             path,
             defaultEnvironment: "default",
             dotIgnoreFiles: [],
-            environments: [{ name: "default", variables: {} }],
+            environments: [{ name: "default", defaultNamespace, variables: {} }],
             providers: [{ name: "foo" }],
             variables: {},
           },
@@ -940,7 +940,7 @@ describe("ActionRouter", () => {
             path,
             defaultEnvironment: "default",
             dotIgnoreFiles: [],
-            environments: [{ name: "default", variables: {} }],
+            environments: [{ name: "default", defaultNamespace, variables: {} }],
             providers: [{ name: "base" }, { name: "foo" }],
             variables: {},
           },
@@ -1005,7 +1005,7 @@ describe("ActionRouter", () => {
             path,
             defaultEnvironment: "default",
             dotIgnoreFiles: [],
-            environments: [{ name: "default", variables: {} }],
+            environments: [{ name: "default", defaultNamespace, variables: {} }],
             providers: [
               { name: "base" },
               // The order here matters, to verify that the dependency ordering works
@@ -1074,7 +1074,7 @@ describe("ActionRouter", () => {
               path,
               defaultEnvironment: "default",
               dotIgnoreFiles: [],
-              environments: [{ name: "default", variables: {} }],
+              environments: [{ name: "default", defaultNamespace, variables: {} }],
               providers: [
                 { name: "base" },
                 // The order here matters, since we use that as a "tie-breaker"
@@ -1131,7 +1131,7 @@ describe("ActionRouter", () => {
             path,
             defaultEnvironment: "default",
             dotIgnoreFiles: [],
-            environments: [{ name: "default", variables: {} }],
+            environments: [{ name: "default", defaultNamespace, variables: {} }],
             providers: [{ name: "base" }, { name: "foo" }],
             variables: {},
           },
@@ -1155,7 +1155,7 @@ describe("ActionRouter", () => {
         path,
         defaultEnvironment: "default",
         dotIgnoreFiles: [],
-        environments: [{ name: "default", variables: {} }],
+        environments: [{ name: "default", defaultNamespace, variables: {} }],
         providers: [{ name: "base" }, { name: "foo" }],
         variables: {},
       }
@@ -1297,7 +1297,7 @@ describe("ActionRouter", () => {
             path,
             defaultEnvironment: "default",
             dotIgnoreFiles: [],
-            environments: [{ name: "default", variables: {} }],
+            environments: [{ name: "default", defaultNamespace, variables: {} }],
             providers: [{ name: "base-a" }, { name: "base-b" }, { name: "foo" }],
             variables: {},
           },
@@ -1389,7 +1389,7 @@ describe("ActionRouter", () => {
           path,
           defaultEnvironment: "default",
           dotIgnoreFiles: [],
-          environments: [{ name: "default", variables: {} }],
+          environments: [{ name: "default", defaultNamespace, variables: {} }],
           providers: [{ name: "foo" }],
           variables: {},
         },

--- a/garden-service/test/unit/src/commands/get/get-outputs.ts
+++ b/garden-service/test/unit/src/commands/get/get-outputs.ts
@@ -10,7 +10,7 @@ import { expect } from "chai"
 import tmp from "tmp-promise"
 import { withDefaultGlobalOpts, TestGarden } from "../../../../helpers"
 import { GetOutputsCommand } from "../../../../../src/commands/get/get-outputs"
-import { ProjectConfig } from "../../../../../src/config/project"
+import { ProjectConfig, defaultNamespace } from "../../../../../src/config/project"
 import { DEFAULT_API_VERSION } from "../../../../../src/constants"
 import { createGardenPlugin } from "../../../../../src/types/plugin/plugin"
 import { exec } from "../../../../../src/util/util"
@@ -31,7 +31,7 @@ describe("GetOutputsCommand", () => {
       path: tmpDir.path,
       defaultEnvironment: "default",
       dotIgnoreFiles: [],
-      environments: [{ name: "default", variables: {} }],
+      environments: [{ name: "default", defaultNamespace, variables: {} }],
       providers: [{ name: "test" }],
       variables: {},
     }

--- a/garden-service/test/unit/src/commands/get/get-status.ts
+++ b/garden-service/test/unit/src/commands/get/get-status.ts
@@ -9,7 +9,7 @@
 import tmp from "tmp-promise"
 import execa from "execa"
 
-import { ProjectConfig } from "../../../../../src/config/project"
+import { ProjectConfig, defaultNamespace } from "../../../../../src/config/project"
 import { DEFAULT_API_VERSION } from "../../../../../src/constants"
 import { createGardenPlugin } from "../../../../../src/types/plugin/plugin"
 import { joi } from "../../../../../src/config/common"
@@ -37,7 +37,7 @@ describe("GetStatusCommand", () => {
       path: tmpDir.path,
       defaultEnvironment: "default",
       dotIgnoreFiles: [],
-      environments: [{ name: "default", variables: {} }],
+      environments: [{ name: "default", defaultNamespace, variables: {} }],
       providers: [{ name: "test" }],
       variables: {},
     }

--- a/garden-service/test/unit/src/commands/run/workflow.ts
+++ b/garden-service/test/unit/src/commands/run/workflow.ts
@@ -15,7 +15,7 @@ import { RunWorkflowCommand } from "../../../../../src/commands/run/workflow"
 import { createGardenPlugin } from "../../../../../src/types/plugin/plugin"
 import { joi } from "../../../../../src/config/common"
 import { RunTaskParams } from "../../../../../src/types/plugin/task/runTask"
-import { ProjectConfig } from "../../../../../src/config/project"
+import { ProjectConfig, defaultNamespace } from "../../../../../src/config/project"
 import { join } from "path"
 import { remove, readFile, pathExists } from "fs-extra"
 import { defaultDotIgnoreFiles } from "../../../../../src/util/fs"
@@ -249,7 +249,7 @@ describe("RunWorkflowCommand", () => {
       path: tmpDir.path,
       defaultEnvironment: "default",
       dotIgnoreFiles: [],
-      environments: [{ name: "default", variables: {} }],
+      environments: [{ name: "default", defaultNamespace, variables: {} }],
       providers: [{ name: "test" }],
       variables: {},
     }
@@ -338,7 +338,7 @@ describe("RunWorkflowCommand", () => {
       path: garden.projectRoot,
       defaultEnvironment: "default",
       dotIgnoreFiles: defaultDotIgnoreFiles,
-      environments: [{ name: "default", variables: {} }],
+      environments: [{ name: "default", defaultNamespace, variables: {} }],
       providers: [{ name: "test" }],
       variables: {},
     }

--- a/garden-service/test/unit/src/commands/tools.ts
+++ b/garden-service/test/unit/src/commands/tools.ts
@@ -26,6 +26,7 @@ import { LogLevel } from "../../../../src/logger/log-node"
 import { dedent } from "../../../../src/util/string"
 import { LogEntry } from "../../../../src/logger/log-entry"
 import { makeDummyGarden } from "../../../../src/cli/cli"
+import { defaultNamespace } from "../../../../src/config/project"
 
 describe("ToolsCommand", () => {
   let tmpDir: TempDirectory
@@ -100,7 +101,7 @@ describe("ToolsCommand", () => {
         path: tmpDir.path,
         defaultEnvironment: "default",
         dotIgnoreFiles: [],
-        environments: [{ name: "default", variables: {} }],
+        environments: [{ name: "default", defaultNamespace, variables: {} }],
         providers: [{ name: "test-a" }],
         variables: {},
       },

--- a/garden-service/test/unit/src/commands/util.ts
+++ b/garden-service/test/unit/src/commands/util.ts
@@ -14,6 +14,7 @@ import { DEFAULT_API_VERSION, GARDEN_GLOBAL_PATH } from "../../../../src/constan
 import { createGardenPlugin } from "../../../../src/types/plugin/plugin"
 import { pick } from "lodash"
 import { join } from "path"
+import { defaultNamespace } from "../../../../src/config/project"
 
 describe("FetchToolsCommand", () => {
   let tmpDir: TempDirectory
@@ -55,7 +56,7 @@ describe("FetchToolsCommand", () => {
         path: tmpDir.path,
         defaultEnvironment: "default",
         dotIgnoreFiles: [],
-        environments: [{ name: "default", variables: {} }],
+        environments: [{ name: "default", defaultNamespace, variables: {} }],
         providers: [{ name: "test" }],
         variables: {},
       },
@@ -98,7 +99,7 @@ describe("FetchToolsCommand", () => {
         path: tmpDir.path,
         defaultEnvironment: "default",
         dotIgnoreFiles: [],
-        environments: [{ name: "default", variables: {} }],
+        environments: [{ name: "default", defaultNamespace, variables: {} }],
         providers: [],
         variables: {},
       },

--- a/garden-service/test/unit/src/config/project.ts
+++ b/garden-service/test/unit/src/config/project.ts
@@ -17,6 +17,7 @@ import {
   defaultVarfilePath,
   defaultEnvVarfilePath,
   parseEnvironment,
+  defaultNamespace,
 } from "../../../../src/config/project"
 import { DEFAULT_API_VERSION } from "../../../../src/constants"
 import { expectError } from "../../../helpers"
@@ -24,6 +25,7 @@ import { defaultDotIgnoreFiles } from "../../../../src/util/fs"
 import { realpath, writeFile } from "fs-extra"
 import { dedent } from "../../../../src/util/string"
 import { resolve } from "path"
+import stripAnsi from "strip-ansi"
 
 describe("resolveProjectConfig", () => {
   it("should pass through a canonical project config", async () => {
@@ -34,7 +36,7 @@ describe("resolveProjectConfig", () => {
       path: "/tmp/foo",
       defaultEnvironment: "default",
       dotIgnoreFiles: defaultDotIgnoreFiles,
-      environments: [{ name: "default", variables: {} }],
+      environments: [{ name: "default", defaultNamespace, variables: {} }],
       outputs: [],
       providers: [{ name: "some-provider" }],
       variables: {},
@@ -45,7 +47,7 @@ describe("resolveProjectConfig", () => {
       environments: [
         {
           name: "default",
-          namespacing: "optional",
+          defaultNamespace,
           production: false,
           providers: [],
           variables: {},
@@ -91,6 +93,7 @@ describe("resolveProjectConfig", () => {
       environments: [
         {
           name: "default",
+          defaultNamespace,
           variables: {
             envVar: "${local.env.TEST_ENV_VAR}",
           },
@@ -115,7 +118,7 @@ describe("resolveProjectConfig", () => {
       environments: [
         {
           name: "default",
-          namespacing: "optional",
+          defaultNamespace,
           production: false,
           providers: [],
           variables: {
@@ -150,6 +153,7 @@ describe("resolveProjectConfig", () => {
       environments: [
         {
           name: "default",
+          defaultNamespace,
           variables: {
             envVar: "foo",
           },
@@ -177,7 +181,7 @@ describe("resolveProjectConfig", () => {
       environments: [
         {
           name: "default",
-          namespacing: "optional",
+          defaultNamespace,
           production: false,
           providers: [],
           variables: {
@@ -262,6 +266,7 @@ describe("resolveProjectConfig", () => {
       environments: [
         {
           name: "default",
+          defaultNamespace,
           variables: {
             envVar: "foo",
           },
@@ -288,7 +293,7 @@ describe("resolveProjectConfig", () => {
       environments: [
         {
           name: "default",
-          namespacing: "optional",
+          defaultNamespace,
           production: false,
           providers: [],
           variables: {
@@ -325,6 +330,7 @@ describe("resolveProjectConfig", () => {
       environments: [
         {
           name: "default",
+          defaultNamespace,
           providers: [
             {
               name: "provider-b",
@@ -351,7 +357,7 @@ describe("resolveProjectConfig", () => {
       environments: [
         {
           name: "default",
-          namespacing: "optional",
+          defaultNamespace,
           providers: [],
           production: false,
           variables: {
@@ -399,7 +405,7 @@ describe("pickEnvironment", () => {
       path: "/tmp/foo",
       defaultEnvironment: "default",
       dotIgnoreFiles: defaultDotIgnoreFiles,
-      environments: [{ name: "default", variables: {} }],
+      environments: [{ name: "default", defaultNamespace, variables: {} }],
       providers: [],
       variables: {},
     }
@@ -415,14 +421,14 @@ describe("pickEnvironment", () => {
       path: "/tmp/foo",
       defaultEnvironment: "default",
       dotIgnoreFiles: defaultDotIgnoreFiles,
-      environments: [{ name: "default", variables: {} }],
+      environments: [{ name: "default", defaultNamespace, variables: {} }],
       providers: [],
       variables: {},
     }
 
     expect(await pickEnvironment(config, "default")).to.eql({
       environmentName: "default",
-      namespace: undefined,
+      namespace: "default",
       providers: [{ name: "exec" }, { name: "container" }],
       production: false,
       variables: {},
@@ -437,7 +443,7 @@ describe("pickEnvironment", () => {
       path: "/tmp/foo",
       defaultEnvironment: "default",
       dotIgnoreFiles: defaultDotIgnoreFiles,
-      environments: [{ name: "default", variables: {} }],
+      environments: [{ name: "default", defaultNamespace, variables: {} }],
       providers: [
         { name: "container", newKey: "foo" },
         { name: "my-provider", a: "a" },
@@ -449,7 +455,7 @@ describe("pickEnvironment", () => {
 
     expect(await pickEnvironment(config, "default")).to.eql({
       environmentName: "default",
-      namespace: undefined,
+      namespace: "default",
       providers: [{ name: "exec" }, { name: "container", newKey: "foo" }, { name: "my-provider", a: "c", b: "b" }],
       production: false,
       variables: {},
@@ -464,7 +470,7 @@ describe("pickEnvironment", () => {
       path: "/tmp/foo",
       defaultEnvironment: "default",
       dotIgnoreFiles: defaultDotIgnoreFiles,
-      environments: [{ name: "default", variables: {} }],
+      environments: [{ name: "default", defaultNamespace, variables: {} }],
       providers: [
         { name: "container", newKey: "foo" },
         { name: "my-provider", a: "a" },
@@ -476,7 +482,7 @@ describe("pickEnvironment", () => {
 
     expect(await pickEnvironment(config, "default")).to.eql({
       environmentName: "default",
-      namespace: undefined,
+      namespace: "default",
       providers: [{ name: "exec" }, { name: "container", newKey: "foo" }, { name: "my-provider", b: "b" }],
       production: false,
       variables: {},
@@ -494,6 +500,7 @@ describe("pickEnvironment", () => {
       environments: [
         {
           name: "default",
+          defaultNamespace,
           variables: {
             b: "env value B",
             c: "env value C",
@@ -552,6 +559,7 @@ describe("pickEnvironment", () => {
       environments: [
         {
           name: "default",
+          defaultNamespace,
           variables: {
             b: "B",
             c: "c",
@@ -591,6 +599,7 @@ describe("pickEnvironment", () => {
       environments: [
         {
           name: "default",
+          defaultNamespace,
           variables: {},
         },
       ],
@@ -630,6 +639,7 @@ describe("pickEnvironment", () => {
       environments: [
         {
           name: "default",
+          defaultNamespace,
           variables: {
             b: "B",
             c: "c",
@@ -670,6 +680,7 @@ describe("pickEnvironment", () => {
       environments: [
         {
           name: "default",
+          defaultNamespace,
           varfile: "foo.env",
           variables: {},
         },
@@ -719,6 +730,7 @@ describe("pickEnvironment", () => {
       environments: [
         {
           name: "default",
+          defaultNamespace,
           // Precedence 2/4
           variables: {
             c: "C",
@@ -756,6 +768,7 @@ describe("pickEnvironment", () => {
       environments: [
         {
           name: "default",
+          defaultNamespace,
           variables: {},
         },
       ],
@@ -781,6 +794,7 @@ describe("pickEnvironment", () => {
       environments: [
         {
           name: "default",
+          defaultNamespace,
           varfile: "foo.env",
           variables: {},
         },
@@ -795,7 +809,7 @@ describe("pickEnvironment", () => {
     )
   })
 
-  it("should set environment namespace if specified", async () => {
+  it("should set environment namespace if specified and defaultNamespace=null", async () => {
     const config: ProjectConfig = {
       apiVersion: DEFAULT_API_VERSION,
       kind: "Project",
@@ -803,7 +817,7 @@ describe("pickEnvironment", () => {
       path: "/tmp/foo",
       defaultEnvironment: "default",
       dotIgnoreFiles: defaultDotIgnoreFiles,
-      environments: [{ name: "default", variables: {} }],
+      environments: [{ name: "default", defaultNamespace, variables: {} }],
       providers: [],
       variables: {},
     }
@@ -817,7 +831,7 @@ describe("pickEnvironment", () => {
     })
   })
 
-  it("should set defaultNamespace if set and no explicit namespace is specified", async () => {
+  it("should use explicit namespace if specified and there is a default", async () => {
     const config: ProjectConfig = {
       apiVersion: DEFAULT_API_VERSION,
       kind: "Project",
@@ -825,36 +839,36 @@ describe("pickEnvironment", () => {
       path: "/tmp/foo",
       defaultEnvironment: "default",
       dotIgnoreFiles: defaultDotIgnoreFiles,
-      environments: [{ name: "default", defaultNamespace: "default-ns", variables: {} }],
+      environments: [{ name: "default", defaultNamespace, variables: {} }],
+      providers: [],
+      variables: {},
+    }
+
+    expect(await pickEnvironment(config, "foo.default")).to.eql({
+      environmentName: "default",
+      namespace: "foo",
+      providers: [{ name: "exec" }, { name: "container" }],
+      production: false,
+      variables: {},
+    })
+  })
+
+  it("should use defaultNamespace if set and no explicit namespace is specified", async () => {
+    const config: ProjectConfig = {
+      apiVersion: DEFAULT_API_VERSION,
+      kind: "Project",
+      name: "my-project",
+      path: "/tmp/foo",
+      defaultEnvironment: "default",
+      dotIgnoreFiles: defaultDotIgnoreFiles,
+      environments: [{ name: "default", defaultNamespace, variables: {} }],
       providers: [],
       variables: {},
     }
 
     expect(await pickEnvironment(config, "default")).to.eql({
       environmentName: "default",
-      namespace: "default-ns",
-      providers: [{ name: "exec" }, { name: "container" }],
-      production: false,
-      variables: {},
-    })
-  })
-
-  it("should use explicit namespace if specified, if defaultNamespace is set", async () => {
-    const config: ProjectConfig = {
-      apiVersion: DEFAULT_API_VERSION,
-      kind: "Project",
-      name: "my-project",
-      path: "/tmp/foo",
-      defaultEnvironment: "default",
-      dotIgnoreFiles: defaultDotIgnoreFiles,
-      environments: [{ name: "default", defaultNamespace: "default-ns", variables: {} }],
-      providers: [],
-      variables: {},
-    }
-
-    expect(await pickEnvironment(config, "foo.default")).to.eql({
-      environmentName: "default",
-      namespace: "foo",
+      namespace: "default",
       providers: [{ name: "exec" }, { name: "container" }],
       production: false,
       variables: {},
@@ -869,7 +883,7 @@ describe("pickEnvironment", () => {
       path: "/tmp/foo",
       defaultEnvironment: "default",
       dotIgnoreFiles: defaultDotIgnoreFiles,
-      environments: [{ name: "default", variables: {} }],
+      environments: [{ name: "default", defaultNamespace, variables: {} }],
       providers: [],
       variables: {},
     }
@@ -883,7 +897,7 @@ describe("pickEnvironment", () => {
     )
   })
 
-  it("should throw if environment requires namespace but none is specified and no defaultNamespace set", async () => {
+  it("should throw if environment requires namespace but none is specified and defaultNamespace=null", async () => {
     const config: ProjectConfig = {
       apiVersion: DEFAULT_API_VERSION,
       kind: "Project",
@@ -891,7 +905,7 @@ describe("pickEnvironment", () => {
       path: "/tmp/foo",
       defaultEnvironment: "default",
       dotIgnoreFiles: defaultDotIgnoreFiles,
-      environments: [{ name: "default", namespacing: "required", variables: {} }],
+      environments: [{ name: "default", defaultNamespace: null, variables: {} }],
       providers: [],
       variables: {},
     }
@@ -899,30 +913,8 @@ describe("pickEnvironment", () => {
     await expectError(
       () => pickEnvironment(config, "default"),
       (err) =>
-        expect(err.message).to.equal(
-          "Environment default requires a namespace, but none was specified and no defaultNamespace is configured."
-        )
-    )
-  })
-
-  it("should throw if environment doesn't allow namespacing but one is specified", async () => {
-    const config: ProjectConfig = {
-      apiVersion: DEFAULT_API_VERSION,
-      kind: "Project",
-      name: "my-project",
-      path: "/tmp/foo",
-      defaultEnvironment: "default",
-      dotIgnoreFiles: defaultDotIgnoreFiles,
-      environments: [{ name: "default", namespacing: "disabled", variables: {} }],
-      providers: [],
-      variables: {},
-    }
-
-    await expectError(
-      () => pickEnvironment(config, "foo.default"),
-      (err) =>
-        expect(err.message).to.equal(
-          "Environment default does not allow namespacing, but namespace 'foo' was specified."
+        expect(stripAnsi(err.message)).to.equal(
+          "Environment default has defaultNamespace set to null, and no explicit namespace was specified. Please either set a defaultNamespace or explicitly set a namespace at runtime (e.g. --env=some-namespace.default)."
         )
     )
   })

--- a/garden-service/test/unit/src/outputs.ts
+++ b/garden-service/test/unit/src/outputs.ts
@@ -12,7 +12,7 @@ import { resolveProjectOutputs } from "../../../src/outputs"
 import { expect } from "chai"
 import { realpath } from "fs-extra"
 import { createGardenPlugin } from "../../../src/types/plugin/plugin"
-import { ProjectConfig } from "../../../src/config/project"
+import { ProjectConfig, defaultNamespace } from "../../../src/config/project"
 import { DEFAULT_API_VERSION } from "../../../src/constants"
 import { exec } from "../../../src/util/util"
 import { ServiceState } from "../../../src/types/service"
@@ -34,7 +34,7 @@ describe("resolveProjectOutputs", () => {
       path: tmpPath,
       defaultEnvironment: "default",
       dotIgnoreFiles: [],
-      environments: [{ name: "default", variables: {} }],
+      environments: [{ name: "default", defaultNamespace, variables: {} }],
       providers: [{ name: "test" }],
       variables: {},
     }

--- a/garden-service/test/unit/src/tasks/deploy.ts
+++ b/garden-service/test/unit/src/tasks/deploy.ts
@@ -9,7 +9,7 @@
 import tmp from "tmp-promise"
 import execa from "execa"
 
-import { ProjectConfig } from "../../../../src/config/project"
+import { ProjectConfig, defaultNamespace } from "../../../../src/config/project"
 import { DEFAULT_API_VERSION } from "../../../../src/constants"
 import { Garden } from "../../../../src/garden"
 import { ConfigGraph } from "../../../../src/config-graph"
@@ -40,7 +40,7 @@ describe("DeployTask", () => {
       path: tmpDir.path,
       defaultEnvironment: "default",
       dotIgnoreFiles: [],
-      environments: [{ name: "default", variables: {} }],
+      environments: [{ name: "default", defaultNamespace, variables: {} }],
       providers: [{ name: "test" }],
       variables: {},
     }

--- a/garden-service/test/unit/src/tasks/get-service-status.ts
+++ b/garden-service/test/unit/src/tasks/get-service-status.ts
@@ -9,7 +9,7 @@
 import tmp from "tmp-promise"
 import execa from "execa"
 
-import { ProjectConfig } from "../../../../src/config/project"
+import { ProjectConfig, defaultNamespace } from "../../../../src/config/project"
 import { DEFAULT_API_VERSION } from "../../../../src/constants"
 import { createGardenPlugin } from "../../../../src/types/plugin/plugin"
 import { joi } from "../../../../src/config/common"
@@ -36,7 +36,7 @@ describe("GetServiceStatusTask", () => {
       path: tmpDir.path,
       defaultEnvironment: "default",
       dotIgnoreFiles: [],
-      environments: [{ name: "default", variables: {} }],
+      environments: [{ name: "default", defaultNamespace, variables: {} }],
       providers: [{ name: "test" }],
       variables: {},
     }

--- a/garden-service/test/unit/src/tasks/resolve-provider.ts
+++ b/garden-service/test/unit/src/tasks/resolve-provider.ts
@@ -18,6 +18,7 @@ import { pathExists, writeFile, remove } from "fs-extra"
 import { join } from "path"
 import { serialize } from "v8"
 import moment from "moment"
+import { defaultNamespace } from "../../../../src/config/project"
 
 describe("ResolveProviderTask", () => {
   let tmpDir: TempDirectory
@@ -46,7 +47,7 @@ describe("ResolveProviderTask", () => {
         path: tmpDir.path,
         defaultEnvironment: "default",
         dotIgnoreFiles: [],
-        environments: [{ name: "default", variables: {} }],
+        environments: [{ name: "default", defaultNamespace, variables: {} }],
         providers: [{ name: "test-plugin" }],
         variables: {},
       },

--- a/garden-service/test/unit/src/tasks/task.ts
+++ b/garden-service/test/unit/src/tasks/task.ts
@@ -9,7 +9,7 @@
 import tmp from "tmp-promise"
 import { expect } from "chai"
 import { TestGarden } from "../../../helpers"
-import { ProjectConfig } from "../../../../src/config/project"
+import { ProjectConfig, defaultNamespace } from "../../../../src/config/project"
 import { DEFAULT_API_VERSION } from "../../../../src/constants"
 import execa from "execa"
 import { createGardenPlugin } from "../../../../src/types/plugin/plugin"
@@ -35,7 +35,7 @@ describe("TaskTask", () => {
       path: tmpDir.path,
       defaultEnvironment: "default",
       dotIgnoreFiles: [],
-      environments: [{ name: "default", variables: {} }],
+      environments: [{ name: "default", defaultNamespace, variables: {} }],
       providers: [{ name: "test" }],
       variables: {},
     }


### PR DESCRIPTION
We now always require a namespace for all environments, and make the
default simply "default". You can override the default namespace with
`environments[].defaultNamespace` as before.

This reduces code branching significantly, especially in the enterprise
UI, and simplifies our configuration as well.

BREAKING CHANGE:

The default namespace in the `kubernetes` provider is now
`<project name>-<environment namespace>` (previously it was just the
project name). Users need to override this to `"${project.name}"` if
they would like to revert to the previous default.
