### PR TITLE
Fix timestamps

### DIFF
--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -186,14 +186,16 @@ ${renderCommands(commands)}
     // Parse command line --var input
     const parsedCliVars = cliVars ? dotenv.parse(cliVars.join("\n")) : {}
 
+    // Init logger
+    const level = parseLogLevel(logLevel)
     let loggerType = <LoggerType>loggerTypeOpt || command.getLoggerType({ opts: parsedOpts, args: parsedArgs })
 
     if (silent || output) {
       loggerType = "quiet"
+    } else if (loggerType === "fancy" && (level > LogLevel.info || showTimestamps)) {
+      loggerType = "basic"
     }
 
-    // Init logger
-    const level = parseLogLevel(logLevel)
     const logger = initLogger({ level, loggerType, emoji, showTimestamps })
 
     // Currently we initialise empty placeholder entries and pass those to the

--- a/core/src/cli/params.ts
+++ b/core/src/cli/params.ts
@@ -313,7 +313,10 @@ export const globalOptions = {
     defaultValue: envSupportsEmoji(),
   }),
   "show-timestamps": new BooleanParameter({
-    help: "Show timestamps with log output.",
+    help: deline`
+      Show timestamps with log output. When enabled, Garden will use the ${chalk.bold(
+        "basic"
+      )} logger. I.e., log status changes are rendered as new lines instead of being updated in-place.`,
     defaultValue: false,
   }),
   "yes": new BooleanParameter({

--- a/core/src/logger/logger.ts
+++ b/core/src/logger/logger.ts
@@ -84,7 +84,7 @@ export class Logger extends LogNode {
   public useEmoji: boolean
   public showTimestamps: boolean
 
-  private static instance: Logger
+  private static instance?: Logger
 
   static getInstance() {
     if (!Logger.instance) {
@@ -134,6 +134,13 @@ export class Logger extends LogNode {
 
     Logger.instance = instance
     return instance
+  }
+
+  /**
+   * Clears the singleton instance. Use this if you need to re-initialise the global logger singleton.
+   */
+  static clearInstance() {
+    Logger.instance = undefined
   }
 
   constructor(config: LoggerConfig) {

--- a/core/src/logger/writers/fancy-terminal-writer.ts
+++ b/core/src/logger/writers/fancy-terminal-writer.ts
@@ -12,7 +12,7 @@ import elegantSpinner from "elegant-spinner"
 import wrapAnsi from "wrap-ansi"
 import chalk from "chalk"
 
-import { formatForTerminal, renderMsg, basicRender, getLeftOffset } from "../renderers"
+import { formatForTerminal, renderMsg, getLeftOffset } from "../renderers"
 import { LogEntry } from "../log-entry"
 import { Logger } from "../logger"
 import { LogLevel } from "../log-node"
@@ -225,15 +225,6 @@ export class FancyTerminalWriter extends Writer {
   }
 
   public onGraphChange(entry: LogEntry, logger: Logger): void {
-    // The fancy stuff doesn't play well with log levels above "info" so we just render that normally
-    if (logger.level > LogLevel.info) {
-      const out = basicRender(entry, logger)
-      if (out) {
-        process.stdout.write(out)
-      }
-      return
-    }
-
     if (!this.stream) {
       this.stream = this.initStream(logger)
     }

--- a/core/test/helpers.ts
+++ b/core/test/helpers.ts
@@ -44,6 +44,8 @@ import { SuiteFunction, TestFunction } from "mocha"
 import { GardenError } from "../src/exceptions"
 import { AnalyticsGlobalConfig } from "../src/config-store"
 import { TestGarden, EventLogEntry } from "../src/util/testing"
+import { Logger } from "../src/logger/logger"
+import { LogLevel } from "../src/logger/log-node"
 
 export { TempDirectory, makeTempDir } from "../src/util/fs"
 export { TestGarden, TestError, TestEventBus } from "../src/util/testing"
@@ -606,4 +608,18 @@ export function getRuntimeStatusEvents(eventLog: EventLogEntry[]) {
       cloned.payload.status = pick(cloned.payload.status, ["state"])
       return cloned
     })
+}
+
+/**
+ * Initialise test logger.
+ *
+ * It doesn't register any writers so it only collects logs but doesn't write them.
+ */
+export function initTestLogger() {
+  // make sure logger is initialized
+  try {
+    Logger.initialize({
+      level: LogLevel.info,
+    })
+  } catch (_) {}
 }

--- a/core/test/setup.ts
+++ b/core/test/setup.ts
@@ -8,22 +8,13 @@
 
 import td from "testdouble"
 import timekeeper from "timekeeper"
-import { Logger } from "../src/logger/logger"
-import { LogLevel } from "../src/logger/log-node"
 import { getDefaultProfiler } from "../src/util/profiling"
 import { gardenEnv } from "../src/constants"
 import { testFlags } from "../src/util/util"
 import { ensureConnected } from "../src/db/connection"
-// import { BasicTerminalWriter } from "../src/logger/writers/basic-terminal-writer"
+import { initTestLogger } from "./helpers"
 
-// make sure logger is initialized
-try {
-  Logger.initialize({
-    level: LogLevel.info,
-    // level: LogLevel.debug,
-    // writers: [new BasicTerminalWriter()],
-  })
-} catch (_) {}
+initTestLogger()
 
 // Global hooks
 before(async () => {

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -27,7 +27,7 @@ The following option flags can be used with any of the CLI commands:
   | `--log-level` | `-l` | `error` `warn` `info` `verbose` `debug` `silly` `0` `1` `2` `3` `4` `5`  | Set logger level. Values can be either string or numeric and are prioritized from 0 to 5 (highest to lowest) as follows: error: 0, warn: 1, info: 2, verbose: 3, debug: 4, silly: 5.
   | `--output` | `-o` | `json` `yaml`  | Output command result in specified format (note: disables progress logging and interactive functionality).
   | `--emoji` |  | boolean | Enable emoji in output (defaults to true if the environment supports it).
-  | `--show-timestamps` |  | boolean | Show timestamps with log output.
+  | `--show-timestamps` |  | boolean | Show timestamps with log output. When enabled, Garden will use the basic logger. I.e., log status changes are rendered as new lines instead of being updated in-place.
   | `--yes` | `-y` | boolean | Automatically approve any yes/no prompts during execution.
   | `--force-refresh` |  | boolean | Force refresh of any caches, e.g. cached provider statuses.
   | `--var` |  | array:string | Set a specific variable value, using the format &lt;key&gt;&#x3D;&lt;value&gt;, e.g. &#x60;--var some-key&#x3D;custom-value&#x60;. This will override any value set in your project configuration. You can specify multiple variables by separating with a comma, e.g. &#x60;--var key-a&#x3D;foo,key-b&#x3D;&quot;value with quotes&quot;&#x60;.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

Previously we would print the timestamp on the log entry proper, as opposed to on the latest message state. That meant that for basic log entries, the message state was being rendered would have the older timestamp of the entry itself. This fixes that.

Also, previously we'd show timestamps with the fancy logger as well but that doesn't really make sense because fancy entries update in-place and it's not clear what timestamp should mean in that context. So now we automatically set the logger to basic when timestamps are enabled. 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
