### PR TITLE
improvement(core): default to new build staging mechanism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,8 +242,6 @@ jobs:
         description: The project environment to use
         type: string
         default: testing
-    environment:
-      GARDEN_EXPERIMENTAL_BUILD_STAGE: "true"
     steps:
       - checkout
       - run: sudo apt-get update && sudo apt-get install rsync

--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -58,7 +58,7 @@ export const gardenEnv = {
   GARDEN_DISABLE_PORT_FORWARDS: env.get("GARDEN_DISABLE_PORT_FORWARDS").required(false).asBool(),
   GARDEN_DISABLE_VERSION_CHECK: env.get("GARDEN_DISABLE_VERSION_CHECK").required(false).asBool(),
   GARDEN_ENABLE_PROFILING: env.get("GARDEN_ENABLE_PROFILING").required(false).asBool(),
-  GARDEN_EXPERIMENTAL_BUILD_STAGE: env.get("GARDEN_EXPERIMENTAL_BUILD_STAGE").required(false).asBool(),
+  GARDEN_LEGACY_BUILD_STAGE: env.get("GARDEN_LEGACY_BUILD_STAGE").required(false).asBool(),
   GARDEN_LOG_LEVEL: env.get("GARDEN_LOG_LEVEL").required(false).asString(),
   GARDEN_LOGGER_TYPE: env.get("GARDEN_LOGGER_TYPE").required(false).asString(),
   GARDEN_GE_SCHEDULED: env.get("GARDEN_GE_SCHEDULED").required(false).asBool(),

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -114,13 +114,13 @@ export type ModuleActionMap = {
 }
 
 export interface GardenOpts {
-  experimentalBuildSync?: boolean
   commandInfo?: CommandInfo
   config?: ProjectConfig
   disablePortForwards?: boolean
   environmentName?: string
   forceRefresh?: boolean
   gardenDirPath?: string
+  legacyBuildSync?: boolean
   log?: LogEntry
   noEnterprise?: boolean
   persistent?: boolean
@@ -362,9 +362,9 @@ export class Garden {
     // Allow overriding variables
     variables = { ...variables, ...(opts.variables || {}) }
 
-    const experimentalBuildSync =
-      opts.experimentalBuildSync === undefined ? gardenEnv.GARDEN_EXPERIMENTAL_BUILD_STAGE : opts.experimentalBuildSync
-    const buildDirCls = experimentalBuildSync ? BuildStaging : BuildDirRsync
+    const legacyBuildSync =
+      opts.legacyBuildSync === undefined ? gardenEnv.GARDEN_LEGACY_BUILD_STAGE : opts.legacyBuildSync
+    const buildDirCls = legacyBuildSync ? BuildDirRsync : BuildStaging
     const buildDir = await buildDirCls.factory(projectRoot, gardenDirPath)
     const workingCopyId = await getWorkingCopyId(gardenDirPath)
 

--- a/core/test/unit/src/build-staging/build-staging.ts
+++ b/core/test/unit/src/build-staging/build-staging.ts
@@ -67,7 +67,7 @@ describe("BuildStaging", () => {
   let buildStaging: BuildStaging
 
   before(async () => {
-    garden = await makeGarden({ experimentalBuildSync: true })
+    garden = await makeGarden()
     log = garden.log
     buildStaging = garden.buildStaging
   })
@@ -234,7 +234,7 @@ describe("BuildStaging", () => {
   })
 })
 
-export function commonSyncTests(experimentalBuildSync: boolean) {
+export function commonSyncTests(legacyBuildSync: boolean) {
   let garden: TestGarden
   let log: LogEntry
   let buildStaging: BuildStaging
@@ -242,7 +242,7 @@ export function commonSyncTests(experimentalBuildSync: boolean) {
   let tmpPath: string
 
   before(async () => {
-    garden = await makeGarden({ experimentalBuildSync })
+    garden = await makeGarden({ legacyBuildSync })
     log = garden.log
     buildStaging = garden.buildStaging
   })

--- a/core/test/unit/src/build-staging/rsync.ts
+++ b/core/test/unit/src/build-staging/rsync.ts
@@ -29,7 +29,7 @@ describe("BuildStagingRsync", () => {
   let garden: TestGarden
 
   before(async () => {
-    garden = await makeTestGarden(projectRoot, { experimentalBuildSync: false })
+    garden = await makeTestGarden(projectRoot, { legacyBuildSync: true })
   })
 
   afterEach(async () => {


### PR DESCRIPTION
We now default to using the new rsync-less build staging mechanism,
which previously had to be explicitly enabled with the
GARDEN_EXPERIMENTAL_BUILD_STAGE environment variable.

In turn, you can now switch _back_ to the older rsync-based mechanism
by setting `GARDEN_LEGACY_BUILD_STAGE=true` in your environment, in
case any unexpected issues come up. Please reach out to us if that
does happen and we'll try and fix any issues promptly.
