### PR TITLE
Fix: resolve issue with build kit not caching

### DIFF
--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -117,7 +117,7 @@ export const buildkitBuildHandler: BuildHandler = async (params) => {
 
   // Prepare the build command (this thing, while an otherwise excellent piece of software, is clearly is not meant for
   // everyday human usage)
-  let outputSpec = `type=image,name=${deploymentImageId},push=true`
+  let outputSpec = `type=image,"name=${deploymentImageId},${deploymentImageName}:latest",push=true`
 
   if (provider.config.deploymentRegistry?.hostname === inClusterRegistryHostname) {
     // The in-cluster registry is not exposed, so we don't configure TLS on it.

--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -139,7 +139,7 @@ export const buildkitBuildHandler: BuildHandler = async (params) => {
     "--export-cache",
     "type=inline",
     "--import-cache",
-    `type=registry,ref=${deploymentImageName}`,
+    `type=registry,ref=${deploymentImageName}:latest`,
     ...getBuildkitFlags(module),
   ]
 

--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -115,9 +115,10 @@ export const buildkitBuildHandler: BuildHandler = async (params) => {
     statusLine.setState(renderOutputStream(line.toString()))
   })
 
+  const cacheTag = "_buildcache"
   // Prepare the build command (this thing, while an otherwise excellent piece of software, is clearly is not meant for
   // everyday human usage)
-  let outputSpec = `type=image,"name=${deploymentImageId},${deploymentImageName}:latest",push=true`
+  let outputSpec = `type=image,"name=${deploymentImageId},${deploymentImageName}:${cacheTag}",push=true`
 
   if (provider.config.deploymentRegistry?.hostname === inClusterRegistryHostname) {
     // The in-cluster registry is not exposed, so we don't configure TLS on it.
@@ -139,7 +140,7 @@ export const buildkitBuildHandler: BuildHandler = async (params) => {
     "--export-cache",
     "type=inline",
     "--import-cache",
-    `type=registry,ref=${deploymentImageName}:latest`,
+    `type=registry,ref=${deploymentImageName}:${cacheTag}`,
     ...getBuildkitFlags(module),
   ]
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a tag to the buildkit output so that it is pushing to latest.

**Which issue(s) this PR fixes**:
Buildkit doesn't actually cache anything because the import-cache is looking for an untagged image (ie. latest) but all the builds are going to the garden module versions.

Fixes #

**Special notes for your reviewer**:
