### PR TITLE
feat: add one-way-replica as additional devMode.sync.mode

### DIFF
--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -178,7 +178,7 @@ const hotReloadConfigSchema = () =>
     with this module as their \`sourceModule\`.
   `)
 
-export type SyncMode = "one-way" | "two-way"
+export type SyncMode = "one-way" | "one-way-replica" | "two-way"
 
 export interface DevModeSyncSpec {
   source: string
@@ -196,7 +196,7 @@ const devModeSyncSchema = () =>
       .example(["dist/**/*", "*.log"]),
     mode: joi
       .string()
-      .allow("one-way", "two-way")
+      .allow("one-way", "one-way-replica", "two-way")
       .default("one-way")
       .description("The sync mode to use for the given paths."),
   })

--- a/core/src/plugins/kubernetes/dev-mode.ts
+++ b/core/src/plugins/kubernetes/dev-mode.ts
@@ -119,6 +119,7 @@ export function configureDevMode({ target, spec, containerName }: ConfigureDevMo
 
 const mutagenModeMap = {
   "one-way": "one-way-safe",
+  "one-way-replica": "one-way-replica",
   "two-way": "two-way-safe",
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds additional option for `devMode.sync.mode` `one-way-replica` that maps to same sync mode in `mutagen`.

The rationale is that for cases where `garden dev` is used to sync source code from developer's machine to remote container, the files are not always overwritten with `one-way` mode.

The reason is that `one-way` mode in `garden` maps to `one-way-safe` mode for `mutagen`, which by design does not overwrite files where the original contents of the file on one end does not match contents on the other end. This behavior is documented in [Modes](https://mutagen.io/documentation/synchronization#modes) section of `mutagen` documentation.

I was hesitant between having `one-way` default to `one-way-replica` as I think the `one-way-safe` mode is less useful, but I chose to create change that is less backwards incompatible. But I am open to changing the mapping of `one-way` from `one-way-safe` to `one-way-replica`.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:
