### PR TITLE
feat(template): allow integer keys in templates to reference array items

### DIFF
--- a/garden-service/src/config/config-context.ts
+++ b/garden-service/src/config/config-context.ts
@@ -109,7 +109,7 @@ export abstract class ConfigContext {
       nestedNodePath = nodePath.concat(lookupPath)
       const stackEntry = nestedNodePath.join(".")
 
-      if (nextKey.startsWith("_")) {
+      if (typeof nextKey === "string" && nextKey.startsWith("_")) {
         value = undefined
       } else {
         value = value instanceof Map ? value.get(nextKey) : value[nextKey]

--- a/garden-service/src/template-string-parser.pegjs
+++ b/garden-service/src/template-string-parser.pegjs
@@ -215,6 +215,7 @@ IdentifierName "identifier"
   = head:IdentifierStart tail:IdentifierPart* {
       return head + tail.join("")
     }
+  / Integer
 
 IdentifierStart
   = UnicodeLetter
@@ -312,7 +313,10 @@ ExponentIndicator
   = "e"i
 
 SignedInteger
-  = [+-]? DecimalDigit+
+  = [+-]? Integer
+
+Integer
+  = DecimalDigit+
 
 HexIntegerLiteral
   = "0x"i digits:$HexDigit+ {

--- a/garden-service/test/unit/src/template-string.ts
+++ b/garden-service/test/unit/src/template-string.ts
@@ -485,6 +485,16 @@ describe("resolveTemplateString", async () => {
     expect(res).to.equal(true)
   })
 
+  it("should handle numeric indices on arrays", () => {
+    const res = resolveTemplateString("${foo.1}", new TestContext({ foo: [false, true] }))
+    expect(res).to.equal(true)
+  })
+
+  it("should resolve keys on objects in arrays", () => {
+    const res = resolveTemplateString("${foo.1.bar}", new TestContext({ foo: [{}, { bar: true }] }))
+    expect(res).to.equal(true)
+  })
+
   it("should correctly propagate errors from nested contexts", async () => {
     await expectError(
       () => resolveTemplateString("${nested.missing}", new TestContext({ nested: new TestContext({}) })),


### PR DESCRIPTION
**What this PR does / why we need it**:

Came across this while experimenting with step outputs. We had a
limitation where integer keys were not handled properly, so we could
not retrieve values from arrays in template strings. This simple fix
addresses that.
