### PR TITLE
fix(config): incorrect handling of bracketed template keys with dots

### DIFF
--- a/garden-service/src/config/provider.ts
+++ b/garden-service/src/config/provider.ts
@@ -127,7 +127,7 @@ export async function getProviderTemplateReferences(config: ProviderConfig) {
 
   for (const key of references) {
     if (key[0] === "providers") {
-      const providerName = key[1]
+      const providerName = key[1] as string
       if (!providerName) {
         throw new ConfigurationError(
           deline`

--- a/garden-service/src/outputs.ts
+++ b/garden-service/src/outputs.ts
@@ -44,14 +44,14 @@ export async function resolveProjectOutputs(garden: Garden, log: LogEntry): Prom
       continue
     }
     if (ref[0] === "providers") {
-      needProviders.push(ref[1])
+      needProviders.push(ref[1] as string)
     } else if (ref[0] === "modules") {
-      needModules.push(ref[1])
+      needModules.push(ref[1] as string)
     } else if (ref[0] === "runtime" && ref[2]) {
       if (ref[1] === "services") {
-        needServices.push(ref[2])
+        needServices.push(ref[2] as string)
       } else if (ref[1] === "tasks") {
-        needTasks.push(ref[2])
+        needTasks.push(ref[2] as string)
       }
     }
   }

--- a/garden-service/src/template-string.ts
+++ b/garden-service/src/template-string.ts
@@ -9,7 +9,13 @@
 import lodash from "lodash"
 import { deepMap } from "./util/util"
 import { GardenBaseError, ConfigurationError } from "./exceptions"
-import { ConfigContext, ContextResolveOpts, ScanContext, ContextResolveOutput } from "./config/config-context"
+import {
+  ConfigContext,
+  ContextResolveOpts,
+  ScanContext,
+  ContextResolveOutput,
+  ContextKeySegment,
+} from "./config/config-context"
 import { difference, flatten, uniq, isPlainObject, isNumber } from "lodash"
 import { Primitive, StringMap, isPrimitive } from "./config/common"
 import { profile } from "./util/profiling"
@@ -117,7 +123,7 @@ export const resolveTemplateStrings = profile(function $resolveTemplateStrings<T
 /**
  * Scans for all template strings in the given object and lists the referenced keys.
  */
-export function collectTemplateReferences<T extends object>(obj: T): string[][] {
+export function collectTemplateReferences<T extends object>(obj: T): ContextKeySegment[][] {
   const context = new ScanContext()
   resolveTemplateStrings(obj, context)
   return uniq(context.foundKeys.entries()).sort()
@@ -144,7 +150,7 @@ export function throwOnMissingSecretKeys<T extends Object>(
   secrets: StringMap,
   prefix: string
 ) {
-  const allMissing: [string, string[]][] = [] // [[key, missing keys]]
+  const allMissing: [string, ContextKeySegment[]][] = [] // [[key, missing keys]]
   for (const [key, config] of Object.entries(configs)) {
     const missing = detectMissingSecretKeys(config, secrets)
     if (missing.length > 0) {
@@ -190,7 +196,7 @@ export function throwOnMissingSecretKeys<T extends Object>(
  * Collects template references to secrets in obj, and returns an array of any secret keys referenced in it that
  * aren't present (or have blank values) in the provided secrets map.
  */
-export function detectMissingSecretKeys<T extends object>(obj: T, secrets: StringMap): string[] {
+export function detectMissingSecretKeys<T extends object>(obj: T, secrets: StringMap): ContextKeySegment[] {
   const referencedKeys = collectTemplateReferences(obj)
     .filter((ref) => ref[0] === "secrets")
     .map((ref) => ref[1])

--- a/garden-service/test/unit/src/template-string.ts
+++ b/garden-service/test/unit/src/template-string.ts
@@ -450,6 +450,16 @@ describe("resolveTemplateString", async () => {
     expect(res).to.equal(true)
   })
 
+  it("should handle member lookup with bracket notation, single quotes and dot in key name", async () => {
+    const res = resolveTemplateString("${foo['bar.baz']}", new TestContext({ foo: { "bar.baz": true } }))
+    expect(res).to.equal(true)
+  })
+
+  it("should handle member lookup with bracket notation, double quotes and dot in key name", async () => {
+    const res = resolveTemplateString('${foo.bar["bla.ble"]}', new TestContext({ foo: { bar: { "bla.ble": 123 } } }))
+    expect(res).to.equal(123)
+  })
+
   it("should handle numeric member lookup with bracket notation", async () => {
     const res = resolveTemplateString("${foo[1]}", new TestContext({ foo: [false, true] }))
     expect(res).to.equal(true)


### PR DESCRIPTION
Partial resolution was mangling key segments with dots in them, as well
as nested template strings.
