### PR TITLE
Fix typo in docs from "containes" to "contains"

### DIFF
--- a/core/src/commands/link/module.ts
+++ b/core/src/commands/link/module.ts
@@ -25,7 +25,7 @@ const linkModuleArguments = {
     required: true,
   }),
   path: new PathParameter({
-    help: "Path to the local directory that containes the module.",
+    help: "Path to the local directory that contains the module.",
     required: true,
   }),
 }

--- a/core/src/commands/link/source.ts
+++ b/core/src/commands/link/source.ts
@@ -26,7 +26,7 @@ const linkSourceArguments = {
     required: true,
   }),
   path: new PathParameter({
-    help: "Path to the local directory that containes the source.",
+    help: "Path to the local directory that contains the source.",
     required: true,
   }),
 }

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1901,7 +1901,7 @@ Examples:
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `source` | Yes | Name of the source to link as declared in the project config.
-  | `path` | Yes | Path to the local directory that containes the source.
+  | `path` | Yes | Path to the local directory that contains the source.
 
 
 #### Outputs
@@ -1941,7 +1941,7 @@ Examples:
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `module` | Yes | Name of the module to link.
-  | `path` | Yes | Path to the local directory that containes the module.
+  | `path` | Yes | Path to the local directory that contains the module.
 
 
 #### Outputs


### PR DESCRIPTION
Fix typo in docs from "containes" to "contains"

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

Fixes the typo in docs.

**Which issue(s) this PR fixes**:

No issue exist for this change

**Special notes for your reviewer**:

none
