### PR TITLE
fix(cloud): retry streaming on network error

### DIFF
--- a/core/src/commands/logout.ts
+++ b/core/src/commands/logout.ts
@@ -46,11 +46,7 @@ export class LogOutCommand extends Command {
         return {}
       }
 
-      await enterpriseApi.post("token/logout", {
-        headers: {
-          Cookie: `rt=${token?.refreshToken}`,
-        },
-      })
+      await enterpriseApi.post("token/logout", { headers: { Cookie: `rt=${token?.refreshToken}` } })
       enterpriseApi.close()
     } catch (err) {
       const msg = dedent`

--- a/core/src/enterprise/workflow-lifecycle.ts
+++ b/core/src/enterprise/workflow-lifecycle.ts
@@ -46,7 +46,11 @@ export async function registerWorkflowRun({
     // TODO: Use API types package here.
     let res: ApiFetchResponse<RegisterWorkflowRunResponse>
     try {
-      res = await enterpriseApi.post("workflow-runs", { body: requestData })
+      res = await enterpriseApi.post("workflow-runs", {
+        body: requestData,
+        retry: true,
+        retryDescription: "Registering workflow run",
+      })
     } catch (err) {
       log.error(`An error occurred while registering workflow run: ${err.message}`)
       throw err

--- a/core/src/plugins/kubernetes/container/util.ts
+++ b/core/src/plugins/kubernetes/container/util.ts
@@ -12,9 +12,9 @@ import { CLUSTER_REGISTRY_DEPLOYMENT_NAME, CLUSTER_REGISTRY_PORT } from "../cons
 import { LogEntry } from "../../../logger/log-entry"
 import { KubernetesPluginContext } from "../config"
 import { getSystemNamespace } from "../namespace"
-import { got, GotOptions } from "../../../util/http"
+import { got, GotTextOptions } from "../../../util/http"
 
-export async function queryRegistry(ctx: KubernetesPluginContext, log: LogEntry, path: string, opts?: GotOptions) {
+export async function queryRegistry(ctx: KubernetesPluginContext, log: LogEntry, path: string, opts?: GotTextOptions) {
   const registryFwd = await getRegistryPortForward(ctx, log)
   const baseUrl = `http://localhost:${registryFwd.localPort}/v2/`
   const url = resolve(baseUrl, path)

--- a/core/src/util/http.ts
+++ b/core/src/util/http.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import _got, { Response, HTTPError as GotHttpError } from "got"
+import _got, { Response, HTTPError as GotHttpError, OptionsOfJSONResponseBody } from "got"
 import { bootstrap } from "global-agent"
 import { OptionsOfTextResponseBody, Headers } from "got"
 
@@ -19,7 +19,8 @@ bootstrap({
 
 // Exporting from here to make sure the global-agent bootstrap is executed, and for convenience as well
 export const got = _got
-export type GotOptions = OptionsOfTextResponseBody
+export type GotTextOptions = OptionsOfTextResponseBody
+export type GotJsonOptions = OptionsOfJSONResponseBody
 export type GotResponse<T = unknown> = Response<T>
 export type GotHeaders = Headers
 export { GotHttpError }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

We now retry the `POST` requests made by `BufferedEventStream` if the request fails with a network- or timeout-related status code.

This should make log & event streaming more robust to unstable network conditions or during periods of high load.

Also added a few more status codes to the retry logic for the k8s API.