### PR TITLE
feat(config): allow environment[].variables to reference top-level vars

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -65,7 +65,8 @@ environments:
     varfile:
 
     # A key/value map of variables that modules can reference when using this environment. These take precedence over
-    # variables defined in the top-level `variables` field.
+    # variables defined in the top-level `variables` field, but may also reference the top-level variables in template
+    # strings.
     variables: {}
 
 # A list of providers that should be used for this project, and their configuration. Please refer to individual
@@ -330,7 +331,7 @@ environments:
 
 [environments](#environments) > variables
 
-A key/value map of variables that modules can reference when using this environment. These take precedence over variables defined in the top-level `variables` field.
+A key/value map of variables that modules can reference when using this environment. These take precedence over variables defined in the top-level `variables` field, but may also reference the top-level variables in template strings.
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |

--- a/docs/reference/template-strings.md
+++ b/docs/reference/template-strings.md
@@ -11,7 +11,7 @@ Note that there are four sections below, since different configuration sections 
 
 ## Project configuration context
 
-The following keys are available in any template strings within project definitions in `garden.yml` config files, except the `name` field (which cannot be templated). See the [Provider](#provider-configuration-context) section below for additional keys available when configuring `providers`:
+The following keys are available in any template strings within project definitions in `garden.yml` config files, except the `name` field (which cannot be templated). See the [Environment](#environment-configuration-context) and [Provider](#provider-configuration-context) sections below for additional keys available when configuring `environments` and `providers`, respectively.
 
 
 ### `${local.*}`
@@ -101,6 +101,130 @@ Example:
 ```yaml
 my-variable: ${project.name}
 ```
+
+
+## Environment configuration context
+
+The following keys are available in template strings under the `environments` key in project configs. Additional keys are available for the `environments[].providers` field, see the [Provider](#provider-configuration-context) section below for those.
+
+
+### `${local.*}`
+
+Context variables that are specific to the currently running environment/machine.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${local.artifactsPath}`
+
+The absolute path to the directory where exported artifacts from test and task runs are stored.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.artifactsPath}
+```
+
+### `${local.env.*}`
+
+A map of all local environment variables (see https://nodejs.org/api/process.html#process_process_env).
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${local.env.<env-var-name>}`
+
+The environment variable value.
+
+| Type     |
+| -------- |
+| `string` |
+
+### `${local.platform}`
+
+A string indicating the platform that the framework is running on (see https://nodejs.org/api/process.html#process_process_platform)
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.platform}
+```
+
+### `${local.username}`
+
+The current username (as resolved by https://github.com/sindresorhus/username)
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.username}
+```
+
+### `${project.*}`
+
+Information about the Garden project.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${project.name}`
+
+The name of the Garden project.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${project.name}
+```
+
+### `${variables.*}`
+
+A map of all variables defined in the project configuration.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${variables.<variable-name>}`
+
+| Type                                             |
+| ------------------------------------------------ |
+| `number | string | boolean | link | array[link]` |
+
+### `${var.*}`
+
+Alias for the variables field.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${var.<name>}`
+
+Number, string or boolean
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
 
 
 ## Provider configuration context
@@ -198,6 +322,36 @@ Example:
 my-variable: ${project.name}
 ```
 
+### `${variables.*}`
+
+A map of all variables defined in the project configuration, including environment-specific variables.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${variables.<variable-name>}`
+
+| Type                                             |
+| ------------------------------------------------ |
+| `number | string | boolean | link | array[link]` |
+
+### `${var.*}`
+
+Alias for the variables field.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${var.<name>}`
+
+Number, string or boolean
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
 ### `${environment.*}`
 
 Information about the environment that Garden is running against.
@@ -247,36 +401,6 @@ Example:
 ```yaml
 my-variable: ${environment.namespace}
 ```
-
-### `${variables.*}`
-
-A map of all variables defined in the project configuration.
-
-| Type     | Default |
-| -------- | ------- |
-| `object` | `{}`    |
-
-### `${variables.<variable-name>}`
-
-| Type                                             |
-| ------------------------------------------------ |
-| `number | string | boolean | link | array[link]` |
-
-### `${var.*}`
-
-Alias for the variables field.
-
-| Type     | Default |
-| -------- | ------- |
-| `object` | `{}`    |
-
-### `${var.<name>}`
-
-Number, string or boolean
-
-| Type                        |
-| --------------------------- |
-| `number | string | boolean` |
 
 ### `${providers.*}`
 
@@ -417,6 +541,36 @@ Example:
 my-variable: ${project.name}
 ```
 
+### `${variables.*}`
+
+A map of all variables defined in the project configuration, including environment-specific variables.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${variables.<variable-name>}`
+
+| Type                                             |
+| ------------------------------------------------ |
+| `number | string | boolean | link | array[link]` |
+
+### `${var.*}`
+
+Alias for the variables field.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${var.<name>}`
+
+Number, string or boolean
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
 ### `${environment.*}`
 
 Information about the environment that Garden is running against.
@@ -466,36 +620,6 @@ Example:
 ```yaml
 my-variable: ${environment.namespace}
 ```
-
-### `${variables.*}`
-
-A map of all variables defined in the project configuration.
-
-| Type     | Default |
-| -------- | ------- |
-| `object` | `{}`    |
-
-### `${variables.<variable-name>}`
-
-| Type                                             |
-| ------------------------------------------------ |
-| `number | string | boolean | link | array[link]` |
-
-### `${var.*}`
-
-Alias for the variables field.
-
-| Type     | Default |
-| -------- | ------- |
-| `object` | `{}`    |
-
-### `${var.<name>}`
-
-Number, string or boolean
-
-| Type                        |
-| --------------------------- |
-| `number | string | boolean` |
 
 ### `${providers.*}`
 
@@ -758,6 +882,36 @@ Example:
 my-variable: ${project.name}
 ```
 
+### `${variables.*}`
+
+A map of all variables defined in the project configuration, including environment-specific variables.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${variables.<variable-name>}`
+
+| Type                                             |
+| ------------------------------------------------ |
+| `number | string | boolean | link | array[link]` |
+
+### `${var.*}`
+
+Alias for the variables field.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${var.<name>}`
+
+Number, string or boolean
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
 ### `${environment.*}`
 
 Information about the environment that Garden is running against.
@@ -807,36 +961,6 @@ Example:
 ```yaml
 my-variable: ${environment.namespace}
 ```
-
-### `${variables.*}`
-
-A map of all variables defined in the project configuration.
-
-| Type     | Default |
-| -------- | ------- |
-| `object` | `{}`    |
-
-### `${variables.<variable-name>}`
-
-| Type                                             |
-| ------------------------------------------------ |
-| `number | string | boolean | link | array[link]` |
-
-### `${var.*}`
-
-Alias for the variables field.
-
-| Type     | Default |
-| -------- | ------- |
-| `object` | `{}`    |
-
-### `${var.<name>}`
-
-Number, string or boolean
-
-| Type                        |
-| --------------------------- |
-| `number | string | boolean` |
 
 ### `${providers.*}`
 
@@ -1096,6 +1220,36 @@ Example:
 my-variable: ${project.name}
 ```
 
+### `${variables.*}`
+
+A map of all variables defined in the project configuration, including environment-specific variables.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${variables.<variable-name>}`
+
+| Type                                             |
+| ------------------------------------------------ |
+| `number | string | boolean | link | array[link]` |
+
+### `${var.*}`
+
+Alias for the variables field.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${var.<name>}`
+
+Number, string or boolean
+
+| Type                        |
+| --------------------------- |
+| `number | string | boolean` |
+
 ### `${environment.*}`
 
 Information about the environment that Garden is running against.
@@ -1145,36 +1299,6 @@ Example:
 ```yaml
 my-variable: ${environment.namespace}
 ```
-
-### `${variables.*}`
-
-A map of all variables defined in the project configuration.
-
-| Type     | Default |
-| -------- | ------- |
-| `object` | `{}`    |
-
-### `${variables.<variable-name>}`
-
-| Type                                             |
-| ------------------------------------------------ |
-| `number | string | boolean | link | array[link]` |
-
-### `${var.*}`
-
-Alias for the variables field.
-
-| Type     | Default |
-| -------- | ------- |
-| `object` | `{}`    |
-
-### `${var.<name>}`
-
-Number, string or boolean
-
-| Type                        |
-| --------------------------- |
-| `number | string | boolean` |
 
 ### `${steps.*}`
 

--- a/garden-service/src/config/common.ts
+++ b/garden-service/src/config/common.ts
@@ -362,7 +362,7 @@ export const identifierRegex = /^(?![0-9]+$)(?!.*-$)(?!-)[a-z0-9-]{1,63}$/
 export const userIdentifierRegex = /^(?!garden)(?=.{1,63}$)[a-z][a-z0-9]*(-[a-z0-9]+)*$/
 export const envVarRegex = /^(?!garden)[a-z_][a-z0-9_\.]*$/i
 export const gitUrlRegex = /(?:git|ssh|https?|git@[-\w.]+):(\/\/)?(.*?)(\/?|\#[-\d\w._\/]+?)$/
-export const variableNameRegex = /[a-zA-Z][a-zA-Z0-9_\-]+/i
+export const variableNameRegex = /[a-zA-Z][a-zA-Z0-9_\-]*/i
 
 export const joiIdentifierDescription =
   "valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and dashes, must start with a letter, " +

--- a/garden-service/src/docs/template-strings.ts
+++ b/garden-service/src/docs/template-strings.ts
@@ -14,6 +14,7 @@ import {
   ProviderConfigContext,
   OutputConfigContext,
   WorkflowStepConfigContext,
+  EnvironmentConfigContext,
 } from "../config/config-context"
 import { readFileSync, writeFileSync } from "fs"
 import handlebars from "handlebars"
@@ -31,6 +32,10 @@ export function writeTemplateStringReferenceDocs(docsRoot: string) {
     schema: ProviderConfigContext.getSchema().required(),
   })
 
+  const environmentContext = renderTemplateStringReference({
+    schema: EnvironmentConfigContext.getSchema().required(),
+  })
+
   const moduleContext = renderTemplateStringReference({
     schema: ModuleConfigContext.getSchema().required(),
   })
@@ -45,7 +50,14 @@ export function writeTemplateStringReferenceDocs(docsRoot: string) {
 
   const templatePath = resolve(TEMPLATES_DIR, "template-strings.hbs")
   const template = handlebars.compile(readFileSync(templatePath).toString())
-  const markdown = template({ projectContext, providerContext, moduleContext, outputContext, workflowContext })
+  const markdown = template({
+    projectContext,
+    environmentContext,
+    providerContext,
+    moduleContext,
+    outputContext,
+    workflowContext,
+  })
 
   writeFileSync(outputPath, markdown)
 }

--- a/garden-service/src/garden.ts
+++ b/garden-service/src/garden.ts
@@ -302,10 +302,12 @@ export class Garden {
       environmentStr = defaultEnvironment
     }
 
-    const { environmentName, namespace, providers, variables, production } = await pickEnvironment(
+    const { environmentName, namespace, providers, variables, production } = await pickEnvironment({
       config,
-      environmentStr
-    )
+      envString: environmentStr,
+      artifactsPath,
+      username: _username,
+    })
 
     const buildDir = await BuildDir.factory(projectRoot, gardenDirPath)
     const workingCopyId = await getWorkingCopyId(gardenDirPath)

--- a/garden-service/src/garden.ts
+++ b/garden-service/src/garden.ts
@@ -303,7 +303,7 @@ export class Garden {
     }
 
     const { environmentName, namespace, providers, variables, production } = await pickEnvironment({
-      config,
+      projectConfig: config,
       envString: environmentStr,
       artifactsPath,
       username: _username,

--- a/garden-service/static/docs/templates/template-strings.hbs
+++ b/garden-service/static/docs/templates/template-strings.hbs
@@ -11,9 +11,15 @@ Note that there are four sections below, since different configuration sections 
 
 ## Project configuration context
 
-The following keys are available in any template strings within project definitions in `garden.yml` config files, except the `name` field (which cannot be templated). See the [Provider](#provider-configuration-context) section below for additional keys available when configuring `providers`:
+The following keys are available in any template strings within project definitions in `garden.yml` config files, except the `name` field (which cannot be templated). See the [Environment](#environment-configuration-context) and [Provider](#provider-configuration-context) sections below for additional keys available when configuring `environments` and `providers`, respectively.
 
 {{{projectContext}}}
+
+## Environment configuration context
+
+The following keys are available in template strings under the `environments` key in project configs. Additional keys are available for the `environments[].providers` field, see the [Provider](#provider-configuration-context) section below for those.
+
+{{{environmentContext}}}
 
 ## Provider configuration context
 

--- a/garden-service/test/unit/src/config/project.ts
+++ b/garden-service/test/unit/src/config/project.ts
@@ -49,8 +49,6 @@ describe("resolveProjectConfig", () => {
         {
           name: "default",
           defaultNamespace,
-          production: false,
-          providers: [],
           variables: {},
         },
       ],
@@ -120,8 +118,6 @@ describe("resolveProjectConfig", () => {
         {
           name: "default",
           defaultNamespace,
-          production: false,
-          providers: [],
           variables: {
             envVar: "${local.env.TEST_ENV_VAR}",
           },
@@ -183,8 +179,6 @@ describe("resolveProjectConfig", () => {
         {
           name: "default",
           defaultNamespace,
-          production: false,
-          providers: [],
           variables: {
             envVar: "foo",
           },
@@ -222,7 +216,6 @@ describe("resolveProjectConfig", () => {
         {
           name: "default",
           defaultNamespace,
-          production: false,
           variables: {
             envVar: "${var.foo}",
           },
@@ -234,7 +227,7 @@ describe("resolveProjectConfig", () => {
 
     const result = resolveProjectConfig(config, "/tmp", "some-user")
 
-    expect(result.environments).to.eql(config.environments)
+    expect(result.environments[0].variables).to.eql(config.environments[0].variables)
   })
 
   it("should set defaultEnvironment to first environment if not configured", async () => {
@@ -322,8 +315,6 @@ describe("resolveProjectConfig", () => {
         {
           name: "default",
           defaultNamespace,
-          production: false,
-          providers: [],
           variables: {
             envVar: "foo",
           },
@@ -386,8 +377,6 @@ describe("resolveProjectConfig", () => {
         {
           name: "default",
           defaultNamespace,
-          providers: [],
-          production: false,
           variables: {
             envVar: "bar",
           },
@@ -441,7 +430,10 @@ describe("pickEnvironment", () => {
       variables: {},
     }
 
-    await expectError(() => pickEnvironment({ config, envString: "foo", artifactsPath, username }), "parameter")
+    await expectError(
+      () => pickEnvironment({ projectConfig: config, envString: "foo", artifactsPath, username }),
+      "parameter"
+    )
   })
 
   it("should include fixed providers in output", async () => {
@@ -457,7 +449,7 @@ describe("pickEnvironment", () => {
       variables: {},
     }
 
-    expect(await pickEnvironment({ config, envString: "default", artifactsPath, username })).to.eql({
+    expect(await pickEnvironment({ projectConfig: config, envString: "default", artifactsPath, username })).to.eql({
       environmentName: "default",
       namespace: "default",
       providers: [{ name: "exec" }, { name: "container" }],
@@ -491,7 +483,7 @@ describe("pickEnvironment", () => {
       variables: {},
     }
 
-    expect(await pickEnvironment({ config, envString: "default", artifactsPath, username })).to.eql({
+    expect(await pickEnvironment({ projectConfig: config, envString: "default", artifactsPath, username })).to.eql({
       environmentName: "default",
       namespace: "default",
       providers: [
@@ -523,7 +515,7 @@ describe("pickEnvironment", () => {
       variables: {},
     }
 
-    expect(await pickEnvironment({ config, envString: "default", artifactsPath, username })).to.eql({
+    expect(await pickEnvironment({ projectConfig: config, envString: "default", artifactsPath, username })).to.eql({
       environmentName: "default",
       namespace: "default",
       providers: [{ name: "exec" }, { name: "container", newKey: "foo" }, { name: "my-provider", b: "b" }],
@@ -567,7 +559,7 @@ describe("pickEnvironment", () => {
       },
     }
 
-    const result = await pickEnvironment({ config, envString: "default", artifactsPath, username })
+    const result = await pickEnvironment({ projectConfig: config, envString: "default", artifactsPath, username })
 
     expect(result.variables).to.eql({
       a: "project value A",
@@ -613,7 +605,7 @@ describe("pickEnvironment", () => {
       variables: {},
     }
 
-    const result = await pickEnvironment({ config, envString: "default", artifactsPath, username })
+    const result = await pickEnvironment({ projectConfig: config, envString: "default", artifactsPath, username })
 
     expect(result.variables).to.eql({
       a: "a",
@@ -653,7 +645,7 @@ describe("pickEnvironment", () => {
       },
     }
 
-    const result = await pickEnvironment({ config, envString: "default", artifactsPath, username })
+    const result = await pickEnvironment({ projectConfig: config, envString: "default", artifactsPath, username })
 
     expect(result.variables).to.eql({
       a: "a",
@@ -694,7 +686,7 @@ describe("pickEnvironment", () => {
       variables: {},
     }
 
-    const result = await pickEnvironment({ config, envString: "default", artifactsPath, username })
+    const result = await pickEnvironment({ projectConfig: config, envString: "default", artifactsPath, username })
 
     expect(result.variables).to.eql({
       a: "a",
@@ -735,7 +727,7 @@ describe("pickEnvironment", () => {
       },
     }
 
-    const result = await pickEnvironment({ config, envString: "default", artifactsPath, username })
+    const result = await pickEnvironment({ projectConfig: config, envString: "default", artifactsPath, username })
 
     expect(result.variables).to.eql({
       a: "a",
@@ -757,7 +749,7 @@ describe("pickEnvironment", () => {
       variables: {},
     }
 
-    const result = await pickEnvironment({ config, envString: "default", artifactsPath, username })
+    const result = await pickEnvironment({ projectConfig: config, envString: "default", artifactsPath, username })
 
     expect(result.variables).to.eql({
       foo: username,
@@ -780,7 +772,7 @@ describe("pickEnvironment", () => {
       variables: {},
     }
 
-    await pickEnvironment({ config, envString: "default", artifactsPath, username })
+    await pickEnvironment({ projectConfig: config, envString: "default", artifactsPath, username })
   })
 
   it("should pass through template strings in the providers field on environments", async () => {
@@ -798,7 +790,7 @@ describe("pickEnvironment", () => {
       variables: {},
     }
 
-    const result = await pickEnvironment({ config, envString: "default", artifactsPath, username })
+    const result = await pickEnvironment({ projectConfig: config, envString: "default", artifactsPath, username })
 
     expect(keyBy(result.providers, "name")["my-provider"].a).to.equal("${var.missing}")
   })
@@ -816,7 +808,7 @@ describe("pickEnvironment", () => {
       variables: { foo: "value" },
     }
 
-    const result = await pickEnvironment({ config, envString: "default", artifactsPath, username })
+    const result = await pickEnvironment({ projectConfig: config, envString: "default", artifactsPath, username })
 
     expect(result.variables).to.eql({
       foo: "value",
@@ -868,7 +860,7 @@ describe("pickEnvironment", () => {
       },
     }
 
-    const result = await pickEnvironment({ config, envString: "default", artifactsPath, username })
+    const result = await pickEnvironment({ projectConfig: config, envString: "default", artifactsPath, username })
 
     expect(result.variables).to.eql({
       a: "a",
@@ -877,6 +869,36 @@ describe("pickEnvironment", () => {
       d: "D",
       e: "e",
     })
+  })
+
+  it("should validate the picked environment", async () => {
+    const config: ProjectConfig = {
+      apiVersion: DEFAULT_API_VERSION,
+      kind: "Project",
+      name: "my-project",
+      path: tmpPath,
+      defaultEnvironment: "default",
+      dotIgnoreFiles: defaultDotIgnoreFiles,
+      environments: [
+        {
+          name: "default",
+          defaultNamespace: "${var.foo}",
+          variables: {},
+        },
+      ],
+      providers: [],
+      variables: {
+        foo: 123,
+      },
+    }
+
+    await expectError(
+      () => pickEnvironment({ projectConfig: config, envString: "default", artifactsPath, username }),
+      (err) =>
+        expect(stripAnsi(err.message)).to.equal(
+          "Error validating environment default (/garden.yml): key .defaultNamespace must be a string"
+        )
+    )
   })
 
   it("should throw if project varfile is set to non-default and it doesn't exist", async () => {
@@ -900,7 +922,7 @@ describe("pickEnvironment", () => {
     }
 
     await expectError(
-      () => pickEnvironment({ config, envString: "default", artifactsPath, username }),
+      () => pickEnvironment({ projectConfig: config, envString: "default", artifactsPath, username }),
       (err) => expect(err.message).to.equal("Could not find varfile at path 'foo.env'")
     )
   })
@@ -926,7 +948,7 @@ describe("pickEnvironment", () => {
     }
 
     await expectError(
-      () => pickEnvironment({ config, envString: "default", artifactsPath, username }),
+      () => pickEnvironment({ projectConfig: config, envString: "default", artifactsPath, username }),
       (err) => expect(err.message).to.equal("Could not find varfile at path 'foo.env'")
     )
   })
@@ -944,7 +966,7 @@ describe("pickEnvironment", () => {
       variables: {},
     }
 
-    expect(await pickEnvironment({ config, envString: "foo.default", artifactsPath, username })).to.eql({
+    expect(await pickEnvironment({ projectConfig: config, envString: "foo.default", artifactsPath, username })).to.eql({
       environmentName: "default",
       namespace: "foo",
       providers: [{ name: "exec" }, { name: "container" }],
@@ -966,7 +988,7 @@ describe("pickEnvironment", () => {
       variables: {},
     }
 
-    expect(await pickEnvironment({ config, envString: "foo.default", artifactsPath, username })).to.eql({
+    expect(await pickEnvironment({ projectConfig: config, envString: "foo.default", artifactsPath, username })).to.eql({
       environmentName: "default",
       namespace: "foo",
       providers: [{ name: "exec" }, { name: "container" }],
@@ -988,7 +1010,7 @@ describe("pickEnvironment", () => {
       variables: {},
     }
 
-    expect(await pickEnvironment({ config, envString: "default", artifactsPath, username })).to.eql({
+    expect(await pickEnvironment({ projectConfig: config, envString: "default", artifactsPath, username })).to.eql({
       environmentName: "default",
       namespace: "default",
       providers: [{ name: "exec" }, { name: "container" }],
@@ -1011,7 +1033,7 @@ describe("pickEnvironment", () => {
     }
 
     await expectError(
-      () => pickEnvironment({ config, envString: "$.%", artifactsPath, username }),
+      () => pickEnvironment({ projectConfig: config, envString: "$.%", artifactsPath, username }),
       (err) =>
         expect(err.message).to.equal(
           "Invalid environment specified ($.%): must be a valid environment name or <namespace>.<environment>"
@@ -1033,7 +1055,7 @@ describe("pickEnvironment", () => {
     }
 
     await expectError(
-      () => pickEnvironment({ config, envString: "default", artifactsPath, username }),
+      () => pickEnvironment({ projectConfig: config, envString: "default", artifactsPath, username }),
       (err) =>
         expect(stripAnsi(err.message)).to.equal(
           "Environment default has defaultNamespace set to null, and no explicit namespace was specified. Please either set a defaultNamespace or explicitly set a namespace at runtime (e.g. --env=some-namespace.default)."


### PR DESCRIPTION
This makes it easier to keep your project config neat and concise, allowing for some deduplication when environment configs repeat a lot of variables.

Also fixes the issue where template strings were resolved in all
environments, instead of just the selected one.

Fixes #1814
