### PR TITLE
fix(core): deploy command wouldn't start port forwards with dev flag

### DIFF
--- a/core/src/commands/deploy.ts
+++ b/core/src/commands/deploy.ts
@@ -27,7 +27,7 @@ import { startServer } from "../server/server"
 import { DeployTask } from "../tasks/deploy"
 import { naturalList } from "../util/string"
 import chalk = require("chalk")
-import { StringsParameter, BooleanParameter } from "../cli/params"
+import { StringsParameter, BooleanParameter, ParameterValues } from "../cli/params"
 
 export const deployArgs = {
   services: new StringsParameter({
@@ -102,7 +102,7 @@ export class DeployCommand extends Command<Args, Opts> {
 
   outputsSchema = () => processCommandResultSchema()
 
-  private isPersistent = (opts) => !!opts.watch || !!opts["hot-reload"]
+  private isPersistent = (opts: ParameterValues<Opts>) => !!opts.watch || !!opts["hot-reload"] || !!opts["dev-mode"]
 
   printHeader({ headerLog }) {
     printHeader(headerLog, "Deploy", "rocket")

--- a/core/test/unit/src/commands/deploy.ts
+++ b/core/test/unit/src/commands/deploy.ts
@@ -25,6 +25,7 @@ import { DeployServiceParams } from "../../../../src/types/plugin/service/deploy
 import { RunTaskParams, RunTaskResult } from "../../../../src/types/plugin/task/runTask"
 import { createGardenPlugin } from "../../../../src/types/plugin/plugin"
 import { sortBy } from "lodash"
+import { getLogger } from "../../../../src/logger/logger"
 
 const placeholderTimestamp = new Date()
 
@@ -623,5 +624,73 @@ describe("DeployCommand", () => {
     }
 
     expect(Object.keys(taskResultOutputs(result!)).includes("deploy.service-b")).to.be.false
+  })
+
+  describe("prepare", () => {
+    it("return persistent=true if --watch is set", async () => {
+      const cmd = new DeployCommand()
+      const log = getLogger().placeholder()
+      const { persistent } = await cmd.prepare({
+        log,
+        headerLog: log,
+        footerLog: log,
+        args: {
+          services: undefined,
+        },
+        opts: withDefaultGlobalOpts({
+          "dev-mode": undefined,
+          "hot-reload": undefined,
+          "watch": true,
+          "force": false,
+          "force-build": true,
+          "skip": ["service-b"],
+        }),
+      })
+      expect(persistent).to.be.true
+    })
+
+    it("return persistent=true if --dev is set", async () => {
+      const cmd = new DeployCommand()
+      const log = getLogger().placeholder()
+      const { persistent } = await cmd.prepare({
+        log,
+        headerLog: log,
+        footerLog: log,
+        args: {
+          services: undefined,
+        },
+        opts: withDefaultGlobalOpts({
+          "dev-mode": ["*"],
+          "hot-reload": undefined,
+          "watch": false,
+          "force": false,
+          "force-build": true,
+          "skip": ["service-b"],
+        }),
+      })
+      expect(persistent).to.be.true
+    })
+
+    it("return persistent=true if --hot-reload is set", async () => {
+      const cmd = new DeployCommand()
+      const log = getLogger().placeholder()
+      const { persistent } = await cmd.prepare({
+        log,
+        headerLog: log,
+        footerLog: log,
+        args: {
+          services: undefined,
+        },
+        opts: withDefaultGlobalOpts({
+          "dev-mode": undefined,
+          "hot-reload": ["*"],
+          "watch": false,
+          "force": false,
+          "force-build": true,
+          "skip": ["service-b"],
+        }),
+      })
+      expect(persistent).to.be.true
+    })
   })
 })


### PR DESCRIPTION
Simple omission, we forgot to check the dev flag when checking if the
method would be persistent (and should thus start proxies).

Fixes #2497
