### PR TITLE
feat(container): custom min/max resources

### DIFF
--- a/core/src/plugins/google/google-cloud-functions.ts
+++ b/core/src/plugins/google/google-cloud-functions.ts
@@ -18,7 +18,7 @@ import { Provider, providerConfigBaseSchema } from "../../config/provider"
 import { ConfigureModuleParams, ConfigureModuleResult } from "../../types/plugin/module/configure"
 import { DeployServiceParams } from "../../types/plugin/service/deployService"
 import { GetServiceStatusParams } from "../../types/plugin/service/getServiceStatus"
-import { ServiceLimitSpec } from "../container/config"
+import { ContainerResourcesSpec, ServiceLimitSpec } from "../container/config"
 import { gardenAnnotationKey } from "../../util/string"
 
 const gcfModuleSpecSchema = () =>
@@ -36,7 +36,9 @@ export interface GcfModuleSpec extends CommonServiceSpec {
   entrypoint?: string
   function: string
   hostname?: string
-  limits: ServiceLimitSpec
+  limits?: ServiceLimitSpec
+  cpu: ContainerResourcesSpec["cpu"]
+  memory: ContainerResourcesSpec["memory"]
   path: string
   project?: string
   tests: ExecTestSpec[]

--- a/core/src/plugins/kubernetes/container/run.ts
+++ b/core/src/plugins/kubernetes/container/run.ts
@@ -69,7 +69,7 @@ export async function runContainerService(params: RunServiceParams<ContainerModu
 
 export async function runContainerTask(params: RunTaskParams<ContainerModule>): Promise<RunTaskResult> {
   const { ctx, log, module, task } = params
-  const { args, command } = task.spec
+  const { args, command, artifacts, env, cpu, memory, timeout, volumes } = task.spec
 
   const image = containerHelpers.getDeploymentImageId(module, module.version, ctx.provider.config.deploymentRegistry)
   const k8sCtx = ctx as KubernetesPluginContext
@@ -79,15 +79,16 @@ export async function runContainerTask(params: RunTaskParams<ContainerModule>): 
     ...params,
     command,
     args,
-    artifacts: task.spec.artifacts,
-    envVars: task.spec.env,
+    artifacts,
+    envVars: env,
+    resources: { cpu, memory },
     image,
     namespace: namespaceStatus.namespaceName,
     podName: makePodName("task", module.name, task.name),
     description: `Task '${task.name}' in container module '${module.name}'`,
-    timeout: task.spec.timeout || undefined,
+    timeout: timeout || undefined,
+    volumes,
     version: task.version,
-    volumes: task.spec.volumes,
   })
 
   const result: RunTaskResult = {

--- a/core/src/plugins/kubernetes/container/test.ts
+++ b/core/src/plugins/kubernetes/container/test.ts
@@ -19,7 +19,7 @@ import { KubernetesPluginContext } from "../config"
 
 export async function testContainerModule(params: TestModuleParams<ContainerModule>): Promise<TestResult> {
   const { ctx, module, test, log } = params
-  const { command, args, artifacts, env, volumes } = test.config.spec
+  const { command, args, artifacts, env, cpu, memory, volumes } = test.config.spec
   const testName = test.name
   const timeout = test.config.timeout || DEFAULT_TEST_TIMEOUT
   const k8sCtx = ctx as KubernetesPluginContext
@@ -33,6 +33,7 @@ export async function testContainerModule(params: TestModuleParams<ContainerModu
     args,
     artifacts,
     envVars: env,
+    resources: { cpu, memory },
     image,
     namespace: namespaceStatus.namespaceName,
     podName: makePodName("test", module.name, testName),

--- a/core/src/plugins/local/local-google-cloud-functions.ts
+++ b/core/src/plugins/local/local-google-cloud-functions.ts
@@ -95,7 +95,8 @@ export const gardenPlugin = () =>
                 ],
                 env: {},
                 healthCheck: { tcpPort: "http" },
-                limits: s.spec.limits,
+                cpu: s.spec.cpu,
+                memory: s.spec.memory,
                 ports: [
                   {
                     name: "http",

--- a/core/test/unit/src/commands/get/get-config.ts
+++ b/core/test/unit/src/commands/get/get-config.ts
@@ -13,7 +13,7 @@ import { GetConfigCommand } from "../../../../../src/commands/get/get-config"
 import { sortBy } from "lodash"
 import { DEFAULT_API_VERSION } from "../../../../../src/constants"
 import { defaultWorkflowResources, WorkflowConfig } from "../../../../../src/config/workflow"
-import { defaultContainerLimits } from "../../../../../src/plugins/container/config"
+import { defaultContainerLimits, defaultContainerResources } from "../../../../../src/plugins/container/config"
 
 describe("GetConfigCommand", () => {
   it("should get the project configuration", async () => {
@@ -488,10 +488,8 @@ describe("GetConfigCommand", () => {
             daemon: false,
             ingresses: [],
             env: {},
-            limits: {
-              cpu: 1000,
-              memory: 1024,
-            },
+            cpu: defaultContainerResources.cpu,
+            memory: defaultContainerResources.memory,
             ports: [],
             volumes: [],
           },
@@ -569,6 +567,8 @@ describe("GetConfigCommand", () => {
             disabled: false,
             timeout: null,
             env: {},
+            cpu: defaultContainerResources.cpu,
+            memory: defaultContainerResources.memory,
             volumes: [],
           },
           timeout: null,
@@ -638,7 +638,7 @@ describe("GetConfigCommand", () => {
       })
 
       const expectedModuleConfigs = (await garden.resolveModules({ log })).map((m) => m._config)
-      // Remove the disabled task
+      // Remove the disabled test
       expectedModuleConfigs[0].testConfigs = [
         {
           name: "test-enabled",
@@ -650,6 +650,8 @@ describe("GetConfigCommand", () => {
             disabled: false,
             timeout: null,
             env: {},
+            cpu: defaultContainerResources.cpu,
+            memory: defaultContainerResources.memory,
             volumes: [],
           },
           timeout: null,

--- a/core/test/unit/src/commands/run/workflow.ts
+++ b/core/test/unit/src/commands/run/workflow.ts
@@ -178,19 +178,7 @@ describe("RunWorkflowCommand", () => {
 
     expect(result).to.exist
     expect(errors).to.not.exist
-    expect(stripAnsi(result?.steps["step-1"].log!).trim()).to.equal(dedent`
-      Checking result...
-      Done
-      Running...
-      Done (took 0 sec)
-
-      Task output:
-      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-      echo OK
-      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-      Done! ✔️
-    `)
+    expect(stripAnsi(result?.steps["step-1"].log!).trim()).to.match(/echo OK/)
   })
 
   it("should abort subsequent steps if a command returns an error", async () => {

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -4173,9 +4173,9 @@ describe("Garden", () => {
     })
 
     context("test against fixed version hashes", async () => {
-      const moduleAVersionString = "v-c8c9a1ad51"
-      const moduleBVersionString = "v-3ce10c22ec"
-      const moduleCVersionString = "v-684fcdddcb"
+      const moduleAVersionString = "v-0e0d9afd11"
+      const moduleBVersionString = "v-8ad15ac4ea"
+      const moduleCVersionString = "v-37a858e2ee"
 
       it("should return the same module versions between runtimes", async () => {
         const projectRoot = getDataDir("test-projects", "fixed-version-hashes-1")

--- a/core/test/unit/src/plugins/container/container.ts
+++ b/core/test/unit/src/plugins/container/container.ts
@@ -17,7 +17,7 @@ import { gardenPlugin, ContainerProvider } from "../../../../../src/plugins/cont
 import { dataDir, expectError, makeTestGarden } from "../../../../helpers"
 import { moduleFromConfig } from "../../../../../src/types/module"
 import { LogEntry } from "../../../../../src/logger/log-entry"
-import { ContainerModuleConfig, defaultContainerLimits } from "../../../../../src/plugins/container/config"
+import { ContainerModuleConfig, defaultContainerResources } from "../../../../../src/plugins/container/config"
 import {
   containerHelpers as helpers,
   minDockerVersion,
@@ -36,6 +36,9 @@ describe("plugins.container", () => {
   const build = handlers.build!
   const publishModule = handlers.publish!
   const getBuildStatus = handlers.getBuildStatus!
+
+  const defaultCpu = defaultContainerResources.cpu
+  const defaultMemory = defaultContainerResources.memory
 
   const baseConfig: ContainerModuleConfig = {
     allowPublish: false,
@@ -106,6 +109,8 @@ describe("plugins.container", () => {
               cpu: 123,
               memory: 456,
             },
+            cpu: defaultCpu,
+            memory: defaultMemory,
             ports: [],
             replicas: 1,
             volumes: [],
@@ -122,6 +127,8 @@ describe("plugins.container", () => {
             env: {
               TASK_ENV_VAR: "value",
             },
+            cpu: defaultCpu,
+            memory: defaultMemory,
             timeout: null,
             volumes: [],
           },
@@ -136,6 +143,8 @@ describe("plugins.container", () => {
             env: {
               TEST_ENV_VAR: "value",
             },
+            cpu: defaultCpu,
+            memory: defaultMemory,
             timeout: null,
             volumes: [],
           },
@@ -246,6 +255,8 @@ describe("plugins.container", () => {
                 cpu: 123,
                 memory: 456,
               },
+              cpu: defaultCpu,
+              memory: defaultMemory,
               ports: [
                 {
                   name: "http",
@@ -269,6 +280,8 @@ describe("plugins.container", () => {
               env: {
                 TASK_ENV_VAR: "value",
               },
+              cpu: defaultCpu,
+              memory: defaultMemory,
               timeout: null,
               volumes: [],
             },
@@ -283,6 +296,8 @@ describe("plugins.container", () => {
               env: {
                 TEST_ENV_VAR: "value",
               },
+              cpu: defaultCpu,
+              memory: defaultMemory,
               timeout: null,
               volumes: [],
             },
@@ -340,6 +355,8 @@ describe("plugins.container", () => {
                   cpu: 123,
                   memory: 456,
                 },
+                cpu: defaultCpu,
+                memory: defaultMemory,
                 ports: [{ name: "http", protocol: "TCP", containerPort: 8080, servicePort: 8080 }],
                 replicas: 1,
                 volumes: [],
@@ -356,6 +373,8 @@ describe("plugins.container", () => {
                 env: {
                   TASK_ENV_VAR: "value",
                 },
+                cpu: defaultCpu,
+                memory: defaultMemory,
                 timeout: null,
                 volumes: [],
               },
@@ -370,6 +389,8 @@ describe("plugins.container", () => {
                 env: {
                   TEST_ENV_VAR: "value",
                 },
+                cpu: defaultCpu,
+                memory: defaultMemory,
                 timeout: null,
                 volumes: [],
               },
@@ -413,6 +434,8 @@ describe("plugins.container", () => {
                   cpu: 123,
                   memory: 456,
                 },
+                cpu: defaultCpu,
+                memory: defaultMemory,
                 ports: [{ name: "http", protocol: "TCP", containerPort: 8080, servicePort: 8080 }],
                 replicas: 1,
                 volumes: [],
@@ -434,6 +457,8 @@ describe("plugins.container", () => {
                 env: {
                   TASK_ENV_VAR: "value",
                 },
+                cpu: defaultCpu,
+                memory: defaultMemory,
                 name: "task-a",
                 timeout: null,
                 volumes: [],
@@ -455,6 +480,8 @@ describe("plugins.container", () => {
                 env: {
                   TEST_ENV_VAR: "value",
                 },
+                cpu: defaultCpu,
+                memory: defaultMemory,
                 timeout: null,
                 volumes: [],
               },
@@ -499,6 +526,8 @@ describe("plugins.container", () => {
                 cpu: 123,
                 memory: 456,
               },
+              cpu: defaultCpu,
+              memory: defaultMemory,
               ports: [],
               replicas: 1,
               volumes: [
@@ -554,6 +583,8 @@ describe("plugins.container", () => {
               dependencies: [],
               disabled: false,
               env: {},
+              cpu: defaultCpu,
+              memory: defaultMemory,
               timeout: null,
               volumes: [
                 {
@@ -607,6 +638,8 @@ describe("plugins.container", () => {
               dependencies: [],
               disabled: false,
               env: {},
+              cpu: defaultCpu,
+              memory: defaultMemory,
               timeout: null,
               volumes: [
                 {
@@ -664,7 +697,8 @@ describe("plugins.container", () => {
                   port: "bla",
                 },
               ],
-              limits: defaultContainerLimits,
+              cpu: defaultCpu,
+              memory: defaultMemory,
               env: {},
               ports: [],
               replicas: 1,
@@ -680,6 +714,8 @@ describe("plugins.container", () => {
               dependencies: [],
               disabled: false,
               env: {},
+              cpu: defaultCpu,
+              memory: defaultMemory,
               timeout: null,
               volumes: [],
             },
@@ -692,6 +728,8 @@ describe("plugins.container", () => {
               dependencies: [],
               disabled: false,
               env: {},
+              cpu: defaultCpu,
+              memory: defaultMemory,
               timeout: null,
               volumes: [],
             },
@@ -741,7 +779,8 @@ describe("plugins.container", () => {
                   port: "bla",
                 },
               },
-              limits: defaultContainerLimits,
+              cpu: defaultCpu,
+              memory: defaultMemory,
               ports: [],
               replicas: 1,
               volumes: [],
@@ -756,6 +795,8 @@ describe("plugins.container", () => {
               dependencies: [],
               disabled: false,
               env: {},
+              cpu: defaultCpu,
+              memory: defaultMemory,
               timeout: null,
               volumes: [],
             },
@@ -803,7 +844,8 @@ describe("plugins.container", () => {
               healthCheck: {
                 tcpPort: "bla",
               },
-              limits: defaultContainerLimits,
+              cpu: defaultCpu,
+              memory: defaultMemory,
               ports: [],
               replicas: 1,
               volumes: [],
@@ -818,6 +860,8 @@ describe("plugins.container", () => {
               dependencies: [],
               disabled: false,
               env: {},
+              cpu: defaultCpu,
+              memory: defaultMemory,
               timeout: null,
               volumes: [],
             },

--- a/core/test/unit/src/plugins/kubernetes/container/ingress.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/ingress.ts
@@ -22,7 +22,7 @@ import { dataDir, makeTestGarden, expectError } from "../../../../../helpers"
 import { Garden } from "../../../../../../src/garden"
 import { moduleFromConfig } from "../../../../../../src/types/module"
 import { createIngressResources } from "../../../../../../src/plugins/kubernetes/container/ingress"
-import { defaultContainerLimits } from "../../../../../../src/plugins/container/config"
+import { defaultContainerResources } from "../../../../../../src/plugins/container/config"
 import {
   ServicePortProtocol,
   ContainerIngressSpec,
@@ -379,7 +379,8 @@ describe("createIngressResources", () => {
       disabled: false,
       env: {},
       ingresses,
-      limits: defaultContainerLimits,
+      cpu: defaultContainerResources.cpu,
+      memory: defaultContainerResources.memory,
       ports,
       replicas: 1,
       volumes: [],

--- a/core/test/unit/src/vcs/vcs.ts
+++ b/core/test/unit/src/vcs/vcs.ts
@@ -423,7 +423,7 @@ describe("getModuleVersionString", () => {
     const garden = await makeTestGarden(projectRoot)
     const module = await garden.resolveModule("module-a")
 
-    const fixedVersionString = "v-c8c9a1ad51"
+    const fixedVersionString = "v-0e0d9afd11"
     expect(module.version.versionString).to.eql(fixedVersionString)
 
     delete process.env.TEST_ENV_VAR

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -308,13 +308,21 @@ services:
     # deployed with hot reloading enabled.
     hotReloadArgs:
 
-    # Specify resource limits for the service.
-    limits:
+    cpu:
+      # The minimum amount of CPU the service needs to be available for it to be deployed, in millicpus (i.e. 1000 = 1
+      # CPU)
+      min: 10
+
       # The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)
-      cpu: 1000
+      max: 1000
+
+    memory:
+      # The minimum amount of RAM the service needs to be available for it to be deployed, in megabytes (i.e. 1024 = 1
+      # GB)
+      min: 90
 
       # The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB)
-      memory: 1024
+      max: 90
 
     # List of ports that the service container exposes.
     ports:
@@ -426,6 +434,22 @@ tests:
     # `GARDEN`) and values must be primitives or references to secrets.
     env: {}
 
+    cpu:
+      # The minimum amount of CPU the test needs to be available for it to be deployed, in millicpus (i.e. 1000 = 1
+      # CPU)
+      min: 10
+
+      # The maximum amount of CPU the test can use, in millicpus (i.e. 1000 = 1 CPU)
+      max: 1000
+
+    memory:
+      # The minimum amount of RAM the test needs to be available for it to be deployed, in megabytes (i.e. 1024 = 1
+      # GB)
+      min: 90
+
+      # The maximum amount of RAM the test can use, in megabytes (i.e. 1024 = 1 GB)
+      max: 90
+
     # List of volumes that should be mounted when deploying the test.
     #
     # Note: If neither `hostPath` nor `module` is specified, an empty ephemeral volume is created and mounted when
@@ -512,6 +536,22 @@ tasks:
     # Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with
     # `GARDEN`) and values must be primitives or references to secrets.
     env: {}
+
+    cpu:
+      # The minimum amount of CPU the task needs to be available for it to be deployed, in millicpus (i.e. 1000 = 1
+      # CPU)
+      min: 10
+
+      # The maximum amount of CPU the task can use, in millicpus (i.e. 1000 = 1 CPU)
+      max: 1000
+
+    memory:
+      # The minimum amount of RAM the task needs to be available for it to be deployed, in megabytes (i.e. 1024 = 1
+      # GB)
+      min: 90
+
+      # The maximum amount of RAM the task can use, in megabytes (i.e. 1024 = 1 GB)
+      max: 90
 
     # List of volumes that should be mounted when deploying the task.
     #
@@ -1385,9 +1425,9 @@ services:
 
 Specify resource limits for the service.
 
-| Type     | Default                      | Required |
-| -------- | ---------------------------- | -------- |
-| `object` | `{"cpu":1000,"memory":1024}` | No       |
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
 
 ### `services[].limits.cpu`
 
@@ -1395,9 +1435,9 @@ Specify resource limits for the service.
 
 The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)
 
-| Type     | Default | Required |
-| -------- | ------- | -------- |
-| `number` | `1000`  | No       |
+| Type     | Required |
+| -------- | -------- |
+| `number` | No       |
 
 ### `services[].limits.memory`
 
@@ -1405,9 +1445,65 @@ The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)
 
 The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB)
 
+| Type     | Required |
+| -------- | -------- |
+| `number` | No       |
+
+### `services[].cpu`
+
+[services](#services) > cpu
+
+| Type     | Default                 | Required |
+| -------- | ----------------------- | -------- |
+| `object` | `{"min":10,"max":1000}` | No       |
+
+### `services[].cpu.min`
+
+[services](#services) > [cpu](#servicescpu) > min
+
+The minimum amount of CPU the service needs to be available for it to be deployed, in millicpus (i.e. 1000 = 1 CPU)
+
 | Type     | Default | Required |
 | -------- | ------- | -------- |
-| `number` | `1024`  | No       |
+| `number` | `10`    | No       |
+
+### `services[].cpu.max`
+
+[services](#services) > [cpu](#servicescpu) > max
+
+The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `1000`  | No       |
+
+### `services[].memory`
+
+[services](#services) > memory
+
+| Type     | Default                 | Required |
+| -------- | ----------------------- | -------- |
+| `object` | `{"min":90,"max":1024}` | No       |
+
+### `services[].memory.min`
+
+[services](#services) > [memory](#servicesmemory) > min
+
+The minimum amount of RAM the service needs to be available for it to be deployed, in megabytes (i.e. 1024 = 1 GB)
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `90`    | No       |
+
+### `services[].memory.max`
+
+[services](#services) > [memory](#servicesmemory) > max
+
+The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB)
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `90`    | No       |
 
 ### `services[].ports[]`
 
@@ -1750,6 +1846,62 @@ tests:
         - {}
 ```
 
+### `tests[].cpu`
+
+[tests](#tests) > cpu
+
+| Type     | Default                 | Required |
+| -------- | ----------------------- | -------- |
+| `object` | `{"min":10,"max":1000}` | No       |
+
+### `tests[].cpu.min`
+
+[tests](#tests) > [cpu](#testscpu) > min
+
+The minimum amount of CPU the test needs to be available for it to be deployed, in millicpus (i.e. 1000 = 1 CPU)
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `10`    | No       |
+
+### `tests[].cpu.max`
+
+[tests](#tests) > [cpu](#testscpu) > max
+
+The maximum amount of CPU the test can use, in millicpus (i.e. 1000 = 1 CPU)
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `1000`  | No       |
+
+### `tests[].memory`
+
+[tests](#tests) > memory
+
+| Type     | Default                 | Required |
+| -------- | ----------------------- | -------- |
+| `object` | `{"min":90,"max":1024}` | No       |
+
+### `tests[].memory.min`
+
+[tests](#tests) > [memory](#testsmemory) > min
+
+The minimum amount of RAM the test needs to be available for it to be deployed, in megabytes (i.e. 1024 = 1 GB)
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `90`    | No       |
+
+### `tests[].memory.max`
+
+[tests](#tests) > [memory](#testsmemory) > max
+
+The maximum amount of RAM the test can use, in megabytes (i.e. 1024 = 1 GB)
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `90`    | No       |
+
 ### `tests[].volumes[]`
 
 [tests](#tests) > volumes
@@ -2008,6 +2160,62 @@ tasks:
               key: some-key
         - {}
 ```
+
+### `tasks[].cpu`
+
+[tasks](#tasks) > cpu
+
+| Type     | Default                 | Required |
+| -------- | ----------------------- | -------- |
+| `object` | `{"min":10,"max":1000}` | No       |
+
+### `tasks[].cpu.min`
+
+[tasks](#tasks) > [cpu](#taskscpu) > min
+
+The minimum amount of CPU the task needs to be available for it to be deployed, in millicpus (i.e. 1000 = 1 CPU)
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `10`    | No       |
+
+### `tasks[].cpu.max`
+
+[tasks](#tasks) > [cpu](#taskscpu) > max
+
+The maximum amount of CPU the task can use, in millicpus (i.e. 1000 = 1 CPU)
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `1000`  | No       |
+
+### `tasks[].memory`
+
+[tasks](#tasks) > memory
+
+| Type     | Default                 | Required |
+| -------- | ----------------------- | -------- |
+| `object` | `{"min":90,"max":1024}` | No       |
+
+### `tasks[].memory.min`
+
+[tasks](#tasks) > [memory](#tasksmemory) > min
+
+The minimum amount of RAM the task needs to be available for it to be deployed, in megabytes (i.e. 1024 = 1 GB)
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `90`    | No       |
+
+### `tasks[].memory.max`
+
+[tasks](#tasks) > [memory](#tasksmemory) > max
+
+The maximum amount of RAM the task can use, in megabytes (i.e. 1024 = 1 GB)
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `90`    | No       |
 
 ### `tasks[].volumes[]`
 

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -306,13 +306,21 @@ services:
     # deployed with hot reloading enabled.
     hotReloadArgs:
 
-    # Specify resource limits for the service.
-    limits:
+    cpu:
+      # The minimum amount of CPU the service needs to be available for it to be deployed, in millicpus (i.e. 1000 = 1
+      # CPU)
+      min: 10
+
       # The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)
-      cpu: 1000
+      max: 1000
+
+    memory:
+      # The minimum amount of RAM the service needs to be available for it to be deployed, in megabytes (i.e. 1024 = 1
+      # GB)
+      min: 90
 
       # The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB)
-      memory: 1024
+      max: 90
 
     # List of ports that the service container exposes.
     ports:
@@ -424,6 +432,22 @@ tests:
     # `GARDEN`) and values must be primitives or references to secrets.
     env: {}
 
+    cpu:
+      # The minimum amount of CPU the test needs to be available for it to be deployed, in millicpus (i.e. 1000 = 1
+      # CPU)
+      min: 10
+
+      # The maximum amount of CPU the test can use, in millicpus (i.e. 1000 = 1 CPU)
+      max: 1000
+
+    memory:
+      # The minimum amount of RAM the test needs to be available for it to be deployed, in megabytes (i.e. 1024 = 1
+      # GB)
+      min: 90
+
+      # The maximum amount of RAM the test can use, in megabytes (i.e. 1024 = 1 GB)
+      max: 90
+
     # List of volumes that should be mounted when deploying the test.
     #
     # Note: If neither `hostPath` nor `module` is specified, an empty ephemeral volume is created and mounted when
@@ -510,6 +534,22 @@ tasks:
     # Key/value map of environment variables. Keys must be valid POSIX environment variable names (must not start with
     # `GARDEN`) and values must be primitives or references to secrets.
     env: {}
+
+    cpu:
+      # The minimum amount of CPU the task needs to be available for it to be deployed, in millicpus (i.e. 1000 = 1
+      # CPU)
+      min: 10
+
+      # The maximum amount of CPU the task can use, in millicpus (i.e. 1000 = 1 CPU)
+      max: 1000
+
+    memory:
+      # The minimum amount of RAM the task needs to be available for it to be deployed, in megabytes (i.e. 1024 = 1
+      # GB)
+      min: 90
+
+      # The maximum amount of RAM the task can use, in megabytes (i.e. 1024 = 1 GB)
+      max: 90
 
     # List of volumes that should be mounted when deploying the task.
     #
@@ -1393,9 +1433,9 @@ services:
 
 Specify resource limits for the service.
 
-| Type     | Default                      | Required |
-| -------- | ---------------------------- | -------- |
-| `object` | `{"cpu":1000,"memory":1024}` | No       |
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
 
 ### `services[].limits.cpu`
 
@@ -1403,9 +1443,9 @@ Specify resource limits for the service.
 
 The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)
 
-| Type     | Default | Required |
-| -------- | ------- | -------- |
-| `number` | `1000`  | No       |
+| Type     | Required |
+| -------- | -------- |
+| `number` | No       |
 
 ### `services[].limits.memory`
 
@@ -1413,9 +1453,65 @@ The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)
 
 The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB)
 
+| Type     | Required |
+| -------- | -------- |
+| `number` | No       |
+
+### `services[].cpu`
+
+[services](#services) > cpu
+
+| Type     | Default                 | Required |
+| -------- | ----------------------- | -------- |
+| `object` | `{"min":10,"max":1000}` | No       |
+
+### `services[].cpu.min`
+
+[services](#services) > [cpu](#servicescpu) > min
+
+The minimum amount of CPU the service needs to be available for it to be deployed, in millicpus (i.e. 1000 = 1 CPU)
+
 | Type     | Default | Required |
 | -------- | ------- | -------- |
-| `number` | `1024`  | No       |
+| `number` | `10`    | No       |
+
+### `services[].cpu.max`
+
+[services](#services) > [cpu](#servicescpu) > max
+
+The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `1000`  | No       |
+
+### `services[].memory`
+
+[services](#services) > memory
+
+| Type     | Default                 | Required |
+| -------- | ----------------------- | -------- |
+| `object` | `{"min":90,"max":1024}` | No       |
+
+### `services[].memory.min`
+
+[services](#services) > [memory](#servicesmemory) > min
+
+The minimum amount of RAM the service needs to be available for it to be deployed, in megabytes (i.e. 1024 = 1 GB)
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `90`    | No       |
+
+### `services[].memory.max`
+
+[services](#services) > [memory](#servicesmemory) > max
+
+The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB)
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `90`    | No       |
 
 ### `services[].ports[]`
 
@@ -1758,6 +1854,62 @@ tests:
         - {}
 ```
 
+### `tests[].cpu`
+
+[tests](#tests) > cpu
+
+| Type     | Default                 | Required |
+| -------- | ----------------------- | -------- |
+| `object` | `{"min":10,"max":1000}` | No       |
+
+### `tests[].cpu.min`
+
+[tests](#tests) > [cpu](#testscpu) > min
+
+The minimum amount of CPU the test needs to be available for it to be deployed, in millicpus (i.e. 1000 = 1 CPU)
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `10`    | No       |
+
+### `tests[].cpu.max`
+
+[tests](#tests) > [cpu](#testscpu) > max
+
+The maximum amount of CPU the test can use, in millicpus (i.e. 1000 = 1 CPU)
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `1000`  | No       |
+
+### `tests[].memory`
+
+[tests](#tests) > memory
+
+| Type     | Default                 | Required |
+| -------- | ----------------------- | -------- |
+| `object` | `{"min":90,"max":1024}` | No       |
+
+### `tests[].memory.min`
+
+[tests](#tests) > [memory](#testsmemory) > min
+
+The minimum amount of RAM the test needs to be available for it to be deployed, in megabytes (i.e. 1024 = 1 GB)
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `90`    | No       |
+
+### `tests[].memory.max`
+
+[tests](#tests) > [memory](#testsmemory) > max
+
+The maximum amount of RAM the test can use, in megabytes (i.e. 1024 = 1 GB)
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `90`    | No       |
+
 ### `tests[].volumes[]`
 
 [tests](#tests) > volumes
@@ -2016,6 +2168,62 @@ tasks:
               key: some-key
         - {}
 ```
+
+### `tasks[].cpu`
+
+[tasks](#tasks) > cpu
+
+| Type     | Default                 | Required |
+| -------- | ----------------------- | -------- |
+| `object` | `{"min":10,"max":1000}` | No       |
+
+### `tasks[].cpu.min`
+
+[tasks](#tasks) > [cpu](#taskscpu) > min
+
+The minimum amount of CPU the task needs to be available for it to be deployed, in millicpus (i.e. 1000 = 1 CPU)
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `10`    | No       |
+
+### `tasks[].cpu.max`
+
+[tasks](#tasks) > [cpu](#taskscpu) > max
+
+The maximum amount of CPU the task can use, in millicpus (i.e. 1000 = 1 CPU)
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `1000`  | No       |
+
+### `tasks[].memory`
+
+[tasks](#tasks) > memory
+
+| Type     | Default                 | Required |
+| -------- | ----------------------- | -------- |
+| `object` | `{"min":90,"max":1024}` | No       |
+
+### `tasks[].memory.min`
+
+[tasks](#tasks) > [memory](#tasksmemory) > min
+
+The minimum amount of RAM the task needs to be available for it to be deployed, in megabytes (i.e. 1024 = 1 GB)
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `90`    | No       |
+
+### `tasks[].memory.max`
+
+[tasks](#tasks) > [memory](#tasksmemory) > max
+
+The maximum amount of RAM the task can use, in megabytes (i.e. 1024 = 1 GB)
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `90`    | No       |
 
 ### `tasks[].volumes[]`
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

Resource requests and limits can now be set for `container` services, tasks and tests via the new `cpu` and `memory` fields.

The `service.limits` field has now been deprecated, and should be removed in a future breaking release. Values set in `service.limits` are still applied when deploying `container` services, and take precedence over the max values set in the `cpu` and `memory` fields.


**Which issue(s) this PR fixes**:

Closes #2317 and #2309.