### PR TITLE
feat(workflows): implemented when modifier

### DIFF
--- a/core/src/commands/run/workflow.ts
+++ b/core/src/commands/run/workflow.ts
@@ -107,6 +107,7 @@ export class RunWorkflowCommand extends Command<Args, {}> {
           outputs: {},
           log: "",
         }
+        garden.events.emit("workflowStepSkipped", { index })
         continue
       }
 

--- a/core/src/config/workflow.ts
+++ b/core/src/config/workflow.ts
@@ -124,7 +124,7 @@ export const workflowFileSchema = () =>
           POSIX-style path to write the file to, relative to the project root (or absolute). If the path contains one
           or more directories, they are created automatically if necessary.
           If any of those directories conflict with existing file paths, or if the file path conflicts with an existing directory path, an error will be thrown.
-          **Any existing file with the same path will be overwritten, so be careful not to accidentally accidentally overwrite files unrelated to your workflow.**
+          **Any existing file with the same path will be overwritten, so be careful not to accidentally overwrite files unrelated to your workflow.**
           `
         )
         .example(".auth/kubeconfig.yaml"),
@@ -144,6 +144,7 @@ export interface WorkflowStepSpec {
   description?: string
   script?: string
   skip?: boolean
+  when?: workflowStepModifier
 }
 
 export const workflowStepSchema = () => {
@@ -198,10 +199,27 @@ export const workflowStepSchema = () => {
           `Set to true to skip this step. Use this with template conditionals to skip steps for certain environments or scenarios.`
         )
         .example("${environment.name != 'prod'}"),
+      when: joi.string().allow("onSuccess", "onError", "always", "never").default("onSuccess").description(dedent`
+        If used, this step will be run under the following conditions (may use template strings):
+
+        \`onSuccess\` (default): This step will be run if all preceding steps succeeded or were skipped.
+
+        \`onError\`: This step will be run if a preceding step failed, or if its preceding step has \`when: onError\`.
+        If the next step has \`when: onError\`, it will also be run. Otherwise, all subsequent steps are ignored.
+
+        \`always\`: This step will always be run, regardless of whether any preceding steps have failed.
+
+        \`never\`: This step will always be ignored.
+
+        See the [workflows guide](https://docs.garden.io/using-garden/workflows#the-skip-and-when-options) for details
+        and examples.
+        `),
     })
     .xor("command", "script")
     .description("A workflow step. Must specify either `command` or `script` (but not both).")
 }
