### PR TITLE
refactor(k8s): officially deprecate the cluster-docker build mode

### DIFF
--- a/core/src/config/common.ts
+++ b/core/src/config/common.ts
@@ -42,7 +42,7 @@ export const enumToArray = (Enum) => Object.values(Enum).filter((k) => typeof k 
 // Extend the Joi module with our custom rules
 interface MetadataKeys {
   internal?: boolean
-  deprecated?: boolean
+  deprecated?: boolean | string
   enterprise?: boolean
   extendable?: boolean
   experimental?: boolean

--- a/core/src/config/project.ts
+++ b/core/src/config/project.ts
@@ -107,10 +107,10 @@ export const environmentSchema = () =>
       `
       )
       .example(true),
-    providers: joiArray(providerConfigBaseSchema()).unique("name").meta({ deprecated: true }).description(deline`
-          DEPRECATED - Please use the top-level \`providers\` field instead, and if needed use the \`environments\` key
-          on the provider configurations to limit them to specific environments.
-        `),
+    providers: joiArray(providerConfigBaseSchema()).unique("name").meta({
+      deprecated:
+        "Please use the top-level `providers` field  instead, and if needed use the `environments` key on the provider configurations to limit them to specific environments.",
+    }),
     varfile: joi
       .posixPath()
       .description(

--- a/core/src/config/workflow.ts
+++ b/core/src/config/workflow.ts
@@ -143,7 +143,10 @@ export const workflowConfigSchema = () =>
         })
         // .default(() => ({}))
         .meta({ enterprise: true }),
-      limits: workflowResourceLimitsSchema().meta({ enterprise: true, deprecated: true }),
+      limits: workflowResourceLimitsSchema().meta({
+        enterprise: true,
+        deprecated: "Please use the `resources.limits` field instead.",
+      }),
       steps: joiSparseArray(workflowStepSchema()).required().min(1).description(deline`
           The steps the workflow should run. At least one step is required. Steps are run sequentially.
           If a step fails, subsequent steps are skipped.

--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -515,7 +515,9 @@ const containerServiceSchema = () =>
         these arguments when the service is deployed with hot reloading enabled.`
       )
       .example(["npm", "run", "dev"]),
-    limits: limitsSchema().description("Specify resource limits for the service.").meta({ deprecated: true }),
+    limits: limitsSchema()
+      .description("Specify resource limits for the service.")
+      .meta({ deprecated: "Please use the `cpu` and `memory` fields instead." }),
     cpu: containerCpuSchema("service").default(defaultContainerResources.cpu),
     memory: containerMemorySchema("service").default(defaultContainerResources.memory),
     ports: joiSparseArray(portSchema()).unique("name").description("List of ports that the service container exposes."),

