### PR TITLE
feat(cloud): add cloud workflow template context

### DIFF
--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -68,5 +68,8 @@ export const gardenEnv = {
   GARDEN_SKIP_TESTS: env.get("GARDEN_SKIP_TESTS").required(false).default("").asString(),
   GARDEN_HARD_CONCURRENCY_LIMIT: env.get("GARDEN_HARD_CONCURRENCY_LIMIT").required(false).default(50).asInt(),
   GARDEN_TASK_CONCURRENCY_LIMIT: env.get("GARDEN_TASK_CONCURRENCY_LIMIT").required(false).default(6).asInt(),
-  GARDEN_WORKFLOW_RUN_UID: env.get("GARDEN_WORKFLOW_RUN_UID").required(false).asString(),
+  GARDEN_CLOUD_WORKFLOW_RUN_UID: env.get("GARDEN_WORKFLOW_RUN_UID").required(false).asString(),
+  GARDEN_CLOUD_REPO_NAME: env.get("GARDEN_REPO_NAME").required(false).asString(),
+  GARDEN_CLOUD_RUN_NUMBER: env.get("GARDEN_RUN_NUMBER").required(false).asInt(),
+  GARDEN_CLOUD_PR_NUMBER: env.get("GARDEN_PR_NUMBER").required(false).asInt(),
 }

--- a/core/src/enterprise/workflow-lifecycle.ts
+++ b/core/src/enterprise/workflow-lifecycle.ts
@@ -41,7 +41,7 @@ export async function registerWorkflowRun({
     workflowRunConfig,
   }
   if (gardenEnv.GARDEN_GE_SCHEDULED) {
-    requestData["workflowRunUid"] = gardenEnv.GARDEN_WORKFLOW_RUN_UID
+    requestData["workflowRunUid"] = gardenEnv.GARDEN_CLOUD_WORKFLOW_RUN_UID
   }
   if (enterpriseApi) {
     // TODO: Use API types package here.

--- a/core/test/unit/src/config/template-contexts/project.ts
+++ b/core/test/unit/src/config/template-contexts/project.ts
@@ -10,6 +10,7 @@ import { expect } from "chai"
 import stripAnsi = require("strip-ansi")
 import { ConfigContext } from "../../../../../src/config/template-contexts/base"
 import { ProjectConfigContext } from "../../../../../src/config/template-contexts/project"
+import { gardenEnv } from "../../../../../src/constants"
 import { resolveTemplateString } from "../../../../../src/template-string/template-string"
 import { deline } from "../../../../../src/util/string"
 
@@ -254,5 +255,25 @@ describe("ProjectConfigContext", () => {
       c
     )
     expect(result).to.be.false
+  })
+
+  it("should resolve cloud workflow context variables", () => {
+    const backup = gardenEnv.GARDEN_CLOUD_PR_NUMBER
+    gardenEnv.GARDEN_CLOUD_PR_NUMBER = 123
+    const c = new ProjectConfigContext({
+      projectName: "some-project",
+      projectRoot: "/tmp",
+      artifactsPath: "/tmp",
+      branch: "main",
+      username: "some-user",
+      secrets: {},
+      commandInfo: { name: "test", args: {}, opts: {} },
+    })
+    expect(c.resolve({ key: ["workflow", "pullRequestNumber"], nodePath: [], opts: {} })).to.eql({
+      resolved: 123,
+    })
+    let result = resolveTemplateString("${workflow.runNumber || 555}", c)
+    expect(result).to.eql(555)
+    gardenEnv.GARDEN_CLOUD_PR_NUMBER = backup
   })
 })

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -1529,7 +1529,7 @@ describe("Garden", () => {
         (err) => {
           expect(err.message).to.equal("Failed resolving one or more providers:\n" + "- test")
           expect(stripAnsi(err.detail.messages[0])).to.equal(
-            "- test: Invalid template string (${bla.ble}): Could not find key bla. Available keys: command, environment, git, local, project, providers, secrets, var and variables."
+            "- test: Invalid template string (${bla.ble}): Could not find key bla. Available keys: command, environment, git, local, project, providers, secrets, var, variables and workflow."
           )
         }
       )

--- a/docs/reference/template-strings.md
+++ b/docs/reference/template-strings.md
@@ -271,6 +271,70 @@ Example:
 my-variable: ${local.usernameLowerCase}
 ```
 
+### `${workflow.*}`
+
+Context variables that are specific to the currently running Garden Cloud workflow. These values are only available for workflows triggered by Garden Cloud in response to VCS event (e.g. from GitHub or GitLab).
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${workflow.runUid}`
+
+The globally unique UID of the workflow run.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${workflow.runUid}
+```
+
+### `${workflow.runNumber}`
+
+The run number of this workflow. This is incremented across all workflows within a given project.
+
+| Type     |
+| -------- |
+| `number` |
+
+Example:
+
+```yaml
+my-variable: ${workflow.runNumber}
+```
+
+### `${workflow.repoName}`
+
+The name of the repo that was cloned to run this workflow
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${workflow.repoName}
+```
+
+### `${workflow.pullRequestNumber}`
+
+The number of the pull/merge request that triggered this workflow.
+
+| Type     |
+| -------- |
+| `number` |
+
+Example:
+
+```yaml
+my-variable: ${workflow.pullRequestNumber}
+```
+
 ### `${command.*}`
 
 Information about the currently running command and its arguments.
@@ -470,6 +534,70 @@ Example:
 
 ```yaml
 my-variable: ${local.usernameLowerCase}
+```
+
+### `${workflow.*}`
+
+Context variables that are specific to the currently running Garden Cloud workflow. These values are only available for workflows triggered by Garden Cloud in response to VCS event (e.g. from GitHub or GitLab).
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${workflow.runUid}`
+
+The globally unique UID of the workflow run.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${workflow.runUid}
+```
+
+### `${workflow.runNumber}`
+
+The run number of this workflow. This is incremented across all workflows within a given project.
+
+| Type     |
+| -------- |
+| `number` |
+
+Example:
+
+```yaml
+my-variable: ${workflow.runNumber}
+```
+
+### `${workflow.repoName}`
+
+The name of the repo that was cloned to run this workflow
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${workflow.repoName}
+```
+
+### `${workflow.pullRequestNumber}`
+
+The number of the pull/merge request that triggered this workflow.
+
+| Type     |
+| -------- |
+| `number` |
+
+Example:
+
+```yaml
+my-variable: ${workflow.pullRequestNumber}
 ```
 
 ### `${command.*}`
@@ -703,6 +831,70 @@ Example:
 
 ```yaml
 my-variable: ${local.usernameLowerCase}
+```
+
+### `${workflow.*}`
+
+Context variables that are specific to the currently running Garden Cloud workflow. These values are only available for workflows triggered by Garden Cloud in response to VCS event (e.g. from GitHub or GitLab).
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${workflow.runUid}`
+
+The globally unique UID of the workflow run.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${workflow.runUid}
+```
+
+### `${workflow.runNumber}`
+
+The run number of this workflow. This is incremented across all workflows within a given project.
+
+| Type     |
+| -------- |
+| `number` |
+
+Example:
+
+```yaml
+my-variable: ${workflow.runNumber}
+```
+
+### `${workflow.repoName}`
+
+The name of the repo that was cloned to run this workflow
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${workflow.repoName}
+```
+
+### `${workflow.pullRequestNumber}`
+
+The number of the pull/merge request that triggered this workflow.
+
+| Type     |
+| -------- |
+| `number` |
+
+Example:
+
+```yaml
+my-variable: ${workflow.pullRequestNumber}
 ```
 
 ### `${command.*}`
@@ -1029,6 +1221,70 @@ Example:
 
 ```yaml
 my-variable: ${local.usernameLowerCase}
+```
+
+### `${workflow.*}`
+
+Context variables that are specific to the currently running Garden Cloud workflow. These values are only available for workflows triggered by Garden Cloud in response to VCS event (e.g. from GitHub or GitLab).
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${workflow.runUid}`
+
+The globally unique UID of the workflow run.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${workflow.runUid}
+```
+
+### `${workflow.runNumber}`
+
+The run number of this workflow. This is incremented across all workflows within a given project.
+
+| Type     |
+| -------- |
+| `number` |
+
+Example:
+
+```yaml
+my-variable: ${workflow.runNumber}
+```
+
+### `${workflow.repoName}`
+
+The name of the repo that was cloned to run this workflow
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${workflow.repoName}
+```
+
+### `${workflow.pullRequestNumber}`
+
+The number of the pull/merge request that triggered this workflow.
+
+| Type     |
+| -------- |
+| `number` |
+
+Example:
+
+```yaml
+my-variable: ${workflow.pullRequestNumber}
 ```
 
 ### `${command.*}`
@@ -1605,6 +1861,70 @@ Example:
 my-variable: ${local.usernameLowerCase}
 ```
 
+### `${workflow.*}`
+
+Context variables that are specific to the currently running Garden Cloud workflow. These values are only available for workflows triggered by Garden Cloud in response to VCS event (e.g. from GitHub or GitLab).
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${workflow.runUid}`
+
+The globally unique UID of the workflow run.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${workflow.runUid}
+```
+
+### `${workflow.runNumber}`
+
+The run number of this workflow. This is incremented across all workflows within a given project.
+
+| Type     |
+| -------- |
+| `number` |
+
+Example:
+
+```yaml
+my-variable: ${workflow.runNumber}
+```
+
+### `${workflow.repoName}`
+
+The name of the repo that was cloned to run this workflow
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${workflow.repoName}
+```
+
+### `${workflow.pullRequestNumber}`
+
+The number of the pull/merge request that triggered this workflow.
+
+| Type     |
+| -------- |
+| `number` |
+
+Example:
+
+```yaml
+my-variable: ${workflow.pullRequestNumber}
+```
+
 ### `${command.*}`
 
 Information about the currently running command and its arguments.
@@ -2084,6 +2404,70 @@ Example:
 
 ```yaml
 my-variable: ${local.usernameLowerCase}
+```
+
+### `${workflow.*}`
+
+Context variables that are specific to the currently running Garden Cloud workflow. These values are only available for workflows triggered by Garden Cloud in response to VCS event (e.g. from GitHub or GitLab).
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${workflow.runUid}`
+
+The globally unique UID of the workflow run.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${workflow.runUid}
+```
+
+### `${workflow.runNumber}`
+
+The run number of this workflow. This is incremented across all workflows within a given project.
+
+| Type     |
+| -------- |
+| `number` |
+
+Example:
+
+```yaml
+my-variable: ${workflow.runNumber}
+```
+
+### `${workflow.repoName}`
+
+The name of the repo that was cloned to run this workflow
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${workflow.repoName}
+```
+
+### `${workflow.pullRequestNumber}`
+
+The number of the pull/merge request that triggered this workflow.
+
+| Type     |
+| -------- |
+| `number` |
+
+Example:
+
+```yaml
+my-variable: ${workflow.pullRequestNumber}
 ```
 
 ### `${command.*}`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

Added a `workflow` config context that is available when using triggered Garden Cloud / Garden Enterprise workflows,

These values will be undefined outside of our workflow runners, so they can be used in conjunction with conditionals in templates to work across different environments.