### PR TITLE
improve(config): allow most template strings in templated module inputs

### DIFF
--- a/core/src/config/config-context.ts
+++ b/core/src/config/config-context.ts
@@ -225,6 +225,20 @@ export abstract class ConfigContext {
   }
 }
 
+/**
+ * A generic context that just wraps an object.
+ */
+export class GenericContext extends ConfigContext {
+  constructor(obj: any) {
+    super()
+    Object.assign(this, obj)
+  }
+
+  static getSchema() {
+    return joi.object()
+  }
+}
+
 export class ScanContext extends ConfigContext {
   foundKeys: KeyedSet<ContextKeySegment[]>
 

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -86,6 +86,7 @@ import {
   resolveModuleTemplate,
   resolveTemplatedModule,
   templateKind,
+  ModuleTemplateConfig,
 } from "./config/module-template"
 import { TemplatedModuleConfig } from "./plugins/templated"
 import { BuildDirRsync } from "./build-staging/rsync"
@@ -184,6 +185,7 @@ export class Garden {
   private actionHelper: ActionRouter
   public readonly events: EventBus
   private tools: { [key: string]: PluginTool }
+  public moduleTemplates: { [name: string]: ModuleTemplateConfig }
 
   public readonly production: boolean
   public readonly projectRoot: string
@@ -1056,6 +1058,7 @@ export class Garden {
       this.log.silly(`Scanned and found ${rawModuleConfigs.length} modules and ${rawWorkflowConfigs.length} workflows`)
 
       this.configsScanned = true
+      this.moduleTemplates = keyBy(moduleTemplates, "name")
     })
   }
 

--- a/core/src/plugins/templated.ts
+++ b/core/src/plugins/templated.ts
@@ -12,6 +12,7 @@ import { templateKind } from "../config/module-template"
 import { joiIdentifier, joi, DeepPrimitiveMap } from "../config/common"
 import { dedent, naturalList } from "../util/string"
 import { omit } from "lodash"
+import { DOCS_BASE_URL } from "../constants"
 
 export interface TemplatedModuleSpec extends ModuleSpec {
   template: string
@@ -31,6 +32,8 @@ export const templatedModuleSpecSchema = () =>
     inputs: joi.object().description(
       dedent`
       A map of inputs to pass to the ${templateKind}. These must match the inputs schema of the ${templateKind}.
+
+      Note: You can use template strings for the inputs, but be aware that inputs that are used to generate the resulting module names and other top-level identifiers must be resolvable when scanning for modules, and thus cannot reference other modules or runtime variables. See the [environment configuration context reference](${DOCS_BASE_URL}/reference/template-strings#environment-configuration-context) to see template strings that are safe to use for inputs used to generate module identifiers.
       `
     ),
   })

--- a/core/test/data/test-projects/module-templates/module-templates.json
+++ b/core/test/data/test-projects/module-templates/module-templates.json
@@ -1,6 +1,11 @@
 {
   "type": "object",
   "properties": {
-    "foo": { "type": "string" }
+    "name": {
+      "type": "string"
+    },
+    "value": {
+      "type": "string"
+    }
   }
 }

--- a/core/test/data/test-projects/module-templates/modules.garden.yml
+++ b/core/test/data/test-projects/module-templates/modules.garden.yml
@@ -3,4 +3,5 @@ type: templated
 template: combo
 name: foo
 inputs:
-  foo: bar
+  name: test
+  value: ${providers.test-plugin.outputs.testKey}

--- a/core/test/data/test-projects/module-templates/source.txt
+++ b/core/test/data/test-projects/module-templates/source.txt
@@ -1,3 +1,3 @@
 Hello I am file!
-input: ${inputs.foo}
-module reference: ${modules["${parent.name}-${inputs.foo}-test-a"].path}
+input: ${inputs.value}
+module reference: ${modules["${parent.name}-${inputs.name}-a"].path}

--- a/core/test/data/test-projects/module-templates/templates.garden.yml
+++ b/core/test/data/test-projects/module-templates/templates.garden.yml
@@ -3,27 +3,28 @@ name: combo
 inputsSchemaPath: "module-templates.json"
 modules:
   - type: test
-    name: ${parent.name}-${inputs.foo}-test-a
+    name: ${parent.name}-${inputs.name}-a
     include: []
+    extraFlags: ["${inputs.value}"]
     generateFiles:
       - targetPath: module-a.log
         value: "hellow"
   - type: test
-    name: ${parent.name}-${inputs.foo}-test-b
+    name: ${parent.name}-${inputs.name}-b
     build:
-      dependencies: ["${parent.name}-${inputs.foo}-test-a"]
+      dependencies: ["${parent.name}-${inputs.name}-a"]
     include: []
     generateFiles:
       - targetPath: module-b.log
         sourcePath: source.txt
   - type: test
