### PR TITLE
feat(template): support nested expressions, maps and numeric keys

### DIFF
--- a/docs/guides/variables-and-templating.md
+++ b/docs/guides/variables-and-templating.md
@@ -6,7 +6,7 @@ This guide introduces the templating capabilities available in Garden configurat
 
 String configuration values in `garden.yml` can be templated to inject variables, information about the user's environment, references to other modules/services and more.
 
-The syntax for templated strings is `${some.key}`. The key is looked up from the context available when resolving the string. The context depends on which top-level key the configuration value belongs to (`project` or `module`).
+The basic syntax for templated strings is `${some.key}`. The key is looked up from the context available when resolving the string. The context depends on which top-level key the configuration value belongs to (`project` or `module`).
 
 For example, for one service you might want to reference something from another module and expose it as an environment variable:
 
@@ -95,6 +95,39 @@ services:
   replicas: ${var.default-replicas * 2}
   ...
 ```
+
+### Nested lookups and maps
+
+In addition to dot-notation for key lookups, we also support bracketed lookups, e.g. `${some["key"]}` and `${some-array[0]}`.
+
+This style offer nested template resolution, which is quite powerful, because you can use the output of one expression to choose a key in a parent expression.
+
+For example, you can declare a mapping variable for your project, and look up values by another variable such as the current environment name. To illustrate, here's an excerpt from a project config with a mapping variable:
+
+```yaml
+kind: Project
+...
+variables:
+  - replicas:
+      dev: 1
+      prod: 3
+  ...
+```
+
+And here that variable is used in a module:
+
+```yaml
+kind: Module
+type: container
+...
+services:
+  replicas: ${var.replicas["${environment.name}"]}
+  ...
+```
+
+When the nested expression is a simple key lookup like above, you can also just use the nested key directly, e.g. `${var.replicas[environment.name]}`.
+
+You can even use one variable to index another variable, e.g. `${var.a[var.b]}`.
 
 ### Optional values
 

--- a/garden-service/src/config/config-context.ts
+++ b/garden-service/src/config/config-context.ts
@@ -22,6 +22,7 @@ import { getProviderUrl, getModuleTypeUrl } from "../docs/common"
 import { Module } from "../types/module"
 import { ModuleConfig } from "./module"
 import { ModuleVersion } from "../vcs/vcs"
+import { isPrimitive } from "util"
 
 export type ContextKey = string[]
 
@@ -109,8 +110,15 @@ export abstract class ConfigContext {
       nestedNodePath = nodePath.concat(lookupPath)
       const stackEntry = nestedNodePath.join(".")
 
-      if (nextKey.startsWith("_")) {
+      if (typeof nextKey === "string" && nextKey.startsWith("_")) {
         value = undefined
+      } else if (isPrimitive(value)) {
+        throw new ConfigurationError(`Attempted to look up key ${JSON.stringify(nextKey)} on a ${typeof value}.`, {
+          value,
+          nodePath,
+          fullPath,
+          opts,
+        })
       } else {
         value = value instanceof Map ? value.get(nextKey) : value[nextKey]
       }

--- a/garden-service/src/template-string.ts
+++ b/garden-service/src/template-string.ts
@@ -11,7 +11,7 @@ import { deepMap } from "./util/util"
 import { GardenBaseError, ConfigurationError } from "./exceptions"
 import { ConfigContext, ContextResolveOpts, ScanContext, ContextResolveOutput } from "./config/config-context"
 import { difference, flatten, uniq, isPlainObject, isNumber } from "lodash"
-import { Primitive, StringMap } from "./config/common"
+import { Primitive, StringMap, isPrimitive } from "./config/common"
 import { profile } from "./util/profiling"
 import { dedent, deline } from "./util/string"
 
@@ -66,6 +66,7 @@ export function resolveTemplateString(string: string, context: ConfigContext, op
       TemplateStringError,
       allowUndefined: opts.allowUndefined,
       optionalSuffix: "}?",
+      isPrimitive,
     })
 
     const outputs: ResolvedClause[] = parsed.map((p: any) => {

--- a/garden-service/test/unit/src/config/config-context.ts
+++ b/garden-service/test/unit/src/config/config-context.ts
@@ -317,8 +317,8 @@ describe("ProjectConfigContext", () => {
     expectError(
       () => c.resolve({ key: ["local", "env", key], nodePath: [], opts: {} }),
       (err) =>
-        expect(stripAnsi(err.message)).to.equal(
-          "Could not find key fiaogsyecgbsjyawecygaewbxrbxajyrgew under local.env."
+        expect(stripAnsi(err.message)).to.match(
+          /Could not find key fiaogsyecgbsjyawecygaewbxrbxajyrgew under local.env. Available keys: /
         )
     )
   })
@@ -424,7 +424,10 @@ describe("ModuleConfigContext", () => {
     it("should throw when resolving a secret with a missing key", async () => {
       await expectError(
         () => c.resolve({ key: ["secrets", "missingSecret"], nodePath: [], opts: {} }),
-        (err) => expect(stripAnsi(err.message)).to.equal("Could not find key missingSecret under secrets.")
+        (err) =>
+          expect(stripAnsi(err.message)).to.equal(
+            "Could not find key missingSecret under secrets. Available keys: someSecret."
+          )
       )
     })
   })
@@ -439,7 +442,10 @@ describe("ModuleConfigContext", () => {
     it("should throw if resolving missing runtime key with allowPartial=false", async () => {
       await expectError(
         () => c.resolve({ key: ["runtime", "some", "key"], nodePath: [], opts: {} }),
-        (err) => expect(stripAnsi(err.message)).to.equal("Could not find key some under runtime.")
+        (err) =>
+          expect(stripAnsi(err.message)).to.equal(
+            "Could not find key some under runtime. Available keys: services and tasks."
+          )
       )
     })
 
@@ -550,7 +556,9 @@ describe("ModuleConfigContext", () => {
             opts: {},
           }),
         (err) =>
-          expect(stripAnsi(err.message)).to.equal("Could not find key boo under runtime.services.service-b.outputs.")
+          expect(stripAnsi(err.message)).to.equal(
+            "Could not find key boo under runtime.services.service-b.outputs. Available keys: foo."
+          )
       )
     })
   })
@@ -610,7 +618,10 @@ describe("WorkflowConfigContext", () => {
     it("should throw when resolving a secret with a missing key", async () => {
       await expectError(
         () => c.resolve({ key: ["secrets", "missingSecret"], nodePath: [], opts: {} }),
-        (err) => expect(stripAnsi(err.message)).to.equal("Could not find key missingSecret under secrets.")
+        (err) =>
+          expect(stripAnsi(err.message)).to.equal(
+            "Could not find key missingSecret under secrets. Available keys: someSecret."
+          )
       )
     })
   })
@@ -682,7 +693,10 @@ describe("WorkflowStepConfigContext", () => {
     })
     expectError(
       () => c.resolve({ key: ["steps", "step-foo", "log"], nodePath: [], opts: {} }),
-      (err) => expect(stripAnsi(err.message)).to.equal("Could not find key step-foo under steps.")
+      (err) =>
+        expect(stripAnsi(err.message)).to.equal(
+          "Could not find key step-foo under steps. Available keys: step-1 and step-2."
+        )
     )
   })
 

--- a/garden-service/test/unit/src/garden.ts
+++ b/garden-service/test/unit/src/garden.ts
@@ -1459,7 +1459,7 @@ describe("Garden", () => {
         (err) => {
           expect(err.message).to.equal("Failed resolving one or more providers:\n" + "- test")
           expect(stripAnsi(err.detail.messages[0])).to.equal(
-            "- test: Invalid template string ${bla.ble}: Could not find key bla."
+            "- test: Invalid template string ${bla.ble}: Could not find key bla. Available keys: environment, local, project, providers, secrets, steps, var and variables."
           )
         }
       )

--- a/garden-service/test/unit/src/template-string.ts
+++ b/garden-service/test/unit/src/template-string.ts
@@ -433,7 +433,10 @@ describe("resolveTemplateString", async () => {
   it("should throw when using comparison operators on missing keys", async () => {
     return expectError(
       () => resolveTemplateString("${a >= b}", new TestContext({ a: 123 })),
-      (err) => expect(stripAnsi(err.message)).to.equal("Invalid template string ${a >= b}: Could not find key b.")
+      (err) =>
+        expect(stripAnsi(err.message)).to.equal(
+          "Invalid template string ${a >= b}: Could not find key b. Available keys: a."
+        )
     )
   })
 
@@ -568,20 +571,24 @@ describe("resolveTemplateString", async () => {
 
   it("should correctly propagate errors from nested contexts", async () => {
     await expectError(
-      () => resolveTemplateString("${nested.missing}", new TestContext({ nested: new TestContext({}) })),
+      () =>
+        resolveTemplateString(
+          "${nested.missing}",
+          new TestContext({ nested: new TestContext({ foo: 123, bar: 456, baz: 789 }) })
+        ),
       (err) =>
         expect(stripAnsi(err.message)).to.equal(
-          "Invalid template string ${nested.missing}: Could not find key missing under nested."
+          "Invalid template string ${nested.missing}: Could not find key missing under nested. Available keys: bar, baz and foo."
         )
     )
   })
 
   it("should correctly propagate errors from nested objects", async () => {
     await expectError(
-      () => resolveTemplateString("${nested.missing}", new TestContext({ nested: {} })),
+      () => resolveTemplateString("${nested.missing}", new TestContext({ nested: { foo: 123, bar: 456 } })),
       (err) =>
         expect(stripAnsi(err.message)).to.equal(
-          "Invalid template string ${nested.missing}: Could not find key missing under nested."
+          "Invalid template string ${nested.missing}: Could not find key missing under nested. Available keys: bar and foo."
         )
     )
   })


### PR DESCRIPTION
This greatly expands the power of our template strings. I'll copy the
added docs here for details:

### Nested lookups and maps

In addition to dot-notation for key lookups, we also support bracketed
lookups, e.g. `${some["key"]}` and `${some-array[0]}`.

This style offer nested template resolution, which is quite powerful,
because you can use the output of one expression to choose a key in a
parent expression.

For example, you can declare a mapping variable for your project, and
look up values by another variable such as the current environment name.
To illustrate, here's an excerpt from a project config with a mapping
variable:

```yaml
kind: Project
...
variables:
  - replicas:
      dev: 1
      prod: 3
  ...
```

And here that variable is used in a module:

```yaml
kind: Module
type: container
...
services:
  replicas: ${var.replicas["${environment.name}"]}
  ...
```

When the nested expression is a simple key lookup like above, you can
also just use the nested key directly, e.g.
`${var.replicas[environment.name]}`.

You can even use one variable to index another variable, e.g.
`${var.a[var.b]}`.

**Which issue(s) this PR fixes**:

Fixes #
