### PR TITLE
fix(local-k8s): add 'docker-desktop' as supported context

### DIFF
--- a/garden-service/src/plugins/kubernetes/local/config.ts
+++ b/garden-service/src/plugins/kubernetes/local/config.ts
@@ -21,7 +21,7 @@ import { isClusterKind } from "./kind"
 
 // note: this is in order of preference, in case neither is set as the current kubectl context
 // and none is explicitly configured in the garden.yml
-const supportedContexts = ["docker-for-desktop", "microk8s", "minikube"]
+const supportedContexts = ["docker-for-desktop", "docker-desktop", "microk8s", "minikube"]
 const nginxServices = ["ingress-controller", "default-backend"]
 
 export interface LocalKubernetesConfig extends KubernetesConfig {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `docker-desktop` as supported context for the `local-kubernetes` provider. Bumped into this after updating Docker for Mac.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
