### PR TITLE
feat(enterprise): register workflow runs

### DIFF
--- a/garden-service/src/cli/cli.ts
+++ b/garden-service/src/cli/cli.ts
@@ -341,21 +341,16 @@ export class GardenCli {
             garden = await Garden.factory(root, contextOpts)
           }
 
-          if (garden.clientAuthToken && garden.enterpriseDomain && garden.projectId) {
+          if (garden.enterpriseContext) {
             log.silly(`Connecting Garden instance to BufferedEventStream`)
             bufferedEventStream.connect({
               eventBus: garden.events,
-              clientAuthToken: garden.clientAuthToken,
-              enterpriseDomain: garden.enterpriseDomain,
-              projectId: garden.projectId,
+              enterpriseContext: garden.enterpriseContext,
               environmentName: garden.environmentName,
               namespace: garden.namespace,
             })
           } else {
             log.silly(`Skip connecting Garden instance to BufferedEventStream`)
-            log.silly(`clientAuthToken present: ${!!garden.clientAuthToken}`)
-            log.silly(`enterpriseDomain: ${garden.enterpriseDomain}`)
-            log.silly(`projectId: ${garden.projectId}`)
           }
 
           // Register log file writers. We need to do this after the Garden class is initialised because

--- a/garden-service/src/commands/get/get-config.ts
+++ b/garden-service/src/commands/get/get-config.ts
@@ -51,7 +51,10 @@ export class GetConfigCommand extends Command<{}, Opts> {
         .description("All workflow configs in the project."),
       projectName: joi.string().description("The name of the project."),
       projectRoot: joi.string().description("The local path to the project root."),
-      projectId: joi.string().description("The project ID (Garden Enterprise only)."),
+      projectId: joi
+        .string()
+        .optional()
+        .description("The project ID (Garden Enterprise only)."),
     })
 
   options = getConfigOptions

