### PR TITLE
feat(core): local targets for build dependencies

### DIFF
--- a/core/src/config/module.ts
+++ b/core/src/config/module.ts
@@ -27,6 +27,7 @@ import { templateKind } from "./module-template"
 export interface BuildCopySpec {
   source: string
   target: string
+  copyToSourceDir: boolean
 }
 
 // TODO: allow : delimited string (e.g. some.file:some-dir/)
@@ -41,9 +42,18 @@ const copySchema = () =>
       .required()
       .description("POSIX-style path or filename of the directory or file(s) to copy to the target."),
     target: joi.posixPath().subPathOnly().default("").description(dedent`
-        POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
-        Defaults to to same as source path.
+        POSIX-style path or filename to copy the directory or file(s), relative to the build directory (or the module
+        source directory if \`copyToSourceDir = true\`). Defaults to to same as source path.
       `),
+    copyToSourceDir: joi
+      .boolean()
+      .description(
+        dedent`
+          If set to true, Garden will copy the directory or file(s) to the module source directory, instead of the
+          Garden build directory (under \`.garden/build/<module-name>\`).
+        `
+      )
+      .default(false),
   })
 
 export interface BuildDependencyConfig {

--- a/core/src/plugins/exec.ts
+++ b/core/src/plugins/exec.ts
@@ -38,7 +38,7 @@ import { RunModuleParams } from "../types/plugin/module/runModule"
 import { RunResult } from "../types/plugin/base"
 
 const execPathDoc = dedent`
-  By default, the command is run inside the Garden build directory (under .garden/build/<module-name>).
+  By default, the command is run inside the Garden build directory (under \`.garden/build/<module-name>\`).
   If the top level \`local\` directive is set to \`true\`, the command runs in the module source directory instead.
 `
 
@@ -196,7 +196,7 @@ export const execModuleSpecSchema = () =>
         .description(
           dedent`
           If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
-          instead of in the Garden build directory (under .garden/build/<module-name>).
+          instead of in the Garden build directory (under \`.garden/build/<module-name>\`).
 
           Garden will therefore not stage the build for local exec modules. This means that include/exclude filters
           and ignore files are not applied to local exec modules.

--- a/core/src/plugins/kubernetes/helm/config.ts
+++ b/core/src/plugins/kubernetes/helm/config.ts
@@ -260,7 +260,7 @@ export async function configureHelmModule({
     }
 
     // We copy the chart on build
-    moduleConfig.build.dependencies.push({ name: base, copy: [{ source: "*", target: "." }] })
+    moduleConfig.build.dependencies.push({ name: base, copy: [{ source: "*", target: ".", copyToSourceDir: false }] })
   }
 
   moduleConfig.buildConfig = omit(moduleConfig.spec, [

--- a/core/src/plugins/local/local-google-cloud-functions.ts
+++ b/core/src/plugins/local/local-google-cloud-functions.ts
@@ -128,6 +128,7 @@ export const gardenPlugin = () =>
                     {
                       source: "child/Dockerfile",
                       target: "Dockerfile",
+                      copyToSourceDir: false,
                     },
                   ],
                 },

--- a/core/test/data/test-projects/build-dir/module-f/garden.yml
+++ b/core/test/data/test-projects/build-dir/module-f/garden.yml
@@ -14,3 +14,4 @@ build:
           target: e/
         - source: some-dir/e2.txt
           target: e/build/
+          copyToSourceDir: true

--- a/core/test/unit/src/actions.ts
+++ b/core/test/unit/src/actions.ts
@@ -242,10 +242,10 @@ describe("ActionRouter", () => {
           ...moduleConfigA,
           build: {
             dependencies: [
-              { name: "module-b", copy: [{ source: "1", target: "1" }] },
-              { name: "module-b", copy: [{ source: "2", target: "2" }] },
-              { name: "module-b", copy: [{ source: "2", target: "2" }] },
-              { name: "module-c", copy: [{ source: "3", target: "3" }] },
+              { name: "module-b", copy: [{ source: "1", target: "1", copyToSourceDir: false }] },
+              { name: "module-b", copy: [{ source: "2", target: "2", copyToSourceDir: false }] },
+              { name: "module-b", copy: [{ source: "2", target: "2", copyToSourceDir: false }] },
+              { name: "module-c", copy: [{ source: "3", target: "3", copyToSourceDir: false }] },
             ],
           },
         }
@@ -255,13 +255,13 @@ describe("ActionRouter", () => {
           {
             name: "module-b",
             copy: [
-              { source: "1", target: "1" },
-              { source: "2", target: "2" },
+              { source: "1", target: "1", copyToSourceDir: false },
+              { source: "2", target: "2", copyToSourceDir: false },
             ],
           },
           {
             name: "module-c",
-            copy: [{ source: "3", target: "3" }],
+            copy: [{ source: "3", target: "3", copyToSourceDir: false }],
           },
         ])
       })

--- a/core/test/unit/src/build-staging/build-staging.ts
+++ b/core/test/unit/src/build-staging/build-staging.ts
@@ -283,6 +283,7 @@ export function commonSyncTests(legacyBuildSync: boolean) {
       const moduleF = await garden.resolveModule("module-f")
       const buildDirD = await buildStaging.buildPath(moduleD)
       const buildDirF = await buildStaging.buildPath(moduleF)
+      const moduleDirF = moduleF.path
 
       // All these destinations should be populated now.
       const buildProductDestinations = [
@@ -291,7 +292,9 @@ export function commonSyncTests(legacyBuildSync: boolean) {
         join(buildDirD, "b", "build_subdir", "b2.txt"),
         join(buildDirF, "d", "build", "d.txt"),
         join(buildDirF, "e", "e1.txt"),
-        join(buildDirF, "e", "build", "e2.txt"),
+
+        // This build dependency uses `copyToSourceDir = true` in its `copy` spec.
+        join(moduleDirF, "e", "build", "e2.txt"),
       ]
 
       for (const p of buildProductDestinations) {
@@ -307,6 +310,10 @@ export function commonSyncTests(legacyBuildSync: boolean) {
       throw e
     }
   })
+
+  // it("should sync dependency products to their specified destinations when using local target", async () => {
+  //   throw new Error("TODO")
+  // })
 
   describe("buildPath", () => {
     it("should ensure the build path and return it", async () => {

--- a/core/test/unit/src/docs/config.ts
+++ b/core/test/unit/src/docs/config.ts
@@ -257,6 +257,7 @@ describe("docs config module", () => {
             copy:
               - source:
                 target: ''
+                copyToSourceDir: false
       `)
     })
 

