### PR TITLE
improvement(cloud): more robust log streaming

### DIFF
--- a/core/src/plugins/kubernetes/helm/run.ts
+++ b/core/src/plugins/kubernetes/helm/run.ts
@@ -107,6 +107,7 @@ export async function runHelmModule({
     log,
     remove: true,
     timeoutSec: timeout,
+    events: ctx.events,
     tty: !!interactive,
   })
 

--- a/core/test/integ/src/plugins/kubernetes/container/logs.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/logs.ts
@@ -7,15 +7,14 @@
  */
 
 import { expect } from "chai"
-import { Garden } from "../../../../../../src/garden"
-import { getDataDir, makeTestGarden } from "../../../../../helpers"
+import { getDataDir, makeTestGarden, TestGarden } from "../../../../../helpers"
 import { ConfigGraph } from "../../../../../../src/config-graph"
 import { DeployTask } from "../../../../../../src/tasks/deploy"
 import { getServiceLogs } from "../../../../../../src/plugins/kubernetes/container/logs"
 import { Stream } from "ts-stream"
 import { ServiceLogEntry } from "../../../../../../src/types/plugin/service/getServiceLogs"
 import { KubernetesPluginContext, KubernetesProvider } from "../../../../../../src/plugins/kubernetes/config"
-import { K8sLogFollower } from "../../../../../../src/plugins/kubernetes/logs"
+import { K8sLogFollower, makeServiceLogEntry } from "../../../../../../src/plugins/kubernetes/logs"
 import { KubeApi } from "../../../../../../src/plugins/kubernetes/api"
 import { emptyRuntimeContext } from "../../../../../../src/runtime-context"
 import { createWorkloadManifest } from "../../../../../../src/plugins/kubernetes/container/deployment"
