### PR TITLE
feat(terraform): add support for workspaces

### DIFF
--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -553,7 +553,7 @@ export class Garden {
     }
 
     if (this.resolvedProviders[name]) {
-      return this.resolvedProviders[name]
+      return cloneDeep(this.resolvedProviders[name])
     }
 
     const providers = await this.resolveProviders(log, false, [name])

--- a/core/src/plugins/terraform/terraform.ts
+++ b/core/src/plugins/terraform/terraform.ts
@@ -58,6 +58,7 @@ const configSchema = providerConfigBaseSchema()
       .default(defaultTerraformVersion).description(dedent`
         The version of Terraform to use. Set to \`null\` to use whichever version of \`terraform\` that is on your PATH.
       `),
+    workspace: joi.string().description("Use the specified Terraform workspace."),
   })
   .unknown(false)
 

--- a/core/test/data/test-projects/terraform-module/garden.yml
+++ b/core/test/data/test-projects/terraform-module/garden.yml
@@ -1,10 +1,14 @@
 kind: Project
 name: terraform-provider
+environments:
+  - name: local
 providers:
   - name: terraform
     variables:
       my-variable: base
   - name: test-plugin
+variables:
+  workspace: default
 ---
 kind: Module
 type: terraform
@@ -12,6 +16,7 @@ name: tf
 include: ["*"]
 autoApply: true
 root: ./tf
+workspace: ${var.workspace}
 variables:
   my-variable: foo
 ---

--- a/core/test/data/test-projects/terraform-module/tf/foo.tf
+++ b/core/test/data/test-projects/terraform-module/tf/foo.tf
@@ -3,7 +3,7 @@ variable "my-variable" {
 }
 
 resource "local_file" "test-file" {
-  content  = var.my-variable
+  content  = terraform.workspace
   filename = "${path.module}/test.log" # using .log extension so that it's ignored by git
 }
 
