### PR TITLE
fix(cli): fix regression in error logging

### DIFF
--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -39,7 +39,7 @@ import { makeEnterpriseContext } from "../enterprise/init"
 import { GardenProcess } from "../db/entities/garden-process"
 import { DashboardEventStream } from "../server/dashboard-event-stream"
 import { GardenPlugin } from "../types/plugin/plugin"
-import { formatGardenError } from "../logger/util"
+import { renderError } from "../logger/renderers"
 
 export async function makeDummyGarden(root: string, gardenOpts: GardenOpts = {}) {
   const environments = gardenOpts.environmentName
@@ -466,9 +466,13 @@ ${renderCommands(commands)}
 
     if (gardenErrors.length > 0) {
       for (const error of gardenErrors) {
+        const entry = logger.error({
+          msg: error.message,
+          error,
+        })
         // Output error details to console when log level is silly
         logger.silly({
-          msg: formatGardenError(error),
+          msg: renderError(entry),
         })
       }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

This fixes a regression introduced in #2109. Non-task errors weren't being logged at the end of command runs.

We've now reinstated the logging of any errors at the end of commands.