### PR TITLE
improvement: include timestamps in JSON logger

### DIFF
--- a/core/src/logger/renderers.ts
+++ b/core/src/logger/renderers.ts
@@ -125,14 +125,17 @@ export function renderTimestamp(entry: LogEntry): string {
   if (!entry.root.showTimestamps) {
     return ""
   }
+  return `[${getTimestamp(entry)}] `
+}
 
+export function getTimestamp(entry: LogEntry): string {
   const { timestamp } = entry.getMessageState()
   let formatted = ""
   try {
     formatted = new Date(timestamp).toISOString()
   } catch (_err) {}
 
-  return `[${formatted}] `
+  return formatted
 }
 
 export function renderMsg(entry: LogEntry): string {
@@ -232,5 +235,6 @@ export function formatForJson(entry: LogEntry): JsonLogEntry {
     data,
     metadata,
     section: cleanForJSON(section),
+    timestamp: getTimestamp(entry),
   }
 }

--- a/core/src/logger/writers/json-terminal-writer.ts
+++ b/core/src/logger/writers/json-terminal-writer.ts
@@ -13,6 +13,7 @@ import { formatForJson } from "../renderers"
 
 export interface JsonLogEntry {
   msg: string
+  timestamp: string
   data?: any
   section?: string
   metadata?: LogEntryMetadata

--- a/core/test/unit/src/logger/renderers.ts
+++ b/core/test/unit/src/logger/renderers.ts
@@ -237,6 +237,7 @@ describe("renderers", () => {
   })
   describe("formatForJson", () => {
     it("should return a JSON representation of a log entry", () => {
+      const now = freezeTime()
       const taskMetadata: TaskMetadata = {
         type: "a",
         key: "a",
@@ -255,18 +256,21 @@ describe("renderers", () => {
       })
       expect(formatForJson(entry)).to.eql({
         msg: "hello",
+        timestamp: now.toISOString(),
         section: "c",
         data: { foo: "bar" },
         metadata: { task: taskMetadata },
       })
     })
     it("should append messages if applicable", () => {
+      const now = freezeTime()
       const entry = logger.info({
         msg: "hello",
       })
       entry.setState({ msg: "world", append: true })
       expect(formatForJson(entry)).to.eql({
         msg: "hello - world",
+        timestamp: now.toISOString(),
         section: "",
         data: undefined,
         metadata: undefined,
@@ -279,6 +283,7 @@ describe("renderers", () => {
         section: "",
         data: undefined,
         metadata: undefined,
+        timestamp: "",
       })
     })
   })

--- a/core/test/unit/src/logger/writers/json-terminal-writer.ts
+++ b/core/test/unit/src/logger/writers/json-terminal-writer.ts
@@ -10,6 +10,7 @@ import { expect } from "chai"
 
 import { JsonTerminalWriter } from "../../../../../src/logger/writers/json-terminal-writer"
 import { getLogger } from "../../../../../src/logger/logger"
+import { freezeTime } from "../../../../helpers"
 
 const logger: any = getLogger()
 
@@ -20,17 +21,19 @@ beforeEach(() => {
 describe("JsonTerminalWriter", () => {
   describe("render", () => {
     it("should return a JSON-formatted message if level is geq than entry level", () => {
+      const now = freezeTime()
       const writer = new JsonTerminalWriter()
       const entry = logger.info("hello logger")
       const out = writer.render(entry, logger)
-      expect(out).to.eql('{"msg":"hello logger","section":""}')
+      expect(out).to.eql(`{"msg":"hello logger","section":"","timestamp":"${now.toISOString()}"}`)
     })
     it("should chain messages with 'append' set to true", () => {
+      const now = freezeTime()
       const writer = new JsonTerminalWriter()
       const entry = logger.info("hello logger")
       entry.setState({ msg: "hello again", append: true })
       const out = writer.render(entry, logger)
-      expect(out).to.eql('{"msg":"hello logger - hello again","section":""}')
+      expect(out).to.eql(`{"msg":"hello logger - hello again","section":"","timestamp":"${now.toISOString()}"}`)
     })
     it("should return null if message is an empty string", () => {
       const writer = new JsonTerminalWriter()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

The JSON logger now includes timestamps in its log entries.

**Which issue(s) this PR fixes**:

Fixes #2095