### PR TITLE
fix(cli): don't print "Tools" header in tools command

### DIFF
--- a/core/src/commands/tools.ts
+++ b/core/src/commands/tools.ts
@@ -12,7 +12,7 @@ import { dedent, renderTable, tablePresets } from "../util/string"
 import { LogEntry } from "../logger/log-entry"
 import { Garden, DummyGarden } from "../garden"
 import { Command, CommandParams } from "./base"
-import { getTerminalWidth, printHeader } from "../logger/util"
+import { getTerminalWidth } from "../logger/util"
 import { LoggerType } from "../logger/logger"
 import { ParameterError } from "../exceptions"
 import { uniqByName, exec, shutdown } from "../util/util"
@@ -74,9 +74,8 @@ export class ToolsCommand extends Command<Args, Opts> {
   getLoggerType(): LoggerType {
     return "basic"
   }
-  printHeader({ headerLog }) {
-    printHeader(headerLog, "Tools", "hammer_and_wrench")
-  }
+
+  printHeader() {}
 
   async prepare({ log }) {
     // Override the logger output, to output to stderr instead of stdout, to avoid contaminating command output


### PR DESCRIPTION
This was getting in the way of automation.
