### PR TITLE
fix: update stable/nginx-ingress -> ingress-nginx/ingress-nginx

### DIFF
--- a/core/src/plugins/kubernetes/helm/build.ts
+++ b/core/src/plugins/kubernetes/helm/build.ts
@@ -42,6 +42,12 @@ export async function buildHelmModule({ ctx, module, log }: BuildModuleParams<He
         log,
         args: ["repo", "add", "stable", "https://kubernetes-charts.storage.googleapis.com/"],
       })
+      // nginx-ingress has moved from the stable repo into ingress-nginx
+      await helm({
+        ctx: k8sCtx,
+        log,
+        args: ["repo", "add", "ingress-nginx", "https://kubernetes.github.io/ingress-nginx"],
+      })
       await helm({ ctx: k8sCtx, log, args: ["repo", "update"] })
       log.debug("Fetching chart (after updating)...")
       await pullChart(k8sCtx, log, module)

--- a/core/src/plugins/kubernetes/helm/config.ts
+++ b/core/src/plugins/kubernetes/helm/config.ts
@@ -132,7 +132,7 @@ export const helmModuleSpecSchema = () =>
         deline`A valid Helm chart name or URI (same as you'd input to \`helm install\`).
       Required if the module doesn't contain the Helm chart itself.`
       )
-      .example("stable/nginx-ingress"),
+      .example("ingress-nginx/ingress-nginx"),
     chartPath: joi
       .posixPath()
       .subPathOnly()

--- a/docs/guides/cloud-provider-setup.md
+++ b/docs/guides/cloud-provider-setup.md
@@ -52,7 +52,7 @@ Run `garden --env=remote plugins kubernetes cluster-init`, then `garden dev --en
 
 ### Optional: Configure DNS
 
-First, get the public IP address of the ingress controller you set up in the previous step. If you configured Garden to set up _nginx_, run: `kubectl describe service --namespace=garden-system garden-nginx-nginx-ingress-controller | grep 'LoadBalancer Ingress'` and make note of returned IP address.
+First, get the public IP address of the ingress controller you set up in the previous step. If you configured Garden to set up _nginx_, run: `kubectl describe service --namespace=garden-system garden-nginx-ingress-nginx-controller | grep 'LoadBalancer Ingress'` and make note of returned IP address.
 
 Then, create a DNS record with your provider of choice, pointing at the IP address you wrote down in the previous step (e.g. an `A` record pointing your-project.your-domain.com at that IP). We recommend setting up a wildcard record as well (e.g *.your-project.your-domain.com).
 

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -626,7 +626,7 @@ A valid Helm chart name or URI (same as you'd input to `helm install`). Required
 Example:
 
 ```yaml
-chart: "stable/nginx-ingress"
+chart: "ingress-nginx/ingress-nginx"
 ```
 
 ### `chartPath`

--- a/static/kubernetes/system/ingress-controller/garden.yml
+++ b/static/kubernetes/system/ingress-controller/garden.yml
@@ -2,29 +2,30 @@ kind: Module
 description: Ingress controller for garden development
 name: ingress-controller
 type: helm
-chart: stable/nginx-ingress
+chart: ingress-nginx/ingress-nginx
 releaseName: garden-nginx
 dependencies:
   - default-backend
-version: 1.26.2
+version: 3.15.2
 values:
   name: ingress-controller
   controller:
-    defaultBackendService: ${var.namespace}/default-backend
+    extraArgs:
+      default-backend-service: ${var.namespace}/default-backend
     kind: DaemonSet
     updateStrategy:
       type: RollingUpdate
       rollingUpdate:
         maxUnavailable: 1
-    daemonset:
-      useHostPort: true
-      hostPorts:
+    hostPort:
+      enabled: true
+      ports:
         http: ${var.ingress-http-port}
         https: ${var.ingress-https-port}
-    service:
-      omitClusterIP: true
     minReadySeconds: 1
     tolerations: ${var.system-tolerations}
     nodeSelector: ${var.system-node-selector}
   defaultBackend:
     enabled: false
+  admissionWebhooks:
+   enabled: false


### PR DESCRIPTION
**What this PR does / why we need it**:

As of Nov. 13th 2020, the `stable/nginx-ingress` is deprecated. It can still be downloaded with helm, but unfortunately the directory structure has changed as part of the deprecation which causes [the helm pull code](https://github.com/garden-io/garden/blob/b3cc5bd6b2aa75ba018942996b79d47eb1489d9e/core/src/plugins/kubernetes/helm/build.ts#L72) to malfunction and move an empty chart definition to the build directory. The resultant error message when setting up the nginx-controller is this:

```
local-kubernetes — an error occurred when configuring environment:
Error: Command "<home>/.garden/tools/helm/4d13a6c3bb98b810/darwin-amd64/helm --kube-context docker-desktop --namespace garden-system install garden-nginx 
<project dir>/.garden/kubernetes.garden/build/ingress-controller/nginx-ingress --dry-run --namespace garden-system --output json --timeout 300s --values 
<project dir>/.garden/kubernetes.garden/build/ingress-controller/nginx-ingress/garden-values.yml" failed with code 1:
Error: validation: chart.metadata is required
```

Unfortunately, this error renders Garden completely unusable on any new machines that do not already have the previous version of this chart cached.

**Special notes for your reviewer**:

### Repro steps (OSX specific):

1. Reset kubernetes cluster (or otherwise destroy ingress).
2. `rm -rf ~/Library/Caches/helm` the helm cache must be cleared to force a new download.
3. `~/.garden/tools/helm/4d13a6c3bb98b810/darwin-amd64/helm repo update`
4. cd `examples/demo-project`
5. `garden dev --force-refresh`

Without this PR's changes, you should see the `chart.metadata is required` error. With this PR's changes, you should be able to successfully install the nginx ingress and start the demo project.

### Other notes

This does wind up updating the nginx ingress chart quite a bit. There are seemingly none of the original deprecated version available in the new repo, and I made the decision to upgrade to the latest version that is currently released. I've tested this with demo-project, as well as our (fairly complex) internal project that we use Garden for, and I've seen no issues. I've also glanced at the changes to the chart, and haven't seen any obvious incompatibilities other than what I've updated. However, you may want to perform some more extensive tests if you can think of some good projects to attempt this on.