-    name: ${parent.name}-${inputs.foo}-test-c
+    name: ${parent.name}-${inputs.name}-c
     build:
-      dependencies: ["${parent.name}-${inputs.foo}-test-a"]
+      dependencies: ["${parent.name}-${inputs.name}-a"]
     include: []
     generateFiles:
       - targetPath: .garden/subdir/module-c.log
         value: |
           Hello I am string!
-          input: ${inputs.foo}
-          module reference: ${modules["${parent.name}-${inputs.foo}-test-a"].path}
+          input: ${inputs.value}
+          module reference: ${modules["${parent.name}-${inputs.name}-a"].path}

--- a/core/test/helpers.ts
+++ b/core/test/helpers.ts
@@ -159,8 +159,12 @@ export const testPlugin = createGardenPlugin({
       return { url: `http://localhost:12345/${page.name}` }
     },
 
+    async getEnvironmentStatus() {
+      return { ready: true, outputs: { testKey: "testValue" } }
+    },
+
     async prepareEnvironment() {
-      return { status: { ready: true, outputs: {} } }
+      return { status: { ready: true, outputs: { testKey: "testValue" } } }
     },
 
     async setSecret({ key, value }) {

--- a/core/test/unit/src/config/base.ts
+++ b/core/test/unit/src/config/base.ts
@@ -182,8 +182,9 @@ describe("loadConfigResources", () => {
         modules: [
           {
             type: "test",
-            name: "${parent.name}-${inputs.foo}-test-a",
+            name: "${parent.name}-${inputs.name}-a",
             include: [],
+            extraFlags: ["${inputs.value}"],
             generateFiles: [
               {
                 targetPath: "module-a.log",
@@ -193,10 +194,10 @@ describe("loadConfigResources", () => {
           },
           {
             type: "test",
-            name: "${parent.name}-${inputs.foo}-test-b",
+            name: "${parent.name}-${inputs.name}-b",
             include: [],
             build: {
-              dependencies: ["${parent.name}-${inputs.foo}-test-a"],
+              dependencies: ["${parent.name}-${inputs.name}-a"],
             },
             generateFiles: [
               {
@@ -207,16 +208,16 @@ describe("loadConfigResources", () => {
           },
           {
             type: "test",
-            name: "${parent.name}-${inputs.foo}-test-c",
+            name: "${parent.name}-${inputs.name}-c",
             include: [],
             build: {
-              dependencies: ["${parent.name}-${inputs.foo}-test-a"],
+              dependencies: ["${parent.name}-${inputs.name}-a"],
             },
             generateFiles: [
               {
                 targetPath: ".garden/subdir/module-c.log",
                 value:
-                  'Hello I am string!\ninput: ${inputs.foo}\nmodule reference: ${modules["${parent.name}-${inputs.foo}-test-a"].path}\n',
+                  'Hello I am string!\ninput: ${inputs.value}\nmodule reference: ${modules["${parent.name}-${inputs.name}-a"].path}\n',
               },
             ],
           },

--- a/docs/reference/module-types/templated.md
+++ b/docs/reference/module-types/templated.md
@@ -127,6 +127,12 @@ generateFiles:
 template:
 
 # A map of inputs to pass to the ModuleTemplate. These must match the inputs schema of the ModuleTemplate.
+#
+# Note: You can use template strings for the inputs, but be aware that inputs that are used to generate the resulting
+# module names and other top-level identifiers must be resolvable when scanning for modules, and thus cannot reference
+# other modules or runtime variables. See the [environment configuration context
+# reference](https://docs.garden.io/reference/template-strings#environment-configuration-context) to see template
+# strings that are safe to use for inputs used to generate module identifiers.
 inputs:
 ```
 
@@ -378,6 +384,8 @@ The ModuleTemplate to use to generate the sub-modules of this module.
 ### `inputs`
 
 A map of inputs to pass to the ModuleTemplate. These must match the inputs schema of the ModuleTemplate.
+
+Note: You can use template strings for the inputs, but be aware that inputs that are used to generate the resulting module names and other top-level identifiers must be resolvable when scanning for modules, and thus cannot reference other modules or runtime variables. See the [environment configuration context reference](https://docs.garden.io/reference/template-strings#environment-configuration-context) to see template strings that are safe to use for inputs used to generate module identifiers.
 
 | Type     | Required |
 | -------- | -------- |


### PR DESCRIPTION
Basically we now defer the full resolution on input template strings,
with the caveat that input values needed for module identifiers need
to be resolvable immediately.

Previously the values passed to the `inputs` field on templated modules
only had a very limited templating context available.

This involved quite a bit of added complexity, which is prompting me to
seriously consider a refactor in our template string resolution logic. This 
does the job for now, but I think we'll soon want to implement at least
partial lazy+recursive resolution of template strings, instead of all
this fine-grained logic to control what's resolved when.