### PR TITLE
fix(core): ensure primitive values are not cast on schema validation

### DIFF
--- a/core/src/config/common.ts
+++ b/core/src/config/common.ts
@@ -357,7 +357,7 @@ joi = joi.extend({
 export const joiPrimitive = () =>
   joi
     .alternatives()
-    .try(joi.number(), joi.string().allow("").allow(null), joi.boolean())
+    .try(joi.string().allow("").allow(null), joi.number(), joi.boolean())
     .description("Number, string or boolean")
 
 export const absolutePathRegex = /^\/.*/ // Note: Only checks for the leading slash

--- a/core/test/unit/src/config/common.ts
+++ b/core/test/unit/src/config/common.ts
@@ -8,7 +8,14 @@
 
 import { expect } from "chai"
 const stripAnsi = require("strip-ansi")
-import { identifierRegex, envVarRegex, userIdentifierRegex, joi, joiRepositoryUrl } from "../../../../src/config/common"
+import {
+  identifierRegex,
+  envVarRegex,
+  userIdentifierRegex,
+  joi,
+  joiRepositoryUrl,
+  joiPrimitive,
+} from "../../../../src/config/common"
 import { validateSchema } from "../../../../src/config/validation"
 import { expectError } from "../../../helpers"
 
@@ -374,6 +381,26 @@ describe("joiRepositoryUrl", () => {
     const schema = joiRepositoryUrl()
     const result = schema.validate(url)
     expect(result.error).to.exist
+  })
+})
+
+describe("joiPrimitive", () => {
+  it("should validate primitives without casting values", () => {
+    const schema = joiPrimitive()
+    const resStrNum = schema.validate("12345")
+    const resStrBool = schema.validate("true")
+    const resNum = schema.validate(12345)
+    const resBool = schema.validate(true)
+    const resArr = schema.validate([1, 2, 3, 4, 5])
+    const resObj = schema.validate({ hello: "world" })
+    const resFun = schema.validate(() => {})
+    expect(resStrNum.value).to.equal("12345")
+    expect(resStrBool.value).to.equal("true")
+    expect(resNum.value).to.equal(12345)
+    expect(resBool.value).to.equal(true)
+    expect(resArr.error).to.exist
+    expect(resObj.error).to.exist
+    expect(resFun.error).to.exist
   })
 })
 

--- a/docs/reference/module-types/terraform.md
+++ b/docs/reference/module-types/terraform.md
@@ -522,5 +522,5 @@ A map of all the outputs defined in the Terraform stack.
 
 | Type                                             |
 | ------------------------------------------------ |
-| `number | string | boolean | link | array[link]` |
+| `string | number | boolean | link | array[link]` |
 

--- a/docs/reference/project-config.md
+++ b/docs/reference/project-config.md
@@ -574,7 +574,7 @@ string.
 
 | Type                        | Required |
 | --------------------------- | -------- |
-| `number | string | boolean` | Yes      |
+| `string | number | boolean` | Yes      |
 
 Example:
 

--- a/docs/reference/template-strings.md
+++ b/docs/reference/template-strings.md
@@ -208,7 +208,7 @@ A map of all variables defined in the project configuration.
 
 | Type                                             |
 | ------------------------------------------------ |
-| `number | string | boolean | link | array[link]` |
+| `string | number | boolean | link | array[link]` |
 
 ### `${var.*}`
 
@@ -224,7 +224,7 @@ Number, string or boolean
 
 | Type                        |
 | --------------------------- |
-| `number | string | boolean` |
+| `string | number | boolean` |
 
 
 ## Provider configuration context
@@ -334,7 +334,7 @@ A map of all variables defined in the project configuration, including environme
 
 | Type                                             |
 | ------------------------------------------------ |
-| `number | string | boolean | link | array[link]` |
+| `string | number | boolean | link | array[link]` |
 
 ### `${var.*}`
 
@@ -350,7 +350,7 @@ Number, string or boolean
 
 | Type                        |
 | --------------------------- |
-| `number | string | boolean` |
+| `string | number | boolean` |
 
 ### `${environment.*}`
 
