### PR TITLE
feat(template): support if-blocks for multi-line conditionals

### DIFF
--- a/core/test/unit/src/actions.ts
+++ b/core/test/unit/src/actions.ts
@@ -1610,7 +1610,7 @@ describe("ActionRouter", () => {
           }),
         (err) =>
           expect(stripAnsi(err.message)).to.equal(
-            "Invalid template string ${runtime.services.service-b.outputs.foo}: Could not find key service-b under runtime.services."
+            "Invalid template string (${runtime.services.service-b.outpu…): Could not find key service-b under runtime.services."
           )
       )
     })
@@ -1785,7 +1785,7 @@ describe("ActionRouter", () => {
           }),
         (err) =>
           expect(stripAnsi(err.message)).to.equal(
-            "Invalid template string ${runtime.services.service-b.outputs.foo}: Could not find key service-b under runtime.services."
+            "Invalid template string (${runtime.services.service-b.outpu…): Could not find key service-b under runtime.services."
           )
       )
     })

--- a/core/test/unit/src/config/config-context.ts
+++ b/core/test/unit/src/config/config-context.ts
@@ -281,7 +281,7 @@ describe("ConfigContext", () => {
         () => resolveKey(c, ["nested", "key"]),
         (err) =>
           expect(err.message).to.equal(
-            "Invalid template string ${'${nested.key}'}: Invalid template string ${nested.key}: Circular reference detected when resolving key nested.key (nested -> nested.key)"
+            "Invalid template string (${'${nested.key}'}): Invalid template string (${nested.key}): Circular reference detected when resolving key nested.key (nested -> nested.key)"
           )
       )
     })

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -1514,7 +1514,7 @@ describe("Garden", () => {
         (err) => {
           expect(err.message).to.equal("Failed resolving one or more providers:\n" + "- test")
           expect(stripAnsi(err.detail.messages[0])).to.equal(
-            "- test: Invalid template string ${bla.ble}: Could not find key bla. Available keys: environment, git, local, project, providers, secrets, var and variables."
+            "- test: Invalid template string (${bla.ble}): Could not find key bla. Available keys: environment, git, local, project, providers, secrets, var and variables."
           )
         }
       )
@@ -2438,7 +2438,7 @@ describe("Garden", () => {
           expect(stripAnsi(err.message)).to.equal(dedent`
             Failed resolving one or more modules:
 
-            module-a: Invalid template string ${key}: Module module-a cannot reference itself.
+            module-a: Invalid template string (${key}): Module module-a cannot reference itself.
           `)
       )
     })

--- a/docs/using-garden/variables-and-templating.md
+++ b/docs/using-garden/variables-and-templating.md
@@ -108,6 +108,31 @@ services:
   ...
 ```
 
+### Multi-line if/else statements
+
+In addition to the conditionals described above, you can use if/else blocks. These are particularly handy when templating multi-line strings and generated files in [module templates](./module-templates.md).
+
+The syntax is `${if <expression>}<content>[${else}]<alternative content>${endif}`, where `<expression>` is any expression you'd put in a normal template string.
+
+Here's a basic example:
+
+```yaml
+variables:
+  some-script: |
+    #!/bin/sh
+    echo "Hello, I'm a bash script!"
+
+    ${if environment.name == "dev"}
+    echo "-> debug mode"
+    DEBUG=true
+    ${else}
+    DEBUG=false
+    ${endif}
+    ...
+```
+
+You can also nest if-blocks, should you need to.
+
 ### Nested lookups and maps
 
 In addition to dot-notation for key lookups, we also support bracketed lookups, e.g. `${some["key"]}` and `${some-array[0]}`.


### PR DESCRIPTION
From the added docs:

In addition to [normal] conditionals [...] you can use if/else
blocks. These are particularly handy when templating multi-line strings
and generated files in [module templates](./module-templates.md).

The syntax is
`${if <expression>}<content>[${else}]<alternative content>${endif}`,
where `<expression>` is any expression you'd put in a normal template
string.

Here's a basic example:

```yaml
variables:
  some-script: |
    #!/bin/sh
    echo "Hello, I'm a bash script!"

    ${if environment.name == "dev"}
    echo "-> debug mode"
    DEBUG=true
    ${else}
    DEBUG=false
    ${endif}
    ...
```

You can also nest if-blocks, should you need to.

We could fairly easily add more types of blocks later, if we come up with some good ideas and use-cases.
