### PR TITLE
improvement(core): increase liveness probes when in hot-reload mode

### DIFF
--- a/core/test/data/test-projects/container/hot-reload/Dockerfile
+++ b/core/test/data/test-projects/container/hot-reload/Dockerfile
@@ -1,0 +1,1 @@
+FROM busybox:1.31.1

--- a/core/test/data/test-projects/container/hot-reload/garden.yml
+++ b/core/test/data/test-projects/container/hot-reload/garden.yml
@@ -1,0 +1,15 @@
+kind: Module
+name: hot-reload
+description: Test module for a simple hot reloadable service
+type: container
+hotReload:
+  sync:
+    - target: /tmp
+services:
+  - name: hot-reload
+    command: [sh, -c, "echo Server running... && nc -l -p 8080"]
+    healthCheck:
+      command: ["echo", "ok"]
+    ports:
+      - name: http
+        containerPort: 8080


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

During a hot reload event, a pod might not respond to liveness probes, e.g. because the server is restarting. This causes issues where K8s terminates the pod mid restart and the process needs start from the scratch. This PR fixes that be increasing the liveness probes on manifests for the container module type when in hot reload mode. 

The values are what we've seen work for GE but happy to receive other suggestions.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
