### PR TITLE
feat: experimental "dev mode" with much better container syncing

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -119,6 +119,7 @@
     "recursive-readdir": "^2.2.2",
     "request": "^2.88.2",
     "request-promise": "^4.2.5",
+    "respawn": "^2.6.0",
     "slash": "^3.0.0",
     "source-map-support": "^0.5.19",
     "split": "^1.0.1",

--- a/core/src/actions.ts
+++ b/core/src/actions.ts
@@ -470,7 +470,7 @@ export class ActionRouter implements TypeGuard {
     })
 
     const runtimeContext = emptyRuntimeContext
-    const status = await this.getServiceStatus({ ...params, runtimeContext, hotReload: false })
+    const status = await this.getServiceStatus({ ...params, runtimeContext, devMode: false, hotReload: false })
 
     if (status.state === "missing") {
       log.setSuccess({
@@ -613,6 +613,8 @@ export class ActionRouter implements TypeGuard {
           graph,
           log,
           service,
+          devModeServiceNames: [],
+          hotReloadServiceNames: [],
         })
     )
     const results = await this.garden.processTasks(tasks, { throwOnError: true })
@@ -633,6 +635,7 @@ export class ActionRouter implements TypeGuard {
           force,
           forceBuild,
           fromWatch: false,
+          devModeServiceNames: [],
           hotReloadServiceNames: [],
         })
     )

--- a/core/src/analytics/analytics.ts
+++ b/core/src/analytics/analytics.ts
@@ -19,7 +19,6 @@ import { Garden } from "../garden"
 import { AnalyticsType } from "./analytics-types"
 import dedent from "dedent"
 import { getGitHubUrl } from "../docs/common"
-import { InternalError } from "../exceptions"
 import { Profile } from "../util/profiling"
 
 const API_KEY = process.env.ANALYTICS_DEV ? SEGMENT_DEV_API_KEY : SEGMENT_PROD_API_KEY
