### PR TITLE
docs: fix links on intro page

### DIFF
--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -10,16 +10,16 @@ To the left you'll find all the different documentation sections. Below you'll f
 
 **If your team has already set up a project for Garden**, and you just need to learn how to use the Garden CLI, you may find it helpful to skip straight to [Installation](./getting-started/1-installation.md) and [Using the CLI](./using-garden/using-the-cli.md), but we do still recommend learning [How Garden Works](./basics/how-garden-works.md) and about [The Stack Graph and the general terminology](./basics/stack-graph.md).
 
-Here's a rundown of the different sections:
+Here's a rundown of the different sections (the section links point to the first page of each section):
 
 | Section | Description |
 | ------- | ----------- |
-| **[Basics](./basics/README.md)** | Learn the essentials of how Garden works, and the terminology involved. |
-| **[Getting Started](./getting-started/README.md)** | Follow the steps here to get Garden installed, connected to a cluster, and a simple example project up and running. |
-| **[Using Garden](./using-garden/README.md)** | Here we dive deeper into how Garden is configured, learn more about all the concepts, as well as how to use the Garden CLI. |
-| **[Guides](./guides/README.md)** | These get into more specific use cases, and more details on how to configure Garden for certain scenarios. |
-| **[Advanced](./advanced/README.md)** | Similar to the Guides section, but generally more advanced use cases. |
-| **[Reference](./reference/README.md)** | Look here for in-depth references for Garden commands and configuration. This includes all the available [providers](./reference/providers/README.md) and different [module types](./reference/module-types/README.md) that you can use to construct your Garden project. |
-| **[Misc](./misc/README.md)** | Find our [FAQ](./misc/faq.md) and [troubleshooting guide](./misc/troubleshooting.md) here, and anything else we couldn't fit into other sections. |
+| **[Basics](./basics/how-garden-works.md)** | Learn the essentials of how Garden works, and the terminology involved. |
+| **[Getting Started](./getting-started/0-introduction.md)** | Follow the steps here to get Garden installed, connected to a cluster, and a simple example project up and running. |
+| **[Using Garden](./using-garden/configuration-overview.md)** | Here we dive deeper into how Garden is configured, learn more about all the concepts, as well as how to use the Garden CLI. |
+| **[Guides](./guides/cloud-provider-setup.md)** | These get into more specific use cases, and more details on how to configure Garden for certain scenarios. |
+| **[Advanced](./advanced/using-remote-sources.md)** | Similar to the Guides section, but generally more advanced use cases. |
+| **[Reference](./reference/providers/README.md)** | Look here for in-depth references for Garden commands and configuration. This includes all the available [providers](./reference/providers/README.md) and different [module types](./reference/module-types/README.md) that you can use to construct your Garden project. |
+| **[Misc](./misc/faq.md)** | Find our [FAQ](./misc/faq.md) and [troubleshooting guide](./misc/troubleshooting.md) here, and anything else we couldn't fit into other sections. |
 
 If there's something you can't find in our docs, we happily encourage you to [join our community Slack](https://chat.garden.io) and/or file an issue on [our GitHub repo](https://github.com/garden-io/garden). We're more than happy to help!


### PR DESCRIPTION
**What this PR does / why we need it**:

The links on the intro paged used to point to the `README.md` file of each
section. However, those READMEs are not included in the summary file
(`docs/README.md`) and therefore won't work on Gitbook. If we want to link
to the section READMEs, we need to explicitly add them to each section.

That is, the sections would look something like:

```
## Basics
Basics ToC (or whatever we'd call it)
How Garden Works
Stack Graph

## Getting Started
Getting Started ToC
0. Introduction

...and so on and so forth.

```

Instead of doing that, I just updated to intro links to point to the first page of each section.

**Which issue(s) this PR fixes**:

Fixes #1937 

**Special notes for your reviewer**:
