### PR TITLE
chore(examples): fix hostname in deployment-strategies example

### DIFF
--- a/examples/deployment-strategies/garden.yml
+++ b/examples/deployment-strategies/garden.yml
@@ -22,6 +22,6 @@ providers:
   - name: kubernetes
     environments: [testing]
     context: gke_garden-dev-200012_europe-west1-b_garden-dev-1
-    defaultHostname: deployment-strategies-testing.dev-1.sys.garden
+    defaultHostname: deployment-strategies-${environment.namespace}.dev-1.sys.garden
     buildMode: cluster-docker
     deploymentStrategy: blue-green


### PR DESCRIPTION
The example was missing templating on the default hostname.