### PR TITLE
Update kubectl and fix ingress spec casing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -734,6 +734,14 @@ workflows:
   # variant and k8s version would be quite expensive, so we try and make sure each of the latest 6-7 k8s versions is
   # tested, and that the most recent versions are broadly tested. The kind tests are the cheapest to run so we use many
   # of those, but they currently don't test in-cluster building, so we do need a range of versions on minikube as well.
+  test-minikube-1.22:
+    jobs:
+      - test-minikube:
+          kubernetesVersion: "1.22.2"
+          minikubeVersion: "v1.23.2"
+          # OpenFaaS project fails without ingress, which doesn't work in CircleCI on minikube v1.12+, which is necessary
+          # for most recent k8s versions.
+          testOpenfaas: false
   test-minikube-1.20:
     jobs:
       - test-minikube:
@@ -746,12 +754,6 @@ workflows:
     jobs:
       - test-minikube:
           kubernetesVersion: "1.19.7"
-          minikubeVersion: "v1.16.0"
-          testOpenfaas: false
-  test-minikube-1.18:
-    jobs:
-      - test-minikube:
-          kubernetesVersion: "1.18.15"
           minikubeVersion: "v1.16.0"
           testOpenfaas: false
   test-minikube-1.14:

--- a/core/src/plugins/kubernetes/container/ingress.ts
+++ b/core/src/plugins/kubernetes/container/ingress.ts
@@ -92,7 +92,7 @@ export async function createIngressResources(
                 paths: [
                   {
                     path: ingress.path,
-                    pathType: "prefix",
+                    pathType: "Prefix",
                     backend: {
                       service: {
                         name: service.name,

--- a/core/src/plugins/kubernetes/kubectl.ts
+++ b/core/src/plugins/kubernetes/kubectl.ts
@@ -219,20 +219,20 @@ export const kubectlSpec: PluginToolSpec = {
     {
       platform: "darwin",
       architecture: "amd64",
-      url: "https://storage.googleapis.com/kubernetes-release/release/v1.20.2/bin/darwin/amd64/kubectl",
-      sha256: "c4b120ab1284222afbc15f28e4e7d8dfcfc3ad2435bd17e5bfec62e17036623c",
+      url: "https://storage.googleapis.com/kubernetes-release/release/v1.22.3/bin/darwin/amd64/kubectl",
+      sha256: "beea08a2a166a002603e2aa015223b5ba558d6e3f6a81098e3cc5d7d2b7a64d9",
     },
     {
       platform: "linux",
       architecture: "amd64",
-      url: "https://storage.googleapis.com/kubernetes-release/release/v1.20.2/bin/linux/amd64/kubectl",
-      sha256: "2583b1c9fbfc5443a722fb04cf0cc83df18e45880a2cf1f6b52d9f595c5beb88",
+      url: "https://storage.googleapis.com/kubernetes-release/release/v1.22.3/bin/linux/amd64/kubectl",
+      sha256: "0751808ca8d7daba56bf76b08848ef5df6b887e9d7e8a9030dd3711080e37b54",
     },
     {
       platform: "windows",
       architecture: "amd64",
-      url: "https://storage.googleapis.com/kubernetes-release/release/v1.20.2/bin/windows/amd64/kubectl.exe",
-      sha256: "d8731ac97166c506441e5d2f69e31d57356983ae15602ba12cc16981862bfdef",
+      url: "https://storage.googleapis.com/kubernetes-release/release/v1.22.3/bin/windows/amd64/kubectl.exe",
+      sha256: "c1c148569b1aa500fc46151756c497d7fbbff0789f316d7be444ace1dc793593"
     },
   ],
 }

--- a/core/src/types/plugin/tools.ts
+++ b/core/src/types/plugin/tools.ts
@@ -40,7 +40,7 @@ const toolBuildSchema = () =>
       .string()
       .required()
       .example("a81b23abe67e70f8395ff7a3659bea6610fba98cda1126ef19e0a995f0075d54")
-      .description("The SHA256 sum the target URL should have."),
+      .description("The SHA256 sum the target file should have."),
     extract: joi
       .object()
       .keys({


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixed casing in ingress spec (to use Proper Case). This was causing problems on newer versions of Minikube.

Also updated kubectl to 1.22.2.

**Which issue(s) this PR fixes**:

Fixes #2573.