### PR TITLE
fix(k8s): incorrect Service name used for port forwards

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -121,8 +121,8 @@ deployments:
         # The protocol of the port.
         protocol:
 
-        # The target hostname of the service (only used for informational purposes).
-        targetHostname:
+        # The target name/hostname to forward to (defaults to the service name).
+        targetName:
 
         # The target port on the service.
         targetPort:
@@ -459,8 +459,8 @@ serviceStatuses:
         # The protocol of the port.
         protocol:
 
-        # The target hostname of the service (only used for informational purposes).
-        targetHostname:
+        # The target name/hostname to forward to (defaults to the service name).
+        targetName:
 
         # The target port on the service.
         targetPort:
@@ -558,8 +558,8 @@ Examples:
       # The protocol of the port.
       protocol:
 
-      # The target hostname of the service (only used for informational purposes).
-      targetHostname:
+      # The target name/hostname to forward to (defaults to the service name).
+      targetName:
 
       # The target port on the service.
       targetPort:
@@ -706,8 +706,8 @@ deployments:
         # The protocol of the port.
         protocol:
 
-        # The target hostname of the service (only used for informational purposes).
-        targetHostname:
+        # The target name/hostname to forward to (defaults to the service name).
+        targetName:
 
         # The target port on the service.
         targetPort:
@@ -1407,8 +1407,8 @@ services:
         # The protocol of the port.
         protocol:
 
-        # The target hostname of the service (only used for informational purposes).
-        targetHostname:
+        # The target name/hostname to forward to (defaults to the service name).
+        targetName:
 
         # The target port on the service.
         targetPort:
@@ -1934,8 +1934,8 @@ deployments:
         # The protocol of the port.
         protocol:
 
-        # The target hostname of the service (only used for informational purposes).
-        targetHostname:
+        # The target name/hostname to forward to (defaults to the service name).
+        targetName:
 
         # The target port on the service.
         targetPort:
@@ -2451,8 +2451,8 @@ deployments:
         # The protocol of the port.
         protocol:
 
-        # The target hostname of the service (only used for informational purposes).
-        targetHostname:
+        # The target name/hostname to forward to (defaults to the service name).
+        targetName:
 
         # The target port on the service.
         targetPort:

--- a/garden-service/src/proxy.ts
+++ b/garden-service/src/proxy.ts
@@ -224,7 +224,7 @@ function stopPortProxy(proxy: PortProxy, log?: LogEntry) {
 }
 
 function getHostname(service: Service, spec: ForwardablePort) {
-  return spec.targetHostname || service.name
+  return spec.targetName || service.name
 }
 
 function getPortKey(service: Service, spec: ForwardablePort) {

--- a/garden-service/src/tasks/deploy.ts
+++ b/garden-service/src/tasks/deploy.ts
@@ -221,7 +221,7 @@ export class DeployTask extends BaseTask {
       const proxies = await startPortProxies(this.garden, log, this.service, status)
 
       for (const proxy of proxies) {
-        const targetHost = proxy.spec.targetHostname || this.service.name
+        const targetHost = proxy.spec.targetName || this.service.name
 
         log.info(
           chalk.gray(

--- a/garden-service/src/types/service.ts
+++ b/garden-service/src/types/service.ts
@@ -157,7 +157,7 @@ export interface ForwardablePort {
   name?: string
   // TODO: support other protocols
   protocol: "TCP"
-  targetHostname?: string
+  targetName?: string
   targetPort: number
   urlProtocol?: string
 }
@@ -171,9 +171,7 @@ export const forwardablePortKeys = {
     .allow("TCP")
     .default("TCP")
     .description("The protocol of the port."),
-  targetHostname: joi
-    .string()
-    .description("The target hostname of the service (only used for informational purposes)."),
+  targetName: joi.string().description("The target name/hostname to forward to (defaults to the service name)."),
   targetPort: joi
     .number()
     .integer()


### PR DESCRIPTION
**What this PR does / why we need it**:

We were using the Garden service name instead of the Kubernetes Service name, which caused problems when those differed.

**Which issue(s) this PR fixes**:

Fixes #1827

**Special notes for your reviewer**:

cc @petr-motejlek
