### PR TITLE
fix: use archive stable repository

### DIFF
--- a/core/src/plugins/kubernetes/helm/build.ts
+++ b/core/src/plugins/kubernetes/helm/build.ts
@@ -40,7 +40,7 @@ export async function buildHelmModule({ ctx, module, log }: BuildModuleParams<He
       await helm({
         ctx: k8sCtx,
         log,
-        args: ["repo", "add", "stable", "https://kubernetes-charts.storage.googleapis.com/"],
+        args: ["repo", "add", "stable", "https://charts.helm.sh/stable", "--force-update"],
       })
       await helm({ ctx: k8sCtx, log, args: ["repo", "update"] })
       log.debug("Fetching chart (after updating)...")


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a temporary fix, in place of #2173. Since the old stable helm repository is no longer usable, this switches to using the stable archive repo as documented here: https://helm.sh/docs/faq/#i-am-getting-a-warning-about-unable-to-get-an-update-from-the-stable-chart-repository

**Special notes for your reviewer**:

### Repro steps (OSX specific):

1. Reset kubernetes cluster (or otherwise destroy ingress).
2. `rm -rf ~/Library/Caches/helm` the helm cache must be cleared to force a new download.
3. `helm repo update && helm repo remove stable`
4. cd `examples/demo-project`
5. `garden dev --force-refresh`

Without this PR's changes, you should see the `chart.metadata is required` error. With this PR's changes, you should be able to successfully install the nginx ingress and start the demo project.