### PR TITLE
fix(k8s): error when using dev mode on certain kubernetes modules

### DIFF
--- a/core/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/src/plugins/kubernetes/helm/deployment.ts
@@ -41,15 +41,13 @@ export async function deployHelmService({
   const provider = k8sCtx.provider
 
   const manifests = await getChartResources({ ctx: k8sCtx, module, devMode, hotReload, log, version: service.version })
-  const baseModule = getBaseModule(module)
 
-  if (devMode || hotReload) {
+  if ((devMode && module.spec.devMode) || hotReload) {
     serviceResourceSpec = getServiceResourceSpec(module, getBaseModule(module))
     serviceResource = await findServiceResource({
       ctx,
       log,
       module,
-      baseModule,
       manifests,
       resourceSpec: serviceResourceSpec,
     })

--- a/core/src/plugins/kubernetes/helm/exec.ts
+++ b/core/src/plugins/kubernetes/helm/exec.ts
@@ -48,7 +48,6 @@ export async function execInHelmService(params: ExecInServiceParams<HelmModule>)
     ctx,
     log,
     module,
-    baseModule,
     manifests,
     resourceSpec: serviceResourceSpec,
   })

--- a/core/src/plugins/kubernetes/helm/run.ts
+++ b/core/src/plugins/kubernetes/helm/run.ts
@@ -66,7 +66,6 @@ export async function runHelmModule({
     log,
     manifests,
     module,
-    baseModule,
     resourceSpec,
   })
   const container = getResourceContainer(target, resourceSpec.containerName)
@@ -139,7 +138,6 @@ export async function runHelmTask(params: RunTaskParams<HelmModule>): Promise<Ru
     log,
     manifests,
     module,
-    baseModule,
     resourceSpec,
   })
   const container = getResourceContainer(target, resourceSpec.containerName)

--- a/core/src/plugins/kubernetes/helm/status.ts
+++ b/core/src/plugins/kubernetes/helm/status.ts
@@ -78,7 +78,6 @@ export async function getServiceStatus({
         ctx,
         log,
         module,
-        baseModule,
         manifests: deployedResources,
         resourceSpec: serviceResourceSpec,
       })

--- a/core/src/plugins/kubernetes/helm/test.ts
+++ b/core/src/plugins/kubernetes/helm/test.ts
@@ -38,7 +38,7 @@ export async function testHelmModule(params: TestModuleParams<HelmModule>): Prom
   })
   const baseModule = getBaseModule(module)
   const resourceSpec = test.config.spec.resource || getServiceResourceSpec(module, baseModule)
