### PR TITLE
fix(cli): fix error rendering for yaml output

### DIFF
--- a/core/src/cli/params.ts
+++ b/core/src/cli/params.ts
@@ -25,7 +25,8 @@ export const OUTPUT_RENDERERS = {
     return stringify(data, null, 2)
   },
   yaml: (data: DeepPrimitiveMap) => {
-    return safeDumpYaml(data, { noRefs: true })
+    // Convert data to JSON object so that `safeDumpYaml` renders any errors.
+    return safeDumpYaml(JSON.parse(JSON.stringify(data)), { noRefs: true })
   },
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

Before this fix, any errors in command results would not be rendered when `-o yaml` was used (instead, an empty array was rendered).