### PR TITLE
fix(core): log outputs from exec service deploy at verbose level

### DIFF
--- a/core/src/plugins/exec.ts
+++ b/core/src/plugins/exec.ts
@@ -463,7 +463,7 @@ export const getExecServiceStatus: ServiceActionHandlers["getServiceStatus"] = a
 }
 
 export const deployExecService: ServiceActionHandlers["deployService"] = async (params) => {
-  const { module, service } = params
+  const { module, service, log } = params
 
   const result = await exec(service.spec.deployCommand.join(" "), [], {
     cwd: module.buildPath,
@@ -474,6 +474,12 @@ export const deployExecService: ServiceActionHandlers["deployService"] = async (
     reject: true,
     shell: true,
   })
+
+  const outputLog = (result.stdout + result.stderr).trim()
+  if (outputLog) {
+    const prefix = `Finished deploying service ${chalk.white(service.name)}. Here is the output:`
+    log.verbose(renderMessageWithDivider(prefix, outputLog, false, chalk.gray))
+  }
 
   return { state: "ready", detail: { deployCommandOutput: result.all } }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

Output logs were missing from exec deploy.

**Which issue(s) this PR fixes**:

Fixes #2457 

**Special notes for your reviewer**:
