### PR TITLE
fix(workflows): forbid use of global options

### DIFF
--- a/core/src/cli/helpers.ts
+++ b/core/src/cli/helpers.ts
@@ -117,10 +117,22 @@ export type ParamSpec = {
 /**
  * Parses the given CLI arguments using minimist. The result should be fed to `processCliArgs()`
  *
- * @param stringArgs Raw string arguments
- * @param command    The Command that the arguments are for, if any
+ * @param stringArgs  Raw string arguments
+ * @param command     The Command that the arguments are for, if any
+ * @param cli         If true, prefer `param.cliDefault` to `param.defaultValue`
+ * @param skipDefault Defaults to `false`. If `true`, don't populate default values.
  */
-export function parseCliArgs({ stringArgs, command, cli }: { stringArgs: string[]; command?: Command; cli: boolean }) {
+export function parseCliArgs({
+  stringArgs,
+  command,
+  cli,
+  skipDefault = false,
+}: {
+  stringArgs: string[]
+  command?: Command
+  cli: boolean
+  skipDefault?: boolean
+}) {
   // Tell minimist which flags are to be treated explicitly as booleans and strings
   const allOptions = { ...globalOptions, ...(command?.options || {}) }
   const booleanKeys = Object.keys(pickBy(allOptions, (spec) => spec.type === "boolean"))
@@ -131,11 +143,15 @@ export function parseCliArgs({ stringArgs, command, cli }: { stringArgs: string[
   const defaultValues = {}
 
   for (const [name, spec] of Object.entries(allOptions)) {
-    defaultValues[name] = spec.getDefaultValue(cli)
+    if (!skipDefault) {
+      defaultValues[name] = spec.getDefaultValue(cli)
+    }
 
     if (spec.alias) {
       aliases[name] = spec.alias
-      defaultValues[spec.alias] = defaultValues[name]
+      if (!skipDefault) {
+        defaultValues[spec.alias] = defaultValues[name]
+      }
     }
   }
 

--- a/core/src/util/util.ts
+++ b/core/src/util/util.ts
@@ -607,6 +607,13 @@ export function isPromise(obj: any): obj is Promise<any> {
   return !!obj && (typeof obj === "object" || typeof obj === "function") && typeof obj.then === "function"
 }
 
+/**
+ * A type guard that's useful e.g. when filtering an array which may have blank entries.
+ */
+export function isTruthy<T>(value: T | undefined | null | false | 0 | ""): value is T {
+  return !!value
+}
+
 // Used to make the platforms more consistent with other tools
 const platformMap = {
   win32: "windows",

--- a/core/test/unit/src/config/workflow.ts
+++ b/core/test/unit/src/config/workflow.ts
@@ -133,6 +133,33 @@ describe("resolveWorkflowConfig", () => {
     )
   })
 
+  it("should throw if a step command uses a global option", async () => {
+    const config: WorkflowConfig = {
+      ...defaults,
+      apiVersion: DEFAULT_API_VERSION,
+      kind: "Workflow",
+      name: "workflow-a",
+      path: "/tmp/foo",
+      description: "Sample workflow",
+      steps: [{ command: ["test", "--env=foo", "-l", "4"] }, { command: ["test", "--silent"] }],
+      triggers: [
+        {
+          environment: "local",
+          events: ["pull-request"],
+          branches: ["feature*"],
+          ignoreBranches: ["feature-ignored*"],
+          tags: ["v1*"],
+          ignoreTags: ["v1-ignored*"],
+        },
+      ],
+    }
+
+    await expectError(
+      () => resolveWorkflowConfig(garden, config),
+      (err) => expect(err.message).to.match(/Invalid step command options for workflow workflow-a/)
+    )
+  })
+
   it("should throw if a trigger uses an environment that isn't defined in the project", async () => {
     const config: WorkflowConfig = {
       ...defaults,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

Global options (such as `--env` or `-l`) have no effect when used in workflow step commands, since the step commands share a Garden instance with the enclosing `run workflow` command.

To prevent user confusion, we now validate that global options are not used in workflow step command specs, and throw an error if any are detected.

For example, the following workflow config
```yaml
kind: Workflow
name: test-workflow
steps:
  - command: [test, "--env=foo", "-l", "4"
```
Would fail validation with the following error message:
```
$ garden validate

Invalid step command options for workflow test-workflow:

In command [test, --env=foo, -l, 4]: --env, -l

See error.log for detailed error message
```