### PR TITLE
improvement(exec): log build output with verbose logger

### DIFF
--- a/core/src/logger/util.ts
+++ b/core/src/logger/util.ts
@@ -7,7 +7,7 @@
  */
 
 import nodeEmoji from "node-emoji"
-import chalk from "chalk"
+import chalk, { Chalk } from "chalk"
 import CircularJSON from "circular-json"
 import { LogNode, LogLevel } from "./log-node"
 import { LogEntry, LogEntryParams, EmojiName } from "./log-entry"
@@ -211,13 +211,14 @@ export function renderDivider() {
   return padEnd("", 80, "━")
 }
 
-export function renderMessageWithDivider(prefix: string, msg: string, isError: boolean) {
-  const color = isError ? chalk.red : chalk.white
+export function renderMessageWithDivider(prefix: string, msg: string, isError: boolean, color?: Chalk) {
+  // Allow overwriting color as an escape hatch. Otherwise defaults to white or red in case of errors.
+  const msgColor = color || (isError ? chalk.red : chalk.white)
   return dedent`
-  \n${color.bold(prefix)}
-  ${color.bold(renderDivider())}
-  ${hasAnsi(msg) ? msg : color(msg)}
-  ${color.bold(renderDivider())}
+  \n${msgColor.bold(prefix)}
+  ${msgColor.bold(renderDivider())}
+  ${hasAnsi(msg) ? msg : msgColor(msg)}
+  ${msgColor.bold(renderDivider())}
   `
 }
 

--- a/core/src/plugins/container/build.ts
+++ b/core/src/plugins/container/build.ts
@@ -65,7 +65,7 @@ export async function buildContainerModule({ ctx, module, log }: BuildModulePara
   }
 
   // Stream log to a status line
-  const outputStream = createOutputStream(log.placeholder({ level: LogLevel.debug }))
+  const outputStream = createOutputStream(log.placeholder({ level: LogLevel.verbose }))
   const timeout = module.spec.build.timeout
   const res = await containerHelpers.dockerCli({
     cwd: module.buildPath,

--- a/core/src/plugins/exec.ts
+++ b/core/src/plugins/exec.ts
@@ -32,6 +32,8 @@ import { LogEntry } from "../logger/log-entry"
 import { providerConfigBaseSchema } from "../config/provider"
 import { ExecaError } from "execa"
 import { artifactsTargetDescription } from "./container/config"
+import chalk = require("chalk")
+import { renderMessageWithDivider } from "../logger/util"
 
 const execPathDoc = dedent`
   By default, the command is run inside the Garden build directory (under .garden/build/<module-name>).
@@ -218,7 +220,7 @@ function getDefaultEnvVars(module: ExecModule) {
   }
 }
 
-export async function buildExecModule({ module }: BuildModuleParams<ExecModule>): Promise<BuildResult> {
+export async function buildExecModule({ module, log }: BuildModuleParams<ExecModule>): Promise<BuildResult> {
   const output: BuildResult = {}
   const { command } = module.spec.build
 
@@ -233,6 +235,10 @@ export async function buildExecModule({ module }: BuildModuleParams<ExecModule>)
     output.buildLog = result.stdout + result.stderr
   }
 
+  if (output.buildLog) {
+    const prefix = `Finished building module ${chalk.white(module.name)}. Here is the output:`
+    log.verbose(renderMessageWithDivider(prefix, output.buildLog, false, chalk.gray))
+  }
   // keep track of which version has been built
   const buildVersionFilePath = join(module.buildMetadataPath, GARDEN_BUILD_VERSION_FILENAME)
   await writeModuleVersionFile(buildVersionFilePath, module.version)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

Logs exec module build logs when log level is verbose or greater. Also sets log level on container builds logs to verbose (from debug).

**Which issue(s) this PR fixes**:

Fixes #2139 

**Special notes for your reviewer**:

![Screenshot 2020-11-19 at 12 53 26](https://user-images.githubusercontent.com/5373776/99662999-4524c300-2a66-11eb-9127-ed2ff5b8c213.png)

