### PR TITLE
fix(enterprise): whitelist commands for streaming

### DIFF
--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -237,6 +237,7 @@ ${renderCommands(commands)}
     })
 
     contextOpts.persistent = persistent
+    const { streamEvents, streamLogEntries } = command
 
     do {
       try {
@@ -262,7 +263,7 @@ ${renderCommands(commands)}
 
           // Connect the dashboard event streamer (making sure it doesn't stream to the local server)
           const commandServerUrl = command.server?.getUrl() || undefined
-          dashboardEventStream.connect({ garden, ignoreHost: commandServerUrl })
+          dashboardEventStream.connect({ garden, ignoreHost: commandServerUrl, streamEvents, streamLogEntries })
           const runningServers = await dashboardEventStream.updateTargets()
 
           if (persistent && command.server) {
@@ -284,6 +285,8 @@ ${renderCommands(commands)}
           log.silly(`Connecting Garden instance to GE BufferedEventStream`)
           bufferedEventStream.connect({
             garden,
+            streamEvents,
+            streamLogEntries,
             targets: [
               {
                 host: enterpriseContext.enterpriseDomain,
@@ -291,8 +294,6 @@ ${renderCommands(commands)}
               },
             ],
           })
-        } else {
-          log.silly(`Skip connecting Garden instance to GE BufferedEventStream`)
         }
 
         // Register log file writers. We need to do this after the Garden class is initialised because

--- a/core/src/commands/base.ts
+++ b/core/src/commands/base.ts
@@ -78,6 +78,8 @@ export abstract class Command<T extends Parameters = {}, U extends Parameters = 
   noProject: boolean = false
   protected: boolean = false
   workflows: boolean = false // Set to true to whitelist for executing in workflow steps
+  streamEvents: boolean = false // Set to true to whitelist for streaming events
+  streamLogEntries: boolean = false // Set to true to whitelist for streaming log entries
   server: GardenServer | undefined = undefined
 
   constructor(private parent?: CommandGroup) {

--- a/core/src/commands/build.ts
+++ b/core/src/commands/build.ts
@@ -48,6 +48,8 @@ export class BuildCommand extends Command<Args, Opts> {
 
   protected = true
   workflows = true
+  streamEvents = true
+  streamLogEntries = true
 
   description = dedent`
     Builds all or specified modules, taking into account build dependency order.

--- a/core/src/commands/call.ts
+++ b/core/src/commands/call.ts
@@ -46,6 +46,8 @@ export class CallCommand extends Command<Args> {
   name = "call"
   help = "Call a service ingress endpoint."
 
+  streamEvents = true
+
   description = dedent`
     Resolves the deployed ingress endpoint for the given service and path, calls the given endpoint and
     outputs the result.

--- a/core/src/commands/delete.ts
+++ b/core/src/commands/delete.ts
@@ -82,6 +82,7 @@ export class DeleteEnvironmentCommand extends Command {
 
   protected = true
   workflows = true
+  streamEvents = true
 
   description = dedent`
     This will delete all services in the specified environment, and trigger providers to clear up any other resources
@@ -132,6 +133,7 @@ export class DeleteServiceCommand extends Command {
 
   protected = true
   workflows = true
+  streamEvents = true
 
   description = dedent`
     Deletes (i.e. un-deploys) the specified services. Note that this command does not take into account any

--- a/core/src/commands/deploy.ts
+++ b/core/src/commands/deploy.ts
@@ -64,6 +64,8 @@ export class DeployCommand extends Command<Args, Opts> {
 
   protected = true
   workflows = true
+  streamEvents = true
+  streamLogEntries = true
 
   description = dedent`
     Deploys all or specified services, taking into account service dependency order.

--- a/core/src/commands/dev.ts
+++ b/core/src/commands/dev.ts
@@ -66,6 +66,9 @@ export class DevCommand extends Command<DevCommandArgs, DevCommandOpts> {
   // Currently it doesn't make sense to do file watching except in the CLI
   cliOnly = true
 
+  streamEvents = true
+  streamLogEntries = true
+
   description = dedent`
     The Garden dev console is a combination of the \`build\`, \`deploy\` and \`test\` commands.
     It builds, deploys and tests all your modules and services, and re-builds, re-deploys and re-tests

--- a/core/src/commands/get/get-status.ts
+++ b/core/src/commands/get/get-status.ts
@@ -50,6 +50,7 @@ export class GetStatusCommand extends Command {
   help = "Outputs the full status of your environment."
 
   workflows = true
+  streamEvents = true
 
   outputsSchema = () =>
     joi.object().keys({

--- a/core/src/commands/get/get-task-result.ts
+++ b/core/src/commands/get/get-task-result.ts
@@ -37,6 +37,7 @@ export class GetTaskResultCommand extends Command<Args> {
   help = "Outputs the latest execution result of a provided task."
 
   workflows = true
+  streamEvents = true
 
   arguments = getTaskResultArgs
 

--- a/core/src/commands/get/get-test-result.ts
+++ b/core/src/commands/get/get-test-result.ts
@@ -41,6 +41,7 @@ export class GetTestResultCommand extends Command<Args> {
   help = "Outputs the latest execution result of a provided test."
 
   workflows = true
+  streamEvents = true
 
   arguments = getTestResultArgs
 

--- a/core/src/commands/publish.ts
+++ b/core/src/commands/publish.ts
@@ -58,6 +58,8 @@ export class PublishCommand extends Command<Args, Opts> {
   help = "Build and publish module(s) to a remote registry."
 
   workflows = true
+  streamEvents = true
+  streamLogEntries = true
 
   description = dedent`
     Publishes built module artifacts for all or specified modules.

--- a/core/src/commands/run/task.ts
+++ b/core/src/commands/run/task.ts
@@ -56,6 +56,8 @@ export class RunTaskCommand extends Command<Args, Opts> {
   help = "Run a task (in the context of its parent module)."
 
   workflows = true
+  streamEvents = true
+  streamLogEntries = true
 
   description = dedent`
     This is useful for re-running tasks ad-hoc, for example after writing/modifying database migrations.

--- a/core/src/commands/run/test.ts
+++ b/core/src/commands/run/test.ts
@@ -72,6 +72,8 @@ export class RunTestCommand extends Command<Args, Opts> {
   help = "Run the specified module test."
 
   workflows = true
+  streamEvents = true
+  streamLogEntries = true
 
   description = dedent`
     This can be useful for debugging tests, particularly integration/end-to-end tests.

--- a/core/src/commands/run/workflow.ts
+++ b/core/src/commands/run/workflow.ts
@@ -48,6 +48,9 @@ export class RunWorkflowCommand extends Command<Args, {}> {
   name = "workflow"
   help = "Run a workflow."
 
+  streamEvents = true
+  streamLogEntries = true
+
   description = dedent`
     Runs the commands and/or scripts defined in the workflow's steps, in sequence.
 

--- a/core/src/commands/test.ts
+++ b/core/src/commands/test.ts
@@ -62,6 +62,8 @@ export class TestCommand extends Command<Args, Opts> {
 
   protected = true
   workflows = true
+  streamEvents = true
+  streamLogEntries = true
 
   description = dedent`
     Runs all or specified tests defined in the project. Also builds modules and dependencies,

--- a/core/test/unit/src/cli/cli.ts
+++ b/core/test/unit/src/cli/cli.ts
@@ -336,6 +336,8 @@ describe("cli", () => {
       class TestCommand extends Command {
         name = "test-command"
         help = "halp!"
+        streamEvents = true
+        streamLogEntries = true
 
         async action({ garden }: CommandParams) {
           garden.events.emit("_test", "funky functional test")

--- a/core/test/unit/src/enterprise/buffered-event-stream.ts
+++ b/core/test/unit/src/enterprise/buffered-event-stream.ts
@@ -20,6 +20,8 @@ function makeDummyRecord(sizeKb: number) {
 describe("BufferedEventStream", () => {
   const getConnectionParams = (garden: Garden) => ({
     garden,
+    streamEvents: true,
+    streamLogEntries: true,
     targets: [
       {
         host: "dummy-platform_url",

--- a/core/test/unit/src/server/dashboard-event-stream.ts
+++ b/core/test/unit/src/server/dashboard-event-stream.ts
@@ -64,6 +64,8 @@ describe("DashboardEventStream", () => {
     streamer = new DashboardEventStream(garden.log, garden.sessionId!)
     streamer.connect({
       garden,
+      streamEvents: true,
+      streamLogEntries: true,
       targets: [
         { host: serverA.getUrl(), clientAuthToken: serverA.authKey },
         { host: serverB.getUrl(), clientAuthToken: serverB.authKey },
@@ -111,6 +113,8 @@ describe("DashboardEventStream", () => {
       streamer = new DashboardEventStream(garden.log, garden.sessionId!)
       streamer.connect({
         garden,
+        streamEvents: true,
+        streamLogEntries: true,
         targets: [],
       })
 
@@ -139,6 +143,8 @@ describe("DashboardEventStream", () => {
       streamer = new DashboardEventStream(garden.log, garden.sessionId!)
       streamer.connect({
         garden,
+        streamEvents: true,
+        streamLogEntries: true,
         targets: [],
       })
 
@@ -166,6 +172,8 @@ describe("DashboardEventStream", () => {
       streamer = new DashboardEventStream(garden.log, garden.sessionId!)
       streamer.connect({
         garden,
+        streamEvents: true,
+        streamLogEntries: true,
         targets: [],
       })
 
@@ -194,6 +202,8 @@ describe("DashboardEventStream", () => {
       streamer.connect({
         garden,
         targets: [],
+        streamEvents: true,
+        streamLogEntries: true,
         ignoreHost: values.serverHost,
       })
 
@@ -215,6 +225,8 @@ describe("DashboardEventStream", () => {
     streamer = new DashboardEventStream(garden.log, garden.sessionId!)
     streamer.connect({
       garden,
+      streamEvents: true,
+      streamLogEntries: true,
       targets: [],
     })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

We now only stream events and log entries to GE for whitelisted commands (those with `streamEvents = true` and/or `streamLogEntries = true`).

**Special notes for your reviewer**:

I couldn't think of a decent way to test this that didn't rely on counting invocations to `BufferedEventStream#connect`. Is this fine as is?