### PR TITLE
feat(core): allow opt aliases in ${command.params}

### DIFF
--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -27,6 +27,7 @@ import {
   processCliArgs,
   pickCommand,
   parseCliArgs,
+  optionsWithAliasValues,
 } from "./helpers"
 import { Parameters, globalOptions, OUTPUT_RENDERERS, GlobalOptions, ParameterValues } from "./params"
 import { defaultEnvironments, ProjectConfig, defaultNamespace, parseEnvironment } from "../config/project"
@@ -227,7 +228,7 @@ ${renderCommands(commands)}
       commandInfo: {
         name: command.getFullName(),
         args: parsedArgs,
-        opts: parsedOpts,
+        opts: optionsWithAliasValues(command, parsedOpts),
       },
       disablePortForwards,
       environmentName,

--- a/core/src/cli/helpers.ts
+++ b/core/src/cli/helpers.ts
@@ -29,6 +29,7 @@ import minimist = require("minimist")
 import { renderTable, tablePresets, naturalList } from "../util/string"
 import { globalOptions, GlobalOptions } from "./params"
 import { Command, CommandGroup } from "../commands/base"
+import { DeepPrimitiveMap } from "../config/common"
 
 export const cliStyles = {
   heading: (str: string) => chalk.white.bold(str),
@@ -292,6 +293,19 @@ export function processCliArgs<A extends Parameters, O extends Parameters>({
     args: <DefaultArgs & ParameterValues<A>>processedArgs,
     opts: <ParameterValues<GlobalOptions> & ParameterValues<O>>processedOpts,
   }
+}
+
+export function optionsWithAliasValues<A extends Parameters, O extends Parameters>(
+  command: Command<A, O>,
+  parsedOpts: DeepPrimitiveMap
+): DeepPrimitiveMap {
+  const withAliases = { ...parsedOpts } // Create a new object instead of mutating.
+  for (const [name, spec] of Object.entries(command.options || {})) {
+    if (spec.alias) {
+      withAliases[spec.alias] = parsedOpts[name]
+    }
+  }
+  return withAliases
 }
 
 export function renderCommands(commands: Command[]) {

--- a/core/src/config/template-contexts/project.ts
+++ b/core/src/config/template-contexts/project.ts
@@ -137,6 +137,8 @@ class CommandContext extends ConfigContext {
         A map of all parameters set when calling the current command. This includes both positional arguments and option flags, and includes any default values set by the framework or specific command. This can be powerful if used right, but do take care since different parameters are only available in certain commands, some have array values etc.
 
         For example, to see if a service is in hot-reload mode, you might do something like \`${commandHotExample}\`. Notice that you currently need to check both for the existence of the parameter, and also to correctly handle the array value.
+
+        Option values can be referenced by the option's default name (e.g. \`dev-mode\`) or its alias (e.g. \`dev\`) if one is defined for that option.
         `
       )
       .example({ force: true, hot: ["my-service"] })

--- a/docs/reference/template-strings.md
+++ b/docs/reference/template-strings.md
@@ -281,6 +281,8 @@ A map of all parameters set when calling the current command. This includes both
 
 For example, to see if a service is in hot-reload mode, you might do something like `${command.params contains 'hot-reload' && command.params.hot-reload contains 'my-service'}`. Notice that you currently need to check both for the existence of the parameter, and also to correctly handle the array value.
 
+Option values can be referenced by the option's default name (e.g. `dev-mode`) or its alias (e.g. `dev`) if one is defined for that option.
+
 | Type     |
 | -------- |
 | `object` |
@@ -479,6 +481,8 @@ my-variable: ${command.name}
 A map of all parameters set when calling the current command. This includes both positional arguments and option flags, and includes any default values set by the framework or specific command. This can be powerful if used right, but do take care since different parameters are only available in certain commands, some have array values etc.
 
 For example, to see if a service is in hot-reload mode, you might do something like `${command.params contains 'hot-reload' && command.params.hot-reload contains 'my-service'}`. Notice that you currently need to check both for the existence of the parameter, and also to correctly handle the array value.
+
+Option values can be referenced by the option's default name (e.g. `dev-mode`) or its alias (e.g. `dev`) if one is defined for that option.
 
 | Type     |
 | -------- |
@@ -710,6 +714,8 @@ my-variable: ${command.name}
 A map of all parameters set when calling the current command. This includes both positional arguments and option flags, and includes any default values set by the framework or specific command. This can be powerful if used right, but do take care since different parameters are only available in certain commands, some have array values etc.
 
 For example, to see if a service is in hot-reload mode, you might do something like `${command.params contains 'hot-reload' && command.params.hot-reload contains 'my-service'}`. Notice that you currently need to check both for the existence of the parameter, and also to correctly handle the array value.
+
+Option values can be referenced by the option's default name (e.g. `dev-mode`) or its alias (e.g. `dev`) if one is defined for that option.
 
 | Type     |
 | -------- |
@@ -1034,6 +1040,8 @@ my-variable: ${command.name}
 A map of all parameters set when calling the current command. This includes both positional arguments and option flags, and includes any default values set by the framework or specific command. This can be powerful if used right, but do take care since different parameters are only available in certain commands, some have array values etc.
 
 For example, to see if a service is in hot-reload mode, you might do something like `${command.params contains 'hot-reload' && command.params.hot-reload contains 'my-service'}`. Notice that you currently need to check both for the existence of the parameter, and also to correctly handle the array value.
+
+Option values can be referenced by the option's default name (e.g. `dev-mode`) or its alias (e.g. `dev`) if one is defined for that option.
 
 | Type     |
 | -------- |
@@ -1607,6 +1615,8 @@ A map of all parameters set when calling the current command. This includes both
 
 For example, to see if a service is in hot-reload mode, you might do something like `${command.params contains 'hot-reload' && command.params.hot-reload contains 'my-service'}`. Notice that you currently need to check both for the existence of the parameter, and also to correctly handle the array value.
 
+Option values can be referenced by the option's default name (e.g. `dev-mode`) or its alias (e.g. `dev`) if one is defined for that option.
+
 | Type     |
 | -------- |
 | `object` |
@@ -2085,6 +2095,8 @@ my-variable: ${command.name}
 A map of all parameters set when calling the current command. This includes both positional arguments and option flags, and includes any default values set by the framework or specific command. This can be powerful if used right, but do take care since different parameters are only available in certain commands, some have array values etc.
 
 For example, to see if a service is in hot-reload mode, you might do something like `${command.params contains 'hot-reload' && command.params.hot-reload contains 'my-service'}`. Notice that you currently need to check both for the existence of the parameter, and also to correctly handle the array value.
+
+Option values can be referenced by the option's default name (e.g. `dev-mode`) or its alias (e.g. `dev`) if one is defined for that option.
 
 | Type     |
 | -------- |


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

The values of a CLI option can now be looked up by alias in template strings.

For example, `${command.params contains 'dev-mode'}` and `${command.params contains 'dev'}` will now both work (previously, only the `dev-mode` key would have the option values populated).

**Which issue(s) this PR fixes**:

Fixes #2397.