### PR TITLE
fix(workflows): defer provider resolution

### DIFF
--- a/core/src/commands/base.ts
+++ b/core/src/commands/base.ts
@@ -59,10 +59,6 @@ export interface PrepareParams<T extends Parameters = {}, U extends Parameters =
 
 export interface CommandParams<T extends Parameters = {}, U extends Parameters = {}> extends PrepareParams<T, U> {
   garden: Garden
-  /**
-   * Only use when running a workflow step command (in which case `true` should be passed).
-   */
-  isWorkflowStepCommand?: boolean
 }
 
 interface PrepareOutput {

--- a/core/src/commands/build.ts
+++ b/core/src/commands/build.ts
@@ -90,7 +90,6 @@ export class BuildCommand extends Command<Args, Opts> {
 
   async action({
     garden,
-    isWorkflowStepCommand,
     log,
     footerLog,
     args,
@@ -104,7 +103,7 @@ export class BuildCommand extends Command<Args, Opts> {
 
     await garden.clearBuilds()
 
-    const graph = await garden.getConfigGraph({ log, emit: !isWorkflowStepCommand })
+    const graph = await garden.getConfigGraph({ log, emit: true })
     const modules = graph.getModules({ names: args.modules })
     const moduleNames = modules.map((m) => m.name)
 

--- a/core/src/commands/call.ts
+++ b/core/src/commands/call.ts
@@ -66,11 +66,11 @@ export class CallCommand extends Command<Args> {
     printHeader(headerLog, "Call", "telephone_receiver")
   }
 
-  async action({ garden, isWorkflowStepCommand, log, args }: CommandParams<Args>): Promise<CommandResult<CallResult>> {
+  async action({ garden, log, args }: CommandParams<Args>): Promise<CommandResult<CallResult>> {
     let [serviceName, path] = splitFirst(args.serviceAndPath, "/")
 
     // TODO: better error when service doesn't exist
-    const graph = await garden.getConfigGraph({ log, emit: !isWorkflowStepCommand })
+    const graph = await garden.getConfigGraph({ log, emit: true })
     const service = graph.getService(serviceName)
     // No need for full context, since we're just checking if the service is running.
     const runtimeContext = emptyRuntimeContext

--- a/core/src/commands/delete.ts
+++ b/core/src/commands/delete.ts
@@ -110,10 +110,10 @@ export class DeleteEnvironmentCommand extends Command {
     printHeader(headerLog, `Deleting environment`, "skull_and_crossbones")
   }
 
-  async action({ garden, isWorkflowStepCommand, log }: CommandParams): Promise<CommandResult<DeleteEnvironmentResult>> {
+  async action({ garden, log }: CommandParams): Promise<CommandResult<DeleteEnvironmentResult>> {
     const actions = await garden.getActionRouter()
 
-    const graph = await garden.getConfigGraph({ log, emit: !isWorkflowStepCommand })
+    const graph = await garden.getConfigGraph({ log, emit: true })
     const serviceStatuses = await actions.deleteServices(graph, log)
 
     log.info("")
@@ -159,8 +159,8 @@ export class DeleteServiceCommand extends Command {
     printHeader(headerLog, "Delete service", "skull_and_crossbones")
   }
 
-  async action({ garden, isWorkflowStepCommand, log, args }: CommandParams<DeleteServiceArgs>): Promise<CommandResult> {
-    const graph = await garden.getConfigGraph({ log, emit: !isWorkflowStepCommand })
+  async action({ garden, log, args }: CommandParams<DeleteServiceArgs>): Promise<CommandResult> {
+    const graph = await garden.getConfigGraph({ log, emit: true })
     const services = graph.getServices({ names: args.services })
 
     if (services.length === 0) {

--- a/core/src/commands/deploy.ts
+++ b/core/src/commands/deploy.ts
@@ -137,7 +137,6 @@ export class DeployCommand extends Command<Args, Opts> {
 
   async action({
     garden,
-    isWorkflowStepCommand,
     log,
     footerLog,
     args,
@@ -149,7 +148,7 @@ export class DeployCommand extends Command<Args, Opts> {
       this.server.setGarden(garden)
     }
 
-    const initGraph = await garden.getConfigGraph({ log, emit: !isWorkflowStepCommand })
+    const initGraph = await garden.getConfigGraph({ log, emit: true })
     let services = initGraph.getServices({ names: args.services, includeDisabled: true })
 
     const disabled = services.filter((s) => s.disabled).map((s) => s.name)

--- a/core/src/commands/dev.ts
+++ b/core/src/commands/dev.ts
@@ -119,7 +119,6 @@ export class DevCommand extends Command<DevCommandArgs, DevCommandOpts> {
 
   async action({
     garden,
-    isWorkflowStepCommand,
     log,
     footerLog,
     args,
@@ -128,7 +127,7 @@ export class DevCommand extends Command<DevCommandArgs, DevCommandOpts> {
     this.garden = garden
     this.server?.setGarden(garden)
 
-    const graph = await garden.getConfigGraph({ log, emit: !isWorkflowStepCommand })
+    const graph = await garden.getConfigGraph({ log, emit: true })
     const modules = graph.getModules()
 
     const skipTests = opts["skip-tests"]

--- a/core/src/commands/get/get-status.ts
+++ b/core/src/commands/get/get-status.ts
@@ -66,14 +66,9 @@ export class GetStatusCommand extends Command {
     printHeader(headerLog, "Get status", "pager")
   }
 
-  async action({
-    garden,
-    isWorkflowStepCommand,
-    log,
-    opts,
-  }: CommandParams): Promise<CommandResult<StatusCommandResult>> {
+  async action({ garden, log, opts }: CommandParams): Promise<CommandResult<StatusCommandResult>> {
     const actions = await garden.getActionRouter()
-    const graph = await garden.getConfigGraph({ log, emit: !isWorkflowStepCommand })
+    const graph = await garden.getConfigGraph({ log, emit: true })
 
     const envStatus = await garden.getEnvironmentStatus(log)
     const serviceStatuses = await actions.getServiceStatuses({ log, graph })

--- a/core/src/commands/get/get-task-result.ts
+++ b/core/src/commands/get/get-task-result.ts
@@ -52,15 +52,10 @@ export class GetTaskResultCommand extends Command<Args> {
     printHeader(headerLog, `Task result for task ${chalk.cyan(taskName)}`, "rocket")
   }
 
-  async action({
-    garden,
-    isWorkflowStepCommand,
-    log,
-    args,
-  }: CommandParams<Args>): Promise<CommandResult<GetTaskResultCommandResult>> {
+  async action({ garden, log, args }: CommandParams<Args>): Promise<CommandResult<GetTaskResultCommandResult>> {
     const taskName = args.name
 
-    const graph: ConfigGraph = await garden.getConfigGraph({ log, emit: !isWorkflowStepCommand })
+    const graph: ConfigGraph = await garden.getConfigGraph({ log, emit: true })
     const task = graph.getTask(taskName)
 
     const actions = await garden.getActionRouter()

--- a/core/src/commands/get/get-test-result.ts
+++ b/core/src/commands/get/get-test-result.ts
@@ -61,16 +61,11 @@ export class GetTestResultCommand extends Command<Args> {
     )
   }
 
-  async action({
-    garden,
-    isWorkflowStepCommand,
-    log,
-    args,
-  }: CommandParams<Args>): Promise<CommandResult<GetTestResultCommandResult>> {
+  async action({ garden, log, args }: CommandParams<Args>): Promise<CommandResult<GetTestResultCommandResult>> {
     const testName = args.name
     const moduleName = args.module
 
-    const graph = await garden.getConfigGraph({ log, emit: !isWorkflowStepCommand })
+    const graph = await garden.getConfigGraph({ log, emit: true })
     const actions = await garden.getActionRouter()
 
     const module = graph.getModule(moduleName)

--- a/core/src/commands/publish.ts
+++ b/core/src/commands/publish.ts
@@ -103,13 +103,12 @@ export class PublishCommand extends Command<Args, Opts> {
 
   async action({
     garden,
-    isWorkflowStepCommand,
     log,
     footerLog,
     args,
     opts,
   }: CommandParams<Args, Opts>): Promise<CommandResult<PublishCommandResult>> {
-    const graph = await garden.getConfigGraph({ log, emit: !isWorkflowStepCommand })
+    const graph = await garden.getConfigGraph({ log, emit: true })
     const modules = graph.getModules({ names: args.modules })
 
     const results = await publishModules({

--- a/core/src/commands/run/task.ts
+++ b/core/src/commands/run/task.ts
@@ -80,14 +80,8 @@ export class RunTaskCommand extends Command<Args, Opts> {
     printHeader(headerLog, msg, "runner")
   }
 
-  async action({
-    garden,
-    isWorkflowStepCommand,
-    log,
-    args,
-    opts,
-  }: CommandParams<Args, Opts>): Promise<CommandResult<RunTaskOutput>> {
-    const graph = await garden.getConfigGraph({ log, emit: !isWorkflowStepCommand })
+  async action({ garden, log, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<RunTaskOutput>> {
+    const graph = await garden.getConfigGraph({ log, emit: true })
     const task = graph.getTask(args.task, true)
 
     if (task.disabled && !opts.force) {

--- a/core/src/commands/run/test.ts
+++ b/core/src/commands/run/test.ts
@@ -93,17 +93,11 @@ export class RunTestCommand extends Command<Args, Opts> {
     printHeader(headerLog, `Running test ${chalk.cyan(args.test)}`, "runner")
   }
 
-  async action({
-    garden,
-    isWorkflowStepCommand,
-    log,
-    args,
-    opts,
-  }: CommandParams<Args, Opts>): Promise<CommandResult<RunTestOutput>> {
+  async action({ garden, log, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<RunTestOutput>> {
     const moduleName = args.module
     const testName = args.test
 
-    const graph = await garden.getConfigGraph({ log, emit: !isWorkflowStepCommand })
+    const graph = await garden.getConfigGraph({ log, emit: true })
     const module = graph.getModule(moduleName, true)
 
     const testConfig = findByName(module.testConfigs, testName)

--- a/core/src/commands/run/workflow.ts
+++ b/core/src/commands/run/workflow.ts
@@ -89,7 +89,6 @@ export class RunWorkflowCommand extends Command<Args, {}> {
     const steps = workflow.steps
     const allStepNames = steps.map((s, i) => getStepName(i, s.name))
     const startedAt = new Date().valueOf()
-    await maybeEmitStackGraphEvent(garden, log, workflow)
 
     const result: WorkflowRunOutput = {
       steps: {},
@@ -331,7 +330,6 @@ export async function runStepCommand({
     headerLog,
     args,
     opts: merge(inheritedOpts, opts),
-    isWorkflowStepCommand: true, // <-----
   })
   return result
 }
@@ -452,27 +450,6 @@ async function registerAndSetUid(garden: Garden, log: LogEntry, config: Workflow
       log,
     })
     garden.events.emit("_workflowRunRegistered", { workflowRunUid })
-  }
-}
-
-/**
- * If one or more steps of the workflow is a command with `streamEvents = true`, we prepare a `ConfigGraph` instance
- * and stream a stack graph event.
- *
- * This is only done once at the beginning of the workflow to avoid streaming the graph for every subcommand having
- * `streamEvents = true` (since we're also passing `isStepCommand = true` to the step command action in
- * `runStepCommand`).
- */
-async function maybeEmitStackGraphEvent(garden: Garden, log: LogEntry, config: WorkflowConfig) {
-  const shouldEmitStackGraphEvent = config.steps.find((s) => {
-    if (!s.command) {
-      return false
-    }
-    const { command } = pickCommand(getAllCommands(), s.command)
-    return command && command.streamEvents
-  })
-  if (shouldEmitStackGraphEvent) {
-    await garden.getConfigGraph({ log, emit: true })
   }
 }
 

--- a/core/src/commands/test.ts
+++ b/core/src/commands/test.ts
@@ -119,7 +119,6 @@ export class TestCommand extends Command<Args, Opts> {
 
   async action({
     garden,
-    isWorkflowStepCommand,
     log,
     footerLog,
     args,
@@ -131,7 +130,7 @@ export class TestCommand extends Command<Args, Opts> {
       this.server.setGarden(garden)
     }
 
-    const graph = await garden.getConfigGraph({ log, emit: !isWorkflowStepCommand })
+    const graph = await garden.getConfigGraph({ log, emit: true })
     const skipDependants = opts["skip-dependants"]
     let modules: GardenModule[]
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

This fixes a regression introduced in `6382d3d` (emit stack graph & task log events), where we began emitting `stackGraph` events before running the workflow's steps.

This caused problems for workflows that rely on script steps to prepare authentication for providers (e.g. k8s credentials).

We now simply emit the `stackGraph` event from the relevant step commands.