### PR TITLE
improvement(core): tweak log output during builds

### DIFF
--- a/core/src/tasks/build.ts
+++ b/core/src/tasks/build.ts
@@ -117,15 +117,6 @@ export class BuildTask extends BaseTask {
 
     let log: LogEntry
 
-    const logSuccess = () => {
-      if (log) {
-        log.setSuccess({
-          msg: chalk.green(`Done (took ${log.getDuration(1)} sec)`),
-          append: true,
-        })
-      }
-    }
-
     if (this.force) {
       log = this.log.info({
         section: this.getName(),
@@ -142,7 +133,10 @@ export class BuildTask extends BaseTask {
       const status = await actions.getBuildStatus({ log: this.log, module })
 
       if (status.ready) {
-        logSuccess()
+        log.setSuccess({
+          msg: chalk.green(`Already built`),
+          append: true,
+        })
         return { fresh: false }
       }
 
@@ -162,7 +156,10 @@ export class BuildTask extends BaseTask {
       throw err
     }
 
-    logSuccess()
+    log.setSuccess({
+      msg: chalk.green(`Done (took ${log.getDuration(1)} sec)`),
+      append: true,
+    })
     return result
   }
 }

--- a/core/src/tasks/stage-build.ts
+++ b/core/src/tasks/stage-build.ts
@@ -70,7 +70,7 @@ export class StageBuildTask extends BaseTask {
     let log: LogEntry | undefined = undefined
 
     if (this.module.version.files.length > 0) {
-      log = this.log.info({
+      log = this.log.verbose({
         section: this.getName(),
         msg: `Syncing module sources (${pluralize("file", this.module.version.files.length, true)})...`,
         status: "active",


### PR DESCRIPTION
Specifically, raised the level for "Syncing module sources..." and
added a touch more clarity when a module is found to be already built.