### PR TITLE
fix(k8s): persistentvolumeclaim modules would include unnecessary files

### DIFF
--- a/core/src/plugins/kubernetes/volumes/persistentvolumeclaim.ts
+++ b/core/src/plugins/kubernetes/volumes/persistentvolumeclaim.ts
@@ -136,6 +136,7 @@ function getKubernetesService(
 
   const config: KubernetesModuleConfig = {
     ...pvcService.module,
+    include: [],
     serviceConfigs: [serviceConfig],
     spec,
     taskConfigs: [],


### PR DESCRIPTION
Lil' one liner.

Fixes #2498
