### PR TITLE
fix(k8s): omit probes in runner pod spec

### DIFF
--- a/core/src/commands/base.ts
+++ b/core/src/commands/base.ts
@@ -82,9 +82,9 @@ export abstract class Command<T extends Parameters = {}, U extends Parameters = 
   hidden: boolean = false
   noProject: boolean = false
   protected: boolean = false
-  workflows: boolean = false // Set to true to whitelist for executing in workflow steps
-  streamEvents: boolean = false // Set to true to whitelist for streaming events
-  streamLogEntries: boolean = false // Set to true to whitelist for streaming log entries
+  workflows: boolean = false // Set to true to allow the command in workflow steps
+  streamEvents: boolean = false // Set to true to stream events for the command
+  streamLogEntries: boolean = false // Set to true to stream log entries for the command
   server: GardenServer | undefined = undefined
 
   constructor(private parent?: CommandGroup) {

--- a/core/src/config/workflow.ts
+++ b/core/src/config/workflow.ts
@@ -417,7 +417,7 @@ export function resolveWorkflowConfig(garden: Garden, config: WorkflowConfig) {
 }
 
 /**
- * Get all commands whitelisted for workflows
+ * Get all commands that are allowed in workflows
  */
 function getStepCommands() {
   return getCoreCommands()

--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -36,7 +36,7 @@ import { baseTaskSpecSchema, BaseTaskSpec, cacheResultSchema } from "../../confi
 import { baseTestSpecSchema, BaseTestSpec } from "../../config/test"
 import { ArtifactSpec } from "../../config/validation"
 import { V1Toleration } from "@kubernetes/client-node"
-import { runPodSpecWhitelist } from "./run"
+import { runPodSpecIncludeFields } from "./run"
 
 export const DEFAULT_KANIKO_IMAGE = "gcr.io/kaniko-project/executor:v1.6.0-debug"
 export interface ProviderSecretRef {
@@ -708,7 +708,7 @@ export const hotReloadArgsSchema = () =>
     .description("If specified, overrides the arguments for the main container when running in hot-reload mode.")
     .example(["nodemon", "my-server.js"])
 
-const runPodSpecWhitelistDescription = runPodSpecWhitelist.map((f) => `* \`${f}\``).join("\n")
+const runPodSpecWhitelistDescription = runPodSpecIncludeFields.map((f) => `* \`${f}\``).join("\n")
 
 export const kubernetesTaskSchema = () =>
   baseTaskSpecSchema()

--- a/core/src/plugins/kubernetes/helm/config.ts
+++ b/core/src/plugins/kubernetes/helm/config.ts
@@ -35,7 +35,7 @@ import {
   hotReloadArgsSchema,
 } from "../config"
 import { posix } from "path"
-import { runPodSpecWhitelist } from "../run"
+import { runPodSpecIncludeFields } from "../run"
 import { omit } from "lodash"
 import { kubernetesDevModeSchema, KubernetesDevModeSpec } from "../dev-mode"
 
@@ -99,7 +99,7 @@ const helmServiceResourceSchema = () =>
     hotReloadArgs: hotReloadArgsSchema(),
   })
 
-const runPodSpecWhitelistDescription = runPodSpecWhitelist.map((f) => `* \`${f}\``).join("\n")
+const runPodSpecWhitelistDescription = runPodSpecIncludeFields.map((f) => `* \`${f}\``).join("\n")
 
 const helmTaskSchema = () =>
   kubernetesTaskSchema().keys({


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

We now no longer include liveness or readiness probes on the pod spec used when running e.g. tests or tasks for `kubernetes` or `helm` modules.

In certain situations, these probes could result in test pods being evicted before the test suite was able to finish. This is fixed here.