### PR TITLE
chore: don't run npm test in pre-push hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-push": "yarn run check-pre-push && npm test"
+      "pre-push": "yarn run check-pre-push"
     }
   },
   "workspaces": [


### PR DESCRIPTION
It was just getting in the way, really.
