### PR TITLE
Fix hot reloading issues

### DIFF
--- a/garden-service/package-lock.json
+++ b/garden-service/package-lock.json
@@ -11540,8 +11540,7 @@
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
     },
     "remove-trailing-slash": {
       "version": "0.1.0",
@@ -13586,6 +13585,24 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
       "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
+    },
+    "unixify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
+      "integrity": "sha1-OmQcjC/7zk2mg6XHDwOkYpQMIJA=",
+      "requires": {
+        "normalize-path": "^2.1.1"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        }
+      }
     },
     "unpipe": {
       "version": "1.0.0",

--- a/garden-service/package.json
+++ b/garden-service/package.json
@@ -127,6 +127,7 @@
     "typeorm": "^0.2.25",
     "typescript-memoize": "^1.0.0-alpha.3",
     "uniqid": "^5.2.0",
+    "unixify": "^1.0.0",
     "unzipper": "^0.10.11",
     "username": "^5.1.0",
     "uuid": "^8.1.0",

--- a/garden-service/src/build-dir.ts
+++ b/garden-service/src/build-dir.ts
@@ -8,12 +8,11 @@
 
 import { map as bluebirdMap } from "bluebird"
 import semver from "semver"
-import normalize = require("normalize-path")
 import { isAbsolute, join, parse, resolve, sep, relative } from "path"
 import { emptyDir, ensureDir } from "fs-extra"
 import { ConfigurationError, RuntimeError } from "./exceptions"
 import { FileCopySpec, Module, getModuleKey } from "./types/module"
-import { normalizeLocalRsyncPath } from "./util/fs"
+import { normalizeLocalRsyncPath, normalizeRelativePath } from "./util/fs"
 import { LogEntry } from "./logger/log-entry"
 import { ModuleConfig } from "./config/module"
 import { ConfigGraph } from "./config-graph"
@@ -100,7 +99,7 @@ export class BuildDir {
     }
 
     // Normalize to relative POSIX-style paths
-    const files = module.version.files.map((f) => normalize(isAbsolute(f) ? relative(module.path, f) : f))
+    const files = module.version.files.map((f) => normalizeRelativePath(module.path, f))
 
     await this.sync({
       module,

--- a/garden-service/src/plugins/kubernetes/hot-reload.ts
+++ b/garden-service/src/plugins/kubernetes/hot-reload.ts
@@ -306,7 +306,6 @@ export async function syncToService({ ctx, service, hotReloadSpec, namespace, wo
 
   const doSync = async () => {
     const portForward = await getPortForward({ ctx, log, namespace, targetResource, port: RSYNC_PORT })
-    const module = service.module
 
     const syncResult = await Bluebird.map(hotReloadSpec.sync, ({ source, target }) => {
       const sourcePath = rsyncSourcePath(service.sourceModule.path, source)
@@ -331,13 +330,15 @@ export async function syncToService({ ctx, service, hotReloadSpec, namespace, wo
         tmpDir,
       ]
 
+      const files = filesForSync(service.sourceModule, source)
+
       return syncWithOptions({
         syncOpts,
         sourcePath,
         destinationPath,
         withDelete: false,
         log,
-        files: filesForSync(module, source),
+        files,
       })
     })
 

--- a/garden-service/src/util/fs.ts
+++ b/garden-service/src/util/fs.ts
@@ -6,6 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import unixify = require("unixify")
 import klaw = require("klaw")
 import glob from "glob"
 import _spawn from "cross-spawn"
@@ -13,8 +14,9 @@ import { pathExists, readFile, writeFile, lstat } from "fs-extra"
 import minimatch = require("minimatch")
 import { some } from "lodash"
 import { join, basename, win32, posix } from "path"
-import { FilesystemError } from "../exceptions"
 import { platform } from "os"
+
+import { FilesystemError } from "../exceptions"
 import { VcsHandler } from "../vcs/vcs"
 import { LogEntry } from "../logger/log-entry"
 import { ModuleConfig } from "../config/module"
@@ -154,6 +156,15 @@ export function toCygwinPath(path: string) {
 
 export function normalizeLocalRsyncPath(path: string) {
   return platform() === "win32" ? toCygwinPath(path) : path
+}
+
+/**
+ * Normalize given path to POSIX-style path relative to `root`
+ */
+export function normalizeRelativePath(root: string, path: string) {
+  root = unixify(root)
+  path = unixify(path)
+  return posix.isAbsolute(path) ? posix.relative(root, path) : path
 }
 
 /**

--- a/garden-service/test/unit/src/plugins/kubernetes/hot-reload.ts
+++ b/garden-service/test/unit/src/plugins/kubernetes/hot-reload.ts
@@ -9,7 +9,7 @@
 import { platform } from "os"
 import { expect } from "chai"
 import td from "testdouble"
-import { HotReloadableResource, rsyncSourcePath, filesForSync } from "../../../../../src/plugins/kubernetes/hot-reload"
+import { HotReloadableResource, rsyncSourcePath, filesForSync, RSYNC_PORT_NAME } from "../../../../../src/plugins/kubernetes/hot-reload"
 
 import {
   removeTrailingSlashes,
@@ -105,6 +105,14 @@ describe("configureHotReload", () => {
                 ],
               },
             ],
+            readinessProbe: {
+              initialDelaySeconds: 2,
+              periodSeconds: 1,
+              timeoutSeconds: 3,
+              successThreshold: 1,
+              failureThreshold: 5,
+              tcpSocket: { port: <object>(<unknown>RSYNC_PORT_NAME) },
+            },
             volumes: [
               {
                 name: "garden-sync",


### PR DESCRIPTION
**What this PR does / why we need it**:

See commits for details. We had a few path handling issues after change made in v0.12.0, in particular on Windows and when hot-reloading `helm` modules.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Would be good to do a sanity check on this. I've tested on both Windows and mac, for container and helm+container syncs, but ya never know.
