### PR TITLE
chore(stalebot): don't mark bugs as stale + increase days until stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 60
+daysUntilStale: 90
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
@@ -15,6 +15,7 @@ exemptLabels:
   - pinned
   - literature
   - discussion
+  - bug
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false
@@ -31,7 +32,7 @@ staleLabel: stale
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it hasn't had any
-  activity in 60 days. It will be closed in 14 days if no further activity occurs
+  activity in 90 days. It will be closed in 14 days if no further activity occurs
   (e.g. changing labels, comments, commits, etc.). Please feel free to
   tag a maintainer and ask them to remove the label if you think it doesn't apply.
   Thank you for submitting this issue and helping make Garden a better product!


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

Configure Stalebot to not close issues with a `bug` label. Instead we can label bugs as `wontfix` and close them manually if needed (e.g. because a reproducible is needed or there's negative cost-benefit balance to fixing the it).

Also increases the `daysUntilStale` value from 60 to 90 days. The former felt a little too short, in particular for feature requests that we might want to look into but can't in the span of two months.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

Does 90 days until stale make sense?