### PR TITLE
fix(enterprise): add project id to config dump

### DIFF
--- a/garden-service/src/garden.ts
+++ b/garden-service/src/garden.ts
@@ -124,6 +124,7 @@ export interface GardenEnterpriseContext {
 export interface GardenParams {
   artifactsPath: string
   buildDir: BuildDir
+  projectId: string | null
   enterpriseContext: GardenEnterpriseContext | null
   dotIgnoreFiles: string[]
   environmentName: string
@@ -163,7 +164,8 @@ export class Garden {
   private readonly taskGraph: TaskGraph
   private watcher: Watcher
   private asyncLock: any
-  public enterpriseContext: GardenEnterpriseContext | null
+  public readonly enterpriseContext: GardenEnterpriseContext | null
+  public readonly projectId: string | null
   public sessionId: string | null
   public readonly configStore: ConfigStore
   public readonly globalConfigStore: GlobalConfigStore
@@ -200,6 +202,7 @@ export class Garden {
   constructor(params: GardenParams) {
     this.buildDir = params.buildDir
     this.enterpriseContext = params.enterpriseContext
+    this.projectId = params.projectId
     this.sessionId = params.sessionId
     this.environmentName = params.environmentName
     this.environmentConfigs = params.environmentConfigs
@@ -339,6 +342,7 @@ export class Garden {
     const garden = new this({
       artifactsPath,
       sessionId,
+      projectId: projectId || null,
       enterpriseContext,
       projectRoot,
       projectName,
@@ -1178,7 +1182,7 @@ export class Garden {
       workflowConfigs: sortBy(workflowConfigs, "name"),
       projectName: this.projectName,
       projectRoot: this.projectRoot,
-      projectId: this.enterpriseContext ? this.enterpriseContext.projectId : undefined,
+      projectId: this.projectId || undefined,
     }
   }
 

--- a/garden-service/test/unit/src/commands/get/get-config.ts
+++ b/garden-service/test/unit/src/commands/get/get-config.ts
@@ -37,7 +37,7 @@ describe("GetConfigCommand", () => {
     expect(res.result?.moduleConfigs).to.deep.equal(expectedModuleConfigs)
   })
 
-  it("should include the project name and all environment names", async () => {
+  it("should include the project name, id and all environment names", async () => {
     const garden = await makeTestGardenA()
     const log = garden.log
     const command = new GetConfigCommand()
@@ -53,8 +53,9 @@ describe("GetConfigCommand", () => {
       })
     ).result
 
-    expect(pick(result, ["projectName", "allEnvironmentNames"])).to.eql({
+    expect(pick(result, ["projectName", "projectId", "allEnvironmentNames"])).to.eql({
       projectName: "test-project-a",
+      projectId: "test-project-id",
       allEnvironmentNames: ["local", "other"],
     })
   })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

This fixes a recent regression where project IDs would not be included in the output of the `get config` command unless logged in.