### PR TITLE
feat(cloud): add trigger support for push events

### DIFF
--- a/core/src/config/workflow.ts
+++ b/core/src/config/workflow.ts
@@ -286,6 +286,7 @@ export const workflowStepSchema = () => {
 export type workflowStepModifier = "onSuccess" | "onError" | "always" | "never"
 
 export const triggerEvents = [
+  "push",
   "pull-request",
   "pull-request-opened",
   "pull-request-reopened",

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1927,7 +1927,7 @@ workflowConfigs:
         # Supported events:
         #
         # `pull-request`, `pull-request-closed`, `pull-request-merged`, `pull-request-opened`,
-        # `pull-request-reopened`, `pull-request-updated`
+        # `pull-request-reopened`, `pull-request-updated`, `push`
         #
         #
         events:

--- a/docs/reference/workflow-config.md
+++ b/docs/reference/workflow-config.md
@@ -171,7 +171,7 @@ triggers:
     # Supported events:
     #
     # `pull-request`, `pull-request-closed`, `pull-request-merged`, `pull-request-opened`, `pull-request-reopened`,
-    # `pull-request-updated`
+    # `pull-request-updated`, `push`
     #
     #
     events:
@@ -575,7 +575,7 @@ See the Garden Cloud documentation on [configuring workflows](https://cloud.docs
 
 Supported events:
 
-`pull-request`, `pull-request-closed`, `pull-request-merged`, `pull-request-opened`, `pull-request-reopened`, `pull-request-updated`
+`pull-request`, `pull-request-closed`, `pull-request-merged`, `pull-request-opened`, `pull-request-reopened`, `pull-request-updated`, `push`
 
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the push event as a supported trigger event type.