### PR TITLE
fix(k8s): rsync with destination-default perms

### DIFF
--- a/core/src/build-staging/rsync.ts
+++ b/core/src/build-staging/rsync.ts
@@ -117,7 +117,7 @@ export class BuildDirRsync extends BuildStaging {
       // Preserve owner + group
       "--owner",
       "--group",
-      // Copy permissions
+      // Preserve permissions
       "--perms",
       // Copy symlinks
       "--links",

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -44,11 +44,10 @@ export const commonSyncArgs = [
   "--recursive",
   // Copy symlinks (Note: These are sanitized while syncing to the build staging dir)
   "--links",
-  // Preserve permissions
-  "--perms",
   // Preserve modification times
   "--times",
   "--compress",
+  "--executability",
 ]
 
 export const builderToleration = {
@@ -93,7 +92,16 @@ export async function syncToBuildSync(params: SyncToSharedBuildSyncParams) {
   // https://stackoverflow.com/questions/1636889/rsync-how-can-i-configure-it-to-create-target-directory-on-server
   let src = normalizeLocalRsyncPath(`${buildRoot}`) + `/./${module.name}/`
   const destination = `rsync://localhost:${syncFwd.localPort}/volume/${ctx.workingCopyId}/`
-  const syncArgs = [...commonSyncArgs, "--relative", "--delete", "--temp-dir", "/tmp", src, destination]
+  const syncArgs = [
+    ...commonSyncArgs,
+    "--relative",
+    "--delete",
+    "--chown=user:user",
+    "--temp-dir",
+    "/tmp",
+    src,
+    destination,
+  ]
 
   log.debug(`Syncing from ${src} to ${destination}`)
   // We retry a couple of times, because we may get intermittent connection issues or concurrency issues

--- a/core/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/src/plugins/kubernetes/container/build/kaniko.ts
@@ -381,13 +381,21 @@ async function runKaniko({
             echo "Copying from ${sourceUrl} to ${contextPath}"
             mkdir -p ${contextPath}
             n=0
-            until [ "$n" -ge 30 ]
+            until [ "$n" -ge 20 ]
             do
-              rsync ${syncArgs.join(" ")} && break
+              rsync ${syncArgs.join(" ")} && echo "Done!" && exit 0
               n=$((n+1))
-              sleep 1
+              if [ "$n" -lt 20 ]
+                then
+                echo "----------------------------"
+                echo "Retrying ($n/20)..."
+                echo "----------------------------"
+                sleep 1
+              fi
             done
-            echo "Done!"
+            echo "----------------------------"
+            echo "Failed!"
+            exit 1
           `,
         ],
         imagePullPolicy: "IfNotPresent",

--- a/core/src/plugins/kubernetes/hot-reload/helpers.ts
+++ b/core/src/plugins/kubernetes/hot-reload/helpers.ts
@@ -294,9 +294,6 @@ export async function syncToService({ ctx, service, hotReloadSpec, namespace, wo
         "--compress",
         // Preserve modification times
         "--times",
-        // Preserve owner + group
-        "--owner",
-        "--group",
         // Copy permissions
         "--perms",
         // Set a temp directory outside of the target directory to avoid potential conflicts


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is an attempt to fix an issue some Windows users have encountered, where the build sync process would run into `rsync` errors because of permission errors.