### PR TITLE
fix(enterprise): add workflowError event

### DIFF
--- a/core/src/commands/run/workflow.ts
+++ b/core/src/commands/run/workflow.ts
@@ -189,6 +189,7 @@ export class RunWorkflowCommand extends Command<Args, {}> {
 
     if (size(stepErrors) > 0) {
       printResult({ startedAt, log: outerLog, workflow, success: false })
+      garden.events.emit("workflowError", {})
       return { result, errors: flatten(Object.values(stepErrors)) }
     }
 

--- a/core/src/events.ts
+++ b/core/src/events.ts
@@ -66,6 +66,9 @@ export function toGraphResultEventPayload(result: GraphResult): GraphResultEvent
   const payload = omit(result, "dependencyResults")
   if (result.output) {
     payload.output = omit(result.output, "dependencyResults", "log", "buildLog")
+    if (result.output.version) {
+      payload.output.version = result.output.version.versionString || null
+    }
   }
   return payload
 }
@@ -160,6 +163,7 @@ export interface Events extends LoggerEvents {
   // Workflow events
   workflowRunning: {}
   workflowComplete: {}
+  workflowError: {}
   workflowStepProcessing: {
     index: number
   }
@@ -204,6 +208,7 @@ export const eventNames: EventName[] = [
   "serviceStatus",
   "workflowRunning",
   "workflowComplete",
+  "workflowError",
   "workflowStepProcessing",
   "workflowStepSkipped",
   "workflowStepError",

--- a/core/test/unit/src/commands/run/workflow.ts
+++ b/core/test/unit/src/commands/run/workflow.ts
@@ -323,6 +323,7 @@ describe("RunWorkflowCommand", () => {
     expect(we[2].name).to.eql("workflowStepError")
     expect(we[2].payload.index).to.eql(0)
     expect(we[2].payload.durationMsec).to.gte(0)
+    expect(we[3].name).to.eql("workflowError")
   })
 
   it("should write a file with string data ahead of the run, before resolving providers", async () => {
@@ -713,6 +714,7 @@ function getWorkflowEvents(garden: TestGarden) {
   const eventNames = [
     "workflowRunning",
     "workflowComplete",
+    "workflowError",
     "workflowStepProcessing",
     "workflowStepSkipped",
     "workflowStepError",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

This new event is necessary to correctly handle failed workflows when combined with the `when` modifier.

Also streamlined the module version included in task outputs in event payloads to avoid bloat.