### PR TITLE
Publish command fixes/improvements

### DIFF
--- a/core/src/actions.ts
+++ b/core/src/actions.ts
@@ -14,7 +14,7 @@ import tmp from "tmp-promise"
 import cpy from "cpy"
 import normalizePath = require("normalize-path")
 
-import { PublishModuleParams, PublishResult } from "./types/plugin/module/publishModule"
+import { PublishModuleParams, PublishModuleResult } from "./types/plugin/module/publishModule"
 import { SetSecretParams, SetSecretResult } from "./types/plugin/provider/setSecret"
 import { validateSchema } from "./config/validation"
 import { defaultProvider } from "./config/provider"
@@ -359,7 +359,7 @@ export class ActionRouter implements TypeGuard {
 
   async publishModule<T extends GardenModule>(
     params: ModuleActionRouterParams<PublishModuleParams<T>>
-  ): Promise<PublishResult> {
+  ): Promise<PublishModuleResult> {
     return this.callModuleHandler({ params, actionType: "publish", defaultHandler: dummyPublishHandler })
   }
 

--- a/core/src/commands/publish.ts
+++ b/core/src/commands/publish.ts
@@ -25,9 +25,9 @@ import { LogEntry } from "../logger/log-entry"
 import { printHeader } from "../logger/util"
 import dedent = require("dedent")
 import { ConfigGraph } from "../config-graph"
-import { PublishResult, publishResultSchema } from "../types/plugin/module/publishModule"
+import { PublishModuleResult, publishResultSchema } from "../types/plugin/module/publishModule"
 import { joiIdentifierMap } from "../config/common"
-import { StringsParameter, BooleanParameter } from "../cli/params"
+import { StringsParameter, BooleanParameter, StringOption } from "../cli/params"
 
 export const publishArgs = {
   modules: new StringsParameter({
@@ -44,25 +44,34 @@ export const publishOpts = {
   "allow-dirty": new BooleanParameter({
     help: "Allow publishing dirty builds (with untracked/uncommitted changes).",
   }),
+  "tag": new StringOption({
+    help:
+      "Override the tag on the built artifacts. You can use the same sorts of template " +
+      "strings as when templating values in module configs, with the addition of " +
+      "${module.*} tags, allowing you to reference the name and Garden version of the " +
+      "module being tagged.",
+  }),
 }
 
 type Args = typeof publishArgs
 type Opts = typeof publishOpts
 
 interface PublishCommandResult extends ProcessCommandResult {
-  published: { [moduleName: string]: PublishResult & ProcessResultMetadata }
+  published: { [moduleName: string]: PublishModuleResult & ProcessResultMetadata }
 }
 
 export class PublishCommand extends Command<Args, Opts> {
   name = "publish"
-  help = "Build and publish module(s) to a remote registry."
+  help = "Build and publish module(s) (e.g. container images) to a remote registry."
 
   workflows = true
   streamEvents = true
 
   description = dedent`
     Publishes built module artifacts for all or specified modules.
-    Also builds modules and dependencies if needed.
+    Also builds modules and build dependencies if needed.
+
+    By default the artifacts/images are tagged with the Garden module version, but you can also specify the \`--tag\` option to specify a specific string tag _or_ a templated tag. Any template values that can be used on the module being tagged are available, in addition to ${"${module.name}"}, ${"${module.version}"} and ${"${module.hash}"} tags that allows referencing the name of the module being tagged, as well as its Garden version. ${"${module.version}"} includes the "v-" prefix normally used for Garden versions, and ${"${module.hash}"} doesn't.
 
     Examples:
 
@@ -70,6 +79,12 @@ export class PublishCommand extends Command<Args, Opts> {
         garden publish my-container   # only publish my-container
         garden publish --force-build  # force re-build of modules before publishing artifacts
         garden publish --allow-dirty  # allow publishing dirty builds (which by default triggers error)
+
+        # Publish my-container with a tag of v0.1
+        garden publish my-container --tag "v0.1"
+
+        # Publish my-container with a tag of v1.2-<hash> (e.g. v1.2-abcdef123)
+        garden publish my-container --tag "v1.2-${"${module.hash}"}"
   `
 
   arguments = publishArgs
@@ -103,6 +118,7 @@ export class PublishCommand extends Command<Args, Opts> {
       modules,
       forceBuild: !!opts["force-build"],
       allowDirty: !!opts["allow-dirty"],
+      tagTemplate: opts.tag,
     })
 
     const output = await handleProcessResults(footerLog, "publish", { taskResults: results })
@@ -124,6 +140,7 @@ export async function publishModules({
   modules,
   forceBuild,
   allowDirty,
+  tagTemplate,
 }: {
   garden: Garden
   graph: ConfigGraph
@@ -131,13 +148,15 @@ export async function publishModules({
   modules: GardenModule<any>[]
   forceBuild: boolean
   allowDirty: boolean
+  tagTemplate?: string
 }): Promise<GraphResults> {
+  // TODO: remove in 0.13
   if (!!allowDirty) {
     log.warn(`The --allow-dirty flag has been deprecated. It no longer has an effect.`)
   }
 
   const tasks = modules.map((module) => {
-    return new PublishTask({ garden, graph, log, module, forceBuild })
+    return new PublishTask({ garden, graph, log, module, forceBuild, tagTemplate })
   })
 
   return await garden.processTasks(tasks)

--- a/core/src/config/config-context.ts
+++ b/core/src/config/config-context.ts
@@ -844,6 +844,20 @@ export class ModuleTemplateConfigContext extends ProjectConfigContext {
   }
 }
 
+export interface ModuleConfigContextParams {
+  garden: Garden
+  resolvedProviders: ProviderMap
+  moduleName?: string
+  dependencies: GardenModule[]
+  // We only supply this when resolving configuration in dependency order.
+  // Otherwise we pass `${runtime.*} template strings through for later resolution.
+  runtimeContext?: RuntimeContext
+  parentName: string | undefined
+  templateName: string | undefined
+  inputs: DeepPrimitiveMap | undefined
+  partialRuntimeResolution: boolean
+}
+
 /**
  * This context is available for template strings under the `module` key in configuration files.
  * It is a superset of the context available under the `project` key.
@@ -895,19 +909,7 @@ export class ModuleConfigContext extends ProviderConfigContext {
     templateName,
     inputs,
     partialRuntimeResolution,
-  }: {
-    garden: Garden
-    resolvedProviders: ProviderMap
-    moduleName?: string
-    dependencies: GardenModule[]
-    // We only supply this when resolving configuration in dependency order.
-    // Otherwise we pass `${runtime.*} template strings through for later resolution.
-    runtimeContext?: RuntimeContext
-    parentName: string | undefined
-    templateName: string | undefined
-    inputs: DeepPrimitiveMap | undefined
-    partialRuntimeResolution: boolean
-  }) {
+  }: ModuleConfigContextParams) {
     super(garden, resolvedProviders)
 
     this.modules = new Map(

--- a/core/src/plugins/container/publish.ts
+++ b/core/src/plugins/container/publish.ts
@@ -10,14 +10,14 @@ import { ContainerModule } from "./config"
 import { PublishModuleParams } from "../../types/plugin/module/publishModule"
 import { containerHelpers } from "./helpers"
 
-export async function publishContainerModule({ ctx, module, log }: PublishModuleParams<ContainerModule>) {
+export async function publishContainerModule({ ctx, module, log, tag }: PublishModuleParams<ContainerModule>) {
   if (!containerHelpers.hasDockerfile(module, module.version)) {
     log.setState({ msg: `Nothing to publish` })
     return { published: false }
   }
 
   const localId = containerHelpers.getLocalImageId(module, module.version)
-  const remoteId = containerHelpers.getPublicImageId(module)
+  const remoteId = containerHelpers.getPublicImageId(module, tag)
 
   log.setState({ msg: `Publishing image ${remoteId}...` })
 

--- a/core/src/plugins/kubernetes/commands/pull-image.ts
+++ b/core/src/plugins/kubernetes/commands/pull-image.ts
@@ -187,9 +187,7 @@ async function pullFromExternalRegistry(
 
   try {
     await importImage({ module, runner, tarName, imageId, log, ctx })
-
     await containerHelpers.dockerCli({ cwd: module.buildPath, args: ["tag", imageId, localId], log, ctx })
-    await containerHelpers.dockerCli({ cwd: module.buildPath, args: ["rmi", imageId], log, ctx })
   } catch (err) {
     throw new RuntimeError(`Failed pulling image for module ${module.name} with image id ${imageId}: ${err}`, {
       err,

--- a/core/src/types/plugin/module/publishModule.ts
+++ b/core/src/types/plugin/module/publishModule.ts
@@ -11,25 +11,31 @@ import { GardenModule } from "../../module"
 import { PluginModuleActionParamsBase, moduleActionParamsSchema } from "../base"
 import { joi } from "../../../config/common"
 
-export interface PublishModuleParams<T extends GardenModule = GardenModule> extends PluginModuleActionParamsBase<T> {}
+export interface PublishModuleParams<T extends GardenModule = GardenModule> extends PluginModuleActionParamsBase<T> {
+  tag?: string
+}
 
-export interface PublishResult {
+export interface PublishModuleResult {
   published: boolean
   message?: string
+  identifier?: string
 }
 
 export const publishResultSchema = () =>
   joi.object().keys({
     published: joi.boolean().required().description("Set to true if the module was published."),
     message: joi.string().description("Optional result message from the provider."),
+    identifier: joi.string().description("The published artifact identifier, if applicable."),
   })
 
 export const publishModule = () => ({
   description: dedent`
-    Publish a built module to a remote registry.
+    Publish a built module artifact (e.g. a container image) to a remote registry.
 
     Called by the \`garden publish\` command.
   `,
-  paramsSchema: moduleActionParamsSchema(),
+  paramsSchema: moduleActionParamsSchema().keys({
+    tag: joi.string().description("A specific tag to apply when publishing the artifact, instead of the default."),
+  }),
   resultSchema: publishResultSchema(),
 })

--- a/core/src/types/plugin/plugin.ts
+++ b/core/src/types/plugin/plugin.ts
@@ -24,7 +24,7 @@ import { GetTaskResultParams, getTaskResult } from "./task/getTaskResult"
 import { GetTestResultParams, getTestResult, TestResult } from "./module/getTestResult"
 import { HotReloadServiceParams, HotReloadServiceResult, hotReloadService } from "./service/hotReloadService"
 import { PrepareEnvironmentParams, PrepareEnvironmentResult, prepareEnvironment } from "./provider/prepareEnvironment"
-import { PublishModuleParams, PublishResult, publishModule } from "./module/publishModule"
+import { PublishModuleParams, PublishModuleResult, publishModule } from "./module/publishModule"
 import { RunModuleParams, runModule } from "./module/runModule"
 import { RunServiceParams, runService } from "./service/runService"
 import { RunTaskParams, RunTaskResult, runTask } from "./task/runTask"
@@ -294,7 +294,7 @@ export interface ModuleActionOutputs extends ServiceActionOutputs {
   suggestModules: SuggestModulesResult
   getBuildStatus: BuildStatus
   build: BuildResult
-  publish: PublishResult
+  publish: PublishModuleResult
   runModule: RunResult
   testModule: TestResult
   getTestResult: TestResult | null

--- a/core/src/vcs/vcs.ts
+++ b/core/src/vcs/vcs.ts
@@ -24,6 +24,7 @@ import { Warning } from "../db/entities/warning"
 import { dedent } from "../util/string"
 import { fixedProjectExcludes } from "../util/fs"
 
+export const versionStringPrefix = "v-"
 export const NEW_MODULE_VERSION = "0000000000"
 const fileCountWarningThreshold = 10000
 
@@ -231,7 +232,8 @@ export async function writeModuleVersionFile(path: string, version: ModuleVersio
  * when the version string is used in template variables in configuration files.
  */
 export function getVersionString(moduleConfig: ModuleConfig, treeVersions: NamedTreeVersion[]) {
-  return `v-${hashVersions(moduleConfig, treeVersions)}`
+  // TODO: allow overriding the prefix
+  return `${versionStringPrefix}${hashVersions(moduleConfig, treeVersions)}`
 }
 
 /**

--- a/core/test/data/test-projects/container/remote-registry-test/garden.yml
+++ b/core/test/data/test-projects/container/remote-registry-test/garden.yml
@@ -2,6 +2,7 @@ kind: Module
 name: remote-registry-test
 description: Test module for pushing to private registry
 type: container
+image: gardendev/remote-registry-test
 services:
   - name: remote-registry-test
     command: [sh, -c, "nc -l -p 8080"]

--- a/core/test/integ/src/plugins/kubernetes/container/build/build.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/build/build.ts
@@ -135,6 +135,19 @@ describe("kubernetes build flow", () => {
 
         expect(message).to.eql("Published gardendev/remote-registry-test:" + module.version.versionString)
       })
+
+      it("should set custom tag if specified", async () => {
+        const module = await buildImage("remote-registry-test")
+
+        const { message } = await k8sPublishContainerModule({
+          ctx,
+          module,
+          log,
+          tag: "foo",
+        })
+
+        expect(message).to.eql("Published gardendev/remote-registry-test:foo")
+      })
     })
   })
 
@@ -272,6 +285,19 @@ describe("kubernetes build flow", () => {
         })
 
         expect(message).to.eql("Published gardendev/remote-registry-test:" + module.version.versionString)
+      })
+
+      it("should set custom tag if specified", async () => {
+        const module = await buildImage("remote-registry-test")
+
+        const { message } = await k8sPublishContainerModule({
+          ctx,
+          module,
+          log,
+          tag: "foo",
+        })
+
+        expect(message).to.eql("Published gardendev/remote-registry-test:foo")
       })
     })
   })
@@ -422,6 +448,19 @@ describe("kubernetes build flow", () => {
         })
 
         expect(message).to.eql("Published gardendev/remote-registry-test:" + module.version.versionString)
+      })
+
+      it("should set custom tag if specified", async () => {
+        const module = await buildImage("remote-registry-test")
+
+        const { message } = await k8sPublishContainerModule({
+          ctx,
+          module,
+          log,
+          tag: "foo",
+        })
+
+        expect(message).to.eql("Published gardendev/remote-registry-test:foo")
       })
     })
   })
@@ -599,6 +638,19 @@ describe("kubernetes build flow", () => {
         })
 
         expect(message).to.eql("Published gardendev/remote-registry-test:" + module.version.versionString)
+      })
+
+      it("should set custom tag if specified", async () => {
+        const module = await buildImage("remote-registry-test")
+
+        const { message } = await k8sPublishContainerModule({
+          ctx,
+          module,
+          log,
+          tag: "foo",
+        })
+
+        expect(message).to.eql("Published gardendev/remote-registry-test:foo")
       })
     })
   })

--- a/core/test/integ/src/plugins/kubernetes/container/container.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/container.ts
@@ -27,7 +27,8 @@ import { clusterInit } from "../../../../../../src/plugins/kubernetes/commands/c
 
 const root = getDataDir("test-projects", "container")
 const defaultEnvironment = process.env.GARDEN_INTEG_TEST_MODE === "remote" ? "cluster-docker" : "local"
-let initializedEnv: string
+const initializedEnvs: string[] = []
+let currentEnv: string
 let localInstance: Garden
 
 export async function getContainerTestGarden(environmentName: string = defaultEnvironment) {
@@ -37,7 +38,7 @@ export async function getContainerTestGarden(environmentName: string = defaultEn
     localInstance = await makeTestGarden(root, { environmentName: "local" })
   }
 
-  const needsInit = !environmentName.startsWith("local") && initializedEnv !== environmentName
+  const needsInit = !environmentName.startsWith("local") && !initializedEnvs.includes(environmentName)
 
   if (needsInit) {
     // Load the test authentication for private registries
@@ -89,7 +90,8 @@ export async function getContainerTestGarden(environmentName: string = defaultEn
   if (needsInit) {
     // Run cluster-init
     await clusterInit.handler({ ctx, log: garden.log, args: [], modules: [] })
-    initializedEnv = environmentName
+    currentEnv = environmentName
+    initializedEnvs.push(environmentName)
   }
 
   return garden

--- a/core/test/integ/src/plugins/kubernetes/container/container.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/container.ts
@@ -28,7 +28,6 @@ import { clusterInit } from "../../../../../../src/plugins/kubernetes/commands/c
 const root = getDataDir("test-projects", "container")
 const defaultEnvironment = process.env.GARDEN_INTEG_TEST_MODE === "remote" ? "cluster-docker" : "local"
 const initializedEnvs: string[] = []
-let currentEnv: string
 let localInstance: Garden
 
 export async function getContainerTestGarden(environmentName: string = defaultEnvironment) {
@@ -90,7 +89,6 @@ export async function getContainerTestGarden(environmentName: string = defaultEn
   if (needsInit) {
     // Run cluster-init
     await clusterInit.handler({ ctx, log: garden.log, args: [], modules: [] })
-    currentEnv = environmentName
     initializedEnvs.push(environmentName)
   }
 

--- a/docs/guides/in-cluster-building.md
+++ b/docs/guides/in-cluster-building.md
@@ -314,19 +314,34 @@ providers:
 
 You can publish images that have been built in your cluster, using the `garden publish` command.
 
-The only caveat is that you currently need to have Docker running locally, and you need to have authenticated with the
-target registry. When publishing, we pull the image from the in-cluster registry to the local Docker daemon, and then
-go on to push it from there. We do this to avoid having to (re-)implement all the various authentication methods (and
-by extension key management) involved in pushing directly from the cluster.
+The only caveat is that you currently need to have Docker running locally, and you need to have authenticated with the target registry. When publishing, we pull the image from the remote registry to the local Docker daemon, and then go on to push it from there. We do this to avoid having to (re-)implement all the various authentication methods (and by extension key management) involved in pushing directly from the cluster, and because it's often not desired to give clusters access to directly push to production registries.
 
-As usual, you need to specify the `image` field on the `container` module in question. For example:
+Unless you're publishing to your configured deployment registry, you need to specify the `image` field on the `container` module in question, to indicate where the image should be published. For example:
 
 ```yaml
 kind: Module
 name: my-module
-image: my-repo/my-image:v1.2.3   # <- omit the tag here if you'd like to use the Garden-generated version tag
+image: my-repo/my-image:v1.2.3   # <- if you omit the tag here, the Garden module version will be used by default
 ...
 ```
+
+By default we use the tag specified in the `container` module `image` field, if any. If none is set there, we default to the Garden module version.
+
+You can also set the `--tag` option on the `garden publish` command to override the tag used for images. You can both set a specific tag or you can _use template strings for the tag_. For example, you can
+
+- Set a specific tag on all published modules: `garden publish --tag "v1.2.3"`
+- Set a custom prefix on tags but include the Garden version hash: `garden publish --tag 'v0.1-${module.hash}'`
+- Set a custom prefix on tags with the current git branch: `garden publish --tag 'v0.1-${git.branch}'`
+
+{% hint style="warning" %}
+Note that you most likely need to wrap templated tags with single quotes, to avoid your shell attempting to perform its own substitution.
+{% endhint %}
+
+Generally, you can use any template strings available for module configs for the tags, with the addition of the following:
+
+- `${module.name}` — the name of module being tagged
+- `${module.version}` — the full Garden version of module being tagged, e.g. `v-abcdef1234`
+- `${module.hash}` — the Garden version hash of module being tagged, e.g. `abcdef1234` (i.e. without the `v-` prefix)
 
 ## Cleaning up cached images
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -2127,10 +2127,12 @@ Examples:
 
 ### garden publish
 
-**Build and publish module(s) to a remote registry.**
+**Build and publish module(s) (e.g. container images) to a remote registry.**
 
 Publishes built module artifacts for all or specified modules.
-Also builds modules and dependencies if needed.
+Also builds modules and build dependencies if needed.
+
+By default the artifacts/images are tagged with the Garden module version, but you can also specify the `--tag` option to specify a specific string tag _or_ a templated tag. Any template values that can be used on the module being tagged are available, in addition to ${module.name}, ${module.version} and ${module.hash} tags that allows referencing the name of the module being tagged, as well as its Garden version. ${module.version} includes the "v-" prefix normally used for Garden versions, and ${module.hash} doesn't.
 
 Examples:
 
@@ -2138,6 +2140,12 @@ Examples:
     garden publish my-container   # only publish my-container
     garden publish --force-build  # force re-build of modules before publishing artifacts
     garden publish --allow-dirty  # allow publishing dirty builds (which by default triggers error)
+
+    # Publish my-container with a tag of v0.1
+    garden publish my-container --tag "v0.1"
+
+    # Publish my-container with a tag of v1.2-<hash> (e.g. v1.2-abcdef123)
+    garden publish my-container --tag "v1.2-${module.hash}"
 
 | Supported in workflows |   |
 | ---------------------- |---|
@@ -2159,6 +2167,7 @@ Examples:
 | -------- | ----- | ---- | ----------- |
   | `--force-build` |  | boolean | Force rebuild of module(s) before publishing.
   | `--allow-dirty` |  | boolean | Allow publishing dirty builds (with untracked/uncommitted changes).
+  | `--tag` |  | string | Override the tag on the built artifacts. You can use the same sorts of template strings as when templating values in module configs, with the addition of ${module.*} tags, allowing you to reference the name and Garden version of the module being tagged.
 
 #### Outputs
 
@@ -2329,6 +2338,9 @@ published:
 
     # Optional result message from the provider.
     message:
+
+    # The published artifact identifier, if applicable.
+    identifier:
 
     # Set to true if the build was not attempted, e.g. if a dependency build failed.
     aborted:


### PR DESCRIPTION
It was time to give the publish command a bit of ❤️. Couple of commits:

**fix(k8s): garden publish command now works with any deploymentRegistry**
We had been making some assumptions that the in-cluster registry was
being used. We already had the code to pull images from other
registries, so this wasn't actually to hard to address. Also added
tests to validate.

**feat(publish): add template-able --tag parameter to publish command**

This should generally make the `garden publish` command a lot more
usable. You can now override the default tag at publish-time, and
even apply template strings on the tags.

From the updated in-cluster building docs:

-------

You can also set the `--tag` option on the `garden publish` command to override the tag used for images. You can both set a specific tag or you can _use template strings for the tag_. For example, you can

- Set a specific tag on all published modules: `garden publish --tag "v1.2.3"`
- Set a custom prefix on tags but include the Garden version hash: `garden publish --tag "v0.1-${module.hash}"`
- Set a custom prefix on tags with the current git branch: `garden publish --tag "v0.1-${git.branch}"`

Generally, you can use any template strings available for module configs for the tags, with the addition of the following:

- `${module.name}` — the name of module being tagged
- `${module.version}` — the full Garden version of module being tagged, e.g. `v-abcdef1234`
- `${module.hash}` — the Garden version hash of module being tagged, e.g. `abcdef1234` (i.e. without the `v-` prefix)

-------

When reviewing, please give the publish command a spin, and try messing about with the `--tag` parameter.
