### PR TITLE
feat(core): allow disabling port forwards

### DIFF
--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -181,6 +181,7 @@ ${renderCommands(commands)}
       output,
       "force-refresh": forceRefresh,
       "var": cliVars,
+      "disable-port-forwards": disablePortForwards,
     } = parsedOpts
 
     // Parse command line --var input
@@ -225,6 +226,7 @@ ${renderCommands(commands)}
         args: parsedArgs,
         opts: parsedOpts,
       },
+      disablePortForwards,
       environmentName,
       log,
       sessionId,

--- a/core/src/cli/params.ts
+++ b/core/src/cli/params.ts
@@ -341,6 +341,10 @@ export const globalOptions = {
     alias: "h",
     help: "Show help",
   }),
+  "disable-port-forwards": new BooleanParameter({
+    help:
+      "Disable automatic port forwarding when in watch/hot-reload mode. Note that you can also set GARDEN_DISABLE_PORT_FORWARDS=true in your environment.",
+  }),
 }
 
 export type GlobalOptions = typeof globalOptions

--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -55,6 +55,7 @@ export const gardenEnv = {
   GARDEN_CACHE_TTL: env.get("GARDEN_CACHE_TTL").required(false).asInt(),
   GARDEN_DB_DIR: env.get("GARDEN_DB_DIR").required(false).default(GARDEN_GLOBAL_PATH).asString(),
   GARDEN_DISABLE_ANALYTICS: env.get("GARDEN_DISABLE_ANALYTICS").required(false).asBool(),
+  GARDEN_DISABLE_PORT_FORWARDS: env.get("GARDEN_DISABLE_PORT_FORWARDS").required(false).asBool(),
   GARDEN_DISABLE_VERSION_CHECK: env.get("GARDEN_DISABLE_VERSION_CHECK").required(false).asBool(),
   GARDEN_ENABLE_PROFILING: env.get("GARDEN_ENABLE_PROFILING").required(false).asBool(),
   GARDEN_EXPERIMENTAL_BUILD_STAGE: env.get("GARDEN_EXPERIMENTAL_BUILD_STAGE").required(false).asBool(),

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -117,6 +117,7 @@ export interface GardenOpts {
   experimentalBuildSync?: boolean
   commandInfo?: CommandInfo
   config?: ProjectConfig
+  disablePortForwards?: boolean
   environmentName?: string
   forceRefresh?: boolean
   gardenDirPath?: string
@@ -134,6 +135,7 @@ export interface GardenParams {
   vcsBranch: string
   buildStaging: BuildStaging
   projectId: string | null
+  disablePortForwards?: boolean
   dotIgnoreFiles: string[]
   environmentName: string
   environmentConfigs: EnvironmentConfig[]
@@ -209,6 +211,7 @@ export class Garden {
   public readonly version: ModuleVersion
   private readonly forceRefresh: boolean
   public readonly enterpriseApi: EnterpriseApi | null
+  public readonly disablePortForwards: boolean
 
   constructor(params: GardenParams) {
     this.buildStaging = params.buildStaging
@@ -279,6 +282,8 @@ export class Garden {
       dependencyVersions: {},
       files: [],
     }
+
+    this.disablePortForwards = gardenEnv.GARDEN_DISABLE_PORT_FORWARDS || params.disablePortForwards || false
   }
 
   static async factory<T extends typeof Garden>(
@@ -286,7 +291,7 @@ export class Garden {
     currentDirectory: string,
     opts: GardenOpts = {}
   ): Promise<InstanceType<T>> {
-    let { environmentName: environmentStr, config, gardenDirPath, plugins = [] } = opts
+    let { environmentName: environmentStr, config, gardenDirPath, plugins = [], disablePortForwards } = opts
 
     if (!config) {
       config = await findProjectConfig(currentDirectory)
@@ -379,6 +384,7 @@ export class Garden {
       artifactsPath,
       vcsBranch,
       sessionId,
+      disablePortForwards,
       projectId,
       projectRoot,
       projectName,

--- a/core/src/proxy.ts
+++ b/core/src/proxy.ts
@@ -8,6 +8,7 @@
 
 import { isEqual, invert } from "lodash"
 import Bluebird from "bluebird"
+import chalk = require("chalk")
 import { createServer, Server, Socket } from "net"
 const AsyncLock = require("async-lock")
 import getPort = require("get-port")
@@ -38,6 +39,11 @@ registerCleanupFunction("kill-service-port-proxies", () => {
 const portLock = new AsyncLock()
 
 export async function startPortProxies(garden: Garden, log: LogEntry, service: Service, status: ServiceStatus) {
+  if (garden.disablePortForwards) {
+    log.info({ msg: chalk.gray("Port forwards disabled") })
+    return []
+  }
+
   return Bluebird.map(status.forwardablePorts || [], (spec) => {
     return startPortProxy(garden, log, service, spec)
   })

--- a/core/test/unit/src/cli/cli.ts
+++ b/core/test/unit/src/cli/cli.ts
@@ -550,6 +550,7 @@ describe("cli", () => {
           "--force-refresh",
           "--var",
           "my=value,other=something",
+          "--disable-port-forwards",
         ],
         exitOnError: false,
       })
@@ -571,6 +572,7 @@ describe("cli", () => {
           "var": ["my=value", "other=something"],
           "version": false,
           "help": false,
+          "disable-port-forwards": true,
         },
       })
     })
@@ -631,6 +633,7 @@ describe("cli", () => {
           "version": false,
           "help": false,
           "floop": "floop-opt",
+          "disable-port-forwards": false,
         },
       })
     })
@@ -701,6 +704,7 @@ describe("cli", () => {
           "version": false,
           "help": false,
           "floop": "floop-opt",
+          "disable-port-forwards": false,
         },
       })
     })
@@ -835,6 +839,27 @@ describe("cli", () => {
 
       const { consoleOutput } = await cli.run({ args: ["test-command", "--output=yaml"], exitOnError: false })
       expect(safeLoad(consoleOutput!)).to.eql({ result: { some: "output" }, success: true })
+    })
+
+    it("should disable port forwards if --disable-port-forwards is set", async () => {
+      class TestCommand extends Command {
+        name = "test-command"
+        help = "halp!"
+        noProject = true
+
+        printHeader() {}
+
+        async action({ garden }: CommandParams) {
+          return { result: { garden } }
+        }
+      }
+
+      const command = new TestCommand()
+      const cli = new GardenCli()
+      cli.addCommand(command)
+
+      const { result } = await cli.run({ args: ["test-command", "--disable-port-forwards"], exitOnError: false })
+      expect(result.garden.disablePortForwards).to.be.true
     })
 
     it(`should configure a dummy environment when command has noProject=true and --env is specified`, async () => {

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -33,6 +33,7 @@ The following option flags can be used with any of the CLI commands:
   | `--var` |  | array:string | Set a specific variable value, using the format &lt;key&gt;&#x3D;&lt;value&gt;, e.g. &#x60;--var some-key&#x3D;custom-value&#x60;. This will override any value set in your project configuration. You can specify multiple variables by separating with a comma, e.g. &#x60;--var key-a&#x3D;foo,key-b&#x3D;&quot;value with quotes&quot;&#x60;.
   | `--version` | `-v` | boolean | Show the current CLI version.
   | `--help` | `-h` | boolean | Show help
+  | `--disable-port-forwards` |  | boolean | Disable automatic port forwarding when in watch/hot-reload mode. Note that you can also set GARDEN_DISABLE_PORT_FORWARDS&#x3D;true in your environment.
 
 ### garden build
 


### PR DESCRIPTION
You can now set `--disable-port-forwards` or
`GARDEN_DISABLE_PORT_FORWARDS=true` to disable automatic port
forwarding, when running deploy/dev commands in watch mode.
