### PR TITLE
improvement(cli): allow `garden delete services` with no arguments

### DIFF
--- a/core/src/commands/delete.ts
+++ b/core/src/commands/delete.ts
@@ -126,7 +126,6 @@ export class DeleteEnvironmentCommand extends Command {
 export const deleteServiceArgs = {
   services: new StringsParameter({
     help: "The name(s) of the service(s) to delete. Use comma as a separator to specify multiple services.",
-    required: true,
   }),
 }
 type DeleteServiceArgs = typeof deleteServiceArgs
@@ -142,13 +141,14 @@ export class DeleteServiceCommand extends Command {
   streamEvents = true
 
   description = dedent`
-    Deletes (i.e. un-deploys) the specified services. Note that this command does not take into account any
-    services depending on the deleted service, and might therefore leave the project in an unstable state.
-    Running \`garden deploy\` will re-deploy any missing services.
+    Deletes (i.e. un-deploys) the specified services. Deletes all services in the project if no arguments are provided.
+    Note that this command does not take into account any services depending on the deleted service/services, and might
+    therefore leave the project in an unstable state. Running \`garden deploy\` will re-deploy any missing services.
 
     Examples:
 
         garden delete service my-service # deletes my-service
+        garden delete service            # deletes all deployed services in the project
   `
 
   outputsSchema = () =>

--- a/core/test/unit/src/cli/helpers.ts
+++ b/core/test/unit/src/cli/helpers.ts
@@ -277,10 +277,10 @@ describe("processCliArgs", () => {
   // })
 
   it("throws an error when a required positional argument is missing", () => {
-    const cmd = new DeleteServiceCommand()
+    const cmd = new RunTaskCommand()
     expectError(
       () => parseAndProcess([], cmd),
-      (err) => expect(stripAnsi(err.message)).to.equal("Missing required argument services")
+      (err) => expect(stripAnsi(err.message)).to.equal("Missing required argument task")
     )
   })
 

--- a/core/test/unit/src/commands/delete.ts
+++ b/core/test/unit/src/commands/delete.ts
@@ -162,6 +162,16 @@ describe("DeleteServiceCommand", () => {
       ingresses: [],
       detail: {},
     },
+    "service-c": {
+      state: "unknown",
+      ingresses: [],
+      detail: {},
+    },
+    "service-d": {
+      state: "unknown",
+      ingresses: [],
+      detail: {},
+    },
   }
 
   const testProvider = createGardenPlugin({
@@ -222,6 +232,26 @@ describe("DeleteServiceCommand", () => {
     expect(result).to.eql({
       "service-a": { forwardablePorts: [], state: "unknown", ingresses: [], detail: {}, outputs: {} },
       "service-b": { forwardablePorts: [], state: "unknown", ingresses: [], detail: {}, outputs: {} },
+    })
+  })
+
+  it("should delete all services if none are specified", async () => {
+    const garden = await TestGarden.factory(projectRootB, { plugins })
+    const log = garden.log
+
+    const { result } = await command.action({
+      garden,
+      log,
+      headerLog: log,
+      footerLog: log,
+      args: { services: undefined },
+      opts: withDefaultGlobalOpts({}),
+    })
+    expect(result).to.eql({
+      "service-a": { forwardablePorts: [], state: "unknown", ingresses: [], detail: {}, outputs: {} },
+      "service-b": { forwardablePorts: [], state: "unknown", ingresses: [], detail: {}, outputs: {} },
+      "service-c": { forwardablePorts: [], state: "unknown", ingresses: [], detail: {}, outputs: {} },
+      "service-d": { forwardablePorts: [], state: "unknown", ingresses: [], detail: {}, outputs: {} },
     })
   })
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -503,13 +503,14 @@ serviceStatuses:
 
 **Deletes running services.**
 
-Deletes (i.e. un-deploys) the specified services. Note that this command does not take into account any
-services depending on the deleted service, and might therefore leave the project in an unstable state.
-Running `garden deploy` will re-deploy any missing services.
+Deletes (i.e. un-deploys) the specified services. Deletes all services in the project if no arguments are provided.
+Note that this command does not take into account any services depending on the deleted service/services, and might
+therefore leave the project in an unstable state. Running `garden deploy` will re-deploy any missing services.
 
 Examples:
 
     garden delete service my-service # deletes my-service
+    garden delete service            # deletes all deployed services in the project
 
 | Supported in workflows |   |
 | ---------------------- |---|
@@ -517,13 +518,13 @@ Examples:
 
 #### Usage
 
-    garden delete service <services> 
+    garden delete service [services] 
 
 #### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
-  | `services` | Yes | The name(s) of the service(s) to delete. Use comma as a separator to specify multiple services.
+  | `services` | No | The name(s) of the service(s) to delete. Use comma as a separator to specify multiple services.
 
 
 #### Outputs


### PR DESCRIPTION
Basically this makes it easy to delete all services in a namespace.
Sort of a silly omission to begin with.
