### PR TITLE
fix(core): omit dependencyResults from events

### DIFF
--- a/core/src/events.ts
+++ b/core/src/events.ts
@@ -6,6 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import { omit } from "lodash"
 import { EventEmitter2 } from "eventemitter2"
 import { GraphResult } from "./task-graph"
 import { LogEntryEvent } from "./enterprise/buffered-event-stream"
@@ -58,6 +59,16 @@ export interface LoggerEvents {
 }
 
 export type LoggerEventName = keyof LoggerEvents
+
+export type GraphResultEventPayload = Omit<GraphResult, "dependencyResults">
+
+export function toGraphResultEventPayload(result: GraphResult): GraphResultEventPayload {
+  const payload = omit(result, "dependencyResults")
+  if (result.output) {
+    payload.output = omit(result.output, "dependencyResults", "log", "buildLog")
+  }
+  return payload
+}
 
 /**
  * Supported Garden events and their interfaces.
@@ -114,8 +125,8 @@ export interface Events extends LoggerEvents {
     name: string
     versionString: string
   }
-  taskComplete: GraphResult // TODO: Omit dependencyResults in this payload type?
-  taskError: GraphResult
+  taskComplete: GraphResultEventPayload
+  taskError: GraphResultEventPayload
   taskCancelled: {
     cancelledAt: Date
     batchId: string

--- a/core/src/task-graph.ts
+++ b/core/src/task-graph.ts
@@ -21,6 +21,7 @@ import { cyclesToString } from "./util/validate-dependencies"
 import { Profile } from "./util/profiling"
 import { renderMessageWithDivider } from "./logger/util"
 import { EventEmitter2 } from "eventemitter2"
+import { toGraphResultEventPayload } from "./events"
 
 class TaskGraphError extends GardenBaseError {
   type = "task-graph"
@@ -237,7 +238,7 @@ export class TaskGraph extends EventEmitter2 {
     } else {
       const result = this.resultCache.get(node.key, node.getVersion())
       if (result) {
-        this.garden.events.emit(result.error ? "taskError" : "taskComplete", result)
+        this.garden.events.emit(result.error ? "taskError" : "taskComplete", toGraphResultEventPayload(result))
       }
     }
   }
@@ -406,11 +407,11 @@ export class TaskGraph extends EventEmitter2 {
         })
         result = await node.process(dependencyResults)
         result.startedAt = startedAt
-        this.garden.events.emit("taskComplete", result)
+        this.garden.events.emit("taskComplete", toGraphResultEventPayload(result))
       } catch (error) {
         success = false
         result = { type, description, key, name, error, startedAt, completedAt: new Date(), batchId, version }
-        this.garden.events.emit("taskError", result)
+        this.garden.events.emit("taskError", toGraphResultEventPayload(result))
         this.logTaskError(node, error)
         this.cancelDependants(node)
       } finally {

--- a/core/test/unit/src/task-graph.ts
+++ b/core/test/unit/src/task-graph.ts
@@ -15,6 +15,7 @@ import { makeTestGarden, freezeTime, dataDir, expectError, TestGarden } from "..
 import { Garden } from "../../../src/garden"
 import { deepFilter, defer, sleep, uuidv4 } from "../../../src/util/util"
 import { range } from "lodash"
+import { toGraphResultEventPayload } from "../../../src/events"
 
 const projectRoot = join(dataDir, "test-project-empty")
 
@@ -164,7 +165,7 @@ describe("task-graph", () => {
             versionString: task.version.versionString,
           },
         },
-        { name: "taskComplete", payload: result["a"] },
+        { name: "taskComplete", payload: toGraphResultEventPayload(result["a"]!) },
         { name: "taskGraphComplete", payload: { completedAt: now } },
       ])
     })
@@ -206,14 +207,13 @@ describe("task-graph", () => {
           payload: {
             startedAt: now,
             completedAt: now,
-            dependencyResults: {},
             batchId: generatedBatchId,
             description: "a",
             key: task.getKey(),
             type: "test",
             name: "a",
-            output: { dependencyResults: {}, result: "result-a" },
             version: task.version.versionString,
+            output: { result: "result-a" },
           },
         },
         { name: "taskGraphComplete", payload: { completedAt: now } },
@@ -765,13 +765,12 @@ describe("task-graph", () => {
         {
           name: "taskComplete",
           payload: {
-            dependencyResults: {},
             description: "a",
             key: "a",
             name: "a",
-            output: { dependencyResults: {}, result: "result-a" },
             type: "test",
             batchId: generatedBatchId,
+            output: { result: "result-a" },
           },
         },
         { name: "taskProcessing", payload: { key: "b", name: "b", type: "test", batchId: generatedBatchId } },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

We've now removed `dependencyResults` from the payload types of the `taskComplete` and `taskError` events (which were previously `GraphResult`).

Since `dependencyResults` is a recursive data structure, it can grow very large. And since `dependencyResults` in event payloads is not currently being used anywhere, it can safely be removed.

We also omit `result.output.log` and `result.output.buildLog` when present, since those strings can grow arbitrarily long (and since we're not currently using those payload fields anywhere).
