### PR TITLE
fix(core): undefined tool error in container module derivatives

### DIFF
--- a/core/src/actions.ts
+++ b/core/src/actions.ts
@@ -720,7 +720,7 @@ export class ActionRouter implements TypeGuard {
     const provider = await this.garden.resolveProvider(log, handler.pluginName)
 
     return {
-      ctx: this.garden.getPluginContext(provider),
+      ctx: await this.garden.getPluginContext(provider),
       log,
       base: handler.base,
     }

--- a/core/src/commands/get/get-config.ts
+++ b/core/src/commands/get/get-config.ts
@@ -10,7 +10,7 @@ import { Command, CommandResult, CommandParams } from "../base"
 import { ConfigDump } from "../../garden"
 import { environmentNameSchema } from "../../config/project"
 import { joiIdentifier, joiVariables, joiArray, joi } from "../../config/common"
-import { providerSchemaWithoutTools, providerConfigBaseSchema } from "../../config/provider"
+import { providerConfigBaseSchema, providerSchema } from "../../config/provider"
 import { moduleConfigSchema } from "../../config/module"
 import { workflowConfigSchema } from "../../config/workflow"
 import { BooleanParameter, ChoicesParameter } from "../../cli/params"
@@ -41,7 +41,7 @@ export class GetConfigCommand extends Command<{}, Opts> {
       allEnvironmentNames: joiArray(environmentNameSchema()).required(),
       environmentName: environmentNameSchema().required(),
       namespace: joiIdentifier().description("The namespace of the current environment (if applicable)."),
-      providers: joiArray(joi.alternatives(providerSchemaWithoutTools(), providerConfigBaseSchema())).description(
+      providers: joiArray(joi.alternatives(providerSchema(), providerConfigBaseSchema())).description(
         "A list of all configured providers in the environment."
       ),
       variables: joiVariables().description("All configured variables in the environment."),

--- a/core/src/commands/plugins.ts
+++ b/core/src/commands/plugins.ts
@@ -103,7 +103,7 @@ export class PluginsCommand extends Command<Args> {
     }
 
     const provider = await garden.resolveProvider(log, args.plugin)
-    const ctx = garden.getPluginContext(provider)
+    const ctx = await garden.getPluginContext(provider)
 
     let modules: GardenModule[] = []
 

--- a/core/src/config/provider.ts
+++ b/core/src/config/provider.ts
@@ -15,7 +15,6 @@ import { uniq } from "lodash"
 import { GardenPlugin } from "../types/plugin/plugin"
 import { EnvironmentStatus } from "../types/plugin/provider/getEnvironmentStatus"
 import { environmentStatusSchema } from "./status"
-import { PluginTools } from "../types/plugin/tools"
 
 export interface BaseProviderConfig {
   name: string
@@ -58,10 +57,9 @@ export interface Provider<T extends BaseProviderConfig = BaseProviderConfig> {
   moduleConfigs: ModuleConfig[]
   config: T
   status: EnvironmentStatus
-  tools: PluginTools
 }
 
-export const providerSchemaWithoutTools = () =>
+export const providerSchema = () =>
   providerFixedFieldsSchema().keys({
     dependencies: joiIdentifierMap(joi.link("..."))
       .description("Map of all the providers that this provider depends on.")
@@ -70,15 +68,6 @@ export const providerSchemaWithoutTools = () =>
     moduleConfigs: joiArray(moduleConfigSchema().optional()),
     status: environmentStatusSchema(),
   })
-
-export const providerSchema = () =>
-  providerSchemaWithoutTools()
-    .keys({
-      tools: joiIdentifierMap(joi.object())
-        .required()
-        .description("Map of tools defined by the provider."),
-    })
-    .id("provider")
 
 export interface ProviderMap {
   [name: string]: Provider<GenericProviderConfig>
@@ -93,15 +82,13 @@ export const defaultProvider: Provider = {
   moduleConfigs: [],
   config: { name: "_default" },
   status: { ready: true, outputs: {} },
-  tools: {},
 }
 
 export function providerFromConfig(
   config: GenericProviderConfig,
   dependencies: ProviderMap,
   moduleConfigs: ModuleConfig[],
-  status: EnvironmentStatus,
-  tools: PluginTools
+  status: EnvironmentStatus
 ): Provider {
   return {
     name: config.name,
@@ -109,7 +96,6 @@ export function providerFromConfig(
     moduleConfigs,
     config,
     status,
-    tools,
   }
 }
 

--- a/core/src/plugins/conftest/conftest.ts
+++ b/core/src/plugins/conftest/conftest.ts
@@ -171,7 +171,7 @@ export const gardenPlugin = createGardenPlugin({
           const args = prepareArgs(ctx, provider, module)
           args.push(...files)
 
-          const result = await provider.tools.conftest.exec({ log, args, ignoreError: true, cwd: buildPath })
+          const result = await ctx.tools["conftest.conftest"].exec({ log, args, ignoreError: true, cwd: buildPath })
 
           const { success, formattedResult } = parseConftestResult(provider, log, result)
 
@@ -245,7 +245,7 @@ export const gardenPlugin = createGardenPlugin({
           const args = prepareArgs(ctx, provider, module)
           args.push("-")
 
-          const result = await provider.tools.conftest.exec({
+          const result = await ctx.tools["conftest.conftest"].exec({
             log,
             args,
             ignoreError: true,

--- a/core/src/plugins/container/helpers.ts
+++ b/core/src/plugins/container/helpers.ts
@@ -29,7 +29,7 @@ import chalk from "chalk"
 import isUrl from "is-url"
 import titleize from "titleize"
 import { stripQuotes } from "../../util/string"
-import { ContainerProvider } from "./container"
+import { PluginContext } from "../../plugin-context"
 
 interface DockerVersion {
   client?: string
@@ -214,18 +214,18 @@ const helpers = {
     }
   },
 
-  async pullImage(module: ContainerModule, log: LogEntry, provider: ContainerProvider) {
+  async pullImage(module: ContainerModule, log: LogEntry, ctx: PluginContext) {
     const identifier = await helpers.getPublicImageId(module)
-    await helpers.dockerCli({ cwd: module.buildPath, args: ["pull", identifier], log, containerProvider: provider })
+    await helpers.dockerCli({ cwd: module.buildPath, args: ["pull", identifier], log, ctx })
   },
 
-  async imageExistsLocally(module: ContainerModule, log: LogEntry, provider: ContainerProvider) {
+  async imageExistsLocally(module: ContainerModule, log: LogEntry, ctx: PluginContext) {
     const identifier = await helpers.getLocalImageId(module)
     const result = await helpers.dockerCli({
       cwd: module.buildPath,
       args: ["images", identifier, "-q"],
       log,
-      containerProvider: provider,
+      ctx,
     })
     const exists = result.stdout!.length > 0
     return exists ? identifier : null
@@ -278,7 +278,7 @@ const helpers = {
     cwd,
     args,
     log,
-    containerProvider,
+    ctx,
     ignoreError = false,
     outputStream,
     timeout,
@@ -286,12 +286,12 @@ const helpers = {
     cwd: string
     args: string[]
     log: LogEntry
-    containerProvider: ContainerProvider
+    ctx: PluginContext
     ignoreError?: boolean
     outputStream?: Writable
     timeout?: number
   }) {
-    const docker = containerProvider.tools.docker
+    const docker = ctx.tools["container.docker"]
 
     try {
       const res = await docker.spawnAndWait({

--- a/core/src/plugins/container/publish.ts
+++ b/core/src/plugins/container/publish.ts
@@ -9,14 +9,12 @@
 import { ContainerModule } from "./config"
 import { PublishModuleParams } from "../../types/plugin/module/publishModule"
 import { containerHelpers } from "./helpers"
-import { ContainerProvider } from "./container"
 
 export async function publishContainerModule({ ctx, module, log }: PublishModuleParams<ContainerModule>) {
   if (!(await containerHelpers.hasDockerfile(module))) {
     log.setState({ msg: `Nothing to publish` })
     return { published: false }
   }
-  const containerProvider = ctx.provider as ContainerProvider
 
   const localId = await containerHelpers.getLocalImageId(module)
   const remoteId = await containerHelpers.getPublicImageId(module)
@@ -28,12 +26,12 @@ export async function publishContainerModule({ ctx, module, log }: PublishModule
       cwd: module.buildPath,
       args: ["tag", localId, remoteId],
       log,
-      containerProvider,
+      ctx,
     })
   }
 
   // TODO: stream output to log if at debug log level
-  await containerHelpers.dockerCli({ cwd: module.buildPath, args: ["push", remoteId], log, containerProvider })
+  await containerHelpers.dockerCli({ cwd: module.buildPath, args: ["push", remoteId], log, ctx })
 
   return { published: true, message: `Published ${remoteId}` }
 }

--- a/core/src/plugins/hadolint/hadolint.ts
+++ b/core/src/plugins/hadolint/hadolint.ts
@@ -186,7 +186,7 @@ export const gardenPlugin = createGardenPlugin({
           }
 
           const args = ["--config", configPath, "--format", "json", dockerfilePath]
-          const result = await ctx.provider.tools.hadolint.exec({ log, args, ignoreError: true })
+          const result = await ctx.tools["hadolint.hadolint"].exec({ log, args, ignoreError: true })
 
           let success = true
 

--- a/core/src/plugins/kubernetes/commands/cluster-init.ts
+++ b/core/src/plugins/kubernetes/commands/cluster-init.ts
@@ -42,7 +42,7 @@ export const clusterInit: PluginCommand = {
 
     log.info("Cleaning up old resources...")
 
-    const systemNamespace = await getSystemNamespace(provider, log)
+    const systemNamespace = await getSystemNamespace(ctx, provider, log)
     try {
       await helm({
         ctx: k8sCtx,

--- a/core/src/plugins/kubernetes/container/deployment.ts
+++ b/core/src/plugins/kubernetes/container/deployment.ts
@@ -66,10 +66,11 @@ export async function deployContainerServiceRolling(
   const provider = k8sCtx.provider
   const pruneSelector = gardenAnnotationKey("service") + "=" + service.name
 
-  await apply({ log, provider, manifests, namespace, pruneSelector })
+  await apply({ log, ctx, provider, manifests, namespace, pruneSelector })
 
   await waitForResources({
     namespace,
+    ctx,
     provider: k8sCtx.provider,
     serviceName: service.name,
     resources: manifests,
@@ -95,7 +96,7 @@ export async function deployContainerServiceBlueGreen(
   const { manifests } = await createContainerManifests(k8sCtx, log, service, runtimeContext, hotReload)
 
   const provider = k8sCtx.provider
-  const api = await KubeApi.factory(log, provider)
+  const api = await KubeApi.factory(log, ctx, provider)
 
   // Retrieve the k8s service referring to the Garden service which is already deployed
   const currentService = (await api.core.listNamespacedService(namespace)).items.filter(
@@ -108,9 +109,10 @@ export async function deployContainerServiceBlueGreen(
   if (!isServiceAlreadyDeployed) {
     // No service found, no need to execute a blue-green deployment
     // Just apply all the resources for the Garden service
-    await apply({ log, provider, manifests, namespace })
+    await apply({ log, ctx, provider, manifests, namespace })
     await waitForResources({
       namespace,
+      ctx,
       provider: k8sCtx.provider,
       serviceName: service.name,
       resources: manifests,
@@ -126,9 +128,10 @@ export async function deployContainerServiceBlueGreen(
     const filteredManifests = manifests.filter((manifest) => manifest.kind !== "Service")
 
     // Apply new Deployment manifest (deploy the Green version)
-    await apply({ log, provider, manifests: filteredManifests, namespace })
+    await apply({ log, ctx, provider, manifests: filteredManifests, namespace })
     await waitForResources({
       namespace,
+      ctx,
       provider: k8sCtx.provider,
       serviceName: `Deploy ${service.name}`,
       resources: filteredManifests,
@@ -160,13 +163,14 @@ export async function deployContainerServiceBlueGreen(
     // If the result is outdated it means something in the Service definition itself changed
     // and we need to apply the whole Service manifest. Otherwise we just patch it.
     if (result.state === "outdated") {
-      await apply({ log, provider, manifests: [patchedServiceManifest], namespace })
+      await apply({ log, ctx, provider, manifests: [patchedServiceManifest], namespace })
     } else {
       await api.core.patchNamespacedService(service.name, namespace, servicePatchBody)
     }
 
     await waitForResources({
       namespace,
+      ctx,
       provider: k8sCtx.provider,
       serviceName: `Update service`,
       resources: [serviceManifest],
@@ -177,6 +181,7 @@ export async function deployContainerServiceBlueGreen(
     // as a feature we delete all the deployments which don't match any deployed Service.
     log.verbose(`Cleaning up old workloads`)
     await deleteObjectsBySelector({
+      ctx,
       log,
       provider,
       namespace,
@@ -206,7 +211,7 @@ export async function createContainerManifests(
   const provider = k8sCtx.provider
   const { production } = ctx
   const namespace = await getAppNamespace(k8sCtx, log, provider)
-  const api = await KubeApi.factory(log, provider)
+  const api = await KubeApi.factory(log, ctx, provider)
   const ingresses = await createIngressResources(api, provider, namespace, service, log)
   const workload = await createWorkloadManifest({
     api,
@@ -634,6 +639,7 @@ export async function deleteService(params: DeleteServiceParams): Promise<Contai
   const provider = k8sCtx.provider
 
   await deleteObjectsBySelector({
+    ctx,
     log,
     provider,
     namespace,

--- a/core/src/plugins/kubernetes/container/logs.ts
+++ b/core/src/plugins/kubernetes/container/logs.ts
@@ -20,7 +20,7 @@ export async function getServiceLogs(params: GetServiceLogsParams<ContainerModul
   const k8sCtx = <KubernetesPluginContext>ctx
   const provider = k8sCtx.provider
   const namespace = await getAppNamespace(k8sCtx, log, provider)
-  const api = await KubeApi.factory(log, provider)
+  const api = await KubeApi.factory(log, ctx, provider)
 
   const resources = [
     await createWorkloadManifest({

--- a/core/src/plugins/kubernetes/container/publish.ts
+++ b/core/src/plugins/kubernetes/container/publish.ts
@@ -12,13 +12,11 @@ import { containerHelpers } from "../../container/helpers"
 import { KubernetesPluginContext } from "../config"
 import { publishContainerModule } from "../../container/publish"
 import { getRegistryPortForward } from "./util"
-import { ContainerProvider } from "../../container/container"
 
 export async function k8sPublishContainerModule(params: PublishModuleParams<ContainerModule>) {
   const { ctx, module, log } = params
   const k8sCtx = ctx as KubernetesPluginContext
   const provider = k8sCtx.provider
-  const containerProvider = provider.dependencies.container as ContainerProvider
 
   if (!(await containerHelpers.hasDockerfile(module))) {
     log.setState({ msg: `Nothing to publish` })
@@ -46,7 +44,7 @@ export async function k8sPublishContainerModule(params: PublishModuleParams<Cont
       cwd: module.buildPath,
       args: ["pull", pullImageName],
       log,
-      containerProvider,
+      ctx,
     })
 
     // We need to tag the remote image with the local ID before we publish it
@@ -55,7 +53,7 @@ export async function k8sPublishContainerModule(params: PublishModuleParams<Cont
       cwd: module.buildPath,
       args: ["tag", pullImageName, localId],
       log,
-      containerProvider,
+      ctx,
     })
   }
 

--- a/core/src/plugins/kubernetes/container/status.ts
+++ b/core/src/plugins/kubernetes/container/status.ts
@@ -42,7 +42,7 @@ export async function getContainerServiceStatus({
   // TODO: hash and compare all the configuration files (otherwise internal changes don't get deployed)
   const version = module.version
   const provider = k8sCtx.provider
-  const api = await KubeApi.factory(log, provider)
+  const api = await KubeApi.factory(log, ctx, provider)
   const namespace = await getAppNamespace(k8sCtx, log, provider)
 
   // FIXME: [objects, matched] and ingresses can be run in parallel

--- a/core/src/plugins/kubernetes/container/util.ts
+++ b/core/src/plugins/kubernetes/container/util.ts
@@ -23,7 +23,7 @@ export async function queryRegistry(ctx: KubernetesPluginContext, log: LogEntry,
 }
 
 export async function getRegistryPortForward(ctx: KubernetesPluginContext, log: LogEntry) {
-  const systemNamespace = await getSystemNamespace(ctx.provider, log)
+  const systemNamespace = await getSystemNamespace(ctx, ctx.provider, log)
 
   return getPortForward({
     ctx,

--- a/core/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/src/plugins/kubernetes/helm/deployment.ts
@@ -97,13 +97,14 @@ export async function deployHelmService({
       containerName: getHotReloadContainerName(module),
     })
 
-    await apply({ log, provider, manifests: [hotReloadTarget], namespace })
+    await apply({ log, ctx, provider, manifests: [hotReloadTarget], namespace })
   }
 
   // FIXME: we should get these objects from the cluster, and not from the local `helm template` command, because
   // they may be legitimately inconsistent.
   const remoteResources = await waitForResources({
     namespace,
+    ctx,
     provider,
     serviceName: service.name,
     resources: manifests,
@@ -142,7 +143,7 @@ export async function deleteService(params: DeleteServiceParams): Promise<HelmSe
   await helm({ ctx: k8sCtx, log, namespace, args: ["uninstall", releaseName] })
 
   // Wait for resources to terminate
-  await deleteResources({ log, provider, resources, namespace })
+  await deleteResources({ log, ctx, provider, resources, namespace })
 
   log.setSuccess("Service deleted")
 

--- a/core/src/plugins/kubernetes/helm/helm-cli.ts
+++ b/core/src/plugins/kubernetes/helm/helm-cli.ts
@@ -78,7 +78,7 @@ export async function helm({
   const helmHome = join(GARDEN_GLOBAL_PATH, `.helm${version}`)
   await mkdirp(helmHome)
 
-  const cmd = ctx.provider.tools.helm
+  const cmd = ctx.tools["kubernetes.helm"]
 
   const envVars: StringMap = {
     ...process.env,

--- a/core/src/plugins/kubernetes/helm/run.ts
+++ b/core/src/plugins/kubernetes/helm/run.ts
@@ -77,10 +77,11 @@ export async function runHelmModule({
     ],
   }
 
-  const api = await KubeApi.factory(log, provider)
+  const api = await KubeApi.factory(log, ctx, provider)
   const podName = makePodName("run", module.name)
 
   const runner = new PodRunner({
+    ctx,
     api,
     podName,
     provider,

--- a/core/src/plugins/kubernetes/hot-reload.ts
+++ b/core/src/plugins/kubernetes/hot-reload.ts
@@ -192,7 +192,7 @@ export async function hotReloadContainer({
   const k8sCtx = ctx as KubernetesPluginContext
   const provider = k8sCtx.provider
   const namespace = await getAppNamespace(k8sCtx, log, provider)
-  const api = await KubeApi.factory(log, provider)
+  const api = await KubeApi.factory(log, ctx, provider)
 
   // Find the currently deployed workload by labels
   const manifest = await createWorkloadManifest({
@@ -209,7 +209,7 @@ export async function hotReloadContainer({
     [gardenAnnotationKey("service")]: service.name,
   })
   // TODO: make and use a KubeApi method for this
-  const res: KubernetesList<KubernetesWorkload> = await kubectl(provider).json({
+  const res: KubernetesList<KubernetesWorkload> = await kubectl(ctx, provider).json({
     args: ["get", manifest.kind, "-l", selector],
     log,
     namespace,
@@ -343,6 +343,7 @@ export async function syncToService({ ctx, service, hotReloadSpec, namespace, wo
     if (postSyncCommand) {
       // Run post-sync callback inside the pod
       const callbackResult = await execInWorkload({
+        ctx,
         log,
         namespace,
         workload,

--- a/core/src/plugins/kubernetes/kubernetes-module/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/handlers.ts
@@ -71,7 +71,7 @@ export async function getKubernetesServiceStatus({
     provider: k8sCtx.provider,
     skipCreate: true,
   })
-  const api = await KubeApi.factory(log, k8sCtx.provider)
+  const api = await KubeApi.factory(log, ctx, k8sCtx.provider)
   // FIXME: We're currently reading the manifests from the module source dir (instead of build dir)
   // because the build may not have been staged.
   // This means that manifests added via the `build.dependencies[].copy` field will not be included.
@@ -95,7 +95,7 @@ export async function deployKubernetesService(
   const { ctx, module, service, log } = params
 
   const k8sCtx = <KubernetesPluginContext>ctx
-  const api = await KubeApi.factory(log, k8sCtx.provider)
+  const api = await KubeApi.factory(log, ctx, k8sCtx.provider)
 
   const namespace = await getModuleNamespace({
     ctx: k8sCtx,
@@ -114,9 +114,10 @@ export async function deployKubernetesService(
 
   if (namespaceManifests.length > 0) {
     // Don't prune namespaces
-    await apply({ log, provider: k8sCtx.provider, manifests: namespaceManifests })
+    await apply({ log, ctx, provider: k8sCtx.provider, manifests: namespaceManifests })
     await waitForResources({
       namespace,
+      ctx,
       provider: k8sCtx.provider,
       serviceName: service.name,
       resources: namespaceManifests,
@@ -126,9 +127,10 @@ export async function deployKubernetesService(
   const pruneSelector = getSelector(service)
   if (otherManifests.length > 0) {
     // Prune everything else
-    await apply({ log, provider: k8sCtx.provider, manifests: otherManifests, pruneSelector })
+    await apply({ log, ctx, provider: k8sCtx.provider, manifests: otherManifests, pruneSelector })
     await waitForResources({
       namespace,
+      ctx,
       provider: k8sCtx.provider,
       serviceName: service.name,
       resources: otherManifests,
@@ -138,6 +140,7 @@ export async function deployKubernetesService(
 
   await waitForResources({
     namespace,
+    ctx,
     provider: k8sCtx.provider,
     serviceName: service.name,
     resources: manifests,
@@ -162,7 +165,7 @@ async function deleteService(params: DeleteServiceParams): Promise<KubernetesSer
     provider: k8sCtx.provider,
   })
   const provider = k8sCtx.provider
-  const api = await KubeApi.factory(log, provider)
+  const api = await KubeApi.factory(log, ctx, provider)
   const manifests = await getManifests({ api, log, module, defaultNamespace: namespace })
 
   /**
@@ -178,6 +181,7 @@ async function deleteService(params: DeleteServiceParams): Promise<KubernetesSer
       const selector = `${gardenAnnotationKey("service")}=${gardenNamespaceAnnotationValue(ns.metadata.name)}`
       return deleteObjectsBySelector({
         log,
+        ctx,
         provider,
         namespace,
         selector,
@@ -189,6 +193,7 @@ async function deleteService(params: DeleteServiceParams): Promise<KubernetesSer
   if (otherManifests.length > 0) {
     await deleteObjectsBySelector({
       log,
+      ctx,
       provider,
       namespace,
       selector: `${gardenAnnotationKey("service")}=${service.name}`,
@@ -210,7 +215,7 @@ async function getServiceLogs(params: GetServiceLogsParams<KubernetesModule>) {
     module,
     provider: k8sCtx.provider,
   })
-  const api = await KubeApi.factory(log, provider)
+  const api = await KubeApi.factory(log, ctx, provider)
   const manifests = await getManifests({ api, log, module, defaultNamespace: namespace })
 
   return getAllLogs({ ...params, provider, defaultNamespace: namespace, resources: manifests })

--- a/core/src/plugins/kubernetes/kubernetes-module/run.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/run.ts
@@ -26,7 +26,7 @@ export async function runKubernetesTask(params: RunTaskParams<KubernetesModule>)
     module,
     provider: k8sCtx.provider,
   })
-  const api = await KubeApi.factory(log, k8sCtx.provider)
+  const api = await KubeApi.factory(log, ctx, k8sCtx.provider)
 
   // Get the container spec to use for running
   const { command, args } = task.spec

--- a/core/src/plugins/kubernetes/kubernetes-module/test.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/test.ts
@@ -27,7 +27,7 @@ export async function testKubernetesModule(params: TestModuleParams<KubernetesMo
     module,
     provider: k8sCtx.provider,
   })
-  const api = await KubeApi.factory(log, k8sCtx.provider)
+  const api = await KubeApi.factory(log, ctx, k8sCtx.provider)
 
   // Get the container spec to use for running
   const manifests = await getManifests({ api, log, module, defaultNamespace: namespace })

--- a/core/src/plugins/kubernetes/kubernetes.ts
+++ b/core/src/plugins/kubernetes/kubernetes.ts
@@ -145,7 +145,7 @@ export async function debugInfo({ ctx, log, includeProject }: GetDebugInfoParams
   const provider = k8sCtx.provider
   const entry = log.info({ section: ctx.provider.name, msg: "collecting provider configuration", status: "active" })
 
-  const systemNamespace = await getSystemNamespace(provider, log)
+  const systemNamespace = await getSystemNamespace(ctx, provider, log)
   const systemMetadataNamespace = getSystemMetadataNamespaceName(provider.config)
 
   const namespacesList = [systemNamespace, systemMetadataNamespace]
@@ -156,7 +156,10 @@ export async function debugInfo({ ctx, log, includeProject }: GetDebugInfoParams
   }
   const namespaces = await Bluebird.map(namespacesList, async (ns) => {
     const nsEntry = entry.info({ section: ns, msg: "collecting namespace configuration", status: "active" })
-    const out = await kubectl(provider).stdout({ log, args: ["get", "all", "--namespace", ns, "--output", "json"] })
+    const out = await kubectl(ctx, provider).stdout({
+      log,
+      args: ["get", "all", "--namespace", ns, "--output", "json"],
+    })
     nsEntry.setSuccess({ msg: chalk.green(`Done (took ${log.getDuration(1)} sec)`), append: true })
     return {
       namespace: ns,
@@ -165,7 +168,7 @@ export async function debugInfo({ ctx, log, includeProject }: GetDebugInfoParams
   })
   entry.setSuccess({ msg: chalk.green(`Done (took ${log.getDuration(1)} sec)`), append: true })
 
-  const version = await kubectl(provider).stdout({ log, args: ["version", "--output", "json"] })
+  const version = await kubectl(ctx, provider).stdout({ log, args: ["version", "--output", "json"] })
 
   return {
     info: { version: JSON.parse(version), namespaces },

--- a/core/src/plugins/kubernetes/local/kind.ts
+++ b/core/src/plugins/kubernetes/local/kind.ts
@@ -14,6 +14,7 @@ import { KubernetesConfig, KubernetesProvider } from "../config"
 import { RuntimeError } from "../../../exceptions"
 import { KubeApi } from "../api"
 import { KubernetesResource } from "../types"
+import { PluginContext } from "../../../plugin-context"
 
 export async function loadImageToKind(buildResult: BuildResult, config: KubernetesConfig): Promise<void> {
   try {
@@ -29,8 +30,8 @@ export async function loadImageToKind(buildResult: BuildResult, config: Kubernet
   }
 }
 
-export async function isClusterKind(provider: KubernetesProvider, log: LogEntry): Promise<boolean> {
-  return (await isKindInstalled(log)) && (await isKindContext(log, provider))
+export async function isClusterKind(ctx: PluginContext, provider: KubernetesProvider, log: LogEntry): Promise<boolean> {
+  return (await isKindInstalled(log)) && (await isKindContext(ctx, provider, log))
 }
 
 async function isKindInstalled(log: LogEntry): Promise<boolean> {
@@ -45,8 +46,8 @@ async function isKindInstalled(log: LogEntry): Promise<boolean> {
   return false
 }
 
-async function isKindContext(log: LogEntry, provider: KubernetesProvider): Promise<boolean> {
-  const kubeApi = await KubeApi.factory(log, provider)
+async function isKindContext(ctx: PluginContext, provider: KubernetesProvider, log: LogEntry): Promise<boolean> {
+  const kubeApi = await KubeApi.factory(log, ctx, provider)
   const manifest: KubernetesResource = {
     apiVersion: "apps/v1",
     kind: "DaemonSet",

--- a/core/src/plugins/kubernetes/local/microk8s.ts
+++ b/core/src/plugins/kubernetes/local/microk8s.ts
@@ -16,7 +16,7 @@ import { BuildStatus } from "../../../types/plugin/module/getBuildStatus"
 import chalk from "chalk"
 import { naturalList, deline } from "../../../util/string"
 import { ExecaReturnValue } from "execa"
-import { ContainerProvider } from "../../container/container"
+import { PluginContext } from "../../../plugin-context"
 
 export async function configureMicrok8sAddons(log: LogEntry, addons: string[]) {
   let statusCommandResult: ExecaReturnValue | undefined = undefined
@@ -70,12 +70,12 @@ export async function loadImageToMicrok8s({
   module,
   imageId,
   log,
-  containerProvider,
+  ctx,
 }: {
   module: ContainerModule
   imageId: string
   log: LogEntry
-  containerProvider: ContainerProvider
+  ctx: PluginContext
 }): Promise<void> {
   try {
     // See https://microk8s.io/docs/registry-images for reference
@@ -84,7 +84,7 @@ export async function loadImageToMicrok8s({
         cwd: module.buildPath,
         args: ["save", "-o", file.path, imageId],
         log,
-        containerProvider,
+        ctx,
       })
       await exec("microk8s.ctr", ["image", "import", file.path])
     })

--- a/core/src/plugins/kubernetes/namespace.ts
+++ b/core/src/plugins/kubernetes/namespace.ts
@@ -64,7 +64,7 @@ export async function createNamespace(api: KubeApi, namespace: string) {
 interface GetNamespaceParams {
   log: LogEntry
   override?: string
-  projectName: string
+  ctx: PluginContext
   provider: KubernetesProvider
   suffix?: string
   skipCreate?: boolean
@@ -77,30 +77,35 @@ interface GetNamespaceParams {
 // TODO: this feels convoluted (=a lot of parameters per line of function code), so let's consider refactoring
 export async function getNamespace({
   log,
+  ctx,
   override,
-  projectName,
   provider,
   suffix,
   skipCreate,
 }: GetNamespaceParams): Promise<string> {
-  let namespace = override || provider.config.namespace || projectName
+  let namespace = override || provider.config.namespace || ctx.projectName
 
   if (suffix) {
     namespace = `${namespace}--${suffix}`
   }
 
   if (!skipCreate) {
-    const api = await KubeApi.factory(log, provider)
+    const api = await KubeApi.factory(log, ctx, provider)
     await ensureNamespace(api, namespace)
   }
 
   return namespace
 }
 
-export async function getSystemNamespace(provider: KubernetesProvider, log: LogEntry, api?: KubeApi): Promise<string> {
+export async function getSystemNamespace(
+  ctx: PluginContext,
+  provider: KubernetesProvider,
+  log: LogEntry,
+  api?: KubeApi
+): Promise<string> {
   const namespace = provider.config.gardenSystemNamespace
   if (!api) {
-    api = await KubeApi.factory(log, provider)
+    api = await KubeApi.factory(log, ctx, provider)
   }
   await ensureNamespace(api, namespace)
 
@@ -110,7 +115,7 @@ export async function getSystemNamespace(provider: KubernetesProvider, log: LogE
 export async function getAppNamespace(ctx: PluginContext, log: LogEntry, provider: KubernetesProvider) {
   return getNamespace({
     log,
-    projectName: ctx.projectName,
+    ctx,
     provider,
   })
 }
@@ -118,7 +123,7 @@ export async function getAppNamespace(ctx: PluginContext, log: LogEntry, provide
 export function getMetadataNamespace(ctx: PluginContext, log: LogEntry, provider: KubernetesProvider) {
   return getNamespace({
     log,
-    projectName: ctx.projectName,
+    ctx,
     provider,
     suffix: "metadata",
   })
@@ -137,7 +142,7 @@ export async function prepareNamespaces({ ctx, log }: GetEnvironmentStatusParams
 
   try {
     // TODO: use API instead of kubectl (I just couldn't find which API call to make)
-    await kubectl(k8sCtx.provider).exec({ log, args: ["version"] })
+    await kubectl(k8sCtx, k8sCtx.provider).exec({ log, args: ["version"] })
   } catch (err) {
     log.setError("Error")
 
@@ -208,8 +213,8 @@ export async function getModuleNamespace({
 }) {
   return getNamespace({
     log,
+    ctx,
     override: module.spec.namespace,
-    projectName: ctx.projectName,
     provider,
     skipCreate,
   })

--- a/core/src/plugins/kubernetes/port-forward.ts
+++ b/core/src/plugins/kubernetes/port-forward.ts
@@ -107,7 +107,7 @@ export async function getPortForward({
     const portForwardArgs = ["port-forward", targetResource, portMapping]
     log.silly(`Running 'kubectl ${portForwardArgs.join(" ")}'`)
 
-    const proc = await kubectl(k8sCtx.provider).spawn({ log, namespace, args: portForwardArgs })
+    const proc = await kubectl(k8sCtx, k8sCtx.provider).spawn({ log, namespace, args: portForwardArgs })
     let output = ""
 
     return new Promise((resolve, reject) => {

--- a/core/src/plugins/kubernetes/secrets.ts
+++ b/core/src/plugins/kubernetes/secrets.ts
@@ -18,7 +18,7 @@ import { LogEntry } from "../../logger/log-entry"
 
 export async function getSecret({ ctx, log, key }: GetSecretParams) {
   const k8sCtx = <KubernetesPluginContext>ctx
-  const api = await KubeApi.factory(log, k8sCtx.provider)
+  const api = await KubeApi.factory(log, ctx, k8sCtx.provider)
   const ns = await getMetadataNamespace(k8sCtx, log, k8sCtx.provider)
 
   try {
@@ -36,7 +36,7 @@ export async function getSecret({ ctx, log, key }: GetSecretParams) {
 export async function setSecret({ ctx, log, key, value }: SetSecretParams) {
   // we store configuration in a separate metadata namespace, so that configs aren't cleared when wiping the namespace
   const k8sCtx = <KubernetesPluginContext>ctx
-  const api = await KubeApi.factory(log, k8sCtx.provider)
+  const api = await KubeApi.factory(log, ctx, k8sCtx.provider)
   const ns = await getMetadataNamespace(k8sCtx, log, k8sCtx.provider)
   const body = {
     body: {
@@ -68,7 +68,7 @@ export async function setSecret({ ctx, log, key, value }: SetSecretParams) {
 
 export async function deleteSecret({ ctx, log, key }: DeleteSecretParams) {
   const k8sCtx = <KubernetesPluginContext>ctx
-  const api = await KubeApi.factory(log, k8sCtx.provider)
+  const api = await KubeApi.factory(log, ctx, k8sCtx.provider)
   const ns = await getMetadataNamespace(k8sCtx, log, k8sCtx.provider)
 
   try {

--- a/core/src/plugins/kubernetes/status/status.ts
+++ b/core/src/plugins/kubernetes/status/status.ts
@@ -163,6 +163,7 @@ export async function checkResourceStatus(
 
 interface WaitParams {
   namespace: string
+  ctx: PluginContext
   provider: KubernetesProvider
   serviceName: string
   resources: KubernetesResource[]
@@ -172,7 +173,7 @@ interface WaitParams {
 /**
  * Wait until the rollout is complete for each of the given Kubernetes objects
  */
-export async function waitForResources({ namespace, provider, serviceName, resources, log }: WaitParams) {
+export async function waitForResources({ namespace, ctx, provider, serviceName, resources, log }: WaitParams) {
   let loops = 0
   let lastMessage: string | undefined
   const startTime = new Date().getTime()
@@ -183,7 +184,7 @@ export async function waitForResources({ namespace, provider, serviceName, resou
     msg: `Waiting for resources to be ready...`,
   })
 
-  const api = await KubeApi.factory(log, provider)
+  const api = await KubeApi.factory(log, ctx, provider)
   let statuses: ResourceStatus[]
 
   while (true) {
@@ -402,7 +403,7 @@ export async function getDeployedResource(
   resource: KubernetesResource,
   log: LogEntry
 ): Promise<KubernetesResource | null> {
-  const api = await KubeApi.factory(log, provider)
+  const api = await KubeApi.factory(log, ctx, provider)
   const namespace = resource.metadata.namespace || (await getAppNamespace(ctx, log, provider))
 
   try {

--- a/core/src/plugins/kubernetes/system.ts
+++ b/core/src/plugins/kubernetes/system.ts
@@ -51,7 +51,7 @@ export async function getSystemGarden(
   variables: DeepPrimitiveMap,
   log: LogEntry
 ): Promise<Garden> {
-  const systemNamespace = await getSystemNamespace(ctx.provider, log)
+  const systemNamespace = await getSystemNamespace(ctx, ctx.provider, log)
 
   const conftest: ConftestProviderConfig = {
     environments: ["default"],
@@ -189,7 +189,7 @@ export async function prepareSystemServices({
   serviceNames,
   force,
 }: PrepareSystemServicesParams) {
-  const api = await KubeApi.factory(log, ctx.provider)
+  const api = await KubeApi.factory(log, ctx, ctx.provider)
 
   const contextForLog = `Preparing environment for plugin "${ctx.provider.name}"`
   const outdated = !(await systemNamespaceUpToDate(api, log, namespace, contextForLog))

--- a/core/src/plugins/kubernetes/task-results.ts
+++ b/core/src/plugins/kubernetes/task-results.ts
@@ -34,7 +34,7 @@ export async function getTaskResult({
   taskVersion,
 }: GetTaskResultParams<ContainerModule | HelmModule | KubernetesModule>): Promise<RunTaskResult | null> {
   const k8sCtx = <KubernetesPluginContext>ctx
-  const api = await KubeApi.factory(log, k8sCtx.provider)
+  const api = await KubeApi.factory(log, ctx, k8sCtx.provider)
   const ns = await getMetadataNamespace(k8sCtx, log, k8sCtx.provider)
   const resultKey = getTaskResultKey(ctx, module, task.name, taskVersion)
 
@@ -94,7 +94,7 @@ export async function storeTaskResult({
   result,
 }: StoreTaskResultParams): Promise<RunTaskResult> {
   const provider = <KubernetesProvider>ctx.provider
-  const api = await KubeApi.factory(log, provider)
+  const api = await KubeApi.factory(log, ctx, provider)
   const namespace = await getMetadataNamespace(ctx, log, provider)
 
   // FIXME: We should store the logs separately, because of the 1MB size limit on ConfigMaps.
@@ -135,7 +135,7 @@ export async function clearTaskResult({
   taskVersion,
 }: GetTaskResultParams<ContainerModule | HelmModule | KubernetesModule>) {
   const provider = <KubernetesProvider>ctx.provider
-  const api = await KubeApi.factory(log, provider)
+  const api = await KubeApi.factory(log, ctx, provider)
   const namespace = await getMetadataNamespace(ctx, log, provider)
 
   const key = getTaskResultKey(ctx, module, task.name, taskVersion)

--- a/core/src/plugins/kubernetes/test-results.ts
+++ b/core/src/plugins/kubernetes/test-results.ts
@@ -32,8 +32,8 @@ export async function getTestResult({
   testVersion,
 }: GetTestResultParams<ContainerModule | HelmModule | KubernetesModule>): Promise<TestResult | null> {
   const k8sCtx = <KubernetesPluginContext>ctx
-  const api = await KubeApi.factory(log, k8sCtx.provider)
-  const testResultNamespace = await getSystemNamespace(k8sCtx.provider, log)
+  const api = await KubeApi.factory(log, ctx, k8sCtx.provider)
+  const testResultNamespace = await getSystemNamespace(k8sCtx, k8sCtx.provider, log)
 
   const resultKey = getTestResultKey(k8sCtx, module, testName, testVersion)
 
@@ -93,8 +93,8 @@ export async function storeTestResult({
   result,
 }: StoreTestResultParams): Promise<TestResult> {
   const k8sCtx = <KubernetesPluginContext>ctx
-  const api = await KubeApi.factory(log, k8sCtx.provider)
-  const testResultNamespace = await getSystemNamespace(k8sCtx.provider, log)
+  const api = await KubeApi.factory(log, ctx, k8sCtx.provider)
+  const testResultNamespace = await getSystemNamespace(k8sCtx, k8sCtx.provider, log)
 
   const data: TestResult = trimRunOutput(result)
 

--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -394,9 +394,14 @@ export function convertDeprecatedManifestVersion(manifest: KubernetesResource): 
   return manifest
 }
 
-export async function getDeploymentPodName(deploymentName: string, provider: KubernetesProvider, log: LogEntry) {
-  const api = await KubeApi.factory(log, provider)
-  const systemNamespace = await getSystemNamespace(provider, log)
+export async function getDeploymentPodName(
+  deploymentName: string,
+  ctx: PluginContext,
+  provider: KubernetesProvider,
+  log: LogEntry
+) {
+  const api = await KubeApi.factory(log, ctx, provider)
+  const systemNamespace = await getSystemNamespace(ctx, provider, log)
 
   const status = await api.apps.readNamespacedDeployment(deploymentName, systemNamespace)
   const pods = await getPods(api, systemNamespace, status.spec.selector.matchLabels)

--- a/core/src/plugins/maven-container/maven-container.ts
+++ b/core/src/plugins/maven-container/maven-container.ts
@@ -204,7 +204,7 @@ async function build(params: BuildModuleParams<MavenContainerModule>) {
 
   log.setState(`Creating jar artifact...`)
 
-  const openJdk = ctx.provider.tools["openjdk-" + jdkVersion]
+  const openJdk = ctx.tools["maven-container.openjdk-" + jdkVersion]
   const openJdkPath = await openJdk.getPath(log)
 
   const mvnArgs = ["package", "--batch-mode", "--projects", ":" + artifactId, "--also-make", ...mvnOpts]
@@ -213,7 +213,7 @@ async function build(params: BuildModuleParams<MavenContainerModule>) {
   // Maven has issues when running concurrent processes, so we're working around that with a lock.
   // TODO: http://takari.io/book/30-team-maven.html would be a more robust solution.
   await buildLock.acquire("mvn", async () => {
-    await ctx.provider.tools.maven.exec({
+    await ctx.tools["maven-container.maven"].exec({
       args: mvnArgs,
       cwd: module.path,
       log,

--- a/core/src/plugins/openfaas/config.ts
+++ b/core/src/plugins/openfaas/config.ts
@@ -237,7 +237,7 @@ async function getInternalGatewayUrl(ctx: PluginContext<OpenFaasConfig>, log: Lo
   const k8sProvider = getK8sProvider(ctx.provider.dependencies)
   const namespace = await getNamespace({
     log,
-    projectName: ctx.projectName,
+    ctx,
     provider: k8sProvider,
     skipCreate: true,
   })

--- a/core/src/plugins/terraform/cli.ts
+++ b/core/src/plugins/terraform/cli.ts
@@ -9,10 +9,11 @@
 import { ConfigurationError } from "../../exceptions"
 import { PluginToolSpec } from "../../types/plugin/tools"
 import { TerraformProvider } from "./terraform"
+import { PluginContext } from "../../plugin-context"
 
-export function terraform(provider: TerraformProvider) {
+export function terraform(ctx: PluginContext, provider: TerraformProvider) {
   const version = provider.config.version
-  const cli = provider.tools["terraform-" + version.replace(/\./g, "-")]
+  const cli = ctx.tools["terraform.terraform-" + version.replace(/\./g, "-")]
 
   if (!cli) {
     throw new ConfigurationError(`Unsupported Terraform version: ${version}`, {

--- a/core/src/plugins/terraform/commands.ts
+++ b/core/src/plugins/terraform/commands.ts
@@ -53,10 +53,10 @@ function makeRootCommand(commandName: string) {
 
       const root = join(ctx.projectRoot, provider.config.initRoot)
 
-      await tfValidate(log, provider, root, provider.config.variables)
+      await tfValidate({ log, ctx, provider, root, variables: provider.config.variables })
 
       args = [commandName, ...(await prepareVariables(root, provider.config.variables)), ...args]
-      await terraform(provider).spawnAndWait({
+      await terraform(ctx, provider).spawnAndWait({
         log,
         args,
         cwd: root,
@@ -87,10 +87,10 @@ function makeModuleCommand(commandName: string) {
       const root = join(module.path, module.spec.root)
 
       const provider = ctx.provider as TerraformProvider
-      await tfValidate(log, provider, root, provider.config.variables)
+      await tfValidate({ log, ctx, provider, root, variables: provider.config.variables })
 
       args = [commandName, ...(await prepareVariables(root, module.spec.variables)), ...args.slice(1)]
-      await terraform(provider).spawnAndWait({
+      await terraform(ctx, provider).spawnAndWait({
         log,
         args,
         cwd: root,

--- a/core/src/plugins/terraform/init.ts
+++ b/core/src/plugins/terraform/init.ts
@@ -25,10 +25,10 @@ export async function getEnvironmentStatus({ ctx, log }: GetEnvironmentStatusPar
   const root = getRoot(ctx, provider)
   const variables = provider.config.variables
 
-  const status = await getStackStatus({ log, provider, root, variables })
+  const status = await getStackStatus({ log, ctx, provider, root, variables })
 
   if (status === "up-to-date") {
-    const outputs = await getTfOutputs(log, provider, root)
+    const outputs = await getTfOutputs({ log, ctx, provider, workingDir: root })
     return { ready: true, outputs }
   } else if (status === "outdated") {
     if (autoApply) {
@@ -41,7 +41,7 @@ export async function getEnvironmentStatus({ ctx, log }: GetEnvironmentStatusPar
           ${chalk.white.bold("garden plugins terraform apply-root")} to make sure the stack is in the intended state.
         `),
       })
-      const outputs = await getTfOutputs(log, provider, root)
+      const outputs = await getTfOutputs({ log, ctx, provider, workingDir: root })
       // Make sure the status is not cached when the stack is not up-to-date
       return { ready: true, outputs, disableCache: true }
     }
@@ -62,10 +62,10 @@ export async function prepareEnvironment({ ctx, log }: PrepareEnvironmentParams)
 
   // Don't run apply when running plugin commands
   if (provider.config.autoApply && !(ctx.command?.name === "plugins" && ctx.command?.args.plugin === provider.name)) {
-    await applyStack({ log, provider, root, variables: provider.config.variables })
+    await applyStack({ ctx, log, provider, root, variables: provider.config.variables })
   }
 
-  const outputs = await getTfOutputs(log, provider, root)
+  const outputs = await getTfOutputs({ log, ctx, provider, workingDir: root })
 
   return {
     status: {

--- a/core/src/plugins/terraform/module.ts
+++ b/core/src/plugins/terraform/module.ts
@@ -108,6 +108,7 @@ export async function getTerraformStatus({
   const root = getModuleStackRoot(module)
   const variables = module.spec.variables
   const status = await getStackStatus({
+    ctx,
     log,
     provider,
     root,
@@ -117,7 +118,7 @@ export async function getTerraformStatus({
   return {
     state: status === "up-to-date" ? "ready" : "outdated",
     version: module.version.versionString,
-    outputs: await getTfOutputs(log, provider, root),
+    outputs: await getTfOutputs({ log, ctx, provider, workingDir: root }),
     detail: {},
   }
 }
@@ -131,7 +132,7 @@ export async function deployTerraform({
   const root = getModuleStackRoot(module)
 
   if (module.spec.autoApply) {
-    await applyStack({ log, provider, root, variables: module.spec.variables })
+    await applyStack({ log, ctx, provider, root, variables: module.spec.variables })
   } else {
     const templateKey = `\${runtime.services.${module.name}.outputs.*}`
     log.warn(
@@ -148,7 +149,7 @@ export async function deployTerraform({
   return {
     state: "ready",
     version: module.version.versionString,
-    outputs: await getTfOutputs(log, provider, root),
+    outputs: await getTfOutputs({ log, ctx, provider, workingDir: root }),
     detail: {},
   }
 }

--- a/core/src/types/plugin/provider/configureProvider.ts
+++ b/core/src/types/plugin/provider/configureProvider.ts
@@ -8,17 +8,16 @@
 
 import { projectNameSchema, projectRootSchema } from "../../../config/project"
 import { GenericProviderConfig, providerConfigBaseSchema, providerSchema, ProviderMap } from "../../../config/provider"
-import { logEntrySchema } from "../base"
+import { logEntrySchema, PluginActionParamsBase, actionParamsSchema } from "../base"
 import { configStoreSchema, ConfigStore } from "../../../config-store"
 import { joiArray, joi, joiIdentifier, joiIdentifierMap } from "../../../config/common"
 import { moduleConfigSchema, ModuleConfig } from "../../../config/module"
 import { deline, dedent } from "../../../util/string"
-import { ActionHandler, ActionHandlerParamsBase } from "../plugin"
+import { ActionHandler } from "../plugin"
 import { LogEntry } from "../../../logger/log-entry"
-import { PluginTools } from "../tools"
 
 // Note: These are the only plugin handler params that don't inherit from PluginActionParamsBase
-export interface ConfigureProviderParams<T extends GenericProviderConfig = any> extends ActionHandlerParamsBase {
+export interface ConfigureProviderParams<T extends GenericProviderConfig = any> extends PluginActionParamsBase {
   config: T
   configStore: ConfigStore
   dependencies: ProviderMap
@@ -27,7 +26,6 @@ export interface ConfigureProviderParams<T extends GenericProviderConfig = any> 
   namespace?: string
   projectName: string
   projectRoot: string
-  tools: PluginTools
   base?: ActionHandler<ConfigureProviderParams<T>, ConfigureProviderResult<T>>
 }
 
@@ -48,7 +46,7 @@ export const configureProvider = () => ({
     Important: This action is called on most executions of Garden commands, so it should return quickly
     and avoid performing expensive processing or network calls.
   `,
-  paramsSchema: joi.object().keys({
+  paramsSchema: actionParamsSchema().keys({
     config: providerConfigBaseSchema().required(),
     environmentName: joiIdentifier(),
     namespace: joiIdentifier(),
@@ -57,7 +55,6 @@ export const configureProvider = () => ({
     projectRoot: projectRootSchema(),
     dependencies: joiIdentifierMap(providerSchema()).description("Map of all providers that this provider depends on."),
     configStore: configStoreSchema(),
-    tools: joiIdentifierMap(joi.object()),
   }),
   resultSchema: joi.object().keys({
     config: providerConfigBaseSchema(),

--- a/core/src/util/ext-tools.ts
+++ b/core/src/util/ext-tools.ts
@@ -52,6 +52,10 @@ interface PluginToolOpts {
   architecture?: string
 }
 
+export interface PluginTools {
+  [key: string]: PluginTool
+}
+
 /**
  * This helper class allows you to declare a tool dependency by providing a URL to a single-file binary,
  * or an archive containing an executable, for each of our supported platforms. When executing the tool,

--- a/core/test/integ/src/plugins/kubernetes/api.ts
+++ b/core/test/integ/src/plugins/kubernetes/api.ts
@@ -26,7 +26,8 @@ describe("KubeApi", () => {
     const root = getDataDir("test-projects", "container")
     garden = await makeTestGarden(root)
     provider = (await garden.resolveProvider(garden.log, "local-kubernetes")) as Provider<KubernetesConfig>
-    api = await KubeApi.factory(garden.log, provider)
+    const ctx = await garden.getPluginContext(provider)
+    api = await KubeApi.factory(garden.log, ctx, provider)
   })
 
   after(async () => {
@@ -35,7 +36,7 @@ describe("KubeApi", () => {
 
   describe("replace", () => {
     it("should replace an existing resource in the cluster", async () => {
-      const ctx = garden.getPluginContext(provider)
+      const ctx = await garden.getPluginContext(provider)
       const namespace = await getAppNamespace(ctx, garden.log, provider)
       const name = randomString()
 

--- a/core/test/integ/src/plugins/kubernetes/commands/pull-image.ts
+++ b/core/test/integ/src/plugins/kubernetes/commands/pull-image.ts
@@ -18,13 +18,11 @@ import { containerHelpers } from "../../../../../../src/plugins/container/helper
 import { expect } from "chai"
 import { LogEntry } from "../../../../../../src/logger/log-entry"
 import { grouped } from "../../../../../helpers"
-import { ContainerProvider } from "../../../../../../src/plugins/container/container"
 
 describe("pull-image plugin command", () => {
   let garden: Garden
   let graph: ConfigGraph
   let provider: KubernetesProvider
-  let containerProvider: ContainerProvider
   let ctx: PluginContext
 
   after(async () => {
@@ -37,8 +35,7 @@ describe("pull-image plugin command", () => {
     garden = await getContainerTestGarden(environmentName)
     graph = await garden.getConfigGraph(garden.log)
     provider = <KubernetesProvider>await garden.resolveProvider(garden.log, "local-kubernetes")
-    containerProvider = <ContainerProvider>await garden.resolveProvider(garden.log, "container")
-    ctx = garden.getPluginContext(provider)
+    ctx = await garden.getPluginContext(provider)
   }
 
   async function ensureImagePulled(module: GardenModule, log: LogEntry) {
@@ -47,7 +44,7 @@ describe("pull-image plugin command", () => {
       cwd: module.buildPath,
       args: ["images", "-q", imageId],
       log,
-      containerProvider,
+      ctx,
     })
 
     expect(imageHash.stdout.length).to.be.greaterThan(0)

--- a/core/test/integ/src/plugins/kubernetes/container/container.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/container.ts
@@ -46,7 +46,7 @@ export async function getContainerTestGarden(environmentName: string = defaultEn
   if (needsInit) {
     // Load the test authentication for private registries
     const localProvider = <KubernetesProvider>await localInstance.resolveProvider(localInstance.log, "local-kubernetes")
-    const api = await KubeApi.factory(garden.log, localProvider)
+    const api = await KubeApi.factory(garden.log, await garden.getPluginContext(localProvider), localProvider)
 
     try {
       const authSecret = JSON.parse(
@@ -88,7 +88,7 @@ export async function getContainerTestGarden(environmentName: string = defaultEn
   }
 
   const provider = <KubernetesProvider>await garden.resolveProvider(garden.log, "local-kubernetes")
-  const ctx = garden.getPluginContext(provider)
+  const ctx = await garden.getPluginContext(provider)
 
   if (needsInit) {
     // Run cluster-init
@@ -135,7 +135,7 @@ describe("kubernetes container module handlers", () => {
       const image = await containerHelpers.getDeploymentImageId(module, provider.config.deploymentRegistry)
 
       const result = await runAndCopy({
-        ctx: garden.getPluginContext(provider),
+        ctx: await garden.getPluginContext(provider),
         log: garden.log,
         command: ["sh", "-c", "echo ok"],
         args: [],
@@ -155,7 +155,7 @@ describe("kubernetes container module handlers", () => {
       const podName = makePodName("test", module.name)
 
       await runAndCopy({
-        ctx: garden.getPluginContext(provider),
+        ctx: await garden.getPluginContext(provider),
         log: garden.log,
         command: ["sh", "-c", "echo ok"],
         args: [],
@@ -167,7 +167,7 @@ describe("kubernetes container module handlers", () => {
         image,
       })
 
-      const api = await KubeApi.factory(garden.log, provider)
+      const api = await KubeApi.factory(garden.log, await garden.getPluginContext(provider), provider)
 
       await expectError(
         () => api.core.readNamespacedPod(podName, namespace),
@@ -181,7 +181,7 @@ describe("kubernetes container module handlers", () => {
       const image = await containerHelpers.getDeploymentImageId(module, provider.config.deploymentRegistry)
 
       const result = await runAndCopy({
-        ctx: garden.getPluginContext(provider),
+        ctx: await garden.getPluginContext(provider),
         log: garden.log,
         command: ["sh", "-c", "echo banana && sleep 10"],
         args: [],
@@ -205,7 +205,7 @@ describe("kubernetes container module handlers", () => {
         const image = await containerHelpers.getDeploymentImageId(module, provider.config.deploymentRegistry)
 
         const result = await runAndCopy({
-          ctx: garden.getPluginContext(provider),
+          ctx: await garden.getPluginContext(provider),
           log: garden.log,
           command: task.spec.command,
           args: [],
@@ -230,7 +230,7 @@ describe("kubernetes container module handlers", () => {
         const podName = makePodName("test", module.name)
 
         await runAndCopy({
-          ctx: garden.getPluginContext(provider),
+          ctx: await garden.getPluginContext(provider),
           log: garden.log,
           command: task.spec.command,
           args: [],
@@ -244,7 +244,7 @@ describe("kubernetes container module handlers", () => {
           image,
         })
 
-        const api = await KubeApi.factory(garden.log, provider)
+        const api = await KubeApi.factory(garden.log, await garden.getPluginContext(provider), provider)
 
         await expectError(
           () => api.core.readNamespacedPod(podName, namespace),
@@ -258,7 +258,7 @@ describe("kubernetes container module handlers", () => {
         const image = await containerHelpers.getDeploymentImageId(module, provider.config.deploymentRegistry)
 
         await runAndCopy({
-          ctx: garden.getPluginContext(provider),
+          ctx: await garden.getPluginContext(provider),
           log: garden.log,
           command: task.spec.command,
           args: [],
@@ -281,7 +281,7 @@ describe("kubernetes container module handlers", () => {
         const image = await containerHelpers.getDeploymentImageId(module, provider.config.deploymentRegistry)
 
         await runAndCopy({
-          ctx: garden.getPluginContext(provider),
+          ctx: await garden.getPluginContext(provider),
           log: garden.log,
           command: ["sh", "-c", "echo ok"],
           args: [],
@@ -301,7 +301,7 @@ describe("kubernetes container module handlers", () => {
         const image = await containerHelpers.getDeploymentImageId(module, provider.config.deploymentRegistry)
 
         await runAndCopy({
-          ctx: garden.getPluginContext(provider),
+          ctx: await garden.getPluginContext(provider),
           log: garden.log,
           command: task.spec.command,
           args: [],
@@ -324,7 +324,7 @@ describe("kubernetes container module handlers", () => {
         const image = await containerHelpers.getDeploymentImageId(module, provider.config.deploymentRegistry)
 
         const result = await runAndCopy({
-          ctx: garden.getPluginContext(provider),
+          ctx: await garden.getPluginContext(provider),
           log: garden.log,
           command: ["sh", "-c", "echo banana && sleep 10"],
           args: [],
@@ -348,7 +348,7 @@ describe("kubernetes container module handlers", () => {
         const image = await containerHelpers.getDeploymentImageId(module, provider.config.deploymentRegistry)
 
         const result = await runAndCopy({
-          ctx: garden.getPluginContext(provider),
+          ctx: await garden.getPluginContext(provider),
           log: garden.log,
           command: ["sh", "-c", "touch /task.txt && sleep 10"],
           args: [],
@@ -380,9 +380,9 @@ describe("kubernetes container module handlers", () => {
         })
 
         await expectError(
-          () =>
+          async () =>
             runAndCopy({
-              ctx: garden.getPluginContext(provider),
+              ctx: await garden.getPluginContext(provider),
               log: garden.log,
               command: ["sh", "-c", "echo ok"],
               args: [],
@@ -420,9 +420,9 @@ describe("kubernetes container module handlers", () => {
         })
 
         await expectError(
-          () =>
+          async () =>
             runAndCopy({
-              ctx: garden.getPluginContext(provider),
+              ctx: await garden.getPluginContext(provider),
               log: garden.log,
               command: ["sh", "-c", "echo ok"],
               args: [],
@@ -453,9 +453,9 @@ describe("kubernetes container module handlers", () => {
         const image = await containerHelpers.getDeploymentImageId(module, provider.config.deploymentRegistry)
 
         await expectError(
-          () =>
+          async () =>
             runAndCopy({
-              ctx: garden.getPluginContext(provider),
+              ctx: await garden.getPluginContext(provider),
               log: garden.log,
               args: [],
               interactive: false,
@@ -498,7 +498,7 @@ describe("kubernetes container module handlers", () => {
       })
 
       const result = await runContainerService({
-        ctx: garden.getPluginContext(provider),
+        ctx: await garden.getPluginContext(provider),
         log: garden.log,
         service,
         module: service.module,
@@ -528,7 +528,7 @@ describe("kubernetes container module handlers", () => {
       })
 
       const result = await runContainerService({
-        ctx: garden.getPluginContext(provider),
+        ctx: await garden.getPluginContext(provider),
         log: garden.log,
         service,
         module: service.module,

--- a/core/test/integ/src/plugins/kubernetes/container/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/deployment.ts
@@ -41,7 +41,7 @@ describe("kubernetes container deployment handlers", () => {
   const init = async (environmentName: string) => {
     garden = await getContainerTestGarden(environmentName)
     provider = <KubernetesProvider>await garden.resolveProvider(garden.log, "local-kubernetes")
-    api = await KubeApi.factory(garden.log, provider)
+    api = await KubeApi.factory(garden.log, await garden.getPluginContext(provider), provider)
   }
 
   describe("createWorkloadManifest", () => {

--- a/core/test/integ/src/plugins/kubernetes/container/logs.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/logs.ts
@@ -29,7 +29,7 @@ describe("kubernetes", () => {
       garden = await makeTestGarden(root)
       graph = await garden.getConfigGraph(garden.log)
       provider = await garden.resolveProvider(garden.log, "local-kubernetes")
-      ctx = garden.getPluginContext(provider)
+      ctx = await garden.getPluginContext(provider)
     })
 
     after(async () => {

--- a/core/test/integ/src/plugins/kubernetes/container/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/run.ts
@@ -51,7 +51,7 @@ describe("runContainerTask", () => {
       version,
     })
 
-    const ctx = garden.getPluginContext(provider)
+    const ctx = await garden.getPluginContext(provider)
     await clearTaskResult({ ctx, log: garden.log, module: task.module, task, taskVersion: version })
 
     const key = testTask.getKey()
@@ -88,7 +88,7 @@ describe("runContainerTask", () => {
       version,
     })
 
-    const ctx = garden.getPluginContext(provider)
+    const ctx = await garden.getPluginContext(provider)
     await clearTaskResult({ ctx, log: garden.log, module: task.module, task, taskVersion: version })
 
     await garden.processTasks([testTask], { throwOnError: true })
@@ -119,7 +119,7 @@ describe("runContainerTask", () => {
       version,
     })
 
-    const ctx = garden.getPluginContext(provider)
+    const ctx = await garden.getPluginContext(provider)
     await clearTaskResult({ ctx, log: garden.log, module: task.module, task, taskVersion: version })
 
     await expectError(

--- a/core/test/integ/src/plugins/kubernetes/helm/common.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/common.ts
@@ -75,7 +75,7 @@ describe("Helm common functions", () => {
   before(async () => {
     garden = await getHelmTestGarden()
     const provider = await garden.resolveProvider(garden.log, "local-kubernetes")
-    ctx = garden.getPluginContext(provider)
+    ctx = await garden.getPluginContext(provider)
     log = garden.log
     graph = await garden.getConfigGraph(garden.log)
     await buildHelmModules(garden, graph)

--- a/core/test/integ/src/plugins/kubernetes/helm/config.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/config.ts
@@ -27,7 +27,7 @@ describe("configureHelmModule", () => {
   before(async () => {
     garden = await getHelmTestGarden()
     const provider = await garden.resolveProvider(garden.log, "local-kubernetes")
-    ctx = garden.getPluginContext(provider)
+    ctx = await garden.getPluginContext(provider)
     await garden.resolveModules({ log: garden.log })
     moduleConfigs = cloneDeep((<any>garden).moduleConfigs)
   })

--- a/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
@@ -25,7 +25,7 @@ describe("deployHelmService", () => {
   before(async () => {
     garden = await getHelmTestGarden()
     provider = <KubernetesProvider>await garden.resolveProvider(garden.log, "local-kubernetes")
-    ctx = <KubernetesPluginContext>garden.getPluginContext(provider)
+    ctx = <KubernetesPluginContext>await garden.getPluginContext(provider)
     const graph = await garden.getConfigGraph(garden.log)
     await buildHelmModules(garden, graph)
   })
@@ -108,7 +108,7 @@ describe("deployHelmService", () => {
 
     expect(status.state).to.equal("ready")
 
-    const api = await KubeApi.factory(garden.log, provider)
+    const api = await KubeApi.factory(garden.log, ctx, provider)
 
     // Namespace should exist
     await api.core.readNamespace(namespace)

--- a/core/test/integ/src/plugins/kubernetes/helm/hot-reload.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/hot-reload.ts
@@ -96,7 +96,7 @@ describe("configureHotReload", () => {
   before(async () => {
     garden = await getHelmTestGarden()
     provider = <KubernetesProvider>await garden.resolveProvider(garden.log, "local-kubernetes")
-    ctx = garden.getPluginContext(provider)
+    ctx = await garden.getPluginContext(provider)
   })
 
   beforeEach(async () => {

--- a/core/test/integ/src/plugins/kubernetes/helm/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/run.ts
@@ -46,7 +46,7 @@ describe("runHelmTask", () => {
 
     // Clear any existing task result
     const provider = await garden.resolveProvider(garden.log, "local-kubernetes")
-    const ctx = garden.getPluginContext(provider)
+    const ctx = await garden.getPluginContext(provider)
     await clearTaskResult({ ctx, log: garden.log, module: task.module, task, taskVersion: version })
 
     const { [key]: result } = await garden.processTasks([testTask], { throwOnError: true })
@@ -85,7 +85,7 @@ describe("runHelmTask", () => {
 
     // Clear any existing task result
     const provider = await garden.resolveProvider(garden.log, "local-kubernetes")
-    const ctx = garden.getPluginContext(provider)
+    const ctx = await garden.getPluginContext(provider)
     await clearTaskResult({ ctx, log: garden.log, module: task.module, task, taskVersion: version })
 
     await garden.processTasks([testTask], { throwOnError: true })

--- a/core/test/integ/src/plugins/kubernetes/kubernetes-module/config.ts
+++ b/core/test/integ/src/plugins/kubernetes/kubernetes-module/config.ts
@@ -24,7 +24,7 @@ describe("validateKubernetesModule", () => {
   before(async () => {
     garden = await getKubernetesTestGarden()
     const provider = await garden.resolveProvider(garden.log, "local-kubernetes")
-    ctx = garden.getPluginContext(provider)
+    ctx = await garden.getPluginContext(provider)
     await garden.resolveModules({ log: garden.log })
     moduleConfigs = cloneDeep((<any>garden).moduleConfigs)
   })

--- a/core/test/integ/src/plugins/kubernetes/kubernetes-module/handlers.ts
+++ b/core/test/integ/src/plugins/kubernetes/kubernetes-module/handlers.ts
@@ -56,8 +56,8 @@ describe("kubernetes-module handlers", () => {
     moduleConfigBackup = await garden.getRawModuleConfigs()
     log = garden.log
     const provider = <KubernetesProvider>await garden.resolveProvider(log, "local-kubernetes")
-    ctx = <KubernetesPluginContext>garden.getPluginContext(provider)
-    api = await KubeApi.factory(log, ctx.provider)
+    ctx = <KubernetesPluginContext>await garden.getPluginContext(provider)
+    api = await KubeApi.factory(log, ctx, ctx.provider)
     tmpDir = await tmp.dir({ unsafeCleanup: true })
     await execa("git", ["init"], { cwd: tmpDir.path })
     nsModuleConfig = {

--- a/core/test/integ/src/plugins/kubernetes/kubernetes-module/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/kubernetes-module/run.ts
@@ -44,7 +44,7 @@ describe("runKubernetesTask", () => {
 
     // Clear any existing task result
     const provider = await garden.resolveProvider(garden.log, "local-kubernetes")
-    const ctx = garden.getPluginContext(provider)
+    const ctx = await garden.getPluginContext(provider)
     await clearTaskResult({ ctx, log: garden.log, module: task.module, task, taskVersion: version })
 
     const key = testTask.getKey()
@@ -84,7 +84,7 @@ describe("runKubernetesTask", () => {
 
     // Clear any existing task result
     const provider = await garden.resolveProvider(garden.log, "local-kubernetes")
-    const ctx = garden.getPluginContext(provider)
+    const ctx = await garden.getPluginContext(provider)
     await clearTaskResult({ ctx, log: garden.log, module: task.module, task, taskVersion: version })
 
     await garden.processTasks([testTask], { throwOnError: true })

--- a/core/test/integ/src/plugins/kubernetes/system.ts
+++ b/core/test/integ/src/plugins/kubernetes/system.ts
@@ -31,7 +31,7 @@ describe("System services", () => {
   })
 
   it("should use conftest to check whether system services have a valid config", async () => {
-    const ctx = <KubernetesPluginContext>garden.getPluginContext(provider)
+    const ctx = <KubernetesPluginContext>await garden.getPluginContext(provider)
     const variables = getKubernetesSystemVariables(provider.config)
     const systemGarden = await getSystemGarden(ctx, variables, garden.log)
     const graph = await systemGarden.getConfigGraph(garden.log)
@@ -50,7 +50,7 @@ describe("System services", () => {
   })
 
   it("should check whether system modules pass the conftest test", async () => {
-    const ctx = <KubernetesPluginContext>garden.getPluginContext(provider)
+    const ctx = <KubernetesPluginContext>await garden.getPluginContext(provider)
     const variables = getKubernetesSystemVariables(provider.config)
     const systemGarden = await getSystemGarden(ctx, variables, garden.log)
     const graph = await systemGarden.getConfigGraph(garden.log)

--- a/core/test/integ/src/plugins/kubernetes/task-results.ts
+++ b/core/test/integ/src/plugins/kubernetes/task-results.ts
@@ -31,7 +31,7 @@ describe("kubernetes task results", () => {
 
   describe("storeTaskResult", () => {
     it("should trim logs when necessary", async () => {
-      const ctx = garden.getPluginContext(provider)
+      const ctx = await garden.getPluginContext(provider)
       const graph = await garden.getConfigGraph(garden.log)
       const task = graph.getTask("echo-task")
 

--- a/core/test/integ/src/plugins/kubernetes/util.ts
+++ b/core/test/integ/src/plugins/kubernetes/util.ts
@@ -43,7 +43,7 @@ describe("util", () => {
     helmGarden = await getHelmTestGarden()
     log = helmGarden.log
     const provider = await helmGarden.resolveProvider(log, "local-kubernetes")
-    ctx = helmGarden.getPluginContext(provider)
+    ctx = await helmGarden.getPluginContext(provider)
     helmGraph = await helmGarden.getConfigGraph(log)
     await buildModules()
   })
@@ -78,7 +78,7 @@ describe("util", () => {
       try {
         const graph = await garden.getConfigGraph(garden.log)
         const provider = (await garden.resolveProvider(garden.log, "local-kubernetes")) as Provider<KubernetesConfig>
-        const api = await KubeApi.factory(garden.log, provider)
+        const api = await KubeApi.factory(garden.log, ctx, provider)
 
         const service = graph.getService("simple-service")
 

--- a/core/test/unit/src/actions.ts
+++ b/core/test/unit/src/actions.ts
@@ -31,7 +31,7 @@ import { joi } from "../../../src/config/common"
 import { validateSchema } from "../../../src/config/validation"
 import { ProjectConfig, defaultNamespace } from "../../../src/config/project"
 import { DEFAULT_API_VERSION } from "../../../src/constants"
-import { defaultProvider } from "../../../src/config/provider"
+import { defaultProvider, providerFromConfig } from "../../../src/config/provider"
 import { RunTaskResult } from "../../../src/types/plugin/task/runTask"
 import { defaultDotIgnoreFiles } from "../../../src/util/fs"
 import stripAnsi from "strip-ansi"
@@ -97,6 +97,7 @@ describe("ActionRouter", () => {
       it("should configure the provider", async () => {
         const config = { name: "test-plugin", foo: "bar" }
         const result = await actions.configureProvider({
+          ctx: await garden.getPluginContext(providerFromConfig(config, {}, [], { ready: false, outputs: {} })),
           environmentName: "default",
           pluginName: "test-plugin",
           log,
@@ -105,7 +106,6 @@ describe("ActionRouter", () => {
           projectName: garden.projectName,
           projectRoot: garden.projectRoot,
           dependencies: {},
-          tools: {},
         })
         expect(result).to.eql({
           config,

--- a/core/test/unit/src/plugins/container/container.ts
+++ b/core/test/unit/src/plugins/container/container.ts
@@ -80,7 +80,7 @@ describe("plugins.container", () => {
     garden = await makeTestGarden(projectRoot, { plugins: [gardenPlugin] })
     log = garden.log
     containerProvider = await garden.resolveProvider(garden.log, "container")
-    ctx = garden.getPluginContext(containerProvider)
+    ctx = await garden.getPluginContext(containerProvider)
 
     td.replace(garden.buildDir, "syncDependencyProducts", () => null)
 
@@ -782,10 +782,10 @@ describe("plugins.container", () => {
         module.buildPath,
       ]
 
-      td.replace(helpers, "dockerCli", async ({ cwd, args, containerProvider: provider }) => {
+      td.replace(helpers, "dockerCli", async ({ cwd, args, ctx: _ctx }) => {
         expect(cwd).to.equal(module.buildPath)
         expect(args).to.eql(cmdArgs)
-        expect(provider).to.exist
+        expect(_ctx).to.exist
         return { all: "log" }
       })
 
@@ -819,10 +819,10 @@ describe("plugins.container", () => {
         module.buildPath,
       ]
 
-      td.replace(helpers, "dockerCli", async ({ cwd, args, containerProvider: provider }) => {
+      td.replace(helpers, "dockerCli", async ({ cwd, args, ctx: _ctx }) => {
         expect(cwd).to.equal(module.buildPath)
         expect(args).to.eql(cmdArgs)
-        expect(provider).to.exist
+        expect(_ctx).to.exist
         return { all: "log" }
       })
 
@@ -857,10 +857,10 @@ describe("plugins.container", () => {
         module.buildPath,
       ]
 
-      td.replace(helpers, "dockerCli", async ({ cwd, args, containerProvider: provider }) => {
+      td.replace(helpers, "dockerCli", async ({ cwd, args, ctx: _ctx }) => {
         expect(cwd).to.equal(module.buildPath)
         expect(args).to.eql(cmdArgs)
-        expect(provider).to.exist
+        expect(_ctx).to.exist
         return { all: "log" }
       })
 
@@ -895,10 +895,10 @@ describe("plugins.container", () => {
       td.replace(helpers, "getLocalImageId", async () => "some/image:12345")
       td.replace(helpers, "getPublicImageId", async () => "some/image:12345")
 
-      td.replace(helpers, "dockerCli", async ({ cwd, args, containerProvider: provider }) => {
+      td.replace(helpers, "dockerCli", async ({ cwd, args, ctx: _ctx }) => {
         expect(cwd).to.equal(module.buildPath)
         expect(args).to.eql(["push", "some/image:12345"])
-        expect(provider).to.exist
+        expect(_ctx).to.exist
         return { all: "log" }
       })
 
@@ -925,7 +925,7 @@ describe("plugins.container", () => {
           cwd: module.buildPath,
           args: ["tag", "some/image:12345", "some/image:1.1"],
           log: td.matchers.anything(),
-          containerProvider: td.matchers.anything(),
+          ctx: td.matchers.anything(),
         })
       )
 
@@ -934,7 +934,7 @@ describe("plugins.container", () => {
           cwd: module.buildPath,
           args: ["push", "some/image:1.1"],
           log: td.matchers.anything(),
-          containerProvider: td.matchers.anything(),
+          ctx: td.matchers.anything(),
         })
       )
     })

--- a/core/test/unit/src/plugins/container/helpers.ts
+++ b/core/test/unit/src/plugins/container/helpers.ts
@@ -70,7 +70,7 @@ describe("containerHelpers", () => {
     garden = await makeTestGarden(projectRoot, { plugins: [gardenPlugin] })
     log = garden.log
     const provider = await garden.resolveProvider(garden.log, "container")
-    ctx = garden.getPluginContext(provider)
+    ctx = await garden.getPluginContext(provider)
 
     td.replace(garden.buildDir, "syncDependencyProducts", () => null)
 

--- a/core/test/unit/src/plugins/exec.ts
+++ b/core/test/unit/src/plugins/exec.ts
@@ -315,7 +315,7 @@ describe("exec plugin", () => {
         },
       })
       const provider = await garden.resolveProvider(garden.log, "test-plugin")
-      const ctx = garden.getPluginContext(provider)
+      const ctx = await garden.getPluginContext(provider)
       await expectError(async () => await configureExecModule({ ctx, moduleConfig, log }), "configuration")
     })
   })

--- a/core/test/unit/src/plugins/kubernetes/kubernetes.ts
+++ b/core/test/unit/src/plugins/kubernetes/kubernetes.ts
@@ -12,8 +12,7 @@ import { defaultSystemNamespace } from "../../../../../src/plugins/kubernetes/sy
 import { makeDummyGarden } from "../../../../../src/cli/cli"
 import { expect } from "chai"
 import { TempDirectory, makeTempDir, grouped } from "../../../../helpers"
-import { keyBy } from "lodash"
-import { PluginTool } from "../../../../../src/util/ext-tools"
+import { providerFromConfig } from "../../../../../src/config/provider"
 
 describe("kubernetes configureProvider", () => {
   const basicConfig: KubernetesConfig = {
@@ -52,9 +51,9 @@ describe("kubernetes configureProvider", () => {
         ...basicConfig,
         buildMode: "cluster-docker",
       }
-      const plugin = garden.registeredPlugins.kubernetes
 
       const result = await configureProvider({
+        ctx: await garden.getPluginContext(providerFromConfig(config, {}, [], { ready: false, outputs: {} })),
         environmentName: "default",
         projectName: garden.projectName,
         projectRoot: garden.projectRoot,
@@ -62,10 +61,6 @@ describe("kubernetes configureProvider", () => {
         log: garden.log,
         dependencies: {},
         configStore: garden.configStore,
-        tools: keyBy(
-          plugin.tools?.map((t) => new PluginTool(t)),
-          "name"
-        ),
       })
 
       expect(result.config.deploymentRegistry).to.eql({
@@ -84,9 +79,9 @@ describe("kubernetes configureProvider", () => {
           namespace: "my-namespace",
         },
       }
-      const plugin = garden.registeredPlugins.kubernetes
 
       const result = await configureProvider({
+        ctx: await garden.getPluginContext(providerFromConfig(config, {}, [], { ready: false, outputs: {} })),
         environmentName: "default",
         projectName: garden.projectName,
         projectRoot: garden.projectRoot,
@@ -94,10 +89,6 @@ describe("kubernetes configureProvider", () => {
         log: garden.log,
         dependencies: {},
         configStore: garden.configStore,
-        tools: keyBy(
-          plugin.tools?.map((t) => new PluginTool(t)),
-          "name"
-        ),
       })
 
       expect(result.config.deploymentRegistry).to.eql({

--- a/core/test/unit/src/plugins/maven-container/maven-container.ts
+++ b/core/test/unit/src/plugins/maven-container/maven-container.ts
@@ -93,7 +93,7 @@ describe("maven-container", () => {
     garden = await makeTestGarden(projectRoot, { plugins: [mavenPlugin] })
     log = garden.log
     const provider = await garden.resolveProvider(garden.log, "maven-container")
-    ctx = garden.getPluginContext(provider)
+    ctx = await garden.getPluginContext(provider)
 
     td.replace(garden.buildDir, "syncDependencyProducts", () => null)
 

--- a/core/test/unit/src/plugins/terraform/terraform.ts
+++ b/core/test/unit/src/plugins/terraform/terraform.ts
@@ -60,7 +60,7 @@ describe("Terraform provider", () => {
 
     it("should expose outputs to template contexts after applying", async () => {
       const provider = await garden.resolveProvider(garden.log, "terraform")
-      const ctx = garden.getPluginContext(provider)
+      const ctx = await garden.getPluginContext(provider)
       const applyRootCommand = findByName(terraformCommands, "apply-root")!
       await applyRootCommand.handler({
         ctx,
@@ -81,7 +81,7 @@ describe("Terraform provider", () => {
     describe("apply-root command", () => {
       it("call terraform apply for the project root", async () => {
         const provider = (await garden.resolveProvider(garden.log, "terraform")) as TerraformProvider
-        const ctx = garden.getPluginContext(provider)
+        const ctx = await garden.getPluginContext(provider)
 
         const command = findByName(terraformCommands, "apply-root")!
         await command.handler({
@@ -96,7 +96,7 @@ describe("Terraform provider", () => {
     describe("plan-root command", () => {
       it("call terraform plan for the project root", async () => {
         const provider = (await garden.resolveProvider(garden.log, "terraform")) as TerraformProvider
-        const ctx = garden.getPluginContext(provider)
+        const ctx = await garden.getPluginContext(provider)
 
         const command = findByName(terraformCommands, "plan-root")!
         await command.handler({
@@ -204,7 +204,7 @@ describe("Terraform module type", () => {
   describe("apply-module command", () => {
     it("call terraform apply for the module root", async () => {
       const provider = (await garden.resolveProvider(garden.log, "terraform")) as TerraformProvider
-      const ctx = garden.getPluginContext(provider)
+      const ctx = await garden.getPluginContext(provider)
       graph = await garden.getConfigGraph(garden.log)
 
       const command = findByName(terraformCommands, "apply-module")!
@@ -220,7 +220,7 @@ describe("Terraform module type", () => {
   describe("plan-module command", () => {
     it("call terraform apply for the module root", async () => {
       const provider = (await garden.resolveProvider(garden.log, "terraform")) as TerraformProvider
-      const ctx = garden.getPluginContext(provider)
+      const ctx = await garden.getPluginContext(provider)
       graph = await garden.getConfigGraph(garden.log)
 
       const command = findByName(terraformCommands, "plan-module")!
@@ -244,7 +244,7 @@ describe("Terraform module type", () => {
 
     it("should expose runtime outputs to template contexts if stack had already been applied", async () => {
       const provider = await garden.resolveProvider(garden.log, "terraform")
-      const ctx = garden.getPluginContext(provider)
+      const ctx = await garden.getPluginContext(provider)
       const applyCommand = findByName(terraformCommands, "apply-module")!
       await applyCommand.handler({
         ctx,
@@ -261,7 +261,7 @@ describe("Terraform module type", () => {
 
     it("should should return outputs with the service status", async () => {
       const provider = await garden.resolveProvider(garden.log, "terraform")
-      const ctx = garden.getPluginContext(provider)
+      const ctx = await garden.getPluginContext(provider)
       const applyCommand = findByName(terraformCommands, "apply-module")!
       await applyCommand.handler({
         ctx,


### PR DESCRIPTION
This needed a fairly large refactor, but it's good to get it out of the
way. We now fetch tools from the PluginContext, instead of picking them
off providers, which was more brittle and harder to reason about.

We do still need to do a bit more work on the `maven-container` module
type, but that's for another PR.

Fixes #2002

