### PR TITLE
fix(core): omit `output.detail` from graph events

### DIFF
--- a/core/src/events.ts
+++ b/core/src/events.ts
@@ -74,7 +74,8 @@ export interface ServiceStatusPayload extends Omit<ServiceStatus, "detail"> {
 export function toGraphResultEventPayload(result: GraphResult): GraphResultEventPayload {
   const payload = omit(result, "dependencyResults")
   if (result.output) {
-    payload.output = omit(result.output, "dependencyResults", "log", "buildLog")
+    // TODO: Use a combined blacklist of fields from all task types instead of hardcoding here.
+    payload.output = omit(result.output, "dependencyResults", "log", "buildLog", "detail")
     if (result.output.version) {
       payload.output.version = result.output.version.versionString || null
     }


### PR DESCRIPTION
**What this PR does / why we need it**:

The values for this field can sometimes be too large to be reliably streamed.