### PR TITLE
feat(config): allow skipping source template rendering in generateFiles

### DIFF
--- a/core/src/config/module.ts
+++ b/core/src/config/module.ts
@@ -71,6 +71,7 @@ export interface BaseBuildSpec {
 export interface ModuleFileSpec {
   sourcePath?: string
   targetPath: string
+  resolveTemplates: boolean
   value?: string
 }
 
@@ -128,6 +129,13 @@ const generatedFileSchema = () =>
 
           Note that any existing file with the same name will be overwritten. If the path contains one or more directories, they will be automatically created if missing.
           `
+        ),
+      resolveTemplates: joi
+        .boolean()
+        // TODO: flip this default in 0.13?
+        .default(true)
+        .description(
+          "By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to skip resolving template strings. Note that this does not apply when setting the `value` field, since that's resolved earlier when parsing the configuration."
         ),
       value: joi.string().description("The desired file contents as a string."),
     })

--- a/core/src/resolve-module.ts
+++ b/core/src/resolve-module.ts
@@ -429,10 +429,23 @@ export class ModuleResolver {
       if (fileSpec.sourcePath) {
         const configDir = resolvedConfig.configPath ? dirname(resolvedConfig.configPath) : resolvedConfig.path
         const sourcePath = resolve(configDir, fileSpec.sourcePath)
-        contents = (await readFile(sourcePath)).toString()
+
+        try {
+          contents = (await readFile(sourcePath)).toString()
+        } catch (err) {
+          throw new ConfigurationError(
+            `Unable to read file at ${sourcePath}, specified under generateFiles in module ${resolvedConfig.name}: ${err}`,
+            {
+              sourcePath,
+            }
+          )
+        }
       }
 
-      const resolvedContents = resolveTemplateString(contents, configContext, { unescape: true })
+      const resolvedContents = fileSpec.resolveTemplates
+        ? resolveTemplateString(contents, configContext, { unescape: true })
+        : contents
+
       const targetDir = resolve(resolvedConfig.path, ...posix.dirname(fileSpec.targetPath).split(posix.sep))
       const targetPath = resolve(resolvedConfig.path, ...fileSpec.targetPath.split(posix.sep))
 

--- a/core/test/unit/src/config/module-template.ts
+++ b/core/test/unit/src/config/module-template.ts
@@ -250,7 +250,7 @@ describe("module templates", () => {
             {
               type: "test",
               name: "foo",
-              generateFiles: [{ sourcePath: "foo/bar.txt", targetPath: "foo.txt" }],
+              generateFiles: [{ sourcePath: "foo/bar.txt", targetPath: "foo.txt", resolveTemplates: true }],
             },
           ],
         },

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1474,6 +1474,11 @@ providers:
             # directories, they will be automatically created if missing.
             targetPath:
 
+            # By default, Garden will attempt to resolve any Garden template strings in source files. Set this to
+            # false to skip resolving template strings. Note that this does not apply when setting the `value` field,
+            # since that's resolved earlier when parsing the configuration.
+            resolveTemplates:
+
             # The desired file contents as a string.
             value:
 
@@ -1747,6 +1752,11 @@ moduleConfigs:
         # Note that any existing file with the same name will be overwritten. If the path contains one or more
         # directories, they will be automatically created if missing.
         targetPath:
+
+        # By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to
+        # skip resolving template strings. Note that this does not apply when setting the `value` field, since that's
+        # resolved earlier when parsing the configuration.
+        resolveTemplates:
 
         # The desired file contents as a string.
         value:
@@ -2251,6 +2261,11 @@ modules:
         # Note that any existing file with the same name will be overwritten. If the path contains one or more
         # directories, they will be automatically created if missing.
         targetPath:
+
+        # By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to
+        # skip resolving template strings. Note that this does not apply when setting the `value` field, since that's
+        # resolved earlier when parsing the configuration.
+        resolveTemplates:
 
         # The desired file contents as a string.
         value:

--- a/docs/reference/module-template-config.md
+++ b/docs/reference/module-template-config.md
@@ -147,6 +147,11 @@ modules:
         # directories, they will be automatically created if missing.
         targetPath:
 
+        # By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to
+        # skip resolving template strings. Note that this does not apply when setting the `value` field, since that's
+        # resolved earlier when parsing the configuration.
+        resolveTemplates: true
+
         # The desired file contents as a string.
         value:
 
@@ -469,6 +474,16 @@ Note that any existing file with the same name will be overwritten. If the path 
 | Type        | Required |
 | ----------- | -------- |
 | `posixPath` | Yes      |
+
+### `modules[].generateFiles[].resolveTemplates`
+
+[modules](#modules) > [generateFiles](#modulesgeneratefiles) > resolveTemplates
+
+By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to skip resolving template strings. Note that this does not apply when setting the `value` field, since that's resolved earlier when parsing the configuration.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 ### `modules[].generateFiles[].value`
 

--- a/docs/reference/module-types/configmap.md
+++ b/docs/reference/module-types/configmap.md
@@ -122,6 +122,11 @@ generateFiles:
     # directories, they will be automatically created if missing.
     targetPath:
 
+    # By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to
+    # skip resolving template strings. Note that this does not apply when setting the `value` field, since that's
+    # resolved earlier when parsing the configuration.
+    resolveTemplates: true
+
     # The desired file contents as a string.
     value:
 
@@ -377,6 +382,16 @@ Note that any existing file with the same name will be overwritten. If the path 
 | Type        | Required |
 | ----------- | -------- |
 | `posixPath` | Yes      |
+
+### `generateFiles[].resolveTemplates`
+
+[generateFiles](#generatefiles) > resolveTemplates
+
+By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to skip resolving template strings. Note that this does not apply when setting the `value` field, since that's resolved earlier when parsing the configuration.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 ### `generateFiles[].value`
 

--- a/docs/reference/module-types/conftest.md
+++ b/docs/reference/module-types/conftest.md
@@ -125,6 +125,11 @@ generateFiles:
     # directories, they will be automatically created if missing.
     targetPath:
 
+    # By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to
+    # skip resolving template strings. Note that this does not apply when setting the `value` field, since that's
+    # resolved earlier when parsing the configuration.
+    resolveTemplates: true
+
     # The desired file contents as a string.
     value:
 
@@ -388,6 +393,16 @@ Note that any existing file with the same name will be overwritten. If the path 
 | Type        | Required |
 | ----------- | -------- |
 | `posixPath` | Yes      |
+
+### `generateFiles[].resolveTemplates`
+
+[generateFiles](#generatefiles) > resolveTemplates
+
+By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to skip resolving template strings. Note that this does not apply when setting the `value` field, since that's resolved earlier when parsing the configuration.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 ### `generateFiles[].value`
 

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -137,6 +137,11 @@ generateFiles:
     # directories, they will be automatically created if missing.
     targetPath:
 
+    # By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to
+    # skip resolving template strings. Note that this does not apply when setting the `value` field, since that's
+    # resolved earlier when parsing the configuration.
+    resolveTemplates: true
+
     # The desired file contents as a string.
     value:
 
@@ -903,6 +908,16 @@ Note that any existing file with the same name will be overwritten. If the path 
 | Type        | Required |
 | ----------- | -------- |
 | `posixPath` | Yes      |
+
+### `generateFiles[].resolveTemplates`
+
+[generateFiles](#generatefiles) > resolveTemplates
+
+By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to skip resolving template strings. Note that this does not apply when setting the `value` field, since that's resolved earlier when parsing the configuration.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 ### `generateFiles[].value`
 

--- a/docs/reference/module-types/exec.md
+++ b/docs/reference/module-types/exec.md
@@ -135,6 +135,11 @@ generateFiles:
     # directories, they will be automatically created if missing.
     targetPath:
 
+    # By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to
+    # skip resolving template strings. Note that this does not apply when setting the `value` field, since that's
+    # resolved earlier when parsing the configuration.
+    resolveTemplates: true
+
     # The desired file contents as a string.
     value:
 
@@ -547,6 +552,16 @@ Note that any existing file with the same name will be overwritten. If the path 
 | Type        | Required |
 | ----------- | -------- |
 | `posixPath` | Yes      |
+
+### `generateFiles[].resolveTemplates`
+
+[generateFiles](#generatefiles) > resolveTemplates
+
+By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to skip resolving template strings. Note that this does not apply when setting the `value` field, since that's resolved earlier when parsing the configuration.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 ### `generateFiles[].value`
 

--- a/docs/reference/module-types/hadolint.md
+++ b/docs/reference/module-types/hadolint.md
@@ -128,6 +128,11 @@ generateFiles:
     # directories, they will be automatically created if missing.
     targetPath:
 
+    # By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to
+    # skip resolving template strings. Note that this does not apply when setting the `value` field, since that's
+    # resolved earlier when parsing the configuration.
+    resolveTemplates: true
+
     # The desired file contents as a string.
     value:
 
@@ -376,6 +381,16 @@ Note that any existing file with the same name will be overwritten. If the path 
 | Type        | Required |
 | ----------- | -------- |
 | `posixPath` | Yes      |
+
+### `generateFiles[].resolveTemplates`
+
+[generateFiles](#generatefiles) > resolveTemplates
+
+By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to skip resolving template strings. Note that this does not apply when setting the `value` field, since that's resolved earlier when parsing the configuration.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 ### `generateFiles[].value`
 

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -127,6 +127,11 @@ generateFiles:
     # directories, they will be automatically created if missing.
     targetPath:
 
+    # By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to
+    # skip resolving template strings. Note that this does not apply when setting the `value` field, since that's
+    # resolved earlier when parsing the configuration.
+    resolveTemplates: true
+
     # The desired file contents as a string.
     value:
 
@@ -788,6 +793,16 @@ Note that any existing file with the same name will be overwritten. If the path 
 | Type        | Required |
 | ----------- | -------- |
 | `posixPath` | Yes      |
+
+### `generateFiles[].resolveTemplates`
+
+[generateFiles](#generatefiles) > resolveTemplates
+
+By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to skip resolving template strings. Note that this does not apply when setting the `value` field, since that's resolved earlier when parsing the configuration.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 ### `generateFiles[].value`
 

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -155,6 +155,11 @@ generateFiles:
     # directories, they will be automatically created if missing.
     targetPath:
 
+    # By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to
+    # skip resolving template strings. Note that this does not apply when setting the `value` field, since that's
+    # resolved earlier when parsing the configuration.
+    resolveTemplates: true
+
     # The desired file contents as a string.
     value:
 
@@ -961,6 +966,16 @@ Note that any existing file with the same name will be overwritten. If the path 
 | Type        | Required |
 | ----------- | -------- |
 | `posixPath` | Yes      |
+
+### `generateFiles[].resolveTemplates`
+
+[generateFiles](#generatefiles) > resolveTemplates
+
+By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to skip resolving template strings. Note that this does not apply when setting the `value` field, since that's resolved earlier when parsing the configuration.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 ### `generateFiles[].value`
 

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -131,6 +131,11 @@ generateFiles:
     # directories, they will be automatically created if missing.
     targetPath:
 
+    # By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to
+    # skip resolving template strings. Note that this does not apply when setting the `value` field, since that's
+    # resolved earlier when parsing the configuration.
+    resolveTemplates: true
+
     # The desired file contents as a string.
     value:
 
@@ -717,6 +722,16 @@ Note that any existing file with the same name will be overwritten. If the path 
 | Type        | Required |
 | ----------- | -------- |
 | `posixPath` | Yes      |
+
+### `generateFiles[].resolveTemplates`
+
+[generateFiles](#generatefiles) > resolveTemplates
+
+By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to skip resolving template strings. Note that this does not apply when setting the `value` field, since that's resolved earlier when parsing the configuration.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 ### `generateFiles[].value`
 

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -137,6 +137,11 @@ generateFiles:
     # directories, they will be automatically created if missing.
     targetPath:
 
+    # By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to
+    # skip resolving template strings. Note that this does not apply when setting the `value` field, since that's
+    # resolved earlier when parsing the configuration.
+    resolveTemplates: true
+
     # The desired file contents as a string.
     value:
 
@@ -913,6 +918,16 @@ Note that any existing file with the same name will be overwritten. If the path 
 | Type        | Required |
 | ----------- | -------- |
 | `posixPath` | Yes      |
+
+### `generateFiles[].resolveTemplates`
+
+[generateFiles](#generatefiles) > resolveTemplates
+
+By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to skip resolving template strings. Note that this does not apply when setting the `value` field, since that's resolved earlier when parsing the configuration.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 ### `generateFiles[].value`
 

--- a/docs/reference/module-types/openfaas.md
+++ b/docs/reference/module-types/openfaas.md
@@ -121,6 +121,11 @@ generateFiles:
     # directories, they will be automatically created if missing.
     targetPath:
 
+    # By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to
+    # skip resolving template strings. Note that this does not apply when setting the `value` field, since that's
+    # resolved earlier when parsing the configuration.
+    resolveTemplates: true
+
     # The desired file contents as a string.
     value:
 
@@ -407,6 +412,16 @@ Note that any existing file with the same name will be overwritten. If the path 
 | Type        | Required |
 | ----------- | -------- |
 | `posixPath` | Yes      |
+
+### `generateFiles[].resolveTemplates`
+
+[generateFiles](#generatefiles) > resolveTemplates
+
+By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to skip resolving template strings. Note that this does not apply when setting the `value` field, since that's resolved earlier when parsing the configuration.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 ### `generateFiles[].value`
 

--- a/docs/reference/module-types/persistentvolumeclaim.md
+++ b/docs/reference/module-types/persistentvolumeclaim.md
@@ -122,6 +122,11 @@ generateFiles:
     # directories, they will be automatically created if missing.
     targetPath:
 
+    # By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to
+    # skip resolving template strings. Note that this does not apply when setting the `value` field, since that's
+    # resolved earlier when parsing the configuration.
+    resolveTemplates: true
+
     # The desired file contents as a string.
     value:
 
@@ -429,6 +434,16 @@ Note that any existing file with the same name will be overwritten. If the path 
 | Type        | Required |
 | ----------- | -------- |
 | `posixPath` | Yes      |
+
+### `generateFiles[].resolveTemplates`
+
+[generateFiles](#generatefiles) > resolveTemplates
+
+By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to skip resolving template strings. Note that this does not apply when setting the `value` field, since that's resolved earlier when parsing the configuration.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 ### `generateFiles[].value`
 

--- a/docs/reference/module-types/templated.md
+++ b/docs/reference/module-types/templated.md
@@ -125,6 +125,11 @@ generateFiles:
     # directories, they will be automatically created if missing.
     targetPath:
 
+    # By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to
+    # skip resolving template strings. Note that this does not apply when setting the `value` field, since that's
+    # resolved earlier when parsing the configuration.
+    resolveTemplates: true
+
     # The desired file contents as a string.
     value:
 
@@ -382,6 +387,16 @@ Note that any existing file with the same name will be overwritten. If the path 
 | Type        | Required |
 | ----------- | -------- |
 | `posixPath` | Yes      |
+
+### `generateFiles[].resolveTemplates`
+
+[generateFiles](#generatefiles) > resolveTemplates
+
+By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to skip resolving template strings. Note that this does not apply when setting the `value` field, since that's resolved earlier when parsing the configuration.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 ### `generateFiles[].value`
 

--- a/docs/reference/module-types/terraform.md
+++ b/docs/reference/module-types/terraform.md
@@ -128,6 +128,11 @@ generateFiles:
     # directories, they will be automatically created if missing.
     targetPath:
 
+    # By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to
+    # skip resolving template strings. Note that this does not apply when setting the `value` field, since that's
+    # resolved earlier when parsing the configuration.
+    resolveTemplates: true
+
     # The desired file contents as a string.
     value:
 
@@ -402,6 +407,16 @@ Note that any existing file with the same name will be overwritten. If the path 
 | Type        | Required |
 | ----------- | -------- |
 | `posixPath` | Yes      |
+
+### `generateFiles[].resolveTemplates`
+
+[generateFiles](#generatefiles) > resolveTemplates
+
+By default, Garden will attempt to resolve any Garden template strings in source files. Set this to false to skip resolving template strings. Note that this does not apply when setting the `value` field, since that's resolved earlier when parsing the configuration.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 ### `generateFiles[].value`
 


### PR DESCRIPTION
In many cases, it's not desirable to pass files specified under
`generateFiles[].sourcePath` through template resolution. This adds a
flag to control that behavior explicitly.
