### PR TITLE
feat(k8s): reverse sync and provider-level dev mode defaults

### DIFF
--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -184,7 +184,7 @@ const hotReloadConfigSchema = () =>
     with this module as their \`sourceModule\`.
   `)
 
-export type SyncMode = "one-way" | "one-way-replica" | "two-way"
+export type SyncMode = "one-way" | "one-way-replica" | "one-way-reverse" | "one-way-replica-reverse" | "two-way"
 
 export interface DevModeSyncSpec {
   source: string
@@ -251,11 +251,11 @@ const devModeSyncSchema = () =>
     exclude: syncExcludeSchema(),
     mode: joi
       .string()
-      .allow("one-way", "one-way-replica", "two-way")
+      .allow("one-way", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way")
       .only()
       .default("one-way")
       .description(
-        "The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `two-way`."
+        "The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `one-way-reverse`, `one-way-replica-reverse` and `two-way`."
       ),
     defaultFileMode: syncDefaultFileModeSchema(),
     defaultDirectoryMode: syncDefaultDirectoryModeSchema(),

--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -37,6 +37,7 @@ import { baseTestSpecSchema, BaseTestSpec } from "../../config/test"
 import { ArtifactSpec } from "../../config/validation"
 import { V1Toleration } from "@kubernetes/client-node"
 import { runPodSpecIncludeFields } from "./run"
+import { KubernetesDevModeDefaults, kubernetesDevModeDefaultsSchema } from "./dev-mode"
 
 export const DEFAULT_KANIKO_IMAGE = "gcr.io/kaniko-project/executor:v1.6.0-debug"
 export interface ProviderSecretRef {
@@ -126,6 +127,9 @@ export interface KubernetesConfig extends BaseProviderConfig {
   defaultHostname?: string
   deploymentRegistry?: ContainerRegistryConfig
   deploymentStrategy?: DeploymentStrategy
+  devMode?: {
+    defaults?: KubernetesDevModeDefaults
+  }
   forceSsl: boolean
   imagePullSecrets: ProviderSecretRef[]
   ingressHttpPort: number
@@ -437,14 +441,22 @@ export const kubernetesConfigBase = () =>
       .allow("rolling", "blue-green")
       .description(
         dedent`
-        Defines the strategy for deploying the project services.
-        Default is "rolling update" and there is experimental support for "blue/green" deployment.
-        The feature only supports modules of type \`container\`: other types will just deploy using the default strategy.
-      `
+          Sets the deployment strategy for \`container\` services.
+
+          The default is \`"rolling"\`, which performs rolling updates. There is also experimental support for blue/green deployments (via the \`"blue-green"\` strategy).
+
+          Note that this setting only applies to \`container\` services (and not, for example,  \`kubernetes\` or \`helm\` services).
+        `
       )
       .meta({
         experimental: true,
       }),
+    devMode: joi
+      .object()
+      .keys({
+        defaults: kubernetesDevModeDefaultsSchema(),
+      })
+      .description("Configuration options for dev mode."),
     forceSsl: joi
       .boolean()
       .default(false)

--- a/core/src/plugins/kubernetes/dev-mode.ts
+++ b/core/src/plugins/kubernetes/dev-mode.ts
@@ -6,7 +6,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { containerDevModeSchema, ContainerDevModeSpec } from "../container/config"
+import {
+  containerDevModeSchema,
+  ContainerDevModeSpec,
+  DevModeSyncSpec,
+  syncDefaultDirectoryModeSchema,
+  syncDefaultFileModeSchema,
+  syncDefaultGroupSchema,
+  syncDefaultOwnerSchema,
+  syncExcludeSchema,
+} from "../container/config"
 import { dedent, gardenAnnotationKey } from "../../util/string"
 import { set } from "lodash"
 import { getResourceContainer, getResourcePodSpec } from "./util"
@@ -16,11 +25,21 @@ import { joinWithPosix } from "../../util/fs"
 import chalk from "chalk"
 import { PluginContext } from "../../plugin-context"
 import { ConfigurationError } from "../../exceptions"
-import { ensureMutagenSync, getKubectlExecDestination, mutagenAgentPath, mutagenConfigLock } from "./mutagen"
-import { joiIdentifier } from "../../config/common"
-import { KubernetesPluginContext } from "./config"
+import {
+  ensureMutagenSync,
+  getKubectlExecDestination,
+  mutagenAgentPath,
+  mutagenConfigLock,
+  SyncConfig,
+} from "./mutagen"
+import { joi, joiIdentifier } from "../../config/common"
+import { KubernetesPluginContext, KubernetesProvider } from "./config"
 
 const syncUtilImageName = "gardendev/k8s-sync:0.1.1"
+
+export const builtInExcludes = ["**/*.git", "**/*.garden"]
+
+export const devModeGuideLink = "https://docs.garden.io/guides/code-synchronization-dev-mode"
 
 interface ConfigureDevModeParams {
   target: HotReloadableResource
@@ -31,6 +50,40 @@ interface ConfigureDevModeParams {
 export interface KubernetesDevModeSpec extends ContainerDevModeSpec {
   containerName?: string
 }
+
+export interface KubernetesDevModeDefaults {
+  exclude?: string[]
+  fileMode?: number
+  directoryMode?: number
+  owner?: number | string
+  group?: number | string
+}
+
+/**
+ * Provider-level dev mode settings for the local and remote k8s providers.
+ */
+export const kubernetesDevModeDefaultsSchema = () =>
+  joi.object().keys({
+    exclude: syncExcludeSchema().description(dedent`
+        Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+
+        Any exclusion patterns defined in individual dev mode sync specs will be applied in addition to these patterns.
+
+        \`.git\` directories and \`.garden\` directories are always ignored.
+      `),
+    fileMode: syncDefaultFileModeSchema(),
+    directoryMode: syncDefaultDirectoryModeSchema(),
+    owner: syncDefaultOwnerSchema(),
+    group: syncDefaultGroupSchema(),
+  }).description(dedent`
+    Specifies default settings for dev mode syncs (e.g. for \`container\`, \`kubernetes\` and \`helm\` services).
+
+    These are overridden/extended by the settings of any individual dev mode sync specs for a given module or service.
+
+    Dev mode is enabled when running the \`garden dev\` command, and by setting the \`--dev\` flag on the \`garden deploy\` command.
+
+    See the [Code Synchronization guide](${devModeGuideLink}) for more information.
+  `)
 
 export const kubernetesDevModeSchema = () =>
   containerDevModeSchema().keys({
@@ -44,7 +97,7 @@ export const kubernetesDevModeSchema = () =>
 
     Dev mode is enabled when running the \`garden dev\` command, and by setting the \`--dev\` flag on the \`garden deploy\` command.
 
-    See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for more information.
+    See the [Code Synchronization guide](${devModeGuideLink}) for more information.
   `)
 
 /**
@@ -152,14 +205,16 @@ export async function startDevModeSync({
     }
 
     const k8sCtx = <KubernetesPluginContext>ctx
+    const k8sProvider = <KubernetesProvider>k8sCtx.provider
+    const defaults = k8sProvider.config.devMode?.defaults || {}
 
     let i = 0
 
     for (const s of spec.sync) {
       const key = `${keyBase}-${i}`
 
-      const alpha = joinWithPosix(moduleRoot, s.source)
-      const beta = await getKubectlExecDestination({
+      const localPath = joinWithPosix(moduleRoot, s.source)
+      const remoteDestination = await getKubectlExecDestination({
         ctx: k8sCtx,
         log,
         namespace,
@@ -181,15 +236,35 @@ export async function startDevModeSync({
         logSection: serviceName,
         sourceDescription,
         targetDescription,
-        config: {
-          alpha,
-          beta,
-          mode: s.mode,
-          ignore: s.exclude || [],
-        },
+        config: makeSyncConfig({ defaults, spec: s, localPath, remoteDestination }),
       })
 
       i++
     }
   })
+}
+
+export function makeSyncConfig({
+  localPath,
+  remoteDestination,
+  defaults,
+  spec,
+}: {
+  localPath: string
+  remoteDestination: string
+  defaults: KubernetesDevModeDefaults | null
+  spec: DevModeSyncSpec
+}): SyncConfig {
+  const s = spec
+  const d = defaults || {}
+  return {
+    alpha: localPath,
+    beta: remoteDestination,
+    mode: s.mode,
+    ignore: [...builtInExcludes, ...(d["exclude"] || []), ...(s.exclude || [])],
+    defaultOwner: s.defaultOwner === undefined ? d["owner"] : s.defaultOwner,
+    defaultGroup: s.defaultGroup === undefined ? d["group"] : s.defaultGroup,
+    defaultDirectoryMode: s.defaultDirectoryMode === undefined ? d["directoryMode"] : s.defaultDirectoryMode,
+    defaultFileMode: s.defaultFileMode === undefined ? d["fileMode"] : s.defaultFileMode,
+  }
 }

--- a/core/src/plugins/kubernetes/mutagen.ts
+++ b/core/src/plugins/kubernetes/mutagen.ts
@@ -31,7 +31,9 @@ let mutagenTmp: TempDirectory
 
 export const mutagenModeMap = {
   "one-way": "one-way-safe",
+  "one-way-reverse": "one-way-safe",
   "one-way-replica": "one-way-replica",
+  "one-way-replica-reverse": "one-way-replica",
   "two-way": "two-way-safe",
 }
 

--- a/core/src/plugins/kubernetes/mutagen.ts
+++ b/core/src/plugins/kubernetes/mutagen.ts
@@ -35,7 +35,7 @@ export const mutagenModeMap = {
   "two-way": "two-way-safe",
 }
 
-interface SyncConfig {
+export interface SyncConfig {
   alpha: string
   beta: string
   mode: keyof typeof mutagenModeMap

--- a/core/test/data/test-projects/container/dev-mode/garden.yml
+++ b/core/test/data/test-projects/container/dev-mode/garden.yml
@@ -7,7 +7,7 @@ services:
     command: [sh, -c, "echo Server running... && nc -l -p 8080"]
     devMode:
       sync:
-        - target: /tmp
+        - target: /tmp/
           mode: two-way
     healthCheck:
       command: ["echo", "ok"]

--- a/core/test/data/test-projects/container/garden.yml
+++ b/core/test/data/test-projects/container/garden.yml
@@ -17,6 +17,10 @@ environments:
 providers:
   - name: local-kubernetes
     environments: [local]
+    devMode:
+      defaults:
+        exclude:
+          - "**/prefix-*"
   - name: local-kubernetes
     deploymentRegistry: &deploymentRegistry
       hostname: index.docker.io

--- a/core/test/integ/src/plugins/kubernetes/dev-mode.ts
+++ b/core/test/integ/src/plugins/kubernetes/dev-mode.ts
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2018-2021 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import { mkdirp, pathExists, readFile, remove, writeFile } from "fs-extra"
+import { join } from "path"
+import { ConfigGraph } from "../../../../../src/config-graph"
+import { Garden } from "../../../../../src/garden"
+import { LogEntry } from "../../../../../src/logger/log-entry"
+import { ContainerService } from "../../../../../src/plugins/container/config"
+import { KubernetesPluginContext, KubernetesProvider } from "../../../../../src/plugins/kubernetes/config"
+import { getContainerServiceStatus } from "../../../../../src/plugins/kubernetes/container/status"
+import { KubernetesWorkload } from "../../../../../src/plugins/kubernetes/types"
+import { execInWorkload } from "../../../../../src/plugins/kubernetes/util"
+import { emptyRuntimeContext } from "../../../../../src/runtime-context"
+import { DeployTask } from "../../../../../src/tasks/deploy"
+import { dedent } from "../../../../../src/util/string"
+import { sleep } from "../../../../../src/util/util"
+import { getContainerTestGarden } from "./container/container"
+
+describe("dev mode deployments and sync behavior", () => {
+  let garden: Garden
+  let graph: ConfigGraph
+  let ctx: KubernetesPluginContext
+  let provider: KubernetesProvider
+
+  const execInPod = async (command: string[], log: LogEntry, workload: KubernetesWorkload) => {
+    const execRes = await execInWorkload({
+      command,
+      ctx,
+      provider,
+      log,
+      namespace: provider.config.namespace!.name!,
+      workload,
+      interactive: false,
+    })
+    return execRes
+  }
+
+  before(async () => {
+    await init("local")
+  })
+
+  beforeEach(async () => {
+    graph = await garden.getConfigGraph({ log: garden.log, emit: false })
+  })
+
+  afterEach(async () => {
+    if (garden) {
+      await garden.close()
+    }
+  })
+
+  const init = async (environmentName: string) => {
+    garden = await getContainerTestGarden(environmentName)
+    provider = <KubernetesProvider>await garden.resolveProvider(garden.log, "local-kubernetes")
+    ctx = <KubernetesPluginContext>await garden.getPluginContext(provider)
+  }
+
+  it("should deploy a service in dev mode and successfully set a two-way sync", async () => {
+    await init("local")
+    const service = graph.getService("dev-mode")
+    const module = service.module
+    const log = garden.log
+    const deployTask = new DeployTask({
+      garden,
+      graph,
+      log,
+      service,
+      force: true,
+      forceBuild: false,
+      devModeServiceNames: [service.name],
+      hotReloadServiceNames: [],
+    })
+
+    await garden.processTasks([deployTask], { throwOnError: true })
+    const status = await getContainerServiceStatus({
+      ctx,
+      module,
+      service,
+      runtimeContext: emptyRuntimeContext,
+      log,
+      devMode: true,
+      hotReload: false,
+    })
+
+    const workload = status.detail.workload!
+
+    // First, we create a file locally and verify that it gets synced into the pod
+    await writeFile(join(module.path, "made_locally"), "foo")
+    await sleep(300)
+    const execRes = await execInPod(["/bin/sh", "-c", "cat /tmp/made_locally"], log, workload)
+    expect(execRes.output.trim()).to.eql("foo")
+
+    // Then, we create a file in the pod and verify that it gets synced back
+    await execInPod(["/bin/sh", "-c", "echo bar > /tmp/made_in_pod"], log, workload)
+    await sleep(500)
+    const localPath = join(module.path, "made_in_pod")
+    expect(await pathExists(localPath)).to.eql(true)
+    expect((await readFile(localPath)).toString().trim()).to.eql("bar")
+
+    // This is to make sure that the two-way sync doesn't recreate the local files we're about to delete here.
+    const actions = await garden.getActionRouter()
+    await actions.deleteService({ graph, log: garden.log, service })
+
+    // Clean up the files we created locally
+    for (const filename of ["made_locally", "made_in_pod"]) {
+      try {
+        await remove(join(module.path, filename))
+      } catch {}
+    }
+  })
+
+  it("should apply ignore rules from the sync spec and the provider-level dev mode defaults", async () => {
+    await init("local")
+    const service: ContainerService = graph.getService("dev-mode")
+
+    // We want to ignore the following directories (all at module root)
+    // somedir
+    // prefix-a         <--- matched by provider-level default excludes
+    // nested/prefix-b  <--- matched by provider-level default excludes
+
+    service.spec.devMode!.sync[0].mode = "one-way-replica"
+    service.spec.devMode!.sync[0].exclude = ["somedir"]
+    const module = service.module
+    const log = garden.log
+    const deployTask = new DeployTask({
+      garden,
+      graph,
+      log,
+      service,
+      force: true,
+      forceBuild: false,
+      devModeServiceNames: [service.name],
+      hotReloadServiceNames: [],
+    })
+
+    await garden.processTasks([deployTask], { throwOnError: true })
+    const status = await getContainerServiceStatus({
+      ctx,
+      module,
+      service,
+      runtimeContext: emptyRuntimeContext,
+      log,
+      devMode: true,
+      hotReload: false,
+    })
+
+    const workload = status.detail.workload!
+
+    // First, we create a non-ignored file locally
+    await writeFile(join(module.path, "made_locally"), "foo")
+
+    // Then, we create files in each of the directories we intended to ignore in the `exclude` spec above, and
+    // verify that they didn't get synced into the pod.
+    await mkdirp(join(module.path, "somedir"))
+    await writeFile(join(module.path, "somedir", "file"), "foo")
+    await mkdirp(join(module.path, "prefix-a"))
+    await writeFile(join(module.path, "prefix-a", "file"), "foo")
+    await mkdirp(join(module.path, "nested", "prefix-b"))
+    await writeFile(join(module.path, "nested", "prefix-b", "file"), "foo")
+    await sleep(500)
+    const ignoreExecRes = await execInPod(["/bin/sh", "-c", "ls -a /tmp /tmp/nested"], log, workload)
+    // Clean up the files we created locally
+    for (const filename of ["made_locally", "somedir", "prefix-a", "nested"]) {
+      try {
+        await remove(join(module.path, filename))
+      } catch {}
+    }
+
+    expect(ignoreExecRes.output.trim()).to.eql(dedent`
+      /tmp:
+      .
+      ..
+      Dockerfile
+      garden.yml
+      made_locally
+      nested
+
+      /tmp/nested:
+      .
+      ..
+    `)
+  })
+})

--- a/core/test/unit/src/plugins/kubernetes/dev-mode.ts
+++ b/core/test/unit/src/plugins/kubernetes/dev-mode.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2018-2021 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import { builtInExcludes, makeSyncConfig } from "../../../../../src/plugins/kubernetes/dev-mode"
+
+describe("k8s dev mode helpers", () => {
+  const localPath = "/path/to/module/src"
+  const remoteDestination = "exec:'various fun connection parameters'"
+  const source = "src"
+  const target = "/app/src"
+  describe("makeSyncConfig", () => {
+    it("should generate a simple sync config", () => {
+      const config = makeSyncConfig({
+        localPath,
+        remoteDestination,
+        defaults: {},
+        spec: {
+          source,
+          target,
+          mode: "one-way",
+        },
+      })
+
+      expect(config).to.eql({
+        alpha: localPath,
+        beta: remoteDestination,
+        ignore: [...builtInExcludes],
+        mode: "one-way",
+        defaultOwner: undefined,
+        defaultGroup: undefined,
+        defaultDirectoryMode: undefined,
+        defaultFileMode: undefined,
+      })
+    })
+
+    it("should apply provider-level defaults", () => {
+      const config = makeSyncConfig({
+        localPath,
+        remoteDestination,
+        defaults: {
+          exclude: ["**/*.log"],
+          owner: "node",
+          group: "admin",
+          fileMode: 600,
+          directoryMode: 700,
+        },
+        spec: {
+          source,
+          target,
+          mode: "one-way",
+        },
+      })
+
+      expect(config).to.eql({
+        alpha: localPath,
+        beta: remoteDestination,
+        ignore: [...builtInExcludes, "**/*.log"],
+        mode: "one-way",
+        defaultOwner: "node",
+        defaultGroup: "admin",
+        defaultFileMode: 600,
+        defaultDirectoryMode: 700,
+      })
+    })
+
+    it("should override/extend provider-level defaults with settings on the sync spec", () => {
+      const config = makeSyncConfig({
+        localPath,
+        remoteDestination,
+        defaults: {
+          exclude: ["**/*.log"],
+          owner: "node",
+          group: "admin",
+          fileMode: 600,
+          directoryMode: 700,
+        },
+        spec: {
+          source,
+          target,
+          mode: "one-way",
+          exclude: ["node_modules"],
+          defaultOwner: "owner_from_spec",
+          defaultGroup: "group_from_spec",
+          defaultFileMode: 700,
+          defaultDirectoryMode: 777,
+        },
+      })
+
+      expect(config).to.eql({
+        alpha: localPath,
+        beta: remoteDestination,
+        ignore: [...builtInExcludes, "**/*.log", "node_modules"],
+        mode: "one-way",
+        defaultOwner: "owner_from_spec",
+        defaultGroup: "group_from_spec",
+        defaultFileMode: 700,
+        defaultDirectoryMode: 777,
+      })
+    })
+  })
+})

--- a/core/test/unit/src/plugins/kubernetes/dev-mode.ts
+++ b/core/test/unit/src/plugins/kubernetes/dev-mode.ts
@@ -103,5 +103,29 @@ describe("k8s dev mode helpers", () => {
         defaultDirectoryMode: 777,
       })
     })
+
+    it("should return a remote alpha and a local beta when called with a reverse sync mode", () => {
+      const config = makeSyncConfig({
+        localPath,
+        remoteDestination,
+        defaults: {},
+        spec: {
+          source,
+          target,
+          mode: "one-way-replica-reverse",
+        },
+      })
+
+      expect(config).to.eql({
+        alpha: remoteDestination, // <----
+        beta: localPath, // <----
+        ignore: [...builtInExcludes],
+        mode: "one-way-replica-reverse",
+        defaultOwner: undefined,
+        defaultGroup: undefined,
+        defaultDirectoryMode: undefined,
+        defaultFileMode: undefined,
+      })
+    })
   })
 })

--- a/docs/guides/code-synchronization-dev-mode.md
+++ b/docs/guides/code-synchronization-dev-mode.md
@@ -6,10 +6,14 @@ Dev mode works similarly to the older [hot reloading functionality](./hot-reload
 
 This new sync mode uses [Mutagen](https://mutagen.io/) under the hood. Garden automatically takes care of fetching Mutagen, so you don't need to install any dependencies yourself to make use of dev mode.
 
-Dev mode sync is not affected by includes/excludes, which makes it more flexible than hot reloading. For example, you can use it to sync your `build`/`dist` directory into your container while running local, incremental builds (without having to remove those directories from your ignorefiles).
+Dev mode sync is not affected by the usual includes/excludes (e.g. rules defind in `.gardenignore` files), which makes it more flexible than hot reloading.
+
+Instead, exclusion rules for dev mode are configured explicitly on the provider level and for each individual sync you configure—more on that below.
+
+For example, you can use it to sync your `build`/`dist` directory into your container while running local, incremental builds (without having to remove those directories from your ignorefiles).
 
 {% hint style="warning" %}
-Please make sure to specify any paths that should not be synced, by setting the `exclude` field on each configured sync! Otherwise you may end up syncing large directories and even run into application errors.
+Please make sure to specify any paths that should not be synced by setting the provider-level default excludes and/or the `exclude` field on each configured sync! Otherwise you may end up syncing large directories and even run into application errors.
 {% endhint %}
 
 ## Configuration
@@ -20,7 +24,6 @@ To configure a service for dev mode, add `devMode` to your module/service config
 
 ```yaml
 kind: Module
-description: Node greeting service
 name: node-service
 type: container
 services:
@@ -30,12 +33,11 @@ services:
       command: [npm, run, dev] # Overrides the container's default when the service is deployed in dev mode
       sync:
         # Source/target configuration for dev mode is the same as for hot reloading.
-        - target: /app
+        - source: src
+          target: /app/src
           # Make sure to specify any paths that should not be synced!
           exclude: [node_modules]
-        # You can use several sync specs for the same service.
-        - source: /tmp/somedir
-          target: /somedir
+          mode: two-way
   ...
 ```
 
@@ -75,6 +77,96 @@ garden deploy --dev=*
 # The dev command deploys services in dev mode by default:
 garden dev myservice
 ```
+Once your services have been deployed, any changes you make that fall under one of the sync specs you've defined will be automatically synced between your local machine and the running service.
+
+Once you quit/terminate the Garden command, all syncs established by the command will be stopped (but the services will still be left running).
+
+## Sync modes
+
+Garden's dev mode supports several sync modes, each of which maps onto a Mutagen sync mode.
+
+In brief: It's generally easiest to get started with the `one-way` or `two-way` sync modes, and then graduate to a more fine-grained setup based on `one-way-replicated` and/or `one-way-replicated-reverse` once you're ready to specify exactly which paths to sync and which files/directories to ignore from the sync.
+
+### `one-way` (shorthand for `one-way-safe`)
+* Syncs a local `source` path to a remote `target` path.
+* When there are conflicts, does not replace/delete files in the remote `target` path.
+* Simple to use, especially when there are files/directories inside the remote `target` that you don't want to override with the contents of the local `source`.
+* On the other hand, if your setup / usage pattern is such that conflicts do sometimes arise for the `source`/`target` pair in question, you may want to use `one-way-replicated` instead.
+
+
+### `one-way-replicated`
+  * Syncs a local `source` path to a remote `target` path, such that `target` is always an exact mirror of `source` (with the exception of excluded paths).
+  * When using this mode, there can be no conflicts—the contents of `source` always override the contents of `target`.
+  * Since conflicts are impossible here, this mode tends to be a better / more reliable choice long-term than `one-way`/`one-way-safe`. However, you may need to configure more fine-grained/specific `source`/`target` pairs and their excludes such that you don't have problems with paths in the remote `target` being overwritten/deleted when they change in the local `source`.
+
+### `one-way-reverse`
+  * Same as `one-way`, except the direction of the sync is reversed.
+  * Syncs a remote `target` path to a local `source` path.
+  * Has the same benefits and drawbacks as `one-way`: Simple to configure, but conflicts are possible.
+
+### `one-way-replicated-reverse`
+  * Same as `one-way-replicated`, except the direction of the sync is reversed.
+  * Syncs a remote `target` path to a local `source` path, such that `source` is always an exact mirror of `target` (with the exception of excluded paths).
+  * When using this mode, there can be no conflicts—the contents of `target` always override the contents of `source`.
+
+### `two-way` (maps to Mutagen's `two-way-safe`)
+  * Bidirectionally syncs a local `source` to a remote `target` path.
+  * Changes made in the local `source` will be synced to the remote `target`.
+  * Changes made in the remote `target` will be synced to the local `source`.
+  * When there are conflicts on either side, does not replace/delete the corresponding conflicting paths on the other side.
+  * Similarly to `one-way`, this mode is simple to configure when there are files in either `source` or `target` that you don't want overriden on the other side when files change or are added/deleted.
+  * Setting up several `one-way-replicated` and `one-way-replicated-reverse` syncs instead of `one-way` and `two-way` is generally the best approach long-term, but may require more fine-grained configuration (more sync specs for specific subpaths and more specific exclusion rules, to make sure things don't get overwritten/deleted in unwanted ways).
+
+In addition to the above, please check out the [Mutagen docs on synchronization](https://mutagen.io/documentation/synchronization) for more info.
+
+### Notes on Mutagen terminology
+
+Mutagen uses the terminology "alpha" and "beta" for the sync endpoints. In Garden's `one-way`, `one-way-replicated` and `two-way` sync modes, alpha is `source` and beta is `target`.
+
+For the reverse sync modes (`one-way-reverse` and `one-way-replicated-reverse`), alpha is `target` and beta is `source`.
+
+## Excluding files and directories from syncs
+
+By design, Garden's dev mode does not apply exclusion rules from ignorefiles (such as `.gardenignore` files) to dev mode syncs.
+
+This is done to grant you more control over precisely which files and directories you'd like to sync while in dev mode.
+
+For example, you might want to ignore `dist` or `build` directories (not version control them, not include them in builds or module versions), but still be able to sync them from your local machine to the running container (or from the running container to your local machine). This is easy to achieve with dev mode.
+
+Exclusion rules can be specified on individual sync configs:
+```yaml
+kind: Module
+name: node-service
+type: container
+services:
+  - name: node-service
+    args: [npm, start]
+    devMode:
+      command: [npm, run, dev]
+      sync:
+        - source: src
+          target: /app/src
+          exclude: [node_modules, tmp, "**/*.log"] # <------ paths matching these patterns won't be synced
+          mode: two-way
+  ...
+```
+Project-wide exclusion rules can be set on the `local-kubernetes` and `kubernetes` providers:
+```yaml
+kind: Project
+...
+providers:
+  - name: kubernetes
+    ...
+    # Configure project-wide exclusion rules and default permission/ownership settings
+    # for synced files/directories.
+    devMode:
+      defaults:
+        exclude:
+          - "/**/node_modules" # <--- with this, we don't have to specify `node_modules` on individual sync specs
+```
+This is great to reduce repetition in your excludes.
+
+See the reference documentation for the [`kubernetes` provider](../reference/providers/kubernetes.md#providersdevmode)) for a full list of provider-level options for dev mode when using the `kubernetes` provider. The same dev-mode options are also available when using `local-kubernetes`.
 
 ## Permissions and ownership
 
@@ -103,3 +195,55 @@ services:
 ```
 
 These options are passed directly to Mutagen. For more information, please see the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions).
+
+### An advanced example
+
+This example demonstrates several of the more advanced options that dev mode offers. For more details on the options available, see the sections above.
+```yaml
+kind: Project
+...
+providers:
+  - name: kubernetes
+    ...
+    # Configure project-wide exclusion rules and default permission/ownership settings
+    # for synced files/directories.
+    devMode:
+      defaults:
+        exclude:
+          - "/**/node_modules"
+        owner: 1000  # <- set an integer user ID or a string name
+        group: 1000  # <- set an integer group ID or a string name
+        fileMode: 0666  # <- set the permission bits (as octals) for synced files
+        directoryMode: 0777  # <- set the permission bits (as octals) for synced directories
+
+---
+
+kind: Module
+description: |
+  Here, we sync source code into the remote, and sync back the `test-artifacts` directory
+  (populated when we run tests) back to the local machine.
+name: node-service
+type: container
+services:
+  - name: node-service
+    args: [npm, start]
+    devMode:
+      command: [npm, run, dev] # Overrides the container's default when the service is deployed in dev mode.
+      sync:
+        # You can use several sync specs for the same service. It's generally a good idea to be specific about
+        # what you want to sync, and to use `one-way-replica` or `one-way-replica-reverse` when possible to keep
+        # things simple and avoid sync conflicts.
+        - source: app
+          target: /app
+          # We don't need to exclude `node_modules` here, since above we added a
+          # project-wide exclusion rule for that.
+          # exclude: [node_modules]
+          mode: one-way-replica
+        - source: test-artifacts
+          target: /test-artifacts
+          # This syncs back any files/folders  on the remote to the local machine, always
+          # overriding the local directory's contents with the remote one. See above for a detailed
+          # description of each available sync mode.
+          mode: one-way-replica-reverse
+  ...
+```

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -251,7 +251,8 @@ services:
           # `.git` directories and `.garden` directories are always ignored.
           exclude:
 
-          # The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `two-way`.
+          # The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`,
+          # `one-way-reverse`, `one-way-replica-reverse` and `two-way`.
           mode: one-way
 
           # The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600
@@ -1252,11 +1253,11 @@ services:
 
 [services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > mode
 
-The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `two-way`.
+The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `one-way-reverse`, `one-way-replica-reverse` and `two-way`.
 
-| Type     | Allowed Values                          | Default     | Required |
-| -------- | --------------------------------------- | ----------- | -------- |
-| `string` | "one-way", "one-way-replica", "two-way" | `"one-way"` | Yes      |
+| Type     | Allowed Values                                                                        | Default     | Required |
+| -------- | ------------------------------------------------------------------------------------- | ----------- | -------- |
+| `string` | "one-way", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way" | `"one-way"` | Yes      |
 
 ### `services[].devMode.sync[].defaultFileMode`
 

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -247,6 +247,8 @@ services:
           target:
 
           # Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+          #
+          # `.git` directories and `.garden` directories are always ignored.
           exclude:
 
           # The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `two-way`.
@@ -1227,6 +1229,8 @@ services:
 [services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > exclude
 
 Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+
+`.git` directories and `.garden` directories are always ignored.
 
 | Type               | Required |
 | ------------------ | -------- |

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -189,7 +189,8 @@ devMode:
       # `.git` directories and `.garden` directories are always ignored.
       exclude:
 
-      # The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `two-way`.
+      # The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `one-way-reverse`,
+      # `one-way-replica-reverse` and `two-way`.
       mode: one-way
 
       # The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600 (user
@@ -969,11 +970,11 @@ devMode:
 
 [devMode](#devmode) > [sync](#devmodesync) > mode
 
-The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `two-way`.
+The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `one-way-reverse`, `one-way-replica-reverse` and `two-way`.
 
-| Type     | Allowed Values                          | Default     | Required |
-| -------- | --------------------------------------- | ----------- | -------- |
-| `string` | "one-way", "one-way-replica", "two-way" | `"one-way"` | Yes      |
+| Type     | Allowed Values                                                                        | Default     | Required |
+| -------- | ------------------------------------------------------------------------------------- | ----------- | -------- |
+| `string` | "one-way", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way" | `"one-way"` | Yes      |
 
 ### `devMode.sync[].defaultFileMode`
 

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -185,6 +185,8 @@ devMode:
       target:
 
       # Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+      #
+      # `.git` directories and `.garden` directories are always ignored.
       exclude:
 
       # The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `two-way`.
@@ -945,6 +947,8 @@ devMode:
 [devMode](#devmode) > [sync](#devmodesync) > exclude
 
 Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+
+`.git` directories and `.garden` directories are always ignored.
 
 | Type               | Required |
 | ------------------ | -------- |

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -269,7 +269,8 @@ services:
           # `.git` directories and `.garden` directories are always ignored.
           exclude:
 
-          # The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `two-way`.
+          # The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`,
+          # `one-way-reverse`, `one-way-replica-reverse` and `two-way`.
           mode: one-way
 
           # The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600
@@ -1310,11 +1311,11 @@ services:
 
 [services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > mode
 
-The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `two-way`.
+The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `one-way-reverse`, `one-way-replica-reverse` and `two-way`.
 
-| Type     | Allowed Values                          | Default     | Required |
-| -------- | --------------------------------------- | ----------- | -------- |
-| `string` | "one-way", "one-way-replica", "two-way" | `"one-way"` | Yes      |
+| Type     | Allowed Values                                                                        | Default     | Required |
+| -------- | ------------------------------------------------------------------------------------- | ----------- | -------- |
+| `string` | "one-way", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way" | `"one-way"` | Yes      |
 
 ### `services[].devMode.sync[].defaultFileMode`
 

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -265,6 +265,8 @@ services:
           target:
 
           # Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+          #
+          # `.git` directories and `.garden` directories are always ignored.
           exclude:
 
           # The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `two-way`.
@@ -1285,6 +1287,8 @@ services:
 [services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > exclude
 
 Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+
+`.git` directories and `.garden` directories are always ignored.
 
 | Type               | Required |
 | ------------------ | -------- |

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -171,6 +171,8 @@ devMode:
       target:
 
       # Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+      #
+      # `.git` directories and `.garden` directories are always ignored.
       exclude:
 
       # The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `two-way`.
@@ -828,6 +830,8 @@ devMode:
 [devMode](#devmode) > [sync](#devmodesync) > exclude
 
 Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+
+`.git` directories and `.garden` directories are always ignored.
 
 | Type               | Required |
 | ------------------ | -------- |

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -175,7 +175,8 @@ devMode:
       # `.git` directories and `.garden` directories are always ignored.
       exclude:
 
-      # The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `two-way`.
+      # The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `one-way-reverse`,
+      # `one-way-replica-reverse` and `two-way`.
       mode: one-way
 
       # The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600 (user
@@ -852,11 +853,11 @@ devMode:
 
 [devMode](#devmode) > [sync](#devmodesync) > mode
 
-The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `two-way`.
+The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `one-way-reverse`, `one-way-replica-reverse` and `two-way`.
 
-| Type     | Allowed Values                          | Default     | Required |
-| -------- | --------------------------------------- | ----------- | -------- |
-| `string` | "one-way", "one-way-replica", "two-way" | `"one-way"` | Yes      |
+| Type     | Allowed Values                                                                        | Default     | Required |
+| -------- | ------------------------------------------------------------------------------------- | ----------- | -------- |
+| `string` | "one-way", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way" | `"one-way"` | Yes      |
 
 ### `devMode.sync[].defaultFileMode`
 

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -251,7 +251,8 @@ services:
           # `.git` directories and `.garden` directories are always ignored.
           exclude:
 
-          # The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `two-way`.
+          # The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`,
+          # `one-way-reverse`, `one-way-replica-reverse` and `two-way`.
           mode: one-way
 
           # The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600
@@ -1262,11 +1263,11 @@ services:
 
 [services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > mode
 
-The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `two-way`.
+The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `one-way-reverse`, `one-way-replica-reverse` and `two-way`.
 
-| Type     | Allowed Values                          | Default     | Required |
-| -------- | --------------------------------------- | ----------- | -------- |
-| `string` | "one-way", "one-way-replica", "two-way" | `"one-way"` | Yes      |
+| Type     | Allowed Values                                                                        | Default     | Required |
+| -------- | ------------------------------------------------------------------------------------- | ----------- | -------- |
+| `string` | "one-way", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way" | `"one-way"` | Yes      |
 
 ### `services[].devMode.sync[].defaultFileMode`
 

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -247,6 +247,8 @@ services:
           target:
 
           # Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+          #
+          # `.git` directories and `.garden` directories are always ignored.
           exclude:
 
           # The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `two-way`.
@@ -1237,6 +1239,8 @@ services:
 [services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > exclude
 
 Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+
+`.git` directories and `.garden` directories are always ignored.
 
 | Type               | Required |
 | ------------------ | -------- |

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -111,10 +111,55 @@ providers:
     # A default hostname to use when no hostname is explicitly configured for a service.
     defaultHostname:
 
-    # Defines the strategy for deploying the project services.
-    # Default is "rolling update" and there is experimental support for "blue/green" deployment.
-    # The feature only supports modules of type `container`: other types will just deploy using the default strategy.
+    # Sets the deployment strategy for `container` services.
+    #
+    # The default is `"rolling"`, which performs rolling updates. There is also experimental support for blue/green
+    # deployments (via the `"blue-green"` strategy).
+    #
+    # Note that this setting only applies to `container` services (and not, for example,  `kubernetes` or `helm`
+    # services).
     deploymentStrategy: rolling
+
+    # Configuration options for dev mode.
+    devMode:
+      # Specifies default settings for dev mode syncs (e.g. for `container`, `kubernetes` and `helm` services).
+      #
+      # These are overridden/extended by the settings of any individual dev mode sync specs for a given module or
+      # service.
+      #
+      # Dev mode is enabled when running the `garden dev` command, and by setting the `--dev` flag on the `garden
+      # deploy` command.
+      #
+      # See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for more
+      # information.
+      defaults:
+        # Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+        #
+        # Any exclusion patterns defined in individual dev mode sync specs will be applied in addition to these
+        # patterns.
+        #
+        # `.git` directories and `.garden` directories are always ignored.
+        exclude:
+
+        # The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600
+        # (user read/write). See the [Mutagen
+        # docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
+        fileMode:
+
+        # The default permission bits, specified as an octal, to set on directories at the sync target. Defaults to
+        # 0700 (user read/write). See the [Mutagen
+        # docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
+        directoryMode:
+
+        # Set the default owner of files and directories at the target. Specify either an integer ID or a string name.
+        # See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for
+        # more information.
+        owner:
+
+        # Set the default group on files and directories at the target. Specify either an integer ID or a string name.
+        # See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for
+        # more information.
+        group:
 
     # Require SSL on all `container` module services. If set to true, an error is raised when no certificate is
     # available for a configured hostname on a `container` module.
@@ -627,13 +672,108 @@ providers:
 **Experimental**: this is an experimental feature and the API might change in the future.
 {% endhint %}
 
-Defines the strategy for deploying the project services.
-Default is "rolling update" and there is experimental support for "blue/green" deployment.
-The feature only supports modules of type `container`: other types will just deploy using the default strategy.
+Sets the deployment strategy for `container` services.
+
+The default is `"rolling"`, which performs rolling updates. There is also experimental support for blue/green deployments (via the `"blue-green"` strategy).
+
+Note that this setting only applies to `container` services (and not, for example,  `kubernetes` or `helm` services).
 
 | Type     | Default     | Required |
 | -------- | ----------- | -------- |
 | `string` | `"rolling"` | No       |
+
+### `providers[].devMode`
+
+[providers](#providers) > devMode
+
+Configuration options for dev mode.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].devMode.defaults`
+
+[providers](#providers) > [devMode](#providersdevmode) > defaults
+
+Specifies default settings for dev mode syncs (e.g. for `container`, `kubernetes` and `helm` services).
+
+These are overridden/extended by the settings of any individual dev mode sync specs for a given module or service.
+
+Dev mode is enabled when running the `garden dev` command, and by setting the `--dev` flag on the `garden deploy` command.
+
+See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for more information.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].devMode.defaults.exclude[]`
+
+[providers](#providers) > [devMode](#providersdevmode) > [defaults](#providersdevmodedefaults) > exclude
+
+Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+
+Any exclusion patterns defined in individual dev mode sync specs will be applied in addition to these patterns.
+
+`.git` directories and `.garden` directories are always ignored.
+
+| Type               | Required |
+| ------------------ | -------- |
+| `array[posixPath]` | No       |
+
+Example:
+
+```yaml
+providers:
+  - devMode:
+      ...
+      defaults:
+        ...
+        exclude:
+          - dist/**/*
+          - '*.log'
+```
+
+### `providers[].devMode.defaults.fileMode`
+
+[providers](#providers) > [devMode](#providersdevmode) > [defaults](#providersdevmodedefaults) > fileMode
+
+The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600 (user read/write). See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
+
+| Type     | Required |
+| -------- | -------- |
+| `number` | No       |
+
+### `providers[].devMode.defaults.directoryMode`
+
+[providers](#providers) > [devMode](#providersdevmode) > [defaults](#providersdevmodedefaults) > directoryMode
+
+The default permission bits, specified as an octal, to set on directories at the sync target. Defaults to 0700 (user read/write). See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
+
+| Type     | Required |
+| -------- | -------- |
+| `number` | No       |
+
+### `providers[].devMode.defaults.owner`
+
+[providers](#providers) > [devMode](#providersdevmode) > [defaults](#providersdevmodedefaults) > owner
+
+Set the default owner of files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
+
+| Type              | Required |
+| ----------------- | -------- |
+| `number | string` | No       |
+
+### `providers[].devMode.defaults.group`
+
+[providers](#providers) > [devMode](#providersdevmode) > [defaults](#providersdevmodedefaults) > group
+
+Set the default group on files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
+
+| Type              | Required |
+| ----------------- | -------- |
+| `number | string` | No       |
 
 ### `providers[].forceSsl`
 

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -107,10 +107,55 @@ providers:
     # A default hostname to use when no hostname is explicitly configured for a service.
     defaultHostname:
 
-    # Defines the strategy for deploying the project services.
-    # Default is "rolling update" and there is experimental support for "blue/green" deployment.
-    # The feature only supports modules of type `container`: other types will just deploy using the default strategy.
+    # Sets the deployment strategy for `container` services.
+    #
+    # The default is `"rolling"`, which performs rolling updates. There is also experimental support for blue/green
+    # deployments (via the `"blue-green"` strategy).
+    #
+    # Note that this setting only applies to `container` services (and not, for example,  `kubernetes` or `helm`
+    # services).
     deploymentStrategy: rolling
+
+    # Configuration options for dev mode.
+    devMode:
+      # Specifies default settings for dev mode syncs (e.g. for `container`, `kubernetes` and `helm` services).
+      #
+      # These are overridden/extended by the settings of any individual dev mode sync specs for a given module or
+      # service.
+      #
+      # Dev mode is enabled when running the `garden dev` command, and by setting the `--dev` flag on the `garden
+      # deploy` command.
+      #
+      # See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for more
+      # information.
+      defaults:
+        # Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+        #
+        # Any exclusion patterns defined in individual dev mode sync specs will be applied in addition to these
+        # patterns.
+        #
+        # `.git` directories and `.garden` directories are always ignored.
+        exclude:
+
+        # The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600
+        # (user read/write). See the [Mutagen
+        # docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
+        fileMode:
+
+        # The default permission bits, specified as an octal, to set on directories at the sync target. Defaults to
+        # 0700 (user read/write). See the [Mutagen
+        # docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
+        directoryMode:
+
+        # Set the default owner of files and directories at the target. Specify either an integer ID or a string name.
+        # See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for
+        # more information.
+        owner:
+
+        # Set the default group on files and directories at the target. Specify either an integer ID or a string name.
+        # See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for
+        # more information.
+        group:
 
     # Require SSL on all `container` module services. If set to true, an error is raised when no certificate is
     # available for a configured hostname on a `container` module.
@@ -589,13 +634,108 @@ providers:
 **Experimental**: this is an experimental feature and the API might change in the future.
 {% endhint %}
 
-Defines the strategy for deploying the project services.
-Default is "rolling update" and there is experimental support for "blue/green" deployment.
-The feature only supports modules of type `container`: other types will just deploy using the default strategy.
+Sets the deployment strategy for `container` services.
+
+The default is `"rolling"`, which performs rolling updates. There is also experimental support for blue/green deployments (via the `"blue-green"` strategy).
+
+Note that this setting only applies to `container` services (and not, for example,  `kubernetes` or `helm` services).
 
 | Type     | Default     | Required |
 | -------- | ----------- | -------- |
 | `string` | `"rolling"` | No       |
+
+### `providers[].devMode`
+
+[providers](#providers) > devMode
+
+Configuration options for dev mode.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].devMode.defaults`
+
+[providers](#providers) > [devMode](#providersdevmode) > defaults
+
+Specifies default settings for dev mode syncs (e.g. for `container`, `kubernetes` and `helm` services).
+
+These are overridden/extended by the settings of any individual dev mode sync specs for a given module or service.
+
+Dev mode is enabled when running the `garden dev` command, and by setting the `--dev` flag on the `garden deploy` command.
+
+See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for more information.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].devMode.defaults.exclude[]`
+
+[providers](#providers) > [devMode](#providersdevmode) > [defaults](#providersdevmodedefaults) > exclude
+
+Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+
+Any exclusion patterns defined in individual dev mode sync specs will be applied in addition to these patterns.
+
+`.git` directories and `.garden` directories are always ignored.
+
+| Type               | Required |
+| ------------------ | -------- |
+| `array[posixPath]` | No       |
+
+Example:
+
+```yaml
+providers:
+  - devMode:
+      ...
+      defaults:
+        ...
+        exclude:
+          - dist/**/*
+          - '*.log'
+```
+
+### `providers[].devMode.defaults.fileMode`
+
+[providers](#providers) > [devMode](#providersdevmode) > [defaults](#providersdevmodedefaults) > fileMode
+
+The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600 (user read/write). See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
+
+| Type     | Required |
+| -------- | -------- |
+| `number` | No       |
+
+### `providers[].devMode.defaults.directoryMode`
+
+[providers](#providers) > [devMode](#providersdevmode) > [defaults](#providersdevmodedefaults) > directoryMode
+
+The default permission bits, specified as an octal, to set on directories at the sync target. Defaults to 0700 (user read/write). See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
+
+| Type     | Required |
+| -------- | -------- |
+| `number` | No       |
+
+### `providers[].devMode.defaults.owner`
+
+[providers](#providers) > [devMode](#providersdevmode) > [defaults](#providersdevmodedefaults) > owner
+
+Set the default owner of files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
+
+| Type              | Required |
+| ----------------- | -------- |
+| `number | string` | No       |
+
+### `providers[].devMode.defaults.group`
+
+[providers](#providers) > [devMode](#providersdevmode) > [defaults](#providersdevmodedefaults) > group
+
+Set the default group on files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
+
+| Type              | Required |
+| ----------------- | -------- |
+| `number | string` | No       |
 
 ### `providers[].forceSsl`
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Added `one-way-reverse` and `one-way-replica-reverse` sync modes for dev mode when using `container`, `kubernetes` and `helm` services.

This adds a great deal of flexibility and specificity when a full two-way sync is not desirable (especially since conflicts can happen with the `two-way-safe` Mutagen mode).

Also expanded the dev mode guide.

Excludes and permission/owner/group settings can now be set on the provider level for `kubernetes` and `local-kubernetes`.

Defaults specified there will be extended/overridden by corresponding settings on individual sync specs.

This helps reduce clutter when the same excludes and permission settings are commonly applied across services/modules.