### PR TITLE
feat(commands): skip-dependants opt for test cmd

### DIFF
--- a/core/src/commands/test.ts
+++ b/core/src/commands/test.ts
@@ -25,20 +25,23 @@ import { getTestTasks } from "../tasks/test"
 import { printHeader } from "../logger/util"
 import { startServer } from "../server/server"
 import { StringsParameter, BooleanParameter } from "../cli/params"
+import { deline } from "../util/string"
 
 export const testArgs = {
   modules: new StringsParameter({
-    help:
-      "The name(s) of the module(s) to test (skip to test all modules). " +
-      "Use comma as a separator to specify multiple modules.",
+    help: deline`
+      The name(s) of the module(s) to test (skip to test all modules).
+      Use comma as a separator to specify multiple modules.
+    `,
   }),
 }
 
 export const testOpts = {
   "name": new StringsParameter({
-    help:
-      "Only run tests with the specfied name (e.g. unit or integ). " +
-      "Accepts glob patterns (e.g. integ* would run both 'integ' and 'integration')",
+    help: deline`
+      Only run tests with the specfied name (e.g. unit or integ).
+      Accepts glob patterns (e.g. integ* would run both 'integ' and 'integration').
+    `,
     alias: "n",
   }),
   "force": new BooleanParameter({
@@ -50,6 +53,12 @@ export const testOpts = {
     help: "Watch for changes in module(s) and auto-test.",
     alias: "w",
     cliOnly: true,
+  }),
+  "skip-dependants": new BooleanParameter({
+    help: deline`
+      When using the modules argument, only run tests for those modules (and skip tests in other modules with
+      dependencies on those modules).
+    `,
   }),
 }
 
@@ -115,11 +124,16 @@ export class TestCommand extends Command<Args, Opts> {
     }
 
     const graph = await garden.getConfigGraph(log)
+    const skipDependants = opts["skip-dependants"]
+    let modules: GardenModule[]
 
-    const modules: GardenModule[] = args.modules
-      ? graph.withDependantModules(graph.getModules({ names: args.modules }))
-      : // All modules are included in this case, so there's no need to compute dependants.
-        graph.getModules()
+    if (args.modules) {
+      modules = skipDependants
+        ? graph.getModules({ names: args.modules })
+        : graph.withDependantModules(graph.getModules({ names: args.modules }))
+    } else {
+      modules = graph.getModules()
+    }
 
     const filterNames = opts.name || []
     const force = opts.force

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -3262,10 +3262,11 @@ Examples:
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
-  | `--name` | `-n` | array:string | Only run tests with the specfied name (e.g. unit or integ). Accepts glob patterns (e.g. integ* would run both &#x27;integ&#x27; and &#x27;integration&#x27;)
+  | `--name` | `-n` | array:string | Only run tests with the specfied name (e.g. unit or integ). Accepts glob patterns (e.g. integ* would run both &#x27;integ&#x27; and &#x27;integration&#x27;).
   | `--force` | `-f` | boolean | Force re-test of module(s).
   | `--force-build` |  | boolean | Force rebuild of module(s).
   | `--watch` | `-w` | boolean | Watch for changes in module(s) and auto-test.
+  | `--skip-dependants` |  | boolean | When using the modules argument, only run tests for those modules (and skip tests in other modules with dependencies on those modules).
 
 #### Outputs
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

The current behavior of the test command when called with a list of module names is to run all tests in those modules, and all tests in modules with dependencies on those modules.

This is not the desired behavior in all cases, so here we add a `--skip-dependants` option to the test command. When used, only tests in the requested modules will be run.