### PR TITLE
fix(core): allow empty replacement strings in 'replace' helper function

### DIFF
--- a/core/src/template-string/functions.ts
+++ b/core/src/template-string/functions.ts
@@ -114,7 +114,11 @@ const helperFunctionSpecs: TemplateHelperFunction[] = [
     arguments: {
       string: joi.string().required().description("The string to convert."),
       substring: joi.string().required().description("The substring to replace."),
-      replacement: joi.string().required().description("The replacement for each instance found of the `substring`."),
+      replacement: joi
+        .string()
+        .required()
+        .allow("")
+        .description("The replacement for each instance found of the `substring`."),
     },
     outputSchema: joi.string(),
     exampleArguments: [


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

Fixes `joi` validation for `replacement` argument of `replace` helper function to allow empty strings.

**Which issue(s) this PR fixes**:

Fixes #2493 

**Special notes for your reviewer**:
