### PR TITLE
improvement(k8s): show more pod log lines by default

### DIFF
--- a/core/src/plugins/kubernetes/status/pod.ts
+++ b/core/src/plugins/kubernetes/status/pod.ts
@@ -14,7 +14,7 @@ import { ResourceStatus } from "./status"
 import chalk from "chalk"
 import { ServiceState, combineStates } from "../../../types/service"
 
-export const podLogLines = 20
+export const POD_LOG_LINES = 30
 
 export function checkPodStatus(pod: KubernetesServerResource<V1Pod>): ServiceState {
   const phase = pod.status!.phase
@@ -147,7 +147,7 @@ export async function getFormattedPodLogs(api: KubeApi, namespace: string, pods:
       podName: pod.metadata.name,
       // Putting 5000 bytes as a length limit in addition to the line limit, just as a precaution in case someone
       // accidentally logs a binary file or something.
-      containers: await getPodLogs({ api, namespace, pod, byteLimit: 5000, lineLimit: podLogLines }),
+      containers: await getPodLogs({ api, namespace, pod, byteLimit: 5000, lineLimit: POD_LOG_LINES }),
     }
   })
 

--- a/core/src/plugins/kubernetes/status/workload.ts
+++ b/core/src/plugins/kubernetes/status/workload.ts
@@ -21,7 +21,7 @@ import {
 } from "@kubernetes/client-node"
 import dedent = require("dedent")
 import { getCurrentWorkloadPods } from "../util"
-import { getFormattedPodLogs, podLogLines } from "./pod"
+import { getFormattedPodLogs, POD_LOG_LINES } from "./pod"
 import { ResourceStatus, StatusHandlerParams } from "./status"
 import { getResourceEvents } from "./events"
 
@@ -89,7 +89,9 @@ export async function checkWorkloadStatus({ api, namespace, resource }: StatusHa
       logs += chalk.white("\n\n━━━ Pod logs ━━━\n")
       logs +=
         chalk.gray(dedent`
-      <Showing last ${podLogLines} lines per pod in this ${workload.kind}. Run the following command for complete logs>
+      <Showing last ${POD_LOG_LINES} lines per pod in this ${
+          workload.kind
+        }. Run the following command for complete logs>
       $ kubectl -n ${namespace} --context=${api.context} logs ${workload.kind.toLowerCase()}/${workload.metadata.name}
       `) +
         "\n" +


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

Show more log lines when K8s deployment fails. I added this because we were sometimes just missing useful log lines. For example:

```
<Showing last 20 lines per pod in this Deployment. Run the following command for complete logs>
$ kubectl -n ge-eysi --context=gke logs deployment/api

****** api-586d46f47f-k6wqv ******
------ api ------    at raiseError (/app/api/node_modules/env-var/lib/variable.js:36:11)
  at Object.asInt (/app/api/node_modules/env-var/lib/variable.js:83:9)
  at Object.<anonymous> (/app/api/dist/constants.js:94:44)
  at Module._compile (internal/modules/cjs/loader.js:1137:30)
  at Object.Module._extensions..js (internal/modules/cjs/loader.js:1157:10)
  at Module.load (internal/modules/cjs/loader.js:985:32)
  at Function.Module._load (internal/modules/cjs/loader.js:878:14)
  at Module.require (internal/modules/cjs/loader.js:1025:19)
  at require (internal/modules/cjs/helpers.js:72:18)
  at Object.<anonymous> (/app/api/dist/utils/trace.js:10:21)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! api@0.0.1 serve: `node dist/server.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the api@0.0.1 serve script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2020-10-09T12_13_06_295Z-debug.log
```

whereas this part is missing:

```
/app/api/node_modules/env-var/lib/variable.js:36
    throw new EnvVarError(errMsg)
    ^
EnvVarError: env-var: "DB_PORT" should be a valid integer, but is set to ""5432""
``` 

Of course we can't guarantee to capture the full error message but I figured bumping the number from 20 to 30 couldn't hurt.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
