### PR TITLE
fix(core): register workflow only if user is logged in

### DIFF
--- a/core/src/commands/run/workflow.ts
+++ b/core/src/commands/run/workflow.ts
@@ -432,7 +432,7 @@ export function logErrors(
 
 async function registerAndSetUid(garden: Garden, log: LogEntry, config: WorkflowConfig) {
   const { enterpriseApi } = garden
-  if (enterpriseApi) {
+  if (enterpriseApi?.isUserLoggedIn) {
     const workflowRunUid = await registerWorkflowRun({
       garden,
       workflowConfig: config,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:
Fixes a regression introduced in `0.12.13` where weren't checking if a user was logged in before trying to register the Workflow.
**Which issue(s) this PR fixes**:

Fixes #2226

**Special notes for your reviewer**:
