### PR TITLE
fix(core): bump file watcher DEFAULT_BUFFER_INTERVAL to 1250

### DIFF
--- a/core/src/watch.ts
+++ b/core/src/watch.ts
@@ -20,7 +20,7 @@ import { InternalError } from "./exceptions"
 import { EventEmitter } from "events"
 
 // How long we wait between processing added files and directories
-const DEFAULT_BUFFER_INTERVAL = 400
+const DEFAULT_BUFFER_INTERVAL = 1250
 
 export type ChangeHandler = (module: GardenModule | null, configChanged: boolean) => Promise<void>
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

This seems like a reasonable buffer and appears to fix a handful of
issues where Garden throws while in watch mode because different git
commands fail, usually because the file system is changing while the git
command is being run.

Obviously this doesn't really fix the underlying issue and we should also look into also retrying git command on enoent errors. Flagging this PR as draft until we get to that. 

**Which issue(s) this PR fixes**:

Fixes #2430 

**Special notes for your reviewer**:
