### PR TITLE
improvement(cloud): better secrets/API errors

### DIFF
--- a/core/src/config/module-template.ts
+++ b/core/src/config/module-template.ts
@@ -54,7 +54,10 @@ export async function resolveModuleTemplate(
     ...resource,
     modules: [],
   }
-  const context = new ProjectConfigContext({ ...garden, branch: garden.vcsBranch })
+  const branch = garden.vcsBranch
+  const loggedIn = !!garden.enterpriseApi
+  const enterpriseDomain = garden.enterpriseApi?.domain
+  const context = new ProjectConfigContext({ ...garden, branch, loggedIn, enterpriseDomain })
   const resolved = resolveTemplateStrings(partial, context)
 
   // Validate the partial config
@@ -112,7 +115,10 @@ export async function resolveTemplatedModule(
   // Resolve template strings for fields. Note that inputs are partially resolved, and will be fully resolved later
   // when resolving the resolving the resulting modules. Inputs that are used in module names must however be resolvable
   // immediately.
-  const templateContext = new EnvironmentConfigContext({ ...garden, branch: garden.vcsBranch })
+  const branch = garden.vcsBranch
+  const loggedIn = !!garden.enterpriseApi
+  const enterpriseDomain = garden.enterpriseApi?.domain
+  const templateContext = new EnvironmentConfigContext({ ...garden, branch, loggedIn, enterpriseDomain })
   const resolvedWithoutInputs = resolveTemplateStrings(
     { ...config, spec: omit(config.spec, "inputs") },
     templateContext
@@ -160,6 +166,8 @@ export async function resolveTemplatedModule(
   const context = new ModuleTemplateConfigContext({
     ...garden,
     branch: garden.vcsBranch,
+    loggedIn: !!garden.enterpriseApi,
+    enterpriseDomain,
     parentName: resolved.name,
     templateName: template.name,
     inputs: partiallyResolvedInputs,

--- a/core/src/config/project.ts
+++ b/core/src/config/project.ts
@@ -403,6 +403,8 @@ export function resolveProjectConfig({
   artifactsPath,
   branch,
   username,
+  loggedIn,
+  enterpriseDomain,
   secrets,
   commandInfo,
 }: {
@@ -411,6 +413,8 @@ export function resolveProjectConfig({
   artifactsPath: string
   branch: string
   username: string
+  loggedIn: boolean
+  enterpriseDomain: string | undefined
   secrets: PrimitiveMap
   commandInfo: CommandInfo
 }): ProjectConfig {
@@ -431,6 +435,8 @@ export function resolveProjectConfig({
       artifactsPath,
       branch,
       username,
+      loggedIn,
+      enterpriseDomain,
       secrets,
       commandInfo,
     })
@@ -511,6 +517,8 @@ export async function pickEnvironment({
   artifactsPath,
   branch,
   username,
+  loggedIn,
+  enterpriseDomain,
   secrets,
   commandInfo,
 }: {
@@ -519,6 +527,8 @@ export async function pickEnvironment({
   artifactsPath: string
   branch: string
   username: string
+  loggedIn: boolean
+  enterpriseDomain: string | undefined
   secrets: PrimitiveMap
   commandInfo: CommandInfo
 }) {
@@ -552,6 +562,8 @@ export async function pickEnvironment({
       branch,
       username,
       variables: projectVariables,
+      loggedIn,
+      enterpriseDomain,
       secrets,
       commandInfo,
     })

--- a/core/src/config/template-contexts/base.ts
+++ b/core/src/config/template-contexts/base.ts
@@ -69,6 +69,14 @@ export abstract class ConfigContext {
     return joi.object().keys(schemas).required()
   }
 
+  /**
+   * Override this method to add more context to error messages thrown in the `resolve` method when a missing key is
+   * referenced.
+   */
+  getMissingKeyErrorFooter(_key: ContextKeySegment, _path: ContextKeySegment[]): string {
+    return ""
+  }
+
   resolve({ key, nodePath, opts }: ContextResolveParams): ContextResolveOutput {
     const path = renderKeyPath(key)
     const fullPath = renderKeyPath(nodePath.concat(key))
@@ -177,6 +185,10 @@ export abstract class ConfigContext {
 
         if (available && available.length) {
           message += chalk.red(" Available keys: " + naturalList(available.sort().map((k) => chalk.white(k))) + ".")
+        }
+        const messageFooter = this.getMissingKeyErrorFooter(nextKey, nestedNodePath.slice(0, -1))
+        if (messageFooter) {
+          message += `\n\n${messageFooter}`
         }
       }
 

--- a/core/src/config/template-contexts/workflow.ts
+++ b/core/src/config/template-contexts/workflow.ts
@@ -40,6 +40,8 @@ export class WorkflowConfigContext extends EnvironmentConfigContext {
       branch: garden.vcsBranch,
       username: garden.username,
       variables: garden.variables,
+      loggedIn: !!garden.enterpriseApi,
+      enterpriseDomain: garden.enterpriseApi?.domain,
       secrets: garden.secrets,
       commandInfo: garden.commandInfo,
     })

--- a/core/src/enterprise/api.ts
+++ b/core/src/enterprise/api.ts
@@ -186,6 +186,12 @@ export class EnterpriseApi {
   }
 
   static async saveAuthToken(log: LogEntry, tokenResponse: AuthTokenResponse) {
+    if (!tokenResponse.token) {
+      throw new EnterpriseApiError(
+        `Received a null/empty client auth token while logging in. Please contact your system administrator.`,
+        { tokenResponse }
+      )
+    }
     try {
       const manager = ClientAuthToken.getConnection().manager
       await manager.transaction(async (transactionalEntityManager) => {
@@ -201,7 +207,10 @@ export class EnterpriseApi {
       })
       log.debug("Saved client auth token to local config db")
     } catch (error) {
-      log.error(`An error occurred while saving client auth token to local config db:\n${error.message}`)
+      throw new EnterpriseApiError(
+        `An error occurred while saving client auth token to local config db:\n${error.message}`,
+        { tokenResponse }
+      )
     }
   }
 

--- a/core/src/enterprise/api.ts
+++ b/core/src/enterprise/api.ts
@@ -27,8 +27,12 @@ export const authTokenHeader =
 
 export const makeAuthHeader = (clientAuthToken: string) => ({ [authTokenHeader]: clientAuthToken })
 
+export function isGotError(error: any, statusCode: number): error is GotHttpError {
+  return error instanceof GotHttpError && error.response.statusCode === statusCode
+}
+
 function is401Error(error: any): error is GotHttpError {
-  return error instanceof GotHttpError && error.response.statusCode === 401
+  return isGotError(error, 401)
 }
 
 const refreshThreshold = 10 // Threshold (in seconds) subtracted to jwt validity when checking if a refresh is needed

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -1211,12 +1211,17 @@ export async function resolveGardenParams(currentDirectory: string, opts: Garden
     }
   }
 
+  const loggedIn = !!enterpriseApi
+  const enterpriseDomain = enterpriseApi?.domain
+
   config = resolveProjectConfig({
     defaultEnvironment: defaultEnvironmentName,
     config,
     artifactsPath,
     branch: vcsBranch,
     username: _username,
+    loggedIn,
+    enterpriseDomain,
     secrets,
     commandInfo,
   })
@@ -1229,6 +1234,8 @@ export async function resolveGardenParams(currentDirectory: string, opts: Garden
     artifactsPath,
     branch: vcsBranch,
     username: _username,
+    loggedIn,
+    enterpriseDomain,
     secrets,
     commandInfo,
   })

--- a/core/test/unit/src/config/project.ts
+++ b/core/test/unit/src/config/project.ts
@@ -29,9 +29,11 @@ import { resolve, join } from "path"
 import stripAnsi from "strip-ansi"
 import { keyBy } from "lodash"
 
+const enterpriseDomain = "https://garden.mydomain.com"
 const commandInfo = { name: "test", args: {}, opts: {} }
 
 describe("resolveProjectConfig", () => {
+
   it("should pass through a canonical project config", async () => {
     const defaultEnvironment = "default"
     const config: ProjectConfig = {
@@ -54,6 +56,8 @@ describe("resolveProjectConfig", () => {
         artifactsPath: "/tmp",
         branch: "main",
         username: "some-user",
+        loggedIn: true,
+        enterpriseDomain,
         secrets: {},
         commandInfo,
       })
@@ -93,6 +97,8 @@ describe("resolveProjectConfig", () => {
         artifactsPath: "/tmp",
         branch: "main",
         username: "some-user",
+        loggedIn: true,
+        enterpriseDomain,
         secrets: {},
         commandInfo,
       })
@@ -148,6 +154,8 @@ describe("resolveProjectConfig", () => {
         artifactsPath: "/tmp",
         branch: "main",
         username: "some-user",
+        loggedIn: true,
+        enterpriseDomain,
         secrets: { foo: "banana" },
         commandInfo,
       })
@@ -223,6 +231,8 @@ describe("resolveProjectConfig", () => {
         artifactsPath: "/tmp",
         branch: "main",
         username: "some-user",
+        loggedIn: true,
+        enterpriseDomain,
         secrets: {},
         commandInfo,
       })
@@ -287,6 +297,8 @@ describe("resolveProjectConfig", () => {
       artifactsPath: "/tmp",
       branch: "main",
       username: "some-user",
+      loggedIn: true,
+      enterpriseDomain,
       secrets: {},
       commandInfo,
     })
@@ -316,6 +328,8 @@ describe("resolveProjectConfig", () => {
         artifactsPath: "/tmp",
         branch: "main",
         username: "some-user",
+        loggedIn: true,
+        enterpriseDomain,
         secrets: {},
         commandInfo,
       })
@@ -350,6 +364,8 @@ describe("resolveProjectConfig", () => {
         artifactsPath: "/tmp",
         branch: "main",
         username: "some-user",
+        loggedIn: true,
+        enterpriseDomain,
         secrets: {},
         commandInfo,
       })
@@ -403,6 +419,8 @@ describe("resolveProjectConfig", () => {
         artifactsPath: "/tmp",
         branch: "main",
         username: "some-user",
+        loggedIn: true,
+        enterpriseDomain,
         secrets: {},
         commandInfo,
       })
@@ -479,6 +497,8 @@ describe("resolveProjectConfig", () => {
         artifactsPath: "/tmp",
         branch: "main",
         username: "some-user",
+        loggedIn: true,
+        enterpriseDomain,
         secrets: {},
         commandInfo,
       })
@@ -550,6 +570,8 @@ describe("pickEnvironment", () => {
           artifactsPath,
           branch: "main",
           username,
+          loggedIn: true,
+          enterpriseDomain,
           secrets: {},
           commandInfo,
         }),
@@ -577,6 +599,8 @@ describe("pickEnvironment", () => {
         artifactsPath,
         branch: "main",
         username,
+        loggedIn: true,
+        enterpriseDomain,
         secrets: {},
         commandInfo,
       })
@@ -621,6 +645,8 @@ describe("pickEnvironment", () => {
         artifactsPath,
         branch: "main",
         username,
+        loggedIn: true,
+        enterpriseDomain,
         secrets: {},
         commandInfo,
       })
@@ -664,6 +690,8 @@ describe("pickEnvironment", () => {
         artifactsPath,
         branch: "main",
         username,
+        loggedIn: true,
+        enterpriseDomain,
         secrets: {},
         commandInfo,
       })
@@ -722,6 +750,8 @@ describe("pickEnvironment", () => {
       artifactsPath,
       branch: "main",
       username,
+      loggedIn: true,
+      enterpriseDomain,
       secrets: {},
       commandInfo,
     })
@@ -776,6 +806,8 @@ describe("pickEnvironment", () => {
       artifactsPath,
       branch: "main",
       username,
+      loggedIn: true,
+      enterpriseDomain,
       secrets: {},
       commandInfo,
     })
@@ -824,6 +856,8 @@ describe("pickEnvironment", () => {
       artifactsPath,
       branch: "main",
       username,
+      loggedIn: true,
+      enterpriseDomain,
       secrets: {},
       commandInfo,
     })
@@ -873,6 +907,8 @@ describe("pickEnvironment", () => {
       artifactsPath,
       branch: "main",
       username,
+      loggedIn: true,
+      enterpriseDomain,
       secrets: {},
       commandInfo,
     })
@@ -922,6 +958,8 @@ describe("pickEnvironment", () => {
       artifactsPath,
       branch: "main",
       username,
+      loggedIn: true,
+      enterpriseDomain,
       secrets: {},
       commandInfo,
     })
@@ -982,6 +1020,8 @@ describe("pickEnvironment", () => {
       artifactsPath,
       branch: "main",
       username,
+      loggedIn: true,
+      enterpriseDomain,
       secrets: {},
       commandInfo,
     })
@@ -1043,6 +1083,8 @@ describe("pickEnvironment", () => {
       artifactsPath,
       branch: "main",
       username,
+      loggedIn: true,
+      enterpriseDomain,
       secrets: {},
       commandInfo,
     })
@@ -1076,6 +1118,8 @@ describe("pickEnvironment", () => {
       artifactsPath,
       branch: "main",
       username,
+      loggedIn: true,
+      enterpriseDomain,
       secrets: { foo: "banana" },
       commandInfo,
     })
@@ -1108,6 +1152,8 @@ describe("pickEnvironment", () => {
       artifactsPath,
       branch: "main",
       username,
+      loggedIn: true,
+      enterpriseDomain,
       secrets: {},
       commandInfo,
     })
@@ -1139,6 +1185,8 @@ describe("pickEnvironment", () => {
       artifactsPath,
       branch: "main",
       username,
+      loggedIn: true,
+      enterpriseDomain,
       secrets: {},
       commandInfo,
     })
@@ -1165,6 +1213,8 @@ describe("pickEnvironment", () => {
       artifactsPath,
       branch: "main",
       username,
+      loggedIn: true,
+      enterpriseDomain,
       secrets: {},
       commandInfo,
     })
@@ -1225,6 +1275,8 @@ describe("pickEnvironment", () => {
       artifactsPath,
       branch: "main",
       username,
+      loggedIn: true,
+      enterpriseDomain,
       secrets: {},
       commandInfo,
     })
@@ -1267,6 +1319,8 @@ describe("pickEnvironment", () => {
           artifactsPath,
           branch: "main",
           username,
+          loggedIn: true,
+          enterpriseDomain,
           secrets: {},
           commandInfo,
         }),
@@ -1305,6 +1359,8 @@ describe("pickEnvironment", () => {
           artifactsPath,
           branch: "main",
           username,
+          loggedIn: true,
+          enterpriseDomain,
           secrets: {},
           commandInfo,
         }),
@@ -1340,6 +1396,8 @@ describe("pickEnvironment", () => {
           artifactsPath,
           branch: "main",
           username,
+          loggedIn: true,
+          enterpriseDomain,
           secrets: {},
           commandInfo,
         }),
@@ -1367,6 +1425,8 @@ describe("pickEnvironment", () => {
         artifactsPath,
         branch: "main",
         username,
+        loggedIn: true,
+        enterpriseDomain,
         secrets: {},
         commandInfo,
       })
@@ -1399,6 +1459,8 @@ describe("pickEnvironment", () => {
         artifactsPath,
         branch: "main",
         username,
+        loggedIn: true,
+        enterpriseDomain,
         secrets: {},
         commandInfo,
       })
@@ -1431,6 +1493,8 @@ describe("pickEnvironment", () => {
         artifactsPath,
         username,
         branch: "main",
+        loggedIn: true,
+        enterpriseDomain,
         secrets: {},
         commandInfo,
       })
@@ -1464,6 +1528,8 @@ describe("pickEnvironment", () => {
           artifactsPath,
           branch: "main",
           username,
+          loggedIn: true,
+          enterpriseDomain,
           secrets: {},
           commandInfo,
         }),
@@ -1495,6 +1561,8 @@ describe("pickEnvironment", () => {
           artifactsPath,
           branch: "main",
           username,
+          loggedIn: true,
+          enterpriseDomain,
           secrets: {},
           commandInfo,
         }),

--- a/core/test/unit/src/config/project.ts
+++ b/core/test/unit/src/config/project.ts
@@ -33,7 +33,6 @@ const enterpriseDomain = "https://garden.mydomain.com"
 const commandInfo = { name: "test", args: {}, opts: {} }
 
 describe("resolveProjectConfig", () => {
-
   it("should pass through a canonical project config", async () => {
     const defaultEnvironment = "default"
     const config: ProjectConfig = {

--- a/core/test/unit/src/config/template-contexts/project.ts
+++ b/core/test/unit/src/config/template-contexts/project.ts
@@ -11,6 +11,7 @@ import stripAnsi = require("strip-ansi")
 import { ConfigContext } from "../../../../../src/config/template-contexts/base"
 import { ProjectConfigContext } from "../../../../../src/config/template-contexts/project"
 import { resolveTemplateString } from "../../../../../src/template-string/template-string"
+import { deline } from "../../../../../src/util/string"
 
 type TestValue = string | ConfigContext | TestValues | TestValueFunction
 type TestValueFunction = () => TestValue | Promise<TestValue>
@@ -19,6 +20,8 @@ interface TestValues {
 }
 
 describe("ProjectConfigContext", () => {
+  const enterpriseDomain = "https://garden.mydomain.com"
+
   it("should resolve local env variables", () => {
     process.env.TEST_VARIABLE = "value"
     const c = new ProjectConfigContext({
@@ -27,6 +30,8 @@ describe("ProjectConfigContext", () => {
       artifactsPath: "/tmp",
       branch: "main",
       username: "some-user",
+      loggedIn: true,
+      enterpriseDomain,
       secrets: {},
       commandInfo: { name: "test", args: {}, opts: {} },
     })
@@ -43,6 +48,8 @@ describe("ProjectConfigContext", () => {
       artifactsPath: "/tmp",
       branch: "main",
       username: "some-user",
+      loggedIn: true,
+      enterpriseDomain,
       secrets: {},
       commandInfo: { name: "test", args: {}, opts: {} },
     })
@@ -51,18 +58,86 @@ describe("ProjectConfigContext", () => {
     })
   })
 
-  it("should resolve secrets", () => {
+  it("should resolve when logged in", () => {
     const c = new ProjectConfigContext({
       projectName: "some-project",
       projectRoot: "/tmp",
       artifactsPath: "/tmp",
       branch: "main",
       username: "some-user",
+      loggedIn: true,
+      enterpriseDomain,
       secrets: { foo: "banana" },
       commandInfo: { name: "test", args: {}, opts: {} },
     })
     expect(c.resolve({ key: ["secrets", "foo"], nodePath: [], opts: {} })).to.eql({
       resolved: "banana",
+    })
+  })
+
+  context("errors thrown when a missing secret is referenced", () => {
+    it("should ask the user to log in if they're logged out", () => {
+      const c = new ProjectConfigContext({
+        projectName: "some-project",
+        projectRoot: "/tmp",
+        artifactsPath: "/tmp",
+        branch: "main",
+        username: "some-user",
+        loggedIn: false, // <-----
+        enterpriseDomain,
+        secrets: { foo: "banana" },
+        commandInfo: { name: "test", args: {}, opts: {} },
+      })
+
+      const { message } = c.resolve({ key: ["secrets", "bar"], nodePath: [], opts: {} })
+
+      expect(stripAnsi(message!)).to.match(/Please log in via the garden login command to use Garden with secrets/)
+    })
+
+    context("when logged in", () => {
+      it("should notify the user if an empty set of secrets was returned by the backend", () => {
+        const c = new ProjectConfigContext({
+          projectName: "some-project",
+          projectRoot: "/tmp",
+          artifactsPath: "/tmp",
+          branch: "main",
+          username: "some-user",
+          loggedIn: true,
+          enterpriseDomain,
+          secrets: {}, // <-----
+          commandInfo: { name: "test", args: {}, opts: {} },
+        })
+
+        const { message } = c.resolve({ key: ["secrets", "bar"], nodePath: [], opts: {} })
+
+        const errMsg = deline`
+          Looks like no secrets have been created for this project and/or environment in Garden Enterprise.
+          To create secrets, please visit ${enterpriseDomain} and navigate to the secrets section for this project.
+        `
+        expect(stripAnsi(message!)).to.match(new RegExp(errMsg))
+      })
+
+      it("if a non-empty set of secrets was returned by the backend, provide a helpful suggestion", () => {
+        const c = new ProjectConfigContext({
+          projectName: "some-project",
+          projectRoot: "/tmp",
+          artifactsPath: "/tmp",
+          branch: "main",
+          username: "some-user",
+          loggedIn: true,
+          enterpriseDomain,
+          secrets: { foo: "banana " }, // <-----
+          commandInfo: { name: "test", args: {}, opts: {} },
+        })
+
+        const { message } = c.resolve({ key: ["secrets", "bar"], nodePath: [], opts: {} })
+
+        const errMsg = deline`
+          Please make sure that all required secrets for this project exist in Garden Enterprise, and are accessible in this
+          environment.
+        `
+        expect(stripAnsi(message!)).to.match(new RegExp(errMsg))
+      })
     })
   })
 
@@ -73,6 +148,8 @@ describe("ProjectConfigContext", () => {
       artifactsPath: "/tmp",
       branch: "main",
       username: "some-user",
+      loggedIn: true,
+      enterpriseDomain,
       secrets: {},
       commandInfo: { name: "test", args: {}, opts: {} },
     })
@@ -92,6 +169,8 @@ describe("ProjectConfigContext", () => {
       artifactsPath: "/tmp",
       branch: "main",
       username: "some-user",
+      loggedIn: true,
+      enterpriseDomain,
       secrets: {},
       commandInfo: { name: "test", args: {}, opts: {} },
     })
@@ -107,6 +186,8 @@ describe("ProjectConfigContext", () => {
       artifactsPath: "/tmp",
       branch: "main",
       username: "SomeUser",
+      loggedIn: true,
+      enterpriseDomain,
       secrets: {},
       commandInfo: { name: "test", args: {}, opts: {} },
     })
@@ -125,6 +206,8 @@ describe("ProjectConfigContext", () => {
       artifactsPath: "/tmp",
       branch: "main",
       username: "SomeUser",
+      loggedIn: true,
+      enterpriseDomain,
       secrets: {},
       commandInfo: { name: "test", args: {}, opts: {} },
     })
@@ -140,6 +223,8 @@ describe("ProjectConfigContext", () => {
       artifactsPath: "/tmp",
       branch: "main",
       username: "SomeUser",
+      loggedIn: true,
+      enterpriseDomain,
       secrets: {},
       commandInfo: { name: "deploy", args: {}, opts: { "hot-reload": ["my-service"] } },
     })
@@ -158,6 +243,8 @@ describe("ProjectConfigContext", () => {
       artifactsPath: "/tmp",
       branch: "main",
       username: "SomeUser",
+      loggedIn: true,
+      enterpriseDomain,
       secrets: {},
       commandInfo: { name: "test", args: {}, opts: {} },
     })

--- a/core/test/unit/src/enterprise/api.ts
+++ b/core/test/unit/src/enterprise/api.ts
@@ -59,7 +59,9 @@ describe("EnterpriseApi", () => {
           },
         ],
         async (token) => {
-          await EnterpriseApi.saveAuthToken(log, token)
+          try {
+            await EnterpriseApi.saveAuthToken(log, token)
+          } catch (err) {}
         }
       )
       const count = await ClientAuthToken.count()

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -1556,30 +1556,6 @@ describe("Garden", () => {
       await expectError(() => garden.resolveProviders(garden.log))
     })
 
-    it.skip("should throw if providers reference missing secrets in template strings", async () => {
-      const test = createGardenPlugin({
-        name: "test",
-      })
-
-      const projectConfig: ProjectConfig = {
-        apiVersion: "garden.io/v0",
-        kind: "Project",
-        name: "test",
-        path: projectRootA,
-        defaultEnvironment: "default",
-        dotIgnoreFiles: defaultDotIgnoreFiles,
-        environments: [{ name: "default", defaultNamespace, variables: {} }],
-        providers: [{ name: "test", foo: "${secrets.missing}" }], // < ------
-        variables: {},
-      }
-
-      const garden = await TestGarden.factory(projectRootA, { config: projectConfig, plugins: [test] })
-      await expectError(
-        () => garden.resolveProviders(garden.log),
-        (err) => expect(err.message).to.match(/Provider test: missing/)
-      )
-    })
-
     it("should add plugin modules if returned by the provider", async () => {
       const pluginModule: ModuleConfig = {
         apiVersion: DEFAULT_API_VERSION,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @solomonope.
-->

**What this PR does / why we need it**:

We now log more informative error messages when a missing secret is referenced, and when trying to fetch secrets for an environment that doesn't exist on the backend.

We also don't throw errors when fetching secrets for an environment that doesn't exist (but we do log additional information around this at the `debug` log level).

In addition to better handling of secret-related errors, this PR improves on the following:
* We now throw an error when a null client auth token / jwt is received from the backend during login. Previously, we were only logging an error, without indicating that the command had failed. The error message was also a bit cryptic.
* When workflow run registration fails due to CLI/backend API incompatibility (i.e. if the shape of the registration request isn't what the API expects), throw a better error, and include the failed request payload in the error detail.