### PR TITLE
fix(cli): don't print dev cmd banner when terminal doesn't support it

### DIFF
--- a/core/src/commands/dev.ts
+++ b/core/src/commands/dev.ts
@@ -98,8 +98,10 @@ export class DevCommand extends Command<DevCommandArgs, DevCommandOpts> {
 
   async prepare({ log, footerLog }: PrepareParams<DevCommandArgs, DevCommandOpts>) {
     // print ANSI banner image
-    const data = await readFile(ansiBannerPath)
-    log.info(data.toString())
+    if (chalk.supportsColor && chalk.supportsColor.level > 2) {
+      const data = await readFile(ansiBannerPath)
+      log.info(data.toString())
+    }
 
     log.info(chalk.gray.italic(`Good ${getGreetingTime()}! Let's get your environment wired up...`))
     log.info("")


### PR DESCRIPTION
This for example was an issue with the default macOS terminal, but
others like iTerm 2 on Mac is fine (and please use that btw!), as well
as the Windows terminal and most Linux ones by now.
