### PR TITLE
fix(cli): avoid cmd.exe windows popping up during execution

### DIFF
--- a/core/src/plugins/exec.ts
+++ b/core/src/plugins/exec.ts
@@ -292,6 +292,7 @@ export async function buildExecModule({ module, log }: BuildModuleParams<ExecMod
     const result = await exec(command.join(" "), [], {
       cwd: module.buildPath,
       env: getDefaultEnvVars(module),
+      // TODO: remove this in 0.13 and alert users to use e.g. sh -c '<script>' instead.
       shell: true,
     })
 

--- a/core/src/util/ext-tools.ts
+++ b/core/src/util/ext-tools.ts
@@ -112,7 +112,7 @@ export class CliWrapper {
     }
 
     log.debug(`Spawning '${path} ${args.join(" ")}' in ${cwd}`)
-    return crossSpawn(path, args, { cwd, env })
+    return crossSpawn(path, args, { cwd, env, windowsHide: true })
   }
 
   async spawnAndWait({ args, cwd, env, log, ignoreError, rawMode, stdout, stderr, timeoutSec, tty }: SpawnParams) {

--- a/core/src/util/util.ts
+++ b/core/src/util/util.ts
@@ -168,7 +168,7 @@ interface ExecOpts extends execa.Options {
  */
 export async function exec(cmd: string, args: string[], opts: ExecOpts = {}) {
   // Ensure buffer is always set to true so that we can read the error output
-  opts = { ...opts, buffer: true, all: true }
+  opts = { windowsHide: true, ...opts, buffer: true, all: true }
   const proc = execa(cmd, args, omit(opts, ["stdout", "stderr"]))
 
   opts.stdout && proc.stdout && proc.stdout.pipe(opts.stdout)
@@ -241,7 +241,7 @@ export function spawn(cmd: string, args: string[], opts: SpawnOpts = {}) {
   } = opts
 
   const stdio = tty ? "inherit" : "pipe"
-  const proc = _spawn(cmd, args, { cwd, env, stdio })
+  const proc = _spawn(cmd, args, { cwd, env, stdio, windowsHide: true })
 
   const result: SpawnOutput = {
     code: 0,


### PR DESCRIPTION
For some reason this never happens during our own testing, but some users have reported this. Should be simple as this.