### PR TITLE
improvement(core): allow wildcard in first label in hostname

### DIFF
--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -264,7 +264,7 @@ const tlsCertificateSchema = () =>
       .example("wildcard"),
     hostnames: joi
       .array()
-      .items(joi.string().hostname())
+      .items(joi.hostname())
       .description(
         "A list of hostnames that this certificate should be used for. " +
           "If you don't specify these, they will be automatically read from the certificate."

--- a/core/src/types/service.ts
+++ b/core/src/types/service.ts
@@ -102,7 +102,7 @@ export interface ServiceIngress extends ServiceIngressSpec {
 }
 
 export const ingressHostnameSchema = () =>
-  joi.string().hostname().description(dedent`
+  joi.hostname().description(dedent`
     The hostname that should route to this service. Defaults to the default hostname configured in the provider configuration.
 
     Note that if you're developing locally you may need to add this hostname to your hosts file.

--- a/core/test/unit/src/config/common.ts
+++ b/core/test/unit/src/config/common.ts
@@ -276,6 +276,24 @@ describe("joi.posixPath", () => {
   })
 })
 
+describe("joi.hostname", () => {
+  const schema = joi.hostname()
+
+  it("should accept valid hostnames", () => {
+    const result = schema.validate("foo.bar.bas")
+    expect(result.error).to.be.undefined
+  })
+  it("should accept hostnames with a wildcard in the first DNS label", () => {
+    const result = schema.validate("*.bar.bas")
+    expect(result.error).to.be.undefined
+  })
+  it("should reject hostnames with wildcard DNS labels that are not the first label", () => {
+    const result = schema.validate("foo.*.bas")
+    expect(result.error).to.exist
+    expect(result!.error!.message).to.eql(`"value" only first DNS label my contain a wildcard.`)
+  })
+})
+
 describe("joi.environment", () => {
   const schema = joi.environment()
 

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -1030,9 +1030,9 @@ The hostname that should route to this service. Defaults to the default hostname
 
 Note that if you're developing locally you may need to add this hostname to your hosts file.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | No       |
+| Type       | Required |
+| ---------- | -------- |
+| `hostname` | No       |
 
 ### `services[].ingresses[].linkUrl`
 

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -1038,9 +1038,9 @@ The hostname that should route to this service. Defaults to the default hostname
 
 Note that if you're developing locally you may need to add this hostname to your hosts file.
 
-| Type     | Required |
-| -------- | -------- |
-| `string` | No       |
+| Type       | Required |
+| ---------- | -------- |
+| `hostname` | No       |
 
 ### `services[].ingresses[].linkUrl`
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow wildcards in the first DNS label of a hostname. I.e., we allow `*.foo.bar`, but not `foo.*.bar`. This is consistent with how Kubernetes treats hostnames.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Only allowing wildcards in the first label in ingress hostnames is pretty contested in the K8s community, see for example this issue: https://github.com/kubernetes/kubernetes/issues/41881.

However, I figured it'd make sense to start with the same restrictions as K8s since that's where the field is most used. 