### PR TITLE
feat: allow passing additional tolerations to kaniko pods

### DIFF
--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -120,6 +120,7 @@ export interface KubernetesConfig extends BaseProviderConfig {
     extraFlags?: string[]
     namespace?: string | null
     nodeSelector?: StringMap
+    tolerations?: V1Toleration[]
   }
   context: string
   defaultHostname?: string

--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -421,6 +421,7 @@ export const kubernetesConfigBase = () =>
             [See here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) for the official Kubernetes guide to assigning Pods to nodes.
           `
         ),
+        tolerations: joiSparseArray(tolerationSchema()),
       })
       .default(() => {})
       .description("Configuration options for the `kaniko` build mode."),
@@ -616,39 +617,40 @@ export const kubernetesConfigBase = () =>
       )
       .example({ disktype: "ssd" })
       .default(() => ({})),
-    registryProxyTolerations: joiSparseArray(
-      joi.object().keys({
-        effect: joi.string().allow("NoSchedule", "PreferNoSchedule", "NoExecute").description(dedent`
-          "Effect" indicates the taint effect to match. Empty means match all taint effects. When specified,
-          allowed values are "NoSchedule", "PreferNoSchedule" and "NoExecute".
-        `),
-        key: joi.string().description(dedent`
-          "Key" is the taint key that the toleration applies to. Empty means match all taint keys.
-          If the key is empty, operator must be "Exists"; this combination means to match all values and all keys.
-        `),
-        operator: joi.string().allow("Exists", "Equal").default("Equal").description(dedent`
-          "Operator" represents a key's relationship to the value. Valid operators are "Exists" and "Equal". Defaults to
-          "Equal". "Exists" is equivalent to wildcard for value, so that a pod can tolerate all taints of a
-          particular category.
-        `),
-        tolerationSeconds: joi.string().description(dedent`
-          "TolerationSeconds" represents the period of time the toleration (which must be of effect "NoExecute",
-          otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate
-          the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately)
-          by the system.
-        `),
-        value: joi.string().description(dedent`
-          "Value" is the taint value the toleration matches to. If the operator is "Exists", the value should be empty,
-          otherwise just a regular string.
-        `),
-      })
-    ).description(dedent`
+    registryProxyTolerations: joiSparseArray(tolerationSchema()).description(dedent`
         For setting tolerations on the registry-proxy when using in-cluster building.
         The registry-proxy is a DaemonSet that proxies connections to the docker registry service on each node.
 
         Use this only if you're doing in-cluster building and the nodes in your cluster
         have [taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/).
       `),
+  })
+
+export const tolerationSchema = () =>
+  joi.object().keys({
+    effect: joi.string().allow("NoSchedule", "PreferNoSchedule", "NoExecute").description(dedent`
+          "Effect" indicates the taint effect to match. Empty means match all taint effects. When specified,
+          allowed values are "NoSchedule", "PreferNoSchedule" and "NoExecute".
+        `),
+    key: joi.string().description(dedent`
+          "Key" is the taint key that the toleration applies to. Empty means match all taint keys.
+          If the key is empty, operator must be "Exists"; this combination means to match all values and all keys.
+        `),
+    operator: joi.string().allow("Exists", "Equal").default("Equal").description(dedent`
+          "Operator" represents a key's relationship to the value. Valid operators are "Exists" and "Equal". Defaults to
+          "Equal". "Exists" is equivalent to wildcard for value, so that a pod can tolerate all taints of a
+          particular category.
+        `),
+    tolerationSeconds: joi.string().description(dedent`
+          "TolerationSeconds" represents the period of time the toleration (which must be of effect "NoExecute",
+          otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate
+          the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately)
+          by the system.
+        `),
+    value: joi.string().description(dedent`
+          "Value" is the taint value the toleration matches to. If the operator is "Exists", the value should be empty,
+          otherwise just a regular string.
+        `),
   })
 
 export const namespaceSchema = () =>

--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -421,7 +421,9 @@ export const kubernetesConfigBase = () =>
             [See here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) for the official Kubernetes guide to assigning Pods to nodes.
           `
         ),
-        tolerations: joiSparseArray(tolerationSchema()),
+        tolerations: joiSparseArray(tolerationSchema()).description(
+          "Specify tolerations to apply to each Kaniko Pod. Useful to control which nodes in a cluster can run builds."
+        ),
       })
       .default(() => {})
       .description("Configuration options for the `kaniko` build mode."),

--- a/core/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/src/plugins/kubernetes/container/build/kaniko.ts
@@ -347,6 +347,7 @@ async function runKaniko({
   }
 
   const kanikoImage = provider.config.kaniko?.image || DEFAULT_KANIKO_IMAGE
+  const kanikoTolerations = [...(provider.config.kaniko?.tolerations || []), builderToleration]
   const utilHostname = `${utilDeploymentName}.${utilNamespace}.svc.cluster.local`
   const sourceUrl = `rsync://${utilHostname}:${utilRsyncPort}/volume/${ctx.workingCopyId}/${module.name}/`
 
@@ -433,7 +434,7 @@ async function runKaniko({
         },
       },
     ],
-    tolerations: [builderToleration],
+    tolerations: kanikoTolerations,
   }
 
   if (provider.config.deploymentRegistry?.hostname === inClusterRegistryHostname) {
@@ -516,6 +517,7 @@ async function runKaniko({
 }
 
 export function getUtilManifests(provider: KubernetesProvider, authSecretName: string) {
+  const kanikoTolerations = [...(provider.config.kaniko?.tolerations || []), builderToleration]
   const deployment: KubernetesDeployment = {
     apiVersion: "apps/v1",
     kind: "Deployment",
@@ -558,7 +560,7 @@ export function getUtilManifests(provider: KubernetesProvider, authSecretName: s
               emptyDir: {},
             },
           ],
-          tolerations: [builderToleration],
+          tolerations: kanikoTolerations,
         },
       },
     },

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -81,6 +81,32 @@ providers:
       # guide to assigning Pods to nodes.
       nodeSelector:
 
+      tolerations:
+        - # "Effect" indicates the taint effect to match. Empty means match all taint effects. When specified,
+          # allowed values are "NoSchedule", "PreferNoSchedule" and "NoExecute".
+          effect:
+
+          # "Key" is the taint key that the toleration applies to. Empty means match all taint keys.
+          # If the key is empty, operator must be "Exists"; this combination means to match all values and all keys.
+          key:
+
+          # "Operator" represents a key's relationship to the value. Valid operators are "Exists" and "Equal".
+          # Defaults to
+          # "Equal". "Exists" is equivalent to wildcard for value, so that a pod can tolerate all taints of a
+          # particular category.
+          operator: Equal
+
+          # "TolerationSeconds" represents the period of time the toleration (which must be of effect "NoExecute",
+          # otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate
+          # the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately)
+          # by the system.
+          tolerationSeconds:
+
+          # "Value" is the taint value the toleration matches to. If the operator is "Exists", the value should be
+          # empty,
+          # otherwise just a regular string.
+          value:
+
     # A default hostname to use when no hostname is explicitly configured for a service.
     defaultHostname:
 
@@ -506,6 +532,72 @@ Exposes the `nodeSelector` field on the PodSpec of the Kaniko pods. This allows 
 | Type     | Required |
 | -------- | -------- |
 | `object` | No       |
+
+### `providers[].kaniko.tolerations[]`
+
+[providers](#providers) > [kaniko](#providerskaniko) > tolerations
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
+
+### `providers[].kaniko.tolerations[].effect`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [tolerations](#providerskanikotolerations) > effect
+
+"Effect" indicates the taint effect to match. Empty means match all taint effects. When specified,
+allowed values are "NoSchedule", "PreferNoSchedule" and "NoExecute".
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.tolerations[].key`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [tolerations](#providerskanikotolerations) > key
+
+"Key" is the taint key that the toleration applies to. Empty means match all taint keys.
+If the key is empty, operator must be "Exists"; this combination means to match all values and all keys.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.tolerations[].operator`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [tolerations](#providerskanikotolerations) > operator
+
+"Operator" represents a key's relationship to the value. Valid operators are "Exists" and "Equal". Defaults to
+"Equal". "Exists" is equivalent to wildcard for value, so that a pod can tolerate all taints of a
+particular category.
+
+| Type     | Default   | Required |
+| -------- | --------- | -------- |
+| `string` | `"Equal"` | No       |
+
+### `providers[].kaniko.tolerations[].tolerationSeconds`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [tolerations](#providerskanikotolerations) > tolerationSeconds
+
+"TolerationSeconds" represents the period of time the toleration (which must be of effect "NoExecute",
+otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate
+the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately)
+by the system.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.tolerations[].value`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [tolerations](#providerskanikotolerations) > value
+
+"Value" is the taint value the toleration matches to. If the operator is "Exists", the value should be empty,
+otherwise just a regular string.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
 
 ### `providers[].defaultHostname`
 

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -81,6 +81,7 @@ providers:
       # guide to assigning Pods to nodes.
       nodeSelector:
 
+      # Specify tolerations to apply to each Kaniko Pod. Useful to control which nodes in a cluster can run builds.
       tolerations:
         - # "Effect" indicates the taint effect to match. Empty means match all taint effects. When specified,
           # allowed values are "NoSchedule", "PreferNoSchedule" and "NoExecute".
@@ -536,6 +537,8 @@ Exposes the `nodeSelector` field on the PodSpec of the Kaniko pods. This allows 
 ### `providers[].kaniko.tolerations[]`
 
 [providers](#providers) > [kaniko](#providerskaniko) > tolerations
+
+Specify tolerations to apply to each Kaniko Pod. Useful to control which nodes in a cluster can run builds.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -77,6 +77,7 @@ providers:
       # guide to assigning Pods to nodes.
       nodeSelector:
 
+      # Specify tolerations to apply to each Kaniko Pod. Useful to control which nodes in a cluster can run builds.
       tolerations:
         - # "Effect" indicates the taint effect to match. Empty means match all taint effects. When specified,
           # allowed values are "NoSchedule", "PreferNoSchedule" and "NoExecute".
@@ -498,6 +499,8 @@ Exposes the `nodeSelector` field on the PodSpec of the Kaniko pods. This allows 
 ### `providers[].kaniko.tolerations[]`
 
 [providers](#providers) > [kaniko](#providerskaniko) > tolerations
+
+Specify tolerations to apply to each Kaniko Pod. Useful to control which nodes in a cluster can run builds.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -77,6 +77,32 @@ providers:
       # guide to assigning Pods to nodes.
       nodeSelector:
 
+      tolerations:
+        - # "Effect" indicates the taint effect to match. Empty means match all taint effects. When specified,
+          # allowed values are "NoSchedule", "PreferNoSchedule" and "NoExecute".
+          effect:
+
+          # "Key" is the taint key that the toleration applies to. Empty means match all taint keys.
+          # If the key is empty, operator must be "Exists"; this combination means to match all values and all keys.
+          key:
+
+          # "Operator" represents a key's relationship to the value. Valid operators are "Exists" and "Equal".
+          # Defaults to
+          # "Equal". "Exists" is equivalent to wildcard for value, so that a pod can tolerate all taints of a
+          # particular category.
+          operator: Equal
+
+          # "TolerationSeconds" represents the period of time the toleration (which must be of effect "NoExecute",
+          # otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate
+          # the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately)
+          # by the system.
+          tolerationSeconds:
+
+          # "Value" is the taint value the toleration matches to. If the operator is "Exists", the value should be
+          # empty,
+          # otherwise just a regular string.
+          value:
+
     # A default hostname to use when no hostname is explicitly configured for a service.
     defaultHostname:
 
@@ -468,6 +494,72 @@ Exposes the `nodeSelector` field on the PodSpec of the Kaniko pods. This allows 
 | Type     | Required |
 | -------- | -------- |
 | `object` | No       |
+
+### `providers[].kaniko.tolerations[]`
+
+[providers](#providers) > [kaniko](#providerskaniko) > tolerations
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
+
+### `providers[].kaniko.tolerations[].effect`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [tolerations](#providerskanikotolerations) > effect
+
+"Effect" indicates the taint effect to match. Empty means match all taint effects. When specified,
+allowed values are "NoSchedule", "PreferNoSchedule" and "NoExecute".
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.tolerations[].key`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [tolerations](#providerskanikotolerations) > key
+
+"Key" is the taint key that the toleration applies to. Empty means match all taint keys.
+If the key is empty, operator must be "Exists"; this combination means to match all values and all keys.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.tolerations[].operator`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [tolerations](#providerskanikotolerations) > operator
+
+"Operator" represents a key's relationship to the value. Valid operators are "Exists" and "Equal". Defaults to
+"Equal". "Exists" is equivalent to wildcard for value, so that a pod can tolerate all taints of a
+particular category.
+
+| Type     | Default   | Required |
+| -------- | --------- | -------- |
+| `string` | `"Equal"` | No       |
+
+### `providers[].kaniko.tolerations[].tolerationSeconds`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [tolerations](#providerskanikotolerations) > tolerationSeconds
+
+"TolerationSeconds" represents the period of time the toleration (which must be of effect "NoExecute",
+otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate
+the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately)
+by the system.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.tolerations[].value`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [tolerations](#providerskanikotolerations) > value
+
+"Value" is the taint value the toleration matches to. If the operator is "Exists", the value should be empty,
+otherwise just a regular string.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
 
 ### `providers[].defaultHostname`
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:
Allows specifying additional tolerations that get passed to kaniko pods (both util and the builder pods).

A nice to have if stuff is run on, say, AKS - where any spot instance automatically has a taint that you need to tolerate in order to run anything.

**Special notes for your reviewer**:
