### PR TITLE
feat(config): add `this` context when resolving modules

### DIFF
--- a/core/src/actions.ts
+++ b/core/src/actions.ts
@@ -861,11 +861,10 @@ export class ActionRouter implements TypeGuard {
       const configContext = new ModuleConfigContext({
         garden: this.garden,
         resolvedProviders: providers,
-        dependencies: modules,
+        modules,
         runtimeContext,
-        parentName: module.parentName,
-        templateName: module.templateName,
-        inputs: module.inputs,
+        moduleConfig: module,
+        buildPath: module.buildPath,
         partialRuntimeResolution: false,
       })
 
@@ -924,11 +923,10 @@ export class ActionRouter implements TypeGuard {
       const configContext = new ModuleConfigContext({
         garden: this.garden,
         resolvedProviders: providers,
-        dependencies: modules,
+        modules,
         runtimeContext,
-        parentName: module.parentName,
-        templateName: module.templateName,
-        inputs: module.inputs,
+        moduleConfig: module,
+        buildPath: module.buildPath,
         partialRuntimeResolution: false,
       })
 

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -610,6 +610,7 @@ export class Garden {
       resolvedProviders: providers,
       modules,
       runtimeContext,
+      partialRuntimeResolution: false,
     })
   }
 

--- a/core/src/outputs.ts
+++ b/core/src/outputs.ts
@@ -67,6 +67,7 @@ export async function resolveProjectOutputs(garden: Garden, log: LogEntry): Prom
         resolvedProviders: {},
         modules: [],
         runtimeContext: emptyRuntimeContext,
+        partialRuntimeResolution: false,
       })
     )
   }

