### PR TITLE
improvement(k8s): get rid of NFS when using kaniko build mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,10 +192,12 @@ jobs:
             - plugins/
   build-dist:
     <<: *node-config
+    resource_class: large
     steps:
       - build_dist
   build-dist-edge:
     <<: *node-config
+    resource_class: large
     steps:
       - build_dist:
           version: edge

--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -486,7 +486,7 @@ export const containerRegistryConfigSchema = () =>
   }).description(dedent`
     The registry where built containers should be pushed to, and then pulled to the cluster when deploying services.
 
-    Important: If you specify this in combination with \`buildMode: cluster-docker\` or \`buildMode: kaniko\`, you must make sure \`imagePullSecrets\` includes authentication with the specified deployment registry, that has the appropriate write privileges (usually full write access to the configured \`deploymentRegistry.namespace\`).
+    Important: If you specify this in combination with in-cluster building, you must make sure \`imagePullSecrets\` includes authentication with the specified deployment registry, that has the appropriate write privileges (usually full write access to the configured \`deploymentRegistry.namespace\`).
   `)
 
 export interface ContainerService extends GardenService<ContainerModule> {}

--- a/core/src/plugins/kubernetes/commands/cluster-init.ts
+++ b/core/src/plugins/kubernetes/commands/cluster-init.ts
@@ -48,7 +48,7 @@ export const clusterInit: PluginCommand = {
         ctx: k8sCtx,
         log,
         namespace: systemNamespace,
-        args: ["delete", "--purge", "garden-nfs-provisioner"],
+        args: ["uninstall", "garden-nfs-provisioner"],
       })
     } catch (_) {}
 

--- a/core/src/plugins/kubernetes/constants.ts
+++ b/core/src/plugins/kubernetes/constants.ts
@@ -17,7 +17,7 @@ export const MAX_CONFIGMAP_DATA_SIZE = 1024 * 1024 // max ConfigMap data size is
 // the outputs field, so we cap at 250kB.
 export const MAX_RUN_RESULT_LOG_LENGTH = 250 * 1024
 
-export const dockerAuthSecretName = "builder-docker-config"
+export const systemDockerAuthSecretName = "builder-docker-config"
 export const dockerAuthSecretKey = ".dockerconfigjson"
 export const inClusterRegistryHostname = "127.0.0.1:5000"
 

--- a/core/src/plugins/kubernetes/container/build/build.ts
+++ b/core/src/plugins/kubernetes/container/build/build.ts
@@ -6,25 +6,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import split2 = require("split2")
 import { ContainerModule } from "../../../container/config"
 import { containerHelpers } from "../../../container/helpers"
-import { getDockerBuildFlags } from "../../../container/build"
 import { GetBuildStatusParams, BuildStatus } from "../../../../types/plugin/module/getBuildStatus"
 import { BuildModuleParams, BuildResult } from "../../../../types/plugin/module/build"
-import { inClusterRegistryHostname, dockerDaemonContainerName, rsyncPort } from "../../constants"
-import { posix } from "path"
-import { KubeApi } from "../../api"
 import { KubernetesProvider, ContainerBuildMode } from "../../config"
-import { BuildError, ConfigurationError } from "../../../../exceptions"
-import { LogLevel } from "../../../../logger/log-node"
-import { renderOutputStream } from "../../../../util/util"
-import { getSystemNamespace } from "../../namespace"
-import chalk = require("chalk")
-import { getKanikoBuildStatus, runKaniko, kanikoBuildFailed, getKanikoFlags } from "./kaniko"
-import { getClusterDockerBuildStatus, getDockerDaemonPodRunner } from "./cluster-docker"
+import { getKanikoBuildStatus, kanikoBuild } from "./kaniko"
+import { clusterDockerBuild, getClusterDockerBuildStatus } from "./cluster-docker"
 import { getLocalBuildStatus, localBuild } from "./local"
-import { BuildStatusHandler, BuildHandler, syncToBuildSync, sharedBuildSyncDeploymentName } from "./common"
+import { BuildStatusHandler, BuildHandler } from "./common"
 import { buildkitBuildHandler, getBuildkitBuildStatus } from "./buildkit"
 
 export async function k8sGetContainerBuildStatus(params: GetBuildStatusParams<ContainerModule>): Promise<BuildStatus> {
@@ -62,144 +52,9 @@ const buildStatusHandlers: { [mode in ContainerBuildMode]: BuildStatusHandler } 
   "kaniko": getKanikoBuildStatus,
 }
 
