### PR TITLE
improvement(core): more efficient file scanning with multiple ignores

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -118,6 +118,7 @@
     "source-map-support": "^0.5.19",
     "split": "^1.0.1",
     "split2": "^3.1.1",
+    "streamfilter": "^3.0.0",
     "string-width": "^4.2.0",
     "strip-ansi": "^6.0.0",
     "supertest": "^4.0.2",

--- a/core/src/util/streams.ts
+++ b/core/src/util/streams.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import split2 = require("split2")
+import { Readable } from "stream"
+import { InternalError } from "../exceptions"
+
+export const splitStream = split2
+
+/**
+ * Takes a list of sorted Readable streams and emits the intersection of all of them.
+ */
+export class SortedStreamIntersection<T> extends Readable {
+  private lastValues: T[]
+  private values: T[][]
+  private ended: boolean[]
+
+  private done: boolean
+  private started: boolean
+
+  constructor(private streams: Readable[], private comparisonFn: (a: T, b: T) => number) {
+    super({ objectMode: true })
+    this.lastValues = []
+    this.ended = []
+    this.values = streams.map(() => [])
+    this.done = false
+    this.started = false
+  }
+
+  // tslint:disable-next-line: function-name
+  _read() {
+    if (!this.started) {
+      this.start()
+    }
+  }
+
+  start() {
+    this.started = true
+
+    this.streams.map((stream, i) => {
+      stream.on("data", (value) => {
+        if (this.done) {
+          return
+        }
+
+        const lastValue = this.lastValues[i]
+        this.lastValues[i] = value
+
+        if (lastValue !== undefined && this.comparisonFn(lastValue, value) > 0) {
+          this.emit("error", new InternalError(`Received unordered stream`, { streamIndex: i }))
+          return
+        }
+
+        // Skip the entry if it is smaller than the smallest entry in the other lists
+        for (let j = 0; j < this.streams.length; j++) {
+          if (i === j) {
+            continue
+          }
+
+          const first = this.values[j][0]
+
+          if (first !== undefined && this.comparisonFn(first, value) > 0) {
+            return
+          }
+        }
+
+        this.values[i].push(value)
+        this.handleBuffer()
+      })
+
+      stream.on("error", (err) => {
+        this.done = true
+        this.emit("error", err)
+      })
+
+      stream.on("end", () => {
+        this.handleBuffer()
+        this.ended[i] = true
+        if (this.ended.length === this.streams.length && this.ended.every((s) => s === true)) {
+          this.push(null)
+          this.done = true
+        }
+      })
+    })
+  }
+
+  handleBuffer() {
+    if (this.done) {
+      return
+    }
+
+    while (!this.values.find((v) => v.length === 0)) {
+      const row = this.values.map((v) => v[0])
+
+      if (row.every((v) => this.comparisonFn(row[0], v) === 0)) {
+        // Emit and shift if the top values are all equal
+        // TODO: Pause if push returns false
+        this.push(row[0])
+        for (let i = 0; i < this.values.length; i++) {
+          this.values[i].shift()
+        }
+      } else {
+        // Trim off every item lower than the lowest item in the highest list
+        const sortedIndices = this.sortedIndices(row)
+        const furthestList = this.values[sortedIndices[sortedIndices.length - 1]]
+        const compared = furthestList[0]
+
+        for (let i = 0; i < sortedIndices.length - 1; i++) {
+          const arrayToTrim = this.values[sortedIndices[i]]
+
+          for (let itemsToShift = 0; itemsToShift < arrayToTrim.length; itemsToShift++) {
+            if (this.comparisonFn(arrayToTrim[itemsToShift], compared) === 0) {
+              this.values[sortedIndices[i]] = arrayToTrim.slice(itemsToShift)
+              break
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private sortedIndices(row: T[]) {
+    const indices = new Array(row.length)
+    for (let i = 0; i < row.length; ++i) {
+      indices[i] = i
+    }
+    indices.sort(this.comparisonFn)
+    return indices
+  }
+}

--- a/core/src/util/util.ts
+++ b/core/src/util/util.ts
@@ -633,10 +633,6 @@ export function getArchitecture() {
   return archMap[arch] || arch
 }
 
-// Wrapping split2 (which splits Buffer streams, by default by newline) for convenience
-// TODO: make type-safe
-export const splitStream = require("split2")
-
 export function getDurationMsec(start: Date, end: Date): number {
   return Math.round(end.getTime() - start.getTime())
 }
@@ -654,8 +650,8 @@ export async function runScript(log: LogEntry, cwd: string, script: string) {
   })
 
   // Stream output to `log`, splitting by line
-  const stdout = splitStream()
-  const stderr = splitStream()
+  const stdout = split2()
+  const stderr = split2()
 
   stdout.on("error", () => {})
   stdout.on("data", (line: Buffer) => {

--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -6,13 +6,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import FilterStream from "streamfilter"
 import { join, resolve, relative, isAbsolute } from "path"
 import { flatten } from "lodash"
 import { ensureDir, pathExists, createReadStream, Stats, realpath, readlink, lstat } from "fs-extra"
-import { PassThrough } from "stream"
+import { PassThrough, Transform } from "stream"
 import hasha from "hasha"
 import split2 = require("split2")
-
 import { VcsHandler, RemoteSourceParams, VcsFile, GetFilesParams } from "./vcs"
 import { ConfigurationError, RuntimeError } from "../exceptions"
 import Bluebird from "bluebird"
@@ -22,6 +22,8 @@ import { splitLast, exec } from "../util/util"
 import { LogEntry } from "../logger/log-entry"
 import parseGitConfig from "parse-git-config"
 import { Profile } from "../util/profiling"
+import { SortedStreamIntersection } from "../util/streams"
+import execa = require("execa")
 
 export function getCommitIdFromRefList(refList: string[]): string {
   try {
@@ -128,17 +130,12 @@ export class GitHandler extends VcsHandler {
     // List all submodule paths in the current repo
     const submodulePaths = (await this.getSubmodules(gitRoot)).map((s) => join(gitRoot, s.path))
 
-    // We run ls-files for each ignoreFile and do a manual set-intersection (by counting elements in an object)
-    // in order to optimize the flow.
-    const paths: { [path: string]: number } = {}
     const files: VcsFile[] = []
 
-    // This function is called for each line output from the ls-files commands that we run, and populates the
-    // `files` array.
-    const handleLine = (data: Buffer) => {
+    const parseLine = (data: Buffer): VcsFile | undefined => {
       const line = data.toString().trim()
       if (!line) {
-        return
+        return undefined
       }
 
       let filePath: string
@@ -154,6 +151,18 @@ export class GitHandler extends VcsHandler {
         hash = split[0].split(" ")[1]
       }
 
+      return { path: filePath, hash }
+    }
+
+    // This function is called for each line output from the ls-files commands that we run, and populates the
+    // `files` array.
+    const handleEntry = (entry: VcsFile | undefined) => {
+      if (!entry) {
+        return
+      }
+
+      let { path: filePath, hash } = entry
+
       // Ignore files that are tracked but still specified in ignore files
       if (trackedButIgnored.has(filePath)) {
         return
@@ -161,50 +170,89 @@ export class GitHandler extends VcsHandler {
 
       const resolvedPath = resolve(path, filePath)
 
-      // Add the path to `paths` or increment the counter to indicate how many of the ls-files outputs
-      // contain the path.
-      if (paths[resolvedPath]) {
-        paths[resolvedPath] += 1
-      } else {
-        paths[resolvedPath] = 1
-      }
-
-      // We push to the output array when all ls-files commands "agree" that it should be included,
-      // and it passes through the include/exclude filters.
-      if (
-        paths[resolvedPath] >= this.ignoreFiles.length &&
-        (matchPath(filePath, include, exclude) || submodulePaths.includes(resolvedPath))
-      ) {
+      // We push to the output array if it passes through the include/exclude filters.
+      if (matchPath(filePath, include, exclude) || submodulePaths.includes(resolvedPath)) {
         files.push({ path: resolvedPath, hash })
       }
     }
 
-    const lsFiles = async (ignoreFile?: string) => {
+    const lsFiles = (ignoreFile?: string) => {
       const args = ["ls-files", "-s", "--others", "--exclude", this.gardenDirPath]
       if (ignoreFile) {
         args.push("--exclude-per-directory", ignoreFile)
       }
       args.push(path)
 
-      // Split the command output by line
-      const splitStream = split2()
-      splitStream.on("data", handleLine)
-
-      try {
-        await exec("git", args, { cwd: path, stdout: splitStream })
-      } catch (err) {
-        // if we get 128 we're not in a repo root, so we just get no files. Otherwise we throw.
-        if (err.exitCode !== 128) {
-          throw err
-        }
-      }
+      return execa("git", args, { cwd: path, buffer: false })
     }
 
-    if (this.ignoreFiles.length === 0) {
-      await lsFiles()
+    if (this.ignoreFiles.length > 1) {
+      // We run ls-files for each ignore file and do a streaming set-intersection (i.e. every ls-files call
+      // needs to "agree" that a file should be included). Then `handleLine()` is called for each resulting entry.
+      const streams = this.ignoreFiles.map(() => {
+        const input = split2()
+        const output = input.pipe(
+          new FilterStream((line: Buffer, _, cb) => {
+            cb(!!line)
+          }).pipe(
+            new Transform({
+              objectMode: true,
+              transform(line: Buffer, _, cb: Function) {
+                this.push(parseLine(line))
+                cb()
+              },
+            })
+          )
+        )
+        return { input, output }
+      })
+
+      await new Promise((_resolve, _reject) => {
+        // Note: The comparison function needs to account for git first returning untracked files, so we prefix with
+        // a zero or one to indicate whether it's a tracked file or not, and then do a simple string comparison
+        const intersection = new SortedStreamIntersection(
+          streams.map(({ output }) => output),
+          (a: VcsFile, b: VcsFile) => {
+            const cmpA = (a.hash ? "1" : "0") + a.path
+            const cmpB = (b.hash ? "1" : "0") + b.path
+            return <any>(cmpA > cmpB) - <any>(cmpA < cmpB)
+          }
+        )
+
+        this.ignoreFiles.map((ignoreFile, i) => {
+          const proc = lsFiles(ignoreFile)
+
+          proc.on("error", (err) => {
+            if (err["exitCode"] !== 128) {
+              _reject(err)
+            }
+          })
+
+          proc.stdout!.pipe(streams[i].input)
+        })
+
+        intersection.on("data", handleEntry)
+        intersection.on("error", (err) => {
+          _reject(err)
+        })
+        intersection.on("end", () => {
+          _resolve()
+        })
+      })
     } else {
-      // We run ls-files for each ignore file and collect each return result line with `handleLine`
-      await Bluebird.map(this.ignoreFiles, lsFiles)
+      const splitStream = split2()
+      splitStream.on("data", (line) => handleEntry(parseLine(line)))
+
+      await new Promise((_resolve, _reject) => {
+        const proc = lsFiles(this.ignoreFiles[0])
+        proc.on("error", (err: execa.ExecaError) => {
+          if (err.exitCode !== 128) {
+            _reject(err)
+          }
+        })
+        proc.stdout?.pipe(splitStream)
+        splitStream.on("end", () => _resolve())
+      })
     }
 
     // Resolve submodules
@@ -241,8 +289,7 @@ export class GitHandler extends VcsHandler {
       }
 
       // We need to special-case handling of symlinks. We disallow any "unsafe" symlinks, i.e. any ones that may
-      // link outside of `path` (which is usually a project or module root). The `hashObject` method also special-cases
-      // symlinks, to match git's hashing behavior (which is to hash the link itself, and not what the link points to).
+      // link outside of `gitRoot`.
       if (stats.isSymbolicLink()) {
         const target = await readlink(resolvedPath)
 
@@ -363,6 +410,8 @@ export class GitHandler extends VcsHandler {
 
   /**
    * Replicates the `git hash-object` behavior. See https://stackoverflow.com/a/5290484/3290965
+   * We deviate from git's behavior when dealing with symlinks, by hashing the target of the symlink and not the
+   * symlink itself. If the symlink cannot be read, we hash the link contents like git normally does.
    */
   async hashObject(stats: Stats, path: string) {
     const stream = new PassThrough()

--- a/core/test/unit/src/util/streams.ts
+++ b/core/test/unit/src/util/streams.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { SortedStreamIntersection } from "../../../../src/util/streams"
+import { expect } from "chai"
+import { splitStream } from "../../../../src/util/streams"
+
+describe("SortedStreamIntersection", () => {
+  const comparator = (a: Buffer, b: Buffer) => a.toString().localeCompare(b.toString())
+
+  it("returns all values if passed a single stream", (done) => {
+    const a = splitStream()
+    const stream = new SortedStreamIntersection([a], comparator)
+    const output: string[] = []
+    stream.on("data", (v) => output.push(v.toString()))
+    stream.on("end", () => {
+      expect(output).to.eql(["a", "b", "c"])
+      done()
+    })
+    a.write("a\nb\nc\n")
+    a.end()
+  })
+
+  it("returns all values if passed identical streams", (done) => {
+    const a = splitStream()
+    const b = splitStream()
+    const stream = new SortedStreamIntersection([a, b], comparator)
+    const output: string[] = []
+    stream.on("data", (v) => output.push(v.toString()))
+    stream.on("end", () => {
+      expect(output).to.eql(["a", "b", "c"])
+      done()
+    })
+    a.write("a\nb\n")
+    b.write("a\n")
+    a.write("c\n")
+    b.write("b\nc\n")
+    a.end()
+    b.end()
+  })
+
+  it("returns the intersection of two streams", (done) => {
+    const a = splitStream()
+    const b = splitStream()
+
+    const stream = new SortedStreamIntersection([a, b], comparator)
+    const output: string[] = []
+    stream.on("data", (v) => output.push(v.toString()))
+    stream.on("end", () => {
+      expect(output).to.eql(["b", "c"])
+      done()
+    })
+
+    a.write("a\nb\n")
+    b.write("b\n")
+    a.write("c\n")
+    b.write("c\nd\n")
+    a.end()
+    b.end()
+  })
+
+  it("returns the intersection of three streams", (done) => {
+    const a = splitStream()
+    const b = splitStream()
+    const c = splitStream()
+
+    const stream = new SortedStreamIntersection([a, b, c], comparator)
+    const output: string[] = []
+    stream.on("data", (v) => output.push(v.toString()))
+    stream.on("end", () => {
+      expect(output).to.eql(["c", "d"])
+      done()
+    })
+
+    a.write("a\nb\nc\nd\n")
+    b.write("b\nc\nd\ne\n")
+    c.write("c\nd\ne\nf\n")
+    a.end()
+    b.end()
+    c.end()
+  })
+
+  it("throws if passed a non-sorted stream", (done) => {
+    const a = splitStream()
+    const b = splitStream()
+
+    const stream = new SortedStreamIntersection([a, b], comparator)
+    stream.on("data", () => {})
+    stream.on("error", (err) => {
+      expect(err.message).to.equal("Received unordered stream")
+      done()
+    })
+
+    a.write("a\nb\nc\nd\ne\n")
+    b.write("b\nd\nc\n")
+    a.end()
+    b.end()
+  })
+})

--- a/examples/vote/garden.yml
+++ b/examples/vote/garden.yml
@@ -1,5 +1,9 @@
 kind: Project
 name: vote
+dotIgnoreFiles:
+  - .gitignore
+  - .gardenignore
+  - .fooignore
 environments:
   - name: local
   - name: remote

--- a/yarn.lock
+++ b/yarn.lock
@@ -16899,6 +16899,13 @@ stream-to-promise@^2.2.0:
     end-of-stream "~1.1.0"
     stream-to-array "~2.3.0"
 
+streamfilter@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/streamfilter/-/streamfilter-3.0.0.tgz#8c61b08179a6c336c6efccc5df30861b7a9675e7"
+  integrity sha512-kvKNfXCmUyC8lAXSSHCIXBUlo/lhsLcCU/OmzACZYpRUdtKIH68xYhm/+HI15jFJYtNJGYtCgn2wmIiExY1VwA==
+  dependencies:
+    readable-stream "^3.0.6"
+
 streamsearch@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"


### PR DESCRIPTION
This fixes a performance and memory consumption issue when specifying
multiple `dotIgnoreFiles`.

We do this using a streaming set intersection, which avoids storing
unnecessary data in memory during the scan, relying on a sorted file
order coming from git.

It's not exactly a trivial implementation but this is only applied when
multiple .ignore files are configured, which is anyway a problematic
routine prone to thrashing the heap.

Closes #2084 (I _think_)
