### PR TITLE
feat(core): stream build statuses

### DIFF
--- a/core/src/types/plugin/base.ts
+++ b/core/src/types/plugin/base.ts
@@ -129,7 +129,7 @@ export const runResultSchema = () =>
 export const artifactsPathSchema = () =>
   joi.string().required().description("A directory path where the handler should write any exported artifacts to.")
 
-export type RunState = "outdated" | "succeeded" | "failed" | "not-implemented"
+export type RunState = "outdated" | "running" | "succeeded" | "failed" | "not-implemented"
 
 export interface RunStatus {
   state: RunState

--- a/core/src/types/plugin/module/build.ts
+++ b/core/src/types/plugin/module/build.ts
@@ -13,6 +13,14 @@ import { joi } from "../../../config/common"
 
 export interface BuildModuleParams<T extends GardenModule = GardenModule> extends PluginModuleActionParamsBase<T> {}
 
+/**
+ * - `fetched`: The build was fetched from a remote repository instead of building.
+ * - `building`: The module is being built.
+ * - `built`: The module was built.
+ * - `failed`: An error occurred while fetching or building the module.
+ */
+export type BuildState = "fetched" | "building" | "built" | "failed"
+
 export interface BuildResult {
   buildLog?: string
   fetched?: boolean


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

We now stream build status events, similarly to how we've been streaming service, test and task status events.

We've also added a `running` state to the `RunState` type, and we include a `building` state in the new `BuildState` type to represent builds/tests/tasks that are in progress.

Additionally, we now emit a `serviceStatus` event with the `deploying` state in the `deployService` action just before the deploy handler is called.
