### PR TITLE
fix(cli): get rid of occasional EPIPE error printed after process exit

### DIFF
--- a/core/src/proxy.ts
+++ b/core/src/proxy.ts
@@ -290,6 +290,9 @@ function stopPortProxy(proxy: PortProxy, log?: LogEntry) {
   delete activeProxies[proxy.key]
 
   try {
+    // Avoid EPIPE errors
+    proxy.server.on("error", () => {})
+
     proxy.server.close()
   } catch {}
 }


### PR DESCRIPTION
I _think_ this will do it, at least I can't seem to reproduce with the
fix in place. Maybe give it a spin during review to be sure.
