### PR TITLE
feat(exec): add script option to exec provider configuration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@
   * [`conftest-container`](./reference/providers/conftest-container.md)
   * [`conftest-kubernetes`](./reference/providers/conftest-kubernetes.md)
   * [`conftest`](./reference/providers/conftest.md)
+  * [`exec`](./reference/providers/exec.md)
   * [`hadolint`](./reference/providers/hadolint.md)
   * [`kubernetes`](./reference/providers/kubernetes.md)
   * [`local-kubernetes`](./reference/providers/local-kubernetes.md)

--- a/docs/reference/providers/README.md
+++ b/docs/reference/providers/README.md
@@ -9,6 +9,7 @@ title: Providers
 * [`conftest-container`](./conftest-container.md)
 * [`kubernetes`](./kubernetes.md)
 * [`conftest-kubernetes`](./conftest-kubernetes.md)
+* [`exec`](./exec.md)
 * [`hadolint`](./hadolint.md)
 * [`local-kubernetes`](./local-kubernetes.md)
 * [`maven-container`](./maven-container.md)

--- a/docs/reference/providers/exec.md
+++ b/docs/reference/providers/exec.md
@@ -1,0 +1,94 @@
+---
+title: "`exec` Provider"
+tocTitle: "`exec`"
+---
+
+# `exec` Provider
+
+## Description
+
+A simple provider that allows running arbitary scripts when initializing providers, and provides the exec
+module type.
+
+_Note: This provider is always loaded when running Garden. You only need to explicitly declare it in your provider
+configuration if you want to configure a script for it to run._
+
+Below is the full schema reference for the provider configuration. For an introduction to configuring a Garden project with providers, please look at our [configuration guide](../../guides/configuration-files.md).
+
+The reference is divided into two sections. The [first section](#complete-yaml-schema) contains the complete YAML schema, and the [second section](#configuration-keys) describes each schema key.
+
+## Complete YAML Schema
+
+The values in the schema below are the default values.
+
+```yaml
+providers:
+  - # The name of the provider plugin to use.
+    name:
+
+    # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
+    # disables the provider. To use a provider in all environments, omit this field.
+    environments:
+
+    # An optional script to run in the project root when initializing providers. This is handy for running an
+    # arbitrary
+    # script when initializing. For example, another provider might declare a dependency on this provider, to ensure
+    # this script runs before resolving that provider.
+    initScript:
+```
+## Configuration Keys
+
+### `providers[]`
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
+
+### `providers[].name`
+
+[providers](#providers) > name
+
+The name of the provider plugin to use.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | Yes      |
+
+Example:
+
+```yaml
+providers:
+  - name: "local-kubernetes"
+```
+
+### `providers[].environments[]`
+
+[providers](#providers) > environments
+
+If specified, this provider will only be used in the listed environments. Note that an empty array effectively disables the provider. To use a provider in all environments, omit this field.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
+Example:
+
+```yaml
+providers:
+  - environments:
+      - dev
+      - stage
+```
+
+### `providers[].initScript`
+
+[providers](#providers) > initScript
+
+An optional script to run in the project root when initializing providers. This is handy for running an arbitrary
+script when initializing. For example, another provider might declare a dependency on this provider, to ensure
+this script runs before resolving that provider.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+

--- a/garden-service/src/docs/generate.ts
+++ b/garden-service/src/docs/generate.ts
@@ -58,6 +58,7 @@ export async function writeConfigReferenceDocs(docsRoot: string) {
         { name: "conftest" },
         { name: "conftest-container" },
         { name: "conftest-kubernetes" },
+        { name: "exec" },
         { name: "hadolint" },
         { name: "kubernetes" },
         { name: "local-kubernetes" },
@@ -77,7 +78,7 @@ export async function writeConfigReferenceDocs(docsRoot: string) {
     const name = plugin.name
 
     // Currently nothing to document for these
-    if (name === "container" || name === "exec") {
+    if (name === "container") {
       continue
     }
 

--- a/garden-service/test/unit/src/actions.ts
+++ b/garden-service/test/unit/src/actions.ts
@@ -803,7 +803,7 @@ describe("ActionRouter", () => {
     it("should return all handlers for a type", async () => {
       const handlers = await actions["getActionHandlers"]("prepareEnvironment")
 
-      expect(Object.keys(handlers)).to.eql(["test-plugin", "test-plugin-b"])
+      expect(Object.keys(handlers)).to.eql(["exec", "test-plugin", "test-plugin-b"])
     })
   })
 


### PR DESCRIPTION
This allows projects to define arbitrary scripts to run on init.

This is handy for running arbitrary script when initializing.
For example, another provider might declare a dependency on this
provider, to ensure this script runs before resolving that provider.
