### PR TITLE
feat(k8s): manual port forward config for helm and kubernetes modules

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -257,7 +257,7 @@
     "migration:generate": "typeorm migration:generate --config ormconfig.js -n",
     "integ-kind": "GARDEN_INTEG_TEST_MODE=local GARDEN_SKIP_TESTS=\"cluster-docker cluster-buildkit cluster-buildkit-rootless kaniko remote-only\" yarn run _integ",
     "integ-local": "GARDEN_LOGGER_TYPE=basic GARDEN_LOG_LEVEL=debug GARDEN_INTEG_TEST_MODE=local GARDEN_SKIP_TESTS=\"cluster-docker\" yarn run _integ",
-    "integ-minikube": "GARDEN_INTEG_TEST_MODE=local GARDEN_SKIP_TESTS=remote-only yarn run _integ",
+    "integ-minikube": "GARDEN_INTEG_TEST_MODE=local GARDEN_SKIP_TESTS=\"cluster-docker kaniko remote-only\" yarn run _integ",
     "integ-remote": "GARDEN_INTEG_TEST_MODE=remote GARDEN_SKIP_TESTS=local-only yarn run _integ",
     "e2e": "cd test/e2e && ../../../bin/garden test",
     "e2e-project": "node build/test/e2e/e2e-project.js",

--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -780,6 +780,39 @@ export const hotReloadArgsSchema = () =>
     .description("If specified, overrides the arguments for the main container when running in hot-reload mode.")
     .example(["nodemon", "my-server.js"])
 
+export interface PortForwardSpec {
+  name?: string
+  resource: string
+  targetPort: number
+  localPort?: number
+}
+
+const portForwardSpecSchema = () =>
+  joi.object().keys({
+    name: joiIdentifier().description("An identifier to describe the port forward."),
+    resource: joi
+      .string()
+      .required()
+      .description(
+        "The full resource kind and name to forward to, e.g. Service/my-service or Deployment/my-deployment. Note that Garden will not validate this ahead of attempting to start the port forward, so you need to make sure this is correctly set. The types of resources supported will match that of the `kubectl port-forward` CLI command."
+      ),
+    targetPort: joi.number().integer().required().description("The port number on the remote resource to forward to."),
+    localPort: joi
+      .number()
+      .integer()
+      .description(
+        "The _preferred_ local port to forward from. If none is set, a random port is chosen. If the specified port is not available, a warning is shown and a random port chosen instead."
+      ),
+  })
+
+export const portForwardsSchema = () =>
+  joi
+    .array()
+    .items(portForwardSpecSchema())
+    .description(
+      "Manually specify port forwards that Garden should set up when deploying in dev or watch mode. If specified, these override the auto-detection of forwardable ports, so you'll need to specify the full list of port forwards to create."
+    )
+
 const runPodSpecWhitelistDescription = runPodSpecIncludeFields.map((f) => `* \`${f}\``).join("\n")
 
 export const kubernetesTaskSchema = () =>

--- a/core/src/plugins/kubernetes/helm/config.ts
+++ b/core/src/plugins/kubernetes/helm/config.ts
@@ -34,6 +34,8 @@ import {
   containerModuleSchema,
   hotReloadArgsSchema,
   serviceResourceDescription,
+  portForwardsSchema,
+  PortForwardSpec,
 } from "../config"
 import { posix } from "path"
 import { runPodSpecIncludeFields } from "../run"
@@ -57,6 +59,7 @@ export interface HelmServiceSpec {
   dependencies: string[]
   devMode?: KubernetesDevModeSpec
   namespace?: string
+  portForwards?: PortForwardSpec[]
   releaseName?: string
   repo?: string
   serviceResource?: ServiceResourceSpec
@@ -169,7 +172,15 @@ export const helmModuleSpecSchema = () =>
       "List of names of services that should be deployed before this chart."
     ),
     devMode: kubernetesDevModeSchema(),