@@ -12,7 +12,7 @@ output "test-file-path" {
 }
 
 output "my-output" {
-  value = "input: ${var.my-variable}"
+  value = "workspace: ${terraform.workspace}, input: ${var.my-variable}"
 }
 
 output "map-output" {

--- a/core/test/data/test-projects/terraform-provider/garden.yml
+++ b/core/test/data/test-projects/terraform-provider/garden.yml
@@ -1,5 +1,7 @@
 kind: Project
 name: terraform-provider
+variables:
+  workspace: default
 environments:
   - name: local
   - name: prod
@@ -9,6 +11,7 @@ providers:
     autoApply: ${environment.name != 'prod'}
     initRoot: tf
     version: "0.13.3"
+    workspace: ${var.workspace}
     variables:
       my-variable: foo
       env: ${environment.name}

--- a/core/test/data/test-projects/terraform-provider/tf/foo.tf
+++ b/core/test/data/test-projects/terraform-provider/tf/foo.tf
@@ -3,7 +3,7 @@ variable "my-variable" {
 }
 
 resource "local_file" "test-file" {
-  content  = var.my-variable
+  content  = terraform.workspace
   filename = "${path.module}/test.log" # using .log extension so that it's ignored by git
 }
 
@@ -12,5 +12,5 @@ output "test-file-path" {
 }
 
 output "my-output" {
-  value = "input: ${var.my-variable}"
+  value = "workspace: ${terraform.workspace}, input: ${var.my-variable}"
 }

--- a/core/test/unit/src/plugins/terraform/common.ts
+++ b/core/test/unit/src/plugins/terraform/common.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { getDataDir, makeTestGarden } from "../../../../helpers"
+import { join } from "path"
+import { Garden } from "../../../../../src/garden"
+import { pathExists, remove } from "fs-extra"
+import { PluginContext } from "../../../../../src/plugin-context"
+import { TerraformProvider } from "../../../../../src/plugins/terraform/terraform"
+import { LogEntry } from "../../../../../src/logger/log-entry"
+import { getWorkspaces, setWorkspace } from "../../../../../src/plugins/terraform/common"
+import { expect } from "chai"
+import { terraform } from "../../../../../src/plugins/terraform/cli"
+
+describe("Terraform common", () => {
+  const testRoot = getDataDir("test-projects", "terraform-provider")
+  const root = join(testRoot, "tf")
+  const stateDirPath = join(root, "terraform.tfstate.d")
+  const testFilePath = join(root, "test.log")
+
+  let garden: Garden
+  let log: LogEntry
+  let ctx: PluginContext
+  let provider: TerraformProvider
+
+  async function reset() {
+    if (await pathExists(testFilePath)) {
+      await remove(testFilePath)
+    }
+    if (await pathExists(stateDirPath)) {
+      await remove(stateDirPath)
+    }
+  }
+
+  before(async () => {
+    garden = await makeTestGarden(testRoot, { environmentName: "prod", forceRefresh: true })
+    log = garden.log
+    provider = (await garden.resolveProvider(log, "terraform")) as TerraformProvider
+    ctx = await garden.getPluginContext(provider)
+  })
+
+  beforeEach(async () => {
+    await reset()
+  })
+
+  after(async () => {
+    await reset()
+  })
+
+  describe("getWorkspaces", () => {
+    it("returns just the default workspace if none other exists", async () => {
+      const { workspaces, selected } = await getWorkspaces({ ctx, provider, log, root })
+      expect(selected).to.equal("default")
+      expect(workspaces).to.eql(["default"])
+    })
+
+    it("returns all workspaces and which is selected", async () => {
+      await terraform(ctx, provider).exec({ args: ["workspace", "new", "foo"], cwd: root, log })
+      await terraform(ctx, provider).exec({ args: ["workspace", "new", "bar"], cwd: root, log })
+
+      const { workspaces, selected } = await getWorkspaces({ ctx, provider, log, root })
+      expect(selected).to.equal("bar")
+      expect(workspaces).to.eql(["default", "bar", "foo"])
+    })
+  })
+
+  describe("setWorkspace", () => {
+    it("does nothing if no workspace is set", async () => {
+      await terraform(ctx, provider).exec({ args: ["workspace", "new", "foo"], cwd: root, log })
+
+      await setWorkspace({ ctx, provider, log, root, workspace: null })
+
+      const { workspaces, selected } = await getWorkspaces({ ctx, provider, log, root })
+      expect(selected).to.equal("foo")
+      expect(workspaces).to.eql(["default", "foo"])
+    })
+
+    it("does nothing if already on requested workspace", async () => {
+      await setWorkspace({ ctx, provider, log, root, workspace: "default" })
+
+      const { workspaces, selected } = await getWorkspaces({ ctx, provider, log, root })
+      expect(selected).to.equal("default")
+      expect(workspaces).to.eql(["default"])
+    })
+
+    it("selects the given workspace if it already exists", async () => {
+      await terraform(ctx, provider).exec({ args: ["workspace", "new", "foo"], cwd: root, log })
+      await terraform(ctx, provider).exec({ args: ["workspace", "select", "default"], cwd: root, log })
+
+      await setWorkspace({ ctx, provider, log, root, workspace: "foo" })
+
+      const { workspaces, selected } = await getWorkspaces({ ctx, provider, log, root })
+      expect(selected).to.equal("foo")
+      expect(workspaces).to.eql(["default", "foo"])
+    })
+
+    it("creates a new workspace if it doesn't already exist", async () => {
+      await setWorkspace({ ctx, provider, log, root, workspace: "foo" })
+
+      const { workspaces, selected } = await getWorkspaces({ ctx, provider, log, root })
+      expect(selected).to.equal("foo")
+      expect(workspaces).to.eql(["default", "foo"])
+    })
+  })
+})

--- a/docs/reference/module-types/terraform.md
+++ b/docs/reference/module-types/terraform.md
@@ -156,6 +156,9 @@ variables:
 # The version of Terraform to use. Defaults to the version set in the provider config.
 # Set to `null` to use whichever version of `terraform` that is on your PATH.
 version:
+
+# Use the specified Terraform workspace.
+workspace:
 ```
 
 ## Configuration Keys
@@ -449,6 +452,14 @@ specified here take precedence.
 
 The version of Terraform to use. Defaults to the version set in the provider config.
 Set to `null` to use whichever version of `terraform` that is on your PATH.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `workspace`
+
+Use the specified Terraform workspace.
 
 | Type     | Required |
 | -------- | -------- |


### PR DESCRIPTION
You can now set the `workspace` field on the Terraform provider as well
as on `terraform` modules. When set, Garden will select (creating if
necessary) the specified Terraform workspace ahead of applying,
planning, destroying etc.

Closes #2024
