### PR TITLE
improvement(cli): allow multiple instances of array option parameters

### DIFF
--- a/core/src/cli/helpers.ts
+++ b/core/src/cli/helpers.ts
@@ -269,9 +269,9 @@ export function processCliArgs<A extends Parameters, O extends Parameters>({
       continue
     }
 
-    if (Array.isArray(value)) {
-      // TODO: support multiple instances of an argument if it's an array type
-      value = value[value.length - 1] // Use the last value if the option is used multiple times
+    if (Array.isArray(value) && !spec.type.startsWith("array:")) {
+      // Use the last value if the option is used multiple times and the spec is not an array type
+      value = value[value.length - 1]
     }
 
     if (value !== undefined) {

--- a/core/src/cli/params.ts
+++ b/core/src/cli/params.ts
@@ -19,6 +19,7 @@ import chalk = require("chalk")
 import { LogLevel } from "../logger/log-node"
 import { safeDumpYaml } from "../util/util"
 import { resolve } from "path"
+import { isArray } from "lodash"
 
 export const OUTPUT_RENDERERS = {
   json: (data: DeepPrimitiveMap) => {
@@ -137,8 +138,13 @@ export class StringsParameter extends Parameter<string[] | undefined> {
     this.variadic = !!args.variadic
   }
 
-  coerce(input?: string): string[] {
-    return input?.split(this.delimiter) || []
+  coerce(input?: string | string[]): string[] {
+    if (!input) {
+      return []
+    } else if (!isArray(input)) {
+      input = [input]
+    }
+    return input.flatMap((v) => v.split(this.delimiter))
   }
 }
 
@@ -154,7 +160,7 @@ export class PathParameter extends Parameter<string> {
 export class PathsParameter extends StringsParameter {
   type = "array:path"
 
-  coerce(input?: string): string[] {
+  coerce(input?: string | string[]): string[] {
     const paths = super.coerce(input)
     return paths.map((p) => resolve(process.cwd(), p))
   }

--- a/core/src/commands/exec.ts
+++ b/core/src/commands/exec.ts
@@ -12,17 +12,16 @@ import { ExecInServiceResult, execInServiceResultSchema } from "../types/plugin/
 import { printHeader } from "../logger/util"
 import { Command, CommandResult, CommandParams } from "./base"
 import dedent = require("dedent")
-import { StringParameter, StringsParameter, BooleanParameter } from "../cli/params"
+import { StringParameter, BooleanParameter } from "../cli/params"
 
 const execArgs = {
   service: new StringParameter({
     help: "The service to exec the command in.",
     required: true,
   }),
-  command: new StringsParameter({
+  command: new StringParameter({
     help: "The command to run.",
     required: true,
-    delimiter: " ",
   }),
 }
 
@@ -76,7 +75,7 @@ export class ExecCommand extends Command<Args> {
 
   async action({ garden, log, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<ExecInServiceResult>> {
     const serviceName = args.service
-    const command = args.command || []
+    const command = args?.command.split(" ") || []
 
     const graph = await garden.getConfigGraph(log)
     const service = graph.getService(serviceName)

--- a/core/src/commands/helpers.ts
+++ b/core/src/commands/helpers.ts
@@ -11,8 +11,11 @@ import { Service } from "../types/service"
 
 export async function getHotReloadServiceNames(namesFromOpt: string[] | undefined, configGraph: ConfigGraph) {
   const names = namesFromOpt || []
-  if (names[0] === "*") {
-    return (await configGraph.getServices()).filter((s) => supportsHotReloading(s)).map((s) => s.name)
+  if (names.includes("*")) {
+    return configGraph
+      .getServices()
+      .filter((s) => supportsHotReloading(s))
+      .map((s) => s.name)
   } else {
     return names
   }
@@ -26,7 +29,7 @@ export async function validateHotReloadServiceNames(
   serviceNames: string[],
   configGraph: ConfigGraph
 ): Promise<string | null> {
-  const services = await configGraph.getServices({ names: serviceNames, includeDisabled: true })
+  const services = configGraph.getServices({ names: serviceNames, includeDisabled: true })
 
   const notHotreloadable = services.filter((s) => !supportsHotReloading(s)).map((s) => s.name)
   if (notHotreloadable.length > 0) {

--- a/core/src/commands/run/module.ts
+++ b/core/src/commands/run/module.ts
@@ -16,7 +16,7 @@ import { dedent, deline } from "../../util/string"
 import { Command, CommandParams, CommandResult, handleRunResult, ProcessResultMetadata } from "../base"
 import { printRuntimeContext } from "./run"
 import { GraphResults } from "../../task-graph"
-import { StringParameter, StringsParameter, BooleanParameter } from "../../cli/params"
+import { StringParameter, StringsParameter, BooleanParameter, StringOption } from "../../cli/params"
 
 const runModuleArgs = {
   module: new StringParameter({
@@ -42,12 +42,11 @@ const runModuleOpts = {
   "force-build": new BooleanParameter({
     help: "Force rebuild of module before running.",
   }),
-  "command": new StringsParameter({
+  "command": new StringOption({
     help: deline`The base command (a.k.a. entrypoint) to run in the module. For container modules, for example,
       this overrides the image's default command/entrypoint. This option may not be relevant for all module types.
       Example: '/bin/sh -c'.`,
     alias: "c",
-    delimiter: " ",
   }),
 }
 
@@ -128,7 +127,7 @@ export class RunModuleCommand extends Command<Args, Opts> {
     const result = await actions.runModule({
       log,
       module,
-      command: opts.command,
+      command: opts.command?.split(" "),
       args: args.arguments || [],
       runtimeContext,
       interactive,

--- a/core/src/commands/test.ts
+++ b/core/src/commands/test.ts
@@ -24,7 +24,7 @@ import { GardenModule } from "../types/module"
 import { getTestTasks } from "../tasks/test"
 import { printHeader } from "../logger/util"
 import { startServer } from "../server/server"
-import { StringsParameter, StringOption, BooleanParameter } from "../cli/params"
+import { StringsParameter, BooleanParameter } from "../cli/params"
 
 export const testArgs = {
   modules: new StringsParameter({
@@ -35,7 +35,7 @@ export const testArgs = {
 }
 
 export const testOpts = {
-  "name": new StringOption({
+  "name": new StringsParameter({
     help:
       "Only run tests with the specfied name (e.g. unit or integ). " +
       "Accepts glob patterns (e.g. integ* would run both 'integ' and 'integration')",
@@ -73,12 +73,13 @@ export class TestCommand extends Command<Args, Opts> {
 
     Examples:
 
-        garden test               # run all tests in the project
-        garden test my-module     # run all tests in the my-module module
-        garden test --name integ  # run all tests with the name 'integ' in the project
-        garden test --name integ* # run all tests with the name starting with 'integ' in the project
-        garden test --force       # force tests to be re-run, even if they've already run successfully
-        garden test --watch       # watch for changes to code
+        garden test                   # run all tests in the project
+        garden test my-module         # run all tests in the my-module module
+        garden test --name integ      # run all tests with the name 'integ' in the project
+        garden test --name integ*     # run all tests with the name starting with 'integ' in the project
+        garden test -n unit -n lint   # run all tests called either 'unit' or 'lint' in the project
+        garden test --force           # force tests to be re-run, even if they've already run successfully
+        garden test --watch           # watch for changes to code
   `
 
   arguments = testArgs
@@ -120,7 +121,7 @@ export class TestCommand extends Command<Args, Opts> {
       : // All modules are included in this case, so there's no need to compute dependants.
         graph.getModules()
 
-    const filterNames = opts.name ? [opts.name] : []
+    const filterNames = opts.name || []
     const force = opts.force
     const forceBuild = opts["force-build"]
 

--- a/core/test/unit/src/cli/helpers.ts
+++ b/core/test/unit/src/cli/helpers.ts
@@ -102,6 +102,13 @@ describe("parseCliArgs", () => {
     expect(argv["log-level"]).to.equal("5")
   })
 
+  it("returns an array for a parameter if multiple instances are specified", () => {
+    const argv = parseCliArgs({ stringArgs: ["test", "--name", "foo", "--name", "bar"], cli: true })
+
+    expect(argv._).to.eql(["test"])
+    expect(argv.name).to.eql(["foo", "bar"])
+  })
+
   it("correctly handles global boolean options", () => {
     const argv = parseCliArgs({
       stringArgs: ["build", "my-module", "--force-refresh", "--silent=false", "-y"],
@@ -202,6 +209,18 @@ describe("processCliArgs", () => {
     const { opts } = parseAndProcess(["-w", "--force-build=false"], cmd)
     expect(opts.watch).to.be.true
     expect(opts["force-build"]).to.be.false
+  })
+
+  it("correctly handles multiple instances of a string array parameter", () => {
+    const cmd = new TestCommand()
+    const { opts } = parseAndProcess(["--name", "foo", "-n", "bar"], cmd)
+    expect(opts.name).to.eql(["foo", "bar"])
+  })
+
+  it("correctly handles multiple instances of a string array parameter where one uses string-delimited values", () => {
+    const cmd = new TestCommand()
+    const { opts } = parseAndProcess(["--name", "foo,bar", "-n", "baz"], cmd)
+    expect(opts.name).to.eql(["foo", "bar", "baz"])
   })
 
   // Note: If an option alias appears before the option (e.g. -w before --watch),

--- a/core/test/unit/src/cli/params.ts
+++ b/core/test/unit/src/cli/params.ts
@@ -10,17 +10,25 @@ import { expect } from "chai"
 import { StringsParameter } from "../../../../src/cli/params"
 
 describe("StringsParameter", () => {
+  const param = new StringsParameter({ help: "" })
+
   it("should by default split on a comma", () => {
-    const param = new StringsParameter({ help: "" })
     expect(param.coerce("service-a,service-b")).to.eql(["service-a", "service-b"])
   })
 
   it("should not split on commas within double-quoted strings", () => {
-    const param = new StringsParameter({ help: "" })
     expect(param.coerce('key-a="comma,in,value",key-b=foo,key-c=bar')).to.eql([
       'key-a="comma,in,value"',
       "key-b=foo",
       "key-c=bar",
     ])
+  })
+
+  it("should handle multiple input values", () => {
+    expect(param.coerce(["service-a", "service-b"])).to.eql(["service-a", "service-b"])
+  })
+
+  it("should split on delimiter for each input value", () => {
+    expect(param.coerce(["service-a", "service-b,service-c"])).to.eql(["service-a", "service-b", "service-c"])
   })
 })

--- a/core/test/unit/src/commands/run/module.ts
+++ b/core/test/unit/src/commands/run/module.ts
@@ -98,7 +98,7 @@ describe("RunModuleCommand", () => {
       opts: withDefaultGlobalOpts({
         "interactive": false,
         "force-build": false,
-        "command": ["/bin/sh", "-c"],
+        "command": "/bin/sh -c",
       }),
     })
 

--- a/core/test/unit/src/commands/test.ts
+++ b/core/test/unit/src/commands/test.ts
@@ -190,7 +190,7 @@ describe("TestCommand", () => {
       footerLog: log,
       args: { modules: ["module-a"] },
       opts: withDefaultGlobalOpts({
-        "name": "int*",
+        "name": ["int*"],
         "force": true,
         "force-build": true,
         "watch": false,

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -2372,7 +2372,7 @@ Examples:
 | -------- | ----- | ---- | ----------- |
   | `--interactive` |  | boolean | Set to false to skip interactive mode and just output the command result.
   | `--force-build` |  | boolean | Force rebuild of module before running.
-  | `--command` | `-c` | array:string | The base command (a.k.a. entrypoint) to run in the module. For container modules, for example, this overrides the image&#x27;s default command/entrypoint. This option may not be relevant for all module types. Example: &#x27;/bin/sh -c&#x27;.
+  | `--command` | `-c` | string | The base command (a.k.a. entrypoint) to run in the module. For container modules, for example, this overrides the image&#x27;s default command/entrypoint. This option may not be relevant for all module types. Example: &#x27;/bin/sh -c&#x27;.
 
 
 ### garden run service
@@ -2647,12 +2647,13 @@ Optionally stays running and automatically re-runs tests if their module source
 
 Examples:
 
-    garden test               # run all tests in the project
-    garden test my-module     # run all tests in the my-module module
-    garden test --name integ  # run all tests with the name 'integ' in the project
-    garden test --name integ* # run all tests with the name starting with 'integ' in the project
-    garden test --force       # force tests to be re-run, even if they've already run successfully
-    garden test --watch       # watch for changes to code
+    garden test                   # run all tests in the project
+    garden test my-module         # run all tests in the my-module module
+    garden test --name integ      # run all tests with the name 'integ' in the project
+    garden test --name integ*     # run all tests with the name starting with 'integ' in the project
+    garden test -n unit -n lint   # run all tests called either 'unit' or 'lint' in the project
+    garden test --force           # force tests to be re-run, even if they've already run successfully
+    garden test --watch           # watch for changes to code
 
 | Supported in workflows |   |
 | ---------------------- |---|
@@ -2672,7 +2673,7 @@ Examples:
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
-  | `--name` | `-n` | string | Only run tests with the specfied name (e.g. unit or integ). Accepts glob patterns (e.g. integ* would run both &#x27;integ&#x27; and &#x27;integration&#x27;)
+  | `--name` | `-n` | array:string | Only run tests with the specfied name (e.g. unit or integ). Accepts glob patterns (e.g. integ* would run both &#x27;integ&#x27; and &#x27;integration&#x27;)
   | `--force` | `-f` | boolean | Force re-test of module(s).
   | `--force-build` |  | boolean | Force rebuild of module(s).
   | `--watch` | `-w` | boolean | Watch for changes in module(s) and auto-test.


### PR DESCRIPTION
This allows you to e.g. specify `--name` multiple times for the
`garden test` command, multiple `--hot` parameters for deploy commands
etc., instead of comma-separating on the same parameter.
