### PR TITLE
feat(workflows): only resolve config being run

### DIFF
--- a/core/src/commands/run/workflow.ts
+++ b/core/src/commands/run/workflow.ts
@@ -71,7 +71,7 @@ export class RunWorkflowCommand extends Command<Args, {}> {
   async action({ garden, log, args, opts }: CommandParams<Args, {}>): Promise<CommandResult<WorkflowRunOutput>> {
     const outerLog = log.placeholder()
     // Prepare any configured files before continuing
-    const workflow = garden.getWorkflowConfig(args.workflow)
+    const workflow = await garden.getWorkflowConfig(args.workflow)
 
     // Merge any workflow-level environment variables into process.env.
     for (const [key, value] of Object.entries(toEnvVars(workflow.envVars))) {

--- a/core/src/commands/validate.ts
+++ b/core/src/commands/validate.ts
@@ -9,6 +9,7 @@
 import { Command, CommandParams, CommandResult } from "./base"
 import { printHeader } from "../logger/util"
 import dedent = require("dedent")
+import { resolveWorkflowConfig } from "../config/workflow"
 
 export class ValidateCommand extends Command {
   name = "validate"
@@ -25,6 +26,17 @@ export class ValidateCommand extends Command {
 
   async action({ garden, log }: CommandParams): Promise<CommandResult> {
     await garden.getConfigGraph(log)
+
+    /*
+     * Normally, workflow configs are only resolved when they're run via the `run workflow` command (and only the
+     * workflow being run).
+     *
+     * Here, we want to validate all workflow configs (so we try resolving them all).
+     */
+    const rawWorkflowConfigs = await garden.getRawWorkflowConfigs()
+    for (const config of rawWorkflowConfigs) {
+      resolveWorkflowConfig(garden, config)
+    }
 
     return {}
   }

--- a/core/test/data/validate/bad-workflow/garden.yml
+++ b/core/test/data/validate/bad-workflow/garden.yml
@@ -1,0 +1,9 @@
+kind: Project
+name: bad-workflow-project
+
+---
+
+kind: Workflow
+steps:
+  - script: [echo, "${var.MISSING_VAR}"]
+

--- a/core/test/unit/src/commands/validate.ts
+++ b/core/test/unit/src/commands/validate.ts
@@ -51,4 +51,24 @@ describe("commands.validate", () => {
       "configuration"
     )
   })
+
+  it("should fail validating the bad-workflow project", async () => {
+    const root = join(dataDir, "validate", "bad-workflow")
+    const garden = await TestGarden.factory(root)
+    const log = garden.log
+    const command = new ValidateCommand()
+
+    await expectError(
+      async () =>
+        await command.action({
+          garden,
+          log,
+          headerLog: log,
+          footerLog: log,
+          args: {},
+          opts: withDefaultGlobalOpts({}),
+        }),
+      "configuration"
+    )
+  })
 })

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -2261,7 +2261,7 @@ describe("Garden", () => {
       const garden = await makeTestGarden(resolve(dataDir, "test-projects", "custom-config-names"))
       await garden.scanAndAddConfigs()
 
-      const workflows = garden.getWorkflowConfigs()
+      const workflows = await garden.getRawWorkflowConfigs()
       expect(getNames(workflows)).to.eql(["workflow-a", "workflow-b"])
     })
 
@@ -2465,22 +2465,6 @@ describe("Garden", () => {
       await expectError(
         () => garden.scanAndAddConfigs(),
         (err) => expect(err.message).to.match(/Module module-a: missing/)
-      )
-    })
-
-    it.skip("should throw an error if references to missing secrets are present in a workflow config", async () => {
-      const garden = await makeTestGarden(join(dataDir, "missing-secrets", "workflow"))
-      await expectError(
-        () => garden.scanAndAddConfigs(),
-        (err) => expect(err.message).to.match(/Workflow test-workflow: missing/)
-      )
-    })
-
-    it("should throw an error if an invalid workflow config is present", async () => {
-      const garden = await makeTestGarden(join(dataDir, "test-project-invalid-workflow"))
-      await expectError(
-        () => garden.scanAndAddConfigs(),
-        (err) => expect(stripAnsi(err.message)).to.match(/key .triggers must be an array/)
       )
     })
   })


### PR DESCRIPTION
**What this PR does / why we need it**:

In the `run workflow` command, we now only resolve the workflow config being run.

This adds flexibility when some workflows reference e.g. secrets that are created by other workflows.