### PR TITLE
feat(config): allow explicitly declaring provider dependencies

### DIFF
--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -779,7 +779,9 @@ export class Garden {
     }
 
     // Walk through all plugins in dependency order, and allow them to augment the graph
-    for (const provider of getDependencyOrder(Object.values(providers), this.registeredPlugins)) {
+    const providerConfigs = Object.values(providers).map((p) => p.config)
+
+    for (const provider of getDependencyOrder(providerConfigs, this.registeredPlugins)) {
       // Skip the routine if the provider doesn't have the handler
       const handler = await actions.getActionHandler({
         actionType: "augmentGraph",

--- a/core/src/plugins/container/container.ts
+++ b/core/src/plugins/container/container.ts
@@ -23,7 +23,7 @@ import { SuggestModulesParams, SuggestModulesResult } from "../../types/plugin/m
 import { listDirectory } from "../../util/fs"
 import { dedent } from "../../util/string"
 import { getModuleTypeUrl } from "../../docs/common"
-import { Provider, GenericProviderConfig } from "../../config/provider"
+import { Provider, GenericProviderConfig, providerConfigBaseSchema } from "../../config/provider"
 
 export interface ContainerProviderConfig extends GenericProviderConfig {}
 export type ContainerProvider = Provider<ContainerProviderConfig>
@@ -246,6 +246,7 @@ export const gardenPlugin = createGardenPlugin({
       },
     },
   ],
+  configSchema: providerConfigBaseSchema(),
   tools: [
     {
       name: "docker",

--- a/core/test/unit/src/actions.ts
+++ b/core/test/unit/src/actions.ts
@@ -95,7 +95,7 @@ describe("ActionRouter", () => {
   describe("environment actions", () => {
     describe("configureProvider", () => {
       it("should configure the provider", async () => {
-        const config = { name: "test-plugin", foo: "bar" }
+        const config = { name: "test-plugin", foo: "bar", dependencies: [] }
         const result = await actions.configureProvider({
           ctx: await garden.getPluginContext(providerFromConfig(config, {}, [], { ready: false, outputs: {} })),
           environmentName: "default",

--- a/core/test/unit/src/config/project.ts
+++ b/core/test/unit/src/config/project.ts
@@ -39,7 +39,7 @@ describe("resolveProjectConfig", () => {
       dotIgnoreFiles: defaultDotIgnoreFiles,
       environments: [{ name: "default", defaultNamespace, variables: {} }],
       outputs: [],
-      providers: [{ name: "some-provider" }],
+      providers: [{ name: "some-provider", dependencies: [] }],
       variables: {},
     }
 
@@ -67,7 +67,7 @@ describe("resolveProjectConfig", () => {
       dotIgnoreFiles: defaultDotIgnoreFiles,
       environments: [],
       outputs: [],
-      providers: [{ name: "some-provider" }],
+      providers: [{ name: "some-provider", dependencies: [] }],
       variables: {},
     }
 
@@ -98,7 +98,7 @@ describe("resolveProjectConfig", () => {
           },
         },
       ],
-      providers: [{ name: "some-provider" }],
+      providers: [{ name: "some-provider", dependencies: [] }],
       sources: [
         {
           name: "${local.env.TEST_ENV_VAR}",
@@ -188,10 +188,12 @@ describe("resolveProjectConfig", () => {
       providers: [
         {
           name: "provider-a",
+          dependencies: [],
           someKey: "${local.env.TEST_ENV_VAR_A}",
         },
         {
           name: "provider-b",
+          dependencies: [],
           environments: ["default"],
           someKey: "${local.env.TEST_ENV_VAR_B}",
         },
@@ -240,7 +242,7 @@ describe("resolveProjectConfig", () => {
       dotIgnoreFiles: defaultDotIgnoreFiles,
       environments: [],
       outputs: [],
-      providers: [{ name: "some-provider" }],
+      providers: [{ name: "some-provider", dependencies: [] }],
       variables: {},
     }
 
@@ -263,7 +265,7 @@ describe("resolveProjectConfig", () => {
       dotIgnoreFiles: defaultDotIgnoreFiles,
       environments: [],
       outputs: [],
-      providers: [{ name: "some-provider" }],
+      providers: [{ name: "some-provider", dependencies: [] }],
       variables: {},
     }
 
@@ -324,13 +326,16 @@ describe("resolveProjectConfig", () => {
       providers: [
         {
           name: "provider-a",
+          dependencies: [],
         },
         {
           name: "provider-b",
           environments: ["default"],
+          dependencies: [],
         },
         {
           name: "provider-c",
+          dependencies: [],
         },
       ],
       sources: [],
@@ -386,6 +391,7 @@ describe("resolveProjectConfig", () => {
       providers: [
         {
           name: "provider-a",
+          dependencies: [],
         },
         {
           name: "provider-b",

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -84,6 +84,9 @@ providers:
   - # The name of the provider plugin to use.
     name:
 
+    # List other providers that should be resolved before this one.
+    dependencies: []
+
     # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
@@ -310,6 +313,22 @@ Example:
 environments:
 ```
 
+### `environments[].providers[].dependencies[]`
+
+[environments](#environments) > [providers](#environmentsproviders) > dependencies
+
+List other providers that should be resolved before this one.
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
+
+Example:
+
+```yaml
+environments:
+```
+
 ### `environments[].providers[].environments[]`
 
 [environments](#environments) > [providers](#environmentsproviders) > environments
@@ -388,6 +407,24 @@ Example:
 ```yaml
 providers:
   - name: "local-kubernetes"
+```
+
+### `providers[].dependencies[]`
+
+[providers](#providers) > dependencies
+
+List other providers that should be resolved before this one.
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
+
+Example:
+
+```yaml
+providers:
+  - dependencies:
+      - exec
 ```
 
 ### `providers[].environments[]`

--- a/docs/reference/providers/conftest-container.md
+++ b/docs/reference/providers/conftest-container.md
@@ -24,6 +24,9 @@ providers:
   - # The name of the provider plugin to use.
     name:
 
+    # List other providers that should be resolved before this one.
+    dependencies: []
+
     # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
@@ -61,6 +64,24 @@ Example:
 ```yaml
 providers:
   - name: "local-kubernetes"
+```
+
+### `providers[].dependencies[]`
+
+[providers](#providers) > dependencies
+
+List other providers that should be resolved before this one.
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
+
+Example:
+
+```yaml
+providers:
+  - dependencies:
+      - exec
 ```
 
 ### `providers[].environments[]`

--- a/docs/reference/providers/conftest-kubernetes.md
+++ b/docs/reference/providers/conftest-kubernetes.md
@@ -30,6 +30,9 @@ providers:
   - # The name of the provider plugin to use.
     name:
 
+    # List other providers that should be resolved before this one.
+    dependencies: []
+
     # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
@@ -67,6 +70,24 @@ Example:
 ```yaml
 providers:
   - name: "local-kubernetes"
+```
+
+### `providers[].dependencies[]`
+
+[providers](#providers) > dependencies
+
+List other providers that should be resolved before this one.
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
+
+Example:
+
+```yaml
+providers:
+  - dependencies:
+      - exec
 ```
 
 ### `providers[].environments[]`

--- a/docs/reference/providers/conftest.md
+++ b/docs/reference/providers/conftest.md
@@ -26,6 +26,9 @@ providers:
   - # The name of the provider plugin to use.
     name:
 
+    # List other providers that should be resolved before this one.
+    dependencies: []
+
     # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
@@ -63,6 +66,24 @@ Example:
 ```yaml
 providers:
   - name: "local-kubernetes"
+```
+
+### `providers[].dependencies[]`
+
+[providers](#providers) > dependencies
+
+List other providers that should be resolved before this one.
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
+
+Example:
+
+```yaml
+providers:
+  - dependencies:
+      - exec
 ```
 
 ### `providers[].environments[]`

--- a/docs/reference/providers/exec.md
+++ b/docs/reference/providers/exec.md
@@ -26,6 +26,9 @@ providers:
   - # The name of the provider plugin to use.
     name:
 
+    # List other providers that should be resolved before this one.
+    dependencies: []
+
     # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
@@ -59,6 +62,24 @@ Example:
 ```yaml
 providers:
   - name: "local-kubernetes"
+```
+
+### `providers[].dependencies[]`
+
+[providers](#providers) > dependencies
+
+List other providers that should be resolved before this one.
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
+
+Example:
+
+```yaml
+providers:
+  - dependencies:
+      - exec
 ```
 
 ### `providers[].environments[]`

--- a/docs/reference/providers/hadolint.md
+++ b/docs/reference/providers/hadolint.md
@@ -26,6 +26,9 @@ providers:
   - # The name of the provider plugin to use.
     name:
 
+    # List other providers that should be resolved before this one.
+    dependencies: []
+
     # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
@@ -61,6 +64,24 @@ Example:
 ```yaml
 providers:
   - name: "local-kubernetes"
+```
+
+### `providers[].dependencies[]`
+
+[providers](#providers) > dependencies
+
+List other providers that should be resolved before this one.
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
+
+Example:
+
+```yaml
+providers:
+  - dependencies:
+      - exec
 ```
 
 ### `providers[].environments[]`

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -27,7 +27,10 @@ The values in the schema below are the default values.
 
 ```yaml
 providers:
-  - # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
+  - # List other providers that should be resolved before this one.
+    dependencies: []
+
+    # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
 
@@ -330,6 +333,24 @@ providers:
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
 | `array[object]` | `[]`    | No       |
+
+### `providers[].dependencies[]`
+
+[providers](#providers) > dependencies
+
+List other providers that should be resolved before this one.
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
+
+Example:
+
+```yaml
+providers:
+  - dependencies:
+      - exec
+```
 
 ### `providers[].environments[]`
 

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -23,7 +23,10 @@ The values in the schema below are the default values.
 
 ```yaml
 providers:
-  - # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
+  - # List other providers that should be resolved before this one.
+    dependencies: []
+
+    # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
 
@@ -297,6 +300,24 @@ providers:
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
 | `array[object]` | `[]`    | No       |
+
+### `providers[].dependencies[]`
+
+[providers](#providers) > dependencies
+
+List other providers that should be resolved before this one.
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
+
+Example:
+
+```yaml
+providers:
+  - dependencies:
+      - exec
+```
 
 ### `providers[].environments[]`
 

--- a/docs/reference/providers/maven-container.md
+++ b/docs/reference/providers/maven-container.md
@@ -24,6 +24,9 @@ providers:
   - # The name of the provider plugin to use.
     name:
 
+    # List other providers that should be resolved before this one.
+    dependencies: []
+
     # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
@@ -51,6 +54,24 @@ Example:
 ```yaml
 providers:
   - name: "local-kubernetes"
+```
+
+### `providers[].dependencies[]`
+
+[providers](#providers) > dependencies
+
+List other providers that should be resolved before this one.
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
+
+Example:
+
+```yaml
+providers:
+  - dependencies:
+      - exec
 ```
 
 ### `providers[].environments[]`

--- a/docs/reference/providers/openfaas.md
+++ b/docs/reference/providers/openfaas.md
@@ -23,7 +23,10 @@ The values in the schema below are the default values.
 
 ```yaml
 providers:
-  - # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
+  - # List other providers that should be resolved before this one.
+    dependencies: []
+
+    # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
 
@@ -61,6 +64,24 @@ providers:
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
 | `array[object]` | `[]`    | No       |
+
+### `providers[].dependencies[]`
+
+[providers](#providers) > dependencies
+
+List other providers that should be resolved before this one.
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
+
+Example:
+
+```yaml
+providers:
+  - dependencies:
+      - exec
+```
 
 ### `providers[].environments[]`
 

--- a/docs/reference/providers/terraform.md
+++ b/docs/reference/providers/terraform.md
@@ -22,6 +22,9 @@ providers:
   - # The name of the provider plugin to use.
     name:
 
+    # List other providers that should be resolved before this one.
+    dependencies: []
+
     # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
     # disables the provider. To use a provider in all environments, omit this field.
     environments:
@@ -68,6 +71,24 @@ Example:
 ```yaml
 providers:
   - name: "local-kubernetes"
+```
+
+### `providers[].dependencies[]`
+
+[providers](#providers) > dependencies
+
+List other providers that should be resolved before this one.
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
+
+Example:
+
+```yaml
+providers:
+  - dependencies:
+      - exec
 ```
 
 ### `providers[].environments[]`


### PR DESCRIPTION
This adds a `providers[].dependencies` field, which can be used to
explicitly declare dependencies at config time. Previously you could
only create implicit dependencies by referencing another provider's
outputs in template strings.

This should be handy when e.g. using the `exec` provider with an
`initScript`, which should run before resolving other providers.