### PR TITLE
feat(container): allow specifying preferred local port for port-forwards

### DIFF
--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -59,6 +59,7 @@ export interface ServicePortSpec {
   name: string
   protocol: ServicePortProtocol
   containerPort: number
+  localPort?: number
   // Defaults to containerPort
   servicePort: number
   hostPort?: number
@@ -387,6 +388,15 @@ export const portSchema = () =>
         The service port maps to the container port:
 
         \`servicePort:80 -> containerPort:8080 -> process:8080\``),
+    localPort: joi
+      .number()
+      .example(10080)
+      .description(
+        dedent`
+        Specify a preferred local port to attach to when creating a port-forward to the service port. If this port is
+        busy, a warning will be shown and an alternative port chosen.
+        `
+      ),
     servicePort: joi
       .number()
       .default((context) => context.containerPort)

--- a/core/src/plugins/kubernetes/container/status.ts
+++ b/core/src/plugins/kubernetes/container/status.ts
@@ -65,6 +65,7 @@ export async function getContainerServiceStatus({
         name: p.name,
         protocol: "TCP",
         targetPort: p.servicePort,
+        preferredLocalPort: p.localPort,
         // TODO: this needs to be configurable
         // urlProtocol: "http",
       }

--- a/core/src/types/service.ts
+++ b/core/src/types/service.ts
@@ -157,6 +157,7 @@ export const serviceIngressSchema = () =>
 export interface ForwardablePort {
   name?: string
   // TODO: support other protocols
+  preferredLocalPort?: number
   protocol: "TCP"
   targetName?: string
   targetPort: number
@@ -167,6 +168,7 @@ export const forwardablePortKeys = () => ({
   name: joiIdentifier().description(
     "A descriptive name for the port. Should correspond to user-configured ports where applicable."
   ),
+  preferredLocalPort: joi.number().integer().description("The preferred local port to use for forwarding."),
   protocol: joi.string().allow("TCP").default("TCP").description("The protocol of the port."),
   targetName: joi.string().description("The target name/hostname to forward to (defaults to the service name)."),
   targetPort: joi.number().integer().required().description("The target port on the service."),

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -132,6 +132,9 @@ deployments:
       - # A descriptive name for the port. Should correspond to user-configured ports where applicable.
         name:
 
+        # The preferred local port to use for forwarding.
+        preferredLocalPort:
+
         # The protocol of the port.
         protocol:
 
@@ -485,6 +488,9 @@ serviceStatuses:
       - # A descriptive name for the port. Should correspond to user-configured ports where applicable.
         name:
 
+        # The preferred local port to use for forwarding.
+        preferredLocalPort:
+
         # The protocol of the port.
         protocol:
 
@@ -592,6 +598,9 @@ Examples:
   forwardablePorts:
     - # A descriptive name for the port. Should correspond to user-configured ports where applicable.
       name:
+
+      # The preferred local port to use for forwarding.
+      preferredLocalPort:
 
       # The protocol of the port.
       protocol:
@@ -751,6 +760,9 @@ deployments:
     forwardablePorts:
       - # A descriptive name for the port. Should correspond to user-configured ports where applicable.
         name:
+
+        # The preferred local port to use for forwarding.
+        preferredLocalPort:
 
         # The protocol of the port.
         protocol:
@@ -2351,6 +2363,9 @@ services:
       - # A descriptive name for the port. Should correspond to user-configured ports where applicable.
         name:
 
+        # The preferred local port to use for forwarding.
+        preferredLocalPort:
+
         # The protocol of the port.
         protocol:
 
@@ -2945,6 +2960,9 @@ deployments:
       - # A descriptive name for the port. Should correspond to user-configured ports where applicable.
         name:
 
+        # The preferred local port to use for forwarding.
+        preferredLocalPort:
+
         # The protocol of the port.
         protocol:
 
@@ -3509,6 +3527,9 @@ deployments:
     forwardablePorts:
       - # A descriptive name for the port. Should correspond to user-configured ports where applicable.
         name:
+
+        # The preferred local port to use for forwarding.
+        preferredLocalPort:
 
         # The protocol of the port.
         protocol:

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -340,6 +340,11 @@ services:
         # `servicePort:80 -> containerPort:8080 -> process:8080`
         containerPort:
 
+        # Specify a preferred local port to attach to when creating a port-forward to the service port. If this port
+        # is
+        # busy, a warning will be shown and an alternative port chosen.
+        localPort:
+
         # The port exposed on the service. Defaults to `containerPort` if not specified.
         # This is the port you use when calling a service from another service within the cluster. For example, if
         # your service name is my-service and the service port is 8090, you would call it with:
@@ -1554,6 +1559,25 @@ Example:
 services:
   - ports:
       - containerPort: 8080
+```
+
+### `services[].ports[].localPort`
+
+[services](#services) > [ports](#servicesports) > localPort
+
+Specify a preferred local port to attach to when creating a port-forward to the service port. If this port is
+busy, a warning will be shown and an alternative port chosen.
+
+| Type     | Required |
+| -------- | -------- |
+| `number` | No       |
+
+Example:
+
+```yaml
+services:
+  - ports:
+      - localPort: 10080
 ```
 
 ### `services[].ports[].servicePort`

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -338,6 +338,11 @@ services:
         # `servicePort:80 -> containerPort:8080 -> process:8080`
         containerPort:
 
+        # Specify a preferred local port to attach to when creating a port-forward to the service port. If this port
+        # is
+        # busy, a warning will be shown and an alternative port chosen.
+        localPort:
+
         # The port exposed on the service. Defaults to `containerPort` if not specified.
         # This is the port you use when calling a service from another service within the cluster. For example, if
         # your service name is my-service and the service port is 8090, you would call it with:
@@ -1562,6 +1567,25 @@ Example:
 services:
   - ports:
       - containerPort: 8080
+```
+
+### `services[].ports[].localPort`
+
+[services](#services) > [ports](#servicesports) > localPort
+
+Specify a preferred local port to attach to when creating a port-forward to the service port. If this port is
+busy, a warning will be shown and an alternative port chosen.
+
+| Type     | Required |
+| -------- | -------- |
+| `number` | No       |
+
+Example:
+
+```yaml
+services:
+  - ports:
+      - localPort: 10080
 ```
 
 ### `services[].ports[].servicePort`


### PR DESCRIPTION
This adds a `localPort` field to the `services[].ports` field, to make
it easier to control the local port used for port forwards. This is
handy for a variety of reasons, one of which is to have a predictable
port for debuggers.
