### PR TITLE
feat(k8s): add `configmap` module type, mountable on container modules

### DIFF
--- a/core/src/docs/module-type.ts
+++ b/core/src/docs/module-type.ts
@@ -21,6 +21,7 @@ const populateModuleSchema = (schema: Joi.ObjectSchema) => baseModuleSpecSchema(
 export const moduleTypes = [
   { name: "exec" },
   { name: "container" },
+  { name: "configmap", pluginName: "local-kubernetes" },
   { name: "conftest", pluginName: "conftest" },
   { name: "hadolint" },
   { name: "helm", pluginName: "local-kubernetes" },

--- a/core/src/plugins/kubernetes/container/deployment.ts
+++ b/core/src/plugins/kubernetes/container/deployment.ts
@@ -702,22 +702,29 @@ export function configureVolumes(
       // Make sure the module is a supported type
       const volumeModule = module.buildDependencies[volume.module]
 
-      if (!volumeModule.compatibleTypes.includes("persistentvolumeclaim")) {
+      if (volumeModule.compatibleTypes.includes("persistentvolumeclaim")) {
+        volumes.push({
+          name: volumeName,
+          persistentVolumeClaim: {
+            claimName: volume.module,
+          },
+        })
+      } else if (volumeModule.compatibleTypes.includes("configmap")) {
+        volumes.push({
+          name: volumeName,
+          configMap: {
+            name: volume.module,
+          },
+        })
+      } else {
         throw new ConfigurationError(
           chalk.red(deline`Container module ${chalk.white(module.name)} specifies a unsupported module
-          ${chalk.white(volumeModule.name)} for volume mount ${chalk.white(volumeName)}. Only persistentvolumeclaim
-          modules are supported at this time.
+          ${chalk.white(volumeModule.name)} for volume mount ${chalk.white(volumeName)}. Only \`persistentvolumeclaim\`
+          and \`configmap\` modules are supported at this time.
           `),
           { volumeSpec: volume }
         )
       }
-
-      volumes.push({
-        name: volumeName,
-        persistentVolumeClaim: {
-          claimName: volume.module,
-        },
-      })
     } else {
       volumes.push({
         name: volumeName,

--- a/core/src/plugins/kubernetes/kubernetes.ts
+++ b/core/src/plugins/kubernetes/kubernetes.ts
@@ -43,6 +43,7 @@ import { sternSpec } from "./logs"
 import { isString } from "lodash"
 import { mutagenCliSpec } from "./mutagen"
 import { Warning } from "../../db/entities/warning"
+import { configMapModuleDefinition } from "./volumes/configmap"
 
 export async function configureProvider({
   log,
@@ -254,6 +255,7 @@ export const gardenPlugin = () =>
         handlers: kubernetesHandlers,
       },
       pvcModuleDefinition(),
+      configMapModuleDefinition(),
     ],
     extendModuleTypes: [
       {

--- a/core/src/plugins/kubernetes/volumes/configmap.ts
+++ b/core/src/plugins/kubernetes/volumes/configmap.ts
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2018-2021 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { joiIdentifier, joi, joiSparseArray, joiStringMap } from "../../../config/common"
+import { dedent } from "../../../util/string"
+import { BaseVolumeSpec } from "../../base-volume"
+import { V1ConfigMap } from "@kubernetes/client-node"
+import { ModuleTypeDefinition } from "../../../types/plugin/plugin"
+import { DOCS_BASE_URL } from "../../../constants"
+import { baseBuildSpecSchema } from "../../../config/module"
+import { ConfigureModuleParams } from "../../../types/plugin/module/configure"
+import { GetServiceStatusParams } from "../../../types/plugin/service/getServiceStatus"
+import { GardenModule } from "../../../types/module"
+import { KubernetesModule, KubernetesModuleConfig } from "../kubernetes-module/config"
+import { KubernetesResource } from "../types"
+import { getKubernetesServiceStatus, deployKubernetesService } from "../kubernetes-module/handlers"
+import { DeployServiceParams } from "../../../types/plugin/service/deployService"
+import { getModuleTypeUrl } from "../../../docs/common"
+import { GardenService } from "../../../types/service"
+
+// TODO: If we make a third one in addition to this and `persistentvolumeclaim`, we should dedupe some code.
+
+export interface ConfigMapSpec extends BaseVolumeSpec {
+  dependencies: string[]
+  namespace: string
+  data: Required<V1ConfigMap["data"]>
+}
+
+type ConfigMapModule = GardenModule<ConfigMapSpec, ConfigMapSpec>
+type ConfigMapService = GardenService<ConfigMapModule>
+
+const containerTypeUrl = getModuleTypeUrl("container")
+
+export const configMapModuleDefinition = (): ModuleTypeDefinition => ({
+  name: "configmap",
+  docs: dedent`
+    Creates a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) in your namespace, that can be referenced and mounted by other resources and [container modules](${containerTypeUrl}).
+
+    See the [Mounting Kubernetes ConfigMaps](${DOCS_BASE_URL}/guides/container-modules#mounting-kubernetes-configmaps) guide for more info and usage examples.
+    `,
+  schema: joi.object().keys({
+    build: baseBuildSpecSchema(),
+    dependencies: joiSparseArray(joiIdentifier()).description(
+      "List of services and tasks to deploy/run before deploying this ConfigMap."
+    ),
+    namespace: joiIdentifier().description(
+      "The namespace to deploy the ConfigMap in. Note that any module referencing the ConfigMap must be in the same namespace, so in most cases you should leave this unset."
+    ),
+    data: joiStringMap(joi.string()).required().description("The ConfigMap data, as a key/value map of string values."),
+  }),
+  handlers: {
+    async configure({ moduleConfig }: ConfigureModuleParams) {
+      // No need to scan for files
+      moduleConfig.include = []
+
+      moduleConfig.spec.accessModes = ["ReadOnlyMany"]
+
+      moduleConfig.serviceConfigs = [
+        {
+          dependencies: moduleConfig.spec.dependencies,
+          disabled: moduleConfig.spec.disabled,
+          hotReloadable: false,
+          name: moduleConfig.name,
+          spec: moduleConfig.spec,
+        },
+      ]
+
+      return { moduleConfig }
+    },
+
+    async getServiceStatus(params: GetServiceStatusParams) {
+      params.service = getKubernetesService(params.service)
+      params.module = params.service.module
+
+      return getKubernetesServiceStatus({
+        ...params,
+        devMode: false,
+      })
+    },
+
+    async deployService(params: DeployServiceParams) {
+      params.service = getKubernetesService(params.service)
+      params.module = params.service.module
+
+      return deployKubernetesService({
+        ...params,
+        devMode: false,
+      })
+    },
+  },
+})
+
+/**
+ * Maps a `configmap` module to a `kubernetes` module (so we can re-use those handlers).
+ */
+function getKubernetesService(configMapService: ConfigMapService): GardenService<KubernetesModule, KubernetesModule> {
+  const configMapManifest: KubernetesResource<V1ConfigMap> = {
+    apiVersion: "v1",
+    kind: "ConfigMap",
+    metadata: {
+      name: configMapService.name,
+    },
+    data: configMapService.spec.data,
+  }
+
+  const spec = {
+    dependencies: configMapService.spec.dependencies,
+    files: [],
+    manifests: [configMapManifest],
+    tasks: [],
+    tests: [],
+  }
+
+  const serviceConfig = {
+    ...configMapService.config,
+    spec,
+  }
+
+  const config: KubernetesModuleConfig = {
+    ...configMapService.module,
+    serviceConfigs: [serviceConfig],
+    spec,
+    taskConfigs: [],
+    testConfigs: [],
+  }
+
+  const module: KubernetesModule = {
+    ...configMapService.module,
+    _config: config,
+    ...config,
+    spec: {
+      ...configMapService.spec,
+      files: [],
+      manifests: [configMapManifest],
+      tasks: [],
+      tests: [],
+    },
+  }
+
+  return {
+    name: configMapService.name,
+    config: serviceConfig,
+    disabled: configMapService.disabled,
+    module,
+    sourceModule: module,
+    spec,
+    version: configMapService.version,
+  }
+}

--- a/core/test/data/test-projects/container/configmap-reference/garden.yml
+++ b/core/test/data/test-projects/container/configmap-reference/garden.yml
@@ -1,0 +1,25 @@
+kind: Module
+name: configmap-reference
+description: Test module for configmap module references
+type: container
+image: busybox:1.31.1
+include: []
+build:
+  dependencies: [simple-service]
+services:
+  - name: configmap-reference
+    command: [sh, -c, "nc -l -p 8080"]
+    ports:
+      - name: http
+        containerPort: 8080
+    volumes:
+      - name: test
+        module: configmap-module
+        containerPath: /config
+---
+kind: Module
+name: configmap-module
+type: configmap
+data:
+  a.config: foo
+  b.config: bar

--- a/core/test/integ/src/plugins/kubernetes/volume/configmap.ts
+++ b/core/test/integ/src/plugins/kubernetes/volume/configmap.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2018-2021 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import tmp from "tmp-promise"
+import { ProjectConfig, defaultNamespace } from "../../../../../../src/config/project"
+import execa = require("execa")
+import { DEFAULT_API_VERSION } from "../../../../../../src/constants"
+import { expect } from "chai"
+import { TestGarden, makeTempDir } from "../../../../../helpers"
+import { DeployTask } from "../../../../../../src/tasks/deploy"
+import { emptyRuntimeContext } from "../../../../../../src/runtime-context"
+import { isSubset } from "../../../../../../src/util/is-subset"
+
+describe("configmap module", () => {
+  let tmpDir: tmp.DirectoryResult
+  let projectConfigFoo: ProjectConfig
+
+  before(async () => {
+    tmpDir = await makeTempDir()
+
+    await execa("git", ["init"], { cwd: tmpDir.path })
+
+    projectConfigFoo = {
+      apiVersion: DEFAULT_API_VERSION,
+      kind: "Project",
+      name: "test",
+      path: tmpDir.path,
+      defaultEnvironment: "default",
+      dotIgnoreFiles: [],
+      environments: [{ name: "default", defaultNamespace, variables: {} }],
+      providers: [{ name: "local-kubernetes", namespace: "default" }],
+      variables: {},
+    }
+  })
+
+  after(async () => {
+    await tmpDir.cleanup()
+  })
+
+  it("should successfully deploy a simple ConfigMap", async () => {
+    const garden = await TestGarden.factory(tmpDir.path, {
+      plugins: [],
+      config: projectConfigFoo,
+    })
+
+    const data = {
+      foo: "bar",
+    }
+
+    garden.setModuleConfigs([
+      {
+        apiVersion: DEFAULT_API_VERSION,
+        name: "test",
+        type: "configmap",
+        allowPublish: false,
+        build: { dependencies: [] },
+        disabled: false,
+        path: tmpDir.path,
+        serviceConfigs: [],
+        taskConfigs: [],
+        testConfigs: [],
+        spec: {
+          data,
+        },
+      },
+    ])
+
+    const graph = await garden.getConfigGraph(garden.log)
+    const service = graph.getService("test")
+
+    const deployTask = new DeployTask({
+      garden,
+      graph,
+      log: garden.log,
+      service,
+      force: true,
+      forceBuild: false,
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
+    })
+
+    await garden.processTasks([deployTask], { throwOnError: true })
+
+    const actions = await garden.getActionRouter()
+    const status = await actions.getServiceStatus({
+      log: garden.log,
+      service,
+      devMode: false,
+      hotReload: false,
+      runtimeContext: emptyRuntimeContext,
+    })
+
+    const remoteResources = status.detail["remoteResources"]
+
+    expect(status.state === "ready")
+    expect(remoteResources.length).to.equal(1)
+    expect(
+      isSubset(remoteResources[0], {
+        apiVersion: "v1",
+        kind: "ConfigMap",
+        metadata: { name: "test", namespace: "default" },
+        data,
+      })
+    ).to.be.true
+
+    await actions.deleteService({ log: garden.log, service })
+  })
+})

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,7 @@
   * [`openfaas`](./reference/providers/openfaas.md)
   * [`terraform`](./reference/providers/terraform.md)
 * [Module Types](./reference/module-types/README.md)
+  * [`configmap`](./reference/module-types/configmap.md)
   * [`conftest`](./reference/module-types/conftest.md)
   * [`container`](./reference/module-types/container.md)
   * [`exec`](./reference/module-types/exec.md)

--- a/docs/guides/container-modules.md
+++ b/docs/guides/container-modules.md
@@ -274,6 +274,39 @@ You can do the same for tests and tasks using the [`tests.volumes`](../reference
 
 Take a look at the [`persistentvolumeclaim` module type](../reference/module-types/persistentvolumeclaim.md) and [`container` module](../reference/module-types/container.md#servicesvolumes) docs for more details.
 
+## Mounting Kubernetes ConfigMaps
+
+Very similarly to the above example, you can also mount Kubernetes ConfigMaps on `container` modules using the [`configmap` module type](../reference/module-types/configmap.md), supported by the `kubernetes` provider. Here's a simple example:
+
+Example:
+
+```yaml
+kind: Module
+name: my-configmap
+type: configmap
+data:
+  config.properties: |
+    some: data
+    or: something
+---
+kind: Module
+name: my-module
+type: container
+services:
+  - name: my-service
+    volumes:
+      - name: my-configmap
+        module: my-configmap
+        containerPath: /config
+    ...
+```
+
+This mounts all the keys in the `data` field on the `my-configmap` module under the `/config` directory in the container. In this case, you'll find the file `/config/config.properties` there, with the value above (`some: data ...`) as the file contents.
+
+You can do the same for tests and tasks using the [`tests.volumes`](../reference/module-types/container.md#testsvolumes) and [`tasks.volumes`](../reference/module-types/container.md#tasksvolumes) fields. `configmap` volumes can of course also be referenced in `kubernetes` and `helm` modules, since they are deployed as standard ConfigMap resources.
+
+Take a look at the [`configmap` module type](../reference/module-types/configmap.md) and [`container` module](../reference/module-types/container.md#servicesvolumes) docs for more details.
+
 ### Shared volumes
 
 For a volume to be shared between multiple replicas, or multiple services, tasks and/or tests, it needs to be configured with a storage class (using the `storageClassName` field) that supports the `ReadWriteMany` (RWX) access mode. The available storage classes that support RWX vary by cloud providers and cluster setups, and in many cases you need to define a `StorageClass` or deploy a _storage class provisioner_ to your cluster.

--- a/docs/reference/module-types/README.md
+++ b/docs/reference/module-types/README.md
@@ -7,6 +7,7 @@ title: Module Types
 
 * [`exec`](./exec.md)
 * [`container`](./container.md)
+* [`configmap`](./configmap.md)
 * [`conftest`](./conftest.md)
 * [`hadolint`](./hadolint.md)
 * [`helm`](./helm.md)

--- a/docs/reference/module-types/configmap.md
+++ b/docs/reference/module-types/configmap.md
@@ -1,0 +1,521 @@
+---
+title: "`configmap` Module Type"
+tocTitle: "`configmap`"
+---
+
+# `configmap` Module Type
+
+## Description
+
+Creates a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) in your namespace, that can be referenced and mounted by other resources and [container modules](https://docs.garden.io/reference/module-types/container).
+
+See the [Mounting Kubernetes ConfigMaps](https://docs.garden.io/guides/container-modules#mounting-kubernetes-configmaps) guide for more info and usage examples.
+
+Below is the full schema reference. For an introduction to configuring Garden modules, please look at our [Configuration
+guide](../../using-garden/configuration-overview.md).
+
+The [first section](#complete-yaml-schema) contains the complete YAML schema, and the [second section](#configuration-keys) describes each schema key.
+
+`configmap` modules also export values that are available in template strings. See the [Outputs](#outputs) section below for details.
+
+## Complete YAML Schema
+
+The values in the schema below are the default values.
+
+```yaml
+# The schema version of this config (currently not used).
+apiVersion: garden.io/v0
+
+kind: Module
+
+# The type of this module.
+type:
+
+# The name of this module.
+name:
+
+# Specify how to build the module. Note that plugins may define additional keys on this object.
+build:
+  # A list of modules that must be built before this module is built.
+  dependencies:
+    - # Module name to build ahead of this module.
+      name:
+
+      # Specify one or more files or directories to copy from the built dependency to this module.
+      copy:
+        - # POSIX-style path or filename of the directory or file(s) to copy to the target.
+          source:
+
+          # POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
+          # Defaults to to same as source path.
+          target: ''
+
+# A description of the module.
+description:
+
+# Set this to `true` to disable the module. You can use this with conditional template strings to disable modules
+# based on, for example, the current environment or other variables (e.g. `disabled: \${environment.name == "prod"}`).
+# This can be handy when you only need certain modules for specific environments, e.g. only for development.
+#
+# Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also
+# means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which
+# case building this module is necessary for the dependant to be built).
+#
+# If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will
+# automatically ignore those dependency declarations. Note however that template strings referencing the module's
+# service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make
+# sure to provide alternate values for those if you're using them, using conditional expressions.
+disabled: false
+
+# Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that
+# do *not* match these paths or globs are excluded when computing the version of the module, when responding to
+# filesystem watch events, and when staging builds.
+#
+# Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source
+# tree, which use the same format as `.gitignore` files. See the [Configuration Files
+# guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for
+# details.
+#
+# Also note that specifying an empty list here means _no sources_ should be included.
+include:
+
+# Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these
+# paths or globs are excluded when computing the version of the module, when responding to filesystem watch events,
+# and when staging builds.
+#
+# Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include`
+# field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration
+# Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories)
+# for details.
+#
+# Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files and
+# directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have large
+# directories that should not be watched for changes.
+exclude:
+
+# A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific
+# branch or tag, with the format: <git remote url>#<branch|tag>
+#
+# Garden will import the repository source code into this module, but read the module's config from the local
+# garden.yml file.
+repositoryUrl:
+
+# When false, disables pushing this module to remote registries.
+allowPublish: true
+
+# A list of files to write to the module directory when resolving this module. This is useful to automatically
+# generate (and template) any supporting files needed for the module.
+generateFiles:
+  - # POSIX-style filename to read the source file contents from, relative to the path of the module (or the
+    # ModuleTemplate configuration file if one is being applied).
+    # This file may contain template strings, much like any other field in the configuration.
+    sourcePath:
+
+    # POSIX-style filename to write the resolved file contents to, relative to the path of the module source directory
+    # (for remote modules this means the root of the module repository, otherwise the directory of the module
+    # configuration).
+    #
+    # Note that any existing file with the same name will be overwritten. If the path contains one or more
+    # directories, they will be automatically created if missing.
+    targetPath:
+
+    # The desired file contents as a string.
+    value:
+
+# A map of variables scoped to this particular module. These are resolved before any other parts of the module
+# configuration and take precedence over project-scoped variables. They may reference project-scoped variables, and
+# generally use any template strings normally allowed when resolving modules.
+variables:
+
+# List of services and tasks to deploy/run before deploying this ConfigMap.
+dependencies: []
+
+# The namespace to deploy the ConfigMap in. Note that any module referencing the ConfigMap must be in the same
+# namespace, so in most cases you should leave this unset.
+namespace:
+
+# The ConfigMap data, as a key/value map of string values.
+data:
+```
+
+## Configuration Keys
+
+### `apiVersion`
+
+The schema version of this config (currently not used).
+
+| Type     | Allowed Values | Default          | Required |
+| -------- | -------------- | ---------------- | -------- |
+| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+
+### `kind`
+
+| Type     | Allowed Values | Default    | Required |
+| -------- | -------------- | ---------- | -------- |
+| `string` | "Module"       | `"Module"` | Yes      |
+
+### `type`
+
+The type of this module.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | Yes      |
+
+Example:
+
+```yaml
+type: "container"
+```
+
+### `name`
+
+The name of this module.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | Yes      |
+
+Example:
+
+```yaml
+name: "my-sweet-module"
+```
+
+### `build`
+
+Specify how to build the module. Note that plugins may define additional keys on this object.
+
+| Type     | Default               | Required |
+| -------- | --------------------- | -------- |
+| `object` | `{"dependencies":[]}` | No       |
+
+### `build.dependencies[]`
+
+[build](#build) > dependencies
+
+A list of modules that must be built before this module is built.
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
+
+Example:
+
+```yaml
+build:
+  ...
+  dependencies:
+    - name: some-other-module-name
+```
+
+### `build.dependencies[].name`
+
+[build](#build) > [dependencies](#builddependencies) > name
+
+Module name to build ahead of this module.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | Yes      |
+
+### `build.dependencies[].copy[]`
+
+[build](#build) > [dependencies](#builddependencies) > copy
+
+Specify one or more files or directories to copy from the built dependency to this module.
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
+
+### `build.dependencies[].copy[].source`
+
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > source
+
+POSIX-style path or filename of the directory or file(s) to copy to the target.
+
+| Type        | Required |
+| ----------- | -------- |
+| `posixPath` | Yes      |
+
+### `build.dependencies[].copy[].target`
+
+[build](#build) > [dependencies](#builddependencies) > [copy](#builddependenciescopy) > target
+
+POSIX-style path or filename to copy the directory or file(s), relative to the build directory.
+Defaults to to same as source path.
+
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `""`    | No       |
+
+### `description`
+
+A description of the module.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `disabled`
+
+Set this to `true` to disable the module. You can use this with conditional template strings to disable modules based on, for example, the current environment or other variables (e.g. `disabled: \${environment.name == "prod"}`). This can be handy when you only need certain modules for specific environments, e.g. only for development.
+
+Disabling a module means that any services, tasks and tests contained in it will not be deployed or run. It also means that the module is not built _unless_ it is declared as a build dependency by another enabled module (in which case building this module is necessary for the dependant to be built).
+
+If you disable the module, and its services, tasks or tests are referenced as _runtime_ dependencies, Garden will automatically ignore those dependency declarations. Note however that template strings referencing the module's service or task outputs (i.e. runtime outputs) will fail to resolve when the module is disabled, so you need to make sure to provide alternate values for those if you're using them, using conditional expressions.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
+
+### `include[]`
+
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
+
+Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+
+Also note that specifying an empty list here means _no sources_ should be included.
+
+| Type               | Required |
+| ------------------ | -------- |
+| `array[posixPath]` | No       |
+
+Example:
+
+```yaml
+include:
+  - Dockerfile
+  - my-app.js
+```
+
+### `exclude[]`
+
+Specify a list of POSIX-style paths or glob patterns that should be excluded from the module. Files that match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
+
+Note that you can also explicitly _include_ files using the `include` field. If you also specify the `include` field, the files/patterns specified here are filtered from the files matched by `include`. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
+
+Unlike the `modules.exclude` field in the project config, the filters here have _no effect_ on which files and directories are watched for changes. Use the project `modules.exclude` field to affect those, if you have large directories that should not be watched for changes.
+
+| Type               | Required |
+| ------------------ | -------- |
+| `array[posixPath]` | No       |
+
+Example:
+
+```yaml
+exclude:
+  - tmp/**/*
+  - '*.log'
+```
+
+### `repositoryUrl`
+
+A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific branch or tag, with the format: <git remote url>#<branch|tag>
+
+Garden will import the repository source code into this module, but read the module's config from the local garden.yml file.
+
+| Type              | Required |
+| ----------------- | -------- |
+| `gitUrl | string` | No       |
+
+Example:
+
+```yaml
+repositoryUrl: "git+https://github.com/org/repo.git#v2.0"
+```
+
+### `allowPublish`
+
+When false, disables pushing this module to remote registries.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
+
+### `generateFiles[]`
+
+A list of files to write to the module directory when resolving this module. This is useful to automatically generate (and template) any supporting files needed for the module.
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
+
+### `generateFiles[].sourcePath`
+
+[generateFiles](#generatefiles) > sourcePath
+
+POSIX-style filename to read the source file contents from, relative to the path of the module (or the ModuleTemplate configuration file if one is being applied).
+This file may contain template strings, much like any other field in the configuration.
+
+| Type        | Required |
+| ----------- | -------- |
+| `posixPath` | No       |
+
+### `generateFiles[].targetPath`
+
+[generateFiles](#generatefiles) > targetPath
+
+POSIX-style filename to write the resolved file contents to, relative to the path of the module source directory (for remote modules this means the root of the module repository, otherwise the directory of the module configuration).
+
+Note that any existing file with the same name will be overwritten. If the path contains one or more directories, they will be automatically created if missing.
+
+| Type        | Required |
+| ----------- | -------- |
+| `posixPath` | Yes      |
+
+### `generateFiles[].value`
+
+[generateFiles](#generatefiles) > value
+
+The desired file contents as a string.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `variables`
+
+A map of variables scoped to this particular module. These are resolved before any other parts of the module configuration and take precedence over project-scoped variables. They may reference project-scoped variables, and generally use any template strings normally allowed when resolving modules.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `dependencies[]`
+
+List of services and tasks to deploy/run before deploying this ConfigMap.
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
+
+### `namespace`
+
+The namespace to deploy the ConfigMap in. Note that any module referencing the ConfigMap must be in the same namespace, so in most cases you should leave this unset.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `data`
+
+The ConfigMap data, as a key/value map of string values.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | Yes      |
+
+
+## Outputs
+
+### Module Outputs
+
+The following keys are available via the `${modules.<module-name>}` template string key for `configmap`
+modules.
+
+### `${modules.<module-name>.buildPath}`
+
+The build path of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${modules.my-module.buildPath}
+```
+
+### `${modules.<module-name>.name}`
+
+The name of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
+### `${modules.<module-name>.path}`
+
+The local path of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${modules.my-module.path}
+```
+
+### `${modules.<module-name>.var.*}`
+
+A map of all variables defined in the module.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${modules.<module-name>.var.<variable-name>}`
+
+| Type                                             |
+| ------------------------------------------------ |
+| `string | number | boolean | link | array[link]` |
+
+### `${modules.<module-name>.version}`
+
+The current version of the module.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${modules.my-module.version}
+```
+
+
+### Service Outputs
+
+The following keys are available via the `${runtime.services.<service-name>}` template string key for `configmap` module services.
+Note that these are only resolved when deploying/running dependants of the service, so they are not usable for every field.
+
+### `${runtime.services.<service-name>.version}`
+
+The current version of the service.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${runtime.services.my-service.version}
+```
+
+
+### Task Outputs
+
+The following keys are available via the `${runtime.tasks.<task-name>}` template string key for `configmap` module tasks.
+Note that these are only resolved when deploying/running dependants of the task, so they are not usable for every field.
+
+### `${runtime.tasks.<task-name>.version}`
+
+The current version of the task.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${runtime.tasks.my-tasks.version}
+```
+


### PR DESCRIPTION
This facilitates mounting ConfigMap resources as volumes in container
modules.

Closes #2456 

The added docs:

---

## Mounting Kubernetes ConfigMaps

Very similar to the above example, you can also mount ConfigMaps on
Kubernetes using the
[`configmap` module type](../reference/module-types/configmap.md),
supported by the `kubernetes` provider. Here's a simple example:

Example:

```yaml
kind: Module
name: my-configmap
type: configmap
data:
  config.properties: |
    some: data
    or: something
---
kind: Module
name: my-module
type: container
services:
  - name: my-service
    volumes:
      - name: my-configmap
        module: my-configmap
        containerPath: /config
    ...
```

This mounts all the keys in the `data` field on the `my-configmap`
module under the `/config` directory in the container. In this case,
you'll find the file `/config/config.properties` there, with the value
above (`some: data ...`) as the file contents.

You can do the same for tests and tasks using the
[`tests.volumes`](../reference/module-types/container.md#testsvolumes)
and
[`tasks.volumes`](../reference/module-types/container.md#tasksvolumes) 
fields. `configmap` volumes can of course also be referenced in
`kubernetes` and `helm` modules, since they are deployed as standard
ConfigMap resources.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
