### PR TITLE
CI fixes

### DIFF
--- a/docs/guides/remote-kubernetes.md
+++ b/docs/guides/remote-kubernetes.md
@@ -97,7 +97,7 @@ case via the `kubectl create secret docker-registry` helper.
 _Note that you do not need to configure the authentication and imagePullSecrets when using GKE along with GCR,
 as long as your deployment registry is in the same project as the GKE cluster._
 
-The lovely folks at [Heptio](https://heptio.com) have prepared good guides on how to configure private registries
+The lovely folks at Heptio have prepared good guides on how to configure private registries
 for Kubernetes, which you can find [here](http://docs.heptio.com/content/private-registries.html).
 
 Once you've created the auth secret in the cluster, you can configure the registry and the secrets in your

--- a/support/alpine-builder.Dockerfile
+++ b/support/alpine-builder.Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --no-cache \
 WORKDIR /tmp/pkg
 
 # Pre-fetch the node12 binary for pkg
-RUN yarn add pkg@4.4.9 && \
+RUN yarn add pkg@4.5.1 && \
   node_modules/.bin/pkg-fetch node12 alpine x64
 
 # Add all the packages


### PR DESCRIPTION
Fixed a couple of recent CI issues:

* Removed link to Heptio homepage in _remote kubernetes_ guide (it was returning a `403` in the `check-docs` script).
* Updated the `pkg` version used in `alpine-builder.Dockerfile`(see https://github.com/vercel/pkg-fetch/issues/137).