### PR TITLE
Exec run module

### DIFF
--- a/core/test/integ/src/plugins/kubernetes/container/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/deployment.ts
@@ -137,6 +137,31 @@ describe("kubernetes container deployment handlers", () => {
       expect(resource.spec.template?.metadata?.annotations).to.eql(service.spec.annotations)
     })
 
+    it("should increase liveness propves when in hot-reload mode", async () => {
+      const service = graph.getService("simple-service")
+      const namespace = provider.config.namespace!.name!
+
+      const resource = await createWorkloadManifest({
+        api,
+        provider,
+        service,
+        runtimeContext: emptyRuntimeContext,
+        namespace,
+        enableHotReload: true,
+        log: garden.log,
+        production: false,
+        blueGreen: false,
+      })
+
+      expect(resource.spec.template?.spec?.containers[0].livenessProbe).to.eql({
+        initialDelaySeconds: 90,
+        periodSeconds: 10,
+        timeoutSeconds: 3,
+        successThreshold: 1,
+        failureThreshold: 30,
+      })
+    })
+
     it("should name the Deployment with a version suffix and set a version label if blueGreen=true", async () => {
       const service = graph.getService("simple-service")
       const namespace = provider.config.namespace!.name!

--- a/core/test/unit/src/plugins/exec.ts
+++ b/core/test/unit/src/plugins/exec.ts
@@ -442,4 +442,22 @@ describe("exec plugin", () => {
       expect(res.log).to.equal(module.version.versionString)
     })
   })
+  describe("runExecModule", () => {
+    it("should run the module with the args that are passed through the command", async () => {
+      const module = graph.getModule("module-local")
+      const actions = await garden.getActionRouter()
+      const res = await actions.runModule({
+        log,
+        module,
+        command: [],
+        args: ["echo", "hello", "world"],
+        interactive: false,
+        runtimeContext: {
+          envVars: {},
+          dependencies: [],
+        },
+      })
+      expect(res.log).to.eql("hello world")
+    })
+  })
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

Adds a `runModule` handler to the `exec` module. The original motivation was to be able to run some modules locally but via Garden instead of something like npm/yarn directly, so that we can use environment variables and other Garden configuration. 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
