### PR TITLE
feat(cli): allow setting environment with GARDEN_ENVIRONMENT

### DIFF
--- a/core/src/cli/params.ts
+++ b/core/src/cli/params.ts
@@ -20,6 +20,7 @@ import { LogLevel } from "../logger/log-node"
 import { safeDumpYaml } from "../util/util"
 import { resolve } from "path"
 import { isArray } from "lodash"
+import { gardenEnv } from "../constants"
 
 export const OUTPUT_RENDERERS = {
   json: (data: DeepPrimitiveMap) => {
@@ -256,6 +257,10 @@ export class EnvironmentOption extends StringParameter {
     // Validate the environment
     parseEnvironment(input)
     return input
+  }
+
+  getDefaultValue() {
+    return gardenEnv.GARDEN_ENVIRONMENT
   }
 }
 

--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -58,6 +58,7 @@ export const gardenEnv = {
   GARDEN_DISABLE_PORT_FORWARDS: env.get("GARDEN_DISABLE_PORT_FORWARDS").required(false).asBool(),
   GARDEN_DISABLE_VERSION_CHECK: env.get("GARDEN_DISABLE_VERSION_CHECK").required(false).asBool(),
   GARDEN_ENABLE_PROFILING: env.get("GARDEN_ENABLE_PROFILING").required(false).asBool(),
+  GARDEN_ENVIRONMENT: env.get("GARDEN_ENVIRONMENT").required(false).asString(),
   GARDEN_LEGACY_BUILD_STAGE: env.get("GARDEN_LEGACY_BUILD_STAGE").required(false).asBool(),
   GARDEN_LOG_LEVEL: env.get("GARDEN_LOG_LEVEL").required(false).asString(),
   GARDEN_LOGGER_TYPE: env.get("GARDEN_LOGGER_TYPE").required(false).asString(),


### PR DESCRIPTION
Nice and simple, we can now set `GARDEN_ENVIRONMENT` instead of the
`--env` option flag.
