### PR TITLE
fix(enterprise): fix start interval when using access tokens

### DIFF
--- a/core/src/commands/logout.ts
+++ b/core/src/commands/logout.ts
@@ -9,6 +9,7 @@
 import { Command, CommandParams, CommandResult } from "./base"
 import { printHeader } from "../logger/util"
 import dedent = require("dedent")
+import { logout } from "../enterprise/auth"
 
 export class LogOutCommand extends Command {
   name = "logout"
@@ -32,7 +33,7 @@ export class LogOutCommand extends Command {
     log.debug({ msg: `Logging out of ${garden.enterpriseApi?.getDomain()}` })
     log.info({ msg: `Logging out of Garden Enterprise.` })
     try {
-      await garden.enterpriseApi.logout()
+      await logout(garden.enterpriseApi, log)
       log.info({ msg: `Succesfully logged out from Garden Enterprise.` })
     } catch (error) {
       log.error(error)

--- a/core/src/enterprise/api.ts
+++ b/core/src/enterprise/api.ts
@@ -81,11 +81,10 @@ export class EnterpriseApi {
       if (!tokenIsValid) {
         // If the token is an Access Token and it's invalid we return.
         if (gardenEnv.GARDEN_AUTH_TOKEN) {
-          this.log.error({
-            msg:
-              "The provided access token is expired or revoked, please create a new one from the Garden Enterprise UI.",
-          })
-          return
+          throw new RuntimeError(
+            "The provided access token is expired or has been revoked, please create a new one from the Garden Enterprise UI.",
+            {}
+          )
         } else {
           // Try to refresh an expired JWT
           // This will throw if it fails to refresh

--- a/core/src/enterprise/api.ts
+++ b/core/src/enterprise/api.ts
@@ -70,19 +70,38 @@ export class EnterpriseApi {
       return
     }
     this.enterpriseDomain = enterpriseDomain
+
+    // Retrieve an authentication token
     const authToken = await this.readAuthToken()
     if (authToken && commandAllowed) {
-      this.log.debug({ msg: `Refreshing auth token and starting refresh interval.` })
+      // Verify a valid token is present
+      this.log.debug({ msg: `Refreshing auth token and trying to start refresh interval.` })
       const tokenIsValid = await this.checkClientAuthToken(this.log)
+
       if (!tokenIsValid) {
-        await this.refreshToken()
+        // If the token is an Access Token and it's invalid we return.
+        if (gardenEnv.GARDEN_AUTH_TOKEN) {
+          this.log.error({
+            msg:
+              "The provided access token is expired or revoked, please create a new one from the Garden Enterprise UI.",
+          })
+          return
+        } else {
+          // Try to refresh an expired JWT
+          // This will throw if it fails to refresh
+          await this.refreshToken()
+        }
       }
       // At this point we can be sure the user is logged in because we have
       // a valid token or refreshing the token did not go through.
       // TODO: Refactor to make a bit more robust (cc @emanuele and @thsig, you
       // know what I'm talking about.)
       this.isUserLoggedIn = true
-      this.startInterval()
+      // Start refresh interval if using JWT
+      if (!gardenEnv.GARDEN_AUTH_TOKEN) {
+        this.log.debug({ msg: `Starting refresh interval.` })
+        this.startInterval()
+      }
     }
   }
 
@@ -90,7 +109,8 @@ export class EnterpriseApi {
     this.log.debug({ msg: `Will run refresh function every ${this.intervalMsec} ms.` })
     this.intervalId = setInterval(() => {
       this.refreshToken().catch((err) => {
-        this.log.debug(err)
+        this.log.debug({ msg: "Something went wrong while trying to refresh the authentication token." })
+        this.log.debug({ msg: err.message })
       })
     }, this.intervalMsec)
   }
@@ -106,9 +126,11 @@ export class EnterpriseApi {
     const invalidCredentialsErrorMsg = "Your Garden Enteprise credentials have expired. Please login again."
     const token = await ClientAuthToken.findOne()
 
-    if (!token) {
-      throw new RuntimeError(invalidCredentialsErrorMsg, {})
+    if (!token || gardenEnv.GARDEN_AUTH_TOKEN) {
+      this.log.debug({ msg: "Nothing to refresh, returning." })
+      return
     }
+
     if (isAfter(new Date(), sub(token.validity, { seconds: refreshThreshold }))) {
       try {
         const res = await this.get(this.log, "token/refresh", {
@@ -205,26 +227,6 @@ export class EnterpriseApi {
     this.log.silly(`Retrieved client auth token from local config db`)
 
     return token
-  }
-
-  async logout() {
-    const token = await ClientAuthToken.findOne()
-    if (!token) {
-      // Noop when the user is not logged in
-      return
-    }
-    try {
-      await this.post(this.log, "token/logout", {
-        headers: {
-          Cookie: `rt=${token?.refreshToken}`,
-        },
-      })
-
-      await this.clearAuthToken()
-    } catch (error) {
-      this.log.error({ msg: "An error occurred while logging out." })
-      this.log.debug({ msg: JSON.stringify(error, null, 2) })
-    }
   }
 
   /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:
This PR fixes a problem we introduced recently where we would start the auth token refresh interval when using an Access Token. 
Additionally, I refactored the `logout` function, replacing old unused code with the actual implementation that was in `EnterpriseApi`

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
