### PR TITLE
fix(enterprise): don't resolve config on login

### DIFF
--- a/core/src/commands/login.ts
+++ b/core/src/commands/login.ts
@@ -10,12 +10,19 @@ import { Command, CommandParams, CommandResult } from "./base"
 import { printHeader } from "../logger/util"
 import dedent = require("dedent")
 import { login } from "../enterprise/auth"
-import { ConfigurationError } from "../exceptions"
+import { CommandError, ConfigurationError } from "../exceptions"
+import { findProjectConfig } from "../config/base"
 
 export class LoginCommand extends Command {
   name = "login"
   help = "Log in to Garden Enterprise."
   hidden = true
+
+  /**
+   * Since we're logging in, we don't want to resolve e.g. the project config (since it may use secrets, which are
+   * only available after we've logged in).
+   */
+  noProject = true
 
   description = dedent`
     Logs you in to Garden Enterprise. Subsequent commands will have access to enterprise features.
@@ -23,7 +30,16 @@ export class LoginCommand extends Command {
 
   async action({ garden, log, headerLog }: CommandParams): Promise<CommandResult> {
     printHeader(headerLog, "Login", "cloud")
-    const enterpriseDomain = garden.enterpriseDomain
+    // Since this command has `noProject = true`, `garden` only has a placeholder project config.
+    // So we find and load it here, without resolving any template strings.
+    const currentDirectory = garden.projectRoot
+    const projectConfig = await findProjectConfig(garden.projectRoot)
+    if (!projectConfig) {
+      throw new CommandError(`Not a project directory (or any of the parent directories): ${currentDirectory}`, {
+        currentDirectory,
+      })
+    }
+    const enterpriseDomain = projectConfig.domain
     if (!enterpriseDomain) {
       throw new ConfigurationError(`Error: Your project configuration does not specify a domain.`, {})
     }

--- a/core/test/data/test-projects/login/has-domain-and-id/garden.yml
+++ b/core/test/data/test-projects/login/has-domain-and-id/garden.yml
@@ -1,0 +1,6 @@
+kind: Project
+name: login
+domain: http://dummy-domain.com
+id: dummy-id
+environments:
+  - test

--- a/core/test/data/test-projects/login/has-domain/garden.yml
+++ b/core/test/data/test-projects/login/has-domain/garden.yml
@@ -1,0 +1,5 @@
+kind: Project
+name: login
+domain: http://dummy-domain.com
+environments:
+  - test

--- a/core/test/data/test-projects/login/missing-domain/garden.yml
+++ b/core/test/data/test-projects/login/missing-domain/garden.yml
@@ -1,0 +1,4 @@
+kind: Project
+name: login
+environments:
+  - test

--- a/core/test/data/test-projects/login/secret-in-project-variables/garden.yml
+++ b/core/test/data/test-projects/login/secret-in-project-variables/garden.yml
@@ -1,0 +1,8 @@
+kind: Project
+name: login
+domain: http://dummy-domain.com
+id: dummy-id
+environments:
+  - test
+variables:
+  foo: ${secrets.foo}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

Fixes an issue where using secrets outside of providers in project configuration would break the login command.