### PR TITLE
deploy util service if using kaniko

### DIFF
--- a/garden-service/src/plugins/kubernetes/kubernetes.ts
+++ b/garden-service/src/plugins/kubernetes/kubernetes.ts
@@ -63,8 +63,10 @@ export async function configureProvider({
 
   if (config.buildMode === "cluster-docker" || config.buildMode === "kaniko") {
     config._systemServices.push("build-sync")
+    
+    const usingInClusterRegistry = (!config.deploymentRegistry || config.deploymentRegistry.hostname === inClusterRegistryHostname)
 
-    if (!config.deploymentRegistry || config.deploymentRegistry.hostname === inClusterRegistryHostname) {
+    if (usingInClusterRegistry) {
       // Deploy an in-cluster registry, unless otherwise specified.
       // This is a special configuration, used in combination with the registry-proxy service,
       // to make sure every node in the cluster can resolve the image from the registry we deploy in-cluster.
@@ -75,7 +77,10 @@ export async function configureProvider({
         namespace: config.deploymentRegistry?.namespace || projectName,
       }
       config._systemServices.push("docker-registry", "registry-proxy")
-    } else {
+    }
+    if (!usingInClusterRegistry || config.buildMode === "kaniko") {
+      // If using an external registry we need the util service
+      // Also the kaniko buildMode needs the util service even if using an in-cluster registry
       config._systemServices.push("util")
     }
 

--- a/garden-service/src/plugins/kubernetes/kubernetes.ts
+++ b/garden-service/src/plugins/kubernetes/kubernetes.ts
@@ -63,8 +63,9 @@ export async function configureProvider({
 
   if (config.buildMode === "cluster-docker" || config.buildMode === "kaniko") {
     config._systemServices.push("build-sync")
-    
-    const usingInClusterRegistry = (!config.deploymentRegistry || config.deploymentRegistry.hostname === inClusterRegistryHostname)
+
+    const usingInClusterRegistry =
+      !config.deploymentRegistry || config.deploymentRegistry.hostname === inClusterRegistryHostname
 
     if (usingInClusterRegistry) {
       // Deploy an in-cluster registry, unless otherwise specified.


### PR DESCRIPTION
The util service was only being deployed if we were using an external registry. However kaniko works fine with an in-cluster registry, and kaniko requires the util service.

Fixes #1962

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/garden-io/garden/1963)
<!-- Reviewable:end -->
