### PR TITLE
feat(k8s): resolve template strings in kubernetes module manifest files 

### DIFF
--- a/core/src/config/template-contexts/module.ts
+++ b/core/src/config/template-contexts/module.ts
@@ -95,9 +95,13 @@ export class ServiceRuntimeContext extends ConfigContext {
   )
   public outputs: PrimitiveMap
 
-  constructor(root: ConfigContext, outputs: PrimitiveMap) {
+  @schema(joi.string().required().description("The current version of the service.").example(exampleVersion))
+  public version: string
+
+  constructor(root: ConfigContext, outputs: PrimitiveMap, version: string) {
     super(root)
     this.outputs = outputs
+    this.version = version
   }
 }
 
@@ -118,6 +122,9 @@ export class TaskRuntimeContext extends ServiceRuntimeContext {
       .meta({ keyPlaceholder: "<output-name>" })
   )
   public outputs: PrimitiveMap
+
+  @schema(joi.string().required().description("The current version of the task.").example(exampleVersion))
+  public version: string
 }
 
 class RuntimeConfigContext extends ConfigContext {
@@ -146,9 +153,9 @@ class RuntimeConfigContext extends ConfigContext {
     if (runtimeContext) {
       for (const dep of runtimeContext.dependencies) {
         if (dep.type === "service") {
-          this.services.set(dep.name, new ServiceRuntimeContext(this, dep.outputs))
+          this.services.set(dep.name, new ServiceRuntimeContext(this, dep.outputs, dep.version))
         } else if (dep.type === "task") {
-          this.tasks.set(dep.name, new TaskRuntimeContext(this, dep.outputs))
+          this.tasks.set(dep.name, new TaskRuntimeContext(this, dep.outputs, dep.version))
         }
       }
     }

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -97,6 +97,7 @@ import { OutputConfigContext } from "./config/template-contexts/module"
 import { ProviderConfigContext } from "./config/template-contexts/provider"
 import { getSecrets } from "./enterprise/get-secrets"
 import { killSyncDaemon } from "./plugins/kubernetes/mutagen"
+import { ConfigContext } from "./config/template-contexts/base"
 
 export interface ActionHandlerMap<T extends keyof PluginActionHandlers> {
   [actionName: string]: PluginActionHandlers[T]
@@ -309,8 +310,20 @@ export class Garden {
     await killSyncDaemon()
   }
 
-  async getPluginContext(provider: Provider) {
-    return createPluginContext(this, provider, this.opts.commandInfo)
+  /**
+   * Returns a new PluginContext, i.e. the `ctx` object that's passed to plugin handlers.
+   *
+   * The object contains a helper to resolve template strings. By default the templating context is set to the
+   * provider template context. Callers should specify the appropriate templating for the handler that will be
+   * called with the PluginContext.
+   */
+  async getPluginContext(provider: Provider, templateContext?: ConfigContext) {
+    return createPluginContext(
+      this,
+      provider,
+      this.opts.commandInfo,
+      templateContext || new ProviderConfigContext(this, provider.dependencies)
+    )
   }
 
   async clearBuilds() {

--- a/core/src/plugins/kubernetes/hot-reload/hot-reload.ts
+++ b/core/src/plugins/kubernetes/hot-reload/hot-reload.ts
@@ -69,7 +69,7 @@ export async function hotReloadK8s({
     })
   } else {
     const api = await KubeApi.factory(log, ctx, k8sCtx.provider)
-    manifests = await getManifests({ api, log, module: <KubernetesModule>module, defaultNamespace: namespace })
+    manifests = await getManifests({ ctx, api, log, module: <KubernetesModule>module, defaultNamespace: namespace })
   }
 
   const resourceSpec = service.spec.serviceResource

--- a/core/src/plugins/kubernetes/kubernetes-module/config.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/config.ts
@@ -74,7 +74,7 @@ export const kubernetesModuleSpecSchema = () =>
           resolve template strings in any of the manifests.`
     ),
     files: joiSparseArray(joi.posixPath().subPathOnly()).description(
-      "POSIX-style paths to YAML files to load manifests from. Each can contain multiple manifests."
+      "POSIX-style paths to YAML files to load manifests from. Each can contain multiple manifests, and can include any Garden template strings, which will be resolved before applying the manifests."
     ),
     include: joiModuleIncludeDirective(dedent`
       If neither \`include\` nor \`exclude\` is set, Garden automatically sets \`include\` to equal the

--- a/core/src/plugins/kubernetes/kubernetes-module/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/handlers.ts
@@ -65,9 +65,9 @@ interface KubernetesStatusDetail {
 
 export type KubernetesServiceStatus = ServiceStatus<KubernetesStatusDetail>
 
-async function build({ module, log }: BuildModuleParams<KubernetesModule>): Promise<BuildResult> {
+async function build({ ctx, module, log }: BuildModuleParams<KubernetesModule>): Promise<BuildResult> {
   // Get the manifests here, just to validate that the files are there and are valid YAML
-  await readManifests(module, log)
+  await readManifests(ctx, module, log)
   return { fresh: true }
 }
 
@@ -92,7 +92,7 @@ export async function getKubernetesServiceStatus({
   // FIXME: We're currently reading the manifests from the module source dir (instead of build dir)
   // because the build may not have been staged.
   // This means that manifests added via the `build.dependencies[].copy` field will not be included.
-  const manifests = await getManifests({ api, log, module, defaultNamespace: namespace, readFromSrcDir: true })
+  const manifests = await getManifests({ ctx, api, log, module, defaultNamespace: namespace, readFromSrcDir: true })
   const prepareResult = await prepareManifestsForSync({
     ctx,
     log,
@@ -160,7 +160,7 @@ export async function deployKubernetesService(
   })
   const namespace = namespaceStatus.namespaceName
 
-  const manifests = await getManifests({ api, log, module, defaultNamespace: namespace })
+  const manifests = await getManifests({ ctx, api, log, module, defaultNamespace: namespace })
 
   // We separate out manifests for namespace resources, since we don't want to apply a prune selector
   // when applying them.
@@ -255,7 +255,7 @@ async function deleteService(params: DeleteServiceParams): Promise<KubernetesSer
   })
   const provider = k8sCtx.provider
   const api = await KubeApi.factory(log, ctx, provider)
-  const manifests = await getManifests({ api, log, module, defaultNamespace: namespace })
+  const manifests = await getManifests({ ctx, api, log, module, defaultNamespace: namespace })
 
   /**
    * We separate out manifests for namespace resources, since we need to delete each of them by name.
@@ -315,7 +315,7 @@ async function getServiceLogs(params: GetServiceLogsParams<KubernetesModule>) {
     provider: k8sCtx.provider,
   })
   const api = await KubeApi.factory(log, ctx, provider)
-  const manifests = await getManifests({ api, log, module, defaultNamespace: namespace })
+  const manifests = await getManifests({ ctx, api, log, module, defaultNamespace: namespace })
 
   return streamK8sLogs({ ...params, provider, defaultNamespace: namespace, resources: manifests })
 }

--- a/core/src/plugins/kubernetes/kubernetes-module/run.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/run.ts
@@ -37,7 +37,7 @@ export async function runKubernetesTask(params: RunTaskParams<KubernetesModule>)
 
   // Get the container spec to use for running
   const { command, args } = task.spec
-  const manifests = await getManifests({ api, log, module, defaultNamespace: namespace })
+  const manifests = await getManifests({ ctx, api, log, module, defaultNamespace: namespace })
   const resourceSpec = task.spec.resource || getServiceResourceSpec(module, undefined)
   const target = await findServiceResource({
     ctx: k8sCtx,

--- a/core/src/plugins/kubernetes/kubernetes-module/test.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/test.ts
@@ -37,7 +37,7 @@ export async function testKubernetesModule(params: TestModuleParams<KubernetesMo
   const namespace = namespaceStatus.namespaceName
 
   // Get the container spec to use for running
-  const manifests = await getManifests({ api, log, module, defaultNamespace: namespace })
+  const manifests = await getManifests({ ctx, api, log, module, defaultNamespace: namespace })
   const resourceSpec = test.config.spec.resource || getServiceResourceSpec(module, undefined)
   const target = await findServiceResource({ ctx: k8sCtx, log, manifests, module, resourceSpec, baseModule: undefined })
   const container = getResourceContainer(target, resourceSpec.containerName)

--- a/core/src/types/plugin/module/getBuildStatus.ts
+++ b/core/src/types/plugin/module/getBuildStatus.ts
@@ -15,6 +15,7 @@ export interface GetBuildStatusParams<T extends GardenModule = GardenModule> ext
 
 export interface BuildStatus {
   ready: boolean
+  detail?: any
 }
 
 export const getBuildStatus = () => ({
@@ -26,5 +27,6 @@ export const getBuildStatus = () => ({
   paramsSchema: moduleActionParamsSchema(),
   resultSchema: joi.object().keys({
     ready: joi.boolean().required().description("Whether an up-to-date build is ready for the module."),
+    detail: joi.any().description("Optional provider-specific information about the build."),
   }),
 })

--- a/core/src/types/service.ts
+++ b/core/src/types/service.ts
@@ -177,7 +177,7 @@ export const forwardablePortKeys = () => ({
 
 const forwardablePortSchema = () => joi.object().keys(forwardablePortKeys())
 
-export interface ServiceStatus<T = {}> {
+export interface ServiceStatus<T = any> {
   createdAt?: string
   detail: T
   namespaceStatuses?: NamespaceStatus[]

--- a/core/test/integ/src/plugins/kubernetes/kubernetes-module/handlers.ts
+++ b/core/test/integ/src/plugins/kubernetes/kubernetes-module/handlers.ts
@@ -193,6 +193,7 @@ describe("kubernetes-module handlers", () => {
         runtimeContext: emptyRuntimeContext,
       }
       const manifests = await getManifests({
+        ctx,
         api,
         log,
         module: service.module,
@@ -238,6 +239,7 @@ describe("kubernetes-module handlers", () => {
         runtimeContext: emptyRuntimeContext,
       }
       const manifests = await getManifests({
+        ctx,
         api,
         log,
         module: service.module,
@@ -267,7 +269,7 @@ describe("kubernetes-module handlers", () => {
       let graph = await garden.getConfigGraph(log)
       let k8smodule = graph.getModule("namespace-resource")
       const defaultNamespace = await getModuleNamespace({ ctx, log, module: k8smodule, provider: ctx.provider })
-      let manifests = await getManifests({ api, log, module: k8smodule, defaultNamespace })
+      let manifests = await getManifests({ ctx, api, log, module: k8smodule, defaultNamespace })
       ns1Manifest = manifests.find((resource) => resource.kind === "Namespace")
 
       const deployTask = new DeployTask({
@@ -306,7 +308,7 @@ describe("kubernetes-module handlers", () => {
       garden.setModuleConfigs([withNamespace(nsModuleConfig, "kubernetes-module-ns-2")])
       graph = await garden.getConfigGraph(log)
       k8smodule = graph.getModule("namespace-resource")
-      manifests = await getManifests({ api, log, module: k8smodule, defaultNamespace })
+      manifests = await getManifests({ ctx, api, log, module: k8smodule, defaultNamespace })
       ns2Manifest = manifests.find((resource) => resource.kind === "Namespace")
       const deployTask2 = new DeployTask({
         garden,

--- a/core/test/unit/src/commands/deploy.ts
+++ b/core/test/unit/src/commands/deploy.ts
@@ -24,6 +24,7 @@ import { GetServiceStatusParams } from "../../../../src/types/plugin/service/get
 import { DeployServiceParams } from "../../../../src/types/plugin/service/deployService"
 import { RunTaskParams, RunTaskResult } from "../../../../src/types/plugin/task/runTask"
 import { createGardenPlugin } from "../../../../src/types/plugin/plugin"
+import { sortBy } from "lodash"
 
 const placeholderTimestamp = new Date()
 
@@ -205,19 +206,24 @@ describe("DeployCommand", () => {
       },
     })
 
-    expect(getRuntimeStatusEvents(garden.events.eventLog)).to.eql([
-      { name: "taskStatus", payload: { taskName: "task-a", status: { state: "not-implemented" } } },
-      { name: "taskStatus", payload: { taskName: "task-c", status: { state: "not-implemented" } } },
-      { name: "serviceStatus", payload: { serviceName: "service-c", status: { state: "ready" } } },
-      { name: "serviceStatus", payload: { serviceName: "service-d", status: { state: "unknown" } } },
+    const sortedEvents = sortBy(
+      getRuntimeStatusEvents(garden.events.eventLog),
+      (e) => `${e.name}.${e.payload.taskName || e.payload.serviceName}.${e.payload.status.state}`
+    )
+
+    expect(sortedEvents).to.eql([
       { name: "serviceStatus", payload: { serviceName: "service-a", status: { state: "ready" } } },
-      { name: "serviceStatus", payload: { serviceName: "service-b", status: { state: "unknown" } } },
-      { name: "serviceStatus", payload: { serviceName: "service-c", status: { state: "ready" } } },
-      { name: "serviceStatus", payload: { serviceName: "service-d", status: { state: "ready" } } },
-      { name: "taskStatus", payload: { taskName: "task-c", status: { state: "succeeded" } } },
-      { name: "taskStatus", payload: { taskName: "task-a", status: { state: "succeeded" } } },
       { name: "serviceStatus", payload: { serviceName: "service-a", status: { state: "ready" } } },
       { name: "serviceStatus", payload: { serviceName: "service-b", status: { state: "ready" } } },
+      { name: "serviceStatus", payload: { serviceName: "service-b", status: { state: "unknown" } } },
+      { name: "serviceStatus", payload: { serviceName: "service-c", status: { state: "ready" } } },
+      { name: "serviceStatus", payload: { serviceName: "service-c", status: { state: "ready" } } },
+      { name: "serviceStatus", payload: { serviceName: "service-d", status: { state: "ready" } } },
+      { name: "serviceStatus", payload: { serviceName: "service-d", status: { state: "unknown" } } },
+      { name: "taskStatus", payload: { taskName: "task-a", status: { state: "not-implemented" } } },
+      { name: "taskStatus", payload: { taskName: "task-a", status: { state: "succeeded" } } },
+      { name: "taskStatus", payload: { taskName: "task-c", status: { state: "not-implemented" } } },
+      { name: "taskStatus", payload: { taskName: "task-c", status: { state: "succeeded" } } },
     ])
   })
 

--- a/docs/reference/module-types/conftest.md
+++ b/docs/reference/module-types/conftest.md
@@ -482,3 +482,43 @@ Example:
 my-variable: ${modules.my-module.version}
 ```
 
+
+### Service Outputs
+
+The following keys are available via the `${runtime.services.<service-name>}` template string key for `conftest` module services.
+Note that these are only resolved when deploying/running dependants of the service, so they are not usable for every field.
+
+### `${runtime.services.<service-name>.version}`
+
+The current version of the service.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${runtime.services.my-service.version}
+```
+
+
+### Task Outputs
+
+The following keys are available via the `${runtime.tasks.<task-name>}` template string key for `conftest` module tasks.
+Note that these are only resolved when deploying/running dependants of the task, so they are not usable for every field.
+
+### `${runtime.tasks.<task-name>.version}`
+
+The current version of the task.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${runtime.tasks.my-tasks.version}
+```
+

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -2192,10 +2192,44 @@ my-variable: ${modules.my-module.outputs.deployment-image-id}
 ```
 
 
+### Service Outputs
+
+The following keys are available via the `${runtime.services.<service-name>}` template string key for `container` module services.
+Note that these are only resolved when deploying/running dependants of the service, so they are not usable for every field.
+
+### `${runtime.services.<service-name>.version}`
+
+The current version of the service.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${runtime.services.my-service.version}
+```
+
+
 ### Task Outputs
 
 The following keys are available via the `${runtime.tasks.<task-name>}` template string key for `container` module tasks.
 Note that these are only resolved when deploying/running dependants of the task, so they are not usable for every field.
+
+### `${runtime.tasks.<task-name>.version}`
+
+The current version of the task.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${runtime.tasks.my-tasks.version}
+```
 
 ### `${runtime.tasks.<task-name>.outputs.log}`
 

--- a/docs/reference/module-types/exec.md
+++ b/docs/reference/module-types/exec.md
@@ -790,10 +790,44 @@ my-variable: ${modules.my-module.version}
 ```
 
 
+### Service Outputs
+
+The following keys are available via the `${runtime.services.<service-name>}` template string key for `exec` module services.
+Note that these are only resolved when deploying/running dependants of the service, so they are not usable for every field.
+
+### `${runtime.services.<service-name>.version}`
+
+The current version of the service.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${runtime.services.my-service.version}
+```
+
+
 ### Task Outputs
 
 The following keys are available via the `${runtime.tasks.<task-name>}` template string key for `exec` module tasks.
 Note that these are only resolved when deploying/running dependants of the task, so they are not usable for every field.
+
+### `${runtime.tasks.<task-name>.version}`
+
+The current version of the task.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${runtime.tasks.my-tasks.version}
+```
 
 ### `${runtime.tasks.<task-name>.outputs.log}`
 

--- a/docs/reference/module-types/hadolint.md
+++ b/docs/reference/module-types/hadolint.md
@@ -435,3 +435,43 @@ Example:
 my-variable: ${modules.my-module.version}
 ```
 
+
+### Service Outputs
+
+The following keys are available via the `${runtime.services.<service-name>}` template string key for `hadolint` module services.
+Note that these are only resolved when deploying/running dependants of the service, so they are not usable for every field.
+
+### `${runtime.services.<service-name>.version}`
+
+The current version of the service.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${runtime.services.my-service.version}
+```
+
+
+### Task Outputs
+
+The following keys are available via the `${runtime.tasks.<task-name>}` template string key for `hadolint` module tasks.
+Note that these are only resolved when deploying/running dependants of the task, so they are not usable for every field.
+
+### `${runtime.tasks.<task-name>.version}`
+
+The current version of the task.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${runtime.tasks.my-tasks.version}
+```
+

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -1688,3 +1688,43 @@ The Helm release name of the service.
 | -------- |
 | `string` |
 
+
+### Service Outputs
+
+The following keys are available via the `${runtime.services.<service-name>}` template string key for `helm` module services.
+Note that these are only resolved when deploying/running dependants of the service, so they are not usable for every field.
+
+### `${runtime.services.<service-name>.version}`
+
+The current version of the service.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${runtime.services.my-service.version}
+```
+
+
+### Task Outputs
+
+The following keys are available via the `${runtime.tasks.<task-name>}` template string key for `helm` module tasks.
+Note that these are only resolved when deploying/running dependants of the task, so they are not usable for every field.
+
+### `${runtime.tasks.<task-name>.version}`
+
+The current version of the task.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${runtime.tasks.my-tasks.version}
+```
+

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -148,7 +148,8 @@ manifests:
       # The name of the resource.
       name:
 
-# POSIX-style paths to YAML files to load manifests from. Each can contain multiple manifests.
+# POSIX-style paths to YAML files to load manifests from. Each can contain multiple manifests, and can include any
+# Garden template strings, which will be resolved before applying the manifests.
 files: []
 
 # A valid Kubernetes namespace name. Must be a valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters,
@@ -693,7 +694,7 @@ The name of the resource.
 
 ### `files[]`
 
-POSIX-style paths to YAML files to load manifests from. Each can contain multiple manifests.
+POSIX-style paths to YAML files to load manifests from. Each can contain multiple manifests, and can include any Garden template strings, which will be resolved before applying the manifests.
 
 | Type               | Default | Required |
 | ------------------ | ------- | -------- |
@@ -1444,5 +1445,45 @@ Example:
 
 ```yaml
 my-variable: ${modules.my-module.version}
+```
+
+
+### Service Outputs
+
+The following keys are available via the `${runtime.services.<service-name>}` template string key for `kubernetes` module services.
+Note that these are only resolved when deploying/running dependants of the service, so they are not usable for every field.
+
+### `${runtime.services.<service-name>.version}`
+
+The current version of the service.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${runtime.services.my-service.version}
+```
+
+
+### Task Outputs
+
+The following keys are available via the `${runtime.tasks.<task-name>}` template string key for `kubernetes` module tasks.
+Note that these are only resolved when deploying/running dependants of the task, so they are not usable for every field.
+
+### `${runtime.tasks.<task-name>.version}`
+
+The current version of the task.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${runtime.tasks.my-tasks.version}
 ```
 

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -2252,3 +2252,43 @@ Example:
 my-variable: ${modules.my-module.outputs.deployment-image-id}
 ```
 
+
+### Service Outputs
+
+The following keys are available via the `${runtime.services.<service-name>}` template string key for `maven-container` module services.
+Note that these are only resolved when deploying/running dependants of the service, so they are not usable for every field.
+
+### `${runtime.services.<service-name>.version}`
+
+The current version of the service.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${runtime.services.my-service.version}
+```
+
+
+### Task Outputs
+
+The following keys are available via the `${runtime.tasks.<task-name>}` template string key for `maven-container` module tasks.
+Note that these are only resolved when deploying/running dependants of the task, so they are not usable for every field.
+
+### `${runtime.tasks.<task-name>.version}`
+
+The current version of the task.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${runtime.tasks.my-tasks.version}
+```
+

--- a/docs/reference/module-types/openfaas.md
+++ b/docs/reference/module-types/openfaas.md
@@ -577,3 +577,43 @@ The full URL to query this service _from within_ the cluster.
 | -------- |
 | `string` |
 
+
+### Service Outputs
+
+The following keys are available via the `${runtime.services.<service-name>}` template string key for `openfaas` module services.
+Note that these are only resolved when deploying/running dependants of the service, so they are not usable for every field.
+
+### `${runtime.services.<service-name>.version}`
+
+The current version of the service.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${runtime.services.my-service.version}
+```
+
+
+### Task Outputs
+
+The following keys are available via the `${runtime.tasks.<task-name>}` template string key for `openfaas` module tasks.
+Note that these are only resolved when deploying/running dependants of the task, so they are not usable for every field.
+
+### `${runtime.tasks.<task-name>.version}`
+
+The current version of the task.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${runtime.tasks.my-tasks.version}
+```
+

--- a/docs/reference/module-types/persistentvolumeclaim.md
+++ b/docs/reference/module-types/persistentvolumeclaim.md
@@ -644,3 +644,43 @@ Example:
 my-variable: ${modules.my-module.version}
 ```
 
+
+### Service Outputs
+
+The following keys are available via the `${runtime.services.<service-name>}` template string key for `persistentvolumeclaim` module services.
+Note that these are only resolved when deploying/running dependants of the service, so they are not usable for every field.
+
+### `${runtime.services.<service-name>.version}`
+
+The current version of the service.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${runtime.services.my-service.version}
+```
+
+
+### Task Outputs
+
+The following keys are available via the `${runtime.tasks.<task-name>}` template string key for `persistentvolumeclaim` module tasks.
+Note that these are only resolved when deploying/running dependants of the task, so they are not usable for every field.
+
+### `${runtime.tasks.<task-name>.version}`
+
+The current version of the task.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${runtime.tasks.my-tasks.version}
+```
+

--- a/docs/reference/module-types/templated.md
+++ b/docs/reference/module-types/templated.md
@@ -451,3 +451,43 @@ Example:
 my-variable: ${modules.my-module.version}
 ```
 
+
+### Service Outputs
+
+The following keys are available via the `${runtime.services.<service-name>}` template string key for `templated` module services.
+Note that these are only resolved when deploying/running dependants of the service, so they are not usable for every field.
+
+### `${runtime.services.<service-name>.version}`
+
+The current version of the service.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${runtime.services.my-service.version}
+```
+
+
+### Task Outputs
+
+The following keys are available via the `${runtime.tasks.<task-name>}` template string key for `templated` module tasks.
+Note that these are only resolved when deploying/running dependants of the task, so they are not usable for every field.
+
+### `${runtime.tasks.<task-name>.version}`
+
+The current version of the task.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${runtime.tasks.my-tasks.version}
+```
+

--- a/docs/reference/module-types/terraform.md
+++ b/docs/reference/module-types/terraform.md
@@ -531,6 +531,20 @@ my-variable: ${modules.my-module.version}
 The following keys are available via the `${runtime.services.<service-name>}` template string key for `terraform` module services.
 Note that these are only resolved when deploying/running dependants of the service, so they are not usable for every field.
 
+### `${runtime.services.<service-name>.version}`
+
+The current version of the service.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${runtime.services.my-service.version}
+```
+
 ### `${runtime.services.<service-name>.outputs.*}`
 
 A map of all the outputs defined in the Terraform stack.
@@ -544,4 +558,24 @@ A map of all the outputs defined in the Terraform stack.
 | Type                                             |
 | ------------------------------------------------ |
 | `string | number | boolean | link | array[link]` |
+
+
+### Task Outputs
+
+The following keys are available via the `${runtime.tasks.<task-name>}` template string key for `terraform` module tasks.
+Note that these are only resolved when deploying/running dependants of the task, so they are not usable for every field.
+
+### `${runtime.tasks.<task-name>.version}`
+
+The current version of the task.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${runtime.tasks.my-tasks.version}
+```
 

--- a/docs/reference/template-strings.md
+++ b/docs/reference/template-strings.md
@@ -1331,6 +1331,20 @@ The service output value. Refer to individual [module type references](https://d
 | --------------------------- |
 | `string | number | boolean` |
 
+### `${runtime.services.<service-name>.version}`
+
+The current version of the service.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${runtime.services.<service-name>.version}
+```
+
 ### `${runtime.tasks.*}`
 
 Runtime information from the tasks that the service/task being run depends on.
@@ -1354,6 +1368,20 @@ The task output value. Refer to individual [module type references](https://docs
 | Type                        |
 | --------------------------- |
 | `string | number | boolean` |
+
+### `${runtime.tasks.<task-name>.version}`
+
+The current version of the task.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${runtime.tasks.<task-name>.version}
+```
 
 ### `${inputs.*}`
 
@@ -1875,6 +1903,20 @@ The service output value. Refer to individual [module type references](https://d
 | --------------------------- |
 | `string | number | boolean` |
 
+### `${runtime.services.<service-name>.version}`
+
+The current version of the service.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${runtime.services.<service-name>.version}
+```
+
 ### `${runtime.tasks.*}`
 
 Runtime information from the tasks that the service/task being run depends on.
@@ -1898,6 +1940,20 @@ The task output value. Refer to individual [module type references](https://docs
 | Type                        |
 | --------------------------- |
 | `string | number | boolean` |
+
+### `${runtime.tasks.<task-name>.version}`
+
+The current version of the task.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${runtime.tasks.<task-name>.version}
+```
 
 
 ## Workflow configuration context

--- a/examples/kubernetes-module/garden.yml
+++ b/examples/kubernetes-module/garden.yml
@@ -2,7 +2,15 @@ kind: Project
 name: kubernetes-module
 environments:
   - name: local
+  - name: testing
+    defaultNamespace: testing-${local.env.CIRCLE_BUILD_NUM || local.username}
 providers:
   - name: local-kubernetes
+    environments: [local]
+  - name: kubernetes
+    environments: [testing]
+    context: gke_garden-dev-200012_europe-west1-b_garden-dev-1
+    buildMode: kaniko
 variables:
   postgres-password: "Y0RGQjBHUmpWZQ=="
+  redis-password: "OHlWVEVYeVdrMg=="

--- a/examples/kubernetes-module/redis/redis.yml
+++ b/examples/kubernetes-module/redis/redis.yml
@@ -11,7 +11,7 @@ metadata:
     heritage: "Tiller"
 type: Opaque
 data:
-  redis-password: "OHlWVEVYeVdrMg=="
+  redis-password: ${var.redis-password}
 ---
 # Source: redis/templates/configmap.yaml
 apiVersion: v1
@@ -171,20 +171,20 @@ spec:
             - -c
             - |
               if [[ -n $REDIS_PASSWORD_FILE ]]; then
-                password_aux=`cat ${REDIS_PASSWORD_FILE}`
+                password_aux=`cat $${REDIS_PASSWORD_FILE}`
                 export REDIS_PASSWORD=$password_aux
               fi
               if [[ -n $REDIS_MASTER_PASSWORD_FILE ]]; then
-                password_aux=`cat ${REDIS_MASTER_PASSWORD_FILE}`
+                password_aux=`cat $${REDIS_MASTER_PASSWORD_FILE}`
                 export REDIS_MASTER_PASSWORD=$password_aux
               fi
-              ARGS=("--port" "${REDIS_PORT}")
-              ARGS+=("--requirepass" "${REDIS_PASSWORD}")
-              ARGS+=("--slaveof" "${REDIS_MASTER_HOST}" "${REDIS_MASTER_PORT_NUMBER}")
-              ARGS+=("--masterauth" "${REDIS_MASTER_PASSWORD}")
+              ARGS=("--port" "$${REDIS_PORT}")
+              ARGS+=("--requirepass" "$${REDIS_PASSWORD}")
+              ARGS+=("--slaveof" "$${REDIS_MASTER_HOST}" "$${REDIS_MASTER_PORT_NUMBER}")
+              ARGS+=("--masterauth" "$${REDIS_MASTER_PASSWORD}")
               ARGS+=("--include" "/opt/bitnami/redis/etc/redis.conf")
               ARGS+=("--include" "/opt/bitnami/redis/etc/replica.conf")
-              /run.sh "${ARGS[@]}"
+              /run.sh "$${ARGS[@]}"
           env:
             - name: REDIS_REPLICATION_MODE
               value: slave
@@ -293,14 +293,14 @@ spec:
             - -c
             - |
               if [[ -n $REDIS_PASSWORD_FILE ]]; then
-                password_aux=`cat ${REDIS_PASSWORD_FILE}`
+                password_aux=`cat $${REDIS_PASSWORD_FILE}`
                 export REDIS_PASSWORD=$password_aux
               fi
-              ARGS=("--port" "${REDIS_PORT}")
-              ARGS+=("--requirepass" "${REDIS_PASSWORD}")
+              ARGS=("--port" "$${REDIS_PORT}")
+              ARGS+=("--requirepass" "$${REDIS_PASSWORD}")
               ARGS+=("--include" "/opt/bitnami/redis/etc/redis.conf")
               ARGS+=("--include" "/opt/bitnami/redis/etc/master.conf")
-              /run.sh ${ARGS[@]}
+              /run.sh $${ARGS[@]}
           env:
             - name: REDIS_REPLICATION_MODE
               value: master


### PR DESCRIPTION
Previously, you could only use template strings when inlining
manifests using the `manifests` field. Now, template strings are also
resolved in the files referenced in the `files` key.

Internally, we now make a `ctx.resolveTemplateStrings()` for all
plugin handlers, so this will be easy to do in other scenarios as well.

Also added a commit to allow referencing service or task versions via e.g.
`${runtime.services.my-service.version}` or
`${runtime.tasks.my-task.version}`.