### PR TITLE
fix(enterprise): wait for event stream to flush

### DIFF
--- a/garden-service/src/cli/cli.ts
+++ b/garden-service/src/cli/cli.ts
@@ -396,6 +396,8 @@ export class GardenCli {
         }
       } while (result.restartRequired)
 
+      await bufferedEventStream.close()
+
       // We attach the action result to cli context so that we can process it in the parse method
       cliContext.details.result = result
     }

--- a/garden-service/test/unit/src/platform/buffered-event-stream.ts
+++ b/garden-service/test/unit/src/platform/buffered-event-stream.ts
@@ -22,9 +22,11 @@ describe("BufferedEventStream", () => {
 
     bufferedEventStream["flushEvents"] = (events: StreamEvent[]) => {
       flushedEvents.push(...events)
+      return Promise.resolve()
     }
     bufferedEventStream["flushLogEntries"] = (logEntries: LogEntryEvent[]) => {
       flushedLogEntries.push(...logEntries)
+      return Promise.resolve()
     }
 
     const eventBus = new EventBus()
@@ -49,9 +51,11 @@ describe("BufferedEventStream", () => {
 
     bufferedEventStream["flushEvents"] = (events: StreamEvent[]) => {
       flushedEvents.push(...events)
+      return Promise.resolve()
     }
     bufferedEventStream["flushLogEntries"] = (logEntries: LogEntryEvent[]) => {
       flushedLogEntries.push(...logEntries)
+      return Promise.resolve()
     }
 
     const oldEventBus = new EventBus()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

We now wait for `BufferedEventStream` to finish flushing any buffered events and log entries before exiting a command.