### PR TITLE
improvement: add plugin alias for plugins command

### DIFF
--- a/core/src/commands/plugins.ts
+++ b/core/src/commands/plugins.ts
@@ -36,6 +36,7 @@ type Args = typeof pluginArgs
 export class PluginsCommand extends Command<Args> {
   name = "plugins"
   help = "Plugin-specific commands."
+  alias = "plugin"
 
   // FIXME: We need this while we're still resolving providers in the AnalyticsHandler
   noProject = true


### PR DESCRIPTION
I kept mistyping it and would see users do the same, so why not :P
