### PR TITLE
Fix a couple of link issues using garden cli

### DIFF
--- a/docs/using-garden/using-the-cli.md
+++ b/docs/using-garden/using-the-cli.md
@@ -67,7 +67,7 @@ garden deploy my-service --watch  # or -w for short
 
 ### Deploying a service in hot-reload mode
 
-See the [Hot reload guide](../guides/hot-reload.md.md) for more information on how to configure and use hot reloading for rapid iteration on services.
+See the [Hot reload guide](../guides/hot-reload.md) for more information on how to configure and use hot reloading for rapid iteration on services.
 Enabling `--hot-reload` implicitly sets `--watch=true`.
 
 ```sh
@@ -238,7 +238,7 @@ garden dev --skip-tests
 
 ### Running garden dev with hot reloading enabled for all supported services
 
-See the [Hot reload guide](../guides/hot-reload.md.md) for more information on how to configure and use hot reloading for rapid iteration on services.
+See the [Hot reload guide](../guides/hot-reload.md) for more information on how to configure and use hot reloading for rapid iteration on services.
 
 ```sh
 garden dev --hot-reload=*
@@ -267,7 +267,7 @@ The dashboard gives you:
 ## Hot reloading
 
 For rapid iteration on a running service, you can use an advanced feature called _hot reloading_.
-See the [Hot reload guide](../guides/hot-reload.md.md) for details on how to configure and use that feature.
+See the [Hot reload guide](../guides/hot-reload.md) for details on how to configure and use that feature.
 
 ## Project outputs
 

--- a/docs/using-garden/using-the-cli.md
+++ b/docs/using-garden/using-the-cli.md
@@ -10,7 +10,7 @@ If you've not installed the CLI yet, please check out the [installation guide](.
 
 Most of the examples below assume that you've already defined a Garden project.
 
-The [garden dev](#garden-dev) command, as well as the [build](#building), [deploy](#services) and [test](#testing) commands (when run with the `--watch` flag) all start a web dashboard that you can open in a browser. See [the dashboard section](#the-dashboard) for more on that.
+The [garden dev](#garden-dev) command, as well as the [build](#building), [deploy](#services) and [test](#tests) commands (when run with the `--watch` flag) all start a web dashboard that you can open in a browser. See [the dashboard section](#the-dashboard) for more on that.
 
 {% hint style="warning" %}
 It is currently not advisable to run multiple dev, build, deploy or test commands in parallel, especially with `--watch`  because they may interfere with each other. It is fine, however, to run one of those and then run other commands to the side, such as `garden logs`. We plan on improving this in the future.
@@ -252,7 +252,7 @@ garden dev --hot-reload=my-service
 
 ## The dashboard
 
-The [garden dev](#garden-dev) command, as well as the [build](#building), [deploy](#services) and [test](#testing) commands when run with the `--watch` flag all start a web dashboard that you can open in a browser. See [the dashboard section](#the-dashboard) for more on that.
+The [garden dev](#garden-dev) command, as well as the [build](#building), [deploy](#services) and [test](#tests) commands when run with the `--watch` flag all start a web dashboard that you can open in a browser. See [the dashboard section](#the-dashboard) for more on that.
 
 The CLI will print a URL which you can copy or click (or Cmd/Ctrl-click, depending on your terminal). The dashboard stays open while the command is running.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a few dead links in the "Using the CLI" guide.