### PR TITLE
chore(enterprise): fix log entry event payload

### DIFF
--- a/core/src/enterprise/buffered-event-stream.ts
+++ b/core/src/enterprise/buffered-event-stream.ts
@@ -11,7 +11,6 @@ import { omit } from "lodash"
 
 import { Events, EventName, EventBus, eventNames } from "../events"
 import { LogEntryMetadata, LogEntry, LogEntryMessage } from "../logger/log-entry"
-import { chainMessages } from "../logger/renderers"
 import { got } from "../util/http"
 import { makeAuthHeader } from "./auth"
 import { LogLevel } from "../logger/log-node"
@@ -28,12 +27,9 @@ export interface LogEntryEventPayload {
   key: string
   parentKey: string | null
   revision: number
-  msg: string | string[]
   timestamp: Date
   level: LogLevel
   message: Omit<LogEntryMessage, "timestamp">
-  data?: any
-  section?: string
   metadata?: LogEntryMetadata
 }
 
@@ -42,15 +38,11 @@ export function formatLogEntryForEventStream(entry: LogEntry): LogEntryEventPayl
   const { key, revision, level } = entry
   const parentKey = entry.parent ? entry.parent.key : null
   const metadata = entry.getMetadata()
-  const msg = chainMessages(entry.getMessages() || [])
   return {
     key,
     parentKey,
     revision,
-    msg,
-    data: message.data,
     metadata,
-    section: message.section,
     timestamp: message.timestamp,
     level,
     message: omit(message, "timestamp"),

--- a/core/src/logger/log-node.ts
+++ b/core/src/logger/log-node.ts
@@ -57,7 +57,7 @@ export abstract class LogNode {
    * A placeholder entry is an empty entry whose children should be aligned with the parent context.
    * Useful for setting a placeholder in the middle of the log that can later be populated.
    */
-  abstract placeholder(PlaceholderOpts?): LogEntry
+  abstract placeholder(opts?: PlaceholderOpts): LogEntry
 
   protected addNode(params: CreateNodeParams): LogEntry {
     const node = this.createNode(params)

--- a/core/src/logger/logger.ts
+++ b/core/src/logger/logger.ts
@@ -161,7 +161,7 @@ export class Logger extends LogNode {
   }
 
   onGraphChange(entry: LogEntry) {
-    if (entry.level <= EVENT_LOG_LEVEL) {
+    if (entry.level <= EVENT_LOG_LEVEL && !entry.isPlaceholder) {
       this.events.emit("logEntry", formatLogEntryForEventStream(entry))
     }
     for (const writer of this.writers) {

--- a/core/src/logger/renderers.ts
+++ b/core/src/logger/renderers.ts
@@ -59,13 +59,12 @@ export function getLeftOffset(entry: LogEntry) {
 }
 
 /**
- * Returns the most recent message's `msg` field if it has `append` set to `false`.
- * Otherwise returns longest chain of messages with `append: true` (starting from the most recent message).
+ * Returns longest chain of messages with `append: true` (starting from the most recent message).
  */
-export function chainMessages(messages: LogEntryMessage[], chain: string[] = []): string | string[] {
+export function chainMessages(messages: LogEntryMessage[], chain: string[] = []): string[] {
   const latestState = messages[messages.length - 1]
   if (!latestState) {
-    return chain.length === 1 ? chain[0] : chain.reverse()
+    return chain.reverse()
   }
 
   chain = latestState.msg !== undefined ? [...chain, latestState.msg] : chain
@@ -144,16 +143,14 @@ export function renderMsg(entry: LogEntry): string {
   const msg = chainMessages(entry.getMessages() || [])
 
   if (fromStdStream) {
-    return isArray(msg) ? msg.join(" ") : msg || ""
+    return msg.join(" ")
   }
 
   const styleFn = status === "error" ? errorStyle : msgStyle
-  if (isArray(msg)) {
-    // We apply the style function to each item (as opposed to the entire string) in case some
-    // part of the message already has a style
-    return msg.map((str) => styleFn(str)).join(styleFn(" → "))
-  }
-  return msg ? styleFn(msg) : ""
+
+  // We apply the style function to each item (as opposed to the entire string) in case some
+  // part of the message already has a style
+  return msg.map((str) => styleFn(str)).join(styleFn(" → "))
 }
 
 export function renderData(entry: LogEntry): string {
@@ -185,7 +182,7 @@ export function formatForTerminal(entry: LogEntry, type: PickFromUnion<LoggerTyp
   const { msg: msg, emoji, section, symbol, data } = entry.getLatestMessage()
   const empty = [msg, section, emoji, symbol, data].every((val) => val === undefined)
 
-  if (empty) {
+  if (entry.isPlaceholder || empty) {
     return ""
   }
 

--- a/core/test/unit/src/commands/run/workflow.ts
+++ b/core/test/unit/src/commands/run/workflow.ts
@@ -93,8 +93,8 @@ describe("RunWorkflowCommand", () => {
     const workflowCompletedEntry = filterLogEntries(entries, /Workflow.*completed/)[0]
 
     expect(runningWorkflowEntry).to.exist
-    expect(runningWorkflowEntry!.getMetadata()).to.eql({})
-    expect(stepHeaderEntries.map((e) => e.getMetadata())).to.eql([{}, {}], "stepHeaderEntries")
+    expect(runningWorkflowEntry!.getMetadata()).to.eql(undefined)
+    expect(stepHeaderEntries.map((e) => e.getMetadata())).to.eql([undefined, undefined], "stepHeaderEntries")
 
     const stepBodyEntriesMetadata = stepBodyEntries.map((e) => e.getMetadata())
     expect(stepBodyEntriesMetadata).to.eql(
@@ -102,9 +102,9 @@ describe("RunWorkflowCommand", () => {
       "stepBodyEntries"
     )
 
-    expect(stepFooterEntries.map((e) => e.getMetadata())).to.eql([{}, {}], "stepFooterEntries")
+    expect(stepFooterEntries.map((e) => e.getMetadata())).to.eql([undefined, undefined], "stepFooterEntries")
     expect(workflowCompletedEntry).to.exist
-    expect(workflowCompletedEntry!.getMetadata()).to.eql({}, "workflowCompletedEntry")
+    expect(workflowCompletedEntry!.getMetadata()).to.eql(undefined, "workflowCompletedEntry")
   })
 
   it("should emit workflow events", async () => {

--- a/core/test/unit/src/logger/renderers.ts
+++ b/core/test/unit/src/logger/renderers.ts
@@ -38,7 +38,7 @@ beforeEach(() => {
 
 describe("renderers", () => {
   describe("renderMsg", () => {
-    it("should return an empty string if the entry is empty", () => {
+    it("should return an empty string for placeholder entries", () => {
       const entry = logger.placeholder()
       expect(renderMsg(entry)).to.equal("")
     })
@@ -166,7 +166,7 @@ describe("renderers", () => {
       const entry = logger.info("")
       expect(formatForTerminal(entry, "fancy")).to.equal("\n")
     })
-    it("should return an empty string without a new line if the entry is empty", () => {
+    it("should return an empty string without a new line if it's a placeholder entry", () => {
       const entry = logger.placeholder()
       expect(formatForTerminal(entry, "fancy")).to.equal("")
     })
@@ -281,13 +281,14 @@ describe("renderers", () => {
       })
     })
     it("should handle undefined messages", () => {
+      const now = freezeTime()
       const entry = logger.placeholder()
       expect(formatForJson(entry)).to.eql({
         msg: "",
         section: "",
         data: undefined,
         metadata: undefined,
-        timestamp: "",
+        timestamp: now.toISOString(),
       })
     })
   })


### PR DESCRIPTION
**What this PR does / why we need it**:

Log entry streaming was failing because GE was throwing validation errors for the request payload. Turns placeholder entries were being shipped along and they were missing timestamps. 

I added timestamps to payload entries for good measure but also made sure we're sending them to begin with. Placeholders are not really log messages, but we've been treating them as such for convenience which requires a few special cases. I left a code comment to remind myself to refactor this.

I also refactored some tests and added new ones.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Once we merge this, Garden core `master` will be incompatible with GE. In particular this applies to the demo server. So we need to make sure to not demo of latest master until it's been updated.

I'll push the corresponding change on GE later today and update the demo server ASAP.
