### PR TITLE
improvement(core): add --forward flag to deploy command

### DIFF
--- a/core/src/commands/deploy.ts
+++ b/core/src/commands/deploy.ts
@@ -65,6 +65,10 @@ export const deployOpts = {
   "skip": new StringsParameter({
     help: "The name(s) of services you'd like to skip when deploying.",
   }),
+  "forward": new BooleanParameter({
+    help: deline`Create port forwards and leave process running without watching
+    for changes. Ignored if --watch/-w flag is set or when in dev or hot-reload mode.`,
+  }),
 }
 
 type Args = typeof deployArgs
@@ -105,7 +109,8 @@ export class DeployCommand extends Command<Args, Opts> {
 
   outputsSchema = () => processCommandResultSchema()
 
-  private isPersistent = (opts: ParameterValues<Opts>) => !!opts.watch || !!opts["hot-reload"] || !!opts["dev-mode"]
+  private isPersistent = (opts: ParameterValues<Opts>) =>
+    !!opts.watch || !!opts["hot-reload"] || !!opts["dev-mode"] || !!opts.forward
 
   printHeader({ headerLog }) {
     printHeader(headerLog, "Deploy", "rocket")

--- a/core/test/unit/src/commands/deploy.ts
+++ b/core/test/unit/src/commands/deploy.ts
@@ -123,6 +123,7 @@ describe("DeployCommand", () => {
         "force": false,
         "force-build": true,
         "skip": undefined,
+        "forward": false,
       }),
     })
 
@@ -470,6 +471,7 @@ describe("DeployCommand", () => {
         "force": false,
         "force-build": true,
         "skip": undefined,
+        "forward": false,
       }),
     })
 
@@ -523,6 +525,7 @@ describe("DeployCommand", () => {
         "force": false,
         "force-build": true,
         "skip": undefined,
+        "forward": false,
       }),
     })
 
@@ -573,6 +576,7 @@ describe("DeployCommand", () => {
         "force": false,
         "force-build": true,
         "skip": undefined,
+        "forward": false,
       }),
     })
 
@@ -616,6 +620,7 @@ describe("DeployCommand", () => {
         "force": false,
         "force-build": true,
         "skip": ["service-b"],
+        "forward": false,
       }),
     })
 
@@ -627,7 +632,7 @@ describe("DeployCommand", () => {
   })
 
   describe("prepare", () => {
-    it("return persistent=true if --watch is set", async () => {
+    it("should return persistent=true if --watch is set", async () => {
       const cmd = new DeployCommand()
       const log = getLogger().placeholder()
       const { persistent } = await cmd.prepare({
@@ -644,12 +649,13 @@ describe("DeployCommand", () => {
           "force": false,
           "force-build": true,
           "skip": ["service-b"],
+          "forward": false,
         }),
       })
       expect(persistent).to.be.true
     })
 
-    it("return persistent=true if --dev is set", async () => {
+    it("should return persistent=true if --dev is set", async () => {
       const cmd = new DeployCommand()
       const log = getLogger().placeholder()
       const { persistent } = await cmd.prepare({
@@ -666,12 +672,13 @@ describe("DeployCommand", () => {
           "force": false,
           "force-build": true,
           "skip": ["service-b"],
+          "forward": false,
         }),
       })
       expect(persistent).to.be.true
     })
 
-    it("return persistent=true if --hot-reload is set", async () => {
+    it("should return persistent=true if --hot-reload is set", async () => {
       const cmd = new DeployCommand()
       const log = getLogger().placeholder()
       const { persistent } = await cmd.prepare({
@@ -688,6 +695,29 @@ describe("DeployCommand", () => {
           "force": false,
           "force-build": true,
           "skip": ["service-b"],
+          "forward": false,
+        }),
+      })
+      expect(persistent).to.be.true
+    })
+    it("should return persistent=true if --follow is set", async () => {
+      const cmd = new DeployCommand()
+      const log = getLogger().placeholder()
+      const { persistent } = await cmd.prepare({
+        log,
+        headerLog: log,
+        footerLog: log,
+        args: {
+          services: undefined,
+        },
+        opts: withDefaultGlobalOpts({
+          "dev-mode": undefined,
+          "hot-reload": undefined,
+          "watch": false,
+          "force": false,
+          "force-build": true,
+          "skip": ["service-b"],
+          "forward": true,
         }),
       })
       expect(persistent).to.be.true

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -698,6 +698,7 @@ Examples:
   | `--dev-mode` | `-dev` | array:string | [EXPERIMENTAL] The name(s) of the service(s) to deploy with dev mode enabled. Use comma as a separator to specify multiple services. Use * to deploy all services with dev mode enabled. When this option is used, the command is run in watch mode (i.e. implicitly sets the --watch/-w flag).
   | `--hot-reload` | `-hot` | array:string | The name(s) of the service(s) to deploy with hot reloading enabled. Use comma as a separator to specify multiple services. Use * to deploy all services with hot reloading enabled (ignores services belonging to modules that don&#x27;t support or haven&#x27;t configured hot reloading). When this option is used, the command is run in watch mode (i.e. implicitly sets the --watch/-w flag).
   | `--skip` |  | array:string | The name(s) of services you&#x27;d like to skip when deploying.
+  | `--forward` |  | boolean | Create port forwards and leave process running without watching for changes. Ignored if --watch/-w flag is set or when in dev or hot-reload mode.
 
 #### Outputs
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

This allows users to run the deploy command as a long lived, persistent
process with port forwards enabled without having Garden watch for
changes.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
