### PR TITLE
feat(k8s): allow setting podSelector on helm/kubernetes resource refs

### DIFF
--- a/core/src/plugins/kubernetes/api.ts
+++ b/core/src/plugins/kubernetes/api.ts
@@ -633,6 +633,14 @@ export class KubeApi {
                   // return the result body directly if applicable
                   .then((res: any) => {
                     if (isPlainObject(res) && res.hasOwnProperty("body")) {
+                      // inexplicably, this API sometimes returns apiVersion and kind as undefined...
+                      if (name === "listNamespacedPod" && res.body.items) {
+                        res.body.items = res.body.items.map((pod: any) => {
+                          pod.apiVersion = "v1"
+                          pod.kind = "Pod"
+                          return pod
+                        })
+                      }
                       return res["body"]
                     } else {
                       return res

--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -704,9 +704,10 @@ export const configSchema = () =>
     .unknown(false)
 
 export interface ServiceResourceSpec {
-  kind: HotReloadableKind
+  kind?: HotReloadableKind
   name?: string
   containerName?: string
+  podSelector?: { [key: string]: string }
   containerModule?: string
   hotReloadCommand?: string[]
   hotReloadArgs?: string[]
@@ -729,34 +730,46 @@ export interface KubernetesTestSpec extends BaseTestSpec {
   resource: ServiceResourceSpec
 }
 
+export const serviceResourceDescription = dedent`
+  This can either reference a workload (i.e. a Deployment, DaemonSet or StatefulSet) via the \`kind\` and \`name\` fields, or a Pod via the \`podSelector\` field.
+`
+
 export const serviceResourceSchema = () =>
-  joi.object().keys({
-    // TODO: consider allowing a `resource` field, that includes the kind and name (e.g. Deployment/my-deployment).
-    kind: joi
-      .string()
-      .valid(...hotReloadableKinds)
-      .default("Deployment")
-      .description("The type of Kubernetes resource to sync files to."),
-    name: joi.string().description(
-      deline`The name of the resource to sync to. If the module contains a single resource of the specified Kind,
+  joi
+    .object()
+    .keys({
+      kind: joi
+        .string()
+        .valid(...hotReloadableKinds)
+        .default("Deployment")
+        .description("The type of Kubernetes resource to sync files to."),
+      name: joi.string().description(
+        deline`The name of the resource to sync to. If the module contains a single resource of the specified Kind,
         this can be omitted.`
-    ),
-    containerName: joi.string().description(
-      deline`The name of a container in the target. Specify this if the target contains more than one container
-        and the main container is not the first container in the spec.`
-    ),
-  })
+      ),
+      containerName: joi
+        .string()
+        .description(
+          `The name of a container in the target. Specify this if the target contains more than one container and the main container is not the first container in the spec.`
+        ),
+      podSelector: joiStringMap(joi.string()).description(
+        dedent`
+          A map of string key/value labels to match on any Pods in the namespace. When specified, a random ready Pod with matching labels will be picked as a target, so make sure the labels will always match a specific Pod type.
+        `
+      ),
+    })
+    .oxor("podSelector", "kind")
+    .oxor("podSelector", "name")
 
 export const containerModuleSchema = () =>
   joiIdentifier()
     .description(
-      deline`The Garden module that contains the sources for the container. This needs to be specified under
-    \`serviceResource\` in order to enable hot-reloading, but is not necessary for tasks and tests.
+      dedent`
+        The Garden module that contains the sources for the container. This needs to be specified under \`serviceResource\` in order to enable hot-reloading and dev mode, but is not necessary for tasks and tests.
 
-    Must be a \`container\` module, and for hot-reloading to work you must specify the \`hotReload\` field
-    on the container module.
+        Must be a \`container\` module, and for hot-reloading to work you must specify the \`hotReload\` field on the container module (not required for dev mode).
 
-    Note: If you specify a module here, you don't need to specify it additionally under \`build.dependencies\``
+        _Note: If you specify a module here, you don't need to specify it additionally under \`build.dependencies\`._`
     )
     .example("my-container-module")
 
@@ -773,9 +786,11 @@ export const kubernetesTaskSchema = () =>
   baseTaskSpecSchema()
     .keys({
       resource: serviceResourceSchema().description(
-        dedent`The Deployment, DaemonSet or StatefulSet that Garden should use to execute this task.
+        dedent`The Deployment, DaemonSet, StatefulSet or Pod that Garden should use to execute this task.
         If not specified, the \`serviceResource\` configured on the module will be used. If neither is specified,
         an error will be thrown.
+
+        ${serviceResourceDescription}
 
         The following pod spec fields from the service resource will be used (if present) when executing the task:
         ${runPodSpecWhitelistDescription}`
@@ -800,9 +815,11 @@ export const kubernetesTestSchema = () =>
   baseTestSpecSchema()
     .keys({
       resource: serviceResourceSchema().description(
-        dedent`The Deployment, DaemonSet or StatefulSet that Garden should use to execute this test suite.
+        dedent`The Deployment, DaemonSet or StatefulSet or Pod that Garden should use to execute this test suite.
         If not specified, the \`serviceResource\` configured on the module will be used. If neither is specified,
         an error will be thrown.
+
+        ${serviceResourceDescription}
 
         The following pod spec fields from the service resource will be used (if present) when executing the test suite:
         ${runPodSpecWhitelistDescription}`

--- a/core/src/plugins/kubernetes/helm/config.ts
+++ b/core/src/plugins/kubernetes/helm/config.ts
@@ -33,6 +33,7 @@ import {
   namespaceNameSchema,
   containerModuleSchema,
   hotReloadArgsSchema,
+  serviceResourceDescription,
 } from "../config"
 import { posix } from "path"
 import { runPodSpecIncludeFields } from "../run"
@@ -104,9 +105,11 @@ const runPodSpecWhitelistDescription = runPodSpecIncludeFields.map((f) => `* \`$
 const helmTaskSchema = () =>
   kubernetesTaskSchema().keys({
     resource: helmServiceResourceSchema().description(
-      dedent`The Deployment, DaemonSet or StatefulSet that Garden should use to execute this task.
+      dedent`The Deployment, DaemonSet or StatefulSet or Pod that Garden should use to execute this task.
         If not specified, the \`serviceResource\` configured on the module will be used. If neither is specified,
         an error will be thrown.
+
+        ${serviceResourceDescription}
 
         The following pod spec fields from the service resource will be used (if present) when executing the task:
         ${runPodSpecWhitelistDescription}`
@@ -116,9 +119,11 @@ const helmTaskSchema = () =>
 const helmTestSchema = () =>
   kubernetesTestSchema().keys({
     resource: helmServiceResourceSchema().description(
-      dedent`The Deployment, DaemonSet or StatefulSet that Garden should use to execute this test suite.
+      dedent`The Deployment, DaemonSet or StatefulSet or Pod that Garden should use to execute this test suite.
         If not specified, the \`serviceResource\` configured on the module will be used. If neither is specified,
         an error will be thrown.
+
+        ${serviceResourceDescription}
 
         The following pod spec fields from the service resource will be used (if present) when executing the test suite:
         ${runPodSpecWhitelistDescription}`
@@ -170,13 +175,13 @@ export const helmModuleSpecSchema = () =>
     ),
     repo: joi.string().description("The repository URL to fetch the chart from."),
     serviceResource: helmServiceResourceSchema().description(
-      deline`The Deployment, DaemonSet or StatefulSet that Garden should regard as the _Garden service_ in this module
-      (not to be confused with Kubernetes Service resources).
-      Because a Helm chart can contain any number of Kubernetes resources, this needs to be specified for certain
-      Garden features and commands to work, such as hot-reloading.
+      dedent`
+      The Deployment, DaemonSet or StatefulSet or Pod that Garden should regard as the _Garden service_ in this module (not to be confused with Kubernetes Service resources).
 
-      We currently map a Helm chart to a single Garden service, because all the resources in a Helm chart are
-      deployed at once.`
+      ${serviceResourceDescription}
+
+      Because a Helm chart can contain any number of Kubernetes resources, this needs to be specified for certain Garden features and commands to work, such as hot-reloading.
+      `
     ),
     skipDeploy: joi
       .boolean()

--- a/core/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/src/plugins/kubernetes/helm/deployment.ts
@@ -18,7 +18,7 @@ import { ContainerHotReloadSpec } from "../../container/config"
 import { DeployServiceParams } from "../../../types/plugin/service/deployService"
 import { DeleteServiceParams } from "../../../types/plugin/service/deleteService"
 import { getForwardablePorts, killPortForwards } from "../port-forward"
-import { findServiceResource, getServiceResourceSpec } from "../util"
+import { getServiceResource, getServiceResourceSpec } from "../util"
 import { getModuleNamespace, getModuleNamespaceStatus } from "../namespace"
 import { getHotReloadSpec, configureHotReload, getHotReloadContainerName } from "../hot-reload/helpers"
 import { configureDevMode, startDevModeSync } from "../dev-mode"
@@ -40,13 +40,22 @@ export async function deployHelmService({
   const k8sCtx = ctx as KubernetesPluginContext
   const provider = k8sCtx.provider
 
+  const namespaceStatus = await getModuleNamespaceStatus({
+    ctx: k8sCtx,
+    log,
+    module,
+    provider: k8sCtx.provider,
+  })
+  const namespace = namespaceStatus.namespaceName
+
   const manifests = await getChartResources({ ctx: k8sCtx, module, devMode, hotReload, log, version: service.version })
 
   if ((devMode && module.spec.devMode) || hotReload) {
     serviceResourceSpec = getServiceResourceSpec(module, getBaseModule(module))
-    serviceResource = await findServiceResource({
+    serviceResource = await getServiceResource({
       ctx,
       log,
+      provider,
       module,
       manifests,
       resourceSpec: serviceResourceSpec,
@@ -58,14 +67,6 @@ export async function deployHelmService({
   }
 
   const chartPath = await getChartPath(module)
-
-  const namespaceStatus = await getModuleNamespaceStatus({
-    ctx: k8sCtx,
-    log,
-    module,
-    provider: k8sCtx.provider,
-  })
-  const namespace = namespaceStatus.namespaceName
 
   const releaseName = getReleaseName(module)
   const releaseStatus = await getReleaseStatus({ ctx: k8sCtx, service, releaseName, log, devMode, hotReload })

--- a/core/src/plugins/kubernetes/helm/exec.ts
+++ b/core/src/plugins/kubernetes/helm/exec.ts
@@ -10,7 +10,7 @@ import { includes } from "lodash"
 import { DeploymentError } from "../../../exceptions"
 import { getAppNamespace } from "../namespace"
 import { KubernetesPluginContext } from "../config"
-import { execInWorkload, findServiceResource, getServiceResourceSpec } from "../util"
+import { execInWorkload, getServiceResource, getServiceResourceSpec } from "../util"
 import { ExecInServiceParams } from "../../../types/plugin/service/execInService"
 import { HelmModule } from "./config"
 import { getServiceStatus } from "./status"
@@ -44,9 +44,10 @@ export async function execInHelmService(params: ExecInServiceParams<HelmModule>)
     version: service.version,
   })
 
-  const serviceResource = await findServiceResource({
+  const serviceResource = await getServiceResource({
     ctx,
     log,
+    provider,
     module,
     manifests,
     resourceSpec: serviceResourceSpec,

--- a/core/src/plugins/kubernetes/helm/run.ts
+++ b/core/src/plugins/kubernetes/helm/run.ts
@@ -10,7 +10,7 @@ import { HelmModule } from "./config"
 import { PodRunner, runAndCopy } from "../run"
 import { getChartResources, getBaseModule } from "./common"
 import {
-  findServiceResource,
+  getServiceResource,
   getResourceContainer,
   getResourcePodSpec,
   getServiceResourceSpec,
@@ -61,9 +61,10 @@ export async function runHelmModule({
   }
 
   const manifests = await getChartResources({ ctx: k8sCtx, module, devMode: false, hotReload: false, log, version })
-  const target = await findServiceResource({
+  const target = await getServiceResource({
     ctx: k8sCtx,
     log,
+    provider: k8sCtx.provider,
     manifests,
     module,
     resourceSpec,
@@ -133,9 +134,10 @@ export async function runHelmTask(params: RunTaskParams<HelmModule>): Promise<Ru
   })
   const baseModule = getBaseModule(module)
   const resourceSpec = task.spec.resource || getServiceResourceSpec(module, baseModule)
-  const target = await findServiceResource({
+  const target = await getServiceResource({
     ctx: k8sCtx,
     log,
+    provider: k8sCtx.provider,
     manifests,
     module,
     resourceSpec,

--- a/core/src/plugins/kubernetes/helm/status.ts
+++ b/core/src/plugins/kubernetes/helm/status.ts
@@ -16,7 +16,7 @@ import { KubernetesPluginContext } from "../config"
 import { getForwardablePorts } from "../port-forward"
 import { KubernetesServerResource } from "../types"
 import { getModuleNamespace, getModuleNamespaceStatus } from "../namespace"
-import { findServiceResource, getServiceResourceSpec } from "../util"
+import { getServiceResource, getServiceResourceSpec } from "../util"
 import chalk from "chalk"
 import { startDevModeSync } from "../dev-mode"
 import { gardenAnnotationKey } from "../../../util/string"
@@ -74,9 +74,10 @@ export async function getServiceStatus({
       // Need to start the dev-mode sync here, since the deployment handler won't be called.
       const baseModule = getBaseModule(module)
       const serviceResourceSpec = getServiceResourceSpec(module, baseModule)
-      const target = await findServiceResource({
-        ctx,
+      const target = await getServiceResource({
+        ctx: k8sCtx,
         log,
+        provider: k8sCtx.provider,
         module,
         manifests: deployedResources,
         resourceSpec: serviceResourceSpec,

--- a/core/src/plugins/kubernetes/helm/test.ts
+++ b/core/src/plugins/kubernetes/helm/test.ts
@@ -16,7 +16,7 @@ import { TestModuleParams } from "../../../types/plugin/module/testModule"
 import { TestResult } from "../../../types/plugin/module/getTestResult"
 import {
   getServiceResourceSpec,
-  findServiceResource,
+  getServiceResource,
   getResourceContainer,
   makePodName,
   getResourcePodSpec,
@@ -38,7 +38,14 @@ export async function testHelmModule(params: TestModuleParams<HelmModule>): Prom
   })
   const baseModule = getBaseModule(module)
   const resourceSpec = test.config.spec.resource || getServiceResourceSpec(module, baseModule)
-  const target = await findServiceResource({ ctx: k8sCtx, log, manifests, module, resourceSpec })
+  const target = await getServiceResource({
+    ctx: k8sCtx,
+    log,
+    provider: k8sCtx.provider,
+    manifests,
+    module,
+    resourceSpec,
+  })
   const container = getResourceContainer(target, resourceSpec.containerName)
   const namespaceStatus = await getModuleNamespaceStatus({
     ctx: k8sCtx,

--- a/core/src/plugins/kubernetes/kubernetes-module/config.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/config.ts
@@ -24,6 +24,7 @@ import {
   namespaceNameSchema,
   containerModuleSchema,
   hotReloadArgsSchema,
+  serviceResourceDescription,
 } from "../config"
 import { ContainerModule } from "../../container/config"
 import { kubernetesDevModeSchema, KubernetesDevModeSpec } from "../dev-mode"
@@ -87,7 +88,10 @@ export const kubernetesModuleSpecSchema = () =>
     serviceResource: serviceResourceSchema()
       .description(
         dedent`
-        The Deployment, DaemonSet or StatefulSet that Garden should regard as the _Garden service_ in this module (not to be confused with Kubernetes Service resources).
+        The Deployment, DaemonSet or StatefulSet or Pod that Garden should regard as the _Garden service_ in this module (not to be confused with Kubernetes Service resources).
+
+        ${serviceResourceDescription}
+
         Because a \`kubernetes\` module can contain any number of Kubernetes resources, this needs to be specified for certain Garden features and commands to work.
         `
       )

--- a/core/src/plugins/kubernetes/kubernetes-module/exec.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/exec.ts
@@ -11,7 +11,7 @@ import { DeploymentError } from "../../../exceptions"
 import { KubernetesModule } from "./config"
 import { getAppNamespace } from "../namespace"
 import { KubernetesPluginContext } from "../config"
-import { execInWorkload, findServiceResource, getServiceResourceSpec } from "../util"
+import { execInWorkload, getServiceResource, getServiceResourceSpec } from "../util"
 import { getKubernetesServiceStatus } from "./handlers"
 import { ExecInServiceParams } from "../../../types/plugin/service/execInService"
 
@@ -33,9 +33,10 @@ export async function execInKubernetesService(params: ExecInServiceParams<Kubern
   const namespace = await getAppNamespace(k8sCtx, log, k8sCtx.provider)
 
   const serviceResourceSpec = getServiceResourceSpec(module, undefined)
-  const serviceResource = await findServiceResource({
+  const serviceResource = await getServiceResource({
     ctx,
     log,
+    provider,
     module,
     manifests: status.detail.remoteResources,
     resourceSpec: serviceResourceSpec,

--- a/core/src/plugins/kubernetes/kubernetes-module/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/handlers.ts
@@ -6,13 +6,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { V1DaemonSet, V1Deployment, V1StatefulSet } from "@kubernetes/client-node"
 import Bluebird from "bluebird"
 import chalk from "chalk"
-
 import { cloneDeep, partition, set, uniq } from "lodash"
 import { LogEntry } from "../../../logger/log-entry"
-import { PluginContext } from "../../../plugin-context"
 import { NamespaceStatus } from "../../../types/plugin/base"
 import { ModuleAndRuntimeActionHandlers } from "../../../types/plugin/plugin"
 import { DeleteServiceParams } from "../../../types/plugin/service/deleteService"
@@ -35,7 +32,7 @@ import { compareDeployedResources, waitForResources } from "../status/status"
 import { getTaskResult } from "../task-results"
 import { getTestResult } from "../test-results"
 import { BaseResource, KubernetesResource, KubernetesServerResource } from "../types"
-import { findServiceResource, getServiceResourceSpec } from "../util"
+import { getServiceResource, getServiceResourceSpec } from "../util"
 import { gardenNamespaceAnnotationValue, getManifests } from "./common"
 import { configureKubernetesModule, KubernetesModule, KubernetesService } from "./config"
 import { execInKubernetesService } from "./exec"
@@ -86,7 +83,7 @@ export async function getKubernetesServiceStatus({
   // This means that manifests added via the `build.dependencies[].copy` field will not be included.
   const manifests = await getManifests({ ctx, api, log, module, defaultNamespace: namespace, readFromSrcDir: true })
   const prepareResult = await prepareManifestsForSync({
-    ctx,
+    ctx: k8sCtx,
     log,
     module,
     service,
@@ -102,9 +99,10 @@ export async function getKubernetesServiceStatus({
   if (state === "ready" && devMode && service.spec.devMode) {
     // Need to start the dev-mode sync here, since the deployment handler won't be called.
     const serviceResourceSpec = getServiceResourceSpec(module, undefined)
-    const target = await findServiceResource({
-      ctx,
+    const target = await getServiceResource({
+      ctx: k8sCtx,
       log,
+      provider: k8sCtx.provider,
       module,
       manifests: remoteResources,
       resourceSpec: serviceResourceSpec,
@@ -176,7 +174,7 @@ export async function deployKubernetesService(
   const pruneSelector = getSelector(service)
   if (otherManifests.length > 0) {
     const prepareResult = await prepareManifestsForSync({
-      ctx,
+      ctx: k8sCtx,
       log,
       module,
       service,
@@ -334,7 +332,7 @@ async function prepareManifestsForSync({
   hotReload,
   manifests,
 }: {
-  ctx: PluginContext
+  ctx: KubernetesPluginContext
   service: KubernetesService | HelmService
   log: LogEntry
   module: KubernetesModule
@@ -342,14 +340,16 @@ async function prepareManifestsForSync({
   hotReload: boolean
   manifests: KubernetesResource<BaseResource>[]
 }) {
-  let target: KubernetesResource<V1Deployment | V1DaemonSet | V1StatefulSet>
+  let target: HotReloadableResource
 
   try {
     const resourceSpec = getServiceResourceSpec(module, undefined)
+
     target = cloneDeep(
-      await findServiceResource({
+      await getServiceResource({
         ctx,
         log,
+        provider: ctx.provider,
         module,
         manifests,
         resourceSpec,

--- a/core/src/plugins/kubernetes/kubernetes-module/run.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/run.ts
@@ -9,7 +9,7 @@
 import { KubernetesModule } from "./config"
 import { runAndCopy } from "../run"
 import {
-  findServiceResource,
+  getServiceResource,
   getResourceContainer,
   getResourcePodSpec,
   getServiceResourceSpec,
@@ -39,9 +39,10 @@ export async function runKubernetesTask(params: RunTaskParams<KubernetesModule>)
   const { command, args } = task.spec
   const manifests = await getManifests({ ctx, api, log, module, defaultNamespace: namespace })
   const resourceSpec = task.spec.resource || getServiceResourceSpec(module, undefined)
-  const target = await findServiceResource({
+  const target = await getServiceResource({
     ctx: k8sCtx,
     log,
+    provider: k8sCtx.provider,
     manifests,
     module,
     resourceSpec,

--- a/core/src/plugins/kubernetes/kubernetes-module/test.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/test.ts
@@ -18,7 +18,7 @@ import { KubeApi } from "../api"
 import { getManifests } from "./common"
 import {
   getServiceResourceSpec,
-  findServiceResource,
+  getServiceResource,
   getResourceContainer,
   makePodName,
   getResourcePodSpec,
@@ -39,7 +39,14 @@ export async function testKubernetesModule(params: TestModuleParams<KubernetesMo
   // Get the container spec to use for running
   const manifests = await getManifests({ ctx, api, log, module, defaultNamespace: namespace })
   const resourceSpec = test.config.spec.resource || getServiceResourceSpec(module, undefined)
-  const target = await findServiceResource({ ctx: k8sCtx, log, manifests, module, resourceSpec })
+  const target = await getServiceResource({
+    ctx: k8sCtx,
+    log,
+    provider: k8sCtx.provider,
+    manifests,
+    module,
+    resourceSpec,
+  })
   const container = getResourceContainer(target, resourceSpec.containerName)
 
   const testName = test.name

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -28,7 +28,7 @@ import { Writable, Readable } from "stream"
 import { uniqByName, sleep } from "../../util/util"
 import { KubeApi } from "./api"
 import { getPodLogs, checkPodStatus } from "./status/pod"
-import { KubernetesResource, KubernetesPod } from "./types"
+import { KubernetesResource, KubernetesPod, KubernetesServerResource } from "./types"
 import { RunModuleParams } from "../../types/plugin/module/runModule"
 import { ContainerEnvVars, ContainerResourcesSpec, ContainerVolumeSpec } from "../container/config"
 import { prepareEnvVars, makePodName } from "./util"
@@ -672,7 +672,7 @@ class PodRunnerParams {
   ctx: PluginContext
   annotations?: { [key: string]: string }
   api: KubeApi
-  pod: KubernetesPod
+  pod: KubernetesPod | KubernetesServerResource<V1Pod>
   namespace: string
   provider: KubernetesProvider
 }

--- a/core/src/plugins/kubernetes/types.ts
+++ b/core/src/plugins/kubernetes/types.ts
@@ -30,11 +30,11 @@ export interface BaseResource {
 
 // Because the Kubernetes API library types currently list all keys as optional, we use this type to wrap the
 // library types and make some fields required that are always required in the API.
-export type KubernetesResource<T extends BaseResource | KubernetesObject = BaseResource> =
+export type KubernetesResource<T extends BaseResource | KubernetesObject = BaseResource, K = string> =
   // Make these always required
   {
     apiVersion: string
-    kind: string
+    kind: K
     metadata: Partial<V1ObjectMeta> & {
       name: string
     }
@@ -77,3 +77,7 @@ export type KubernetesStatefulSet = KubernetesResource<V1StatefulSet>
 export type KubernetesPod = KubernetesResource<V1Pod>
 
 export type KubernetesWorkload = KubernetesResource<V1DaemonSet | V1Deployment | V1ReplicaSet | V1StatefulSet>
+
+export function isPodResource(resource: KubernetesWorkload | KubernetesPod): resource is KubernetesPod {
+  return resource.kind === "Pod"
+}

--- a/core/test/integ/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/build/buildkit.ts
@@ -22,7 +22,7 @@ import { buildDockerAuthConfig } from "../../../../../../../src/plugins/kubernet
 import { dockerAuthSecretKey } from "../../../../../../../src/plugins/kubernetes/constants"
 import { grouped } from "../../../../../../helpers"
 
-describe("ensureBuildkit", () => {
+grouped("cluster-buildkit").describe("ensureBuildkit", () => {
   let garden: Garden
   let provider: KubernetesProvider
   let ctx: PluginContext

--- a/core/test/integ/src/plugins/kubernetes/hot-reload.ts
+++ b/core/test/integ/src/plugins/kubernetes/hot-reload.ts
@@ -14,7 +14,11 @@ import { ConfigGraph } from "../../../../../src/config-graph"
 import { getHelmTestGarden, buildHelmModules } from "./helm/common"
 import { getChartResources } from "../../../../../src/plugins/kubernetes/helm/common"
 import { KubernetesProvider, KubernetesPluginContext } from "../../../../../src/plugins/kubernetes/config"
-import { findServiceResource, getServiceResourceSpec } from "../../../../../src/plugins/kubernetes/util"
+import {
+  getServiceResource,
+  getResourcePodSpec,
+  getServiceResourceSpec,
+} from "../../../../../src/plugins/kubernetes/util"
 import {
   getHotReloadSpec,
   getHotReloadContainerName,
@@ -119,9 +123,10 @@ describe("configureHotReload", () => {
     })
     const resourceSpec = getServiceResourceSpec(module, undefined)
     const hotReloadSpec = getHotReloadSpec(service)
-    const hotReloadTarget = await findServiceResource({
+    const hotReloadTarget = await getServiceResource({
       ctx,
       log,
+      provider,
       module,
       manifests,
       resourceSpec,
@@ -132,7 +137,7 @@ describe("configureHotReload", () => {
       hotReloadSpec,
       target: hotReloadTarget,
     })
-    const containers: any[] = hotReloadTarget.spec.template.spec?.containers || []
+    const containers: any[] = getResourcePodSpec(hotReloadTarget)?.containers || []
     // This is a second, non-main/resource container included by the Helm chart, which should not mount the sync volume.
     const secondContainer = containers.find((c) => c.name === "second-container")
 

--- a/core/test/integ/src/plugins/kubernetes/util.ts
+++ b/core/test/integ/src/plugins/kubernetes/util.ts
@@ -14,12 +14,17 @@ import { ConfigGraph } from "../../../../../src/config-graph"
 import { Provider } from "../../../../../src/config/provider"
 import { DeployTask } from "../../../../../src/tasks/deploy"
 import { KubeApi } from "../../../../../src/plugins/kubernetes/api"
-import { KubernetesConfig, KubernetesPluginContext } from "../../../../../src/plugins/kubernetes/config"
+import {
+  KubernetesConfig,
+  KubernetesPluginContext,
+  ServiceResourceSpec,
+} from "../../../../../src/plugins/kubernetes/config"
 import {
   getWorkloadPods,
   getServiceResourceSpec,
-  findServiceResource,
+  getServiceResource,
   getResourceContainer,
+  getResourcePodSpec,
 } from "../../../../../src/plugins/kubernetes/util"
 import { createWorkloadManifest } from "../../../../../src/plugins/kubernetes/container/deployment"
 import { emptyRuntimeContext } from "../../../../../src/runtime-context"
@@ -27,16 +32,18 @@ import { getHelmTestGarden } from "./helm/common"
 import { deline } from "../../../../../src/util/string"
 import { getBaseModule, getChartResources } from "../../../../../src/plugins/kubernetes/helm/common"
 import { buildHelmModule } from "../../../../../src/plugins/kubernetes/helm/build"
-import { HotReloadableResource } from "../../../../../src/plugins/kubernetes/hot-reload/hot-reload"
 import { LogEntry } from "../../../../../src/logger/log-entry"
 import { BuildTask } from "../../../../../src/tasks/build"
 import { getContainerTestGarden } from "./container/container"
+import { KubernetesDeployment, KubernetesPod, KubernetesWorkload } from "../../../../../src/plugins/kubernetes/types"
+import { getAppNamespace } from "../../../../../src/plugins/kubernetes/namespace"
 
 describe("util", () => {
   let helmGarden: TestGarden
   let helmGraph: ConfigGraph
   let ctx: KubernetesPluginContext
   let log: LogEntry
+  let api: KubeApi
 
   before(async () => {
     helmGarden = await getHelmTestGarden()
@@ -45,6 +52,7 @@ describe("util", () => {
     ctx = (await helmGarden.getPluginContext(provider)) as KubernetesPluginContext
     helmGraph = await helmGarden.getConfigGraph(log)
     await buildModules()
+    api = await KubeApi.factory(helmGarden.log, ctx, ctx.provider)
   })
 
   beforeEach(async () => {
@@ -56,7 +64,7 @@ describe("util", () => {
   })
 
   async function buildModules() {
-    const modules = await helmGraph.getModules()
+    const modules = helmGraph.getModules()
     const tasks = modules.map(
       (module) => new BuildTask({ garden: helmGarden, graph: helmGraph, log, module, force: false, _guard: true })
     )
@@ -77,7 +85,6 @@ describe("util", () => {
       try {
         const graph = await garden.getConfigGraph(garden.log)
         const provider = (await garden.resolveProvider(garden.log, "local-kubernetes")) as Provider<KubernetesConfig>
-        const api = await KubeApi.factory(garden.log, ctx, provider)
 
         const service = graph.getService("simple-service")
 
@@ -113,17 +120,52 @@ describe("util", () => {
         await garden.close()
       }
     })
+
+    it("should read a Pod from a namespace directly when given a Pod manifest", async () => {
+      const garden = await getContainerTestGarden("local")
+
+      try {
+        const graph = await garden.getConfigGraph(garden.log)
+        const service = graph.getService("simple-service")
+
+        const deployTask = new DeployTask({
+          force: false,
+          forceBuild: false,
+          garden,
+          graph,
+          log: garden.log,
+          service,
+          devModeServiceNames: [],
+          hotReloadServiceNames: [],
+        })
+
+        const provider = (await garden.resolveProvider(garden.log, "local-kubernetes")) as Provider<KubernetesConfig>
+        await garden.processTasks([deployTask], { throwOnError: true })
+
+        const namespace = await getAppNamespace(ctx, log, provider)
+        const allPods = await api.core.listNamespacedPod(namespace)
+
+        const pod = allPods.items[0]
+
+        const pods = await getWorkloadPods(api, namespace, pod)
+        expect(pods.length).to.equal(1)
+        expect(pods[0].kind).to.equal("Pod")
+        expect(pods[0].metadata.name).to.equal(pod.metadata.name)
+      } finally {
+        await garden.close()
+      }
+    })
   })
 
   describe("getServiceResourceSpec", () => {
     it("should return the spec on the given module if it has no base module", async () => {
-      const module = await helmGraph.getModule("api")
+      const module = helmGraph.getModule("api")
       expect(getServiceResourceSpec(module, undefined)).to.eql(module.spec.serviceResource)
     })
 
     it("should return the spec on the base module if there is none on the module", async () => {
-      const module = await helmGraph.getModule("api")
-      const baseModule = await helmGraph.getModule("postgres")
+      const module = helmGraph.getModule("api")
+      const baseModule = helmGraph.getModule("postgres")
       module.spec.base = "postgres"
       delete module.spec.serviceResource
       module.buildDependencies = { postgres: baseModule }
@@ -131,8 +173,8 @@ describe("util", () => {
     })
 
     it("should merge the specs if both module and base have specs", async () => {
-      const module = await helmGraph.getModule("api")
-      const baseModule = await helmGraph.getModule("postgres")
+      const module = helmGraph.getModule("api")
+      const baseModule = helmGraph.getModule("postgres")
       module.spec.base = "postgres"
       module.buildDependencies = { postgres: baseModule }
       expect(getServiceResourceSpec(module, baseModule)).to.eql({
@@ -143,7 +185,7 @@ describe("util", () => {
     })
 
     it("should throw if there is no base module and the module has no serviceResource spec", async () => {
-      const module = await helmGraph.getModule("api")
+      const module = helmGraph.getModule("api")
       delete module.spec.serviceResource
       await expectError(
         () => getServiceResourceSpec(module, undefined),
@@ -157,8 +199,8 @@ describe("util", () => {
     })
 
     it("should throw if there is a base module but neither module has a spec", async () => {
-      const module = await helmGraph.getModule("api")
-      const baseModule = await helmGraph.getModule("postgres")
+      const module = helmGraph.getModule("api")
+      const baseModule = helmGraph.getModule("postgres")
       module.spec.base = "postgres"
       module.buildDependencies = { postgres: baseModule }
       delete module.spec.serviceResource
@@ -175,7 +217,7 @@ describe("util", () => {
     })
   })
 
-  describe("findServiceResource", () => {
+  describe("getServiceResource", () => {
     it("should return the resource specified by serviceResource", async () => {
       const module = helmGraph.getModule("api")
       const manifests = await getChartResources({
@@ -186,16 +228,46 @@ describe("util", () => {
         log,
         version: module.version.versionString,
       })
-      const resourceSpec = await getServiceResourceSpec(module, undefined)
-      const result = await findServiceResource({
+      const result = await getServiceResource({
         ctx,
         log,
+        provider: ctx.provider,
         module,
         manifests,
-        resourceSpec,
+        resourceSpec: getServiceResourceSpec(module, undefined),
       })
       const expected = find(manifests, (r) => r.kind === "Deployment")
       expect(result).to.eql(expected)
+    })
+
+    it("should throw if no resourceSpec or serviceResource is specified", async () => {
+      const module = helmGraph.getModule("api")
+      const manifests = await getChartResources({
+        ctx,
+        module,
+        devMode: false,
+        hotReload: false,
+        log,
+        version: module.version.versionString,
+      })
+      delete module.spec.serviceResource
+      await expectError(
+        () =>
+          getServiceResource({
+            ctx,
+            log,
+            provider: ctx.provider,
+            module,
+            manifests,
+            resourceSpec: getServiceResourceSpec(module, undefined),
+          }),
+        (err) =>
+          expect(stripAnsi(err.message)).to.equal(
+            deline`helm module api doesn't specify a serviceResource in its configuration.
+          You must specify a resource in the module config in order to use certain Garden features,
+          such as hot reloading, tasks and tests.`
+          )
+      )
     })
 
     it("should throw if no resource of the specified kind is in the chart", async () => {
@@ -214,9 +286,10 @@ describe("util", () => {
       }
       await expectError(
         () =>
-          findServiceResource({
+          getServiceResource({
             ctx,
             log,
+            provider: ctx.provider,
             module,
             manifests,
             resourceSpec,
@@ -241,9 +314,10 @@ describe("util", () => {
       }
       await expectError(
         () =>
-          findServiceResource({
+          getServiceResource({
             ctx,
             log,
+            provider: ctx.provider,
             module,
             manifests,
             resourceSpec,
@@ -264,12 +338,20 @@ describe("util", () => {
       })
       const deployment = find(manifests, (r) => r.kind === "Deployment")
       manifests.push(deployment!)
-      const resourceSpec = getServiceResourceSpec(module, undefined)
+
       await expectError(
-        () => findServiceResource({ ctx, log, module, manifests, resourceSpec }),
+        () =>
+          getServiceResource({
+            ctx,
+            log,
+            provider: ctx.provider,
+            module,
+            manifests,
+            resourceSpec: getServiceResourceSpec(module, undefined),
+          }),
         (err) =>
           expect(stripAnsi(err.message)).to.equal(
-            "helm module api contains multiple Deployments. You must specify resource.name or serviceResource.name in the module config in order to identify the correct Deployment to use."
+            "helm module api contains multiple Deployments. You must specify a resource name in the appropriate config in order to identify the correct Deployment to use."
           )
       )
     })
@@ -286,16 +368,131 @@ describe("util", () => {
         version: module.version.versionString,
       })
       module.spec.serviceResource.name = `{{ template "postgresql.master.fullname" . }}`
-      const resourceSpec = getServiceResourceSpec(module, undefined)
-      const result = await findServiceResource({
+      const result = await getServiceResource({
         ctx,
         log,
+        provider: ctx.provider,
         module,
         manifests,
-        resourceSpec,
+        resourceSpec: getServiceResourceSpec(module, undefined),
       })
       const expected = find(manifests, (r) => r.kind === "StatefulSet")
       expect(result).to.eql(expected)
+    })
+
+    context("podSelector", () => {
+      before(async () => {
+        const service = helmGraph.getService("api")
+
+        const deployTask = new DeployTask({
+          force: false,
+          forceBuild: false,
+          garden: helmGarden,
+          graph: helmGraph,
+          log: helmGarden.log,
+          service,
+          devModeServiceNames: [],
+          hotReloadServiceNames: [],
+        })
+
+        await helmGarden.processTasks([deployTask], { throwOnError: true })
+      })
+
+      it("returns running Pod if one is found matching podSelector", async () => {
+        const module = helmGraph.getModule("api")
+        const resourceSpec: ServiceResourceSpec = {
+          podSelector: {
+            "app.kubernetes.io/name": "api",
+            "app.kubernetes.io/instance": "api-release",
+          },
+        }
+
+        const pod = await getServiceResource({
+          ctx,
+          log,
+          provider: ctx.provider,
+          module,
+          manifests: [],
+
+          resourceSpec,
+        })
+
+        expect(pod.kind).to.equal("Pod")
+        expect(pod.metadata.labels?.["app.kubernetes.io/name"]).to.equal("api")
+        expect(pod.metadata.labels?.["app.kubernetes.io/instance"]).to.equal("api-release")
+      })
+
+      it("throws if podSelector is set and no Pod is found matching the selector", async () => {
+        const module = helmGraph.getModule("api")
+        const resourceSpec: ServiceResourceSpec = {
+          podSelector: {
+            "app.kubernetes.io/name": "boo",
+            "app.kubernetes.io/instance": "foo",
+          },
+        }
+
+        await expectError(
+          () =>
+            getServiceResource({
+              ctx,
+              log,
+              provider: ctx.provider,
+              module,
+              manifests: [],
+
+              resourceSpec,
+            }),
+          (err) =>
+            expect(stripAnsi(err.message)).to.equal(
+              "Could not find any Pod matching provided podSelector (app.kubernetes.io/name=boo,app.kubernetes.io/instance=foo) for resource in helm module api"
+            )
+        )
+      })
+    })
+  })
+
+  describe("getResourcePodSpec", () => {
+    it("should return the spec for a Pod resource", () => {
+      const pod: KubernetesPod = {
+        apiVersion: "v1",
+        kind: "Pod",
+        metadata: {
+          name: "foo",
+          namespace: "bar",
+        },
+        spec: {
+          containers: [
+            {
+              name: "main",
+            },
+          ],
+        },
+      }
+      expect(getResourcePodSpec(pod)).to.equal(pod.spec)
+    })
+
+    it("should returns the Pod template spec for a Deployment", () => {
+      const deployment: KubernetesDeployment = {
+        apiVersion: "v1",
+        kind: "Deployment",
+        metadata: {
+          name: "foo",
+          namespace: "bar",
+        },
+        spec: {
+          selector: {},
+          template: {
+            spec: {
+              containers: [
+                {
+                  name: "main",
+                },
+              ],
+            },
+          },
+        },
+      }
+      expect(getResourcePodSpec(deployment)).to.equal(deployment.spec.template.spec)
     })
   })
 
@@ -310,24 +507,44 @@ describe("util", () => {
         log,
         version: module.version.versionString,
       })
-      return <HotReloadableResource>find(manifests, (r) => r.kind === "Deployment")!
+      return <KubernetesWorkload>find(manifests, (r) => r.kind === "Deployment")!
     }
 
     it("should get the first container on the resource if no name is specified", async () => {
       const deployment = await getDeployment()
-      const expected = deployment.spec.template.spec!.containers[0]
+      const expected = deployment.spec.template?.spec!.containers[0]
       expect(getResourceContainer(deployment)).to.equal(expected)
     })
 
     it("should pick the container by name if specified", async () => {
       const deployment = await getDeployment()
-      const expected = deployment.spec.template.spec!.containers[0]
+      const expected = deployment.spec.template?.spec!.containers[0]
       expect(getResourceContainer(deployment, "api")).to.equal(expected)
+    })
+
+    it("should return a container from a Pod resource", async () => {
+      const pod: KubernetesPod = {
+        apiVersion: "v1",
+        kind: "Pod",
+        metadata: {
+          name: "foo",
+          namespace: "bar",
+        },
+        spec: {
+          containers: [
+            {
+              name: "main",
+            },
+          ],
+        },
+      }
+      const expected = pod.spec!.containers[0]
+      expect(getResourceContainer(pod)).to.equal(expected)
     })
 
     it("should throw if no containers are in resource", async () => {
       const deployment = await getDeployment()
-      deployment.spec.template.spec!.containers = []
+      deployment.spec.template!.spec!.containers = []
       await expectError(
         () => getResourceContainer(deployment),
         (err) => expect(err.message).to.equal("Deployment api-release has no containers configured.")

--- a/core/test/unit/src/plugins/kubernetes/util.ts
+++ b/core/test/unit/src/plugins/kubernetes/util.ts
@@ -18,7 +18,7 @@ import {
   makePodName,
   matchSelector,
 } from "../../../../../src/plugins/kubernetes/util"
-import { KubernetesServerResource } from "../../../../../src/plugins/kubernetes/types"
+import { KubernetesPod, KubernetesServerResource } from "../../../../../src/plugins/kubernetes/types"
 import { V1Pod } from "@kubernetes/client-node"
 import { sleep } from "../../../../../src/util/util"
 
@@ -288,7 +288,7 @@ describe("getStaticLabelsFromPod", () => {
         },
       },
       spec: {},
-    } as unknown) as KubernetesServerResource<V1Pod>
+    } as unknown) as KubernetesPod
 
     const labels = getStaticLabelsFromPod(pod)
 
@@ -307,7 +307,7 @@ describe("getSelectorString", () => {
     }
     const selectorString = getSelectorString(labels)
 
-    expect(selectorString).to.eql("-lmodule=a,service=a")
+    expect(selectorString).to.eql("module=a,service=a")
   })
 })
 

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -200,11 +200,14 @@ releaseName:
 # The repository URL to fetch the chart from.
 repo:
 
-# The Deployment, DaemonSet or StatefulSet that Garden should regard as the _Garden service_ in this module (not to be
-# confused with Kubernetes Service resources). Because a Helm chart can contain any number of Kubernetes resources,
-# this needs to be specified for certain Garden features and commands to work, such as hot-reloading.
-# We currently map a Helm chart to a single Garden service, because all the resources in a Helm chart are deployed at
-# once.
+# The Deployment, DaemonSet or StatefulSet or Pod that Garden should regard as the _Garden service_ in this module
+# (not to be confused with Kubernetes Service resources).
+#
+# This can either reference a workload (i.e. a Deployment, DaemonSet or StatefulSet) via the `kind` and `name` fields,
+# or a Pod via the `podSelector` field.
+#
+# Because a Helm chart can contain any number of Kubernetes resources, this needs to be specified for certain Garden
+# features and commands to work, such as hot-reloading.
 serviceResource:
   # The type of Kubernetes resource to sync files to.
   kind: Deployment
@@ -212,6 +215,10 @@ serviceResource:
   # The name of a container in the target. Specify this if the target contains more than one container and the main
   # container is not the first container in the spec.
   containerName:
+
+  # A map of string key/value labels to match on any Pods in the namespace. When specified, a random ready Pod with
+  # matching labels will be picked as a target, so make sure the labels will always match a specific Pod type.
+  podSelector:
 
   # The name of the resource to sync to. If the chart contains a single resource of the specified Kind,
   # this can be omitted.
@@ -223,10 +230,12 @@ serviceResource:
   name:
 
   # The Garden module that contains the sources for the container. This needs to be specified under `serviceResource`
-  # in order to enable hot-reloading, but is not necessary for tasks and tests.
+  # in order to enable hot-reloading and dev mode, but is not necessary for tasks and tests.
+  #
   # Must be a `container` module, and for hot-reloading to work you must specify the `hotReload` field on the
-  # container module.
-  # Note: If you specify a module here, you don't need to specify it additionally under `build.dependencies`
+  # container module (not required for dev mode).
+  #
+  # _Note: If you specify a module here, you don't need to specify it additionally under `build.dependencies`._
   containerModule:
 
   # If specified, overrides the arguments for the main container when running in hot-reload mode.
@@ -289,9 +298,12 @@ tasks:
         # `.garden/artifacts`.
         target: .
 
-    # The Deployment, DaemonSet or StatefulSet that Garden should use to execute this task.
+    # The Deployment, DaemonSet or StatefulSet or Pod that Garden should use to execute this task.
     # If not specified, the `serviceResource` configured on the module will be used. If neither is specified,
     # an error will be thrown.
+    #
+    # This can either reference a workload (i.e. a Deployment, DaemonSet or StatefulSet) via the `kind` and `name`
+    # fields, or a Pod via the `podSelector` field.
     #
     # The following pod spec fields from the service resource will be used (if present) when executing the task:
     # * `affinity`
@@ -330,6 +342,11 @@ tasks:
       # main container is not the first container in the spec.
       containerName:
 
+      # A map of string key/value labels to match on any Pods in the namespace. When specified, a random ready Pod
+      # with matching labels will be picked as a target, so make sure the labels will always match a specific Pod
+      # type.
+      podSelector:
+
       # The name of the resource to sync to. If the chart contains a single resource of the specified Kind,
       # this can be omitted.
       #
@@ -341,10 +358,12 @@ tasks:
       name:
 
       # The Garden module that contains the sources for the container. This needs to be specified under
-      # `serviceResource` in order to enable hot-reloading, but is not necessary for tasks and tests.
+      # `serviceResource` in order to enable hot-reloading and dev mode, but is not necessary for tasks and tests.
+      #
       # Must be a `container` module, and for hot-reloading to work you must specify the `hotReload` field on the
-      # container module.
-      # Note: If you specify a module here, you don't need to specify it additionally under `build.dependencies`
+      # container module (not required for dev mode).
+      #
+      # _Note: If you specify a module here, you don't need to specify it additionally under `build.dependencies`._
       containerModule:
 
       # If specified, overrides the arguments for the main container when running in hot-reload mode.
@@ -388,9 +407,12 @@ tests:
         # `.garden/artifacts`.
         target: .
 
-    # The Deployment, DaemonSet or StatefulSet that Garden should use to execute this test suite.
+    # The Deployment, DaemonSet or StatefulSet or Pod that Garden should use to execute this test suite.
     # If not specified, the `serviceResource` configured on the module will be used. If neither is specified,
     # an error will be thrown.
+    #
+    # This can either reference a workload (i.e. a Deployment, DaemonSet or StatefulSet) via the `kind` and `name`
+    # fields, or a Pod via the `podSelector` field.
     #
     # The following pod spec fields from the service resource will be used (if present) when executing the test suite:
     # * `affinity`
@@ -429,6 +451,11 @@ tests:
       # main container is not the first container in the spec.
       containerName:
 
+      # A map of string key/value labels to match on any Pods in the namespace. When specified, a random ready Pod
+      # with matching labels will be picked as a target, so make sure the labels will always match a specific Pod
+      # type.
+      podSelector:
+
       # The name of the resource to sync to. If the chart contains a single resource of the specified Kind,
       # this can be omitted.
       #
@@ -440,10 +467,12 @@ tests:
       name:
 
       # The Garden module that contains the sources for the container. This needs to be specified under
-      # `serviceResource` in order to enable hot-reloading, but is not necessary for tasks and tests.
+      # `serviceResource` in order to enable hot-reloading and dev mode, but is not necessary for tasks and tests.
+      #
       # Must be a `container` module, and for hot-reloading to work you must specify the `hotReload` field on the
-      # container module.
-      # Note: If you specify a module here, you don't need to specify it additionally under `build.dependencies`
+      # container module (not required for dev mode).
+      #
+      # _Note: If you specify a module here, you don't need to specify it additionally under `build.dependencies`._
       containerModule:
 
       # If specified, overrides the arguments for the main container when running in hot-reload mode.
@@ -925,8 +954,11 @@ The repository URL to fetch the chart from.
 
 ### `serviceResource`
 
-The Deployment, DaemonSet or StatefulSet that Garden should regard as the _Garden service_ in this module (not to be confused with Kubernetes Service resources). Because a Helm chart can contain any number of Kubernetes resources, this needs to be specified for certain Garden features and commands to work, such as hot-reloading.
-We currently map a Helm chart to a single Garden service, because all the resources in a Helm chart are deployed at once.
+The Deployment, DaemonSet or StatefulSet or Pod that Garden should regard as the _Garden service_ in this module (not to be confused with Kubernetes Service resources).
+
+This can either reference a workload (i.e. a Deployment, DaemonSet or StatefulSet) via the `kind` and `name` fields, or a Pod via the `podSelector` field.
+
+Because a Helm chart can contain any number of Kubernetes resources, this needs to be specified for certain Garden features and commands to work, such as hot-reloading.
 
 | Type     | Required |
 | -------- | -------- |
@@ -952,6 +984,16 @@ The name of a container in the target. Specify this if the target contains more 
 | -------- | -------- |
 | `string` | No       |
 
+### `serviceResource.podSelector`
+
+[serviceResource](#serviceresource) > podSelector
+
+A map of string key/value labels to match on any Pods in the namespace. When specified, a random ready Pod with matching labels will be picked as a target, so make sure the labels will always match a specific Pod type.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
 ### `serviceResource.name`
 
 [serviceResource](#serviceresource) > name
@@ -972,9 +1014,11 @@ the string for the YAML to be parsed correctly.
 
 [serviceResource](#serviceresource) > containerModule
 
-The Garden module that contains the sources for the container. This needs to be specified under `serviceResource` in order to enable hot-reloading, but is not necessary for tasks and tests.
-Must be a `container` module, and for hot-reloading to work you must specify the `hotReload` field on the container module.
-Note: If you specify a module here, you don't need to specify it additionally under `build.dependencies`
+The Garden module that contains the sources for the container. This needs to be specified under `serviceResource` in order to enable hot-reloading and dev mode, but is not necessary for tasks and tests.
+
+Must be a `container` module, and for hot-reloading to work you must specify the `hotReload` field on the container module (not required for dev mode).
+
+_Note: If you specify a module here, you don't need to specify it additionally under `build.dependencies`._
 
 | Type     | Required |
 | -------- | -------- |
@@ -1200,9 +1244,11 @@ tasks:
 
 [tasks](#tasks) > resource
 
-The Deployment, DaemonSet or StatefulSet that Garden should use to execute this task.
+The Deployment, DaemonSet or StatefulSet or Pod that Garden should use to execute this task.
 If not specified, the `serviceResource` configured on the module will be used. If neither is specified,
 an error will be thrown.
+
+This can either reference a workload (i.e. a Deployment, DaemonSet or StatefulSet) via the `kind` and `name` fields, or a Pod via the `podSelector` field.
 
 The following pod spec fields from the service resource will be used (if present) when executing the task:
 * `affinity`
@@ -1258,6 +1304,16 @@ The name of a container in the target. Specify this if the target contains more 
 | -------- | -------- |
 | `string` | No       |
 
+### `tasks[].resource.podSelector`
+
+[tasks](#tasks) > [resource](#tasksresource) > podSelector
+
+A map of string key/value labels to match on any Pods in the namespace. When specified, a random ready Pod with matching labels will be picked as a target, so make sure the labels will always match a specific Pod type.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
 ### `tasks[].resource.name`
 
 [tasks](#tasks) > [resource](#tasksresource) > name
@@ -1278,9 +1334,11 @@ the string for the YAML to be parsed correctly.
 
 [tasks](#tasks) > [resource](#tasksresource) > containerModule
 
-The Garden module that contains the sources for the container. This needs to be specified under `serviceResource` in order to enable hot-reloading, but is not necessary for tasks and tests.
-Must be a `container` module, and for hot-reloading to work you must specify the `hotReload` field on the container module.
-Note: If you specify a module here, you don't need to specify it additionally under `build.dependencies`
+The Garden module that contains the sources for the container. This needs to be specified under `serviceResource` in order to enable hot-reloading and dev mode, but is not necessary for tasks and tests.
+
+Must be a `container` module, and for hot-reloading to work you must specify the `hotReload` field on the container module (not required for dev mode).
+
+_Note: If you specify a module here, you don't need to specify it additionally under `build.dependencies`._
 
 | Type     | Required |
 | -------- | -------- |
@@ -1479,9 +1537,11 @@ tests:
 
 [tests](#tests) > resource
 
-The Deployment, DaemonSet or StatefulSet that Garden should use to execute this test suite.
+The Deployment, DaemonSet or StatefulSet or Pod that Garden should use to execute this test suite.
 If not specified, the `serviceResource` configured on the module will be used. If neither is specified,
 an error will be thrown.
+
+This can either reference a workload (i.e. a Deployment, DaemonSet or StatefulSet) via the `kind` and `name` fields, or a Pod via the `podSelector` field.
 
 The following pod spec fields from the service resource will be used (if present) when executing the test suite:
 * `affinity`
@@ -1537,6 +1597,16 @@ The name of a container in the target. Specify this if the target contains more 
 | -------- | -------- |
 | `string` | No       |
 
+### `tests[].resource.podSelector`
+
+[tests](#tests) > [resource](#testsresource) > podSelector
+
+A map of string key/value labels to match on any Pods in the namespace. When specified, a random ready Pod with matching labels will be picked as a target, so make sure the labels will always match a specific Pod type.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
 ### `tests[].resource.name`
 
 [tests](#tests) > [resource](#testsresource) > name
@@ -1557,9 +1627,11 @@ the string for the YAML to be parsed correctly.
 
 [tests](#tests) > [resource](#testsresource) > containerModule
 
-The Garden module that contains the sources for the container. This needs to be specified under `serviceResource` in order to enable hot-reloading, but is not necessary for tasks and tests.
-Must be a `container` module, and for hot-reloading to work you must specify the `hotReload` field on the container module.
-Note: If you specify a module here, you don't need to specify it additionally under `build.dependencies`
+The Garden module that contains the sources for the container. This needs to be specified under `serviceResource` in order to enable hot-reloading and dev mode, but is not necessary for tasks and tests.
+
+Must be a `container` module, and for hot-reloading to work you must specify the `hotReload` field on the container module (not required for dev mode).
+
+_Note: If you specify a module here, you don't need to specify it additionally under `build.dependencies`._
 
 | Type     | Required |
 | -------- | -------- |

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -197,8 +197,12 @@ devMode:
   # workload is used.
   containerName:
 
-# The Deployment, DaemonSet or StatefulSet that Garden should regard as the _Garden service_ in this module (not to be
-# confused with Kubernetes Service resources).
+# The Deployment, DaemonSet or StatefulSet or Pod that Garden should regard as the _Garden service_ in this module
+# (not to be confused with Kubernetes Service resources).
+#
+# This can either reference a workload (i.e. a Deployment, DaemonSet or StatefulSet) via the `kind` and `name` fields,
+# or a Pod via the `podSelector` field.
+#
 # Because a `kubernetes` module can contain any number of Kubernetes resources, this needs to be specified for certain
 # Garden features and commands to work.
 serviceResource:
@@ -213,11 +217,17 @@ serviceResource:
   # container is not the first container in the spec.
   containerName:
 
+  # A map of string key/value labels to match on any Pods in the namespace. When specified, a random ready Pod with
+  # matching labels will be picked as a target, so make sure the labels will always match a specific Pod type.
+  podSelector:
+
   # The Garden module that contains the sources for the container. This needs to be specified under `serviceResource`
-  # in order to enable hot-reloading, but is not necessary for tasks and tests.
+  # in order to enable hot-reloading and dev mode, but is not necessary for tasks and tests.
+  #
   # Must be a `container` module, and for hot-reloading to work you must specify the `hotReload` field on the
-  # container module.
-  # Note: If you specify a module here, you don't need to specify it additionally under `build.dependencies`
+  # container module (not required for dev mode).
+  #
+  # _Note: If you specify a module here, you don't need to specify it additionally under `build.dependencies`._
   containerModule:
 
   # If specified, overrides the arguments for the main container when running in hot-reload mode.
@@ -250,9 +260,12 @@ tasks:
     # Maximum duration (in seconds) of the task's execution.
     timeout: null
 
-    # The Deployment, DaemonSet or StatefulSet that Garden should use to execute this task.
+    # The Deployment, DaemonSet, StatefulSet or Pod that Garden should use to execute this task.
     # If not specified, the `serviceResource` configured on the module will be used. If neither is specified,
     # an error will be thrown.
+    #
+    # This can either reference a workload (i.e. a Deployment, DaemonSet or StatefulSet) via the `kind` and `name`
+    # fields, or a Pod via the `podSelector` field.
     #
     # The following pod spec fields from the service resource will be used (if present) when executing the task:
     # * `affinity`
@@ -294,6 +307,11 @@ tasks:
       # The name of a container in the target. Specify this if the target contains more than one container and the
       # main container is not the first container in the spec.
       containerName:
+
+      # A map of string key/value labels to match on any Pods in the namespace. When specified, a random ready Pod
+      # with matching labels will be picked as a target, so make sure the labels will always match a specific Pod
+      # type.
+      podSelector:
 
     # Set to false if you don't want the task's result to be cached. Use this if the task needs to be run any time
     # your project (or one or more of the task's dependants) is deployed. Otherwise the task is only re-run when its
@@ -337,9 +355,12 @@ tests:
     # Maximum duration (in seconds) of the test run.
     timeout: null
 
-    # The Deployment, DaemonSet or StatefulSet that Garden should use to execute this test suite.
+    # The Deployment, DaemonSet or StatefulSet or Pod that Garden should use to execute this test suite.
     # If not specified, the `serviceResource` configured on the module will be used. If neither is specified,
     # an error will be thrown.
+    #
+    # This can either reference a workload (i.e. a Deployment, DaemonSet or StatefulSet) via the `kind` and `name`
+    # fields, or a Pod via the `podSelector` field.
     #
     # The following pod spec fields from the service resource will be used (if present) when executing the test suite:
     # * `affinity`
@@ -381,6 +402,11 @@ tests:
       # The name of a container in the target. Specify this if the target contains more than one container and the
       # main container is not the first container in the spec.
       containerName:
+
+      # A map of string key/value labels to match on any Pods in the namespace. When specified, a random ready Pod
+      # with matching labels will be picked as a target, so make sure the labels will always match a specific Pod
+      # type.
+      podSelector:
 
     # The command/entrypoint used to run the test inside the container.
     command:
@@ -849,7 +875,10 @@ Optionally specify the name of a specific container to sync to. If not specified
 
 ### `serviceResource`
 
-The Deployment, DaemonSet or StatefulSet that Garden should regard as the _Garden service_ in this module (not to be confused with Kubernetes Service resources).
+The Deployment, DaemonSet or StatefulSet or Pod that Garden should regard as the _Garden service_ in this module (not to be confused with Kubernetes Service resources).
+
+This can either reference a workload (i.e. a Deployment, DaemonSet or StatefulSet) via the `kind` and `name` fields, or a Pod via the `podSelector` field.
+
 Because a `kubernetes` module can contain any number of Kubernetes resources, this needs to be specified for certain Garden features and commands to work.
 
 | Type     | Required |
@@ -886,13 +915,25 @@ The name of a container in the target. Specify this if the target contains more 
 | -------- | -------- |
 | `string` | No       |
 
+### `serviceResource.podSelector`
+
+[serviceResource](#serviceresource) > podSelector
+
+A map of string key/value labels to match on any Pods in the namespace. When specified, a random ready Pod with matching labels will be picked as a target, so make sure the labels will always match a specific Pod type.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
 ### `serviceResource.containerModule`
 
 [serviceResource](#serviceresource) > containerModule
 
-The Garden module that contains the sources for the container. This needs to be specified under `serviceResource` in order to enable hot-reloading, but is not necessary for tasks and tests.
-Must be a `container` module, and for hot-reloading to work you must specify the `hotReload` field on the container module.
-Note: If you specify a module here, you don't need to specify it additionally under `build.dependencies`
+The Garden module that contains the sources for the container. This needs to be specified under `serviceResource` in order to enable hot-reloading and dev mode, but is not necessary for tasks and tests.
+
+Must be a `container` module, and for hot-reloading to work you must specify the `hotReload` field on the container module (not required for dev mode).
+
+_Note: If you specify a module here, you don't need to specify it additionally under `build.dependencies`._
 
 | Type     | Required |
 | -------- | -------- |
@@ -990,9 +1031,11 @@ Maximum duration (in seconds) of the task's execution.
 
 [tasks](#tasks) > resource
 
-The Deployment, DaemonSet or StatefulSet that Garden should use to execute this task.
+The Deployment, DaemonSet, StatefulSet or Pod that Garden should use to execute this task.
 If not specified, the `serviceResource` configured on the module will be used. If neither is specified,
 an error will be thrown.
+
+This can either reference a workload (i.e. a Deployment, DaemonSet or StatefulSet) via the `kind` and `name` fields, or a Pod via the `podSelector` field.
 
 The following pod spec fields from the service resource will be used (if present) when executing the task:
 * `affinity`
@@ -1057,6 +1100,16 @@ The name of a container in the target. Specify this if the target contains more 
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
+
+### `tasks[].resource.podSelector`
+
+[tasks](#tasks) > [resource](#tasksresource) > podSelector
+
+A map of string key/value labels to match on any Pods in the namespace. When specified, a random ready Pod with matching labels will be picked as a target, so make sure the labels will always match a specific Pod type.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
 
 ### `tasks[].cacheResult`
 
@@ -1229,9 +1282,11 @@ Maximum duration (in seconds) of the test run.
 
 [tests](#tests) > resource
 
-The Deployment, DaemonSet or StatefulSet that Garden should use to execute this test suite.
+The Deployment, DaemonSet or StatefulSet or Pod that Garden should use to execute this test suite.
 If not specified, the `serviceResource` configured on the module will be used. If neither is specified,
 an error will be thrown.
+
+This can either reference a workload (i.e. a Deployment, DaemonSet or StatefulSet) via the `kind` and `name` fields, or a Pod via the `podSelector` field.
 
 The following pod spec fields from the service resource will be used (if present) when executing the test suite:
 * `affinity`
@@ -1296,6 +1351,16 @@ The name of a container in the target. Specify this if the target contains more 
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
+
+### `tests[].resource.podSelector`
+
+[tests](#tests) > [resource](#testsresource) > podSelector
+
+A map of string key/value labels to match on any Pods in the namespace. When specified, a random ready Pod with matching labels will be picked as a target, so make sure the labels will always match a specific Pod type.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
 
 ### `tests[].command[]`
 

--- a/examples/vote-helm/vote-image/package.json
+++ b/examples/vote-helm/vote-image/package.json
@@ -7,7 +7,7 @@
     "build": "vue-cli-service build",
     "test:unit": "vue-cli-service test:unit",
     "lint": "vue-cli-service lint",
-    "test:integ": "node_modules/mocha/bin/mocha tests/integ/test.js"
+    "test:integ": "node_modules/mocha/bin/mocha tests/integ/test.js --timeout 30000"
   },
   "dependencies": {
     "axios": "^0.19.0",


### PR DESCRIPTION
Previously you could only reference workload resources contained in the
module/chart when choosing which resource to sync to or to use as base
for test/task Pod specs. Now you can reference any Pod by a label
selector, which provides a good deal of flexibility.