--- a/core/src/tasks/publish.ts
+++ b/core/src/tasks/publish.ts
@@ -88,14 +88,12 @@ export class PublishTask extends BaseTask {
 
       const templateContext = new ModuleTagContext({
         garden: this.garden,
-        module,
+        moduleConfig: module,
         resolvedProviders,
-        moduleName: module.name,
-        dependencies,
+        module,
+        buildPath: module.buildPath,
+        modules: dependencies,
         runtimeContext: emptyRuntimeContext,
-        parentName: module.parentName,
-        templateName: module.templateName,
-        inputs: module.inputs,
         partialRuntimeResolution: true,
       })
 

--- a/docs/reference/module-types/conftest.md
+++ b/docs/reference/module-types/conftest.md
@@ -446,6 +446,14 @@ Example:
 my-variable: ${modules.my-module.buildPath}
 ```
 
+### `${modules.<module-name>.name}`
+
+The name of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
 ### `${modules.<module-name>.path}`
 
 The local path of the module.

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -1927,6 +1927,14 @@ Example:
 my-variable: ${modules.my-module.buildPath}
 ```
 
+### `${modules.<module-name>.name}`
+
+The name of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
 ### `${modules.<module-name>.path}`
 
 The local path of the module.

--- a/docs/reference/module-types/exec.md
+++ b/docs/reference/module-types/exec.md
@@ -753,6 +753,14 @@ Example:
 my-variable: ${modules.my-module.buildPath}
 ```
 
+### `${modules.<module-name>.name}`
+
+The name of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
 ### `${modules.<module-name>.path}`
 
 The local path of the module.

--- a/docs/reference/module-types/hadolint.md
+++ b/docs/reference/module-types/hadolint.md
@@ -399,6 +399,14 @@ Example:
 my-variable: ${modules.my-module.buildPath}
 ```
 
+### `${modules.<module-name>.name}`
+
+The name of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
 ### `${modules.<module-name>.path}`
 
 The local path of the module.

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -1485,6 +1485,14 @@ Example:
 my-variable: ${modules.my-module.buildPath}
 ```
 
+### `${modules.<module-name>.name}`
+
+The name of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
 ### `${modules.<module-name>.path}`
 
 The local path of the module.

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -1249,6 +1249,14 @@ Example:
 my-variable: ${modules.my-module.buildPath}
 ```
 
+### `${modules.<module-name>.name}`
+
+The name of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
 ### `${modules.<module-name>.path}`
 
 The local path of the module.

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -1988,6 +1988,14 @@ Example:
 my-variable: ${modules.my-module.buildPath}
 ```
 
+### `${modules.<module-name>.name}`
+
+The name of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
 ### `${modules.<module-name>.path}`
 
 The local path of the module.

--- a/docs/reference/module-types/openfaas.md
+++ b/docs/reference/module-types/openfaas.md
@@ -533,6 +533,14 @@ Example:
 my-variable: ${modules.my-module.buildPath}
 ```
 
+### `${modules.<module-name>.name}`
+
+The name of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
 ### `${modules.<module-name>.path}`
 
 The local path of the module.

--- a/docs/reference/module-types/persistentvolumeclaim.md
+++ b/docs/reference/module-types/persistentvolumeclaim.md
@@ -608,6 +608,14 @@ Example:
 my-variable: ${modules.my-module.buildPath}
 ```
 
+### `${modules.<module-name>.name}`
+
+The name of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
 ### `${modules.<module-name>.path}`
 
 The local path of the module.

--- a/docs/reference/module-types/templated.md
+++ b/docs/reference/module-types/templated.md
@@ -415,6 +415,14 @@ Example:
 my-variable: ${modules.my-module.buildPath}
 ```
 
+### `${modules.<module-name>.name}`
+
+The name of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
 ### `${modules.<module-name>.path}`
 
 The local path of the module.

--- a/docs/reference/module-types/terraform.md
+++ b/docs/reference/module-types/terraform.md
@@ -489,6 +489,14 @@ Example:
 my-variable: ${modules.my-module.buildPath}
 ```
 
+### `${modules.<module-name>.name}`
+
+The name of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
 ### `${modules.<module-name>.path}`
 
 The local path of the module.

--- a/docs/reference/template-strings.md
+++ b/docs/reference/template-strings.md
@@ -1107,6 +1107,28 @@ Example:
 my-variable: ${modules.<module-name>.buildPath}
 ```
 
+### `${modules.<module-name>.name}`
+
+The name of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
+### `${modules.<module-name>.path}`
+
+The local path of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${modules.<module-name>.path}
+```
+
 ### `${modules.<module-name>.outputs.*}`
 
 The outputs defined by the module (see individual module type [references](https://docs.garden.io/reference/module-types) for details).
@@ -1122,20 +1144,6 @@ The module output value. Refer to individual [module type references](https://do
 | Type                        |
 | --------------------------- |
 | `string | number | boolean` |
-
-### `${modules.<module-name>.path}`
-
-The local path of the module.
-
-| Type     |
-| -------- |
-| `string` |
-
-Example:
-
-```yaml
-my-variable: ${modules.<module-name>.path}
-```
 
 ### `${modules.<module-name>.version}`
 
@@ -1207,6 +1215,20 @@ The task output value. Refer to individual [module type references](https://docs
 | --------------------------- |
 | `string | number | boolean` |
 
+### `${inputs.*}`
+
+The inputs provided to the module through a undefined, if applicable.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${inputs.<input-key>}`
+
+| Type                                             |
+| ------------------------------------------------ |
+| `string | number | boolean | link | array[link]` |
+
 ### `${parent.*}`
 
 Information about the parent module (if the module is a submodule, e.g. generated in a templated module).
@@ -1239,19 +1261,49 @@ The name of the undefined being resolved.
 | -------- |
 | `string` |
 
-### `${inputs.*}`
+### `${this.*}`
 
-The inputs provided to the module through a undefined, if applicable.
+Information about the module currently being resolved.
 
-| Type     | Default |
-| -------- | ------- |
-| `object` | `{}`    |
+| Type     |
+| -------- |
+| `object` |
 
-### `${inputs.<input-key>}`
+### `${this.buildPath}`
 
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
+The build path of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${this.buildPath}
+```
+
+### `${this.name}`
+
+The name of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
+### `${this.path}`
+
+The local path of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${this.path}
+```
 
 
 ## Output configuration context
@@ -1600,6 +1652,28 @@ Example:
 my-variable: ${modules.<module-name>.buildPath}
 ```
 
+### `${modules.<module-name>.name}`
+
+The name of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
+### `${modules.<module-name>.path}`
+
+The local path of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${modules.<module-name>.path}
+```
+
 ### `${modules.<module-name>.outputs.*}`
 
 The outputs defined by the module (see individual module type [references](https://docs.garden.io/reference/module-types) for details).
@@ -1615,20 +1689,6 @@ The module output value. Refer to individual [module type references](https://do
 | Type                        |
 | --------------------------- |
 | `string | number | boolean` |
-
-### `${modules.<module-name>.path}`
-
-The local path of the module.
-
-| Type     |
-| -------- |
-| `string` |
-
-Example:
-
-```yaml
-my-variable: ${modules.<module-name>.path}
-```
 
 ### `${modules.<module-name>.version}`
 
@@ -1699,52 +1759,6 @@ The task output value. Refer to individual [module type references](https://docs
 | Type                        |
 | --------------------------- |
 | `string | number | boolean` |
-
-### `${parent.*}`
-
-Information about the parent module (if the module is a submodule, e.g. generated in a templated module).
-
-| Type     |
-| -------- |
-| `object` |
-
-### `${parent.name}`
-
-The name of the parent module.
-
-| Type     |
-| -------- |
-| `string` |
-
-### `${template.*}`
-
-Information about the undefined used when generating the module.
-
-| Type     |
-| -------- |
-| `object` |
-
-### `${template.name}`
-
-The name of the undefined being resolved.
-
-| Type     |
-| -------- |
-| `string` |
-
-### `${inputs.*}`
-
-The inputs provided to the module through a undefined, if applicable.
-
-| Type     | Default |
-| -------- | ------- |
-| `object` | `{}`    |
-
-### `${inputs.<input-key>}`
-
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
 
 
 ## Workflow configuration context


### PR DESCRIPTION
This adds `${this.name}`, `${this.buildPath}` and `${this.path}` to the
template context when resolving modules.

Because someone might ask, `${this.version}` is not included because the
module version is determined after resolving the configuration.

I'm adding this both as a convenience and as a part of a different
project, where I'll add further keys to the `this.*` context.
