### PR TITLE
fix(enterprise): don't throw if log out fails

### DIFF
--- a/core/src/commands/login.ts
+++ b/core/src/commands/login.ts
@@ -48,7 +48,7 @@ export class LoginCommand extends Command {
         enteprise: garden.enterpriseApi,
       })
     }
-    log.info({ msg: `Project domain detected: Opening ${garden.enterpriseApi?.getDomain()}.` })
+    log.info({ msg: `Logging in to ${garden.enterpriseApi?.getDomain()}.` })
 
     await login(garden.enterpriseApi, log)
 

--- a/core/src/enterprise/auth.ts
+++ b/core/src/enterprise/auth.ts
@@ -68,11 +68,10 @@ export async function logout(enterpriseApi: EnterpriseApi, log: LogEntry): Promi
         Cookie: `rt=${token?.refreshToken}`,
       },
     })
-
-    await enterpriseApi.clearAuthToken()
   } catch (error) {
-    log.error({ msg: "An error occurred while logging out." })
-    log.debug({ msg: JSON.stringify(error, null, 2) })
+    log.debug({ msg: `An error occurred while logging out from Garden Enterprise: ${error.message}` })
+  } finally {
+    await enterpriseApi.clearAuthToken()
   }
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

Previously, running `garden logout` would throw if the logout API call fails and the access token would not be removed.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
