### PR TITLE
fix(enterprise): limit log streaming to workflows

### DIFF
--- a/core/src/commands/build.ts
+++ b/core/src/commands/build.ts
@@ -49,7 +49,6 @@ export class BuildCommand extends Command<Args, Opts> {
   protected = true
   workflows = true
   streamEvents = true
-  streamLogEntries = true
 
   description = dedent`
     Builds all or specified modules, taking into account build dependency order.

--- a/core/src/commands/deploy.ts
+++ b/core/src/commands/deploy.ts
@@ -65,7 +65,6 @@ export class DeployCommand extends Command<Args, Opts> {
   protected = true
   workflows = true
   streamEvents = true
-  streamLogEntries = true
 
   description = dedent`
     Deploys all or specified services, taking into account service dependency order.

--- a/core/src/commands/dev.ts
+++ b/core/src/commands/dev.ts
@@ -68,7 +68,6 @@ export class DevCommand extends Command<DevCommandArgs, DevCommandOpts> {
   cliOnly = true
 
   streamEvents = true
-  streamLogEntries = true
 
   description = dedent`
     The Garden dev console is a combination of the \`build\`, \`deploy\` and \`test\` commands.

--- a/core/src/commands/publish.ts
+++ b/core/src/commands/publish.ts
@@ -59,7 +59,6 @@ export class PublishCommand extends Command<Args, Opts> {
 
   workflows = true
   streamEvents = true
-  streamLogEntries = true
 
   description = dedent`
     Publishes built module artifacts for all or specified modules.

--- a/core/src/commands/run/task.ts
+++ b/core/src/commands/run/task.ts
@@ -57,7 +57,6 @@ export class RunTaskCommand extends Command<Args, Opts> {
 
   workflows = true
   streamEvents = true
-  streamLogEntries = true
 
   description = dedent`
     This is useful for re-running tasks ad-hoc, for example after writing/modifying database migrations.

--- a/core/src/commands/run/test.ts
+++ b/core/src/commands/run/test.ts
@@ -73,7 +73,6 @@ export class RunTestCommand extends Command<Args, Opts> {
 
   workflows = true
   streamEvents = true
-  streamLogEntries = true
 
   description = dedent`
     This can be useful for debugging tests, particularly integration/end-to-end tests.

--- a/core/src/commands/test.ts
+++ b/core/src/commands/test.ts
@@ -63,7 +63,6 @@ export class TestCommand extends Command<Args, Opts> {
   protected = true
   workflows = true
   streamEvents = true
-  streamLogEntries = true
 
   description = dedent`
     Runs all or specified tests defined in the project. Also builds modules and dependencies,


### PR DESCRIPTION
For now, we'll only stream log entries for the `run workflow` command (when logged in).