### PR TITLE
chore: replace postgres chart in tasks example

### DIFF
--- a/examples/tasks/postgres/garden.yml
+++ b/examples/tasks/postgres/garden.yml
@@ -2,8 +2,12 @@ kind: Module
 description: Postgres database for storing user names
 type: helm
 name: postgres
-chart: stable/postgresql
-version: 5.3.11
+chart: postgresql
+repo: https://charts.bitnami.com/bitnami
+version: "8.10.5"
+serviceResource:
+  kind: StatefulSet
+  name: postgres
 values:
   # This is a more digestable name than the default one in the template
   fullnameOverride: postgres


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

The chart used for the `postgres` module for the `tasks` example was no longer deploying, which caused problems in CI.

This was fixed by using the same Helm chart for `postgres` as in the `vote-helm` example project.