### PR TITLE
fix(core): catch EPIPE error when closing port proxies

### DIFF
--- a/core/src/proxy.ts
+++ b/core/src/proxy.ts
@@ -258,7 +258,10 @@ function stopPortProxy(proxy: PortProxy, log?: LogEntry) {
   // TODO: call stopPortForward handler
   log && log.debug(`Stopping port forward to ${proxy.key}`)
   delete activeProxies[proxy.key]
-  proxy.server.close()
+
+  try {
+    proxy.server.close()
+  } catch {}
 }
 
 function getHostname(service: GardenService, spec: ForwardablePort) {


### PR DESCRIPTION
Fixes #2370

Basically this happens when the server is already closed. So we just swallow the error, can't think of any legit error that would come about there.