### PR TITLE
feat(core): allow variables in remote sources

### DIFF
--- a/core/src/config/project.ts
+++ b/core/src/config/project.ts
@@ -418,16 +418,16 @@ export function resolveProjectConfig({
   secrets: PrimitiveMap
   commandInfo: CommandInfo
 }): ProjectConfig {
-  // Resolve template strings for non-environment-specific fields
-  const { environments = [], name } = config
+  // Resolve template strings for non-environment-specific fields (apart from `sources`).
+  const { environments = [], name, sources = [] } = config
 
   const globalConfig = resolveTemplateStrings(
     {
       apiVersion: config.apiVersion,
-      sources: config.sources,
       varfile: config.varfile,
       variables: config.variables,
       environments: [],
+      sources: [],
     },
     new ProjectConfigContext({
       projectName: name,
@@ -450,6 +450,7 @@ export function resolveProjectConfig({
       name,
       defaultEnvironment,
       environments: [],
+      sources: [],
     },
     schema: projectSchema(),
     configType: "project",
@@ -477,6 +478,7 @@ export function resolveProjectConfig({
     ...config,
     environments: config.environments || [],
     providers,
+    sources,
   }
 
   config.defaultEnvironment = getDefaultEnvironmentName(defaultEnvironment, config)

--- a/core/src/config/template-contexts/workflow.ts
+++ b/core/src/config/template-contexts/workflow.ts
@@ -10,46 +10,13 @@ import { joiIdentifierMap, DeepPrimitiveMap, joiVariables } from "../common"
 import { Garden } from "../../garden"
 import { joi } from "../common"
 import { dedent } from "../../util/string"
-import { EnvironmentConfigContext } from "./project"
-import { schema, EnvironmentContext, ConfigContext, ErrorContext } from "./base"
+import { RemoteSourceConfigContext } from "./project"
+import { schema, ConfigContext, ErrorContext } from "./base"
 
 /**
  * This context is available for template strings in all workflow config fields except `name` and `triggers[]`.
  */
-export class WorkflowConfigContext extends EnvironmentConfigContext {
-  @schema(
-    EnvironmentContext.getSchema().description("Information about the environment that Garden is running against.")
-  )
-  public environment: EnvironmentContext
-
-  // Overriding to update the description. Same schema as base.
-  @schema(
-    joiVariables()
-      .description(
-        "A map of all variables defined in the project configuration, including environment-specific variables."
-      )
-      .meta({ keyPlaceholder: "<variable-name>" })
-  )
-  public variables: DeepPrimitiveMap
-
-  constructor(garden: Garden) {
-    super({
-      projectName: garden.projectName,
-      projectRoot: garden.projectRoot,
-      artifactsPath: garden.artifactsPath,
-      branch: garden.vcsBranch,
-      username: garden.username,
-      variables: garden.variables,
-      loggedIn: !!garden.enterpriseApi,
-      enterpriseDomain: garden.enterpriseApi?.domain,
-      secrets: garden.secrets,
-      commandInfo: garden.commandInfo,
-    })
-
-    const fullEnvName = garden.namespace ? `${garden.namespace}.${garden.environmentName}` : garden.environmentName
-    this.environment = new EnvironmentContext(this, garden.environmentName, fullEnvName, garden.namespace)
-  }
-}
+export class WorkflowConfigContext extends RemoteSourceConfigContext {}
 
 class WorkflowStepContext extends ConfigContext {
   @schema(joi.string().description("The full output log from the step."))

--- a/core/src/docs/template-strings.ts
+++ b/core/src/docs/template-strings.ts
@@ -11,7 +11,11 @@ import { TEMPLATES_DIR, renderTemplateStringReference } from "./config"
 import { readFileSync, writeFileSync } from "fs"
 import handlebars from "handlebars"
 import { GARDEN_CORE_ROOT } from "../constants"
-import { ProjectConfigContext, EnvironmentConfigContext } from "../config/template-contexts/project"
+import {
+  ProjectConfigContext,
+  EnvironmentConfigContext,
+  RemoteSourceConfigContext,
+} from "../config/template-contexts/project"
 import { ProviderConfigContext } from "../config/template-contexts/provider"
 import { ModuleConfigContext, OutputConfigContext } from "../config/template-contexts/module"
 import { WorkflowStepConfigContext } from "../config/template-contexts/workflow"
@@ -26,12 +30,16 @@ export function writeTemplateStringReferenceDocs(docsRoot: string) {
     schema: ProjectConfigContext.getSchema().required(),
   })
 
-  const providerContext = renderTemplateStringReference({
-    schema: ProviderConfigContext.getSchema().required(),
+  const remoteSourceContext = renderTemplateStringReference({
+    schema: RemoteSourceConfigContext.getSchema().required(),
   })
 
   const environmentContext = renderTemplateStringReference({
     schema: EnvironmentConfigContext.getSchema().required(),
+  })
+
+  const providerContext = renderTemplateStringReference({
+    schema: ProviderConfigContext.getSchema().required(),
   })
 
   const moduleContext = renderTemplateStringReference({
@@ -51,6 +59,7 @@ export function writeTemplateStringReferenceDocs(docsRoot: string) {
   const markdown = template({
     helperFunctions: sortBy(Object.values(helperFunctions), "name"),
     projectContext,
+    remoteSourceContext,
     environmentContext,
     providerContext,
     moduleContext,

--- a/docs/reference/template-strings.md
+++ b/docs/reference/template-strings.md
@@ -374,6 +374,287 @@ The secret's value.
 | `string` |
 
 
+## Remote source configuration context
+
+The following keys are available in template strings under the `sources` key in project configs.
+
+### `${local.*}`
+
+Context variables that are specific to the currently running environment/machine.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${local.artifactsPath}`
+
+The absolute path to the directory where exported artifacts from test and task runs are stored.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.artifactsPath}
+```
+
+### `${local.env.*}`
+
+A map of all local environment variables (see https://nodejs.org/api/process.html#process_process_env).
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${local.env.<env-var-name>}`
+
+The environment variable value.
+
+| Type     |
+| -------- |
+| `string` |
+
+### `${local.platform}`
+
+A string indicating the platform that the framework is running on (see https://nodejs.org/api/process.html#process_process_platform)
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.platform}
+```
+
+### `${local.projectPath}`
+
+The absolute path to the project root directory.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.projectPath}
+```
+
+### `${local.username}`
+
+The current username (as resolved by https://github.com/sindresorhus/username).
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.username}
+```
+
+### `${local.usernameLowerCase}`
+
+The current username (as resolved by https://github.com/sindresorhus/username), with any upper case characters converted to lower case.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.usernameLowerCase}
+```
+
+### `${command.*}`
+
+Information about the currently running command and its arguments.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${command.name}`
+
+The currently running Garden CLI command, without positional arguments or option flags. This can be handy to e.g. change some variables based on whether you're running `garden test` or some other specific command.
+
+Note that this will currently always resolve to `"run workflow"` when running Workflows, as opposed to individual workflow step commands. This may be revisited at a later time, but currently all configuration is resolved once for all workflow steps.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${command.name}
+```
+
+### `${command.params.*}`
+
+A map of all parameters set when calling the current command. This includes both positional arguments and option flags, and includes any default values set by the framework or specific command. This can be powerful if used right, but do take care since different parameters are only available in certain commands, some have array values etc.
+
+For example, to see if a service is in hot-reload mode, you might do something like `${command.params contains 'hot-reload' && command.params.hot-reload contains 'my-service'}`. Notice that you currently need to check both for the existence of the parameter, and also to correctly handle the array value.
+
+Option values can be referenced by the option's default name (e.g. `dev-mode`) or its alias (e.g. `dev`) if one is defined for that option.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${command.params.<name>}`
+
+| Type  |
+| ----- |
+| `any` |
+
+### `${project.*}`
+
+Information about the Garden project.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${project.name}`
+
+The name of the Garden project.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${project.name}
+```
+
+### `${git.*}`
+
+Information about the current state of the project's local git repository.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${git.branch}`
+
+The current Git branch, if available. Resolves to an empty string if HEAD is in a detached state
+(e.g. when rebasing), or if the repository has no commits.
+
+When using remote sources, the branch used is that of the project/top-level repository (the one that contains
+the project configuration).
+
+The branch is computed at the start of the Garden command's execution, and is not updated if the current
+branch changes during the command's execution (which could happen, for example, when using watch-mode
+commands).
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${git.branch}
+```
+
+### `${secrets.<secret-name>}`
+
+The secret's value.
+
+| Type     |
+| -------- |
+| `string` |
+
+### `${variables.*}`
+
+A map of all variables defined in the project configuration, including environment-specific variables.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${variables.<variable-name>}`
+
+| Type                                             |
+| ------------------------------------------------ |
+| `string | number | boolean | link | array[link]` |
+
+### `${var.*}`
+
+Alias for the variables field.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${var.<name>}`
+
+Number, string or boolean
+
+| Type                        |
+| --------------------------- |
+| `string | number | boolean` |
+
+### `${environment.*}`
+
+Information about the environment that Garden is running against.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${environment.name}`
+
+The name of the environment Garden is running against, excluding the namespace.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${environment.name}
+```
+
+### `${environment.fullName}`
+
+The full name of the environment Garden is running against, including the namespace.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${environment.fullName}
+```
+
+### `${environment.namespace}`
+
+The currently active namespace (if any).
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${environment.namespace}
+```
+
+
 ## Environment configuration context
 
 The following keys are available in template strings under the `environments` key in project configs. Additional keys are available for the `environments[].providers` field, see the [Provider](#provider-configuration-context) section below for those.
@@ -607,7 +888,7 @@ Number, string or boolean
 
 ## Provider configuration context
 
-The following keys are available in template strings under the `providers` key (or `environments[].providers) in project configs.
+The following keys are available in template strings under the `providers` key (or `environments[].providers`) in project configs.
 
 Providers can also reference outputs defined by other providers, via the `${providers.<provider-name>.outputs}` key. For details on which outputs are available for a given provider, please refer to the [reference](https://docs.garden.io/reference/providers) docs for the provider in question, and look for the _Outputs_ section.
 

--- a/static/docs/templates/template-strings.hbs
+++ b/static/docs/templates/template-strings.hbs
@@ -29,6 +29,11 @@ Examples:
 The following keys are available in any template strings within project definitions in `garden.yml` config files, except the `name` field (which cannot be templated). See the [Environment](#environment-configuration-context) and [Provider](#provider-configuration-context) sections below for additional keys available when configuring `environments` and `providers`, respectively.
 {{{projectContext}}}
 
+## Remote source configuration context
+
+The following keys are available in template strings under the `sources` key in project configs.
+{{{remoteSourceContext}}}
+
 ## Environment configuration context
 
 The following keys are available in template strings under the `environments` key in project configs. Additional keys are available for the `environments[].providers` field, see the [Provider](#provider-configuration-context) section below for those.
@@ -36,7 +41,7 @@ The following keys are available in template strings under the `environments` k
 
 ## Provider configuration context
 
-The following keys are available in template strings under the `providers` key (or `environments[].providers) in project configs.
+The following keys are available in template strings under the `providers` key (or `environments[].providers`) in project configs.
 
 Providers can also reference outputs defined by other providers, via the `${providers.<provider-name>.outputs}` key. For details on which outputs are available for a given provider, please refer to the [reference](https://docs.garden.io/reference/providers) docs for the provider in question, and look for the _Outputs_ section.
 {{{providerContext}}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

Template strings in remote sources now have access to the same variables as provider configs.

This adds flexibility when using remote sources in conjunction with automation (e.g. when using dynamic Git branches / tags for remote sources, depending on project- and environment-level variables).

**Which issue(s) this PR fixes**:

Fixes #2436.

**Special notes for your reviewer**:

Previously, referencing `${var.*}` in remote sources would result in a template string error, since remote sources were being resolved at the same time as the top-level project config (which is before project- and environment-level variables are resolved).

We now only resolve template strings in remote sources on demand, when `getProjectSources` are called. Is this a good approach, or should we do this as part of the main init flow of the `Garden` class?