### PR TITLE
fix(cli): less noisy error rendering for workflows

### DIFF
--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -34,12 +34,12 @@ import { ERROR_LOG_FILENAME, DEFAULT_API_VERSION, DEFAULT_GARDEN_DIR_NAME, LOGS_
 import { generateBasicDebugInfoReport } from "../commands/get/get-debug-info"
 import { AnalyticsHandler } from "../analytics/analytics"
 import { defaultDotIgnoreFiles } from "../util/fs"
-import { renderError } from "../logger/renderers"
 import { BufferedEventStream } from "../enterprise/buffered-event-stream"
 import { makeEnterpriseContext } from "../enterprise/init"
 import { GardenProcess } from "../db/entities/garden-process"
 import { DashboardEventStream } from "../server/dashboard-event-stream"
 import { GardenPlugin } from "../types/plugin/plugin"
+import { formatGardenError } from "../logger/util"
 
 export async function makeDummyGarden(root: string, gardenOpts: GardenOpts = {}) {
   const environments = gardenOpts.environmentName
@@ -466,13 +466,9 @@ ${renderCommands(commands)}
 
     if (gardenErrors.length > 0) {
       for (const error of gardenErrors) {
-        const entry = logger.error({
-          msg: error.message,
-          error,
-        })
         // Output error details to console when log level is silly
         logger.silly({
-          msg: renderError(entry),
+          msg: formatGardenError(error),
         })
       }
 

--- a/core/src/commands/base.ts
+++ b/core/src/commands/base.ts
@@ -11,7 +11,7 @@ import chalk from "chalk"
 import dedent = require("dedent")
 import inquirer = require("inquirer")
 import stripAnsi from "strip-ansi"
-import { fromPairs } from "lodash"
+import { fromPairs, pickBy, size } from "lodash"
 
 import { joi, joiIdentifierMap, joiStringMap } from "../config/common"
 import { InternalError, RuntimeError, GardenBaseError } from "../exceptions"
@@ -431,12 +431,11 @@ export async function handleProcessResults(
     graphResults,
   }
 
-  const failed = Object.values(results.taskResults).filter((r) => r && r.error).length
+  const failed = pickBy(results.taskResults, (r) => r && r.error)
+  const failedCount = size(failed)
 
-  if (failed) {
-    const error = new RuntimeError(`${failed} ${taskType} task(s) failed!`, {
-      results,
-    })
+  if (failedCount > 0) {
+    const error = new RuntimeError(`${failedCount} ${taskType} task(s) failed!`, { results: failed })
     return { result, errors: [error], restartRequired: false }
   }
 

--- a/core/src/task-graph.ts
+++ b/core/src/task-graph.ts
@@ -608,9 +608,7 @@ export class TaskGraph extends EventEmitter2 {
   private logError(err: Error, errMessagePrefix: string) {
     const error = toGardenError(err)
     const errorMessage = error.message.trim()
-
     const msg = renderMessageWithDivider(errMessagePrefix, errorMessage, true)
-
     const entry = this.log.error({ msg, error })
     this.log.silly({ msg: renderError(entry) })
   }

--- a/core/test/unit/src/logger/renderers.ts
+++ b/core/test/unit/src/logger/renderers.ts
@@ -86,7 +86,9 @@ describe("renderers", () => {
       const entry = logger.info({ msg: "foo", error })
       expect(renderError(entry)).to.equal(dedent`
           hello error
+
           Error Details:
+
           foo: bar\n
         `)
     })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

Previously, we were logging the details of failed tasks (along with their successfully executed dependencies, if any) when a workflow failed.

We've now simplified this to only render the error messages by default, and rendering the details of the failed tasks only (without dependencies) for log levels `debug` and higher.

The output logged to `error.log` has been streamlined in the same way, omitting details of successful dependencies of failed tasks.