-  const target = await findServiceResource({ ctx: k8sCtx, log, manifests, module, baseModule, resourceSpec })
+  const target = await findServiceResource({ ctx: k8sCtx, log, manifests, module, resourceSpec })
   const container = getResourceContainer(target, resourceSpec.containerName)
   const namespaceStatus = await getModuleNamespaceStatus({
     ctx: k8sCtx,

--- a/core/src/plugins/kubernetes/hot-reload/hot-reload.ts
+++ b/core/src/plugins/kubernetes/hot-reload/hot-reload.ts
@@ -20,9 +20,8 @@ import { HotReloadServiceParams, HotReloadServiceResult } from "../../../types/p
 import { BaseResource, KubernetesResource, KubernetesWorkload } from "../types"
 import { createWorkloadManifest } from "../container/deployment"
 import { KubeApi } from "../api"
-import { GardenModule } from "../../../types/module"
 import { PluginContext } from "../../../plugin-context"
-import { getBaseModule, getChartResources } from "../helm/common"
+import { getChartResources } from "../helm/common"
 import { HelmModule } from "../helm/config"
 import { getManifests } from "../kubernetes-module/common"
 import { KubernetesModule } from "../kubernetes-module/config"
@@ -56,9 +55,8 @@ export async function hotReloadK8s({
   })
 
   let manifests: KubernetesResource<BaseResource>[]
-  let baseModule: GardenModule | undefined = undefined
+
   if (module.type === "helm") {
-    baseModule = getBaseModule(<HelmModule>module)
     manifests = await getChartResources({
       ctx: k8sCtx,
       module: service.module,
@@ -79,7 +77,6 @@ export async function hotReloadK8s({
     ctx,
     log,
     module,
-    baseModule,
     manifests,
     resourceSpec,
   })

--- a/core/src/plugins/kubernetes/kubernetes-module/exec.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/exec.ts
@@ -37,7 +37,6 @@ export async function execInKubernetesService(params: ExecInServiceParams<Kubern
     ctx,
     log,
     module,
-    baseModule: undefined,
     manifests: status.detail.remoteResources,
     resourceSpec: serviceResourceSpec,
   })

--- a/core/src/plugins/kubernetes/kubernetes-module/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/handlers.ts
@@ -106,7 +106,6 @@ export async function getKubernetesServiceStatus({
       ctx,
       log,
       module,
-      baseModule: undefined,
       manifests: remoteResources,
       resourceSpec: serviceResourceSpec,
     })
@@ -344,19 +343,19 @@ async function prepareManifestsForSync({
   let target: KubernetesResource<V1Deployment | V1DaemonSet | V1StatefulSet>
 
   try {
+    const resourceSpec = getServiceResourceSpec(module, undefined)
     target = cloneDeep(
       await findServiceResource({
         ctx,
         log,
         module,
-        baseModule: undefined,
         manifests,
-        resourceSpec: service.spec.serviceResource,
+        resourceSpec,
       })
     )
   } catch (err) {
-    // This is only an error if we're actually trying to hot reload.
-    if (devMode || hotReload) {
+    // This is only an error if we're actually trying to hot reload or start dev mode.
+    if ((devMode && service.spec.devMode) || hotReload) {
       throw err
     } else {
       // Nothing to do, so we return the original manifests

--- a/core/src/plugins/kubernetes/kubernetes-module/run.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/run.ts
@@ -44,7 +44,6 @@ export async function runKubernetesTask(params: RunTaskParams<KubernetesModule>)
     log,
     manifests,
     module,
-    baseModule: undefined,
     resourceSpec,
   })
   const container = getResourceContainer(target, resourceSpec.containerName)

--- a/core/src/plugins/kubernetes/kubernetes-module/test.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/test.ts
@@ -39,7 +39,7 @@ export async function testKubernetesModule(params: TestModuleParams<KubernetesMo
   // Get the container spec to use for running
   const manifests = await getManifests({ ctx, api, log, module, defaultNamespace: namespace })
   const resourceSpec = test.config.spec.resource || getServiceResourceSpec(module, undefined)
-  const target = await findServiceResource({ ctx: k8sCtx, log, manifests, module, resourceSpec, baseModule: undefined })
+  const target = await findServiceResource({ ctx: k8sCtx, log, manifests, module, resourceSpec })
   const container = getResourceContainer(target, resourceSpec.containerName)
 
   const testName = test.name

--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -534,8 +534,7 @@ interface GetServiceResourceParams {
   log: LogEntry
   manifests: KubernetesResource[]
   module: HelmModule | KubernetesModule
-  baseModule: HelmModule | undefined
-  resourceSpec?: ServiceResourceSpec
+  resourceSpec: ServiceResourceSpec
 }
 
 /**
@@ -552,15 +551,8 @@ export async function findServiceResource({
   log,
   manifests,
   module,
-  baseModule,
   resourceSpec,
 }: GetServiceResourceParams): Promise<HotReloadableResource> {
-  const resourceMsgName = resourceSpec ? "resource" : "serviceResource"
-
-  if (!resourceSpec) {
-    resourceSpec = getServiceResourceSpec(module, baseModule)
-  }
-
   const targetKind = resourceSpec.kind
   let targetName = resourceSpec.name
 
@@ -599,8 +591,8 @@ export async function findServiceResource({
       throw new ConfigurationError(
         chalk.red(
           deline`${module.type} module ${chalk.white(module.name)} contains multiple ${targetKind}s.
-          You must specify ${chalk.underline(`${resourceMsgName}.name`)} in the module config in order to identify
-          the correct ${targetKind} to use.`
+          You must specify ${chalk.underline("resource.name")} or ${chalk.underline("serviceResource.name")}
+          in the module config in order to identify the correct ${targetKind} to use.`
         ),
         { resourceSpec, chartResourceNames }
       )

--- a/core/test/integ/src/plugins/kubernetes/hot-reload.ts
+++ b/core/test/integ/src/plugins/kubernetes/hot-reload.ts
@@ -125,7 +125,6 @@ describe("configureHotReload", () => {
       module,
       manifests,
       resourceSpec,
-      baseModule: undefined,
     })
     const containerName = getHotReloadContainerName(module)
     configureHotReload({

--- a/core/test/integ/src/plugins/kubernetes/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/run.ts
@@ -628,7 +628,6 @@ describe("kubernetes Pod runner functions", () => {
         log: helmLog,
         manifests: helmManifests,
         module: helmModule,
-        baseModule: helmBaseModule,
         resourceSpec: helmResourceSpec,
       })
       helmContainer = getResourceContainer(helmTarget, helmResourceSpec.containerName)


### PR DESCRIPTION
Specifically, modules without a serviceResource declaration. This is
an error introduced alongside the new dev mode.

There was a prior fix but it turns out it wasn't quite enough.