--- a/core/test/unit/src/plugins/kubernetes/kubernetes.ts
+++ b/core/test/unit/src/plugins/kubernetes/kubernetes.ts
@@ -72,7 +72,7 @@ describe("kubernetes configureProvider", () => {
   it("should apply a default namespace if none is configured", async () => {
     const result = await configure({
       ...basicConfig,
-      buildMode: "cluster-docker",
+      buildMode: "kaniko",
       namespace: undefined,
     })
 
@@ -84,7 +84,7 @@ describe("kubernetes configureProvider", () => {
   it("should convert the string shorthand for the namespace parameter", async () => {
     const result = await configure({
       ...basicConfig,
-      buildMode: "cluster-docker",
+      buildMode: "kaniko",
       namespace: <any>(<unknown>"foo"),
     })
 
@@ -96,7 +96,7 @@ describe("kubernetes configureProvider", () => {
   it("should pass through a full namespace spec", async () => {
     const result = await configure({
       ...basicConfig,
-      buildMode: "cluster-docker",
+      buildMode: "kaniko",
       namespace: {
         name: "foo",
         annotations: { bla: "ble" },
@@ -114,7 +114,7 @@ describe("kubernetes configureProvider", () => {
   it("should set a default deploymentRegistry with projectName as namespace", async () => {
     const result = await configure({
       ...basicConfig,
-      buildMode: "cluster-docker",
+      buildMode: "kaniko",
     })
 
     expect(result.config.deploymentRegistry).to.eql({
@@ -126,7 +126,7 @@ describe("kubernetes configureProvider", () => {
   it("should allow overriding the deploymentRegistry namespace for the in-cluster registry", async () => {
     const result = await configure({
       ...basicConfig,
-      buildMode: "cluster-docker",
+      buildMode: "kaniko",
       deploymentRegistry: {
         hostname: "127.0.0.1:5000",
         namespace: "my-namespace",

--- a/docs/guides/in-cluster-building.md
+++ b/docs/guides/in-cluster-building.md
@@ -69,7 +69,7 @@ Garden supports multiple methods for building images and making them available t
 
 1. [**`kaniko`**](#kaniko) — Individual [Kaniko](https://github.com/GoogleContainerTools/kaniko) pods created for each build.
 2. [**`cluster-buildkit`**](#cluster-buildkit) — A [BuildKit](https://github.com/moby/buildkit) deployment created for each project namespace.
-3. [**`cluster-docker`**](#cluster-docker) — A single Docker daemon installed in the `garden-system` namespace and shared between users/deployments.
+3. [**`cluster-docker`**](#cluster-docker) — (**Deprecated**) A single Docker daemon installed in the `garden-system` namespace and shared between users/deployments. It is **no longer recommended** and we will remove it in future releases.
 4. `local-docker` — Build using the local Docker daemon on the developer/CI machine before pushing to the cluster/registry.
 
 The `local-docker` mode is set by default. You should definitely use that when using _Docker for Desktop_, _Minikube_ and most other local development clusters.
@@ -79,10 +79,9 @@ The other modes—which are why you're reading this guide—all build your image
 The remote building options each have some pros and cons. You'll find more details below but **here are our general recommendations** at the moment:
 
 - [**`kaniko`**](#kaniko) is a solid choice for most cases and is _currently our first recommendation_. It is battle-tested among Garden's most demanding users (including the Garden team itself). It also scales horizontally and elastically, since individual Pods are created for each build. It doesn't require priviliged containers to run and requires no shared cluster-wide services.
-- [**`cluster-buildkit`**](#cluster-buildkit) is a new addition and is meant to replace the `cluster-docker` mode. Unlike the `cluster-docker` mode, which deploys cluster-wide services in the `garden-system` namespace, a [BuildKit](https://github.com/moby/buildkit) Deployment is dynamically created in each project namespace and much like Kaniko requires no other cluster-wide services. This mode also offers a _rootless_ option, which runs without any elevated privileges, in clusters that support it.
-- [**`cluster-docker`**](#cluster-docker) was the first implementation included with Garden. It's pretty quick and efficient for small team setups, but relies on a single Docker daemon for all users of a cluster, and also requires supporting services in `garden-system` and some operations to keep it from filling its data volume. It is **no longer recommended** and we may remove it in future releases.
+- [**`cluster-buildkit`**](#cluster-buildkit) is a new addition and replaces the older `cluster-docker` mode. A [BuildKit](https://github.com/moby/buildkit) Deployment is dynamically created in each project namespace and much like Kaniko requires no other cluster-wide services. This mode also offers a _rootless_ option, which runs without any elevated privileges, in clusters that support it.
 
-Generally we recommend picking either `kaniko` or `cluster-buildkit`, based on your usage patterns and scalability requirements. For ephemeral namespaces, `kaniko` is generally the better option, since the persistent BuildKit deployment won't have a warm cache anyway. For long-lived namespaces, like the ones a developer uses while working, `cluster-buildkit` may be a more performant option.
+We recommend picking a mode based on your usage patterns and scalability requirements. For ephemeral namespaces, `kaniko` is generally the better option, since the persistent BuildKit deployment won't have a warm cache anyway. For long-lived namespaces, like the ones a developer uses while working, `cluster-buildkit` may be a more performant option.
 
 Let's look at how each mode works in more detail, and how you configure them:
 
@@ -174,7 +173,7 @@ This allows you to set corresponding [Taints](https://kubernetes.io/docs/concept
 ### cluster-docker
 
 {% hint style="warning" %}
-The `cluster-docker` build mode may be deprecated and removed in an upcoming release. Please consider `kaniko` or `cluster-buildkit` instead.
+The `cluster-docker` build mode has been **deprecated** and will be removed in an upcoming release. Please use `kaniko` or `cluster-buildkit` instead.
 {% endhint %}
 
 The `cluster-docker` mode installs a standalone Docker daemon into your cluster, that is then used for builds across all users of the clusters, along with a handful of other supporting services.

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -1441,6 +1441,10 @@ services:
 
 [services](#services) > limits
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Specify resource limits for the service.
 
 | Type     | Required |
@@ -1451,6 +1455,10 @@ Specify resource limits for the service.
 
 [services](#services) > [limits](#serviceslimits) > cpu
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)
 
 | Type     | Required |
@@ -1460,6 +1468,10 @@ The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)
 ### `services[].limits.memory`
 
 [services](#services) > [limits](#serviceslimits) > memory
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB)
 
@@ -1618,6 +1630,10 @@ services:
 ### `services[].ports[].hostPort`
 
 [services](#services) > [ports](#servicesports) > hostPort
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 | Type     | Required |
 | -------- | -------- |

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -1449,6 +1449,10 @@ services:
 
 [services](#services) > limits
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Specify resource limits for the service.
 
 | Type     | Required |
@@ -1459,6 +1463,10 @@ Specify resource limits for the service.
 
 [services](#services) > [limits](#serviceslimits) > cpu
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)
 
 | Type     | Required |
@@ -1468,6 +1476,10 @@ The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)
 ### `services[].limits.memory`
 
 [services](#services) > [limits](#serviceslimits) > memory
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB)
 
@@ -1626,6 +1638,10 @@ services:
 ### `services[].ports[].hostPort`
 
 [services](#services) > [ports](#servicesports) > hostPort
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 | Type     | Required |
 | -------- | -------- |

--- a/docs/reference/project-config.md
+++ b/docs/reference/project-config.md
@@ -294,7 +294,9 @@ environments:
 
 [environments](#environments) > providers
 
-DEPRECATED - Please use the top-level `providers` field instead, and if needed use the `environments` key on the provider configurations to limit them to specific environments.
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
@@ -314,7 +316,8 @@ Example:
 
 ```yaml
 environments:
-        name: "local-kubernetes"
+  - providers:
+      - name: "local-kubernetes"
 ```
 
 ### `environments[].providers[].dependencies[]`
@@ -331,7 +334,8 @@ Example:
 
 ```yaml
 environments:
-        dependencies:
+  - providers:
+      - dependencies:
           - exec
 ```
 
@@ -349,7 +353,8 @@ Example:
 
 ```yaml
 environments:
-        environments:
+  - providers:
+      - environments:
           - dev
           - stage
 ```

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -35,12 +35,14 @@ providers:
     environments:
 
     # Choose the mechanism for building container images before deploying. By default your local Docker daemon is
-    # used, but you can set it to `cluster-buildkit`, `cluster-docker` or `kaniko` to sync files to the cluster, and
-    # build container images there. This removes the need to run Docker locally, and allows you to share layer and
-    # image caches between multiple developers, as well as between your development and CI workflows.
+    # used, but you can set it to `cluster-buildkit` or `kaniko` to sync files to the cluster, and build container
+    # images there. This removes the need to run Docker locally, and allows you to share layer and image caches
+    # between multiple developers, as well as between your development and CI workflows.
     #
     # For more details on all the different options and what makes sense to use for your setup, please check out the
     # [in-cluster building guide](https://docs.garden.io/guides/in-cluster-building).
+    #
+    # **Note:** The `cluster-docker` mode has been deprecated and will be removed in a future release!
     buildMode: local-docker
 
     # Configuration options for the `cluster-buildkit` build mode.
@@ -56,12 +58,6 @@ providers:
       # [See here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) for the official Kubernetes
       # guide to assigning Pods to nodes.
       nodeSelector: {}
-
-    # Configuration options for the `cluster-docker` build mode.
-    clusterDocker:
-      # Enable [BuildKit](https://github.com/moby/buildkit) support. This should in most cases work well and be more
-      # performant, but we're opting to keep it optional until it's enabled by default in Docker.
-      enableBuildKit: false
 
     # Configuration options for the `kaniko` build mode.
     kaniko:
@@ -122,7 +118,8 @@ providers:
       #
       # When `buildMode` is `cluster-docker`, this applies to the single Docker Daemon that is installed and run
       # cluster-wide. This is shared across all users and builds in the cluster, so it should be resourced
-      # accordingly, factoring in how many concurrent builds you expect and how heavy your builds tend to be.
+      # accordingly, factoring in how many concurrent builds you expect and how heavy your builds tend to be. **Note
+      # that the cluster-docker build mode has been deprecated!**
       builder:
         limits:
           # CPU limit in millicpu.
@@ -158,48 +155,12 @@ providers:
           # Memory request in megabytes.
           memory: 512
 
-      # Resource requests and limits for the code sync service, which we use to sync build contexts to the cluster
-      # ahead of building images. This generally is not resource intensive, but you might want to adjust the
-      # defaults if you have many concurrent users.
-      sync:
-        limits:
-          # CPU limit in millicpu.
-          cpu: 500
-
-          # Memory limit in megabytes.
-          memory: 512
-
-        requests:
-          # CPU request in millicpu.
-          cpu: 100
-
-          # Memory request in megabytes.
-          memory: 90
-
     # Storage parameters to set for the in-cluster builder, container registry and code sync persistent volumes
     # (which are automatically installed and used when `buildMode` is `cluster-docker` or `kaniko`).
     #
     # These are all shared cluster-wide across all users and builds, so they should be resourced accordingly,
     # factoring in how many concurrent builds you expect and how large your images and build contexts tend to be.
     storage:
-      # Storage parameters for the data volume for the in-cluster Docker Daemon.
-      #
-      # Only applies when `buildMode` is set to `cluster-docker`, ignored otherwise.
-      builder:
-        # Volume size in megabytes.
-        size: 20480
-
-        # Storage class to use for the volume.
-        storageClass: null
-
-      # Storage parameters for the NFS provisioner, which we automatically create for the sync volume, _unless_
-      # you specify a `storageClass` for the sync volume. See the below `sync` parameter for more.
-      #
-      # Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored otherwise.
-      nfs:
-        # Storage class to use as backing storage for NFS .
-        storageClass: null
-
       # Storage parameters for the in-cluster Docker registry volume. Built images are stored here, so that they
       # are available to all the nodes in your cluster.
       #
@@ -207,21 +168,6 @@ providers:
       registry:
         # Volume size in megabytes.
         size: 20480
-
-        # Storage class to use for the volume.
-        storageClass: null
-
-      # Storage parameters for the code sync volume, which build contexts are synced to ahead of running
-      # in-cluster builds.
-      #
-      # Important: The storage class configured here has to support _ReadWriteMany_ access.
-      # If you don't specify a storage class, Garden creates an NFS provisioner and provisions an
-      # NFS volume for the sync data volume.
-      #
-      # Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored otherwise.
-      sync:
-        # Volume size in megabytes.
-        size: 10240
 
         # Storage class to use for the volume.
         storageClass: null
@@ -414,9 +360,11 @@ providers:
 
 [providers](#providers) > buildMode
 
-Choose the mechanism for building container images before deploying. By default your local Docker daemon is used, but you can set it to `cluster-buildkit`, `cluster-docker` or `kaniko` to sync files to the cluster, and build container images there. This removes the need to run Docker locally, and allows you to share layer and image caches between multiple developers, as well as between your development and CI workflows.
+Choose the mechanism for building container images before deploying. By default your local Docker daemon is used, but you can set it to `cluster-buildkit` or `kaniko` to sync files to the cluster, and build container images there. This removes the need to run Docker locally, and allows you to share layer and image caches between multiple developers, as well as between your development and CI workflows.
 
 For more details on all the different options and what makes sense to use for your setup, please check out the [in-cluster building guide](https://docs.garden.io/guides/in-cluster-building).
+
+**Note:** The `cluster-docker` mode has been deprecated and will be removed in a future release!
 
 | Type     | Default          | Required |
 | -------- | ---------------- | -------- |
@@ -469,6 +417,10 @@ providers:
 
 [providers](#providers) > clusterDocker
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Configuration options for the `cluster-docker` build mode.
 
 | Type     | Required |
@@ -478,6 +430,10 @@ Configuration options for the `cluster-docker` build mode.
 ### `providers[].clusterDocker.enableBuildKit`
 
 [providers](#providers) > [clusterDocker](#providersclusterdocker) > enableBuildKit
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 Enable [BuildKit](https://github.com/moby/buildkit) support. This should in most cases work well and be more performant, but we're opting to keep it optional until it's enabled by default in Docker.
 
@@ -559,7 +515,10 @@ providers:
 ### `providers[].deploymentStrategy`
 
 [providers](#providers) > deploymentStrategy
-> ⚠️ **Experimental**: this is an experimental feature and the API might change in the future.
+
+{% hint style="warning" %}
+**Experimental**: this is an experimental feature and the API might change in the future.
+{% endhint %}
 
 Defines the strategy for deploying the project services.
 Default is "rolling update" and there is experimental support for "blue/green" deployment.
@@ -639,7 +598,7 @@ When `buildMode` is `kaniko`, this refers to _each Kaniko pod_, i.e. each indivi
 
 When `buildMode` is `cluster-buildkit`, this applies to the BuildKit deployment created in _each project namespace_. So think of this as the resource spec for each individual user or project namespace.
 
-When `buildMode` is `cluster-docker`, this applies to the single Docker Daemon that is installed and run cluster-wide. This is shared across all users and builds in the cluster, so it should be resourced accordingly, factoring in how many concurrent builds you expect and how heavy your builds tend to be.
+When `buildMode` is `cluster-docker`, this applies to the single Docker Daemon that is installed and run cluster-wide. This is shared across all users and builds in the cluster, so it should be resourced accordingly, factoring in how many concurrent builds you expect and how heavy your builds tend to be. **Note that the cluster-docker build mode has been deprecated!**
 
 | Type     | Default                                                                     | Required |
 | -------- | --------------------------------------------------------------------------- | -------- |
@@ -879,6 +838,10 @@ providers:
 
 [providers](#providers) > [resources](#providersresources) > sync
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Resource requests and limits for the code sync service, which we use to sync build contexts to the cluster
 ahead of building images. This generally is not resource intensive, but you might want to adjust the
 defaults if you have many concurrent users.
@@ -891,6 +854,10 @@ defaults if you have many concurrent users.
 
 [providers](#providers) > [resources](#providersresources) > [sync](#providersresourcessync) > limits
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 | Type     | Default                    | Required |
 | -------- | -------------------------- | -------- |
 | `object` | `{"cpu":500,"memory":512}` | No       |
@@ -898,6 +865,10 @@ defaults if you have many concurrent users.
 ### `providers[].resources.sync.limits.cpu`
 
 [providers](#providers) > [resources](#providersresources) > [sync](#providersresourcessync) > [limits](#providersresourcessynclimits) > cpu
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 CPU limit in millicpu.
 
@@ -922,6 +893,10 @@ providers:
 
 [providers](#providers) > [resources](#providersresources) > [sync](#providersresourcessync) > [limits](#providersresourcessynclimits) > memory
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Memory limit in megabytes.
 
 | Type     | Default | Required |
@@ -945,6 +920,10 @@ providers:
 
 [providers](#providers) > [resources](#providersresources) > [sync](#providersresourcessync) > requests
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 | Type     | Default                   | Required |
 | -------- | ------------------------- | -------- |
 | `object` | `{"cpu":100,"memory":90}` | No       |
@@ -952,6 +931,10 @@ providers:
 ### `providers[].resources.sync.requests.cpu`
 
 [providers](#providers) > [resources](#providersresources) > [sync](#providersresourcessync) > [requests](#providersresourcessyncrequests) > cpu
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 CPU request in millicpu.
 
@@ -975,6 +958,10 @@ providers:
 ### `providers[].resources.sync.requests.memory`
 
 [providers](#providers) > [resources](#providersresources) > [sync](#providersresourcessync) > [requests](#providersresourcessyncrequests) > memory
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 Memory request in megabytes.
 
@@ -1013,6 +1000,10 @@ factoring in how many concurrent builds you expect and how large your images and
 
 [providers](#providers) > [storage](#providersstorage) > builder
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Storage parameters for the data volume for the in-cluster Docker Daemon.
 
 Only applies when `buildMode` is set to `cluster-docker`, ignored otherwise.
@@ -1025,6 +1016,10 @@ Only applies when `buildMode` is set to `cluster-docker`, ignored otherwise.
 
 [providers](#providers) > [storage](#providersstorage) > [builder](#providersstoragebuilder) > size
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Volume size in megabytes.
 
 | Type     | Default | Required |
@@ -1035,6 +1030,10 @@ Volume size in megabytes.
 
 [providers](#providers) > [storage](#providersstorage) > [builder](#providersstoragebuilder) > storageClass
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Storage class to use for the volume.
 
 | Type     | Default | Required |
@@ -1044,6 +1043,10 @@ Storage class to use for the volume.
 ### `providers[].storage.nfs`
 
 [providers](#providers) > [storage](#providersstorage) > nfs
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 Storage parameters for the NFS provisioner, which we automatically create for the sync volume, _unless_
 you specify a `storageClass` for the sync volume. See the below `sync` parameter for more.
@@ -1057,6 +1060,10 @@ Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored ot
 ### `providers[].storage.nfs.storageClass`
 
 [providers](#providers) > [storage](#providersstorage) > [nfs](#providersstoragenfs) > storageClass
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 Storage class to use as backing storage for NFS .
 
@@ -1101,6 +1108,10 @@ Storage class to use for the volume.
 
 [providers](#providers) > [storage](#providersstorage) > sync
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Storage parameters for the code sync volume, which build contexts are synced to ahead of running
 in-cluster builds.
 
@@ -1108,7 +1119,7 @@ Important: The storage class configured here has to support _ReadWriteMany_ acce
 If you don't specify a storage class, Garden creates an NFS provisioner and provisions an
 NFS volume for the sync data volume.
 
-Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored otherwise.
+Only applies when `buildMode` is set to `cluster-docker`, ignored otherwise.
 
 | Type     | Default                              | Required |
 | -------- | ------------------------------------ | -------- |
@@ -1117,6 +1128,10 @@ Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored ot
 ### `providers[].storage.sync.size`
 
 [providers](#providers) > [storage](#providersstorage) > [sync](#providersstoragesync) > size
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 Volume size in megabytes.
 
@@ -1127,6 +1142,10 @@ Volume size in megabytes.
 ### `providers[].storage.sync.storageClass`
 
 [providers](#providers) > [storage](#providersstorage) > [sync](#providersstoragesync) > storageClass
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 Storage class to use for the volume.
 
@@ -1654,6 +1673,10 @@ The default hostname configured on the provider.
 | `string` |
 
 ### `${providers.<provider-name>.outputs.metadata-namespace}`
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The namespace used for Garden metadata (currently always the same as app-namespace).
 

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -31,12 +31,14 @@ providers:
     environments:
 
     # Choose the mechanism for building container images before deploying. By default your local Docker daemon is
-    # used, but you can set it to `cluster-buildkit`, `cluster-docker` or `kaniko` to sync files to the cluster, and
-    # build container images there. This removes the need to run Docker locally, and allows you to share layer and
-    # image caches between multiple developers, as well as between your development and CI workflows.
+    # used, but you can set it to `cluster-buildkit` or `kaniko` to sync files to the cluster, and build container
+    # images there. This removes the need to run Docker locally, and allows you to share layer and image caches
+    # between multiple developers, as well as between your development and CI workflows.
     #
     # For more details on all the different options and what makes sense to use for your setup, please check out the
     # [in-cluster building guide](https://docs.garden.io/guides/in-cluster-building).
+    #
+    # **Note:** The `cluster-docker` mode has been deprecated and will be removed in a future release!
     buildMode: local-docker
 
     # Configuration options for the `cluster-buildkit` build mode.
@@ -52,12 +54,6 @@ providers:
       # [See here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) for the official Kubernetes
       # guide to assigning Pods to nodes.
       nodeSelector: {}
-
-    # Configuration options for the `cluster-docker` build mode.
-    clusterDocker:
-      # Enable [BuildKit](https://github.com/moby/buildkit) support. This should in most cases work well and be more
-      # performant, but we're opting to keep it optional until it's enabled by default in Docker.
-      enableBuildKit: false
 
     # Configuration options for the `kaniko` build mode.
     kaniko:
@@ -118,7 +114,8 @@ providers:
       #
       # When `buildMode` is `cluster-docker`, this applies to the single Docker Daemon that is installed and run
       # cluster-wide. This is shared across all users and builds in the cluster, so it should be resourced
-      # accordingly, factoring in how many concurrent builds you expect and how heavy your builds tend to be.
+      # accordingly, factoring in how many concurrent builds you expect and how heavy your builds tend to be. **Note
+      # that the cluster-docker build mode has been deprecated!**
       builder:
         limits:
           # CPU limit in millicpu.
@@ -154,48 +151,12 @@ providers:
           # Memory request in megabytes.
           memory: 512
 
-      # Resource requests and limits for the code sync service, which we use to sync build contexts to the cluster
-      # ahead of building images. This generally is not resource intensive, but you might want to adjust the
-      # defaults if you have many concurrent users.
-      sync:
-        limits:
-          # CPU limit in millicpu.
-          cpu: 500
-
-          # Memory limit in megabytes.
-          memory: 512
-
-        requests:
-          # CPU request in millicpu.
-          cpu: 100
-
-          # Memory request in megabytes.
-          memory: 90
-
     # Storage parameters to set for the in-cluster builder, container registry and code sync persistent volumes
     # (which are automatically installed and used when `buildMode` is `cluster-docker` or `kaniko`).
     #
     # These are all shared cluster-wide across all users and builds, so they should be resourced accordingly,
     # factoring in how many concurrent builds you expect and how large your images and build contexts tend to be.
     storage:
-      # Storage parameters for the data volume for the in-cluster Docker Daemon.
-      #
-      # Only applies when `buildMode` is set to `cluster-docker`, ignored otherwise.
-      builder:
-        # Volume size in megabytes.
-        size: 20480
-
-        # Storage class to use for the volume.
-        storageClass: null
-
-      # Storage parameters for the NFS provisioner, which we automatically create for the sync volume, _unless_
-      # you specify a `storageClass` for the sync volume. See the below `sync` parameter for more.
-      #
-      # Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored otherwise.
-      nfs:
-        # Storage class to use as backing storage for NFS .
-        storageClass: null
-
       # Storage parameters for the in-cluster Docker registry volume. Built images are stored here, so that they
       # are available to all the nodes in your cluster.
       #
@@ -203,21 +164,6 @@ providers:
       registry:
         # Volume size in megabytes.
         size: 20480
-
-        # Storage class to use for the volume.
-        storageClass: null
-
-      # Storage parameters for the code sync volume, which build contexts are synced to ahead of running
-      # in-cluster builds.
-      #
-      # Important: The storage class configured here has to support _ReadWriteMany_ access.
-      # If you don't specify a storage class, Garden creates an NFS provisioner and provisions an
-      # NFS volume for the sync data volume.
-      #
-      # Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored otherwise.
-      sync:
-        # Volume size in megabytes.
-        size: 10240
 
         # Storage class to use for the volume.
         storageClass: null
@@ -376,9 +322,11 @@ providers:
 
 [providers](#providers) > buildMode
 
-Choose the mechanism for building container images before deploying. By default your local Docker daemon is used, but you can set it to `cluster-buildkit`, `cluster-docker` or `kaniko` to sync files to the cluster, and build container images there. This removes the need to run Docker locally, and allows you to share layer and image caches between multiple developers, as well as between your development and CI workflows.
+Choose the mechanism for building container images before deploying. By default your local Docker daemon is used, but you can set it to `cluster-buildkit` or `kaniko` to sync files to the cluster, and build container images there. This removes the need to run Docker locally, and allows you to share layer and image caches between multiple developers, as well as between your development and CI workflows.
 
 For more details on all the different options and what makes sense to use for your setup, please check out the [in-cluster building guide](https://docs.garden.io/guides/in-cluster-building).
+
+**Note:** The `cluster-docker` mode has been deprecated and will be removed in a future release!
 
 | Type     | Default          | Required |
 | -------- | ---------------- | -------- |
@@ -431,6 +379,10 @@ providers:
 
 [providers](#providers) > clusterDocker
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Configuration options for the `cluster-docker` build mode.
 
 | Type     | Required |
@@ -440,6 +392,10 @@ Configuration options for the `cluster-docker` build mode.
 ### `providers[].clusterDocker.enableBuildKit`
 
 [providers](#providers) > [clusterDocker](#providersclusterdocker) > enableBuildKit
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 Enable [BuildKit](https://github.com/moby/buildkit) support. This should in most cases work well and be more performant, but we're opting to keep it optional until it's enabled by default in Docker.
 
@@ -521,7 +477,10 @@ providers:
 ### `providers[].deploymentStrategy`
 
 [providers](#providers) > deploymentStrategy
-> ⚠️ **Experimental**: this is an experimental feature and the API might change in the future.
+
+{% hint style="warning" %}
+**Experimental**: this is an experimental feature and the API might change in the future.
+{% endhint %}
 
 Defines the strategy for deploying the project services.
 Default is "rolling update" and there is experimental support for "blue/green" deployment.
@@ -601,7 +560,7 @@ When `buildMode` is `kaniko`, this refers to _each Kaniko pod_, i.e. each indivi
 
 When `buildMode` is `cluster-buildkit`, this applies to the BuildKit deployment created in _each project namespace_. So think of this as the resource spec for each individual user or project namespace.
 
-When `buildMode` is `cluster-docker`, this applies to the single Docker Daemon that is installed and run cluster-wide. This is shared across all users and builds in the cluster, so it should be resourced accordingly, factoring in how many concurrent builds you expect and how heavy your builds tend to be.
+When `buildMode` is `cluster-docker`, this applies to the single Docker Daemon that is installed and run cluster-wide. This is shared across all users and builds in the cluster, so it should be resourced accordingly, factoring in how many concurrent builds you expect and how heavy your builds tend to be. **Note that the cluster-docker build mode has been deprecated!**
 
 | Type     | Default                                                                     | Required |
 | -------- | --------------------------------------------------------------------------- | -------- |
@@ -841,6 +800,10 @@ providers:
 
 [providers](#providers) > [resources](#providersresources) > sync
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Resource requests and limits for the code sync service, which we use to sync build contexts to the cluster
 ahead of building images. This generally is not resource intensive, but you might want to adjust the
 defaults if you have many concurrent users.
@@ -853,6 +816,10 @@ defaults if you have many concurrent users.
 
 [providers](#providers) > [resources](#providersresources) > [sync](#providersresourcessync) > limits
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 | Type     | Default                    | Required |
 | -------- | -------------------------- | -------- |
 | `object` | `{"cpu":500,"memory":512}` | No       |
@@ -860,6 +827,10 @@ defaults if you have many concurrent users.
 ### `providers[].resources.sync.limits.cpu`
 
 [providers](#providers) > [resources](#providersresources) > [sync](#providersresourcessync) > [limits](#providersresourcessynclimits) > cpu
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 CPU limit in millicpu.
 
@@ -884,6 +855,10 @@ providers:
 
 [providers](#providers) > [resources](#providersresources) > [sync](#providersresourcessync) > [limits](#providersresourcessynclimits) > memory
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Memory limit in megabytes.
 
 | Type     | Default | Required |
@@ -907,6 +882,10 @@ providers:
 
 [providers](#providers) > [resources](#providersresources) > [sync](#providersresourcessync) > requests
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 | Type     | Default                   | Required |
 | -------- | ------------------------- | -------- |
 | `object` | `{"cpu":100,"memory":90}` | No       |
@@ -914,6 +893,10 @@ providers:
 ### `providers[].resources.sync.requests.cpu`
 
 [providers](#providers) > [resources](#providersresources) > [sync](#providersresourcessync) > [requests](#providersresourcessyncrequests) > cpu
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 CPU request in millicpu.
 
@@ -937,6 +920,10 @@ providers:
 ### `providers[].resources.sync.requests.memory`
 
 [providers](#providers) > [resources](#providersresources) > [sync](#providersresourcessync) > [requests](#providersresourcessyncrequests) > memory
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 Memory request in megabytes.
 
@@ -975,6 +962,10 @@ factoring in how many concurrent builds you expect and how large your images and
 
 [providers](#providers) > [storage](#providersstorage) > builder
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Storage parameters for the data volume for the in-cluster Docker Daemon.
 
 Only applies when `buildMode` is set to `cluster-docker`, ignored otherwise.
@@ -987,6 +978,10 @@ Only applies when `buildMode` is set to `cluster-docker`, ignored otherwise.
 
 [providers](#providers) > [storage](#providersstorage) > [builder](#providersstoragebuilder) > size
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Volume size in megabytes.
 
 | Type     | Default | Required |
@@ -997,6 +992,10 @@ Volume size in megabytes.
 
 [providers](#providers) > [storage](#providersstorage) > [builder](#providersstoragebuilder) > storageClass
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Storage class to use for the volume.
 
 | Type     | Default | Required |
@@ -1006,6 +1005,10 @@ Storage class to use for the volume.
 ### `providers[].storage.nfs`
 
 [providers](#providers) > [storage](#providersstorage) > nfs
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 Storage parameters for the NFS provisioner, which we automatically create for the sync volume, _unless_
 you specify a `storageClass` for the sync volume. See the below `sync` parameter for more.
@@ -1019,6 +1022,10 @@ Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored ot
 ### `providers[].storage.nfs.storageClass`
 
 [providers](#providers) > [storage](#providersstorage) > [nfs](#providersstoragenfs) > storageClass
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 Storage class to use as backing storage for NFS .
 
@@ -1063,6 +1070,10 @@ Storage class to use for the volume.
 
 [providers](#providers) > [storage](#providersstorage) > sync
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Storage parameters for the code sync volume, which build contexts are synced to ahead of running
 in-cluster builds.
 
@@ -1070,7 +1081,7 @@ Important: The storage class configured here has to support _ReadWriteMany_ acce
 If you don't specify a storage class, Garden creates an NFS provisioner and provisions an
 NFS volume for the sync data volume.
 
-Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored otherwise.
+Only applies when `buildMode` is set to `cluster-docker`, ignored otherwise.
 
 | Type     | Default                              | Required |
 | -------- | ------------------------------------ | -------- |
@@ -1079,6 +1090,10 @@ Only applies when `buildMode` is set to `cluster-docker` or `kaniko`, ignored ot
 ### `providers[].storage.sync.size`
 
 [providers](#providers) > [storage](#providersstorage) > [sync](#providersstoragesync) > size
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 Volume size in megabytes.
 
@@ -1089,6 +1104,10 @@ Volume size in megabytes.
 ### `providers[].storage.sync.storageClass`
 
 [providers](#providers) > [storage](#providersstorage) > [sync](#providersstoragesync) > storageClass
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 Storage class to use for the volume.
 

--- a/docs/reference/workflow-config.md
+++ b/docs/reference/workflow-config.md
@@ -364,6 +364,10 @@ The maximum amount of RAM the workflow pod can use, in megabytes (i.e. 1024 = 1 
 
 ### `limits`
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 | Type     | Required |
 | -------- | -------- |
 | `object` | No       |

--- a/static/docs/templates/config-partial.hbs
+++ b/static/docs/templates/config-partial.hbs
@@ -6,7 +6,16 @@
 {{{breadCrumbs}}}
 {{/if}}
 {{#if experimentalFeature}}
-> ⚠️ **Experimental**: this is an experimental feature and the API might change in the future.
+
+{% hint style="warning" %}
+**Experimental**: this is an experimental feature and the API might change in the future.
+{% endhint %}
+{{/if}}
+{{#if deprecated}}
+
+{% hint style="warning" %}
+**Deprecated**: {{ deprecatedDescription }}
+{% endhint %}
 {{/if}}
 {{#if description}}
 


### PR DESCRIPTION
It's time. We now show a warning when still using the cluster-docker build mode, and docs/references reflect the deprecated feature status.