### PR TITLE
fix(core): regression when copying single files in build dependencies

### DIFF
--- a/core/src/build-staging/rsync.ts
+++ b/core/src/build-staging/rsync.ts
@@ -15,7 +15,6 @@ import { exec } from "../util/util"
 import { deline } from "../util/string"
 import { syncWithOptions } from "../util/sync"
 import { BuildStaging, SyncParams } from "./build-staging"
-import { FileStatsHelper } from "./helpers"
 
 const minRsyncVersion = "3.1.0"
 const versionRegex = /rsync  version [v]*([\d\.]+)  /
@@ -90,17 +89,8 @@ export class BuildDirRsync extends BuildStaging {
     let sourcePath = joinWithPosix(sourceRoot, sourceRelPath)
     let targetPath = joinWithPosix(targetRoot, targetRelPath)
 
-    const statsHelpers = new FileStatsHelper()
-    const targetStat = await statsHelpers.extendedStat({ path: targetPath })
-    let targetDir: string
-
-    if (targetStat && !targetStat.isDirectory()) {
-      targetDir = parse(targetPath).dir
-    } else {
-      targetDir = targetPath
-    }
-
-    const tmpDir = targetDir + ".tmp"
+    const targetDir = parse(targetPath).dir
+    const tmpDir = targetRoot + ".tmp"
 
     await ensureDir(targetDir)
     await ensureDir(tmpDir)

--- a/core/test/unit/src/build-staging/rsync.ts
+++ b/core/test/unit/src/build-staging/rsync.ts
@@ -25,7 +25,7 @@ import { commonSyncTests } from "./build-staging"
 
 const projectRoot = join(dataDir, "test-projects", "build-dir")
 
-describe("BuildDirRsync", () => {
+describe("BuildStagingRsync", () => {
   let garden: TestGarden
 
   before(async () => {


### PR DESCRIPTION
Reported here:
https://kubernetes.slack.com/archives/CKM7CP8P9/p1606839970383500

This was a bit of a blunder, sorry about that. I had forgotten to move
some tests over to the common tests for both the rsync and the new
experimental implementation, and introduced a regression.
