### PR TITLE
feat(template): allow escaping template strings for generated files

### DIFF
--- a/core/src/config/config-context.ts
+++ b/core/src/config/config-context.ts
@@ -43,6 +43,8 @@ export interface ContextResolveOpts {
   allowPartial?: boolean
   // a list of previously resolved paths, used to detect circular references
   stack?: string[]
+  // Unescape escaped template strings
+  unescape?: boolean
 }
 
 export interface ContextResolveParams {

--- a/core/src/config/module.ts
+++ b/core/src/config/module.ts
@@ -119,7 +119,7 @@ const generatedFileSchema = () =>
         .required()
         .description(
           dedent`
-          POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+          POSIX-style filename to write the resolved file contents to, relative to the path of the module source directory (for remote modules this means the root of the module repository, otherwise the directory of the module configuration).
 
           Note that any existing file with the same name will be overwritten. If the path contains one or more directories, they will be automatically created if missing.
           `

--- a/core/src/resolve-module.ts
+++ b/core/src/resolve-module.ts
@@ -403,10 +403,9 @@ export class ModuleResolver {
 
       if (fileSpec.sourcePath) {
         contents = (await readFile(fileSpec.sourcePath)).toString()
-        contents = await resolveTemplateString(contents, configContext)
       }
 
-      const resolvedContents = resolveTemplateString(contents, configContext)
+      const resolvedContents = resolveTemplateString(contents, configContext, { unescape: true })
       const targetDir = resolve(resolvedConfig.path, ...posix.dirname(fileSpec.targetPath).split(posix.sep))
       const targetPath = resolve(resolvedConfig.path, ...fileSpec.targetPath.split(posix.sep))
 

--- a/core/src/template-string.ts
+++ b/core/src/template-string.ts
@@ -27,6 +27,7 @@ export type StringOrStringPromise = Promise<string> | string
 
 const missingKeyExceptionType = "template-string-missing-key"
 const passthroughExceptionType = "template-string-passthrough"
+const escapePrefix = "$${"
 
 class TemplateStringError extends GardenBaseError {
   type = "template-string"
@@ -95,6 +96,8 @@ export function resolveTemplateString(string: string, context: ConfigContext, op
       missingKeyExceptionType,
       passthroughExceptionType,
       allowPartial: !!opts.allowPartial,
+      unescape: !!opts.unescape,
+      escapePrefix,
       optionalSuffix: "}?",
       isPlainObject,
       isPrimitive,

--- a/core/src/util/fs.ts
+++ b/core/src/util/fs.ts
@@ -278,6 +278,9 @@ export async function makeTempDir({ git = false }: { git?: boolean } = {}): Prom
 
   if (git) {
     await exec("git", ["init"], { cwd: tmpDir.path })
+    await writeFile(join(tmpDir.path, "foo"), "bar")
+    await exec("git", ["add", "."], { cwd: tmpDir.path })
+    await exec("git", ["commit", "-m", "first commit"], { cwd: tmpDir.path })
   }
 
   return tmpDir

--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -58,6 +58,26 @@ describe("resolveTemplateString", async () => {
     expect(res).to.equal("${foo}?")
   })
 
+  it("should support a string literal in a template string as a means to escape it", async () => {
+    const res = resolveTemplateString("${'$'}{bar}", new TestContext({}))
+    expect(res).to.equal("${bar}")
+  })
+
+  it("should pass through a template string with a double $$ prefix", async () => {
+    const res = resolveTemplateString("$${bar}", new TestContext({}))
+    expect(res).to.equal("$${bar}")
+  })
+
+  it("should allow unescaping a template string with a double $$ prefix", async () => {
+    const res = resolveTemplateString("$${bar}", new TestContext({}), { unescape: true })
+    expect(res).to.equal("${bar}")
+  })
+
+  it("should allow mixing normal and escaped strings", async () => {
+    const res = resolveTemplateString("${foo}-and-$${var.nope}", new TestContext({ foo: "yes" }), { unescape: true })
+    expect(res).to.equal("yes-and-${var.nope}")
+  })
+
   it("should interpolate a format string with a prefix", async () => {
     const res = resolveTemplateString("prefix-${some}", new TestContext({ some: "value" }))
     expect(res).to.equal("prefix-value")

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1146,7 +1146,9 @@ providers:
         # The module spec, as defined by the provider plugin.
         spec:
 
-            # POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+            # POSIX-style filename to write the resolved file contents to, relative to the path of the module source
+            # directory (for remote modules this means the root of the module repository, otherwise the directory of
+            # the module configuration).
             #
             # Note that any existing file with the same name will be overwritten. If the path contains one or more
             # directories, they will be automatically created if missing.
@@ -1390,7 +1392,9 @@ moduleConfigs:
     # The module spec, as defined by the provider plugin.
     spec:
 
-        # POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+        # POSIX-style filename to write the resolved file contents to, relative to the path of the module source
+        # directory (for remote modules this means the root of the module repository, otherwise the directory of the
+        # module configuration).
         #
         # Note that any existing file with the same name will be overwritten. If the path contains one or more
         # directories, they will be automatically created if missing.
@@ -1841,7 +1845,9 @@ modules:
     # The module spec, as defined by the provider plugin.
     spec:
 
-        # POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+        # POSIX-style filename to write the resolved file contents to, relative to the path of the module source
+        # directory (for remote modules this means the root of the module repository, otherwise the directory of the
+        # module configuration).
         #
         # Note that any existing file with the same name will be overwritten. If the path contains one or more
         # directories, they will be automatically created if missing.

--- a/docs/reference/module-template-config.md
+++ b/docs/reference/module-template-config.md
@@ -136,7 +136,9 @@ modules:
         # This file may contain template strings, much like any other field in the configuration.
         sourcePath:
 
-        # POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+        # POSIX-style filename to write the resolved file contents to, relative to the path of the module source
+        # directory (for remote modules this means the root of the module repository, otherwise the directory of the
+        # module configuration).
         #
         # Note that any existing file with the same name will be overwritten. If the path contains one or more
         # directories, they will be automatically created if missing.
@@ -442,7 +444,7 @@ This file may contain template strings, much like any other field in the configu
 
 [modules](#modules) > [generateFiles](#modulesgeneratefiles) > targetPath
 
-POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+POSIX-style filename to write the resolved file contents to, relative to the path of the module source directory (for remote modules this means the root of the module repository, otherwise the directory of the module configuration).
 
 Note that any existing file with the same name will be overwritten. If the path contains one or more directories, they will be automatically created if missing.
 

--- a/docs/reference/module-types/conftest.md
+++ b/docs/reference/module-types/conftest.md
@@ -114,7 +114,9 @@ generateFiles:
     # This file may contain template strings, much like any other field in the configuration.
     sourcePath:
 
-    # POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+    # POSIX-style filename to write the resolved file contents to, relative to the path of the module source directory
+    # (for remote modules this means the root of the module repository, otherwise the directory of the module
+    # configuration).
     #
     # Note that any existing file with the same name will be overwritten. If the path contains one or more
     # directories, they will be automatically created if missing.
@@ -361,7 +363,7 @@ This file may contain template strings, much like any other field in the configu
 
 [generateFiles](#generatefiles) > targetPath
 
-POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+POSIX-style filename to write the resolved file contents to, relative to the path of the module source directory (for remote modules this means the root of the module repository, otherwise the directory of the module configuration).
 
 Note that any existing file with the same name will be overwritten. If the path contains one or more directories, they will be automatically created if missing.
 

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -129,7 +129,9 @@ generateFiles:
     # This file may contain template strings, much like any other field in the configuration.
     sourcePath:
 
-    # POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+    # POSIX-style filename to write the resolved file contents to, relative to the path of the module source directory
+    # (for remote modules this means the root of the module repository, otherwise the directory of the module
+    # configuration).
     #
     # Note that any existing file with the same name will be overwritten. If the path contains one or more
     # directories, they will be automatically created if missing.
@@ -747,7 +749,7 @@ This file may contain template strings, much like any other field in the configu
 
 [generateFiles](#generatefiles) > targetPath
 
-POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+POSIX-style filename to write the resolved file contents to, relative to the path of the module source directory (for remote modules this means the root of the module repository, otherwise the directory of the module configuration).
 
 Note that any existing file with the same name will be overwritten. If the path contains one or more directories, they will be automatically created if missing.
 

--- a/docs/reference/module-types/exec.md
+++ b/docs/reference/module-types/exec.md
@@ -124,7 +124,9 @@ generateFiles:
     # This file may contain template strings, much like any other field in the configuration.
     sourcePath:
 
-    # POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+    # POSIX-style filename to write the resolved file contents to, relative to the path of the module source directory
+    # (for remote modules this means the root of the module repository, otherwise the directory of the module
+    # configuration).
     #
     # Note that any existing file with the same name will be overwritten. If the path contains one or more
     # directories, they will be automatically created if missing.
@@ -472,7 +474,7 @@ This file may contain template strings, much like any other field in the configu
 
 [generateFiles](#generatefiles) > targetPath
 
-POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+POSIX-style filename to write the resolved file contents to, relative to the path of the module source directory (for remote modules this means the root of the module repository, otherwise the directory of the module configuration).
 
 Note that any existing file with the same name will be overwritten. If the path contains one or more directories, they will be automatically created if missing.
 

--- a/docs/reference/module-types/hadolint.md
+++ b/docs/reference/module-types/hadolint.md
@@ -117,7 +117,9 @@ generateFiles:
     # This file may contain template strings, much like any other field in the configuration.
     sourcePath:
 
-    # POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+    # POSIX-style filename to write the resolved file contents to, relative to the path of the module source directory
+    # (for remote modules this means the root of the module repository, otherwise the directory of the module
+    # configuration).
     #
     # Note that any existing file with the same name will be overwritten. If the path contains one or more
     # directories, they will be automatically created if missing.
@@ -349,7 +351,7 @@ This file may contain template strings, much like any other field in the configu
 
 [generateFiles](#generatefiles) > targetPath
 
-POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+POSIX-style filename to write the resolved file contents to, relative to the path of the module source directory (for remote modules this means the root of the module repository, otherwise the directory of the module configuration).
 
 Note that any existing file with the same name will be overwritten. If the path contains one or more directories, they will be automatically created if missing.
 

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -116,7 +116,9 @@ generateFiles:
     # This file may contain template strings, much like any other field in the configuration.
     sourcePath:
 
-    # POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+    # POSIX-style filename to write the resolved file contents to, relative to the path of the module source directory
+    # (for remote modules this means the root of the module repository, otherwise the directory of the module
+    # configuration).
     #
     # Note that any existing file with the same name will be overwritten. If the path contains one or more
     # directories, they will be automatically created if missing.
@@ -653,7 +655,7 @@ This file may contain template strings, much like any other field in the configu
 
 [generateFiles](#generatefiles) > targetPath
 
-POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+POSIX-style filename to write the resolved file contents to, relative to the path of the module source directory (for remote modules this means the root of the module repository, otherwise the directory of the module configuration).
 
 Note that any existing file with the same name will be overwritten. If the path contains one or more directories, they will be automatically created if missing.
 

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -120,7 +120,9 @@ generateFiles:
     # This file may contain template strings, much like any other field in the configuration.
     sourcePath:
 
-    # POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+    # POSIX-style filename to write the resolved file contents to, relative to the path of the module source directory
+    # (for remote modules this means the root of the module repository, otherwise the directory of the module
+    # configuration).
     #
     # Note that any existing file with the same name will be overwritten. If the path contains one or more
     # directories, they will be automatically created if missing.
@@ -580,7 +582,7 @@ This file may contain template strings, much like any other field in the configu
 
 [generateFiles](#generatefiles) > targetPath
 
-POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+POSIX-style filename to write the resolved file contents to, relative to the path of the module source directory (for remote modules this means the root of the module repository, otherwise the directory of the module configuration).
 
 Note that any existing file with the same name will be overwritten. If the path contains one or more directories, they will be automatically created if missing.
 

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -127,7 +127,9 @@ generateFiles:
     # This file may contain template strings, much like any other field in the configuration.
     sourcePath:
 
-    # POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+    # POSIX-style filename to write the resolved file contents to, relative to the path of the module source directory
+    # (for remote modules this means the root of the module repository, otherwise the directory of the module
+    # configuration).
     #
     # Note that any existing file with the same name will be overwritten. If the path contains one or more
     # directories, they will be automatically created if missing.
@@ -755,7 +757,7 @@ This file may contain template strings, much like any other field in the configu
 
 [generateFiles](#generatefiles) > targetPath
 
-POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+POSIX-style filename to write the resolved file contents to, relative to the path of the module source directory (for remote modules this means the root of the module repository, otherwise the directory of the module configuration).
 
 Note that any existing file with the same name will be overwritten. If the path contains one or more directories, they will be automatically created if missing.
 

--- a/docs/reference/module-types/openfaas.md
+++ b/docs/reference/module-types/openfaas.md
@@ -110,7 +110,9 @@ generateFiles:
     # This file may contain template strings, much like any other field in the configuration.
     sourcePath:
 
-    # POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+    # POSIX-style filename to write the resolved file contents to, relative to the path of the module source directory
+    # (for remote modules this means the root of the module repository, otherwise the directory of the module
+    # configuration).
     #
     # Note that any existing file with the same name will be overwritten. If the path contains one or more
     # directories, they will be automatically created if missing.
@@ -380,7 +382,7 @@ This file may contain template strings, much like any other field in the configu
 
 [generateFiles](#generatefiles) > targetPath
 
-POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+POSIX-style filename to write the resolved file contents to, relative to the path of the module source directory (for remote modules this means the root of the module repository, otherwise the directory of the module configuration).
 
 Note that any existing file with the same name will be overwritten. If the path contains one or more directories, they will be automatically created if missing.
 

--- a/docs/reference/module-types/persistentvolumeclaim.md
+++ b/docs/reference/module-types/persistentvolumeclaim.md
@@ -111,7 +111,9 @@ generateFiles:
     # This file may contain template strings, much like any other field in the configuration.
     sourcePath:
 
-    # POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+    # POSIX-style filename to write the resolved file contents to, relative to the path of the module source directory
+    # (for remote modules this means the root of the module repository, otherwise the directory of the module
+    # configuration).
     #
     # Note that any existing file with the same name will be overwritten. If the path contains one or more
     # directories, they will be automatically created if missing.
@@ -402,7 +404,7 @@ This file may contain template strings, much like any other field in the configu
 
 [generateFiles](#generatefiles) > targetPath
 
-POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+POSIX-style filename to write the resolved file contents to, relative to the path of the module source directory (for remote modules this means the root of the module repository, otherwise the directory of the module configuration).
 
 Note that any existing file with the same name will be overwritten. If the path contains one or more directories, they will be automatically created if missing.
 

--- a/docs/reference/module-types/templated.md
+++ b/docs/reference/module-types/templated.md
@@ -114,7 +114,9 @@ generateFiles:
     # This file may contain template strings, much like any other field in the configuration.
     sourcePath:
 
-    # POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+    # POSIX-style filename to write the resolved file contents to, relative to the path of the module source directory
+    # (for remote modules this means the root of the module repository, otherwise the directory of the module
+    # configuration).
     #
     # Note that any existing file with the same name will be overwritten. If the path contains one or more
     # directories, they will be automatically created if missing.
@@ -355,7 +357,7 @@ This file may contain template strings, much like any other field in the configu
 
 [generateFiles](#generatefiles) > targetPath
 
-POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+POSIX-style filename to write the resolved file contents to, relative to the path of the module source directory (for remote modules this means the root of the module repository, otherwise the directory of the module configuration).
 
 Note that any existing file with the same name will be overwritten. If the path contains one or more directories, they will be automatically created if missing.
 

--- a/docs/reference/module-types/terraform.md
+++ b/docs/reference/module-types/terraform.md
@@ -117,7 +117,9 @@ generateFiles:
     # This file may contain template strings, much like any other field in the configuration.
     sourcePath:
 
-    # POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+    # POSIX-style filename to write the resolved file contents to, relative to the path of the module source directory
+    # (for remote modules this means the root of the module repository, otherwise the directory of the module
+    # configuration).
     #
     # Note that any existing file with the same name will be overwritten. If the path contains one or more
     # directories, they will be automatically created if missing.
@@ -380,7 +382,7 @@ This file may contain template strings, much like any other field in the configu
 
 [generateFiles](#generatefiles) > targetPath
 
-POSIX-style filename to write the resolved file contents to, relative to the path of the module.
+POSIX-style filename to write the resolved file contents to, relative to the path of the module source directory (for remote modules this means the root of the module repository, otherwise the directory of the module configuration).
 
 Note that any existing file with the same name will be overwritten. If the path contains one or more directories, they will be automatically created if missing.
 

--- a/docs/using-garden/module-templates.md
+++ b/docs/using-garden/module-templates.md
@@ -111,6 +111,12 @@ This reads a source file from `template/manifests.yml` (the `sourcePath` is rela
 
 Instead of specifying `sourcePath`, you can also specify `value` to provide the file contents directly as a string.
 
+#### Escaping template strings
+
+Sometimes you may want to pass template strings through when generating files, instead of having Garden resolve them. This could for example be handy when templating a Terraform configuration file which uses a similar templating syntax.
+
+To do this, simply add an additional `$` in front of the template string, e.g. `$${var.dont-resolve-me}`.
+
 ### Module references within a templated module
 
 In many cases, it's important for the different modules in a single template to depend on one another, and to reference outputs from one another. You do this basically the same way as in normal modules, but because module names in a template are generally templated themselves, it's helpful to look at how to use templates in module references.


### PR DESCRIPTION
This addresses an issue where template strings couldn't easily be
escaped, such that Garden _wouldn't_ attempt to resolve them.

From the docs:

Sometimes you may want to pass template strings through when generating
files, instead of having Garden resolve them. This could for example be
handy when templating a Terraform configuration file which uses a
similar templating syntax.

To do this, simply add an additional `$` in front of the template
string, e.g. `$${var.dont-resolve-me}`.
