### PR TITLE
chore: remove left out v prefixes from version strings

### DIFF
--- a/core/src/docs/common.ts
+++ b/core/src/docs/common.ts
@@ -75,7 +75,7 @@ export function getProviderUrl(type?: string) {
  * Returns a versioned link to the source code on GitHub using the path provided.
  */
 export function getGitHubUrl(path: string) {
-  const version = "v" + getPackageVersion()
+  const version = getPackageVersion()
   if (path.startsWith("/")) {
     path = path.substring(1)
   }

--- a/scripts/test-release.sh
+++ b/scripts/test-release.sh
@@ -61,7 +61,7 @@ test_release() {
 
   echo $release_version
 
-  if [ "$version" != "v$release_version" ]; then
+  if [ "$version" != "$release_version" ]; then
     echo "Versions don't match, ${version} and ${release_version}"
     return 1
   fi


### PR DESCRIPTION
**What this PR does / why we need it**:

There was some code that was still anticipating the `v` prefix in version strings.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