-const remoteBuild: BuildHandler = async (params) => {
-  const { ctx, module, log } = params
-  const provider = <KubernetesProvider>ctx.provider
-  const systemNamespace = await getSystemNamespace(ctx, provider, log)
-  const api = await KubeApi.factory(log, ctx, provider)
-
-  const localId = containerHelpers.getLocalImageId(module, module.version)
-  const deploymentImageId = containerHelpers.getDeploymentImageId(
-    module,
-    module.version,
-    provider.config.deploymentRegistry
-  )
-  const dockerfile = module.spec.dockerfile || "Dockerfile"
-
-  const { contextPath } = await syncToBuildSync({
-    ...params,
-    api,
-    namespace: systemNamespace,
-    deploymentName: sharedBuildSyncDeploymentName,
-    rsyncPort,
-  })
-
-  log.setState(`Building image ${localId}...`)
-
-  let buildLog = ""
-
-  // Stream debug log to a status line
-  const stdout = split2()
-  const statusLine = log.placeholder({ level: LogLevel.verbose })
-
-  stdout.on("error", () => {})
-  stdout.on("data", (line: Buffer) => {
-    statusLine.setState(renderOutputStream(line.toString()))
-  })
-
-  if (provider.config.buildMode === "cluster-docker") {
-    // Prepare the build command
-    const dockerfilePath = posix.join(contextPath, dockerfile)
-
-    let args = [
-      "docker",
-      "build",
-      "-t",
-      deploymentImageId,
-      "-f",
-      dockerfilePath,
-      contextPath,
-      ...getDockerBuildFlags(module),
-    ]
-
-    // Execute the build
-    const containerName = dockerDaemonContainerName
-    const buildTimeout = module.spec.build.timeout
-
-    if (provider.config.clusterDocker && provider.config.clusterDocker.enableBuildKit) {
-      args = ["/bin/sh", "-c", "DOCKER_BUILDKIT=1 " + args.join(" ")]
-    }
-
-    const runner = await getDockerDaemonPodRunner({ api, ctx, provider, systemNamespace })
-
-    const buildRes = await runner.exec({
-      log,
-      command: args,
-      timeoutSec: buildTimeout,
-      containerName,
-      stdout,
-      buffer: true,
-    })
-
-    buildLog = buildRes.log
-
-    // Push the image to the registry
-    log.setState({ msg: `Pushing image ${localId} to registry...` })
-
-    const dockerCmd = ["docker", "push", deploymentImageId]
-    const pushArgs = ["/bin/sh", "-c", dockerCmd.join(" ")]
-
-    const pushRes = await runner.exec({
-      log,
-      command: pushArgs,
-      timeoutSec: 300,
-      containerName,
-      stdout,
-      buffer: true,
-    })
-
-    buildLog += pushRes.log
-  } else if (provider.config.buildMode === "kaniko") {
-    // build with Kaniko
-    const args = [
-      "--context",
-      "dir://" + contextPath,
-      "--dockerfile",
-      dockerfile,
-      "--destination",
-      deploymentImageId,
-      ...getKanikoFlags(module.spec.extraFlags, provider.config.kaniko?.extraFlags),
-    ]
-
-    if (provider.config.deploymentRegistry?.hostname === inClusterRegistryHostname) {
-      // The in-cluster registry is not exposed, so we don't configure TLS on it.
-      args.push("--insecure")
-    }
-
-    args.push(...getDockerBuildFlags(module))
-
-    // Execute the build
-    const buildRes = await runKaniko({
-      ctx,
-      provider,
-      log,
-      namespace: systemNamespace,
-      module,
-      args,
-      outputStream: stdout,
-    })
-    buildLog = buildRes.log
-
-    if (kanikoBuildFailed(buildRes)) {
-      throw new BuildError(`Failed building module ${chalk.bold(module.name)}:\n\n${buildLog}`, { buildLog })
-    }
-  } else {
-    throw new ConfigurationError("Uknown build mode", { buildMode: provider.config.buildMode })
-  }
-
-  log.silly(buildLog)
-
-  return {
-    buildLog,
-    fetched: false,
-    fresh: true,
-    version: module.version.versionString,
-  }
-}
-
 const buildHandlers: { [mode in ContainerBuildMode]: BuildHandler } = {
   "local-docker": localBuild,
   "cluster-buildkit": buildkitBuildHandler,
-  "cluster-docker": remoteBuild,
-  "kaniko": remoteBuild,
+  "cluster-docker": clusterDockerBuild,
+  "kaniko": kanikoBuild,
 }

--- a/core/src/plugins/kubernetes/container/build/cluster-docker.ts
+++ b/core/src/plugins/kubernetes/container/build/cluster-docker.ts
@@ -7,15 +7,27 @@
  */
 
 import { getDeploymentPod } from "../../util"
-import { dockerDaemonDeploymentName, dockerDaemonContainerName } from "../../constants"
+import { dockerDaemonDeploymentName, dockerDaemonContainerName, rsyncPort } from "../../constants"
 import { KubeApi } from "../../api"
 import { KubernetesProvider, KubernetesPluginContext } from "../../config"
 import { InternalError } from "../../../../exceptions"
 import { PodRunner } from "../../run"
 import { getSystemNamespace } from "../../namespace"
-import chalk = require("chalk")
+import chalk from "chalk"
 import { PluginContext } from "../../../../plugin-context"
-import { BuildStatusHandler, getManifestInspectArgs } from "./common"
+import {
+  BuildHandler,
+  BuildStatusHandler,
+  getManifestInspectArgs,
+  sharedBuildSyncDeploymentName,
+  syncToBuildSync,
+} from "./common"
+import { posix } from "path"
+import split2 = require("split2")
+import { LogLevel } from "../../../../logger/log-node"
+import { renderOutputStream } from "../../../../util/util"
+import { getDockerBuildFlags } from "../../../container/build"
+import { containerHelpers } from "../../../container/helpers"
 
 export const getClusterDockerBuildStatus: BuildStatusHandler = async (params) => {
   const { ctx, module, log } = params
@@ -54,6 +66,103 @@ export const getClusterDockerBuildStatus: BuildStatusHandler = async (params) =>
     }
 
     return { ready: false }
+  }
+}
+
+export const clusterDockerBuild: BuildHandler = async (params) => {
+  const { ctx, module, log } = params
+  const provider = <KubernetesProvider>ctx.provider
+  const systemNamespace = await getSystemNamespace(ctx, provider, log)
+  const api = await KubeApi.factory(log, ctx, provider)
+
+  const localId = containerHelpers.getLocalImageId(module, module.version)
+  const deploymentImageId = containerHelpers.getDeploymentImageId(
+    module,
+    module.version,
+    provider.config.deploymentRegistry
+  )
+  const dockerfile = module.spec.dockerfile || "Dockerfile"
+
+  const { contextPath } = await syncToBuildSync({
+    ...params,
+    api,
+    namespace: systemNamespace,
+    deploymentName: sharedBuildSyncDeploymentName,
+    rsyncPort,
+  })
+
+  log.setState(`Building image ${localId}...`)
+
+  let buildLog = ""
+
+  // Stream debug log to a status line
+  const stdout = split2()
+  const statusLine = log.placeholder({ level: LogLevel.verbose })
+
+  stdout.on("error", () => {})
+  stdout.on("data", (line: Buffer) => {
+    statusLine.setState(renderOutputStream(line.toString()))
+  })
+
+  // Prepare the build command
+  const dockerfilePath = posix.join(contextPath, dockerfile)
+
+  let args = [
+    "docker",
+    "build",
+    "-t",
+    deploymentImageId,
+    "-f",
+    dockerfilePath,
+    contextPath,
+    ...getDockerBuildFlags(module),
+  ]
+
+  // Execute the build
+  const containerName = dockerDaemonContainerName
+  const buildTimeout = module.spec.build.timeout
+
+  if (provider.config.clusterDocker && provider.config.clusterDocker.enableBuildKit) {
+    args = ["/bin/sh", "-c", "DOCKER_BUILDKIT=1 " + args.join(" ")]
+  }
+
+  const runner = await getDockerDaemonPodRunner({ api, ctx, provider, systemNamespace })
+
+  const buildRes = await runner.exec({
+    log,
+    command: args,
+    timeoutSec: buildTimeout,
+    containerName,
+    stdout,
+    buffer: true,
+  })
+
+  buildLog = buildRes.log
+
+  // Push the image to the registry
+  log.setState({ msg: `Pushing image ${localId} to registry...` })
+
+  const dockerCmd = ["docker", "push", deploymentImageId]
+  const pushArgs = ["/bin/sh", "-c", dockerCmd.join(" ")]
+
+  const pushRes = await runner.exec({
+    log,
+    command: pushArgs,
+    timeoutSec: 300,
+    containerName,
+    stdout,
+    buffer: true,
+  })
+
+  buildLog += pushRes.log
+
+  log.silly(buildLog)
+
+  return {
+    buildLog,
+    fetched: false,
+    fresh: true,
+    version: module.version.versionString,
   }
 }
 

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -12,7 +12,14 @@ import { containerHelpers } from "../../../container/helpers"
 import { GetBuildStatusParams, BuildStatus } from "../../../../types/plugin/module/getBuildStatus"
 import { BuildModuleParams, BuildResult } from "../../../../types/plugin/module/build"
 import { getDeploymentPod } from "../../util"
-import { gardenUtilDaemonDeploymentName, inClusterRegistryHostname } from "../../constants"
+import {
+  buildSyncVolumeName,
+  dockerAuthSecretKey,
+  gardenUtilDaemonDeploymentName,
+  inClusterRegistryHostname,
+  k8sUtilImageName,
+  rsyncPortName,
+} from "../../constants"
 import { KubeApi } from "../../api"
 import { KubernetesProvider } from "../../config"
 import { PodRunner } from "../../run"
@@ -20,14 +27,36 @@ import { PluginContext } from "../../../../plugin-context"
 import { resolve } from "path"
 import { getPortForward } from "../../port-forward"
 import { normalizeLocalRsyncPath } from "../../../../util/fs"
-import { exec } from "../../../../util/util"
+import { exec, hashString } from "../../../../util/util"
 import { InternalError, RuntimeError } from "../../../../exceptions"
 import { LogEntry } from "../../../../logger/log-entry"
 import { getInClusterRegistryHostname } from "../../init"
