### PR TITLE
Prepare imagePullSecrets on helm module deployments

### DIFF
--- a/core/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/src/plugins/kubernetes/helm/deployment.ts
@@ -18,6 +18,7 @@ import { ContainerHotReloadSpec } from "../../container/config"
 import { DeployServiceParams } from "../../../types/plugin/service/deployService"
 import { DeleteServiceParams } from "../../../types/plugin/service/deleteService"
 import { getForwardablePorts, killPortForwards } from "../port-forward"
+import { prepareImagePullSecrets } from "../secrets"
 import { getServiceResource, getServiceResourceSpec } from "../util"
 import { getModuleNamespace, getModuleNamespaceStatus } from "../namespace"
 import { getHotReloadSpec, configureHotReload, getHotReloadContainerName } from "../hot-reload/helpers"
@@ -38,6 +39,7 @@ export async function deployHelmService({
 
   const k8sCtx = ctx as KubernetesPluginContext
   const provider = k8sCtx.provider
+  const api = await KubeApi.factory(log, ctx, provider)
 
   const namespaceStatus = await getModuleNamespaceStatus({
     ctx: k8sCtx,
@@ -64,6 +66,8 @@ export async function deployHelmService({
   if (hotReload) {
     hotReloadSpec = getHotReloadSpec(service)
   }
+
+  await prepareImagePullSecrets({ api, provider, namespace, log })
 
   const chartPath = await getChartPath(module)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Prepares the `imagePullSecrets` in the deployed namespace.

**Which issue(s) this PR fixes**:

When deploying our own charts through the helm module we are having issues pulling the image, I think because the image pull secret is not being copied to the deployment namespace.

We've set `imagePullSecrets` in the helm chart and the container image seems to be correct:

```
# deployment yaml
# ..
    spec:          
      containers:                                                                       
      - image: 346163573116.dkr.ecr.us-east-2.amazonaws.com/uniphore/tenants:v-596c9dd183

# ...
      imagePullSecrets:               
      - name: ecr-config

```

**Special notes for your reviewer**:

I didn't check if this fix works or not but looking at garden code I think is the approach to take.

Our intention is using garden to develop our services while we build the Helm charts since we think preparing Helm charts for our service is a good idea for business reasons. At same time, it seems to be proper the way inject garden variables. We know we can define the manifests in the `kubernetes` module itself but we using Helm would be our preference.

We'd appreciate some insights about the good practices when deploying with Helm charts.

Thanks.
