### PR TITLE
fix(kubernetes-module): fix regression

### DIFF
--- a/core/src/plugins/kubernetes/kubernetes-module/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/handlers.ts
@@ -286,8 +286,7 @@ async function prepareManifestsForHotReload({
     }
   }
 
-  const hotReloadSpec = getHotReloadSpec(service)
-
+  const hotReloadSpec = hotReload ? getHotReloadSpec(service) : null
   if (hotReload && hotReloadSpec) {
     const resourceSpec = getServiceResourceSpec(module, undefined)
     configureHotReload({

--- a/core/test/data/test-projects/kubernetes-module/module-simple/garden.yml
+++ b/core/test/data/test-projects/kubernetes-module/module-simple/garden.yml
@@ -22,6 +22,7 @@ manifests:
           containers:
             - name: busybox
               image: busybox:1.31.1
+              args: [sleep, "100"]
               ports:
                 - containerPort: 80
 serviceResource:

--- a/core/test/data/test-projects/kubernetes-module/with-namespace/garden.yml
+++ b/core/test/data/test-projects/kubernetes-module/with-namespace/garden.yml
@@ -23,6 +23,7 @@ manifests:
           containers:
             - name: busybox
               image: busybox:1.31.1
+              args: [sleep, "100"]
               ports:
                 - containerPort: 80
               env:

--- a/core/test/integ/src/plugins/kubernetes/kubernetes-module/config.ts
+++ b/core/test/integ/src/plugins/kubernetes/kubernetes-module/config.ts
@@ -128,6 +128,7 @@ describe("validateKubernetesModule", () => {
                         {
                           image: "busybox:1.31.1",
                           name: "busybox",
+                          args: ["sleep", "100"],
                           ports: [
                             {
                               containerPort: 80,
@@ -180,6 +181,7 @@ describe("validateKubernetesModule", () => {
                     {
                       image: "busybox:1.31.1",
                       name: "busybox",
+                      args: ["sleep", "100"],
                       ports: [
                         {
                           containerPort: 80,

--- a/core/test/integ/src/plugins/kubernetes/kubernetes-module/handlers.ts
+++ b/core/test/integ/src/plugins/kubernetes/kubernetes-module/handlers.ts
@@ -114,6 +114,21 @@ describe("kubernetes-module handlers", () => {
   })
 
   describe("deployKubernetesService", () => {
+    it("should successfully deploy when serviceResource doesn't have a containerModule", async () => {
+      const graph = await garden.getConfigGraph(garden.log)
+      const service = graph.getService("module-simple")
+      const deployParams = {
+        ctx,
+        log: garden.log,
+        module: service.module,
+        service,
+        force: false,
+        hotReload: false,
+        runtimeContext: emptyRuntimeContext,
+      }
+      await deployKubernetesService(deployParams)
+    })
+
     it("should toggle hot reload", async () => {
       const graph = await garden.getConfigGraph(garden.log)
       const service = graph.getService("with-source-module")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

This fixes a regression introduced when we added hot reloading support for the `kubernetes-module` module type.

Also added an integ test case to guard against this regression in the future.