+
+export type workflowStepModifier = "onSuccess" | "onError" | "always" | "never"
 
 export const triggerEvents = [
   "create",

--- a/core/src/enterprise/workflow-lifecycle.ts
+++ b/core/src/enterprise/workflow-lifecycle.ts
@@ -10,7 +10,7 @@ import { got, GotResponse } from "../util/http"
 import { makeAuthHeader } from "./auth"
 import { WorkflowConfig, makeRunConfig } from "../config/workflow"
 import { LogEntry } from "../logger/log-entry"
-import { PlatformError } from "../exceptions"
+import { EnterpriseApiError } from "../exceptions"
 import { GardenEnterpriseContext } from "./init"
 import { gardenEnv } from "../constants"
 
@@ -54,7 +54,7 @@ export async function registerWorkflowRun({
   if (res && res["workflowRunUid"] && res["status"] === "success") {
     return res["workflowRunUid"]
   } else {
-    throw new PlatformError(`Error while registering workflow run: Request failed with status ${res["status"]}`, {
+    throw new EnterpriseApiError(`Error while registering workflow run: Request failed with status ${res["status"]}`, {
       status: res["status"],
       workflowRunUid: res["workflowRunUid"],
     })

--- a/core/src/events.ts
+++ b/core/src/events.ts
@@ -163,6 +163,9 @@ export interface Events extends LoggerEvents {
   workflowStepProcessing: {
     index: number
   }
+  workflowStepSkipped: {
+    index: number
+  }
   workflowStepComplete: {
     index: number
     durationMsec: number
@@ -202,6 +205,7 @@ export const eventNames: EventName[] = [
   "workflowRunning",
   "workflowComplete",
   "workflowStepProcessing",
+  "workflowStepSkipped",
   "workflowStepError",
   "workflowStepComplete",
 ]

--- a/core/src/exceptions.ts
+++ b/core/src/exceptions.ts
@@ -97,6 +97,10 @@ export class NotFoundError extends GardenBaseError {
   type = "not-found"
 }
 
-export class PlatformError extends GardenBaseError {
-  type = "platform"
+export class WorkflowScriptError extends GardenBaseError {
+  type = "workflow-script"
+}
+
+export class EnterpriseApiError extends GardenBaseError {
+  type = "enterprise-api"
 }

--- a/core/test/unit/src/commands/run/workflow.ts
+++ b/core/test/unit/src/commands/run/workflow.ts
@@ -122,7 +122,7 @@ describe("RunWorkflowCommand", () => {
         name: "workflow-a",
         kind: "Workflow",
         path: garden.projectRoot,
-        steps: [{ command: ["deploy"] }, { command: ["test"] }],
+        steps: [{ command: ["deploy"] }, { command: ["build"], skip: true }, { command: ["test"] }],
       },
     ])
 
@@ -137,13 +137,15 @@ describe("RunWorkflowCommand", () => {
     expect(we[2].payload.index).to.eql(0)
     expect(we[2].payload.durationMsec).to.gte(0)
 
-    expect(we[3]).to.eql({ name: "workflowStepProcessing", payload: { index: 1 } })
+    expect(we[3]).to.eql({ name: "workflowStepSkipped", payload: { index: 1 } })
 
-    expect(we[4].name).to.eql("workflowStepComplete")
-    expect(we[4].payload.index).to.eql(1)
-    expect(we[4].payload.durationMsec).to.gte(0)
+    expect(we[4]).to.eql({ name: "workflowStepProcessing", payload: { index: 2 } })
 
-    expect(we[5]).to.eql({ name: "workflowComplete", payload: {} })
+    expect(we[5].name).to.eql("workflowStepComplete")
+    expect(we[5].payload.index).to.eql(2)
+    expect(we[5].payload.durationMsec).to.gte(0)
+
+    expect(we[6]).to.eql({ name: "workflowComplete", payload: {} })
   })
 
   function filterLogEntries(entries: LogEntry[], msgRegex: RegExp): LogEntry[] {
@@ -663,6 +665,7 @@ function getWorkflowEvents(garden: TestGarden) {
     "workflowRunning",
     "workflowComplete",
     "workflowStepProcessing",
+    "workflowStepSkipped",
     "workflowStepError",
     "workflowStepComplete",
   ]

--- a/core/test/unit/src/commands/run/workflow.ts
+++ b/core/test/unit/src/commands/run/workflow.ts
@@ -11,7 +11,7 @@ import tmp from "tmp-promise"
 import { expect } from "chai"
 import { TestGarden, makeTestGardenA, withDefaultGlobalOpts, expectError } from "../../../../helpers"
 import { DEFAULT_API_VERSION } from "../../../../../src/constants"
-import { RunWorkflowCommand } from "../../../../../src/commands/run/workflow"
+import { RunWorkflowCommand, shouldBeDropped } from "../../../../../src/commands/run/workflow"
 import { createGardenPlugin } from "../../../../../src/types/plugin/plugin"
 import { joi } from "../../../../../src/config/common"
 import { RunTaskParams } from "../../../../../src/types/plugin/task/runTask"
@@ -22,6 +22,7 @@ import { defaultDotIgnoreFiles } from "../../../../../src/util/fs"
 import { dedent } from "../../../../../src/util/string"
 import stripAnsi from "strip-ansi"
 import { LogEntry } from "../../../../../src/logger/log-entry"
+import { WorkflowStepSpec } from "../../../../../src/config/workflow"
 
 describe("RunWorkflowCommand", () => {
   const cmd = new RunWorkflowCommand()
@@ -160,11 +161,7 @@ describe("RunWorkflowCommand", () => {
         kind: "Workflow",
         path: garden.projectRoot,
         files: [],
-        steps: [
-          {
-            command: ["run", "task", "task-a"],
-          },
-        ],
+        steps: [{ command: ["run", "task", "task-a"] }],
       },
     ])
 
@@ -226,7 +223,7 @@ describe("RunWorkflowCommand", () => {
               return result
             },
             testModule: async ({}) => {
-              testModuleLog.push("tests have been run") // <--------
+              testModuleLog.push("tests have been run")
               const now = new Date()
               return {
                 moduleName: "",
@@ -496,6 +493,84 @@ describe("RunWorkflowCommand", () => {
     expect(result?.steps["step-2"].log).to.equal("")
   })
 
+  describe("shouldBeDropped", () => {
+    context("step has no when modifier", () => {
+      it("should include the step if no error has been thrown by previous steps", () => {
+        const steps: WorkflowStepSpec[] = [
+          { command: ["deploy"] },
+          { command: ["test"], when: "onError" },
+          { command: ["build"] }, // <-- checking this step
+        ]
+        expect(shouldBeDropped(2, steps, {})).to.be.false
+      })
+
+      it("should drop the step when errors have been thrown by previous steps", () => {
+        const steps: WorkflowStepSpec[] = [
+          { command: ["deploy"] }, // <-- error thrown here
+          { command: ["test"], when: "onError" },
+          { command: ["build"] }, // <-- checking this step
+        ]
+        expect(shouldBeDropped(2, steps, { 0: [new Error()] })).to.be.true
+      })
+    })
+
+    context("step has when = always", () => {
+      it("should include the step even when errors have been thrown by previous steps", () => {
+        const steps: WorkflowStepSpec[] = [
+          { command: ["deploy"] }, // <-- error thrown here
+          { command: ["test"] },
+          { command: ["build"], when: "always" }, // <-- checking this step
+        ]
+        expect(shouldBeDropped(2, steps, { 0: [new Error()] })).to.be.false
+      })
+    })
+
+    context("step has when = never", () => {
+      it("should drop the step even if no error has been thrown by previous steps", () => {
+        const steps: WorkflowStepSpec[] = [
+          { command: ["deploy"] },
+          { command: ["test"] },
+          { command: ["build"], when: "never" },
+        ]
+        expect(shouldBeDropped(2, steps, {})).to.be.true
+      })
+    })
+
+    context("step has when = onError", () => {
+      it("should be dropped if no previous steps have failed", () => {
+        const steps: WorkflowStepSpec[] = [
+          { command: ["deploy"] },
+          { command: ["test"] },
+          { command: ["build"], when: "onError" },
+        ]
+        expect(shouldBeDropped(2, steps, {})).to.be.true
+      })
+
+      it("should be included if a step in the current sequence failed", () => {
+        const steps: WorkflowStepSpec[] = [
+          { command: ["deploy"] }, // <-- error thrown here
+          { command: ["test"] },
+          { command: ["build"], when: "onError" }, // <-- checking this step
+          { command: ["test"], when: "onError" }, // <-- checking this step
+        ]
+        expect(shouldBeDropped(2, steps, { 0: [new Error()] })).to.be.false
+        expect(shouldBeDropped(3, steps, { 0: [new Error()] })).to.be.false
+      })
+
+      it("should be dropped if a step in a preceding sequence failed", () => {
+        const steps: WorkflowStepSpec[] = [
+          { command: ["deploy"] }, // <-- error thrown here
+          { command: ["test"] },
+          { command: ["build"], when: "onError" },
+          { command: ["test"], when: "onError" },
+          { command: ["test"] },
+          { command: ["test"], when: "onError" }, // <-- checking this step
+        ]
+        expect(shouldBeDropped(5, steps, { 0: [new Error()] })).to.be.true
+      })
+    })
+  })
+
   it("should collect log outputs, including stderr, from a script step", async () => {
     garden.setWorkflowConfigs([
       {
@@ -548,14 +623,7 @@ describe("RunWorkflowCommand", () => {
         kind: "Workflow",
         path: garden.projectRoot,
         files: [],
-        steps: [
-          {
-            command: ["get", "config"],
-          },
-          {
-            command: ["run", "task", "task-a"],
-          },
-        ],
+        steps: [{ command: ["get", "config"] }, { command: ["run", "task", "task-a"] }],
       },
     ])
 
@@ -581,12 +649,7 @@ describe("RunWorkflowCommand", () => {
         kind: "Workflow",
         path: garden.projectRoot,
         files: [],
-        steps: [
-          {
-            name: "test",
-            command: ["run", "task", "task-a"],
-          },
-        ],
+        steps: [{ name: "test", command: ["run", "task", "task-a"] }],
       },
     ])
 
@@ -609,14 +672,7 @@ describe("RunWorkflowCommand", () => {
         kind: "Workflow",
         path: garden.projectRoot,
         files: [],
-        steps: [
-          {
-            command: ["get", "outputs"],
-          },
-          {
-            command: ["run", "task", "${steps.step-1.outputs.taskName}"],
-          },
-        ],
+        steps: [{ command: ["get", "outputs"] }, { command: ["run", "task", "${steps.step-1.outputs.taskName}"] }],
       },
     ])
 
@@ -638,14 +694,7 @@ describe("RunWorkflowCommand", () => {
         kind: "Workflow",
         path: garden.projectRoot,
         files: [],
-        steps: [
-          {
-            command: ["get", "outputs"],
-          },
-          {
-            script: "echo ${steps.step-1.outputs.taskName}",
-          },
-        ],
+        steps: [{ command: ["get", "outputs"] }, { script: "echo ${steps.step-1.outputs.taskName}" }],
       },
     ])
 

--- a/core/test/unit/src/config/workflow.ts
+++ b/core/test/unit/src/config/workflow.ts
@@ -42,8 +42,8 @@ describe("resolveWorkflowConfig", () => {
       path: "/tmp/foo",
       description: "Sample workflow",
       steps: [
-        { description: "Deploy the stack", command: ["deploy"], skip: false },
-        { command: ["test"], skip: false },
+        { description: "Deploy the stack", command: ["deploy"], skip: false, when: "onSuccess" },
+        { command: ["test"], skip: false, when: "onSuccess" },
       ],
       triggers: [
         {
@@ -72,8 +72,8 @@ describe("resolveWorkflowConfig", () => {
       path: "/tmp/foo",
       description: "Secret: ${secrets.foo}, var: ${variables.foo}",
       steps: [
-        { description: "Deploy the stack", command: ["deploy"], skip: false },
-        { command: ["test"], skip: false },
+        { description: "Deploy the stack", command: ["deploy"], skip: false, when: "onSuccess" },
+        { command: ["test"], skip: false, when: "onSuccess" },
       ],
     }
 
@@ -97,8 +97,8 @@ describe("resolveWorkflowConfig", () => {
       ...config,
       ...defaults,
       steps: [
-        { description: "Deploy the stack", command: ["deploy"], skip: false },
-        { command: ["test"], skip: false },
+        { description: "Deploy the stack", command: ["deploy"], skip: false, when: "onSuccess" },
+        { command: ["test"], skip: false, when: "onSuccess" },
       ],
     })
   })

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1161,8 +1161,8 @@ workflowConfigs:
         # or more directories, they are created automatically if necessary.
         # If any of those directories conflict with existing file paths, or if the file path conflicts with an
         # existing directory path, an error will be thrown.
-        # **Any existing file with the same path will be overwritten, so be careful not to accidentally accidentally
-        # overwrite files unrelated to your workflow.**
+        # **Any existing file with the same path will be overwritten, so be careful not to accidentally overwrite
+        # files unrelated to your workflow.**
         path:
 
         # The file data as a string.
@@ -1235,6 +1235,22 @@ workflowConfigs:
         # Set to true to skip this step. Use this with template conditionals to skip steps for certain environments or
         # scenarios.
         skip:
+
+        # If used, this step will be run under the following conditions (may use template strings):
+        #
+        # `onSuccess` (default): This step will be run if all preceding steps succeeded or were skipped.
+        #
+        # `onError`: This step will be run if a preceding step failed, or if its preceding step has `when: onError`.
+        # If the next step has `when: onError`, it will also be run. Otherwise, all subsequent steps are ignored.
+        #
+        # `always`: This step will always be run, regardless of whether any preceding steps have failed.
+        #
+        # `never`: This step will always be ignored.
+        #
+        # See the [workflows guide](https://docs.garden.io/using-garden/workflows#the-skip-and-when-options) for
+        # details
+        # and examples.
+        when:
 
     # A list of triggers that determine when the workflow should be run, and which environment should be used (Garden
     # Enterprise only).

--- a/docs/reference/workflow-config.md
+++ b/docs/reference/workflow-config.md
@@ -40,8 +40,8 @@ files:
     # or more directories, they are created automatically if necessary.
     # If any of those directories conflict with existing file paths, or if the file path conflicts with an existing
     # directory path, an error will be thrown.
-    # **Any existing file with the same path will be overwritten, so be careful not to accidentally accidentally
-    # overwrite files unrelated to your workflow.**
+    # **Any existing file with the same path will be overwritten, so be careful not to accidentally overwrite files
+    # unrelated to your workflow.**
     path:
 
     # The file data as a string.
@@ -113,6 +113,21 @@ steps:
     # Set to true to skip this step. Use this with template conditionals to skip steps for certain environments or
     # scenarios.
     skip: false
+
+    # If used, this step will be run under the following conditions (may use template strings):
+    #
+    # `onSuccess` (default): This step will be run if all preceding steps succeeded or were skipped.
+    #
+    # `onError`: This step will be run if a preceding step failed, or if its preceding step has `when: onError`.
+    # If the next step has `when: onError`, it will also be run. Otherwise, all subsequent steps are ignored.
+    #
+    # `always`: This step will always be run, regardless of whether any preceding steps have failed.
+    #
+    # `never`: This step will always be ignored.
+    #
+    # See the [workflows guide](https://docs.garden.io/using-garden/workflows#the-skip-and-when-options) for details
+    # and examples.
+    when: onSuccess
 
 # A list of triggers that determine when the workflow should be run, and which environment should be used (Garden
 # Enterprise only).
@@ -207,7 +222,7 @@ Note that you cannot reference provider configuration in template strings within
 POSIX-style path to write the file to, relative to the project root (or absolute). If the path contains one
 or more directories, they are created automatically if necessary.
 If any of those directories conflict with existing file paths, or if the file path conflicts with an existing directory path, an error will be thrown.
-**Any existing file with the same path will be overwritten, so be careful not to accidentally accidentally overwrite files unrelated to your workflow.**
+**Any existing file with the same path will be overwritten, so be careful not to accidentally overwrite files unrelated to your workflow.**
 
 | Type        | Required |
 | ----------- | -------- |
@@ -383,6 +398,28 @@ Example:
 steps:
   - skip: "${environment.name != 'prod'}"
 ```
+
+### `steps[].when`
+
+[steps](#steps) > when
+
+If used, this step will be run under the following conditions (may use template strings):
+
+`onSuccess` (default): This step will be run if all preceding steps succeeded or were skipped.
+
+`onError`: This step will be run if a preceding step failed, or if its preceding step has `when: onError`.
+If the next step has `when: onError`, it will also be run. Otherwise, all subsequent steps are ignored.
+
+`always`: This step will always be run, regardless of whether any preceding steps have failed.
+
+`never`: This step will always be ignored.
+
+See the [workflows guide](https://docs.garden.io/using-garden/workflows#the-skip-and-when-options) for details
+and examples.
+
+| Type     | Default       | Required |
+| -------- | ------------- | -------- |
+| `string` | `"onSuccess"` | No       |
 
 ### `triggers[]`
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

Workflow steps can now use the `when: always | never | onError` modifier.

Steps with `when: always` can be used e.g. for running scripts or commands at the end of the workflow, regardless of whether the workflow failed.

Steps with `when: onError` can facilitate custom error handling and cleanup after failed steps or sequences of steps.

See the updated workflows guide (under Using Garden) for more details.