### PR TITLE
docs: add path to artifacts dir to artifacts field description

### DIFF
--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -6,8 +6,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import deline = require("deline")
-
 import { GardenModule, FileCopySpec } from "../../types/module"
 import {
   joiUserIdentifier,
@@ -28,7 +26,7 @@ import { CommonServiceSpec, ServiceConfig, baseServiceSpecSchema } from "../../c
 import { baseTaskSpecSchema, BaseTaskSpec, cacheResultSchema } from "../../config/task"
 import { baseTestSpecSchema, BaseTestSpec } from "../../config/test"
 import { joiStringMap } from "../../config/common"
-import { dedent } from "../../util/string"
+import { dedent, deline } from "../../util/string"
 import { getModuleTypeUrl } from "../../docs/common"
 
 export const defaultContainerLimits: ServiceLimitSpec = {
@@ -427,6 +425,15 @@ export const containerRegistryConfigSchema = () =>
 
 export interface ContainerService extends Service<ContainerModule> {}
 
+export const artifactsDescription = dedent`
+  Specify artifacts to copy out of the container after the run. The artifacts are stored locally under
+  the \`.garden/artifacts\` directory.
+`
+
+export const artifactsTargetDescription = dedent`
+  A POSIX-style path to copy the artifacts to, relative to the project artifacts directory at \`.garden/artifacts\`.
+`
+
 export const containerArtifactSchema = () =>
   joi.object().keys({
     source: joi
@@ -441,7 +448,7 @@ export const containerArtifactSchema = () =>
       .relativeOnly()
       .subPathOnly()
       .default(".")
-      .description("A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.")
+      .description(artifactsTargetDescription)
       .example("outputs/foo/"),
   })
 
@@ -451,7 +458,7 @@ const artifactsSchema = () =>
     .items(containerArtifactSchema())
     .description(
       deline`
-      Specify artifacts to copy out of the container after the run.
+      ${artifactsDescription}\n
 
       Note: Depending on the provider, this may require the container image to include \`sh\` \`tar\`, in order
       to enable the file transfer.

--- a/core/src/plugins/exec.ts
+++ b/core/src/plugins/exec.ts
@@ -31,6 +31,7 @@ import { ConfigurationError, RuntimeError } from "../exceptions"
 import { LogEntry } from "../logger/log-entry"
 import { providerConfigBaseSchema } from "../config/provider"
 import { ExecaError } from "execa"
+import { artifactsTargetDescription } from "./container/config"
 
 const execPathDoc = dedent`
   By default, the command is run inside the Garden build directory (under .garden/build/<module-name>).
@@ -46,12 +47,7 @@ const artifactSchema = () =>
       .subPathOnly()
       .required()
       .description("A POSIX-style path or glob to copy, relative to the build root."),
-    target: joi
-      .posixPath()
-      .relativeOnly()
-      .subPathOnly()
-      .default(".")
-      .description("A POSIX-style path to copy the artifact to, relative to the project artifacts directory."),
+    target: joi.posixPath().relativeOnly().subPathOnly().default(".").description(artifactsTargetDescription),
   })
 
 const artifactsSchema = () => joi.array().items(artifactSchema())

--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -17,6 +17,7 @@ import {
   containerEnvVarsSchema,
   containerArtifactSchema,
   ContainerEnvVars,
+  artifactsDescription,
 } from "../container/config"
 import { PluginContext } from "../../plugin-context"
 import { deline } from "../../util/string"
@@ -639,9 +640,7 @@ export const kubernetesTaskSchema = () =>
         .description("The arguments to pass to the container used for execution.")
         .example(["rake", "db:migrate"]),
       env: containerEnvVarsSchema(),
-      artifacts: joiArray(containerArtifactSchema()).description(
-        "Specify artifacts to copy out of the container after the task is complete."
-      ),
+      artifacts: joiArray(containerArtifactSchema()).description(artifactsDescription),
     })
     .description("The task definitions for this module.")
 
