### PR TITLE
fix(k8s): bad handling of directory paths for artifact sources

### DIFF
--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -6,7 +6,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { resolve } from "path"
 import tar from "tar"
 import tmp from "tmp-promise"
 import { cloneDeep, omit, pick } from "lodash"
@@ -32,9 +31,8 @@ import { KubernetesResource, KubernetesPod } from "./types"
 import { RunModuleParams } from "../../types/plugin/module/runModule"
 import { ContainerEnvVars, ContainerResourcesSpec, ContainerVolumeSpec } from "../container/config"
 import { prepareEnvVars, makePodName } from "./util"
-import { deline } from "../../util/string"
+import { deline, randomString } from "../../util/string"
 import { ArtifactSpec } from "../../config/validation"
-import cpy from "cpy"
 import { prepareImagePullSecrets } from "./secrets"
 import { configureVolumes } from "./container/deployment"
 import { PluginContext } from "../../plugin-context"
@@ -42,6 +40,7 @@ import { waitForResources, ResourceStatus } from "./status/status"
 import { RuntimeContext } from "../../runtime-context"
 import { getResourceRequirements } from "./container/util"
 import { KUBECTL_DEFAULT_TIMEOUT } from "./kubectl"
+import { copy } from "fs-extra"
 
 // Default timeout for individual run/exec operations
 const defaultTimeout = 600
@@ -576,79 +575,81 @@ async function runWithArtifacts({
       }
     }
 
+    // TODO: only interpret target as directory if it ends with a slash (breaking change, so slated for 0.13)
+    const directoriesToCreate = artifacts.map((a) => a.target).filter((target) => !!target && target !== ".")
+    const tmpPath = "/tmp/.garden-artifacts-" + randomString(8)
+
+    // This script will
+    // 1. Create temp directory in the container
+    // 2. Create directories for each target, as necessary
+    // 3. Recursively (and silently) copy all specified artifact files/directories into the temp directory
+    // 4. Tarball the directory and pipe to stdout
+    // TODO: escape the user paths somehow?
+    const tarScript = `
+rm -rf ${tmpPath} >/dev/null || true
+mkdir -p ${tmpPath}
+cd ${tmpPath}
+touch .garden-placeholder
+${directoriesToCreate.map((target) => `mkdir -p ${target}`).join("\n")}
+${artifacts.map(({ source, target }) => `cp -r ${source} ${target || "."} >/dev/null || true`).join("\n")}
+tar -c -z -f - . | cat
+rm -rf ${tmpPath} >/dev/null || true
+    `
+
     // Copy the artifacts