--- a/core/test/unit/src/plugins/exec.ts
+++ b/core/test/unit/src/plugins/exec.ts
@@ -375,6 +375,7 @@ describe("exec plugin", () => {
                 {
                   source: ".",
                   target: ".",
+                  copyToSourceDir: false,
                 },
               ],
             },

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1283,9 +1283,15 @@ providers:
                 - # POSIX-style path or filename of the directory or file(s) to copy to the target.
                   source:
 
-                  # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
-                  # Defaults to to same as source path.
+                  # POSIX-style path or filename to copy the directory or file(s), relative to the build directory (or
+                  # the module
+                  # source directory if `copyToSourceDir = true`). Defaults to to same as source path.
                   target:
+
+                  # If set to true, Garden will copy the directory or file(s) to the module source directory, instead
+                  # of the
+                  # Garden build directory (under `.garden/build/<module-name>`).
+                  copyToSourceDir:
 
         # A description of the module.
         description:
@@ -1550,9 +1556,15 @@ moduleConfigs:
             - # POSIX-style path or filename of the directory or file(s) to copy to the target.
               source:
 
-              # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
-              # Defaults to to same as source path.
+              # POSIX-style path or filename to copy the directory or file(s), relative to the build directory (or the
+              # module
+              # source directory if `copyToSourceDir = true`). Defaults to to same as source path.
               target:
+
+              # If set to true, Garden will copy the directory or file(s) to the module source directory, instead of
+              # the
+              # Garden build directory (under `.garden/build/<module-name>`).
+              copyToSourceDir:
 
     # A description of the module.
     description:
@@ -2048,9 +2060,15 @@ modules:
             - # POSIX-style path or filename of the directory or file(s) to copy to the target.
               source:
 
-              # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
-              # Defaults to to same as source path.
+              # POSIX-style path or filename to copy the directory or file(s), relative to the build directory (or the
+              # module
+              # source directory if `copyToSourceDir = true`). Defaults to to same as source path.
               target:
