### PR TITLE
Section width

### DIFF
--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -63,6 +63,7 @@ export const gardenEnv = {
   GARDEN_LEGACY_BUILD_STAGE: env.get("GARDEN_LEGACY_BUILD_STAGE").required(false).asBool(),
   GARDEN_LOG_LEVEL: env.get("GARDEN_LOG_LEVEL").required(false).asString(),
   GARDEN_LOGGER_TYPE: env.get("GARDEN_LOGGER_TYPE").required(false).asString(),
+  GARDEN_LOGGER_SECTION_WIDTH: env.get("GARDEN_LOGGER_SECTION_WIDTH").required(false).default(25).asIntPositive(),
   GARDEN_GE_SCHEDULED: env.get("GARDEN_GE_SCHEDULED").required(false).asBool(),
   GARDEN_SERVER_PORT: env.get("GARDEN_SERVER_PORT").required(false).asPortNumber(),
   GARDEN_SKIP_TESTS: env.get("GARDEN_SKIP_TESTS").required(false).default("").asString(),

--- a/core/src/logger/renderers.ts
+++ b/core/src/logger/renderers.ts
@@ -19,19 +19,19 @@ import { JsonLogEntry } from "./writers/json-terminal-writer"
 import { highlightYaml, PickFromUnion, safeDumpYaml } from "../util/util"
 import { printEmoji, formatGardenError } from "./util"
 import { LoggerType, Logger } from "./logger"
+import { gardenEnv } from "../constants"
 
 type RenderFn = (entry: LogEntry) => string
 
 /*** STYLE HELPERS ***/
 
-export const MAX_SECTION_WIDTH = 25
 const cliPadEnd = (s: string, width: number): string => {
   const diff = width - stringWidth(s)
   return diff <= 0 ? s : s + repeat(" ", diff)
 }
 
-export function formatSection(section: string, width: number = MAX_SECTION_WIDTH) {
-  const minWidth = Math.min(width, MAX_SECTION_WIDTH)
+export function formatSection(section: string, width: number = gardenEnv.GARDEN_LOGGER_SECTION_WIDTH) {
+  const minWidth = Math.min(width, gardenEnv.GARDEN_LOGGER_SECTION_WIDTH)
   return [section]
     .map((s) => cliTruncate(s, minWidth))
     .map((s) => cliPadEnd(s, minWidth))

--- a/core/test/unit/src/logger/renderers.ts
+++ b/core/test/unit/src/logger/renderers.ts
@@ -18,7 +18,6 @@ import {
   renderError,
   formatForJson,
   renderSection,
-  MAX_SECTION_WIDTH,
   renderData,
 } from "../../../../src/logger/renderers"
 import { GardenError } from "../../../../src/exceptions"
@@ -28,6 +27,7 @@ import logSymbols = require("log-symbols")
 import stripAnsi = require("strip-ansi")
 import { highlightYaml, safeDumpYaml } from "../../../../src/util/util"
 import { freezeTime } from "../../../helpers"
+import { gardenEnv } from "../../../../src/constants"
 
 const logger: Logger = getLogger()
 
@@ -102,13 +102,13 @@ describe("renderers", () => {
   describe("renderSection", () => {
     it("should render the log entry section", () => {
       const entry = logger.info({ msg: "foo", section: "hello" })
-      const withWhitespace = "hello".padEnd(MAX_SECTION_WIDTH, " ")
+      const withWhitespace = "hello".padEnd(gardenEnv.GARDEN_LOGGER_SECTION_WIDTH, " ")
       const rendered = stripAnsi(renderSection(entry))
       expect(rendered).to.equal(`${withWhitespace} → `)
     })
     it("should not render arrow if message is empty", () => {
       const entry = logger.info({ section: "hello" })
-      const withWhitespace = "hello".padEnd(MAX_SECTION_WIDTH, " ")
+      const withWhitespace = "hello".padEnd(gardenEnv.GARDEN_LOGGER_SECTION_WIDTH, " ")
       const rendered = stripAnsi(renderSection(entry))
       expect(rendered).to.equal(`${withWhitespace}`)
     })
@@ -118,9 +118,18 @@ describe("renderers", () => {
       const rendered = stripAnsi(renderSection(entry))
       expect(rendered).to.equal(`${withWhitespace} → `)
     })
+    it("should read section width from env", () => {
+      const originalSectionWidth = gardenEnv["GARDEN_LOGGER_SECTION_WIDTH"]
+      gardenEnv["GARDEN_LOGGER_SECTION_WIDTH"] = 5
+      const entry = logger.info({ msg: "foo", section: "hello" })
+      const withWhitespace = "hello".padEnd(5, " ")
+      const rendered = stripAnsi(renderSection(entry))
+      expect(rendered).to.equal(`${withWhitespace} → `)
+      gardenEnv["GARDEN_LOGGER_SECTION_WIDTH"] = originalSectionWidth
+    })
     it("should not let custom section width exceed max section width", () => {
       const entry = logger.info({ msg: "foo", section: "hello", maxSectionWidth: 99 })
-      const withWhitespace = "hello".padEnd(MAX_SECTION_WIDTH, " ")
+      const withWhitespace = "hello".padEnd(gardenEnv.GARDEN_LOGGER_SECTION_WIDTH, " ")
       const rendered = stripAnsi(renderSection(entry))
       expect(rendered).to.equal(`${withWhitespace} → `)
     })

--- a/docs/misc/faq.md
+++ b/docs/misc/faq.md
@@ -317,3 +317,7 @@ We have a team of people working on it full-time, and we make it a priority to a
 ### Does Garden work offline?
 
 Garden is not currently designed to work in air-gapped environments This would require a fair amount of workarounds, unfortunately.
+
+### How do I prevent module and service names from being truncated in the log output?
+
+You can use the `GARDEN_LOGGER_SECTION_WIDTH` environment variable to change the default module/service section width.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

Quick fix to allow users to configure the logger section width to prevent long module and service names from being truncated. As a more long term solution, we could look into implementing #2478.
