### PR TITLE
improvement(dev-mode): log sync conflicts

### DIFF
--- a/core/src/plugins/kubernetes/dev-mode.ts
+++ b/core/src/plugins/kubernetes/dev-mode.ts
@@ -237,11 +237,11 @@ export async function startDevModeSync({
 
       const description = `${sourceDescription} to ${targetDescription}`
 
-      ctx.log.info({ symbol: "info", section: serviceName, msg: chalk.gray(`Syncing ${description} (${s.mode})`) })
+      log.info({ symbol: "info", section: serviceName, msg: chalk.gray(`Syncing ${description} (${s.mode})`) })
 
       await ensureMutagenSync({
         // Prefer to log to the main view instead of the handler log context
-        log: ctx.log,
+        log,
         key,
         logSection: serviceName,
         sourceDescription,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

We now log an informative warning message when mutagen sync conflicts are detected.

We've also started logging more sync-related log lines again to make it clear to the user when the sync has been established (and which pairs are being synced).

<img width="620" alt="Screenshot 2021-09-28 at 17 21 27" src="https://user-images.githubusercontent.com/382137/135168056-a1c96c00-193e-434d-9083-8ead63bf5b0b.png">

