### PR TITLE
chore: fix symlink that would break VSCode file watching

### DIFF
--- a/core/test/data/test-projects/build-dir/symlink-absolute/symlink.txt
+++ b/core/test/data/test-projects/build-dir/symlink-absolute/symlink.txt
@@ -1,1 +1,1 @@
-/tmp
+/tmp/foo/bla/ble


### PR DESCRIPTION
Symlinking to /tmp was a Bad Idea™. Took me a while to figure out why
things suddenly were going haywire.