### PR TITLE
fix(cert): remove namespace for certificate secrets

### DIFF
--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -270,9 +270,10 @@ const tlsCertificateSchema = () =>
           "If you don't specify these, they will be automatically read from the certificate."
       )
       .example(["www.mydomain.com"]),
-    secretRef: secretRef
+    secretRef: joiIdentifier()
+      .required()
       .description("A reference to the Kubernetes secret that contains the TLS certificate and key for the domain.")
-      .example({ name: "my-tls-secret", namespace: "default" }),
+      .example("my-tls-secret"),
     managedBy: joi
       .string()
       .description(

--- a/docs/advanced/cert-manager-integration.md
+++ b/docs/advanced/cert-manager-integration.md
@@ -48,6 +48,7 @@ To enable cert-manager, you'll need to configure it in the `kubernetes` provider
 ```
 
 Unless you want to use your own installation of cert-manager, you will need to set the option `install: true`. Garden will then install cert-manager for you under the `cert-manager` namespace.
+
 > Note: Garden will wait until all the pods required by cert-manager will be up and running. This might take more than 2 minutes depending on the cluster.
 
 If nothing is specified or `install: false`, Garden will assume you already have a valid and running cert-manager installation in the `cert-manager` namespace.
@@ -85,7 +86,6 @@ When you set `managedBy: cert-manager` on a certificate specified in the `tlsCer
               - your-domain-name.com # the domain name(s) to be covered by the certificate
             secretRef:
               name: tls-secret-for-certificate # the secret where cert-manager will store the TLS certificate once it's generated
-              namespace: cert-manager-example
 ```
 
 The above configuration will trigger the following workflow:
@@ -93,7 +93,7 @@ The above configuration will trigger the following workflow:
 1. cert-manager will create a ClusterIssuer in your cluster which will generate your certificate. Each certificate gets an associated ClusterIssuer, which will take care of performing the issue challenge.
 2. Garden will then create a Certificate resource to request the TLS certificate.
 3. cert-manager will then automatically create an Ingress to solve the HTTP-01 ACME challenge.
-4. Once the challenge is solved the TLS certificate will be stored as a Secret using the name/namespace specified above (e.g. `cert-manager-example/tls-secret-for-certificate`).
+4. Once the challenge is solved the TLS certificate will be stored as a Secret using the name/namespace specified above (e.g. `<your-app-namespace>/tls-secret-for-certificate`).
 
 All the steps above will happen at system startup/init. All your services will be built/tested/deployed after all the secrets have been populated.
 
@@ -122,4 +122,5 @@ $: kubectl describe Certificate certificate-name -n your-namespace
 Please find more info in the ["Issuing an ACME certificate using HTTP validation"](https://docs.cert-manager.io/en/release-0.11/tutorials/acme/http-validation.html#issuing-an-acme-certificate-using-http-validation) guide in the official cert-manager documentation.
 
 ---
+
 If have any issue, find a bug, or something is not clear from the documentation, please don't hesitate opening a new [GitHub issue](https://github.com/garden-io/garden/issues/new?template=BUG_REPORT.md) or ask us questions in our [Slack channel](https://chat.garden.io/).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:
This issue was https://github.com/garden-io/garden/issues/2098 was reported,  the investigation revealed that it is misleading to specify a namespace because cert-manager would create the Certificate Secret in the same namespace as the secret.

This PR removes the namespace parameter for the Certificate secret and only request the name. An alternative solution would be to copy that secret to the specified namespace

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
