### PR TITLE
docs: add supported github events

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1240,7 +1240,17 @@ workflowConfigs:
         # this trigger's environment, as defined in your project's environment configs.
         namespace:
 
-        # A list of GitHub events that should trigger this workflow.
+        # A list of [GitHub
+        # events](https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads) that should
+        # trigger this workflow.
+        #
+        # Supported events:
+        #
+        # `create`, `pull-request`, `pull-request-created`, `pull-request-updated`, `push`, `release`,
+        # `release-created`, `release-deleted`, `release-edited`, `release-prereleased`, `release-published`,
+        # `release-unpublished`
+        #
+        #
         events:
 
         # If specified, only run the workflow for branches matching one of these filters.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -986,7 +986,15 @@ triggers:
     # this trigger's environment, as defined in your project's environment configs.
     namespace:
 
-    # A list of GitHub events that should trigger this workflow.
+    # A list of [GitHub events](https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads)
+    # that should trigger this workflow.
+    #
+    # Supported events:
+    #
+    # `create`, `pull-request`, `pull-request-created`, `pull-request-updated`, `push`, `release`, `release-created`,
+    # `release-deleted`, `release-edited`, `release-prereleased`, `release-published`, `release-unpublished`
+    #
+    #
     events:
 
     # If specified, only run the workflow for branches matching one of these filters.
@@ -1249,7 +1257,13 @@ The namespace to use for the workflow when matched by this trigger. Follows the 
 
 [triggers](#triggers) > events
 
-A list of GitHub events that should trigger this workflow.
+A list of [GitHub events](https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads) that should trigger this workflow.
+
+Supported events:
+
+`create`, `pull-request`, `pull-request-created`, `pull-request-updated`, `push`, `release`, `release-created`, `release-deleted`, `release-edited`, `release-prereleased`, `release-published`, `release-unpublished`
+
+
 
 | Type            | Required |
 | --------------- | -------- |

--- a/garden-service/src/config/workflow.ts
+++ b/garden-service/src/config/workflow.ts
@@ -213,8 +213,13 @@ export interface TriggerSpec {
   ignoreTags?: string[]
 }
 
-export const triggerSchema = () =>
-  joi.object().keys({
+export const triggerSchema = () => {
+  const eventDescriptions = triggerEvents
+    .sort()
+    .map((event) => `\`${event}\``)
+    .join(", ")
+
+  return joi.object().keys({
     environment: joi.string().required().description(deline`
         The environment name (from your project configuration) to use for the workflow when matched by this trigger.
       `),
@@ -226,7 +231,16 @@ export const triggerSchema = () =>
       .array()
       .items(joi.string().valid(...triggerEvents))
       .unique()
-      .description("A list of GitHub events that should trigger this workflow."),
+      .description(
+        dedent`
+        A list of [GitHub events](https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads) that should trigger this workflow.
+
+        Supported events:
+
+        ${eventDescriptions}
+        \n
+        `
+      ),
     branches: joi
       .array()
       .items(joi.string())
@@ -248,6 +262,7 @@ export const triggerSchema = () =>
       .unique()
       .description("If specified, do not run the workflow for tags matching one of these filters."),
   })
+}
 
 export interface WorkflowConfigMap {
   [key: string]: WorkflowConfig


### PR DESCRIPTION
**What this PR does / why we need it**:

Documents the currently supported GitHub events that can be used as workflow triggers, as these currently aren't documented anywhere. We should probably do this automatically at some point.