### PR TITLE
docs: Update kind create cluster snippet

### DIFF
--- a/docs/guides/local-kubernetes.md
+++ b/docs/guides/local-kubernetes.md
@@ -94,7 +94,6 @@ nodes:
     nodeRegistration:
       kubeletExtraArgs:
         node-labels: "ingress-ready=true"
-        authorization-mode: "AlwaysAllow"
   extraPortMappings:
   - containerPort: 80
     hostPort: 80


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

I had a bad time using `kind` in both Linux (Ubuntu 20.04) and OSX (Big Sur 11.1).

Checked both garden and kind docs and I saw the `authorization-mode: "AlwaysAllow"` is [no longer shown in kind docs](https://kind.sigs.k8s.io/docs/user/ingress/#create-cluster).

I tried removing the line and `kind` worked just fine and garden was happy with it.

**Which issue(s) this PR fixes**:

I didn't create an issue for this, sorry.

Fixes #

**Special notes for your reviewer**:
