### PR TITLE
feat(core): throw workflow config errors on scan

### DIFF
--- a/garden-service/src/commands/run/workflow.ts
+++ b/garden-service/src/commands/run/workflow.ts
@@ -62,17 +62,14 @@ export class RunWorkflowCommand extends Command<Args, {}> {
     opts,
   }: CommandParams<Args, {}>): Promise<CommandResult<WorkflowRunOutput>> {
     const outerLog = log.placeholder()
-    // Partially resolve the workflow config, and prepare any configured files before continuing
-    const rawWorkflow = garden.getRawWorkflowConfig(args.workflow)
+    // Prepare any configured files before continuing
+    const workflow = garden.getWorkflowConfig(args.workflow)
     const templateContext = new WorkflowConfigContext(garden)
-    const files = resolveTemplateStrings(rawWorkflow.files || [], templateContext)
+    const files = resolveTemplateStrings(workflow.files || [], templateContext)
 
     // Write all the configured files for the workflow
     await Bluebird.map(files, (file) => writeWorkflowFile(garden, file))
 
-    // Fully resolve the config
-    // (aside from the step script and command fields, since they need to be resolved just-in-time)
-    const workflow = await garden.getWorkflowConfig(args.workflow)
     const steps = workflow.steps
     const allStepNames = steps.map((s, i) => getStepName(i, s.name))
 

--- a/garden-service/src/garden.ts
+++ b/garden-service/src/garden.ts
@@ -644,25 +644,16 @@ export class Garden {
     return keyBy(providers, "name")
   }
 
-  getRawWorkflowConfig(name: string) {
-    return this.getRawWorkflowConfigs([name])[0]
+  getWorkflowConfig(name: string): WorkflowConfig {
+    return this.getWorkflowConfigs([name])[0]
   }
 
-  getRawWorkflowConfigs(names?: string[]) {
+  getWorkflowConfigs(names?: string[]): WorkflowConfig[] {
     if (names) {
       return Object.values(pickKeys(this.workflowConfigs, names, "workflow"))
     } else {
       return Object.values(this.workflowConfigs)
     }
-  }
-
-  async getWorkflowConfig(name: string): Promise<WorkflowConfig> {
-    return (await this.getWorkflowConfigs([name]))[0]
-  }
-
-  async getWorkflowConfigs(names?: string[]): Promise<WorkflowConfig[]> {
-    const configs = this.getRawWorkflowConfigs(names)
-    return configs.map((config) => resolveWorkflowConfig(this, config))
   }
 
   /**
@@ -1033,8 +1024,9 @@ export class Garden {
   }
 
   /**
-   * Add a workflow config to the context after validating that its name doesn't conflict with
-   * previously added workflows.
+   * Add a workflow config to the context after validating that its name doesn't conflict with previously
+   * added workflows, and partially resolving it (i.e. without fully resolving step configs, which
+   * is done just-in-time before a given step is run).
    */
   private async addWorkflow(config: WorkflowConfig) {
     const key = config.name
@@ -1052,7 +1044,7 @@ export class Garden {
       })
     }
 
-    this.workflowConfigs[key] = config
+    this.workflowConfigs[key] = resolveWorkflowConfig(this, config)
   }
 
   /**

--- a/garden-service/test/data/test-project-invalid-workflow/garden.yml
+++ b/garden-service/test/data/test-project-invalid-workflow/garden.yml
@@ -1,0 +1,16 @@
+kind: Project
+name: test-project-invalid-workflow
+environments:
+  - name: local
+providers:
+  - name: test-plugin
+
+---
+
+kind: Workflow
+name: invalid
+steps:
+  - command: [test]
+triggers: # <--- should be an array, not a map
+  events: [push, pull-request]
+  environment: local

--- a/garden-service/test/unit/src/garden.ts
+++ b/garden-service/test/unit/src/garden.ts
@@ -2228,6 +2228,14 @@ describe("Garden", () => {
         (err) => expect(err.message).to.match(/Workflow test-workflow: missing/)
       )
     })
+
+    it("should throw an error if an invalid workflow config is present", async () => {
+      const garden = await makeTestGarden(join(dataDir, "test-project-invalid-workflow"))
+      await expectError(
+        () => garden.scanAndAddConfigs(),
+        (err) => expect(stripAnsi(err.message)).to.match(/key .triggers must be an array/)
+      )
+    })
   })
 
   describe("loadConfigs", () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

We now throw validation errors for invalid workflow configs immediately after scanning and adding workflow configs.

Now that partially resolving workflow configs (i.e. everything except step configs, which are resolved just-in-time before they're run) has become cheap, performing this validation at scan-time warns the user of invalid workflow configs earlier in development.

**Which issue(s) this PR fixes**:

Fixes #1931.