### PR TITLE
feat(enterprise): include log level when streaming

### DIFF
--- a/garden-service/src/enterprise/buffered-event-stream.ts
+++ b/garden-service/src/enterprise/buffered-event-stream.ts
@@ -12,6 +12,7 @@ import { LogEntryMetadata, LogEntry } from "../logger/log-entry"
 import { chainMessages } from "../logger/renderers"
 import { got } from "../util/http"
 import { makeAuthHeader } from "./auth"
+import { LogLevel } from "../logger/log-node"
 
 const workflowRunUid = process.env.GARDEN_WORKFLOW_RUN_UID || null
 
@@ -27,6 +28,7 @@ export interface LogEntryEvent {
   revision: number
   msg: string | string[]
   timestamp: Date
+  level: LogLevel
   data?: any
   section?: string
   metadata?: LogEntryMetadata
@@ -34,12 +36,12 @@ export interface LogEntryEvent {
 
 export function formatForEventStream(entry: LogEntry): LogEntryEvent {
   const { section, data } = entry.getMessageState()
-  const { key, revision } = entry
+  const { key, revision, level } = entry
   const parentKey = entry.parent ? entry.parent.key : null
   const metadata = entry.getMetadata()
   const msg = chainMessages(entry.getMessageStates() || [])
   const timestamp = new Date()
-  return { key, parentKey, revision, msg, data, metadata, section, timestamp }
+  return { key, parentKey, revision, msg, data, metadata, section, timestamp, level }
 }
 
 export const FLUSH_INTERVAL_MSEC = 1000


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

We now include the log level of streamed log entries sent from `BufferedEventSream`.
