### PR TITLE
improvement(core): more granular version hashes

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -241,6 +241,7 @@
     "build": "gulp pegjs",
     "check-package-lock": "git diff-index --quiet HEAD -- yarn.lock || (echo 'yarn.lock is dirty!' && exit 1)",
     "clean": "shx rm -rf build",
+    "dev": "gulp pegjs-watch",
     "fix-format": "prettier --write \"{src,test}/**/*.ts\"",
     "lint": "tslint -p .",
     "migration:generate": "typeorm migration:generate --config ormconfig.js -n",

--- a/core/src/actions.ts
+++ b/core/src/actions.ts
@@ -80,7 +80,7 @@ import { HotReloadServiceParams, HotReloadServiceResult } from "./types/plugin/s
 import { RunServiceParams } from "./types/plugin/service/runService"
 import { GetTaskResultParams } from "./types/plugin/task/getTaskResult"
 import { RunTaskParams, RunTaskResult } from "./types/plugin/task/runTask"
-import { ServiceStatus, ServiceStatusMap, ServiceState, Service } from "./types/service"
+import { ServiceStatus, ServiceStatusMap, ServiceState, GardenService } from "./types/service"
 import { Omit, getNames } from "./util/util"
 import { DebugInfoMap } from "./types/plugin/provider/getDebugInfo"
 import { PrepareEnvironmentParams, PrepareEnvironmentResult } from "./types/plugin/provider/prepareEnvironment"
@@ -92,7 +92,7 @@ import { getServiceStatuses } from "./tasks/base"
 import { getRuntimeTemplateReferences, resolveTemplateStrings } from "./template-string"
 import { getPluginBases, getPluginDependencies, getModuleTypeBases } from "./plugins"
 import { ConfigureProviderParams, ConfigureProviderResult } from "./types/plugin/provider/configureProvider"
-import { Task } from "./types/task"
+import { GardenTask } from "./types/task"
 import { ConfigureModuleParams, ConfigureModuleResult } from "./types/plugin/module/configure"
 import { PluginContext } from "./plugin-context"
 import { DeleteServiceTask, deletedServiceStatuses } from "./tasks/delete-service"
