### PR TITLE
chore: Update azure.Docker file to work with Azure DevOps Pipelines

### DIFF
--- a/support/azure.Dockerfile
+++ b/support/azure.Dockerfile
@@ -1,11 +1,29 @@
 ARG TAG=latest
 FROM gardendev/garden:${TAG}
+ENV KUBELOGIN_VERSION="v0.0.9"
 
 # Build dependencies
 RUN apk add --virtual=build gcc libffi-dev musl-dev openssl-dev make \
 # Runtime dependency
-  && apk add python3-dev && pip3 install -U pip \
+  && apk add  python3-dev && pip3 install -U pip \
 # Actual azure cli
   && pip3 --no-cache-dir install azure-cli \
 # Remove build dependencies
   && apk del --purge build
+
+# Azure DevOps Pipeline Dependencies
+RUN apk add --no-cache --virtual .pipeline-deps readline linux-pam  \
+  && apk add bash sudo shadow \
+  && apk del .pipeline-deps
+
+# Ensure kubelogin is available
+RUN wget -O kubelogin-linux-amd64.zip https://github.com/Azure/kubelogin/releases/download/$KUBELOGIN_VERSION/kubelogin-linux-amd64.zip  \
+ && unzip kubelogin-linux-amd64.zip \
+ && cp bin/linux_amd64/kubelogin /usr/local/bin/ \
+ && rm kubelogin-linux-amd64.zip
+
+
+LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/local/bin/node"
+
+ENTRYPOINT []
+

--- a/support/azure.Dockerfile
+++ b/support/azure.Dockerfile
@@ -1,28 +1,24 @@
 ARG TAG=latest
 FROM gardendev/garden:${TAG}
-ENV KUBELOGIN_VERSION="v0.0.9"
+
 
 # Build dependencies
-RUN apk add --virtual=build gcc libffi-dev musl-dev openssl-dev make \
+RUN apk add --virtual=build gcc libffi-dev musl-dev openssl-dev make readline linux-pam \
 # Runtime dependency
-  && apk add  python3-dev && pip3 install -U pip \
+  && apk add bash sudo shadow python3-dev && pip3 install -U pip \
 # Actual azure cli
   && pip3 --no-cache-dir install azure-cli \
 # Remove build dependencies
   && apk del --purge build
 
-# Azure DevOps Pipeline Dependencies
-RUN apk add --no-cache --virtual .pipeline-deps readline linux-pam  \
-  && apk add bash sudo shadow \
-  && apk del .pipeline-deps
-
 # Ensure kubelogin is available
+ENV KUBELOGIN_VERSION="v0.0.9"
 RUN wget -O kubelogin-linux-amd64.zip https://github.com/Azure/kubelogin/releases/download/$KUBELOGIN_VERSION/kubelogin-linux-amd64.zip  \
  && unzip kubelogin-linux-amd64.zip \
  && cp bin/linux_amd64/kubelogin /usr/local/bin/ \
  && rm kubelogin-linux-amd64.zip
 
-
+# Required by Azure DevOps to tell the system where node is installed
 LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/local/bin/node"
 
 ENTRYPOINT []


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the correct items needed for this Docker image to run on Azure DevOps

**Which issue(s) this PR fixes**:
Fixes #2502 

**Special notes for your reviewer**:

@edvald I checked the code I copied from Stack Overflow, it was in fact all needed -  I purposely chose to add the extra bits for Azure DevOps in a second run command so that it creates a separate layer for reuse in other images as necessary. I'm pretty sure this can all be collapsed in to a single run command if you prefer.

The Endpoint and label are both required by Azure DevOps for the image to run.

I've deployed this image to our internal registry and updated our CI/CD pipeline to use it.