### PR TITLE
fix(core): don't apply dev mode to PVC modules

### DIFF
--- a/core/src/plugins/kubernetes/volumes/persistentvolumeclaim.ts
+++ b/core/src/plugins/kubernetes/volumes/persistentvolumeclaim.ts
@@ -88,14 +88,20 @@ export const pvcModuleDefinition = (): ModuleTypeDefinition => ({
       params.service = getKubernetesService(params.service)
       params.module = params.service.module
 
-      return getKubernetesServiceStatus(params)
+      return getKubernetesServiceStatus({
+        ...params,
+        devMode: false,
+      })
     },
 
     async deployService(params: DeployServiceParams) {
       params.service = getKubernetesService(params.service)
       params.module = params.service.module
 
-      return deployKubernetesService(params)
+      return deployKubernetesService({
+        ...params,
+        devMode: false,
+      })
     },
   },
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

Previously, `persistentvolumeclaim` modules wouldn't work when used with the `dev` command, because the `devMode: true` flag was being passed to the `getServiceStatus` and `deployService` handlers.

We now ensure that dev-mode-related changes to the generated manifests are not applied for PVC modules.

**Which issue(s) this PR fixes**:

Fixes #2369.
