### PR TITLE
Revert "Fixing typo for ingress annotations in container module docs"

### DIFF
--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -1027,7 +1027,7 @@ services:
   - ingresses:
       - path: /api
         port: http
-        annotations:
+      - annotations:
             nginx.ingress.kubernetes.io/proxy-body-size: '0'
 ```
 


### PR DESCRIPTION
This reverts commit ad6548ffdfd4ba113dcc5f71481f130981e38300.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