@@ -664,9 +663,7 @@ export const kubernetesTestSchema = () =>
         .description("The arguments to pass to the container used for testing.")
         .example(["npm", "test"]),
       env: containerEnvVarsSchema(),
-      artifacts: joiArray(containerArtifactSchema()).description(
-        "Specify artifacts to copy out of the container after the test is complete."
-      ),
+      artifacts: joiArray(containerArtifactSchema()).description(artifactsDescription),
     })
     .description("The test suite definitions for this module.")
 

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -346,14 +346,17 @@ tests:
     # The arguments used to run the test inside the container.
     args:
 
-    # Specify artifacts to copy out of the container after the run.
+    # Specify artifacts to copy out of the container after the run. The artifacts are stored locally under the
+    # `.garden/artifacts` directory.
+    #
     # Note: Depending on the provider, this may require the container image to include `sh` `tar`, in order to enable
     # the file transfer.
     artifacts:
       - # A POSIX-style path or glob to copy. Must be an absolute path. May contain wildcards.
         source:
 
-        # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
+        # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory at
+        # `.garden/artifacts`.
         target: .
 
     # The command/entrypoint used to run the test inside the container.
@@ -425,14 +428,17 @@ tasks:
     # The arguments used to run the task inside the container.
     args:
 
-    # Specify artifacts to copy out of the container after the run.
+    # Specify artifacts to copy out of the container after the run. The artifacts are stored locally under the
+    # `.garden/artifacts` directory.
+    #
     # Note: Depending on the provider, this may require the container image to include `sh` `tar`, in order to enable
     # the file transfer.
     artifacts:
       - # A POSIX-style path or glob to copy. Must be an absolute path. May contain wildcards.
         source:
 
-        # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
+        # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory at
+        # `.garden/artifacts`.
         target: .
 
     # Set to false if you don't want the task's result to be cached. Use this if the task needs to be run any time
