### PR TITLE
improvement(core): set smarter limits on concurrent graph actions

### DIFF
--- a/garden-service/src/commands/base.ts
+++ b/garden-service/src/commands/base.ts
@@ -311,7 +311,7 @@ export abstract class Command<T extends Parameters = {}, U extends Parameters = 
     return !!this.parent ? `${this.parent.getFullName()} ${this.name}` : this.name
   }
 
-  getPath() {
+  getPath(): string[] {
     return !!this.parent ? [...this.parent.getPath(), this.name] : [this.name]
   }
 
@@ -633,7 +633,11 @@ export type ParamSpec = {
  * @param argSpec The arguments spec for the command in question.
  * @param optSpec The options spec for the command in question.
  */
-export function parseCliArgs(args: string[], argSpec: ParamSpec, optSpec: ParamSpec): { args: any; opts: any } {
+export function parseCliArgs(
+  args: string[],
+  argSpec: ParamSpec,
+  optSpec: ParamSpec
+): { args: Parameters; opts: Parameters } {
   const parsed = minimist(args)
   const argKeys = Object.keys(argSpec)
   const parsedArgs = {}

--- a/garden-service/src/constants.ts
+++ b/garden-service/src/constants.ts
@@ -100,6 +100,11 @@ export const gardenEnv = {
     .required(false)
     .default("")
     .asString(),
+  GARDEN_HARD_CONCURRENCY_LIMIT: env
+    .get("GARDEN_HARD_CONCURRENCY_LIMIT")
+    .required(false)
+    .default(50)
+    .asInt(),
   GARDEN_TASK_CONCURRENCY_LIMIT: env
     .get("GARDEN_TASK_CONCURRENCY_LIMIT")
     .required(false)

--- a/garden-service/src/tasks/base.ts
+++ b/garden-service/src/tasks/base.ts
@@ -48,6 +48,10 @@ export interface TaskParams {
 @Profile()
 export abstract class BaseTask {
   abstract type: TaskType
+
+  // How many tasks of this exact type are allowed to run concurrently
+  concurrencyLimit = 10
+
   garden: Garden
   log: LogEntry
   uid: string

--- a/garden-service/src/tasks/build.ts
+++ b/garden-service/src/tasks/build.ts
@@ -29,6 +29,7 @@ export interface BuildTaskParams {
 @Profile()
 export class BuildTask extends BaseTask {
   type: TaskType = "build"
+  concurrencyLimit = 5
 
   private graph: ConfigGraph
   private module: Module

--- a/garden-service/src/tasks/delete-service.ts
+++ b/garden-service/src/tasks/delete-service.ts
@@ -24,6 +24,7 @@ export interface DeleteServiceTaskParams {
 
 export class DeleteServiceTask extends BaseTask {
   type: TaskType = "delete-service"
+  concurrencyLimit = 10
 
   private graph: ConfigGraph
   private service: Service

--- a/garden-service/src/tasks/deploy.ts
+++ b/garden-service/src/tasks/deploy.ts
@@ -37,6 +37,7 @@ export interface DeployTaskParams {
 @Profile()
 export class DeployTask extends BaseTask {
   type: TaskType = "deploy"
+  concurrencyLimit = 10
 
   private graph: ConfigGraph
   private service: Service

--- a/garden-service/src/tasks/get-service-status.ts
+++ b/garden-service/src/tasks/get-service-status.ts
@@ -32,6 +32,7 @@ export interface GetServiceStatusTaskParams {
 @Profile()
 export class GetServiceStatusTask extends BaseTask {
   type: TaskType = "get-service-status"
+  concurrencyLimit = 20
 
   private graph: ConfigGraph
   private service: Service

--- a/garden-service/src/tasks/get-task-result.ts
+++ b/garden-service/src/tasks/get-task-result.ts
@@ -26,6 +26,7 @@ export interface GetTaskResultTaskParams {
 @Profile()
 export class GetTaskResultTask extends BaseTask {
   type: TaskType = "get-task-result"
+  concurrencyLimit = 20
 
   private task: Task
 

--- a/garden-service/src/tasks/hot-reload.ts
+++ b/garden-service/src/tasks/hot-reload.ts
@@ -26,6 +26,7 @@ interface Params {
 @Profile()
 export class HotReloadTask extends BaseTask {
   type: TaskType = "hot-reload"
+  concurrencyLimit = 10
 
   // private graph: ConfigGraph
   // private hotReloadServiceNames: string[]

--- a/garden-service/src/tasks/publish.ts
+++ b/garden-service/src/tasks/publish.ts
@@ -25,6 +25,7 @@ export interface PublishTaskParams {
 
 export class PublishTask extends BaseTask {
   type: TaskType = "publish"
+  concurrencyLimit = 5
 
   private graph: ConfigGraph
   private module: Module

--- a/garden-service/src/tasks/resolve-module.ts
+++ b/garden-service/src/tasks/resolve-module.ts
@@ -129,12 +129,18 @@ interface ResolveModuleTaskParams {
   runtimeContext?: RuntimeContext
 }
 
+export const moduleResolutionConcurrencyLimit = 40
+
 /**
  * Fully resolve the given module config, including its final version and dependencies.
  */
 @Profile()
 export class ResolveModuleTask extends BaseTask {
   type: TaskType = "resolve-module"
+
+  // It's advisable to have _some_ limit (say if you have hundreds of modules), because the filesystem scan can cost
+  // a bit of memory, but we make it quite a bit higher than other tasks.
+  concurrencyLimit = moduleResolutionConcurrencyLimit
 
   private moduleConfig: ModuleConfig
   private resolvedProviders: ProviderMap

--- a/garden-service/src/tasks/resolve-provider.ts
+++ b/garden-service/src/tasks/resolve-provider.ts
@@ -62,6 +62,7 @@ const defaultCacheTtl = 3600 // 1 hour
 @Profile()
 export class ResolveProviderTask extends BaseTask {
   type: TaskType = "resolve-provider"
+  concurrencyLimit = 20
 
   private config: ProviderConfig
   private plugin: GardenPlugin

--- a/garden-service/src/tasks/stage-build.ts
+++ b/garden-service/src/tasks/stage-build.ts
@@ -29,6 +29,7 @@ export interface StageBuildTaskParams {
 @Profile()
 export class StageBuildTask extends BaseTask {
   type: TaskType = "stage-build"
+  concurrencyLimit = 10
 
   private graph: ConfigGraph
   private module: Module


### PR DESCRIPTION
**What this PR does / why we need it**:

We now set concurrency limits for individual action types, which should
better align with resource pressure from different types.

We also set a hard global limit and some upper limit on module and
provider resolution, which was previously completely unlimited, which
could cause memory thrashing (even crashes) with very large projects
(200+ modules).
