### PR TITLE
feat(k8s): allow mounting custom volumes/secrets in cluster builders

### DIFF
--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -54,6 +54,613 @@ providers:
       # performant, but we're opting to keep it optional until it's enabled by default in Docker.
       enableBuildKit: false
 
+      # A list of volumes that you'd like to attach to the in-cluster Docker deployment Pod. Note that you also need
+      # to specify corresponding mounts using the `volumeMounts` field, much like how you specify `volumes` and
+      # `containers[].volumeMounts` separately in a Kubernetes Pod spec. In fact, the schema for this field is
+      # precisely the same as on the `volumes` field on a Pod spec, and is passed directly to the Docker Deployment
+      # spec.
+      #
+      # Typical examples would be referencing a Kubernetes Secret, containing e.g. auth information for private
+      # package repositories, as well as cache volumes to accelerate image builds.
+      #
+      # **Important: Volumes declared here must must be available in the garden-system namespace.**
+      volumes: []
+        - # Represents a Persistent Disk resource in AWS.
+          #
+          # An AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as
+          # the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership
+          # management and SELinux relabeling.
+          awsElasticBlockStore:
+            # Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported
+            # by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if
+            # unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+            fsType:
+
+            # The partition in the volume that you want to mount. If omitted, the default is to mount by volume name.
+            # Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for
+            # /dev/sda is "0" (or you can leave the property empty).
+            partition:
+
+            # Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default
+            # is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+            readOnly:
+
+            # Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+            volumeID:
+
+          # AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+          azureDisk:
+            # Host Caching mode: None, Read Only, Read Write.
+            cachingMode:
+
+            # The Name of the data disk in the blob storage
+            diskName:
+
+            # The URI the data disk in the blob storage
+            diskURI:
+
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4",
+            # "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+            fsType:
+
+            # Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage
+            # account  Managed: azure managed data disk (only in managed availability set). defaults to shared
+            kind:
+
+            # Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            readOnly:
+
+          # AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+          azureFile:
+            # Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            readOnly:
+
+            # the name of secret that contains Azure Storage Account Name and Key
+            secretName:
+
+            # Share Name
+            shareName:
+
+          # Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support
+          # ownership management or SELinux relabeling.
+          cephfs:
+            # Required: Monitors is a collection of Ceph monitors More info:
+            # https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+            monitors:
+
+            # Optional: Used as the mounted root, rather than the full Ceph tree, default is /
+            path:
+
+            # Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            # More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+            readOnly:
+
+            # Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info:
+            # https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+            secretFile:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            secretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+            # Optional: User is the rados user name, default is admin More info:
+            # https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+            user:
+
+          # Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a
+          # container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership
+          # management and SELinux relabeling.
+          cinder:
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples:
+            # "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info:
+            # https://examples.k8s.io/mysql-cinder-pd/README.md
+            fsType:
+
+            # Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            # More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+            readOnly:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            secretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+            # volume id used to identify the volume in cinder. More info:
+            # https://examples.k8s.io/mysql-cinder-pd/README.md
+            volumeID:
+
+          # Adapts a ConfigMap into a volume.
+          #
+          # The contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in
+          # the Data field as the file names, unless the items element is populated with specific mappings of keys to
+          # paths. ConfigMap volumes support ownership management and SELinux relabeling.
+          configMap:
+            # Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to
+            # 0644. Directories within the path are not affected by this setting. This might be in conflict with other
+            # options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+            defaultMode:
+
+            # If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into
+            # the volume as a file whose name is the key and content is the value. If specified, the listed keys will
+            # be projected into the specified paths, and unlisted keys will not be present. If a key is specified
+            # which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths
+            # must be relative and may not contain the '..' path or start with '..'.
+            items:
+
+            # Name of the referent. More info:
+            # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+            name:
+
+            # Specify whether the ConfigMap or its keys must be defined
+            optional:
+
+          # Represents a source location of a volume to mount, managed by an external CSI driver
+          csi:
+            # Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct
+            # name as registered in the cluster.
+            driver:
+
+            # Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the
+            # associated CSI driver which will determine the default filesystem to apply.
+            fsType:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            nodePublishSecretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+            # Specifies a read-only configuration for the volume. Defaults to false (read/write).
+            readOnly:
+
+            # VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your
+            # driver's documentation for supported values.
+            volumeAttributes:
+
+          # DownwardAPIVolumeSource represents a volume containing downward API info. Downward API volumes support
+          # ownership management and SELinux relabeling.
+          downwardAPI:
+            # Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to
+            # 0644. Directories within the path are not affected by this setting. This might be in conflict with other
+            # options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+            defaultMode:
+
+            # Items is a list of downward API volume file
+            items:
+
+          # Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux
+          # relabeling.
+          emptyDir:
+            # What type of storage medium should back this directory. The default is "" which means to use the node's
+            # default medium. Must be an empty string (default) or Memory. More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+            medium:
+
+            sizeLimit:
+
+          # Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre
+          # Channel volumes support ownership management and SELinux relabeling.
+          fc:
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4",
+            # "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+            fsType:
+
+            # Optional: FC target lun number
+            lun:
+
+            # Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            readOnly:
+
+            # Optional: FC target worldwide names (WWNs)
+            targetWWNs:
+
+            # Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun
+            # must be set, but not both simultaneously.
+            wwids:
+
+          # FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+          flexVolume:
+            # Driver is the name of the driver to use for this volume.
+            driver:
+
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4",
+            # "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+            fsType:
+
+            # Optional: Extra command options if any.
+            options:
+
+            # Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            readOnly:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            secretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+          # Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID
+          # should be set. Flocker volumes do not support ownership management or SELinux relabeling.
+          flocker:
+            # Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as
+            # deprecated
+            datasetName:
+
+            # UUID of the dataset. This is unique identifier of a Flocker dataset
+            datasetUUID:
+
+          # Represents a Persistent Disk resource in Google Compute Engine.
+          #
+          # A GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone
+          # as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support
+          # ownership management and SELinux relabeling.
+          gcePersistentDisk:
+            # Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported
+            # by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if
+            # unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+            fsType:
+
+            # The partition in the volume that you want to mount. If omitted, the default is to mount by volume name.
+            # Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for
+            # /dev/sda is "0" (or you can leave the property empty). More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+            partition:
+
+            # Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+            pdName:
+
+            # ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+            readOnly:
+
+          # Represents a volume that is populated with the contents of a git repository. Git repo volumes do not
+          # support ownership management. Git repo volumes support SELinux relabeling.
+          #
+          # DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an
+          # InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.
+          gitRepo:
+            # Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory
+            # will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the
+            # subdirectory with the given name.
+            directory:
+
+            # Repository URL
+            repository:
+
+            # Commit hash for the specified revision.
+            revision:
+
+          # Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership
+          # management or SELinux relabeling.
+          glusterfs:
+            # EndpointsName is the endpoint name that details Glusterfs topology. More info:
+            # https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+            endpoints:
+
+            # Path is the Glusterfs volume path. More info:
+            # https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+            path:
+
+            # ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to
+            # false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+            readOnly:
+
+          # Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux
+          # relabeling.
+          hostPath:
+            # Path of the directory on the host. If the path is a symlink, it will follow the link to the real path.
+            # More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+            path:
+
+            # Type for HostPath Volume Defaults to "" More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+            type:
+
+          # Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support
+          # ownership management and SELinux relabeling.
+          iscsi:
+            # whether support iSCSI Discovery CHAP authentication
+            chapAuthDiscovery:
+
+            # whether support iSCSI Session CHAP authentication
+            chapAuthSession:
+
+            # Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported
+            # by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if
+            # unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+            fsType:
+
+            # Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI
+            # interface <target portal>:<volume name> will be created for the connection.
+            initiatorName:
+
+            # Target iSCSI Qualified Name.
+            iqn:
+
+            # iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+            iscsiInterface:
+
+            # iSCSI Target Lun number.
+            lun:
+
+            # iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default
+            # (typically TCP ports 860 and 3260).
+            portals:
+
+            # ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+            readOnly:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            secretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+            # iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default
+            # (typically TCP ports 860 and 3260).
+            targetPortal:
+
+          # Volume's name. Must be a DNS_LABEL and unique within the pod. More info:
+          # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+          name:
+
+          # Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management
+          # or SELinux relabeling.
+          nfs:
+            # Path that is exported by the NFS server. More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#nfs
+            path:
+
+            # ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false.
+            # More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+            readOnly:
+
+            # Server is the hostname or IP address of the NFS server. More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#nfs
+            server:
+
+          # PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the
+          # bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a
+          # wrapper around another type of volume that is owned by someone else (the system).
+          persistentVolumeClaim:
+            # ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+            # More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+            claimName:
+
+            # Will force the ReadOnly setting in VolumeMounts. Default false.
+            readOnly:
+
+          # Represents a Photon Controller persistent disk resource.
+          photonPersistentDisk:
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4",
+            # "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+            fsType:
+
+            # ID that identifies Photon Controller persistent disk
+            pdID:
+
+          # PortworxVolumeSource represents a Portworx volume resource.
+          portworxVolume:
+            # FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating
+            # system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+            fsType:
+
+            # Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            readOnly:
+
+            # VolumeID uniquely identifies a Portworx volume
+            volumeID:
+
+          # Represents a projected volume source
+          projected:
+            # Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the
+            # path are not affected by this setting. This might be in conflict with other options that affect the file
+            # mode, like fsGroup, and the result can be other mode bits set.
+            defaultMode:
+
+            # list of volume projections
+            sources:
+
+          # Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership
+          # management or SELinux relabeling.
+          quobyte:
+            # Group to map volume access to Default is no group
+            group:
+
+            # ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+            readOnly:
+
+            # Registry represents a single or multiple Quobyte Registry services specified as a string as host:port
+            # pair (multiple entries are separated with commas) which acts as the central registry for volumes
+            registry:
+
+            # Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes,
+            # value is set by the plugin
+            tenant:
+
+            # User to map volume access to Defaults to serivceaccount user
+            user:
+
+            # Volume is a string that references an already created Quobyte volume by name.
+            volume:
+
+          # Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership
+          # management and SELinux relabeling.
+          rbd:
+            # Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported
+            # by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if
+            # unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+            fsType:
+
+            # The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+            image:
+
+            # Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info:
+            # https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+            keyring:
+
+            # A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+            monitors:
+
+            # The rados pool name. Default is rbd. More info:
+            # https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+            pool:
+
+            # ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info:
+            # https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+            readOnly:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            secretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+            # The rados user name. Default is admin. More info:
+            # https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+            user:
+
+          # ScaleIOVolumeSource represents a persistent ScaleIO volume
+          scaleIO:
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4",
+            # "xfs", "ntfs". Default is "xfs".
+            fsType:
+
+            # The host address of the ScaleIO API Gateway.
+            gateway:
+
+            # The name of the ScaleIO Protection Domain for the configured storage.
+            protectionDomain:
+
+            # Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            readOnly:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            secretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+            # Flag to enable/disable SSL communication with Gateway, default false
+            sslEnabled:
+
+            # Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is
+            # ThinProvisioned.
+            storageMode:
+
+            # The ScaleIO Storage Pool associated with the protection domain.
+            storagePool:
+
+            # The name of the storage system as configured in ScaleIO.
+            system:
+
+            # The name of a volume already created in the ScaleIO system that is associated with this volume source.
+            volumeName:
+
+          # Adapts a Secret into a volume.
+          #
+          # The contents of the target Secret's Data field will be presented in a volume as files using the keys in
+          # the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.
+          secret:
+            # Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to
+            # 0644. Directories within the path are not affected by this setting. This might be in conflict with other
+            # options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+            defaultMode:
+
+            # If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into
+            # the volume as a file whose name is the key and content is the value. If specified, the listed keys will
+            # be projected into the specified paths, and unlisted keys will not be present. If a key is specified
+            # which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must
+            # be relative and may not contain the '..' path or start with '..'.
+            items:
+
+            # Specify whether the Secret or its keys must be defined
+            optional:
+
+            # Name of the secret in the pod's namespace to use. More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#secret
+            secretName:
+
+          # Represents a StorageOS persistent volume resource.
+          storageos:
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4",
+            # "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+            fsType:
+
+            # Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            readOnly:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            secretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+            # VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a
+            # namespace.
+            volumeName:
+
+            # VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then
+            # the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within
+            # StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to
+            # "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within
+            # StorageOS will be created.
+            volumeNamespace:
+
+          # Represents a vSphere volume resource.
+          vsphereVolume:
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4",
+            # "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+            fsType:
+
+            # Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+            storagePolicyID:
+
+            # Storage Policy Based Management (SPBM) profile name.
+            storagePolicyName:
+
+            # Path that identifies vSphere volume vmdk
+            volumePath:
+
+      # A list of volume mounts, referencing the volumes defined in the `volumes` field, specifying how and where to
+      # mount the volume in the Docker deployment container. The schema for this field is the same as on the
+      # `containers[].volumeMounts` field on a Pod spec.
+      volumeMounts: []
+        - # Path within the container at which the volume should be mounted.  Must not contain ':'.
+          mountPath:
+
+          # mountPropagation determines how mounts are propagated from the host to container and the other way around.
+          # When not set, MountPropagationNone is used. This field is beta in 1.10.
+          mountPropagation:
+
+          # This must match the Name of a Volume.
+          name:
+
+          # Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+          readOnly:
+
+          # Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's
+          # root).
+          subPath:
+
+          # Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to
+          # SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+          # Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+          subPathExpr:
+
     # Configuration options for the `kaniko` build mode.
     kaniko:
       # Change the kaniko image (repository/image:tag) to use when building in kaniko mode.
@@ -62,6 +669,613 @@ providers:
       # Specify extra flags to use when building the container image with kaniko. Flags set on container module take
       # precedence over these.
       extraFlags:
+
+      # A list of volumes that you'd like to attach to every Kaniko Pod during builds. Note that you also need to
+      # specify corresponding mounts using the `volumeMounts` field, much like how you specify `volumes` and
+      # `containers[].volumeMounts` separately in a Kubernetes Pod spec. In fact, the schema for this field is
+      # precisely the same as on the `volumes` field on a Pod spec, and is passed directly to the Kaniko Pods.
+      #
+      # Typical examples would be referencing a Kubernetes Secret, containing e.g. auth information for private
+      # package repositories, as well as shared cache volumes to accelerate image builds.
+      #
+      # **Important: Volumes declared here must support ReadWriteMany access, since multiple Kaniko Pods will run at
+      # the same time, and must also be available in the garden-system namespace.**
+      volumes: []
+        - # Represents a Persistent Disk resource in AWS.
+          #
+          # An AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as
+          # the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership
+          # management and SELinux relabeling.
+          awsElasticBlockStore:
+            # Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported
+            # by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if
+            # unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+            fsType:
+
+            # The partition in the volume that you want to mount. If omitted, the default is to mount by volume name.
+            # Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for
+            # /dev/sda is "0" (or you can leave the property empty).
+            partition:
+
+            # Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default
+            # is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+            readOnly:
+
+            # Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+            volumeID:
+
+          # AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+          azureDisk:
+            # Host Caching mode: None, Read Only, Read Write.
+            cachingMode:
+
+            # The Name of the data disk in the blob storage
+            diskName:
+
+            # The URI the data disk in the blob storage
+            diskURI:
+
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4",
+            # "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+            fsType:
+
+            # Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage
+            # account  Managed: azure managed data disk (only in managed availability set). defaults to shared
+            kind:
+
+            # Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            readOnly:
+
+          # AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+          azureFile:
+            # Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            readOnly:
+
+            # the name of secret that contains Azure Storage Account Name and Key
+            secretName:
+
+            # Share Name
+            shareName:
+
+          # Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support
+          # ownership management or SELinux relabeling.
+          cephfs:
+            # Required: Monitors is a collection of Ceph monitors More info:
+            # https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+            monitors:
+
+            # Optional: Used as the mounted root, rather than the full Ceph tree, default is /
+            path:
+
+            # Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            # More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+            readOnly:
+
+            # Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info:
+            # https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+            secretFile:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            secretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+            # Optional: User is the rados user name, default is admin More info:
+            # https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+            user:
+
+          # Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a
+          # container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership
+          # management and SELinux relabeling.
+          cinder:
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples:
+            # "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info:
+            # https://examples.k8s.io/mysql-cinder-pd/README.md
+            fsType:
+
+            # Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            # More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+            readOnly:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            secretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+            # volume id used to identify the volume in cinder. More info:
+            # https://examples.k8s.io/mysql-cinder-pd/README.md
+            volumeID:
+
+          # Adapts a ConfigMap into a volume.
+          #
+          # The contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in
+          # the Data field as the file names, unless the items element is populated with specific mappings of keys to
+          # paths. ConfigMap volumes support ownership management and SELinux relabeling.
+          configMap:
+            # Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to
+            # 0644. Directories within the path are not affected by this setting. This might be in conflict with other
+            # options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+            defaultMode:
+
+            # If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into
+            # the volume as a file whose name is the key and content is the value. If specified, the listed keys will
+            # be projected into the specified paths, and unlisted keys will not be present. If a key is specified
+            # which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths
+            # must be relative and may not contain the '..' path or start with '..'.
+            items:
+
+            # Name of the referent. More info:
+            # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+            name:
+
+            # Specify whether the ConfigMap or its keys must be defined
+            optional:
+
+          # Represents a source location of a volume to mount, managed by an external CSI driver
+          csi:
+            # Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct
+            # name as registered in the cluster.
+            driver:
+
+            # Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the
+            # associated CSI driver which will determine the default filesystem to apply.
+            fsType:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            nodePublishSecretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+            # Specifies a read-only configuration for the volume. Defaults to false (read/write).
+            readOnly:
+
+            # VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your
+            # driver's documentation for supported values.
+            volumeAttributes:
+
+          # DownwardAPIVolumeSource represents a volume containing downward API info. Downward API volumes support
+          # ownership management and SELinux relabeling.
+          downwardAPI:
+            # Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to
+            # 0644. Directories within the path are not affected by this setting. This might be in conflict with other
+            # options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+            defaultMode:
+
+            # Items is a list of downward API volume file
+            items:
+
+          # Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux
+          # relabeling.
+          emptyDir:
+            # What type of storage medium should back this directory. The default is "" which means to use the node's
+            # default medium. Must be an empty string (default) or Memory. More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+            medium:
+
+            sizeLimit:
+
+          # Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre
+          # Channel volumes support ownership management and SELinux relabeling.
+          fc:
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4",
+            # "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+            fsType:
+
+            # Optional: FC target lun number
+            lun:
+
+            # Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            readOnly:
+
+            # Optional: FC target worldwide names (WWNs)
+            targetWWNs:
+
+            # Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun
+            # must be set, but not both simultaneously.
+            wwids:
+
+          # FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+          flexVolume:
+            # Driver is the name of the driver to use for this volume.
+            driver:
+
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4",
+            # "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+            fsType:
+
+            # Optional: Extra command options if any.
+            options:
+
+            # Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            readOnly:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            secretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+          # Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID
+          # should be set. Flocker volumes do not support ownership management or SELinux relabeling.
+          flocker:
+            # Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as
+            # deprecated
+            datasetName:
+
+            # UUID of the dataset. This is unique identifier of a Flocker dataset
+            datasetUUID:
+
+          # Represents a Persistent Disk resource in Google Compute Engine.
+          #
+          # A GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone
+          # as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support
+          # ownership management and SELinux relabeling.
+          gcePersistentDisk:
+            # Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported
+            # by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if
+            # unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+            fsType:
+
+            # The partition in the volume that you want to mount. If omitted, the default is to mount by volume name.
+            # Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for
+            # /dev/sda is "0" (or you can leave the property empty). More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+            partition:
+
+            # Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+            pdName:
+
+            # ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+            readOnly:
+
+          # Represents a volume that is populated with the contents of a git repository. Git repo volumes do not
+          # support ownership management. Git repo volumes support SELinux relabeling.
+          #
+          # DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an
+          # InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.
+          gitRepo:
+            # Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory
+            # will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the
+            # subdirectory with the given name.
+            directory:
+
+            # Repository URL
+            repository:
+
+            # Commit hash for the specified revision.
+            revision:
+
+          # Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership
+          # management or SELinux relabeling.
+          glusterfs:
+            # EndpointsName is the endpoint name that details Glusterfs topology. More info:
+            # https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+            endpoints:
+
+            # Path is the Glusterfs volume path. More info:
+            # https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+            path:
+
+            # ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to
+            # false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+            readOnly:
+
+          # Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux
+          # relabeling.
+          hostPath:
+            # Path of the directory on the host. If the path is a symlink, it will follow the link to the real path.
+            # More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+            path:
+
+            # Type for HostPath Volume Defaults to "" More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+            type:
+
+          # Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support
+          # ownership management and SELinux relabeling.
+          iscsi:
+            # whether support iSCSI Discovery CHAP authentication
+            chapAuthDiscovery:
+
+            # whether support iSCSI Session CHAP authentication
+            chapAuthSession:
+
+            # Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported
+            # by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if
+            # unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+            fsType:
+
+            # Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI
+            # interface <target portal>:<volume name> will be created for the connection.
+            initiatorName:
+
+            # Target iSCSI Qualified Name.
+            iqn:
+
+            # iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+            iscsiInterface:
+
+            # iSCSI Target Lun number.
+            lun:
+
+            # iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default
+            # (typically TCP ports 860 and 3260).
+            portals:
+
+            # ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+            readOnly:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            secretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+            # iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default
+            # (typically TCP ports 860 and 3260).
+            targetPortal:
+
+          # Volume's name. Must be a DNS_LABEL and unique within the pod. More info:
+          # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+          name:
+
+          # Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management
+          # or SELinux relabeling.
+          nfs:
+            # Path that is exported by the NFS server. More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#nfs
+            path:
+
+            # ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false.
+            # More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+            readOnly:
+
+            # Server is the hostname or IP address of the NFS server. More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#nfs
+            server:
+
+          # PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the
+          # bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a
+          # wrapper around another type of volume that is owned by someone else (the system).
+          persistentVolumeClaim:
+            # ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+            # More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+            claimName:
+
+            # Will force the ReadOnly setting in VolumeMounts. Default false.
+            readOnly:
+
+          # Represents a Photon Controller persistent disk resource.
+          photonPersistentDisk:
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4",
+            # "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+            fsType:
+
+            # ID that identifies Photon Controller persistent disk
+            pdID:
+
+          # PortworxVolumeSource represents a Portworx volume resource.
+          portworxVolume:
+            # FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating
+            # system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+            fsType:
+
+            # Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            readOnly:
+
+            # VolumeID uniquely identifies a Portworx volume
+            volumeID:
+
+          # Represents a projected volume source
+          projected:
+            # Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the
+            # path are not affected by this setting. This might be in conflict with other options that affect the file
+            # mode, like fsGroup, and the result can be other mode bits set.
+            defaultMode:
+
+            # list of volume projections
+            sources:
+
+          # Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership
+          # management or SELinux relabeling.
+          quobyte:
+            # Group to map volume access to Default is no group
+            group:
+
+            # ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+            readOnly:
+
+            # Registry represents a single or multiple Quobyte Registry services specified as a string as host:port
+            # pair (multiple entries are separated with commas) which acts as the central registry for volumes
+            registry:
+
+            # Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes,
+            # value is set by the plugin
+            tenant:
+
+            # User to map volume access to Defaults to serivceaccount user
+            user:
+
+            # Volume is a string that references an already created Quobyte volume by name.
+            volume:
+
+          # Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership
+          # management and SELinux relabeling.
+          rbd:
+            # Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported
+            # by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if
+            # unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+            fsType:
+
+            # The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+            image:
+
+            # Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info:
+            # https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+            keyring:
+
+            # A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+            monitors:
+
+            # The rados pool name. Default is rbd. More info:
+            # https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+            pool:
+
+            # ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info:
+            # https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+            readOnly:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            secretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+            # The rados user name. Default is admin. More info:
+            # https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+            user:
+
+          # ScaleIOVolumeSource represents a persistent ScaleIO volume
+          scaleIO:
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4",
+            # "xfs", "ntfs". Default is "xfs".
+            fsType:
+
+            # The host address of the ScaleIO API Gateway.
+            gateway:
+
+            # The name of the ScaleIO Protection Domain for the configured storage.
+            protectionDomain:
+
+            # Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            readOnly:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            secretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+            # Flag to enable/disable SSL communication with Gateway, default false
+            sslEnabled:
+
+            # Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is
+            # ThinProvisioned.
+            storageMode:
+
+            # The ScaleIO Storage Pool associated with the protection domain.
+            storagePool:
+
+            # The name of the storage system as configured in ScaleIO.
+            system:
+
+            # The name of a volume already created in the ScaleIO system that is associated with this volume source.
+            volumeName:
+
+          # Adapts a Secret into a volume.
+          #
+          # The contents of the target Secret's Data field will be presented in a volume as files using the keys in
+          # the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.
+          secret:
+            # Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to
+            # 0644. Directories within the path are not affected by this setting. This might be in conflict with other
+            # options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+            defaultMode:
+
+            # If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into
+            # the volume as a file whose name is the key and content is the value. If specified, the listed keys will
+            # be projected into the specified paths, and unlisted keys will not be present. If a key is specified
+            # which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must
+            # be relative and may not contain the '..' path or start with '..'.
+            items:
+
+            # Specify whether the Secret or its keys must be defined
+            optional:
+
+            # Name of the secret in the pod's namespace to use. More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#secret
+            secretName:
+
+          # Represents a StorageOS persistent volume resource.
+          storageos:
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4",
+            # "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+            fsType:
+
+            # Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            readOnly:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            secretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+            # VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a
+            # namespace.
+            volumeName:
+
+            # VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then
+            # the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within
+            # StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to
+            # "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within
+            # StorageOS will be created.
+            volumeNamespace:
+
+          # Represents a vSphere volume resource.
+          vsphereVolume:
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4",
+            # "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+            fsType:
+
+            # Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+            storagePolicyID:
+
+            # Storage Policy Based Management (SPBM) profile name.
+            storagePolicyName:
+
+            # Path that identifies vSphere volume vmdk
+            volumePath:
+
+      # A list of volume mounts, referencing the volumes defined in the `volumes` field, specifying how and where to
+      # mount the volume in the Kaniko Pod container. The schema for this field is the same as on the
+      # `containers[].volumeMounts` field on a Pod spec, and is passed directly to the Kaniko Pod container spec.
+      volumeMounts: []
+        - # Path within the container at which the volume should be mounted.  Must not contain ':'.
+          mountPath:
+
+          # mountPropagation determines how mounts are propagated from the host to container and the other way around.
+          # When not set, MountPropagationNone is used. This field is beta in 1.10.
+          mountPropagation:
+
+          # This must match the Name of a Volume.
+          name:
+
+          # Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+          readOnly:
+
+          # Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's
+          # root).
+          subPath:
+
+          # Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to
+          # SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+          # Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+          subPathExpr:
 
     # A default hostname to use when no hostname is explicitly configured for a service.
     defaultHostname:
@@ -394,6 +1608,1691 @@ Enable [BuildKit](https://github.com/moby/buildkit) support. This should in most
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
+### `providers[].clusterDocker.volumes[]`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > volumes
+
+A list of volumes that you'd like to attach to the in-cluster Docker deployment Pod. Note that you also need to specify corresponding mounts using the `volumeMounts` field, much like how you specify `volumes` and `containers[].volumeMounts` separately in a Kubernetes Pod spec. In fact, the schema for this field is precisely the same as on the `volumes` field on a Pod spec, and is passed directly to the Docker Deployment spec.
+
+Typical examples would be referencing a Kubernetes Secret, containing e.g. auth information for private package repositories, as well as cache volumes to accelerate image builds.
+
+**Important: Volumes declared here must must be available in the garden-system namespace.**
+
+| Type                  | Default | Required |
+| --------------------- | ------- | -------- |
+| `array[customObject]` | `[]`    | No       |
+
+Example:
+
+```yaml
+providers:
+  - clusterDocker:
+      ...
+      volumes:
+        name: my-auth-secret
+        secret:
+          secretName: my-auth-secret
+```
+
+### `providers[].clusterDocker.volumes[].awsElasticBlockStore`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > awsElasticBlockStore
+
+Represents a Persistent Disk resource in AWS.
+
+An AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].awsElasticBlockStore.fsType`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [awsElasticBlockStore](#providersclusterdockervolumesawselasticblockstore) > fsType
+
+Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].awsElasticBlockStore.partition`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [awsElasticBlockStore](#providersclusterdockervolumesawselasticblockstore) > partition
+
+The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].clusterDocker.volumes[].awsElasticBlockStore.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [awsElasticBlockStore](#providersclusterdockervolumesawselasticblockstore) > readOnly
+
+Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].awsElasticBlockStore.volumeID`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [awsElasticBlockStore](#providersclusterdockervolumesawselasticblockstore) > volumeID
+
+Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].azureDisk`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > azureDisk
+
+AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].azureDisk.cachingMode`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [azureDisk](#providersclusterdockervolumesazuredisk) > cachingMode
+
+Host Caching mode: None, Read Only, Read Write.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].azureDisk.diskName`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [azureDisk](#providersclusterdockervolumesazuredisk) > diskName
+
+The Name of the data disk in the blob storage
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].azureDisk.diskURI`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [azureDisk](#providersclusterdockervolumesazuredisk) > diskURI
+
+The URI the data disk in the blob storage
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].azureDisk.fsType`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [azureDisk](#providersclusterdockervolumesazuredisk) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].azureDisk.kind`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [azureDisk](#providersclusterdockervolumesazuredisk) > kind
+
+Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].azureDisk.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [azureDisk](#providersclusterdockervolumesazuredisk) > readOnly
+
+Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].azureFile`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > azureFile
+
+AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].azureFile.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [azureFile](#providersclusterdockervolumesazurefile) > readOnly
+
+Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].azureFile.secretName`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [azureFile](#providersclusterdockervolumesazurefile) > secretName
+
+the name of secret that contains Azure Storage Account Name and Key
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].azureFile.shareName`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [azureFile](#providersclusterdockervolumesazurefile) > shareName
+
+Share Name
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].cephfs`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > cephfs
+
+Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].cephfs.monitors[]`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [cephfs](#providersclusterdockervolumescephfs) > monitors
+
+Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].clusterDocker.volumes[].cephfs.path`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [cephfs](#providersclusterdockervolumescephfs) > path
+
+Optional: Used as the mounted root, rather than the full Ceph tree, default is /
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].cephfs.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [cephfs](#providersclusterdockervolumescephfs) > readOnly
+
+Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].cephfs.secretFile`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [cephfs](#providersclusterdockervolumescephfs) > secretFile
+
+Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].cephfs.secretRef`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [cephfs](#providersclusterdockervolumescephfs) > secretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].cephfs.secretRef.name`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [cephfs](#providersclusterdockervolumescephfs) > [secretRef](#providersclusterdockervolumescephfssecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].cephfs.user`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [cephfs](#providersclusterdockervolumescephfs) > user
+
+Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].cinder`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > cinder
+
+Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].cinder.fsType`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [cinder](#providersclusterdockervolumescinder) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].cinder.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [cinder](#providersclusterdockervolumescinder) > readOnly
+
+Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].cinder.secretRef`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [cinder](#providersclusterdockervolumescinder) > secretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].cinder.secretRef.name`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [cinder](#providersclusterdockervolumescinder) > [secretRef](#providersclusterdockervolumescindersecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].cinder.volumeID`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [cinder](#providersclusterdockervolumescinder) > volumeID
+
+volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].configMap`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > configMap
+
+Adapts a ConfigMap into a volume.
+
+The contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].configMap.defaultMode`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [configMap](#providersclusterdockervolumesconfigmap) > defaultMode
+
+Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].clusterDocker.volumes[].configMap.items[]`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [configMap](#providersclusterdockervolumesconfigmap) > items
+
+If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].clusterDocker.volumes[].configMap.name`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [configMap](#providersclusterdockervolumesconfigmap) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].configMap.optional`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [configMap](#providersclusterdockervolumesconfigmap) > optional
+
+Specify whether the ConfigMap or its keys must be defined
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].csi`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > csi
+
+Represents a source location of a volume to mount, managed by an external CSI driver
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].csi.driver`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [csi](#providersclusterdockervolumescsi) > driver
+
+Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].csi.fsType`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [csi](#providersclusterdockervolumescsi) > fsType
+
+Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].csi.nodePublishSecretRef`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [csi](#providersclusterdockervolumescsi) > nodePublishSecretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].csi.nodePublishSecretRef.name`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [csi](#providersclusterdockervolumescsi) > [nodePublishSecretRef](#providersclusterdockervolumescsinodepublishsecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].csi.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [csi](#providersclusterdockervolumescsi) > readOnly
+
+Specifies a read-only configuration for the volume. Defaults to false (read/write).
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].csi.volumeAttributes`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [csi](#providersclusterdockervolumescsi) > volumeAttributes
+
+VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].downwardAPI`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > downwardAPI
+
+DownwardAPIVolumeSource represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].downwardAPI.defaultMode`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [downwardAPI](#providersclusterdockervolumesdownwardapi) > defaultMode
+
+Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].clusterDocker.volumes[].downwardAPI.items[]`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [downwardAPI](#providersclusterdockervolumesdownwardapi) > items
+
+Items is a list of downward API volume file
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].clusterDocker.volumes[].emptyDir`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > emptyDir
+
+Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].emptyDir.medium`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [emptyDir](#providersclusterdockervolumesemptydir) > medium
+
+What type of storage medium should back this directory. The default is "" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].emptyDir.sizeLimit`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [emptyDir](#providersclusterdockervolumesemptydir) > sizeLimit
+
+| Type              | Required |
+| ----------------- | -------- |
+| `string | number` | No       |
+
+### `providers[].clusterDocker.volumes[].fc`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > fc
+
+Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].fc.fsType`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [fc](#providersclusterdockervolumesfc) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].fc.lun`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [fc](#providersclusterdockervolumesfc) > lun
+
+Optional: FC target lun number
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].clusterDocker.volumes[].fc.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [fc](#providersclusterdockervolumesfc) > readOnly
+
+Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].fc.targetWWNs[]`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [fc](#providersclusterdockervolumesfc) > targetWWNs
+
+Optional: FC target worldwide names (WWNs)
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].clusterDocker.volumes[].fc.wwids[]`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [fc](#providersclusterdockervolumesfc) > wwids
+
+Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].clusterDocker.volumes[].flexVolume`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > flexVolume
+
+FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].flexVolume.driver`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [flexVolume](#providersclusterdockervolumesflexvolume) > driver
+
+Driver is the name of the driver to use for this volume.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].flexVolume.fsType`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [flexVolume](#providersclusterdockervolumesflexvolume) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].flexVolume.options`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [flexVolume](#providersclusterdockervolumesflexvolume) > options
+
+Optional: Extra command options if any.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].flexVolume.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [flexVolume](#providersclusterdockervolumesflexvolume) > readOnly
+
+Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].flexVolume.secretRef`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [flexVolume](#providersclusterdockervolumesflexvolume) > secretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].flexVolume.secretRef.name`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [flexVolume](#providersclusterdockervolumesflexvolume) > [secretRef](#providersclusterdockervolumesflexvolumesecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].flocker`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > flocker
+
+Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].flocker.datasetName`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [flocker](#providersclusterdockervolumesflocker) > datasetName
+
+Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].flocker.datasetUUID`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [flocker](#providersclusterdockervolumesflocker) > datasetUUID
+
+UUID of the dataset. This is unique identifier of a Flocker dataset
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].gcePersistentDisk`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > gcePersistentDisk
+
+Represents a Persistent Disk resource in Google Compute Engine.
+
+A GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].gcePersistentDisk.fsType`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [gcePersistentDisk](#providersclusterdockervolumesgcepersistentdisk) > fsType
+
+Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].gcePersistentDisk.partition`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [gcePersistentDisk](#providersclusterdockervolumesgcepersistentdisk) > partition
+
+The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].clusterDocker.volumes[].gcePersistentDisk.pdName`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [gcePersistentDisk](#providersclusterdockervolumesgcepersistentdisk) > pdName
+
+Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].gcePersistentDisk.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [gcePersistentDisk](#providersclusterdockervolumesgcepersistentdisk) > readOnly
+
+ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].gitRepo`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > gitRepo
+
+Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.
+
+DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].gitRepo.directory`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [gitRepo](#providersclusterdockervolumesgitrepo) > directory
+
+Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].gitRepo.repository`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [gitRepo](#providersclusterdockervolumesgitrepo) > repository
+
+Repository URL
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].gitRepo.revision`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [gitRepo](#providersclusterdockervolumesgitrepo) > revision
+
+Commit hash for the specified revision.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].glusterfs`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > glusterfs
+
+Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].glusterfs.endpoints`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [glusterfs](#providersclusterdockervolumesglusterfs) > endpoints
+
+EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].glusterfs.path`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [glusterfs](#providersclusterdockervolumesglusterfs) > path
+
+Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].glusterfs.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [glusterfs](#providersclusterdockervolumesglusterfs) > readOnly
+
+ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].hostPath`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > hostPath
+
+Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].hostPath.path`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [hostPath](#providersclusterdockervolumeshostpath) > path
+
+Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].hostPath.type`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [hostPath](#providersclusterdockervolumeshostpath) > type
+
+Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].iscsi`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > iscsi
+
+Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].iscsi.chapAuthDiscovery`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [iscsi](#providersclusterdockervolumesiscsi) > chapAuthDiscovery
+
+whether support iSCSI Discovery CHAP authentication
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].iscsi.chapAuthSession`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [iscsi](#providersclusterdockervolumesiscsi) > chapAuthSession
+
+whether support iSCSI Session CHAP authentication
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].iscsi.fsType`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [iscsi](#providersclusterdockervolumesiscsi) > fsType
+
+Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].iscsi.initiatorName`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [iscsi](#providersclusterdockervolumesiscsi) > initiatorName
+
+Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].iscsi.iqn`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [iscsi](#providersclusterdockervolumesiscsi) > iqn
+
+Target iSCSI Qualified Name.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].iscsi.iscsiInterface`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [iscsi](#providersclusterdockervolumesiscsi) > iscsiInterface
+
+iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].iscsi.lun`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [iscsi](#providersclusterdockervolumesiscsi) > lun
+
+iSCSI Target Lun number.
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].clusterDocker.volumes[].iscsi.portals[]`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [iscsi](#providersclusterdockervolumesiscsi) > portals
+
+iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].clusterDocker.volumes[].iscsi.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [iscsi](#providersclusterdockervolumesiscsi) > readOnly
+
+ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].iscsi.secretRef`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [iscsi](#providersclusterdockervolumesiscsi) > secretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].iscsi.secretRef.name`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [iscsi](#providersclusterdockervolumesiscsi) > [secretRef](#providersclusterdockervolumesiscsisecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].iscsi.targetPortal`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [iscsi](#providersclusterdockervolumesiscsi) > targetPortal
+
+iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].name`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > name
+
+Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].nfs`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > nfs
+
+Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].nfs.path`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [nfs](#providersclusterdockervolumesnfs) > path
+
+Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].nfs.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [nfs](#providersclusterdockervolumesnfs) > readOnly
+
+ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].nfs.server`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [nfs](#providersclusterdockervolumesnfs) > server
+
+Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].persistentVolumeClaim`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > persistentVolumeClaim
+
+PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].persistentVolumeClaim.claimName`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [persistentVolumeClaim](#providersclusterdockervolumespersistentvolumeclaim) > claimName
+
+ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].persistentVolumeClaim.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [persistentVolumeClaim](#providersclusterdockervolumespersistentvolumeclaim) > readOnly
+
+Will force the ReadOnly setting in VolumeMounts. Default false.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].photonPersistentDisk`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > photonPersistentDisk
+
+Represents a Photon Controller persistent disk resource.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].photonPersistentDisk.fsType`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [photonPersistentDisk](#providersclusterdockervolumesphotonpersistentdisk) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].photonPersistentDisk.pdID`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [photonPersistentDisk](#providersclusterdockervolumesphotonpersistentdisk) > pdID
+
+ID that identifies Photon Controller persistent disk
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].portworxVolume`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > portworxVolume
+
+PortworxVolumeSource represents a Portworx volume resource.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].portworxVolume.fsType`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [portworxVolume](#providersclusterdockervolumesportworxvolume) > fsType
+
+FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].portworxVolume.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [portworxVolume](#providersclusterdockervolumesportworxvolume) > readOnly
+
+Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].portworxVolume.volumeID`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [portworxVolume](#providersclusterdockervolumesportworxvolume) > volumeID
+
+VolumeID uniquely identifies a Portworx volume
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].projected`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > projected
+
+Represents a projected volume source
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].projected.defaultMode`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [projected](#providersclusterdockervolumesprojected) > defaultMode
+
+Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].clusterDocker.volumes[].projected.sources[]`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [projected](#providersclusterdockervolumesprojected) > sources
+
+list of volume projections
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].clusterDocker.volumes[].quobyte`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > quobyte
+
+Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].quobyte.group`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [quobyte](#providersclusterdockervolumesquobyte) > group
+
+Group to map volume access to Default is no group
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].quobyte.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [quobyte](#providersclusterdockervolumesquobyte) > readOnly
+
+ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].quobyte.registry`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [quobyte](#providersclusterdockervolumesquobyte) > registry
+
+Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].quobyte.tenant`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [quobyte](#providersclusterdockervolumesquobyte) > tenant
+
+Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].quobyte.user`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [quobyte](#providersclusterdockervolumesquobyte) > user
+
+User to map volume access to Defaults to serivceaccount user
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].quobyte.volume`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [quobyte](#providersclusterdockervolumesquobyte) > volume
+
+Volume is a string that references an already created Quobyte volume by name.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].rbd`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > rbd
+
+Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].rbd.fsType`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [rbd](#providersclusterdockervolumesrbd) > fsType
+
+Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].rbd.image`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [rbd](#providersclusterdockervolumesrbd) > image
+
+The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].rbd.keyring`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [rbd](#providersclusterdockervolumesrbd) > keyring
+
+Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].rbd.monitors[]`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [rbd](#providersclusterdockervolumesrbd) > monitors
+
+A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].clusterDocker.volumes[].rbd.pool`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [rbd](#providersclusterdockervolumesrbd) > pool
+
+The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].rbd.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [rbd](#providersclusterdockervolumesrbd) > readOnly
+
+ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].rbd.secretRef`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [rbd](#providersclusterdockervolumesrbd) > secretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].rbd.secretRef.name`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [rbd](#providersclusterdockervolumesrbd) > [secretRef](#providersclusterdockervolumesrbdsecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].rbd.user`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [rbd](#providersclusterdockervolumesrbd) > user
+
+The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].scaleIO`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > scaleIO
+
+ScaleIOVolumeSource represents a persistent ScaleIO volume
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].scaleIO.fsType`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [scaleIO](#providersclusterdockervolumesscaleio) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].scaleIO.gateway`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [scaleIO](#providersclusterdockervolumesscaleio) > gateway
+
+The host address of the ScaleIO API Gateway.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].scaleIO.protectionDomain`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [scaleIO](#providersclusterdockervolumesscaleio) > protectionDomain
+
+The name of the ScaleIO Protection Domain for the configured storage.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].scaleIO.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [scaleIO](#providersclusterdockervolumesscaleio) > readOnly
+
+Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].scaleIO.secretRef`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [scaleIO](#providersclusterdockervolumesscaleio) > secretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].scaleIO.secretRef.name`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [scaleIO](#providersclusterdockervolumesscaleio) > [secretRef](#providersclusterdockervolumesscaleiosecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].scaleIO.sslEnabled`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [scaleIO](#providersclusterdockervolumesscaleio) > sslEnabled
+
+Flag to enable/disable SSL communication with Gateway, default false
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].scaleIO.storageMode`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [scaleIO](#providersclusterdockervolumesscaleio) > storageMode
+
+Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].scaleIO.storagePool`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [scaleIO](#providersclusterdockervolumesscaleio) > storagePool
+
+The ScaleIO Storage Pool associated with the protection domain.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].scaleIO.system`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [scaleIO](#providersclusterdockervolumesscaleio) > system
+
+The name of the storage system as configured in ScaleIO.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].scaleIO.volumeName`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [scaleIO](#providersclusterdockervolumesscaleio) > volumeName
+
+The name of a volume already created in the ScaleIO system that is associated with this volume source.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].secret`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > secret
+
+Adapts a Secret into a volume.
+
+The contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].secret.defaultMode`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [secret](#providersclusterdockervolumessecret) > defaultMode
+
+Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].clusterDocker.volumes[].secret.items[]`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [secret](#providersclusterdockervolumessecret) > items
+
+If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].clusterDocker.volumes[].secret.optional`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [secret](#providersclusterdockervolumessecret) > optional
+
+Specify whether the Secret or its keys must be defined
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].secret.secretName`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [secret](#providersclusterdockervolumessecret) > secretName
+
+Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].storageos`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > storageos
+
+Represents a StorageOS persistent volume resource.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].storageos.fsType`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [storageos](#providersclusterdockervolumesstorageos) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].storageos.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [storageos](#providersclusterdockervolumesstorageos) > readOnly
+
+Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].storageos.secretRef`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [storageos](#providersclusterdockervolumesstorageos) > secretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].storageos.secretRef.name`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [storageos](#providersclusterdockervolumesstorageos) > [secretRef](#providersclusterdockervolumesstorageossecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].storageos.volumeName`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [storageos](#providersclusterdockervolumesstorageos) > volumeName
+
+VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].storageos.volumeNamespace`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [storageos](#providersclusterdockervolumesstorageos) > volumeNamespace
+
+VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].vsphereVolume`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > vsphereVolume
+
+Represents a vSphere volume resource.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].vsphereVolume.fsType`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [vsphereVolume](#providersclusterdockervolumesvspherevolume) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].vsphereVolume.storagePolicyID`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [vsphereVolume](#providersclusterdockervolumesvspherevolume) > storagePolicyID
+
+Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].vsphereVolume.storagePolicyName`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [vsphereVolume](#providersclusterdockervolumesvspherevolume) > storagePolicyName
+
+Storage Policy Based Management (SPBM) profile name.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].vsphereVolume.volumePath`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [vsphereVolume](#providersclusterdockervolumesvspherevolume) > volumePath
+
+Path that identifies vSphere volume vmdk
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumeMounts[]`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > volumeMounts
+
+A list of volume mounts, referencing the volumes defined in the `volumes` field, specifying how and where to mount the volume in the Docker deployment container. The schema for this field is the same as on the `containers[].volumeMounts` field on a Pod spec.
+
+| Type                  | Default | Required |
+| --------------------- | ------- | -------- |
+| `array[customObject]` | `[]`    | No       |
+
+Example:
+
+```yaml
+providers:
+  - clusterDocker:
+      ...
+      volumeMounts:
+        name: my-auth-secret
+        mountPath: /.my-custom-auth
+```
+
+### `providers[].clusterDocker.volumeMounts[].mountPath`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumeMounts](#providersclusterdockervolumemounts) > mountPath
+
+Path within the container at which the volume should be mounted.  Must not contain ':'.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumeMounts[].mountPropagation`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumeMounts](#providersclusterdockervolumemounts) > mountPropagation
+
+mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumeMounts[].name`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumeMounts](#providersclusterdockervolumemounts) > name
+
+This must match the Name of a Volume.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumeMounts[].readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumeMounts](#providersclusterdockervolumemounts) > readOnly
+
+Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumeMounts[].subPath`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumeMounts](#providersclusterdockervolumemounts) > subPath
+
+Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumeMounts[].subPathExpr`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumeMounts](#providersclusterdockervolumemounts) > subPathExpr
+
+Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
 ### `providers[].kaniko`
 
 [providers](#providers) > kaniko
@@ -423,6 +3322,1691 @@ Specify extra flags to use when building the container image with kaniko. Flags 
 | Type            | Required |
 | --------------- | -------- |
 | `array[string]` | No       |
+
+### `providers[].kaniko.volumes[]`
+
+[providers](#providers) > [kaniko](#providerskaniko) > volumes
+
+A list of volumes that you'd like to attach to every Kaniko Pod during builds. Note that you also need to specify corresponding mounts using the `volumeMounts` field, much like how you specify `volumes` and `containers[].volumeMounts` separately in a Kubernetes Pod spec. In fact, the schema for this field is precisely the same as on the `volumes` field on a Pod spec, and is passed directly to the Kaniko Pods.
+
+Typical examples would be referencing a Kubernetes Secret, containing e.g. auth information for private package repositories, as well as shared cache volumes to accelerate image builds.
+
+**Important: Volumes declared here must support ReadWriteMany access, since multiple Kaniko Pods will run at the same time, and must also be available in the garden-system namespace.**
+
+| Type                  | Default | Required |
+| --------------------- | ------- | -------- |
+| `array[customObject]` | `[]`    | No       |
+
+Example:
+
+```yaml
+providers:
+  - kaniko:
+      ...
+      volumes:
+        name: my-auth-secret
+        secret:
+          secretName: my-auth-secret
+```
+
+### `providers[].kaniko.volumes[].awsElasticBlockStore`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > awsElasticBlockStore
+
+Represents a Persistent Disk resource in AWS.
+
+An AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].awsElasticBlockStore.fsType`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [awsElasticBlockStore](#providerskanikovolumesawselasticblockstore) > fsType
+
+Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].awsElasticBlockStore.partition`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [awsElasticBlockStore](#providerskanikovolumesawselasticblockstore) > partition
+
+The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].kaniko.volumes[].awsElasticBlockStore.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [awsElasticBlockStore](#providerskanikovolumesawselasticblockstore) > readOnly
+
+Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].awsElasticBlockStore.volumeID`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [awsElasticBlockStore](#providerskanikovolumesawselasticblockstore) > volumeID
+
+Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].azureDisk`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > azureDisk
+
+AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].azureDisk.cachingMode`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [azureDisk](#providerskanikovolumesazuredisk) > cachingMode
+
+Host Caching mode: None, Read Only, Read Write.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].azureDisk.diskName`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [azureDisk](#providerskanikovolumesazuredisk) > diskName
+
+The Name of the data disk in the blob storage
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].azureDisk.diskURI`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [azureDisk](#providerskanikovolumesazuredisk) > diskURI
+
+The URI the data disk in the blob storage
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].azureDisk.fsType`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [azureDisk](#providerskanikovolumesazuredisk) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].azureDisk.kind`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [azureDisk](#providerskanikovolumesazuredisk) > kind
+
+Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].azureDisk.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [azureDisk](#providerskanikovolumesazuredisk) > readOnly
+
+Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].azureFile`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > azureFile
+
+AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].azureFile.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [azureFile](#providerskanikovolumesazurefile) > readOnly
+
+Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].azureFile.secretName`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [azureFile](#providerskanikovolumesazurefile) > secretName
+
+the name of secret that contains Azure Storage Account Name and Key
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].azureFile.shareName`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [azureFile](#providerskanikovolumesazurefile) > shareName
+
+Share Name
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].cephfs`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > cephfs
+
+Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].cephfs.monitors[]`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [cephfs](#providerskanikovolumescephfs) > monitors
+
+Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].kaniko.volumes[].cephfs.path`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [cephfs](#providerskanikovolumescephfs) > path
+
+Optional: Used as the mounted root, rather than the full Ceph tree, default is /
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].cephfs.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [cephfs](#providerskanikovolumescephfs) > readOnly
+
+Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].cephfs.secretFile`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [cephfs](#providerskanikovolumescephfs) > secretFile
+
+Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].cephfs.secretRef`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [cephfs](#providerskanikovolumescephfs) > secretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].cephfs.secretRef.name`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [cephfs](#providerskanikovolumescephfs) > [secretRef](#providerskanikovolumescephfssecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].cephfs.user`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [cephfs](#providerskanikovolumescephfs) > user
+
+Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].cinder`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > cinder
+
+Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].cinder.fsType`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [cinder](#providerskanikovolumescinder) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].cinder.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [cinder](#providerskanikovolumescinder) > readOnly
+
+Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].cinder.secretRef`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [cinder](#providerskanikovolumescinder) > secretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].cinder.secretRef.name`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [cinder](#providerskanikovolumescinder) > [secretRef](#providerskanikovolumescindersecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].cinder.volumeID`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [cinder](#providerskanikovolumescinder) > volumeID
+
+volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].configMap`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > configMap
+
+Adapts a ConfigMap into a volume.
+
+The contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].configMap.defaultMode`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [configMap](#providerskanikovolumesconfigmap) > defaultMode
+
+Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].kaniko.volumes[].configMap.items[]`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [configMap](#providerskanikovolumesconfigmap) > items
+
+If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].kaniko.volumes[].configMap.name`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [configMap](#providerskanikovolumesconfigmap) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].configMap.optional`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [configMap](#providerskanikovolumesconfigmap) > optional
+
+Specify whether the ConfigMap or its keys must be defined
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].csi`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > csi
+
+Represents a source location of a volume to mount, managed by an external CSI driver
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].csi.driver`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [csi](#providerskanikovolumescsi) > driver
+
+Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].csi.fsType`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [csi](#providerskanikovolumescsi) > fsType
+
+Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].csi.nodePublishSecretRef`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [csi](#providerskanikovolumescsi) > nodePublishSecretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].csi.nodePublishSecretRef.name`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [csi](#providerskanikovolumescsi) > [nodePublishSecretRef](#providerskanikovolumescsinodepublishsecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].csi.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [csi](#providerskanikovolumescsi) > readOnly
+
+Specifies a read-only configuration for the volume. Defaults to false (read/write).
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].csi.volumeAttributes`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [csi](#providerskanikovolumescsi) > volumeAttributes
+
+VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].downwardAPI`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > downwardAPI
+
+DownwardAPIVolumeSource represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].downwardAPI.defaultMode`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [downwardAPI](#providerskanikovolumesdownwardapi) > defaultMode
+
+Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].kaniko.volumes[].downwardAPI.items[]`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [downwardAPI](#providerskanikovolumesdownwardapi) > items
+
+Items is a list of downward API volume file
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].kaniko.volumes[].emptyDir`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > emptyDir
+
+Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].emptyDir.medium`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [emptyDir](#providerskanikovolumesemptydir) > medium
+
+What type of storage medium should back this directory. The default is "" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].emptyDir.sizeLimit`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [emptyDir](#providerskanikovolumesemptydir) > sizeLimit
+
+| Type              | Required |
+| ----------------- | -------- |
+| `string | number` | No       |
+
+### `providers[].kaniko.volumes[].fc`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > fc
+
+Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].fc.fsType`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [fc](#providerskanikovolumesfc) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].fc.lun`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [fc](#providerskanikovolumesfc) > lun
+
+Optional: FC target lun number
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].kaniko.volumes[].fc.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [fc](#providerskanikovolumesfc) > readOnly
+
+Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].fc.targetWWNs[]`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [fc](#providerskanikovolumesfc) > targetWWNs
+
+Optional: FC target worldwide names (WWNs)
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].kaniko.volumes[].fc.wwids[]`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [fc](#providerskanikovolumesfc) > wwids
+
+Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].kaniko.volumes[].flexVolume`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > flexVolume
+
+FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].flexVolume.driver`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [flexVolume](#providerskanikovolumesflexvolume) > driver
+
+Driver is the name of the driver to use for this volume.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].flexVolume.fsType`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [flexVolume](#providerskanikovolumesflexvolume) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].flexVolume.options`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [flexVolume](#providerskanikovolumesflexvolume) > options
+
+Optional: Extra command options if any.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].flexVolume.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [flexVolume](#providerskanikovolumesflexvolume) > readOnly
+
+Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].flexVolume.secretRef`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [flexVolume](#providerskanikovolumesflexvolume) > secretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].flexVolume.secretRef.name`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [flexVolume](#providerskanikovolumesflexvolume) > [secretRef](#providerskanikovolumesflexvolumesecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].flocker`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > flocker
+
+Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].flocker.datasetName`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [flocker](#providerskanikovolumesflocker) > datasetName
+
+Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].flocker.datasetUUID`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [flocker](#providerskanikovolumesflocker) > datasetUUID
+
+UUID of the dataset. This is unique identifier of a Flocker dataset
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].gcePersistentDisk`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > gcePersistentDisk
+
+Represents a Persistent Disk resource in Google Compute Engine.
+
+A GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].gcePersistentDisk.fsType`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [gcePersistentDisk](#providerskanikovolumesgcepersistentdisk) > fsType
+
+Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].gcePersistentDisk.partition`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [gcePersistentDisk](#providerskanikovolumesgcepersistentdisk) > partition
+
+The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].kaniko.volumes[].gcePersistentDisk.pdName`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [gcePersistentDisk](#providerskanikovolumesgcepersistentdisk) > pdName
+
+Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].gcePersistentDisk.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [gcePersistentDisk](#providerskanikovolumesgcepersistentdisk) > readOnly
+
+ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].gitRepo`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > gitRepo
+
+Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.
+
+DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].gitRepo.directory`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [gitRepo](#providerskanikovolumesgitrepo) > directory
+
+Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].gitRepo.repository`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [gitRepo](#providerskanikovolumesgitrepo) > repository
+
+Repository URL
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].gitRepo.revision`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [gitRepo](#providerskanikovolumesgitrepo) > revision
+
+Commit hash for the specified revision.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].glusterfs`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > glusterfs
+
+Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].glusterfs.endpoints`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [glusterfs](#providerskanikovolumesglusterfs) > endpoints
+
+EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].glusterfs.path`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [glusterfs](#providerskanikovolumesglusterfs) > path
+
+Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].glusterfs.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [glusterfs](#providerskanikovolumesglusterfs) > readOnly
+
+ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].hostPath`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > hostPath
+
+Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].hostPath.path`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [hostPath](#providerskanikovolumeshostpath) > path
+
+Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].hostPath.type`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [hostPath](#providerskanikovolumeshostpath) > type
+
+Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].iscsi`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > iscsi
+
+Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].iscsi.chapAuthDiscovery`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [iscsi](#providerskanikovolumesiscsi) > chapAuthDiscovery
+
+whether support iSCSI Discovery CHAP authentication
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].iscsi.chapAuthSession`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [iscsi](#providerskanikovolumesiscsi) > chapAuthSession
+
+whether support iSCSI Session CHAP authentication
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].iscsi.fsType`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [iscsi](#providerskanikovolumesiscsi) > fsType
+
+Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].iscsi.initiatorName`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [iscsi](#providerskanikovolumesiscsi) > initiatorName
+
+Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].iscsi.iqn`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [iscsi](#providerskanikovolumesiscsi) > iqn
+
+Target iSCSI Qualified Name.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].iscsi.iscsiInterface`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [iscsi](#providerskanikovolumesiscsi) > iscsiInterface
+
+iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].iscsi.lun`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [iscsi](#providerskanikovolumesiscsi) > lun
+
+iSCSI Target Lun number.
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].kaniko.volumes[].iscsi.portals[]`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [iscsi](#providerskanikovolumesiscsi) > portals
+
+iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].kaniko.volumes[].iscsi.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [iscsi](#providerskanikovolumesiscsi) > readOnly
+
+ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].iscsi.secretRef`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [iscsi](#providerskanikovolumesiscsi) > secretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].iscsi.secretRef.name`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [iscsi](#providerskanikovolumesiscsi) > [secretRef](#providerskanikovolumesiscsisecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].iscsi.targetPortal`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [iscsi](#providerskanikovolumesiscsi) > targetPortal
+
+iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].name`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > name
+
+Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].nfs`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > nfs
+
+Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].nfs.path`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [nfs](#providerskanikovolumesnfs) > path
+
+Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].nfs.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [nfs](#providerskanikovolumesnfs) > readOnly
+
+ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].nfs.server`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [nfs](#providerskanikovolumesnfs) > server
+
+Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].persistentVolumeClaim`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > persistentVolumeClaim
+
+PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].persistentVolumeClaim.claimName`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [persistentVolumeClaim](#providerskanikovolumespersistentvolumeclaim) > claimName
+
+ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].persistentVolumeClaim.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [persistentVolumeClaim](#providerskanikovolumespersistentvolumeclaim) > readOnly
+
+Will force the ReadOnly setting in VolumeMounts. Default false.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].photonPersistentDisk`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > photonPersistentDisk
+
+Represents a Photon Controller persistent disk resource.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].photonPersistentDisk.fsType`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [photonPersistentDisk](#providerskanikovolumesphotonpersistentdisk) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].photonPersistentDisk.pdID`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [photonPersistentDisk](#providerskanikovolumesphotonpersistentdisk) > pdID
+
+ID that identifies Photon Controller persistent disk
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].portworxVolume`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > portworxVolume
+
+PortworxVolumeSource represents a Portworx volume resource.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].portworxVolume.fsType`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [portworxVolume](#providerskanikovolumesportworxvolume) > fsType
+
+FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].portworxVolume.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [portworxVolume](#providerskanikovolumesportworxvolume) > readOnly
+
+Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].portworxVolume.volumeID`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [portworxVolume](#providerskanikovolumesportworxvolume) > volumeID
+
+VolumeID uniquely identifies a Portworx volume
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].projected`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > projected
+
+Represents a projected volume source
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].projected.defaultMode`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [projected](#providerskanikovolumesprojected) > defaultMode
+
+Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].kaniko.volumes[].projected.sources[]`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [projected](#providerskanikovolumesprojected) > sources
+
+list of volume projections
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].kaniko.volumes[].quobyte`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > quobyte
+
+Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].quobyte.group`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [quobyte](#providerskanikovolumesquobyte) > group
+
+Group to map volume access to Default is no group
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].quobyte.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [quobyte](#providerskanikovolumesquobyte) > readOnly
+
+ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].quobyte.registry`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [quobyte](#providerskanikovolumesquobyte) > registry
+
+Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].quobyte.tenant`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [quobyte](#providerskanikovolumesquobyte) > tenant
+
+Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].quobyte.user`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [quobyte](#providerskanikovolumesquobyte) > user
+
+User to map volume access to Defaults to serivceaccount user
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].quobyte.volume`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [quobyte](#providerskanikovolumesquobyte) > volume
+
+Volume is a string that references an already created Quobyte volume by name.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].rbd`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > rbd
+
+Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].rbd.fsType`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [rbd](#providerskanikovolumesrbd) > fsType
+
+Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].rbd.image`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [rbd](#providerskanikovolumesrbd) > image
+
+The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].rbd.keyring`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [rbd](#providerskanikovolumesrbd) > keyring
+
+Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].rbd.monitors[]`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [rbd](#providerskanikovolumesrbd) > monitors
+
+A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].kaniko.volumes[].rbd.pool`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [rbd](#providerskanikovolumesrbd) > pool
+
+The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].rbd.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [rbd](#providerskanikovolumesrbd) > readOnly
+
+ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].rbd.secretRef`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [rbd](#providerskanikovolumesrbd) > secretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].rbd.secretRef.name`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [rbd](#providerskanikovolumesrbd) > [secretRef](#providerskanikovolumesrbdsecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].rbd.user`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [rbd](#providerskanikovolumesrbd) > user
+
+The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].scaleIO`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > scaleIO
+
+ScaleIOVolumeSource represents a persistent ScaleIO volume
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].scaleIO.fsType`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [scaleIO](#providerskanikovolumesscaleio) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].scaleIO.gateway`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [scaleIO](#providerskanikovolumesscaleio) > gateway
+
+The host address of the ScaleIO API Gateway.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].scaleIO.protectionDomain`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [scaleIO](#providerskanikovolumesscaleio) > protectionDomain
+
+The name of the ScaleIO Protection Domain for the configured storage.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].scaleIO.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [scaleIO](#providerskanikovolumesscaleio) > readOnly
+
+Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].scaleIO.secretRef`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [scaleIO](#providerskanikovolumesscaleio) > secretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].scaleIO.secretRef.name`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [scaleIO](#providerskanikovolumesscaleio) > [secretRef](#providerskanikovolumesscaleiosecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].scaleIO.sslEnabled`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [scaleIO](#providerskanikovolumesscaleio) > sslEnabled
+
+Flag to enable/disable SSL communication with Gateway, default false
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].scaleIO.storageMode`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [scaleIO](#providerskanikovolumesscaleio) > storageMode
+
+Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].scaleIO.storagePool`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [scaleIO](#providerskanikovolumesscaleio) > storagePool
+
+The ScaleIO Storage Pool associated with the protection domain.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].scaleIO.system`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [scaleIO](#providerskanikovolumesscaleio) > system
+
+The name of the storage system as configured in ScaleIO.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].scaleIO.volumeName`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [scaleIO](#providerskanikovolumesscaleio) > volumeName
+
+The name of a volume already created in the ScaleIO system that is associated with this volume source.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].secret`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > secret
+
+Adapts a Secret into a volume.
+
+The contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].secret.defaultMode`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [secret](#providerskanikovolumessecret) > defaultMode
+
+Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].kaniko.volumes[].secret.items[]`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [secret](#providerskanikovolumessecret) > items
+
+If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].kaniko.volumes[].secret.optional`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [secret](#providerskanikovolumessecret) > optional
+
+Specify whether the Secret or its keys must be defined
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].secret.secretName`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [secret](#providerskanikovolumessecret) > secretName
+
+Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].storageos`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > storageos
+
+Represents a StorageOS persistent volume resource.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].storageos.fsType`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [storageos](#providerskanikovolumesstorageos) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].storageos.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [storageos](#providerskanikovolumesstorageos) > readOnly
+
+Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].storageos.secretRef`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [storageos](#providerskanikovolumesstorageos) > secretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].storageos.secretRef.name`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [storageos](#providerskanikovolumesstorageos) > [secretRef](#providerskanikovolumesstorageossecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].storageos.volumeName`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [storageos](#providerskanikovolumesstorageos) > volumeName
+
+VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].storageos.volumeNamespace`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [storageos](#providerskanikovolumesstorageos) > volumeNamespace
+
+VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].vsphereVolume`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > vsphereVolume
+
+Represents a vSphere volume resource.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].vsphereVolume.fsType`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [vsphereVolume](#providerskanikovolumesvspherevolume) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].vsphereVolume.storagePolicyID`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [vsphereVolume](#providerskanikovolumesvspherevolume) > storagePolicyID
+
+Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].vsphereVolume.storagePolicyName`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [vsphereVolume](#providerskanikovolumesvspherevolume) > storagePolicyName
+
+Storage Policy Based Management (SPBM) profile name.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].vsphereVolume.volumePath`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [vsphereVolume](#providerskanikovolumesvspherevolume) > volumePath
+
+Path that identifies vSphere volume vmdk
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumeMounts[]`
+
+[providers](#providers) > [kaniko](#providerskaniko) > volumeMounts
+
+A list of volume mounts, referencing the volumes defined in the `volumes` field, specifying how and where to mount the volume in the Kaniko Pod container. The schema for this field is the same as on the `containers[].volumeMounts` field on a Pod spec, and is passed directly to the Kaniko Pod container spec.
+
+| Type                  | Default | Required |
+| --------------------- | ------- | -------- |
+| `array[customObject]` | `[]`    | No       |
+
+Example:
+
+```yaml
+providers:
+  - kaniko:
+      ...
+      volumeMounts:
+        name: my-auth-secret
+        mountPath: /.my-custom-auth
+```
+
+### `providers[].kaniko.volumeMounts[].mountPath`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumeMounts](#providerskanikovolumemounts) > mountPath
+
+Path within the container at which the volume should be mounted.  Must not contain ':'.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumeMounts[].mountPropagation`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumeMounts](#providerskanikovolumemounts) > mountPropagation
+
+mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumeMounts[].name`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumeMounts](#providerskanikovolumemounts) > name
+
+This must match the Name of a Volume.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumeMounts[].readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumeMounts](#providerskanikovolumemounts) > readOnly
+
+Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumeMounts[].subPath`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumeMounts](#providerskanikovolumemounts) > subPath
+
+Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumeMounts[].subPathExpr`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumeMounts](#providerskanikovolumemounts) > subPathExpr
+
+Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
 
 ### `providers[].defaultHostname`
 

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -50,6 +50,613 @@ providers:
       # performant, but we're opting to keep it optional until it's enabled by default in Docker.
       enableBuildKit: false
 
+      # A list of volumes that you'd like to attach to the in-cluster Docker deployment Pod. Note that you also need
+      # to specify corresponding mounts using the `volumeMounts` field, much like how you specify `volumes` and
+      # `containers[].volumeMounts` separately in a Kubernetes Pod spec. In fact, the schema for this field is
+      # precisely the same as on the `volumes` field on a Pod spec, and is passed directly to the Docker Deployment
+      # spec.
+      #
+      # Typical examples would be referencing a Kubernetes Secret, containing e.g. auth information for private
+      # package repositories, as well as cache volumes to accelerate image builds.
+      #
+      # **Important: Volumes declared here must must be available in the garden-system namespace.**
+      volumes: []
+        - # Represents a Persistent Disk resource in AWS.
+          #
+          # An AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as
+          # the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership
+          # management and SELinux relabeling.
+          awsElasticBlockStore:
+            # Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported
+            # by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if
+            # unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+            fsType:
+
+            # The partition in the volume that you want to mount. If omitted, the default is to mount by volume name.
+            # Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for
+            # /dev/sda is "0" (or you can leave the property empty).
+            partition:
+
+            # Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default
+            # is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+            readOnly:
+
+            # Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+            volumeID:
+
+          # AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+          azureDisk:
+            # Host Caching mode: None, Read Only, Read Write.
+            cachingMode:
+
+            # The Name of the data disk in the blob storage
+            diskName:
+
+            # The URI the data disk in the blob storage
+            diskURI:
+
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4",
+            # "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+            fsType:
+
+            # Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage
+            # account  Managed: azure managed data disk (only in managed availability set). defaults to shared
+            kind:
+
+            # Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            readOnly:
+
+          # AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+          azureFile:
+            # Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            readOnly:
+
+            # the name of secret that contains Azure Storage Account Name and Key
+            secretName:
+
+            # Share Name
+            shareName:
+
+          # Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support
+          # ownership management or SELinux relabeling.
+          cephfs:
+            # Required: Monitors is a collection of Ceph monitors More info:
+            # https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+            monitors:
+
+            # Optional: Used as the mounted root, rather than the full Ceph tree, default is /
+            path:
+
+            # Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            # More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+            readOnly:
+
+            # Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info:
+            # https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+            secretFile:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            secretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+            # Optional: User is the rados user name, default is admin More info:
+            # https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+            user:
+
+          # Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a
+          # container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership
+          # management and SELinux relabeling.
+          cinder:
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples:
+            # "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info:
+            # https://examples.k8s.io/mysql-cinder-pd/README.md
+            fsType:
+
+            # Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            # More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+            readOnly:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            secretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+            # volume id used to identify the volume in cinder. More info:
+            # https://examples.k8s.io/mysql-cinder-pd/README.md
+            volumeID:
+
+          # Adapts a ConfigMap into a volume.
+          #
+          # The contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in
+          # the Data field as the file names, unless the items element is populated with specific mappings of keys to
+          # paths. ConfigMap volumes support ownership management and SELinux relabeling.
+          configMap:
+            # Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to
+            # 0644. Directories within the path are not affected by this setting. This might be in conflict with other
+            # options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+            defaultMode:
+
+            # If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into
+            # the volume as a file whose name is the key and content is the value. If specified, the listed keys will
+            # be projected into the specified paths, and unlisted keys will not be present. If a key is specified
+            # which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths
+            # must be relative and may not contain the '..' path or start with '..'.
+            items:
+
+            # Name of the referent. More info:
+            # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+            name:
+
+            # Specify whether the ConfigMap or its keys must be defined
+            optional:
+
+          # Represents a source location of a volume to mount, managed by an external CSI driver
+          csi:
+            # Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct
+            # name as registered in the cluster.
+            driver:
+
+            # Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the
+            # associated CSI driver which will determine the default filesystem to apply.
+            fsType:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            nodePublishSecretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+            # Specifies a read-only configuration for the volume. Defaults to false (read/write).
+            readOnly:
+
+            # VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your
+            # driver's documentation for supported values.
+            volumeAttributes:
+
+          # DownwardAPIVolumeSource represents a volume containing downward API info. Downward API volumes support
+          # ownership management and SELinux relabeling.
+          downwardAPI:
+            # Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to
+            # 0644. Directories within the path are not affected by this setting. This might be in conflict with other
+            # options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+            defaultMode:
+
+            # Items is a list of downward API volume file
+            items:
+
+          # Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux
+          # relabeling.
+          emptyDir:
+            # What type of storage medium should back this directory. The default is "" which means to use the node's
+            # default medium. Must be an empty string (default) or Memory. More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+            medium:
+
+            sizeLimit:
+
+          # Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre
+          # Channel volumes support ownership management and SELinux relabeling.
+          fc:
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4",
+            # "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+            fsType:
+
+            # Optional: FC target lun number
+            lun:
+
+            # Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            readOnly:
+
+            # Optional: FC target worldwide names (WWNs)
+            targetWWNs:
+
+            # Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun
+            # must be set, but not both simultaneously.
+            wwids:
+
+          # FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+          flexVolume:
+            # Driver is the name of the driver to use for this volume.
+            driver:
+
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4",
+            # "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+            fsType:
+
+            # Optional: Extra command options if any.
+            options:
+
+            # Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            readOnly:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            secretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+          # Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID
+          # should be set. Flocker volumes do not support ownership management or SELinux relabeling.
+          flocker:
+            # Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as
+            # deprecated
+            datasetName:
+
+            # UUID of the dataset. This is unique identifier of a Flocker dataset
+            datasetUUID:
+
+          # Represents a Persistent Disk resource in Google Compute Engine.
+          #
+          # A GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone
+          # as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support
+          # ownership management and SELinux relabeling.
+          gcePersistentDisk:
+            # Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported
+            # by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if
+            # unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+            fsType:
+
+            # The partition in the volume that you want to mount. If omitted, the default is to mount by volume name.
+            # Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for
+            # /dev/sda is "0" (or you can leave the property empty). More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+            partition:
+
+            # Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+            pdName:
+
+            # ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+            readOnly:
+
+          # Represents a volume that is populated with the contents of a git repository. Git repo volumes do not
+          # support ownership management. Git repo volumes support SELinux relabeling.
+          #
+          # DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an
+          # InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.
+          gitRepo:
+            # Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory
+            # will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the
+            # subdirectory with the given name.
+            directory:
+
+            # Repository URL
+            repository:
+
+            # Commit hash for the specified revision.
+            revision:
+
+          # Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership
+          # management or SELinux relabeling.
+          glusterfs:
+            # EndpointsName is the endpoint name that details Glusterfs topology. More info:
+            # https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+            endpoints:
+
+            # Path is the Glusterfs volume path. More info:
+            # https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+            path:
+
+            # ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to
+            # false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+            readOnly:
+
+          # Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux
+          # relabeling.
+          hostPath:
+            # Path of the directory on the host. If the path is a symlink, it will follow the link to the real path.
+            # More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+            path:
+
+            # Type for HostPath Volume Defaults to "" More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+            type:
+
+          # Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support
+          # ownership management and SELinux relabeling.
+          iscsi:
+            # whether support iSCSI Discovery CHAP authentication
+            chapAuthDiscovery:
+
+            # whether support iSCSI Session CHAP authentication
+            chapAuthSession:
+
+            # Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported
+            # by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if
+            # unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+            fsType:
+
+            # Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI
+            # interface <target portal>:<volume name> will be created for the connection.
+            initiatorName:
+
+            # Target iSCSI Qualified Name.
+            iqn:
+
+            # iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+            iscsiInterface:
+
+            # iSCSI Target Lun number.
+            lun:
+
+            # iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default
+            # (typically TCP ports 860 and 3260).
+            portals:
+
+            # ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+            readOnly:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            secretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+            # iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default
+            # (typically TCP ports 860 and 3260).
+            targetPortal:
+
+          # Volume's name. Must be a DNS_LABEL and unique within the pod. More info:
+          # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+          name:
+
+          # Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management
+          # or SELinux relabeling.
+          nfs:
+            # Path that is exported by the NFS server. More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#nfs
+            path:
+
+            # ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false.
+            # More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+            readOnly:
+
+            # Server is the hostname or IP address of the NFS server. More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#nfs
+            server:
+
+          # PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the
+          # bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a
+          # wrapper around another type of volume that is owned by someone else (the system).
+          persistentVolumeClaim:
+            # ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+            # More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+            claimName:
+
+            # Will force the ReadOnly setting in VolumeMounts. Default false.
+            readOnly:
+
+          # Represents a Photon Controller persistent disk resource.
+          photonPersistentDisk:
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4",
+            # "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+            fsType:
+
+            # ID that identifies Photon Controller persistent disk
+            pdID:
+
+          # PortworxVolumeSource represents a Portworx volume resource.
+          portworxVolume:
+            # FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating
+            # system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+            fsType:
+
+            # Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            readOnly:
+
+            # VolumeID uniquely identifies a Portworx volume
+            volumeID:
+
+          # Represents a projected volume source
+          projected:
+            # Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the
+            # path are not affected by this setting. This might be in conflict with other options that affect the file
+            # mode, like fsGroup, and the result can be other mode bits set.
+            defaultMode:
+
+            # list of volume projections
+            sources:
+
+          # Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership
+          # management or SELinux relabeling.
+          quobyte:
+            # Group to map volume access to Default is no group
+            group:
+
+            # ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+            readOnly:
+
+            # Registry represents a single or multiple Quobyte Registry services specified as a string as host:port
+            # pair (multiple entries are separated with commas) which acts as the central registry for volumes
+            registry:
+
+            # Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes,
+            # value is set by the plugin
+            tenant:
+
+            # User to map volume access to Defaults to serivceaccount user
+            user:
+
+            # Volume is a string that references an already created Quobyte volume by name.
+            volume:
+
+          # Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership
+          # management and SELinux relabeling.
+          rbd:
+            # Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported
+            # by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if
+            # unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+            fsType:
+
+            # The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+            image:
+
+            # Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info:
+            # https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+            keyring:
+
+            # A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+            monitors:
+
+            # The rados pool name. Default is rbd. More info:
+            # https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+            pool:
+
+            # ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info:
+            # https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+            readOnly:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            secretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+            # The rados user name. Default is admin. More info:
+            # https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+            user:
+
+          # ScaleIOVolumeSource represents a persistent ScaleIO volume
+          scaleIO:
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4",
+            # "xfs", "ntfs". Default is "xfs".
+            fsType:
+
+            # The host address of the ScaleIO API Gateway.
+            gateway:
+
+            # The name of the ScaleIO Protection Domain for the configured storage.
+            protectionDomain:
+
+            # Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            readOnly:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            secretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+            # Flag to enable/disable SSL communication with Gateway, default false
+            sslEnabled:
+
+            # Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is
+            # ThinProvisioned.
+            storageMode:
+
+            # The ScaleIO Storage Pool associated with the protection domain.
+            storagePool:
+
+            # The name of the storage system as configured in ScaleIO.
+            system:
+
+            # The name of a volume already created in the ScaleIO system that is associated with this volume source.
+            volumeName:
+
+          # Adapts a Secret into a volume.
+          #
+          # The contents of the target Secret's Data field will be presented in a volume as files using the keys in
+          # the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.
+          secret:
+            # Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to
+            # 0644. Directories within the path are not affected by this setting. This might be in conflict with other
+            # options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+            defaultMode:
+
+            # If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into
+            # the volume as a file whose name is the key and content is the value. If specified, the listed keys will
+            # be projected into the specified paths, and unlisted keys will not be present. If a key is specified
+            # which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must
+            # be relative and may not contain the '..' path or start with '..'.
+            items:
+
+            # Specify whether the Secret or its keys must be defined
+            optional:
+
+            # Name of the secret in the pod's namespace to use. More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#secret
+            secretName:
+
+          # Represents a StorageOS persistent volume resource.
+          storageos:
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4",
+            # "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+            fsType:
+
+            # Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            readOnly:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            secretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+            # VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a
+            # namespace.
+            volumeName:
+
+            # VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then
+            # the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within
+            # StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to
+            # "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within
+            # StorageOS will be created.
+            volumeNamespace:
+
+          # Represents a vSphere volume resource.
+          vsphereVolume:
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4",
+            # "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+            fsType:
+
+            # Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+            storagePolicyID:
+
+            # Storage Policy Based Management (SPBM) profile name.
+            storagePolicyName:
+
+            # Path that identifies vSphere volume vmdk
+            volumePath:
+
+      # A list of volume mounts, referencing the volumes defined in the `volumes` field, specifying how and where to
+      # mount the volume in the Docker deployment container. The schema for this field is the same as on the
+      # `containers[].volumeMounts` field on a Pod spec.
+      volumeMounts: []
+        - # Path within the container at which the volume should be mounted.  Must not contain ':'.
+          mountPath:
+
+          # mountPropagation determines how mounts are propagated from the host to container and the other way around.
+          # When not set, MountPropagationNone is used. This field is beta in 1.10.
+          mountPropagation:
+
+          # This must match the Name of a Volume.
+          name:
+
+          # Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+          readOnly:
+
+          # Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's
+          # root).
+          subPath:
+
+          # Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to
+          # SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+          # Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+          subPathExpr:
+
     # Configuration options for the `kaniko` build mode.
     kaniko:
       # Change the kaniko image (repository/image:tag) to use when building in kaniko mode.
@@ -58,6 +665,613 @@ providers:
       # Specify extra flags to use when building the container image with kaniko. Flags set on container module take
       # precedence over these.
       extraFlags:
+
+      # A list of volumes that you'd like to attach to every Kaniko Pod during builds. Note that you also need to
+      # specify corresponding mounts using the `volumeMounts` field, much like how you specify `volumes` and
+      # `containers[].volumeMounts` separately in a Kubernetes Pod spec. In fact, the schema for this field is
+      # precisely the same as on the `volumes` field on a Pod spec, and is passed directly to the Kaniko Pods.
+      #
+      # Typical examples would be referencing a Kubernetes Secret, containing e.g. auth information for private
+      # package repositories, as well as shared cache volumes to accelerate image builds.
+      #
+      # **Important: Volumes declared here must support ReadWriteMany access, since multiple Kaniko Pods will run at
+      # the same time, and must also be available in the garden-system namespace.**
+      volumes: []
+        - # Represents a Persistent Disk resource in AWS.
+          #
+          # An AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as
+          # the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership
+          # management and SELinux relabeling.
+          awsElasticBlockStore:
+            # Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported
+            # by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if
+            # unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+            fsType:
+
+            # The partition in the volume that you want to mount. If omitted, the default is to mount by volume name.
+            # Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for
+            # /dev/sda is "0" (or you can leave the property empty).
+            partition:
+
+            # Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default
+            # is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+            readOnly:
+
+            # Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+            volumeID:
+
+          # AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+          azureDisk:
+            # Host Caching mode: None, Read Only, Read Write.
+            cachingMode:
+
+            # The Name of the data disk in the blob storage
+            diskName:
+
+            # The URI the data disk in the blob storage
+            diskURI:
+
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4",
+            # "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+            fsType:
+
+            # Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage
+            # account  Managed: azure managed data disk (only in managed availability set). defaults to shared
+            kind:
+
+            # Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            readOnly:
+
+          # AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+          azureFile:
+            # Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            readOnly:
+
+            # the name of secret that contains Azure Storage Account Name and Key
+            secretName:
+
+            # Share Name
+            shareName:
+
+          # Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support
+          # ownership management or SELinux relabeling.
+          cephfs:
+            # Required: Monitors is a collection of Ceph monitors More info:
+            # https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+            monitors:
+
+            # Optional: Used as the mounted root, rather than the full Ceph tree, default is /
+            path:
+
+            # Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            # More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+            readOnly:
+
+            # Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info:
+            # https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+            secretFile:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            secretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+            # Optional: User is the rados user name, default is admin More info:
+            # https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+            user:
+
+          # Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a
+          # container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership
+          # management and SELinux relabeling.
+          cinder:
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples:
+            # "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info:
+            # https://examples.k8s.io/mysql-cinder-pd/README.md
+            fsType:
+
+            # Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            # More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+            readOnly:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            secretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+            # volume id used to identify the volume in cinder. More info:
+            # https://examples.k8s.io/mysql-cinder-pd/README.md
+            volumeID:
+
+          # Adapts a ConfigMap into a volume.
+          #
+          # The contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in
+          # the Data field as the file names, unless the items element is populated with specific mappings of keys to
+          # paths. ConfigMap volumes support ownership management and SELinux relabeling.
+          configMap:
+            # Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to
+            # 0644. Directories within the path are not affected by this setting. This might be in conflict with other
+            # options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+            defaultMode:
+
+            # If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into
+            # the volume as a file whose name is the key and content is the value. If specified, the listed keys will
+            # be projected into the specified paths, and unlisted keys will not be present. If a key is specified
+            # which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths
+            # must be relative and may not contain the '..' path or start with '..'.
+            items:
+
+            # Name of the referent. More info:
+            # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+            name:
+
+            # Specify whether the ConfigMap or its keys must be defined
+            optional:
+
+          # Represents a source location of a volume to mount, managed by an external CSI driver
+          csi:
+            # Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct
+            # name as registered in the cluster.
+            driver:
+
+            # Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the
+            # associated CSI driver which will determine the default filesystem to apply.
+            fsType:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            nodePublishSecretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+            # Specifies a read-only configuration for the volume. Defaults to false (read/write).
+            readOnly:
+
+            # VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your
+            # driver's documentation for supported values.
+            volumeAttributes:
+
+          # DownwardAPIVolumeSource represents a volume containing downward API info. Downward API volumes support
+          # ownership management and SELinux relabeling.
+          downwardAPI:
+            # Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to
+            # 0644. Directories within the path are not affected by this setting. This might be in conflict with other
+            # options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+            defaultMode:
+
+            # Items is a list of downward API volume file
+            items:
+
+          # Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux
+          # relabeling.
+          emptyDir:
+            # What type of storage medium should back this directory. The default is "" which means to use the node's
+            # default medium. Must be an empty string (default) or Memory. More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+            medium:
+
+            sizeLimit:
+
+          # Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre
+          # Channel volumes support ownership management and SELinux relabeling.
+          fc:
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4",
+            # "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+            fsType:
+
+            # Optional: FC target lun number
+            lun:
+
+            # Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            readOnly:
+
+            # Optional: FC target worldwide names (WWNs)
+            targetWWNs:
+
+            # Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun
+            # must be set, but not both simultaneously.
+            wwids:
+
+          # FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+          flexVolume:
+            # Driver is the name of the driver to use for this volume.
+            driver:
+
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4",
+            # "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+            fsType:
+
+            # Optional: Extra command options if any.
+            options:
+
+            # Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            readOnly:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            secretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+          # Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID
+          # should be set. Flocker volumes do not support ownership management or SELinux relabeling.
+          flocker:
+            # Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as
+            # deprecated
+            datasetName:
+
+            # UUID of the dataset. This is unique identifier of a Flocker dataset
+            datasetUUID:
+
+          # Represents a Persistent Disk resource in Google Compute Engine.
+          #
+          # A GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone
+          # as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support
+          # ownership management and SELinux relabeling.
+          gcePersistentDisk:
+            # Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported
+            # by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if
+            # unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+            fsType:
+
+            # The partition in the volume that you want to mount. If omitted, the default is to mount by volume name.
+            # Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for
+            # /dev/sda is "0" (or you can leave the property empty). More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+            partition:
+
+            # Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+            pdName:
+
+            # ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+            readOnly:
+
+          # Represents a volume that is populated with the contents of a git repository. Git repo volumes do not
+          # support ownership management. Git repo volumes support SELinux relabeling.
+          #
+          # DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an
+          # InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.
+          gitRepo:
+            # Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory
+            # will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the
+            # subdirectory with the given name.
+            directory:
+
+            # Repository URL
+            repository:
+
+            # Commit hash for the specified revision.
+            revision:
+
+          # Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership
+          # management or SELinux relabeling.
+          glusterfs:
+            # EndpointsName is the endpoint name that details Glusterfs topology. More info:
+            # https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+            endpoints:
+
+            # Path is the Glusterfs volume path. More info:
+            # https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+            path:
+
+            # ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to
+            # false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+            readOnly:
+
+          # Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux
+          # relabeling.
+          hostPath:
+            # Path of the directory on the host. If the path is a symlink, it will follow the link to the real path.
+            # More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+            path:
+
+            # Type for HostPath Volume Defaults to "" More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+            type:
+
+          # Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support
+          # ownership management and SELinux relabeling.
+          iscsi:
+            # whether support iSCSI Discovery CHAP authentication
+            chapAuthDiscovery:
+
+            # whether support iSCSI Session CHAP authentication
+            chapAuthSession:
+
+            # Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported
+            # by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if
+            # unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+            fsType:
+
+            # Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI
+            # interface <target portal>:<volume name> will be created for the connection.
+            initiatorName:
+
+            # Target iSCSI Qualified Name.
+            iqn:
+
+            # iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+            iscsiInterface:
+
+            # iSCSI Target Lun number.
+            lun:
+
+            # iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default
+            # (typically TCP ports 860 and 3260).
+            portals:
+
+            # ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+            readOnly:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            secretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+            # iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default
+            # (typically TCP ports 860 and 3260).
+            targetPortal:
+
+          # Volume's name. Must be a DNS_LABEL and unique within the pod. More info:
+          # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+          name:
+
+          # Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management
+          # or SELinux relabeling.
+          nfs:
+            # Path that is exported by the NFS server. More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#nfs
+            path:
+
+            # ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false.
+            # More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+            readOnly:
+
+            # Server is the hostname or IP address of the NFS server. More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#nfs
+            server:
+
+          # PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the
+          # bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a
+          # wrapper around another type of volume that is owned by someone else (the system).
+          persistentVolumeClaim:
+            # ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+            # More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+            claimName:
+
+            # Will force the ReadOnly setting in VolumeMounts. Default false.
+            readOnly:
+
+          # Represents a Photon Controller persistent disk resource.
+          photonPersistentDisk:
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4",
+            # "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+            fsType:
+
+            # ID that identifies Photon Controller persistent disk
+            pdID:
+
+          # PortworxVolumeSource represents a Portworx volume resource.
+          portworxVolume:
+            # FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating
+            # system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+            fsType:
+
+            # Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            readOnly:
+
+            # VolumeID uniquely identifies a Portworx volume
+            volumeID:
+
+          # Represents a projected volume source
+          projected:
+            # Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the
+            # path are not affected by this setting. This might be in conflict with other options that affect the file
+            # mode, like fsGroup, and the result can be other mode bits set.
+            defaultMode:
+
+            # list of volume projections
+            sources:
+
+          # Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership
+          # management or SELinux relabeling.
+          quobyte:
+            # Group to map volume access to Default is no group
+            group:
+
+            # ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+            readOnly:
+
+            # Registry represents a single or multiple Quobyte Registry services specified as a string as host:port
+            # pair (multiple entries are separated with commas) which acts as the central registry for volumes
+            registry:
+
+            # Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes,
+            # value is set by the plugin
+            tenant:
+
+            # User to map volume access to Defaults to serivceaccount user
+            user:
+
+            # Volume is a string that references an already created Quobyte volume by name.
+            volume:
+
+          # Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership
+          # management and SELinux relabeling.
+          rbd:
+            # Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported
+            # by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if
+            # unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+            fsType:
+
+            # The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+            image:
+
+            # Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info:
+            # https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+            keyring:
+
+            # A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+            monitors:
+
+            # The rados pool name. Default is rbd. More info:
+            # https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+            pool:
+
+            # ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info:
+            # https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+            readOnly:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            secretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+            # The rados user name. Default is admin. More info:
+            # https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+            user:
+
+          # ScaleIOVolumeSource represents a persistent ScaleIO volume
+          scaleIO:
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4",
+            # "xfs", "ntfs". Default is "xfs".
+            fsType:
+
+            # The host address of the ScaleIO API Gateway.
+            gateway:
+
+            # The name of the ScaleIO Protection Domain for the configured storage.
+            protectionDomain:
+
+            # Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            readOnly:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            secretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+            # Flag to enable/disable SSL communication with Gateway, default false
+            sslEnabled:
+
+            # Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is
+            # ThinProvisioned.
+            storageMode:
+
+            # The ScaleIO Storage Pool associated with the protection domain.
+            storagePool:
+
+            # The name of the storage system as configured in ScaleIO.
+            system:
+
+            # The name of a volume already created in the ScaleIO system that is associated with this volume source.
+            volumeName:
+
+          # Adapts a Secret into a volume.
+          #
+          # The contents of the target Secret's Data field will be presented in a volume as files using the keys in
+          # the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.
+          secret:
+            # Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to
+            # 0644. Directories within the path are not affected by this setting. This might be in conflict with other
+            # options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+            defaultMode:
+
+            # If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into
+            # the volume as a file whose name is the key and content is the value. If specified, the listed keys will
+            # be projected into the specified paths, and unlisted keys will not be present. If a key is specified
+            # which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must
+            # be relative and may not contain the '..' path or start with '..'.
+            items:
+
+            # Specify whether the Secret or its keys must be defined
+            optional:
+
+            # Name of the secret in the pod's namespace to use. More info:
+            # https://kubernetes.io/docs/concepts/storage/volumes#secret
+            secretName:
+
+          # Represents a StorageOS persistent volume resource.
+          storageos:
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4",
+            # "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+            fsType:
+
+            # Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+            readOnly:
+
+            # LocalObjectReference contains enough information to let you locate the referenced object inside the same
+            # namespace.
+            secretRef:
+              # Name of the referent. More info:
+              # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+              name:
+
+            # VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a
+            # namespace.
+            volumeName:
+
+            # VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then
+            # the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within
+            # StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to
+            # "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within
+            # StorageOS will be created.
+            volumeNamespace:
+
+          # Represents a vSphere volume resource.
+          vsphereVolume:
+            # Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4",
+            # "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+            fsType:
+
+            # Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+            storagePolicyID:
+
+            # Storage Policy Based Management (SPBM) profile name.
+            storagePolicyName:
+
+            # Path that identifies vSphere volume vmdk
+            volumePath:
+
+      # A list of volume mounts, referencing the volumes defined in the `volumes` field, specifying how and where to
+      # mount the volume in the Kaniko Pod container. The schema for this field is the same as on the
+      # `containers[].volumeMounts` field on a Pod spec, and is passed directly to the Kaniko Pod container spec.
+      volumeMounts: []
+        - # Path within the container at which the volume should be mounted.  Must not contain ':'.
+          mountPath:
+
+          # mountPropagation determines how mounts are propagated from the host to container and the other way around.
+          # When not set, MountPropagationNone is used. This field is beta in 1.10.
+          mountPropagation:
+
+          # This must match the Name of a Volume.
+          name:
+
+          # Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+          readOnly:
+
+          # Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's
+          # root).
+          subPath:
+
+          # Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to
+          # SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+          # Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+          subPathExpr:
 
     # A default hostname to use when no hostname is explicitly configured for a service.
     defaultHostname:
@@ -361,6 +1575,1691 @@ Enable [BuildKit](https://github.com/moby/buildkit) support. This should in most
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
+### `providers[].clusterDocker.volumes[]`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > volumes
+
+A list of volumes that you'd like to attach to the in-cluster Docker deployment Pod. Note that you also need to specify corresponding mounts using the `volumeMounts` field, much like how you specify `volumes` and `containers[].volumeMounts` separately in a Kubernetes Pod spec. In fact, the schema for this field is precisely the same as on the `volumes` field on a Pod spec, and is passed directly to the Docker Deployment spec.
+
+Typical examples would be referencing a Kubernetes Secret, containing e.g. auth information for private package repositories, as well as cache volumes to accelerate image builds.
+
+**Important: Volumes declared here must must be available in the garden-system namespace.**
+
+| Type                  | Default | Required |
+| --------------------- | ------- | -------- |
+| `array[customObject]` | `[]`    | No       |
+
+Example:
+
+```yaml
+providers:
+  - clusterDocker:
+      ...
+      volumes:
+        name: my-auth-secret
+        secret:
+          secretName: my-auth-secret
+```
+
+### `providers[].clusterDocker.volumes[].awsElasticBlockStore`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > awsElasticBlockStore
+
+Represents a Persistent Disk resource in AWS.
+
+An AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].awsElasticBlockStore.fsType`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [awsElasticBlockStore](#providersclusterdockervolumesawselasticblockstore) > fsType
+
+Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].awsElasticBlockStore.partition`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [awsElasticBlockStore](#providersclusterdockervolumesawselasticblockstore) > partition
+
+The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].clusterDocker.volumes[].awsElasticBlockStore.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [awsElasticBlockStore](#providersclusterdockervolumesawselasticblockstore) > readOnly
+
+Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].awsElasticBlockStore.volumeID`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [awsElasticBlockStore](#providersclusterdockervolumesawselasticblockstore) > volumeID
+
+Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].azureDisk`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > azureDisk
+
+AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].azureDisk.cachingMode`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [azureDisk](#providersclusterdockervolumesazuredisk) > cachingMode
+
+Host Caching mode: None, Read Only, Read Write.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].azureDisk.diskName`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [azureDisk](#providersclusterdockervolumesazuredisk) > diskName
+
+The Name of the data disk in the blob storage
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].azureDisk.diskURI`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [azureDisk](#providersclusterdockervolumesazuredisk) > diskURI
+
+The URI the data disk in the blob storage
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].azureDisk.fsType`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [azureDisk](#providersclusterdockervolumesazuredisk) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].azureDisk.kind`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [azureDisk](#providersclusterdockervolumesazuredisk) > kind
+
+Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].azureDisk.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [azureDisk](#providersclusterdockervolumesazuredisk) > readOnly
+
+Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].azureFile`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > azureFile
+
+AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].azureFile.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [azureFile](#providersclusterdockervolumesazurefile) > readOnly
+
+Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].azureFile.secretName`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [azureFile](#providersclusterdockervolumesazurefile) > secretName
+
+the name of secret that contains Azure Storage Account Name and Key
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].azureFile.shareName`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [azureFile](#providersclusterdockervolumesazurefile) > shareName
+
+Share Name
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].cephfs`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > cephfs
+
+Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].cephfs.monitors[]`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [cephfs](#providersclusterdockervolumescephfs) > monitors
+
+Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].clusterDocker.volumes[].cephfs.path`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [cephfs](#providersclusterdockervolumescephfs) > path
+
+Optional: Used as the mounted root, rather than the full Ceph tree, default is /
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].cephfs.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [cephfs](#providersclusterdockervolumescephfs) > readOnly
+
+Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].cephfs.secretFile`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [cephfs](#providersclusterdockervolumescephfs) > secretFile
+
+Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].cephfs.secretRef`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [cephfs](#providersclusterdockervolumescephfs) > secretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].cephfs.secretRef.name`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [cephfs](#providersclusterdockervolumescephfs) > [secretRef](#providersclusterdockervolumescephfssecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].cephfs.user`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [cephfs](#providersclusterdockervolumescephfs) > user
+
+Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].cinder`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > cinder
+
+Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].cinder.fsType`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [cinder](#providersclusterdockervolumescinder) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].cinder.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [cinder](#providersclusterdockervolumescinder) > readOnly
+
+Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].cinder.secretRef`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [cinder](#providersclusterdockervolumescinder) > secretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].cinder.secretRef.name`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [cinder](#providersclusterdockervolumescinder) > [secretRef](#providersclusterdockervolumescindersecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].cinder.volumeID`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [cinder](#providersclusterdockervolumescinder) > volumeID
+
+volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].configMap`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > configMap
+
+Adapts a ConfigMap into a volume.
+
+The contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].configMap.defaultMode`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [configMap](#providersclusterdockervolumesconfigmap) > defaultMode
+
+Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].clusterDocker.volumes[].configMap.items[]`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [configMap](#providersclusterdockervolumesconfigmap) > items
+
+If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].clusterDocker.volumes[].configMap.name`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [configMap](#providersclusterdockervolumesconfigmap) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].configMap.optional`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [configMap](#providersclusterdockervolumesconfigmap) > optional
+
+Specify whether the ConfigMap or its keys must be defined
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].csi`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > csi
+
+Represents a source location of a volume to mount, managed by an external CSI driver
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].csi.driver`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [csi](#providersclusterdockervolumescsi) > driver
+
+Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].csi.fsType`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [csi](#providersclusterdockervolumescsi) > fsType
+
+Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].csi.nodePublishSecretRef`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [csi](#providersclusterdockervolumescsi) > nodePublishSecretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].csi.nodePublishSecretRef.name`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [csi](#providersclusterdockervolumescsi) > [nodePublishSecretRef](#providersclusterdockervolumescsinodepublishsecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].csi.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [csi](#providersclusterdockervolumescsi) > readOnly
+
+Specifies a read-only configuration for the volume. Defaults to false (read/write).
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].csi.volumeAttributes`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [csi](#providersclusterdockervolumescsi) > volumeAttributes
+
+VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].downwardAPI`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > downwardAPI
+
+DownwardAPIVolumeSource represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].downwardAPI.defaultMode`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [downwardAPI](#providersclusterdockervolumesdownwardapi) > defaultMode
+
+Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].clusterDocker.volumes[].downwardAPI.items[]`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [downwardAPI](#providersclusterdockervolumesdownwardapi) > items
+
+Items is a list of downward API volume file
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].clusterDocker.volumes[].emptyDir`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > emptyDir
+
+Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].emptyDir.medium`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [emptyDir](#providersclusterdockervolumesemptydir) > medium
+
+What type of storage medium should back this directory. The default is "" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].emptyDir.sizeLimit`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [emptyDir](#providersclusterdockervolumesemptydir) > sizeLimit
+
+| Type              | Required |
+| ----------------- | -------- |
+| `string | number` | No       |
+
+### `providers[].clusterDocker.volumes[].fc`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > fc
+
+Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].fc.fsType`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [fc](#providersclusterdockervolumesfc) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].fc.lun`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [fc](#providersclusterdockervolumesfc) > lun
+
+Optional: FC target lun number
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].clusterDocker.volumes[].fc.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [fc](#providersclusterdockervolumesfc) > readOnly
+
+Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].fc.targetWWNs[]`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [fc](#providersclusterdockervolumesfc) > targetWWNs
+
+Optional: FC target worldwide names (WWNs)
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].clusterDocker.volumes[].fc.wwids[]`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [fc](#providersclusterdockervolumesfc) > wwids
+
+Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].clusterDocker.volumes[].flexVolume`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > flexVolume
+
+FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].flexVolume.driver`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [flexVolume](#providersclusterdockervolumesflexvolume) > driver
+
+Driver is the name of the driver to use for this volume.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].flexVolume.fsType`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [flexVolume](#providersclusterdockervolumesflexvolume) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].flexVolume.options`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [flexVolume](#providersclusterdockervolumesflexvolume) > options
+
+Optional: Extra command options if any.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].flexVolume.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [flexVolume](#providersclusterdockervolumesflexvolume) > readOnly
+
+Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].flexVolume.secretRef`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [flexVolume](#providersclusterdockervolumesflexvolume) > secretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].flexVolume.secretRef.name`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [flexVolume](#providersclusterdockervolumesflexvolume) > [secretRef](#providersclusterdockervolumesflexvolumesecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].flocker`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > flocker
+
+Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].flocker.datasetName`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [flocker](#providersclusterdockervolumesflocker) > datasetName
+
+Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].flocker.datasetUUID`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [flocker](#providersclusterdockervolumesflocker) > datasetUUID
+
+UUID of the dataset. This is unique identifier of a Flocker dataset
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].gcePersistentDisk`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > gcePersistentDisk
+
+Represents a Persistent Disk resource in Google Compute Engine.
+
+A GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].gcePersistentDisk.fsType`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [gcePersistentDisk](#providersclusterdockervolumesgcepersistentdisk) > fsType
+
+Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].gcePersistentDisk.partition`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [gcePersistentDisk](#providersclusterdockervolumesgcepersistentdisk) > partition
+
+The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].clusterDocker.volumes[].gcePersistentDisk.pdName`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [gcePersistentDisk](#providersclusterdockervolumesgcepersistentdisk) > pdName
+
+Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].gcePersistentDisk.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [gcePersistentDisk](#providersclusterdockervolumesgcepersistentdisk) > readOnly
+
+ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].gitRepo`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > gitRepo
+
+Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.
+
+DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].gitRepo.directory`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [gitRepo](#providersclusterdockervolumesgitrepo) > directory
+
+Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].gitRepo.repository`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [gitRepo](#providersclusterdockervolumesgitrepo) > repository
+
+Repository URL
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].gitRepo.revision`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [gitRepo](#providersclusterdockervolumesgitrepo) > revision
+
+Commit hash for the specified revision.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].glusterfs`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > glusterfs
+
+Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].glusterfs.endpoints`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [glusterfs](#providersclusterdockervolumesglusterfs) > endpoints
+
+EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].glusterfs.path`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [glusterfs](#providersclusterdockervolumesglusterfs) > path
+
+Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].glusterfs.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [glusterfs](#providersclusterdockervolumesglusterfs) > readOnly
+
+ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].hostPath`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > hostPath
+
+Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].hostPath.path`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [hostPath](#providersclusterdockervolumeshostpath) > path
+
+Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].hostPath.type`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [hostPath](#providersclusterdockervolumeshostpath) > type
+
+Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].iscsi`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > iscsi
+
+Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].iscsi.chapAuthDiscovery`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [iscsi](#providersclusterdockervolumesiscsi) > chapAuthDiscovery
+
+whether support iSCSI Discovery CHAP authentication
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].iscsi.chapAuthSession`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [iscsi](#providersclusterdockervolumesiscsi) > chapAuthSession
+
+whether support iSCSI Session CHAP authentication
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].iscsi.fsType`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [iscsi](#providersclusterdockervolumesiscsi) > fsType
+
+Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].iscsi.initiatorName`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [iscsi](#providersclusterdockervolumesiscsi) > initiatorName
+
+Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].iscsi.iqn`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [iscsi](#providersclusterdockervolumesiscsi) > iqn
+
+Target iSCSI Qualified Name.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].iscsi.iscsiInterface`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [iscsi](#providersclusterdockervolumesiscsi) > iscsiInterface
+
+iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].iscsi.lun`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [iscsi](#providersclusterdockervolumesiscsi) > lun
+
+iSCSI Target Lun number.
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].clusterDocker.volumes[].iscsi.portals[]`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [iscsi](#providersclusterdockervolumesiscsi) > portals
+
+iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].clusterDocker.volumes[].iscsi.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [iscsi](#providersclusterdockervolumesiscsi) > readOnly
+
+ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].iscsi.secretRef`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [iscsi](#providersclusterdockervolumesiscsi) > secretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].iscsi.secretRef.name`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [iscsi](#providersclusterdockervolumesiscsi) > [secretRef](#providersclusterdockervolumesiscsisecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].iscsi.targetPortal`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [iscsi](#providersclusterdockervolumesiscsi) > targetPortal
+
+iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].name`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > name
+
+Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].nfs`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > nfs
+
+Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].nfs.path`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [nfs](#providersclusterdockervolumesnfs) > path
+
+Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].nfs.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [nfs](#providersclusterdockervolumesnfs) > readOnly
+
+ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].nfs.server`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [nfs](#providersclusterdockervolumesnfs) > server
+
+Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].persistentVolumeClaim`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > persistentVolumeClaim
+
+PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].persistentVolumeClaim.claimName`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [persistentVolumeClaim](#providersclusterdockervolumespersistentvolumeclaim) > claimName
+
+ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].persistentVolumeClaim.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [persistentVolumeClaim](#providersclusterdockervolumespersistentvolumeclaim) > readOnly
+
+Will force the ReadOnly setting in VolumeMounts. Default false.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].photonPersistentDisk`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > photonPersistentDisk
+
+Represents a Photon Controller persistent disk resource.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].photonPersistentDisk.fsType`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [photonPersistentDisk](#providersclusterdockervolumesphotonpersistentdisk) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].photonPersistentDisk.pdID`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [photonPersistentDisk](#providersclusterdockervolumesphotonpersistentdisk) > pdID
+
+ID that identifies Photon Controller persistent disk
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].portworxVolume`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > portworxVolume
+
+PortworxVolumeSource represents a Portworx volume resource.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].portworxVolume.fsType`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [portworxVolume](#providersclusterdockervolumesportworxvolume) > fsType
+
+FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].portworxVolume.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [portworxVolume](#providersclusterdockervolumesportworxvolume) > readOnly
+
+Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].portworxVolume.volumeID`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [portworxVolume](#providersclusterdockervolumesportworxvolume) > volumeID
+
+VolumeID uniquely identifies a Portworx volume
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].projected`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > projected
+
+Represents a projected volume source
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].projected.defaultMode`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [projected](#providersclusterdockervolumesprojected) > defaultMode
+
+Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].clusterDocker.volumes[].projected.sources[]`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [projected](#providersclusterdockervolumesprojected) > sources
+
+list of volume projections
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].clusterDocker.volumes[].quobyte`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > quobyte
+
+Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].quobyte.group`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [quobyte](#providersclusterdockervolumesquobyte) > group
+
+Group to map volume access to Default is no group
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].quobyte.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [quobyte](#providersclusterdockervolumesquobyte) > readOnly
+
+ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].quobyte.registry`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [quobyte](#providersclusterdockervolumesquobyte) > registry
+
+Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].quobyte.tenant`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [quobyte](#providersclusterdockervolumesquobyte) > tenant
+
+Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].quobyte.user`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [quobyte](#providersclusterdockervolumesquobyte) > user
+
+User to map volume access to Defaults to serivceaccount user
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].quobyte.volume`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [quobyte](#providersclusterdockervolumesquobyte) > volume
+
+Volume is a string that references an already created Quobyte volume by name.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].rbd`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > rbd
+
+Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].rbd.fsType`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [rbd](#providersclusterdockervolumesrbd) > fsType
+
+Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].rbd.image`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [rbd](#providersclusterdockervolumesrbd) > image
+
+The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].rbd.keyring`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [rbd](#providersclusterdockervolumesrbd) > keyring
+
+Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].rbd.monitors[]`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [rbd](#providersclusterdockervolumesrbd) > monitors
+
+A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].clusterDocker.volumes[].rbd.pool`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [rbd](#providersclusterdockervolumesrbd) > pool
+
+The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].rbd.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [rbd](#providersclusterdockervolumesrbd) > readOnly
+
+ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].rbd.secretRef`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [rbd](#providersclusterdockervolumesrbd) > secretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].rbd.secretRef.name`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [rbd](#providersclusterdockervolumesrbd) > [secretRef](#providersclusterdockervolumesrbdsecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].rbd.user`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [rbd](#providersclusterdockervolumesrbd) > user
+
+The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].scaleIO`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > scaleIO
+
+ScaleIOVolumeSource represents a persistent ScaleIO volume
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].scaleIO.fsType`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [scaleIO](#providersclusterdockervolumesscaleio) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].scaleIO.gateway`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [scaleIO](#providersclusterdockervolumesscaleio) > gateway
+
+The host address of the ScaleIO API Gateway.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].scaleIO.protectionDomain`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [scaleIO](#providersclusterdockervolumesscaleio) > protectionDomain
+
+The name of the ScaleIO Protection Domain for the configured storage.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].scaleIO.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [scaleIO](#providersclusterdockervolumesscaleio) > readOnly
+
+Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].scaleIO.secretRef`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [scaleIO](#providersclusterdockervolumesscaleio) > secretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].scaleIO.secretRef.name`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [scaleIO](#providersclusterdockervolumesscaleio) > [secretRef](#providersclusterdockervolumesscaleiosecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].scaleIO.sslEnabled`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [scaleIO](#providersclusterdockervolumesscaleio) > sslEnabled
+
+Flag to enable/disable SSL communication with Gateway, default false
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].scaleIO.storageMode`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [scaleIO](#providersclusterdockervolumesscaleio) > storageMode
+
+Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].scaleIO.storagePool`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [scaleIO](#providersclusterdockervolumesscaleio) > storagePool
+
+The ScaleIO Storage Pool associated with the protection domain.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].scaleIO.system`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [scaleIO](#providersclusterdockervolumesscaleio) > system
+
+The name of the storage system as configured in ScaleIO.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].scaleIO.volumeName`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [scaleIO](#providersclusterdockervolumesscaleio) > volumeName
+
+The name of a volume already created in the ScaleIO system that is associated with this volume source.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].secret`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > secret
+
+Adapts a Secret into a volume.
+
+The contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].secret.defaultMode`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [secret](#providersclusterdockervolumessecret) > defaultMode
+
+Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].clusterDocker.volumes[].secret.items[]`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [secret](#providersclusterdockervolumessecret) > items
+
+If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].clusterDocker.volumes[].secret.optional`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [secret](#providersclusterdockervolumessecret) > optional
+
+Specify whether the Secret or its keys must be defined
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].secret.secretName`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [secret](#providersclusterdockervolumessecret) > secretName
+
+Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].storageos`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > storageos
+
+Represents a StorageOS persistent volume resource.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].storageos.fsType`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [storageos](#providersclusterdockervolumesstorageos) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].storageos.readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [storageos](#providersclusterdockervolumesstorageos) > readOnly
+
+Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumes[].storageos.secretRef`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [storageos](#providersclusterdockervolumesstorageos) > secretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].storageos.secretRef.name`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [storageos](#providersclusterdockervolumesstorageos) > [secretRef](#providersclusterdockervolumesstorageossecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].storageos.volumeName`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [storageos](#providersclusterdockervolumesstorageos) > volumeName
+
+VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].storageos.volumeNamespace`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [storageos](#providersclusterdockervolumesstorageos) > volumeNamespace
+
+VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].vsphereVolume`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > vsphereVolume
+
+Represents a vSphere volume resource.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].clusterDocker.volumes[].vsphereVolume.fsType`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [vsphereVolume](#providersclusterdockervolumesvspherevolume) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].vsphereVolume.storagePolicyID`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [vsphereVolume](#providersclusterdockervolumesvspherevolume) > storagePolicyID
+
+Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].vsphereVolume.storagePolicyName`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [vsphereVolume](#providersclusterdockervolumesvspherevolume) > storagePolicyName
+
+Storage Policy Based Management (SPBM) profile name.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumes[].vsphereVolume.volumePath`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumes](#providersclusterdockervolumes) > [vsphereVolume](#providersclusterdockervolumesvspherevolume) > volumePath
+
+Path that identifies vSphere volume vmdk
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumeMounts[]`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > volumeMounts
+
+A list of volume mounts, referencing the volumes defined in the `volumes` field, specifying how and where to mount the volume in the Docker deployment container. The schema for this field is the same as on the `containers[].volumeMounts` field on a Pod spec.
+
+| Type                  | Default | Required |
+| --------------------- | ------- | -------- |
+| `array[customObject]` | `[]`    | No       |
+
+Example:
+
+```yaml
+providers:
+  - clusterDocker:
+      ...
+      volumeMounts:
+        name: my-auth-secret
+        mountPath: /.my-custom-auth
+```
+
+### `providers[].clusterDocker.volumeMounts[].mountPath`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumeMounts](#providersclusterdockervolumemounts) > mountPath
+
+Path within the container at which the volume should be mounted.  Must not contain ':'.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumeMounts[].mountPropagation`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumeMounts](#providersclusterdockervolumemounts) > mountPropagation
+
+mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumeMounts[].name`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumeMounts](#providersclusterdockervolumemounts) > name
+
+This must match the Name of a Volume.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumeMounts[].readOnly`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumeMounts](#providersclusterdockervolumemounts) > readOnly
+
+Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].clusterDocker.volumeMounts[].subPath`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumeMounts](#providersclusterdockervolumemounts) > subPath
+
+Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].clusterDocker.volumeMounts[].subPathExpr`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > [volumeMounts](#providersclusterdockervolumemounts) > subPathExpr
+
+Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
 ### `providers[].kaniko`
 
 [providers](#providers) > kaniko
@@ -390,6 +3289,1691 @@ Specify extra flags to use when building the container image with kaniko. Flags 
 | Type            | Required |
 | --------------- | -------- |
 | `array[string]` | No       |
+
+### `providers[].kaniko.volumes[]`
+
+[providers](#providers) > [kaniko](#providerskaniko) > volumes
+
+A list of volumes that you'd like to attach to every Kaniko Pod during builds. Note that you also need to specify corresponding mounts using the `volumeMounts` field, much like how you specify `volumes` and `containers[].volumeMounts` separately in a Kubernetes Pod spec. In fact, the schema for this field is precisely the same as on the `volumes` field on a Pod spec, and is passed directly to the Kaniko Pods.
+
+Typical examples would be referencing a Kubernetes Secret, containing e.g. auth information for private package repositories, as well as shared cache volumes to accelerate image builds.
+
+**Important: Volumes declared here must support ReadWriteMany access, since multiple Kaniko Pods will run at the same time, and must also be available in the garden-system namespace.**
+
+| Type                  | Default | Required |
+| --------------------- | ------- | -------- |
+| `array[customObject]` | `[]`    | No       |
+
+Example:
+
+```yaml
+providers:
+  - kaniko:
+      ...
+      volumes:
+        name: my-auth-secret
+        secret:
+          secretName: my-auth-secret
+```
+
+### `providers[].kaniko.volumes[].awsElasticBlockStore`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > awsElasticBlockStore
+
+Represents a Persistent Disk resource in AWS.
+
+An AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].awsElasticBlockStore.fsType`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [awsElasticBlockStore](#providerskanikovolumesawselasticblockstore) > fsType
+
+Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].awsElasticBlockStore.partition`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [awsElasticBlockStore](#providerskanikovolumesawselasticblockstore) > partition
+
+The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].kaniko.volumes[].awsElasticBlockStore.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [awsElasticBlockStore](#providerskanikovolumesawselasticblockstore) > readOnly
+
+Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].awsElasticBlockStore.volumeID`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [awsElasticBlockStore](#providerskanikovolumesawselasticblockstore) > volumeID
+
+Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].azureDisk`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > azureDisk
+
+AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].azureDisk.cachingMode`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [azureDisk](#providerskanikovolumesazuredisk) > cachingMode
+
+Host Caching mode: None, Read Only, Read Write.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].azureDisk.diskName`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [azureDisk](#providerskanikovolumesazuredisk) > diskName
+
+The Name of the data disk in the blob storage
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].azureDisk.diskURI`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [azureDisk](#providerskanikovolumesazuredisk) > diskURI
+
+The URI the data disk in the blob storage
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].azureDisk.fsType`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [azureDisk](#providerskanikovolumesazuredisk) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].azureDisk.kind`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [azureDisk](#providerskanikovolumesazuredisk) > kind
+
+Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].azureDisk.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [azureDisk](#providerskanikovolumesazuredisk) > readOnly
+
+Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].azureFile`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > azureFile
+
+AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].azureFile.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [azureFile](#providerskanikovolumesazurefile) > readOnly
+
+Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].azureFile.secretName`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [azureFile](#providerskanikovolumesazurefile) > secretName
+
+the name of secret that contains Azure Storage Account Name and Key
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].azureFile.shareName`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [azureFile](#providerskanikovolumesazurefile) > shareName
+
+Share Name
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].cephfs`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > cephfs
+
+Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].cephfs.monitors[]`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [cephfs](#providerskanikovolumescephfs) > monitors
+
+Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].kaniko.volumes[].cephfs.path`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [cephfs](#providerskanikovolumescephfs) > path
+
+Optional: Used as the mounted root, rather than the full Ceph tree, default is /
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].cephfs.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [cephfs](#providerskanikovolumescephfs) > readOnly
+
+Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].cephfs.secretFile`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [cephfs](#providerskanikovolumescephfs) > secretFile
+
+Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].cephfs.secretRef`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [cephfs](#providerskanikovolumescephfs) > secretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].cephfs.secretRef.name`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [cephfs](#providerskanikovolumescephfs) > [secretRef](#providerskanikovolumescephfssecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].cephfs.user`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [cephfs](#providerskanikovolumescephfs) > user
+
+Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].cinder`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > cinder
+
+Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].cinder.fsType`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [cinder](#providerskanikovolumescinder) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].cinder.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [cinder](#providerskanikovolumescinder) > readOnly
+
+Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].cinder.secretRef`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [cinder](#providerskanikovolumescinder) > secretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].cinder.secretRef.name`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [cinder](#providerskanikovolumescinder) > [secretRef](#providerskanikovolumescindersecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].cinder.volumeID`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [cinder](#providerskanikovolumescinder) > volumeID
+
+volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].configMap`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > configMap
+
+Adapts a ConfigMap into a volume.
+
+The contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].configMap.defaultMode`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [configMap](#providerskanikovolumesconfigmap) > defaultMode
+
+Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].kaniko.volumes[].configMap.items[]`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [configMap](#providerskanikovolumesconfigmap) > items
+
+If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].kaniko.volumes[].configMap.name`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [configMap](#providerskanikovolumesconfigmap) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].configMap.optional`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [configMap](#providerskanikovolumesconfigmap) > optional
+
+Specify whether the ConfigMap or its keys must be defined
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].csi`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > csi
+
+Represents a source location of a volume to mount, managed by an external CSI driver
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].csi.driver`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [csi](#providerskanikovolumescsi) > driver
+
+Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].csi.fsType`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [csi](#providerskanikovolumescsi) > fsType
+
+Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].csi.nodePublishSecretRef`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [csi](#providerskanikovolumescsi) > nodePublishSecretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].csi.nodePublishSecretRef.name`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [csi](#providerskanikovolumescsi) > [nodePublishSecretRef](#providerskanikovolumescsinodepublishsecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].csi.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [csi](#providerskanikovolumescsi) > readOnly
+
+Specifies a read-only configuration for the volume. Defaults to false (read/write).
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].csi.volumeAttributes`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [csi](#providerskanikovolumescsi) > volumeAttributes
+
+VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].downwardAPI`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > downwardAPI
+
+DownwardAPIVolumeSource represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].downwardAPI.defaultMode`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [downwardAPI](#providerskanikovolumesdownwardapi) > defaultMode
+
+Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].kaniko.volumes[].downwardAPI.items[]`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [downwardAPI](#providerskanikovolumesdownwardapi) > items
+
+Items is a list of downward API volume file
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].kaniko.volumes[].emptyDir`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > emptyDir
+
+Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].emptyDir.medium`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [emptyDir](#providerskanikovolumesemptydir) > medium
+
+What type of storage medium should back this directory. The default is "" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].emptyDir.sizeLimit`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [emptyDir](#providerskanikovolumesemptydir) > sizeLimit
+
+| Type              | Required |
+| ----------------- | -------- |
+| `string | number` | No       |
+
+### `providers[].kaniko.volumes[].fc`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > fc
+
+Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].fc.fsType`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [fc](#providerskanikovolumesfc) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].fc.lun`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [fc](#providerskanikovolumesfc) > lun
+
+Optional: FC target lun number
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].kaniko.volumes[].fc.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [fc](#providerskanikovolumesfc) > readOnly
+
+Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].fc.targetWWNs[]`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [fc](#providerskanikovolumesfc) > targetWWNs
+
+Optional: FC target worldwide names (WWNs)
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].kaniko.volumes[].fc.wwids[]`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [fc](#providerskanikovolumesfc) > wwids
+
+Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].kaniko.volumes[].flexVolume`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > flexVolume
+
+FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].flexVolume.driver`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [flexVolume](#providerskanikovolumesflexvolume) > driver
+
+Driver is the name of the driver to use for this volume.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].flexVolume.fsType`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [flexVolume](#providerskanikovolumesflexvolume) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].flexVolume.options`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [flexVolume](#providerskanikovolumesflexvolume) > options
+
+Optional: Extra command options if any.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].flexVolume.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [flexVolume](#providerskanikovolumesflexvolume) > readOnly
+
+Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].flexVolume.secretRef`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [flexVolume](#providerskanikovolumesflexvolume) > secretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].flexVolume.secretRef.name`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [flexVolume](#providerskanikovolumesflexvolume) > [secretRef](#providerskanikovolumesflexvolumesecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].flocker`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > flocker
+
+Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].flocker.datasetName`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [flocker](#providerskanikovolumesflocker) > datasetName
+
+Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].flocker.datasetUUID`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [flocker](#providerskanikovolumesflocker) > datasetUUID
+
+UUID of the dataset. This is unique identifier of a Flocker dataset
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].gcePersistentDisk`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > gcePersistentDisk
+
+Represents a Persistent Disk resource in Google Compute Engine.
+
+A GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].gcePersistentDisk.fsType`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [gcePersistentDisk](#providerskanikovolumesgcepersistentdisk) > fsType
+
+Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].gcePersistentDisk.partition`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [gcePersistentDisk](#providerskanikovolumesgcepersistentdisk) > partition
+
+The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].kaniko.volumes[].gcePersistentDisk.pdName`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [gcePersistentDisk](#providerskanikovolumesgcepersistentdisk) > pdName
+
+Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].gcePersistentDisk.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [gcePersistentDisk](#providerskanikovolumesgcepersistentdisk) > readOnly
+
+ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].gitRepo`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > gitRepo
+
+Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.
+
+DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].gitRepo.directory`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [gitRepo](#providerskanikovolumesgitrepo) > directory
+
+Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].gitRepo.repository`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [gitRepo](#providerskanikovolumesgitrepo) > repository
+
+Repository URL
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].gitRepo.revision`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [gitRepo](#providerskanikovolumesgitrepo) > revision
+
+Commit hash for the specified revision.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].glusterfs`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > glusterfs
+
+Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].glusterfs.endpoints`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [glusterfs](#providerskanikovolumesglusterfs) > endpoints
+
+EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].glusterfs.path`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [glusterfs](#providerskanikovolumesglusterfs) > path
+
+Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].glusterfs.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [glusterfs](#providerskanikovolumesglusterfs) > readOnly
+
+ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].hostPath`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > hostPath
+
+Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].hostPath.path`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [hostPath](#providerskanikovolumeshostpath) > path
+
+Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].hostPath.type`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [hostPath](#providerskanikovolumeshostpath) > type
+
+Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].iscsi`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > iscsi
+
+Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].iscsi.chapAuthDiscovery`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [iscsi](#providerskanikovolumesiscsi) > chapAuthDiscovery
+
+whether support iSCSI Discovery CHAP authentication
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].iscsi.chapAuthSession`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [iscsi](#providerskanikovolumesiscsi) > chapAuthSession
+
+whether support iSCSI Session CHAP authentication
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].iscsi.fsType`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [iscsi](#providerskanikovolumesiscsi) > fsType
+
+Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].iscsi.initiatorName`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [iscsi](#providerskanikovolumesiscsi) > initiatorName
+
+Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].iscsi.iqn`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [iscsi](#providerskanikovolumesiscsi) > iqn
+
+Target iSCSI Qualified Name.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].iscsi.iscsiInterface`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [iscsi](#providerskanikovolumesiscsi) > iscsiInterface
+
+iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].iscsi.lun`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [iscsi](#providerskanikovolumesiscsi) > lun
+
+iSCSI Target Lun number.
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].kaniko.volumes[].iscsi.portals[]`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [iscsi](#providerskanikovolumesiscsi) > portals
+
+iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].kaniko.volumes[].iscsi.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [iscsi](#providerskanikovolumesiscsi) > readOnly
+
+ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].iscsi.secretRef`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [iscsi](#providerskanikovolumesiscsi) > secretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].iscsi.secretRef.name`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [iscsi](#providerskanikovolumesiscsi) > [secretRef](#providerskanikovolumesiscsisecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].iscsi.targetPortal`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [iscsi](#providerskanikovolumesiscsi) > targetPortal
+
+iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].name`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > name
+
+Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].nfs`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > nfs
+
+Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].nfs.path`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [nfs](#providerskanikovolumesnfs) > path
+
+Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].nfs.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [nfs](#providerskanikovolumesnfs) > readOnly
+
+ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].nfs.server`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [nfs](#providerskanikovolumesnfs) > server
+
+Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].persistentVolumeClaim`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > persistentVolumeClaim
+
+PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].persistentVolumeClaim.claimName`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [persistentVolumeClaim](#providerskanikovolumespersistentvolumeclaim) > claimName
+
+ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].persistentVolumeClaim.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [persistentVolumeClaim](#providerskanikovolumespersistentvolumeclaim) > readOnly
+
+Will force the ReadOnly setting in VolumeMounts. Default false.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].photonPersistentDisk`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > photonPersistentDisk
+
+Represents a Photon Controller persistent disk resource.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].photonPersistentDisk.fsType`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [photonPersistentDisk](#providerskanikovolumesphotonpersistentdisk) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].photonPersistentDisk.pdID`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [photonPersistentDisk](#providerskanikovolumesphotonpersistentdisk) > pdID
+
+ID that identifies Photon Controller persistent disk
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].portworxVolume`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > portworxVolume
+
+PortworxVolumeSource represents a Portworx volume resource.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].portworxVolume.fsType`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [portworxVolume](#providerskanikovolumesportworxvolume) > fsType
+
+FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].portworxVolume.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [portworxVolume](#providerskanikovolumesportworxvolume) > readOnly
+
+Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].portworxVolume.volumeID`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [portworxVolume](#providerskanikovolumesportworxvolume) > volumeID
+
+VolumeID uniquely identifies a Portworx volume
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].projected`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > projected
+
+Represents a projected volume source
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].projected.defaultMode`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [projected](#providerskanikovolumesprojected) > defaultMode
+
+Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].kaniko.volumes[].projected.sources[]`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [projected](#providerskanikovolumesprojected) > sources
+
+list of volume projections
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].kaniko.volumes[].quobyte`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > quobyte
+
+Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].quobyte.group`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [quobyte](#providerskanikovolumesquobyte) > group
+
+Group to map volume access to Default is no group
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].quobyte.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [quobyte](#providerskanikovolumesquobyte) > readOnly
+
+ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].quobyte.registry`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [quobyte](#providerskanikovolumesquobyte) > registry
+
+Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].quobyte.tenant`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [quobyte](#providerskanikovolumesquobyte) > tenant
+
+Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].quobyte.user`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [quobyte](#providerskanikovolumesquobyte) > user
+
+User to map volume access to Defaults to serivceaccount user
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].quobyte.volume`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [quobyte](#providerskanikovolumesquobyte) > volume
+
+Volume is a string that references an already created Quobyte volume by name.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].rbd`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > rbd
+
+Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].rbd.fsType`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [rbd](#providerskanikovolumesrbd) > fsType
+
+Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].rbd.image`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [rbd](#providerskanikovolumesrbd) > image
+
+The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].rbd.keyring`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [rbd](#providerskanikovolumesrbd) > keyring
+
+Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].rbd.monitors[]`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [rbd](#providerskanikovolumesrbd) > monitors
+
+A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].kaniko.volumes[].rbd.pool`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [rbd](#providerskanikovolumesrbd) > pool
+
+The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].rbd.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [rbd](#providerskanikovolumesrbd) > readOnly
+
+ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].rbd.secretRef`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [rbd](#providerskanikovolumesrbd) > secretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].rbd.secretRef.name`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [rbd](#providerskanikovolumesrbd) > [secretRef](#providerskanikovolumesrbdsecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].rbd.user`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [rbd](#providerskanikovolumesrbd) > user
+
+The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].scaleIO`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > scaleIO
+
+ScaleIOVolumeSource represents a persistent ScaleIO volume
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].scaleIO.fsType`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [scaleIO](#providerskanikovolumesscaleio) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].scaleIO.gateway`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [scaleIO](#providerskanikovolumesscaleio) > gateway
+
+The host address of the ScaleIO API Gateway.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].scaleIO.protectionDomain`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [scaleIO](#providerskanikovolumesscaleio) > protectionDomain
+
+The name of the ScaleIO Protection Domain for the configured storage.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].scaleIO.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [scaleIO](#providerskanikovolumesscaleio) > readOnly
+
+Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].scaleIO.secretRef`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [scaleIO](#providerskanikovolumesscaleio) > secretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].scaleIO.secretRef.name`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [scaleIO](#providerskanikovolumesscaleio) > [secretRef](#providerskanikovolumesscaleiosecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].scaleIO.sslEnabled`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [scaleIO](#providerskanikovolumesscaleio) > sslEnabled
+
+Flag to enable/disable SSL communication with Gateway, default false
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].scaleIO.storageMode`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [scaleIO](#providerskanikovolumesscaleio) > storageMode
+
+Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].scaleIO.storagePool`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [scaleIO](#providerskanikovolumesscaleio) > storagePool
+
+The ScaleIO Storage Pool associated with the protection domain.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].scaleIO.system`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [scaleIO](#providerskanikovolumesscaleio) > system
+
+The name of the storage system as configured in ScaleIO.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].scaleIO.volumeName`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [scaleIO](#providerskanikovolumesscaleio) > volumeName
+
+The name of a volume already created in the ScaleIO system that is associated with this volume source.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].secret`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > secret
+
+Adapts a Secret into a volume.
+
+The contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].secret.defaultMode`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [secret](#providerskanikovolumessecret) > defaultMode
+
+Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+
+| Type      | Required |
+| --------- | -------- |
+| `integer` | No       |
+
+### `providers[].kaniko.volumes[].secret.items[]`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [secret](#providerskanikovolumessecret) > items
+
+If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
+
+### `providers[].kaniko.volumes[].secret.optional`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [secret](#providerskanikovolumessecret) > optional
+
+Specify whether the Secret or its keys must be defined
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].secret.secretName`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [secret](#providerskanikovolumessecret) > secretName
+
+Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].storageos`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > storageos
+
+Represents a StorageOS persistent volume resource.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].storageos.fsType`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [storageos](#providerskanikovolumesstorageos) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].storageos.readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [storageos](#providerskanikovolumesstorageos) > readOnly
+
+Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumes[].storageos.secretRef`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [storageos](#providerskanikovolumesstorageos) > secretRef
+
+LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].storageos.secretRef.name`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [storageos](#providerskanikovolumesstorageos) > [secretRef](#providerskanikovolumesstorageossecretref) > name
+
+Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].storageos.volumeName`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [storageos](#providerskanikovolumesstorageos) > volumeName
+
+VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].storageos.volumeNamespace`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [storageos](#providerskanikovolumesstorageos) > volumeNamespace
+
+VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].vsphereVolume`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > vsphereVolume
+
+Represents a vSphere volume resource.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.volumes[].vsphereVolume.fsType`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [vsphereVolume](#providerskanikovolumesvspherevolume) > fsType
+
+Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].vsphereVolume.storagePolicyID`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [vsphereVolume](#providerskanikovolumesvspherevolume) > storagePolicyID
+
+Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].vsphereVolume.storagePolicyName`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [vsphereVolume](#providerskanikovolumesvspherevolume) > storagePolicyName
+
+Storage Policy Based Management (SPBM) profile name.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumes[].vsphereVolume.volumePath`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumes](#providerskanikovolumes) > [vsphereVolume](#providerskanikovolumesvspherevolume) > volumePath
+
+Path that identifies vSphere volume vmdk
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumeMounts[]`
+
+[providers](#providers) > [kaniko](#providerskaniko) > volumeMounts
+
+A list of volume mounts, referencing the volumes defined in the `volumes` field, specifying how and where to mount the volume in the Kaniko Pod container. The schema for this field is the same as on the `containers[].volumeMounts` field on a Pod spec, and is passed directly to the Kaniko Pod container spec.
+
+| Type                  | Default | Required |
+| --------------------- | ------- | -------- |
+| `array[customObject]` | `[]`    | No       |
+
+Example:
+
+```yaml
+providers:
+  - kaniko:
+      ...
+      volumeMounts:
+        name: my-auth-secret
+        mountPath: /.my-custom-auth
+```
+
+### `providers[].kaniko.volumeMounts[].mountPath`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumeMounts](#providerskanikovolumemounts) > mountPath
+
+Path within the container at which the volume should be mounted.  Must not contain ':'.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumeMounts[].mountPropagation`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumeMounts](#providerskanikovolumemounts) > mountPropagation
+
+mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumeMounts[].name`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumeMounts](#providerskanikovolumemounts) > name
+
+This must match the Name of a Volume.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumeMounts[].readOnly`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumeMounts](#providerskanikovolumemounts) > readOnly
+
+Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+
+| Type      | Required |
+| --------- | -------- |
+| `boolean` | No       |
+
+### `providers[].kaniko.volumeMounts[].subPath`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumeMounts](#providerskanikovolumemounts) > subPath
+
+Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.volumeMounts[].subPathExpr`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [volumeMounts](#providerskanikovolumemounts) > subPathExpr
+
+Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
 
 ### `providers[].defaultHostname`
 

--- a/garden-service/src/docs/json-schema.ts
+++ b/garden-service/src/docs/json-schema.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { flatten, isArray } from "lodash"
+import { flatten, isArray, uniq } from "lodash"
 import { NormalizedSchemaDescription, NormalizeOptions } from "./common"
 import { ValidationError } from "../exceptions"
 import { safeDumpYaml } from "../util/util"
@@ -140,11 +140,13 @@ function normalizeJsonKeyDescription(
 }
 
 function getType(schema: any): string {
-  const { type } = schema
+  const { type, oneOf } = schema
 
   if (isArray(type)) {
     // TODO: handle multiple type options
     return type.filter((t) => t !== null)[0]
+  } else if (oneOf) {
+    return uniq(oneOf.map(formatType)).join(" | ")
   } else {
     return type
   }

--- a/garden-service/src/plugins/kubernetes/config.ts
+++ b/garden-service/src/plugins/kubernetes/config.ts
@@ -25,7 +25,8 @@ import { hotReloadableKinds, HotReloadableKind } from "./hot-reload"
 import { baseTaskSpecSchema, BaseTaskSpec, cacheResultSchema } from "../../config/task"
 import { baseTestSpecSchema, BaseTestSpec } from "../../config/test"
 import { ArtifactSpec } from "../../config/validation"
-import { V1Toleration } from "@kubernetes/client-node"
+import { V1Toleration, V1Volume, V1VolumeMount } from "@kubernetes/client-node"
+import { volumeSchema, volumeMountSchema } from "./volumes/volume"
 
 export const DEFAULT_KANIKO_IMAGE = "gcr.io/kaniko-project/executor:debug-v0.23.0"
 export interface ProviderSecretRef {
@@ -91,10 +92,14 @@ export interface KubernetesConfig extends ProviderConfig {
   buildMode: ContainerBuildMode
   clusterDocker?: {
     enableBuildKit?: boolean
+    volumes?: V1Volume[]
+    volumeMounts?: V1VolumeMount[]
   }
   kaniko?: {
     image?: string
     extraFlags?: string[]
+    volumes?: V1Volume[]
+    volumeMounts?: V1VolumeMount[]
   }
   context: string
   defaultHostname?: string
@@ -292,13 +297,14 @@ const tlsCertificateSchema = () =>
       .example("cert-manager"),
   })
 
-export const kubernetesConfigBase = providerConfigBaseSchema().keys({
-  buildMode: joi
-    .string()
-    .allow("local-docker", "cluster-docker", "kaniko")
-    .default("local-docker")
-    .description(
-      dedent`
+export const kubernetesConfigBase = () =>
+  providerConfigBaseSchema().keys({
+    buildMode: joi
+      .string()
+      .allow("local-docker", "cluster-docker", "kaniko")
+      .default("local-docker")
+      .description(
+        dedent`
         Choose the mechanism for building container images before deploying. By default it uses the local Docker
         daemon, but you can set it to \`cluster-docker\` or \`kaniko\` to sync files to a remote Docker daemon,
         installed in the cluster, and build container images there. This removes the need to run Docker or
@@ -315,80 +321,128 @@ export const kubernetesConfigBase = providerConfigBaseSchema().keys({
         this is less secure than Kaniko, but in turn it is generally faster. See the
         [Kaniko docs](https://github.com/GoogleContainerTools/kaniko) for more information on Kaniko.
       `
-    ),
-  clusterDocker: joi
-    .object()
-    .keys({
-      enableBuildKit: joi
-        .boolean()
-        .default(false)
-        .description(
-          deline`
+      ),
+    clusterDocker: joi
+      .object()
+      .keys({
+        enableBuildKit: joi
+          .boolean()
+          .default(false)
+          .description(
+            deline`
             Enable [BuildKit](https://github.com/moby/buildkit) support. This should in most cases work well and be
             more performant, but we're opting to keep it optional until it's enabled by default in Docker.
           `
-        ),
-    })
-    .default(() => {})
-    .description("Configuration options for the `cluster-docker` build mode."),
-  kaniko: joi
-    .object()
-    .keys({
-      image: joi
-        .string()
-        .default(DEFAULT_KANIKO_IMAGE)
-        .description(
-          deline`
+          ),
+        volumes: joiArray(volumeSchema())
+          .description(
+            dedent`
+            A list of volumes that you'd like to attach to the in-cluster Docker deployment Pod. Note that you also need to specify corresponding mounts using the \`volumeMounts\` field, much like how you specify \`volumes\` and \`containers[].volumeMounts\` separately in a Kubernetes Pod spec. In fact, the schema for this field is precisely the same as on the \`volumes\` field on a Pod spec, and is passed directly to the Docker Deployment spec.
+
+            Typical examples would be referencing a Kubernetes Secret, containing e.g. auth information for private package repositories, as well as cache volumes to accelerate image builds.
+
+            **Important: Volumes declared here must must be available in the garden-system namespace.**
+            `
+          )
+          .example({
+            name: "my-auth-secret",
+            secret: {
+              secretName: "my-auth-secret",
+            },
+          }),
+        volumeMounts: joiArray(volumeMountSchema())
+          .description(
+            "A list of volume mounts, referencing the volumes defined in the `volumes` field, specifying how and where to mount the volume in the Docker deployment container. The schema for this field is the same as on the `containers[].volumeMounts` field on a Pod spec."
+          )
+          .example({
+            name: "my-auth-secret",
+            mountPath: "/.my-custom-auth",
+          }),
+      })
+      .default(() => {})
+      .description("Configuration options for the `cluster-docker` build mode."),
+    kaniko: joi
+      .object()
+      .keys({
+        image: joi
+          .string()
+          .default(DEFAULT_KANIKO_IMAGE)
+          .description(
+            deline`
             Change the kaniko image (repository/image:tag) to use when building in kaniko mode.
           `
-        ),
-      extraFlags: joi.array().items(joi.string()).description(deline`
+          ),
+        extraFlags: joi.array().items(joi.string()).description(deline`
         Specify extra flags to use when building the container image with kaniko.
         Flags set on container module take precedence over these.`),
-    })
-    .default(() => {})
-    .description("Configuration options for the `kaniko` build mode."),
-  defaultHostname: joi
-    .string()
-    .description("A default hostname to use when no hostname is explicitly configured for a service.")
-    .example("api.mydomain.com"),
-  deploymentStrategy: joi
-    .string()
-    .default("rolling")
-    .allow("rolling", "blue-green")
-    .description(
-      dedent`
+        volumes: joiArray(volumeSchema())
+          .description(
+            dedent`
+            A list of volumes that you'd like to attach to every Kaniko Pod during builds. Note that you also need to specify corresponding mounts using the \`volumeMounts\` field, much like how you specify \`volumes\` and \`containers[].volumeMounts\` separately in a Kubernetes Pod spec. In fact, the schema for this field is precisely the same as on the \`volumes\` field on a Pod spec, and is passed directly to the Kaniko Pods.
+
+            Typical examples would be referencing a Kubernetes Secret, containing e.g. auth information for private package repositories, as well as shared cache volumes to accelerate image builds.
+
+            **Important: Volumes declared here must support ReadWriteMany access, since multiple Kaniko Pods will run at the same time, and must also be available in the garden-system namespace.**
+            `
+          )
+          .example({
+            name: "my-auth-secret",
+            secret: {
+              secretName: "my-auth-secret",
+            },
+          }),
+        volumeMounts: joiArray(volumeMountSchema())
+          .description(
+            "A list of volume mounts, referencing the volumes defined in the `volumes` field, specifying how and where to mount the volume in the Kaniko Pod container. The schema for this field is the same as on the `containers[].volumeMounts` field on a Pod spec, and is passed directly to the Kaniko Pod container spec."
+          )
+          .example({
+            name: "my-auth-secret",
+            mountPath: "/.my-custom-auth",
+          }),
+      })
+      .default(() => {})
+      .description("Configuration options for the `kaniko` build mode."),
+    defaultHostname: joi
+      .string()
+      .description("A default hostname to use when no hostname is explicitly configured for a service.")
+      .example("api.mydomain.com"),
+    deploymentStrategy: joi
+      .string()
+      .default("rolling")
+      .allow("rolling", "blue-green")
+      .description(
+        dedent`
         Defines the strategy for deploying the project services.
         Default is "rolling update" and there is experimental support for "blue/green" deployment.
         The feature only supports modules of type \`container\`: other types will just deploy using the default strategy.
       `
-    )
-    .meta({
-      experimental: true,
-    }),
-  forceSsl: joi
-    .boolean()
-    .default(false)
-    .description(
-      "Require SSL on all `container` module services. If set to true, an error is raised when no certificate " +
-        "is available for a configured hostname on a `container` module."
-    ),
-  gardenSystemNamespace: joi
-    .string()
-    .default(defaultSystemNamespace)
-    .description(
-      dedent`
+      )
+      .meta({
+        experimental: true,
+      }),
+    forceSsl: joi
+      .boolean()
+      .default(false)
+      .description(
+        "Require SSL on all `container` module services. If set to true, an error is raised when no certificate " +
+          "is available for a configured hostname on a `container` module."
+      ),
+    gardenSystemNamespace: joi
+      .string()
+      .default(defaultSystemNamespace)
+      .description(
+        dedent`
       Override the garden-system namespace name. This option is mainly used for testing.
       In most cases you should leave the default value.
       `
-    )
-    .meta({ internal: true }),
-  imagePullSecrets: imagePullSecretsSchema(),
-  // TODO: invert the resources and storage config schemas
-  resources: joi
-    .object()
-    .keys({
-      builder: resourceSchema(defaultResources.builder).description(dedent`
+      )
+      .meta({ internal: true }),
+    imagePullSecrets: imagePullSecretsSchema(),
+    // TODO: invert the resources and storage config schemas
+    resources: joi
+      .object()
+      .keys({
+        builder: resourceSchema(defaultResources.builder).description(dedent`
             Resource requests and limits for the in-cluster builder.
 
             When \`buildMode\` is \`cluster-docker\`, this refers to the Docker Daemon that is installed and run
@@ -398,53 +452,53 @@ export const kubernetesConfigBase = providerConfigBaseSchema().keys({
             When \`buildMode\` is \`kaniko\`, this refers to _each instance_ of Kaniko, so you'd generally use lower
             limits/requests, but you should evaluate based on your needs.
           `),
-      registry: resourceSchema(defaultResources.registry).description(dedent`
+        registry: resourceSchema(defaultResources.registry).description(dedent`
             Resource requests and limits for the in-cluster image registry. Built images are pushed to this registry,
             so that they are available to all the nodes in your cluster.
 
             This is shared across all users and builds, so it should be resourced accordingly, factoring
             in how many concurrent builds you expect and how large your images tend to be.
           `),
-      sync: resourceSchema(defaultResources.sync).description(dedent`
+        sync: resourceSchema(defaultResources.sync).description(dedent`
             Resource requests and limits for the code sync service, which we use to sync build contexts to the cluster
             ahead of building images. This generally is not resource intensive, but you might want to adjust the
             defaults if you have many concurrent users.
           `),
-    })
-    .default(defaultResources).description(deline`
+      })
+      .default(defaultResources).description(deline`
         Resource requests and limits for the in-cluster builder, container registry and code sync service.
         (which are automatically installed and used when \`buildMode\` is \`cluster-docker\` or \`kaniko\`).
       `),
-  storage: joi
-    .object()
-    .keys({
-      builder: storageSchema(defaultStorage.builder).description(dedent`
+    storage: joi
+      .object()
+      .keys({
+        builder: storageSchema(defaultStorage.builder).description(dedent`
             Storage parameters for the data volume for the in-cluster Docker Daemon.
 
             Only applies when \`buildMode\` is set to \`cluster-docker\`, ignored otherwise.
           `),
-      nfs: joi
-        .object()
-        .keys({
-          storageClass: joi
-            .string()
-            .allow(null)
-            .default(null)
-            .description("Storage class to use as backing storage for NFS ."),
-        })
-        .default({ storageClass: null }).description(dedent`
+        nfs: joi
+          .object()
+          .keys({
+            storageClass: joi
+              .string()
+              .allow(null)
+              .default(null)
+              .description("Storage class to use as backing storage for NFS ."),
+          })
+          .default({ storageClass: null }).description(dedent`
             Storage parameters for the NFS provisioner, which we automatically create for the sync volume, _unless_
             you specify a \`storageClass\` for the sync volume. See the below \`sync\` parameter for more.
 
             Only applies when \`buildMode\` is set to \`cluster-docker\` or \`kaniko\`, ignored otherwise.
           `),
-      registry: storageSchema(defaultStorage.registry).description(dedent`
+        registry: storageSchema(defaultStorage.registry).description(dedent`
             Storage parameters for the in-cluster Docker registry volume. Built images are stored here, so that they
             are available to all the nodes in your cluster.
 
             Only applies when \`buildMode\` is set to \`cluster-docker\` or \`kaniko\`, ignored otherwise.
           `),
-      sync: storageSchema(defaultStorage.sync).description(dedent`
+        sync: storageSchema(defaultStorage.sync).description(dedent`
             Storage parameters for the code sync volume, which build contexts are synced to ahead of running
             in-cluster builds.
 
@@ -454,136 +508,137 @@ export const kubernetesConfigBase = providerConfigBaseSchema().keys({
 
             Only applies when \`buildMode\` is set to \`cluster-docker\` or \`kaniko\`, ignored otherwise.
           `),
-    })
-    .default(defaultStorage).description(dedent`
+      })
+      .default(defaultStorage).description(dedent`
         Storage parameters to set for the in-cluster builder, container registry and code sync persistent volumes
         (which are automatically installed and used when \`buildMode\` is \`cluster-docker\` or \`kaniko\`).
 
         These are all shared cluster-wide across all users and builds, so they should be resourced accordingly,
         factoring in how many concurrent builds you expect and how large your images and build contexts tend to be.
       `),
-  tlsCertificates: joiArray(tlsCertificateSchema())
-    .unique("name")
-    .description("One or more certificates to use for ingress."),
-  certManager: joi
-    .object()
-    .optional()
-    .keys({
-      install: joi.bool().default(false).description(dedent`
+    tlsCertificates: joiArray(tlsCertificateSchema())
+      .unique("name")
+      .description("One or more certificates to use for ingress."),
+    certManager: joi
+      .object()
+      .optional()
+      .keys({
+        install: joi.bool().default(false).description(dedent`
           Automatically install \`cert-manager\` on initialization. See the
           [cert-manager integration guide](https://docs.garden.io/advanced/cert-manager-integration) for details.
         `),
-      email: joi
-        .string()
-        .required()
-        .description("The email to use when requesting Let's Encrypt certificates.")
-        .example("yourname@example.com"),
-      issuer: joi
-        .string()
-        .allow("acme")
-        .default("acme")
-        .description("The type of issuer for the certificate (only ACME is supported for now).")
-        .example("acme"),
-      acmeServer: joi
-        .string()
-        .allow("letsencrypt-staging", "letsencrypt-prod")
-        .default("letsencrypt-staging")
-        .description(
-          deline`Specify which ACME server to request certificates from. Currently Let's Encrypt staging and prod
+        email: joi
+          .string()
+          .required()
+          .description("The email to use when requesting Let's Encrypt certificates.")
+          .example("yourname@example.com"),
+        issuer: joi
+          .string()
+          .allow("acme")
+          .default("acme")
+          .description("The type of issuer for the certificate (only ACME is supported for now).")
+          .example("acme"),
+        acmeServer: joi
+          .string()
+          .allow("letsencrypt-staging", "letsencrypt-prod")
+          .default("letsencrypt-staging")
+          .description(
+            deline`Specify which ACME server to request certificates from. Currently Let's Encrypt staging and prod
           servers are supported.`
-        )
-        .example("letsencrypt-staging"),
-      acmeChallengeType: joi
-        .string()
-        .allow("HTTP-01")
-        .default("HTTP-01")
-        .description(
-          deline`The type of ACME challenge used to validate hostnames and generate the certificates
+          )
+          .example("letsencrypt-staging"),
+        acmeChallengeType: joi
+          .string()
+          .allow("HTTP-01")
+          .default("HTTP-01")
+          .description(
+            deline`The type of ACME challenge used to validate hostnames and generate the certificates
           (only HTTP-01 is supported for now).`
-        )
-        .example("HTTP-01"),
-    }).description(dedent`cert-manager configuration, for creating and managing TLS certificates. See the
+          )
+          .example("HTTP-01"),
+      }).description(dedent`cert-manager configuration, for creating and managing TLS certificates. See the
         [cert-manager guide](https://docs.garden.io/advanced/cert-manager-integration) for details.`),
-  _systemServices: joiArray(joiIdentifier()).meta({ internal: true }),
-  systemNodeSelector: joiStringMap(joi.string())
-    .description(
-      dedent`
+    _systemServices: joiArray(joiIdentifier()).meta({ internal: true }),
+    systemNodeSelector: joiStringMap(joi.string())
+      .description(
+        dedent`
       Exposes the \`nodeSelector\` field on the PodSpec of system services. This allows you to constrain
       the system services to only run on particular nodes. [See here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) for the official Kubernetes guide to assigning Pods to nodes.
     `
-    )
-    .example({ disktype: "ssd" })
-    .default(() => ({})),
-  registryProxyTolerations: joiArray(
-    joi.object().keys({
-      effect: joi.string().allow("NoSchedule", "PreferNoSchedule", "NoExecute").description(dedent`
+      )
+      .example({ disktype: "ssd" })
+      .default(() => ({})),
+    registryProxyTolerations: joiArray(
+      joi.object().keys({
+        effect: joi.string().allow("NoSchedule", "PreferNoSchedule", "NoExecute").description(dedent`
           "Effect" indicates the taint effect to match. Empty means match all taint effects. When specified,
           allowed values are "NoSchedule", "PreferNoSchedule" and "NoExecute".
         `),
-      key: joi.string().description(dedent`
+        key: joi.string().description(dedent`
           "Key" is the taint key that the toleration applies to. Empty means match all taint keys.
           If the key is empty, operator must be "Exists"; this combination means to match all values and all keys.
         `),
-      operator: joi
-        .string()
-        .allow("Exists", "Equal")
-        .default("Equal").description(dedent`
+        operator: joi
+          .string()
+          .allow("Exists", "Equal")
+          .default("Equal").description(dedent`
           "Operator" represents a key's relationship to the value. Valid operators are "Exists" and "Equal". Defaults to
           "Equal". "Exists" is equivalent to wildcard for value, so that a pod can tolerate all taints of a
           particular category.
         `),
-      tolerationSeconds: joi.string().description(dedent`
+        tolerationSeconds: joi.string().description(dedent`
           "TolerationSeconds" represents the period of time the toleration (which must be of effect "NoExecute",
           otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate
           the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately)
           by the system.
         `),
-      value: joi.string().description(dedent`
+        value: joi.string().description(dedent`
           "Value" is the taint value the toleration matches to. If the operator is "Exists", the value should be empty,
           otherwise just a regular string.
         `),
-    })
-  ).description(dedent`
+      })
+    ).description(dedent`
         For setting tolerations on the registry-proxy when using in-cluster building.
         The registry-proxy is a DaemonSet that proxies connections to the docker registry service on each node.
 
         Use this only if you're doing in-cluster building and the nodes in your cluster
         have [taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/).
       `),
-})
+  })
 
-export const configSchema = kubernetesConfigBase
-  .keys({
-    name: joiProviderName("kubernetes"),
-    context: k8sContextSchema().required(),
-    deploymentRegistry: containerRegistryConfigSchema(),
-    ingressClass: joi.string().description(dedent`
+export const configSchema = () =>
+  kubernetesConfigBase()
+    .keys({
+      name: joiProviderName("kubernetes"),
+      context: k8sContextSchema().required(),
+      deploymentRegistry: containerRegistryConfigSchema(),
+      ingressClass: joi.string().description(dedent`
         The ingress class to use on configured Ingresses (via the \`kubernetes.io/ingress.class\` annotation)
         when deploying \`container\` services. Use this if you have multiple ingress controllers in your cluster.
       `),
-    ingressHttpPort: joi
-      .number()
-      .default(80)
-      .description("The external HTTP port of the cluster's ingress controller."),
-    ingressHttpsPort: joi
-      .number()
-      .default(443)
-      .description("The external HTTPS port of the cluster's ingress controller."),
-    kubeconfig: joi
-      .posixPath()
-      .description("Path to kubeconfig file to use instead of the system default. Must be a POSIX-style path."),
-    namespace: joi.string().description(dedent`
+      ingressHttpPort: joi
+        .number()
+        .default(80)
+        .description("The external HTTP port of the cluster's ingress controller."),
+      ingressHttpsPort: joi
+        .number()
+        .default(443)
+        .description("The external HTTPS port of the cluster's ingress controller."),
+      kubeconfig: joi
+        .posixPath()
+        .description("Path to kubeconfig file to use instead of the system default. Must be a POSIX-style path."),
+      namespace: joi.string().description(dedent`
       Specify which namespace to deploy services to. Defaults to \`<project name>-<environment namespace>\`.
 
       Note that the framework may generate other namespaces as well with this name as a prefix.
       `),
-    setupIngressController: joi
-      .string()
-      .allow("nginx", false, null)
-      .default(false)
-      .description("Set this to `nginx` to install/enable the NGINX ingress controller."),
-  })
-  .unknown(false)
+      setupIngressController: joi
+        .string()
+        .allow("nginx", false, null)
+        .default(false)
+        .description("Set this to `nginx` to install/enable the NGINX ingress controller."),
+    })
+    .unknown(false)
 
 export interface ServiceResourceSpec {
   kind: HotReloadableKind

--- a/garden-service/src/plugins/kubernetes/container/build.ts
+++ b/garden-service/src/plugins/kubernetes/container/build.ts
@@ -497,6 +497,7 @@ async function runKaniko({ provider, namespace, log, module, args, outputStream 
         name: commsVolumeName,
         emptyDir: {},
       },
+      ...(provider.config.kaniko?.volumes || []),
     ],
     containers: [
       {
@@ -517,6 +518,7 @@ async function runKaniko({ provider, namespace, log, module, args, outputStream 
             name: commsVolumeName,
             mountPath: commsMountPath,
           },
+          ...(provider.config.kaniko?.volumeMounts || []),
         ],
         resources: {
           limits: {

--- a/garden-service/src/plugins/kubernetes/init.ts
+++ b/garden-service/src/plugins/kubernetes/init.ts
@@ -391,6 +391,13 @@ export function getKubernetesSystemVariables(config: KubernetesConfig) {
     "builder-storage-size": megabytesToString(config.storage.builder.size!),
     "builder-storage-class": config.storage.builder.storageClass,
 
+    // Need any casts here for this to match the `DeepPrimitiveMap` interface
+    "cluster-docker-volumes": <any[]>(config.clusterDocker?.volumes || []),
+    "cluster-docker-volumemounts": <any[]>(config.clusterDocker?.volumeMounts || []),
+
+    "kaniko-volumes": <any[]>(config.kaniko?.volumes || []),
+    "kaniko-volumemounts": <any[]>(config.kaniko?.volumeMounts || []),
+
     "ingress-http-port": config.ingressHttpPort,
     "ingress-https-port": config.ingressHttpsPort,
 

--- a/garden-service/src/plugins/kubernetes/kubernetes.ts
+++ b/garden-service/src/plugins/kubernetes/kubernetes.ts
@@ -192,7 +192,7 @@ export const gardenPlugin = createGardenPlugin({
 
     Note that if you're using a local Kubernetes cluster (e.g. minikube or Docker Desktop), the [local-kubernetes provider](${localKubernetesUrl}) simplifies (and automates) the configuration and setup quite a bit.
   `,
-  configSchema,
+  configSchema: configSchema(),
   outputsSchema,
   commands: [cleanupClusterRegistry, clusterInit, uninstallGardenServices, pullImage],
   handlers: {

--- a/garden-service/src/plugins/kubernetes/local/config.ts
+++ b/garden-service/src/plugins/kubernetes/local/config.ts
@@ -28,23 +28,24 @@ export interface LocalKubernetesConfig extends KubernetesConfig {
   setupIngressController: string | null
 }
 
-export const configSchema = kubernetesConfigBase
-  .keys({
-    name: joiProviderName("local-kubernetes"),
-    context: k8sContextSchema().optional(),
-    namespace: joi
-      .string()
-      .description(
-        "Specify which namespace to deploy services to (defaults to the project name). " +
-          "Note that the framework generates other namespaces as well with this name as a prefix."
-      ),
-    setupIngressController: joi
-      .string()
-      .allow("nginx", false, null)
-      .default("nginx")
-      .description("Set this to null or false to skip installing/enabling the `nginx` ingress controller."),
-  })
-  .description("The provider configuration for the local-kubernetes plugin.")
+export const configSchema = () =>
+  kubernetesConfigBase()
+    .keys({
+      name: joiProviderName("local-kubernetes"),
+      context: k8sContextSchema().optional(),
+      namespace: joi
+        .string()
+        .description(
+          "Specify which namespace to deploy services to (defaults to the project name). " +
+            "Note that the framework generates other namespaces as well with this name as a prefix."
+        ),
+      setupIngressController: joi
+        .string()
+        .allow("nginx", false, null)
+        .default("nginx")
+        .description("Set this to null or false to skip installing/enabling the `nginx` ingress controller."),
+    })
+    .description("The provider configuration for the local-kubernetes plugin.")
 
 export async function configureProvider(params: ConfigureProviderParams<LocalKubernetesConfig>) {
   const { base, log, projectName, tools } = params

--- a/garden-service/src/plugins/kubernetes/local/local.ts
+++ b/garden-service/src/plugins/kubernetes/local/local.ts
@@ -24,7 +24,7 @@ export const gardenPlugin = createGardenPlugin({
 
     If you're working with a remote Kubernetes cluster, please refer to the [\`kubernetes\` provider](${providerUrl}) docs, and the [Remote Kubernetes guide](${DOCS_BASE_URL}/guides/remote-kubernetes) guide.
   `,
-  configSchema,
+  configSchema: configSchema(),
   handlers: {
     configureProvider,
   },

--- a/garden-service/src/plugins/kubernetes/volumes/volume.ts
+++ b/garden-service/src/plugins/kubernetes/volumes/volume.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { joi } from "../../../config/common"
+import { readFileSync } from "fs-extra"
+import { join } from "path"
+import { STATIC_DIR } from "../../../constants"
+
+export const volumeSchema = () => {
+  // The JSON file is copied from the handy kubernetes-json-schema repo
+  // (https://github.com/instrumenta/kubernetes-json-schema/tree/master/v1.17.0-standalone).
+  const volumeJsonSchema = JSON.parse(readFileSync(join(STATIC_DIR, "kubernetes", "volume.json")).toString())
+
+  return joi
+    .customObject()
+    .jsonSchema(volumeJsonSchema)
+    .required()
+    .description(
+      "The spec for the volume reference. This has the exact same schema as the `volumes` field on a standard Kubernetes Pod spec. See https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#volume-v1-core for reference."
+    )
+}
+
+export const volumeMountSchema = () => {
+  // The JSON file is copied from the handy kubernetes-json-schema repo
+  // (https://github.com/instrumenta/kubernetes-json-schema/tree/master/v1.17.0-standalone).
+  const volumeMountJsonSchema = JSON.parse(readFileSync(join(STATIC_DIR, "kubernetes", "volumemount.json")).toString())
+
+  return joi
+    .customObject()
+    .jsonSchema(volumeMountJsonSchema)
+    .required()
+    .description(
+      "The spec for the volume mount. This has the exact same schema as the `volumeMounts` field on a standard Kubernetes container spec in a Pod spec. See https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#volumemount-v1-core for reference."
+    )
+}

--- a/garden-service/static/kubernetes/system/docker-daemon/garden.yml
+++ b/garden-service/static/kubernetes/system/docker-daemon/garden.yml
@@ -25,3 +25,5 @@ values:
       name: ${var.sync-volume-name}
   tolerations: ${var.system-tolerations}
   nodeSelector: ${var.system-node-selector}
+  volumes: ${var.cluster-docker-volumes}
+  volumeMounts: ${var.cluster-docker-volumemounts}

--- a/garden-service/static/kubernetes/system/docker-daemon/templates/deployment.yaml
+++ b/garden-service/static/kubernetes/system/docker-daemon/templates/deployment.yaml
@@ -35,6 +35,7 @@ spec:
             items:
               - key: .dockerconfigjson
                 path: config.json
+        {{- toYaml .Values.volumes | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -62,6 +63,7 @@ spec:
               mountPath: /garden-build
             - name: docker-config
               mountPath: /root/.docker
+            {{- toYaml .Values.volumeMounts | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
         - name: proxy

--- a/garden-service/static/kubernetes/volume.json
+++ b/garden-service/static/kubernetes/volume.json
@@ -1,0 +1,1609 @@
+{
+  "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+  "properties": {
+    "awsElasticBlockStore": {
+      "description": "Represents a Persistent Disk resource in AWS.\n\nAn AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "fsType": {
+          "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "partition": {
+          "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "readOnly": {
+          "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "volumeID": {
+          "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+          "type": "string"
+        }
+      },
+      "required": [
+        "volumeID"
+      ],
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "azureDisk": {
+      "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+      "properties": {
+        "cachingMode": {
+          "description": "Host Caching mode: None, Read Only, Read Write.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "diskName": {
+          "description": "The Name of the data disk in the blob storage",
+          "type": "string"
+        },
+        "diskURI": {
+          "description": "The URI the data disk in the blob storage",
+          "type": "string"
+        },
+        "fsType": {
+          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "kind": {
+          "description": "Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "readOnly": {
+          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "diskName",
+        "diskURI"
+      ],
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "azureFile": {
+      "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+      "properties": {
+        "readOnly": {
+          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "secretName": {
+          "description": "the name of secret that contains Azure Storage Account Name and Key",
+          "type": "string"
+        },
+        "shareName": {
+          "description": "Share Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "secretName",
+        "shareName"
+      ],
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "cephfs": {
+      "description": "Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.",
+      "properties": {
+        "monitors": {
+          "description": "Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "type": "array"
+        },
+        "path": {
+          "description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "readOnly": {
+          "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "secretFile": {
+          "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "secretRef": {
+          "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+          "properties": {
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "user": {
+          "description": "Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "monitors"
+      ],
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "cinder": {
+      "description": "Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "fsType": {
+          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "readOnly": {
+          "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "secretRef": {
+          "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+          "properties": {
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "volumeID": {
+          "description": "volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+          "type": "string"
+        }
+      },
+      "required": [
+        "volumeID"
+      ],
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "configMap": {
+      "description": "Adapts a ConfigMap into a volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "defaultMode": {
+          "description": "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "items": {
+          "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+          "items": {
+            "description": "Maps a string key to a path within a volume.",
+            "properties": {
+              "key": {
+                "description": "The key to project.",
+                "type": "string"
+              },
+              "mode": {
+                "description": "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "path": {
+                "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "key",
+              "path"
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "name": {
+          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "optional": {
+          "description": "Specify whether the ConfigMap or its keys must be defined",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "csi": {
+      "description": "Represents a source location of a volume to mount, managed by an external CSI driver",
+      "properties": {
+        "driver": {
+          "description": "Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+          "type": "string"
+        },
+        "fsType": {
+          "description": "Filesystem type to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "nodePublishSecretRef": {
+          "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+          "properties": {
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "readOnly": {
+          "description": "Specifies a read-only configuration for the volume. Defaults to false (read/write).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "volumeAttributes": {
+          "additionalProperties": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "description": "VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+          "type": [
+            "object",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "driver"
+      ],
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "downwardAPI": {
+      "description": "DownwardAPIVolumeSource represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "defaultMode": {
+          "description": "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "items": {
+          "description": "Items is a list of downward API volume file",
+          "items": {
+            "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+            "properties": {
+              "fieldRef": {
+                "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
+                "properties": {
+                  "apiVersion": {
+                    "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "fieldPath": {
+                    "description": "Path of the field to select in the specified API version.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "fieldPath"
+                ],
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "mode": {
+                "description": "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "path": {
+                "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                "type": "string"
+              },
+              "resourceFieldRef": {
+                "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+                "properties": {
+                  "containerName": {
+                    "description": "Container name: required for volumes, optional for env vars",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "divisor": {
+                    "oneOf": [
+                      {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      {
+                        "type": [
+                          "number",
+                          "null"
+                        ]
+                      }
+                    ]
+                  },
+                  "resource": {
+                    "description": "Required: resource to select",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "resource"
+                ],
+                "type": [
+                  "object",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "path"
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "emptyDir": {
+      "description": "Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "medium": {
+          "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sizeLimit": {
+          "oneOf": [
+            {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            {
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          ]
+        }
+      },
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "fc": {
+      "description": "Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "fsType": {
+          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "lun": {
+          "description": "Optional: FC target lun number",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "readOnly": {
+          "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "targetWWNs": {
+          "description": "Optional: FC target worldwide names (WWNs)",
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "wwids": {
+          "description": "Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "flexVolume": {
+      "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
+      "properties": {
+        "driver": {
+          "description": "Driver is the name of the driver to use for this volume.",
+          "type": "string"
+        },
+        "fsType": {
+          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "options": {
+          "additionalProperties": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "description": "Optional: Extra command options if any.",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "readOnly": {
+          "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "secretRef": {
+          "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+          "properties": {
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": [
+            "object",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "driver"
+      ],
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "flocker": {
+      "description": "Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.",
+      "properties": {
+        "datasetName": {
+          "description": "Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "datasetUUID": {
+          "description": "UUID of the dataset. This is unique identifier of a Flocker dataset",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "gcePersistentDisk": {
+      "description": "Represents a Persistent Disk resource in Google Compute Engine.\n\nA GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.",
+      "properties": {
+        "fsType": {
+          "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "partition": {
+          "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "pdName": {
+          "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "pdName"
+      ],
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "gitRepo": {
+      "description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
+      "properties": {
+        "directory": {
+          "description": "Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "repository": {
+          "description": "Repository URL",
+          "type": "string"
+        },
+        "revision": {
+          "description": "Commit hash for the specified revision.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "repository"
+      ],
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "glusterfs": {
+      "description": "Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.",
+      "properties": {
+        "endpoints": {
+          "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+          "type": "string"
+        },
+        "path": {
+          "description": "Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "endpoints",
+        "path"
+      ],
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "hostPath": {
+      "description": "Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.",
+      "properties": {
+        "path": {
+          "description": "Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "iscsi": {
+      "description": "Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "chapAuthDiscovery": {
+          "description": "whether support iSCSI Discovery CHAP authentication",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "chapAuthSession": {
+          "description": "whether support iSCSI Session CHAP authentication",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "fsType": {
+          "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "initiatorName": {
+          "description": "Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "iqn": {
+          "description": "Target iSCSI Qualified Name.",
+          "type": "string"
+        },
+        "iscsiInterface": {
+          "description": "iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "lun": {
+          "description": "iSCSI Target Lun number.",
+          "type": "integer"
+        },
+        "portals": {
+          "description": "iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "readOnly": {
+          "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "secretRef": {
+          "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+          "properties": {
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "targetPortal": {
+          "description": "iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "targetPortal",
+        "iqn",
+        "lun"
+      ],
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "name": {
+      "description": "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "nfs": {
+      "description": "Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.",
+      "properties": {
+        "path": {
+          "description": "Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "server": {
+          "description": "Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+          "type": "string"
+        }
+      },
+      "required": [
+        "server",
+        "path"
+      ],
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "persistentVolumeClaim": {
+      "description": "PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).",
+      "properties": {
+        "claimName": {
+          "description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+          "type": "string"
+        },
+        "readOnly": {
+          "description": "Will force the ReadOnly setting in VolumeMounts. Default false.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "claimName"
+      ],
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "photonPersistentDisk": {
+      "description": "Represents a Photon Controller persistent disk resource.",
+      "properties": {
+        "fsType": {
+          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pdID": {
+          "description": "ID that identifies Photon Controller persistent disk",
+          "type": "string"
+        }
+      },
+      "required": [
+        "pdID"
+      ],
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "portworxVolume": {
+      "description": "PortworxVolumeSource represents a Portworx volume resource.",
+      "properties": {
+        "fsType": {
+          "description": "FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "readOnly": {
+          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "volumeID": {
+          "description": "VolumeID uniquely identifies a Portworx volume",
+          "type": "string"
+        }
+      },
+      "required": [
+        "volumeID"
+      ],
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "projected": {
+      "description": "Represents a projected volume source",
+      "properties": {
+        "defaultMode": {
+          "description": "Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "sources": {
+          "description": "list of volume projections",
+          "items": {
+            "description": "Projection that may be projected along with other supported volume types",
+            "properties": {
+              "configMap": {
+                "description": "Adapts a ConfigMap into a projected volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.",
+                "properties": {
+                  "items": {
+                    "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                    "items": {
+                      "description": "Maps a string key to a path within a volume.",
+                      "properties": {
+                        "key": {
+                          "description": "The key to project.",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "description": "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "path": {
+                          "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "path"
+                      ],
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
+                    "type": [
+                      "array",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "optional": {
+                    "description": "Specify whether the ConfigMap or its keys must be defined",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  }
+                },
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "downwardAPI": {
+                "description": "Represents downward API info for projecting into a projected volume. Note that this is identical to a downwardAPI volume source without the default mode.",
+                "properties": {
+                  "items": {
+                    "description": "Items is a list of DownwardAPIVolume file",
+                    "items": {
+                      "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                      "properties": {
+                        "fieldRef": {
+                          "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
+                          "properties": {
+                            "apiVersion": {
+                              "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "fieldPath": {
+                              "description": "Path of the field to select in the specified API version.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "fieldPath"
+                          ],
+                          "type": [
+                            "object",
+                            "null"
+                          ]
+                        },
+                        "mode": {
+                          "description": "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "path": {
+                          "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                          "type": "string"
+                        },
+                        "resourceFieldRef": {
+                          "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+                          "properties": {
+                            "containerName": {
+                              "description": "Container name: required for volumes, optional for env vars",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "divisor": {
+                              "oneOf": [
+                                {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                {
+                                  "type": [
+                                    "number",
+                                    "null"
+                                  ]
+                                }
+                              ]
+                            },
+                            "resource": {
+                              "description": "Required: resource to select",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "resource"
+                          ],
+                          "type": [
+                            "object",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "path"
+                      ],
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
+                    "type": [
+                      "array",
+                      "null"
+                    ]
+                  }
+                },
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "secret": {
+                "description": "Adapts a secret into a projected volume.\n\nThe contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.",
+                "properties": {
+                  "items": {
+                    "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                    "items": {
+                      "description": "Maps a string key to a path within a volume.",
+                      "properties": {
+                        "key": {
+                          "description": "The key to project.",
+                          "type": "string"
+                        },
+                        "mode": {
+                          "description": "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "path": {
+                          "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "path"
+                      ],
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
+                    "type": [
+                      "array",
+                      "null"
+                    ]
+                  },
+                  "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "optional": {
+                    "description": "Specify whether the Secret or its key must be defined",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  }
+                },
+                "type": [
+                  "object",
+                  "null"
+                ]
+              },
+              "serviceAccountToken": {
+                "description": "ServiceAccountTokenProjection represents a projected service account token volume. This projection can be used to insert a service account token into the pods runtime filesystem for use against APIs (Kubernetes API Server or otherwise).",
+                "properties": {
+                  "audience": {
+                    "description": "Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "expirationSeconds": {
+                    "description": "ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "path": {
+                    "description": "Path is the path relative to the mount point of the file to project the token into.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "path"
+                ],
+                "type": [
+                  "object",
+                  "null"
+                ]
+              }
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "sources"
+      ],
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "quobyte": {
+      "description": "Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.",
+      "properties": {
+        "group": {
+          "description": "Group to map volume access to Default is no group",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "readOnly": {
+          "description": "ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "registry": {
+          "description": "Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+          "type": "string"
+        },
+        "tenant": {
+          "description": "Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "user": {
+          "description": "User to map volume access to Defaults to serivceaccount user",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "volume": {
+          "description": "Volume is a string that references an already created Quobyte volume by name.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "registry",
+        "volume"
+      ],
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "rbd": {
+      "description": "Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "fsType": {
+          "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "image": {
+          "description": "The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+          "type": "string"
+        },
+        "keyring": {
+          "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "monitors": {
+          "description": "A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "type": "array"
+        },
+        "pool": {
+          "description": "The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "readOnly": {
+          "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "secretRef": {
+          "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+          "properties": {
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "user": {
+          "description": "The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "monitors",
+        "image"
+      ],
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "scaleIO": {
+      "description": "ScaleIOVolumeSource represents a persistent ScaleIO volume",
+      "properties": {
+        "fsType": {
+          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "gateway": {
+          "description": "The host address of the ScaleIO API Gateway.",
+          "type": "string"
+        },
+        "protectionDomain": {
+          "description": "The name of the ScaleIO Protection Domain for the configured storage.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "readOnly": {
+          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "secretRef": {
+          "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+          "properties": {
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "sslEnabled": {
+          "description": "Flag to enable/disable SSL communication with Gateway, default false",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "storageMode": {
+          "description": "Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "storagePool": {
+          "description": "The ScaleIO Storage Pool associated with the protection domain.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "system": {
+          "description": "The name of the storage system as configured in ScaleIO.",
+          "type": "string"
+        },
+        "volumeName": {
+          "description": "The name of a volume already created in the ScaleIO system that is associated with this volume source.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "gateway",
+        "system",
+        "secretRef"
+      ],
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "secret": {
+      "description": "Adapts a Secret into a volume.\n\nThe contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.",
+      "properties": {
+        "defaultMode": {
+          "description": "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "items": {
+          "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+          "items": {
+            "description": "Maps a string key to a path within a volume.",
+            "properties": {
+              "key": {
+                "description": "The key to project.",
+                "type": "string"
+              },
+              "mode": {
+                "description": "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "path": {
+                "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "key",
+              "path"
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "optional": {
+          "description": "Specify whether the Secret or its keys must be defined",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "secretName": {
+          "description": "Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "storageos": {
+      "description": "Represents a StorageOS persistent volume resource.",
+      "properties": {
+        "fsType": {
+          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "readOnly": {
+          "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "secretRef": {
+          "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+          "properties": {
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "volumeName": {
+          "description": "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "volumeNamespace": {
+          "description": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "vsphereVolume": {
+      "description": "Represents a vSphere volume resource.",
+      "properties": {
+        "fsType": {
+          "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "storagePolicyID": {
+          "description": "Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "storagePolicyName": {
+          "description": "Storage Policy Based Management (SPBM) profile name.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "volumePath": {
+          "description": "Path that identifies vSphere volume vmdk",
+          "type": "string"
+        }
+      },
+      "required": [
+        "volumePath"
+      ],
+      "type": [
+        "object",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "name"
+  ],
+  "type": "object",
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/garden-service/static/kubernetes/volumemount.json
+++ b/garden-service/static/kubernetes/volumemount.json
@@ -1,0 +1,53 @@
+{
+  "description": "VolumeMount describes a mounting of a Volume within a container.",
+  "properties": {
+    "mountPath": {
+      "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "mountPropagation": {
+      "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "name": {
+      "description": "This must match the Name of a Volume.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "readOnly": {
+      "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "subPath": {
+      "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "subPathExpr": {
+      "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "name",
+    "mountPath"
+  ],
+  "type": "object",
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/garden-service/test/data/test-projects/container/custom-auth/Dockerfile
+++ b/garden-service/test/data/test-projects/container/custom-auth/Dockerfile
@@ -1,0 +1,5 @@
+FROM busybox:1.31.1
+
+COPY /.test-custom-auth/key.json key.json
+
+RUN cat key.json

--- a/garden-service/test/data/test-projects/container/custom-auth/garden.yml
+++ b/garden-service/test/data/test-projects/container/custom-auth/garden.yml
@@ -1,0 +1,4 @@
+kind: Module
+name: custom-auth
+description: Test module for using custom volume mounts in builders
+type: container

--- a/garden-service/test/data/test-projects/container/garden.yml
+++ b/garden-service/test/data/test-projects/container/garden.yml
@@ -5,7 +5,6 @@ environments:
   - name: local-remote-registry
   - name: cluster-docker
   - name: cluster-docker-buildkit
-  - name: cluster-docker-auth
   - name: cluster-docker-remote-registry
   - name: kaniko
   - name: kaniko-image-override
@@ -26,12 +25,19 @@ providers:
       # Note: We populate this secret in the test code
       - name: test-docker-auth
       - name: test-cred-helper-auth
+    clusterDocker:
+      volumes:
+        - name: test-custom-auth
+          secret:
+            # Note: We populate this secret in the test code
+            secretName: test-custom-auth
+      volumeMounts:
+        - name: test-custom-auth
+          mountPath: /.test-custom-auth
   - <<: *clusterDocker
     environments: [cluster-docker-buildkit]
     clusterDocker:
       enableBuildKit: true
-  - <<: *clusterDocker
-    environments: [cluster-docker-auth]
   - <<: *clusterDocker
     environments: [cluster-docker-remote-registry]
     deploymentRegistry: *deploymentRegistry

--- a/garden-service/test/integ/src/plugins/kubernetes/container/build.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/container/build.ts
@@ -133,6 +133,18 @@ describe("kubernetes build flow", () => {
       })
     })
 
+    it("should expose mounted volumes to builds", async () => {
+      const module = graph.getModule("custom-auth")
+      await garden.buildDir.syncFromSrc(module, garden.log)
+
+      // The build would fail if the configured custom auth secret were not mounted in the builder
+      await k8sBuildContainer({
+        ctx,
+        log: garden.log,
+        module,
+      })
+    })
+
     grouped("remote-only").it("should support pulling from private registries", async () => {
       const module = graph.getModule("private-base")
       await garden.buildDir.syncFromSrc(module, garden.log)
@@ -321,6 +333,18 @@ describe("kubernetes build flow", () => {
       const module = graph.getModule("simple-service")
       await garden.buildDir.syncFromSrc(module, garden.log)
 
+      await k8sBuildContainer({
+        ctx,
+        log: garden.log,
+        module,
+      })
+    })
+
+    it("should expose mounted volumes to builds", async () => {
+      const module = graph.getModule("custom-auth")
+      await garden.buildDir.syncFromSrc(module, garden.log)
+
+      // The build would fail if the configured custom auth secret were not mounted in the builder
       await k8sBuildContainer({
         ctx,
         log: garden.log,

--- a/garden-service/test/integ/src/plugins/kubernetes/container/container.ts
+++ b/garden-service/test/integ/src/plugins/kubernetes/container/container.ts
@@ -72,6 +72,20 @@ export async function getContainerTestGarden(environmentName: string = defaultEn
       await api.upsert({ kind: "Secret", namespace: "default", obj: authSecret, log: garden.log })
     }
 
+    // Used for testing custom volume mounts
+    const customAuth: KubernetesResource<V1Secret> = {
+      apiVersion: "v1",
+      kind: "Secret",
+      metadata: {
+        name: "test-custom-auth",
+        namespace: "garden-system",
+      },
+      stringData: {
+        "key.json": "some-key",
+      },
+    }
+    await api.upsert({ kind: "Secret", namespace: "garden-system", obj: customAuth, log: garden.log })
+
     const credentialHelperAuth: KubernetesResource<V1Secret> = {
       apiVersion: "v1",
       kind: "Secret",


### PR DESCRIPTION
You can now attach and mount arbitrary volumes for in-cluster builder
pods. This works for both `cluster-docker` and `kaniko` build modes.

Typically you'd use this to mount secrets containing keys necessary for
builds, e.g. to access private repositories, or you could mount shared
data or cache volumes (Note: When using `kaniko`, those volumes must
support ReadWriteMany access).

Closes #1793
