### PR TITLE
feat(terraform): add allowDestroy flags to automatically destroy stacks

### DIFF
--- a/core/src/plugins/terraform/commands.ts
+++ b/core/src/plugins/terraform/commands.ts
@@ -19,7 +19,7 @@ import { join } from "path"
 import { remove } from "fs-extra"
 import { getProviderStatusCachePath } from "../../tasks/resolve-provider"
 
-const commandsToWrap = ["apply", "plan"]
+const commandsToWrap = ["apply", "plan", "destroy"]
 const initCommand = chalk.bold("terraform init")
 
 export const terraformCommands: PluginCommand[] = commandsToWrap.flatMap((commandName) => [

--- a/core/src/plugins/terraform/common.ts
+++ b/core/src/plugins/terraform/common.ts
@@ -23,6 +23,7 @@ import chalk from "chalk"
 export const variablesSchema = () => joiStringMap(joi.any())
 
 export interface TerraformBaseSpec {
+  allowDestroy: boolean
   autoApply: boolean
   dependencies: string[]
   variables: PrimitiveMap

--- a/core/test/data/test-projects/terraform-provider/garden.yml
+++ b/core/test/data/test-projects/terraform-provider/garden.yml
@@ -5,6 +5,7 @@ environments:
   - name: prod
 providers:
   - name: terraform
+    allowDestroy: ${environment.name != 'prod'}
     autoApply: ${environment.name != 'prod'}
     initRoot: tf
     variables:

--- a/docs/reference/module-types/terraform.md
+++ b/docs/reference/module-types/terraform.md
@@ -109,6 +109,10 @@ build:
           # Defaults to to same as source path.
           target: ''
 
+# If set to true, Garden will run `terraform destroy` on the stack when calling `garden delete env` or `garden delete
+# service <module name>`.
+allowDestroy: false
+
 # If set to true, Garden will automatically run `terraform apply -auto-approve` when the stack is not
 # up-to-date. Otherwise, a warning is logged if the stack is out-of-date, and an error thrown if it is missing
 # entirely.
@@ -331,6 +335,14 @@ Defaults to to same as source path.
 | Type        | Default | Required |
 | ----------- | ------- | -------- |
 | `posixPath` | `""`    | No       |
+
+### `allowDestroy`
+
+If set to true, Garden will run `terraform destroy` on the stack when calling `garden delete env` or `garden delete service <module name>`.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `autoApply`
 

--- a/docs/reference/providers/container.md
+++ b/docs/reference/providers/container.md
@@ -23,6 +23,9 @@ providers:
   - # The name of the provider plugin to use.
     name:
 
+    # List other providers that should be resolved before this one.
+    dependencies: []
+
     # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
@@ -50,6 +53,24 @@ Example:
 ```yaml
 providers:
   - name: "local-kubernetes"
+```
+
+### `providers[].dependencies[]`
+
+[providers](#providers) > dependencies
+
+List other providers that should be resolved before this one.
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
+
+Example:
+
+```yaml
+providers:
+  - dependencies:
+      - exec
 ```
 
 ### `providers[].environments[]`

--- a/docs/reference/providers/terraform.md
+++ b/docs/reference/providers/terraform.md
@@ -29,6 +29,9 @@ providers:
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
 
+    # If set to true, Garden will run `terraform destroy` on the project root stack when calling `garden delete env`.
+    allowDestroy: false
+
     # If set to true, Garden will automatically run `terraform apply -auto-approve` when a stack is not up-to-date.
     # Otherwise, a warning is logged if the stack is out-of-date, and an error thrown if it is missing entirely.
     #
@@ -109,6 +112,16 @@ providers:
       - dev
       - stage
 ```
+
+### `providers[].allowDestroy`
+
+[providers](#providers) > allowDestroy
+
+If set to true, Garden will run `terraform destroy` on the project root stack when calling `garden delete env`.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `providers[].autoApply`
 


### PR DESCRIPTION
You can now set `allowDestroy: true` in both the provider config and
`terraform` module configs, which if set allow Garden to automatically
destroy stacks when calling `garden delete env` and/or
`garden delete service <module name>`.

Also added are new `garden plugins terraform destroy-root` and
`garden plugins terraform destroy-module` commands.

Closes #1928

cc @noizwaves 
