### PR TITLE
improvement(enterprise): include message metadata with log entries

### DIFF
--- a/core/src/events.ts
+++ b/core/src/events.ts
@@ -9,7 +9,7 @@
 import { omit } from "lodash"
 import { EventEmitter2 } from "eventemitter2"
 import { GraphResult } from "./task-graph"
-import { LogEntryEvent } from "./enterprise/buffered-event-stream"
+import { LogEntryEventPayload } from "./enterprise/buffered-event-stream"
 import { ServiceStatus } from "./types/service"
 import { RunStatus } from "./types/plugin/base"
 import { Omit } from "./util/util"
@@ -55,7 +55,7 @@ export class EventBus extends EventEmitter2 {
  */
 export interface LoggerEvents {
   _test: any
-  logEntry: LogEntryEvent
+  logEntry: LogEntryEventPayload
 }
 
 export type LoggerEventName = keyof LoggerEvents

--- a/core/src/logger/log-entry.ts
+++ b/core/src/logger/log-entry.ts
@@ -53,8 +53,8 @@ interface MessageBase {
   maxSectionWidth?: number
 }
 
-export interface MessageState extends MessageBase {
-  timestamp: number
+export interface LogEntryMessage extends MessageBase {
+  timestamp: Date
 }
 
 export interface UpdateLogEntryParams extends MessageBase {
@@ -63,8 +63,6 @@ export interface UpdateLogEntryParams extends MessageBase {
 
 export interface LogEntryParams extends UpdateLogEntryParams {
   error?: GardenError
-  data?: any // to be rendered as e.g. YAML or JSON
-  dataFormat?: "json" | "yaml" // how to render the data object
   indent?: number
   childEntriesInheritLevel?: boolean
   fromStdStream?: boolean
@@ -89,7 +87,7 @@ function resolveParams(params?: string | UpdateLogEntryParams): UpdateLogEntryPa
 }
 
 export class LogEntry extends LogNode {
-  private messageStates?: MessageState[]
+  private messages?: LogEntryMessage[]
   private metadata?: LogEntryMetadata
   public readonly root: Logger
   public readonly fromStdStream?: boolean
@@ -130,38 +128,38 @@ export class LogEntry extends LogNode {
   /**
    * Updates the log entry with a few invariants:
    * 1. msg, emoji, section, status, and symbol can only be replaced with a value of same type, not removed
-   * 2. append is always set explicitly (the next message state does not inherit the previous value)
+   * 2. append is always set explicitly (the next message does not inherit the previous value)
    * 3. next metadata is merged with the previous metadata
    */
   protected update(updateParams: UpdateLogEntryParams): void {
     this.revision = this.revision + 1
-    const messageState = this.getMessageState()
+    const latestMessage = this.getLatestMessage()
 
     // Explicitly set all the fields so the shape stays consistent
-    const nextMessageState: MessageState = {
+    const nextMessage: LogEntryMessage = {
       // Ensure empty string gets set
-      msg: typeof updateParams.msg === "string" ? updateParams.msg : messageState.msg,
-      emoji: updateParams.emoji || messageState.emoji,
-      section: updateParams.section || messageState.section,
-      status: updateParams.status || messageState.status,
-      symbol: updateParams.symbol || messageState.symbol,
-      data: updateParams.data || messageState.data,
-      dataFormat: updateParams.dataFormat || messageState.dataFormat,
-      // Next state does not inherit the append field
+      msg: typeof updateParams.msg === "string" ? updateParams.msg : latestMessage.msg,
+      emoji: updateParams.emoji || latestMessage.emoji,
+      section: updateParams.section || latestMessage.section,
+      status: updateParams.status || latestMessage.status,
+      symbol: updateParams.symbol || latestMessage.symbol,
+      data: updateParams.data || latestMessage.data,
+      dataFormat: updateParams.dataFormat || latestMessage.dataFormat,
+      // Next message does not inherit the append field
       append: updateParams.append,
-      timestamp: Date.now(),
+      timestamp: new Date(),
       maxSectionWidth:
-        updateParams.maxSectionWidth !== undefined ? updateParams.maxSectionWidth : messageState.maxSectionWidth,
+        updateParams.maxSectionWidth !== undefined ? updateParams.maxSectionWidth : latestMessage.maxSectionWidth,
     }
 
     // Hack to preserve section alignment if spinner disappears
-    const hadSpinner = messageState.status === "active"
-    const hasSymbolOrSpinner = nextMessageState.symbol || nextMessageState.status === "active"
-    if (nextMessageState.section && hadSpinner && !hasSymbolOrSpinner) {
-      nextMessageState.symbol = "empty"
+    const hadSpinner = latestMessage.status === "active"
+    const hasSymbolOrSpinner = nextMessage.symbol || nextMessage.status === "active"
+    if (nextMessage.section && hadSpinner && !hasSymbolOrSpinner) {
+      nextMessage.symbol = "empty"
     }
 
-    this.messageStates = [...(this.messageStates || []), nextMessageState]
+    this.messages = [...(this.messages || []), nextMessage]
 
     if (updateParams.metadata) {
       this.metadata = { ...(this.metadata || {}), ...updateParams.metadata }
@@ -170,14 +168,14 @@ export class LogEntry extends LogNode {
 
   // Update node and child nodes
   private deepUpdate(updateParams: UpdateLogEntryParams): void {
-    const wasActive = this.getMessageState().status === "active"
+    const wasActive = this.getLatestMessage().status === "active"
 
     this.update(updateParams)
 
     // Stop active child nodes if no longer active
     if (wasActive && updateParams.status !== "active") {
       getChildEntries(this).forEach((entry) => {
-        if (entry.getMessageState().status === "active") {
+        if (entry.getLatestMessage().status === "active") {
           entry.update({ status: "done" })
         }
       })
@@ -210,23 +208,23 @@ export class LogEntry extends LogNode {
     return this.metadata
   }
 
-  getMessageStates() {
-    return this.messageStates
+  getMessages() {
+    return this.messages
   }
 
   /**
-   * Returns a deep copy of the latest message state, if availble.
-   * Otherwise return an empty object of type MessageState for convenience.
+   * Returns a deep copy of the latest message, if availble.
+   * Otherwise returns an empty object of type LogEntryMessage for convenience.
    */
-  getMessageState() {
-    if (!this.messageStates) {
-      return <MessageState>{}
+  getLatestMessage() {
+    if (!this.messages) {
+      return <LogEntryMessage>{}
     }
 
     // Use spread operator to clone the array
-    const msgState = [...this.messageStates][this.messageStates.length - 1]
+    const message = [...this.messages][this.messages.length - 1]
     // ...and the object itself
-    return { ...msgState }
+    return { ...message }
   }
 
   placeholder({
@@ -296,7 +294,7 @@ export class LogEntry extends LogNode {
 
   stop() {
     // Stop gracefully if still in active state
-    if (this.getMessageState().status === "active") {
+    if (this.getLatestMessage().status === "active") {
       this.update({ symbol: "empty", status: "done" })
       this.onGraphChange(this)
     }
@@ -316,7 +314,7 @@ export class LogEntry extends LogNode {
   toString(filter?: (log: LogEntry) => boolean) {
     return this.getChildEntries()
       .filter((entry) => (filter ? filter(entry) : true))
-      .flatMap((entry) => entry.getMessageStates()?.map((state) => state.msg))
+      .flatMap((entry) => entry.getMessages()?.map((message) => message.msg))
       .join("\n")
   }
 }

--- a/core/src/logger/log-node.ts
+++ b/core/src/logger/log-node.ts
@@ -40,13 +40,13 @@ export function resolveParams(level: LogLevel, params: string | LogEntryParams):
 }
 
 export abstract class LogNode {
-  public readonly timestamp: number
+  public readonly timestamp: Date
   public readonly key: string
   public readonly children: LogEntry[]
 
   constructor(public readonly level: LogLevel, public readonly parent?: LogEntry, public readonly id?: string) {
     this.key = uniqid()
-    this.timestamp = Date.now()
+    this.timestamp = new Date()
     this.children = []
   }
 
@@ -94,6 +94,6 @@ export abstract class LogNode {
    * Returns the duration in seconds, defaults to 2 decimal precision
    */
   getDuration(precision: number = 2): number {
-    return round((Date.now() - this.timestamp) / 1000, precision)
+    return round((new Date().getTime() - this.timestamp.getTime()) / 1000, precision)
   }
 }

--- a/core/src/logger/logger.ts
+++ b/core/src/logger/logger.ts
@@ -176,7 +176,7 @@ export class Logger extends LogNode {
   }
 
   filterBySection(section: string): LogEntry[] {
-    return getChildEntries(this).filter((entry) => entry.getMessageState().section === section)
+    return getChildEntries(this).filter((entry) => entry.getLatestMessage().section === section)
   }
 
   findById(id: string): LogEntry | void {

--- a/core/src/logger/util.ts
+++ b/core/src/logger/util.ts
@@ -83,7 +83,7 @@ export function tailChildEntries(node: LogNode | LogEntry, level: LogLevel, line
   traverseChildren<LogNode, LogEntry>(node, (entry) => {
     if (entry.level <= level) {
       output.push(entry)
-      const msg = entry.getMessageState().msg || ""
+      const msg = entry.getLatestMessage().msg || ""
       outputLines += msg.length > 0 ? msg.split("\n").length : 0
 
       if (outputLines >= lines) {

--- a/core/src/logger/writers/fancy-terminal-writer.ts
+++ b/core/src/logger/writers/fancy-terminal-writer.ts
@@ -181,7 +181,7 @@ export class FancyTerminalWriter extends Writer {
         let spinnerX: number
         let spinnerCoords: Coords | undefined
 
-        if (entry.getMessageState().status === "active") {
+        if (entry.getLatestMessage().status === "active") {
           spinnerX = getLeftOffset(entry)
           spinnerFrame = this.tickSpinner(entry.key)
           spinnerCoords = [spinnerX, currentLineNumber]

--- a/core/src/logger/writers/fullscreen-terminal-writer.ts
+++ b/core/src/logger/writers/fullscreen-terminal-writer.ts
@@ -464,7 +464,7 @@ export class FullscreenTerminalWriter extends Writer {
     let spinnerFrame = ""
     let spinnerX: number | undefined
 
-    if (entry.getMessageState().status === "active") {
+    if (entry.getLatestMessage().status === "active") {
       spinnerX = leftPad(entry).length
       spinnerFrame = this.tickSpinner(entry.key)
     } else {

--- a/core/test/helpers.ts
+++ b/core/test/helpers.ts
@@ -517,7 +517,7 @@ export function getLogMessages(log: LogEntry, filter?: (log: LogEntry) => boolea
   return log
     .getChildEntries()
     .filter((entry) => (filter ? filter(entry) : true))
-    .flatMap((entry) => entry.getMessageStates()?.map((state) => stripAnsi(state.msg || "")) || [])
+    .flatMap((entry) => entry.getMessages()?.map((state) => stripAnsi(state.msg || "")) || [])
 }
 
 const skipGroups = gardenEnv.GARDEN_SKIP_TESTS.split(" ")

--- a/core/test/unit/src/cli/cli.ts
+++ b/core/test/unit/src/cli/cli.ts
@@ -414,7 +414,7 @@ describe("cli", () => {
 
       await cli.run({ args, exitOnError: false })
 
-      const serverStatus = cmd.server!["statusLog"].getMessageState().msg!
+      const serverStatus = cmd.server!["statusLog"].getLatestMessage().msg!
       expect(stripAnsi(serverStatus)).to.equal(`Garden dashboard running at ${cmd.server!.getUrl()}`)
     })
 
@@ -468,7 +468,7 @@ describe("cli", () => {
         await server.close()
       }
 
-      const serverStatus = cmd.server!["statusLog"].getMessageState().msg!
+      const serverStatus = cmd.server!["statusLog"].getLatestMessage().msg!
       expect(stripAnsi(serverStatus)).to.equal(`Garden dashboard running at ${server.getUrl()}`)
     })
 

--- a/core/test/unit/src/commands/run/workflow.ts
+++ b/core/test/unit/src/commands/run/workflow.ts
@@ -150,7 +150,7 @@ describe("RunWorkflowCommand", () => {
   })
 
   function filterLogEntries(entries: LogEntry[], msgRegex: RegExp): LogEntry[] {
-    return entries.filter((e) => msgRegex.test(e.getMessageState().msg || ""))
+    return entries.filter((e) => msgRegex.test(e.getLatestMessage().msg || ""))
   }
 
   it("should collect log outputs from a command step", async () => {

--- a/core/test/unit/src/enterprise/buffered-event-stream.ts
+++ b/core/test/unit/src/enterprise/buffered-event-stream.ts
@@ -7,7 +7,11 @@
  */
 
 import { expect } from "chai"
-import { StreamEvent, LogEntryEvent, BufferedEventStream } from "../../../../src/enterprise/buffered-event-stream"
+import {
+  StreamEvent,
+  LogEntryEventPayload,
+  BufferedEventStream,
+} from "../../../../src/enterprise/buffered-event-stream"
 import { getLogger } from "../../../../src/logger/logger"
 import { Garden } from "../../../../src/garden"
 import { makeTestGardenA } from "../../../helpers"
@@ -32,7 +36,7 @@ describe("BufferedEventStream", () => {
 
   it("should flush events and log entries emitted by a connected event emitter", async () => {
     const flushedEvents: StreamEvent[] = []
-    const flushedLogEntries: LogEntryEvent[] = []
+    const flushedLogEntries: LogEntryEventPayload[] = []
 
     const log = getLogger().placeholder()
 
@@ -42,7 +46,7 @@ describe("BufferedEventStream", () => {
       flushedEvents.push(...events)
       return Promise.resolve()
     }
-    bufferedEventStream["flushLogEntries"] = (logEntries: LogEntryEvent[]) => {
+    bufferedEventStream["flushLogEntries"] = (logEntries: LogEntryEventPayload[]) => {
       flushedLogEntries.push(...logEntries)
       return Promise.resolve()
     }
@@ -61,7 +65,7 @@ describe("BufferedEventStream", () => {
 
   it("should only flush events or log entries emitted by the last connected Garden bus", async () => {
     const flushedEvents: StreamEvent[] = []
-    const flushedLogEntries: LogEntryEvent[] = []
+    const flushedLogEntries: LogEntryEventPayload[] = []
 
     const log = getLogger().placeholder()
 
@@ -71,7 +75,7 @@ describe("BufferedEventStream", () => {
       flushedEvents.push(...events)
       return Promise.resolve()
     }
-    bufferedEventStream["flushLogEntries"] = (logEntries: LogEntryEvent[]) => {
+    bufferedEventStream["flushLogEntries"] = (logEntries: LogEntryEventPayload[]) => {
       flushedLogEntries.push(...logEntries)
       return Promise.resolve()
     }

--- a/core/test/unit/src/logger/log-node.ts
+++ b/core/test/unit/src/logger/log-node.ts
@@ -7,12 +7,13 @@
  */
 
 import { expect } from "chai"
-import { getLogger } from "../../../../src/logger/logger"
+import { getLogger, Logger } from "../../../../src/logger/logger"
 
-const logger: any = getLogger()
+const logger: Logger = getLogger()
 
 beforeEach(() => {
-  logger.children = []
+  // tslint:disable-next-line: prettier
+  (logger["children"] as any) = []
 })
 
 describe("LogNode", () => {

--- a/core/test/unit/src/logger/logger.ts
+++ b/core/test/unit/src/logger/logger.ts
@@ -10,19 +10,20 @@ import { expect } from "chai"
 import { omit } from "lodash"
 
 import { LogLevel } from "../../../../src/logger/log-node"
-import { getLogger } from "../../../../src/logger/logger"
-import { LogEntryEvent, formatLogEntryForEventStream } from "../../../../src/enterprise/buffered-event-stream"
+import { getLogger, Logger } from "../../../../src/logger/logger"
+import { LogEntryEventPayload, formatLogEntryForEventStream } from "../../../../src/enterprise/buffered-event-stream"
 
-const logger: any = getLogger()
+const logger: Logger = getLogger()
 
 beforeEach(() => {
-  logger.children = []
+  // tslint:disable-next-line: prettier
+  (logger["children"] as any) = []
 })
 
 describe("Logger", () => {
   describe("events", () => {
-    let loggerEvents: LogEntryEvent[] = []
-    let listener = (event: LogEntryEvent) => loggerEvents.push(event)
+    let loggerEvents: LogEntryEventPayload[] = []
+    let listener = (event: LogEntryEventPayload) => loggerEvents.push(event)
 
     before(() => logger.events.on("logEntry", listener))
     after(() => logger.events.off("logEntry", listener))
@@ -56,7 +57,7 @@ describe("Logger", () => {
       logger.info({ msg: "0" })
       logger.info({ msg: "a1", id: "a" })
       logger.info({ msg: "a2", id: "a" })
-      expect(logger.findById("a")["messageStates"][0]["msg"]).to.eql("a1")
+      expect(logger.findById("a")["messages"][0]["msg"]).to.eql("a1")
       expect(logger.findById("z")).to.be.undefined
     })
   })

--- a/core/test/unit/src/logger/renderers.ts
+++ b/core/test/unit/src/logger/renderers.ts
@@ -8,7 +8,7 @@
 
 import { expect } from "chai"
 
-import { getLogger } from "../../../../src/logger/logger"
+import { getLogger, Logger } from "../../../../src/logger/logger"
 import {
   renderMsg,
   msgStyle,
@@ -29,10 +29,11 @@ import stripAnsi = require("strip-ansi")
 import { highlightYaml, safeDumpYaml } from "../../../../src/util/util"
 import { freezeTime } from "../../../helpers"
 
-const logger: any = getLogger()
+const logger: Logger = getLogger()
 
 beforeEach(() => {
-  logger.children = []
+  // tslint:disable-next-line: prettier
+  (logger["children"] as any) = []
 })
 
 describe("renderers", () => {
@@ -126,8 +127,8 @@ describe("renderers", () => {
   })
   describe("chainMessages", () => {
     it("should correctly chain log messages", () => {
-      const timestamp = Date.now()
-      const messageStateTable = [
+      const timestamp = new Date()
+      const messagesTable = [
         [
           { msg: "1", append: true },
           { msg: "2", append: true },
@@ -155,7 +156,7 @@ describe("renderers", () => {
         ],
       ].map((msgStates) => msgStates.map((msgState) => ({ ...msgState, timestamp })))
       const expects = [["1", "2", "3"], ["1", "2", "3"], ["2", "3"], ["2", "3"], ["3"]]
-      messageStateTable.forEach((msgState, index) => {
+      messagesTable.forEach((msgState, index) => {
         expect(chainMessages(msgState)).to.eql(expects[index])
       })
     })
@@ -173,7 +174,7 @@ describe("renderers", () => {
       const entry = logger.info({})
       expect(formatForTerminal(entry, "fancy")).to.equal("")
     })
-    it("should return a string with a new line if any of the members of entry.messageState is not empty", () => {
+    it("should return a string with a new line if any of the members of entry.messages is not empty", () => {
       const entryMsg = logger.info({ msg: "msg" })
       expect(formatForTerminal(entryMsg, "fancy")).contains("\n")
 
@@ -217,10 +218,11 @@ describe("renderers", () => {
 
           expect(formatForTerminal(entry, "basic")).to.equal(`[${now.toISOString()}] ${msgStyle("hello world")}\n`)
         })
-        it("should show the timestamp for the most recent message state", () => {
+        it("should show the timestamp for the most recent message state", async () => {
           const entry = logger.info("hello world")
+          const date = new Date(1600555650583) // Some date that's different from the current one
+          freezeTime(date)
           entry.setState("update entry")
-          entry.messageStates[1].timestamp = 1600555650583
 
           expect(formatForTerminal(entry, "basic")).to.equal(`[2020-09-19T22:47:30.583Z] ${msgStyle("update entry")}\n`)
         })

--- a/core/test/unit/src/logger/writers/basic-terminal-writer.ts
+++ b/core/test/unit/src/logger/writers/basic-terminal-writer.ts
@@ -9,13 +9,14 @@
 import { expect } from "chai"
 
 import { BasicTerminalWriter } from "../../../../../src/logger/writers/basic-terminal-writer"
-import { getLogger } from "../../../../../src/logger/logger"
+import { getLogger, Logger } from "../../../../../src/logger/logger"
 import { formatForTerminal } from "../../../../../src/logger/renderers"
 
-const logger: any = getLogger()
+const logger: Logger = getLogger()
 
 beforeEach(() => {
-  logger.children = []
+  // tslint:disable-next-line: prettier
+  (logger["children"] as any) = []
 })
 
 describe("BasicTerminalWriter", () => {

--- a/core/test/unit/src/logger/writers/fancy-terminal-writer.ts
+++ b/core/test/unit/src/logger/writers/fancy-terminal-writer.ts
@@ -9,12 +9,13 @@
 import { expect } from "chai"
 
 import { FancyTerminalWriter } from "../../../../../src/logger/writers/fancy-terminal-writer"
-import { getLogger } from "../../../../../src/logger/logger"
+import { getLogger, Logger } from "../../../../../src/logger/logger"
 
-const logger: any = getLogger()
+const logger: Logger = getLogger()
 
 beforeEach(() => {
-  logger.children = []
+  // tslint:disable-next-line: prettier
+  (logger["children"] as any) = []
 })
 
 describe("FancyTerminalWriter", () => {

--- a/core/test/unit/src/logger/writers/file-writer.ts
+++ b/core/test/unit/src/logger/writers/file-writer.ts
@@ -11,14 +11,15 @@ import chalk from "chalk"
 import stripAnsi from "strip-ansi"
 
 import { LogLevel } from "../../../../../src/logger/log-node"
-import { getLogger } from "../../../../../src/logger/logger"
+import { getLogger, Logger } from "../../../../../src/logger/logger"
 import { renderError } from "../../../../../src/logger/renderers"
 import { render } from "../../../../../src/logger/writers/file-writer"
 
-const logger: any = getLogger()
+const logger: Logger = getLogger()
 
 beforeEach(() => {
-  logger.children = []
+  // tslint:disable-next-line: prettier
+  (logger["children"] as any) = []
 })
 
 describe("FileWriter", () => {

--- a/core/test/unit/src/logger/writers/json-terminal-writer.ts
+++ b/core/test/unit/src/logger/writers/json-terminal-writer.ts
@@ -9,13 +9,14 @@
 import { expect } from "chai"
 
 import { JsonTerminalWriter } from "../../../../../src/logger/writers/json-terminal-writer"
-import { getLogger } from "../../../../../src/logger/logger"
+import { getLogger, Logger } from "../../../../../src/logger/logger"
 import { freezeTime } from "../../../../helpers"
 
-const logger: any = getLogger()
+const logger: Logger = getLogger()
 
 beforeEach(() => {
-  logger.children = []
+  // tslint:disable-next-line: prettier
+  (logger["children"] as any) = []
 })
 
 describe("JsonTerminalWriter", () => {

--- a/core/test/unit/src/server/server.ts
+++ b/core/test/unit/src/server/server.ts
@@ -41,7 +41,7 @@ describe("GardenServer", () => {
 
   it("should show no URL on startup", async () => {
     const line = gardenServer["statusLog"]
-    expect(line.getMessageState().msg).to.be.undefined
+    expect(line.getLatestMessage().msg).to.be.undefined
   })
 
   it("should update dashboard URL with own if the external dashboard goes down", async () => {
@@ -51,7 +51,7 @@ describe("GardenServer", () => {
     })
     const line = gardenServer["statusLog"]
     await sleep(1) // This is enough to let go of the control loop
-    const status = stripAnsi(line.getMessageState().msg || "")
+    const status = stripAnsi(line.getLatestMessage().msg || "")
     expect(status).to.equal(`Garden dashboard running at ${gardenServer.getUrl()}`)
   })
 
@@ -62,7 +62,7 @@ describe("GardenServer", () => {
     })
     const line = gardenServer["statusLog"]
     await sleep(1) // This is enough to let go of the control loop
-    const status = stripAnsi(line.getMessageState().msg || "")
+    const status = stripAnsi(line.getLatestMessage().msg || "")
     expect(status).to.equal(`Garden dashboard running at http://localhost:9800`)
   })
 

--- a/core/test/unit/src/util/util.ts
+++ b/core/test/unit/src/util/util.ts
@@ -128,7 +128,7 @@ describe("util", () => {
 
       await exec("echo", ["hello"], { stdout: createOutputStream(entry) })
 
-      expect(entry.getMessageState().msg).to.equal(renderOutputStream("hello"))
+      expect(entry.getLatestMessage().msg).to.equal(renderOutputStream("hello"))
     })
 
     it("should optionally pipe stderr to an output stream", async () => {
@@ -137,7 +137,7 @@ describe("util", () => {
 
       await exec("sh", ["-c", "echo hello 1>&2"], { stderr: createOutputStream(entry) })
 
-      expect(entry.getMessageState().msg).to.equal(renderOutputStream("hello"))
+      expect(entry.getLatestMessage().msg).to.equal(renderOutputStream("hello"))
     })
 
     it("should throw a standardised error message on error", async () => {


### PR DESCRIPTION
**What this PR does / why we need it**:

The log entries we were sending over didn't include all the message metadata to properly render them in GE. We were also including previous message states with the message sent which we shouldn't do. 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

I kept the previous fields in the payload to maintain compatibility. We need to discuss how we do this moving forward. 

I also renamed some fields for clarity.