--- a/garden-service/src/commands/login.ts
+++ b/garden-service/src/commands/login.ts
@@ -23,10 +23,11 @@ export class LoginCommand extends Command {
 
   async action({ garden, log, headerLog }: CommandParams): Promise<CommandResult> {
     printHeader(headerLog, "Login", "cloud")
-    if (!garden.enterpriseDomain) {
+    const enterpriseDomain = garden.enterpriseContext?.enterpriseDomain
+    if (!enterpriseDomain) {
       throw new ConfigurationError(`Error: Your project configuration does not specify a domain.`, {})
     }
-    await login(garden.enterpriseDomain, log)
+    await login(enterpriseDomain, log)
     return {}
   }
 }

--- a/garden-service/src/constants.ts
+++ b/garden-service/src/constants.ts
@@ -87,6 +87,10 @@ export const gardenEnv = {
     .get("GARDEN_LOGGER_TYPE")
     .required(false)
     .asString(),
+  GARDEN_PLATFORM_SCHEDULED: env
+    .get("GARDEN_PLATFORM_SCHEDULED")
+    .required(false)
+    .asBool(),
   GARDEN_SERVER_PORT: env
     .get("GARDEN_SERVER_PORT")
     .required(false)

--- a/garden-service/src/enterprise/workflow-lifecycle.ts
+++ b/garden-service/src/enterprise/workflow-lifecycle.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { got, GotResponse } from "../util/http"
+import { makeAuthHeader } from "./auth"
+import { WorkflowConfig } from "../config/workflow"
+import { LogEntry } from "../logger/log-entry"
+import { PlatformError } from "../exceptions"
+import { GardenEnterpriseContext } from "../garden"
+
+export interface RegisterWorkflowRunParams {
+  workflowConfig: WorkflowConfig
+  enterpriseContext: GardenEnterpriseContext
+  environment: string
+  namespace: string
+  log: LogEntry
+}
+
+/**
+ * Registers the workflow run with the platform, and returns the UID generated for the run.
+ */
+export async function registerWorkflowRun({
+  workflowConfig,
+  enterpriseContext,
+  environment,
+  namespace,
+  log,
+}: RegisterWorkflowRunParams): Promise<string> {
+  const { clientAuthToken, projectId, enterpriseDomain } = enterpriseContext
+  log.debug(`Registering workflow run for ${workflowConfig.name}...`)
+  const headers = makeAuthHeader(clientAuthToken)
+  const requestData = {
+    projectUid: projectId,
+    environment,
+    namespace,
+    workflowName: workflowConfig.name,
+  }
+  let res
+  try {
+    res = await got.post(`${enterpriseDomain}/workflow-runs`, { json: requestData, headers }).json<GotResponse<any>>()
+  } catch (err) {
+    log.error(`An error occurred while registering workflow run: ${err.message}`)
+    throw err
+  }
+
+  if (res && res["workflowRunUid"] && res["status"] === "success") {
+    return res["workflowRunUid"]
+  } else {
+    throw new PlatformError(`Error while registering workflow run: Request failed with status ${res["status"]}`, {
+      status: res["status"],
+      workflowRunUid: res["workflowRunUid"],
+    })
+  }
+}

--- a/garden-service/src/events.ts
+++ b/garden-service/src/events.ts
@@ -65,6 +65,9 @@ export interface Events extends LoggerEvents {
   _exit: {}
   _restart: {}
   _test: any
+  _workflowRunRegistered: {
+    workflowRunUid: string
+  }
 
   // Watcher events
   configAdded: {
@@ -137,6 +140,8 @@ export interface Events extends LoggerEvents {
   }
 
   // Workflow events
+  workflowRunning: {}
+  workflowComplete: {}
   workflowStepProcessing: {
     index: number
   }
@@ -157,6 +162,7 @@ export const eventNames: EventName[] = [
   "_exit",
   "_restart",
   "_test",
+  "_workflowRunRegistered",
   "configAdded",
   "configRemoved",
   "internalError",
@@ -175,6 +181,8 @@ export const eventNames: EventName[] = [
   "taskStatus",
   "testStatus",
   "serviceStatus",
+  "workflowRunning",
+  "workflowComplete",
   "workflowStepProcessing",
   "workflowStepError",
   "workflowStepComplete",

--- a/garden-service/src/exceptions.ts
+++ b/garden-service/src/exceptions.ts
@@ -94,3 +94,7 @@ export class TimeoutError extends GardenBaseError {
 export class NotFoundError extends GardenBaseError {
   type = "not-found"
 }
+
+export class PlatformError extends GardenBaseError {
+  type = "platform"
+}

--- a/garden-service/test/unit/src/commands/run/workflow.ts
+++ b/garden-service/test/unit/src/commands/run/workflow.ts
@@ -106,7 +106,7 @@ describe("RunWorkflowCommand", () => {
     expect(workflowCompletedEntry!.getMetadata()).to.eql({}, "workflowCompletedEntry")
   })
 
-  it("should emit workflow step events", async () => {
+  it("should emit workflow events", async () => {
     const _garden = await makeTestGardenA()
     const _log = _garden.log
     const _defaultParams = {
@@ -130,17 +130,20 @@ describe("RunWorkflowCommand", () => {
 
     const we = getWorkflowEvents(_garden)
 
-    expect(we[0]).to.eql({ name: "workflowStepProcessing", payload: { index: 0 } })
+    expect(we[0]).to.eql({ name: "workflowRunning", payload: {} })
+    expect(we[1]).to.eql({ name: "workflowStepProcessing", payload: { index: 0 } })
 
-    expect(we[1].name).to.eql("workflowStepComplete")
-    expect(we[1].payload.index).to.eql(0)
-    expect(we[1].payload.durationMsec).to.gte(0)
+    expect(we[2].name).to.eql("workflowStepComplete")
+    expect(we[2].payload.index).to.eql(0)
+    expect(we[2].payload.durationMsec).to.gte(0)
 
-    expect(we[2]).to.eql({ name: "workflowStepProcessing", payload: { index: 1 } })
+    expect(we[3]).to.eql({ name: "workflowStepProcessing", payload: { index: 1 } })
 
-    expect(we[3].name).to.eql("workflowStepComplete")
-    expect(we[3].payload.index).to.eql(1)
-    expect(we[3].payload.durationMsec).to.gte(0)
+    expect(we[4].name).to.eql("workflowStepComplete")
+    expect(we[4].payload.index).to.eql(1)
+    expect(we[4].payload.durationMsec).to.gte(0)
+
+    expect(we[5]).to.eql({ name: "workflowComplete", payload: {} })
   })
 
   function filterLogEntries(entries: LogEntry[], msgRegex: RegExp): LogEntry[] {
@@ -317,10 +320,11 @@ describe("RunWorkflowCommand", () => {
 
     const we = getWorkflowEvents(_garden)
 
-    expect(we[0]).to.eql({ name: "workflowStepProcessing", payload: { index: 0 } })
-    expect(we[1].name).to.eql("workflowStepError")
-    expect(we[1].payload.index).to.eql(0)
-    expect(we[1].payload.durationMsec).to.gte(0)
+    expect(we[0]).to.eql({ name: "workflowRunning", payload: {} })
+    expect(we[1]).to.eql({ name: "workflowStepProcessing", payload: { index: 0 } })
+    expect(we[2].name).to.eql("workflowStepError")
+    expect(we[2].payload.index).to.eql(0)
+    expect(we[2].payload.durationMsec).to.gte(0)
   })
 
   it("should write a file with string data ahead of the run, before resolving providers", async () => {
@@ -634,6 +638,12 @@ describe("RunWorkflowCommand", () => {
 })
 
 function getWorkflowEvents(garden: TestGarden) {
-  const eventNames = ["workflowStepProcessing", "workflowStepError", "workflowStepComplete"]
+  const eventNames = [
+    "workflowRunning",
+    "workflowComplete",
+    "workflowStepProcessing",
+    "workflowStepError",
+    "workflowStepComplete",
+  ]
   return garden.events.eventLog.filter((e) => eventNames.includes(e.name))
 }

--- a/garden-service/test/unit/src/platform/buffered-event-stream.ts
+++ b/garden-service/test/unit/src/platform/buffered-event-stream.ts
@@ -14,9 +14,11 @@ import { EventBus } from "../../../../src/events"
 describe("BufferedEventStream", () => {
   const getConnectionParams = (eventBus: EventBus) => ({
     eventBus,
-    clientAuthToken: "dummy-client-token",
-    enterpriseDomain: "dummy-platform_url",
-    projectId: "myproject",
+    enterpriseContext: {
+      clientAuthToken: "dummy-client-token",
+      enterpriseDomain: "dummy-platform_url",
+      projectId: "myproject",
+    },
     environmentName: "my-env",
     namespace: "my-ns",
   })


### PR DESCRIPTION
**What this PR does / why we need it**:

When the user is logged in to Garden Enterprise, the `run workflow` command will now register a workflow run with the backend, and include the workflow run's UID in streamed events and log entries.

This enables `run workflow` command invocations from e.g. a local machine or an external CI system to be represented in Garden Enterprise.

**Special notes for your reviewer**:

Depends on #1936, so we should merge that first (I'll rebase on `master` and mark this PR as ready for review once that's done).

The `_workflowRunRegistered` control event seemed like the least hacky way to communicate the workflow run UID from the `run workflow` command to `BufferedEventStream`, but I'm open to other suggestions.