### PR TITLE
fix(core): handle undefined stdout/stderr on exec module failures

### DIFF
--- a/core/src/plugins/exec.ts
+++ b/core/src/plugins/exec.ts
@@ -351,7 +351,9 @@ export async function runExecModule(params: RunModuleParams<ExecModule>): Promis
     })
 
     completedAt = new Date()
-    outputLog = (commandResult.stdout + commandResult.stderr).trim()
+    // Despite the types saying otherwise, stdout and stderr can be undefined when in
+    // interactive mode.
+    outputLog = ((commandResult.stdout || "") + (commandResult.stderr || "")).trim()
     success = commandResult.exitCode === 0
   } else {
     completedAt = startedAt


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

Before this, you'd see`(commandResult.stdout + commandResult.stderr).trim is not a function` in the command output if the command fails, when running a local exec module in interactive mode .

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
