### PR TITLE
fix(core): error with rsync v3.2.3 and later on certain OSes

### DIFF
--- a/garden-service/src/build-dir.ts
+++ b/garden-service/src/build-dir.ts
@@ -22,7 +22,7 @@ import { Profile } from "./util/profiling"
 import { syncWithOptions } from "./util/sync"
 
 const minRsyncVersion = "3.1.0"
-const versionRegex = /rsync  version ([\d\.]+)  /
+const versionRegex = /rsync  version [v]*([\d\.]+)  /
 
 // FIXME: We don't want to keep special casing this module type so we need to think
 // of a better way around this.

--- a/garden-service/test/data/dummy-rsync/min-version/rsync
+++ b/garden-service/test/data/dummy-rsync/min-version/rsync
@@ -1,7 +1,6 @@
 #!/bin/sh
 
-# Note: version 3.2.3 adds a "v" prefix on the version string
-echo "rsync  version v3.2.3  protocol version 31
+echo "rsync  version 3.1.0  protocol version 31
 Copyright (C) 1996-2018 by Andrew Tridgell, Wayne Davison, and others.
 Web site: http://rsync.samba.org/
 Capabilities:

--- a/garden-service/test/unit/src/build-dir.ts
+++ b/garden-service/test/unit/src/build-dir.ts
@@ -76,6 +76,28 @@ describe("BuildDir", () => {
     }
   })
 
+  it("should work with rsync v3.1.0", async () => {
+    const orgPath = process.env.PATH
+
+    try {
+      process.env.PATH = getDataDir("dummy-rsync", "min-version")
+      await BuildDir.factory(garden.projectRoot, garden.gardenDirPath)
+    } finally {
+      process.env.PATH = orgPath
+    }
+  })
+
+  it("should work with rsync v3.2.3", async () => {
+    const orgPath = process.env.PATH
+
+    try {
+      process.env.PATH = getDataDir("dummy-rsync", "new-version")
+      await BuildDir.factory(garden.projectRoot, garden.gardenDirPath)
+    } finally {
+      process.env.PATH = orgPath
+    }
+  })
+
   it("should throw if rsync is too old", async () => {
     const orgPath = process.env.PATH
 


### PR DESCRIPTION
**What this PR does / why we need it**:

New rsync versions add a "v" prefix on the version string, and our regex didn't expect that. Fun!
 