### PR TITLE
feat(cloud): emit session events on exit

### DIFF
--- a/core/src/events.ts
+++ b/core/src/events.ts
@@ -101,6 +101,11 @@ export interface Events extends LoggerEvents {
   }
   receivedToken: AuthTokenResponse
 
+  // Session events - one of these is emitted when the command process ends
+  sessionCompleted: {} // Command exited with a 0 status
+  sessionFailed: {} // Command exited with a nonzero status
+  sessionCancelled: {} // Command exited because of an interrupt signal (e.g. CTRL-C)
+
   // Watcher events
   configAdded: {
     path: string
@@ -125,6 +130,7 @@ export interface Events extends LoggerEvents {
 
   // Command/project metadata events
   commandInfo: CommandInfo
+
   // Stack Graph events
   stackGraph: RenderedActionGraph
 
@@ -269,6 +275,9 @@ export const pipedEventNames: EventName[] = [
   "_restart",
   "_test",
   "_workflowRunRegistered",
+  "sessionCompleted",
+  "sessionFailed",
+  "sessionCancelled",
   "configAdded",
   "configRemoved",
   "internalError",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

We now emit session end events when the command exits.