### PR TITLE
fix(k8s): intermittent errors when building/syncing to cluster 

### DIFF
--- a/core/src/plugins/kubernetes/api.ts
+++ b/core/src/plugins/kubernetes/api.ts
@@ -28,7 +28,6 @@ import {
   ApiextensionsV1beta1Api,
   PolicyV1beta1Api,
   KubernetesObject,
-  V1Status,
   Exec,
   Attach,
   V1Deployment,

--- a/core/src/plugins/kubernetes/commands/cleanup-cluster-registry.ts
+++ b/core/src/plugins/kubernetes/commands/cleanup-cluster-registry.ts
@@ -25,7 +25,7 @@ import { apply } from "../kubectl"
 import { waitForResources } from "../status/status"
 import { dedent, deline } from "../../../util/string"
 import { sharedBuildSyncDeploymentName } from "../container/build/common"
-import { execInWorkload, getDeploymentPod } from "../util"
+import { execInWorkload, getRunningDeploymentPod } from "../util"
 import { getSystemNamespace } from "../namespace"
 import { PluginContext } from "../../../plugin-context"
 import { PodRunner } from "../run"
@@ -433,7 +433,11 @@ async function cleanupBuildSyncVolume({
     status: "active",
   })
 
-  const pod = await getDeploymentPod({ api, deploymentName: sharedBuildSyncDeploymentName, namespace: systemNamespace })
+  const pod = await getRunningDeploymentPod({
+    api,
+    deploymentName: sharedBuildSyncDeploymentName,
+    namespace: systemNamespace,
+  })
 
   const runner = new PodRunner({
     api,

--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -34,7 +34,7 @@ import { LogLevel } from "../../../../logger/logger"
 import { renderOutputStream, sleep } from "../../../../util/util"
 import { ContainerModule } from "../../../container/config"
 import { getDockerBuildArgs } from "../../../container/build"
-import { getDeploymentPod, millicpuToString, megabytesToString } from "../../util"
+import { getRunningDeploymentPod, millicpuToString, megabytesToString } from "../../util"
 import { PodRunner } from "../../run"
 
 export const buildkitImageName = "gardendev/buildkit:v0.8.1-4"
@@ -147,7 +147,7 @@ export const buildkitBuildHandler: BuildHandler = async (params) => {
   // Execute the build
   const buildTimeout = module.spec.build.timeout
 
-  const pod = await getDeploymentPod({ api, deploymentName: buildkitDeploymentName, namespace })
+  const pod = await getRunningDeploymentPod({ api, deploymentName: buildkitDeploymentName, namespace })
 
   const runner = new PodRunner({
     api,

--- a/core/src/plugins/kubernetes/container/build/cluster-docker.ts
+++ b/core/src/plugins/kubernetes/container/build/cluster-docker.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { getDeploymentPod } from "../../util"
+import { getRunningDeploymentPod } from "../../util"
 import { dockerDaemonDeploymentName, dockerDaemonContainerName, rsyncPort } from "../../constants"
 import { KubeApi } from "../../api"
 import { KubernetesProvider, KubernetesPluginContext } from "../../config"
@@ -177,7 +177,11 @@ export async function getDockerDaemonPodRunner({
   ctx: PluginContext
   provider: KubernetesProvider
 }) {
-  const pod = await getDeploymentPod({ api, deploymentName: dockerDaemonDeploymentName, namespace: systemNamespace })
+  const pod = await getRunningDeploymentPod({
+    api,
+    deploymentName: dockerDaemonDeploymentName,
+    namespace: systemNamespace,
+  })
 
   return new PodRunner({
     api,

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -11,7 +11,7 @@ import { ContainerModule, ContainerRegistryConfig } from "../../../container/con
 import { containerHelpers } from "../../../container/helpers"
 import { GetBuildStatusParams, BuildStatus } from "../../../../types/plugin/module/getBuildStatus"
 import { BuildModuleParams, BuildResult } from "../../../../types/plugin/module/build"
-import { getDeploymentPod } from "../../util"
+import { getRunningDeploymentPod } from "../../util"
 import {
   buildSyncVolumeName,
   dockerAuthSecretKey,
@@ -71,7 +71,7 @@ interface SyncToSharedBuildSyncParams extends BuildModuleParams<ContainerModule>
 export async function syncToBuildSync(params: SyncToSharedBuildSyncParams) {
   const { ctx, module, log, api, namespace, deploymentName, rsyncPort } = params
 
-  const buildSyncPod = await getDeploymentPod({
+  const buildSyncPod = await getRunningDeploymentPod({
     api,
     deploymentName,
     namespace,
@@ -148,7 +148,7 @@ export async function skopeoBuildStatus({
 
   const podCommand = ["sh", "-c", skopeoCommand.join(" ")]
 
-  const pod = await getDeploymentPod({
+  const pod = await getRunningDeploymentPod({
     api,
     deploymentName,
     namespace,
@@ -198,7 +198,7 @@ export async function getUtilDaemonPodRunner({
   ctx: PluginContext
   provider: KubernetesProvider
 }) {
-  const pod = await getDeploymentPod({
+  const pod = await getRunningDeploymentPod({
     api,
     deploymentName: gardenUtilDaemonDeploymentName,
     namespace: systemNamespace,

--- a/core/src/plugins/kubernetes/status/pod.ts
+++ b/core/src/plugins/kubernetes/status/pod.ts
@@ -174,6 +174,10 @@ export async function getFormattedPodLogs(api: KubeApi, namespace: string, pods:
 }
 
 export function getExecExitCode(status: V1Status) {
+  if (!status) {
+    return 1
+  }
+
   let exitCode = 0
 
   if (status.status !== "Success") {

--- a/core/src/plugins/kubernetes/status/service.ts
+++ b/core/src/plugins/kubernetes/status/service.ts
@@ -11,10 +11,9 @@ import { flatten } from "lodash"
 import { KubeApi } from "../api"
 import { KubernetesServerResource } from "../types"
 import { TimeoutError } from "../../../exceptions"
-import { getPods } from "../util"
+import { getReadyPods } from "../util"
 import { sleep } from "../../../util/util"
 import { LogEntry } from "../../../logger/log-entry"
-import { checkWorkloadPodStatus } from "./pod"
 
 // There's something strange going on if this takes more than 10 seconds to resolve
 const timeout = 10000
@@ -42,10 +41,8 @@ export async function waitForServiceEndpoints(
     const serviceName = service.metadata.name
     const serviceNamespace = service.metadata?.namespace || namespace
 
-    const pods = await getPods(api, serviceNamespace, selector)
-    const readyPodNames = pods
-      .filter((p) => checkWorkloadPodStatus(p, [p]).state === "ready")
-      .map((p) => p.metadata.name)
+    const pods = await getReadyPods(api, serviceNamespace, selector)
+    const readyPodNames = pods.map((p) => p.metadata.name)
 
     while (true) {
       const endpoints = await api.core.readNamespacedEndpoints(serviceName, serviceNamespace)


### PR DESCRIPTION
I spotted a little Kubernetes delight, where k8s sometimes reports pods
as "Running" even though they are in fact Terminated. We'd fixed that
check elsewhere but had left an older check in one place. This should
get rid of that problem.

Also fixed an issue related to the WebSocket wrapper, where connection
interruptions could unnecessarily throw an error.