### PR TITLE
chore(workflow-runner): add kubelogin to workflow runner image

### DIFF
--- a/support/aws-gcloud-azure.Dockerfile
+++ b/support/aws-gcloud-azure.Dockerfile
@@ -6,6 +6,7 @@ RUN gcloud components install kubectl
 FROM gardendev/garden:${TAG}
 
 ENV CLOUDSDK_PYTHON=python3
+ENV KUBELOGIN_VERSION=v0.0.9
 
 COPY --from=gcloud /google-cloud-sdk /google-cloud-sdk
 
@@ -30,4 +31,7 @@ RUN apk add --virtual=build gcc libffi-dev musl-dev openssl-dev make py3-pip\
   && /azure-cli/bin/python -m pip --no-cache-dir install azure-cli \
   && echo "#!/usr/bin/env sh" > /usr/bin/az \
   && echo '/azure-cli/bin/python -m azure.cli "$@"' >> /usr/bin/az \
-  && chmod +x /usr/bin/az
+  && chmod +x /usr/bin/az \
+  && wget https://github.com/Azure/kubelogin/releases/download/${KUBELOGIN_VERSION}/kubelogin-linux-amd64.zip \
+  && unzip kubelogin-linux-amd64.zip \
+  && cp bin/linux_amd64/kubelogin /usr/bin/


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

This PR add the kubelogin tool to the aws-gcloud-azure image. Kubelogin can be used to authenticate with Azure AD to AKS clusters.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