@@ -376,7 +376,7 @@ export class ActionRouter implements TypeGuard {
     try {
       const result = await this.callModuleHandler({ params: { ...params, artifactsPath }, actionType: "testModule" })
       this.garden.events.emit("testStatus", {
-        testName: params.testConfig.name,
+        testName: params.test.name,
         moduleName: params.module.name,
         status: runStatus(result),
       })
@@ -387,7 +387,7 @@ export class ActionRouter implements TypeGuard {
         await this.copyArtifacts(
           params.log,
           artifactsPath,
-          getArtifactKey("test", params.testConfig.name, params.module.version.versionString)
+          getArtifactKey("test", params.test.name, params.test.version)
         )
       } finally {
         await tmpDir.cleanup()
@@ -404,7 +404,7 @@ export class ActionRouter implements TypeGuard {
       defaultHandler: async () => null,
     })
     this.garden.events.emit("testStatus", {
-      testName: params.testName,
+      testName: params.test.name,
       moduleName: params.module.name,
       status: runStatus(result),
     })
@@ -437,7 +437,7 @@ export class ActionRouter implements TypeGuard {
     return result
   }
 
-  private validateServiceOutputs(service: Service, result: ServiceStatus) {
+  private validateServiceOutputs(service: GardenService, result: ServiceStatus) {
     const spec = this.moduleTypes[service.module.type]
 
     if (spec.serviceOutputsSchema) {
@@ -547,7 +547,7 @@ export class ActionRouter implements TypeGuard {
         await this.copyArtifacts(
           params.log,
           artifactsPath,
-          getArtifactKey("task", params.task.name, params.task.module.version.versionString)
+          getArtifactKey("task", params.task.name, params.task.version)
         )
       } finally {
         await tmpDir.cleanup()
@@ -569,7 +569,7 @@ export class ActionRouter implements TypeGuard {
     return result
   }
 
-  private validateTaskOutputs(task: Task, result: RunTaskResult) {
+  private validateTaskOutputs(task: GardenTask, result: RunTaskResult) {
     const spec = this.moduleTypes[task.module.type]
 
     if (spec.taskOutputsSchema) {

--- a/core/src/commands/get/get-task-result.ts
+++ b/core/src/commands/get/get-task-result.ts
@@ -9,7 +9,6 @@
 import { ConfigGraph } from "../../config-graph"
 import { Command, CommandResult, CommandParams } from "../base"
 import { printHeader } from "../../logger/util"
-import { getTaskVersion } from "../../tasks/task"
 import { RunTaskResult } from "../../types/plugin/task/runTask"
 import chalk from "chalk"
 import { getArtifactFileList, getArtifactKey } from "../../util/artifacts"
@@ -64,14 +63,13 @@ export class GetTaskResultCommand extends Command<Args> {
     const taskResult = await actions.getTaskResult({
       log,
       task,
-      taskVersion: await getTaskVersion(garden, graph, task),
     })
 
     let result: GetTaskResultCommandResult = null
 
     if (taskResult) {
       const artifacts = await getArtifactFileList({
-        key: getArtifactKey("task", task.name, task.module.version.versionString),
+        key: getArtifactKey("task", task.name, task.version),
         artifactsPath: garden.artifactsPath,
         log: garden.log,
       })

--- a/core/src/commands/get/get-tasks.ts
+++ b/core/src/commands/get/get-tasks.ts
@@ -11,7 +11,7 @@ import indentString from "indent-string"
 import { sortBy, omit, uniq } from "lodash"
 import { Command, CommandResult, CommandParams } from "../base"
 import { printHeader } from "../../logger/util"
-import { Task } from "../../types/task"
+import { GardenTask } from "../../types/task"
 import { StringsParameter } from "../../cli/params"
 
 const getTasksArgs = {
@@ -22,7 +22,7 @@ const getTasksArgs = {
 
 type Args = typeof getTasksArgs
 
-export function prettyPrintTask(task: Task): string {
+export function prettyPrintTask(task: GardenTask): string {
   let out = `${chalk.cyan.bold(task.name)}`
 
   if (task.spec.args || task.spec.args === null) {

--- a/core/src/commands/helpers.ts
+++ b/core/src/commands/helpers.ts
@@ -7,7 +7,7 @@
  */
 
 import { ConfigGraph } from "../config-graph"
-import { Service } from "../types/service"
+import { GardenService } from "../types/service"
 
 export async function getHotReloadServiceNames(namesFromOpt: string[] | undefined, configGraph: ConfigGraph) {
   const names = namesFromOpt || []
@@ -44,6 +44,6 @@ export async function validateHotReloadServiceNames(
   return null
 }
 
-function supportsHotReloading(service: Service) {
+function supportsHotReloading(service: GardenService) {
   return service.config.hotReloadable
 }

--- a/core/src/commands/logs.ts
+++ b/core/src/commands/logs.ts
@@ -11,7 +11,7 @@ import chalk from "chalk"
 import { maxBy } from "lodash"
 import { ServiceLogEntry } from "../types/plugin/service/getServiceLogs"
 import Bluebird = require("bluebird")
-import { Service } from "../types/service"
+import { GardenService } from "../types/service"
 import Stream from "ts-stream"
 import { LoggerType } from "../logger/logger"
 import dedent = require("dedent")
@@ -106,7 +106,7 @@ export class LogsCommand extends Command<Args, Opts> {
     const actions = await garden.getActionRouter()
     const voidLog = log.placeholder({ level: LogLevel.silly, childEntriesInheritLevel: true })
 
-    await Bluebird.map(services, async (service: Service<any>) => {
+    await Bluebird.map(services, async (service: GardenService<any>) => {
       const status = await actions.getServiceStatus({
         hotReload: false,
         log: voidLog,

--- a/core/src/commands/run/module.ts
+++ b/core/src/commands/run/module.ts
@@ -111,7 +111,8 @@ export class RunModuleCommand extends Command<Args, Opts> {
       garden,
       graph,
       dependencies,
-      version: module.version,
+      version: module.version.versionString,
+      moduleVersion: module.version.versionString,
       serviceStatuses: {},
       taskResults: {},
     })

--- a/core/src/commands/run/service.ts
+++ b/core/src/commands/run/service.ts
@@ -72,7 +72,6 @@ export class RunServiceCommand extends Command<Args, Opts> {
     const serviceName = args.service
     const graph = await garden.getConfigGraph(log)
     const service = graph.getService(serviceName, true)
-    const module = service.module
 
     if (service.disabled && !opts.force) {
       throw new CommandError(
@@ -107,7 +106,8 @@ export class RunServiceCommand extends Command<Args, Opts> {
       garden,
       graph,
       dependencies,
-      version: module.version,
+      version: service.version,
+      moduleVersion: service.module.version.versionString,
       serviceStatuses,
       taskResults,
     })

--- a/core/src/commands/run/task.ts
+++ b/core/src/commands/run/task.ts
@@ -95,7 +95,7 @@ export class RunTaskCommand extends Command<Args, Opts> {
       )
     }
 
-    const taskTask = await TaskTask.factory({ garden, graph, task, log, force: true, forceBuild: opts["force-build"] })
+    const taskTask = new TaskTask({ garden, graph, task, log, force: true, forceBuild: opts["force-build"] })
     const graphResults = await garden.processTasks([taskTask])
 
     return handleTaskResult({ log, actionDescription: "task", graphResults, key: taskTask.getKey() })

--- a/core/src/commands/run/test.ts
+++ b/core/src/commands/run/test.ts
@@ -130,14 +130,13 @@ export class RunTestCommand extends Command<Args, Opts> {
     const interactive = opts.interactive
 
     // Make sure all dependencies are ready and collect their outputs for the runtime context
-    const testTask = await TestTask.factory({
+    const testTask = new TestTask({
       force: true,
       forceBuild: opts["force-build"],
       garden,
       graph,
       log,
-      module,
-      testConfig,
+      test,
     })
 
     const dependencyResults = await garden.processTasks(await testTask.resolveDependencies())
@@ -151,7 +150,8 @@ export class RunTestCommand extends Command<Args, Opts> {
       garden,
       graph,
       dependencies,
-      version: module.version,
+      version: test.version,
+      moduleVersion: module.version.versionString,
       serviceStatuses,
       taskResults,
     })
@@ -168,8 +168,7 @@ export class RunTestCommand extends Command<Args, Opts> {
       silent: false,
       interactive,
       runtimeContext,
-      testConfig,
-      testVersion: testTask.version,
+      test,
     })
 
     return handleRunResult({ log, actionDescription: "test", result, interactive, graphResults: dependencyResults })

--- a/core/src/config-graph.ts
+++ b/core/src/config-graph.ts
@@ -10,8 +10,8 @@ import toposort from "toposort"
 import { flatten, pick, uniq, sortBy, pickBy } from "lodash"
 import { BuildDependencyConfig } from "./config/module"
 import { GardenModule, getModuleKey, moduleNeedsBuild } from "./types/module"
-import { Service, serviceFromConfig } from "./types/service"
-import { Task, taskFromConfig } from "./types/task"
+import { GardenService, serviceFromConfig } from "./types/service"
+import { GardenTask, taskFromConfig } from "./types/task"
 import { TestConfig } from "./config/test"
 import { uniqByName, pickKeys } from "./util/util"
 import { ConfigurationError } from "./exceptions"
@@ -22,6 +22,7 @@ import { TaskConfig } from "./config/task"
 import { makeTestTaskName } from "./tasks/helpers"
 import { TaskType, makeBaseKey } from "./tasks/base"
 import { ModuleTypeMap } from "./types/plugin/plugin"
+import { testFromModule, GardenTest } from "./types/test"
 
 // Each of these types corresponds to a Task class (e.g. BuildTask, DeployTask, ...).
 export type DependencyGraphNodeType = "build" | "deploy" | "run" | "test"
@@ -29,8 +30,8 @@ export type DependencyGraphNodeType = "build" | "deploy" | "run" | "test"
 // The primary output type (for dependencies and dependants).
 export type DependencyRelations = {
   build: GardenModule[]
-  deploy: Service[]
-  run: Task[]
+  deploy: GardenService[]
+  run: GardenTask[]
   test: TestConfig[]
 }
 
@@ -308,15 +309,23 @@ export class ConfigGraph {
   /**
    * Returns the Service with the specified name. Throws error if it doesn't exist.
    */
-  getService(name: string, includeDisabled?: boolean): Service {
+  getService(name: string, includeDisabled?: boolean): GardenService {
     return this.getServices({ names: [name], includeDisabled })[0]
   }
 
   /**
    * Returns the Task with the specified name. Throws error if it doesn't exist.
    */
-  getTask(name: string, includeDisabled?: boolean): Task {
+  getTask(name: string, includeDisabled?: boolean): GardenTask {
     return this.getTasks({ names: [name], includeDisabled })[0]
+  }
+
+  /**
+   * Returns the `testName` test from the `moduleName` module. Throws if either is not found.
+   */
+  getTest(moduleName: string, testName: string, includeDisabled?: boolean): GardenTest {
+    const module = this.getModule(moduleName, includeDisabled)
+    return testFromModule(module, testName)
   }
 
   /*

--- a/core/src/config/common.ts
+++ b/core/src/config/common.ts
@@ -519,14 +519,14 @@ export function isPrimitive(value: any) {
   return typeof value === "string" || typeof value === "number" || typeof value === "boolean" || value === null
 }
 
-const versionStringSchema = () =>
-  joi.string().regex(/^v/).required().description("String representation of the module version.")
+export const versionStringSchema = () =>
+  joi.string().regex(/^v/).required().description("A Stack Graph node (i.e. module, service, task or test) version.")
 
 const fileNamesSchema = () => joiArray(joi.string()).description("List of file paths included in the version.")
 
 export const treeVersionSchema = () =>
   joi.object().keys({
-    contentHash: joi.string().required().description("The hash of all files in the directory, after filtering."),
+    contentHash: joi.string().required().description("The hash of all files belonging to the Garden module."),
     files: fileNamesSchema(),
   })
 

--- a/core/src/config/module.ts
+++ b/core/src/config/module.ts
@@ -219,6 +219,7 @@ export interface ModuleConfig<M extends {} = any, S extends {} = any, T extends 
   path: string
   configPath?: string
   plugin?: string // used to identify modules that are bundled as part of a plugin
+  buildConfig?: object
   serviceConfigs: ServiceConfig<S>[]
   testConfigs: TestConfig<T>[]
   taskConfigs: TaskConfig<W>[]
@@ -242,6 +243,16 @@ export const moduleConfigSchema = () =>
       plugin: joiIdentifier()
         .meta({ internal: true })
         .description("The name of a the parent plugin of the module, if applicable."),
+      buildConfig: joi
+        .object()
+        .unknown(true)
+        .description(
+          dedent`
+          The resolved build configuration of the module. If this is returned by the configure handler for the module type, we can provide more granular versioning for the module, with a separate build version (i.e. module version), as well as separate service, task and test versions, instead of applying the same version to all of them.
+
+          When this is specified, it is **very important** that this field contains all configurable (or otherwise dynamic) parameters that will affect the built artifacts/images, aside from source files that is (the hash of those is separately computed).
+          `
+        ),
       serviceConfigs: joiArray(serviceConfigSchema()).description("List of services configured by this module."),
       taskConfigs: joiArray(taskConfigSchema()).description("List of tasks configured by this module."),
       testConfigs: joiArray(testConfigSchema()).description("List of tests configured by this module."),

--- a/core/src/config/task.ts
+++ b/core/src/config/task.ts
@@ -75,19 +75,3 @@ export const taskConfigSchema = () =>
         .description("The task's specification, as defined by its provider plugin."),
     })
     .description("The configuration for a module's task.")
-
-export const taskSchema = () =>
-  joi
-    .object()
-    .options({ presence: "required" })
-    .keys({
-      name: joiUserIdentifier().description("The name of the task."),
-      description: joi.string().optional().description("A description of the task."),
-      disabled: joi.boolean().default(false).description("Set to true if the task or its module is disabled."),
-      module: joi.object().unknown(true),
-      config: taskConfigSchema(),
-      spec: joi
-        .object()
-        .meta({ extendable: true })
-        .description("The configuration of the task (specific to each plugin)."),
-    })

--- a/core/src/outputs.ts
+++ b/core/src/outputs.ts
@@ -89,9 +89,9 @@ export async function resolveProjectOutputs(garden: Garden, log: LogEntry): Prom
           service,
         })
     ),
-    ...(await Promise.all(
-      tasks.map((task) =>
-        TaskTask.factory({
+    ...tasks.map(
+      (task) =>
+        new TaskTask({
           force: false,
           forceBuild: false,
           garden,
@@ -99,8 +99,7 @@ export async function resolveProjectOutputs(garden: Garden, log: LogEntry): Prom
           log,
           task,
         })
-      )
-    )),
+    ),
   ]
 
   const dependencyResults: GraphResults = graphTasks.length > 0 ? await garden.processTasks(graphTasks) : {}
@@ -118,6 +117,7 @@ export async function resolveProjectOutputs(garden: Garden, log: LogEntry): Prom
       test: [],
     },
     version: garden.version,
+    moduleVersion: garden.version,
     serviceStatuses,
     taskResults,
   })

--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -19,7 +19,7 @@ import {
   joiSparseArray,
 } from "../../config/common"
 import { ArtifactSpec } from "./../../config/validation"
-import { Service, ingressHostnameSchema, linkUrlSchema } from "../../types/service"
+import { GardenService, ingressHostnameSchema, linkUrlSchema } from "../../types/service"
 import { DEFAULT_PORT_PROTOCOL } from "../../constants"
 import { ModuleSpec, ModuleConfig, baseBuildSpecSchema, BaseBuildSpec } from "../../config/module"
 import { CommonServiceSpec, ServiceConfig, baseServiceSpecSchema } from "../../config/service"
@@ -423,7 +423,7 @@ export const containerRegistryConfigSchema = () =>
     Important: If you specify this in combination with \`buildMode: cluster-docker\` or \`buildMode: kaniko\`, you must make sure \`imagePullSecrets\` includes authentication with the specified deployment registry, that has the appropriate write privileges (usually full write access to the configured \`deploymentRegistry.namespace\`).
   `)
 
-export interface ContainerService extends Service<ContainerModule> {}
+export interface ContainerService extends GardenService<ContainerModule> {}
 
 export const artifactsDescription = dedent`
   Specify artifacts to copy out of the container after the run. The artifacts are stored locally under

--- a/core/src/plugins/container/container.ts
+++ b/core/src/plugins/container/container.ts
@@ -188,6 +188,14 @@ export async function configureContainerModule({ log, moduleConfig }: ConfigureM
     }
   })
 
+  // All the config keys that affect the build version
+  moduleConfig.buildConfig = {
+    buildArgs: moduleConfig.spec.buildArgs,
+    targetImage: moduleConfig.spec.build?.targetImage,
+    extraFlags: moduleConfig.spec.extraFlags,
+    dockerfile: moduleConfig.spec.dockerfile,
+  }
+
   // Automatically set the include field based on the Dockerfile and config, if not explicitly set
   if (!(moduleConfig.include || moduleConfig.exclude)) {
     moduleConfig.include = await containerHelpers.autoResolveIncludes(moduleConfig, log)

--- a/core/src/plugins/google/google-cloud-functions.ts
+++ b/core/src/plugins/google/google-cloud-functions.ts
@@ -8,7 +8,7 @@
 
 import { joiArray, joi } from "../../config/common"
 import { GardenModule } from "../../types/module"
-import { ServiceState, ServiceStatus, ingressHostnameSchema, Service } from "../../types/service"
+import { ServiceState, ServiceStatus, ingressHostnameSchema, GardenService } from "../../types/service"
 import { resolve } from "path"
 import { ExecTestSpec, execTestSchema } from "../exec"
 import { prepareEnvironment, gcloud, getEnvironmentStatus, GOOGLE_CLOUD_DEFAULT_REGION } from "./common"
@@ -46,7 +46,7 @@ export type GcfServiceSpec = GcfModuleSpec
 
 export interface GcfModule extends GardenModule<GcfModuleSpec, GcfServiceSpec, ExecTestSpec> {}
 
-function getGcfProject<T extends GcfModule>(service: Service<T>, provider: Provider<any>) {
+function getGcfProject<T extends GcfModule>(service: GardenService<T>, provider: Provider<any>) {
   return service.spec.project || provider.config.defaultProject || null
 }
 

--- a/core/src/plugins/hadolint/hadolint.ts
+++ b/core/src/plugins/hadolint/hadolint.ts
@@ -158,7 +158,7 @@ export const gardenPlugin = () =>
             moduleConfig.testConfigs = [{ name: "lint", dependencies: [], spec: {}, timeout: 10, disabled: false }]
             return { moduleConfig }
           },
-          testModule: async ({ ctx, log, module, testConfig }: TestModuleParams<HadolintModule>) => {
+          testModule: async ({ ctx, log, module, test }: TestModuleParams<HadolintModule>) => {
             const dockerfilePath = join(module.path, module.spec.dockerfilePath)
             const startedAt = new Date()
             let dockerfile: string
@@ -242,10 +242,10 @@ export const gardenPlugin = () =>
             }
 
             return {
-              testName: testConfig.name,
+              testName: test.name,
               moduleName: module.name,
               command: ["hadolint", ...args],
-              version: module.version.versionString,
+              version: test.version,
               success,
               startedAt,
               completedAt: new Date(),

--- a/core/src/plugins/kubernetes/container/status.ts
+++ b/core/src/plugins/kubernetes/container/status.ts
@@ -8,7 +8,7 @@
 
 import { PluginContext } from "../../../plugin-context"
 import { LogEntry } from "../../../logger/log-entry"
-import { Service, ServiceStatus, ForwardablePort } from "../../../types/service"
+import { GardenService, ServiceStatus, ForwardablePort } from "../../../types/service"
 import { createContainerManifests } from "./deployment"
 import { KUBECTL_DEFAULT_TIMEOUT } from "../kubectl"
 import { DeploymentError } from "../../../exceptions"
@@ -32,7 +32,6 @@ export type ContainerServiceStatus = ServiceStatus<ContainerStatusDetail>
 
 export async function getContainerServiceStatus({
   ctx,
-  module,
   service,
   runtimeContext,
   log,
@@ -40,7 +39,6 @@ export async function getContainerServiceStatus({
 }: GetServiceStatusParams<ContainerModule>): Promise<ContainerServiceStatus> {
   const k8sCtx = <KubernetesPluginContext>ctx
   // TODO: hash and compare all the configuration files (otherwise internal changes don't get deployed)
-  const version = module.version
   const provider = k8sCtx.provider
   const api = await KubeApi.factory(log, ctx, provider)
   const namespace = await getAppNamespace(k8sCtx, log, provider)
@@ -73,7 +71,7 @@ export async function getContainerServiceStatus({
     forwardablePorts,
     ingresses,
     state,
-    version: state === "ready" ? version.versionString : undefined,
+    version: state === "ready" ? service.version : undefined,
     detail: { remoteResources, workload },
   }
 }
@@ -86,7 +84,7 @@ export async function waitForContainerService(
   ctx: PluginContext,
   log: LogEntry,
   runtimeContext: RuntimeContext,
-  service: Service,
+  service: GardenService,
   hotReload: boolean
 ) {
   const startTime = new Date().getTime()

--- a/core/src/plugins/kubernetes/container/test.ts
+++ b/core/src/plugins/kubernetes/container/test.ts
@@ -18,10 +18,10 @@ import { getAppNamespace } from "../namespace"
 import { KubernetesPluginContext } from "../config"
 
 export async function testContainerModule(params: TestModuleParams<ContainerModule>): Promise<TestResult> {
-  const { ctx, module, testConfig, testVersion, log } = params
-  const { command, args } = testConfig.spec
-  const testName = testConfig.name
-  const timeout = testConfig.timeout || DEFAULT_TEST_TIMEOUT
+  const { ctx, module, test, log } = params
+  const { command, args, artifacts, env, volumes } = test.config.spec
+  const testName = test.name
+  const timeout = test.config.timeout || DEFAULT_TEST_TIMEOUT
   const k8sCtx = ctx as KubernetesPluginContext
 
   const image = containerHelpers.getDeploymentImageId(module, module.version, ctx.provider.config.deploymentRegistry)
@@ -31,22 +31,22 @@ export async function testContainerModule(params: TestModuleParams<ContainerModu
     ...params,
     command,
     args,
-    artifacts: testConfig.spec.artifacts,
-    envVars: testConfig.spec.env,
+    artifacts,
+    envVars: env,
     image,
     namespace,
     podName: makePodName("test", module.name, testName),
     description: `Test '${testName}' in container module '${module.name}'`,
     timeout,
-    volumes: testConfig.spec.volumes,
+    version: test.version,
+    volumes,
   })
 
   return storeTestResult({
     ctx,
     log,
     module,
-    testName,
-    testVersion,
+    test,
     result: {
       testName,
       ...result,

--- a/core/src/plugins/kubernetes/helm/config.ts
+++ b/core/src/plugins/kubernetes/helm/config.ts
@@ -19,7 +19,7 @@ import { GardenModule } from "../../../types/module"
 import { containsSource } from "./common"
 import { ConfigurationError } from "../../../exceptions"
 import { deline, dedent } from "../../../util/string"
-import { Service } from "../../../types/service"
+import { GardenService } from "../../../types/service"
 import { ContainerModule } from "../../container/config"
 import { baseBuildSpecSchema } from "../../../config/module"
 import { ConfigureModuleParams, ConfigureModuleResult } from "../../../types/plugin/module/configure"
@@ -36,6 +36,7 @@ import {
 } from "../config"
 import { posix } from "path"
 import { runPodSpecWhitelist } from "../run"
+import { omit } from "lodash"
 
 export const defaultHelmTimeout = 300
 
@@ -65,7 +66,7 @@ export interface HelmServiceSpec {
   valueFiles: string[]
 }
 
-export type HelmService = Service<HelmModule, ContainerModule>
+export type HelmService = GardenService<HelmModule, ContainerModule>
 
 const parameterValueSchema = () =>
   joi
@@ -258,6 +259,14 @@ export async function configureHelmModule({
     // We copy the chart on build
     moduleConfig.build.dependencies.push({ name: base, copy: [{ source: "*", target: "." }] })
   }
+
+  moduleConfig.buildConfig = omit(moduleConfig.spec, [
+    "atomicInstall",
+    "serviceResource",
+    "skipDeploy",
+    "tasks",
+    "tests",
+  ])
 
   moduleConfig.taskConfigs = tasks.map((spec) => {
     if (spec.resource && spec.resource.containerModule) {

--- a/core/src/plugins/kubernetes/helm/logs.ts
+++ b/core/src/plugins/kubernetes/helm/logs.ts
@@ -14,7 +14,7 @@ import { getChartResources } from "./common"
 import { getModuleNamespace } from "../namespace"
 
 export async function getServiceLogs(params: GetServiceLogsParams<HelmModule>) {
-  const { ctx, module, log } = params
+  const { ctx, module, log, service } = params
   const k8sCtx = <KubernetesPluginContext>ctx
   const provider = k8sCtx.provider
   const namespace = await getModuleNamespace({
@@ -24,7 +24,7 @@ export async function getServiceLogs(params: GetServiceLogsParams<HelmModule>) {
     provider: k8sCtx.provider,
   })
 
-  const resources = await getChartResources(k8sCtx, module, false, log)
+  const resources = await getChartResources({ ctx: k8sCtx, module, hotReload: false, log, version: service.version })
 
   return streamK8sLogs({ ...params, provider, defaultNamespace: namespace, resources })
 }

--- a/core/src/plugins/kubernetes/hot-reload/helpers.ts
+++ b/core/src/plugins/kubernetes/hot-reload/helpers.ts
@@ -11,7 +11,7 @@ import { RuntimeError, ConfigurationError } from "../../../exceptions"
 import { resolve as resolvePath, dirname, posix } from "path"
 import { deline, gardenAnnotationKey } from "../../../util/string"
 import { set, flatten } from "lodash"
-import { Service } from "../../../types/service"
+import { GardenService } from "../../../types/service"
 import { LogEntry } from "../../../logger/log-entry"
 import { getResourceContainer, getServiceResourceSpec } from "../util"
 import { execInWorkload } from "../container/exec"
@@ -266,7 +266,7 @@ function rsyncTargetPath(path: string) {
 
 interface SyncToServiceParams {
   ctx: KubernetesPluginContext
-  service: Service
+  service: GardenService
   hotReloadSpec: ContainerHotReloadSpec
   namespace: string
   workload: KubernetesWorkload

--- a/core/src/plugins/kubernetes/hot-reload/hot-reload.ts
+++ b/core/src/plugins/kubernetes/hot-reload/hot-reload.ts
@@ -11,7 +11,7 @@ import { ContainerModule } from "../../container/config"
 import { RuntimeError, ConfigurationError } from "../../../exceptions"
 import { gardenAnnotationKey } from "../../../util/string"
 import { sortBy } from "lodash"
-import { Service } from "../../../types/service"
+import { GardenService } from "../../../types/service"
 import { LogEntry } from "../../../logger/log-entry"
 import { findServiceResource } from "../util"
 import { getAppNamespace, getModuleNamespace } from "../namespace"
@@ -43,7 +43,7 @@ export async function hotReloadK8s({
   service,
 }: {
   ctx: PluginContext
-  service: Service
+  service: GardenService
   log: LogEntry
   module: KubernetesModule | HelmModule
 }): Promise<HotReloadServiceResult> {
@@ -59,7 +59,13 @@ export async function hotReloadK8s({
   let baseModule: GardenModule | undefined = undefined
   if (module.type === "helm") {
     baseModule = getBaseModule(<HelmModule>module)
-    manifests = await getChartResources(ctx, service.module, true, log)
+    manifests = await getChartResources({
+      ctx: k8sCtx,
+      module: service.module,
+      hotReload: true,
+      log,
+      version: service.version,
+    })
   } else {
     const api = await KubeApi.factory(log, ctx, k8sCtx.provider)
     manifests = await getManifests({ api, log, module: <KubernetesModule>module, defaultNamespace: namespace })

--- a/core/src/plugins/kubernetes/kubernetes-module/config.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/config.ts
@@ -10,7 +10,7 @@ import { dependenciesSchema } from "../../../config/service"
 import { joi, joiModuleIncludeDirective, joiSparseArray } from "../../../config/common"
 import { GardenModule } from "../../../types/module"
 import { ConfigureModuleParams, ConfigureModuleResult } from "../../../types/plugin/module/configure"
-import { Service } from "../../../types/service"
+import { GardenService } from "../../../types/service"
 import { baseBuildSpecSchema } from "../../../config/module"
 import { KubernetesResource } from "../types"
 import { deline, dedent } from "../../../util/string"
@@ -44,7 +44,7 @@ export interface KubernetesServiceSpec {
   tests: KubernetesTestSpec[]
 }
 
-export type KubernetesService = Service<KubernetesModule, ContainerModule>
+export type KubernetesService = GardenService<KubernetesModule, ContainerModule>
 
 const kubernetesResourceSchema = () =>
   joi

--- a/core/src/plugins/kubernetes/kubernetes-module/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/handlers.ts
@@ -12,7 +12,7 @@ import { cloneDeep, partition, set, uniq } from "lodash"
 import { KubernetesModule, configureKubernetesModule, KubernetesService } from "./config"
 import { KubernetesPluginContext } from "../config"
 import { BaseResource, KubernetesResource, KubernetesServerResource } from "../types"
-import { Service, ServiceStatus } from "../../../types/service"
+import { GardenService, ServiceStatus } from "../../../types/service"
 import { compareDeployedResources, waitForResources } from "../status/status"
 import { KubeApi } from "../api"
 import { ModuleAndRuntimeActionHandlers } from "../../../types/plugin/plugin"
@@ -101,7 +101,7 @@ export async function getKubernetesServiceStatus({
   return {
     forwardablePorts,
     state,
-    version: state === "ready" ? module.version.versionString : undefined,
+    version: state === "ready" ? service.version : undefined,
     detail: { remoteResources },
   }
 }
@@ -257,7 +257,7 @@ async function prepareManifestsForHotReload({
   manifests,
 }: {
   ctx: PluginContext
-  service: Service
+  service: GardenService
   log: LogEntry
   module: KubernetesModule
   hotReload: boolean

--- a/core/src/plugins/kubernetes/kubernetes-module/run.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/run.ts
@@ -24,7 +24,7 @@ import { getModuleNamespace } from "../namespace"
 import { DEFAULT_TASK_TIMEOUT } from "../../../constants"
 
 export async function runKubernetesTask(params: RunTaskParams<KubernetesModule>): Promise<RunTaskResult> {
-  const { ctx, log, module, task, taskVersion } = params
+  const { ctx, log, module, task } = params
   const k8sCtx = <KubernetesPluginContext>ctx
   const namespace = await getModuleNamespace({
     ctx: k8sCtx,
@@ -61,6 +61,7 @@ export async function runKubernetesTask(params: RunTaskParams<KubernetesModule>)
     podName: makePodName("task", module.name, task.name),
     description: `Task '${task.name}' in container module '${module.name}'`,
     timeout: task.config.timeout || DEFAULT_TASK_TIMEOUT,
+    version: task.version,
   })
 
   const result = {
@@ -77,8 +78,7 @@ export async function runKubernetesTask(params: RunTaskParams<KubernetesModule>)
       log,
       module,
       result,
-      taskVersion,
-      taskName: task.name,
+      task,
     })
   }
 

--- a/core/src/plugins/kubernetes/logs.ts
+++ b/core/src/plugins/kubernetes/logs.ts
@@ -15,7 +15,7 @@ import { GetServiceLogsResult, ServiceLogEntry } from "../../types/plugin/servic
 import { KubernetesResource, KubernetesPod } from "./types"
 import { getAllPods, getStaticLabelsFromPod, getSelectorString } from "./util"
 import { KubeApi } from "./api"
-import { Service } from "../../types/service"
+import { GardenService } from "../../types/service"
 import Stream from "ts-stream"
 import { LogEntry } from "../../logger/log-entry"
 import Bluebird from "bluebird"
@@ -30,7 +30,7 @@ interface GetAllLogsParams {
   defaultNamespace: string
   log: LogEntry
   provider: KubernetesProvider
-  service: Service
+  service: GardenService
   stream: Stream<ServiceLogEntry>
   follow: boolean
   tail: number
@@ -77,7 +77,7 @@ async function readLogsFromApi({
   log: LogEntry
   ctx: PluginContext
   provider: KubernetesProvider
-  service: Service
+  service: GardenService
   stream: Stream<ServiceLogEntry>
   tail?: number
   pod: KubernetesPod
@@ -129,7 +129,7 @@ async function followLogs({
   ctx: PluginContext
   log: LogEntry
   provider: KubernetesProvider
-  service: Service
+  service: GardenService
   stream: Stream<ServiceLogEntry>
   tail: number
   pod: KubernetesPod

--- a/core/src/plugins/kubernetes/port-forward.ts
+++ b/core/src/plugins/kubernetes/port-forward.ts
@@ -19,7 +19,7 @@ import { registerCleanupFunction, sleep } from "../../util/util"
 import { PluginContext } from "../../plugin-context"
 import { kubectl } from "./kubectl"
 import { KubernetesResource } from "./types"
-import { ForwardablePort, Service } from "../../types/service"
+import { ForwardablePort, GardenService } from "../../types/service"
 import { isBuiltIn } from "./util"
 import { LogEntry } from "../../logger/log-entry"
 import { RuntimeError } from "../../exceptions"
@@ -53,7 +53,7 @@ export function killPortForward(targetResource: string, targetPort: number, log?
   }
 }
 
-export function killPortForwards(service: Service, forwardablePorts: ForwardablePort[], log: LogEntry) {
+export function killPortForwards(service: GardenService, forwardablePorts: ForwardablePort[], log: LogEntry) {
   for (const port of forwardablePorts) {
     const targetResource = getTargetResource(service, port.targetName)
     killPortForward(targetResource, port.targetPort, log)
@@ -202,7 +202,7 @@ export async function getPortForwardHandler({
   }
 }
 
-function getTargetResource(service: Service, targetName?: string) {
+function getTargetResource(service: GardenService, targetName?: string) {
   return `Service/${targetName || service.name}`
 }
 

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -106,6 +106,7 @@ export async function runAndCopy({
   stdout,
   stderr,
   namespace,
+  version,
   volumes,
 }: RunModuleParams<GardenModule> & {
   image: string
@@ -119,6 +120,7 @@ export async function runAndCopy({
   stdout?: Writable
   stderr?: Writable
   namespace: string
+  version: string
   volumes?: ContainerVolumeSpec[]
 }): Promise<RunResult> {
   const provider = <KubernetesProvider>ctx.provider
@@ -171,6 +173,7 @@ export async function runAndCopy({
     podSpec,
     podName,
     namespace,
+    version,
   }
 
   if (getArtifacts) {
@@ -300,12 +303,14 @@ async function runWithoutArtifacts({
   podName,
   namespace,
   interactive,
+  version,
 }: RunModuleParams<GardenModule> & {
   api: KubeApi
   provider: KubernetesProvider
   podSpec: V1PodSpec
   podName: string
   namespace: string
+  version: string
 }): Promise<RunResult> {
   const pod: KubernetesResource<V1Pod> = {
     apiVersion: "v1",
@@ -336,7 +341,7 @@ async function runWithoutArtifacts({
       moduleName: module.name,
       startedAt,
       success: false,
-      version: module.version.versionString,
+      version,
     }
   }
 
@@ -350,7 +355,7 @@ async function runWithoutArtifacts({
     result = {
       ...res,
       moduleName: module.name,
-      version: module.version.versionString,
+      version,
     }
   } catch (err) {
     if (err.type === "timeout") {
@@ -360,7 +365,7 @@ async function runWithoutArtifacts({
       result = {
         log: err.detail.logs || err.message,
         moduleName: module.name,
-        version: module.version.versionString,
+        version,
         success: false,
         startedAt,
         completedAt: new Date(),
@@ -393,6 +398,7 @@ async function runWithArtifacts({
   stdout,
   stderr,
   namespace,
+  version,
 }: RunModuleParams<GardenModule> & {
   podSpec: V1PodSpec
   podName: string
@@ -406,6 +412,7 @@ async function runWithArtifacts({
   stdout?: Writable
   stderr?: Writable
   namespace: string
+  version: string
 }): Promise<RunResult> {
   const pod: KubernetesResource<V1Pod> = {
     apiVersion: "v1",
@@ -436,7 +443,7 @@ async function runWithArtifacts({
       moduleName: module.name,
       startedAt,
       success: false,
-      version: module.version.versionString,
+      version,
     }
   }
 
@@ -531,7 +538,7 @@ async function runWithArtifacts({
         ...res,
         log: (await runner.getMainContainerLogs()).trim() || res.log,
         moduleName: module.name,
-        version: module.version.versionString,
+        version,
       }
     } catch (err) {
       const res = err.detail.result
@@ -544,7 +551,7 @@ async function runWithArtifacts({
         result = {
           log: (await runner.getMainContainerLogs()).trim() || err.message,
           moduleName: module.name,
-          version: module.version.versionString,
+          version,
           success: false,
           startedAt,
           completedAt: new Date(),

--- a/core/src/plugins/local/local-docker-swarm.ts
+++ b/core/src/plugins/local/local-docker-swarm.ts
@@ -43,9 +43,7 @@ export const gardenPlugin = () =>
 
           async deployService({ ctx, module, service, runtimeContext, log }: DeployServiceParams<ContainerModule>) {
             // TODO: split this method up and test
-            const { versionString } = service.module.version
-
-            log.info({ section: service.name, msg: `Deploying version ${versionString}` })
+            log.info({ section: service.name, msg: `Deploying version ${service.version}` })
 
             const identifier = containerHelpers.getLocalImageId(module, module.version)
             const ports = service.spec.ports.map((p) => {
@@ -123,7 +121,7 @@ export const gardenPlugin = () =>
             let serviceId
 
             if (serviceStatus.externalId) {
-              const swarmService = await docker.getService(serviceStatus.externalId)
+              const swarmService = docker.getService(serviceStatus.externalId)
               swarmServiceStatus = await swarmService.inspect()
               opts.version = parseInt(swarmServiceStatus.Version.Index, 10)
               log.verbose({

--- a/core/src/plugins/maven-container/maven-container.ts
+++ b/core/src/plugins/maven-container/maven-container.ts
@@ -151,6 +151,8 @@ export async function configureMavenContainerModule(params: ConfigureModuleParam
     ? moduleConfig.spec.dockerfile || defaultDockerfileName
     : moduleConfig.spec.dockerfile
 
+  configured.moduleConfig.buildConfig.dockerfile = dockerfile
+
   return {
     moduleConfig: {
       ...configured.moduleConfig,

--- a/core/src/plugins/openfaas/config.ts
+++ b/core/src/plugins/openfaas/config.ts
@@ -12,7 +12,7 @@ import { resolve as urlResolve } from "url"
 import { PluginContext } from "../../plugin-context"
 import { joiProviderName, joi, joiEnvVars, DeepPrimitiveMap, joiSparseArray } from "../../config/common"
 import { GardenModule } from "../../types/module"
-import { Service } from "../../types/service"
+import { GardenService } from "../../types/service"
 import { ExecModuleSpecBase, ExecTestSpec } from "../exec"
 import { CommonServiceSpec } from "../../config/service"
 import { Provider, providerConfigBaseSchema, GenericProviderConfig } from "../../config/provider"
@@ -78,7 +78,7 @@ export const openfaasModuleOutputsSchema = () =>
 
 export interface OpenFaasModule extends GardenModule<OpenFaasModuleSpec, CommonServiceSpec, ExecTestSpec> {}
 export type OpenFaasModuleConfig = OpenFaasModule["_config"]
-export interface OpenFaasService extends Service<OpenFaasModule> {}
+export interface OpenFaasService extends GardenService<OpenFaasModule> {}
 
 export interface OpenFaasConfig extends GenericProviderConfig {
   gatewayUrl: string

--- a/core/src/plugins/terraform/module.ts
+++ b/core/src/plugins/terraform/module.ts
@@ -112,6 +112,7 @@ export async function getTerraformStatus({
   ctx,
   log,
   module,
+  service,
 }: GetServiceStatusParams<TerraformModule>): Promise<ServiceStatus> {
   const provider = ctx.provider as TerraformProvider
   const root = getModuleStackRoot(module)
@@ -129,7 +130,7 @@ export async function getTerraformStatus({
 
   return {
     state: status === "up-to-date" ? "ready" : "outdated",
-    version: module.version.versionString,
+    version: service.version,
     outputs: await getTfOutputs({ log, ctx, provider, root }),
     detail: {},
   }
@@ -139,6 +140,7 @@ export async function deployTerraform({
   ctx,
   log,
   module,
+  service,
 }: DeployServiceParams<TerraformModule>): Promise<ServiceStatus> {
   const provider = ctx.provider as TerraformProvider
   const workspace = module.spec.workspace || null
@@ -162,7 +164,7 @@ export async function deployTerraform({
 
   return {
     state: "ready",
-    version: module.version.versionString,
+    version: service.version,
     outputs: await getTfOutputs({ log, ctx, provider, root }),
     detail: {},
   }
@@ -172,6 +174,7 @@ export async function deleteTerraformModule({
   ctx,
   log,
   module,
+  service,
 }: DeleteServiceParams<TerraformModule>): Promise<ServiceStatus> {
   const provider = ctx.provider as TerraformProvider
 
@@ -194,7 +197,7 @@ export async function deleteTerraformModule({
 
   return {
     state: "missing",
-    version: module.version.versionString,
+    version: service.version,
     outputs: {},
     detail: {},
   }

--- a/core/src/resolve-module.ts
+++ b/core/src/resolve-module.ts
@@ -433,7 +433,12 @@ export class ModuleResolver {
       this.garden.cache.invalidateUp(cacheContext)
     }
 
-    const module = await moduleFromConfig(this.garden, this.log, resolvedConfig, dependencies)
+    const module = await moduleFromConfig({
+      garden: this.garden,
+      log: this.log,
+      config: resolvedConfig,
+      buildDependencies: dependencies,
+    })
 
     const moduleTypeDefinitions = await this.garden.getModuleTypes()
     const description = moduleTypeDefinitions[module.type]!

--- a/core/src/runtime-context.ts
+++ b/core/src/runtime-context.ts
@@ -8,7 +8,6 @@
 
 import { getEnvVarName } from "./util/util"
 import { PrimitiveMap, joiEnvVars, joiPrimitive, joi, joiIdentifier, moduleVersionSchema } from "./config/common"
-import { ModuleVersion } from "./vcs/vcs"
 import { Garden } from "./garden"
 import { ConfigGraph, DependencyRelations } from "./config-graph"
 import { ServiceStatus } from "./types/service"
@@ -67,7 +66,8 @@ interface PrepareRuntimeContextParams {
   dependencies: DependencyRelations
   serviceStatuses: { [name: string]: ServiceStatus }
   taskResults: { [name: string]: RunTaskResult }
-  version: ModuleVersion
+  version: string
+  moduleVersion: string
 }
 
 /**
@@ -84,11 +84,11 @@ export async function prepareRuntimeContext({
   serviceStatuses,
   taskResults,
   version,
+  moduleVersion,
 }: PrepareRuntimeContextParams): Promise<RuntimeContext> {
-  const { versionString } = version
   const envVars = {
-    GARDEN_VERSION: versionString, // TODO: deprecate, prefer the more verbose option
-    GARDEN_MODULE_VERSION: versionString,
+    GARDEN_VERSION: version,
+    GARDEN_MODULE_VERSION: moduleVersion,
   }
 
   // DEPRECATED: Remove in v0.13
@@ -127,7 +127,7 @@ export async function prepareRuntimeContext({
       name: service.name,
       outputs,
       type: "service",
-      version: service.module.version.versionString,
+      version: service.version,
     })
   }
 
@@ -143,7 +143,7 @@ export async function prepareRuntimeContext({
       name: task.name,
       outputs,
       type: "task",
-      version: task.module.version.versionString,
+      version: task.version,
     })
   }
 

--- a/core/src/task-graph.ts
+++ b/core/src/task-graph.ts
@@ -403,7 +403,7 @@ export class TaskGraph extends EventEmitter2 {
           key,
           batchId,
           startedAt: new Date(),
-          versionString: task.version.versionString,
+          versionString: task.version,
         })
         result = await node.process(dependencyResults)
         result.startedAt = startedAt
@@ -631,7 +631,7 @@ function metadataForLog(task: BaseTask, status: TaskLogStatus): LogEntryMetadata
       key: task.getKey(),
       status,
       uid: task.uid,
-      versionString: task.version.versionString,
+      versionString: task.version,
     },
   }
 }
@@ -751,7 +751,7 @@ class TaskNode {
   }
 
   getVersion() {
-    return this.task.version.versionString
+    return this.task.version
   }
 
   // For testing/debugging purposes

--- a/core/src/tasks/base.ts
+++ b/core/src/tasks/base.ts
@@ -7,7 +7,6 @@
  */
 
 import { GraphResults } from "../task-graph"
-import { ModuleVersion } from "../vcs/vcs"
 import { v1 as uuidv1 } from "uuid"
 import { Garden } from "../garden"
 import { LogEntry } from "../logger/log-entry"
@@ -42,7 +41,7 @@ export interface TaskParams {
   garden: Garden
   log: LogEntry
   force?: boolean
-  version: ModuleVersion
+  version: string
 }
 
 @Profile()
@@ -56,7 +55,7 @@ export abstract class BaseTask {
   log: LogEntry
   uid: string
   force: boolean
-  version: ModuleVersion
+  version: string
 
   _resolvedDependencies?: BaseTask[]
 

--- a/core/src/tasks/build.ts
+++ b/core/src/tasks/build.ts
@@ -36,7 +36,7 @@ export class BuildTask extends BaseTask {
 
   constructor({ garden, graph, log, module, force }: BuildTaskParams & { _guard: true }) {
     // Note: The _guard attribute is to prevent accidentally bypassing the factory method
-    super({ garden, log, force, version: module.version })
+    super({ garden, log, force, version: module.version.versionString })
     this.graph = graph
     this.module = module
   }

--- a/core/src/tasks/delete-service.ts
+++ b/core/src/tasks/delete-service.ts
@@ -8,7 +8,7 @@
 
 import { LogEntry } from "../logger/log-entry"
 import { BaseTask, TaskType } from "./base"
-import { Service, ServiceStatus } from "../types/service"
+import { GardenService, ServiceStatus } from "../types/service"
 import { Garden } from "../garden"
 import { ConfigGraph } from "../config-graph"
 import { GraphResults, GraphResult } from "../task-graph"
@@ -17,7 +17,7 @@ import { StageBuildTask } from "./stage-build"
 export interface DeleteServiceTaskParams {
   garden: Garden
   graph: ConfigGraph
-  service: Service
+  service: GardenService
   log: LogEntry
   includeDependants?: boolean
 }
@@ -27,11 +27,11 @@ export class DeleteServiceTask extends BaseTask {
   concurrencyLimit = 10
 
   private graph: ConfigGraph
-  private service: Service
+  private service: GardenService
   private includeDependants: boolean
 
   constructor({ garden, graph, log, service, includeDependants = false }: DeleteServiceTaskParams) {
-    super({ garden, log, force: false, version: service.module.version })
+    super({ garden, log, force: false, version: service.version })
     this.graph = graph
     this.service = service
     this.includeDependants = includeDependants

--- a/core/src/tasks/get-service-status.ts
+++ b/core/src/tasks/get-service-status.ts
@@ -9,12 +9,11 @@
 import { includes } from "lodash"
 import { LogEntry } from "../logger/log-entry"
 import { BaseTask, TaskType, getServiceStatuses, getRunTaskResults } from "./base"
-import { Service, ServiceStatus } from "../types/service"
+import { GardenService, ServiceStatus } from "../types/service"
 import { Garden } from "../garden"
 import { ConfigGraph } from "../config-graph"
 import { GraphResults } from "../task-graph"
 import { prepareRuntimeContext } from "../runtime-context"
-import { getTaskVersion } from "./task"
 import Bluebird from "bluebird"
 import { GetTaskResultTask } from "./get-task-result"
 import chalk from "chalk"
@@ -23,7 +22,7 @@ import { Profile } from "../util/profiling"
 export interface GetServiceStatusTaskParams {
   garden: Garden
   graph: ConfigGraph
-  service: Service
+  service: GardenService
   force: boolean
   log: LogEntry
   hotReloadServiceNames?: string[]
@@ -35,11 +34,11 @@ export class GetServiceStatusTask extends BaseTask {
   concurrencyLimit = 20
 
   private graph: ConfigGraph
-  private service: Service
+  private service: GardenService
   private hotReloadServiceNames: string[]
 
   constructor({ garden, graph, log, service, force, hotReloadServiceNames = [] }: GetServiceStatusTaskParams) {
-    super({ garden, log, force, version: service.module.version })
+    super({ garden, log, force, version: service.version })
     this.graph = graph
     this.service = service
     this.hotReloadServiceNames = hotReloadServiceNames
@@ -65,7 +64,6 @@ export class GetServiceStatusTask extends BaseTask {
         log: this.log,
         task,
         force: false,
-        version: await getTaskVersion(this.garden, this.graph, task),
       })
     })
 
@@ -99,6 +97,7 @@ export class GetServiceStatusTask extends BaseTask {
       graph: this.graph,
       dependencies,
       version: this.version,
+      moduleVersion: this.service.module.version.versionString,
       serviceStatuses,
       taskResults,
     })

--- a/core/src/tasks/get-task-result.ts
+++ b/core/src/tasks/get-task-result.ts
@@ -10,17 +10,15 @@ import chalk from "chalk"
 import { LogEntry } from "../logger/log-entry"
 import { BaseTask, TaskType } from "./base"
 import { Garden } from "../garden"
-import { Task } from "../types/task"
+import { GardenTask } from "../types/task"
 import { RunTaskResult } from "../types/plugin/task/runTask"
-import { ModuleVersion } from "../vcs/vcs"
 import { Profile } from "../util/profiling"
 
 export interface GetTaskResultTaskParams {
   force: boolean
   garden: Garden
   log: LogEntry
-  task: Task
-  version: ModuleVersion
+  task: GardenTask
 }
 
 @Profile()
@@ -28,10 +26,10 @@ export class GetTaskResultTask extends BaseTask {
   type: TaskType = "get-task-result"
   concurrencyLimit = 20
 
-  private task: Task
+  private task: GardenTask
 
-  constructor({ force, garden, log, task, version }: GetTaskResultTaskParams) {
-    super({ garden, log, force, version })
+  constructor({ force, garden, log, task }: GetTaskResultTaskParams) {
+    super({ garden, log, force, version: task.version })
     this.task = task
   }
 
@@ -61,7 +59,6 @@ export class GetTaskResultTask extends BaseTask {
       result = await actions.getTaskResult({
         task: this.task,
         log,
-        taskVersion: this.version,
       })
     } catch (err) {
       log.setError()

--- a/core/src/tasks/hot-reload.ts
+++ b/core/src/tasks/hot-reload.ts
@@ -9,7 +9,7 @@
 import chalk from "chalk"
 import { LogEntry } from "../logger/log-entry"
 import { BaseTask, TaskType } from "./base"
-import { Service } from "../types/service"
+import { GardenService } from "../types/service"
 import { Garden } from "../garden"
 import { ConfigGraph } from "../config-graph"
 import { Profile } from "../util/profiling"
@@ -20,7 +20,7 @@ interface Params {
   graph: ConfigGraph
   hotReloadServiceNames?: string[]
   log: LogEntry
-  service: Service
+  service: GardenService
 }
 
 @Profile()
@@ -30,10 +30,10 @@ export class HotReloadTask extends BaseTask {
 
   // private graph: ConfigGraph
   // private hotReloadServiceNames: string[]
-  private service: Service
+  private service: GardenService
 
   constructor({ garden, log, service, force }: Params) {
-    super({ garden, log, force, version: service.module.version })
+    super({ garden, log, force, version: service.version })
     // this.graph = graph
     // this.hotReloadServiceNames = hotReloadServiceNames || []
     this.service = service

--- a/core/src/tasks/publish.ts
+++ b/core/src/tasks/publish.ts
@@ -40,7 +40,7 @@ export class PublishTask extends BaseTask {
   private tagTemplate?: string
 
   constructor({ garden, graph, log, module, forceBuild, tagTemplate }: PublishTaskParams) {
-    super({ garden, log, version: module.version })
+    super({ garden, log, version: module.version.versionString })
     this.graph = graph
     this.module = module
     this.forceBuild = forceBuild

--- a/core/src/tasks/stage-build.ts
+++ b/core/src/tasks/stage-build.ts
@@ -36,7 +36,7 @@ export class StageBuildTask extends BaseTask {
   private extraDependencies: BaseTask[]
 
   constructor({ garden, graph, log, module, force, dependencies }: StageBuildTaskParams) {
-    super({ garden, log, force, version: module.version })
+    super({ garden, log, force, version: module.version.versionString })
     this.graph = graph
     this.module = module
     this.extraDependencies = dependencies || []

--- a/core/src/types/module.ts
+++ b/core/src/types/module.ts
@@ -86,13 +86,20 @@ export interface ModuleConfigMap<T extends ModuleConfig = ModuleConfig> {
   [key: string]: T
 }
 
-export async function moduleFromConfig(
-  garden: Garden,
-  log: LogEntry,
-  config: ModuleConfig,
+export async function moduleFromConfig({
+  garden,
+  log,
+  config,
+  buildDependencies,
+  forceVersion = false,
+}: {
+  garden: Garden
+  log: LogEntry
+  config: ModuleConfig
   buildDependencies: GardenModule[]
-): Promise<GardenModule> {
-  const version = await garden.resolveVersion(config, config.build.dependencies)
+  forceVersion?: boolean
+}): Promise<GardenModule> {
+  const version = await garden.resolveModuleVersion(config, config.build.dependencies, forceVersion)
   const actions = await garden.getActionRouter()
   const { outputs } = await actions.getModuleOutputs({ log, moduleConfig: config, version })
   const moduleTypes = await garden.getModuleTypes()

--- a/core/src/types/plugin/base.ts
+++ b/core/src/types/plugin/base.ts
@@ -10,9 +10,9 @@ import { LogEntry } from "../../logger/log-entry"
 import { PluginContext, pluginContextSchema } from "../../plugin-context"
 import { GardenModule, moduleSchema } from "../module"
 import { RuntimeContext, runtimeContextSchema } from "../../runtime-context"
-import { Service, serviceSchema } from "../service"
-import { Task } from "../task"
-import { taskSchema } from "../../config/task"
+import { GardenService, serviceSchema } from "../service"
+import { GardenTask } from "../task"
+import { taskSchema } from "../../types/task"
 import { joi } from "../../config/common"
 import { ActionHandlerParamsBase } from "./plugin"
 
@@ -47,7 +47,7 @@ export interface PluginServiceActionParamsBase<
   S extends GardenModule = GardenModule
 > extends PluginModuleActionParamsBase<M> {
   runtimeContext?: RuntimeContext
-  service: Service<M, S>
+  service: GardenService<M, S>
 }
 export const serviceActionParamsSchema = () =>
   moduleActionParamsSchema().keys({
@@ -57,7 +57,7 @@ export const serviceActionParamsSchema = () =>
 
 export interface PluginTaskActionParamsBase<T extends GardenModule = GardenModule>
   extends PluginModuleActionParamsBase<T> {
-  task: Task<T>
+  task: GardenTask<T>
 }
 export const taskActionParamsSchema = () =>
   moduleActionParamsSchema().keys({

--- a/core/src/types/plugin/module/getTestResult.ts
+++ b/core/src/types/plugin/module/getTestResult.ts
@@ -9,12 +9,11 @@
 import { dedent, deline } from "../../../util/string"
 import { GardenModule } from "../../module"
 import { PluginModuleActionParamsBase, moduleActionParamsSchema, RunResult, runResultSchema } from "../base"
-import { ModuleVersion } from "../../../vcs/vcs"
 import { joi, joiPrimitive, moduleVersionSchema } from "../../../config/common"
+import { GardenTest, testSchema } from "../../test"
 
 export interface GetTestResultParams<T extends GardenModule = GardenModule> extends PluginModuleActionParamsBase<T> {
-  testName: string
-  testVersion: ModuleVersion
+  test: GardenTest<T>
 }
 
 export interface TestResult extends RunResult {
@@ -46,8 +45,7 @@ export const getTestResult = () => ({
   `,
 
   paramsSchema: moduleActionParamsSchema().keys({
-    testName: joi.string().description("A unique name to identify the test run."),
-    testVersion: testVersionSchema(),
+    test: testSchema(),
   }),
 
   resultSchema: testResultSchema().allow(null),

--- a/core/src/types/plugin/module/testModule.ts
+++ b/core/src/types/plugin/module/testModule.ts
@@ -10,18 +10,16 @@ import { dedent } from "../../../util/string"
 import { GardenModule } from "../../module"
 import { PluginModuleActionParamsBase, artifactsPathSchema } from "../base"
 import { RuntimeContext } from "../../../runtime-context"
-import { ModuleVersion } from "../../../vcs/vcs"
-import { testConfigSchema } from "../../../config/test"
 import { runModuleBaseSchema } from "./runModule"
-import { testResultSchema, testVersionSchema } from "./getTestResult"
+import { testResultSchema } from "./getTestResult"
+import { GardenTest, testSchema } from "../../test"
 
 export interface TestModuleParams<T extends GardenModule = GardenModule> extends PluginModuleActionParamsBase<T> {
   artifactsPath: string
   interactive: boolean
   runtimeContext: RuntimeContext
   silent: boolean
-  testConfig: T["testConfigs"][0]
-  testVersion: ModuleVersion
+  test: GardenTest<T>
 }
 
 export const testModule = () => ({
@@ -40,8 +38,7 @@ export const testModule = () => ({
   `,
   paramsSchema: runModuleBaseSchema().keys({
     artifactsPath: artifactsPathSchema(),
-    testConfig: testConfigSchema(),
-    testVersion: testVersionSchema(),
+    test: testSchema(),
   }),
   resultSchema: testResultSchema(),
 })

--- a/core/src/types/plugin/task/getTaskResult.ts
+++ b/core/src/types/plugin/task/getTaskResult.ts
@@ -9,7 +9,6 @@
 import { taskActionParamsSchema, PluginTaskActionParamsBase } from "../base"
 import { dedent, deline } from "../../../util/string"
 import { GardenModule } from "../../module"
-import { ModuleVersion } from "../../../vcs/vcs"
 import { joi, joiPrimitive, moduleVersionSchema } from "../../../config/common"
 
 export const taskVersionSchema = () =>
@@ -17,9 +16,7 @@ export const taskVersionSchema = () =>
     The task run's version. In addition to the parent module's version, this also
     factors in the module versions of the tasks's runtime dependencies (if any).`)
 
-export interface GetTaskResultParams<T extends GardenModule = GardenModule> extends PluginTaskActionParamsBase<T> {
-  taskVersion: ModuleVersion
-}
+export interface GetTaskResultParams<T extends GardenModule = GardenModule> extends PluginTaskActionParamsBase<T> {}
 
 export const taskResultSchema = () =>
   joi
@@ -53,9 +50,6 @@ export const getTaskResult = () => ({
     well as any runtime dependencies configured for the task, so it may not match the current version
     of the module itself.
   `,
-  paramsSchema: taskActionParamsSchema().keys({
-    taskVersion: taskVersionSchema(),
-  }),
-
+  paramsSchema: taskActionParamsSchema(),
   resultSchema: taskResultSchema().allow(null),
 })

--- a/core/src/types/plugin/task/runTask.ts
+++ b/core/src/types/plugin/task/runTask.ts
@@ -16,15 +16,13 @@ import {
 import { dedent } from "../../../util/string"
 import { GardenModule } from "../../module"
 import { RuntimeContext } from "../../../runtime-context"
-import { ModuleVersion } from "../../../vcs/vcs"
-import { taskVersionSchema, taskResultSchema } from "./getTaskResult"
+import { taskResultSchema } from "./getTaskResult"
 import { PrimitiveMap } from "../../../config/common"
 
 export interface RunTaskParams<T extends GardenModule = GardenModule> extends PluginTaskActionParamsBase<T> {
   artifactsPath: string
   interactive: boolean
   runtimeContext: RuntimeContext
-  taskVersion: ModuleVersion
   timeout?: number
 }
 
@@ -40,7 +38,6 @@ export const runTask = () => ({
   `,
   paramsSchema: taskActionParamsSchema().keys(runBaseParams()).keys({
     artifactsPath: artifactsPathSchema(),
-    taskVersion: taskVersionSchema(),
   }),
   resultSchema: taskResultSchema(),
 })

--- a/core/src/types/task.ts
+++ b/core/src/types/task.ts
@@ -7,23 +7,44 @@
  */
 
 import { GardenModule } from "./module"
-import { TaskConfig } from "../config/task"
+import { TaskConfig, taskConfigSchema } from "../config/task"
+import { getEntityVersion } from "../vcs/vcs"
+import { joi, joiUserIdentifier, versionStringSchema } from "../config/common"
 
-export interface Task<M extends GardenModule = GardenModule> {
+export interface GardenTask<M extends GardenModule = GardenModule> {
   name: string
   description?: string
   module: M
   disabled: boolean
   config: M["taskConfigs"][0]
   spec: M["taskConfigs"][0]["spec"]
+  version: string
 }
 
-export function taskFromConfig<M extends GardenModule = GardenModule>(module: M, config: TaskConfig): Task<M> {
+export const taskSchema = () =>
+  joi
+    .object()
+    .options({ presence: "required" })
+    .keys({
+      name: joiUserIdentifier().description("The name of the task."),
+      description: joi.string().optional().description("A description of the task."),
+      disabled: joi.boolean().default(false).description("Set to true if the task or its module is disabled."),
+      module: joi.object().unknown(true),
+      config: taskConfigSchema(),
+      spec: joi
+        .object()
+        .meta({ extendable: true })
+        .description("The configuration of the task (specific to each plugin)."),
+      version: versionStringSchema().description("The version of the task."),
+    })
+
+export function taskFromConfig<M extends GardenModule = GardenModule>(module: M, config: TaskConfig): GardenTask<M> {
   return {
     name: config.name,
     module,
     disabled: module.disabled || config.disabled,
     config,
     spec: config.spec,
+    version: getEntityVersion(module, config),
   }
 }

--- a/core/src/types/test.ts
+++ b/core/src/types/test.ts
@@ -7,22 +7,51 @@
  */
 
 import { GardenModule } from "./module"
-import { TestConfig } from "../config/test"
+import { TestConfig, testConfigSchema } from "../config/test"
+import { getEntityVersion } from "../vcs/vcs"
+import { findByName } from "../util/util"
+import { NotFoundError } from "../exceptions"
+import { joi, joiUserIdentifier, versionStringSchema } from "../config/common"
 
-export interface Test<M extends GardenModule = GardenModule> {
+export interface GardenTest<M extends GardenModule = GardenModule> {
   name: string
   module: M
   disabled: boolean
   config: M["testConfigs"][0]
   spec: M["testConfigs"][0]["spec"]
+  version: string
 }
 
-export function testFromConfig<M extends GardenModule = GardenModule>(module: M, config: TestConfig): Test<M> {
+export const testSchema = () =>
+  joi
+    .object()
+    .options({ presence: "required" })
+    .keys({
+      name: joiUserIdentifier().description("The name of the test."),
+      module: joi.object().unknown(true), // This causes a stack overflow: joi.lazy(() => moduleSchema()),
+      disabled: joi.boolean().default(false).description("Set to true if the test is disabled."),
+      config: testConfigSchema(),
+      spec: joi.object().description("The raw configuration of the test (specific to each plugin)."),
+      version: versionStringSchema().description("The version of the test."),
+    })
+
+export function testFromConfig<M extends GardenModule = GardenModule>(module: M, config: TestConfig): GardenTest<M> {
   return {
     name: config.name,
     module,
     disabled: module.disabled || config.disabled,
     config,
     spec: config.spec,
+    version: getEntityVersion(module, config),
   }
+}
+
+export function testFromModule<M extends GardenModule = GardenModule>(module: M, name: string): GardenTest<M> {
+  const config = findByName(module.testConfigs, name)
+
+  if (!config) {
+    throw new NotFoundError(`Could not find test ${name} in module ${module.name}`, { module, name })
+  }
+
+  return testFromConfig(module, config)
 }

--- a/core/test/helpers.ts
+++ b/core/test/helpers.ts
@@ -299,7 +299,7 @@ export const testPluginC = () => {
   })
 }
 
-const defaultModuleConfig: ModuleConfig = {
+export const defaultModuleConfig: ModuleConfig = {
   apiVersion: DEFAULT_API_VERSION,
   type: "test",
   name: "test",

--- a/core/test/integ/src/plugins/hadolint/hadolint.ts
+++ b/core/test/integ/src/plugins/hadolint/hadolint.ts
@@ -18,6 +18,7 @@ import { TestTask } from "../../../../../src/tasks/test"
 import { writeFile, remove, pathExists } from "fs-extra"
 import { join } from "path"
 import { createGardenPlugin } from "../../../../../src/types/plugin/plugin"
+import { testFromConfig } from "../../../../../src/types/test"
 
 describe("hadolint provider", () => {
   let tmpDir: tmp.DirectoryResult
@@ -183,14 +184,11 @@ describe("hadolint provider", () => {
 
       const testTask = new TestTask({
         garden,
-        module,
         log: garden.log,
         graph,
-        testConfig: module.testConfigs[0],
+        test: testFromConfig(module, module.testConfigs[0]),
         force: true,
         forceBuild: false,
-        version: module.version,
-        _guard: true,
       })
 
       const key = testTask.getKey()
@@ -248,14 +246,11 @@ describe("hadolint provider", () => {
 
       const testTask = new TestTask({
         garden,
-        module,
         log: garden.log,
         graph,
-        testConfig: module.testConfigs[0],
+        test: testFromConfig(module, module.testConfigs[0]),
         force: true,
         forceBuild: false,
-        version: module.version,
-        _guard: true,
       })
 
       const key = testTask.getKey()
@@ -308,14 +303,11 @@ describe("hadolint provider", () => {
 
       const testTask = new TestTask({
         garden,
-        module,
         log: garden.log,
         graph,
-        testConfig: module.testConfigs[0],
+        test: testFromConfig(module, module.testConfigs[0]),
         force: true,
         forceBuild: false,
-        version: module.version,
-        _guard: true,
       })
 
       const key = testTask.getKey()
@@ -362,14 +354,11 @@ describe("hadolint provider", () => {
 
       const testTask = new TestTask({
         garden,
-        module,
         log: garden.log,
         graph,
-        testConfig: module.testConfigs[0],
+        test: testFromConfig(module, module.testConfigs[0]),
         force: true,
         forceBuild: false,
-        version: module.version,
-        _guard: true,
       })
 
       const key = testTask.getKey()
@@ -406,14 +395,11 @@ describe("hadolint provider", () => {
 
       const testTask = new TestTask({
         garden,
-        module,
         log: garden.log,
         graph,
-        testConfig: module.testConfigs[0],
+        test: testFromConfig(module, module.testConfigs[0]),
         force: true,
         forceBuild: false,
-        version: module.version,
-        _guard: true,
       })
 
       const key = testTask.getKey()
@@ -453,14 +439,11 @@ describe("hadolint provider", () => {
 
       const testTask = new TestTask({
         garden,
-        module,
+        test: testFromConfig(module, module.testConfigs[0]),
         log: garden.log,
         graph,
-        testConfig: module.testConfigs[0],
         force: true,
         forceBuild: false,
-        version: module.version,
-        _guard: true,
       })
 
       const key = testTask.getKey()

--- a/core/test/integ/src/plugins/kubernetes/container/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/deployment.ts
@@ -65,7 +65,7 @@ describe("kubernetes container deployment handlers", () => {
         blueGreen: false,
       })
 
-      const version = service.module.version.versionString
+      const buildVersion = service.module.version.versionString
 
       expect(resource).to.eql({
         kind: "Deployment",
@@ -86,7 +86,7 @@ describe("kubernetes container deployment handlers", () => {
               containers: [
                 {
                   name: "simple-service",
-                  image: "simple-service:" + version,
+                  image: "simple-service:" + buildVersion,
                   command: ["sh", "-c", "echo Server running... && nc -l -p 8080"],
                   env: [
                     { name: "POD_HOST_IP", valueFrom: { fieldRef: { fieldPath: "status.hostIP" } } },
@@ -131,7 +131,7 @@ describe("kubernetes container deployment handlers", () => {
         blueGreen: true,
       })
 
-      const version = service.module.version.versionString
+      const version = service.version
 
       expect(resource.metadata.name).to.equal("simple-service-" + version)
       expect(resource.metadata.labels).to.eql({

--- a/core/test/integ/src/plugins/kubernetes/container/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/run.ts
@@ -39,7 +39,6 @@ describe("runContainerTask", () => {
 
   it("should run a basic task", async () => {
     const task = graph.getTask("echo-task")
-    const version = task.module.version
 
     const testTask = new TaskTask({
       garden,
@@ -48,11 +47,10 @@ describe("runContainerTask", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
-      version,
     })
 
     const ctx = await garden.getPluginContext(provider)
-    await clearTaskResult({ ctx, log: garden.log, module: task.module, task, taskVersion: version })
+    await clearTaskResult({ ctx, log: garden.log, module: task.module, task })
 
     const key = testTask.getKey()
     const { [key]: result } = await garden.processTasks([testTask], { throwOnError: true })
@@ -67,7 +65,6 @@ describe("runContainerTask", () => {
     const storedResult = await actions.getTaskResult({
       log: garden.log,
       task,
-      taskVersion: task.module.version,
     })
 
     expect(storedResult).to.exist
@@ -75,7 +72,6 @@ describe("runContainerTask", () => {
 
   it("should not store task results if cacheResult=false", async () => {
     const task = graph.getTask("echo-task")
-    const version = task.module.version
     task.config.cacheResult = false
 
     const testTask = new TaskTask({
@@ -85,11 +81,10 @@ describe("runContainerTask", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
-      version,
     })
 
     const ctx = await garden.getPluginContext(provider)
-    await clearTaskResult({ ctx, log: garden.log, module: task.module, task, taskVersion: version })
+    await clearTaskResult({ ctx, log: garden.log, module: task.module, task })
 
     await garden.processTasks([testTask], { throwOnError: true })
 
@@ -98,7 +93,6 @@ describe("runContainerTask", () => {
     const storedResult = await actions.getTaskResult({
       log: garden.log,
       task,
-      taskVersion: task.module.version,
     })
 
     expect(storedResult).to.not.exist
@@ -107,7 +101,6 @@ describe("runContainerTask", () => {
   it("should fail if an error occurs, but store the result", async () => {
     const task = graph.getTask("echo-task")
     task.config.spec.command = ["bork"] // this will fail
-    const version = task.module.version
 
     const testTask = new TaskTask({
       garden,
@@ -116,11 +109,10 @@ describe("runContainerTask", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
-      version,
     })
 
     const ctx = await garden.getPluginContext(provider)
-    await clearTaskResult({ ctx, log: garden.log, module: task.module, task, taskVersion: version })
+    await clearTaskResult({ ctx, log: garden.log, module: task.module, task })
 
     await expectError(
       async () => await garden.processTasks([testTask], { throwOnError: true }),
@@ -132,7 +124,6 @@ describe("runContainerTask", () => {
     const result = await actions.getTaskResult({
       log: garden.log,
       task,
-      taskVersion: version,
     })
 
     expect(result).to.exist
@@ -149,7 +140,6 @@ describe("runContainerTask", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
-        version: task.module.version,
       })
 
       await emptyDir(garden.artifactsPath)
@@ -170,7 +160,6 @@ describe("runContainerTask", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
-        version: task.module.version,
       })
       await emptyDir(garden.artifactsPath)
 
@@ -192,7 +181,6 @@ describe("runContainerTask", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
-        version: task.module.version,
       })
 
       await emptyDir(garden.artifactsPath)
@@ -213,7 +201,6 @@ describe("runContainerTask", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
-        version: task.module.version,
       })
 
       const result = await garden.processTasks([testTask])
@@ -239,7 +226,6 @@ describe("runContainerTask", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
-        version: task.module.version,
       })
 
       const result = await garden.processTasks([testTask])

--- a/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
@@ -50,13 +50,19 @@ describe("deployHelmService", () => {
     })
 
     const releaseName = getReleaseName(service.module)
-    const status = await getReleaseStatus(ctx, service.module, releaseName, garden.log, false)
+    const status = await getReleaseStatus({
+      ctx,
+      service,
+      releaseName,
+      log: garden.log,
+      hotReload: false,
+    })
 
     expect(status.state).to.equal("ready")
     expect(status.detail["values"][".garden"]).to.eql({
       moduleName: "api",
       projectName: garden.projectName,
-      version: service.module.version.versionString,
+      version: service.version,
     })
   })
 
@@ -75,13 +81,19 @@ describe("deployHelmService", () => {
     })
 
     const releaseName = getReleaseName(service.module)
-    const status = await getReleaseStatus(ctx, service.module, releaseName, garden.log, true)
+    const status = await getReleaseStatus({
+      ctx,
+      service,
+      releaseName,
+      log: garden.log,
+      hotReload: true,
+    })
 
     expect(status.state).to.equal("ready")
     expect(status.detail["values"][".garden"]).to.eql({
       moduleName: "api",
       projectName: garden.projectName,
-      version: service.module.version.versionString,
+      version: service.version,
       hotReload: true,
     })
   })
@@ -104,7 +116,13 @@ describe("deployHelmService", () => {
     })
 
     const releaseName = getReleaseName(service.module)
-    const status = await getReleaseStatus(ctx, service.module, releaseName, garden.log, false)
+    const status = await getReleaseStatus({
+      ctx,
+      service,
+      releaseName,
+      log: garden.log,
+      hotReload: false,
+    })
 
     expect(status.state).to.equal("ready")
 

--- a/core/test/integ/src/plugins/kubernetes/helm/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/run.ts
@@ -30,7 +30,6 @@ describe("runHelmTask", () => {
 
   it("should run a basic task and store its result", async () => {
     const task = graph.getTask("echo-task")
-    const version = task.module.version
 
     const testTask = new TaskTask({
       garden,
@@ -39,7 +38,6 @@ describe("runHelmTask", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
-      version,
     })
 
     const key = testTask.getKey()
@@ -47,7 +45,7 @@ describe("runHelmTask", () => {
     // Clear any existing task result
     const provider = await garden.resolveProvider(garden.log, "local-kubernetes")
     const ctx = await garden.getPluginContext(provider)
-    await clearTaskResult({ ctx, log: garden.log, module: task.module, task, taskVersion: version })
+    await clearTaskResult({ ctx, log: garden.log, module: task.module, task })
 
     const { [key]: result } = await garden.processTasks([testTask], { throwOnError: true })
 
@@ -62,7 +60,6 @@ describe("runHelmTask", () => {
     const storedResult = await actions.getTaskResult({
       log: garden.log,
       task,
-      taskVersion: task.module.version,
     })
 
     expect(storedResult).to.exist
@@ -70,7 +67,6 @@ describe("runHelmTask", () => {
 
   it("should not store task results if cacheResult=false", async () => {
     const task = graph.getTask("echo-task")
-    const version = task.module.version
     task.config.cacheResult = false
 
     const testTask = new TaskTask({
@@ -80,13 +76,12 @@ describe("runHelmTask", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
-      version,
     })
 
     // Clear any existing task result
     const provider = await garden.resolveProvider(garden.log, "local-kubernetes")
     const ctx = await garden.getPluginContext(provider)
-    await clearTaskResult({ ctx, log: garden.log, module: task.module, task, taskVersion: version })
+    await clearTaskResult({ ctx, log: garden.log, module: task.module, task })
 
     await garden.processTasks([testTask], { throwOnError: true })
 
@@ -95,7 +90,6 @@ describe("runHelmTask", () => {
     const storedResult = await actions.getTaskResult({
       log: garden.log,
       task,
-      taskVersion: task.module.version,
     })
 
     expect(storedResult).to.not.exist
@@ -111,7 +105,6 @@ describe("runHelmTask", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
-      version: task.module.version,
     })
 
     const key = testTask.getKey()
@@ -135,7 +128,6 @@ describe("runHelmTask", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
-      version: task.module.version,
     })
 
     await expectError(
@@ -149,7 +141,6 @@ describe("runHelmTask", () => {
     const result = await actions.getTaskResult({
       log: garden.log,
       task,
-      taskVersion: task.module.version,
     })
 
     expect(result).to.exist
@@ -166,7 +157,6 @@ describe("runHelmTask", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
-        version: task.module.version,
       })
 
       await emptyDir(garden.artifactsPath)
@@ -187,7 +177,6 @@ describe("runHelmTask", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
-        version: task.module.version,
       })
       await emptyDir(garden.artifactsPath)
 
@@ -209,7 +198,6 @@ describe("runHelmTask", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
-        version: task.module.version,
       })
 
       await emptyDir(garden.artifactsPath)

--- a/core/test/integ/src/plugins/kubernetes/hot-reload.ts
+++ b/core/test/integ/src/plugins/kubernetes/hot-reload.ts
@@ -13,8 +13,7 @@ import { deline } from "../../../../../src/util/string"
 import { ConfigGraph } from "../../../../../src/config-graph"
 import { getHelmTestGarden, buildHelmModules } from "./helm/common"
 import { getChartResources } from "../../../../../src/plugins/kubernetes/helm/common"
-import { PluginContext } from "../../../../../src/plugin-context"
-import { KubernetesProvider } from "../../../../../src/plugins/kubernetes/config"
+import { KubernetesProvider, KubernetesPluginContext } from "../../../../../src/plugins/kubernetes/config"
 import { findServiceResource, getServiceResourceSpec } from "../../../../../src/plugins/kubernetes/util"
 import {
   getHotReloadSpec,
@@ -94,12 +93,12 @@ describe("configureHotReload", () => {
   let garden: TestGarden
   let graph: ConfigGraph
   let provider: KubernetesProvider
-  let ctx: PluginContext
+  let ctx: KubernetesPluginContext
 
   before(async () => {
     garden = await getHelmTestGarden()
     provider = <KubernetesProvider>await garden.resolveProvider(garden.log, "local-kubernetes")
-    ctx = await garden.getPluginContext(provider)
+    ctx = (await garden.getPluginContext(provider)) as KubernetesPluginContext
   })
 
   beforeEach(async () => {
@@ -110,7 +109,7 @@ describe("configureHotReload", () => {
     const log = garden.log
     const service = graph.getService("two-containers")
     const module = service.module
-    const manifests = await getChartResources(ctx, module, true, log)
+    const manifests = await getChartResources({ ctx, module, hotReload: true, log, version: service.version })
     const resourceSpec = getServiceResourceSpec(module, undefined)
     const hotReloadSpec = getHotReloadSpec(service)
     const hotReloadTarget = await findServiceResource({

--- a/core/test/integ/src/plugins/kubernetes/kubernetes-module/config.ts
+++ b/core/test/integ/src/plugins/kubernetes/kubernetes-module/config.ts
@@ -225,7 +225,7 @@ describe("validateKubernetesModule", () => {
     const module = await garden.resolveModule("with-source-module")
     const graph = await garden.getConfigGraph(garden.log)
     const imageModule = graph.getModule("api-image")
-    const { versionString } = imageModule.version
+    const imageVersion = imageModule.version.versionString
 
     const serviceResource = {
       kind: "Deployment",
@@ -315,7 +315,7 @@ describe("validateKubernetesModule", () => {
                     spec: {
                       containers: [
                         {
-                          image: `api-image:${versionString}`,
+                          image: `api-image:${imageVersion}`,
                           args: ["python", "app.py"],
                           name: "api",
                           ports: [
@@ -368,7 +368,7 @@ describe("validateKubernetesModule", () => {
                 spec: {
                   containers: [
                     {
-                      image: `api-image:${versionString}`,
+                      image: `api-image:${imageVersion}`,
                       args: ["python", "app.py"],
                       name: "api",
                       ports: [

--- a/core/test/integ/src/plugins/kubernetes/kubernetes-module/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/kubernetes-module/run.ts
@@ -30,7 +30,6 @@ describe("runKubernetesTask", () => {
 
   it("should run a basic task and store its result", async () => {
     const task = graph.getTask("echo-task")
-    const version = task.module.version
 
     const testTask = new TaskTask({
       garden,
@@ -39,13 +38,12 @@ describe("runKubernetesTask", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
-      version,
     })
 
     // Clear any existing task result
     const provider = await garden.resolveProvider(garden.log, "local-kubernetes")
     const ctx = await garden.getPluginContext(provider)
-    await clearTaskResult({ ctx, log: garden.log, module: task.module, task, taskVersion: version })
+    await clearTaskResult({ ctx, log: garden.log, module: task.module, task })
 
     const key = testTask.getKey()
     const { [key]: result } = await garden.processTasks([testTask], { throwOnError: true })
@@ -61,7 +59,6 @@ describe("runKubernetesTask", () => {
     const storedResult = await actions.getTaskResult({
       log: garden.log,
       task,
-      taskVersion: task.module.version,
     })
 
     expect(storedResult).to.exist
@@ -69,7 +66,6 @@ describe("runKubernetesTask", () => {
 
   it("should not store task results if cacheResult=false", async () => {
     const task = graph.getTask("echo-task")
-    const version = task.module.version
     task.config.cacheResult = false
 
     const testTask = new TaskTask({
@@ -79,13 +75,12 @@ describe("runKubernetesTask", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
-      version,
     })
 
     // Clear any existing task result
     const provider = await garden.resolveProvider(garden.log, "local-kubernetes")
     const ctx = await garden.getPluginContext(provider)
-    await clearTaskResult({ ctx, log: garden.log, module: task.module, task, taskVersion: version })
+    await clearTaskResult({ ctx, log: garden.log, module: task.module, task })
 
     await garden.processTasks([testTask], { throwOnError: true })
 
@@ -94,7 +89,6 @@ describe("runKubernetesTask", () => {
     const storedResult = await actions.getTaskResult({
       log: garden.log,
       task,
-      taskVersion: task.module.version,
     })
 
     expect(storedResult).to.not.exist
@@ -110,7 +104,6 @@ describe("runKubernetesTask", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
-      version: task.module.version,
     })
 
     const key = testTask.getKey()
@@ -134,7 +127,6 @@ describe("runKubernetesTask", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
-      version: task.module.version,
     })
 
     await expectError(
@@ -148,7 +140,6 @@ describe("runKubernetesTask", () => {
     const result = await actions.getTaskResult({
       log: garden.log,
       task,
-      taskVersion: task.module.version,
     })
 
     expect(result).to.exist
@@ -165,7 +156,6 @@ describe("runKubernetesTask", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
-        version: task.module.version,
       })
 
       await emptyDir(garden.artifactsPath)
@@ -177,7 +167,7 @@ describe("runKubernetesTask", () => {
     })
 
     it("should fail if an error occurs, but copy the artifacts out of the container", async () => {
-      const task = await graph.getTask("artifacts-task-fail")
+      const task = graph.getTask("artifacts-task-fail")
 
       const testTask = new TaskTask({
         garden,
@@ -186,7 +176,6 @@ describe("runKubernetesTask", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
-        version: task.module.version,
       })
       await emptyDir(garden.artifactsPath)
 
@@ -208,7 +197,6 @@ describe("runKubernetesTask", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
-        version: task.module.version,
       })
 
       await emptyDir(garden.artifactsPath)

--- a/core/test/integ/src/plugins/kubernetes/kubernetes-module/test.ts
+++ b/core/test/integ/src/plugins/kubernetes/kubernetes-module/test.ts
@@ -15,6 +15,7 @@ import { TestTask } from "../../../../../../src/tasks/test"
 import { findByName } from "../../../../../../src/util/util"
 import { emptyDir, pathExists } from "fs-extra"
 import { join } from "path"
+import { testFromModule, testFromConfig } from "../../../../../../src/types/test"
 
 describe("testKubernetesModule", () => {
   let garden: TestGarden
@@ -31,11 +32,10 @@ describe("testKubernetesModule", () => {
   it("should run a basic test", async () => {
     const module = graph.getModule("module-simple")
 
-    const testTask = await TestTask.factory({
+    const testTask = new TestTask({
       garden,
       graph,
-      module,
-      testConfig: findByName(module.testConfigs, "echo-test")!,
+      test: testFromModule(module, "echo-test"),
       log: garden.log,
       force: true,
       forceBuild: false,
@@ -52,11 +52,10 @@ describe("testKubernetesModule", () => {
   it("should run a test in different namespace, if configured", async () => {
     const module = graph.getModule("with-namespace")
 
-    const testTask = await TestTask.factory({
+    const testTask = new TestTask({
       garden,
       graph,
-      module,
-      testConfig: findByName(module.testConfigs, "with-namespace-test")!,
+      test: testFromModule(module, "with-namespace-test"),
       log: garden.log,
       force: true,
       forceBuild: false,
@@ -76,16 +75,15 @@ describe("testKubernetesModule", () => {
     const testConfig = findByName(module.testConfigs, "echo-test")!
     testConfig.spec.command = ["bork"] // this will fail
 
+    const test = testFromConfig(module, testConfig)
+
     const testTask = new TestTask({
       garden,
       graph,
-      module,
-      testConfig,
+      test,
       log: garden.log,
       force: true,
       forceBuild: false,
-      version: module.version,
-      _guard: true,
     })
 
     await expectError(
@@ -99,8 +97,7 @@ describe("testKubernetesModule", () => {
     const result = await actions.getTestResult({
       log: garden.log,
       module,
-      testName: testConfig.name,
-      testVersion: testTask.version,
+      test,
     })
 
     expect(result).to.exist
@@ -110,11 +107,10 @@ describe("testKubernetesModule", () => {
     it("should copy artifacts out of the container", async () => {
       const module = graph.getModule("artifacts")
 
-      const testTask = await TestTask.factory({
+      const testTask = new TestTask({
         garden,
         graph,
-        module,
-        testConfig: findByName(module.testConfigs, "artifacts-test")!,
+        test: testFromModule(module, "artifacts-test"),
         log: garden.log,
         force: true,
         forceBuild: false,
@@ -129,18 +125,15 @@ describe("testKubernetesModule", () => {
     })
 
     it("should fail if an error occurs, but copy the artifacts out of the container", async () => {
-      const module = await graph.getModule("artifacts")
+      const module = graph.getModule("artifacts")
 
       const testTask = new TestTask({
         garden,
         graph,
-        module,
-        testConfig: findByName(module.testConfigs, "artifacts-test-fail")!,
+        test: testFromModule(module, "artifacts-test-fail"),
         log: garden.log,
         force: true,
         forceBuild: false,
-        version: module.version,
-        _guard: true,
       })
 
       await emptyDir(garden.artifactsPath)
@@ -156,11 +149,10 @@ describe("testKubernetesModule", () => {
     it("should handle globs when copying artifacts out of the container", async () => {
       const module = graph.getModule("artifacts")
 
-      const testTask = await TestTask.factory({
+      const testTask = new TestTask({
         garden,
         graph,
-        module,
-        testConfig: findByName(module.testConfigs, "globs-test")!,
+        test: testFromModule(module, "globs-test"),
         log: garden.log,
         force: true,
         forceBuild: false,

--- a/core/test/integ/src/plugins/kubernetes/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/run.ts
@@ -437,7 +437,13 @@ describe("kubernetes Pod runner functions", () => {
       await buildHelmModules(helmGarden, helmGraph)
       helmModule = helmGraph.getModule("artifacts")
 
-      helmManifests = await getChartResources(helmCtx, helmModule, false, helmLog)
+      helmManifests = await getChartResources({
+        ctx: helmCtx,
+        module: helmModule,
+        hotReload: false,
+        log: helmLog,
+        version: helmModule.version.versionString,
+      })
       helmBaseModule = getBaseModule(helmModule)
       helmResourceSpec = getServiceResourceSpec(helmModule, helmBaseModule)
       helmTarget = await findServiceResource({
@@ -605,6 +611,7 @@ describe("kubernetes Pod runner functions", () => {
         namespace,
         runtimeContext: { envVars: {}, dependencies: [] },
         image,
+        version: module.version.versionString,
       })
 
       expect(result.log.trim()).to.equal("ok")
@@ -626,6 +633,7 @@ describe("kubernetes Pod runner functions", () => {
         podName,
         runtimeContext: { envVars: {}, dependencies: [] },
         image,
+        version: module.version.versionString,
       })
 
       await expectError(
@@ -650,6 +658,7 @@ describe("kubernetes Pod runner functions", () => {
         runtimeContext: { envVars: {}, dependencies: [] },
         image,
         timeout: 4,
+        version: module.version.versionString,
       })
 
       // Note: Kubernetes doesn't always return the logs when commands time out.
@@ -675,6 +684,7 @@ describe("kubernetes Pod runner functions", () => {
           artifacts: task.spec.artifacts,
           artifactsPath: tmpDir.path,
           image,
+          version: module.version.versionString,
         })
 
         expect(result.log.trim()).to.equal("ok")
@@ -701,6 +711,7 @@ describe("kubernetes Pod runner functions", () => {
           artifacts: task.spec.artifacts,
           artifactsPath: tmpDir.path,
           image,
+          version: module.version.versionString,
         })
 
         await expectError(
@@ -726,6 +737,7 @@ describe("kubernetes Pod runner functions", () => {
           artifacts: task.spec.artifacts,
           artifactsPath: tmpDir.path,
           image,
+          version: module.version.versionString,
         })
 
         expect(await pathExists(join(tmpDir.path, "subdir", "task.txt"))).to.be.true
@@ -749,6 +761,7 @@ describe("kubernetes Pod runner functions", () => {
           artifacts: task.spec.artifacts,
           artifactsPath: tmpDir.path,
           image,
+          version: module.version.versionString,
         })
       })
 
@@ -769,6 +782,7 @@ describe("kubernetes Pod runner functions", () => {
           artifacts: task.spec.artifacts,
           artifactsPath: tmpDir.path,
           image,
+          version: module.version.versionString,
         })
 
         expect(await pathExists(join(tmpDir.path, "my-task-report"))).to.be.true
@@ -793,6 +807,7 @@ describe("kubernetes Pod runner functions", () => {
           artifactsPath: tmpDir.path,
           image,
           timeout: 3,
+          version: module.version.versionString,
         })
 
         expect(result.log.trim()).to.equal("Command timed out. Here are the logs until the timeout occurred:\n\nbanana")
@@ -817,6 +832,7 @@ describe("kubernetes Pod runner functions", () => {
           artifactsPath: tmpDir.path,
           image,
           timeout: 3,
+          version: module.version.versionString,
         })
 
         expect(result.log.trim()).to.equal("Command timed out.")
@@ -854,6 +870,7 @@ describe("kubernetes Pod runner functions", () => {
               timeout: 20000,
               stdout: process.stdout,
               stderr: process.stderr,
+              version: module.version.versionString,
             }),
           (err) =>
             expect(err.message).to.equal(deline`
@@ -894,6 +911,7 @@ describe("kubernetes Pod runner functions", () => {
               timeout: 20000,
               stdout: process.stdout,
               stderr: process.stderr,
+              version: module.version.versionString,
             }),
           (err) =>
             expect(err.message).to.equal(deline`
@@ -923,6 +941,7 @@ describe("kubernetes Pod runner functions", () => {
               artifactsPath: tmpDir.path,
               description: "Foo",
               image,
+              version: module.version.versionString,
             }),
           (err) =>
             expect(err.message).to.equal(deline`

--- a/core/test/integ/src/plugins/kubernetes/task-results.ts
+++ b/core/test/integ/src/plugins/kubernetes/task-results.ts
@@ -41,8 +41,7 @@ describe("kubernetes task results", () => {
         ctx,
         log: garden.log,
         module: task.module,
-        taskName: task.name,
-        taskVersion: task.module.version,
+        task,
         result: {
           moduleName: task.module.name,
           taskName: task.name,
@@ -51,7 +50,7 @@ describe("kubernetes task results", () => {
           startedAt: new Date(),
           completedAt: new Date(),
           command: [],
-          version: task.module.version.versionString,
+          version: task.version,
           success: true,
         },
       })
@@ -63,7 +62,6 @@ describe("kubernetes task results", () => {
         log: garden.log,
         module: task.module,
         task,
-        taskVersion: task.module.version,
       })
 
       expect(stored).to.exist

--- a/core/test/unit/src/commands/get/get-task-result.ts
+++ b/core/test/unit/src/commands/get/get-task-result.ts
@@ -123,8 +123,8 @@ describe("GetTaskResultCommand", () => {
     const name = "task-a"
 
     const graph = await garden.getConfigGraph(garden.log)
-    const module = graph.getModule("module-a")
-    const artifactKey = getArtifactKey("task", name, module.version.versionString)
+    const task = graph.getTask("task-a")
+    const artifactKey = getArtifactKey("task", name, task.version)
     const metadataPath = join(garden.artifactsPath, `.metadata.${artifactKey}.json`)
     const metadata = {
       key: artifactKey,

--- a/core/test/unit/src/commands/get/get-test-result.ts
+++ b/core/test/unit/src/commands/get/get-test-result.ts
@@ -52,7 +52,7 @@ const testPlugin = createGardenPlugin({
       schema: joi.object(),
       handlers: {
         configure: configureTestModule,
-        getTestResult: async (params: GetTestResultParams) => testResults[params.testName],
+        getTestResult: async (params: GetTestResultParams) => testResults[params.test.name],
       },
     },
   ],
@@ -124,8 +124,8 @@ describe("GetTestResultCommand", () => {
     const name = "unit"
 
     const graph = await garden.getConfigGraph(garden.log)
-    const module = graph.getModule("module-a")
-    const artifactKey = getArtifactKey("test", name, module.version.versionString)
+    const test = graph.getTest("module-a", "unit")
+    const artifactKey = getArtifactKey("test", name, test.version)
     const metadataPath = join(garden.artifactsPath, `.metadata.${artifactKey}.json`)
     const metadata = {
       key: artifactKey,

--- a/core/test/unit/src/commands/run/module.ts
+++ b/core/test/unit/src/commands/run/module.ts
@@ -20,7 +20,7 @@ describe("RunModuleCommand", () => {
   let log
 
   beforeEach(async () => {
-    td.replace(Garden.prototype, "resolveVersion", async () => testModuleVersion)
+    td.replace(Garden.prototype, "resolveModuleVersion", async () => testModuleVersion)
     garden = await makeTestGardenA()
     log = garden.log
   })

--- a/core/test/unit/src/commands/run/service.ts
+++ b/core/test/unit/src/commands/run/service.ts
@@ -22,7 +22,7 @@ describe("RunServiceCommand", () => {
   const cmd = new RunServiceCommand()
 
   beforeEach(async () => {
-    td.replace(Garden.prototype, "resolveVersion", async () => testModuleVersion)
+    td.replace(Garden.prototype, "resolveModuleVersion", async () => testModuleVersion)
     garden = await makeTestGardenA()
     log = garden.log
   })

--- a/core/test/unit/src/commands/run/workflow.ts
+++ b/core/test/unit/src/commands/run/workflow.ts
@@ -218,7 +218,7 @@ describe("RunWorkflowCommand", () => {
                 log: "",
                 startedAt: new Date(),
                 completedAt: new Date(),
-                version: task.module.version.versionString,
+                version: task.version,
               }
 
               return result

--- a/core/test/unit/src/commands/test.ts
+++ b/core/test/unit/src/commands/test.ts
@@ -10,7 +10,6 @@ import { expect } from "chai"
 import { TestCommand } from "../../../../src/commands/test"
 import isSubset = require("is-subset")
 import { makeTestGardenA, taskResultOutputs, withDefaultGlobalOpts } from "../../../helpers"
-import { keyBy } from "lodash"
 
 describe("TestCommand", () => {
   const command = new TestCommand()
@@ -19,7 +18,6 @@ describe("TestCommand", () => {
     const garden = await makeTestGardenA()
     const log = garden.log
     const graph = await garden.getConfigGraph(log)
-    const modules = keyBy(graph.getModules(), "name")
 
     const { result } = await command.action({
       garden,
@@ -83,7 +81,7 @@ describe("TestCommand", () => {
         moduleName: "module-a",
         command: ["echo", "OK"],
         testName: "unit",
-        version: modules["module-a"].version.versionString,
+        version: graph.getTest("module-a", "unit").version,
         success: true,
         startedAt: dummyDate,
         completedAt: dummyDate,
@@ -96,7 +94,7 @@ describe("TestCommand", () => {
         moduleName: "module-a",
         command: ["echo", "OK"],
         testName: "integration",
-        version: modules["module-a"].version.versionString,
+        version: graph.getTest("module-a", "integration").version,
         success: true,
         startedAt: dummyDate,
         completedAt: dummyDate,
@@ -109,7 +107,7 @@ describe("TestCommand", () => {
         moduleName: "module-b",
         command: ["echo", "OK"],
         testName: "unit",
-        version: modules["module-b"].version.versionString,
+        version: graph.getTest("module-b", "unit").version,
         success: true,
         startedAt: dummyDate,
         completedAt: dummyDate,
@@ -122,7 +120,7 @@ describe("TestCommand", () => {
         moduleName: "module-c",
         command: ["echo", "OK"],
         testName: "unit",
-        version: modules["module-c"].version.versionString,
+        version: graph.getTest("module-c", "unit").version,
         success: true,
         startedAt: dummyDate,
         completedAt: dummyDate,
@@ -135,7 +133,7 @@ describe("TestCommand", () => {
         moduleName: "module-c",
         command: ["echo", "OK"],
         testName: "integ",
-        version: modules["module-c"].version.versionString,
+        version: graph.getTest("module-c", "integ").version,
         success: true,
         startedAt: dummyDate,
         completedAt: dummyDate,

--- a/core/test/unit/src/config/template-contexts/module.ts
+++ b/core/test/unit/src/config/template-contexts/module.ts
@@ -13,7 +13,7 @@ import { keyBy } from "lodash"
 import { ConfigContext } from "../../../../../src/config/template-contexts/base"
 import { expectError, makeTestGardenA, TestGarden } from "../../../../helpers"
 import { prepareRuntimeContext } from "../../../../../src/runtime-context"
-import { Service } from "../../../../../src/types/service"
+import { GardenService } from "../../../../../src/types/service"
 import { resolveTemplateString } from "../../../../../src/template-string"
 import { ModuleConfigContext } from "../../../../../src/config/template-contexts/module"
 import { WorkflowConfigContext, WorkflowStepConfigContext } from "../../../../../src/config/template-contexts/workflow"
@@ -81,7 +81,7 @@ describe("ModuleConfigContext", () => {
 
   it("should should resolve the version of a module", async () => {
     const config = await garden.resolveModule("module-a")
-    const { versionString } = await garden.resolveVersion(config, [])
+    const { versionString } = await garden.resolveModuleVersion(config, [])
     expect(c.resolve({ key: ["modules", "module-a", "version"], nodePath: [], opts: {} })).to.eql({
       resolved: versionString,
     })
@@ -111,7 +111,7 @@ describe("ModuleConfigContext", () => {
 
   context("runtimeContext is set", () => {
     let withRuntime: ModuleConfigContext
-    let serviceA: Service
+    let serviceA: GardenService
 
     before(async () => {
       const graph = await garden.getConfigGraph(garden.log)
@@ -129,7 +129,8 @@ describe("ModuleConfigContext", () => {
           run: [taskB],
           test: [],
         },
-        version: serviceA.module.version,
+        version: serviceA.version,
+        moduleVersion: serviceA.module.version.versionString,
         serviceStatuses: {
           "service-b": {
             state: "ready",
@@ -144,7 +145,7 @@ describe("ModuleConfigContext", () => {
             command: [],
             outputs: { moo: "boo" },
             success: true,
-            version: taskB.module.version.versionString,
+            version: taskB.version,
             startedAt: new Date(),
             completedAt: new Date(),
             log: "boo",

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -77,7 +77,7 @@ describe("Garden", () => {
   })
 
   beforeEach(async () => {
-    td.replace(Garden.prototype, "resolveVersion", async () => testModuleVersion)
+    td.replace(Garden.prototype, "resolveModuleVersion", async () => testModuleVersion)
   })
 
   describe("factory", () => {
@@ -4134,7 +4134,7 @@ describe("Garden", () => {
     })
   })
 
-  describe("resolveVersion", () => {
+  describe("resolveModuleVersion", () => {
     beforeEach(() => td.reset())
 
     it("should return result from cache if available", async () => {
@@ -4147,7 +4147,7 @@ describe("Garden", () => {
       }
       garden.cache.set(["moduleVersions", config.name], version, getModuleCacheContext(config))
 
-      const result = await garden.resolveVersion(config, [])
+      const result = await garden.resolveModuleVersion(config, [])
 
       expect(result).to.eql(version)
     })
@@ -4159,7 +4159,7 @@ describe("Garden", () => {
       garden.cache.delete(["moduleVersions", "module-b"])
 
       const config = await garden.resolveModule("module-b")
-      const resolveStub = td.replace(garden.vcs, "resolveVersion")
+      const resolveStub = td.replace(garden.vcs, "resolveModuleVersion")
       const version: ModuleVersion = {
         versionString: "banana",
         dependencyVersions: {},
@@ -4168,7 +4168,7 @@ describe("Garden", () => {
 
       td.when(resolveStub(), { ignoreExtraArgs: true }).thenResolve(version)
 
-      const result = await garden.resolveVersion(config, [])
+      const result = await garden.resolveModuleVersion(config, [])
 
       expect(result).to.eql(version)
     })
@@ -4183,15 +4183,15 @@ describe("Garden", () => {
       }
       garden.cache.set(["moduleVersions", config.name], version, getModuleCacheContext(config))
 
-      const result = await garden.resolveVersion(config, [], true)
+      const result = await garden.resolveModuleVersion(config, [], true)
 
       expect(result).to.not.eql(version)
     })
 
     context("test against fixed version hashes", async () => {
-      const moduleAVersionString = "v-6aec27c89f"
-      const moduleBVersionString = "v-b201651929"
-      const moduleCVersionString = "v-878395c3ad"
+      const moduleAVersionString = "v-c8c9a1ad51"
+      const moduleBVersionString = "v-3ce10c22ec"
+      const moduleCVersionString = "v-684fcdddcb"
 
       it("should return the same module versions between runtimes", async () => {
         const projectRoot = getDataDir("test-projects", "fixed-version-hashes-1")

--- a/core/test/unit/src/plugins/container/helpers.ts
+++ b/core/test/unit/src/plugins/container/helpers.ts
@@ -79,12 +79,12 @@ describe("containerHelpers", () => {
     ctx = await garden.getPluginContext(provider)
 
     td.replace(garden.buildStaging, "syncDependencyProducts", () => null)
-    td.replace(Garden.prototype, "resolveVersion", async () => dummyVersion)
+    td.replace(Garden.prototype, "resolveModuleVersion", async () => dummyVersion)
   })
 
   async function getTestModule(moduleConfig: ContainerModuleConfig) {
     const parsed = await configure({ ctx, moduleConfig, log })
-    return moduleFromConfig(garden, log, parsed.moduleConfig, [])
+    return moduleFromConfig({ garden, log, config: parsed.moduleConfig, buildDependencies: [] })
   }
 
   describe("getLocalImageId", () => {

--- a/core/test/unit/src/plugins/kubernetes/container/ingress.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/ingress.ts
@@ -335,7 +335,7 @@ describe("createIngressResources", () => {
 
     td.replace(garden.buildStaging, "syncDependencyProducts", () => null)
 
-    td.replace(Garden.prototype, "resolveVersion", async () => ({
+    td.replace(Garden.prototype, "resolveModuleVersion", async () => ({
       versionString: "1234",
       dependencyVersions: {},
       files: [],
@@ -413,7 +413,12 @@ describe("createIngressResources", () => {
     const ctx = await garden.getPluginContext(provider)
     ctx.tools["kubernetes.kubectl"] = new PluginTool(kubectlSpec)
     const parsed = await configure({ ctx, moduleConfig, log: garden.log })
-    const module = await moduleFromConfig(garden, garden.log, parsed.moduleConfig, [])
+    const module = await moduleFromConfig({
+      garden,
+      log: garden.log,
+      config: parsed.moduleConfig,
+      buildDependencies: [],
+    })
 
     return {
       name: spec.name,
@@ -428,6 +433,7 @@ describe("createIngressResources", () => {
       module,
       sourceModule: module,
       spec,
+      version: module.version.versionString,
     }
   }
 

--- a/core/test/unit/src/plugins/kubernetes/container/service.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/service.ts
@@ -82,7 +82,7 @@ describe("createServiceResources", () => {
           ],
           selector: {
             [gardenAnnotationKey("service")]: "service-a",
-            [gardenAnnotationKey("version")]: service.module.version.versionString,
+            [gardenAnnotationKey("version")]: service.version,
           },
           type: "ClusterIP",
         },

--- a/core/test/unit/src/plugins/maven-container/maven-container.ts
+++ b/core/test/unit/src/plugins/maven-container/maven-container.ts
@@ -96,16 +96,18 @@ describe("maven-container", () => {
 
     td.replace(garden.buildStaging, "syncDependencyProducts", () => null)
 
-    td.replace(Garden.prototype, "resolveVersion", async () => ({
+    td.replace(Garden.prototype, "resolveModuleVersion", async () => ({
       versionString: "1234",
       dependencyVersions: {},
       files: [],
     }))
+
+    td.replace(helpers, "checkDockerServerVersion", () => null)
   })
 
   async function getTestModule(moduleConfig: MavenContainerModuleConfig) {
     const parsed = await configure({ ctx, moduleConfig, log, base: configureBase })
-    return moduleFromConfig(garden, log, parsed.moduleConfig, [])
+    return moduleFromConfig({ garden, log, config: parsed.moduleConfig, buildDependencies: [] })
   }
 
   describe("configure", () => {

--- a/core/test/unit/src/plugins/terraform/terraform.ts
+++ b/core/test/unit/src/plugins/terraform/terraform.ts
@@ -320,7 +320,6 @@ describe("Terraform module type", () => {
       log: garden.log,
       force: false,
       forceBuild: false,
-      version: task.module.version,
     })
 
     return garden.processTasks([taskTask], { throwOnError: true })
@@ -569,7 +568,6 @@ describe("Terraform module type", () => {
         log: _garden.log,
         force: false,
         forceBuild: false,
-        version: task.module.version,
       })
 
       const result = await _garden.processTasks([taskTask], { throwOnError: true })

--- a/core/test/unit/src/runtime-context.ts
+++ b/core/test/unit/src/runtime-context.ts
@@ -28,7 +28,8 @@ describe("prepareRuntimeContext", () => {
     const runtimeContext = await prepareRuntimeContext({
       garden,
       graph,
-      version: module.version,
+      version: module.version.versionString,
+      moduleVersion: module.version.versionString,
       dependencies: {
         build: [],
         deploy: [],
@@ -40,6 +41,7 @@ describe("prepareRuntimeContext", () => {
     })
 
     expect(runtimeContext.envVars.GARDEN_VERSION).to.equal(module.version.versionString)
+    expect(runtimeContext.envVars.GARDEN_MODULE_VERSION).to.equal(module.version.versionString)
   })
 
   it("should add project variables to the output envVars", async () => {
@@ -50,7 +52,8 @@ describe("prepareRuntimeContext", () => {
     const runtimeContext = await prepareRuntimeContext({
       garden,
       graph,
-      version: module.version,
+      version: module.version.versionString,
+      moduleVersion: module.version.versionString,
       dependencies: {
         build: [],
         deploy: [],
@@ -73,7 +76,8 @@ describe("prepareRuntimeContext", () => {
     const runtimeContext = await prepareRuntimeContext({
       garden,
       graph,
-      version: module.version,
+      version: module.version.versionString,
+      moduleVersion: module.version.versionString,
       dependencies: {
         build: [moduleB],
         deploy: [],
@@ -106,7 +110,8 @@ describe("prepareRuntimeContext", () => {
     const runtimeContext = await prepareRuntimeContext({
       garden,
       graph,
-      version: module.version,
+      version: module.version.versionString,
+      moduleVersion: module.version.versionString,
       dependencies: {
         build: [],
         deploy: [serviceB],
@@ -129,7 +134,7 @@ describe("prepareRuntimeContext", () => {
         name: "service-b",
         outputs,
         type: "service",
-        version: serviceB.module.version.versionString,
+        version: serviceB.version,
       },
     ])
   })
@@ -145,7 +150,8 @@ describe("prepareRuntimeContext", () => {
     const runtimeContext = await prepareRuntimeContext({
       garden,
       graph,
-      version: module.version,
+      version: module.version.versionString,
+      moduleVersion: module.version.versionString,
       dependencies: {
         build: [],
         deploy: [],
@@ -163,7 +169,7 @@ describe("prepareRuntimeContext", () => {
           startedAt: new Date(),
           success: true,
           taskName: "task-b",
-          version: taskB.module.version.versionString,
+          version: taskB.version,
         },
       },
     })
@@ -174,7 +180,7 @@ describe("prepareRuntimeContext", () => {
         name: "task-b",
         outputs,
         type: "task",
-        version: taskB.module.version.versionString,
+        version: taskB.version,
       },
     ])
   })
@@ -187,7 +193,8 @@ describe("prepareRuntimeContext", () => {
     const runtimeContext = await prepareRuntimeContext({
       garden,
       graph,
-      version: module.version,
+      version: module.version.versionString,
+      moduleVersion: module.version.versionString,
       dependencies: {
         build: [],
         deploy: [serviceB],

--- a/core/test/unit/src/task-graph.ts
+++ b/core/test/unit/src/task-graph.ts
@@ -42,11 +42,7 @@ export class TestTask extends BaseTask {
     super({
       garden,
       log: garden.log,
-      version: {
-        versionString: (options && options.versionString) || "12345-6789",
-        dependencyVersions: {},
-        files: [],
-      },
+      version: (options && options.versionString) || "12345-6789",
       force,
     })
 
@@ -125,7 +121,7 @@ describe("task-graph", () => {
             dependencyResults: {},
           },
           dependencyResults: {},
-          version: task.version.versionString,
+          version: task.version,
         },
       }
 
@@ -162,7 +158,7 @@ describe("task-graph", () => {
             key: task.getKey(),
             name: task.name,
             type: task.type,
-            versionString: task.version.versionString,
+            versionString: task.version,
           },
         },
         { name: "taskComplete", payload: toGraphResultEventPayload(result["a"]!) },
@@ -212,7 +208,7 @@ describe("task-graph", () => {
             key: task.getKey(),
             type: "test",
             name: "a",
-            version: task.version.versionString,
+            version: task.version,
             output: { result: "result-a" },
           },
         },
@@ -250,7 +246,7 @@ describe("task-graph", () => {
             key: task.getKey(),
             name: task.name,
             type: task.type,
-            versionString: task.version.versionString,
+            versionString: task.version,
           },
         },
         { name: "taskError", payload: result["a"] },
@@ -448,7 +444,7 @@ describe("task-graph", () => {
           dependencyResults: {},
         },
         dependencyResults: {},
-        version: taskA.version.versionString,
+        version: taskA.version,
       }
       const resultB: GraphResult = {
         type: "test",
@@ -463,7 +459,7 @@ describe("task-graph", () => {
           dependencyResults: { a: resultA },
         },
         dependencyResults: { a: resultA },
-        version: taskB.version.versionString,
+        version: taskB.version,
       }
       const resultC: GraphResult = {
         type: "test",
@@ -478,7 +474,7 @@ describe("task-graph", () => {
           dependencyResults: { b: resultB },
         },
         dependencyResults: { b: resultB },
-        version: taskC.version.versionString,
+        version: taskC.version,
       }
 
       const expected: GraphResults = {
@@ -504,7 +500,7 @@ describe("task-graph", () => {
             b: resultB,
             c: resultC,
           },
-          version: taskD.version.versionString,
+          version: taskD.version,
         },
       }
 
@@ -735,7 +731,7 @@ describe("task-graph", () => {
           dependencyResults: {},
         },
         dependencyResults: {},
-        version: taskA.version.versionString,
+        version: taskA.version,
       }
 
       const filteredKeys: Set<string | number> = new Set([

--- a/core/test/unit/src/tasks/deploy.ts
+++ b/core/test/unit/src/tasks/deploy.ts
@@ -81,7 +81,7 @@ describe("DeployTask", () => {
                 log,
                 startedAt: new Date(),
                 completedAt: new Date(),
-                version: task.module.version.versionString,
+                version: task.version,
               }
             },
           },

--- a/core/test/unit/src/tasks/get-service-status.ts
+++ b/core/test/unit/src/tasks/get-service-status.ts
@@ -76,7 +76,7 @@ describe("GetServiceStatusTask", () => {
                   log,
                   startedAt: new Date(),
                   completedAt: new Date(),
-                  version: task.module.version.versionString,
+                  version: task.version,
                 }
               },
             },

--- a/core/test/unit/src/tasks/task.ts
+++ b/core/test/unit/src/tasks/task.ts
@@ -16,7 +16,7 @@ import { createGardenPlugin } from "../../../../src/types/plugin/plugin"
 import { joi } from "../../../../src/config/common"
 import { RunTaskParams, RunTaskResult } from "../../../../src/types/plugin/task/runTask"
 import { TaskTask } from "../../../../src/tasks/task"
-import { Task } from "../../../../src/types/task"
+import { GardenTask } from "../../../../src/types/task"
 import { GetTaskResultParams } from "../../../../src/types/plugin/task/getTaskResult"
 
 describe("TaskTask", () => {
@@ -52,8 +52,8 @@ describe("TaskTask", () => {
       cache = {}
     })
 
-    const getKey = (task: Task) => {
-      return `${task.name}-${task.module.version.versionString}`
+    const getKey = (task: GardenTask) => {
+      return `${task.name}-${task.version}`
     }
 
     const testPlugin = createGardenPlugin({
@@ -77,7 +77,7 @@ describe("TaskTask", () => {
                 log,
                 startedAt: new Date(),
                 completedAt: new Date(),
-                version: task.module.version.versionString,
+                version: task.version,
               }
 
               cache[getKey(task)] = result
@@ -121,7 +121,7 @@ describe("TaskTask", () => {
       ])
 
       let graph = await garden.getConfigGraph(garden.log)
-      let taskTask = await TaskTask.factory({
+      let taskTask = new TaskTask({
         garden,
         graph,
         task: graph.getTask("test"),
@@ -171,7 +171,7 @@ describe("TaskTask", () => {
       ])
 
       let graph = await garden.getConfigGraph(garden.log)
-      let taskTask = await TaskTask.factory({
+      let taskTask = new TaskTask({
         garden,
         graph,
         task: graph.getTask("test"),

--- a/core/test/unit/src/tasks/test.ts
+++ b/core/test/unit/src/tasks/test.ts
@@ -9,12 +9,10 @@
 import { expect } from "chai"
 import { resolve } from "path"
 import { TestTask, getTestTasks } from "../../../../src/tasks/test"
-import td from "testdouble"
 import { dataDir, makeTestGarden, TestGarden } from "../../../helpers"
 import { LogEntry } from "../../../../src/logger/log-entry"
 import { ConfigGraph } from "../../../../src/config-graph"
-import { ModuleVersion } from "../../../../src/vcs/vcs"
-import { findByName } from "../../../../src/util/util"
+import { testFromConfig } from "../../../../src/types/test"
 
 describe("TestTask", () => {
   let garden: TestGarden
@@ -27,68 +25,16 @@ describe("TestTask", () => {
     log = garden.log
   })
 
-  it("should correctly resolve version for tests with dependencies", async () => {
-    const resolveVersion = td.replace(garden, "resolveVersion")
-
-    const versionA: ModuleVersion = {
-      versionString: "v6fb19922cd",
-      dependencyVersions: {
-        "module-b": {
-          contentHash: "abcdefg1234",
-          files: [],
-        },
-      },
-      files: [],
-    }
-
-    const versionB: ModuleVersion = {
-      versionString: "abcdefg1234",
-      dependencyVersions: {},
-      files: [],
-    }
-
-    const modules = await garden.resolveModules({ log: garden.log })
-
-    const configA = findByName(modules, "module-a")!
-    const configB = findByName(modules, "module-b")!
-
-    td.when(resolveVersion(configA, [])).thenResolve(versionA)
-    td.when(resolveVersion(configB, [])).thenResolve(versionB)
-
-    const moduleB = graph.getModule("module-b")
-
-    td.when(resolveVersion(configA, [moduleB])).thenResolve(versionA)
-
-    const moduleA = graph.getModule("module-a")
-
-    td.when(resolveVersion(moduleA, [moduleB])).thenResolve(versionA)
-
-    const testConfig = moduleA.testConfigs[0]
-
-    const task = await TestTask.factory({
-      garden,
-      graph,
-      log,
-      module: moduleA,
-      testConfig,
-      force: true,
-      forceBuild: false,
-    })
-
-    expect(task.version).to.eql(versionA)
-  })
-
   describe("getDependencies", () => {
     it("should include task dependencies", async () => {
       const moduleA = graph.getModule("module-a")
       const testConfig = moduleA.testConfigs[0]
 
-      const task = await TestTask.factory({
+      const task = new TestTask({
         garden,
         log,
         graph,
-        module: moduleA,
-        testConfig,
+        test: testFromConfig(moduleA, testConfig),
         force: true,
         forceBuild: false,
       })

--- a/docs/basics/stack-graph.md
+++ b/docs/basics/stack-graph.md
@@ -39,6 +39,22 @@ Importantly, what happens within each of the actions that the graph describes—
 All the Garden plugins are currently built-in; we will soon release a plugin SDK to allow any user to easily make their
 own plugins.
 
+## Versions
+
+Garden generates a _Garden version_ for each module, service, task and test, based on a hash of the source files and configuration involved, as well as any build and runtime dependencies. When using Garden, you'll see various instances of `v-<some hash>` strings scattered around logs, e.g. when building, deploying, running tests etc.
+
+These versions are used by Garden and the Stack Graph to work out which actions need to be performed whenever you want to build, deploy, run a workflow, test your project etc. Specifically, Garden uses these generated versions to see which builds need to be performed, whether a deployed service is up-to-date, whether a test has already been run, and so on.
+
+Each version also factors in the versions of every dependency (both build and runtime dependencies, as is applicable for each case). This means that anytime a version of something that is _depended upon_ changes, every dependant's version also changes.
+
+The _precise_ semantics that go into a Garden version vary a bit by the module type and the specific entity involved, but generally it works as follows:
+
+1. A _module_ has a version that captures everything involved in a build, including hashes of source files any any specifics involved in building the image/artifact/etc, as well as the versions of any build dependencies. The _module version_ is sometimes referred to as the _build version_ of the module.
+2. A _service_ has a version that factors in the _module version_ of the module that defines it, as well as any specific configuration needed to deploy the service. This might for example include environment variables, hostnames etc. that wouldn't impact how the underlying code is _built_, but it does change how the service is deployed.
+3. _Tests_ and _tasks_ have a version that factors in the _module version_ of the module that defines it, as well as any specific configuration needed to run the task or test.
+
+A simple example would be a [Container Module](../guides/container-modules.md) with a `Dockerfile` next to it, as well as any number of services, tests and tasks. The _module version_ will reflect the source code and build arguments involved, and will be visible in the image tag. The services, tasks and tests will each have separate versions because those also factor in the service configuration, test commands, environment variables and so forth.
+
 ## Next Steps
 
 Head over to the [Getting Started](../getting-started/README.md) section to learn the basics on how to get up and running with Garden.

--- a/docs/misc/faq.md
+++ b/docs/misc/faq.md
@@ -51,6 +51,12 @@ Alternatively you can hoist your `garden.yml` file so that it is at the same lev
 
 See this [GitHub issue](https://github.com/garden-io/garden/issues/1954) for more discussion on the two approaches.
 
+### What do all those `v-<something>` versions mean, and why are they sometimes different between building and deploying?
+
+These are the _Garden versions_ that are computed for each node in the Stack Graph at runtime, based on source files and configuration for each module, service, task and test. See [here](../basics/stack-graph.md#versions) for more information about how these work and how they're used.
+
+You may notice that a _build version_ (e.g. an image tag for a `container` module) is generally different from the version of a _service_ defined in the same module. This is because the _service version_ also factors in the runtime configuration for that service, which often differs between environments, but we don't want those changes to require a rebuild of the container image.
+
 ## Builds
 
 ### How do I target a specific image from a multi-stage Dockerfile?

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1050,6 +1050,16 @@ providers:
         # The filesystem path of the module config file.
         configPath:
 
+        # The resolved build configuration of the module. If this is returned by the configure handler for the module
+        # type, we can provide more granular versioning for the module, with a separate build version (i.e. module
+        # version), as well as separate service, task and test versions, instead of applying the same version to all
+        # of them.
+        #
+        # When this is specified, it is **very important** that this field contains all configurable (or otherwise
+        # dynamic) parameters that will affect the built artifacts/images, aside from source files that is (the hash
+        # of those is separately computed).
+        buildConfig:
+
         # List of services configured by this module.
         serviceConfigs:
           - # Valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and dashes, must start with a
@@ -1296,6 +1306,16 @@ moduleConfigs:
 
     # The filesystem path of the module config file.
     configPath:
+
+    # The resolved build configuration of the module. If this is returned by the configure handler for the module
+    # type, we can provide more granular versioning for the module, with a separate build version (i.e. module
+    # version), as well as separate service, task and test versions, instead of applying the same version to all of
+    # them.
+    #
+    # When this is specified, it is **very important** that this field contains all configurable (or otherwise
+    # dynamic) parameters that will affect the built artifacts/images, aside from source files that is (the hash of
+    # those is separately computed).
+    buildConfig:
 
     # List of services configured by this module.
     serviceConfigs:
@@ -1765,6 +1785,16 @@ modules:
     # The filesystem path of the module.
     path:
 
+    # The resolved build configuration of the module. If this is returned by the configure handler for the module
+    # type, we can provide more granular versioning for the module, with a separate build version (i.e. module
+    # version), as well as separate service, task and test versions, instead of applying the same version to all of
+    # them.
+    #
+    # When this is specified, it is **very important** that this field contains all configurable (or otherwise
+    # dynamic) parameters that will affect the built artifacts/images, aside from source files that is (the hash of
+    # those is separately computed).
+    buildConfig:
+
     # List of services configured by this module.
     serviceConfigs:
       - # Valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and dashes, must start with a
@@ -1897,13 +1927,13 @@ modules:
     configPath:
 
     version:
-      # String representation of the module version.
+      # A Stack Graph node (i.e. module, service, task or test) version.
       versionString:
 
       # The version of each of the dependencies of the module.
       dependencyVersions:
         <name>:
-          # The hash of all files in the directory, after filtering.
+          # The hash of all files belonging to the Garden module.
           contentHash:
 
           # List of file paths included in the version.

--- a/docs/reference/module-types/persistentvolumeclaim.md
+++ b/docs/reference/module-types/persistentvolumeclaim.md
@@ -154,12 +154,12 @@ spec:
   # ResourceRequirements describes the compute resource requirements.
   resources:
     # Limits describes the maximum amount of compute resources allowed. More info:
-    # https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+    # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
     limits:
 
     # Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it
     # defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info:
-    # https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+    # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
     requests:
 
   # A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are
@@ -510,7 +510,7 @@ ResourceRequirements describes the compute resource requirements.
 
 [spec](#spec) > [resources](#specresources) > limits
 
-Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 | Type     | Required |
 | -------- | -------- |
@@ -520,7 +520,7 @@ Limits describes the maximum amount of compute resources allowed. More info: htt
 
 [spec](#spec) > [resources](#specresources) > requests
 
-Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 | Type     | Required |
 | -------- | -------- |

--- a/plugins/conftest-kubernetes/test/conftest-kubernetes.ts
+++ b/plugins/conftest-kubernetes/test/conftest-kubernetes.ts
@@ -16,6 +16,7 @@ import { dedent } from "@garden-io/sdk/util/string"
 import { makeTestGarden } from "@garden-io/sdk/testing"
 
 import { TestTask } from "@garden-io/core/build/src/tasks/test"
+import { testFromConfig } from "@garden-io/core/build/src/types/test"
 
 describe("conftest-kubernetes provider", () => {
   const projectRoot = join(__dirname, "test-project")
@@ -72,14 +73,11 @@ describe("conftest-kubernetes provider", () => {
 
       const testTask = new TestTask({
         garden,
-        module,
         log: garden.log,
         graph,
-        testConfig: module.testConfigs[0],
+        test: testFromConfig(module, module.testConfigs[0]),
         force: true,
         forceBuild: true,
-        version: module.version,
-        _guard: true,
       })
 
       const key = testTask.getKey()

--- a/plugins/conftest/index.ts
+++ b/plugins/conftest/index.ts
@@ -143,7 +143,7 @@ export const gardenPlugin = () => createGardenPlugin({
           moduleConfig.testConfigs = [{ name: "test", dependencies: [], spec: {}, disabled: false, timeout: 10 }]
           return { moduleConfig }
         },
-        testModule: async ({ ctx, log, module, testConfig }: TestModuleParams<ConftestModule>) => {
+        testModule: async ({ ctx, log, module, test }: TestModuleParams<ConftestModule>) => {
           const startedAt = new Date()
           const provider = ctx.provider as ConftestProvider
 
@@ -157,10 +157,10 @@ export const gardenPlugin = () => createGardenPlugin({
 
           if (files.length === 0) {
             return {
-              testName: testConfig.name,
+              testName: test.name,
               moduleName: module.name,
               command: [],
-              version: module.version.versionString,
+              version: test.version,
               success: true,
               startedAt,
               completedAt: new Date(),
@@ -176,10 +176,10 @@ export const gardenPlugin = () => createGardenPlugin({
           const { success, formattedResult } = parseConftestResult(provider, log, result)
 
           return {
-            testName: testConfig.name,
+            testName: test.name,
             moduleName: module.name,
             command: ["conftest", ...args],
-            version: module.version.versionString,
+            version: test.version,
             success,
             startedAt,
             completedAt: new Date(),
@@ -222,7 +222,7 @@ export const gardenPlugin = () => createGardenPlugin({
           ]
           return { moduleConfig }
         },
-        testModule: async ({ ctx, log, module, testConfig }: TestModuleParams<ConftestModule>) => {
+        testModule: async ({ ctx, log, module, test }: TestModuleParams<ConftestModule>) => {
           const startedAt = new Date()
           const provider = ctx.provider as ConftestProvider
 
@@ -239,7 +239,13 @@ export const gardenPlugin = () => createGardenPlugin({
             })
           }
 
-          const templates = await renderTemplates(k8sCtx, sourceModule, false, log)
+          const templates = await renderTemplates({
+            ctx: k8sCtx,
+            module: sourceModule,
+            hotReload: false,
+            log,
+            version: sourceModule.version.versionString,
+          })
 
           // Run conftest, piping the rendered chart to stdin
           const args = prepareArgs(ctx, provider, module)
@@ -257,10 +263,10 @@ export const gardenPlugin = () => createGardenPlugin({
           const { success, formattedResult } = parseConftestResult(provider, log, result)
 
           return {
-            testName: testConfig.name,
+            testName: test.name,
             moduleName: module.name,
             command: ["conftest", ...args],
-            version: module.version.versionString,
+            version: test.version,
             success,
             startedAt,
             completedAt: new Date(),

--- a/plugins/conftest/test/conftest.ts
+++ b/plugins/conftest/test/conftest.ts
@@ -17,6 +17,7 @@ import { ProjectConfig } from "@garden-io/sdk/types"
 import { makeTestGarden } from "@garden-io/sdk/testing"
 
 import { TestTask } from "@garden-io/core/build/src/tasks/test"
+import { testFromConfig } from "@garden-io/core/build/src/types/test"
 
 describe("conftest provider", () => {
   const projectRoot = join(__dirname, "test-project")
@@ -45,14 +46,11 @@ describe("conftest provider", () => {
 
       const testTask = new TestTask({
         garden,
-        module,
         log: garden.log,
         graph,
-        testConfig: module.testConfigs[0],
+        test: testFromConfig(module, module.testConfigs[0]),
         force: true,
         forceBuild: false,
-        version: module.version,
-        _guard: true,
       })
 
       const key = testTask.getKey()
@@ -82,14 +80,11 @@ describe("conftest provider", () => {
 
       const testTask = new TestTask({
         garden,
-        module,
         log: garden.log,
         graph,
-        testConfig: module.testConfigs[0],
+        test: testFromConfig(module, module.testConfigs[0]),
         force: true,
         forceBuild: false,
-        version: module.version,
-        _guard: true,
       })
 
       const key = testTask.getKey()
@@ -110,14 +105,11 @@ describe("conftest provider", () => {
 
       const testTask = new TestTask({
         garden,
-        module,
         log: garden.log,
         graph,
-        testConfig: module.testConfigs[0],
+        test: testFromConfig(module, module.testConfigs[0]),
         force: true,
         forceBuild: false,
-        version: module.version,
-        _guard: true,
       })
 
       const key = testTask.getKey()
@@ -141,14 +133,11 @@ describe("conftest provider", () => {
 
       const testTask = new TestTask({
         garden,
-        module,
         log: garden.log,
         graph,
-        testConfig: module.testConfigs[0],
+        test: testFromConfig(module, module.testConfigs[0]),
         force: true,
         forceBuild: false,
-        version: module.version,
-        _guard: true,
       })
 
       const key = testTask.getKey()

--- a/static/kubernetes/persistentvolumeclaim.json
+++ b/static/kubernetes/persistentvolumeclaim.json
@@ -325,7 +325,7 @@
                   }
                 ]
               },
-              "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+              "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
               "type": [
                 "object",
                 "null"
@@ -348,7 +348,7 @@
                   }
                 ]
               },
-              "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+              "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
               "type": [
                 "object",
                 "null"


### PR DESCRIPTION
This change addresses a long-standing issue where changes to runtime
configuration (e.g. services, test and tasks) would also impact build
versions of container images.

We now tackle versioning more specifically for each entity within any
given module. Module types can control which parts of a configuration
should affect the build version, which is applied in different ways by
different module type handlers.

This change does mean that service, task and test versions are _always_
different from module (i.e. build) versions. This is because the
versions are now computed with the service/test/task configuration
hashed on top of the module configuration, even if there is no natural
distinction between the build version and a runtime version for that
particular module.

This generally has no practical downsides except that users might be
expecting versions to match, which they would previously _sometimes_ do,
e.g. a container service would have the same version as its module—which
is in fact the problem we're solving here.

I've added a documentation section and an FAQ entry, but we should also
mention this in release notes and in the community when announcing the
change.

**Special notes for your reviewer**:

This could use some manual testing, even though I did my best to write functional tests to validate the behavior. This touches on a lot of critical paths, so we should be careful when reviewing and evaluating this.