+    include: joiModuleIncludeDirective(dedent`
+      If neither \`include\` nor \`exclude\` is set, and the module has local chart sources, Garden
+      automatically sets \`include\` to: \`["*", "charts/**/*", "templates/**/*"]\`.
+
+      If neither \`include\` nor \`exclude\` is set and the module specifies a remote chart, Garden
+      automatically sets \`ìnclude\` to \`[]\`.
+    `),
     namespace: namespaceNameSchema(),
+    portForwards: portForwardsSchema(),
     releaseName: joiIdentifier().description(
       "Optionally override the release name used when installing (defaults to the module name)."
     ),
@@ -190,13 +201,6 @@ export const helmModuleSpecSchema = () =>
         deline`Set this to true if the chart should only be built, but not deployed as a service.
       Use this, for example, if the chart should only be used as a base for other modules.`
       ),
-    include: joiModuleIncludeDirective(dedent`
-      If neither \`include\` nor \`exclude\` is set, and the module has local chart sources, Garden
-      automatically sets \`include\` to: \`["*", "charts/**/*", "templates/**/*"]\`.
-
-      If neither \`include\` nor \`exclude\` is set and the module specifies a remote chart, Garden
-      automatically sets \`ìnclude\` to \`[]\`.
-    `),
     tasks: joiSparseArray(helmTaskSchema()).description("The task definitions for this module."),
     tests: joiSparseArray(helmTestSchema()).description("The test suite definitions for this module."),
     timeout: joi

--- a/core/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/src/plugins/kubernetes/helm/deployment.ts
@@ -127,7 +127,7 @@ export async function deployHelmService({
     timeoutSec: module.spec.timeout,
   })
 
-  const forwardablePorts = getForwardablePorts(manifests)
+  const forwardablePorts = getForwardablePorts(manifests, service)
 
   // Make sure port forwards work after redeployment
   killPortForwards(service, forwardablePorts || [], log)