@@ -1409,7 +1415,8 @@ tests:
 
 [tests](#tests) > artifacts
 
-Specify artifacts to copy out of the container after the run.
+Specify artifacts to copy out of the container after the run. The artifacts are stored locally under the `.garden/artifacts` directory.
+
 Note: Depending on the provider, this may require the container image to include `sh` `tar`, in order to enable the file transfer.
 
 | Type            | Required |
@@ -1447,7 +1454,7 @@ tests:
 
 [tests](#tests) > [artifacts](#testsartifacts) > target
 
-A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
+A POSIX-style path to copy the artifacts to, relative to the project artifacts directory at `.garden/artifacts`.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |
@@ -1657,7 +1664,8 @@ tasks:
 
 [tasks](#tasks) > artifacts
 
-Specify artifacts to copy out of the container after the run.
+Specify artifacts to copy out of the container after the run. The artifacts are stored locally under the `.garden/artifacts` directory.
+
 Note: Depending on the provider, this may require the container image to include `sh` `tar`, in order to enable the file transfer.
 
 | Type            | Required |
@@ -1695,7 +1703,7 @@ tasks:
 
 [tasks](#tasks) > [artifacts](#tasksartifacts) > target
 
-A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
+A POSIX-style path to copy the artifacts to, relative to the project artifacts directory at `.garden/artifacts`.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |

--- a/docs/reference/module-types/exec.md
+++ b/docs/reference/module-types/exec.md
@@ -160,7 +160,8 @@ tasks:
       - # A POSIX-style path or glob to copy, relative to the build root.
         source:
 
-        # A POSIX-style path to copy the artifact to, relative to the project artifacts directory.
+        # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory at
+        # `.garden/artifacts`.
         target: .
 
     # The command to run.
@@ -206,7 +207,8 @@ tests:
       - # A POSIX-style path or glob to copy, relative to the build root.
         source:
 
-        # A POSIX-style path to copy the artifact to, relative to the project artifacts directory.
+        # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory at
+        # `.garden/artifacts`.
         target: .
 ```
 
@@ -536,7 +538,7 @@ A POSIX-style path or glob to copy, relative to the build root.
 
 [tasks](#tasks) > [artifacts](#tasksartifacts) > target
 
-A POSIX-style path to copy the artifact to, relative to the project artifacts directory.
+A POSIX-style path to copy the artifacts to, relative to the project artifacts directory at `.garden/artifacts`.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |
@@ -663,7 +665,7 @@ A POSIX-style path or glob to copy, relative to the build root.
 
 [tests](#tests) > [artifacts](#testsartifacts) > target
 
-A POSIX-style path to copy the artifact to, relative to the project artifacts directory.
+A POSIX-style path to copy the artifacts to, relative to the project artifacts directory at `.garden/artifacts`.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -213,12 +213,14 @@ tasks:
     # `GARDEN`) and values must be primitives or references to secrets.
     env: {}
 
-    # Specify artifacts to copy out of the container after the task is complete.
+    # Specify artifacts to copy out of the container after the run. The artifacts are stored locally under
+    # the `.garden/artifacts` directory.
     artifacts:
       - # A POSIX-style path or glob to copy. Must be an absolute path. May contain wildcards.
         source:
 
-        # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
+        # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory at
+        # `.garden/artifacts`.
         target: .
 
     # The Deployment, DaemonSet or StatefulSet that Garden should use to execute this task. If not specified, the
@@ -277,12 +279,14 @@ tests:
     # `GARDEN`) and values must be primitives or references to secrets.
     env: {}
 
-    # Specify artifacts to copy out of the container after the test is complete.
+    # Specify artifacts to copy out of the container after the run. The artifacts are stored locally under
+    # the `.garden/artifacts` directory.
     artifacts:
       - # A POSIX-style path or glob to copy. Must be an absolute path. May contain wildcards.
         source:
 
-        # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
+        # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory at
+        # `.garden/artifacts`.
         target: .
 
     # The Deployment, DaemonSet or StatefulSet that Garden should use to execute this test suite. If not specified,
@@ -832,7 +836,8 @@ tasks:
 
 [tasks](#tasks) > artifacts
 
-Specify artifacts to copy out of the container after the task is complete.
+Specify artifacts to copy out of the container after the run. The artifacts are stored locally under
+the `.garden/artifacts` directory.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
@@ -860,7 +865,7 @@ tasks:
 
 [tasks](#tasks) > [artifacts](#tasksartifacts) > target
 
-A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
+A POSIX-style path to copy the artifacts to, relative to the project artifacts directory at `.garden/artifacts`.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |
@@ -1073,7 +1078,8 @@ tests:
 
 [tests](#tests) > artifacts
 
-Specify artifacts to copy out of the container after the test is complete.
+Specify artifacts to copy out of the container after the run. The artifacts are stored locally under
+the `.garden/artifacts` directory.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
@@ -1101,7 +1107,7 @@ tests:
 
 [tests](#tests) > [artifacts](#testsartifacts) > target
 
-A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
+A POSIX-style path to copy the artifacts to, relative to the project artifacts directory at `.garden/artifacts`.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -206,12 +206,14 @@ tasks:
     # `GARDEN`) and values must be primitives or references to secrets.
     env: {}
 
-    # Specify artifacts to copy out of the container after the task is complete.
+    # Specify artifacts to copy out of the container after the run. The artifacts are stored locally under
+    # the `.garden/artifacts` directory.
     artifacts:
       - # A POSIX-style path or glob to copy. Must be an absolute path. May contain wildcards.
         source:
 
-        # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
+        # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory at
+        # `.garden/artifacts`.
         target: .
 
 tests:
@@ -255,12 +257,14 @@ tests:
     # `GARDEN`) and values must be primitives or references to secrets.
     env: {}
 
-    # Specify artifacts to copy out of the container after the test is complete.
+    # Specify artifacts to copy out of the container after the run. The artifacts are stored locally under
+    # the `.garden/artifacts` directory.
     artifacts:
       - # A POSIX-style path or glob to copy. Must be an absolute path. May contain wildcards.
         source:
 
-        # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
+        # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory at
+        # `.garden/artifacts`.
         target: .
 ```
 
@@ -746,7 +750,8 @@ tasks:
 
 [tasks](#tasks) > artifacts
 
-Specify artifacts to copy out of the container after the task is complete.
+Specify artifacts to copy out of the container after the run. The artifacts are stored locally under
+the `.garden/artifacts` directory.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
@@ -774,7 +779,7 @@ tasks:
 
 [tasks](#tasks) > [artifacts](#tasksartifacts) > target
 
-A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
+A POSIX-style path to copy the artifacts to, relative to the project artifacts directory at `.garden/artifacts`.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |
@@ -942,7 +947,8 @@ tests:
 
 [tests](#tests) > artifacts
 
-Specify artifacts to copy out of the container after the test is complete.
+Specify artifacts to copy out of the container after the run. The artifacts are stored locally under
+the `.garden/artifacts` directory.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
@@ -970,7 +976,7 @@ tests:
 
 [tests](#tests) > [artifacts](#testsartifacts) > target
 
-A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
+A POSIX-style path to copy the artifacts to, relative to the project artifacts directory at `.garden/artifacts`.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -344,14 +344,17 @@ tests:
     # The arguments used to run the test inside the container.
     args:
 
-    # Specify artifacts to copy out of the container after the run.
+    # Specify artifacts to copy out of the container after the run. The artifacts are stored locally under the
+    # `.garden/artifacts` directory.
+    #
     # Note: Depending on the provider, this may require the container image to include `sh` `tar`, in order to enable
     # the file transfer.
     artifacts:
       - # A POSIX-style path or glob to copy. Must be an absolute path. May contain wildcards.
         source:
 
-        # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
+        # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory at
+        # `.garden/artifacts`.
         target: .
 
     # The command/entrypoint used to run the test inside the container.
@@ -423,14 +426,17 @@ tasks:
     # The arguments used to run the task inside the container.
     args:
 
-    # Specify artifacts to copy out of the container after the run.
+    # Specify artifacts to copy out of the container after the run. The artifacts are stored locally under the
+    # `.garden/artifacts` directory.
+    #
     # Note: Depending on the provider, this may require the container image to include `sh` `tar`, in order to enable
     # the file transfer.
     artifacts:
       - # A POSIX-style path or glob to copy. Must be an absolute path. May contain wildcards.
         source:
 
-        # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
+        # A POSIX-style path to copy the artifacts to, relative to the project artifacts directory at
+        # `.garden/artifacts`.
         target: .
 
     # Set to false if you don't want the task's result to be cached. Use this if the task needs to be run any time
@@ -1417,7 +1423,8 @@ tests:
 
 [tests](#tests) > artifacts
 
-Specify artifacts to copy out of the container after the run.
+Specify artifacts to copy out of the container after the run. The artifacts are stored locally under the `.garden/artifacts` directory.
+
 Note: Depending on the provider, this may require the container image to include `sh` `tar`, in order to enable the file transfer.
 
 | Type            | Required |
@@ -1455,7 +1462,7 @@ tests:
 
 [tests](#tests) > [artifacts](#testsartifacts) > target
 
-A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
+A POSIX-style path to copy the artifacts to, relative to the project artifacts directory at `.garden/artifacts`.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |
@@ -1665,7 +1672,8 @@ tasks:
 
 [tasks](#tasks) > artifacts
 
-Specify artifacts to copy out of the container after the run.
+Specify artifacts to copy out of the container after the run. The artifacts are stored locally under the `.garden/artifacts` directory.
+
 Note: Depending on the provider, this may require the container image to include `sh` `tar`, in order to enable the file transfer.
 
 | Type            | Required |
@@ -1703,7 +1711,7 @@ tasks:
 
 [tasks](#tasks) > [artifacts](#tasksartifacts) > target
 
-A POSIX-style path to copy the artifacts to, relative to the project artifacts directory.
+A POSIX-style path to copy the artifacts to, relative to the project artifacts directory at `.garden/artifacts`.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |


### PR DESCRIPTION
**What this PR does / why we need it**:

The location of the artifacts dir was missing from the field description.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
