### PR TITLE
fix(enterprise): enforce stream batch size

### DIFF
--- a/core/src/actions.ts
+++ b/core/src/actions.ts
@@ -421,7 +421,7 @@ export class ActionRouter implements TypeGuard {
     const { result } = await this.callServiceHandler({ params, actionType: "getServiceStatus" })
     this.garden.events.emit("serviceStatus", {
       serviceName: params.service.name,
-      status: result,
+      status: omit(result, "detail"),
     })
     this.validateServiceOutputs(params.service, result)
     return result
@@ -431,7 +431,7 @@ export class ActionRouter implements TypeGuard {
     const { result } = await this.callServiceHandler({ params, actionType: "deployService" })
     this.garden.events.emit("serviceStatus", {
       serviceName: params.service.name,
-      status: result,
+      status: omit(result, "detail"),
     })
     this.validateServiceOutputs(params.service, result)
     return result

--- a/core/src/events.ts
+++ b/core/src/events.ts
@@ -7,11 +7,11 @@
  */
 
 import { EventEmitter2 } from "eventemitter2"
-import { ModuleVersion } from "./vcs/vcs"
 import { GraphResult } from "./task-graph"
 import { LogEntryEvent } from "./enterprise/buffered-event-stream"
 import { ServiceStatus } from "./types/service"
 import { RunStatus } from "./types/plugin/base"
+import { Omit } from "./util/util"
 
 export type GardenEventListener<T extends EventName> = (payload: Events[T]) => void
 
@@ -112,9 +112,9 @@ export interface Events extends LoggerEvents {
     key: string
     type: string
     name: string
-    version: ModuleVersion
+    versionString: string
   }
-  taskComplete: GraphResult
+  taskComplete: GraphResult // TODO: Omit dependencyResults in this payload type?
   taskError: GraphResult
   taskCancelled: {
     cancelledAt: Date
@@ -143,7 +143,7 @@ export interface Events extends LoggerEvents {
   }
   serviceStatus: {
     serviceName: string
-    status: ServiceStatus
+    status: Omit<ServiceStatus, "detail">
   }
 
   // Workflow events

--- a/core/src/logger/log-entry.ts
+++ b/core/src/logger/log-entry.ts
@@ -39,7 +39,7 @@ export interface WorkflowStepMetadata {
   index: number
 }
 
-export const EVENT_LOG_LEVEL = LogLevel.debug
+export const EVENT_LOG_LEVEL = LogLevel.info
 
 interface MessageBase {
   msg?: string

--- a/core/src/task-graph.ts
+++ b/core/src/task-graph.ts
@@ -402,7 +402,7 @@ export class TaskGraph extends EventEmitter2 {
           key,
           batchId,
           startedAt: new Date(),
-          version: task.version,
+          versionString: task.version.versionString,
         })
         result = await node.process(dependencyResults)
         result.startedAt = startedAt

--- a/core/test/unit/src/platform/buffered-event-stream.ts
+++ b/core/test/unit/src/platform/buffered-event-stream.ts
@@ -47,7 +47,7 @@ describe("BufferedEventStream", () => {
     garden.events.emit("_test", "event")
     log.root.events.emit("_test", "log")
 
-    await bufferedEventStream.flushBuffered({ flushAll: true })
+    await bufferedEventStream.flushAll()
 
     expect(find(flushedEvents, (e) => isMatch(e, { name: "_test", payload: "event" }))).to.exist
     expect(flushedLogEntries).to.include("log")
@@ -79,13 +79,13 @@ describe("BufferedEventStream", () => {
     log.root.events.emit("_test", "log")
     gardenA.events.emit("_test", "event")
 
-    await bufferedEventStream.flushBuffered({ flushAll: true })
+    await bufferedEventStream.flushAll()
 
     expect(flushedEvents.length).to.eql(0)
     expect(flushedLogEntries).to.include("log")
 
     gardenB.events.emit("_test", "event")
-    await bufferedEventStream.flushBuffered({ flushAll: true })
+    await bufferedEventStream.flushAll()
 
     expect(find(flushedEvents, (e) => isMatch(e, { name: "_test", payload: "event" }))).to.exist
   })

--- a/core/test/unit/src/task-graph.ts
+++ b/core/test/unit/src/task-graph.ts
@@ -161,7 +161,7 @@ describe("task-graph", () => {
             key: task.getKey(),
             name: task.name,
             type: task.type,
-            version: task.version,
+            versionString: task.version.versionString,
           },
         },
         { name: "taskComplete", payload: result["a"] },
@@ -250,7 +250,7 @@ describe("task-graph", () => {
             key: task.getKey(),
             name: task.name,
             type: task.type,
-            version: task.version,
+            versionString: task.version.versionString,
           },
         },
         { name: "taskError", payload: result["a"] },
@@ -740,6 +740,7 @@ describe("task-graph", () => {
 
       const filteredKeys: Set<string | number> = new Set([
         "version",
+        "versionString",
         "error",
         "addedAt",
         "startedAt",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

Changed `BufferedEventStream`'s batching logic to fill batches with events / log entries up to a constant maximum byte count.

Compared to the previous batching logic, the new implementation is fundamentally robust with respect to request size, and generally drains its buffer much faster.

Also streamlined some event payloads to omit unnecessary and potentially very large fields.