### PR TITLE
fix(k8s): missing stderr in verbose buildkit+kaniko build logs

### DIFF
--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -107,11 +107,11 @@ export const buildkitBuildHandler: BuildHandler = async (params) => {
   let buildLog = ""
 
   // Stream debug log to a status line
-  const stdout = split2()
+  const outputStream = split2()
   const statusLine = log.placeholder({ level: LogLevel.verbose })
 
-  stdout.on("error", () => {})
-  stdout.on("data", (line: Buffer) => {
+  outputStream.on("error", () => {})
+  outputStream.on("data", (line: Buffer) => {
     statusLine.setState(renderOutputStream(line.toString()))
   })
 
@@ -161,7 +161,8 @@ export const buildkitBuildHandler: BuildHandler = async (params) => {
     command,
     timeoutSec: buildTimeout,
     containerName: buildkitContainerName,
-    stdout,
+    stdout: outputStream,
+    stderr: outputStream,
     buffer: true,
   })
 

--- a/core/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/src/plugins/kubernetes/container/build/kaniko.ts
@@ -122,11 +122,11 @@ export const kanikoBuild: BuildHandler = async (params) => {
   let buildLog = ""
 
   // Stream debug log to a status line
-  const stdout = split2()
+  const outputStream = split2()
   const statusLine = log.placeholder({ level: LogLevel.verbose })
 
-  stdout.on("error", () => {})
-  stdout.on("data", (line: Buffer) => {
+  outputStream.on("error", () => {})
+  outputStream.on("data", (line: Buffer) => {
     statusLine.setState(renderOutputStream(line.toString()))
   })
 
@@ -180,7 +180,7 @@ export const kanikoBuild: BuildHandler = async (params) => {
     authSecretName: authSecret.metadata.name,
     module,
     args,
-    outputStream: stdout,
+    outputStream,
   })
 
   buildLog = buildRes.log
@@ -497,6 +497,7 @@ async function runKaniko({
     remove: true,
     timeoutSec: module.spec.build.timeout,
     stdout: outputStream,
+    stderr: outputStream,
     tty: false,
   })
 


### PR DESCRIPTION
Turns out we were only tapping stdout when streaming logs directly from buildkit+kaniko builds.