### PR TITLE
feat(core): lower case username for templates

### DIFF
--- a/core/src/config/config-context.ts
+++ b/core/src/config/config-context.ts
@@ -289,10 +289,23 @@ class LocalContext extends ConfigContext {
   @schema(
     joi
       .string()
-      .description("The current username (as resolved by https://github.com/sindresorhus/username)")
+      .description("The current username (as resolved by https://github.com/sindresorhus/username).")
       .example("tenzing_norgay")
   )
   public username?: string
+
+  @schema(
+    joi
+      .string()
+      .description(
+        deline`
+          The current username (as resolved by https://github.com/sindresorhus/username), with any upper case
+          characters converted to lower case.
+        `
+      )
+      .example("tenzing_norgay")
+  )
+  public usernameLowerCase?: string
 
   constructor(root: ConfigContext, artifactsPath: string, projectRoot: string, username?: string) {
     super(root)
@@ -301,6 +314,7 @@ class LocalContext extends ConfigContext {
     this.platform = process.platform
     this.projectPath = projectRoot
     this.username = username
+    this.usernameLowerCase = username ? username.toLowerCase() : undefined
   }
 }
 

--- a/core/test/unit/src/config/config-context.ts
+++ b/core/test/unit/src/config/config-context.ts
@@ -400,6 +400,23 @@ describe("ProjectConfigContext", () => {
       resolved: process.platform,
     })
   })
+
+  it("should resolve the local username (both regular and lower case versions)", () => {
+    const c = new ProjectConfigContext({
+      projectName: "some-project",
+      projectRoot: "/tmp",
+      artifactsPath: "/tmp",
+      branch: "main",
+      username: "SomeUser",
+      secrets: {},
+    })
+    expect(c.resolve({ key: ["local", "username"], nodePath: [], opts: {} })).to.eql({
+      resolved: "SomeUser",
+    })
+    expect(c.resolve({ key: ["local", "usernameLowerCase"], nodePath: [], opts: {} })).to.eql({
+      resolved: "someuser",
+    })
+  })
 })
 
 describe("ProviderConfigContext", () => {

--- a/docs/reference/template-strings.md
+++ b/docs/reference/template-strings.md
@@ -82,7 +82,7 @@ my-variable: ${local.projectPath}
 
 ### `${local.username}`
 
-The current username (as resolved by https://github.com/sindresorhus/username)
+The current username (as resolved by https://github.com/sindresorhus/username).
 
 | Type     |
 | -------- |
@@ -92,6 +92,20 @@ Example:
 
 ```yaml
 my-variable: ${local.username}
+```
+
+### `${local.usernameLowerCase}`
+
+The current username (as resolved by https://github.com/sindresorhus/username), with any upper case characters converted to lower case.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.usernameLowerCase}
 ```
 
 ### `${project.*}`
@@ -220,7 +234,7 @@ my-variable: ${local.projectPath}
 
 ### `${local.username}`
 
-The current username (as resolved by https://github.com/sindresorhus/username)
+The current username (as resolved by https://github.com/sindresorhus/username).
 
 | Type     |
 | -------- |
@@ -230,6 +244,20 @@ Example:
 
 ```yaml
 my-variable: ${local.username}
+```
+
+### `${local.usernameLowerCase}`
+
+The current username (as resolved by https://github.com/sindresorhus/username), with any upper case characters converted to lower case.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.usernameLowerCase}
 ```
 
 ### `${project.*}`
@@ -390,7 +418,7 @@ my-variable: ${local.projectPath}
 
 ### `${local.username}`
 
-The current username (as resolved by https://github.com/sindresorhus/username)
+The current username (as resolved by https://github.com/sindresorhus/username).
 
 | Type     |
 | -------- |
@@ -400,6 +428,20 @@ Example:
 
 ```yaml
 my-variable: ${local.username}
+```
+
+### `${local.usernameLowerCase}`
+
+The current username (as resolved by https://github.com/sindresorhus/username), with any upper case characters converted to lower case.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.usernameLowerCase}
 ```
 
 ### `${project.*}`
@@ -653,7 +695,7 @@ my-variable: ${local.projectPath}
 
 ### `${local.username}`
 
-The current username (as resolved by https://github.com/sindresorhus/username)
+The current username (as resolved by https://github.com/sindresorhus/username).
 
 | Type     |
 | -------- |
@@ -663,6 +705,20 @@ Example:
 
 ```yaml
 my-variable: ${local.username}
+```
+
+### `${local.usernameLowerCase}`
+
+The current username (as resolved by https://github.com/sindresorhus/username), with any upper case characters converted to lower case.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.usernameLowerCase}
 ```
 
 ### `${project.*}`
@@ -1084,7 +1140,7 @@ my-variable: ${local.projectPath}
 
 ### `${local.username}`
 
-The current username (as resolved by https://github.com/sindresorhus/username)
+The current username (as resolved by https://github.com/sindresorhus/username).
 
 | Type     |
 | -------- |
@@ -1094,6 +1150,20 @@ Example:
 
 ```yaml
 my-variable: ${local.username}
+```
+
+### `${local.usernameLowerCase}`
+
+The current username (as resolved by https://github.com/sindresorhus/username), with any upper case characters converted to lower case.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.usernameLowerCase}
 ```
 
 ### `${project.*}`
@@ -1512,7 +1582,7 @@ my-variable: ${local.projectPath}
 
 ### `${local.username}`
 
-The current username (as resolved by https://github.com/sindresorhus/username)
+The current username (as resolved by https://github.com/sindresorhus/username).
 
 | Type     |
 | -------- |
@@ -1522,6 +1592,20 @@ Example:
 
 ```yaml
 my-variable: ${local.username}
+```
+
+### `${local.usernameLowerCase}`
+
+The current username (as resolved by https://github.com/sindresorhus/username), with any upper case characters converted to lower case.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.usernameLowerCase}
 ```
 
 ### `${project.*}`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

In addition to the `local.username` template variable, we now provide `local.usernameLowerCase`.

This is useful e.g. when templating in the local username in namespaces or hostnames.