### PR TITLE
fix(core): prohibit templates in workflow name

### DIFF
--- a/core/src/config/config-context.ts
+++ b/core/src/config/config-context.ts
@@ -466,6 +466,9 @@ class EnvironmentContext extends ConfigContext {
   }
 }
 
+/**
+ * This context is available for template strings in all workflow config fields except `name` and `triggers[]`.
+ */
 export class WorkflowConfigContext extends EnvironmentConfigContext {
   @schema(
     EnvironmentContext.getSchema().description("Information about the environment that Garden is running against.")

--- a/core/src/config/workflow.ts
+++ b/core/src/config/workflow.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { cloneDeep, isEqual, merge, omit, take } from "lodash"
+import { isEqual, merge, omit, take } from "lodash"
 import { joi, joiUserIdentifier, joiVariableName, joiIdentifier } from "./common"
 import { DEFAULT_API_VERSION } from "../constants"
 import { deline, dedent } from "../util/string"
@@ -307,7 +307,13 @@ export function resolveWorkflowConfig(garden: Garden, config: WorkflowConfig) {
   const log = garden.log
   const context = new WorkflowConfigContext(garden)
   log.silly(`Resolving template strings for workflow ${config.name}`)
-  let resolvedConfig = resolveTemplateStrings(cloneDeep(config), context, { allowPartial: true })
+  let resolvedConfig = {
+    ...resolveTemplateStrings(omit(config, "name", "triggers"), context, { allowPartial: true }),
+    name: config.name,
+  }
+  if (config.triggers) {
+    resolvedConfig["triggers"] = config.triggers
+  }
   log.silly(`Validating config for workflow ${config.name}`)
 
   resolvedConfig = <WorkflowConfig>validateWithPath({


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

We don't want to allow template strings in workflow names or trigger specs.