### PR TITLE
ci(core): missing authentication when publishing npm core package

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -11,7 +11,6 @@ jobs:
       - name: Set Environment Variables
         run: |
           echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
-          echo "CURRENT_CORE_VERSION=`node -e "console.log(require('./package.json').version);"`" >> $GITHUB_ENV
       - uses: actions/checkout@v1
       - name: Use Node.js 12.x
         uses: actions/setup-node@v1
@@ -21,15 +20,21 @@ jobs:
         run: |
           npm install
           npm build
+      - name: Setup npm registry authentication
+        working-directory: ./core
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > .npmrc
       - name: Publish edge version if pre-release
         if: github.event.release.prerelease == true
         working-directory: ./core
+        # We fetch the current version from the package.json because at this point the version has
+        # already been bumped during the pre-release process.
         run: |
+          CURRENT_CORE_VERSION=`node -e "console.log(require('./package.json').version);"`
           npm version $CURRENT_CORE_VERSION-edge.$SHORT_SHA
           npm publish --tag edge
       - name: Publish stable version if normal release
         if: github.event.release.prerelease != true
         working-directory: ./core
         run: |
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > .npmrc
           npm publish


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:
In the previous refactor I messed up the authentication line therefore the script was trying to publish without a valid access token in the `.npmrc` file. Furthermore I also realized we were trying to fetch the current version from the `package.json` before the checkout step. 🤭 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
