### PR TITLE
fix(config): pass optional templates through during partial resolution

### DIFF
--- a/core/src/template-string-parser.pegjs
+++ b/core/src/template-string-parser.pegjs
@@ -62,14 +62,14 @@ FormatString
           // We allow certain configuration contexts (e.g. placeholders for runtime.*) to indicate that a template
           // string should be returned partially resolved even if allowPartial=false.
           return text()
+        } else if (options.allowPartial) {
+          return text()
         } else if (allowUndefined) {
           if (e && e._error) {
             return { ...e, _error: undefined }
           } else {
             return e
           }
-        } else if (options.allowPartial) {
-          return text()
         } else if (e && e._error) {
           return e
         } else {

--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -43,9 +43,19 @@ describe("resolveTemplateString", async () => {
     expect(res).to.equal("value")
   })
 
+  it("should correctly resolve if ? suffix is present but value exists", async () => {
+    const res = resolveTemplateString("${foo}?", new TestContext({ foo: "bar" }))
+    expect(res).to.equal("bar")
+  })
+
   it("should allow undefined values if ? suffix is present", async () => {
     const res = resolveTemplateString("${foo}?", new TestContext({}))
     expect(res).to.equal(undefined)
+  })
+
+  it("should pass optional string through if allowPartial=true", async () => {
+    const res = resolveTemplateString("${foo}?", new TestContext({}), { allowPartial: true })
+    expect(res).to.equal("${foo}?")
   })
 
   it("should interpolate a format string with a prefix", async () => {
@@ -1017,6 +1027,23 @@ describe("resolveTemplateStrings", () => {
         nested: "else",
         noTemplate: "at-all",
       },
+    })
+  })
+
+  it("should correctly handle optional template strings", async () => {
+    const obj = {
+      some: "${key}?",
+      other: "${missing}?",
+    }
+    const templateContext = new TestContext({
+      key: "value",
+    })
+
+    const result = resolveTemplateStrings(obj, templateContext)
+
+    expect(result).to.eql({
+      some: "value",
+      other: undefined,
     })
   })
 


### PR DESCRIPTION
Previously, we would immediately resolve an optional template string
as undefined during partial resolution, which would cause problems when
using optional template strings for variables that are only available
later in the process. We now leave them unchanged until the final
resolution occurs.

Fixes #2241
