### PR TITLE
improvement(core): warn on large file count in modules

### DIFF
--- a/cli/src/add-version-files.ts
+++ b/cli/src/add-version-files.ts
@@ -35,7 +35,7 @@ async function addVersionFiles() {
     const versionFilePath = resolve(path, GARDEN_VERSIONFILE_NAME)
 
     const vcsHandler = new GitHandler(garden.gardenDirPath, garden.dotIgnoreFiles)
-    const treeVersion = await vcsHandler.getTreeVersion(garden.log, config)
+    const treeVersion = await vcsHandler.getTreeVersion(garden.log, garden.projectName, config)
 
     // tslint:disable-next-line: no-console
     console.log(`${config.name} -> ${relative(STATIC_DIR, versionFilePath)}`)

--- a/core/src/commands/util/hide-warning.ts
+++ b/core/src/commands/util/hide-warning.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Command, CommandParams } from "../base"
+import dedent from "dedent"
+import { StringParameter } from "../../cli/params"
+import { Warning } from "../../db/entities/warning"
+
+const hideWarningArgs = {
+  key: new StringParameter({
+    help: "The key of the warning to hide (this will be shown along with relevant warning messages).",
+    required: true,
+  }),
+}
+
+type Args = typeof hideWarningArgs
+
+export class HideWarningCommand extends Command<Args, {}> {
+  name = "hide-warning"
+  help = "Hide a specific warning message."
+  cliOnly = true
+
+  noProject = true
+
+  description = dedent`
+    Hides the specified warning message. The command and key is generally provided along with displayed warning messages.
+  `
+
+  arguments = hideWarningArgs
+
+  async action({ args }: CommandParams<Args, {}>) {
+    await Warning.hide(args.key)
+
+    return {}
+  }
+}

--- a/core/src/commands/util/util.ts
+++ b/core/src/commands/util/util.ts
@@ -8,10 +8,11 @@
 
 import { CommandGroup } from "../base"
 import { FetchToolsCommand } from "./fetch-tools"
+import { HideWarningCommand } from "./hide-warning"
 
 export class UtilCommand extends CommandGroup {
   name = "util"
   help = "Misc utility commands."
 
-  subCommands = [FetchToolsCommand]
+  subCommands = [FetchToolsCommand, HideWarningCommand]
 }