+
+              # If set to true, Garden will copy the directory or file(s) to the module source directory, instead of
+              # the
+              # Garden build directory (under `.garden/build/<module-name>`).
+              copyToSourceDir:
 
     # A description of the module.
     description:

--- a/docs/reference/module-template-config.md
+++ b/docs/reference/module-template-config.md
@@ -69,9 +69,15 @@ modules:
             - # POSIX-style path or filename of the directory or file(s) to copy to the target.
               source:
 
-              # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
-              # Defaults to to same as source path.
+              # POSIX-style path or filename to copy the directory or file(s), relative to the build directory (or the
+              # module
+              # source directory if `copyToSourceDir = true`). Defaults to to same as source path.
               target: ''
+
+              # If set to true, Garden will copy the directory or file(s) to the module source directory, instead of
+              # the
+              # Garden build directory (under `.garden/build/<module-name>`).
+              copyToSourceDir: false
 
     # A description of the module.
     description:
@@ -313,12 +319,23 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 
 [modules](#modules) > [build](#modulesbuild) > [dependencies](#modulesbuilddependencies) > [copy](#modulesbuilddependenciescopy) > target
 
-POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
-Defaults to to same as source path.
+POSIX-style path or filename to copy the directory or file(s), relative to the build directory (or the module
+source directory if `copyToSourceDir = true`). Defaults to to same as source path.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |
 | `posixPath` | `""`    | No       |
+
+### `modules[].build.dependencies[].copy[].copyToSourceDir`
+
+[modules](#modules) > [build](#modulesbuild) > [dependencies](#modulesbuilddependencies) > [copy](#modulesbuilddependenciescopy) > copyToSourceDir
+
+If set to true, Garden will copy the directory or file(s) to the module source directory, instead of the
+Garden build directory (under `.garden/build/<module-name>`).
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `modules[].description`
 

--- a/docs/reference/module-types/conftest.md
+++ b/docs/reference/module-types/conftest.md
@@ -49,9 +49,14 @@ build:
         - # POSIX-style path or filename of the directory or file(s) to copy to the target.
           source:
 
-          # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
-          # Defaults to to same as source path.
+          # POSIX-style path or filename to copy the directory or file(s), relative to the build directory (or the
+          # module
+          # source directory if `copyToSourceDir = true`). Defaults to to same as source path.
           target: ''
+
+          # If set to true, Garden will copy the directory or file(s) to the module source directory, instead of the
+          # Garden build directory (under `.garden/build/<module-name>`).
+          copyToSourceDir: false
 
 # A description of the module.
 description:
@@ -249,12 +254,23 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 
 [build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > target
 
-POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
-Defaults to to same as source path.
+POSIX-style path or filename to copy the directory or file(s), relative to the build directory (or the module
+source directory if `copyToSourceDir = true`). Defaults to to same as source path.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |
 | `posixPath` | `""`    | No       |
+
+### `build.dependencies[].copy[].copyToSourceDir`
+
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > copyToSourceDir
+
+If set to true, Garden will copy the directory or file(s) to the module source directory, instead of the
+Garden build directory (under `.garden/build/<module-name>`).
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `description`
 

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -50,9 +50,14 @@ build:
         - # POSIX-style path or filename of the directory or file(s) to copy to the target.
           source:
 
-          # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
-          # Defaults to to same as source path.
+          # POSIX-style path or filename to copy the directory or file(s), relative to the build directory (or the
+          # module
+          # source directory if `copyToSourceDir = true`). Defaults to to same as source path.
           target: ''
+
+          # If set to true, Garden will copy the directory or file(s) to the module source directory, instead of the
+          # Garden build directory (under `.garden/build/<module-name>`).
+          copyToSourceDir: false
 
   # For multi-stage Dockerfiles, specify which image to build (see
   # https://docs.docker.com/engine/reference/commandline/build/#specifying-target-build-stage---target for details).
@@ -694,12 +699,23 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 
 [build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > target
 
-POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
-Defaults to to same as source path.
+POSIX-style path or filename to copy the directory or file(s), relative to the build directory (or the module
+source directory if `copyToSourceDir = true`). Defaults to to same as source path.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |
 | `posixPath` | `""`    | No       |
+
+### `build.dependencies[].copy[].copyToSourceDir`
+
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > copyToSourceDir
+
+If set to true, Garden will copy the directory or file(s) to the module source directory, instead of the
+Garden build directory (under `.garden/build/<module-name>`).
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `build.targetImage`
 

--- a/docs/reference/module-types/exec.md
+++ b/docs/reference/module-types/exec.md
@@ -53,13 +53,18 @@ build:
         - # POSIX-style path or filename of the directory or file(s) to copy to the target.
           source:
 
-          # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
-          # Defaults to to same as source path.
+          # POSIX-style path or filename to copy the directory or file(s), relative to the build directory (or the
+          # module
+          # source directory if `copyToSourceDir = true`). Defaults to to same as source path.
           target: ''
+
+          # If set to true, Garden will copy the directory or file(s) to the module source directory, instead of the
+          # Garden build directory (under `.garden/build/<module-name>`).
+          copyToSourceDir: false
 
   # The command to run to perform the build.
   #
-  # By default, the command is run inside the Garden build directory (under .garden/build/<module-name>).
+  # By default, the command is run inside the Garden build directory (under `.garden/build/<module-name>`).
   # If the top level `local` directive is set to `true`, the command runs in the module source directory instead.
   command: []
 
@@ -136,7 +141,7 @@ generateFiles:
     value:
 
 # If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
-# instead of in the Garden build directory (under .garden/build/<module-name>).
+# instead of in the Garden build directory (under `.garden/build/<module-name>`).
 #
 # Garden will therefore not stage the build for local exec modules. This means that include/exclude filters
 # and ignore files are not applied to local exec modules.
@@ -172,7 +177,7 @@ services:
 
     # The command to run to deploy the service.
     #
-    # By default, the command is run inside the Garden build directory (under .garden/build/<module-name>).
+    # By default, the command is run inside the Garden build directory (under `.garden/build/<module-name>`).
     # If the top level `local` directive is set to `true`, the command runs in the module source directory instead.
     deployCommand:
 
@@ -183,13 +188,13 @@ services:
     # If this is not specified, the service is always reported as "unknown", so it's highly recommended to specify
     # this command if possible.
     #
-    # By default, the command is run inside the Garden build directory (under .garden/build/<module-name>).
+    # By default, the command is run inside the Garden build directory (under `.garden/build/<module-name>`).
     # If the top level `local` directive is set to `true`, the command runs in the module source directory instead.
     statusCommand:
 
     # Optionally set a command to clean the service up, e.g. when running `garden delete env`.
     #
-    # By default, the command is run inside the Garden build directory (under .garden/build/<module-name>).
+    # By default, the command is run inside the Garden build directory (under `.garden/build/<module-name>`).
     # If the top level `local` directive is set to `true`, the command runs in the module source directory instead.
     cleanupCommand:
 
@@ -235,7 +240,7 @@ tasks:
 
     # The command to run.
     #
-    # By default, the command is run inside the Garden build directory (under .garden/build/<module-name>).
+    # By default, the command is run inside the Garden build directory (under `.garden/build/<module-name>`).
     # If the top level `local` directive is set to `true`, the command runs in the module source directory instead.
     command:
 
@@ -262,7 +267,7 @@ tests:
 
     # The command to run to test the module.
     #
-    # By default, the command is run inside the Garden build directory (under .garden/build/<module-name>).
+    # By default, the command is run inside the Garden build directory (under `.garden/build/<module-name>`).
     # If the top level `local` directive is set to `true`, the command runs in the module source directory instead.
     command:
 
@@ -384,12 +389,23 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 
 [build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > target
 
-POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
-Defaults to to same as source path.
+POSIX-style path or filename to copy the directory or file(s), relative to the build directory (or the module
+source directory if `copyToSourceDir = true`). Defaults to to same as source path.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |
 | `posixPath` | `""`    | No       |
+
+### `build.dependencies[].copy[].copyToSourceDir`
+
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > copyToSourceDir
+
+If set to true, Garden will copy the directory or file(s) to the module source directory, instead of the
+Garden build directory (under `.garden/build/<module-name>`).
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `build.command[]`
 
@@ -397,7 +413,7 @@ Defaults to to same as source path.
 
 The command to run to perform the build.
 
-By default, the command is run inside the Garden build directory (under .garden/build/<module-name>).
+By default, the command is run inside the Garden build directory (under `.garden/build/<module-name>`).
 If the top level `local` directive is set to `true`, the command runs in the module source directory instead.
 
 | Type            | Default | Required |
@@ -543,7 +559,7 @@ The desired file contents as a string.
 ### `local`
 
 If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
-instead of in the Garden build directory (under .garden/build/<module-name>).
+instead of in the Garden build directory (under `.garden/build/<module-name>`).
 
 Garden will therefore not stage the build for local exec modules. This means that include/exclude filters
 and ignore files are not applied to local exec modules.
@@ -608,7 +624,7 @@ Note however that template strings referencing the service's outputs (i.e. runti
 
 The command to run to deploy the service.
 
-By default, the command is run inside the Garden build directory (under .garden/build/<module-name>).
+By default, the command is run inside the Garden build directory (under `.garden/build/<module-name>`).
 If the top level `local` directive is set to `true`, the command runs in the module source directory instead.
 
 | Type            | Required |
@@ -626,7 +642,7 @@ already deployed and the `deployCommand` is not run.
 If this is not specified, the service is always reported as "unknown", so it's highly recommended to specify
 this command if possible.
 
-By default, the command is run inside the Garden build directory (under .garden/build/<module-name>).
+By default, the command is run inside the Garden build directory (under `.garden/build/<module-name>`).
 If the top level `local` directive is set to `true`, the command runs in the module source directory instead.
 
 | Type            | Required |
@@ -639,7 +655,7 @@ If the top level `local` directive is set to `true`, the command runs in the mod
 
 Optionally set a command to clean the service up, e.g. when running `garden delete env`.
 
-By default, the command is run inside the Garden build directory (under .garden/build/<module-name>).
+By default, the command is run inside the Garden build directory (under `.garden/build/<module-name>`).
 If the top level `local` directive is set to `true`, the command runs in the module source directory instead.
 
 | Type            | Required |
@@ -754,7 +770,7 @@ A POSIX-style path to copy the artifacts to, relative to the project artifacts d
 
 The command to run.
 
-By default, the command is run inside the Garden build directory (under .garden/build/<module-name>).
+By default, the command is run inside the Garden build directory (under `.garden/build/<module-name>`).
 If the top level `local` directive is set to `true`, the command runs in the module source directory instead.
 
 | Type            | Required |
@@ -828,7 +844,7 @@ Maximum duration (in seconds) of the test run.
 
 The command to run to test the module.
 
-By default, the command is run inside the Garden build directory (under .garden/build/<module-name>).
+By default, the command is run inside the Garden build directory (under `.garden/build/<module-name>`).
 If the top level `local` directive is set to `true`, the command runs in the module source directory instead.
 
 | Type            | Required |

--- a/docs/reference/module-types/hadolint.md
+++ b/docs/reference/module-types/hadolint.md
@@ -52,9 +52,14 @@ build:
         - # POSIX-style path or filename of the directory or file(s) to copy to the target.
           source:
 
-          # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
-          # Defaults to to same as source path.
+          # POSIX-style path or filename to copy the directory or file(s), relative to the build directory (or the
+          # module
+          # source directory if `copyToSourceDir = true`). Defaults to to same as source path.
           target: ''
+
+          # If set to true, Garden will copy the directory or file(s) to the module source directory, instead of the
+          # Garden build directory (under `.garden/build/<module-name>`).
+          copyToSourceDir: false
 
 # A description of the module.
 description:
@@ -237,12 +242,23 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 
 [build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > target
 
-POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
-Defaults to to same as source path.
+POSIX-style path or filename to copy the directory or file(s), relative to the build directory (or the module
+source directory if `copyToSourceDir = true`). Defaults to to same as source path.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |
 | `posixPath` | `""`    | No       |
+
+### `build.dependencies[].copy[].copyToSourceDir`
+
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > copyToSourceDir
+
+If set to true, Garden will copy the directory or file(s) to the module source directory, instead of the
+Garden build directory (under `.garden/build/<module-name>`).
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `description`
 

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -45,9 +45,14 @@ build:
         - # POSIX-style path or filename of the directory or file(s) to copy to the target.
           source:
 
-          # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
-          # Defaults to to same as source path.
+          # POSIX-style path or filename to copy the directory or file(s), relative to the build directory (or the
+          # module
+          # source directory if `copyToSourceDir = true`). Defaults to to same as source path.
           target: ''
+
+          # If set to true, Garden will copy the directory or file(s) to the module source directory, instead of the
+          # Garden build directory (under `.garden/build/<module-name>`).
+          copyToSourceDir: false
 
 # A description of the module.
 description:
@@ -571,12 +576,23 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 
 [build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > target
 
-POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
-Defaults to to same as source path.
+POSIX-style path or filename to copy the directory or file(s), relative to the build directory (or the module
+source directory if `copyToSourceDir = true`). Defaults to to same as source path.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |
 | `posixPath` | `""`    | No       |
+
+### `build.dependencies[].copy[].copyToSourceDir`
+
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > copyToSourceDir
+
+If set to true, Garden will copy the directory or file(s) to the module source directory, instead of the
+Garden build directory (under `.garden/build/<module-name>`).
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `description`
 

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -52,9 +52,14 @@ build:
         - # POSIX-style path or filename of the directory or file(s) to copy to the target.
           source:
 
-          # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
-          # Defaults to to same as source path.
+          # POSIX-style path or filename to copy the directory or file(s), relative to the build directory (or the
+          # module
+          # source directory if `copyToSourceDir = true`). Defaults to to same as source path.
           target: ''
+
+          # If set to true, Garden will copy the directory or file(s) to the module source directory, instead of the
+          # Garden build directory (under `.garden/build/<module-name>`).
+          copyToSourceDir: false
 
 # A description of the module.
 description:
@@ -503,12 +508,23 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 
 [build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > target
 
-POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
-Defaults to to same as source path.
+POSIX-style path or filename to copy the directory or file(s), relative to the build directory (or the module
+source directory if `copyToSourceDir = true`). Defaults to to same as source path.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |
 | `posixPath` | `""`    | No       |
+
+### `build.dependencies[].copy[].copyToSourceDir`
+
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > copyToSourceDir
+
+If set to true, Garden will copy the directory or file(s) to the module source directory, instead of the
+Garden build directory (under `.garden/build/<module-name>`).
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `description`
 

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -55,9 +55,14 @@ build:
         - # POSIX-style path or filename of the directory or file(s) to copy to the target.
           source:
 
-          # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
-          # Defaults to to same as source path.
+          # POSIX-style path or filename to copy the directory or file(s), relative to the build directory (or the
+          # module
+          # source directory if `copyToSourceDir = true`). Defaults to to same as source path.
           target: ''
+
+          # If set to true, Garden will copy the directory or file(s) to the module source directory, instead of the
+          # Garden build directory (under `.garden/build/<module-name>`).
+          copyToSourceDir: false
 
   # For multi-stage Dockerfiles, specify which image to build (see
   # https://docs.docker.com/engine/reference/commandline/build/#specifying-target-build-stage---target for details).
@@ -709,12 +714,23 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 
 [build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > target
 
-POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
-Defaults to to same as source path.
+POSIX-style path or filename to copy the directory or file(s), relative to the build directory (or the module
+source directory if `copyToSourceDir = true`). Defaults to to same as source path.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |
 | `posixPath` | `""`    | No       |
+
+### `build.dependencies[].copy[].copyToSourceDir`
+
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > copyToSourceDir
+
+If set to true, Garden will copy the directory or file(s) to the module source directory, instead of the
+Garden build directory (under `.garden/build/<module-name>`).
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `build.targetImage`
 

--- a/docs/reference/module-types/openfaas.md
+++ b/docs/reference/module-types/openfaas.md
@@ -45,9 +45,14 @@ build:
         - # POSIX-style path or filename of the directory or file(s) to copy to the target.
           source:
 
-          # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
-          # Defaults to to same as source path.
+          # POSIX-style path or filename to copy the directory or file(s), relative to the build directory (or the
+          # module
+          # source directory if `copyToSourceDir = true`). Defaults to to same as source path.
           target: ''
+
+          # If set to true, Garden will copy the directory or file(s) to the module source directory, instead of the
+          # Garden build directory (under `.garden/build/<module-name>`).
+          copyToSourceDir: false
 
 # A description of the module.
 description:
@@ -268,12 +273,23 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 
 [build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > target
 
-POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
-Defaults to to same as source path.
+POSIX-style path or filename to copy the directory or file(s), relative to the build directory (or the module
+source directory if `copyToSourceDir = true`). Defaults to to same as source path.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |
 | `posixPath` | `""`    | No       |
+
+### `build.dependencies[].copy[].copyToSourceDir`
+
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > copyToSourceDir
+
+If set to true, Garden will copy the directory or file(s) to the module source directory, instead of the
+Garden build directory (under `.garden/build/<module-name>`).
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `description`
 

--- a/docs/reference/module-types/persistentvolumeclaim.md
+++ b/docs/reference/module-types/persistentvolumeclaim.md
@@ -46,9 +46,14 @@ build:
         - # POSIX-style path or filename of the directory or file(s) to copy to the target.
           source:
 
-          # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
-          # Defaults to to same as source path.
+          # POSIX-style path or filename to copy the directory or file(s), relative to the build directory (or the
+          # module
+          # source directory if `copyToSourceDir = true`). Defaults to to same as source path.
           target: ''
+
+          # If set to true, Garden will copy the directory or file(s) to the module source directory, instead of the
+          # Garden build directory (under `.garden/build/<module-name>`).
+          copyToSourceDir: false
 
 # A description of the module.
 description:
@@ -290,12 +295,23 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 
 [build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > target
 
-POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
-Defaults to to same as source path.
+POSIX-style path or filename to copy the directory or file(s), relative to the build directory (or the module
+source directory if `copyToSourceDir = true`). Defaults to to same as source path.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |
 | `posixPath` | `""`    | No       |
+
+### `build.dependencies[].copy[].copyToSourceDir`
+
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > copyToSourceDir
+
+If set to true, Garden will copy the directory or file(s) to the module source directory, instead of the
+Garden build directory (under `.garden/build/<module-name>`).
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `description`
 

--- a/docs/reference/module-types/templated.md
+++ b/docs/reference/module-types/templated.md
@@ -49,9 +49,14 @@ build:
         - # POSIX-style path or filename of the directory or file(s) to copy to the target.
           source:
 
-          # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
-          # Defaults to to same as source path.
+          # POSIX-style path or filename to copy the directory or file(s), relative to the build directory (or the
+          # module
+          # source directory if `copyToSourceDir = true`). Defaults to to same as source path.
           target: ''
+
+          # If set to true, Garden will copy the directory or file(s) to the module source directory, instead of the
+          # Garden build directory (under `.garden/build/<module-name>`).
+          copyToSourceDir: false
 
 # A description of the module.
 description:
@@ -243,12 +248,23 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 
 [build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > target
 
-POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
-Defaults to to same as source path.
+POSIX-style path or filename to copy the directory or file(s), relative to the build directory (or the module
+source directory if `copyToSourceDir = true`). Defaults to to same as source path.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |
 | `posixPath` | `""`    | No       |
+
+### `build.dependencies[].copy[].copyToSourceDir`
+
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > copyToSourceDir
+
+If set to true, Garden will copy the directory or file(s) to the module source directory, instead of the
+Garden build directory (under `.garden/build/<module-name>`).
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `description`
 

--- a/docs/reference/module-types/terraform.md
+++ b/docs/reference/module-types/terraform.md
@@ -52,9 +52,14 @@ build:
         - # POSIX-style path or filename of the directory or file(s) to copy to the target.
           source:
 
-          # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
-          # Defaults to to same as source path.
+          # POSIX-style path or filename to copy the directory or file(s), relative to the build directory (or the
+          # module
+          # source directory if `copyToSourceDir = true`). Defaults to to same as source path.
           target: ''
+
+          # If set to true, Garden will copy the directory or file(s) to the module source directory, instead of the
+          # Garden build directory (under `.garden/build/<module-name>`).
+          copyToSourceDir: false
 
 # A description of the module.
 description:
@@ -268,12 +273,23 @@ POSIX-style path or filename of the directory or file(s) to copy to the target.
 
 [build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > target
 
-POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
-Defaults to to same as source path.
+POSIX-style path or filename to copy the directory or file(s), relative to the build directory (or the module
+source directory if `copyToSourceDir = true`). Defaults to to same as source path.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |
 | `posixPath` | `""`    | No       |
+
+### `build.dependencies[].copy[].copyToSourceDir`
+
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > copyToSourceDir
+
+If set to true, Garden will copy the directory or file(s) to the module source directory, instead of the
+Garden build directory (under `.garden/build/<module-name>`).
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `description`
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

Added an optional `copyToSourceDir` flag to `build.dependencies[].copy[]`.

When used, build dependencies are copied to the module (source) directory of the dependant module instead of the build directory.

This is useful for many flows, especially when using the `exec` module for custom build flows, and has been indirectly requested by many of our users.