### PR TITLE
fix(cli): ensure help exits with code 0

### DIFF
--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -399,7 +399,7 @@ ${renderCommands(commands)}
     const { command } = pickCommand(Object.values(this.commands), argv._)
 
     if (!command) {
-      const exitCode = argv.h || argv.help ? 0 : 1
+      const exitCode = argv.h || argv.help || argv._[0] === "help" ? 0 : 1
       return done(exitCode, this.renderHelp())
     }
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

Previously running `garden --help` and `garden -h` would exit with code
`0` but running `garden help` would exit with code `1`. This fixes that.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
