### PR TITLE
chore(docs): remove link to Heptio homepage

### DIFF
--- a/docs/guides/remote-kubernetes.md
+++ b/docs/guides/remote-kubernetes.md
@@ -97,7 +97,7 @@ case via the `kubectl create secret docker-registry` helper.
 _Note that you do not need to configure the authentication and imagePullSecrets when using GKE along with GCR,
 as long as your deployment registry is in the same project as the GKE cluster._
 
-The lovely folks at [Heptio](https://heptio.com) have prepared good guides on how to configure private registries
+The lovely folks at Heptio have prepared good guides on how to configure private registries
 for Kubernetes, which you can find [here](http://docs.heptio.com/content/private-registries.html).
 
 Once you've created the auth secret in the cluster, you can configure the registry and the secrets in your


### PR DESCRIPTION
The link to Heptio's homepage in the _remote kubernetes_ guide was consistently throwing `403` errors in the linting step.

Visiting that page results in a redirect to https://tanzu.vmware.com/tanzu, maybe that's the root cause.

This link has been removed here—the link to the actual Heptio docs still works, so we're keeping that.