### PR TITLE
Fix dev command issues

### DIFF
--- a/core/src/actions.ts
+++ b/core/src/actions.ts
@@ -299,7 +299,7 @@ export class ActionRouter implements TypeGuard {
     const { log, moduleConfig: config } = params
     const moduleType = config.type
 
-    this.garden.log.silly(`Calling 'configure' handler for '${moduleType}'`)
+    this.garden.log.silly(`Calling configure handler for ${moduleType} module '${config.name}'`)
 
     const handler = await this.getModuleActionHandler({
       actionType: "configure",
@@ -326,7 +326,7 @@ export class ActionRouter implements TypeGuard {
     }
     result.moduleConfig.build.dependencies = Object.values(buildDeps)
 
-    this.garden.log.silly(`Called 'configure' handler for '${moduleType}'`)
+    this.garden.log.silly(`Called configure handler for ${moduleType} module '${config.name}'`)
 
     return result
   }

--- a/core/src/build-staging/build-staging.ts
+++ b/core/src/build-staging/build-staging.ts
@@ -231,7 +231,7 @@ export class BuildStaging {
 
     let logMsg =
       `Syncing ${files ? files.length + " files " : ""}from ` +
-      `${relative(this.projectRoot, sourceRoot)} to ${relative(this.projectRoot, targetPath)}`
+      `${relative(this.projectRoot, sourceRoot) || "."} to ${relative(this.projectRoot, targetPath)}`
 
     if (withDelete) {
       logMsg += " (and removing any extraneous files)"

--- a/core/src/commands/build.ts
+++ b/core/src/commands/build.ts
@@ -113,7 +113,7 @@ export class BuildCommand extends Command<Args, Opts> {
       watch: opts.watch,
       initialTasks,
       changeHandler: async (newGraph, module) => {
-        const deps = await newGraph.getDependants({ nodeType: "build", name: module.name, recursive: true })
+        const deps = newGraph.getDependants({ nodeType: "build", name: module.name, recursive: true })
         const tasks = [module]
           .concat(deps.build)
           .filter((m) => moduleNames.includes(m.name))

--- a/core/src/tasks/deploy.ts
+++ b/core/src/tasks/deploy.ts
@@ -70,7 +70,7 @@ export class DeployTask extends BaseTask {
   async resolveDependencies() {
     const dg = this.graph
 
-    const skipServiceDeps = [...this.hotReloadServiceNames, ...this.devModeServiceNames]
+    const skipServiceDeps = [...this.hotReloadServiceNames]
 
     // We filter out service dependencies on services configured for hot reloading or dev mode (if any)
     const deps = dg.getDependencies({
@@ -91,7 +91,7 @@ export class DeployTask extends BaseTask {
     })
 
     if (this.fromWatch && includes(skipServiceDeps, this.service.name)) {
-      // Only need to get existing statuses and results when hot-reloading or in dev mode
+      // Only need to get existing statuses and results when hot-reloading
       const dependencyStatusTasks = deps.deploy.map((service) => {
         return new GetServiceStatusTask({
           garden: this.garden,

--- a/core/test/unit/src/tasks/helpers.ts
+++ b/core/test/unit/src/tasks/helpers.ts
@@ -97,7 +97,7 @@ describe("TaskHelpers", () => {
         hotReloadServiceNames: [],
       })
 
-      expect(sortedBaseKeys(tasks)).to.eql(["build.module-a", "build.module-b", "deploy.service-b"])
+      expect(sortedBaseKeys(tasks)).to.eql(["deploy.service-b"])
     })
 
     it("should omit tasks for disabled dependant modules", async () => {
@@ -163,7 +163,7 @@ describe("TaskHelpers", () => {
         hotReloadServiceNames: [],
       })
 
-      expect(sortedBaseKeys(tasks)).to.eql(["build.module-a", "deploy.service-a"])
+      expect(sortedBaseKeys(tasks)).to.eql(["deploy.service-a"])
     })
 
     it("should not add a build task for a hot-reload-enabled service's sourceModule", async () => {
@@ -230,9 +230,6 @@ describe("TaskHelpers", () => {
         {
           moduleName: "build-dependency",
           expectedTasks: [
-            "build.build-dependant",
-            "build.build-dependency",
-            "build.good-morning",
             "deploy.build-dependant",
             "deploy.build-dependency",
             "deploy.good-morning",
@@ -243,8 +240,6 @@ describe("TaskHelpers", () => {
         {
           moduleName: "good-morning",
           expectedTasks: [
-            "build.build-dependant",
-            "build.good-morning",
             "deploy.build-dependant",
             "deploy.good-morning",
             "deploy.service-dependant",
@@ -253,15 +248,15 @@ describe("TaskHelpers", () => {
         },
         {
           moduleName: "good-evening",
-          expectedTasks: ["build.good-evening", "deploy.good-evening"],
+          expectedTasks: ["deploy.good-evening"],
         },
         {
           moduleName: "build-dependant",
-          expectedTasks: ["build.build-dependant", "deploy.build-dependant"],
+          expectedTasks: ["deploy.build-dependant"],
         },
         {
           moduleName: "service-dependant",
-          expectedTasks: ["build.service-dependant", "deploy.service-dependant"],
+          expectedTasks: ["deploy.service-dependant"],
         },
       ]
 
@@ -324,7 +319,7 @@ describe("TaskHelpers", () => {
           hotReloadServiceNames: [],
         })
 
-        expect(sortedBaseKeys(tasks)).to.eql(["build.module-a"])
+        expect(sortedBaseKeys(tasks)).to.eql([])
       })
 
       it("should omit deploy tasks for disabled dependant services", async () => {
@@ -390,7 +385,7 @@ describe("TaskHelpers", () => {
           hotReloadServiceNames: [],
         })
 
-        expect(sortedBaseKeys(tasks)).to.eql(["build.module-a", "build.module-b", "deploy.service-a"])
+        expect(sortedBaseKeys(tasks)).to.eql(["deploy.service-a"])
       })
     })
 
@@ -399,9 +394,6 @@ describe("TaskHelpers", () => {
         {
           moduleName: "build-dependency",
           expectedTasks: [
-            "build.build-dependant",
-            "build.build-dependency",
-            "build.good-morning",
             "deploy.build-dependant",
             "deploy.build-dependency",
             "deploy.service-dependant",
@@ -411,7 +403,6 @@ describe("TaskHelpers", () => {
         {
           moduleName: "good-morning",
           expectedTasks: [
-            "build.build-dependant",
             "deploy.build-dependant",
             "deploy.service-dependant",
             "deploy.service-dependant2",
@@ -420,15 +411,15 @@ describe("TaskHelpers", () => {
         },
         {
           moduleName: "good-evening",
-          expectedTasks: ["build.good-evening", "deploy.good-evening"],
+          expectedTasks: ["deploy.good-evening"],
         },
         {
           moduleName: "build-dependant",
-          expectedTasks: ["build.build-dependant", "deploy.build-dependant"],
+          expectedTasks: ["deploy.build-dependant"],
         },
         {
           moduleName: "service-dependant",
-          expectedTasks: ["build.service-dependant", "deploy.service-dependant"],
+          expectedTasks: ["deploy.service-dependant"],
         },
       ]
 
@@ -557,7 +548,7 @@ describe("TaskHelpers", () => {
           hotReloadServiceNames: ["service-a", "service-b"],
         })
 
-        expect(sortedBaseKeys(tasks)).to.eql(["build.module-b", "hot-reload.service-a"])
+        expect(sortedBaseKeys(tasks)).to.eql(["hot-reload.service-a"])
       })
     })
   })


### PR DESCRIPTION
Couple of issues fixed here:

**improvement(core): don't explicitly create build tasks in dev command**
There's really no reason to run builds explicitly when running
`garden dev`. Users generally won't expect generally unnecessary builds
to happen as they edit code. Builds should happen only if they are
required by deployments, tests and tasks.

**fix(core): don't omit dev mode services from deployment dependencies**
This was done a little carelessly (by me). There's a different behavior for
dev mode, compared to hot reload, in that we don't expressly signal
whether a service supports dev mode. So when running the dev command
or `deploy --dev=*` this would in effect completely mess up the
dependency order of actions.