### PR TITLE
feat(k8s): use pod spec fields in tasks and tests

### DIFF
--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -27,6 +27,7 @@ import { baseTaskSpecSchema, BaseTaskSpec, cacheResultSchema } from "../../confi
 import { baseTestSpecSchema, BaseTestSpec } from "../../config/test"
 import { ArtifactSpec } from "../../config/validation"
 import { V1Toleration } from "@kubernetes/client-node"
+import { runPodSpecWhitelist } from "./run"
 
 export const DEFAULT_KANIKO_IMAGE = "gcr.io/kaniko-project/executor:debug-v1.2.0"
 export interface ProviderSecretRef {
@@ -640,13 +641,18 @@ export const hotReloadArgsSchema = () =>
     .description("If specified, overrides the arguments for the main container when running in hot-reload mode.")
     .example(["nodemon", "my-server.js"])
 
+const runPodSpecWhitelistDescription = runPodSpecWhitelist.map((f) => `* \`${f}\``).join("\n")
+
 export const kubernetesTaskSchema = () =>
   baseTaskSpecSchema()
     .keys({
       resource: serviceResourceSchema().description(
-        deline`The Deployment, DaemonSet or StatefulSet that Garden should use to execute this task.
+        dedent`The Deployment, DaemonSet or StatefulSet that Garden should use to execute this task.
         If not specified, the \`serviceResource\` configured on the module will be used. If neither is specified,
-        an error will be thrown.`
+        an error will be thrown.
+
+        The following pod spec fields from the service resource will be used (if present) when executing the task:
+        ${runPodSpecWhitelistDescription}`
       ),
       cacheResult: cacheResultSchema(),
       command: joi
@@ -668,9 +674,12 @@ export const kubernetesTestSchema = () =>
   baseTestSpecSchema()
     .keys({
       resource: serviceResourceSchema().description(
-        deline`The Deployment, DaemonSet or StatefulSet that Garden should use to execute this test suite.
+        dedent`The Deployment, DaemonSet or StatefulSet that Garden should use to execute this test suite.
         If not specified, the \`serviceResource\` configured on the module will be used. If neither is specified,
-        an error will be thrown.`
+        an error will be thrown.
+
+        The following pod spec fields from the service resource will be used (if present) when executing the test suite:
+        ${runPodSpecWhitelistDescription}`
       ),
       command: joi
         .array()

--- a/core/src/plugins/kubernetes/helm/config.ts
+++ b/core/src/plugins/kubernetes/helm/config.ts
@@ -35,6 +35,7 @@ import {
   hotReloadArgsSchema,
 } from "../config"
 import { posix } from "path"
+import { runPodSpecWhitelist } from "../run"
 
 export const defaultHelmTimeout = 300
 
@@ -82,7 +83,7 @@ export const helmModuleOutputsSchema = () =>
 const helmServiceResourceSchema = () =>
   serviceResourceSchema().keys({
     name: joi.string().description(
-      deline`The name of the resource to sync to. If the chart contains a single resource of the specified Kind,
+      dedent`The name of the resource to sync to. If the chart contains a single resource of the specified Kind,
         this can be omitted.
 
         This can include a Helm template string, e.g. '{{ template "my-chart.fullname" . }}'.
@@ -94,21 +95,29 @@ const helmServiceResourceSchema = () =>
     hotReloadArgs: hotReloadArgsSchema(),
   })
 
+const runPodSpecWhitelistDescription = runPodSpecWhitelist.map((f) => `* \`${f}\``).join("\n")
+
 const helmTaskSchema = () =>
   kubernetesTaskSchema().keys({
     resource: helmServiceResourceSchema().description(
-      deline`The Deployment, DaemonSet or StatefulSet that Garden should use to execute this task.
+      dedent`The Deployment, DaemonSet or StatefulSet that Garden should use to execute this task.
         If not specified, the \`serviceResource\` configured on the module will be used. If neither is specified,
-        an error will be thrown.`
+        an error will be thrown.
+
+        The following pod spec fields from the service resource will be used (if present) when executing the task:
+        ${runPodSpecWhitelistDescription}`
     ),
   })
 
 const helmTestSchema = () =>
   kubernetesTestSchema().keys({
     resource: helmServiceResourceSchema().description(
-      deline`The Deployment, DaemonSet or StatefulSet that Garden should use to execute this test suite.
+      dedent`The Deployment, DaemonSet or StatefulSet that Garden should use to execute this test suite.
         If not specified, the \`serviceResource\` configured on the module will be used. If neither is specified,
-        an error will be thrown.`
+        an error will be thrown.
+
+        The following pod spec fields from the service resource will be used (if present) when executing the test suite:
+        ${runPodSpecWhitelistDescription}`
     ),
   })
 

--- a/core/src/plugins/kubernetes/helm/run.ts
+++ b/core/src/plugins/kubernetes/helm/run.ts
@@ -9,7 +9,13 @@
 import { HelmModule } from "./config"
 import { PodRunner, runAndCopy } from "../run"
 import { getChartResources, getBaseModule } from "./common"
-import { findServiceResource, getResourceContainer, getServiceResourceSpec, makePodName } from "../util"
+import {
+  findServiceResource,
+  getResourceContainer,
+  getResourcePodSpec,
+  getServiceResourceSpec,
+  makePodName,
+} from "../util"
 import { ConfigurationError } from "../../../exceptions"
 import { KubernetesPluginContext } from "../config"
 import { storeTaskResult } from "../task-results"
@@ -137,6 +143,7 @@ export async function runHelmTask(params: RunTaskParams<HelmModule>): Promise<Ru
   const res = await runAndCopy({
     ...params,
     container,
+    podSpec: getResourcePodSpec(target),
     command,
     args,
     artifacts: task.spec.artifacts,

--- a/core/src/plugins/kubernetes/helm/test.ts
+++ b/core/src/plugins/kubernetes/helm/test.ts
@@ -14,7 +14,13 @@ import { getChartResources, getBaseModule } from "./common"
 import { KubernetesPluginContext } from "../config"
 import { TestModuleParams } from "../../../types/plugin/module/testModule"
 import { TestResult } from "../../../types/plugin/module/getTestResult"
-import { getServiceResourceSpec, findServiceResource, getResourceContainer, makePodName } from "../util"
+import {
+  getServiceResourceSpec,
+  findServiceResource,
+  getResourceContainer,
+  makePodName,
+  getResourcePodSpec,
+} from "../util"
 import { getModuleNamespace } from "../namespace"
 
 export async function testHelmModule(params: TestModuleParams<HelmModule>): Promise<TestResult> {
@@ -42,6 +48,7 @@ export async function testHelmModule(params: TestModuleParams<HelmModule>): Prom
   const result = await runAndCopy({
     ...params,
     container,
+    podSpec: getResourcePodSpec(target),
     command,
     args,
     artifacts: testConfig.spec.artifacts,

--- a/core/src/plugins/kubernetes/kubernetes-module/run.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/run.ts
@@ -8,7 +8,13 @@
 
 import { KubernetesModule } from "./config"
 import { runAndCopy } from "../run"
-import { findServiceResource, getResourceContainer, getServiceResourceSpec, makePodName } from "../util"
+import {
+  findServiceResource,
+  getResourceContainer,
+  getResourcePodSpec,
+  getServiceResourceSpec,
+  makePodName,
+} from "../util"
 import { KubernetesPluginContext } from "../config"
 import { storeTaskResult } from "../task-results"
 import { RunTaskParams, RunTaskResult } from "../../../types/plugin/task/runTask"
@@ -45,6 +51,7 @@ export async function runKubernetesTask(params: RunTaskParams<KubernetesModule>)
   const res = await runAndCopy({
     ...params,
     container,
+    podSpec: getResourcePodSpec(target),
     command,
     args,
     artifacts: task.spec.artifacts,

--- a/core/src/plugins/kubernetes/kubernetes-module/test.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/test.ts
@@ -16,7 +16,13 @@ import { TestResult } from "../../../types/plugin/module/getTestResult"
 import { getModuleNamespace } from "../namespace"
 import { KubeApi } from "../api"
 import { getManifests } from "./common"
-import { getServiceResourceSpec, findServiceResource, getResourceContainer, makePodName } from "../util"
+import {
+  getServiceResourceSpec,
+  findServiceResource,
+  getResourceContainer,
+  makePodName,
+  getResourcePodSpec,
+} from "../util"
 
 export async function testKubernetesModule(params: TestModuleParams<KubernetesModule>): Promise<TestResult> {
   const { ctx, log, module, testConfig, testVersion } = params
@@ -43,6 +49,7 @@ export async function testKubernetesModule(params: TestModuleParams<KubernetesMo
   const result = await runAndCopy({
     ...params,
     container,
+    podSpec: getResourcePodSpec(target),
     command,
     args,
     artifacts: testConfig.spec.artifacts,

--- a/core/test/data/test-projects/helm/artifacts/templates/deployment.yaml
+++ b/core/test/data/test-projects/helm/artifacts/templates/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         app.kubernetes.io/name: {{ include "api.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      terminationGracePeriodSeconds: 60
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -30,10 +31,7 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      shareProcessNamespace: {{ .Values.shareProcessNamespace }}
     {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/core/test/data/test-projects/helm/artifacts/values.yaml
+++ b/core/test/data/test-projects/helm/artifacts/values.yaml
@@ -41,7 +41,8 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 
-nodeSelector: {}
+# This field is whitelisted in `runPodSpecWhitelist`, so it should be included when running tests/tasks
+shareProcessNamespace: true
 
 tolerations: []
 

--- a/core/test/integ/src/plugins/kubernetes/helm/common.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/common.ts
@@ -28,6 +28,7 @@ import { deline, dedent } from "../../../../../../src/util/string"
 import { ConfigGraph } from "../../../../../../src/config-graph"
 import { KubernetesPluginContext } from "../../../../../../src/plugins/kubernetes/config"
 import { safeLoadAll } from "js-yaml"
+import { Garden } from "../../../../../../src"
 
 let helmTestGarden: TestGarden
 
@@ -44,7 +45,7 @@ export async function getHelmTestGarden() {
   return garden
 }
 
-export async function buildHelmModules(garden: TestGarden, graph: ConfigGraph) {
+export async function buildHelmModules(garden: Garden | TestGarden, graph: ConfigGraph) {
   const modules = graph.getModules()
   const tasks = modules.map(
     (module) =>

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -165,12 +165,13 @@ serviceResource:
   # container is not the first container in the spec.
   containerName:
 
-  # The name of the resource to sync to. If the chart contains a single resource of the specified Kind, this can be
-  # omitted.
-  # This can include a Helm template string, e.g. '{{ template "my-chart.fullname" . }}'. This allows you to easily
-  # match the dynamic names given by Helm. In most cases you should copy this directly from the template in question
-  # in order to match it. Note that you may need to add single quotes around the string for the YAML to be parsed
-  # correctly.
+  # The name of the resource to sync to. If the chart contains a single resource of the specified Kind,
+  # this can be omitted.
+  #
+  # This can include a Helm template string, e.g. '{{ template "my-chart.fullname" . }}'.
+  # This allows you to easily match the dynamic names given by Helm. In most cases you should copy this
+  # directly from the template in question in order to match it. Note that you may need to add single quotes around
+  # the string for the YAML to be parsed correctly.
   name:
 
   # The Garden module that contains the sources for the container. This needs to be specified under `serviceResource`
@@ -240,8 +241,39 @@ tasks:
         # `.garden/artifacts`.
         target: .
 
-    # The Deployment, DaemonSet or StatefulSet that Garden should use to execute this task. If not specified, the
-    # `serviceResource` configured on the module will be used. If neither is specified, an error will be thrown.
+    # The Deployment, DaemonSet or StatefulSet that Garden should use to execute this task.
+    # If not specified, the `serviceResource` configured on the module will be used. If neither is specified,
+    # an error will be thrown.
+    #
+    # The following pod spec fields from the service resource will be used (if present) when executing the task:
+    # * `affinity`
+    # * `automountServiceAccountToken`
+    # * `containers`
+    # * `dnsConfig`
+    # * `dnsPolicy`
+    # * `enableServiceLinks`
+    # * `hostAliases`
+    # * `hostIPC`
+    # * `hostNetwork`
+    # * `hostPID`
+    # * `hostname`
+    # * `imagePullSecrets`
+    # * `nodeName`
+    # * `nodeSelector`
+    # * `overhead`
+    # * `preemptionPolicy`
+    # * `priority`
+    # * `priorityClassName`
+    # * `runtimeClassName`
+    # * `schedulerName`
+    # * `securityContext`
+    # * `serviceAccount`
+    # * `serviceAccountName`
+    # * `shareProcessNamespace`
+    # * `subdomain`
+    # * `tolerations`
+    # * `topologySpreadConstraints`
+    # * `volumes`
     resource:
       # The type of Kubernetes resource to sync files to.
       kind: Deployment
@@ -250,12 +282,14 @@ tasks:
       # main container is not the first container in the spec.
       containerName:
 
-      # The name of the resource to sync to. If the chart contains a single resource of the specified Kind, this can
-      # be omitted.
-      # This can include a Helm template string, e.g. '{{ template "my-chart.fullname" . }}'. This allows you to
-      # easily match the dynamic names given by Helm. In most cases you should copy this directly from the template in
-      # question in order to match it. Note that you may need to add single quotes around the string for the YAML to
-      # be parsed correctly.
+      # The name of the resource to sync to. If the chart contains a single resource of the specified Kind,
+      # this can be omitted.
+      #
+      # This can include a Helm template string, e.g. '{{ template "my-chart.fullname" . }}'.
+      # This allows you to easily match the dynamic names given by Helm. In most cases you should copy this
+      # directly from the template in question in order to match it. Note that you may need to add single quotes
+      # around
+      # the string for the YAML to be parsed correctly.
       name:
 
       # The Garden module that contains the sources for the container. This needs to be specified under
@@ -306,8 +340,39 @@ tests:
         # `.garden/artifacts`.
         target: .
 
-    # The Deployment, DaemonSet or StatefulSet that Garden should use to execute this test suite. If not specified,
-    # the `serviceResource` configured on the module will be used. If neither is specified, an error will be thrown.
+    # The Deployment, DaemonSet or StatefulSet that Garden should use to execute this test suite.
+    # If not specified, the `serviceResource` configured on the module will be used. If neither is specified,
+    # an error will be thrown.
+    #
+    # The following pod spec fields from the service resource will be used (if present) when executing the test suite:
+    # * `affinity`
+    # * `automountServiceAccountToken`
+    # * `containers`
+    # * `dnsConfig`
+    # * `dnsPolicy`
+    # * `enableServiceLinks`
+    # * `hostAliases`
+    # * `hostIPC`
+    # * `hostNetwork`
+    # * `hostPID`
+    # * `hostname`
+    # * `imagePullSecrets`
+    # * `nodeName`
+    # * `nodeSelector`
+    # * `overhead`
+    # * `preemptionPolicy`
+    # * `priority`
+    # * `priorityClassName`
+    # * `runtimeClassName`
+    # * `schedulerName`
+    # * `securityContext`
+    # * `serviceAccount`
+    # * `serviceAccountName`
+    # * `shareProcessNamespace`
+    # * `subdomain`
+    # * `tolerations`
+    # * `topologySpreadConstraints`
+    # * `volumes`
     resource:
       # The type of Kubernetes resource to sync files to.
       kind: Deployment
@@ -316,12 +381,14 @@ tests:
       # main container is not the first container in the spec.
       containerName:
 
-      # The name of the resource to sync to. If the chart contains a single resource of the specified Kind, this can
-      # be omitted.
-      # This can include a Helm template string, e.g. '{{ template "my-chart.fullname" . }}'. This allows you to
-      # easily match the dynamic names given by Helm. In most cases you should copy this directly from the template in
-      # question in order to match it. Note that you may need to add single quotes around the string for the YAML to
-      # be parsed correctly.
+      # The name of the resource to sync to. If the chart contains a single resource of the specified Kind,
+      # this can be omitted.
+      #
+      # This can include a Helm template string, e.g. '{{ template "my-chart.fullname" . }}'.
+      # This allows you to easily match the dynamic names given by Helm. In most cases you should copy this
+      # directly from the template in question in order to match it. Note that you may need to add single quotes
+      # around
+      # the string for the YAML to be parsed correctly.
       name:
 
       # The Garden module that contains the sources for the container. This needs to be specified under
@@ -702,8 +769,13 @@ The name of a container in the target. Specify this if the target contains more 
 
 [serviceResource](#serviceresource) > name
 
-The name of the resource to sync to. If the chart contains a single resource of the specified Kind, this can be omitted.
-This can include a Helm template string, e.g. '{{ template "my-chart.fullname" . }}'. This allows you to easily match the dynamic names given by Helm. In most cases you should copy this directly from the template in question in order to match it. Note that you may need to add single quotes around the string for the YAML to be parsed correctly.
+The name of the resource to sync to. If the chart contains a single resource of the specified Kind,
+this can be omitted.
+
+This can include a Helm template string, e.g. '{{ template "my-chart.fullname" . }}'.
+This allows you to easily match the dynamic names given by Helm. In most cases you should copy this
+directly from the template in question in order to match it. Note that you may need to add single quotes around
+the string for the YAML to be parsed correctly.
 
 | Type     | Required |
 | -------- | -------- |
@@ -941,7 +1013,39 @@ tasks:
 
 [tasks](#tasks) > resource
 
-The Deployment, DaemonSet or StatefulSet that Garden should use to execute this task. If not specified, the `serviceResource` configured on the module will be used. If neither is specified, an error will be thrown.
+The Deployment, DaemonSet or StatefulSet that Garden should use to execute this task.
+If not specified, the `serviceResource` configured on the module will be used. If neither is specified,
+an error will be thrown.
+
+The following pod spec fields from the service resource will be used (if present) when executing the task:
+* `affinity`
+* `automountServiceAccountToken`
+* `containers`
+* `dnsConfig`
+* `dnsPolicy`
+* `enableServiceLinks`
+* `hostAliases`
+* `hostIPC`
+* `hostNetwork`
+* `hostPID`
+* `hostname`
+* `imagePullSecrets`
+* `nodeName`
+* `nodeSelector`
+* `overhead`
+* `preemptionPolicy`
+* `priority`
+* `priorityClassName`
+* `runtimeClassName`
+* `schedulerName`
+* `securityContext`
+* `serviceAccount`
+* `serviceAccountName`
+* `shareProcessNamespace`
+* `subdomain`
+* `tolerations`
+* `topologySpreadConstraints`
+* `volumes`
 
 | Type     | Required |
 | -------- | -------- |
@@ -971,8 +1075,13 @@ The name of a container in the target. Specify this if the target contains more 
 
 [tasks](#tasks) > [resource](#tasksresource) > name
 
-The name of the resource to sync to. If the chart contains a single resource of the specified Kind, this can be omitted.
-This can include a Helm template string, e.g. '{{ template "my-chart.fullname" . }}'. This allows you to easily match the dynamic names given by Helm. In most cases you should copy this directly from the template in question in order to match it. Note that you may need to add single quotes around the string for the YAML to be parsed correctly.
+The name of the resource to sync to. If the chart contains a single resource of the specified Kind,
+this can be omitted.
+
+This can include a Helm template string, e.g. '{{ template "my-chart.fullname" . }}'.
+This allows you to easily match the dynamic names given by Helm. In most cases you should copy this
+directly from the template in question in order to match it. Note that you may need to add single quotes around
+the string for the YAML to be parsed correctly.
 
 | Type     | Required |
 | -------- | -------- |
@@ -1183,7 +1292,39 @@ tests:
 
 [tests](#tests) > resource
 
-The Deployment, DaemonSet or StatefulSet that Garden should use to execute this test suite. If not specified, the `serviceResource` configured on the module will be used. If neither is specified, an error will be thrown.
+The Deployment, DaemonSet or StatefulSet that Garden should use to execute this test suite.
+If not specified, the `serviceResource` configured on the module will be used. If neither is specified,
+an error will be thrown.
+
+The following pod spec fields from the service resource will be used (if present) when executing the test suite:
+* `affinity`
+* `automountServiceAccountToken`
+* `containers`
+* `dnsConfig`
+* `dnsPolicy`
+* `enableServiceLinks`
+* `hostAliases`
+* `hostIPC`
+* `hostNetwork`
+* `hostPID`
+* `hostname`
+* `imagePullSecrets`
+* `nodeName`
+* `nodeSelector`
+* `overhead`
+* `preemptionPolicy`
+* `priority`
+* `priorityClassName`
+* `runtimeClassName`
+* `schedulerName`
+* `securityContext`
+* `serviceAccount`
+* `serviceAccountName`
+* `shareProcessNamespace`
+* `subdomain`
+* `tolerations`
+* `topologySpreadConstraints`
+* `volumes`
 
 | Type     | Required |
 | -------- | -------- |
@@ -1213,8 +1354,13 @@ The name of a container in the target. Specify this if the target contains more 
 
 [tests](#tests) > [resource](#testsresource) > name
 
-The name of the resource to sync to. If the chart contains a single resource of the specified Kind, this can be omitted.
-This can include a Helm template string, e.g. '{{ template "my-chart.fullname" . }}'. This allows you to easily match the dynamic names given by Helm. In most cases you should copy this directly from the template in question in order to match it. Note that you may need to add single quotes around the string for the YAML to be parsed correctly.
+The name of the resource to sync to. If the chart contains a single resource of the specified Kind,
+this can be omitted.
+
+This can include a Helm template string, e.g. '{{ template "my-chart.fullname" . }}'.
+This allows you to easily match the dynamic names given by Helm. In most cases you should copy this
+directly from the template in question in order to match it. Note that you may need to add single quotes around
+the string for the YAML to be parsed correctly.
 
 | Type     | Required |
 | -------- | -------- |

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -204,8 +204,39 @@ tasks:
     # Maximum duration (in seconds) of the task's execution.
     timeout: null
 
-    # The Deployment, DaemonSet or StatefulSet that Garden should use to execute this task. If not specified, the
-    # `serviceResource` configured on the module will be used. If neither is specified, an error will be thrown.
+    # The Deployment, DaemonSet or StatefulSet that Garden should use to execute this task.
+    # If not specified, the `serviceResource` configured on the module will be used. If neither is specified,
+    # an error will be thrown.
+    #
+    # The following pod spec fields from the service resource will be used (if present) when executing the task:
+    # * `affinity`
+    # * `automountServiceAccountToken`
+    # * `containers`
+    # * `dnsConfig`
+    # * `dnsPolicy`
+    # * `enableServiceLinks`
+    # * `hostAliases`
+    # * `hostIPC`
+    # * `hostNetwork`
+    # * `hostPID`
+    # * `hostname`
+    # * `imagePullSecrets`
+    # * `nodeName`
+    # * `nodeSelector`
+    # * `overhead`
+    # * `preemptionPolicy`
+    # * `priority`
+    # * `priorityClassName`
+    # * `runtimeClassName`
+    # * `schedulerName`
+    # * `securityContext`
+    # * `serviceAccount`
+    # * `serviceAccountName`
+    # * `shareProcessNamespace`
+    # * `subdomain`
+    # * `tolerations`
+    # * `topologySpreadConstraints`
+    # * `volumes`
     resource:
       # The type of Kubernetes resource to sync files to.
       kind: Deployment
@@ -260,8 +291,39 @@ tests:
     # Maximum duration (in seconds) of the test run.
     timeout: null
 
-    # The Deployment, DaemonSet or StatefulSet that Garden should use to execute this test suite. If not specified,
-    # the `serviceResource` configured on the module will be used. If neither is specified, an error will be thrown.
+    # The Deployment, DaemonSet or StatefulSet that Garden should use to execute this test suite.
+    # If not specified, the `serviceResource` configured on the module will be used. If neither is specified,
+    # an error will be thrown.
+    #
+    # The following pod spec fields from the service resource will be used (if present) when executing the test suite:
+    # * `affinity`
+    # * `automountServiceAccountToken`
+    # * `containers`
+    # * `dnsConfig`
+    # * `dnsPolicy`
+    # * `enableServiceLinks`
+    # * `hostAliases`
+    # * `hostIPC`
+    # * `hostNetwork`
+    # * `hostPID`
+    # * `hostname`
+    # * `imagePullSecrets`
+    # * `nodeName`
+    # * `nodeSelector`
+    # * `overhead`
+    # * `preemptionPolicy`
+    # * `priority`
+    # * `priorityClassName`
+    # * `runtimeClassName`
+    # * `schedulerName`
+    # * `securityContext`
+    # * `serviceAccount`
+    # * `serviceAccountName`
+    # * `shareProcessNamespace`
+    # * `subdomain`
+    # * `tolerations`
+    # * `topologySpreadConstraints`
+    # * `volumes`
     resource:
       # The type of Kubernetes resource to sync files to.
       kind: Deployment
@@ -747,7 +809,39 @@ Maximum duration (in seconds) of the task's execution.
 
 [tasks](#tasks) > resource
 
-The Deployment, DaemonSet or StatefulSet that Garden should use to execute this task. If not specified, the `serviceResource` configured on the module will be used. If neither is specified, an error will be thrown.
+The Deployment, DaemonSet or StatefulSet that Garden should use to execute this task.
+If not specified, the `serviceResource` configured on the module will be used. If neither is specified,
+an error will be thrown.
+
+The following pod spec fields from the service resource will be used (if present) when executing the task:
+* `affinity`
+* `automountServiceAccountToken`
+* `containers`
+* `dnsConfig`
+* `dnsPolicy`
+* `enableServiceLinks`
+* `hostAliases`
+* `hostIPC`
+* `hostNetwork`
+* `hostPID`
+* `hostname`
+* `imagePullSecrets`
+* `nodeName`
+* `nodeSelector`
+* `overhead`
+* `preemptionPolicy`
+* `priority`
+* `priorityClassName`
+* `runtimeClassName`
+* `schedulerName`
+* `securityContext`
+* `serviceAccount`
+* `serviceAccountName`
+* `shareProcessNamespace`
+* `subdomain`
+* `tolerations`
+* `topologySpreadConstraints`
+* `volumes`
 
 | Type     | Required |
 | -------- | -------- |
@@ -954,7 +1048,39 @@ Maximum duration (in seconds) of the test run.
 
 [tests](#tests) > resource
 
-The Deployment, DaemonSet or StatefulSet that Garden should use to execute this test suite. If not specified, the `serviceResource` configured on the module will be used. If neither is specified, an error will be thrown.
+The Deployment, DaemonSet or StatefulSet that Garden should use to execute this test suite.
+If not specified, the `serviceResource` configured on the module will be used. If neither is specified,
+an error will be thrown.
+
+The following pod spec fields from the service resource will be used (if present) when executing the test suite:
+* `affinity`
+* `automountServiceAccountToken`
+* `containers`
+* `dnsConfig`
+* `dnsPolicy`
+* `enableServiceLinks`
+* `hostAliases`
+* `hostIPC`
+* `hostNetwork`
+* `hostPID`
+* `hostname`
+* `imagePullSecrets`
+* `nodeName`
+* `nodeSelector`
+* `overhead`
+* `preemptionPolicy`
+* `priority`
+* `priorityClassName`
+* `runtimeClassName`
+* `schedulerName`
+* `securityContext`
+* `serviceAccount`
+* `serviceAccountName`
+* `shareProcessNamespace`
+* `subdomain`
+* `tolerations`
+* `topologySpreadConstraints`
+* `volumes`
 
 | Type     | Required |
 | -------- | -------- |


### PR DESCRIPTION
**What this PR does / why we need it**:

For `helm` and `kubernetes` modules, we now use all pod spec fields from the service resource when running the task/test (excluding a fixed blacklist of pod spec fields).

This allows tasks/tests to e.g. use custom service accounts, node selectors etc.

Also refactored / broke up the `runAndCopy` function.

**Which issue(s) this PR fixes**:

Fixes #2118.

**Special notes for reviewer**:

What do we think of the blacklist as it is here? Do we want to add/remove any fields?