--- a/core/src/db/connection.ts
+++ b/core/src/db/connection.ts
@@ -20,13 +20,15 @@ export function getConnection(): Connection {
     const { LocalAddress } = require("./entities/local-address")
     const { ClientAuthToken } = require("./entities/client-auth-token")
     const { GardenProcess } = require("./entities/garden-process")
+    const { Warning } = require("./entities/warning")
+
     // Prepare the connection (the ormconfig.json in the static dir is only used for the typeorm CLI during dev)
     const options: ConnectionOptions = {
       type: "sqlite",
       database: databasePath,
       // IMPORTANT: All entities and migrations need to be manually referenced here because of how we
       // package the garden binary
-      entities: [LocalAddress, ClientAuthToken, GardenProcess],
+      entities: [LocalAddress, ClientAuthToken, GardenProcess, Warning],
       migrations: [],
       // Auto-create new tables on init
       synchronize: true,

--- a/core/src/db/entities/local-address.ts
+++ b/core/src/db/entities/local-address.ts
@@ -38,11 +38,12 @@ export class LocalAddress extends GardenEntity {
   }
 
   static async resolve(values: { projectName: string; moduleName: string; serviceName: string; hostname: string }) {
-    await this.createQueryBuilder()
-      .insert()
-      .values({ ...values })
-      .onConflict("DO NOTHING")
-      .execute()
+    try {
+      await this.createQueryBuilder()
+        .insert()
+        .values({ ...values })
+        .execute()
+    } catch {}
 
     return this.findOneOrFail({ where: values })
   }

--- a/core/src/db/entities/warning.ts
+++ b/core/src/db/entities/warning.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Entity, Column, Index } from "typeorm"
+import { GardenEntity } from "../base-entity"
+import { LogEntry } from "../../logger/log-entry"
+import chalk from "chalk"
+
+/**
+ * Provides a mechanism to emit warnings that the user can then hide, via the `garden util hide-warning` command.
+ */
+@Entity()
+@Index(["key"], { unique: true })
+export class Warning extends GardenEntity {
+  @Column()
+  key: string
+
+  @Column()
+  hidden: boolean
+
+  static async emit({ key, log, message }: { key: string; log: LogEntry; message: string }) {
+    const existing = await this.findOne({ where: { key } })
+
+    if (!existing || !existing.hidden) {
+      log.warn(
+        chalk.yellow(message + `\nRun ${chalk.underline(`garden util hide-warning ${key}`)} to disable this warning.`)
+      )
+    }
+  }
+
+  static async hide(key: string) {
+    try {
+      await this.createQueryBuilder().insert().values({ key, hidden: true }).execute()
+    } catch {}
+  }
+}

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -960,7 +960,7 @@ export class Garden {
     const dependencies = await this.getRawModuleConfigs(dependencyKeys)
     const cacheContexts = dependencies.concat([moduleConfig]).map((c) => getModuleCacheContext(c))
 
-    const version = await this.vcs.resolveVersion(this.log, moduleConfig, dependencies)
+    const version = await this.vcs.resolveVersion(this.log, this.projectName, moduleConfig, dependencies)
 
     this.cache.set(cacheKey, version, ...cacheContexts)
     return version

--- a/core/test/unit/src/commands/util/hide-warning.ts
+++ b/core/test/unit/src/commands/util/hide-warning.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { withDefaultGlobalOpts, getLogMessages, projectRootA } from "../../../../helpers"
+import { expect } from "chai"
+import { Warning } from "../../../../../src/db/entities/warning"
+import { getConnection } from "../../../../../src/db/connection"
+import { HideWarningCommand } from "../../../../../src/commands/util/hide-warning"
+import { makeDummyGarden } from "../../../../../src/cli/cli"
+import { randomString } from "../../../../../src/util/string"
+
+describe("HideWarningCommand", () => {
+  it("should hide a warning message", async () => {
+    const garden = await makeDummyGarden(projectRootA)
+    const log = garden.log.placeholder()
+    const cmd = new HideWarningCommand()
+    const key = randomString(10)
+
+    try {
+      await cmd.action({
+        garden,
+        args: { key },
+        opts: withDefaultGlobalOpts({}),
+        log: garden.log,
+        headerLog: garden.log,
+        footerLog: garden.log,
+      })
+      await Warning.emit({
+        key,
+        log,
+        message: "foo",
+      })
+      expect(getLogMessages(log).length).to.equal(0)
+    } finally {
+      await getConnection().getRepository(Warning).createQueryBuilder().delete().where({ key }).execute()
+    }
+  })
+})

--- a/core/test/unit/src/db/entities/warning.ts
+++ b/core/test/unit/src/db/entities/warning.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import { randomString } from "../../../../../src/util/string"
+import { ensureConnected, getConnection } from "../../../../../src/db/connection"
+import { Warning } from "../../../../../src/db/entities/warning"
+import { getLogger } from "../../../../../src/logger/logger"
+import { getLogMessages } from "../../../../helpers"
+
+describe("Warning", () => {
+  const key = randomString(10)
+
+  before(async () => {
+    await ensureConnected()
+  })
+
+  afterEach(async () => {
+    await getConnection().getRepository(Warning).createQueryBuilder().delete().where({ key }).execute()
+  })
+
+  describe("hide", () => {
+    it("should flag a warning key as hidden", async () => {
+      await Warning.hide(key)
+      const record = await Warning.findOneOrFail({ where: { key } })
+      expect(record.hidden).to.be.true
+    })
+
+    it("should be a no-op if a key is already hidden", async () => {
+      await Warning.hide(key)
+      await Warning.hide(key)
+    })
+  })
+
+  describe("emit", () => {
+    it("should log a warning if the key has not been hidden", async () => {
+      const log = getLogger().placeholder()
+      const message = "Oh noes!"
+      await Warning.emit({ key, log, message })
+      const logs = getLogMessages(log)
+      expect(logs.length).to.equal(1)
+      expect(logs[0]).to.equal(message + `\nRun garden util hide-warning ${key} to disable this warning.`)
+    })
+
+    it("should not log a warning if the key has been hidden", async () => {
+      const log = getLogger().placeholder()
+      const message = "Oh noes!"
+      await Warning.hide(key)
+      await Warning.emit({ key, log, message })
+      const logs = getLogMessages(log)
+      expect(logs.length).to.equal(0)
+    })
+  })
+})

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -2792,6 +2792,28 @@ Examples:
   | `--all` |  | boolean | Fetch all tools for registered plugins, instead of just ones in the current env/project.
 
 
+### garden util hide-warning
+
+**Hide a specific warning message.**
+
+Hides the specified warning message. The command and key is generally provided along with displayed warning messages.
+
+| Supported in workflows |   |
+| ---------------------- |---|
+| No |                                                  |
+
+#### Usage
+
+    garden util hide-warning <key> 
+
+#### Arguments
+
+| Argument | Required | Description |
+| -------- | -------- | ----------- |
+  | `key` | Yes | The key of the warning to hide (this will be shown along with relevant warning messages).
+
+
+
 ### garden validate
 
 **Check your garden configuration for errors.**


### PR DESCRIPTION
Yet another enhancement geared towards alerting users about potential
misconfiguration.

This includes a new command and mechanism to suppress individual
warnings. We can use that to emit more warnings of this nature, where
the warning may or may not be relevant and could be annoying to see on
every invocation.