@@ -140,9 +139,6 @@ export class AnalyticsHandler {
   private projectMetadata: ProjectMetadata
 
   private constructor(garden: Garden, log: LogEntry) {
-    if (!garden.sessionId) {
-      throw new InternalError(`Garden instance with null sessionId passed to AnalyticsHandler constructor.`, {})
-    }
     this.segment = new segmentClient(API_KEY, { flushAt: 20, flushInterval: 300 })
     this.log = log
     this.garden = garden

--- a/core/src/commands/call.ts
+++ b/core/src/commands/call.ts
@@ -75,7 +75,7 @@ export class CallCommand extends Command<Args> {
     // No need for full context, since we're just checking if the service is running.
     const runtimeContext = emptyRuntimeContext
     const actions = await garden.getActionRouter()
-    const status = await actions.getServiceStatus({ service, log, hotReload: false, runtimeContext })
+    const status = await actions.getServiceStatus({ service, log, devMode: false, hotReload: false, runtimeContext })
 
     if (!includes(["ready", "outdated"], status.state)) {
       throw new RuntimeError(`Service ${service.name} is not running`, {

--- a/core/src/commands/helpers.ts
+++ b/core/src/commands/helpers.ts
@@ -17,6 +17,7 @@ export async function getDevModeServiceNames(namesFromOpt: string[] | undefined,
     return names
   }
 }
+
 export async function getHotReloadServiceNames(namesFromOpt: string[] | undefined, configGraph: ConfigGraph) {
   const names = namesFromOpt || []
   if (names.includes("*")) {

--- a/core/src/commands/helpers.ts
+++ b/core/src/commands/helpers.ts
@@ -9,6 +9,14 @@
 import { ConfigGraph } from "../config-graph"
 import { GardenService } from "../types/service"
 
+export async function getDevModeServiceNames(namesFromOpt: string[] | undefined, configGraph: ConfigGraph) {
+  const names = namesFromOpt || []
+  if (names.includes("*")) {
+    return configGraph.getServices().map((s) => s.name)
+  } else {
+    return names
+  }
+}
 export async function getHotReloadServiceNames(namesFromOpt: string[] | undefined, configGraph: ConfigGraph) {
   const names = namesFromOpt || []
   if (names.includes("*")) {

--- a/core/src/commands/logs.ts
+++ b/core/src/commands/logs.ts
@@ -19,7 +19,6 @@ import { LogLevel } from "../logger/log-node"
 import { emptyRuntimeContext } from "../runtime-context"
 import { StringsParameter, BooleanParameter, IntegerParameter } from "../cli/params"
 import { printHeader } from "../logger/util"
-import { sleep } from "../util/util"
 
 const logsArgs = {
   services: new StringsParameter({
@@ -108,36 +107,23 @@ export class LogsCommand extends Command<Args, Opts> {
     const voidLog = log.placeholder({ level: LogLevel.silly, childEntriesInheritLevel: true })
 
     await Bluebird.map(services, async (service: GardenService<any>) => {
-      while (true) {
-        const status = await actions.getServiceStatus({
-          devMode: false,
-          hotReload: false,
-          log: voidLog,
-          // This shouldn't matter for this context, we're just checking if the service is up or not
-          runtimeContext: emptyRuntimeContext,
-          service,
-        })
+      const status = await actions.getServiceStatus({
+        devMode: false,
+        hotReload: false,
+        log: voidLog,
+        // This shouldn't matter for this context, we're just checking if the service is up or not
+        runtimeContext: emptyRuntimeContext,
+        service,
+      })
 
-        if (status.state === "ready" || status.state === "outdated") {
-          await actions.getServiceLogs({ log, service, stream, follow, tail })
-          return
-        } else if (follow) {
-          await stream.write({
-            serviceName: service.name,
-            timestamp: new Date(),
-            msg: chalk.yellow(`<Service not running (state: ${status.state}). Trying again in 5 seconds.>`),
-          })
-          await sleep(5000)
-        } else {
-          await stream.write({
-            serviceName: service.name,
-            timestamp: new Date(),
-            msg: chalk.yellow(
-              `<Service not running (state: ${status.state}). Please deploy the service and try again.>`
-            ),
-          })
-          return
-        }
+      if (status.state === "ready" || status.state === "outdated") {
+        await actions.getServiceLogs({ log, service, stream, follow, tail })
+      } else {
+        await stream.write({
+          serviceName: service.name,
+          timestamp: new Date(),
+          msg: chalk.yellow(`<Service not running (state: ${status.state}). Please deploy the service and try again.>`),
+        })
       }
     })
 

--- a/core/src/commands/run/service.ts
+++ b/core/src/commands/run/service.ts
@@ -94,6 +94,8 @@ export class RunServiceCommand extends Command<Args, Opts> {
       graph,
       log,
       service,
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
     })
     const dependencyResults = await garden.processTasks(await deployTask.resolveDependencies())
 

--- a/core/src/commands/run/task.ts
+++ b/core/src/commands/run/task.ts
@@ -95,7 +95,16 @@ export class RunTaskCommand extends Command<Args, Opts> {
       )
     }
 
-    const taskTask = new TaskTask({ garden, graph, task, log, force: true, forceBuild: opts["force-build"] })
+    const taskTask = new TaskTask({
+      garden,
+      graph,
+      task,
+      log,
+      force: true,
+      forceBuild: opts["force-build"],
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
+    })
     const graphResults = await garden.processTasks([taskTask])
 
     return handleTaskResult({ log, actionDescription: "task", graphResults, key: taskTask.getKey() })

--- a/core/src/commands/run/test.ts
+++ b/core/src/commands/run/test.ts
@@ -137,6 +137,8 @@ export class RunTestCommand extends Command<Args, Opts> {
       graph,
       log,
       test,
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
     })
 
     const dependencyResults = await garden.processTasks(await testTask.resolveDependencies())

--- a/core/src/commands/test.ts
+++ b/core/src/commands/test.ts
@@ -149,6 +149,8 @@ export class TestCommand extends Command<Args, Opts> {
           filterNames,
           force,
           forceBuild,
+          devModeServiceNames: [],
+          hotReloadServiceNames: [],
         })
       )
     )
@@ -173,6 +175,8 @@ export class TestCommand extends Command<Args, Opts> {
               filterNames,
               force,
               forceBuild,
+              devModeServiceNames: [],
+              hotReloadServiceNames: [],
             })
           )
         )

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -29,7 +29,7 @@ import {
   parseEnvironment,
   getDefaultEnvironmentName,
 } from "./config/project"
-import { findByName, pickKeys, getPackageVersion, getNames, findByNames, duplicatesByKey } from "./util/util"
+import { findByName, pickKeys, getPackageVersion, getNames, findByNames, duplicatesByKey, uuidv4 } from "./util/util"
 import { ConfigurationError, PluginError, RuntimeError } from "./exceptions"
 import { VcsHandler, ModuleVersion } from "./vcs/vcs"
 import { GitHandler } from "./vcs/git"
@@ -162,7 +162,7 @@ export interface GardenParams {
   providerConfigs: GenericProviderConfig[]
   variables: DeepPrimitiveMap
   secrets: StringMap
-  sessionId: string | null
+  sessionId: string
   username: string | undefined
   vcs: VcsHandler
   workingCopyId: string
@@ -185,7 +185,7 @@ export class Garden {
   private asyncLock: any
   public readonly projectId?: string
   public readonly enterpriseDomain?: string
-  public sessionId: string | null
+  public sessionId: string
   public readonly configStore: ConfigStore
   public readonly globalConfigStore: GlobalConfigStore
   public readonly vcs: VcsHandler
@@ -1179,7 +1179,7 @@ export async function resolveGardenParams(currentDirectory: string, opts: Garden
 
   const { environment: environmentName } = parseEnvironment(environmentStr)
 
-  const sessionId = opts.sessionId || null
+  const sessionId = opts.sessionId || uuidv4()
 
   let secrets: StringMap = {}
   const enterpriseApi = opts.enterpriseApi || null

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -96,6 +96,7 @@ import { DefaultEnvironmentContext } from "./config/template-contexts/project"
 import { OutputConfigContext } from "./config/template-contexts/module"
 import { ProviderConfigContext } from "./config/template-contexts/provider"
 import { getSecrets } from "./enterprise/get-secrets"
+import { killSyncDaemon } from "./plugins/kubernetes/mutagen"
 
 export interface ActionHandlerMap<T extends keyof PluginActionHandlers> {
   [actionName: string]: PluginActionHandlers[T]
@@ -305,6 +306,7 @@ export class Garden {
   async close() {
     this.events.removeAllListeners()
     this.watcher && (await this.watcher.stop())
+    await killSyncDaemon()
   }
 
   async getPluginContext(provider: Provider) {

--- a/core/src/outputs.ts
+++ b/core/src/outputs.ts
@@ -88,6 +88,8 @@ export async function resolveProjectOutputs(garden: Garden, log: LogEntry): Prom
           graph,
           log,
           service,
+          devModeServiceNames: [],
+          hotReloadServiceNames: [],
         })
     ),
     ...tasks.map(
@@ -99,6 +101,8 @@ export async function resolveProjectOutputs(garden: Garden, log: LogEntry): Prom
           graph,
           log,
           task,
+          devModeServiceNames: [],
+          hotReloadServiceNames: [],
         })
     ),
   ]

--- a/core/src/plugin-context.ts
+++ b/core/src/plugin-context.ts
@@ -22,6 +22,7 @@ type WrappedFromGarden = Pick<
   // TODO: remove this from the interface
   | "environmentName"
   | "production"
+  | "sessionId"
 >
 
 export interface CommandInfo {
@@ -67,6 +68,7 @@ export const pluginContextSchema = () =>
       projectRoot: joi.string().description("The absolute path of the project root."),
       projectSources: projectSourcesSchema(),
       provider: providerSchema().description("The provider being used for this context.").id("ctxProviderSchema"),
+      sessionId: joi.string().description("The unique ID of the currently active session."),
       tools: joiStringMap(joi.object()),
       workingCopyId: joi.string().description("A unique ID assigned to the current project working copy."),
     })
@@ -85,7 +87,8 @@ export async function createPluginContext(
     projectSources: garden.getProjectSources(),
     provider,
     production: garden.production,
-    workingCopyId: garden.workingCopyId,
+    sessionId: garden.sessionId,
     tools: await garden.getTools(),
+    workingCopyId: garden.workingCopyId,
   }
 }

--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -17,7 +17,6 @@ import {
   joiModuleIncludeDirective,
   joiIdentifier,
   joiSparseArray,
-  joiArray,
 } from "../../config/common"
 import { ArtifactSpec } from "./../../config/validation"
 import { GardenService, ingressHostnameSchema, linkUrlSchema } from "../../types/service"

--- a/core/src/plugins/kubernetes/container/deployment.ts
+++ b/core/src/plugins/kubernetes/container/deployment.ts
@@ -113,7 +113,7 @@ export async function deployContainerServiceRolling(params: DeployServiceParams<
     log,
     service,
     runtimeContext,
-    enableDevMode: !!devMode,
+    enableDevMode: devMode,
     enableHotReload: hotReload,
     blueGreen: false,
   })
@@ -144,7 +144,7 @@ export async function deployContainerServiceBlueGreen(params: DeployServiceParam
     log,
     service,
     runtimeContext,
-    enableDevMode: !!devMode,
+    enableDevMode: devMode,
     enableHotReload: hotReload,
     blueGreen: true,
   })
@@ -418,7 +418,7 @@ export async function createWorkloadManifest({
   }
 
   if (spec.healthCheck) {
-    configureHealthCheck(container, spec, enableHotReload)
+    configureHealthCheck(container, spec, enableHotReload || enableDevMode)
   }
 
   if (spec.volumes && spec.volumes.length) {
@@ -625,7 +625,7 @@ function workloadConfig({
   }
 }
 
-function configureHealthCheck(container: V1Container, spec: ContainerServiceConfig["spec"], hotReload: boolean): void {
+function configureHealthCheck(container: V1Container, spec: ContainerServiceConfig["spec"], dev: boolean): void {
   const readinessPeriodSeconds = 1
   const readinessFailureThreshold = 90
 
@@ -644,10 +644,10 @@ function configureHealthCheck(container: V1Container, spec: ContainerServiceConf
   // hot reload event.
   container.livenessProbe = {
     initialDelaySeconds: readinessPeriodSeconds * readinessFailureThreshold,
-    periodSeconds: hotReload ? 10 : 5,
+    periodSeconds: dev ? 10 : 5,
     timeoutSeconds: 3,
     successThreshold: 1,
-    failureThreshold: hotReload ? 30 : 3,
+    failureThreshold: dev ? 30 : 3,
   }
 
   const portsByName = keyBy(spec.ports, "name")

--- a/core/src/plugins/kubernetes/container/exec.ts
+++ b/core/src/plugins/kubernetes/container/exec.ts
@@ -31,6 +31,7 @@ export async function execInService(params: ExecInServiceParams<ContainerModule>
       envVars: {},
       dependencies: [],
     },
+    devMode: false,
     hotReload: false,
   })
   const namespace = await getAppNamespace(k8sCtx, log, k8sCtx.provider)

--- a/core/src/plugins/kubernetes/container/logs.ts
+++ b/core/src/plugins/kubernetes/container/logs.ts
@@ -30,6 +30,7 @@ export async function getServiceLogs(params: GetServiceLogsParams<ContainerModul
       // No need for the proper context here
       runtimeContext: emptyRuntimeContext,
       namespace,
+      enableDevMode: false,
       enableHotReload: false,
       production: ctx.production,
       log,

--- a/core/src/plugins/kubernetes/dev-mode.ts
+++ b/core/src/plugins/kubernetes/dev-mode.ts
@@ -1,0 +1,242 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+const AsyncLock = require("async-lock")
+import { containerDevModeSchema, ContainerDevModeSpec } from "../container/config"
+import { dedent, gardenAnnotationKey } from "../../util/string"
+import { fromPairs, set } from "lodash"
+import { getResourceContainer } from "./util"
+import { HotReloadableResource } from "./hot-reload/hot-reload"
+import { LogEntry } from "../../logger/log-entry"
+import { joinWithPosix } from "../../util/fs"
+import chalk from "chalk"
+import { pathExists, readFile, writeFile } from "fs-extra"
+import { PluginContext } from "../../plugin-context"
+import { join } from "path"
+import { safeDump, safeLoad } from "js-yaml"
+import { ConfigurationError } from "../../exceptions"
+import { ensureMutagenDaemon } from "./mutagen"
+import { joiIdentifier } from "../../config/common"
+
+const syncUtilImageName = "gardendev/k8s-sync:0.1.1"
+const mutagenAgentPath = "/.garden/mutagen-agent"
+
+interface ActiveSync {
+  spec: ContainerDevModeSpec
+}
+
+const activeSyncs: { [key: string]: ActiveSync } = {}
+const syncStartLock = new AsyncLock()
+
+interface ConfigureDevModeParams {
+  target: HotReloadableResource
+  spec: ContainerDevModeSpec
+  containerName?: string
+}
+
+export interface KubernetesDevModeSpec extends ContainerDevModeSpec {
+  containerName?: string
+}
+
+export const kubernetesDevModeSchema = () =>
+  containerDevModeSchema().keys({
+    containerName: joiIdentifier().description(
+      `Optionally specify the name of a specific container to sync to. If not specified, the first container in the workload is used.`
+    ),
+  }).description(dedent`
+    **EXPERIMENTAL**
+
+    Specifies which files or directories to sync to which paths inside the running containers of the service when it's in dev mode, and overrides for the container command and/or arguments.
+
+    Note that \`serviceResource\` must also be specified to enable dev mode.
+
+    Dev mode is enabled when running the \`garden dev\` command, and by setting the \`--dev\` flag on the \`garden deploy\` command.
+`)
+
+/**
+ * Configures the specified Deployment, DaemonSet or StatefulSet for dev mode.
+ */
+export function configureDevMode({ target, spec, containerName }: ConfigureDevModeParams): void {
+  set(target, ["metadata", "annotations", gardenAnnotationKey("dev-mode")], "true")
+  const mainContainer = getResourceContainer(target, containerName)
+
+  if (spec.command) {
+    mainContainer.command = spec.command
+  }
+
+  if (spec.args) {
+    mainContainer.args = spec.args
+  }
+
+  if (!spec.sync.length) {
+    return
+  }
+
+  // Inject mutagen agent on init
+  const gardenVolumeName = `garden`
+  const gardenVolumeMount = {
+    name: gardenVolumeName,
+    mountPath: "/.garden",
+  }
+
+  if (!target.spec.template.spec!.volumes) {
+    target.spec.template.spec!.volumes = []
+  }
+
+  target.spec.template.spec!.volumes.push({
+    name: gardenVolumeName,
+    emptyDir: {},
+  })
+
+  const initContainer = {
+    name: "garden-dev-init",
+    image: syncUtilImageName,
+    // TODO: inject agent + SSH server
+    command: ["/bin/sh", "-c", "cp /usr/local/bin/mutagen-agent " + mutagenAgentPath],
+    imagePullPolicy: "IfNotPresent",
+    volumeMounts: [gardenVolumeMount],
+  }
+
+  if (!target.spec.template.spec!.initContainers) {
+    target.spec.template.spec!.initContainers = []
+  }
+  target.spec.template.spec!.initContainers.push(initContainer)
+
+  if (!mainContainer.volumeMounts) {
+    mainContainer.volumeMounts = []
+  }
+
+  mainContainer.volumeMounts.push(gardenVolumeMount)
+}
+
+const mutagenModeMap = {
+  "one-way": "one-way-safe",
+  "two-way": "two-way-safe",
+}
+
+interface StartDevModeSyncParams extends ConfigureDevModeParams {
+  ctx: PluginContext
+  log: LogEntry
+  moduleRoot: string
+  namespace: string
+}
+
+export async function startDevModeSync({
+  containerName,
+  ctx,
+  log,
+  moduleRoot,
+  namespace,
+  spec,
+  target,
+}: StartDevModeSyncParams) {
+  if (spec.sync.length === 0) {
+    return
+  }
+
+  namespace = target.metadata.namespace || namespace
+  const resourceName = `${target.kind}/${target.metadata.name}`
+  const key = `${target.kind}--${namespace}--${target.metadata.name}`
+
+  return syncStartLock.acquire("start-sync", async () => {
+    // Check for already active sync
+    if (activeSyncs[key]) {
+      return activeSyncs[key]
+    }
+
+    // Validate the target
+    if (target.metadata.annotations?.[gardenAnnotationKey("dev-mode")] !== "true") {
+      throw new ConfigurationError(`Resource ${resourceName} is not deployed in dev mode`, {
+        target,
+      })
+    }
+
+    if (!containerName) {
+      containerName = target.spec.template.spec?.containers[0]?.name
+    }
+
+    if (!containerName) {
+      throw new ConfigurationError(`Resource ${resourceName} doesn't have any containers`, {
+        target,
+      })
+    }
+
+    const kubectl = ctx.tools["kubernetes.kubectl"]
+    const kubectlPath = await kubectl.getPath(log)
+
+    const mutagen = ctx.tools["kubernetes.mutagen"]
+    const dataDir = await ensureMutagenDaemon(log, mutagen)
+
+    // Configure Mutagen with all the syncs
+    const syncConfigs = fromPairs(
+      spec.sync.map((s, i) => {
+        const command = [
+          kubectlPath,
+          "exec",
+          "-i",
+          "--namespace",
+          namespace,
+          "--container",
+          containerName,
+          `${target.kind}/${target.metadata.name}`,
+          "--",
+          mutagenAgentPath,
+          "synchronizer",
+        ]
+
+        const syncConfig = {
+          alpha: joinWithPosix(moduleRoot, s.source),
+          beta: `exec:'${command.join(" ")}':${s.target}`,
+          mode: mutagenModeMap[s.mode],
+          ignore: {
+            paths: s.exclude || [],
+          },
+        }
+
+        log.info(
+          chalk.gray(
+            `→ Syncing ${chalk.white(s.source)} to ${chalk.white(s.target)} in ${chalk.white(resourceName)} (${s.mode})`
+          )
+        )
+
+        return [`${key}-${i}`, syncConfig]
+      })
+    )
+
+    let config: any = {
+      sync: {},
+    }
+
+    const configPath = join(dataDir, "mutagen.yml")
+
+    if (await pathExists(configPath)) {
+      config = safeLoad((await readFile(configPath)).toString())
+    }
+
+    config.sync = { ...config.sync, ...syncConfigs }
+
+    await writeFile(configPath, safeDump(config))
+
+    // Commit the configuration to the Mutagen daemon
+    await mutagen.exec({
+      cwd: dataDir,
+      args: ["project", "start"],
+      log,
+      env: {
+        MUTAGEN_DATA_DIRECTORY: dataDir,
+      },
+    })
+
+    // TODO: Attach to Mutagen GRPC to poll for sync updates
+
+    const sync: ActiveSync = { spec }
+    activeSyncs[key] = sync
+
+    return sync
+  })
+}

--- a/core/src/plugins/kubernetes/helm/config.ts
+++ b/core/src/plugins/kubernetes/helm/config.ts
@@ -37,6 +37,7 @@ import {
 import { posix } from "path"
 import { runPodSpecWhitelist } from "../run"
 import { omit } from "lodash"
+import { kubernetesDevModeSchema, KubernetesDevModeSpec } from "../dev-mode"
 
 export const defaultHelmTimeout = 300
 
@@ -53,6 +54,7 @@ export interface HelmServiceSpec {
   chart?: string
   chartPath: string
   dependencies: string[]
+  devMode?: KubernetesDevModeSpec
   namespace?: string
   releaseName?: string
   repo?: string
@@ -161,6 +163,7 @@ export const helmModuleSpecSchema = () =>
     dependencies: joiSparseArray(joiIdentifier()).description(
       "List of names of services that should be deployed before this chart."
     ),
+    devMode: kubernetesDevModeSchema(),
     namespace: namespaceNameSchema(),
     releaseName: joiIdentifier().description(
       "Optionally override the release name used when installing (defaults to the module name)."

--- a/core/src/plugins/kubernetes/helm/logs.ts
+++ b/core/src/plugins/kubernetes/helm/logs.ts
@@ -24,7 +24,14 @@ export async function getServiceLogs(params: GetServiceLogsParams<HelmModule>) {
     provider: k8sCtx.provider,
   })
 
-  const resources = await getChartResources({ ctx: k8sCtx, module, hotReload: false, log, version: service.version })
+  const resources = await getChartResources({
+    ctx: k8sCtx,
+    module,
+    devMode: false,
+    hotReload: false,
+    log,
+    version: service.version,
+  })
 
   return streamK8sLogs({ ...params, provider, defaultNamespace: namespace, resources })
 }

--- a/core/src/plugins/kubernetes/helm/run.ts
+++ b/core/src/plugins/kubernetes/helm/run.ts
@@ -59,7 +59,7 @@ export async function runHelmModule({
     )
   }
 
-  const manifests = await getChartResources({ ctx: k8sCtx, module, hotReload: false, log, version })
+  const manifests = await getChartResources({ ctx: k8sCtx, module, devMode: false, hotReload: false, log, version })
   const target = await findServiceResource({
     ctx: k8sCtx,
     log,
@@ -125,6 +125,7 @@ export async function runHelmTask(params: RunTaskParams<HelmModule>): Promise<Ru
   const manifests = await getChartResources({
     ctx: k8sCtx,
     module,
+    devMode: false,
     hotReload: false,
     log,
     version: module.version.versionString,

--- a/core/src/plugins/kubernetes/helm/status.ts
+++ b/core/src/plugins/kubernetes/helm/status.ts
@@ -11,11 +11,15 @@ import { GetServiceStatusParams } from "../../../types/plugin/service/getService
 import { LogEntry } from "../../../logger/log-entry"
 import { helm } from "./helm-cli"
 import { HelmModule } from "./config"
-import { getReleaseName, loadTemplate } from "./common"
+import { getBaseModule, getReleaseName, loadTemplate } from "./common"
 import { KubernetesPluginContext } from "../config"
 import { getForwardablePorts } from "../port-forward"
 import { KubernetesServerResource } from "../types"
 import { getModuleNamespace } from "../namespace"
+import { findServiceResource, getServiceResourceSpec } from "../util"
+import chalk from "chalk"
+import { startDevModeSync } from "../dev-mode"
+import { gardenAnnotationKey } from "../../../util/string"
 
 const helmStatusMap: { [status: string]: ServiceState } = {
   unknown: "unknown",
@@ -37,6 +41,7 @@ export async function getServiceStatus({
   module,
   service,
   log,
+  devMode,
   hotReload,
 }: GetServiceStatusParams<HelmModule>): Promise<HelmServiceStatus> {
   const k8sCtx = <KubernetesPluginContext>ctx
@@ -46,7 +51,7 @@ export async function getServiceStatus({
   let state: ServiceState
 
   try {
-    const helmStatus = await getReleaseStatus({ ctx: k8sCtx, service, releaseName, log, hotReload })
+    const helmStatus = await getReleaseStatus({ ctx: k8sCtx, service, releaseName, log, devMode, hotReload })
     state = helmStatus.state
   } catch (err) {
     state = "missing"
@@ -57,6 +62,45 @@ export async function getServiceStatus({
   if (state !== "missing") {
     const deployedResources = await getDeployedResources({ ctx: k8sCtx, module, releaseName, log })
     forwardablePorts = getForwardablePorts(deployedResources)
+
+    if (state === "ready" && devMode && service.spec.devMode) {
+      // Need to start the dev-mode sync here, since the deployment handler won't be called.
+      const baseModule = getBaseModule(module)
+      const serviceResourceSpec = getServiceResourceSpec(module, baseModule)
+      const target = await findServiceResource({
+        ctx,
+        log,
+        module,
+        baseModule,
+        manifests: deployedResources,
+        resourceSpec: serviceResourceSpec,
+      })
+
+      // Make sure we don't fail if the service isn't actually properly configured (we don't want to throw in the
+      // status handler, generally)
+      if (target.metadata.annotations?.[gardenAnnotationKey("dev-mode")] === "true") {
+        const namespace =
+          target.metadata.namespace ||
+          (await getModuleNamespace({
+            ctx: k8sCtx,
+            log,
+            module,
+            provider: k8sCtx.provider,
+          }))
+
+        await startDevModeSync({
+          ctx,
+          log: log.info({ section: service.name, symbol: "info", msg: chalk.gray(`Starting sync`) }),
+          moduleRoot: service.sourceModule.path,
+          namespace,
+          target,
+          spec: service.spec.devMode,
+          containerName: service.spec.devMode.containerName,
+        })
+      } else {
+        state = "outdated"
+      }
+    }
   }
 
   return {
@@ -100,12 +144,14 @@ export async function getReleaseStatus({
   service,
   releaseName,
   log,
+  devMode,
   hotReload,
 }: {
   ctx: KubernetesPluginContext
   service: GardenService
   releaseName: string
   log: LogEntry
+  devMode: boolean
   hotReload: boolean
 }): Promise<ServiceStatus> {
   try {
@@ -133,9 +179,15 @@ export async function getReleaseStatus({
         })
       )
       const deployedVersion = values[".garden"] && values[".garden"].version
+      const devModeEnabled = values[".garden"] && values[".garden"].devMode === true
       const hotReloadEnabled = values[".garden"] && values[".garden"].hotReload === true
 
-      if ((hotReload && !hotReloadEnabled) || !deployedVersion || deployedVersion !== service.version) {
+      if (
+        (devMode && !devModeEnabled) ||
+        (hotReload && !hotReloadEnabled) ||
+        !deployedVersion ||
+        deployedVersion !== service.version
+      ) {
         state = "outdated"
       }
     }

--- a/core/src/plugins/kubernetes/helm/test.ts
+++ b/core/src/plugins/kubernetes/helm/test.ts
@@ -28,7 +28,14 @@ export async function testHelmModule(params: TestModuleParams<HelmModule>): Prom
   const k8sCtx = <KubernetesPluginContext>ctx
 
   // Get the container spec to use for running
-  const manifests = await getChartResources({ ctx: k8sCtx, module, hotReload: false, log, version: test.version })
+  const manifests = await getChartResources({
+    ctx: k8sCtx,
+    module,
+    devMode: false,
+    hotReload: false,
+    log,
+    version: test.version,
+  })
   const baseModule = getBaseModule(module)
   const resourceSpec = test.config.spec.resource || getServiceResourceSpec(module, baseModule)
   const target = await findServiceResource({ ctx: k8sCtx, log, manifests, module, baseModule, resourceSpec })

--- a/core/src/plugins/kubernetes/hot-reload/hot-reload.ts
+++ b/core/src/plugins/kubernetes/hot-reload/hot-reload.ts
@@ -31,7 +31,7 @@ import { getHotReloadSpec, syncToService } from "./helpers"
 export type HotReloadableResource = KubernetesResource<V1Deployment | V1DaemonSet | V1StatefulSet>
 export type HotReloadableKind = "Deployment" | "DaemonSet" | "StatefulSet"
 
-export const hotReloadableKinds: HotReloadableKind[] = ["Deployment", "DaemonSet", "StatefulSet"]
+export const hotReloadableKinds: string[] = ["Deployment", "DaemonSet", "StatefulSet"]
 
 /**
  * The hot reload action handler for helm charts and kubernetes modules.
@@ -62,6 +62,7 @@ export async function hotReloadK8s({
     manifests = await getChartResources({
       ctx: k8sCtx,
       module: service.module,
+      devMode: false,
       hotReload: true,
       log,
       version: service.version,
@@ -125,6 +126,7 @@ export async function hotReloadContainer({
     service,
     runtimeContext: { envVars: {}, dependencies: [] },
     namespace,
+    enableDevMode: false,
     enableHotReload: true,
     production: k8sCtx.production,
     log,

--- a/core/src/plugins/kubernetes/kubectl.ts
+++ b/core/src/plugins/kubernetes/kubectl.ts
@@ -170,27 +170,44 @@ class Kubectl extends PluginTool {
 
   prepareArgs(params: KubectlParams) {
     const { namespace, configPath, args } = params
-
-    const opts: string[] = []
-
-    if (this.provider.config.context) {
-      opts.push(`--context=${this.provider.config.context}`)
-    }
-
-    if (this.provider.config.kubeconfig) {
-      opts.push(`--kubeconfig=${this.provider.config.kubeconfig}`)
-    }
-
-    if (namespace) {
-      opts.push(`--namespace=${namespace}`)
-    }
-
-    if (configPath) {
-      opts.push(`--kubeconfig=${configPath}`)
-    }
+    const opts = prepareConnectionOpts({
+      provider: this.provider,
+      configPath,
+      namespace,
+    })
 
     return { ...params, args: opts.concat(args) }
   }
+}
+
+export function prepareConnectionOpts({
+  provider,
+  configPath,
+  namespace,
+}: {
+  provider: KubernetesProvider
+  configPath?: string
+  namespace?: string
+}): string[] {
+  const opts: string[] = []
+
+  if (provider.config.context) {
+    opts.push(`--context=${provider.config.context}`)
+  }
+
+  if (provider.config.kubeconfig) {
+    opts.push(`--kubeconfig=${provider.config.kubeconfig}`)
+  }
+
+  if (namespace) {
+    opts.push(`--namespace=${namespace}`)
+  }
+
+  if (configPath) {
+    opts.push(`--kubeconfig=${configPath}`)
+  }
+
+  return opts
 }
 
 export const kubectlSpec: PluginToolSpec = {

--- a/core/src/plugins/kubernetes/kubernetes-module/config.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/config.ts
@@ -26,6 +26,7 @@ import {
   hotReloadArgsSchema,
 } from "../config"
 import { ContainerModule } from "../../container/config"
+import { kubernetesDevModeSchema, KubernetesDevModeSpec } from "../dev-mode"
 
 // A Kubernetes Module always maps to a single Service
 export type KubernetesModuleSpec = KubernetesServiceSpec
@@ -36,6 +37,7 @@ export type KubernetesModuleConfig = KubernetesModule["_config"]
 
 export interface KubernetesServiceSpec {
   dependencies: string[]
+  devMode?: KubernetesDevModeSpec
   files: string[]
   namespace?: string
   manifests: KubernetesResource[]
@@ -79,12 +81,13 @@ export const kubernetesModuleSpecSchema = () =>
       \`files\` directive so that only the Kubernetes manifests get included.
     `),
     namespace: namespaceNameSchema(),
+    devMode: kubernetesDevModeSchema(),
     serviceResource: serviceResourceSchema()
       .description(
-        deline`The Deployment, DaemonSet or StatefulSet that Garden should regard as the _Garden service_ in this module
-        (not to be confused with Kubernetes Service resources).
-        Because a \`kubernetes-module\` can contain any number of Kubernetes resources, this needs to be specified for certain
-        Garden features and commands to work.`
+        dedent`
+        The Deployment, DaemonSet or StatefulSet that Garden should regard as the _Garden service_ in this module (not to be confused with Kubernetes Service resources).
+        Because a \`kubernetes\` module can contain any number of Kubernetes resources, this needs to be specified for certain Garden features and commands to work.
+        `
       )
       .keys({
         containerModule: containerModuleSchema(),

--- a/core/src/plugins/kubernetes/kubernetes-module/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/handlers.ts
@@ -12,7 +12,7 @@ import { cloneDeep, partition, set, uniq } from "lodash"
 import { KubernetesModule, configureKubernetesModule, KubernetesService } from "./config"
 import { KubernetesPluginContext } from "../config"
 import { BaseResource, KubernetesResource, KubernetesServerResource } from "../types"
-import { GardenService, ServiceStatus } from "../../../types/service"
+import { ServiceStatus } from "../../../types/service"
 import { compareDeployedResources, waitForResources } from "../status/status"
 import { KubeApi } from "../api"
 import { ModuleAndRuntimeActionHandlers } from "../../../types/plugin/plugin"
@@ -31,12 +31,15 @@ import { runKubernetesTask } from "./run"
 import { getTestResult } from "../test-results"
 import { getTaskResult } from "../task-results"
 import { getModuleNamespace } from "../namespace"
-import { hotReloadK8s } from "../hot-reload/hot-reload"
+import { HotReloadableResource, hotReloadK8s } from "../hot-reload/hot-reload"
 import { findServiceResource, getServiceResourceSpec } from "../util"
 import { getHotReloadSpec, configureHotReload, getHotReloadContainerName } from "../hot-reload/helpers"
 import { LogEntry } from "../../../logger/log-entry"
 import { PluginContext } from "../../../plugin-context"
 import { V1Deployment, V1DaemonSet, V1StatefulSet } from "@kubernetes/client-node"
+import { HelmService } from "../helm/config"
+import { configureDevMode, startDevModeSync } from "../dev-mode"
+import chalk from "chalk"
 
 export const kubernetesHandlers: Partial<ModuleAndRuntimeActionHandlers<KubernetesModule>> = {
   build,
@@ -70,6 +73,7 @@ export async function getKubernetesServiceStatus({
   module,
   log,
   service,
+  devMode,
   hotReload,
 }: GetServiceStatusParams<KubernetesModule>): Promise<KubernetesServiceStatus> {
   const k8sCtx = <KubernetesPluginContext>ctx
@@ -85,18 +89,46 @@ export async function getKubernetesServiceStatus({
   // because the build may not have been staged.
   // This means that manifests added via the `build.dependencies[].copy` field will not be included.
   const manifests = await getManifests({ api, log, module, defaultNamespace: namespace, readFromSrcDir: true })
-  const preparedForHotReload = await prepareManifestsForHotReload({
+  const prepareResult = await prepareManifestsForSync({
     ctx,
     log,
     module,
     service,
+    devMode,
     hotReload,
     manifests,
   })
 
-  const { state, remoteResources } = await compareDeployedResources(k8sCtx, api, namespace, preparedForHotReload, log)
+  let { state, remoteResources } = await compareDeployedResources(k8sCtx, api, namespace, prepareResult.manifests, log)
 
   const forwardablePorts = getForwardablePorts(remoteResources)
+
+  if (state === "ready" && devMode && service.spec.devMode) {
+    // Need to start the dev-mode sync here, since the deployment handler won't be called.
+    const serviceResourceSpec = getServiceResourceSpec(module, undefined)
+    const target = await findServiceResource({
+      ctx,
+      log,
+      module,
+      baseModule: undefined,
+      manifests: remoteResources,
+      resourceSpec: serviceResourceSpec,
+    })
+
+    if (target.metadata.annotations?.[gardenAnnotationKey("dev-mode")] === "true") {
+      await startDevModeSync({
+        ctx,
+        log: log.info({ section: service.name, symbol: "info", msg: chalk.gray(`Starting sync`) }),
+        moduleRoot: service.sourceModule.path,
+        namespace,
+        target,
+        spec: service.spec.devMode,
+        containerName: service.spec.devMode.containerName,
+      })
+    } else {
+      state = "outdated"
+    }
+  }
 
   return {
     forwardablePorts,
@@ -109,7 +141,7 @@ export async function getKubernetesServiceStatus({
 export async function deployKubernetesService(
   params: DeployServiceParams<KubernetesModule>
 ): Promise<KubernetesServiceStatus> {
-  const { ctx, module, service, log, hotReload } = params
+  const { ctx, module, service, log, hotReload, devMode } = params
 
   const k8sCtx = <KubernetesPluginContext>ctx
   const api = await KubeApi.factory(log, ctx, k8sCtx.provider)
@@ -140,24 +172,29 @@ export async function deployKubernetesService(
     })
   }
 
+  let target: HotReloadableResource | undefined
+
   const pruneSelector = getSelector(service)
   if (otherManifests.length > 0) {
-    const preparedForHotReload = await prepareManifestsForHotReload({
+    const prepareResult = await prepareManifestsForSync({
       ctx,
       log,
       module,
       service,
+      devMode,
       hotReload,
       manifests,
     })
 
-    await apply({ log, ctx, provider: k8sCtx.provider, manifests: preparedForHotReload, pruneSelector })
+    target = prepareResult.target
+
+    await apply({ log, ctx, provider: k8sCtx.provider, manifests: prepareResult.manifests, pruneSelector })
     await waitForResources({
       namespace,
       ctx,
       provider: k8sCtx.provider,
       serviceName: service.name,
-      resources: preparedForHotReload,
+      resources: prepareResult.manifests,
       log,
     })
   }
@@ -166,6 +203,18 @@ export async function deployKubernetesService(
 
   // Make sure port forwards work after redeployment
   killPortForwards(service, status.forwardablePorts || [], log)
+
+  if (devMode && service.spec.devMode && target) {
+    await startDevModeSync({
+      ctx,
+      log: log.info({ section: service.name, symbol: "info", msg: chalk.gray(`Starting sync`) }),
+      moduleRoot: service.sourceModule.path,
+      namespace,
+      target,
+      spec: service.spec.devMode,
+      containerName: service.spec.devMode.containerName,
+    })
+  }
 
   return status
 }
@@ -241,32 +290,34 @@ function getSelector(service: KubernetesService) {
 }
 
 /**
- * Looks for a hot reload target in a list of manifests. If found, the target is either
- * configured for hot reloading or annotated with `hot-reload: false`.
+ * Looks for a hot-reload or dev-mode target in a list of manifests. If found, the target is either
+ * configured for hot-reloading/dev-mode or annotated with `dev-mode: false` and/or `hot-reload: false`.
  *
  * Returns the manifests with the original hot reload resource replaced by the modified spec
  *
- * No-op if no hot reload target found and hot reloading is not enabled.
+ * No-op if no target found and neither hot-reloading nor dev-mode is enabled.
  */
-async function prepareManifestsForHotReload({
+async function prepareManifestsForSync({
   ctx,
   log,
   module,
   service,
+  devMode,
   hotReload,
   manifests,
 }: {
   ctx: PluginContext
-  service: GardenService
+  service: KubernetesService | HelmService
   log: LogEntry
   module: KubernetesModule
+  devMode: boolean
   hotReload: boolean
   manifests: KubernetesResource<BaseResource>[]
 }) {
-  let hotReloadTarget: KubernetesResource<V1Deployment | V1DaemonSet | V1StatefulSet>
+  let target: KubernetesResource<V1Deployment | V1DaemonSet | V1StatefulSet>
 
   try {
-    hotReloadTarget = cloneDeep(
+    target = cloneDeep(
       await findServiceResource({
         ctx,
         log,
@@ -278,30 +329,41 @@ async function prepareManifestsForHotReload({
     )
   } catch (err) {
     // This is only an error if we're actually trying to hot reload.
-    if (hotReload) {
+    if (devMode || hotReload) {
       throw err
     } else {
       // Nothing to do, so we return the original manifests
-      return manifests
+      return { manifests, target: undefined }
     }
   }
 
+  set(target, ["metadata", "annotations", gardenAnnotationKey("dev-mode")], "false")
+  set(target, ["metadata", "annotations", gardenAnnotationKey("hot-reload")], "false")
+
+  const devModeSpec = service.spec.devMode
   const hotReloadSpec = hotReload ? getHotReloadSpec(service) : null
-  if (hotReload && hotReloadSpec) {
+
+  if (devMode && devModeSpec) {
+    configureDevMode({
+      target,
+      spec: devModeSpec,
+      containerName: devModeSpec.containerName,
+    })
+  } else if (hotReload && hotReloadSpec) {
     const resourceSpec = getServiceResourceSpec(module, undefined)
     configureHotReload({
-      target: hotReloadTarget,
+      target,
       hotReloadSpec,
       hotReloadArgs: resourceSpec.hotReloadArgs,
       containerName: getHotReloadContainerName(module),
     })
-    set(hotReloadTarget, ["metadata", "annotations", gardenAnnotationKey("hot-reload")], "true")
-  } else {
-    set(hotReloadTarget, ["metadata", "annotations", gardenAnnotationKey("hot-reload")], "false")
+    set(target, ["metadata", "annotations", gardenAnnotationKey("hot-reload")], "true")
   }
 
   // Replace the original hot reload resource with the modified spec
-  return manifests
-    .filter((m) => !(m.kind === hotReloadTarget!.kind && hotReloadTarget?.metadata.name === m.metadata.name))
-    .concat(<KubernetesResource<BaseResource>>hotReloadTarget)
+  const preparedManifests = manifests
+    .filter((m) => !(m.kind === target!.kind && target?.metadata.name === m.metadata.name))
+    .concat(<KubernetesResource<BaseResource>>target)
+
+  return { target, manifests: preparedManifests }
 }

--- a/core/src/plugins/kubernetes/kubernetes-module/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/handlers.ts
@@ -344,6 +344,7 @@ async function prepareManifestsForSync({
   const hotReloadSpec = hotReload ? getHotReloadSpec(service) : null
 
   if (devMode && devModeSpec) {
+    // The "dev-mode" annotation is set in `configureDevMode`.
     configureDevMode({
       target,
       spec: devModeSpec,

--- a/core/src/plugins/kubernetes/kubernetes.ts
+++ b/core/src/plugins/kubernetes/kubernetes.ts
@@ -41,6 +41,7 @@ import { getModuleTypeUrl, getProviderUrl } from "../../docs/common"
 import { helm3Spec } from "./helm/helm-cli"
 import { sternSpec } from "./logs"
 import { isString } from "lodash"
+import { mutagenCliSpec } from "./mutagen"
 
 export async function configureProvider({
   namespace,
@@ -262,5 +263,5 @@ export const gardenPlugin = () =>
         handlers: containerHandlers,
       },
     ],
-    tools: [kubectlSpec, helm3Spec, sternSpec],
+    tools: [kubectlSpec, helm3Spec, mutagenCliSpec, sternSpec],
   })

--- a/core/src/plugins/kubernetes/mutagen.ts
+++ b/core/src/plugins/kubernetes/mutagen.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2018-2020 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import chalk from "chalk"
+import { mkdirp, removeSync } from "fs-extra"
+import respawn from "respawn"
+import { LogEntry } from "../../logger/log-entry"
+import { PluginToolSpec } from "../../types/plugin/tools"
+import { PluginTool } from "../../util/ext-tools"
+import { makeTempDir, TempDirectory } from "../../util/fs"
+import { registerCleanupFunction } from "../../util/util"
+
+const maxRestarts = 10
+
+let daemonProc: any
+let mutagenTmp: TempDirectory
+
+registerCleanupFunction("kill-sync-daaemon", () => {
+  try {
+    daemonProc?.stop()
+  } catch {}
+
+  mutagenTmp && removeSync(mutagenTmp.path)
+})
+
+export async function ensureMutagenDaemon(log: LogEntry, mutagen: PluginTool) {
+  if (!mutagenTmp) {
+    mutagenTmp = await makeTempDir()
+  }
+
+  const dataDir = mutagenTmp.path
+
+  if (daemonProc && daemonProc.status === "running") {
+    return dataDir
+  }
+
+  const mutagenPath = await mutagen.getPath(log)
+
+  await mkdirp(dataDir)
+
+  daemonProc = respawn([mutagenPath, "daemon", "run"], {
+    cwd: dataDir,
+    name: "mutagen",
+    env: {
+      MUTAGEN_DATA_DIRECTORY: dataDir,
+    },
+    maxRestarts,
+    sleep: 1000,
+    kill: 500,
+    stdio: "pipe",
+    fork: false,
+  })
+
+  const crashMessage = `Synchronization daemon has crashed ${maxRestarts} times. Aborting.`
+
+  daemonProc.on("crash", () => {
+    log.root.warn(chalk.yellow(crashMessage))
+  })
+
+  daemonProc.on("exit", (code: number) => {
+    if (code !== 0) {
+      log.root.warn(chalk.yellow(`Synchronization daemon exited with code ${code}.`))
+    }
+  })
+
+  daemonProc.on("stdout", (data: Buffer) => {
+    log.silly({ section: "mutagen", msg: data.toString() })
+  })
+  daemonProc.on("stderr", (data: Buffer) => {
+    log.silly({ section: "mutagen", msg: data.toString() })
+  })
+
+  return new Promise<string>((resolve, reject) => {
+    let resolved = false
+
+    daemonProc.once("spawn", () => {
+      if (resolved) {
+        return
+      }
+
+      setTimeout(() => {
+        if (daemonProc.status === "running") {
+          log.info("→ Synchronization daemon started")
+          resolved = true
+          resolve(dataDir)
+        }
+      }, 500)
+    })
+
+    daemonProc.once("crash", () => {
+      if (!resolved) {
+        reject(crashMessage)
+      }
+    })
+
+    daemonProc.start()
+  })
+}
+
+export const mutagenCliSpec: PluginToolSpec = {
+  name: "mutagen",
+  description: "The mutagen synchronization tool.",
+  type: "binary",
+  _includeInGardenImage: false,
+  builds: [
+    {
+      platform: "darwin",
+      architecture: "amd64",
+      url:
+        "https://github.com/garden-io/mutagen/releases/download/v0.12.0-garden-alpha1/mutagen_darwin_amd64_v0.12.0-beta2.tar.gz",
+      sha256: "de45df05e6eddb4ad9672da8240ca43302cd901d8d58b627ca8a26c94d1f24bf",
+      extract: {
+        format: "tar",
+        targetPath: "mutagen",
+      },
+    },
+    {
+      platform: "linux",
+      architecture: "amd64",
+      url:
+        "https://github.com/garden-io/mutagen/releases/download/v0.12.0-garden-alpha1/mutagen_linux_amd64_v0.12.0-beta2.tar.gz",
+      sha256: "b423dc5fd396b174a53dcf348ccc229169976a3ea390a2ce4ba9d7a3d13c2619",
+      extract: {
+        format: "tar",
+        targetPath: "mutagen",
+      },
+    },
+    {
+      platform: "windows",
+      architecture: "amd64",
+      url:
+        "https://github.com/garden-io/mutagen/releases/download/v0.12.0-garden-alpha1/mutagen_windows_amd64_v0.12.0-beta2.tar.gz",
+      sha256: "f526221a1078cbad48115b0d02c7e2c0118f2b3d46778d19717c654c7096f242",
+      extract: {
+        format: "tar",
+        targetPath: "mutagen.exe",
+      },
+    },
+  ],
+}

--- a/core/src/plugins/local/local-docker-swarm.ts
+++ b/core/src/plugins/local/local-docker-swarm.ts
@@ -115,6 +115,7 @@ export const gardenPlugin = () =>
               module,
               runtimeContext,
               log,
+              devMode: false,
               hotReload: false,
             })
             let swarmServiceStatus
@@ -172,7 +173,7 @@ export const gardenPlugin = () =>
               msg: `Ready`,
             })
 
-            return getServiceStatus({ ctx, module, service, runtimeContext, log, hotReload: false })
+            return getServiceStatus({ ctx, module, service, runtimeContext, log, devMode: false, hotReload: false })
           },
 
           async execInService({ ctx, service, command, log }: ExecInServiceParams<ContainerModule>) {
@@ -186,6 +187,7 @@ export const gardenPlugin = () =>
                 dependencies: [],
               },
               log,
+              devMode: false,
               hotReload: false,
             })
 

--- a/core/src/plugins/openfaas/openfaas.ts
+++ b/core/src/plugins/openfaas/openfaas.ts
@@ -331,6 +331,7 @@ async function deleteService(params: DeleteServiceParams<OpenFaasModule>): Promi
         dependencies: [],
       },
       module: service.module,
+      devMode: false,
       hotReload: false,
     })
 

--- a/core/src/tasks/base.ts
+++ b/core/src/tasks/base.ts
@@ -28,6 +28,7 @@ export type TaskType =
   | "resolve-module"
   | "resolve-provider"
   | "stage-build"
+  | "start-sync"
   | "task"
   | "test"
 

--- a/core/src/tasks/get-service-status.ts
+++ b/core/src/tasks/get-service-status.ts
@@ -39,7 +39,15 @@ export class GetServiceStatusTask extends BaseTask {
   private devModeServiceNames: string[]
   private hotReloadServiceNames: string[]
 
-  constructor({ garden, graph, log, service, force, devModeServiceNames, hotReloadServiceNames }: GetServiceStatusTaskParams) {
+  constructor({
+    garden,
+    graph,
+    log,
+    service,
+    force,
+    devModeServiceNames,
+    hotReloadServiceNames,
+  }: GetServiceStatusTaskParams) {
     super({ garden, log, force, version: service.version })
     this.graph = graph
     this.service = service

--- a/core/src/tasks/helpers.ts
+++ b/core/src/tasks/helpers.ts
@@ -55,9 +55,8 @@ export async function getModuleWatchTasks({
   const serviceNamesUsingModule = [...module.serviceNames, ...dependantSourceModuleServiceNames]
 
   /**
-   * If a service is deployed with hot reloading or dev modenabled, we don't rebuild its module
-   * (or its sourceModule, if the service instead uses a sourceModule) when its
-   * sources change.
+   * If a service is deployed with hot reloading or has dev mode enabled, we don't rebuild its module
+   * (or its sourceModule, if the service instead uses a sourceModule) when its sources change.
    *
    * Therefore, we skip adding a build task for module if one of its services is in
    * hotReloadServiceNames, or if one of its build dependants' services is in

--- a/core/src/tasks/hot-reload.ts
+++ b/core/src/tasks/hot-reload.ts
@@ -18,7 +18,7 @@ interface Params {
   force: boolean
   garden: Garden
   graph: ConfigGraph
-  hotReloadServiceNames?: string[]
+  hotReloadServiceNames: string[]
   log: LogEntry
   service: GardenService
 }

--- a/core/src/tasks/task.ts
+++ b/core/src/tasks/task.ts
@@ -28,6 +28,8 @@ export interface TaskTaskParams {
   task: GardenTask
   force: boolean
   forceBuild: boolean
+  devModeServiceNames: string[]
+  hotReloadServiceNames: string[]
 }
 
 class RunTaskError extends Error {
@@ -44,13 +46,26 @@ export class TaskTask extends BaseTask {
   private graph: ConfigGraph
   private task: GardenTask
   private forceBuild: boolean
+  private devModeServiceNames: string[]
+  private hotReloadServiceNames: string[]
 
-  constructor({ garden, log, graph, task, force, forceBuild }: TaskTaskParams) {
+  constructor({
+    garden,
+    log,
+    graph,
+    task,
+    force,
+    forceBuild,
+    devModeServiceNames,
+    hotReloadServiceNames,
+  }: TaskTaskParams) {
     super({ garden, log, force, version: task.version })
     this.graph = graph
     this.task = task
     this.force = force
     this.forceBuild = forceBuild
+    this.devModeServiceNames = devModeServiceNames
+    this.hotReloadServiceNames = hotReloadServiceNames
   }
 
   async resolveDependencies(): Promise<BaseTask[]> {
@@ -72,6 +87,8 @@ export class TaskTask extends BaseTask {
         graph: this.graph,
         force: false,
         forceBuild: false,
+        devModeServiceNames: this.devModeServiceNames,
+        hotReloadServiceNames: this.hotReloadServiceNames,
       })
     })
 
@@ -83,6 +100,8 @@ export class TaskTask extends BaseTask {
         graph: this.graph,
         force: false,
         forceBuild: false,
+        devModeServiceNames: this.devModeServiceNames,
+        hotReloadServiceNames: this.hotReloadServiceNames,
       })
     })
 

--- a/core/src/tasks/test.ts
+++ b/core/src/tasks/test.ts
@@ -39,7 +39,8 @@ export interface TestTaskParams {
   test: GardenTest
   force: boolean
   forceBuild: boolean
-  hotReloadServiceNames?: string[]
+  devModeServiceNames: string[]
+  hotReloadServiceNames: string[]
 }
 
 @Profile()
@@ -49,14 +50,25 @@ export class TestTask extends BaseTask {
   private test: GardenTest
   private graph: ConfigGraph
   private forceBuild: boolean
+  private devModeServiceNames: string[]
   private hotReloadServiceNames: string[]
 
-  constructor({ garden, graph, log, test, force, forceBuild, hotReloadServiceNames = [] }: TestTaskParams) {
+  constructor({
+    garden,
+    graph,
+    log,
+    test,
+    force,
+    forceBuild,
+    devModeServiceNames,
+    hotReloadServiceNames,
+  }: TestTaskParams) {
     super({ garden, log, force, version: test.version })
     this.test = test
     this.graph = graph
     this.force = force
     this.forceBuild = forceBuild
+    this.devModeServiceNames = devModeServiceNames
     this.hotReloadServiceNames = hotReloadServiceNames
   }
 
@@ -71,7 +83,11 @@ export class TestTask extends BaseTask {
       nodeType: "test",
       name: this.getName(),
       recursive: false,
-      filter: (depNode) => !(depNode.type === "deploy" && includes(this.hotReloadServiceNames, depNode.name)),
+      filter: (depNode) =>
+        !(
+          depNode.type === "deploy" &&
+          includes([...this.devModeServiceNames, ...this.hotReloadServiceNames], depNode.name)
+        ),
     })
 
     const buildTasks = await BuildTask.factory({
@@ -90,6 +106,8 @@ export class TestTask extends BaseTask {
         graph: this.graph,
         force: this.force,
         forceBuild: this.forceBuild,
+        devModeServiceNames: this.devModeServiceNames,
+        hotReloadServiceNames: this.hotReloadServiceNames,
       })
     })
 
@@ -102,6 +120,8 @@ export class TestTask extends BaseTask {
           service,
           force: false,
           forceBuild: this.forceBuild,
+          devModeServiceNames: this.devModeServiceNames,
+          hotReloadServiceNames: this.hotReloadServiceNames,
         })
     )
 
@@ -209,6 +229,7 @@ export async function getTestTasks({
   graph,
   module,
   filterNames,
+  devModeServiceNames,
   hotReloadServiceNames,
   force = false,
   forceBuild = false,
@@ -218,7 +239,8 @@ export async function getTestTasks({
   graph: ConfigGraph
   module: GardenModule
   filterNames?: string[]
-  hotReloadServiceNames?: string[]
+  devModeServiceNames: string[]
+  hotReloadServiceNames: string[]
   force?: boolean
   forceBuild?: boolean
 }) {
@@ -240,6 +262,7 @@ export async function getTestTasks({
         force,
         forceBuild,
         test: testFromConfig(module, testConfig, graph),
+        devModeServiceNames,
         hotReloadServiceNames,
       })
   )

--- a/core/src/types/plugin/service/deployService.ts
+++ b/core/src/types/plugin/service/deployService.ts
@@ -15,6 +15,7 @@ import { joi } from "../../../config/common"
 
 export interface DeployServiceParams<M extends GardenModule = GardenModule, S extends GardenModule = GardenModule>
   extends PluginServiceActionParamsBase<M, S> {
+  devMode: boolean
   force: boolean
   hotReload: boolean
   runtimeContext: RuntimeContext
@@ -28,6 +29,7 @@ export const deployService = () => ({
     Called by the \`garden deploy\` and \`garden dev\` commands.
   `,
   paramsSchema: serviceActionParamsSchema().keys({
+    devMode: joi.boolean().default(false).description("Whether to configure the service for development."),
     force: joi.boolean().description("Whether to force a re-deploy, even if the service is already deployed."),
     runtimeContext: runtimeContextSchema(),
     hotReload: joi.boolean().default(false).description("Whether to configure the service for hot-reloading."),

--- a/core/src/types/plugin/service/deployService.ts
+++ b/core/src/types/plugin/service/deployService.ts
@@ -29,7 +29,7 @@ export const deployService = () => ({
     Called by the \`garden deploy\` and \`garden dev\` commands.
   `,
   paramsSchema: serviceActionParamsSchema().keys({
-    devMode: joi.boolean().default(false).description("Whether to configure the service for development."),
+    devMode: joi.boolean().default(false).description("Whether the service should be configured in dev mode."),
     force: joi.boolean().description("Whether to force a re-deploy, even if the service is already deployed."),
     runtimeContext: runtimeContextSchema(),
     hotReload: joi.boolean().default(false).description("Whether to configure the service for hot-reloading."),

--- a/core/src/types/plugin/service/getServiceStatus.ts
+++ b/core/src/types/plugin/service/getServiceStatus.ts
@@ -17,6 +17,7 @@ export type hotReloadStatus = "enabled" | "disabled"
 
 export interface GetServiceStatusParams<M extends GardenModule = GardenModule, S extends GardenModule = GardenModule>
   extends PluginServiceActionParamsBase<M, S> {
+  devMode: boolean
   hotReload: boolean
   runtimeContext: RuntimeContext
 }
@@ -33,6 +34,7 @@ export const getServiceStatus = () => ({
   `,
   paramsSchema: serviceActionParamsSchema().keys({
     runtimeContext: runtimeContextSchema(),
+    devMode: joi.boolean().default(false).description("Whether the service should be configured in dev mode."),
     hotReload: joi.boolean().default(false).description("Whether the service should be configured for hot-reloading."),
   }),
   resultSchema: serviceStatusSchema(),

--- a/core/src/util/string.ts
+++ b/core/src/util/string.ts
@@ -25,6 +25,7 @@ export const stableStringify = _stableStringify
 const gardenAnnotationPrefix = "garden.io/"
 
 export type GardenAnnotationKey =
+  | "dev-mode"
   | "generated"
   | "helm-migrated"
   | "hot-reload"

--- a/core/test/data/test-projects/container/dev-mode/Dockerfile
+++ b/core/test/data/test-projects/container/dev-mode/Dockerfile
@@ -1,0 +1,1 @@
+FROM busybox:1.31.1

--- a/core/test/data/test-projects/container/dev-mode/garden.yml
+++ b/core/test/data/test-projects/container/dev-mode/garden.yml
@@ -1,0 +1,16 @@
+kind: Module
+name: dev-mode
+description: Test module for a simple hot reloadable service
+type: container
+services:
+  - name: dev-mode
+    command: [sh, -c, "echo Server running... && nc -l -p 8080"]
+    devMode:
+      sync:
+        - target: /tmp
+          mode: two-way
+    healthCheck:
+      command: ["echo", "ok"]
+    ports:
+      - name: http
+        containerPort: 8080

--- a/core/test/data/test-projects/helm/api/garden.yml
+++ b/core/test/data/test-projects/helm/api/garden.yml
@@ -3,6 +3,10 @@ description: The API backend for the voting UI
 type: helm
 name: api
 releaseName: api-release
+devMode:
+  sync:
+  - target: /app
+    mode: two-way
 serviceResource:
   kind: Deployment
   containerModule: api-image

--- a/core/test/data/test-projects/kubernetes-module/with-source-module/garden.yml
+++ b/core/test/data/test-projects/kubernetes-module/with-source-module/garden.yml
@@ -2,6 +2,10 @@ kind: Module
 type: kubernetes
 name: with-source-module
 description: Simple Kubernetes module with minimum config that has a container source module
+devMode:
+  sync:
+  - source: "*"
+    target: /app
 manifests:
   - apiVersion: apps/v1
     kind: Deployment

--- a/core/test/e2e/src/pre-release.ts
+++ b/core/test/e2e/src/pre-release.ts
@@ -98,8 +98,8 @@ describe("PreReleaseTests", () => {
   if (project === "demo-project") {
     describe("demo-project", () => {
       describe("top-level sanity checks", () => {
-        it("runs the dev command", async () => {
-          const gardenWatch = watchWithEnv(["dev"])
+        it("runs the deploy command", async () => {
+          const gardenWatch = watchWithEnv(["deploy", "--watch"])
 
           const testSteps = [
             taskCompletedStep("deploy.backend", 1),
@@ -156,9 +156,9 @@ describe("PreReleaseTests", () => {
 
   if (project === "hot-reload") {
     describe("hot-reload", () => {
-      it("runs the dev command with hot reloading enabled", async () => {
+      it("runs the deploy command with hot reloading enabled", async () => {
         const hotReloadProjectPath = resolve(examplesDir, "hot-reload")
-        const gardenWatch = watchWithEnv(["dev", "--hot=node-service"])
+        const gardenWatch = watchWithEnv(["deploy", "--hot=node-service"])
 
         const testSteps = [
           waitingForChangesStep(),
@@ -187,7 +187,7 @@ describe("PreReleaseTests", () => {
       })
 
       it("should get logs after a hot reload event", async () => {
-        const gardenWatch = watchWithEnv(["dev", "--hot=node-service"])
+        const gardenWatch = watchWithEnv(["deploy", "--hot=node-service"])
         const hotReloadProjectPath = resolve(examplesDir, "hot-reload")
 
         const testSteps = [
@@ -211,9 +211,9 @@ describe("PreReleaseTests", () => {
 
         await gardenWatch.run({ testSteps })
       })
-      it("runs the dev command with hot reloading enabled, using a post-sync command", async () => {
+      it("runs the deploy command with hot reloading enabled, using a post-sync command", async () => {
         const hotReloadProjectPath = resolve(examplesDir, "hot-reload-post-sync-command")
-        const gardenWatch = watchWithEnv(["dev", "--hot=node-service"])
+        const gardenWatch = watchWithEnv(["deploy", "--hot=node-service"])
 
         const testSteps = [
           waitingForChangesStep(),
@@ -245,8 +245,8 @@ describe("PreReleaseTests", () => {
 
   if (project === "vote-helm") {
     describe("vote-helm: helm & dependency calculations", () => {
-      it("runs the dev command", async () => {
-        const gardenWatch = watchWithEnv(["dev"])
+      it("runs the deploy command", async () => {
+        const gardenWatch = watchWithEnv(["deploy", "--watch"])
 
         const testSteps = [
           waitingForChangesStep(),
@@ -264,8 +264,8 @@ describe("PreReleaseTests", () => {
 
   if (project === "vote") {
     describe("vote: dependency calculations", () => {
-      it("runs the dev command", async () => {
-        const gardenWatch = watchWithEnv(["dev"])
+      it("runs the deploy command", async () => {
+        const gardenWatch = watchWithEnv(["deploy", "--watch"])
 
         const testSteps = [
           waitingForChangesStep(),
@@ -297,8 +297,8 @@ describe("PreReleaseTests", () => {
 
   if (project === "deployment-strategies") {
     describe("deployment-strategies: top-level sanity checks", () => {
-      it("runs the dev command", async () => {
-        const gardenWatch = watchWithEnv(["dev"])
+      it("runs the deploy command", async () => {
+        const gardenWatch = watchWithEnv(["deploy", "--watch"])
 
         const testSteps = [
           taskCompletedStep("deploy.backend", 1),

--- a/core/test/integ/src/plugins/hadolint/hadolint.ts
+++ b/core/test/integ/src/plugins/hadolint/hadolint.ts
@@ -189,6 +189,8 @@ describe("hadolint provider", () => {
         test: testFromConfig(module, module.testConfigs[0], graph),
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       const key = testTask.getKey()
@@ -251,6 +253,8 @@ describe("hadolint provider", () => {
         test: testFromConfig(module, module.testConfigs[0], graph),
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       const key = testTask.getKey()
@@ -308,6 +312,8 @@ describe("hadolint provider", () => {
         test: testFromConfig(module, module.testConfigs[0], graph),
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       const key = testTask.getKey()
@@ -359,6 +365,8 @@ describe("hadolint provider", () => {
         test: testFromConfig(module, module.testConfigs[0], graph),
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       const key = testTask.getKey()
@@ -400,6 +408,8 @@ describe("hadolint provider", () => {
         test: testFromConfig(module, module.testConfigs[0], graph),
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       const key = testTask.getKey()
@@ -444,6 +454,8 @@ describe("hadolint provider", () => {
         graph,
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       const key = testTask.getKey()

--- a/core/test/integ/src/plugins/kubernetes/container/container.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/container.ts
@@ -188,6 +188,8 @@ describe("kubernetes container module handlers", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       const result = await garden.processTasks([testTask], { throwOnError: true })
@@ -212,6 +214,8 @@ describe("kubernetes container module handlers", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       await expectError(
@@ -244,6 +248,8 @@ describe("kubernetes container module handlers", () => {
           log: garden.log,
           force: true,
           forceBuild: false,
+          devModeServiceNames: [],
+          hotReloadServiceNames: [],
         })
 
         await emptyDir(garden.artifactsPath)
@@ -264,6 +270,8 @@ describe("kubernetes container module handlers", () => {
           log: garden.log,
           force: true,
           forceBuild: false,
+          devModeServiceNames: [],
+          hotReloadServiceNames: [],
         })
 
         await emptyDir(garden.artifactsPath)
@@ -286,6 +294,8 @@ describe("kubernetes container module handlers", () => {
           log: garden.log,
           force: true,
           forceBuild: false,
+          devModeServiceNames: [],
+          hotReloadServiceNames: [],
         })
 
         await emptyDir(garden.artifactsPath)
@@ -306,6 +316,8 @@ describe("kubernetes container module handlers", () => {
           log: garden.log,
           force: true,
           forceBuild: false,
+          devModeServiceNames: [],
+          hotReloadServiceNames: [],
         })
 
         const result = await garden.processTasks([testTask])
@@ -330,6 +342,8 @@ describe("kubernetes container module handlers", () => {
           log: garden.log,
           force: true,
           forceBuild: false,
+          devModeServiceNames: [],
+          hotReloadServiceNames: [],
         })
 
         const result = await garden.processTasks([testTask])

--- a/core/test/integ/src/plugins/kubernetes/container/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/deployment.ts
@@ -59,6 +59,7 @@ describe("kubernetes container deployment handlers", () => {
         service,
         runtimeContext: emptyRuntimeContext,
         namespace,
+        enableDevMode: false,
         enableHotReload: false,
         log: garden.log,
         production: false,
@@ -128,6 +129,7 @@ describe("kubernetes container deployment handlers", () => {
         service,
         runtimeContext: emptyRuntimeContext,
         namespace,
+        enableDevMode: false,
         enableHotReload: false,
         log: garden.log,
         production: false,
@@ -147,6 +149,7 @@ describe("kubernetes container deployment handlers", () => {
         service,
         runtimeContext: emptyRuntimeContext,
         namespace,
+        enableDevMode: false,
         enableHotReload: true,
         log: garden.log,
         production: false,
@@ -168,6 +171,14 @@ describe("kubernetes container deployment handlers", () => {
       })
     })
 
+    it("should configure the service for sync with dev mode enabled", async () => {
+      throw "TODO"
+    })
+
+    it("should increase liveness probes when in dev mode", async () => {
+      throw "TODO"
+    })
+
     it("should name the Deployment with a version suffix and set a version label if blueGreen=true", async () => {
       const service = graph.getService("simple-service")
       const namespace = provider.config.namespace!.name!
@@ -178,6 +189,7 @@ describe("kubernetes container deployment handlers", () => {
         service,
         runtimeContext: emptyRuntimeContext,
         namespace,
+        enableDevMode: false,
         enableHotReload: false,
         log: garden.log,
         production: false,
@@ -223,6 +235,7 @@ describe("kubernetes container deployment handlers", () => {
         service,
         runtimeContext: emptyRuntimeContext,
         namespace,
+        enableDevMode: false,
         enableHotReload: false,
         log: garden.log,
         production: false,
@@ -262,6 +275,7 @@ describe("kubernetes container deployment handlers", () => {
         service,
         runtimeContext: emptyRuntimeContext,
         namespace,
+        enableDevMode: false,
         enableHotReload: false,
         log: garden.log,
         production: false,
@@ -283,6 +297,7 @@ describe("kubernetes container deployment handlers", () => {
         service,
         runtimeContext: emptyRuntimeContext,
         namespace,
+        enableDevMode: false,
         enableHotReload: false,
         log: garden.log,
         production: false,
@@ -309,6 +324,7 @@ describe("kubernetes container deployment handlers", () => {
             service,
             runtimeContext: emptyRuntimeContext,
             namespace,
+            enableDevMode: false,
             enableHotReload: false,
             log: garden.log,
             production: false,
@@ -338,6 +354,8 @@ describe("kubernetes container deployment handlers", () => {
           service,
           force: true,
           forceBuild: false,
+          devModeServiceNames: [],
+          hotReloadServiceNames: [],
         })
 
         const results = await garden.processTasks([deployTask], { throwOnError: true })
@@ -359,6 +377,8 @@ describe("kubernetes container deployment handlers", () => {
           service,
           force: true,
           forceBuild: false,
+          devModeServiceNames: [],
+          hotReloadServiceNames: [],
         })
 
         const results = await garden.processTasks([deployTask], { throwOnError: true })
@@ -391,6 +411,8 @@ describe("kubernetes container deployment handlers", () => {
           service,
           force: true,
           forceBuild: false,
+          devModeServiceNames: [],
+          hotReloadServiceNames: [],
         })
 
         const results = await garden.processTasks([deployTask], { throwOnError: true })
@@ -412,6 +434,8 @@ describe("kubernetes container deployment handlers", () => {
           service,
           force: true,
           forceBuild: false,
+          devModeServiceNames: [],
+          hotReloadServiceNames: [],
         })
 
         const results = await garden.processTasks([deployTask], { throwOnError: true })
@@ -444,6 +468,8 @@ describe("kubernetes container deployment handlers", () => {
           service,
           force: true,
           forceBuild: false,
+          devModeServiceNames: [],
+          hotReloadServiceNames: [],
         })
 
         const results = await garden.processTasks([deployTask], { throwOnError: true })
@@ -471,6 +497,8 @@ describe("kubernetes container deployment handlers", () => {
           service,
           force: true,
           forceBuild: false,
+          devModeServiceNames: [],
+          hotReloadServiceNames: [],
         })
 
         const results = await garden.processTasks([deployTask], { throwOnError: true })
@@ -498,6 +526,8 @@ describe("kubernetes container deployment handlers", () => {
           service,
           force: true,
           forceBuild: false,
+          devModeServiceNames: [],
+          hotReloadServiceNames: [],
         })
 
         const results = await garden.processTasks([deployTask], { throwOnError: true })

--- a/core/test/integ/src/plugins/kubernetes/container/logs.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/logs.ts
@@ -49,6 +49,8 @@ describe("kubernetes", () => {
         graph,
         log: garden.log,
         service,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       await garden.processTasks([deployTask], { throwOnError: true })

--- a/core/test/integ/src/plugins/kubernetes/container/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/run.ts
@@ -47,6 +47,8 @@ describe("runContainerTask", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
     })
 
     const ctx = await garden.getPluginContext(provider)
@@ -81,6 +83,8 @@ describe("runContainerTask", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
     })
 
     const ctx = await garden.getPluginContext(provider)
@@ -109,6 +113,8 @@ describe("runContainerTask", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
     })
 
     const ctx = await garden.getPluginContext(provider)
@@ -140,6 +146,8 @@ describe("runContainerTask", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       await emptyDir(garden.artifactsPath)
@@ -160,6 +168,8 @@ describe("runContainerTask", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
       await emptyDir(garden.artifactsPath)
 
@@ -181,6 +191,8 @@ describe("runContainerTask", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       await emptyDir(garden.artifactsPath)
@@ -201,6 +213,8 @@ describe("runContainerTask", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       const result = await garden.processTasks([testTask])
@@ -226,6 +240,8 @@ describe("runContainerTask", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       const result = await garden.processTasks([testTask])

--- a/core/test/integ/src/plugins/kubernetes/helm/common.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/common.ts
@@ -104,6 +104,7 @@ describe("Helm common functions", () => {
       const templates = await renderTemplates({
         ctx,
         module,
+        devMode: false,
         hotReload: false,
         log,
         version: module.version.versionString,
@@ -193,6 +194,7 @@ describe("Helm common functions", () => {
       const templates = await renderTemplates({
         ctx,
         module,
+        devMode: false,
         hotReload: false,
         log,
         version: module.version.versionString,
@@ -214,6 +216,7 @@ describe("Helm common functions", () => {
       const resources = await getChartResources({
         ctx,
         module,
+        devMode: false,
         hotReload: false,
         log,
         version: module.version.versionString,
@@ -338,6 +341,7 @@ describe("Helm common functions", () => {
       const resources = await getChartResources({
         ctx,
         module,
+        devMode: false,
         hotReload: false,
         log,
         version: module.version.versionString,
@@ -353,8 +357,16 @@ describe("Helm common functions", () => {
 
     it("should handle duplicate keys in template", async () => {
       const module = graph.getModule("duplicate-keys-in-template")
-      expect(await getChartResources({ ctx, module, hotReload: false, log, version: module.version.versionString })).to
-        .not.throw
+      expect(
+        await getChartResources({
+          ctx,
+          module,
+          devMode: false,
+          hotReload: false,
+          log,
+          version: module.version.versionString,
+        })
+      ).to.not.throw
     })
 
     it("should filter out resources with hooks", async () => {
@@ -362,6 +374,7 @@ describe("Helm common functions", () => {
       const resources = await getChartResources({
         ctx,
         module,
+        devMode: false,
         hotReload: false,
         log,
         version: module.version.versionString,
@@ -472,14 +485,26 @@ describe("Helm common functions", () => {
       const module = graph.getModule("api")
       module.spec.valueFiles = []
       const gardenValuesPath = getGardenValuesPath(module.buildPath)
-      expect(await getValueArgs(module, false)).to.eql(["--values", gardenValuesPath])
+      expect(await getValueArgs(module, false, false)).to.eql(["--values", gardenValuesPath])
+    })
+
+    it("should add a --set flag if devMode=true", async () => {
+      const module = graph.getModule("api")
+      module.spec.valueFiles = []
+      const gardenValuesPath = getGardenValuesPath(module.buildPath)
+      expect(await getValueArgs(module, true, false)).to.eql([
+        "--values",
+        gardenValuesPath,
+        "--set",
+        "\\.garden.devMode=true",
+      ])
     })
 
     it("should add a --set flag if hotReload=true", async () => {
       const module = graph.getModule("api")
       module.spec.valueFiles = []
       const gardenValuesPath = getGardenValuesPath(module.buildPath)
-      expect(await getValueArgs(module, true)).to.eql([
+      expect(await getValueArgs(module, false, true)).to.eql([
         "--values",
         gardenValuesPath,
         "--set",
@@ -492,7 +517,7 @@ describe("Helm common functions", () => {
       module.spec.valueFiles = ["foo.yaml", "bar.yaml"]
       const gardenValuesPath = getGardenValuesPath(module.buildPath)
 
-      expect(await getValueArgs(module, false)).to.eql([
+      expect(await getValueArgs(module, false, false)).to.eql([
         "--values",
         resolve(module.buildPath, "foo.yaml"),
         "--values",

--- a/core/test/integ/src/plugins/kubernetes/helm/config.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/config.ts
@@ -53,6 +53,15 @@ describe("configureHelmModule", () => {
         dependencies: [],
       },
       chartPath: ".",
+      devMode: {
+        sync: [
+          {
+            mode: "two-way",
+            source: ".",
+            target: "/app",
+          },
+        ],
+      },
       dependencies: [],
       releaseName: "api-release",
       serviceResource: {

--- a/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
@@ -45,6 +45,7 @@ describe("deployHelmService", () => {
       module: service.module,
       service,
       force: false,
+      devMode: false,
       hotReload: false,
       runtimeContext: emptyRuntimeContext,
     })
@@ -55,6 +56,7 @@ describe("deployHelmService", () => {
       service,
       releaseName,
       log: garden.log,
+      devMode: false,
       hotReload: false,
     })
 
@@ -76,6 +78,7 @@ describe("deployHelmService", () => {
       module: service.module,
       service,
       force: false,
+      devMode: false,
       hotReload: true,
       runtimeContext: emptyRuntimeContext,
     })
@@ -86,6 +89,7 @@ describe("deployHelmService", () => {
       service,
       releaseName,
       log: garden.log,
+      devMode: false,
       hotReload: true,
     })
 
@@ -96,6 +100,10 @@ describe("deployHelmService", () => {
       version: service.version,
       hotReload: true,
     })
+  })
+
+  it("should deploy a chart with devMode enabled", async () => {
+    throw "TODO"
   })
 
   it("should deploy a chart with an alternate namespace set", async () => {
@@ -111,6 +119,7 @@ describe("deployHelmService", () => {
       module: service.module,
       service,
       force: false,
+      devMode: false,
       hotReload: false,
       runtimeContext: emptyRuntimeContext,
     })
@@ -121,6 +130,7 @@ describe("deployHelmService", () => {
       service,
       releaseName,
       log: garden.log,
+      devMode: false,
       hotReload: false,
     })
 

--- a/core/test/integ/src/plugins/kubernetes/helm/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/run.ts
@@ -38,6 +38,8 @@ describe("runHelmTask", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
     })
 
     const key = testTask.getKey()
@@ -76,6 +78,8 @@ describe("runHelmTask", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
     })
 
     // Clear any existing task result
@@ -105,6 +109,8 @@ describe("runHelmTask", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
     })
 
     const key = testTask.getKey()
@@ -128,6 +134,8 @@ describe("runHelmTask", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
     })
 
     await expectError(
@@ -157,6 +165,8 @@ describe("runHelmTask", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       await emptyDir(garden.artifactsPath)
@@ -177,6 +187,8 @@ describe("runHelmTask", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
       await emptyDir(garden.artifactsPath)
 
@@ -198,6 +210,8 @@ describe("runHelmTask", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       await emptyDir(garden.artifactsPath)

--- a/core/test/integ/src/plugins/kubernetes/helm/test.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/test.ts
@@ -39,6 +39,8 @@ describe("testHelmModule", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
     })
 
     const key = testTask.getKey()
@@ -59,6 +61,8 @@ describe("testHelmModule", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
     })
 
     const key = testTask.getKey()
@@ -84,6 +88,8 @@ describe("testHelmModule", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
     })
 
     await expectError(
@@ -114,6 +120,8 @@ describe("testHelmModule", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       await emptyDir(garden.artifactsPath)
@@ -134,6 +142,8 @@ describe("testHelmModule", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       await emptyDir(garden.artifactsPath)
@@ -156,6 +166,8 @@ describe("testHelmModule", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       await emptyDir(garden.artifactsPath)

--- a/core/test/integ/src/plugins/kubernetes/hot-reload.ts
+++ b/core/test/integ/src/plugins/kubernetes/hot-reload.ts
@@ -109,7 +109,14 @@ describe("configureHotReload", () => {
     const log = garden.log
     const service = graph.getService("two-containers")
     const module = service.module
-    const manifests = await getChartResources({ ctx, module, hotReload: true, log, version: service.version })
+    const manifests = await getChartResources({
+      ctx,
+      module,
+      devMode: false,
+      hotReload: true,
+      log,
+      version: service.version,
+    })
     const resourceSpec = getServiceResourceSpec(module, undefined)
     const hotReloadSpec = getHotReloadSpec(service)
     const hotReloadTarget = await findServiceResource({

--- a/core/test/integ/src/plugins/kubernetes/kubernetes-module/config.ts
+++ b/core/test/integ/src/plugins/kubernetes/kubernetes-module/config.ts
@@ -288,6 +288,15 @@ describe("validateKubernetesModule", () => {
               dependencies: [],
             },
             dependencies: [],
+            devMode: {
+              sync: [
+                {
+                  mode: "one-way",
+                  source: "*",
+                  target: "/app",
+                },
+              ],
+            },
             files: [],
             manifests: [
               {
@@ -341,6 +350,15 @@ describe("validateKubernetesModule", () => {
           dependencies: [],
         },
         dependencies: [],
+        devMode: {
+          sync: [
+            {
+              mode: "one-way",
+              source: "*",
+              target: "/app",
+            },
+          ],
+        },
         files: [],
         manifests: [
           {

--- a/core/test/integ/src/plugins/kubernetes/kubernetes-module/handlers.ts
+++ b/core/test/integ/src/plugins/kubernetes/kubernetes-module/handlers.ts
@@ -126,6 +126,7 @@ describe("kubernetes-module handlers", () => {
         module: service.module,
         service,
         force: false,
+        devMode: false,
         hotReload: false,
         runtimeContext: emptyRuntimeContext,
       }
@@ -153,6 +154,7 @@ describe("kubernetes-module handlers", () => {
         module: service.module,
         service,
         force: false,
+        devMode: false,
         hotReload: false,
         runtimeContext: emptyRuntimeContext,
       }
@@ -175,6 +177,7 @@ describe("kubernetes-module handlers", () => {
         module: service.module,
         service,
         force: false,
+        devMode: false,
         hotReload: false,
         runtimeContext: emptyRuntimeContext,
       }
@@ -218,6 +221,8 @@ describe("kubernetes-module handlers", () => {
         service: graph.getService("namespace-resource"),
         force: false,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
       await garden.processTasks([deployTask], { throwOnError: true })
       ns1Resource = await getDeployedResource(ctx, ctx.provider, ns1Manifest!, log)
@@ -239,6 +244,8 @@ describe("kubernetes-module handlers", () => {
         service: graph.getService("namespace-resource"),
         force: true,
         forceBuild: true,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
       await garden.processTasks([deployTask2], { throwOnError: true })
       ns2Resource = await getDeployedResource(ctx, ctx.provider, ns2Manifest!, log)

--- a/core/test/integ/src/plugins/kubernetes/kubernetes-module/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/kubernetes-module/run.ts
@@ -38,6 +38,8 @@ describe("runKubernetesTask", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
     })
 
     // Clear any existing task result
@@ -75,6 +77,8 @@ describe("runKubernetesTask", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
     })
 
     // Clear any existing task result
@@ -104,6 +108,8 @@ describe("runKubernetesTask", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
     })
 
     const key = testTask.getKey()
@@ -127,6 +133,8 @@ describe("runKubernetesTask", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
     })
 
     await expectError(
@@ -156,6 +164,8 @@ describe("runKubernetesTask", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       await emptyDir(garden.artifactsPath)
@@ -176,6 +186,8 @@ describe("runKubernetesTask", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
       await emptyDir(garden.artifactsPath)
 
@@ -197,6 +209,8 @@ describe("runKubernetesTask", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       await emptyDir(garden.artifactsPath)

--- a/core/test/integ/src/plugins/kubernetes/kubernetes-module/test.ts
+++ b/core/test/integ/src/plugins/kubernetes/kubernetes-module/test.ts
@@ -39,6 +39,8 @@ describe("testKubernetesModule", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
     })
 
     const key = testTask.getKey()
@@ -59,6 +61,8 @@ describe("testKubernetesModule", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
     })
 
     const key = testTask.getKey()
@@ -84,6 +88,8 @@ describe("testKubernetesModule", () => {
       log: garden.log,
       force: true,
       forceBuild: false,
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
     })
 
     await expectError(
@@ -114,6 +120,8 @@ describe("testKubernetesModule", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       await emptyDir(garden.artifactsPath)
@@ -134,6 +142,8 @@ describe("testKubernetesModule", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       await emptyDir(garden.artifactsPath)
@@ -156,6 +166,8 @@ describe("testKubernetesModule", () => {
         log: garden.log,
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       await emptyDir(garden.artifactsPath)

--- a/core/test/integ/src/plugins/kubernetes/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/run.ts
@@ -440,6 +440,7 @@ describe("kubernetes Pod runner functions", () => {
       helmManifests = await getChartResources({
         ctx: helmCtx,
         module: helmModule,
+        devMode: false,
         hotReload: false,
         log: helmLog,
         version: helmModule.version.versionString,

--- a/core/test/integ/src/plugins/kubernetes/system.ts
+++ b/core/test/integ/src/plugins/kubernetes/system.ts
@@ -69,6 +69,8 @@ describe("System services", () => {
         graph,
         force: true,
         forceBuild: true,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
       const key = testTask.getKey()
       const result = await systemGarden.processTasks([testTask])

--- a/core/test/integ/src/plugins/kubernetes/util.ts
+++ b/core/test/integ/src/plugins/kubernetes/util.ts
@@ -88,6 +88,8 @@ describe("util", () => {
           graph,
           log: garden.log,
           service,
+          devModeServiceNames: [],
+          hotReloadServiceNames: [],
         })
 
         const resource = await createWorkloadManifest({
@@ -96,6 +98,7 @@ describe("util", () => {
           service,
           runtimeContext: emptyRuntimeContext,
           namespace: provider.config.namespace!.name!,
+          enableDevMode: false,
           enableHotReload: false,
           log: garden.log,
           production: false,
@@ -178,6 +181,7 @@ describe("util", () => {
       const manifests = await getChartResources({
         ctx,
         module,
+        devMode: false,
         hotReload: false,
         log,
         version: module.version.versionString,
@@ -198,6 +202,7 @@ describe("util", () => {
       const manifests = await getChartResources({
         ctx,
         module,
+        devMode: false,
         hotReload: false,
         log,
         version: module.version.versionString,
@@ -219,6 +224,7 @@ describe("util", () => {
       const manifests = await getChartResources({
         ctx,
         module,
+        devMode: false,
         hotReload: false,
         log,
         version: module.version.versionString,
@@ -246,6 +252,7 @@ describe("util", () => {
       const manifests = await getChartResources({
         ctx,
         module,
+        devMode: false,
         hotReload: false,
         log,
         version: module.version.versionString,
@@ -273,6 +280,7 @@ describe("util", () => {
       const manifests = await getChartResources({
         ctx,
         module,
+        devMode: false,
         hotReload: false,
         log,
         version: module.version.versionString,
@@ -295,6 +303,7 @@ describe("util", () => {
       const manifests = await getChartResources({
         ctx,
         module,
+        devMode: false,
         hotReload: false,
         log,
         version: module.version.versionString,
@@ -318,6 +327,7 @@ describe("util", () => {
       const manifests = await getChartResources({
         ctx,
         module,
+        devMode: false,
         hotReload: false,
         log,
         version: module.version.versionString,

--- a/core/test/integ/src/plugins/kubernetes/volume/persistentvolumeclaim.ts
+++ b/core/test/integ/src/plugins/kubernetes/volume/persistentvolumeclaim.ts
@@ -85,6 +85,8 @@ describe("persistentvolumeclaim", () => {
       service,
       force: true,
       forceBuild: false,
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
     })
 
     await garden.processTasks([deployTask], { throwOnError: true })
@@ -93,6 +95,7 @@ describe("persistentvolumeclaim", () => {
     const status = await actions.getServiceStatus({
       log: garden.log,
       service,
+      devMode: false,
       hotReload: false,
       runtimeContext: emptyRuntimeContext,
     })

--- a/core/test/unit/src/actions.ts
+++ b/core/test/unit/src/actions.ts
@@ -489,13 +489,19 @@ describe("ActionRouter", () => {
   describe("service actions", () => {
     describe("getServiceStatus", () => {
       it("should correctly call the corresponding plugin handler", async () => {
-        const result = await actions.getServiceStatus({ log, service, runtimeContext, hotReload: false })
+        const result = await actions.getServiceStatus({
+          log,
+          service,
+          runtimeContext,
+          devMode: false,
+          hotReload: false,
+        })
         expect(result).to.eql({ forwardablePorts: [], state: "ready", detail: {}, outputs: { base: "ok", foo: "ok" } })
       })
 
       it("should emit a serviceStatus event", async () => {
         garden.events.eventLog = []
-        await actions.getServiceStatus({ log, service, runtimeContext, hotReload: false })
+        await actions.getServiceStatus({ log, service, runtimeContext, devMode: false, hotReload: false })
         const event = garden.events.eventLog[0]
         expect(event).to.exist
         expect(event.name).to.eql("serviceStatus")
@@ -509,7 +515,7 @@ describe("ActionRouter", () => {
         })
 
         await expectError(
-          () => actions.getServiceStatus({ log, service, runtimeContext, hotReload: false }),
+          () => actions.getServiceStatus({ log, service, runtimeContext, devMode: false, hotReload: false }),
           (err) =>
             expect(stripAnsi(err.message)).to.equal(
               "Error validating outputs from service 'service-a': key .foo must be a string"
@@ -523,7 +529,7 @@ describe("ActionRouter", () => {
         })
 
         await expectError(
-          () => actions.getServiceStatus({ log, service, runtimeContext, hotReload: false }),
+          () => actions.getServiceStatus({ log, service, runtimeContext, devMode: false, hotReload: false }),
           (err) =>
             expect(stripAnsi(err.message)).to.equal(
               "Error validating outputs from service 'service-a': key .base must be a string"
@@ -534,13 +540,20 @@ describe("ActionRouter", () => {
 
     describe("deployService", () => {
       it("should correctly call the corresponding plugin handler", async () => {
-        const result = await actions.deployService({ log, service, runtimeContext, force: true, hotReload: false })
+        const result = await actions.deployService({
+          log,
+          service,
+          runtimeContext,
+          force: true,
+          devMode: false,
+          hotReload: false,
+        })
         expect(result).to.eql({ forwardablePorts: [], state: "ready", detail: {}, outputs: { base: "ok", foo: "ok" } })
       })
 
       it("should emit a serviceStatus event", async () => {
         garden.events.eventLog = []
-        await actions.deployService({ log, service, runtimeContext, force: true, hotReload: false })
+        await actions.deployService({ log, service, runtimeContext, force: true, devMode: false, hotReload: false })
         const event = garden.events.eventLog[0]
         expect(event).to.exist
         expect(event.name).to.eql("serviceStatus")
@@ -554,7 +567,7 @@ describe("ActionRouter", () => {
         })
 
         await expectError(
-          () => actions.deployService({ log, service, runtimeContext, force: true, hotReload: false }),
+          () => actions.deployService({ log, service, runtimeContext, force: true, devMode: false, hotReload: false }),
           (err) =>
             expect(stripAnsi(err.message)).to.equal(
               "Error validating outputs from service 'service-a': key .foo must be a string"
@@ -568,7 +581,7 @@ describe("ActionRouter", () => {
         })
 
         await expectError(
-          () => actions.deployService({ log, service, runtimeContext, force: true, hotReload: false }),
+          () => actions.deployService({ log, service, runtimeContext, force: true, devMode: false, hotReload: false }),
           (err) =>
             expect(stripAnsi(err.message)).to.equal(
               "Error validating outputs from service 'service-a': key .base must be a string"
@@ -1509,6 +1522,7 @@ describe("ActionRouter", () => {
           service: serviceA,
           runtimeContext,
           log,
+          devMode: false,
           hotReload: false,
           force: false,
         },
@@ -1558,6 +1572,7 @@ describe("ActionRouter", () => {
           service: serviceA,
           runtimeContext: _runtimeContext,
           log,
+          devMode: false,
           hotReload: false,
           force: false,
         },
@@ -1606,6 +1621,7 @@ describe("ActionRouter", () => {
               service: serviceA,
               runtimeContext: _runtimeContext,
               log,
+              devMode: false,
               hotReload: false,
               force: false,
             },

--- a/core/test/unit/src/commands/deploy.ts
+++ b/core/test/unit/src/commands/deploy.ts
@@ -115,6 +115,7 @@ describe("DeployCommand", () => {
         services: undefined,
       },
       opts: withDefaultGlobalOpts({
+        "dev-mode": undefined,
         "hot-reload": undefined,
         "watch": false,
         "force": false,
@@ -234,6 +235,7 @@ describe("DeployCommand", () => {
         services: ["service-b"],
       },
       opts: withDefaultGlobalOpts({
+        "dev-mode": undefined,
         "hot-reload": undefined,
         "watch": false,
         "force": false,
@@ -286,6 +288,7 @@ describe("DeployCommand", () => {
         services: undefined,
       },
       opts: withDefaultGlobalOpts({
+        "dev-mode": undefined,
         "hot-reload": undefined,
         "watch": false,
         "force": false,
@@ -335,6 +338,7 @@ describe("DeployCommand", () => {
         services: undefined,
       },
       opts: withDefaultGlobalOpts({
+        "dev-mode": undefined,
         "hot-reload": undefined,
         "watch": false,
         "force": false,
@@ -377,6 +381,7 @@ describe("DeployCommand", () => {
         services: undefined,
       },
       opts: withDefaultGlobalOpts({
+        "dev-mode": undefined,
         "hot-reload": undefined,
         "watch": false,
         "force": false,

--- a/core/test/unit/src/commands/dev.ts
+++ b/core/test/unit/src/commands/dev.ts
@@ -76,7 +76,7 @@ describe("DevCommand", () => {
   it("should deploy, run and test everything in a project", async () => {
     const garden = await makeTestGardenA()
 
-    const args = {}
+    const args = { services: undefined }
     const opts = withDefaultGlobalOpts({
       "force-build": false,
       "hot-reload": undefined,
@@ -127,6 +127,8 @@ describe("DevCommand", () => {
       log,
       graph,
       modules,
+      services: graph.getServices(),
+      devModeServiceNames: [],
       // Note: service-a is a runtime dependency of module-a's integration test spec, so in this test case
       // we're implicitly verifying that tests with runtime dependencies on services being deployed with
       // hot reloading don't request non-hot-reload-enabled deploys for those same services.
@@ -154,7 +156,7 @@ describe("DevCommand", () => {
     await garden.scanAndAddConfigs()
     garden["moduleConfigs"]["module-c"].spec.services[0].disabled = true
 
-    const args = {}
+    const args = { services: undefined }
     const opts = withDefaultGlobalOpts({
       "force-build": false,
       "hot-reload": undefined,
@@ -175,7 +177,7 @@ describe("DevCommand", () => {
     await garden.scanAndAddConfigs()
     garden["moduleConfigs"]["module-c"].spec.tasks[0].disabled = true
 
-    const args = {}
+    const args = { services: undefined }
     const opts = withDefaultGlobalOpts({
       "force-build": false,
       "hot-reload": undefined,
@@ -196,7 +198,7 @@ describe("DevCommand", () => {
     await garden.scanAndAddConfigs()
     garden["moduleConfigs"]["module-b"].spec.tests[0].disabled = true
 
-    const args = {}
+    const args = { services: undefined }
     const opts = withDefaultGlobalOpts({
       "force-build": false,
       "hot-reload": undefined,
@@ -217,7 +219,7 @@ describe("DevCommand", () => {
     await garden.scanAndAddConfigs()
     garden["moduleConfigs"]["module-c"].disabled = true
 
-    const args = {}
+    const args = { services: undefined }
     const opts = withDefaultGlobalOpts({
       "force-build": false,
       "hot-reload": undefined,
@@ -238,7 +240,7 @@ describe("DevCommand", () => {
     await garden.scanAndAddConfigs()
     garden["moduleConfigs"]["module-c"].disabled = true
 
-    const args = {}
+    const args = { services: undefined }
     const opts = withDefaultGlobalOpts({
       "force-build": false,
       "hot-reload": undefined,
@@ -259,7 +261,7 @@ describe("DevCommand", () => {
     await garden.scanAndAddConfigs()
     garden["moduleConfigs"]["module-c"].disabled = true
 
-    const args = {}
+    const args = { services: undefined }
     const opts = withDefaultGlobalOpts({
       "force-build": false,
       "hot-reload": undefined,
@@ -287,6 +289,8 @@ describe("getDevCommandWatchTasks", () => {
       log,
       updatedGraph: graph,
       module: graph.getModule("module-b"),
+      servicesWatched: graph.getServices().map((s) => s.name),
+      devModeServiceNames: [],
       hotReloadServiceNames: [],
       testNames: undefined,
       skipTests: false,

--- a/core/test/unit/src/plugins/exec.ts
+++ b/core/test/unit/src/plugins/exec.ts
@@ -244,6 +244,8 @@ describe("exec plugin", () => {
       log: _garden.log,
       force: false,
       forceBuild: false,
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
     })
     const results = await _garden.processTasks([taskTask])
 
@@ -267,6 +269,8 @@ describe("exec plugin", () => {
       log: _garden.log,
       force: false,
       forceBuild: false,
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
     })
 
     await emptyDir(_garden.artifactsPath)
@@ -288,6 +292,8 @@ describe("exec plugin", () => {
       log: _garden.log,
       force: false,
       forceBuild: false,
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
     })
 
     await emptyDir(_garden.artifactsPath)

--- a/core/test/unit/src/plugins/terraform/terraform.ts
+++ b/core/test/unit/src/plugins/terraform/terraform.ts
@@ -300,6 +300,8 @@ describe("Terraform module type", () => {
       log: garden.log,
       force: false,
       forceBuild: false,
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
     })
 
     return garden.processTasks([deployTask], { throwOnError: true })
@@ -320,6 +322,8 @@ describe("Terraform module type", () => {
       log: garden.log,
       force: false,
       forceBuild: false,
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
     })
 
     return garden.processTasks([taskTask], { throwOnError: true })
@@ -491,6 +495,7 @@ describe("Terraform module type", () => {
       const actions = await garden.getActionRouter()
       const status = await actions.getServiceStatus({
         service: graph.getService("tf"),
+        devMode: false,
         hotReload: false,
         log: garden.log,
         runtimeContext: emptyRuntimeContext,
@@ -525,6 +530,7 @@ describe("Terraform module type", () => {
       const actions = await _garden.getActionRouter()
       const status = await actions.getServiceStatus({
         service: graph.getService("tf"),
+        devMode: false,
         hotReload: false,
         log: _garden.log,
         runtimeContext: emptyRuntimeContext,
@@ -568,6 +574,8 @@ describe("Terraform module type", () => {
         log: _garden.log,
         force: false,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       const result = await _garden.processTasks([taskTask], { throwOnError: true })

--- a/core/test/unit/src/tasks/deploy.ts
+++ b/core/test/unit/src/tasks/deploy.ts
@@ -147,6 +147,8 @@ describe("DeployTask", () => {
         forceBuild: false,
         fromWatch: false,
         log: garden.log,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       expect((await forcedDeployTask.resolveDependencies()).find((dep) => dep.type === "task")!.force).to.be.false
@@ -159,6 +161,8 @@ describe("DeployTask", () => {
         forceBuild: false,
         fromWatch: false,
         log: garden.log,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       expect((await unforcedDeployTask.resolveDependencies()).find((dep) => dep.type === "task")!.force).to.be.false
@@ -171,6 +175,8 @@ describe("DeployTask", () => {
         forceBuild: false,
         fromWatch: true,
         log: garden.log,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       expect((await deployTaskFromWatch.resolveDependencies()).find((dep) => dep.type === "task")!.force).to.be.false
@@ -188,6 +194,8 @@ describe("DeployTask", () => {
         force: true,
         forceBuild: false,
         log: garden.log,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       const result = await garden.processTasks([deployTask], { throwOnError: true })

--- a/core/test/unit/src/tasks/get-service-status.ts
+++ b/core/test/unit/src/tasks/get-service-status.ts
@@ -132,6 +132,8 @@ describe("GetServiceStatusTask", () => {
         service: testService,
         force: true,
         log: garden.log,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       const key = statusTask.getKey()
@@ -210,6 +212,8 @@ describe("GetServiceStatusTask", () => {
         service: testService,
         force: true,
         log: garden.log,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       const key = statusTask.getKey()

--- a/core/test/unit/src/tasks/helpers.ts
+++ b/core/test/unit/src/tasks/helpers.ts
@@ -92,6 +92,8 @@ describe("TaskHelpers", () => {
         graph,
         log,
         module,
+        servicesWatched: graph.getServices().map((s) => s.name),
+        devModeServiceNames: [],
         hotReloadServiceNames: [],
       })
 
@@ -156,6 +158,8 @@ describe("TaskHelpers", () => {
         graph,
         log,
         module,
+        servicesWatched: graph.getServices().map((s) => s.name),
+        devModeServiceNames: [],
         hotReloadServiceNames: [],
       })
 
@@ -213,6 +217,8 @@ describe("TaskHelpers", () => {
         graph,
         log,
         module,
+        servicesWatched: graph.getServices().map((s) => s.name),
+        devModeServiceNames: [],
         hotReloadServiceNames: ["service-b"],
       })
 
@@ -269,6 +275,8 @@ describe("TaskHelpers", () => {
             graph,
             log,
             module,
+            servicesWatched: graph.getServices().map((s) => s.name),
+            devModeServiceNames: [],
             hotReloadServiceNames: [],
           })
           expect(sortedBaseKeys(tasks)).to.eql(expectedTasks.sort())
@@ -311,6 +319,8 @@ describe("TaskHelpers", () => {
           graph,
           log,
           module,
+          servicesWatched: graph.getServices().map((s) => s.name),
+          devModeServiceNames: [],
           hotReloadServiceNames: [],
         })
 
@@ -375,6 +385,8 @@ describe("TaskHelpers", () => {
           graph,
           log,
           module,
+          servicesWatched: graph.getServices().map((s) => s.name),
+          devModeServiceNames: [],
           hotReloadServiceNames: [],
         })
 
@@ -430,6 +442,8 @@ describe("TaskHelpers", () => {
             graph,
             log,
             module,
+            servicesWatched: graph.getServices().map((s) => s.name),
+            devModeServiceNames: [],
             hotReloadServiceNames: ["good-morning"],
           })
           expect(sortedBaseKeys(tasks)).to.eql(expectedTasks.sort())
@@ -472,6 +486,8 @@ describe("TaskHelpers", () => {
           graph,
           log,
           module,
+          servicesWatched: ["service-a"],
+          devModeServiceNames: [],
           hotReloadServiceNames: ["service-a"],
         })
 
@@ -536,6 +552,8 @@ describe("TaskHelpers", () => {
           graph,
           log,
           module,
+          servicesWatched: ["service-a", "service-b"],
+          devModeServiceNames: [],
           hotReloadServiceNames: ["service-a", "service-b"],
         })
 

--- a/core/test/unit/src/tasks/task.ts
+++ b/core/test/unit/src/tasks/task.ts
@@ -128,6 +128,8 @@ describe("TaskTask", () => {
         force: false,
         forceBuild: false,
         log: garden.log,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       let result = await garden.processTasks([taskTask], { throwOnError: true })
@@ -178,6 +180,8 @@ describe("TaskTask", () => {
         force: false,
         forceBuild: false,
         log: garden.log,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       let result = await garden.processTasks([taskTask], { throwOnError: true })

--- a/core/test/unit/src/tasks/test.ts
+++ b/core/test/unit/src/tasks/test.ts
@@ -37,6 +37,8 @@ describe("TestTask", () => {
         test: testFromConfig(moduleA, testConfig, graph),
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       const deps = await task.resolveDependencies()
@@ -54,6 +56,7 @@ describe("TestTask", () => {
         log,
         graph,
         module: moduleA,
+        devModeServiceNames: [],
         hotReloadServiceNames: ["service-b"],
       })
 

--- a/docs/guides/hot-reload.md
+++ b/docs/guides/hot-reload.md
@@ -1,5 +1,9 @@
 # Hot Reload
 
+{% hint style="info"}
+Check out the section below on the brand-new, faster (and still experimental) dev mode—which includes bidirectional sync!
+{% endhint %}
+
 When the `local-kubernetes` or `kubernetes` provider is used, `container` modules can be configured to hot-reload their running services when the module's sources change (i.e. without redeploying). In essence, hot-reloading copies syncs files into the appropriate running containers (local or remote) when code is changed by the user, and optionally runs a post-sync command inside the container.
 
 For example, services that can be run with a file system watcher that automatically updates the running application process when sources change (e.g. nodemon, Django, Ruby on Rails, and many other web app frameworks) are a natural fit for this feature.
@@ -71,4 +75,66 @@ services:
     args: [npm, start]
     hotReloadArgs: [npm, run, dev] # Runs modemon main.js --watch hotreloadfile
   ...
+```
+
+## Dev mode (experimental)
+
+Dev mode works similarly to hot reloading, but is much faster and more reliable. It also supports bidirectional syncing, which enables you to sync new/changed files from your containers to your local machine.
+
+This new sync mode uses [Mutagen](https://mutagen.io/) under the hood. Garden automatically takes care of fetching Mutagen, so you don't need to install any dependencies yourself to make use of dev mode.
+
+Dev mode sync is not affected by includes/excludes, which makes it more flexible than hot reloading. For example, you can use it to sync your `build`/`dist` directory into your container while running local, incremental builds (without having to remove those directories from your ignorefiles).
+
+Eventually, the plan is to deprecate hot reloading in favor of dev mode.
+
+Dev mode opens up exciting, productive new ways to set up your inner dev loop with Garden. Happy hacking!
+
+Dev mode is currently supported for `container`, `kubernetes` and `helm` modules.
+
+To configure a service for dev mode, add `devMode` to your module/service configuration:
+
+### `container` module example
+```yaml
+kind: Module
+description: Node greeting service
+name: node-service
+type: container
+services:
+  - name: node-service
+    args: [npm, start]
+    devMode:
+      command: [npm, run, dev] # Overrides the container's default when the service is deployed in dev mode
+      sync:
+        # Source/target configuration for dev mode is the same as for hot reloading.
+        - target: /app
+        # You can use several sync specs for the same service.
+        - source: /tmp/somedir
+          target: /somedir
+  ...
+```
+
+### Configuring dev mode for `kubernetes` and `helm` modules
+```yaml
+kind: Module
+type: kubernetes # this example looks the same for helm modules (i.e. with `type: helm`)
+name: node-service
+# For `kubernetes` and `helm` modules, the `devMode` field is located at the top level.
+devMode:
+  command: [npm, run, dev]
+  sync:
+    - target: /app
+    - source: /tmp/somedir
+      target: /somedir
+serviceResource:
+  kind: Deployment
+  name: node-service-deployment
+  containerModule: node-service-image
+  containerName: node-service
+...
+```
+To deploy your services with dev mode enabled, you can use the `deploy` or `dev` commands:
+```
+garden deploy --dev myservice
+garden deploy --dev myservice,my-other-service
+garden dev myservice # the dev command deploys services in dev mode by default
 ```

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -641,7 +641,8 @@ Examples:
   | `--force` |  | boolean | Force redeploy of service(s).
   | `--force-build` |  | boolean | Force rebuild of module(s).
   | `--watch` | `-w` | boolean | Watch for changes in module(s) and auto-deploy.
-  | `--hot-reload` | `-hot` | array:string | The name(s) of the service(s) to deploy with hot reloading enabled. Use comma as a separator to specify multiple services. Use * to deploy all services with hot reloading enabled (ignores services belonging to modules that don&#x27;t support or haven&#x27;t configured hot reloading). When this option is used, the command is run in watch mode (i.e. implicitly assumes the --watch/-w flag).
+  | `--dev-mode` | `-dev` | array:string | [EXPERIMENTAL] The name(s) of the service(s) to deploy with dev mode enabled. Use comma as a separator to specify multiple services. Use * to deploy all services with dev mode enabled. When this option is used, the command is run in watch mode (i.e. implicitly sets the --watch/-w flag).
+  | `--hot-reload` | `-hot` | array:string | The name(s) of the service(s) to deploy with hot reloading enabled. Use comma as a separator to specify multiple services. Use * to deploy all services with hot reloading enabled (ignores services belonging to modules that don&#x27;t support or haven&#x27;t configured hot reloading). When this option is used, the command is run in watch mode (i.e. implicitly sets the --watch/-w flag).
   | `--skip` |  | array:string | The name(s) of services you&#x27;d like to skip when deploying.
 
 #### Outputs
@@ -829,7 +830,13 @@ Examples:
 
 #### Usage
 
-    garden dev [options]
+    garden dev [services] [options]
+
+#### Arguments
+
+| Argument | Required | Description |
+| -------- | -------- | ----------- |
+  | `services` | No | Specify which services to develop (defaults to all configured services).
 
 #### Options
 

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -161,7 +161,7 @@ hotReload:
   # Specify one or more source files or directories to automatically sync into the running container.
   sync:
     - # POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be
-      # a relative path if provided. Defaults to the module's top-level directory if no value is provided.
+      # a relative path. Defaults to the module's top-level directory if no value is provided.
       source: .
 
       # POSIX-style absolute path to sync the directory to inside the container. The root path (i.e. "/") is not
@@ -215,6 +215,36 @@ services:
     # Whether to run the service as a daemon (to ensure exactly one instance runs per node). May not be supported by
     # all providers.
     daemon: false
+
+    # **EXPERIMENTAL**
+    #
+    # Specifies which files or directories to sync to which paths inside the running containers of the service when
+    # it's in dev mode, and overrides for the container command and/or arguments.
+    #
+    # Dev mode is enabled when running the `garden dev` command, and by setting the `--dev` flag on the `garden
+    # deploy` command.
+    devMode:
+      # Override the default container arguments when in dev mode.
+      args:
+
+      # Override the default container command (i.e. entrypoint) when in dev mode.
+      command:
+
+      # Specify one or more source files or directories to automatically sync with the running container.
+      sync:
+        - # POSIX-style path of the directory to sync to the target, relative to the module's top-level directory.
+          # Must be a relative path. Defaults to the module's top-level directory if no value is provided.
+          source: .
+
+          # POSIX-style absolute path to sync the directory to inside the container. The root path (i.e. "/") is not
+          # allowed.
+          target:
+
+          # Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+          exclude:
+
+          # The sync mode to use for the given paths.
+          mode: one-way
 
     # List of ingress endpoints that the service exposes.
     ingresses:
@@ -820,7 +850,7 @@ Specify one or more source files or directories to automatically sync into the r
 
 [hotReload](#hotreload) > [sync](#hotreloadsync) > source
 
-POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be a relative path if provided. Defaults to the module's top-level directory if no value is provided.
+POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be a relative path. Defaults to the module's top-level directory if no value is provided.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |
@@ -990,6 +1020,122 @@ Whether to run the service as a daemon (to ensure exactly one instance runs per 
 | Type      | Default | Required |
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
+
+### `services[].devMode`
+
+[services](#services) > devMode
+
+**EXPERIMENTAL**
+
+Specifies which files or directories to sync to which paths inside the running containers of the service when it's in dev mode, and overrides for the container command and/or arguments.
+
+Dev mode is enabled when running the `garden dev` command, and by setting the `--dev` flag on the `garden deploy` command.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `services[].devMode.args[]`
+
+[services](#services) > [devMode](#servicesdevmode) > args
+
+Override the default container arguments when in dev mode.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
+### `services[].devMode.command[]`
+
+[services](#services) > [devMode](#servicesdevmode) > command
+
+Override the default container command (i.e. entrypoint) when in dev mode.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
+### `services[].devMode.sync[]`
+
+[services](#services) > [devMode](#servicesdevmode) > sync
+
+Specify one or more source files or directories to automatically sync with the running container.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[object]` | No       |
+
+### `services[].devMode.sync[].source`
+
+[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > source
+
+POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be a relative path. Defaults to the module's top-level directory if no value is provided.
+
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `"."`   | No       |
+
+Example:
+
+```yaml
+services:
+  - devMode:
+      ...
+      sync:
+        - source: "src"
+```
+
+### `services[].devMode.sync[].target`
+
+[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > target
+
+POSIX-style absolute path to sync the directory to inside the container. The root path (i.e. "/") is not allowed.
+
+| Type        | Required |
+| ----------- | -------- |
+| `posixPath` | Yes      |
+
+Example:
+
+```yaml
+services:
+  - devMode:
+      ...
+      sync:
+        - target: "/app/src"
+```
+
+### `services[].devMode.sync[].exclude[]`
+
+[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > exclude
+
+Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+
+| Type               | Required |
+| ------------------ | -------- |
+| `array[posixPath]` | No       |
+
+Example:
+
+```yaml
+services:
+  - devMode:
+      ...
+      sync:
+        - exclude:
+            - dist/**/*
+            - '*.log'
+```
+
+### `services[].devMode.sync[].mode`
+
+[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > mode
+
+The sync mode to use for the given paths.
+
+| Type     | Default     | Required |
+| -------- | ----------- | -------- |
+| `string` | `"one-way"` | No       |
 
 ### `services[].ingresses[]`
 

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -149,6 +149,42 @@ chartPath: .
 # List of names of services that should be deployed before this chart.
 dependencies: []
 
+# **EXPERIMENTAL**
+#
+# Specifies which files or directories to sync to which paths inside the running containers of the service when it's
+# in dev mode, and overrides for the container command and/or arguments.
+#
+# Note that `serviceResource` must also be specified to enable dev mode.
+#
+# Dev mode is enabled when running the `garden dev` command, and by setting the `--dev` flag on the `garden deploy`
+# command.
+devMode:
+  # Override the default container arguments when in dev mode.
+  args:
+
+  # Override the default container command (i.e. entrypoint) when in dev mode.
+  command:
+
+  # Specify one or more source files or directories to automatically sync with the running container.
+  sync:
+    - # POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be
+      # a relative path. Defaults to the module's top-level directory if no value is provided.
+      source: .
+
+      # POSIX-style absolute path to sync the directory to inside the container. The root path (i.e. "/") is not
+      # allowed.
+      target:
+
+      # Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+      exclude:
+
+      # The sync mode to use for the given paths.
+      mode: one-way
+
+  # Optionally specify the name of a specific container to sync to. If not specified, the first container in the
+  # workload is used.
+  containerName:
+
 # A valid Kubernetes namespace name. Must be a valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters,
 # numbers and dashes, must start with a letter, and cannot end with a dash) and must not be longer than 63 characters.
 namespace:
@@ -726,6 +762,129 @@ List of names of services that should be deployed before this chart.
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
 | `array[string]` | `[]`    | No       |
+
+### `devMode`
+
+**EXPERIMENTAL**
+
+Specifies which files or directories to sync to which paths inside the running containers of the service when it's in dev mode, and overrides for the container command and/or arguments.
+
+Note that `serviceResource` must also be specified to enable dev mode.
+
+Dev mode is enabled when running the `garden dev` command, and by setting the `--dev` flag on the `garden deploy` command.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `devMode.args[]`
+
+[devMode](#devmode) > args
+
+Override the default container arguments when in dev mode.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
+### `devMode.command[]`
+
+[devMode](#devmode) > command
+
+Override the default container command (i.e. entrypoint) when in dev mode.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
+### `devMode.sync[]`
+
+[devMode](#devmode) > sync
+
+Specify one or more source files or directories to automatically sync with the running container.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[object]` | No       |
+
+### `devMode.sync[].source`
+
+[devMode](#devmode) > [sync](#devmodesync) > source
+
+POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be a relative path. Defaults to the module's top-level directory if no value is provided.
+
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `"."`   | No       |
+
+Example:
+
+```yaml
+devMode:
+  ...
+  sync:
+    - source: "src"
+```
+
+### `devMode.sync[].target`
+
+[devMode](#devmode) > [sync](#devmodesync) > target
+
+POSIX-style absolute path to sync the directory to inside the container. The root path (i.e. "/") is not allowed.
+
+| Type        | Required |
+| ----------- | -------- |
+| `posixPath` | Yes      |
+
+Example:
+
+```yaml
+devMode:
+  ...
+  sync:
+    - target: "/app/src"
+```
+
+### `devMode.sync[].exclude[]`
+
+[devMode](#devmode) > [sync](#devmodesync) > exclude
+
+Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+
+| Type               | Required |
+| ------------------ | -------- |
+| `array[posixPath]` | No       |
+
+Example:
+
+```yaml
+devMode:
+  ...
+  sync:
+    - exclude:
+        - dist/**/*
+        - '*.log'
+```
+
+### `devMode.sync[].mode`
+
+[devMode](#devmode) > [sync](#devmodesync) > mode
+
+The sync mode to use for the given paths.
+
+| Type     | Default     | Required |
+| -------- | ----------- | -------- |
+| `string` | `"one-way"` | No       |
+
+### `devMode.containerName`
+
+[devMode](#devmode) > containerName
+
+Optionally specify the name of a specific container to sync to. If not specified, the first container in the workload is used.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
 
 ### `namespace`
 

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -155,9 +155,46 @@ files: []
 # numbers and dashes, must start with a letter, and cannot end with a dash) and must not be longer than 63 characters.
 namespace:
 
+# **EXPERIMENTAL**
+#
+# Specifies which files or directories to sync to which paths inside the running containers of the service when it's
+# in dev mode, and overrides for the container command and/or arguments.
+#
+# Note that `serviceResource` must also be specified to enable dev mode.
+#
+# Dev mode is enabled when running the `garden dev` command, and by setting the `--dev` flag on the `garden deploy`
+# command.
+devMode:
+  # Override the default container arguments when in dev mode.
+  args:
+
+  # Override the default container command (i.e. entrypoint) when in dev mode.
+  command:
+
+  # Specify one or more source files or directories to automatically sync with the running container.
+  sync:
+    - # POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be
+      # a relative path. Defaults to the module's top-level directory if no value is provided.
+      source: .
+
+      # POSIX-style absolute path to sync the directory to inside the container. The root path (i.e. "/") is not
+      # allowed.
+      target:
+
+      # Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+      exclude:
+
+      # The sync mode to use for the given paths.
+      mode: one-way
+
+  # Optionally specify the name of a specific container to sync to. If not specified, the first container in the
+  # workload is used.
+  containerName:
+
 # The Deployment, DaemonSet or StatefulSet that Garden should regard as the _Garden service_ in this module (not to be
-# confused with Kubernetes Service resources). Because a `kubernetes-module` can contain any number of Kubernetes
-# resources, this needs to be specified for certain Garden features and commands to work.
+# confused with Kubernetes Service resources).
+# Because a `kubernetes` module can contain any number of Kubernetes resources, this needs to be specified for certain
+# Garden features and commands to work.
 serviceResource:
   # The type of Kubernetes resource to sync files to.
   kind: Deployment
@@ -670,9 +707,133 @@ A valid Kubernetes namespace name. Must be a valid RFC1035/RFC1123 (DNS) label (
 | -------- | -------- |
 | `string` | No       |
 
+### `devMode`
+
+**EXPERIMENTAL**
+
+Specifies which files or directories to sync to which paths inside the running containers of the service when it's in dev mode, and overrides for the container command and/or arguments.
+
+Note that `serviceResource` must also be specified to enable dev mode.
+
+Dev mode is enabled when running the `garden dev` command, and by setting the `--dev` flag on the `garden deploy` command.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `devMode.args[]`
+
+[devMode](#devmode) > args
+
+Override the default container arguments when in dev mode.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
+### `devMode.command[]`
+
+[devMode](#devmode) > command
+
+Override the default container command (i.e. entrypoint) when in dev mode.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
+### `devMode.sync[]`
+
+[devMode](#devmode) > sync
+
+Specify one or more source files or directories to automatically sync with the running container.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[object]` | No       |
+
+### `devMode.sync[].source`
+
+[devMode](#devmode) > [sync](#devmodesync) > source
+
+POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be a relative path. Defaults to the module's top-level directory if no value is provided.
+
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `"."`   | No       |
+
+Example:
+
+```yaml
+devMode:
+  ...
+  sync:
+    - source: "src"
+```
+
+### `devMode.sync[].target`
+
+[devMode](#devmode) > [sync](#devmodesync) > target
+
+POSIX-style absolute path to sync the directory to inside the container. The root path (i.e. "/") is not allowed.
+
+| Type        | Required |
+| ----------- | -------- |
+| `posixPath` | Yes      |
+
+Example:
+
+```yaml
+devMode:
+  ...
+  sync:
+    - target: "/app/src"
+```
+
+### `devMode.sync[].exclude[]`
+
+[devMode](#devmode) > [sync](#devmodesync) > exclude
+
+Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+
+| Type               | Required |
+| ------------------ | -------- |
+| `array[posixPath]` | No       |
+
+Example:
+
+```yaml
+devMode:
+  ...
+  sync:
+    - exclude:
+        - dist/**/*
+        - '*.log'
+```
+
+### `devMode.sync[].mode`
+
+[devMode](#devmode) > [sync](#devmodesync) > mode
+
+The sync mode to use for the given paths.
+
+| Type     | Default     | Required |
+| -------- | ----------- | -------- |
+| `string` | `"one-way"` | No       |
+
+### `devMode.containerName`
+
+[devMode](#devmode) > containerName
+
+Optionally specify the name of a specific container to sync to. If not specified, the first container in the workload is used.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
 ### `serviceResource`
 
-The Deployment, DaemonSet or StatefulSet that Garden should regard as the _Garden service_ in this module (not to be confused with Kubernetes Service resources). Because a `kubernetes-module` can contain any number of Kubernetes resources, this needs to be specified for certain Garden features and commands to work.
+The Deployment, DaemonSet or StatefulSet that Garden should regard as the _Garden service_ in this module (not to be confused with Kubernetes Service resources).
+Because a `kubernetes` module can contain any number of Kubernetes resources, this needs to be specified for certain Garden features and commands to work.
 
 | Type     | Required |
 | -------- | -------- |

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -159,7 +159,7 @@ hotReload:
   # Specify one or more source files or directories to automatically sync into the running container.
   sync:
     - # POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be
-      # a relative path if provided. Defaults to the module's top-level directory if no value is provided.
+      # a relative path. Defaults to the module's top-level directory if no value is provided.
       source: .
 
       # POSIX-style absolute path to sync the directory to inside the container. The root path (i.e. "/") is not
@@ -213,6 +213,36 @@ services:
     # Whether to run the service as a daemon (to ensure exactly one instance runs per node). May not be supported by
     # all providers.
     daemon: false
+
+    # **EXPERIMENTAL**
+    #
+    # Specifies which files or directories to sync to which paths inside the running containers of the service when
+    # it's in dev mode, and overrides for the container command and/or arguments.
+    #
+    # Dev mode is enabled when running the `garden dev` command, and by setting the `--dev` flag on the `garden
+    # deploy` command.
+    devMode:
+      # Override the default container arguments when in dev mode.
+      args:
+
+      # Override the default container command (i.e. entrypoint) when in dev mode.
+      command:
+
+      # Specify one or more source files or directories to automatically sync with the running container.
+      sync:
+        - # POSIX-style path of the directory to sync to the target, relative to the module's top-level directory.
+          # Must be a relative path. Defaults to the module's top-level directory if no value is provided.
+          source: .
+
+          # POSIX-style absolute path to sync the directory to inside the container. The root path (i.e. "/") is not
+          # allowed.
+          target:
+
+          # Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+          exclude:
+
+          # The sync mode to use for the given paths.
+          mode: one-way
 
     # List of ingress endpoints that the service exposes.
     ingresses:
@@ -828,7 +858,7 @@ Specify one or more source files or directories to automatically sync into the r
 
 [hotReload](#hotreload) > [sync](#hotreloadsync) > source
 
-POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be a relative path if provided. Defaults to the module's top-level directory if no value is provided.
+POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be a relative path. Defaults to the module's top-level directory if no value is provided.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |
@@ -998,6 +1028,122 @@ Whether to run the service as a daemon (to ensure exactly one instance runs per 
 | Type      | Default | Required |
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
+
+### `services[].devMode`
+
+[services](#services) > devMode
+
+**EXPERIMENTAL**
+
+Specifies which files or directories to sync to which paths inside the running containers of the service when it's in dev mode, and overrides for the container command and/or arguments.
+
+Dev mode is enabled when running the `garden dev` command, and by setting the `--dev` flag on the `garden deploy` command.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `services[].devMode.args[]`
+
+[services](#services) > [devMode](#servicesdevmode) > args
+
+Override the default container arguments when in dev mode.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
+### `services[].devMode.command[]`
+
+[services](#services) > [devMode](#servicesdevmode) > command
+
+Override the default container command (i.e. entrypoint) when in dev mode.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
+### `services[].devMode.sync[]`
+
+[services](#services) > [devMode](#servicesdevmode) > sync
+
+Specify one or more source files or directories to automatically sync with the running container.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[object]` | No       |
+
+### `services[].devMode.sync[].source`
+
+[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > source
+
+POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be a relative path. Defaults to the module's top-level directory if no value is provided.
+
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `"."`   | No       |
+
+Example:
+
+```yaml
+services:
+  - devMode:
+      ...
+      sync:
+        - source: "src"
+```
+
+### `services[].devMode.sync[].target`
+
+[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > target
+
+POSIX-style absolute path to sync the directory to inside the container. The root path (i.e. "/") is not allowed.
+
+| Type        | Required |
+| ----------- | -------- |
+| `posixPath` | Yes      |
+
+Example:
+
+```yaml
+services:
+  - devMode:
+      ...
+      sync:
+        - target: "/app/src"
+```
+
+### `services[].devMode.sync[].exclude[]`
+
+[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > exclude
+
+Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+
+| Type               | Required |
+| ------------------ | -------- |
+| `array[posixPath]` | No       |
+
+Example:
+
+```yaml
+services:
+  - devMode:
+      ...
+      sync:
+        - exclude:
+            - dist/**/*
+            - '*.log'
+```
+
+### `services[].devMode.sync[].mode`
+
+[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > mode
+
+The sync mode to use for the given paths.
+
+| Type     | Default     | Required |
+| -------- | ----------- | -------- |
+| `string` | `"one-way"` | No       |
 
 ### `services[].ingresses[]`
 

--- a/examples/vote-helm/vote-image/src/foo
+++ b/examples/vote-helm/vote-image/src/foo
@@ -1,3 +1,0 @@
-bla
-ble
-blo

--- a/examples/vote-helm/vote-image/src/foo
+++ b/examples/vote-helm/vote-image/src/foo
@@ -1,0 +1,3 @@
+bla
+ble
+blo

--- a/examples/vote-helm/vote/garden.yml
+++ b/examples/vote-helm/vote/garden.yml
@@ -2,6 +2,11 @@ kind: Module
 description: Helm chart for the voting UI
 type: helm
 name: vote
+devMode:
+  sync:
+    - target: /app/src
+      source: src
+      mode: two-way
 serviceResource:
   kind: Deployment
   containerModule: vote-image

--- a/examples/vote/vote/garden.yml
+++ b/examples/vote/vote/garden.yml
@@ -3,13 +3,14 @@ description: The voting UI
 name: vote
 # repositoryUrl: http://github.com/garden-io/garden...
 type: container
-hotReload:
-  sync:
-    - target: /app/src
-      source: src
 services:
   - name: vote
     args: [npm, run, serve]
+    devMode:
+      sync:
+        - target: /app/src
+          source: src
+          mode: two-way
     ports:
       - name: http
         containerPort: 8080

--- a/images/k8s-sync/Dockerfile
+++ b/images/k8s-sync/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.13.5
+
+RUN apk add --no-cache curl
+
+# Get mutagen agent
+RUN curl -fsSL "https://github.com/garden-io/mutagen/releases/download/v0.12.0-garden-alpha1/mutagen-agent-linux-amd64.tar.gz" \
+  | tar xz --to-stdout mutagen-agent \
+  > /usr/local/bin/mutagen-agent && chmod +x /usr/local/bin/mutagen-agent

--- a/images/k8s-sync/garden.yml
+++ b/images/k8s-sync/garden.yml
@@ -1,0 +1,6 @@
+kind: Module
+type: container
+name: k8s-sync
+description: Used by the kubernetes provider for dev mode sync setup
+image: gardendev/k8s-sync:0.1.1
+dockerfile: Dockerfile

--- a/plugins/conftest-kubernetes/test/conftest-kubernetes.ts
+++ b/plugins/conftest-kubernetes/test/conftest-kubernetes.ts
@@ -78,6 +78,8 @@ describe("conftest-kubernetes provider", () => {
         test: testFromConfig(module, module.testConfigs[0], graph),
         force: true,
         forceBuild: true,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       const key = testTask.getKey()

--- a/plugins/conftest/index.ts
+++ b/plugins/conftest/index.ts
@@ -242,6 +242,7 @@ export const gardenPlugin = () => createGardenPlugin({
           const templates = await renderTemplates({
             ctx: k8sCtx,
             module: sourceModule,
+            devMode: false,
             hotReload: false,
             log,
             version: sourceModule.version.versionString,

--- a/plugins/conftest/test/conftest.ts
+++ b/plugins/conftest/test/conftest.ts
@@ -51,6 +51,8 @@ describe("conftest provider", () => {
         test: testFromConfig(module, module.testConfigs[0], graph),
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       const key = testTask.getKey()
@@ -85,6 +87,8 @@ describe("conftest provider", () => {
         test: testFromConfig(module, module.testConfigs[0], graph),
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       const key = testTask.getKey()
@@ -110,6 +114,8 @@ describe("conftest provider", () => {
         test: testFromConfig(module, module.testConfigs[0], graph),
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       const key = testTask.getKey()
@@ -138,6 +144,8 @@ describe("conftest provider", () => {
         test: testFromConfig(module, module.testConfigs[0], graph),
         force: true,
         forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
       })
 
       const key = testTask.getKey()

--- a/yarn.lock
+++ b/yarn.lock
@@ -7451,6 +7451,19 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
+event-stream@=3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
+  integrity sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=
+  dependencies:
+    duplexer "~0.1.1"
+    from "~0"
+    map-stream "~0.1.0"
+    pause-stream "0.0.11"
+    split "0.3"
+    stream-combiner "~0.0.4"
+    through "~2.3.1"
+
 event-stream@^3.3.2:
   version "3.3.5"
   resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.5.tgz#e5dd8989543630d94c6cf4d657120341fa31636b"
@@ -8179,7 +8192,7 @@ from2@^2.1.0, from2@^2.3.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
-from@^0.1.7:
+from@^0.1.7, from@~0:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
   integrity sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=
@@ -11891,6 +11904,11 @@ map-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.0.7.tgz#8a1f07896d82b10926bd3744a2420009f88974a8"
   integrity sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=
 
+map-stream@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
+  integrity sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=
+
 map-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
@@ -13743,7 +13761,7 @@ pathval@^1.1.0:
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
   integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
-pause-stream@^0.0.11:
+pause-stream@0.0.11, pause-stream@^0.0.11:
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
   integrity sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=
@@ -14815,6 +14833,13 @@ prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
   integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
+
+ps-tree@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.2.0.tgz#5e7425b89508736cdd4f2224d028f7bb3f722ebd"
+  integrity sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==
+  dependencies:
+    event-stream "=3.3.4"
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -15908,6 +15933,14 @@ resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.11.1, resolve@^1.12.
     is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
+respawn@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/respawn/-/respawn-2.6.0.tgz#6e310a2c8aebcfea87629f613c00ee73ddfcbf66"
+  integrity sha512-4fs4W4GD6+zTHvhzOMaeJ56zdmgr35550SgC08WsjdQVGl8d+cp/SZOwlJQKaTQeZTR2iKOMbHIAecWCeLe+Tg==
+  dependencies:
+    ps-tree "^1.2.0"
+    xtend "^4.0.1"
+
 responselike@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/responselike/-/responselike-2.0.0.tgz#26391bcc3174f750f9a79eacc40a12a5c42d7723"
@@ -16683,6 +16716,13 @@ split2@^3.0.0, split2@^3.1.1, split2@^3.2.2:
   dependencies:
     readable-stream "^3.0.0"
 
+split@0.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
+  integrity sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=
+  dependencies:
+    through "2"
+
 split@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/split/-/split-1.0.1.tgz#605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
@@ -16813,6 +16853,13 @@ stream-combiner@^0.2.2:
   dependencies:
     duplexer "~0.1.1"
     through "~2.3.4"
+
+stream-combiner@~0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
+  integrity sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=
+  dependencies:
+    duplexer "~0.1.1"
 
 stream-each@^1.1.0:
   version "1.2.3"
@@ -17480,7 +17527,7 @@ through2@^4.0.0:
   dependencies:
     readable-stream "3"
 
-through@2, "through@>=2.2.7 <3", through@^2.3.6, through@^2.3.8, through@~2.3, through@~2.3.4:
+through@2, "through@>=2.2.7 <3", through@^2.3.6, through@^2.3.8, through@~2.3, through@~2.3.1, through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=


### PR DESCRIPTION
This introduces a new notion of _dev mode_ for services, along with a complete replacement for the current _hot reloading_ mechanism, based on the excellent [Mutagen](https://github.com/mutagen-io/mutagen) project by @xenoscopic, which is *vastly* superior to the prior rsync-based implementation in performance, and allows for two-way syncing as well.

I'm very excited by how well this works in my testing, but because this is such a major change and also introduces new semantics and configuration layouts, this will be flagged as experimental for a bit. The older hot reloading mechanism will still be around, but will eventually be deprecated and completely removed.

To use the feature, services need to be configured with the `devMode` field, which is similar to the existing `hotReload` field in shape, but is configured per-service instead of just at the `container` module level. 

Couple of examples from the vote and vote-helm example projects:

```yaml
kind: Module
description: The voting UI
name: vote
type: container
services:
  - name: vote
    args: [npm, run, serve]
    devMode:
      sync:
        - target: /app/src
          source: src
          mode: two-way
...
```

```yaml
kind: Module
description: Helm chart for the voting UI
type: helm
name: vote
dependencies:
  - api

serviceResource:
  kind: Deployment
  containerModule: vote-image
devMode:
  sync:
    - target: /app/src
      source: src
      mode: two-way
```

Notice the new `mode` field, which allows enabling two-way sync.

To run services in dev mode, once configured, you can simply run `garden dev` as usual, `garden dev <service name>`, or `garden deploy --dev=<service-name>`.

In order to make the Mutagen integration work, we're temporarily running a fork of it, which includes a new transport protocol. Hopefully it'll make its way upstream soon.

TODO
- [x] Integration tests
- [x] Documentation
- [x] Test on Windows+Linux
- [ ] Support postSyncCommand in dev mode (I left it off the devMode configuration schema for now)
