### PR TITLE
fix(k8s): correctly handle Ingress API versions for container modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -494,7 +494,7 @@ jobs:
       - run:
           name: Install kind
           command: |
-            curl -LO https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-linux-amd64
+            curl -LO https://github.com/kubernetes-sigs/kind/releases/download/v0.11.1/kind-linux-amd64
             chmod +x kind-linux-amd64
             sudo mv kind-linux-amd64 /usr/local/bin/kind
       - run:
@@ -503,7 +503,7 @@ jobs:
             # Create the kind cluster with a custom config to enable the default ingress controller
             cat \<<EOF | kind create cluster \
                 --image <<parameters.kindNodeImage>> \
-                --wait=120s \
+                --wait=600s \
                 --config=-
 
             kind: Cluster
@@ -539,7 +539,7 @@ jobs:
             # Notes:
             # - We skip tests that only work for remote environments
             # - We currently don't support in-cluster building on kind.
-            yarn integ-kind -b
+            yarn integ-kind
       - run:
           name: Plugin tests
           command: yarn run test:plugins
@@ -604,7 +604,7 @@ jobs:
             # - Need to run with sudo to work with microk8s, because CircleCI doesn't allow us to log out
             #   and back in to add the circleci user to the microk8s group.
             # - We currently don't support in-cluster building on microk8s.
-            GARDEN_SKIP_TESTS="cluster-docker kaniko remote-only" sudo -E npm run integ -b
+            GARDEN_SKIP_TESTS="cluster-docker kaniko remote-only" sudo -E npm run integ
       - run:
           name: Plugin tests
           command: sudo -E npm run test:plugins
@@ -781,6 +781,10 @@ workflows:
     jobs:
       - test-kind:
           kindNodeImage: kindest/node:v1.20.2
+  test-kind-1.21:
+    jobs:
+      - test-kind:
+          kindNodeImage: kindest/node:v1.21.2
   commit:
     jobs:
       ### ALL BRANCHES ###

--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -18,7 +18,7 @@ import {
   joiIdentifierDescription,
   joiSparseArray,
 } from "../../config/common"
-import { Provider, providerConfigBaseSchema, GenericProviderConfig } from "../../config/provider"
+import { Provider, providerConfigBaseSchema, BaseProviderConfig } from "../../config/provider"
 import {
   containerRegistryConfigSchema,
   ContainerRegistryConfig,
@@ -104,7 +104,7 @@ export interface NamespaceConfig {
   labels?: StringMap
 }
 
-export interface KubernetesConfig extends GenericProviderConfig {
+export interface KubernetesConfig extends BaseProviderConfig {
   buildMode: ContainerBuildMode
   clusterBuildkit?: {
     rootless?: boolean
@@ -131,6 +131,7 @@ export interface KubernetesConfig extends GenericProviderConfig {
   kubeconfig?: string
   namespace?: NamespaceConfig
   registryProxyTolerations: V1Toleration[]
+  setupIngressController: string | null
   systemNodeSelector: { [key: string]: string }
   resources: KubernetesResources
   storage: KubernetesStorage

--- a/core/src/plugins/kubernetes/kubernetes-module/common.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/common.ts
@@ -47,17 +47,10 @@ export async function getManifests({
         manifest.metadata = {}
       }
 
-      try {
-        const info = await api.getApiResourceInfo(log, manifest.apiVersion, manifest.kind)
+      const info = await api.getApiResourceInfo(log, manifest.apiVersion, manifest.kind)
 
-        if (info.namespaced) {
-          manifest.metadata.namespace = defaultNamespace
-        }
-      } catch (err) {
-        // We can get a 404 if a resource type can't be found, e.g. a missing CRD
-        if (err.statusCode !== 404) {
-          throw err
-        }
+      if (info?.namespaced) {
+        manifest.metadata.namespace = defaultNamespace
       }
     }
 

--- a/core/src/util/util.ts
+++ b/core/src/util/util.ts
@@ -36,6 +36,7 @@ const exitHookNames: string[] = [] // For debugging/testing/inspection purposes
 export type PickFromUnion<T, U extends T> = U
 export type ValueOf<T> = T[keyof T]
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
+export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
 export type Diff<T, U> = T extends U ? never : T
 export type Mutable<T> = { -readonly [K in keyof T]: T[K] }
 export type Nullable<T> = { [P in keyof T]: T[P] | null }

--- a/core/test/integ/src/plugins/kubernetes/namespace.ts
+++ b/core/test/integ/src/plugins/kubernetes/namespace.ts
@@ -55,7 +55,7 @@ describe("ensureNamespace", () => {
       [gardenAnnotationKey("version")]: getPackageVersion(),
       ...namespace.annotations,
     })
-    expect(result?.metadata.labels).to.eql(namespace.labels)
+    expect(result?.metadata.labels?.floo).to.equal("blar")
   })
 
   it("should add configured annotations if any are missing", async () => {
@@ -104,7 +104,8 @@ describe("ensureNamespace", () => {
     const result = await ensureNamespace(api, namespace, log)
 
     expect(result?.metadata.name).to.equal(namespaceName)
-    expect(result?.metadata.labels).to.eql({ foo: "bar", floo: "blar" })
+    expect(result?.metadata.labels?.foo).to.equal("bar")
+    expect(result?.metadata.labels?.floo).to.equal("blar")
   })
 
   it("should do nothing if the namespace has already been configured", async () => {

--- a/core/test/unit/src/plugins/kubernetes/init.ts
+++ b/core/test/unit/src/plugins/kubernetes/init.ts
@@ -56,6 +56,7 @@ const basicConfig: KubernetesConfig = {
   ingressHttpsPort: 443,
   resources: defaultResources,
   storage: defaultStorage,
+  setupIngressController: null,
   systemNodeSelector: {},
   registryProxyTolerations: [],
   tlsCertificates: [],

--- a/core/test/unit/src/plugins/kubernetes/kubernetes.ts
+++ b/core/test/unit/src/plugins/kubernetes/kubernetes.ts
@@ -29,6 +29,7 @@ describe("kubernetes configureProvider", () => {
     ingressHttpsPort: 443,
     resources: defaultResources,
     storage: defaultStorage,
+    setupIngressController: null,
     systemNodeSelector: {},
     registryProxyTolerations: [],
     tlsCertificates: [],


### PR DESCRIPTION
We now auto-detect the most up-to-date supported Ingress API version
and create resources accordingly.