@@ -424,7 +424,7 @@ The provider config key value. Refer to individual [provider references](https:/
 
 | Type                        |
 | --------------------------- |
-| `number | string | boolean` |
+| `string | number | boolean` |
 
 ### `${providers.<provider-name>.outputs.*}`
 
@@ -440,7 +440,7 @@ The provider output value. Refer to individual [provider references](https://doc
 
 | Type                        |
 | --------------------------- |
-| `number | string | boolean` |
+| `string | number | boolean` |
 
 
 ## Module configuration context
@@ -553,7 +553,7 @@ A map of all variables defined in the project configuration, including environme
 
 | Type                                             |
 | ------------------------------------------------ |
-| `number | string | boolean | link | array[link]` |
+| `string | number | boolean | link | array[link]` |
 
 ### `${var.*}`
 
@@ -569,7 +569,7 @@ Number, string or boolean
 
 | Type                        |
 | --------------------------- |
-| `number | string | boolean` |
+| `string | number | boolean` |
 
 ### `${environment.*}`
 
@@ -643,7 +643,7 @@ The provider config key value. Refer to individual [provider references](https:/
 
 | Type                        |
 | --------------------------- |
-| `number | string | boolean` |
+| `string | number | boolean` |
 
 ### `${providers.<provider-name>.outputs.*}`
 
@@ -659,7 +659,7 @@ The provider output value. Refer to individual [provider references](https://doc
 
 | Type                        |
 | --------------------------- |
-| `number | string | boolean` |
+| `string | number | boolean` |
 
 ### `${modules.*}`
 
@@ -697,7 +697,7 @@ The module output value. Refer to individual [module type references](https://do
 
 | Type                        |
 | --------------------------- |
-| `number | string | boolean` |
+| `string | number | boolean` |
 
 ### `${modules.<module-name>.path}`
 
@@ -757,7 +757,7 @@ The service output value. Refer to individual [module type references](https://d
 
 | Type                        |
 | --------------------------- |
-| `number | string | boolean` |
+| `string | number | boolean` |
 
 ### `${runtime.tasks.*}`
 
@@ -781,7 +781,7 @@ The task output value. Refer to individual [module type references](https://docs
 
 | Type                        |
 | --------------------------- |
-| `number | string | boolean` |
+| `string | number | boolean` |
 
 ### `${parent.*}`
 
@@ -827,7 +827,7 @@ The inputs provided to the module through a ModuleTemplate, if applicable.
 
 | Type                                             |
 | ------------------------------------------------ |
-| `number | string | boolean | link | array[link]` |
+| `string | number | boolean | link | array[link]` |
 
 
 ## Output configuration context
@@ -940,7 +940,7 @@ A map of all variables defined in the project configuration, including environme
 
 | Type                                             |
 | ------------------------------------------------ |
-| `number | string | boolean | link | array[link]` |
+| `string | number | boolean | link | array[link]` |
 
 ### `${var.*}`
 
@@ -956,7 +956,7 @@ Number, string or boolean
 
 | Type                        |
 | --------------------------- |
-| `number | string | boolean` |
+| `string | number | boolean` |
 
 ### `${environment.*}`
 
@@ -1030,7 +1030,7 @@ The provider config key value. Refer to individual [provider references](https:/
 
 | Type                        |
 | --------------------------- |
-| `number | string | boolean` |
+| `string | number | boolean` |
 
 ### `${providers.<provider-name>.outputs.*}`
 
@@ -1046,7 +1046,7 @@ The provider output value. Refer to individual [provider references](https://doc
 
 | Type                        |
 | --------------------------- |
-| `number | string | boolean` |
+| `string | number | boolean` |
 
 ### `${modules.*}`
 
@@ -1084,7 +1084,7 @@ The module output value. Refer to individual [module type references](https://do
 
 | Type                        |
 | --------------------------- |
-| `number | string | boolean` |
+| `string | number | boolean` |
 
 ### `${modules.<module-name>.path}`
 
@@ -1144,7 +1144,7 @@ The service output value. Refer to individual [module type references](https://d
 
 | Type                        |
 | --------------------------- |
-| `number | string | boolean` |
+| `string | number | boolean` |
 
 ### `${runtime.tasks.*}`
 
@@ -1168,7 +1168,7 @@ The task output value. Refer to individual [module type references](https://docs
 
 | Type                        |
 | --------------------------- |
-| `number | string | boolean` |
+| `string | number | boolean` |
 
 ### `${parent.*}`
 
@@ -1214,7 +1214,7 @@ The inputs provided to the module through a ModuleTemplate, if applicable.
 
 | Type                                             |
 | ------------------------------------------------ |
-| `number | string | boolean | link | array[link]` |
+| `string | number | boolean | link | array[link]` |
 
 
 ## Workflow configuration context
@@ -1324,7 +1324,7 @@ A map of all variables defined in the project configuration, including environme
 
 | Type                                             |
 | ------------------------------------------------ |
-| `number | string | boolean | link | array[link]` |
+| `string | number | boolean | link | array[link]` |
 
 ### `${var.*}`
 
@@ -1340,7 +1340,7 @@ Number, string or boolean
 
 | Type                        |
 | --------------------------- |
-| `number | string | boolean` |
+| `string | number | boolean` |
 
 ### `${environment.*}`
 
@@ -1424,5 +1424,5 @@ for its output schema.
 
 | Type                                             |
 | ------------------------------------------------ |
-| `number | string | boolean | link | array[link]` |
+| `string | number | boolean | link | array[link]` |
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes issue where primitive values would get cast on schema validation. For example, something like `DB_PORT: "8080"` would be resolved as `DB_PORT: 8080`.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
