### PR TITLE
fix(enterprise): fix login flow

### DIFF
--- a/garden-service/src/cli/cli.ts
+++ b/garden-service/src/cli/cli.ts
@@ -43,6 +43,7 @@ import { defaultDotIgnoreFiles } from "../util/fs"
 import { renderError } from "../logger/renderers"
 import { getDefaultProfiler } from "../util/profiling"
 import { BufferedEventStream } from "../enterprise/buffered-event-stream"
+import { makeEnterpriseContext } from "../enterprise/init"
 
 export async function makeDummyGarden(root: string, gardenOpts: GardenOpts = {}) {
   const environments = gardenOpts.environmentName
@@ -229,11 +230,12 @@ ${renderCommands(commands)}
           garden = await Garden.factory(root, contextOpts)
         }
 
-        if (garden.enterpriseContext) {
+        const enterpriseContext = makeEnterpriseContext(garden)
+        if (enterpriseContext) {
           log.silly(`Connecting Garden instance to BufferedEventStream`)
           bufferedEventStream.connect({
+            enterpriseContext,
             eventBus: garden.events,
-            enterpriseContext: garden.enterpriseContext,
             environmentName: garden.environmentName,
             namespace: garden.namespace,
           })

--- a/garden-service/src/commands/login.ts
+++ b/garden-service/src/commands/login.ts
@@ -23,7 +23,7 @@ export class LoginCommand extends Command {
 
   async action({ garden, log, headerLog }: CommandParams): Promise<CommandResult> {
     printHeader(headerLog, "Login", "cloud")
-    const enterpriseDomain = garden.enterpriseContext?.enterpriseDomain
+    const enterpriseDomain = garden.enterpriseDomain
     if (!enterpriseDomain) {
       throw new ConfigurationError(`Error: Your project configuration does not specify a domain.`, {})
     }

--- a/garden-service/src/commands/run/workflow.ts
+++ b/garden-service/src/commands/run/workflow.ts
@@ -30,6 +30,7 @@ import { registerWorkflowRun } from "../../enterprise/workflow-lifecycle"
 import { parseCliArgs, pickCommand, processCliArgs } from "../../cli/helpers"
 import { StringParameter } from "../../cli/params"
 import { getAllCommands } from "../commands"
+import { makeEnterpriseContext } from "../../enterprise/init"
 
 const runWorkflowArgs = {
   workflow: new StringParameter({
@@ -347,10 +348,11 @@ export function logErrors(
 }
 
 async function registerAndSetUid(garden: Garden, log: LogEntry, config: WorkflowConfig) {
-  if (garden.enterpriseContext && !gardenEnv.GARDEN_PLATFORM_SCHEDULED) {
+  const enterpriseContext = makeEnterpriseContext(garden)
+  if (enterpriseContext && !gardenEnv.GARDEN_PLATFORM_SCHEDULED) {
     const workflowRunUid = await registerWorkflowRun({
+      enterpriseContext,
       workflowConfig: config,
-      enterpriseContext: garden.enterpriseContext,
       environment: garden.environmentName,
       namespace: garden.namespace,
       log,

--- a/garden-service/src/config/project.ts
+++ b/garden-service/src/config/project.ts
@@ -333,8 +333,9 @@ export const projectDocsSchema = () =>
       // TODO: Refer to enterprise documentation for more details.
       domain: joi
         .string()
+        .uri()
         .meta({ internal: true })
-        .description("The domain to use for cloud features. Should point to the API/backend base URL."),
+        .description("The domain to use for cloud features. Should be the full API/backend URL."),
       // Note: We provide a different schema below for actual validation, but need to define it this way for docs
       // because joi.alternatives() isn't handled well in the doc generation.
       environments: joi

--- a/garden-service/src/enterprise/buffered-event-stream.ts
+++ b/garden-service/src/enterprise/buffered-event-stream.ts
@@ -14,7 +14,7 @@ import { got } from "../util/http"
 import { makeAuthHeader } from "./auth"
 import { LogLevel } from "../logger/log-node"
 import { gardenEnv } from "../constants"
-import { GardenEnterpriseContext } from "../garden"
+import { GardenEnterpriseContext } from "./init"
 
 export type StreamEvent = {
   name: EventName

--- a/garden-service/src/enterprise/workflow-lifecycle.ts
+++ b/garden-service/src/enterprise/workflow-lifecycle.ts
@@ -11,7 +11,7 @@ import { makeAuthHeader } from "./auth"
 import { WorkflowConfig } from "../config/workflow"
 import { LogEntry } from "../logger/log-entry"
 import { PlatformError } from "../exceptions"
-import { GardenEnterpriseContext } from "../garden"
+import { GardenEnterpriseContext } from "./init"
 
 export interface RegisterWorkflowRunParams {
   workflowConfig: WorkflowConfig

--- a/garden-service/test/unit/src/commands/get/get-outputs.ts
+++ b/garden-service/test/unit/src/commands/get/get-outputs.ts
@@ -37,6 +37,10 @@ describe("GetOutputsCommand", () => {
     }
   })
 
+  after(async () => {
+    await tmpDir.cleanup()
+  })
+
   it("should resolve and return defined project outputs", async () => {
     const plugin = createGardenPlugin({
       name: "test",

--- a/garden-service/test/unit/src/commands/login.ts
+++ b/garden-service/test/unit/src/commands/login.ts
@@ -32,7 +32,7 @@ function makeCommandParams(garden: TestGarden) {
 describe("LoginCommand", () => {
   let tmpDir: tmp.DirectoryResult
   let projectConfig: ProjectConfig
-  const dummyDomain = "dummy-domain"
+  const dummyDomain = "http://dummy-domain.com"
 
   before(async () => {
     tmpDir = await tmp.dir({ unsafeCleanup: true })

--- a/garden-service/test/unit/src/commands/login.ts
+++ b/garden-service/test/unit/src/commands/login.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import td from "testdouble"
+import tmp from "tmp-promise"
+import { ProjectConfig, defaultNamespace } from "../../../../src/config/project"
+import { exec } from "../../../../src/util/util"
+import { DEFAULT_API_VERSION } from "../../../../src/constants"
+import { TestGarden, withDefaultGlobalOpts, expectError } from "../../../helpers"
+const Auth = require("../../../../src/enterprise/auth")
+import { LoginCommand } from "../../../../src/commands/login"
+import stripAnsi from "strip-ansi"
+
+function makeCommandParams(garden: TestGarden) {
+  const log = garden.log
+  return {
+    garden,
+    log,
+    headerLog: log,
+    footerLog: log,
+    args: {},
+    opts: withDefaultGlobalOpts({}),
+  }
+}
+
+describe("LoginCommand", () => {
+  let tmpDir: tmp.DirectoryResult
+  let projectConfig: ProjectConfig
+  const dummyDomain = "dummy-domain"
+
+  before(async () => {
+    tmpDir = await tmp.dir({ unsafeCleanup: true })
+    await exec("git", ["init"], { cwd: tmpDir.path })
+
+    projectConfig = {
+      apiVersion: DEFAULT_API_VERSION,
+      kind: "Project",
+      name: "test",
+      path: tmpDir.path,
+      defaultEnvironment: "default",
+      dotIgnoreFiles: [],
+      environments: [{ name: "default", defaultNamespace, variables: {} }],
+      providers: [{ name: "test" }],
+      variables: {},
+    }
+  })
+
+  beforeEach(async () => {
+    td.replace(Auth, "login", async () => "dummy-auth-token")
+  })
+
+  after(async () => {
+    await tmpDir.cleanup()
+  })
+
+  it("should log in if the project has a domain and an id", async () => {
+    const config = { ...projectConfig, domain: dummyDomain, id: "dummy-id" }
+    const garden = await TestGarden.factory(tmpDir.path, { config })
+    const command = new LoginCommand()
+    await command.action(makeCommandParams(garden))
+  })
+
+  it("should log in if the project has a domain but no id", async () => {
+    const config = { ...projectConfig, domain: dummyDomain }
+    const garden = await TestGarden.factory(tmpDir.path, { config })
+    const command = new LoginCommand()
+    await command.action(makeCommandParams(garden))
+  })
+
+  it("should throw if the project doesn't have a domain", async () => {
+    const garden = await TestGarden.factory(tmpDir.path, { config: projectConfig })
+    const command = new LoginCommand()
+    await expectError(
+      () => command.action(makeCommandParams(garden)),
+      (err) => expect(stripAnsi(err.message)).to.match(/Your project configuration does not specify a domain/)
+    )
+  })
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

Fixes a recent regression in the login flow, and stops throwing enterprise-related errors for non-enterprise projects when the user is logged in.

Also added unit tests for the `login` command.