### PR TITLE
improvement(exec): show test and task logs when log level is verbose

### DIFF
--- a/core/src/plugins/exec.ts
+++ b/core/src/plugins/exec.ts
@@ -271,6 +271,12 @@ export async function testExecModule({
 
   await copyArtifacts(log, test.config.spec.artifacts, module.buildPath, artifactsPath)
 
+  const outputLog = (result.stdout + result.stderr).trim()
+  if (outputLog) {
+    const prefix = `Finished running test ${chalk.white(test.name)}. Here is the output:`
+    log.verbose(renderMessageWithDivider(prefix, outputLog, false, chalk.gray))
+  }
+
   return {
     moduleName: module.name,
     command,
@@ -279,7 +285,7 @@ export async function testExecModule({
     success: result.exitCode === 0,
     startedAt,
     completedAt: new Date(),
-    log: result.stdout + result.stderr,
+    log: outputLog,
   }
 }
 
@@ -311,6 +317,11 @@ export async function runExecTask(params: RunTaskParams<ExecModule>): Promise<Ru
   } else {
     completedAt = startedAt
     outputLog = ""
+  }
+
+  if (outputLog) {
+    const prefix = `Finished running task ${chalk.white(task.name)}. Here is the output:`
+    log.verbose(renderMessageWithDivider(prefix, outputLog, false, chalk.gray))
   }
 
   await copyArtifacts(log, task.spec.artifacts, module.buildPath, artifactsPath)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

A user from our community pointed out that test and task logs were missing from the `exec` module. We now log them when log level is set to verbose or higher.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
