### PR TITLE
feat(cli): add --skip parameter to deploy command

### DIFF
--- a/core/src/commands/deploy.ts
+++ b/core/src/commands/deploy.ts
@@ -53,6 +53,9 @@ export const deployOpts = {
     `,
     alias: "hot",
   }),
+  "skip": new StringsParameter({
+    help: "The name(s) of services you'd like to skip when deploying.",
+  }),
 }
 
 type Args = typeof deployArgs
@@ -83,6 +86,7 @@ export class DeployCommand extends Command<Args, Opts> {
         garden deploy --hot=my-service     # deploys all services, with hot reloading enabled for my-service
         garden deploy --hot=*              # deploys all compatible services with hot reloading enabled
         garden deploy --env stage          # deploy your services to an environment called stage
+        garden deploy --skip service-b     # deploy all services except service-b
   `
 
   arguments = deployArgs
@@ -128,7 +132,9 @@ export class DeployCommand extends Command<Args, Opts> {
       log.info({ symbol: "info", msg: chalk.white(msg) })
     }
 
-    services = services.filter((s) => !s.disabled)
+    const skipped = opts.skip || []
+
+    services = services.filter((s) => !s.disabled && !skipped.includes(s.name))
 
     if (services.length === 0) {
       log.error({ msg: "No services to deploy. Aborting." })

--- a/core/test/unit/src/commands/deploy.ts
+++ b/core/test/unit/src/commands/deploy.ts
@@ -119,6 +119,7 @@ describe("DeployCommand", () => {
         "watch": false,
         "force": false,
         "force-build": true,
+        "skip": undefined,
       }),
     })
 
@@ -237,6 +238,7 @@ describe("DeployCommand", () => {
         "watch": false,
         "force": false,
         "force-build": true,
+        "skip": undefined,
       }),
     })
 
@@ -288,6 +290,7 @@ describe("DeployCommand", () => {
         "watch": false,
         "force": false,
         "force-build": true,
+        "skip": undefined,
       }),
     })
 
@@ -336,6 +339,7 @@ describe("DeployCommand", () => {
         "watch": false,
         "force": false,
         "force-build": true,
+        "skip": undefined,
       }),
     })
 
@@ -355,5 +359,36 @@ describe("DeployCommand", () => {
       "stage-build.module-b",
       "task.task-a",
     ])
+  })
+
+  it("should skip services set in the --skip option", async () => {
+    const garden = await makeTestGarden(projectRootB, { plugins })
+    const log = garden.log
+    const command = new DeployCommand()
+
+    await garden.scanAndAddConfigs()
+
+    const { result, errors } = await command.action({
+      garden,
+      log,
+      headerLog: log,
+      footerLog: log,
+      args: {
+        services: undefined,
+      },
+      opts: withDefaultGlobalOpts({
+        "hot-reload": undefined,
+        "watch": false,
+        "force": false,
+        "force-build": true,
+        "skip": ["service-b"],
+      }),
+    })
+
+    if (errors) {
+      throw errors[0]
+    }
+
+    expect(Object.keys(taskResultOutputs(result!)).includes("deploy.service-b")).to.be.false
   })
 })

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -617,6 +617,7 @@ Examples:
     garden deploy --hot=my-service     # deploys all services, with hot reloading enabled for my-service
     garden deploy --hot=*              # deploys all compatible services with hot reloading enabled
     garden deploy --env stage          # deploy your services to an environment called stage
+    garden deploy --skip service-b     # deploy all services except service-b
 
 | Supported in workflows |   |
 | ---------------------- |---|
@@ -640,6 +641,7 @@ Examples:
   | `--force-build` |  | boolean | Force rebuild of module(s).
   | `--watch` | `-w` | boolean | Watch for changes in module(s) and auto-deploy.
   | `--hot-reload` | `-hot` | array:string | The name(s) of the service(s) to deploy with hot reloading enabled. Use comma as a separator to specify multiple services. Use * to deploy all services with hot reloading enabled (ignores services belonging to modules that don&#x27;t support or haven&#x27;t configured hot reloading). When this option is used, the command is run in watch mode (i.e. implicitly assumes the --watch/-w flag).
+  | `--skip` |  | array:string | The name(s) of services you&#x27;d like to skip when deploying.
 
 #### Outputs
 


### PR DESCRIPTION
Simply allows skipping specific services when running `garden deploy`,
nice and simple.