### PR TITLE
docs(readme): fix docs.garden.io link in readme Documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Users typically implement Garden for one or more of the following:
 
 ## Documentation
 
-You can find Garden’s full documentation at <https://docs.garden.io.>.
+You can find Garden’s full documentation at <https://docs.garden.io>.
 
 ## How does Garden work?
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:
The link to docs.garden.io is broken in [README.md Documentation section](https://github.com/garden-io/garden#documentation).
