### PR TITLE
chore: re-enable analytics in container images

### DIFF
--- a/support/alpine.Dockerfile
+++ b/support/alpine.Dockerfile
@@ -19,12 +19,10 @@ ADD . /garden
 
 WORKDIR /project
 
-ENV GARDEN_DISABLE_ANALYTICS=true
-ENV GARDEN_DISABLE_VERSION_CHECK=true
-
 RUN chmod +x /garden/garden \
   && ln -s /garden/garden /bin/garden \
   && chmod +x /bin/garden \
-  && cd /garden/static && garden util fetch-tools --all --garden-image-build --logger-type=basic
+  && cd /garden/static \
+  && GARDEN_DISABLE_ANALYTICS=true GARDEN_DISABLE_VERSION_CHECK=true garden util fetch-tools --all --garden-image-build --logger-type=basic
 
 ENTRYPOINT ["/garden/garden"]

--- a/support/buster.Dockerfile
+++ b/support/buster.Dockerfile
@@ -26,13 +26,10 @@ ADD . /garden
 
 WORKDIR /project
 
-ENV GARDEN_DISABLE_ANALYTICS=true
-ENV GARDEN_DISABLE_VERSION_CHECK=true
-
 RUN ln -s /garden/garden /bin/garden \
   && chmod +x /bin/garden \
   && cd /garden/static \
   && git init \
-  && garden util fetch-tools --all --garden-image-build --logger-type=basic
+  && GARDEN_DISABLE_ANALYTICS=true GARDEN_DISABLE_VERSION_CHECK=true garden util fetch-tools --all --garden-image-build --logger-type=basic
 
 ENTRYPOINT ["/garden/garden"]


### PR DESCRIPTION
The flag was only intended for the build flow, not the actual runtime
environment for Garden in the container.