--- a/core/src/plugins/kubernetes/helm/status.ts
+++ b/core/src/plugins/kubernetes/helm/status.ts
@@ -67,7 +67,7 @@ export async function getServiceStatus({
 
   if (state !== "missing") {
     const deployedResources = await getDeployedResources({ ctx: k8sCtx, module, releaseName, log })
-    forwardablePorts = getForwardablePorts(deployedResources)
+    forwardablePorts = getForwardablePorts(deployedResources, service)
 
     if (state === "ready" && devMode && service.spec.devMode) {
       // Need to start the dev-mode sync here, since the deployment handler won't be called.

--- a/core/src/plugins/kubernetes/kubernetes-module/config.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/config.ts
@@ -25,6 +25,8 @@ import {
   containerModuleSchema,
   hotReloadArgsSchema,
   serviceResourceDescription,
+  portForwardsSchema,
+  PortForwardSpec,
 } from "../config"
 import { ContainerModule } from "../../container/config"
 import { kubernetesDevModeSchema, KubernetesDevModeSpec } from "../dev-mode"
@@ -41,8 +43,9 @@ export interface KubernetesServiceSpec {
   dependencies: string[]
   devMode?: KubernetesDevModeSpec
   files: string[]
-  namespace?: string
   manifests: KubernetesResource[]
+  namespace?: string
+  portForwards?: PortForwardSpec[]
   serviceResource?: ServiceResourceSpec
   tasks: KubernetesTaskSpec[]
   tests: KubernetesTestSpec[]
@@ -71,11 +74,7 @@ export const kubernetesModuleSpecSchema = () =>
   joi.object().keys({
     build: baseBuildSpecSchema(),
     dependencies: dependenciesSchema(),
-    manifests: joiSparseArray(kubernetesResourceSchema()).description(
-      deline`
-          List of Kubernetes resource manifests to deploy. Use this instead of the \`files\` field if you need to
-          resolve template strings in any of the manifests.`
-    ),
+    devMode: kubernetesDevModeSchema(),
     files: joiSparseArray(joi.posixPath().subPathOnly()).description(
       "POSIX-style paths to YAML files to load manifests from. Each can contain multiple manifests, and can include any Garden template strings, which will be resolved before applying the manifests."
     ),
@@ -83,8 +82,13 @@ export const kubernetesModuleSpecSchema = () =>
       If neither \`include\` nor \`exclude\` is set, Garden automatically sets \`include\` to equal the
       \`files\` directive so that only the Kubernetes manifests get included.
     `),
+    manifests: joiSparseArray(kubernetesResourceSchema()).description(
+      deline`
+          List of Kubernetes resource manifests to deploy. Use this instead of the \`files\` field if you need to
+          resolve template strings in any of the manifests.`
+    ),
     namespace: namespaceNameSchema(),
-    devMode: kubernetesDevModeSchema(),
+    portForwards: portForwardsSchema(),
     serviceResource: serviceResourceSchema()
       .description(
         dedent`

--- a/core/src/plugins/kubernetes/kubernetes-module/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/handlers.ts
@@ -93,7 +93,7 @@ export async function getKubernetesServiceStatus({
 
   let { state, remoteResources } = await compareDeployedResources(k8sCtx, api, namespace, prepareResult.manifests, log)
 
-  const forwardablePorts = getForwardablePorts(remoteResources)
+  const forwardablePorts = getForwardablePorts(remoteResources, service)
 
   if (state === "ready" && devMode && service.spec.devMode) {
     // Need to start the dev-mode sync here, since the deployment handler won't be called.

--- a/core/test/integ/src/plugins/kubernetes/container/build/build.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/build/build.ts
@@ -152,7 +152,8 @@ describe("kubernetes build flow", () => {
     })
   })
 
-  grouped("cluster-docker").context("cluster-docker mode", () => {
+  // TODO: Reenable these tests e.g. for Minikube?
+  grouped("cluster-docker", "remote-only").context("cluster-docker mode", () => {
     before(async () => {
       await init("cluster-docker")
     })

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -215,6 +215,25 @@ devMode:
 # numbers and dashes, must start with a letter, and cannot end with a dash) and must not be longer than 63 characters.
 namespace:
 
+# Manually specify port forwards that Garden should set up when deploying in dev or watch mode. If specified, these
+# override the auto-detection of forwardable ports, so you'll need to specify the full list of port forwards to
+# create.
+portForwards:
+  - # An identifier to describe the port forward.
+    name:
+
+    # The full resource kind and name to forward to, e.g. Service/my-service or Deployment/my-deployment. Note that
+    # Garden will not validate this ahead of attempting to start the port forward, so you need to make sure this is
+    # correctly set. The types of resources supported will match that of the `kubectl port-forward` CLI command.
+    resource:
+
+    # The port number on the remote resource to forward to.
+    targetPort:
+
+    # The _preferred_ local port to forward from. If none is set, a random port is chosen. If the specified port is
+    # not available, a warning is shown and a random port chosen instead.
+    localPort:
+
 # Optionally override the release name used when installing (defaults to the module name).
 releaseName:
 
@@ -996,6 +1015,54 @@ A valid Kubernetes namespace name. Must be a valid RFC1035/RFC1123 (DNS) label (
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
+
+### `portForwards[]`
+
+Manually specify port forwards that Garden should set up when deploying in dev or watch mode. If specified, these override the auto-detection of forwardable ports, so you'll need to specify the full list of port forwards to create.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[object]` | No       |
+
+### `portForwards[].name`
+
+[portForwards](#portforwards) > name
+
+An identifier to describe the port forward.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `portForwards[].resource`
+
+[portForwards](#portforwards) > resource
+
+The full resource kind and name to forward to, e.g. Service/my-service or Deployment/my-deployment. Note that Garden will not validate this ahead of attempting to start the port forward, so you need to make sure this is correctly set. The types of resources supported will match that of the `kubectl port-forward` CLI command.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | Yes      |
+
+### `portForwards[].targetPort`
+
+[portForwards](#portforwards) > targetPort
+
+The port number on the remote resource to forward to.
+
+| Type     | Required |
+| -------- | -------- |
+| `number` | Yes      |
+
+### `portForwards[].localPort`
+
+[portForwards](#portforwards) > localPort
+
+The _preferred_ local port to forward from. If none is set, a random port is chosen. If the specified port is not available, a warning is shown and a random port chosen instead.
+
+| Type     | Required |
+| -------- | -------- |
+| `number` | No       |
 
 ### `releaseName`
 

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -140,27 +140,6 @@ variables:
 # executed before this service is deployed.
 dependencies: []
 
-# List of Kubernetes resource manifests to deploy. Use this instead of the `files` field if you need to resolve
-# template strings in any of the manifests.
-manifests:
-  - # The API version of the resource.
-    apiVersion:
-
-    # The kind of the resource.
-    kind:
-
-    metadata:
-      # The name of the resource.
-      name:
-
-# POSIX-style paths to YAML files to load manifests from. Each can contain multiple manifests, and can include any
-# Garden template strings, which will be resolved before applying the manifests.
-files: []
-
-# A valid Kubernetes namespace name. Must be a valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters,
-# numbers and dashes, must start with a letter, and cannot end with a dash) and must not be longer than 63 characters.
-namespace:
-
 # Specifies which files or directories to sync to which paths inside the running containers of the service when it's
 # in dev mode, and overrides for the container command and/or arguments.
 #
@@ -217,6 +196,46 @@ devMode:
   # Optionally specify the name of a specific container to sync to. If not specified, the first container in the
   # workload is used.
   containerName:
+
+# POSIX-style paths to YAML files to load manifests from. Each can contain multiple manifests, and can include any
+# Garden template strings, which will be resolved before applying the manifests.
+files: []
+
+# List of Kubernetes resource manifests to deploy. Use this instead of the `files` field if you need to resolve
+# template strings in any of the manifests.
+manifests:
+  - # The API version of the resource.
+    apiVersion:
+
+    # The kind of the resource.
+    kind:
+
+    metadata:
+      # The name of the resource.
+      name:
+
+# A valid Kubernetes namespace name. Must be a valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters,
+# numbers and dashes, must start with a letter, and cannot end with a dash) and must not be longer than 63 characters.
+namespace:
+
+# Manually specify port forwards that Garden should set up when deploying in dev or watch mode. If specified, these
+# override the auto-detection of forwardable ports, so you'll need to specify the full list of port forwards to
+# create.
+portForwards:
+  - # An identifier to describe the port forward.
+    name:
+
+    # The full resource kind and name to forward to, e.g. Service/my-service or Deployment/my-deployment. Note that
+    # Garden will not validate this ahead of attempting to start the port forward, so you need to make sure this is
+    # correctly set. The types of resources supported will match that of the `kubectl port-forward` CLI command.
+    resource:
+
+    # The port number on the remote resource to forward to.
+    targetPort:
+
+    # The _preferred_ local port to forward from. If none is set, a random port is chosen. If the specified port is
+    # not available, a warning is shown and a random port chosen instead.
+    localPort:
 
 # The Deployment, DaemonSet or StatefulSet or Pod that Garden should regard as the _Garden service_ in this module
 # (not to be confused with Kubernetes Service resources).
@@ -709,68 +728,6 @@ The names of any services that this service depends on at runtime, and the names
 | --------------- | ------- | -------- |
 | `array[string]` | `[]`    | No       |
 
-### `manifests[]`
-
-List of Kubernetes resource manifests to deploy. Use this instead of the `files` field if you need to resolve template strings in any of the manifests.
-
-| Type            | Default | Required |
-| --------------- | ------- | -------- |
-| `array[object]` | `[]`    | No       |
-
-### `manifests[].apiVersion`
-
-[manifests](#manifests) > apiVersion
-
-The API version of the resource.
-
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
-
-### `manifests[].kind`
-
-[manifests](#manifests) > kind
-
-The kind of the resource.
-
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
-
-### `manifests[].metadata`
-
-[manifests](#manifests) > metadata
-
-| Type     | Required |
-| -------- | -------- |
-| `object` | Yes      |
-
-### `manifests[].metadata.name`
-
-[manifests](#manifests) > [metadata](#manifestsmetadata) > name
-
-The name of the resource.
-
-| Type     | Required |
-| -------- | -------- |
-| `string` | Yes      |
-
-### `files[]`
-
-POSIX-style paths to YAML files to load manifests from. Each can contain multiple manifests, and can include any Garden template strings, which will be resolved before applying the manifests.
-
-| Type               | Default | Required |
-| ------------------ | ------- | -------- |
-| `array[posixPath]` | `[]`    | No       |
-
-### `namespace`
-
-A valid Kubernetes namespace name. Must be a valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and dashes, must start with a letter, and cannot end with a dash) and must not be longer than 63 characters.
-
-| Type     | Required |
-| -------- | -------- |
-| `string` | No       |
-
 ### `devMode`
 
 Specifies which files or directories to sync to which paths inside the running containers of the service when it's in dev mode, and overrides for the container command and/or arguments.
@@ -933,6 +890,116 @@ Optionally specify the name of a specific container to sync to. If not specified
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
+
+### `files[]`
+
+POSIX-style paths to YAML files to load manifests from. Each can contain multiple manifests, and can include any Garden template strings, which will be resolved before applying the manifests.
+
+| Type               | Default | Required |
+| ------------------ | ------- | -------- |
+| `array[posixPath]` | `[]`    | No       |
+
+### `manifests[]`
+
+List of Kubernetes resource manifests to deploy. Use this instead of the `files` field if you need to resolve template strings in any of the manifests.
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
+
+### `manifests[].apiVersion`
+
+[manifests](#manifests) > apiVersion
+
+The API version of the resource.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | Yes      |
+
+### `manifests[].kind`
+
+[manifests](#manifests) > kind
+
+The kind of the resource.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | Yes      |
+
+### `manifests[].metadata`
+
+[manifests](#manifests) > metadata
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | Yes      |
+
+### `manifests[].metadata.name`
+
+[manifests](#manifests) > [metadata](#manifestsmetadata) > name
+
+The name of the resource.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | Yes      |
+
+### `namespace`
+
+A valid Kubernetes namespace name. Must be a valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and dashes, must start with a letter, and cannot end with a dash) and must not be longer than 63 characters.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `portForwards[]`
+
+Manually specify port forwards that Garden should set up when deploying in dev or watch mode. If specified, these override the auto-detection of forwardable ports, so you'll need to specify the full list of port forwards to create.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[object]` | No       |
+
+### `portForwards[].name`
+
+[portForwards](#portforwards) > name
+
+An identifier to describe the port forward.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `portForwards[].resource`
+
+[portForwards](#portforwards) > resource
+
+The full resource kind and name to forward to, e.g. Service/my-service or Deployment/my-deployment. Note that Garden will not validate this ahead of attempting to start the port forward, so you need to make sure this is correctly set. The types of resources supported will match that of the `kubectl port-forward` CLI command.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | Yes      |
+
+### `portForwards[].targetPort`
+
+[portForwards](#portforwards) > targetPort
+
+The port number on the remote resource to forward to.
+
+| Type     | Required |
+| -------- | -------- |
+| `number` | Yes      |
+
+### `portForwards[].localPort`
+
+[portForwards](#portforwards) > localPort
+
+The _preferred_ local port to forward from. If none is set, a random port is chosen. If the specified port is not available, a warning is shown and a random port chosen instead.
+
+| Type     | Required |
+| -------- | -------- |
+| `number` | No       |
 
 ### `serviceResource`
 


### PR DESCRIPTION
This allows users to explicitly configure the ports to forward for
kubernetes and helm modules, including which local port to forward to.

Example:

```yaml
kind: Module
type: kubernetes
...
portForwards:
  - name: http
    resource: Service/my-service
    targetPort: 80
    localPort: 8080
```

Closes #2504 

cc @ITHedgeHog 