### PR TITLE
feat(k8s): port-forward to Deployments and DaemonSets

### DIFF
--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -29,6 +29,7 @@ import { getChartPath, renderHelmTemplateString } from "./helm/common"
 import { HotReloadableResource } from "./hot-reload/hot-reload"
 import { ProviderMap } from "../../config/provider"
 import { PodRunner } from "./run"
+import { isSubset } from "../../util/is-subset"
 
 export const skopeoImage = "gardendev/skopeo:1.41.0-2"
 
@@ -480,6 +481,17 @@ export function getSelectorString(labels: { [key: string]: string }) {
     selectorString += `${label}=${labels[label]},`
   }
   return selectorString.trimEnd().slice(0, -1)
+}
+
+/**
+ * Returns true if the provided matchLabels selector matches the given labels. Use to e.g. match the selector on a
+ * Service with Pod templates from a Deployment.
+ *
+ * @param selector The selector on the Service, or the `matchLabels` part of a Deployment spec selector
+ * @param labels The workload labels to match agains
+ */
+export function matchSelector(selector: { [key: string]: string }, labels: { [key: string]: string }) {
+  return Object.keys(selector).length > 0 && isSubset(labels, selector)
 }
 
 /**

--- a/core/test/unit/src/plugins/kubernetes/port-forward.ts
+++ b/core/test/unit/src/plugins/kubernetes/port-forward.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2018-2021 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import { getForwardablePorts } from "../../../../../src/plugins/kubernetes/port-forward"
+
+describe("getForwardablePorts", () => {
+  it("returns all ports for Service resources", () => {
+    const ports = getForwardablePorts([
+      {
+        apiVersion: "v1",
+        kind: "Service",
+        metadata: {
+          name: "foo",
+        },
+        spec: {
+          ports: [{ port: 12345 }],
+        },
+      },
+    ])
+
+    expect(ports).to.eql([
+      {
+        name: undefined,
+        protocol: "TCP",
+        targetName: "Service/foo",
+        targetPort: 12345,
+      },
+    ])
+  })
+
+  it("returns all ports for Deployment resources", () => {
+    const ports = getForwardablePorts([
+      {
+        apiVersion: "apps/v1",
+        kind: "Deployment",
+        metadata: {
+          name: "foo",
+        },
+        spec: {
+          template: {
+            spec: {
+              containers: [
+                {
+                  ports: [{ containerPort: 12345 }],
+                },
+              ],
+            },
+          },
+        },
+      },
+    ])
+
+    expect(ports).to.eql([
+      {
+        name: undefined,
+        protocol: "TCP",
+        targetName: "Deployment/foo",
+        targetPort: 12345,
+      },
+    ])
+  })
+
+  it("returns all ports for DaemonSet resources", () => {
+    const ports = getForwardablePorts([
+      {
+        apiVersion: "apps/v1",
+        kind: "DaemonSet",
+        metadata: {
+          name: "foo",
+        },
+        spec: {
+          template: {
+            spec: {
+              containers: [
+                {
+                  ports: [{ containerPort: 12345 }],
+                },
+              ],
+            },
+          },
+        },
+      },
+    ])
+
+    expect(ports).to.eql([
+      {
+        name: undefined,
+        protocol: "TCP",
+        targetName: "DaemonSet/foo",
+        targetPort: 12345,
+      },
+    ])
+  })
+
+  it("omits a Deployment port that is already pointed to by a Service resource", () => {
+    const ports = getForwardablePorts([
+      {
+        apiVersion: "v1",
+        kind: "Service",
+        metadata: {
+          name: "foo",
+        },
+        spec: {
+          selector: {
+            app: "foo",
+          },
+          ports: [{ port: 12345, targetPort: 12346 }],
+        },
+      },
+      {
+        apiVersion: "apps/v1",
+        kind: "Deployment",
+        metadata: {
+          name: "foo",
+        },
+        spec: {
+          template: {
+            metadata: {
+              labels: {
+                app: "foo",
+              },
+            },
+            spec: {
+              containers: [
+                {
+                  ports: [{ containerPort: 12346 }],
+                },
+              ],
+            },
+          },
+        },
+      },
+    ])
+
+    expect(ports).to.eql([
+      {
+        name: undefined,
+        protocol: "TCP",
+        targetName: "Service/foo",
+        targetPort: 12345,
+      },
+    ])
+  })
+})

--- a/core/test/unit/src/plugins/kubernetes/util.ts
+++ b/core/test/unit/src/plugins/kubernetes/util.ts
@@ -16,6 +16,7 @@ import {
   getStaticLabelsFromPod,
   getSelectorString,
   makePodName,
+  matchSelector,
 } from "../../../../../src/plugins/kubernetes/util"
 import { KubernetesServerResource } from "../../../../../src/plugins/kubernetes/types"
 import { V1Pod } from "@kubernetes/client-node"
@@ -332,5 +333,32 @@ describe("makePodName", () => {
     const name = makePodName("test", "some-module-with-a-really-unnecessarily-long-name", "really-long-test-name-too")
     expect(name.length).to.equal(63)
     expect(name.slice(0, -7)).to.equal("test-some-module-with-a-really-unnecessarily-long-name-r")
+  })
+})
+
+describe("matchSelector", () => {
+  it("should return false if selector is empty", () => {
+    const matched = matchSelector({}, { foo: "bar" })
+    expect(matched).to.be.false
+  })
+
+  it("should return false if selector contains key missing from labels", () => {
+    const matched = matchSelector({ foo: "bar" }, { nope: "nyet" })
+    expect(matched).to.be.false
+  })
+
+  it("should return false if selector contains value mismatched with a label", () => {
+    const matched = matchSelector({ foo: "bar" }, { foo: "nyet" })
+    expect(matched).to.be.false
+  })
+
+  it("should return true if selector matches labels exactly", () => {
+    const matched = matchSelector({ foo: "bar" }, { foo: "bar" })
+    expect(matched).to.be.true
+  })
+
+  it("should return true if selector is a subset of labels", () => {
+    const matched = matchSelector({ foo: "bar" }, { foo: "bar", something: "else" })
+    expect(matched).to.be.true
   })
 })


### PR DESCRIPTION
Previously we only created port forwards for Service resources. We
still prefer those when applicable but also create port forwards
directly to Deployment and DaemonSet container ports.
