### PR TITLE
fix(core): default back to rsync build staging on Windows

### DIFF
--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -59,6 +59,7 @@ export const gardenEnv = {
   GARDEN_DISABLE_VERSION_CHECK: env.get("GARDEN_DISABLE_VERSION_CHECK").required(false).asBool(),
   GARDEN_ENABLE_PROFILING: env.get("GARDEN_ENABLE_PROFILING").required(false).asBool(),
   GARDEN_ENVIRONMENT: env.get("GARDEN_ENVIRONMENT").required(false).asString(),
+  GARDEN_EXPERIMENTAL_BUILD_STAGE: env.get("GARDEN_EXPERIMENTAL_BUILD_STAGE").required(false).asBool(),
   GARDEN_LEGACY_BUILD_STAGE: env.get("GARDEN_LEGACY_BUILD_STAGE").required(false).asBool(),
   GARDEN_LOG_LEVEL: env.get("GARDEN_LOG_LEVEL").required(false).asString(),
   GARDEN_LOGGER_TYPE: env.get("GARDEN_LOGGER_TYPE").required(false).asString(),

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -1200,8 +1200,14 @@ export async function resolveGardenParams(currentDirectory: string, opts: Garden
   // Allow overriding variables
   variables = { ...variables, ...(opts.variables || {}) }
 
+  // Use the legacy build sync mode if
+  // A) GARDEN_LEGACY_BUILD_STAGE=true is set or
+  // B) if running Windows and GARDEN_EXPERIMENTAL_BUILD_STAGE != true (until #2299 is properly fixed)
   const legacyBuildSync =
-    opts.legacyBuildSync === undefined ? gardenEnv.GARDEN_LEGACY_BUILD_STAGE : opts.legacyBuildSync
+    opts.legacyBuildSync === undefined
+      ? gardenEnv.GARDEN_LEGACY_BUILD_STAGE || (platform() === "win32" && !gardenEnv.GARDEN_EXPERIMENTAL_BUILD_STAGE)
+      : opts.legacyBuildSync
+
   const buildDirCls = legacyBuildSync ? BuildDirRsync : BuildStaging
   const buildDir = await buildDirCls.factory(projectRoot, gardenDirPath)
   const workingCopyId = await getWorkingCopyId(gardenDirPath)


### PR DESCRIPTION
This temporarily mitigates #2299 by reverting back to using rsync for
build staging on Windows, while we work out why exactly it fails for
some users/projects.

Users can still opt into the newer rsync-less mode by setting
`GARDEN_EXPERIMENTAL_BUILD_STAGE=true` in their shell environment.
