### PR TITLE
fix(core): warn instead of error when attempting to scan non-directory

### DIFF
--- a/core/src/util/fs.ts
+++ b/core/src/util/fs.ts
@@ -11,7 +11,7 @@ import klaw = require("klaw")
 import glob from "glob"
 import tmp from "tmp-promise"
 import _spawn from "cross-spawn"
-import { pathExists, readFile, writeFile, lstat, realpath } from "fs-extra"
+import { pathExists, readFile, writeFile, lstat, realpath, Stats } from "fs-extra"
 import { join, basename, win32, posix } from "path"
 import { platform } from "os"
 
@@ -307,4 +307,29 @@ export async function makeTempDir({ git = false }: { git?: boolean } = {}): Prom
   }
 
   return tmpDir
+}
+
+/**
+ * Returns the type of the given fs.Stats object as a string.
+ *
+ * @param stats an fs.Stats instance
+ */
+export function getStatsType(stats: Stats) {
+  if (stats.isBlockDevice()) {
+    return "block device"
+  } else if (stats.isCharacterDevice()) {
+    return "character device"
+  } else if (stats.isDirectory()) {
+    return "directory"
+  } else if (stats.isFIFO()) {
+    return "named pipe"
+  } else if (stats.isFile()) {
+    return "file"
+  } else if (stats.isSocket()) {
+    return "socket"
+  } else if (stats.isSymbolicLink()) {
+    return "symbolic link"
+  } else {
+    return "unknown"
+  }
 }

--- a/core/test/unit/src/vcs/git.ts
+++ b/core/test/unit/src/vcs/git.ts
@@ -435,6 +435,21 @@ describe("GitHandler", () => {
       expect(files).to.eql([filePath])
     })
 
+    it("gracefully aborts if given path doesn't exist", async () => {
+      const path = resolve(tmpPath, "foo")
+
+      const files = (await handler.getFiles({ path, exclude: [], log })).map((f) => f.path)
+      expect(files).to.eql([])
+    })
+
+    it("gracefully aborts if given path is not a directory", async () => {
+      const path = resolve(tmpPath, "foo")
+      await createFile(path)
+
+      const files = (await handler.getFiles({ path, exclude: [], log })).map((f) => f.path)
+      expect(files).to.eql([])
+    })
+
     context("path contains a submodule", () => {
       let submodule: tmp.DirectoryResult
       let submodulePath: string
@@ -543,6 +558,27 @@ describe("GitHandler", () => {
         const paths = files.map((f) => relative(tmpPath, f.path)).sort()
 
         expect(paths).to.include(join("sub", initFile))
+      })
+
+      it("gracefully skips submodule if its path doesn't exist", async () => {
+        const subPath = join(tmpPath, "sub")
+        await remove(subPath)
+
+        const files = await handler.getFiles({ path: tmpPath, log })
+        const paths = files.map((f) => relative(tmpPath, f.path))
+
+        expect(paths).to.eql([".gitmodules"])
+      })
+
+      it("gracefully skips submodule if its path doesn't point to a directory", async () => {
+        const subPath = join(tmpPath, "sub")
+        await remove(subPath)
+        await createFile(subPath)
+
+        const files = await handler.getFiles({ path: tmpPath, log })
+        const paths = files.map((f) => relative(tmpPath, f.path))
+
+        expect(paths).to.eql([".gitmodules"])
       })
 
       context("submodule contains another submodule", () => {


### PR DESCRIPTION
Fixes #2430

Also adds more specific and helpful error messages when we encounter
missing/invalid submodule paths.