+import { prepareDockerAuth } from "../../init"
+import chalk from "chalk"
+import { V1Container } from "@kubernetes/client-node"
 
 const inClusterRegistryPort = 5000
 
 export const sharedBuildSyncDeploymentName = "garden-build-sync"
+export const utilRsyncPort = 8730
+
+export const commonSyncArgs = [
+  "--recursive",
+  // Copy symlinks (Note: These are sanitized while syncing to the build staging dir)
+  "--links",
+  // Preserve permissions
+  "--perms",
+  // Preserve modification times
+  "--times",
+  "--compress",
+]
+
+export const builderToleration = {
+  key: "garden-build",
+  operator: "Equal",
+  value: "true",
+  effect: "NoSchedule",
+}
 
 export type BuildStatusHandler = (params: GetBuildStatusParams<ContainerModule>) => Promise<BuildStatus>
 export type BuildHandler = (params: BuildModuleParams<ContainerModule>) => Promise<BuildResult>
@@ -64,22 +93,7 @@ export async function syncToBuildSync(params: SyncToSharedBuildSyncParams) {
   // https://stackoverflow.com/questions/1636889/rsync-how-can-i-configure-it-to-create-target-directory-on-server
   let src = normalizeLocalRsyncPath(`${buildRoot}`) + `/./${module.name}/`
   const destination = `rsync://localhost:${syncFwd.localPort}/volume/${ctx.workingCopyId}/`
-  const syncArgs = [
-    "--recursive",
-    "--relative",
-    // Copy symlinks (Note: These are sanitized while syncing to the build staging dir)
-    "--links",
-    // Preserve permissions
-    "--perms",
-    // Preserve modification times
-    "--times",
-    "--compress",
-    "--delete",
-    "--temp-dir",
-    "/tmp",
-    src,
-    destination,
-  ]
+  const syncArgs = [...commonSyncArgs, "--relative", "--delete", "--temp-dir", "/tmp", src, destination]
 
   log.debug(`Syncing from ${src} to ${destination}`)
   // We retry a couple of times, because we may get intermittent connection issues or concurrency issues
@@ -230,6 +244,99 @@ export async function getManifestInspectArgs(module: ContainerModule, deployment
   return dockerArgs
 }
 
+/**
+ * Creates and saves a Kubernetes Docker authentication Secret in the specified namespace, suitable for mounting in
+ * builders and as an imagePullSecret.
+ *
+ * Returns the created Secret manifest.
+ */
+export async function ensureBuilderSecret({
+  provider,
+  log,
+  api,
+  namespace,
+}: {
+  provider: KubernetesProvider
+  log: LogEntry
+  api: KubeApi
+  namespace: string
+}) {
+  // Ensure docker auth secret is available and up-to-date in the namespace
+  const authSecret = await prepareDockerAuth(api, provider, namespace)
+  let updated = false
+
+  // Create a unique name based on the contents of the auth (otherwise different Garden runs can step over each other
+  // in shared namespaces).
+  const hash = hashString(authSecret.data![dockerAuthSecretKey], 6)
+  const secretName = `garden-docker-auth-${hash}`
+  authSecret.metadata.name = secretName
+
+  const existingSecret = await api.readOrNull({ log, namespace, manifest: authSecret })
+
+  if (!existingSecret || authSecret.data?.[dockerAuthSecretKey] !== existingSecret.data?.[dockerAuthSecretKey]) {
+    log.setState(chalk.gray(`-> Updating Docker auth secret in namespace ${namespace}`))
+    await api.upsert({ kind: "Secret", namespace, log, obj: authSecret })
+    updated = true
+  }
+
+  return { authSecret, updated }
+}
+
 function isLocalHostname(hostname: string) {
   return hostname === "localhost" || hostname.startsWith("127.")
+}
+
+export function getUtilContainer(authSecretName: string): V1Container {
+  return {
+    name: "util",
+    image: k8sUtilImageName,
+    imagePullPolicy: "IfNotPresent",
+    command: ["/rsync-server.sh"],
+    env: [
+      // This makes sure the server is accessible on any IP address, because CIDRs can be different across clusters.
+      // K8s can be trusted to secure the port. - JE
+      { name: "ALLOW", value: "0.0.0.0/0" },
+      {
+        name: "RSYNC_PORT",
+        value: "" + utilRsyncPort,
+      },
+    ],
+    volumeMounts: [
+      {
+        name: authSecretName,
+        mountPath: "/home/user/.docker",
+        readOnly: true,
+      },
+      {
+        name: buildSyncVolumeName,
+        mountPath: "/data",
+      },
+    ],
+    ports: [
+      {
+        name: rsyncPortName,
+        protocol: "TCP",
+        containerPort: utilRsyncPort,
+      },
+    ],
+    readinessProbe: {
+      initialDelaySeconds: 1,
+      periodSeconds: 1,
+      timeoutSeconds: 3,
+      successThreshold: 2,
+      failureThreshold: 5,
+      tcpSocket: { port: <object>(<unknown>rsyncPortName) },
+    },
+    resources: {
+      // This should be ample
+      limits: {
+        cpu: "256m",
+        memory: "512Mi",
+      },
+    },
+    securityContext: {
+      runAsUser: 1000,
+      runAsGroup: 1000,
+    },
+  }
 }

--- a/core/src/plugins/kubernetes/init.ts
+++ b/core/src/plugins/kubernetes/init.ts
@@ -32,7 +32,7 @@ import {
 import { ConfigurationError } from "../../exceptions"
 import Bluebird from "bluebird"
 import { readSecret } from "./secrets"
-import { dockerAuthSecretName, dockerAuthSecretKey } from "./constants"
+import { systemDockerAuthSecretName, dockerAuthSecretKey } from "./constants"
 import { V1Secret, V1Toleration } from "@kubernetes/client-node"
 import { KubernetesResource } from "./types"
 import { compareDeployedResources } from "./status/status"
@@ -504,7 +504,7 @@ export async function prepareDockerAuth(
     apiVersion: "v1",
     kind: "Secret",
     metadata: {
-      name: dockerAuthSecretName,
+      name: systemDockerAuthSecretName,
       namespace,
     },
     data: {

--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -17,7 +17,7 @@ import { KubernetesResource, KubernetesWorkload, KubernetesPod, KubernetesServer
 import { splitLast, serializeValues, findByName } from "../../util/util"
 import { KubeApi, KubernetesError } from "./api"
 import { gardenAnnotationKey, base64, deline, stableStringify } from "../../util/string"
-import { MAX_CONFIGMAP_DATA_SIZE, dockerAuthSecretName, dockerAuthSecretKey } from "./constants"
+import { MAX_CONFIGMAP_DATA_SIZE, systemDockerAuthSecretName } from "./constants"
 import { ContainerEnvVars } from "../container/config"
 import { ConfigurationError, PluginError } from "../../exceptions"
 import { ServiceResourceSpec, KubernetesProvider } from "./config"
@@ -600,19 +600,6 @@ export function makePodName(type: string, ...parts: string[]) {
 }
 
 /**
- * Gets the Docker auth volume details to be mounted into a container.
- */
-export function getDockerAuthVolume() {
-  return {
-    name: dockerAuthSecretName,
-    secret: {
-      secretName: dockerAuthSecretName,
-      items: [{ key: dockerAuthSecretKey, path: "config.json" }],
-    },
-  }
-}
-
-/**
  * Creates a skopeo container configuration to be execued by a PodRunner.
  *
  * @param command the skopeo command to execute
@@ -624,7 +611,7 @@ export function getSkopeoContainer(command: string) {
     command: ["sh", "-c", command],
     volumeMounts: [
       {
-        name: dockerAuthSecretName,
+        name: systemDockerAuthSecretName,
         mountPath: "/root/.docker",
         readOnly: true,
       },

--- a/core/test/data/test-projects/container/garden.yml
+++ b/core/test/data/test-projects/container/garden.yml
@@ -8,6 +8,7 @@ environments:
   - name: cluster-docker-auth
   - name: cluster-docker-remote-registry
   - name: kaniko
+  - name: kaniko-project-namespace
   - name: kaniko-image-override
   - name: kaniko-remote-registry
   - name: cluster-buildkit
@@ -41,6 +42,11 @@ providers:
   - <<: *clusterDocker
     environments: [kaniko]
     buildMode: kaniko
+  - <<: *clusterDocker
+    environments: [kaniko-project-namespace]
+    buildMode: kaniko
+    kaniko:
+      namespace: null
   - <<: *clusterDocker
     environments: [kaniko-remote-registry]
     buildMode: kaniko

--- a/docs/advanced/terraform.md
+++ b/docs/advanced/terraform.md
@@ -47,7 +47,7 @@ providers:
     kubeconfig: ${providers.terraform.outputs.kubeconfig_path}
     context: gke
     defaultHostname: terraform-gke-${local.username}.dev-2.sys.garden
-    buildMode: cluster-docker
+    buildMode: kaniko
 ```
 
 The `initRoot` parameter tells Garden that there is a Terraform working directory at the specified path. If you don't specify this, Garden doesn't attempt to apply a stack when initializing the provider.

--- a/docs/guides/cloud-provider-setup.md
+++ b/docs/guides/cloud-provider-setup.md
@@ -44,7 +44,7 @@ name: your-project
       - name: kubernetes
         context: <name-of-your-gke-kubernetes-context>
         defaultHostname: your-project.yourdomain.com     # <- replace this with your intended ingress hostname
-        buildMode: cluster-docker                        # <- (optional) enable in-cluster building
+        buildMode: kaniko                                # <- (optional) enable in-cluster building
         setupIngressController: nginx                    # <- skip this if you want to install your own ingress controller
 ```
 
@@ -98,7 +98,7 @@ environments:
       - name: kubernetes
         context: <name-of-your-azure-kubernetes-context>
         defaultHostname: your-project.yourdomain.com     # <- replace this with your intended ingress hostname
-        buildMode: cluster-docker                        # <- (optional) enable in-cluster building
+        buildMode: kaniko                              # <- (optional) enable in-cluster building
         setupIngressController: nginx                    # <- skip this if you want to install your own ingress controller
   - name: some-other-environment
     ...
@@ -133,7 +133,7 @@ environments:
       - name: kubernetes
         context: <name-of-your-eks-kubernetes-context>
         defaultHostname: your-project.yourdomain.com     # <- replace this with your intended ingress hostname
-        buildMode: cluster-docker                        # <- (optional) enable in-cluster building
+        buildMode: kaniko                                # <- (optional) enable in-cluster building
         setupIngressController: nginx                    # <- skip this if you want to install your own ingress controller
   - name: some-other-environment
     ...
@@ -172,7 +172,7 @@ environments:
       - name: kubernetes
         context: <name-of-your-kops-kubernetes-context>
         defaultHostname: your-project.yourdomain.com     # <- replace this with your intended ingress hostname
-        buildMode: cluster-docker                        # <- (optional) enable in-cluster building
+        buildMode: kaniko                                # <- (optional) enable in-cluster building
         setupIngressController: nginx                    # <- skip this if you want to install your own ingress controller
     ...
 ```

--- a/docs/guides/using-garden-in-ci.md
+++ b/docs/guides/using-garden-in-ci.md
@@ -50,7 +50,7 @@ providers:
     environments: [preview]
     context: my-preview-cluster
     defaultHostname: ${environment.namespace}.preview.my-domain
-    buildMode: cluster-docker
+    buildMode: kaniko
 ```
 
 Notice that we're using the `CIRCLE_BRANCH` environment variable to label the project namespace. This ensures that each pull request gets deployed into its own namespace.

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -61,12 +61,25 @@ providers:
 
     # Configuration options for the `kaniko` build mode.
     kaniko:
-      # Change the kaniko image (repository/image:tag) to use when building in kaniko mode.
-      image: 'gcr.io/kaniko-project/executor:debug-v1.2.0'
-
-      # Specify extra flags to use when building the container image with kaniko. Flags set on container module take
-      # precedence over these.
+      # Specify extra flags to use when building the container image with kaniko. Flags set on `container` modules
+      # take precedence over these.
       extraFlags:
+
+      # Change the kaniko image (repository/image:tag) to use when building in kaniko mode.
+      image: 'gcr.io/kaniko-project/executor:v1.6.0-debug'
+
+      # Choose the namespace where the Kaniko pods will be run. Set to `null` to use the project namespace.
+      #
+      # **IMPORTANT: The default namespace will change to the project namespace instead of the garden-system namespace
+      # in an upcoming release!**
+      namespace: garden-system
+
+      # Exposes the `nodeSelector` field on the PodSpec of the Kaniko pods. This allows you to constrain the Kaniko
+      # pods to only run on particular nodes.
+      #
+      # [See here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) for the official Kubernetes
+      # guide to assigning Pods to nodes.
+      nodeSelector:
 
     # A default hostname to use when no hostname is explicitly configured for a service.
     defaultHostname:
@@ -116,7 +129,7 @@ providers:
 
         requests:
           # CPU request in millicpu.
-          cpu: 200
+          cpu: 100
 
           # Memory request in megabytes.
           memory: 512
@@ -444,6 +457,16 @@ Configuration options for the `kaniko` build mode.
 | -------- | -------- |
 | `object` | No       |
 
+### `providers[].kaniko.extraFlags[]`
+
+[providers](#providers) > [kaniko](#providerskaniko) > extraFlags
+
+Specify extra flags to use when building the container image with kaniko. Flags set on `container` modules take precedence over these.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
 ### `providers[].kaniko.image`
 
 [providers](#providers) > [kaniko](#providerskaniko) > image
@@ -452,17 +475,31 @@ Change the kaniko image (repository/image:tag) to use when building in kaniko mo
 
 | Type     | Default                                         | Required |
 | -------- | ----------------------------------------------- | -------- |
-| `string` | `"gcr.io/kaniko-project/executor:debug-v1.2.0"` | No       |
+| `string` | `"gcr.io/kaniko-project/executor:v1.6.0-debug"` | No       |
 
-### `providers[].kaniko.extraFlags[]`
+### `providers[].kaniko.namespace`
 
-[providers](#providers) > [kaniko](#providerskaniko) > extraFlags
+[providers](#providers) > [kaniko](#providerskaniko) > namespace
 
-Specify extra flags to use when building the container image with kaniko. Flags set on container module take precedence over these.
+Choose the namespace where the Kaniko pods will be run. Set to `null` to use the project namespace.
 
-| Type            | Required |
-| --------------- | -------- |
-| `array[string]` | No       |
+**IMPORTANT: The default namespace will change to the project namespace instead of the garden-system namespace in an upcoming release!**
+
+| Type     | Default           | Required |
+| -------- | ----------------- | -------- |
+| `string` | `"garden-system"` | No       |
+
+### `providers[].kaniko.nodeSelector`
+
+[providers](#providers) > [kaniko](#providerskaniko) > nodeSelector
+
+Exposes the `nodeSelector` field on the PodSpec of the Kaniko pods. This allows you to constrain the Kaniko pods to only run on particular nodes.
+
+[See here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) for the official Kubernetes guide to assigning Pods to nodes.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
 
 ### `providers[].defaultHostname`
 
@@ -552,7 +589,7 @@ Resource requests and limits for the in-cluster builder, container registry and 
 
 | Type     | Default                                                                                                                                                                                                                                                    | Required |
 | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `object` | `{"builder":{"limits":{"cpu":4000,"memory":8192},"requests":{"cpu":200,"memory":512}},"registry":{"limits":{"cpu":2000,"memory":4096},"requests":{"cpu":200,"memory":512}},"sync":{"limits":{"cpu":500,"memory":512},"requests":{"cpu":100,"memory":90}}}` | No       |
+| `object` | `{"builder":{"limits":{"cpu":4000,"memory":8192},"requests":{"cpu":100,"memory":512}},"registry":{"limits":{"cpu":2000,"memory":4096},"requests":{"cpu":200,"memory":512}},"sync":{"limits":{"cpu":500,"memory":512},"requests":{"cpu":100,"memory":90}}}` | No       |
 
 ### `providers[].resources.builder`
 
@@ -568,7 +605,7 @@ When `buildMode` is `cluster-docker`, this applies to the single Docker Daemon t
 
 | Type     | Default                                                                     | Required |
 | -------- | --------------------------------------------------------------------------- | -------- |
-| `object` | `{"limits":{"cpu":4000,"memory":8192},"requests":{"cpu":200,"memory":512}}` | No       |
+| `object` | `{"limits":{"cpu":4000,"memory":8192},"requests":{"cpu":100,"memory":512}}` | No       |
 
 ### `providers[].resources.builder.limits`
 
@@ -630,7 +667,7 @@ providers:
 
 | Type     | Default                    | Required |
 | -------- | -------------------------- | -------- |
-| `object` | `{"cpu":200,"memory":512}` | No       |
+| `object` | `{"cpu":100,"memory":512}` | No       |
 
 ### `providers[].resources.builder.requests.cpu`
 
@@ -640,7 +677,7 @@ CPU request in millicpu.
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |
-| `number` | `200`   | No       |
+| `number` | `100`   | No       |
 
 Example:
 
@@ -652,7 +689,7 @@ providers:
         ...
         requests:
           ...
-          cpu: 200
+          cpu: 100
 ```
 
 ### `providers[].resources.builder.requests.memory`

--- a/examples/build-dependencies/garden.yml
+++ b/examples/build-dependencies/garden.yml
@@ -13,4 +13,4 @@ providers:
     # Replace these values as appropriate
     context: gke_garden-dev-200012_europe-west1-b_garden-dev-1
     defaultHostname: ${environment.namespace}.dev-1.sys.garden
-    buildMode: cluster-docker
+    buildMode: kaniko

--- a/examples/demo-project/garden.yml
+++ b/examples/demo-project/garden.yml
@@ -13,4 +13,4 @@ providers:
     context: gke_garden-dev-200012_europe-west1-b_garden-dev-1
     namespace: demo-project-testing-${local.env.USER || local.username}
     defaultHostname: ${local.env.USER || local.username}-demo-project.dev-1.sys.garden
-    buildMode: cluster-docker
+    buildMode: kaniko

--- a/examples/deployment-strategies/garden.yml
+++ b/examples/deployment-strategies/garden.yml
@@ -23,5 +23,5 @@ providers:
     environments: [testing]
     context: gke_garden-dev-200012_europe-west1-b_garden-dev-1
     defaultHostname: deployment-strategies-${environment.namespace}.dev-1.sys.garden
-    buildMode: cluster-docker
+    buildMode: kaniko
     deploymentStrategy: blue-green

--- a/examples/disabled-configs/garden.yml
+++ b/examples/disabled-configs/garden.yml
@@ -13,4 +13,4 @@ providers:
     # Replace these values as appropriate
     context: gke_garden-dev-200012_europe-west1-b_garden-dev-1
     defaultHostname: ${local.username}-disabled-configs.dev-1.sys.garden
-    buildMode: cluster-docker
+    buildMode: kaniko

--- a/examples/hadolint/garden.yml
+++ b/examples/hadolint/garden.yml
@@ -12,4 +12,4 @@ providers:
     environments: [testing]
     context: gke_garden-dev-200012_europe-west1-b_garden-dev-1
     defaultHostname: ${environment.namespace}.dev-1.sys.garden
-    buildMode: cluster-docker
+    buildMode: kaniko

--- a/examples/hot-reload-k8s/garden.yml
+++ b/examples/hot-reload-k8s/garden.yml
@@ -18,4 +18,4 @@ providers:
     context: gke_garden-dev-200012_europe-west1-b_garden-dev-1
     namespace: hot-reload-k8s-testing-${local.username}
     defaultHostname: ${var.default-hostname}
-    buildMode: cluster-docker
+    buildMode: kaniko

--- a/examples/hot-reload-post-sync-command/garden.yml
+++ b/examples/hot-reload-post-sync-command/garden.yml
@@ -11,4 +11,4 @@ providers:
     environments: [testing]
     context: gke_garden-dev-200012_europe-west1-b_garden-dev-1
     defaultHostname: ${environment.namespace}.dev-1.sys.garden
-    buildMode: cluster-docker
+    buildMode: kaniko

--- a/examples/kaniko/garden.yml
+++ b/examples/kaniko/garden.yml
@@ -13,3 +13,5 @@ providers:
     context: gke_garden-dev-200012_europe-west1-b_garden-dev-1
     defaultHostname: ${environment.namespace}.dev-1.sys.garden
     buildMode: kaniko
+    kaniko:
+      namespace: null

--- a/examples/openfaas/garden.yml
+++ b/examples/openfaas/garden.yml
@@ -11,5 +11,5 @@ providers:
     environments: [testing]
     context: gke_garden-dev-200012_europe-west1-b_garden-dev-1
     defaultHostname: ${environment.namespace}.dev-1.sys.garden
-    buildMode: cluster-docker
+    buildMode: kaniko
   - name: openfaas

--- a/examples/remote-k8s/garden.yml
+++ b/examples/remote-k8s/garden.yml
@@ -19,4 +19,4 @@ providers:
         secretRef:
           name: garden-example-tls
           namespace: default
-    buildMode: cluster-docker
+    buildMode: kaniko

--- a/examples/remote-sources/garden.yml
+++ b/examples/remote-sources/garden.yml
@@ -16,7 +16,7 @@ providers:
     environments: [testing]
     context: gke_garden-dev-200012_europe-west1-b_garden-dev-1
     defaultHostname: ${environment.namespace}.dev-1.sys.garden
-    buildMode: cluster-docker
+    buildMode: kaniko
 variables:
   postgres-database: postgres
   # Only use for testing!

--- a/examples/tasks/garden.yml
+++ b/examples/tasks/garden.yml
@@ -11,4 +11,4 @@ providers:
     environments: [testing]
     context: gke_garden-dev-200012_europe-west1-b_garden-dev-1
     defaultHostname: ${environment.namespace}.dev-1.sys.garden
-    buildMode: cluster-docker
+    buildMode: kaniko

--- a/examples/templated-k8s-container/project.garden.yml
+++ b/examples/templated-k8s-container/project.garden.yml
@@ -12,4 +12,4 @@ providers:
     context: gke_garden-dev-200012_europe-west1-b_garden-dev-1
     namespace: templated-k8s-container-testing-${local.username}
     defaultHostname: ${local.username}-templated-k8s-container.dev-1.sys.garden
-    buildMode: cluster-docker
+    buildMode: kaniko

--- a/examples/terraform-gke/garden.yml
+++ b/examples/terraform-gke/garden.yml
@@ -13,4 +13,4 @@ providers:
     kubeconfig: ${providers.terraform.outputs.kubeconfig_path}
     context: gke
     defaultHostname: terraform-gke-${local.username}.dev-2.sys.garden
-    buildMode: cluster-docker
+    buildMode: kaniko

--- a/examples/vote/api/garden.yml
+++ b/examples/vote/api/garden.yml
@@ -24,6 +24,6 @@ tests:
     args: [echo, ok]
   - name: integ
     args: [python, /app/test.py]
-    timeout: 60
+    timeout: 200
     dependencies:
       - api

--- a/examples/vote/garden.yml
+++ b/examples/vote/garden.yml
@@ -19,7 +19,7 @@ providers:
     environments: [remote]
     # Replace these values as appropriate
     context: ${var.remoteContext}
-    buildMode: cluster-docker
+    buildMode: kaniko
   - name: kubernetes
     environments: [testing]
     context: ${var.remoteContext}


### PR DESCRIPTION
I'm sure this'll be a big relief for many users. This is a drop-in upgrade that removes the need for NFS, `build-sync` and other cluster-wide services when using the `kaniko` build mode.

Additionally, users can set `kaniko.namespace: null` in their `kubernetes` provider configs to run the Kaniko pods in the project namespace instead of `garden-system`, which will be helpful in scenarios where it's problematic to allow users to run pods in a shared namespace.

It's also no longer necessary to run `garden plugins kubernetes cluster-init` when using Kaniko, except to install unrelated services (like an ingress controller etc.).

I've updated the documentation and examples to default to Kaniko, and updated the in-cluster building guide and recommendations therein to reflect the changes.

Closes #1798 