### PR TITLE
fix(k8s): fix potential GCR auth issue + simpler GKE+GCR instructions

### DIFF
--- a/core/src/plugins/kubernetes/init.ts
+++ b/core/src/plugins/kubernetes/init.ts
@@ -49,17 +49,6 @@ See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-
 a registry auth secret.
 `
 
-// Used to automatically support GCR auth on GKE.
-// Users can override by setting other values for any of these keys in any of their imagePullSecrets.
-const defaultCredHelpers = {
-  "asia.gcr.io": "gcr",
-  "eu.gcr.io": "gcr",
-  "gcr.io": "gcr",
-  "marketplace.gcr.io": "gcr",
-  "staging-k8s.gcr.io": "gcr",
-  "us.gcr.io": "gcr",
-}
-
 interface KubernetesProviderOutputs extends PrimitiveMap {
   "app-namespace": string
   "metadata-namespace": string
@@ -502,7 +491,7 @@ export async function buildDockerAuthConfig(
         credHelpers: { ...accumulator.credHelpers, ...decoded.credHelpers },
       }
     },
-    { experimental: "enabled", auths: {}, credHelpers: defaultCredHelpers }
+    { experimental: "enabled", auths: {}, credHelpers: {} }
   )
 }
 

--- a/examples/gke/garden.yml
+++ b/examples/gke/garden.yml
@@ -3,26 +3,32 @@ name: gke
 environments:
   - name: gke-kaniko
     variables:
-      build-mode: kaniko
+      buildMode: kaniko
+      imagePullSecrets: []
   - name: gke-kaniko-gcr
     variables:
-      build-mode: kaniko
-      deployment-registry:
+      buildMode: kaniko
+      deploymentRegistry:
         # Replace these values as appropriate
         hostname: eu.gcr.io            # <- set this according to the region your cluster runs in
         namespace: garden-dev-200012   # <- set this to the project ID of the target cluster
+      imagePullSecrets:
+        # Make sure this matches the name and namespace of the secret you created
+        - name: gcr-config
+          namespace: default
 providers:
   - name: kubernetes
-    context: ${var.gke-context}
+    context: ${var.gkeContext}
     namespace: ${var.namespace}
-    defaultHostname: ${var.default-hostname}
-    buildMode: ${var.build-mode}
-    deploymentRegistry: ${var.deployment-registry}?  # <- note the ? suffix, which allows this to be undefined
+    defaultHostname: ${var.defaultHostname}
+    buildMode: ${var.buildMode}
+    deploymentRegistry: ${var.deploymentRegistry}?  # <- note the ? suffix, which allows this to be undefined
+    imagePullSecrets: ${var.imagePullSecrets}
 variables:
   # Replace these values as appropriate
   # > the kube context of the cluster
-  gke-context: gke_garden-dev-200012_europe-west1-b_garden-dev-1
+  gkeContext: gke_garden-dev-200012_europe-west1-b_garden-dev-1
   # > any hostname that points to your cluster's ingress controller
-  default-hostname: ${local.env.CIRCLE_BUILD_NUM || local.username}-gke.dev-1.sys.garden
+  defaultHostname: ${local.env.CIRCLE_BUILD_NUM || local.username}-gke.dev-1.sys.garden
   # > the namespace to deploy to in the cluster
   namespace: gke-testing-${local.env.CIRCLE_BUILD_NUM || local.username}


### PR DESCRIPTION
Turns out automatically including the `credHelpers` entries for GCR
could cause conflicts if users already had token auth set up.

I've also gone with a different suggested approach for GCR auth with
Kaniko, that is both simpler to implement and will also work seamlessly
for `cluster-docker` and `cluster-buildkit`.