-    await Promise.all(
-      artifacts.map(async (artifact) => {
-        const tmpDir = await tmp.dir({ unsafeCleanup: true })
-        // Remove leading slash (which is required in the schema)
-        const sourcePath = artifact.source.slice(1)
-        const targetPath = resolve(artifactsPath, artifact.target || ".")
+    const tmpDir = await tmp.dir({ unsafeCleanup: true })
 
-        const tarCmd = [
-          "tar",
-          "-c", // create an archive
-          "-f",
-          "-", // pipe to stdout
-          // Files to match. The .DS_Store file is a trick to avoid errors when no files are matched. The file is
-          // ignored later when copying from the temp directory. See https://github.com/sindresorhus/cpy#ignorejunk
-          `$(ls ${sourcePath} 2>/dev/null) /tmp/.DS_Store`,
-          // Fix issue https://github.com/garden-io/garden/issues/2445
-          "| cat",
-        ]
+    try {
+      await new Promise<void>((_resolve, reject) => {
+        // Create an extractor to receive the tarball we will stream from the container
+        // and extract to the artifacts directory.
+        let done = 0
 
-        try {
-          await new Promise<void>((_resolve, reject) => {
-            // Create an extractor to receive the tarball we will stream from the container
-            // and extract to the artifacts directory.
-            let done = 0
+        const extractor = tar.x({
+          cwd: tmpDir.path,
+          strict: true,
+          onentry: (entry) => log.debug("tar: got entry " + entry.path),
+        })
 
-            const extractor = tar.x({
-              cwd: tmpDir.path,
-              strict: true,
-              onentry: (entry) => log.debug("tar: got file " + entry.path),
-            })
+        extractor.on("end", () => {
+          // Need to make sure both processes are complete before resolving (may happen in either order)
+          done++
+          done === 2 && _resolve()
+        })
+        extractor.on("error", (err) => {
+          reject(err)
+        })
 
-            extractor.on("end", () => {
-              // Need to make sure both processes are complete before resolving (may happen in either order)
-              done++
-              done === 2 && _resolve()
-            })
-            extractor.on("error", (err) => {
-              reject(err)
-            })
-
-            // Tarball the requested files and stream to the above extractor.
-            runner
-              .exec({
-                command: ["sh", "-c", "cd / && touch /tmp/.DS_Store && " + tarCmd.join(" ")],
-                containerName: mainContainerName,
-                log,
-                stdout: extractor,
-                timeoutSec,
-                buffer: false,
-              })
-              .then(() => {
-                // Need to make sure both processes are complete before resolving (may happen in either order)
-                done++
-                done === 2 && _resolve()
-              })
-              .catch(reject)
+        // Tarball the requested files and stream to the above extractor.
+        runner
+          .exec({
+            command: ["sh", "-c", tarScript],
+            containerName: mainContainerName,
+            log,
+            stdout: extractor,
+            timeoutSec,
+            buffer: false,
           })
-
-          // Copy the resulting files to the artifacts directory
-          try {
-            await cpy("**/*", targetPath, { cwd: tmpDir.path, ignoreJunk: true })
-          } catch (err) {
-            // Ignore error thrown when the directory is empty
-            if (err.name !== "CpyError" || !err.message.includes("the file doesn't exist")) {
-              throw err
-            }
-          }
-        } finally {
-          await tmpDir.cleanup()
-        }
+          .then(() => {
+            // Need to make sure both processes are complete before resolving (may happen in either order)
+            done++
+            done === 2 && _resolve()
+          })
+          .catch(reject)
       })
-    )
+
+      // Copy the resulting files to the artifacts directory
+      try {
+        await copy(tmpDir.path, artifactsPath, { filter: (f) => !f.endsWith(".garden-placeholder") })
+      } catch (err) {
+        // Ignore error thrown when the directory is empty
+        if (err.name !== "CpyError" || !err.message.includes("the file doesn't exist")) {
+          throw err
+        }
+      }
+    } finally {
+      await tmpDir.cleanup()
+    }
   } finally {
     await runner.stop()
   }

--- a/core/test/data/test-projects/container/simple/garden.yml
+++ b/core/test/data/test-projects/container/simple/garden.yml
@@ -2,6 +2,7 @@ kind: Module
 name: simple
 type: container
 image: busybox:1.31.1
+
 services:
   - name: echo-service
     command: [sh, -c, "echo ok"]
@@ -9,6 +10,7 @@ services:
     command: [sh, -c, "echo $ENV_VAR"]
     env:
       ENV_VAR: foo
+
 tasks:
   - name: echo-task
     command: [sh, -c, "echo ok"]
@@ -30,11 +32,7 @@ tasks:
       - source: /task.*
         target: subdir
       - source: /tasks/*
-  - name: dir-task
-    command: [sh, -c, "mkdir -p /report && touch /report/output.txt && echo ok"]
-    artifacts:
-      - source: /report/*
-        target: my-task-report
+
 tests:
   - name: echo-test
     command: [sh, -c, "echo ok"]

--- a/core/test/integ/src/plugins/kubernetes/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/run.ts
@@ -931,6 +931,8 @@ describe("kubernetes Pod runner functions", () => {
   })
 
   describe("runAndCopy", () => {
+    const image = "busybox:1.31.1"
+
     let tmpDir: tmp.DirectoryResult
 
     beforeEach(async () => {
@@ -943,7 +945,6 @@ describe("kubernetes Pod runner functions", () => {
 
     it("should run a basic module", async () => {
       const module = graph.getModule("simple")
-      const image = containerHelpers.getDeploymentImageId(module, module.version, provider.config.deploymentRegistry)
 
       const result = await runAndCopy({
         ctx: await garden.getPluginContext(provider),
@@ -963,7 +964,6 @@ describe("kubernetes Pod runner functions", () => {
 
     it("should clean up the created container", async () => {
       const module = graph.getModule("simple")
-      const image = containerHelpers.getDeploymentImageId(module, module.version, provider.config.deploymentRegistry)
       const podName = makePodName("test", module.name)
 
       await runAndCopy({
@@ -989,7 +989,6 @@ describe("kubernetes Pod runner functions", () => {
     it("should return with success=false when command exceeds timeout", async () => {
       const task = graph.getTask("artifacts-task")
       const module = task.module
-      const image = containerHelpers.getDeploymentImageId(module, module.version, provider.config.deploymentRegistry)
 
       const result = await runAndCopy({
         ctx: await garden.getPluginContext(provider),
@@ -1014,7 +1013,6 @@ describe("kubernetes Pod runner functions", () => {
       it("should copy artifacts out of the container", async () => {
         const task = graph.getTask("artifacts-task")
         const module = task.module
-        const image = containerHelpers.getDeploymentImageId(module, module.version, provider.config.deploymentRegistry)
 
         const result = await runAndCopy({
           ctx: await garden.getPluginContext(provider),
@@ -1039,7 +1037,7 @@ describe("kubernetes Pod runner functions", () => {
       it("should clean up the created Pod", async () => {
         const task = graph.getTask("artifacts-task")
         const module = task.module
-        const image = containerHelpers.getDeploymentImageId(module, module.version, provider.config.deploymentRegistry)
+
         const podName = makePodName("test", module.name)
 
         await runAndCopy({
@@ -1067,7 +1065,6 @@ describe("kubernetes Pod runner functions", () => {
       it("should handle globs when copying artifacts out of the container", async () => {
         const task = graph.getTask("globs-task")
         const module = task.module
-        const image = containerHelpers.getDeploymentImageId(module, module.version, provider.config.deploymentRegistry)
 
         await runAndCopy({
           ctx: await garden.getPluginContext(provider),
@@ -1091,7 +1088,6 @@ describe("kubernetes Pod runner functions", () => {
       it("should not throw when an artifact is missing", async () => {
         const task = graph.getTask("artifacts-task")
         const module = task.module
-        const image = containerHelpers.getDeploymentImageId(module, module.version, provider.config.deploymentRegistry)
 
         await runAndCopy({
           ctx: await garden.getPluginContext(provider),
@@ -1110,20 +1106,23 @@ describe("kubernetes Pod runner functions", () => {
       })
 
       it("should correctly copy a whole directory", async () => {
-        const task = graph.getTask("dir-task")
-        const module = task.module
-        const image = containerHelpers.getDeploymentImageId(module, module.version, provider.config.deploymentRegistry)
+        const module = graph.getModule("simple")
 
         await runAndCopy({
           ctx: await garden.getPluginContext(provider),
           log: garden.log,
-          command: task.spec.command,
+          command: ["sh", "-c", "mkdir -p /report && touch /report/output.txt && echo ok"],
           args: [],
           interactive: false,
           module,
           namespace,
           runtimeContext: { envVars: {}, dependencies: [] },
-          artifacts: task.spec.artifacts,
+          artifacts: [
+            {
+              source: "/report/*",
+              target: "my-task-report",
+            },
+          ],
           artifactsPath: tmpDir.path,
           image,
           version: module.version.versionString,
@@ -1133,10 +1132,35 @@ describe("kubernetes Pod runner functions", () => {
         expect(await pathExists(join(tmpDir.path, "my-task-report", "output.txt"))).to.be.true
       })
 
+      it("should correctly copy a whole directory without setting a wildcard or target", async () => {
+        const module = graph.getModule("simple")
+
+        await runAndCopy({
+          ctx: await garden.getPluginContext(provider),
+          log: garden.log,
+          command: ["sh", "-c", "mkdir -p /report && touch /report/output.txt && echo ok"],
+          args: [],
+          interactive: false,
+          module,
+          namespace,
+          runtimeContext: { envVars: {}, dependencies: [] },
+          artifacts: [
+            {
+              source: "/report",
+            },
+          ],
+          artifactsPath: tmpDir.path,
+          image,
+          version: module.version.versionString,
+        })
+
+        expect(await pathExists(join(tmpDir.path, "report"))).to.be.true
+        expect(await pathExists(join(tmpDir.path, "report", "output.txt"))).to.be.true
+      })
+
       it("should return with logs and success=false when command exceeds timeout", async () => {
         const task = graph.getTask("artifacts-task")
         const module = task.module
-        const image = containerHelpers.getDeploymentImageId(module, module.version, provider.config.deploymentRegistry)
 
         const result = await runAndCopy({
           ctx: await garden.getPluginContext(provider),
@@ -1161,7 +1185,6 @@ describe("kubernetes Pod runner functions", () => {
       it("should copy artifacts out of the container even when task times out", async () => {
         const task = graph.getTask("artifacts-task")
         const module = task.module
-        const image = containerHelpers.getDeploymentImageId(module, module.version, provider.config.deploymentRegistry)
 
         const result = await runAndCopy({
           ctx: await garden.getPluginContext(provider),
@@ -1187,7 +1210,7 @@ describe("kubernetes Pod runner functions", () => {
       it("should throw when container doesn't contain sh", async () => {
         const task = graph.getTask("missing-sh-task")
         const module = task.module
-        const image = containerHelpers.getDeploymentImageId(module, module.version, provider.config.deploymentRegistry)
+        const _image = containerHelpers.getDeploymentImageId(module, module.version, provider.config.deploymentRegistry)
 
         const actions = await garden.getActionRouter()
         await garden.buildStaging.syncFromSrc(module, garden.log)
@@ -1210,7 +1233,7 @@ describe("kubernetes Pod runner functions", () => {
               artifacts: task.spec.artifacts,
               artifactsPath: tmpDir.path,
               description: "Foo",
-              image,
+              image: _image,
               timeout: 20000,
               stdout: process.stdout,
               stderr: process.stderr,
@@ -1228,7 +1251,7 @@ describe("kubernetes Pod runner functions", () => {
       it("should throw when container doesn't contain tar", async () => {
         const task = graph.getTask("missing-tar-task")
         const module = task.module
-        const image = containerHelpers.getDeploymentImageId(module, module.version, provider.config.deploymentRegistry)
+        const _image = containerHelpers.getDeploymentImageId(module, module.version, provider.config.deploymentRegistry)
 
         const actions = await garden.getActionRouter()
         await garden.buildStaging.syncFromSrc(module, garden.log)
@@ -1251,7 +1274,7 @@ describe("kubernetes Pod runner functions", () => {
               artifacts: task.spec.artifacts,
               artifactsPath: tmpDir.path,
               description: "Foo",
-              image,
+              image: _image,
               timeout: 20000,
               stdout: process.stdout,
               stderr: process.stderr,
@@ -1269,7 +1292,6 @@ describe("kubernetes Pod runner functions", () => {
       it("should throw when no command is specified", async () => {
         const task = graph.getTask("missing-tar-task")
         const module = task.module
-        const image = containerHelpers.getDeploymentImageId(module, module.version, provider.config.deploymentRegistry)
 
         await expectError(
           async () =>

--- a/examples/vote/api/test.py
+++ b/examples/vote/api/test.py
@@ -1,5 +1,14 @@
 import requests
 import unittest
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
+
+retry_strategy = Retry(
+    total=10,
+    status_forcelist=[429, 500, 502, 503, 504],
+    method_whitelist=["HEAD", "GET", "OPTIONS"]
+)
+adapter = HTTPAdapter(max_retries=retry_strategy)
 
 class IntegTest(unittest.TestCase):
     def test_post(self):
@@ -7,7 +16,10 @@ class IntegTest(unittest.TestCase):
             'Content-Type': 'application/x-www-form-urlencoded',
             'Access-Control-Allow-Origin': '*',
         }
-        response = requests.post("http://api/api/vote", headers=headers, data="vote=a")
+        http = requests.Session()
+        http.mount("http://", adapter)
+
+        response = http.post("http://api/api/vote", headers=headers, data="vote=a")
         self.assertEqual(response.status_code, 200)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #1777

Also makes the copying process more efficient by putting it all in one
copy command, and also compressing the files (which we clumsily
neglected to do previously).
