### PR TITLE
feat(k8s): apply container service annotations to Pod templates as well

### DIFF
--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -347,7 +347,11 @@ export function getContainerVolumesSchema(targetType: string) {
 const containerServiceSchema = () =>
   baseServiceSpecSchema().keys({
     annotations: annotationsSchema().description(
-      "Annotations to attach to the service (Note: May not be applicable to all providers)."
+      dedent`
+      Annotations to attach to the service _(note: May not be applicable to all providers)_.
+
+      When using the Kubernetes provider, these annotations are applied to both Service and Pod resources. You can generally specify the annotations intended for both Pods or Services here, and the ones that don't apply on either side will be ignored (i.e. if you put a Service annotation here, it'll also appear on Pod specs but will be safely ignored there, and vice versa).
+      `
     ),
     command: joi
       .array()

--- a/core/src/plugins/kubernetes/container/deployment.ts
+++ b/core/src/plugins/kubernetes/container/deployment.ts
@@ -550,6 +550,9 @@ function workloadConfig({
       selector,
       template: {
         metadata: {
+          // Note: We only have the one set of annotations for both Service and Pod resources. One intended for the
+          // other will just be ignored since they don't overlap in any cases I could find with commonly used tools.
+          annotations: service.spec.annotations,
           labels,
         },
         spec: {

--- a/core/test/integ/src/plugins/kubernetes/container/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/deployment.ts
@@ -80,6 +80,7 @@ describe("kubernetes container deployment handlers", () => {
           selector: { matchLabels: { service: "simple-service" } },
           template: {
             metadata: {
+              annotations: {},
               labels: { module: "simple-service", service: "simple-service" },
             },
             spec: {
@@ -113,6 +114,27 @@ describe("kubernetes container deployment handlers", () => {
           revisionHistoryLimit: 3,
         },
       })
+    })
+
+    it("should attach service annotations to Pod template", async () => {
+      const service = graph.getService("simple-service")
+      const namespace = provider.config.namespace!.name!
+
+      service.spec.annotations = { "annotation.key": "someValue" }
+
+      const resource = await createWorkloadManifest({
+        api,
+        provider,
+        service,
+        runtimeContext: emptyRuntimeContext,
+        namespace,
+        enableHotReload: false,
+        log: garden.log,
+        production: false,
+        blueGreen: false,
+      })
+
+      expect(resource.spec.template?.metadata?.annotations).to.eql(service.spec.annotations)
     })
 
     it("should name the Deployment with a version suffix and set a version label if blueGreen=true", async () => {

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -198,7 +198,12 @@ services:
     # them, using conditional expressions.
     disabled: false
 
-    # Annotations to attach to the service (Note: May not be applicable to all providers).
+    # Annotations to attach to the service _(note: May not be applicable to all providers)_.
+    #
+    # When using the Kubernetes provider, these annotations are applied to both Service and Pod resources. You can
+    # generally specify the annotations intended for both Pods or Services here, and the ones that don't apply on
+    # either side will be ignored (i.e. if you put a Service annotation here, it'll also appear on Pod specs but will
+    # be safely ignored there, and vice versa).
     annotations: {}
 
     # The command/entrypoint to run the container with when starting the service.
@@ -922,7 +927,9 @@ Note however that template strings referencing the service's outputs (i.e. runti
 
 [services](#services) > annotations
 
-Annotations to attach to the service (Note: May not be applicable to all providers).
+Annotations to attach to the service _(note: May not be applicable to all providers)_.
+
+When using the Kubernetes provider, these annotations are applied to both Service and Pod resources. You can generally specify the annotations intended for both Pods or Services here, and the ones that don't apply on either side will be ignored (i.e. if you put a Service annotation here, it'll also appear on Pod specs but will be safely ignored there, and vice versa).
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -196,7 +196,12 @@ services:
     # them, using conditional expressions.
     disabled: false
 
-    # Annotations to attach to the service (Note: May not be applicable to all providers).
+    # Annotations to attach to the service _(note: May not be applicable to all providers)_.
+    #
+    # When using the Kubernetes provider, these annotations are applied to both Service and Pod resources. You can
+    # generally specify the annotations intended for both Pods or Services here, and the ones that don't apply on
+    # either side will be ignored (i.e. if you put a Service annotation here, it'll also appear on Pod specs but will
+    # be safely ignored there, and vice versa).
     annotations: {}
 
     # The command/entrypoint to run the container with when starting the service.
@@ -930,7 +935,9 @@ Note however that template strings referencing the service's outputs (i.e. runti
 
 [services](#services) > annotations
 
-Annotations to attach to the service (Note: May not be applicable to all providers).
+Annotations to attach to the service _(note: May not be applicable to all providers)_.
+
+When using the Kubernetes provider, these annotations are applied to both Service and Pod resources. You can generally specify the annotations intended for both Pods or Services here, and the ones that don't apply on either side will be ignored (i.e. if you put a Service annotation here, it'll also appear on Pod specs but will be safely ignored there, and vice versa).
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |


### PR DESCRIPTION
When using the Kubernetes provider, the annotations set on
`services[].annotations` in container modules are now applied to both
Service and Pod resources. You can generally specify the annotations
intended for both Pods or Services here, and the ones that don't apply
on either side will be ignored (i.e. if you put a Service annotation
here, it'll also appear on Pod specs but will be safely ignored there,
and vice versa).