### PR TITLE
feat(config): add support for module-level variables

### DIFF
--- a/core/src/commands/run/workflow.ts
+++ b/core/src/commands/run/workflow.ts
@@ -80,7 +80,7 @@ export class RunWorkflowCommand extends Command<Args, {}> {
 
     await registerAndSetUid(garden, log, workflow)
     garden.events.emit("workflowRunning", {})
-    const templateContext = new WorkflowConfigContext(garden)
+    const templateContext = new WorkflowConfigContext(garden, garden.variables)
     const files = resolveTemplateStrings(workflow.files || [], templateContext)
 
     // Write all the configured files for the workflow

--- a/core/src/config/base.ts
+++ b/core/src/config/base.ts
@@ -153,6 +153,17 @@ export function prepareModuleResource(spec: any, configPath: string, projectRoot
     dependencies = spec.build.dependencies.map((dep: any) => (typeof dep === "string" ? { name: dep, copy: [] } : dep))
   }
 
+  const cleanedSpec = {
+    ...omit(spec, baseModuleSchemaKeys()),
+    build: { ...spec.build, dependencies },
+  }
+
+  // Had a bit of a naming conflict in the terraform module type with the new module variables concept...
+  // FIXME: remove this hack sometime after 0.13
+  if (spec.type === "terraform") {
+    cleanedSpec["variables"] = spec.variables
+  }
+
   // Built-in keys are validated here and the rest are put into the `spec` field
   const config: ModuleResource = {
     apiVersion: spec.apiVersion || DEFAULT_API_VERSION,
@@ -171,10 +182,7 @@ export function prepareModuleResource(spec: any, configPath: string, projectRoot
     path: dirname(configPath),
     repositoryUrl: spec.repositoryUrl,
     serviceConfigs: [],
-    spec: {
-      ...omit(spec, baseModuleSchemaKeys()),
-      build: { ...spec.build, dependencies },
-    },
+    spec: cleanedSpec,
     testConfigs: [],
     type: spec.type,
     taskConfigs: [],

--- a/core/src/config/module.ts
+++ b/core/src/config/module.ts
@@ -86,6 +86,7 @@ interface ModuleSpecCommon {
   path?: string
   repositoryUrl?: string
   type: string
+  variables?: DeepPrimitiveMap
 }
 
 export interface AddModuleSpec extends ModuleSpecCommon {
@@ -209,6 +210,9 @@ export const baseModuleSpecKeys = () => ({
     .description("When false, disables pushing this module to remote registries."),
   generateFiles: joiSparseArray(generatedFileSchema()).description(dedent`
     A list of files to write to the module directory when resolving this module. This is useful to automatically generate (and template) any supporting files needed for the module.
+  `),
+  variables: joiVariables().default(() => undefined).description(dedent`
+    A map of variables scoped to this particular module. These are resolved before any other parts of the module configuration and take precedence over project-scoped variables. They may reference project-scoped variables, and generally use any template strings normally allowed when resolving modules.
   `),
 })
 

--- a/core/src/config/template-contexts/project.ts
+++ b/core/src/config/template-contexts/project.ts
@@ -316,18 +316,18 @@ export class RemoteSourceConfigContext extends EnvironmentConfigContext {
   )
   public variables: DeepPrimitiveMap
 
-  constructor(garden: Garden) {
+  constructor(garden: Garden, variables: DeepPrimitiveMap) {
     super({
       projectName: garden.projectName,
       projectRoot: garden.projectRoot,
       artifactsPath: garden.artifactsPath,
       branch: garden.vcsBranch,
       username: garden.username,
-      variables: garden.variables,
       loggedIn: !!garden.enterpriseApi,
       enterpriseDomain: garden.enterpriseApi?.domain,
       secrets: garden.secrets,
       commandInfo: garden.commandInfo,
+      variables,
     })
 
     const fullEnvName = garden.namespace ? `${garden.namespace}.${garden.environmentName}` : garden.environmentName

--- a/core/src/config/template-contexts/provider.ts
+++ b/core/src/config/template-contexts/provider.ts
@@ -7,7 +7,7 @@
  */
 
 import { mapValues } from "lodash"
-import { PrimitiveMap, joiIdentifierMap, joiPrimitive } from "../common"
+import { PrimitiveMap, joiIdentifierMap, joiPrimitive, DeepPrimitiveMap } from "../common"
 import { Provider, GenericProviderConfig, ProviderMap } from "../provider"
 import { Garden } from "../../garden"
 import { joi } from "../common"
@@ -63,8 +63,8 @@ export class ProviderConfigContext extends WorkflowConfigContext {
   )
   public providers: Map<string, ProviderContext>
 
-  constructor(garden: Garden, resolvedProviders: ProviderMap) {
-    super(garden)
+  constructor(garden: Garden, resolvedProviders: ProviderMap, variables: DeepPrimitiveMap) {
+    super(garden, variables)
 
     this.providers = new Map(Object.entries(mapValues(resolvedProviders, (p) => new ProviderContext(this, p))))
   }

--- a/core/src/config/template-contexts/workflow.ts
+++ b/core/src/config/template-contexts/workflow.ts
@@ -75,7 +75,7 @@ export class WorkflowStepConfigContext extends WorkflowConfigContext {
     resolvedSteps: { [name: string]: WorkflowStepResult }
     stepName: string
   }) {
-    super(garden)
+    super(garden, garden.variables)
 
     this.steps = new Map<string, WorkflowStepContext | ErrorContext>()
 

--- a/core/src/config/workflow.ts
+++ b/core/src/config/workflow.ts
@@ -323,7 +323,7 @@ export const triggerSchema = () => {
         dedent`
         A list of [GitHub events](https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads) that should trigger this workflow.
 
-        See the Garden Enterprise documentation on [configuring workflows](https://enterprise.docs.garden.io/getting-started/workflows) for more details.
+        See the Garden Cloud documentation on [configuring workflows](https://cloud.docs.garden.io/getting-started/workflows) for more details.
 
         Supported events:
 
@@ -356,7 +356,7 @@ export interface WorkflowConfigMap {
 
 export function resolveWorkflowConfig(garden: Garden, config: WorkflowConfig) {
   const log = garden.log
-  const context = new WorkflowConfigContext(garden)
+  const context = new WorkflowConfigContext(garden, garden.variables)
 
   log.silly(`Resolving template strings for workflow ${config.name}`)
 

--- a/core/src/docs/module-type.ts
+++ b/core/src/docs/module-type.ts
@@ -12,7 +12,7 @@ import { resolve } from "path"
 import { baseModuleSpecSchema } from "../config/module"
 import handlebars = require("handlebars")
 import { joi } from "../config/common"
-import { ModuleContext, ServiceRuntimeContext, TaskRuntimeContext } from "../config/template-contexts/module"
+import { ModuleReferenceContext, ServiceRuntimeContext, TaskRuntimeContext } from "../config/template-contexts/module"
 import { ModuleTypeDefinition } from "../types/plugin/plugin"
 import { renderConfigReference, renderTemplateStringReference, TEMPLATES_DIR } from "./config"
 
@@ -64,7 +64,7 @@ export function renderModuleTypeReference(name: string, definitions: { [name: st
   }
 
   const moduleOutputsReference = renderTemplateStringReference({
-    schema: ModuleContext.getSchema().keys({
+    schema: ModuleReferenceContext.getSchema().keys({
       outputs: getOutputsSchema(desc, "moduleOutputsSchema").required(),
     }),
     prefix: "modules",

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -324,7 +324,7 @@ export class Garden {
       this,
       provider,
       this.opts.commandInfo,
-      templateContext || new ProviderConfigContext(this, provider.dependencies)
+      templateContext || new ProviderConfigContext(this, provider.dependencies, this.variables)
     )
   }
 
@@ -642,6 +642,7 @@ export class Garden {
     return new OutputConfigContext({
       garden: this,
       resolvedProviders: providers,
+      variables: this.variables,
       modules,
       runtimeContext,
       partialRuntimeResolution: false,
@@ -1025,7 +1026,7 @@ export class Garden {
    * Returns the configured project sources, and resolves any template strings on them.
    */
   public getProjectSources() {
-    const context = new RemoteSourceConfigContext(this)
+    const context = new RemoteSourceConfigContext(this, this.variables)
     const resolved = validateSchema(resolveTemplateStrings(this.projectSources, context), projectSourcesSchema(), {
       context: "remote source",
     })

--- a/core/src/outputs.ts
+++ b/core/src/outputs.ts
@@ -65,6 +65,7 @@ export async function resolveProjectOutputs(garden: Garden, log: LogEntry): Prom
       new OutputConfigContext({
         garden,
         resolvedProviders: {},
+        variables: garden.variables,
         modules: [],
         runtimeContext: emptyRuntimeContext,
         partialRuntimeResolution: false,

--- a/core/src/tasks/publish.ts
+++ b/core/src/tasks/publish.ts
@@ -89,6 +89,7 @@ export class PublishTask extends BaseTask {
       const templateContext = new ModuleTagContext({
         garden: this.garden,
         moduleConfig: module,
+        variables: { ...this.garden.variables, ...module.variables },
         resolvedProviders,
         module,
         buildPath: module.buildPath,

--- a/core/src/tasks/resolve-provider.ts
+++ b/core/src/tasks/resolve-provider.ts
@@ -144,7 +144,7 @@ export class ResolveProviderTask extends BaseTask {
       return alreadyResolvedProviders
     }
 
-    const context = new ProviderConfigContext(this.garden, resolvedProviders)
+    const context = new ProviderConfigContext(this.garden, resolvedProviders, this.garden.variables)
 
     this.log.silly(`Resolving template strings for provider ${this.config.name}`)
     let resolvedConfig = resolveTemplateStrings(this.config, context)

--- a/core/src/types/module.ts
+++ b/core/src/types/module.ts
@@ -12,7 +12,15 @@ import { ModuleConfig, moduleConfigSchema } from "../config/module"
 import { ModuleVersion } from "../vcs/vcs"
 import { pathToCacheContext } from "../cache"
 import { Garden } from "../garden"
-import { joiArray, joiIdentifier, joiIdentifierMap, joi, moduleVersionSchema, PrimitiveMap } from "../config/common"
+import {
+  joiArray,
+  joiIdentifier,
+  joiIdentifierMap,
+  joi,
+  moduleVersionSchema,
+  PrimitiveMap,
+  DeepPrimitiveMap,
+} from "../config/common"
 import { getModuleTypeBases } from "../plugins"
 import { ModuleType } from "./plugin/plugin"
 import { moduleOutputsSchema } from "./plugin/module/getModuleOutputs"
@@ -42,6 +50,8 @@ export interface GardenModule<M extends {} = any, S extends {} = any, T extends 
 
   taskNames: string[]
   taskDependencyNames: string[]
+
+  variables: DeepPrimitiveMap
 
   compatibleTypes: string[]
   _config: ModuleConfig<M, S, T, W>
@@ -126,6 +136,8 @@ export async function moduleFromConfig({
     taskDependencyNames: uniq(
       flatten(config.taskConfigs.map((taskConfig) => taskConfig.dependencies).filter((deps) => !!deps))
     ),
+
+    variables: config.variables || {},
 
     compatibleTypes,
     _config: config,

--- a/core/test/integ/src/plugins/kubernetes/helm/config.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/config.ts
@@ -117,6 +117,7 @@ describe("configureHelmModule", () => {
       testConfigs: [],
       type: "helm",
       taskConfigs: [],
+      variables: undefined,
     })
   })
 

--- a/core/test/integ/src/plugins/kubernetes/kubernetes-module/config.ts
+++ b/core/test/integ/src/plugins/kubernetes/kubernetes-module/config.ts
@@ -218,6 +218,7 @@ describe("validateKubernetesModule", () => {
         },
       ],
       type: "kubernetes",
+      variables: undefined,
     })
   })
 
@@ -425,6 +426,7 @@ describe("validateKubernetesModule", () => {
         },
       ],
       type: "kubernetes",
+      variables: undefined,
     })
   })
 

--- a/core/test/unit/src/config/template-contexts/module.ts
+++ b/core/test/unit/src/config/template-contexts/module.ts
@@ -43,6 +43,7 @@ describe("ModuleConfigContext", () => {
     c = new ModuleConfigContext({
       garden,
       resolvedProviders: keyBy(await garden.resolveProviders(garden.log), "name"),
+      variables: garden.variables,
       modules,
       moduleConfig: module,
       buildPath: module.buildPath,
@@ -176,6 +177,7 @@ describe("ModuleConfigContext", () => {
       withRuntime = new ModuleConfigContext({
         garden,
         resolvedProviders: keyBy(await garden.resolveProviders(garden.log), "name"),
+        variables: garden.variables,
         modules,
         moduleConfig: serviceA.module,
         buildPath: serviceA.module.buildPath,
@@ -219,7 +221,7 @@ describe("WorkflowConfigContext", () => {
   before(async () => {
     garden = await makeTestGardenA()
     garden["secrets"] = { someSecret: "someSecretValue" }
-    c = new WorkflowConfigContext(garden)
+    c = new WorkflowConfigContext(garden, garden.variables)
   })
 
   it("should resolve local env variables", async () => {

--- a/core/test/unit/src/config/template-contexts/provider.ts
+++ b/core/test/unit/src/config/template-contexts/provider.ts
@@ -20,14 +20,14 @@ interface TestValues {
 describe("ProviderConfigContext", () => {
   it("should set an empty namespace and environment.fullName to environment.name if no namespace is set", async () => {
     const garden = await makeTestGarden(projectRootA, { environmentName: "local" })
-    const c = new ProviderConfigContext(garden, await garden.resolveProviders(garden.log))
+    const c = new ProviderConfigContext(garden, await garden.resolveProviders(garden.log), garden.variables)
 
     expect(c.resolve({ key: ["environment", "name"], nodePath: [], opts: {} })).to.eql({ resolved: "local" })
   })
 
   it("should set environment.namespace and environment.fullName to properly if namespace is set", async () => {
     const garden = await makeTestGarden(projectRootA, { environmentName: "foo.local" })
-    const c = new ProviderConfigContext(garden, await garden.resolveProviders(garden.log))
+    const c = new ProviderConfigContext(garden, await garden.resolveProviders(garden.log), garden.variables)
 
     expect(c.resolve({ key: ["environment", "name"], nodePath: [], opts: {} })).to.eql({ resolved: "local" })
     expect(c.resolve({ key: ["environment", "namespace"], nodePath: [], opts: {} })).to.eql({ resolved: "foo" })

--- a/core/test/unit/src/config/template-contexts/workflow.ts
+++ b/core/test/unit/src/config/template-contexts/workflow.ts
@@ -28,7 +28,7 @@ describe("WorkflowConfigContext", () => {
     garden = await makeTestGardenA()
     garden["secrets"] = { someSecret: "someSecretValue" }
     currentBranch = garden.vcsBranch
-    c = new WorkflowConfigContext(garden)
+    c = new WorkflowConfigContext(garden, garden.variables)
   })
 
   it("should resolve local env variables", async () => {

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1343,6 +1343,12 @@ providers:
         # When false, disables pushing this module to remote registries.
         allowPublish:
 
+        # A map of variables scoped to this particular module. These are resolved before any other parts of the module
+        # configuration and take precedence over project-scoped variables. They may reference project-scoped
+        # variables, and generally use any template strings normally allowed when resolving modules.
+        variables:
+          <name>:
+
         # The filesystem path of the module.
         path:
 
@@ -1608,6 +1614,12 @@ moduleConfigs:
 
     # When false, disables pushing this module to remote registries.
     allowPublish:
+
+    # A map of variables scoped to this particular module. These are resolved before any other parts of the module
+    # configuration and take precedence over project-scoped variables. They may reference project-scoped variables,
+    # and generally use any template strings normally allowed when resolving modules.
+    variables:
+      <name>:
 
     # The filesystem path of the module.
     path:
@@ -1902,8 +1914,8 @@ workflowConfigs:
         # events](https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads) that should
         # trigger this workflow.
         #
-        # See the Garden Enterprise documentation on [configuring
-        # workflows](https://enterprise.docs.garden.io/getting-started/workflows) for more details.
+        # See the Garden Cloud documentation on [configuring
+        # workflows](https://cloud.docs.garden.io/getting-started/workflows) for more details.
         #
         # Supported events:
         #
@@ -2106,6 +2118,12 @@ modules:
 
     # When false, disables pushing this module to remote registries.
     allowPublish:
+
+    # A map of variables scoped to this particular module. These are resolved before any other parts of the module
+    # configuration and take precedence over project-scoped variables. They may reference project-scoped variables,
+    # and generally use any template strings normally allowed when resolving modules.
+    variables:
+      <name>:
 
     # The filesystem path of the module.
     path:

--- a/docs/reference/module-template-config.md
+++ b/docs/reference/module-template-config.md
@@ -147,6 +147,11 @@ modules:
         # The desired file contents as a string.
         value:
 
+    # A map of variables scoped to this particular module. These are resolved before any other parts of the module
+    # configuration and take precedence over project-scoped variables. They may reference project-scoped variables,
+    # and generally use any template strings normally allowed when resolving modules.
+    variables:
+
     # POSIX-style path of a sub-directory to set as the module root. If the directory does not exist, it is
     # automatically created.
     path:
@@ -461,6 +466,16 @@ The desired file contents as a string.
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
+
+### `modules[].variables`
+
+[modules](#modules) > variables
+
+A map of variables scoped to this particular module. These are resolved before any other parts of the module configuration and take precedence over project-scoped variables. They may reference project-scoped variables, and generally use any template strings normally allowed when resolving modules.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
 
 ### `modules[].path`
 

--- a/docs/reference/module-types/conftest.md
+++ b/docs/reference/module-types/conftest.md
@@ -125,6 +125,11 @@ generateFiles:
     # The desired file contents as a string.
     value:
 
+# A map of variables scoped to this particular module. These are resolved before any other parts of the module
+# configuration and take precedence over project-scoped variables. They may reference project-scoped variables, and
+# generally use any template strings normally allowed when resolving modules.
+variables:
+
 # Specify a module whose sources we want to test.
 sourceModule:
 
@@ -381,6 +386,14 @@ The desired file contents as a string.
 | -------- | -------- |
 | `string` | No       |
 
+### `variables`
+
+A map of variables scoped to this particular module. These are resolved before any other parts of the module configuration and take precedence over project-scoped variables. They may reference project-scoped variables, and generally use any template strings normally allowed when resolving modules.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
 ### `sourceModule`
 
 Specify a module whose sources we want to test.
@@ -467,6 +480,20 @@ Example:
 ```yaml
 my-variable: ${modules.my-module.path}
 ```
+
+### `${modules.<module-name>.var.*}`
+
+A map of all variables defined in the module.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${modules.<module-name>.var.<variable-name>}`
+
+| Type                                             |
+| ------------------------------------------------ |
+| `string | number | boolean | link | array[link]` |
 
 ### `${modules.<module-name>.version}`
 

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -140,6 +140,11 @@ generateFiles:
     # The desired file contents as a string.
     value:
 
+# A map of variables scoped to this particular module. These are resolved before any other parts of the module
+# configuration and take precedence over project-scoped variables. They may reference project-scoped variables, and
+# generally use any template strings normally allowed when resolving modules.
+variables:
+
 # Specify build arguments to use when building the container image.
 #
 # Note: Garden will always set a `GARDEN_MODULE_VERSION` argument with the module version at build time.
@@ -852,6 +857,14 @@ The desired file contents as a string.
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
+
+### `variables`
+
+A map of variables scoped to this particular module. These are resolved before any other parts of the module configuration and take precedence over project-scoped variables. They may reference project-scoped variables, and generally use any template strings normally allowed when resolving modules.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
 
 ### `buildArgs`
 
@@ -2352,6 +2365,20 @@ Example:
 ```yaml
 my-variable: ${modules.my-module.path}
 ```
+
+### `${modules.<module-name>.var.*}`
+
+A map of all variables defined in the module.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${modules.<module-name>.var.<variable-name>}`
+
+| Type                                             |
+| ------------------------------------------------ |
+| `string | number | boolean | link | array[link]` |
 
 ### `${modules.<module-name>.version}`
 

--- a/docs/reference/module-types/exec.md
+++ b/docs/reference/module-types/exec.md
@@ -135,6 +135,11 @@ generateFiles:
     # The desired file contents as a string.
     value:
 
+# A map of variables scoped to this particular module. These are resolved before any other parts of the module
+# configuration and take precedence over project-scoped variables. They may reference project-scoped variables, and
+# generally use any template strings normally allowed when resolving modules.
+variables:
+
 # If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
 # instead of in the Garden build directory (under .garden/build/<module-name>).
 #
@@ -540,6 +545,14 @@ The desired file contents as a string.
 | -------- | -------- |
 | `string` | No       |
 
+### `variables`
+
+A map of variables scoped to this particular module. These are resolved before any other parts of the module configuration and take precedence over project-scoped variables. They may reference project-scoped variables, and generally use any template strings normally allowed when resolving modules.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
 ### `local`
 
 If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
@@ -918,6 +931,20 @@ Example:
 ```yaml
 my-variable: ${modules.my-module.path}
 ```
+
+### `${modules.<module-name>.var.*}`
+
+A map of all variables defined in the module.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${modules.<module-name>.var.<variable-name>}`
+
+| Type                                             |
+| ------------------------------------------------ |
+| `string | number | boolean | link | array[link]` |
 
 ### `${modules.<module-name>.version}`
 

--- a/docs/reference/module-types/hadolint.md
+++ b/docs/reference/module-types/hadolint.md
@@ -128,6 +128,11 @@ generateFiles:
     # The desired file contents as a string.
     value:
 
+# A map of variables scoped to this particular module. These are resolved before any other parts of the module
+# configuration and take precedence over project-scoped variables. They may reference project-scoped variables, and
+# generally use any template strings normally allowed when resolving modules.
+variables:
+
 # POSIX-style path to a Dockerfile that you want to lint with `hadolint`.
 dockerfilePath:
 ```
@@ -369,6 +374,14 @@ The desired file contents as a string.
 | -------- | -------- |
 | `string` | No       |
 
+### `variables`
+
+A map of variables scoped to this particular module. These are resolved before any other parts of the module configuration and take precedence over project-scoped variables. They may reference project-scoped variables, and generally use any template strings normally allowed when resolving modules.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
 ### `dockerfilePath`
 
 POSIX-style path to a Dockerfile that you want to lint with `hadolint`.
@@ -420,6 +433,20 @@ Example:
 ```yaml
 my-variable: ${modules.my-module.path}
 ```
+
+### `${modules.<module-name>.var.*}`
+
+A map of all variables defined in the module.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${modules.<module-name>.var.<variable-name>}`
+
+| Type                                             |
+| ------------------------------------------------ |
+| `string | number | boolean | link | array[link]` |
 
 ### `${modules.<module-name>.version}`
 

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -127,6 +127,11 @@ generateFiles:
     # The desired file contents as a string.
     value:
 
+# A map of variables scoped to this particular module. These are resolved before any other parts of the module
+# configuration and take precedence over project-scoped variables. They may reference project-scoped variables, and
+# generally use any template strings normally allowed when resolving modules.
+variables:
+
 # Whether to set the --atomic flag during installs and upgrades. Set to false if e.g. you want to see more information
 # about failures and then manually roll back, instead of having Helm do it automatically on failure.
 atomicInstall: true
@@ -708,6 +713,14 @@ The desired file contents as a string.
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
+
+### `variables`
+
+A map of variables scoped to this particular module. These are resolved before any other parts of the module configuration and take precedence over project-scoped variables. They may reference project-scoped variables, and generally use any template strings normally allowed when resolving modules.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
 
 ### `atomicInstall`
 
@@ -1665,6 +1678,20 @@ Example:
 ```yaml
 my-variable: ${modules.my-module.path}
 ```
+
+### `${modules.<module-name>.var.*}`
+
+A map of all variables defined in the module.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${modules.<module-name>.var.<variable-name>}`
+
+| Type                                             |
+| ------------------------------------------------ |
+| `string | number | boolean | link | array[link]` |
 
 ### `${modules.<module-name>.version}`
 

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -131,6 +131,11 @@ generateFiles:
     # The desired file contents as a string.
     value:
 
+# A map of variables scoped to this particular module. These are resolved before any other parts of the module
+# configuration and take precedence over project-scoped variables. They may reference project-scoped variables, and
+# generally use any template strings normally allowed when resolving modules.
+variables:
+
 # The names of any services that this service depends on at runtime, and the names of any tasks that should be
 # executed before this service is deployed.
 dependencies: []
@@ -637,6 +642,14 @@ The desired file contents as a string.
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
+
+### `variables`
+
+A map of variables scoped to this particular module. These are resolved before any other parts of the module configuration and take precedence over project-scoped variables. They may reference project-scoped variables, and generally use any template strings normally allowed when resolving modules.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
 
 ### `dependencies[]`
 
@@ -1432,6 +1445,20 @@ Example:
 ```yaml
 my-variable: ${modules.my-module.path}
 ```
+
+### `${modules.<module-name>.var.*}`
+
+A map of all variables defined in the module.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${modules.<module-name>.var.<variable-name>}`
+
+| Type                                             |
+| ------------------------------------------------ |
+| `string | number | boolean | link | array[link]` |
 
 ### `${modules.<module-name>.version}`
 

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -138,6 +138,11 @@ generateFiles:
     # The desired file contents as a string.
     value:
 
+# A map of variables scoped to this particular module. These are resolved before any other parts of the module
+# configuration and take precedence over project-scoped variables. They may reference project-scoped variables, and
+# generally use any template strings normally allowed when resolving modules.
+variables:
+
 # Specify build arguments to use when building the container image.
 #
 # Note: Garden will always set a `GARDEN_MODULE_VERSION` argument with the module version at build time.
@@ -860,6 +865,14 @@ The desired file contents as a string.
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
+
+### `variables`
+
+A map of variables scoped to this particular module. These are resolved before any other parts of the module configuration and take precedence over project-scoped variables. They may reference project-scoped variables, and generally use any template strings normally allowed when resolving modules.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
 
 ### `buildArgs`
 
@@ -2413,6 +2426,20 @@ Example:
 ```yaml
 my-variable: ${modules.my-module.path}
 ```
+
+### `${modules.<module-name>.var.*}`
+
+A map of all variables defined in the module.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${modules.<module-name>.var.<variable-name>}`
+
+| Type                                             |
+| ------------------------------------------------ |
+| `string | number | boolean | link | array[link]` |
 
 ### `${modules.<module-name>.version}`
 

--- a/docs/reference/module-types/openfaas.md
+++ b/docs/reference/module-types/openfaas.md
@@ -121,6 +121,11 @@ generateFiles:
     # The desired file contents as a string.
     value:
 
+# A map of variables scoped to this particular module. These are resolved before any other parts of the module
+# configuration and take precedence over project-scoped variables. They may reference project-scoped variables, and
+# generally use any template strings normally allowed when resolving modules.
+variables:
+
 # The names of services/functions that this function depends on at runtime.
 dependencies: []
 
@@ -400,6 +405,14 @@ The desired file contents as a string.
 | -------- | -------- |
 | `string` | No       |
 
+### `variables`
+
+A map of variables scoped to this particular module. These are resolved before any other parts of the module configuration and take precedence over project-scoped variables. They may reference project-scoped variables, and generally use any template strings normally allowed when resolving modules.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
 ### `dependencies[]`
 
 The names of services/functions that this function depends on at runtime.
@@ -554,6 +567,20 @@ Example:
 ```yaml
 my-variable: ${modules.my-module.path}
 ```
+
+### `${modules.<module-name>.var.*}`
+
+A map of all variables defined in the module.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${modules.<module-name>.var.<variable-name>}`
+
+| Type                                             |
+| ------------------------------------------------ |
+| `string | number | boolean | link | array[link]` |
 
 ### `${modules.<module-name>.version}`
 

--- a/docs/reference/module-types/persistentvolumeclaim.md
+++ b/docs/reference/module-types/persistentvolumeclaim.md
@@ -122,6 +122,11 @@ generateFiles:
     # The desired file contents as a string.
     value:
 
+# A map of variables scoped to this particular module. These are resolved before any other parts of the module
+# configuration and take precedence over project-scoped variables. They may reference project-scoped variables, and
+# generally use any template strings normally allowed when resolving modules.
+variables:
+
 # List of services and tasks to deploy/run before deploying this PVC.
 dependencies: []
 
@@ -422,6 +427,14 @@ The desired file contents as a string.
 | -------- | -------- |
 | `string` | No       |
 
+### `variables`
+
+A map of variables scoped to this particular module. These are resolved before any other parts of the module configuration and take precedence over project-scoped variables. They may reference project-scoped variables, and generally use any template strings normally allowed when resolving modules.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
 ### `dependencies[]`
 
 List of services and tasks to deploy/run before deploying this PVC.
@@ -629,6 +642,20 @@ Example:
 ```yaml
 my-variable: ${modules.my-module.path}
 ```
+
+### `${modules.<module-name>.var.*}`
+
+A map of all variables defined in the module.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${modules.<module-name>.var.<variable-name>}`
+
+| Type                                             |
+| ------------------------------------------------ |
+| `string | number | boolean | link | array[link]` |
 
 ### `${modules.<module-name>.version}`
 

--- a/docs/reference/module-types/templated.md
+++ b/docs/reference/module-types/templated.md
@@ -12,7 +12,7 @@ A special module type, for rendering [module templates](../../using-garden/modul
 Specify the name of a ModuleTemplate with the `template` field, and provide any expected inputs using the `inputs` field. The generated modules becomes sub-modules of this module.
 
 Note that the following common Module configuration fields are disallowed for this module type:
-`build`, `description`, `include`, `exclude`, `repositoryUrl`, `allowPublish` and `generateFiles`
+`build`, `description`, `include`, `exclude`, `repositoryUrl`, `allowPublish`, `generateFiles` and `variables`
 
 Below is the full schema reference. For an introduction to configuring Garden modules, please look at our [Configuration
 guide](../../using-garden/configuration-overview.md).
@@ -124,6 +124,11 @@ generateFiles:
 
     # The desired file contents as a string.
     value:
+
+# A map of variables scoped to this particular module. These are resolved before any other parts of the module
+# configuration and take precedence over project-scoped variables. They may reference project-scoped variables, and
+# generally use any template strings normally allowed when resolving modules.
+variables:
 
 # The ModuleTemplate to use to generate the sub-modules of this module.
 template:
@@ -375,6 +380,14 @@ The desired file contents as a string.
 | -------- | -------- |
 | `string` | No       |
 
+### `variables`
+
+A map of variables scoped to this particular module. These are resolved before any other parts of the module configuration and take precedence over project-scoped variables. They may reference project-scoped variables, and generally use any template strings normally allowed when resolving modules.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
 ### `template`
 
 The ModuleTemplate to use to generate the sub-modules of this module.
@@ -436,6 +449,20 @@ Example:
 ```yaml
 my-variable: ${modules.my-module.path}
 ```
+
+### `${modules.<module-name>.var.*}`
+
+A map of all variables defined in the module.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${modules.<module-name>.var.<variable-name>}`
+
+| Type                                             |
+| ------------------------------------------------ |
+| `string | number | boolean | link | array[link]` |
 
 ### `${modules.<module-name>.version}`
 

--- a/docs/reference/module-types/terraform.md
+++ b/docs/reference/module-types/terraform.md
@@ -128,6 +128,13 @@ generateFiles:
     # The desired file contents as a string.
     value:
 
+# A map of variables to use when applying the stack. You can define these here or you can place a
+# `terraform.tfvars` file in the working directory root.
+#
+# If you specified `variables` in the `terraform` provider config, those will be included but the variables
+# specified here take precedence.
+variables:
+
 # If set to true, Garden will run `terraform destroy` on the stack when calling `garden delete env` or `garden delete
 # service <module name>`.
 allowDestroy: false
@@ -147,13 +154,6 @@ dependencies: []
 
 # Specify the path to the working directory root—i.e. where your Terraform files are—relative to the module root.
 root: .
-
-# A map of variables to use when applying the stack. You can define these here or you can place a
-# `terraform.tfvars` file in the working directory root.
-#
-# If you specified `variables` in the `terraform` provider config, those will be included but the variables
-# specified here take precedence.
-variables:
 
 # The version of Terraform to use. Defaults to the version set in the provider config.
 # Set to `null` to use whichever version of `terraform` that is on your PATH.
@@ -400,6 +400,18 @@ The desired file contents as a string.
 | -------- | -------- |
 | `string` | No       |
 
+### `variables`
+
+A map of variables to use when applying the stack. You can define these here or you can place a
+`terraform.tfvars` file in the working directory root.
+
+If you specified `variables` in the `terraform` provider config, those will be included but the variables
+specified here take precedence.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
 ### `allowDestroy`
 
 If set to true, Garden will run `terraform destroy` on the stack when calling `garden delete env` or `garden delete service <module name>`.
@@ -437,18 +449,6 @@ Specify the path to the working directory root—i.e. where your Terraform files
 | Type        | Default | Required |
 | ----------- | ------- | -------- |
 | `posixPath` | `"."`   | No       |
-
-### `variables`
-
-A map of variables to use when applying the stack. You can define these here or you can place a
-`terraform.tfvars` file in the working directory root.
-
-If you specified `variables` in the `terraform` provider config, those will be included but the variables
-specified here take precedence.
-
-| Type     | Required |
-| -------- | -------- |
-| `object` | No       |
 
 ### `version`
 
@@ -510,6 +510,20 @@ Example:
 ```yaml
 my-variable: ${modules.my-module.path}
 ```
+
+### `${modules.<module-name>.var.*}`
+
+A map of all variables defined in the module.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${modules.<module-name>.var.<variable-name>}`
+
+| Type                                             |
+| ------------------------------------------------ |
+| `string | number | boolean | link | array[link]` |
 
 ### `${modules.<module-name>.version}`
 

--- a/docs/reference/template-strings.md
+++ b/docs/reference/template-strings.md
@@ -1594,6 +1594,20 @@ The module output value. Refer to individual [module type references](https://do
 | --------------------------- |
 | `string | number | boolean` |
 
+### `${modules.<module-name>.var.*}`
+
+A map of all variables defined in the module.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${modules.<module-name>.var.<variable-name>}`
+
+| Type                                             |
+| ------------------------------------------------ |
+| `string | number | boolean | link | array[link]` |
+
 ### `${modules.<module-name>.version}`
 
 The current version of the module.
@@ -2167,6 +2181,20 @@ The module output value. Refer to individual [module type references](https://do
 | Type                        |
 | --------------------------- |
 | `string | number | boolean` |
+
+### `${modules.<module-name>.var.*}`
+
+A map of all variables defined in the module.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${modules.<module-name>.var.<variable-name>}`
+
+| Type                                             |
+| ------------------------------------------------ |
+| `string | number | boolean | link | array[link]` |
 
 ### `${modules.<module-name>.version}`
 

--- a/docs/reference/workflow-config.md
+++ b/docs/reference/workflow-config.md
@@ -165,8 +165,8 @@ triggers:
     # A list of [GitHub events](https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads)
     # that should trigger this workflow.
     #
-    # See the Garden Enterprise documentation on [configuring
-    # workflows](https://enterprise.docs.garden.io/getting-started/workflows) for more details.
+    # See the Garden Cloud documentation on [configuring
+    # workflows](https://cloud.docs.garden.io/getting-started/workflows) for more details.
     #
     # Supported events:
     #
@@ -567,7 +567,7 @@ The namespace to use for the workflow when matched by this trigger. Follows the 
 
 A list of [GitHub events](https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads) that should trigger this workflow.
 
-See the Garden Enterprise documentation on [configuring workflows](https://enterprise.docs.garden.io/getting-started/workflows) for more details.
+See the Garden Cloud documentation on [configuring workflows](https://cloud.docs.garden.io/getting-started/workflows) for more details.
 
 Supported events:
 


### PR DESCRIPTION
This introduces _module variables_ to help make configurations cleaner
and easier to manage, especially for larger projects.

From the added docs:

--

## Module variables

Each Garden module can specify its own set of variables, that can be
re-used within the module, as well as referenced by other dependant
modules.

Simply specify the `variables` field on the module, same as in the
project configuration. For example:

```yaml
# my-service/garden.yml
kind: Module
name: my-service
variables:
  # This overrides the project-level hostname variable
  hostname: my-service.${var.hostname}
  # You can specify maps or lists as variables
  envVars:
    LOG_LEVEL: debug
    DATABASE_PASSWORD: ${var.database-password}
services:
  - name: my-service
    ...
    ingresses:
      - path: /
        port: http
        # This resolved to the hostname variable set above,
        # not the project-level one
        hostname: ${var.hostname}
    # Referencing the above envVar module variable
    env: ${var.envVars}
tests:
  - name: my-test
    ...
    # Re-using the envVar module variable
    env: ${var.envVars}
```

Notice that you can override variables defined at the project-level,
and even reference project-scoped variables when defining the module
variables.

Also notice the generally handy use-case of re-using a common value (in
this case a map of environment variables) in multiple spots in the
module configuration.

### Referencing module variables

On top of that, you can reference the resolved module variables in
other modules. With the above example, another module might for example
reference `${modules.my-service.var.hostname}`. For larger projects
this can be much cleaner than, say, hoisting a lot of variables up to
the project level.

**Special notes for your reviewer**:

Please give it a quick spin, see if it works alright outside of unit/functional tests.
