### PR TITLE
feat(enterprise): include env and ns in events

### DIFF
--- a/garden-service/src/cli/cli.ts
+++ b/garden-service/src/cli/cli.ts
@@ -337,12 +337,14 @@ export class GardenCli {
 
           if (garden.clientAuthToken && garden.enterpriseDomain && garden.projectId) {
             log.silly(`Connecting Garden instance to BufferedEventStream`)
-            bufferedEventStream.connect(
-              garden.events,
-              garden.clientAuthToken,
-              garden.enterpriseDomain,
-              garden.projectId
-            )
+            bufferedEventStream.connect({
+              eventBus: garden.events,
+              clientAuthToken: garden.clientAuthToken,
+              enterpriseDomain: garden.enterpriseDomain,
+              projectId: garden.projectId,
+              environmentName: garden.environmentName,
+              namespace: garden.namespace,
+            })
           } else {
             log.silly(`Skip connecting Garden instance to BufferedEventStream`)
             log.silly(`clientAuthToken present: ${!!garden.clientAuthToken}`)

--- a/garden-service/test/unit/src/platform/buffered-event-stream.ts
+++ b/garden-service/test/unit/src/platform/buffered-event-stream.ts
@@ -12,6 +12,15 @@ import { getLogger } from "../../../../src/logger/logger"
 import { EventBus } from "../../../../src/events"
 
 describe("BufferedEventStream", () => {
+  const getConnectionParams = (eventBus: EventBus) => ({
+    eventBus,
+    clientAuthToken: "dummy-client-token",
+    enterpriseDomain: "dummy-platform_url",
+    projectId: "myproject",
+    environmentName: "my-env",
+    namespace: "my-ns",
+  })
+
   it("should flush events and log entries emitted by a connected event emitter", async () => {
     const flushedEvents: StreamEvent[] = []
     const flushedLogEntries: LogEntryEvent[] = []
@@ -30,7 +39,7 @@ describe("BufferedEventStream", () => {
     }
 
     const eventBus = new EventBus()
-    bufferedEventStream.connect(eventBus, "dummy-client-token", "dummy-platform_url", "myproject")
+    bufferedEventStream.connect(getConnectionParams(eventBus))
 
     eventBus.emit("_test", {})
     log.root.events.emit("_test", {})
@@ -59,9 +68,9 @@ describe("BufferedEventStream", () => {
     }
 
     const oldEventBus = new EventBus()
-    bufferedEventStream.connect(oldEventBus, "dummy-client-token", "dummy-platform_url", "myproject")
+    bufferedEventStream.connect(getConnectionParams(oldEventBus))
     const newEventBus = new EventBus()
-    bufferedEventStream.connect(newEventBus, "dummy-client-token", "dummy-platform_url", "myproject")
+    bufferedEventStream.connect(getConnectionParams(newEventBus))
 
     log.root.events.emit("_test", {})
     oldEventBus.emit("_test", {})


### PR DESCRIPTION
**What this PR does / why we need it**:

We now include the current environment name and namespace in requests when streaming events to the platform.
