### PR TITLE
feat(k8s): allow setting annotations and labels on project namespace

### DIFF
--- a/cli/src/generate-docs.ts
+++ b/cli/src/generate-docs.ts
@@ -12,6 +12,7 @@ import { Logger } from "@garden-io/core/build/src/logger/logger"
 import { LogLevel } from "@garden-io/core/build/src/logger/log-node"
 import { GARDEN_CLI_ROOT } from "@garden-io/core/build/src/constants"
 import { getBundledPlugins } from "./cli"
+import { getSupportedPlugins } from "@garden-io/core/build/src/plugins/plugins"
 
 require("source-map-support").install()
 
@@ -24,7 +25,9 @@ try {
   })
 } catch (_) {}
 
-generateDocs(resolve(GARDEN_CLI_ROOT, "..", "docs"), getBundledPlugins())
+const plugins = [...getBundledPlugins(), ...getSupportedPlugins()]
+
+generateDocs(resolve(GARDEN_CLI_ROOT, "..", "docs"), plugins)
   .then(() => {
     // tslint:disable-next-line: no-console
     console.log("Done!")

--- a/core/src/plugins/kubernetes/helm/config.ts
+++ b/core/src/plugins/kubernetes/helm/config.ts
@@ -30,7 +30,7 @@ import {
   ServiceResourceSpec,
   KubernetesTestSpec,
   KubernetesTaskSpec,
-  namespaceSchema,
+  namespaceNameSchema,
   containerModuleSchema,
   hotReloadArgsSchema,
 } from "../config"
@@ -153,7 +153,7 @@ export const helmModuleSpecSchema = () =>
     dependencies: joiArray(joiIdentifier()).description(
       "List of names of services that should be deployed before this chart."
     ),
-    namespace: namespaceSchema(),
+    namespace: namespaceNameSchema(),
     releaseName: joiIdentifier().description(
       "Optionally override the release name used when installing (defaults to the module name)."
     ),

--- a/core/src/plugins/kubernetes/init.ts
+++ b/core/src/plugins/kubernetes/init.ts
@@ -15,7 +15,7 @@ import {
   getSystemNamespace,
 } from "./namespace"
 import { KubernetesPluginContext, KubernetesConfig, KubernetesProvider, ProviderSecretRef } from "./config"
-import { prepareSystemServices, getSystemServiceStatus, getSystemGarden, systemNamespaceUpToDate } from "./system"
+import { prepareSystemServices, getSystemServiceStatus, getSystemGarden } from "./system"
 import { GetEnvironmentStatusParams, EnvironmentStatus } from "../../types/plugin/provider/getEnvironmentStatus"
 import { PrepareEnvironmentParams, PrepareEnvironmentResult } from "../../types/plugin/provider/prepareEnvironment"
 import { CleanupEnvironmentParams } from "../../types/plugin/provider/cleanupEnvironment"
@@ -105,7 +105,7 @@ export async function getEnvironmentStatus({
     // No need to continue if we don't need any system services
     systemServiceNames.length === 0 ||
     // Make sure we don't recurse infinitely
-    provider.config.namespace === systemNamespace
+    provider.config.namespace?.name === systemNamespace
   ) {
     return result
   }
@@ -148,9 +148,6 @@ export async function getEnvironmentStatus({
     }
   }
 
-  const contextForLog = `Checking Garden system service status for plugin "${ctx.provider.name}"`
-  const sysNamespaceUpToDate = await systemNamespaceUpToDate(api, log, systemNamespace, contextForLog)
-
   // Check if builder auth secret is up-to-date
   let secretsUpToDate = true
 
@@ -169,7 +166,7 @@ export async function getEnvironmentStatus({
     serviceNames: systemServiceNames,
   })
 
-  if (!sysNamespaceUpToDate || !secretsUpToDate || systemServiceStatus.state !== "ready") {
+  if (!secretsUpToDate || systemServiceStatus.state !== "ready") {
     result.ready = false
     detail.systemReady = false
   }

--- a/core/src/plugins/kubernetes/integrations/cert-manager.ts
+++ b/core/src/plugins/kubernetes/integrations/cert-manager.ts
@@ -224,9 +224,9 @@ export async function setupCertManager({ ctx, provider, log, status }: SetupCert
     if (!systemCertManagerReady) {
       entry.setState("Installing to cert-manager namespace...")
       const api = await KubeApi.factory(log, ctx, provider)
-      await ensureNamespace(api, "cert-manager")
+      await ensureNamespace(api, { name: "cert-manager" }, log)
       const customResourcesPath = join(STATIC_DIR, "kubernetes", "system", "cert-manager", "cert-manager-crd.yaml")
-      const crd = await yaml.safeLoadAll((await readFile(customResourcesPath)).toString()).filter((x) => x)
+      const crd = yaml.safeLoadAll((await readFile(customResourcesPath)).toString()).filter((x) => x)
       entry.setState("Installing Custom Resources...")
       await apply({ log, ctx, provider, manifests: crd, validate: false })
 
@@ -252,7 +252,7 @@ export async function setupCertManager({ ctx, provider, log, status }: SetupCert
       const issuers: any[] = []
       const certificates: any[] = []
       const secretNames: string[] = []
-      const namespace = provider.config.namespace || ctx.projectName
+      const namespace = provider.config.namespace?.name || ctx.projectName
       provider.config.tlsCertificates
         .filter((cert) => cert.managedBy === "cert-manager")
         .map((cert) => {

--- a/core/src/plugins/kubernetes/kubernetes-module/config.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/config.ts
@@ -21,7 +21,7 @@ import {
   ServiceResourceSpec,
   KubernetesTestSpec,
   KubernetesTaskSpec,
-  namespaceSchema,
+  namespaceNameSchema,
   containerModuleSchema,
   hotReloadArgsSchema,
 } from "../config"
@@ -78,7 +78,7 @@ export const kubernetesModuleSpecSchema = () =>
     If neither \`include\` nor \`exclude\` is set, Garden automatically sets \`include\` to equal the
     \`files\` directive so that only the Kubernetes manifests get included.
   `),
-    namespace: namespaceSchema(),
+    namespace: namespaceNameSchema(),
     serviceResource: serviceResourceSchema()
       .description(
         deline`The Deployment, DaemonSet or StatefulSet that Garden should regard as the _Garden service_ in this module

--- a/core/src/plugins/kubernetes/kubernetes.ts
+++ b/core/src/plugins/kubernetes/kubernetes.ts
@@ -40,6 +40,7 @@ import { pvcModuleDefinition } from "./volumes/persistentvolumeclaim"
 import { getModuleTypeUrl, getProviderUrl } from "../../docs/common"
 import { helm3Spec } from "./helm/helm-cli"
 import { sternSpec } from "./logs"
+import { isString } from "lodash"
 
 export async function configureProvider({
   namespace,
@@ -49,8 +50,13 @@ export async function configureProvider({
 }: ConfigureProviderParams<KubernetesConfig>) {
   config._systemServices = []
 
+  // Convert string shorthand to canonical format
+  if (isString(config.namespace)) {
+    config.namespace = { name: config.namespace }
+  }
+
   if (!config.namespace) {
-    config.namespace = `${projectName}-${namespace}`
+    config.namespace = { name: `${projectName}-${namespace}` }
   }
 
   if (config.setupIngressController === "nginx") {
@@ -201,7 +207,7 @@ export const gardenPlugin = () =>
 
     For usage information, please refer to the [guides section](${DOCS_BASE_URL}/guides). A good place to start is
     the [Remote Kubernetes guide](${DOCS_BASE_URL}/guides/remote-kubernetes) guide if you're connecting to remote clusters.
-    The [demo-project](${DOCS_BASE_URL}/example-projects/getting-started/2-initialize-a-project) example project and guide are also helpful as an introduction.
+    The [Getting Started](${DOCS_BASE_URL}/getting-started/0-introduction) guide is also helpful as an introduction.
 
     Note that if you're using a local Kubernetes cluster (e.g. minikube or Docker Desktop), the [local-kubernetes provider](${localKubernetesUrl}) simplifies (and automates) the configuration and setup quite a bit.
   `,

--- a/core/src/plugins/kubernetes/local/config.ts
+++ b/core/src/plugins/kubernetes/local/config.ts
@@ -6,7 +6,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { KubernetesConfig, kubernetesConfigBase, k8sContextSchema, KubernetesProvider } from "../config"
+import {
+  KubernetesConfig,
+  kubernetesConfigBase,
+  k8sContextSchema,
+  KubernetesProvider,
+  namespaceSchema,
+} from "../config"
 import { ConfigureProviderParams } from "../../../types/plugin/provider/configureProvider"
 import { joiProviderName, joi } from "../../../config/common"
 import { getKubeConfig } from "../api"
@@ -37,12 +43,10 @@ export const configSchema = () =>
     .keys({
       name: joiProviderName("local-kubernetes"),
       context: k8sContextSchema().optional(),
-      namespace: joi
-        .string()
-        .description(
-          "Specify which namespace to deploy services to (defaults to the project name). " +
-            "Note that the framework generates other namespaces as well with this name as a prefix."
-        ),
+      namespace: namespaceSchema().description(
+        "Specify which namespace to deploy services to (defaults to the project name). " +
+          "Note that the framework generates other namespaces as well with this name as a prefix."
+      ),
       setupIngressController: joi
         .string()
         .allow("nginx", false, null)

--- a/core/src/plugins/kubernetes/local/local.ts
+++ b/core/src/plugins/kubernetes/local/local.ts
@@ -21,7 +21,7 @@ export const gardenPlugin = () =>
     docs: dedent`
     The \`local-kubernetes\` provider is a specialized version of the [\`kubernetes\` provider](${providerUrl}) that automates and simplifies working with local Kubernetes clusters.
 
-    For general Kubernetes usage information, please refer to the [guides section](${DOCS_BASE_URL}/guides). For local clusters a good place to start is the [Local Kubernetes guide](${DOCS_BASE_URL}/guides/local-kubernetes) guide. The [demo-project](${DOCS_BASE_URL}/example-projects/getting-started/2-initialize-a-project) example project and guide are also helpful as an introduction.
+    For general Kubernetes usage information, please refer to the [guides section](${DOCS_BASE_URL}/guides). For local clusters a good place to start is the [Local Kubernetes guide](${DOCS_BASE_URL}/guides/local-kubernetes) guide. The [Getting Started](${DOCS_BASE_URL}/getting-started/0-introduction) guide is also helpful as an introduction.
 
     If you're working with a remote Kubernetes cluster, please refer to the [\`kubernetes\` provider](${providerUrl}) docs, and the [Remote Kubernetes guide](${DOCS_BASE_URL}/guides/remote-kubernetes) guide.
   `,

--- a/core/src/plugins/octant/octant.ts
+++ b/core/src/plugins/octant/octant.ts
@@ -49,8 +49,8 @@ export const gardenPlugin = () =>
           if (k8sProvider.config.context) {
             args.push("--context", k8sProvider.config.context)
           }
-          if (k8sProvider.config.namespace) {
-            args.push("--namespace", k8sProvider.config.namespace)
+          if (k8sProvider.config.namespace?.name) {
+            args.push("--namespace", k8sProvider.config.namespace.name)
           }
 
           octantProc = execa(path, args, { buffer: false, cleanup: true })

--- a/core/src/plugins/plugins.ts
+++ b/core/src/plugins/plugins.ts
@@ -9,7 +9,7 @@
 import { InternalError } from "../exceptions"
 import { GardenPluginCallback } from "../types/plugin/plugin"
 
-// These plugins are always registered
+// These plugins are always registered and the providers documented
 export const getSupportedPlugins = () =>
   [
     require("./container/container"),
@@ -21,7 +21,6 @@ export const getSupportedPlugins = () =>
     require("./octant/octant"),
     require("./openfaas/openfaas"),
     require("./terraform/terraform"),
-    require("./templated"),
   ].map(resolvePluginFromModule)
 
 // These plugins are always registered
@@ -32,6 +31,7 @@ export const getBuiltinPlugins = () =>
       require("./google/google-cloud-functions"),
       require("./local/local-google-cloud-functions"),
       require("./npm-package"),
+      require("./templated"),
     ].map(resolvePluginFromModule)
   )
 

--- a/core/src/types/plugin/provider/configureProvider.ts
+++ b/core/src/types/plugin/provider/configureProvider.ts
@@ -23,7 +23,7 @@ export interface ConfigureProviderParams<T extends GenericProviderConfig = any> 
   dependencies: ProviderMap
   environmentName: string
   log: LogEntry
-  namespace?: string
+  namespace: string
   projectName: string
   projectRoot: string
   base?: ActionHandler<ConfigureProviderParams<T>, ConfigureProviderResult<T>>
@@ -47,7 +47,7 @@ export const configureProvider = () => ({
     and avoid performing expensive processing or network calls.
   `,
   paramsSchema: actionParamsSchema().keys({
-    config: providerConfigBaseSchema().required(),
+    config: providerConfigBaseSchema(),
     environmentName: joiIdentifier(),
     namespace: joiIdentifier(),
     log: logEntrySchema(),

--- a/core/test/integ/src/plugins/kubernetes/container/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/deployment.ts
@@ -51,7 +51,7 @@ describe("kubernetes container deployment handlers", () => {
 
     it("should create a basic Deployment resource", async () => {
       const service = graph.getService("simple-service")
-      const namespace = provider.config.namespace!
+      const namespace = provider.config.namespace!.name!
 
       const resource = await createWorkloadManifest({
         api,
@@ -117,7 +117,7 @@ describe("kubernetes container deployment handlers", () => {
 
     it("should name the Deployment with a version suffix and set a version label if blueGreen=true", async () => {
       const service = graph.getService("simple-service")
-      const namespace = provider.config.namespace!
+      const namespace = provider.config.namespace!.name!
 
       const resource = await createWorkloadManifest({
         api,
@@ -160,7 +160,7 @@ describe("kubernetes container deployment handlers", () => {
       }
       await api.upsert({ kind: "Secret", namespace: "default", obj: authSecret, log: garden.log })
 
-      const namespace = provider.config.namespace!
+      const namespace = provider.config.namespace!.name!
       const _provider = cloneDeep(provider)
       _provider.config.imagePullSecrets = [{ name: secretName, namespace: "default" }]
 
@@ -199,7 +199,7 @@ describe("kubernetes container deployment handlers", () => {
       }
       await api.upsert({ kind: "Secret", namespace: "default", obj: authSecret, log: garden.log })
 
-      const namespace = provider.config.namespace!
+      const namespace = provider.config.namespace!.name!
       const _provider = cloneDeep(provider)
       _provider.config.imagePullSecrets = [{ name: secretName, namespace: "default" }]
 
@@ -222,7 +222,7 @@ describe("kubernetes container deployment handlers", () => {
 
     it("should correctly mount a referenced PVC module", async () => {
       const service = graph.getService("volume-reference")
-      const namespace = provider.config.namespace!
+      const namespace = provider.config.namespace!.name!
 
       const resource = await createWorkloadManifest({
         api,
@@ -244,7 +244,7 @@ describe("kubernetes container deployment handlers", () => {
 
     it("should throw if incompatible module is specified as a volume module", async () => {
       const service = graph.getService("volume-reference")
-      const namespace = provider.config.namespace!
+      const namespace = provider.config.namespace!.name!
 
       service.spec.volumes = [{ name: "test", module: "simple-service" }]
 

--- a/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
@@ -91,7 +91,7 @@ describe("deployHelmService", () => {
     const service = graph.getService("chart-with-namespace")
 
     const namespace = service.module.spec.namespace
-    expect(namespace).to.equal(provider.config.namespace + "-extra")
+    expect(namespace).to.equal(provider.config.namespace!.name + "-extra")
 
     await deployHelmService({
       ctx,

--- a/core/test/integ/src/plugins/kubernetes/namespace.ts
+++ b/core/test/integ/src/plugins/kubernetes/namespace.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { randomString, gardenAnnotationKey } from "../../../../../src/util/string"
+import { KubeApi } from "../../../../../src/plugins/kubernetes/api"
+import { getDataDir, makeTestGarden } from "../../../../helpers"
+import { Provider } from "../../../../../src/config/provider"
+import { KubernetesConfig } from "../../../../../src/plugins/kubernetes/config"
+import { ensureNamespace } from "../../../../../src/plugins/kubernetes/namespace"
+import { LogEntry } from "../../../../../src/logger/log-entry"
+import { expect } from "chai"
+import { getPackageVersion } from "../../../../../src/util/util"
+
+describe("ensureNamespace", () => {
+  let api: KubeApi
+  let log: LogEntry
+  let namespaceName: string
+
+  before(async () => {
+    const root = getDataDir("test-projects", "container")
+    const garden = await makeTestGarden(root)
+    const provider = (await garden.resolveProvider(garden.log, "local-kubernetes")) as Provider<KubernetesConfig>
+    const ctx = await garden.getPluginContext(provider)
+    log = garden.log
+    api = await KubeApi.factory(log, ctx, provider)
+  })
+
+  beforeEach(() => {
+    namespaceName = "testing-" + randomString(10)
+  })
+
+  afterEach(async () => {
+    try {
+      await api.core.deleteNamespace(namespaceName)
+    } catch {}
+  })
+
+  it("should create the namespace if it doesn't exist, with configured annotations and labels", async () => {
+    const namespace = {
+      name: namespaceName,
+      annotations: { foo: "bar" },
+      labels: { floo: "blar" },
+    }
+
+    const result = await ensureNamespace(api, namespace, log)
+
+    expect(result?.metadata.name).to.equal(namespaceName)
+    expect(result?.metadata.annotations).to.eql({
+      [gardenAnnotationKey("generated")]: "true",
+      [gardenAnnotationKey("version")]: getPackageVersion(),
+      ...namespace.annotations,
+    })
+    expect(result?.metadata.labels).to.eql(namespace.labels)
+  })
+
+  it("should add configured annotations if any are missing", async () => {
+    await api.core.createNamespace({
+      apiVersion: "v1",
+      kind: "Namespace",
+      metadata: {
+        name: namespaceName,
+        annotations: {
+          [gardenAnnotationKey("generated")]: "true",
+          [gardenAnnotationKey("version")]: getPackageVersion(),
+        },
+      },
+    })
+
+    const namespace = {
+      name: namespaceName,
+      annotations: { foo: "bar" },
+    }
+
+    const result = await ensureNamespace(api, namespace, log)
+
+    expect(result?.metadata.name).to.equal(namespaceName)
+    expect(result?.metadata.annotations).to.eql({
+      [gardenAnnotationKey("generated")]: "true",
+      [gardenAnnotationKey("version")]: getPackageVersion(),
+      foo: "bar",
+    })
+  })
+
+  it("should add configured labels if any are missing", async () => {
+    await api.core.createNamespace({
+      apiVersion: "v1",
+      kind: "Namespace",
+      metadata: {
+        name: namespaceName,
+        labels: { foo: "bar" },
+      },
+    })
+
+    const namespace = {
+      name: namespaceName,
+      labels: { floo: "blar" },
+    }
+
+    const result = await ensureNamespace(api, namespace, log)
+
+    expect(result?.metadata.name).to.equal(namespaceName)
+    expect(result?.metadata.labels).to.eql({ foo: "bar", floo: "blar" })
+  })
+
+  it("should do nothing if the namespace has already been configured", async () => {
+    await api.core.createNamespace({
+      apiVersion: "v1",
+      kind: "Namespace",
+      metadata: {
+        name: namespaceName,
+        annotations: {
+          [gardenAnnotationKey("generated")]: "true",
+          [gardenAnnotationKey("version")]: getPackageVersion(),
+          foo: "bar",
+        },
+        labels: { existing: "label", floo: "blar" },
+      },
+    })
+
+    const namespace = {
+      name: namespaceName,
+      annotations: { foo: "bar" },
+      labels: { floo: "blar" },
+    }
+
+    const result = await ensureNamespace(api, namespace, log)
+
+    expect(result).to.be.null
+  })
+})

--- a/core/test/integ/src/plugins/kubernetes/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/run.ts
@@ -53,7 +53,7 @@ describe("kubernetes Pod runner functions", () => {
     garden = await getContainerTestGarden()
     provider = <KubernetesProvider>await garden.resolveProvider(garden.log, "local-kubernetes")
     ctx = await garden.getPluginContext(provider)
-    namespace = provider.config.namespace!
+    namespace = provider.config.namespace!.name!
     api = await KubeApi.factory(garden.log, ctx, provider)
     log = garden.log
   })
@@ -621,7 +621,7 @@ describe("kubernetes Pod runner functions", () => {
         args: [],
         interactive: false,
         module,
-        namespace: provider.config.namespace!,
+        namespace: provider.config.namespace!.name!,
         podName,
         runtimeContext: { envVars: {}, dependencies: [] },
         image,

--- a/core/test/integ/src/plugins/kubernetes/util.ts
+++ b/core/test/integ/src/plugins/kubernetes/util.ts
@@ -96,7 +96,7 @@ describe("util", () => {
           provider,
           service,
           runtimeContext: emptyRuntimeContext,
-          namespace: provider.config.namespace!,
+          namespace: provider.config.namespace!.name!,
           enableHotReload: false,
           log: garden.log,
           production: false,

--- a/core/test/unit/src/actions.ts
+++ b/core/test/unit/src/actions.ts
@@ -107,6 +107,7 @@ describe("ActionRouter", () => {
               status: { ready: false, outputs: {} },
             })
           ),
+          namespace: "default",
           environmentName: "default",
           pluginName: "test-plugin",
           log,

--- a/core/test/unit/src/docs/common.ts
+++ b/core/test/unit/src/docs/common.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { joi } from "../../../../src/config/common"
+import { JoiKeyDescription, JoiDescription } from "../../../../src/docs/joi-schema"
+import { flattenSchema } from "../../../../src/docs/common"
+import { expect } from "chai"
+
+describe("flattenSchema", () => {
+  it("should return all keys in an object schema", async () => {
+    const schema = joi.object().keys({
+      a: joi.string(),
+      b: joi.number(),
+      c: joi.object().keys({
+        c1: joi.string(),
+        c2: joi.number(),
+      }),
+    })
+
+    const desc = new JoiKeyDescription({
+      joiDescription: schema.describe() as JoiDescription,
+      name: undefined,
+      level: 0,
+    })
+
+    const result = flattenSchema(desc)
+
+    expect(result.length).to.equal(5)
+    expect(result[0].fullKey()).to.equal("a")
+    expect(result[1].fullKey()).to.equal("b")
+    expect(result[2].fullKey()).to.equal("c")
+    expect(result[3].fullKey()).to.equal("c.c1")
+    expect(result[4].fullKey()).to.equal("c.c2")
+  })
+
+  it("should correctly handle nested object schemas on arrays", async () => {
+    const schema = joi.object().keys({
+      a: joi.string(),
+      b: joi.array().items(
+        joi.object().keys({
+          b1: joi.string(),
+          b2: joi.number(),
+        })
+      ),
+    })
+
+    const desc = new JoiKeyDescription({
+      joiDescription: schema.describe() as JoiDescription,
+      name: undefined,
+      level: 0,
+    })
+
+    const result = flattenSchema(desc)
+
+    expect(result.length).to.equal(4)
+    expect(result[0].fullKey()).to.equal("a")
+    expect(result[1].fullKey()).to.equal("b[]")
+    expect(result[2].parent).to.equal(result[1])
+    expect(result[3].parent).to.equal(result[1])
+    expect(result[2].fullKey()).to.equal("b[].b1")
+    expect(result[3].fullKey()).to.equal("b[].b2")
+  })
+})

--- a/core/test/unit/src/docs/joi-schema.ts
+++ b/core/test/unit/src/docs/joi-schema.ts
@@ -8,26 +8,95 @@
 
 import { expect } from "chai"
 import { joi } from "../../../../src/config/common"
-import { getJoiDefaultValue, JoiDescription, normalizeJoiSchemaDescription } from "../../../../src/docs/joi-schema"
+import { JoiDescription, JoiKeyDescription } from "../../../../src/docs/joi-schema"
 import { testJsonSchema } from "./json-schema"
-import { normalizeJsonSchema } from "../../../../src/docs/json-schema"
 
-describe("normalizeJoiSchemaDescription", () => {
-  it("should correctly handle joi.object().jsonSchema() schemas", async () => {
-    const schema = joi.object().jsonSchema(testJsonSchema)
-    const result = normalizeJoiSchemaDescription(schema.describe() as JoiDescription)
-    expect(result).to.eql(normalizeJsonSchema(testJsonSchema))
+describe("JoiKeyDescription", () => {
+  it("correctly set the basic attributes of an object schema", () => {
+    const joiSchema = joi
+      .string()
+      .required()
+      .allow("a", "b")
+      .only()
+      .meta({ internal: true, deprecated: true, experimental: true })
+      .description("some description")
+
+    const desc = new JoiKeyDescription({
+      joiDescription: joiSchema.describe() as JoiDescription,
+      name: "foo",
+      level: 0,
+    })
+
+    expect(desc.formatAllowedValues()).to.equal('"a", "b"')
+    expect(desc.type).to.equal("string")
+    expect(desc.required).to.be.true
+    expect(desc.internal).to.be.true
+    expect(desc.deprecated).to.be.true
+    expect(desc.experimental).to.be.true
+    expect(desc.description).to.equal("some description")
   })
-})
 
-describe("getJoiDefaultValue", () => {
-  const testDefaultSchema = joi
-    .number()
-    .default(() => "result")
-    .description("description")
+  describe("getChildren", () => {
+    it("should correctly handle array schemas", () => {
+      const schema = joi.array().items(joi.object().keys({ a: joi.string().description("array object key") }))
+      const desc = new JoiKeyDescription({
+        joiDescription: schema.describe() as JoiDescription,
+        name: undefined,
+        level: 0,
+      })
+      const children = desc.getChildren(true)
 
-  it("should get the default return of the function over the param", () => {
-    const value = getJoiDefaultValue(testDefaultSchema.describe() as JoiDescription)
-    expect(value).to.equal("result")
+      expect(children.length).to.equal(1)
+      expect(children[0].type).to.equal("object")
+      expect(children[0].parent).to.equal(desc)
+    })
+
+    it("should correctly handle joi.object().jsonSchema() schemas", () => {
+      const schema = joi.object().jsonSchema(testJsonSchema)
+      const desc = new JoiKeyDescription({
+        joiDescription: schema.describe() as JoiDescription,
+        name: "foo",
+        level: 0,
+      })
+      const children = desc.getChildren(true)
+
+      expect(children.length).to.equal(3)
+      expect(children[0].name).to.equal("apiVersion")
+      expect(children[1].name).to.equal("kind")
+      expect(children[2].name).to.equal("metadata")
+
+      for (const c of children) {
+        expect(c.parent).to.equal(desc)
+        expect(c.level).to.equal(1)
+      }
+    })
+  })
+
+  describe("getDefaultValue", () => {
+    it("should get the default value", () => {
+      const schema = joi.number().default("result")
+      const desc = new JoiKeyDescription({
+        joiDescription: schema.describe() as JoiDescription,
+        name: undefined,
+        level: 0,
+      })
+      const value = desc.getDefaultValue()
+      expect(value).to.equal("result")
+    })
+
+    it("should get the default return of the function over the param", () => {
+      const schema = joi
+        .number()
+        .default(() => "result")
+        .description("description")
+
+      const desc = new JoiKeyDescription({
+        joiDescription: schema.describe() as JoiDescription,
+        name: undefined,
+        level: 0,
+      })
+      const value = desc.getDefaultValue()
+      expect(value).to.equal("result")
+    })
   })
 })

--- a/core/test/unit/src/docs/json-schema.ts
+++ b/core/test/unit/src/docs/json-schema.ts
@@ -7,104 +7,41 @@
  */
 
 import { expect } from "chai"
-import { normalizeJsonSchema } from "../../../../src/docs/json-schema"
+import { JsonKeyDescription } from "../../../../src/docs/json-schema"
 
-describe("normalizeJsonSchema", () => {
-  it("should normalize a type=oject JSON Schema", () => {
-    const keys = normalizeJsonSchema(testJsonSchema)
+describe("JsonKeyDescription", () => {
+  it("correctly set the basic attributes of an object schema", () => {
+    const desc = new JsonKeyDescription({
+      schema: testJsonSchema,
+      name: undefined,
+      level: 0,
+    })
 
-    expect(keys).to.eql([
-      {
-        type: "string",
-        name: "apiVersion",
-        allowedValuesOnly: false,
-        defaultValue: "v1",
-        deprecated: false,
-        description: testJsonSchema.properties.apiVersion.description,
-        experimental: false,
-        fullKey: "apiVersion",
-        formattedExample: undefined,
-        formattedName: "apiVersion",
-        formattedType: "string",
-        hasChildren: false,
-        internal: false,
+    expect(desc.type).to.equal("object")
+    expect(desc.internal).to.be.false
+    expect(desc.deprecated).to.be.false
+    expect(desc.experimental).to.be.false
+    expect(desc.description).to.equal(testJsonSchema.description)
+  })
+
+  describe("getChildren", () => {
+    it("should correctly handle object schemas", () => {
+      const desc = new JsonKeyDescription({
+        schema: testJsonSchema,
+        name: "foo",
         level: 0,
-        parent: undefined,
-        required: false,
-      },
-      {
-        type: "string",
-        name: "kind",
-        allowedValuesOnly: true,
-        defaultValue: undefined,
-        deprecated: false,
-        description: testJsonSchema.properties.kind.description,
-        experimental: false,
-        fullKey: "kind",
-        formattedExample: undefined,
-        formattedName: "kind",
-        formattedType: "string",
-        hasChildren: false,
-        internal: false,
-        level: 0,
-        parent: undefined,
-        required: false,
-        allowedValues: '"PersistentVolumeClaim"',
-      },
-      {
-        type: "object",
-        name: "metadata",
-        allowedValuesOnly: false,
-        defaultValue: undefined,
-        deprecated: false,
-        description: testJsonSchema.properties.metadata.description,
-        experimental: false,
-        fullKey: "metadata",
-        formattedExample: undefined,
-        formattedName: "metadata",
-        formattedType: "object",
-        hasChildren: true,
-        internal: false,
-        level: 0,
-        parent: undefined,
-        required: false,
-      },
-      {
-        type: "string",
-        name: "lastTransitionTime",
-        allowedValuesOnly: false,
-        defaultValue: undefined,
-        deprecated: false,
-        description: testJsonSchema.properties.metadata.properties.lastTransitionTime.description,
-        experimental: false,
-        fullKey: "metadata.lastTransitionTime",
-        formattedExample: undefined,
-        formattedName: "lastTransitionTime",
-        formattedType: "string",
-        hasChildren: false,
-        internal: false,
-        level: 1,
-        parent: {
-          type: "object",
-          name: "metadata",
-          allowedValuesOnly: false,
-          defaultValue: undefined,
-          deprecated: false,
-          description: testJsonSchema.properties.metadata.description,
-          experimental: false,
-          fullKey: "metadata",
-          formattedExample: undefined,
-          formattedName: "metadata",
-          formattedType: "object",
-          hasChildren: true,
-          internal: false,
-          level: 0,
-          parent: undefined,
-          required: false,
-        },
-        required: false,
-      },
-    ])
+      })
+      const children = desc.getChildren()
+
+      expect(children.length).to.equal(3)
+      expect(children[0].type).to.equal("string")
+      expect(children[1].type).to.equal("string")
+      expect(children[2].type).to.equal("object")
+
+      for (const c of children) {
+        expect(c.parent).to.equal(desc)
+      }
+    })
   })
 })
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -937,6 +937,268 @@ namespace:
 
 # A list of all configured providers in the environment.
 providers:
+  - # The name of the provider plugin to use.
+    name:
+
+    # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
+    # disables the provider. To use a provider in all environments, omit this field.
+    environments:
+
+    # Map of all the providers that this provider depends on.
+    dependencies:
+      <name>:
+
+    config:
+      # The name of the provider plugin to use.
+      name:
+
+      # List other providers that should be resolved before this one.
+      dependencies:
+
+      # If specified, this provider will only be used in the listed environments. Note that an empty array effectively
+      # disables the provider. To use a provider in all environments, omit this field.
+      environments:
+
+    moduleConfigs:
+      - # The schema version of this config (currently not used).
+        apiVersion:
+
+        kind:
+
+        # The type of this module.
+        type:
+
+        # The name of this module.
+        name:
+
+        # Specify how to build the module. Note that plugins may define additional keys on this object.
+        build:
+          # A list of modules that must be built before this module is built.
+          dependencies:
+            - # Module name to build ahead of this module.
+              name:
+
+              # Specify one or more files or directories to copy from the built dependency to this module.
+              copy:
+                - # POSIX-style path or filename of the directory or file(s) to copy to the target.
+                  source:
+
+                  # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
+                  # Defaults to to same as source path.
+                  target:
+
+        # A description of the module.
+        description:
+
+        # Set this to `true` to disable the module. You can use this with conditional template strings to disable
+        # modules based on, for example, the current environment or other variables (e.g. `disabled:
+        # \${environment.name == "prod"}`). This can be handy when you only need certain modules for specific
+        # environments, e.g. only for development.
+        #
+        # Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It
+        # also means that the module is not built _unless_ it is declared as a build dependency by another enabled
+        # module (in which case building this module is necessary for the dependant to be built).
+        #
+        # If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden
+        # will automatically ignore those dependency declarations. Note however that template strings referencing the
+        # module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so
+        # you need to make sure to provide alternate values for those if you're using them, using conditional
+        # expressions.
+        disabled:
+
+        # Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module.
+        # Files that do *not* match these paths or globs are excluded when computing the version of the module, when
+        # responding to filesystem watch events, and when staging builds.
+        #
+        # Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your
+        # source tree, which use the same format as `.gitignore` files. See the [Configuration Files
+        # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
+        # for details.
+        #
+        # Also note that specifying an empty list here means _no sources_ should be included.
+        include:
+
+        # Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that
+        # match these paths or globs are excluded when computing the version of the module, when responding to
+        # filesystem watch events, and when staging builds.
+        #
+        # Note that you can also explicitly _include_ files using the `include` field. If you also specify the
+        # `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the
+        # [Configuration Files
+        # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
+        # for details.
+        #
+        # Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files
+        # and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you
+        # have large directories that should not be watched for changes.
+        exclude:
+
+        # A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a
+        # specific branch or tag, with the format: <git remote url>#<branch|tag>
+        #
+        # Garden will import the repository source code into this module, but read the module's config from the local
+        # garden.yml file.
+        repositoryUrl:
+
+        # When false, disables pushing this module to remote registries.
+        allowPublish:
+
+        # The filesystem path of the module.
+        path:
+
+        # The filesystem path of the module config file.
+        configPath:
+
+        # List of services configured by this module.
+        serviceConfigs:
+          - # Valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and dashes, must start with a
+            # letter, and cannot end with a dash), cannot contain consecutive dashes or start with `garden`, or be
+            # longer than 63 characters.
+            name:
+
+            # The names of any services that this service depends on at runtime, and the names of any tasks that
+            # should be executed before this service is deployed.
+            dependencies:
+
+            # Set this to `true` to disable the service. You can use this with conditional template strings to
+            # enable/disable services based on, for example, the current environment or other variables (e.g.
+            # `enabled: \${environment.name != "prod"}`). This can be handy when you only need certain services for
+            # specific environments, e.g. only for development.
+            #
+            # Disabling a service means that it will not be deployed, and will also be ignored if it is declared as a
+            # runtime dependency for another service, test or task.
+            #
+            # Note however that template strings referencing the service's outputs (i.e. runtime outputs) will fail to
+            # resolve when the service is disabled, so you need to make sure to provide alternate values for those if
+            # you're using them, using conditional expressions.
+            disabled:
+
+            # Set this to true if the module and service configuration supports hot reloading.
+            hotReloadable:
+
+            # The `validate` module action should populate this, if the service's code sources are contained in a
+            # separate module from the parent module. For example, when the service belongs to a module that contains
+            # manifests (e.g. a Helm chart), but the actual code lives in a different module (e.g. a container
+            # module).
+            sourceModuleName:
+
+            # The service's specification, as defined by its provider plugin.
+            spec:
+
+        # List of tasks configured by this module.
+        taskConfigs:
+          - # The name of the task.
+            name:
+
+            # A description of the task.
+            description:
+
+            # The names of any tasks that must be executed, and the names of any services that must be running, before
+            # this task is executed.
+            dependencies:
+
+            # Set this to `true` to disable the task. You can use this with conditional template strings to
+            # enable/disable tasks based on, for example, the current environment or other variables (e.g. `enabled:
+            # \${environment.name != "prod"}`). This can be handy when you only want certain tasks to run in specific
+            # environments, e.g. only for development.
+            #
+            # Disabling a task means that it will not be run, and will also be ignored if it is declared as a runtime
+            # dependency for another service, test or task.
+            #
+            # Note however that template strings referencing the task's outputs (i.e. runtime outputs) will fail to
+            # resolve when the task is disabled, so you need to make sure to provide alternate values for those if
+            # you're using them, using conditional expressions.
+            disabled:
+
+            # Maximum duration (in seconds) of the task's execution.
+            timeout:
+
+            # Set to false if you don't want the task's result to be cached. Use this if the task needs to be run any
+            # time your project (or one or more of the task's dependants) is deployed. Otherwise the task is only
+            # re-run when its version changes (i.e. the module or one of its dependencies is modified), or when you
+            # run `garden run task`.
+            cacheResult:
+
+            # The task's specification, as defined by its provider plugin.
+            spec:
+
+        # List of tests configured by this module.
+        testConfigs:
+          - # The name of the test.
+            name:
+
+            # The names of any services that must be running, and the names of any tasks that must be executed, before
+            # the test is run.
+            dependencies:
+
+            # Set this to `true` to disable the test. You can use this with conditional template strings to
+            # enable/disable tests based on, for example, the current environment or other variables (e.g.
+            # `enabled: \${environment.name != "prod"}`). This is handy when you only want certain tests to run in
+            # specific environments, e.g. only during CI.
+            disabled:
+
+            # Maximum duration (in seconds) of the test run.
+            timeout:
+
+            # The configuration for the test, as specified by its module's provider.
+            spec:
+
+        # The module spec, as defined by the provider plugin.
+        spec:
+
+            # POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+            #
+            # Note that any existing file with the same name will be overwritten. If the path contains one or more
+            # directories, they will be automatically created if missing.
+            targetPath:
+
+            # The desired file contents as a string.
+            value:
+
+            sourcePath:
+
+        # The name of the parent module (e.g. a templated module that generated this module), if applicable.
+        parentName:
+
+        # The module template that generated the module, if applicable.
+        templateName:
+
+        # Inputs provided when rendering the module from a module template, if applicable.
+        inputs:
+          <name>:
+
+    # Description of an environment's status for a provider.
+    status:
+      # Set to true if the environment is fully configured for a provider.
+      ready:
+
+      # Use this to include additional information that is specific to the provider.
+      detail:
+
+      # Output variables that modules and other variables can reference.
+      outputs:
+        <name>:
+
+      # Set to true to disable caching of the status.
+      disableCache:
+
+    # A list of pages that the provider adds to the Garden dashboard.
+    dashboardPages:
+      - # A unique identifier for the page.
+        name:
+
+        # The link title to show in the menu bar (max length 32).
+        title:
+
+        # A description to show when hovering over the link.
+        description:
+
+        # The URL to open in the dashboard pane when clicking the link. If none is specified, the provider must
+        # specify a `getDashboardPage` handler that resolves the URL given the `name` of this page.
+        url:
+
+        # Set to true if the link should open in a new browser tab/window.
+        newWindow:
 
 # All configured variables in the environment.
 variables:
@@ -1127,6 +1389,17 @@ moduleConfigs:
 
     # The module spec, as defined by the provider plugin.
     spec:
+
+        # POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+        #
+        # Note that any existing file with the same name will be overwritten. If the path contains one or more
+        # directories, they will be automatically created if missing.
+        targetPath:
+
+        # The desired file contents as a string.
+        value:
+
+        sourcePath:
 
     # The name of the parent module (e.g. a templated module that generated this module), if applicable.
     parentName:
@@ -1567,6 +1840,17 @@ modules:
 
     # The module spec, as defined by the provider plugin.
     spec:
+
+        # POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+        #
+        # Note that any existing file with the same name will be overwritten. If the path contains one or more
+        # directories, they will be automatically created if missing.
+        targetPath:
+
+        # The desired file contents as a string.
+        value:
+
+        sourcePath:
 
     # The name of the parent module (e.g. a templated module that generated this module), if applicable.
     parentName:

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -143,7 +143,8 @@ chartPath: .
 # List of names of services that should be deployed before this chart.
 dependencies: []
 
-# Deploy to a different namespace than the default one configured in the provider.
+# A valid Kubernetes namespace name. Must be a valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters,
+# numbers and dashes, must start with a letter, and cannot end with a dash) and must not be longer than 63 characters.
 namespace:
 
 # Optionally override the release name used when installing (defaults to the module name).
@@ -714,7 +715,7 @@ List of names of services that should be deployed before this chart.
 
 ### `namespace`
 
-Deploy to a different namespace than the default one configured in the provider.
+A valid Kubernetes namespace name. Must be a valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and dashes, must start with a letter, and cannot end with a dash) and must not be longer than 63 characters.
 
 | Type     | Required |
 | -------- | -------- |

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -149,7 +149,8 @@ manifests:
 # POSIX-style paths to YAML files to load manifests from. Each can contain multiple manifests.
 files: []
 
-# Deploy to a different namespace than the default one configured in the provider.
+# A valid Kubernetes namespace name. Must be a valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters,
+# numbers and dashes, must start with a letter, and cannot end with a dash) and must not be longer than 63 characters.
 namespace:
 
 # The Deployment, DaemonSet or StatefulSet that Garden should regard as the _Garden service_ in this module (not to be
@@ -661,7 +662,7 @@ POSIX-style paths to YAML files to load manifests from. Each can contain multipl
 
 ### `namespace`
 
-Deploy to a different namespace than the default one configured in the provider.
+A valid Kubernetes namespace name. Must be a valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and dashes, must start with a letter, and cannot end with a dash) and must not be longer than 63 characters.
 
 | Type     | Required |
 | -------- | -------- |

--- a/docs/reference/module-types/persistentvolumeclaim.md
+++ b/docs/reference/module-types/persistentvolumeclaim.md
@@ -482,7 +482,7 @@ Kind is the type of resource being referenced
 
 | Type     | Required |
 | -------- | -------- |
-| `string` | No       |
+| `string` | Yes      |
 
 ### `spec.dataSource.name`
 
@@ -492,7 +492,7 @@ Name is the name of resource being referenced
 
 | Type     | Required |
 | -------- | -------- |
-| `string` | No       |
+| `string` | Yes      |
 
 ### `spec.resources`
 

--- a/docs/reference/project-config.md
+++ b/docs/reference/project-config.md
@@ -50,6 +50,16 @@ environments:
     # For more details please check the documentation for the providers in use.
     production: false
 
+        # The name of the provider plugin to use.
+        name:
+
+        # List other providers that should be resolved before this one.
+        dependencies: []
+
+        # If specified, this provider will only be used in the listed environments. Note that an empty array
+        # effectively disables the provider. To use a provider in all environments, omit this field.
+        environments:
+
     # Specify a path (relative to the project root) to a file containing variables, that we apply on top of the
     # _environment-specific_ `variables` field.
     #
@@ -99,7 +109,6 @@ defaultEnvironment: ''
 # guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
 # details.
 dotIgnoreFiles:
-  - .gardenignore
 
 # Control where to scan for modules in the project.
 modules:
@@ -305,6 +314,7 @@ Example:
 
 ```yaml
 environments:
+        name: "local-kubernetes"
 ```
 
 ### `environments[].providers[].dependencies[]`
@@ -321,6 +331,8 @@ Example:
 
 ```yaml
 environments:
+        dependencies:
+          - exec
 ```
 
 ### `environments[].providers[].environments[]`
@@ -337,6 +349,9 @@ Example:
 
 ```yaml
 environments:
+        environments:
+          - dev
+          - stage
 ```
 
 ### `environments[].varfile`

--- a/docs/reference/providers/terraform.md
+++ b/docs/reference/providers/terraform.md
@@ -48,8 +48,11 @@ providers:
     # `terraform` module configs, or you can place a `terraform.tfvars` file in each working directory.
     variables:
 
-    # The version of Terraform to use.
-    version: 0.12.26
+    # The version of Terraform to use. Set to `null` to use whichever version of `terraform` that is on your PATH.
+    version: 0.13.3
+
+    # Use the specified Terraform workspace.
+    workspace:
 ```
 ## Configuration Keys
 
@@ -162,9 +165,19 @@ A map of variables to use when applying Terraform stacks. You can define these h
 
 [providers](#providers) > version
 
-The version of Terraform to use.
+The version of Terraform to use. Set to `null` to use whichever version of `terraform` that is on your PATH.
 
-| Type     | Default     | Required |
-| -------- | ----------- | -------- |
-| `string` | `"0.12.26"` | No       |
+| Type     | Default    | Required |
+| -------- | ---------- | -------- |
+| `string` | `"0.13.3"` | No       |
+
+### `providers[].workspace`
+
+[providers](#providers) > workspace
+
+Use the specified Terraform workspace.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
 

--- a/docs/reference/template-strings.md
+++ b/docs/reference/template-strings.md
@@ -160,6 +160,14 @@ Example:
 my-variable: ${git.branch}
 ```
 
+### `${secrets.<secret-name>}`
+
+The secret's value.
+
+| Type     |
+| -------- |
+| `string` |
+
 
 ## Environment configuration context
 
@@ -311,6 +319,14 @@ Example:
 ```yaml
 my-variable: ${git.branch}
 ```
+
+### `${secrets.<secret-name>}`
+
+The secret's value.
+
+| Type     |
+| -------- |
+| `string` |
 
 ### `${variables.*}`
 
@@ -495,6 +511,14 @@ Example:
 ```yaml
 my-variable: ${git.branch}
 ```
+
+### `${secrets.<secret-name>}`
+
+The secret's value.
+
+| Type     |
+| -------- |
+| `string` |
 
 ### `${variables.*}`
 
@@ -772,6 +796,14 @@ Example:
 ```yaml
 my-variable: ${git.branch}
 ```
+
+### `${secrets.<secret-name>}`
+
+The secret's value.
+
+| Type     |
+| -------- |
+| `string` |
 
 ### `${variables.*}`
 
@@ -1218,6 +1250,14 @@ Example:
 my-variable: ${git.branch}
 ```
 
+### `${secrets.<secret-name>}`
+
+The secret's value.
+
+| Type     |
+| -------- |
+| `string` |
+
 ### `${variables.*}`
 
 A map of all variables defined in the project configuration, including environment-specific variables.
@@ -1659,6 +1699,14 @@ Example:
 ```yaml
 my-variable: ${git.branch}
 ```
+
+### `${secrets.<secret-name>}`
+
+The secret's value.
+
+| Type     |
+| -------- |
+| `string` |
 
 ### `${variables.*}`
 


### PR DESCRIPTION
You can now configure both annotations and labels on namespaces. The
`namespace` field on the `kubernetes` provider now also accepts an
object instead of just a string, so you can specify the desired
annotations and/or labels there.

These will be applied when creating namespaces, and Garden will also
attempt to ensure those annotations and labels are on existing
namespaces (emitting a warning if e.g. not allowed to modify the
namespace).

Closes #2096 

**Note:**
I was forced to update our docs gen code to make the documentation properly do its thing (we weren't handling "alternatives" schemas properly). So a bunch of the changes are to do with that.