### PR TITLE
Expose build version in exec and container builds

### DIFF
--- a/docs/guides/container-modules.md
+++ b/docs/guides/container-modules.md
@@ -21,6 +21,23 @@ name: my-container
 
 If you have a `Dockerfile` next to this file, this is enough to tell Garden to build it. You can also specify `dockerfile: <path-to-Dockerfile>` if you need to override the Dockerfile name. You might also want to explicitly [include or exclude](../using-garden/configuration-overview.md#includingexcluding-files-and-directories) files in the build context.
 
+### Build arguments
+
+You can specify [build arguments](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg) using the [`buildArgs`](../reference/module-types/container.md#buildArgs) field. This can be quite handy, especially when e.g. referencing other modules such as build dependencies:
+
+```yaml
+# garden.yml
+kind: Module
+type: container
+name: my-container
+build:
+  depdendencies: [base-image]
+buildArgs:
+  baseImageVersion: ${modules.base-image.version}
+```
+
+Garden will also automatically set `GARDEN_MODULE_VERSION` as a build argument, so that you can reference the version of module being built.
+
 ## Using remote images
 
 If you're not building the container image yourself and just need to deploy an external image, you can skip the Dockerfile and specify the `image` field:

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -122,6 +122,8 @@ build:
   timeout: 1200
 
 # Specify build arguments to use when building the container image.
+#
+# Note: Garden will always set a `GARDEN_MODULE_VERSION` argument with the module version at build time.
 buildArgs: {}
 
 # Specify extra flags to use when building the container image. Note that arguments may not be portable across
@@ -702,6 +704,8 @@ Maximum time in seconds to wait for build to finish.
 ### `buildArgs`
 
 Specify build arguments to use when building the container image.
+
+Note: Garden will always set a `GARDEN_MODULE_VERSION` argument with the module version at build time.
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -120,6 +120,8 @@ build:
   timeout: 1200
 
 # Specify build arguments to use when building the container image.
+#
+# Note: Garden will always set a `GARDEN_MODULE_VERSION` argument with the module version at build time.
 buildArgs: {}
 
 # Specify extra flags to use when building the container image. Note that arguments may not be portable across
@@ -710,6 +712,8 @@ Maximum time in seconds to wait for build to finish.
 ### `buildArgs`
 
 Specify build arguments to use when building the container image.
+
+Note: Garden will always set a `GARDEN_MODULE_VERSION` argument with the module version at build time.
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |

--- a/garden-service/src/plugins/container/build.ts
+++ b/garden-service/src/plugins/container/build.ts
@@ -14,6 +14,7 @@ import { BuildModuleParams } from "../../types/plugin/module/build"
 import { LogLevel } from "../../logger/log-node"
 import { createOutputStream } from "../../util/util"
 import { ContainerProvider } from "./container"
+import { PrimitiveMap } from "../../config/common"
 
 export async function getContainerBuildStatus({ ctx, module, log }: GetBuildStatusParams<ContainerModule>) {
   const containerProvider = ctx.provider as ContainerProvider
@@ -84,7 +85,12 @@ export async function buildContainerModule({ ctx, module, log }: BuildModulePara
 export function getDockerBuildFlags(module: ContainerModule) {
   const args: string[] = []
 
-  for (const [key, value] of Object.entries(module.spec.buildArgs)) {
+  const buildArgs: PrimitiveMap = {
+    GARDEN_MODULE_VERSION: module.version.versionString,
+    ...module.spec.buildArgs,
+  }
+
+  for (const [key, value] of Object.entries(buildArgs)) {
     // 0 is falsy
     if (value || value === 0) {
       args.push("--build-arg", `${key}=${value}`)

--- a/garden-service/src/plugins/container/config.ts
+++ b/garden-service/src/plugins/container/config.ts
@@ -579,8 +579,11 @@ export const containerModuleSpecSchema = () =>
       buildArgs: joi
         .object()
         .pattern(/.+/, joiPrimitive())
-        .default(() => ({}))
-        .description("Specify build arguments to use when building the container image."),
+        .default(() => ({})).description(dedent`
+          Specify build arguments to use when building the container image.
+
+          Note: Garden will always set a \`GARDEN_MODULE_VERSION\` argument with the module version at build time.
+        `),
       extraFlags: joi.array().items(joi.string()).description(deline`
         Specify extra flags to use when building the container image.
         Note that arguments may not be portable across implementations.`),

--- a/garden-service/src/plugins/exec.ts
+++ b/garden-service/src/plugins/exec.ts
@@ -213,6 +213,14 @@ export async function configureExecModule({
   return { moduleConfig }
 }
 
+function getDefaultEnvVars(module: ExecModule) {
+  return {
+    ...process.env,
+    GARDEN_MODULE_VERSION: module.version.versionString,
+    ...mapValues(module.spec.env, (v) => v.toString()),
+  }
+}
+
 export async function buildExecModule({ module }: BuildModuleParams<ExecModule>): Promise<BuildResult> {
   const output: BuildResult = {}
   const { command } = module.spec.build
@@ -220,10 +228,7 @@ export async function buildExecModule({ module }: BuildModuleParams<ExecModule>)
   if (command.length) {
     const result = await exec(command.join(" "), [], {
       cwd: module.buildPath,
-      env: {
-        ...process.env,
-        ...mapValues(module.spec.env, (v) => v.toString()),
-      },
+      env: getDefaultEnvVars(module),
       shell: true,
     })
 
@@ -250,9 +255,7 @@ export async function testExecModule({
   const result = await exec(command.join(" "), [], {
     cwd: module.buildPath,
     env: {
-      ...process.env,
-      // need to cast the values to strings
-      ...mapValues(module.spec.env, (v) => v + ""),
+      ...getDefaultEnvVars(module),
       ...mapValues(testConfig.spec.env, (v) => v + ""),
     },
     reject: false,
@@ -287,8 +290,7 @@ export async function runExecTask(params: RunTaskParams<ExecModule>): Promise<Ru
     const commandResult = await exec(command.join(" "), [], {
       cwd: module.buildPath,
       env: {
-        ...process.env,
-        ...mapValues(module.spec.env, (v) => v.toString()),
+        ...getDefaultEnvVars(module),
         ...mapValues(task.spec.env, (v) => v.toString()),
       },
       // We handle the error at the command level

--- a/garden-service/src/runtime-context.ts
+++ b/garden-service/src/runtime-context.ts
@@ -90,10 +90,11 @@ export async function prepareRuntimeContext({
 }: PrepareRuntimeContextParams): Promise<RuntimeContext> {
   const { versionString } = version
   const envVars = {
-    GARDEN_VERSION: versionString,
+    GARDEN_VERSION: versionString, // TODO: deprecate, prefer the more verbose option
+    GARDEN_MODULE_VERSION: versionString,
   }
 
-  // DEPRECATED: Remove in v0.12
+  // DEPRECATED: Remove in v0.13
   for (const [key, value] of Object.entries(garden.variables)) {
     // Only store primitive values, objects and arrays cause issues further down.
     if (isPrimitive(value)) {

--- a/garden-service/test/data/test-projects/exec-artifacts/garden.yml
+++ b/garden-service/test/data/test-projects/exec-artifacts/garden.yml
@@ -1,2 +1,4 @@
 kind: Project
 name: exec-artifacts
+environments:
+  - name: default

--- a/garden-service/test/unit/src/plugins/container/container.ts
+++ b/garden-service/test/unit/src/plugins/container/container.ts
@@ -773,7 +773,14 @@ describe("plugins.container", () => {
       td.replace(helpers, "imageExistsLocally", async () => false)
       td.replace(helpers, "getLocalImageId", async () => "some/image")
 
-      const cmdArgs = ["build", "-t", "some/image", module.buildPath]
+      const cmdArgs = [
+        "build",
+        "-t",
+        "some/image",
+        "--build-arg",
+        `GARDEN_MODULE_VERSION=${module.version.versionString}`,
+        module.buildPath,
+      ]
 
       td.replace(helpers, "dockerCli", async ({ cwd, args, containerProvider: provider }) => {
         expect(cwd).to.equal(module.buildPath)
@@ -801,7 +808,16 @@ describe("plugins.container", () => {
       td.replace(helpers, "imageExistsLocally", async () => false)
       td.replace(helpers, "getLocalImageId", async () => "some/image")
 
-      const cmdArgs = ["build", "-t", "some/image", "--target", "foo", module.buildPath]
+      const cmdArgs = [
+        "build",
+        "-t",
+        "some/image",
+        "--build-arg",
+        `GARDEN_MODULE_VERSION=${module.version.versionString}`,
+        "--target",
+        "foo",
+        module.buildPath,
+      ]
 
       td.replace(helpers, "dockerCli", async ({ cwd, args, containerProvider: provider }) => {
         expect(cwd).to.equal(module.buildPath)
@@ -834,6 +850,8 @@ describe("plugins.container", () => {
         "build",
         "-t",
         "some/image",
+        "--build-arg",
+        `GARDEN_MODULE_VERSION=${module.version.versionString}`,
         "--file",
         join(module.buildPath, relDockerfilePath),
         module.buildPath,
@@ -998,7 +1016,42 @@ describe("plugins.container", () => {
 
       const args = getDockerBuildFlags(module)
 
-      expect(args).to.eql(["--cache-from", "some-image:latest"])
+      expect(args.slice(-2)).to.eql(["--cache-from", "some-image:latest"])
+    })
+
+    it("should set GARDEN_MODULE_VERSION", async () => {
+      const module = await getTestModule({
+        allowPublish: false,
+        build: {
+          dependencies: [],
+        },
+        disabled: false,
+        apiVersion: "garden.io/v0",
+        name: "module-a",
+        outputs: {},
+        path: modulePath,
+        type: "container",
+
+        spec: {
+          build: {
+            dependencies: [],
+            timeout: DEFAULT_BUILD_TIMEOUT,
+          },
+          buildArgs: {},
+          extraFlags: [],
+          services: [],
+          tasks: [],
+          tests: [],
+        },
+
+        serviceConfigs: [],
+        taskConfigs: [],
+        testConfigs: [],
+      })
+
+      const args = getDockerBuildFlags(module)
+
+      expect(args.slice(0, 2)).to.eql(["--build-arg", `GARDEN_MODULE_VERSION=${module.version.versionString}`])
     })
   })
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

This allows users to reference the module version at build time, which
can be quite useful to e.g. set deterministic values for build
artifacts.

For container builds, a `GARDEN_MODULE_VERSION` build arg is provided.
For exec module builds, tasks and tests, a `GARDEN_MODULE_VERSION` env variable is exposed to the command/script.
