### PR TITLE
fix(core): don't add mutating env vars to runtime context

### DIFF
--- a/core/src/runtime-context.ts
+++ b/core/src/runtime-context.ts
@@ -6,14 +6,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { getEnvVarName } from "./util/util"
 import { PrimitiveMap, joiEnvVars, joiPrimitive, joi, joiIdentifier, moduleVersionSchema } from "./config/common"
 import { Garden } from "./garden"
 import { ConfigGraph, DependencyRelations } from "./config-graph"
 import { ServiceStatus } from "./types/service"
 import { RunTaskResult } from "./types/plugin/task/runTask"
 import { joiArray } from "./config/common"
-import { isPrimitive } from "util"
 
 interface RuntimeDependency {
   moduleName: string
@@ -79,7 +77,6 @@ interface PrepareRuntimeContextParams {
  * This should be called just ahead of calling relevant service, task and test action handlers.
  */
 export async function prepareRuntimeContext({
-  garden,
   dependencies,
   serviceStatuses,
   taskResults,
@@ -89,15 +86,6 @@ export async function prepareRuntimeContext({
   const envVars = {
     GARDEN_VERSION: version,
     GARDEN_MODULE_VERSION: moduleVersion,
-  }
-
-  // DEPRECATED: Remove in v0.13
-  for (const [key, value] of Object.entries(garden.variables)) {
-    // Only store primitive values, objects and arrays cause issues further down.
-    if (isPrimitive(value)) {
-      const envVarName = `GARDEN_VARIABLES_${getEnvVarName(key)}`
-      envVars[envVarName] = value
-    }
   }
 
   const result: RuntimeContext = {
@@ -147,7 +135,5 @@ export async function prepareRuntimeContext({
     })
   }
 
-  // Make the full list of dependencies without outputs available as JSON as well
-  result.envVars.GARDEN_DEPENDENCIES = JSON.stringify(result.dependencies.map((d) => ({ ...d, outputs: undefined })))
   return result
 }

--- a/core/test/unit/src/runtime-context.ts
+++ b/core/test/unit/src/runtime-context.ts
@@ -11,7 +11,6 @@ import { makeTestGardenA } from "../../helpers"
 import { ConfigGraph } from "../../../src/config-graph"
 import { prepareRuntimeContext } from "../../../src/runtime-context"
 import { expect } from "chai"
-import { omit } from "lodash"
 
 describe("prepareRuntimeContext", () => {
   let garden: Garden
@@ -42,29 +41,6 @@ describe("prepareRuntimeContext", () => {
 
     expect(runtimeContext.envVars.GARDEN_VERSION).to.equal(module.version.versionString)
     expect(runtimeContext.envVars.GARDEN_MODULE_VERSION).to.equal(module.version.versionString)
-  })
-
-  it("should add project variables to the output envVars", async () => {
-    const module = graph.getModule("module-a")
-
-    garden["variables"]["my-var"] = "foo"
-
-    const runtimeContext = await prepareRuntimeContext({
-      garden,
-      graph,
-      version: module.version.versionString,
-      moduleVersion: module.version.versionString,
-      dependencies: {
-        build: [],
-        deploy: [],
-        run: [],
-        test: [],
-      },
-      serviceStatuses: {},
-      taskResults: {},
-    })
-
-    expect(runtimeContext.envVars.GARDEN_VARIABLES_MY_VAR).to.equal("foo")
   })
 
   it("should add outputs for every build dependency output", async () => {
@@ -183,29 +159,5 @@ describe("prepareRuntimeContext", () => {
         version: taskB.version,
       },
     ])
-  })
-
-  it("should output the list of dependencies as an env variable", async () => {
-    const module = graph.getModule("module-a")
-    const serviceB = graph.getService("service-b")
-    const taskB = graph.getTask("task-c")
-
-    const runtimeContext = await prepareRuntimeContext({
-      garden,
-      graph,
-      version: module.version.versionString,
-      moduleVersion: module.version.versionString,
-      dependencies: {
-        build: [],
-        deploy: [serviceB],
-        run: [taskB],
-        test: [],
-      },
-      serviceStatuses: {},
-      taskResults: {},
-    })
-
-    const parsed = JSON.parse(runtimeContext.envVars.GARDEN_DEPENDENCIES as string)
-    expect(parsed).to.eql(runtimeContext.dependencies.map((d) => omit(d, "outputs")))
   })
 })


### PR DESCRIPTION
This was causing unnecessary re-deployments of container modules.
We had previously flagged this as a breaking change, but on reflection
this behavior is undocumented and should not have been used for a long
while now, and it's causing meaningful user issues.
