### PR TITLE
fix(core): support git 2.32.0

### DIFF
--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -127,7 +127,7 @@ export class GitHandler extends VcsHandler {
     // to make sure the path handling is consistent with normal POSIX-style globs used generally by Garden.
     // Note: We unfortunately can't exclude at this level because it simply doesn't work in git, for reasons unknown.
     const patterns = [...(include || []).map((p) => ":(glob)" + p)]
-    const lsFilesCommonArgs = ["--exclude", this.gardenDirPath]
+    const lsFilesCommonArgs = ["--cached", "--exclude", this.gardenDirPath]
 
     // List tracked but ignored files (we currently exclude those as well, so we need to query that specially)
     // TODO: change in 0.13 to no longer exclude these


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

In a recent minor version update of Git, either the `--cache` or the `--other` flag has to be passed when using the `--ignore` flag.

The `--cache` flag (on by default) is now explicitly passed in the relevant calls to `git ls-files`.

**Which issue(s) this PR fixes**:

Fixes #2426.