@@ -23,7 +22,7 @@ import { sleep } from "../../../../../../src/util/util"
 import { DeleteServiceTask } from "../../../../../../src/tasks/delete-service"
 
 describe("kubernetes", () => {
-  let garden: Garden
+  let garden: TestGarden
   let graph: ConfigGraph
   let provider: KubernetesProvider
   let ctx: KubernetesPluginContext
@@ -77,7 +76,7 @@ describe("kubernetes", () => {
       expect(entries[0].msg).to.include("Server running...")
     })
     describe("K8sLogsFollower", () => {
-      let logsFollower: K8sLogFollower
+      let logsFollower: K8sLogFollower<ServiceLogEntry>
 
       afterEach(() => {
         logsFollower.close()
@@ -126,8 +125,9 @@ describe("kubernetes", () => {
         ]
         logsFollower = new K8sLogFollower({
           defaultNamespace: provider.config.namespace!.name!,
-          service,
+          log,
           stream,
+          entryConverter: makeServiceLogEntry(service.name),
           resources,
           k8sApi: api,
         })
@@ -137,19 +137,16 @@ describe("kubernetes", () => {
         }, 2500)
         await logsFollower.followLogs()
 
-        const debugEntry = entries.find((e) => e.msg.includes("Connected to container 'simple-service'"))
-        const serviceLog = entries.find((e) => e.msg.includes("Server running..."))
+        expect(ctx.log.toString()).to.match(/Connected to container 'simple-service'/)
 
-        expect(debugEntry).to.exist
-        expect(debugEntry!.serviceName).to.eql("simple-service")
-        expect(debugEntry!.timestamp).to.be.an.instanceOf(Date)
-        expect(debugEntry!.level).to.eql(4)
+        const serviceLog = entries.find((e) => e.msg.includes("Server running..."))
 
         expect(serviceLog).to.exist
         expect(serviceLog!.serviceName).to.eql("simple-service")
         expect(serviceLog!.timestamp).to.be.an.instanceOf(Date)
         expect(serviceLog!.level).to.eql(2)
       })
+
       it("should automatically connect if a service that was missing is deployed", async () => {
         const service = graph.getService("simple-service")
         const log = garden.log
@@ -199,8 +196,9 @@ describe("kubernetes", () => {
         const retryIntervalMs = 1000
         logsFollower = new K8sLogFollower({
           defaultNamespace: provider.config.namespace!.name!,
-          service,
           stream,
+          log,
+          entryConverter: makeServiceLogEntry(service.name),
           resources,
           k8sApi: api,
           retryIntervalMs,
@@ -221,33 +219,20 @@ describe("kubernetes", () => {
 
         logsFollower.close()
 
-        const missingContainerDebugEntry = entries.find((e) =>
-          e.msg.includes(`<No running containers found for service. Will retry in ${retryIntervalMs / 1000}s...>`)
+        const missingContainerRegex = new RegExp(
+          `<No running containers found for service. Will retry in ${retryIntervalMs / 1000}s...>`
         )
-        const connectedDebugEntry = entries.find((e) =>
-          e.msg.includes("<Connected to container 'simple-service' in Pod")
-        )
-        const serviceLog = entries.find((e) => e.msg.includes("Server running..."))
+        const connectedRegex = new RegExp("<Connected to container 'simple-service' in Pod")
+        const serverRunningRegex = new RegExp("Server running...")
+        expect(ctx.log.toString()).to.match(missingContainerRegex)
+        expect(ctx.log.toString()).to.match(connectedRegex)
+        expect(ctx.log.toString()).to.match(serverRunningRegex)
 
         // First we expect to see a "missing container" entry because the service hasn't been deployed
-        expect(missingContainerDebugEntry).to.exist
-        expect(missingContainerDebugEntry!.serviceName).to.eql("simple-service")
-        expect(missingContainerDebugEntry!.timestamp).to.be.an.instanceOf(Date)
-        expect(missingContainerDebugEntry!.level).to.eql(4)
 
         // Then we expect to see a "container connected" entry when the service has been deployed
-        expect(connectedDebugEntry).to.exist
-        expect(connectedDebugEntry!.serviceName).to.eql("simple-service")
-        expect(connectedDebugEntry!.timestamp).to.be.an.instanceOf(Date)
-        expect(connectedDebugEntry!.timestamp!.getTime() > missingContainerDebugEntry!.timestamp!.getTime()).to.be.true
-        expect(connectedDebugEntry!.level).to.eql(4)
 
         // Finally we expect to see the service log
-        expect(serviceLog).to.exist
-        expect(serviceLog!.serviceName).to.eql("simple-service")
-        expect(serviceLog!.timestamp).to.be.an.instanceOf(Date)
-        expect(serviceLog!.timestamp!.getTime() > connectedDebugEntry!.timestamp!.getTime()).to.be.true
-        expect(serviceLog!.level).to.eql(2)
       })
     })
   })

--- a/core/test/integ/src/plugins/kubernetes/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/run.ts
@@ -251,7 +251,7 @@ describe("kubernetes Pod runner functions", () => {
           provider,
         })
 
-        const res = await runner.runAndWait({ log, remove: true, tty: false })
+        const res = await runner.runAndWait({ log, remove: true, tty: false, events: ctx.events })
 
         expect(res.log.trim()).to.equal("foo")
         expect(res.success).to.be.true
@@ -268,7 +268,7 @@ describe("kubernetes Pod runner functions", () => {
           provider,
         })
 
-        const res = await runner.runAndWait({ log, remove: true, tty: false })
+        const res = await runner.runAndWait({ log, remove: true, tty: false, events: ctx.events })
 
         expect(res.log.trim()).to.equal("foo")
         expect(res.success).to.be.false
@@ -297,7 +297,7 @@ describe("kubernetes Pod runner functions", () => {
 
         const stdout = new StringCollector()
 
-        const res = await runner.runAndWait({ log, remove: true, stdout, tty: false })
+        const res = await runner.runAndWait({ log, remove: true, tty: false, events: ctx.events })
 
         const output = stdout.getString()
 
@@ -338,7 +338,7 @@ describe("kubernetes Pod runner functions", () => {
         })
 
         await expectError(
-          () => runner.runAndWait({ log, remove: true, tty: false }),
+          () => runner.runAndWait({ log, remove: true, tty: false, events: ctx.events }),
           (err) => expect(err.message).to.include("Failed to create Pod")
         )
       })
@@ -356,7 +356,7 @@ describe("kubernetes Pod runner functions", () => {
         })
 
         await expectError(
-          () => runner.runAndWait({ log, remove: true, tty: false }),
+          () => runner.runAndWait({ log, remove: true, tty: false, events: ctx.events }),
           (err) => expect(err.message).to.include("Failed to start Pod")
         )
       })
@@ -432,7 +432,7 @@ describe("kubernetes Pod runner functions", () => {
         td.when(core.readNamespacedPodStatus(runner.podName, namespace)).thenResolve(readNamespacedPodStatusRes)
 
         await expectError(
-          () => runner.runAndWait({ log, remove: true, tty: false }),
+          () => runner.runAndWait({ log, remove: true, tty: false, events: ctx.events }),
           (err) => {
             expect(err.type).to.eql("out-of-memory")
             expect(err.message).to.include("OOMKilled")
@@ -511,7 +511,7 @@ describe("kubernetes Pod runner functions", () => {
         td.when(core.readNamespacedPodStatus(runner.podName, namespace)).thenResolve(readNamespacedPodStatusRes)
 
         await expectError(
-          () => runner.runAndWait({ log, remove: true, tty: false }),
+          () => runner.runAndWait({ log, remove: true, tty: false, events: ctx.events }),
           (err) => {
             expect(err.type).to.eql("out-of-memory")
             expect(err.message).to.include("OOMKilled")
@@ -541,7 +541,7 @@ describe("kubernetes Pod runner functions", () => {
             provider,
           })
 
-          const res = await runner.runAndWait({ log, remove: true, tty: true })
+          const res = await runner.runAndWait({ log, remove: true, tty: true, events: ctx.events })
 
           expect(res.log.trim().replace(/\r\n/g, "\n")).to.equal(dedent`
             Log line 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

We now reuse the machinery from the new Kubernetes logs follower for gathering real-time log output from `runAndCopy` when run without artifacts.

This should ensure that all log lines are captured, and makes the log gathering process more robust when the connection to the pod fails and has to be reestablished.

When the connection has to be reestablished, we replay past log lines and deduplicate them against a fixed-size buffer of log entries for the pod + container in question to ensure that no lines are lost, while not emitting duplicate log lines.