### PR TITLE
improvement(core): don't watch dev-enabled modules

### DIFF
--- a/core/src/commands/dev.ts
+++ b/core/src/commands/dev.ts
@@ -22,7 +22,7 @@ import { processModules } from "../process"
 import { GardenModule } from "../types/module"
 import { getTestTasks } from "../tasks/test"
 import { ConfigGraph } from "../config-graph"
-import { getHotReloadServiceNames, validateHotReloadServiceNames } from "./helpers"
+import { getDevModeModules, getHotReloadServiceNames, validateHotReloadServiceNames } from "./helpers"
 import { startServer } from "../server/server"
 import { BuildTask } from "../tasks/build"
 import { DeployTask } from "../tasks/deploy"
@@ -140,9 +140,9 @@ export class DevCommand extends Command<DevCommandArgs, DevCommandOpts> {
       return {}
     }
 
-    const hotReloadServiceNames = await getHotReloadServiceNames(opts["hot-reload"], graph)
+    const hotReloadServiceNames = getHotReloadServiceNames(opts["hot-reload"], graph)
     if (hotReloadServiceNames.length > 0) {
-      const errMsg = await validateHotReloadServiceNames(hotReloadServiceNames, graph)
+      const errMsg = validateHotReloadServiceNames(hotReloadServiceNames, graph)
       if (errMsg) {
         log.error({ msg: errMsg })
         return { result: {} }
@@ -176,6 +176,7 @@ export class DevCommand extends Command<DevCommandArgs, DevCommandOpts> {
       modules,
       watch: true,
       initialTasks,
+      skipWatchModules: getDevModeModules(devModeServiceNames, graph),
       changeHandler: async (updatedGraph: ConfigGraph, module: GardenModule) => {
         return getDevCommandWatchTasks({
           garden,

--- a/core/src/commands/helpers.ts
+++ b/core/src/commands/helpers.ts
@@ -15,8 +15,9 @@ import { GardenModule } from "../types/module"
 import { GardenService } from "../types/service"
 import { GardenTask } from "../types/task"
 import { GardenTest } from "../types/test"
+import { uniqByName } from "../util/util"
 
-export async function getDevModeServiceNames(namesFromOpt: string[] | undefined, configGraph: ConfigGraph) {
+export function getDevModeServiceNames(namesFromOpt: string[] | undefined, configGraph: ConfigGraph) {
   const names = namesFromOpt || []
   if (names.includes("*") || (!!namesFromOpt && namesFromOpt.length === 0)) {
     return configGraph.getServices().map((s) => s.name)
@@ -25,7 +26,7 @@ export async function getDevModeServiceNames(namesFromOpt: string[] | undefined,
   }
 }
 
-export async function getHotReloadServiceNames(namesFromOpt: string[] | undefined, configGraph: ConfigGraph) {
+export function getHotReloadServiceNames(namesFromOpt: string[] | undefined, configGraph: ConfigGraph) {
   const names = namesFromOpt || []
   if (names.includes("*")) {
     return configGraph
@@ -37,14 +38,15 @@ export async function getHotReloadServiceNames(namesFromOpt: string[] | undefine
   }
 }
 
+export function getDevModeModules(devModeServiceNames: string[], graph: ConfigGraph): GardenModule[] {
+  return uniqByName(graph.getServices({ names: devModeServiceNames }).map((s) => s.module))
+}
+
 /**
  * Returns an error message string if one or more serviceNames refers to a service that's not configured for
  * hot reloading, or if one or more of serviceNames referes to a non-existent service. Returns null otherwise.
  */
-export async function validateHotReloadServiceNames(
-  serviceNames: string[],
-  configGraph: ConfigGraph
-): Promise<string | null> {
+export function validateHotReloadServiceNames(serviceNames: string[], configGraph: ConfigGraph): string | null {
   const services = configGraph.getServices({ names: serviceNames, includeDisabled: true })
 
   const notHotreloadable = services.filter((s) => !supportsHotReloading(s)).map((s) => s.name)

--- a/core/src/process.ts
+++ b/core/src/process.ts
@@ -50,6 +50,8 @@ export interface ProcessResults {
   restartRequired?: boolean
 }
 
+let statusLine: LogEntry
+
 export async function processModules({
   garden,
   graph,
@@ -75,14 +77,13 @@ export async function processModules({
     log.info(renderDivider())
   }
 
-  let statusLine: LogEntry
-
   if (watch && !!footerLog) {
-    statusLine = footerLog.info("").placeholder()
+    if (!statusLine) {
+      statusLine = footerLog.info("").placeholder()
+    }
 
     garden.events.on("taskGraphProcessing", () => {
-      const emoji = printEmoji("hourglass_flowing_sand", statusLine)
-      statusLine.setState(`${emoji} Processing...`)
+      statusLine.setState({ emoji: "hourglass_flowing_sand", msg: "Processing..." })
     })
   }
 

--- a/core/src/process.ts
+++ b/core/src/process.ts
@@ -30,6 +30,10 @@ interface ProcessParams {
   log: LogEntry
   footerLog?: LogEntry
   watch: boolean
+  /**
+   * If provided, and if `watch === true`, don't watch files in the module roots of these modules.
+   */
+  skipWatchModules?: GardenModule[]
   initialTasks: BaseTask[]
   /**
    * Use this if the behavior should be different on watcher changes than on initial processing
@@ -53,6 +57,7 @@ export async function processModules({
   footerLog,
   modules,
   initialTasks,
+  skipWatchModules,
   watch,
   changeHandler,
 }: ProcessModulesParams): Promise<ProcessResults> {
@@ -66,7 +71,7 @@ export async function processModules({
 
   if (linkedModulesMsg.length > 0) {
     log.info(renderDivider())
-    log.info(chalk.gray(`Following modules are linked to a local path:\n${linkedModulesMsg.join("\n")}`))
+    log.info(chalk.gray(`The following modules are linked to a local path:\n${linkedModulesMsg.join("\n")}`))
     log.info(renderDivider())
   }
 
@@ -119,7 +124,7 @@ export async function processModules({
   const modulesToWatch = uniqByName(deps.build.concat(modules))
   const modulesByName = keyBy(modulesToWatch, "name")
 
-  await garden.startWatcher(graph)
+  await garden.startWatcher({ graph, skipModules: skipWatchModules })
 
   const waiting = () => {
     if (!!statusLine) {

--- a/core/src/watch.ts
+++ b/core/src/watch.ts
@@ -39,19 +39,39 @@ let watcher: FSWatcher | undefined
  * This needs to be enabled by calling the `.start()` method, and stopped with the `.stop()` method.
  */
 export class Watcher extends EventEmitter {
+  private garden: Garden
+  private log: LogEntry
+  private paths: string[]
+  private skipPaths: string[]
+  private modules: GardenModule[]
+  private bufferInterval: number = DEFAULT_BUFFER_INTERVAL
   private watcher?: FSWatcher
   private buffer: { [path: string]: ChangedPath }
   private running: boolean
   public processing: boolean
 
-  constructor(
-    private garden: Garden,
-    private log: LogEntry,
-    private paths: string[],
-    private modules: GardenModule[],
-    private bufferInterval: number = DEFAULT_BUFFER_INTERVAL
-  ) {
+  constructor({
+    garden,
+    log,
+    paths,
+    modules,
+    skipPaths,
+    bufferInterval,
+  }: {
+    garden: Garden
+    log: LogEntry
+    paths: string[]
+    modules: GardenModule[]
+    skipPaths?: string[]
+    bufferInterval?: number
+  }) {
     super()
+    this.garden = garden
+    this.log = log
+    this.paths = paths
+    this.modules = modules
+    this.skipPaths = skipPaths || []
+    this.bufferInterval = bufferInterval || DEFAULT_BUFFER_INTERVAL
     this.buffer = {}
     this.running = false
     this.processing = false
@@ -83,7 +103,7 @@ export class Watcher extends EventEmitter {
       // See https://github.com/garden-io/garden/issues/1269.
       // TODO: see if we can extract paths from dotignore files as well (we'd have to deal with negations etc. somehow).
       const projectExcludes = this.garden.moduleExcludePatterns.map((p) => resolve(this.garden.projectRoot, p))
-      const ignored = [...projectExcludes]
+      const ignored = [...projectExcludes, ...this.skipPaths]
       // TODO: filter paths based on module excludes as well
       //       (requires more complex logic to handle overlapping module sources).
       // const moduleExcludes = flatten(this.modules.map((m) => (m.exclude || []).map((p) => resolve(m.path, p))))
@@ -93,7 +113,7 @@ export class Watcher extends EventEmitter {
         this.log.debug(`Watcher: Using existing FSWatcher`)
         this.watcher = watcher
 
-        this.log.debug(`Watcher: Ignore ${ignored.join(", ")}`)
+        this.log.debug(`Watcher: Ignoring paths ${ignored.join(", ")}`)
         watcher.unwatch(ignored)
 
         this.log.debug(`Watcher: Watch ${this.paths}`)

--- a/core/test/unit/src/commands/helpers.ts
+++ b/core/test/unit/src/commands/helpers.ts
@@ -20,17 +20,17 @@ describe("getDevModeServiceNames", () => {
   })
 
   it("should return all services if --dev-mode=* is set", async () => {
-    const result = await getDevModeServiceNames(["*"], graph)
+    const result = getDevModeServiceNames(["*"], graph)
     expect(result).to.eql(graph.getServices().map((s) => s.name))
   })
 
   it("should return all services if --dev-mode is set with no value", async () => {
-    const result = await getDevModeServiceNames([], graph)
+    const result = getDevModeServiceNames([], graph)
     expect(result).to.eql(graph.getServices().map((s) => s.name))
   })
 
   it("should return specific service if --dev-mode is set with a service name", async () => {
-    const result = await getDevModeServiceNames(["service-a"], graph)
+    const result = getDevModeServiceNames(["service-a"], graph)
     expect(result).to.eql(["service-a"])
   })
 })

--- a/core/test/unit/src/watch.ts
+++ b/core/test/unit/src/watch.ts
@@ -43,7 +43,10 @@ describe("Watcher", () => {
     doubleModulePath = resolve(garden.projectRoot, "double-module")
     includeModulePath = resolve(garden.projectRoot, "with-include")
     moduleContext = pathToCacheContext(modulePath)
-    await garden.startWatcher(await garden.getConfigGraph({ log: garden.log, emit: false }), 10)
+    await garden.startWatcher({
+      graph: await garden.getConfigGraph({ log: garden.log, emit: false }),
+      bufferInterval: 10,
+    })
   })
 
   beforeEach(async () => {
@@ -337,7 +340,7 @@ describe("Watcher", () => {
       // This is not an issue in practice because there are specific commands just for linking
       // so the user will always have a new instance of Garden when they run their next command.
       garden = await makeExtModuleSourcesGarden()
-      await garden.startWatcher(await garden.getConfigGraph({ log: garden.log, emit: false }))
+      await garden.startWatcher({ graph: await garden.getConfigGraph({ log: garden.log, emit: false }) })
     })
 
     after(async () => {
@@ -400,7 +403,7 @@ describe("Watcher", () => {
       // This is not an issue in practice because there are specific commands just for linking
       // so the user will always have a new instance of Garden when they run their next command.
       garden = await makeExtProjectSourcesGarden()
-      await garden.startWatcher(await garden.getConfigGraph({ log: garden.log, emit: false }))
+      await garden.startWatcher({ graph: await garden.getConfigGraph({ log: garden.log, emit: false }) })
     })
 
     after(async () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

This is a performance optimization that lowers resource use when using dev mode. We now don't watch files inside the module roots of modules having one or more services deployed with dev mode, except for the modules' Garden config path.

The rationale here is that FS watches can be resource intensive, especially when there's a lot of churn (and especially on Linux). Since Mutagen takes care of the dev-mode sync (and doesn't go through the framework-native watch logic), this is usually unwanted overhead.

Also fixed a UI bug for watch-mode commands where an additional "Waiting for code changes..." footer log line would be rendered if a Garden config was changed.

**Which issue(s) this PR fixes**:

This PR is an attempt to fix OOM issues that some of our Linux users have encountered during long dev-mode sessions.