### PR TITLE
feat(enterprise): enable authentication via ci-tokens

### DIFF
--- a/core/src/enterprise/auth.ts
+++ b/core/src/enterprise/auth.ts
@@ -20,7 +20,10 @@ import { got } from "../util/http"
 import { RuntimeError, InternalError } from "../exceptions"
 import { gardenEnv } from "../constants"
 
-export const authTokenHeader = "x-access-auth-token"
+// If a GARDEN_AUTH_TOKEN is present and Garden is NOT running from a workflow runner pod,
+// switch to ci-token authentication method.
+export const authTokenHeader =
+  gardenEnv.GARDEN_AUTH_TOKEN && !gardenEnv.GARDEN_GE_SCHEDULED ? "x-ci-token" : "x-access-auth-token"
 export const makeAuthHeader = (clientAuthToken: string) => ({ [authTokenHeader]: clientAuthToken })
 
 // TODO: Add error handling and tests for all of this

--- a/core/src/enterprise/secrets/garden/get-secret.ts
+++ b/core/src/enterprise/secrets/garden/get-secret.ts
@@ -9,6 +9,7 @@
 import { got, GotResponse } from "../../../util/http"
 import { GetSecretsParams } from ".."
 import { StringMap } from "../../../config/common"
+import { authTokenHeader } from "../../auth"
 
 export async function getSecretsFromGardenCloud({
   log,
@@ -19,7 +20,7 @@ export async function getSecretsFromGardenCloud({
 }: GetSecretsParams): Promise<StringMap> {
   try {
     const url = `${enterpriseDomain}/secrets/projectUid/${projectId}/env/${environmentName}`
-    const headers = { "x-access-auth-token": clientAuthToken }
+    const headers = { [authTokenHeader]: clientAuthToken }
     const res = await got(url, { headers }).json<GotResponse<any>>()
     if (res && res["status"] === "success") {
       return res["data"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:
This PR changes the authentication behaviour if a user set `GARDEN_AUTH_TOKEN`.
Before we would expect the value of `GARDEN_AUTH_TOKEN` to be a jwt and all the requests to GE were authenticated through `x-access-auth-token`.
We introduced in GE a new authentication header `x-ci-token`, which will get set if `GARDEN_AUTH_TOKEN`.

The old behaviour of overriding a persisted token remains unchanged, as well as the error/inconsistency handling.

**Special notes for your reviewer**:
