### PR TITLE
ci(core): fix unnecessary version bump when releasing npm package

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -8,8 +8,10 @@ jobs:
   publish-npm-package:
     runs-on: macOS-latest
     steps:
-      - name: Add SHORT_SHA env property with commit short sha
-        run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+      - name: Set Environment Variables
+        run: |
+          echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+          echo "CURRENT_CORE_VERSION=`node -e "console.log(require('./package.json').version);"`" >> $GITHUB_ENV
       - uses: actions/checkout@v1
       - name: Use Node.js 12.x
         uses: actions/setup-node@v1
@@ -19,12 +21,14 @@ jobs:
         run: |
           npm install
           npm build
-      - name: Change version if pre-release
+      - name: Publish edge version if pre-release
         if: github.event.release.prerelease == true
         working-directory: ./core
         run: |
-          npm version prerelease -preid=${SHORT_SHA}
-      - name: Release npm package
+          npm version $CURRENT_CORE_VERSION-edge.$SHORT_SHA
+          npm publish --tag edge
+      - name: Publish stable version if normal release
+        if: github.event.release.prerelease != true
         working-directory: ./core
         run: |
           echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > .npmrc


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

This PR fixes the double version bump which was happening in the previous version of the script.
Furthemore we now tag the pre-releases with the `edge` tag and so we can better manage dependencies on the consumer side. 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
