### PR TITLE
chore(test): fix flaky watcher test

### DIFF
--- a/core/test/unit/src/watch.ts
+++ b/core/test/unit/src/watch.ts
@@ -184,12 +184,12 @@ describe("Watcher", () => {
     it("containing both modules' names when a source file is changed for two co-located modules", async () => {
       const pathsChanged = [resolve(doubleModulePath, "foo.txt")]
       emitEvent(garden, "change", pathsChanged[0])
-      expect(getEventLog()).to.eql([
-        {
-          name: "moduleSourcesChanged",
-          payload: { names: ["module-b", "module-c"], pathsChanged },
-        },
-      ])
+      const event = getEventLog()[0]
+      event.payload.names = event.payload.names.sort()
+      expect(event).to.eql({
+        name: "moduleSourcesChanged",
+        payload: { names: ["module-b", "module-c"], pathsChanged },
+      })
     })
   })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

The module names in the event payload here sometimes came out in a different order in CI. Sorting the array should resolve this.

See for example:

https://app.circleci.com/pipelines/github/garden-io/garden/8599/workflows/f81edeb2-f1b1-4547-95d1-482b2fa1f890/jobs/106375