### PR TITLE
fix(k8s): timeout/OOM error when pulling large image to local docker

### DIFF
--- a/core/src/plugins/kubernetes/constants.ts
+++ b/core/src/plugins/kubernetes/constants.ts
@@ -24,6 +24,6 @@ export const inClusterRegistryHostname = "127.0.0.1:5000"
 export const gardenUtilDaemonDeploymentName = "garden-util-daemon"
 export const dockerDaemonDeploymentName = "garden-docker-daemon"
 
-export const k8sUtilImageName = "gardendev/k8s-util:0.3.5"
+export const k8sUtilImageName = "gardendev/k8s-util:0.4.0"
 export const dockerDaemonContainerName = "docker-daemon"
 export const skopeoDaemonContainerName = "util"

--- a/images/k8s-util/Dockerfile
+++ b/images/k8s-util/Dockerfile
@@ -1,6 +1,6 @@
-FROM danifernandezs/skopeo:1.41.0-alpine3.10.3
+FROM alpine:3.13.5
 
-RUN apk add --no-cache curl rsync
+RUN apk add --no-cache curl rsync skopeo
 RUN cd /usr/local/bin && \
   curl -O https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.4.0/linux-amd64/docker-credential-ecr-login && \
   chmod +x docker-credential-ecr-login

--- a/images/k8s-util/garden.yml
+++ b/images/k8s-util/garden.yml
@@ -2,5 +2,5 @@ kind: Module
 type: container
 name: k8s-util
 description: Used by the kubernetes provider for build-related activities
-image: gardendev/k8s-util:0.3.1
+image: gardendev/k8s-util:0.4.0
 dockerfile: Dockerfile


### PR DESCRIPTION
Hunting down a sporadic issue, reported by a customer. Timeouts extended and made more consistent, memory request set for the image pull pod, and updating Skopeo along the way to rule out any fixed upstream issues.