### PR TITLE
feat(cloud): dynamic dev command

### DIFF
--- a/core/src/commands/dev.ts
+++ b/core/src/commands/dev.ts
@@ -6,23 +6,37 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import WebSocket from "ws"
 import Bluebird from "bluebird"
 import deline = require("deline")
 import dedent = require("dedent")
 import chalk from "chalk"
 import { readFile } from "fs-extra"
-import { flatten } from "lodash"
+import { flatten, isEmpty, omit } from "lodash"
 import moment = require("moment")
 import { join } from "path"
 
 import { getModuleWatchTasks } from "../tasks/helpers"
-import { Command, CommandResult, CommandParams, handleProcessResults, PrepareParams } from "./base"
-import { STATIC_DIR } from "../constants"
+import {
+  Command,
+  CommandResult,
+  CommandParams,
+  handleProcessResults,
+  PrepareParams,
+  SessionSettings,
+  prepareSessionSettings,
+} from "./base"
+import { gardenEnv, STATIC_DIR } from "../constants"
 import { processModules } from "../process"
 import { GardenModule } from "../types/module"
 import { getTestTasks } from "../tasks/test"
 import { ConfigGraph } from "../config-graph"
-import { getDevModeModules, getHotReloadServiceNames, validateHotReloadServiceNames } from "./helpers"
+import {
+  getDevModeModules,
+  getDevModeServiceNames,
+  getHotReloadServiceNames,
+  validateHotReloadServiceNames,
+} from "./helpers"
 import { startServer } from "../server/server"
 import { BuildTask } from "../tasks/build"
 import { DeployTask } from "../tasks/deploy"
@@ -30,7 +44,6 @@ import { Garden } from "../garden"
 import { LogEntry } from "../logger/log-entry"
 import { StringsParameter, BooleanParameter } from "../cli/params"
 import { printHeader } from "../logger/util"
-import { GardenService } from "../types/service"
 
 const ansiBannerPath = join(STATIC_DIR, "garden-banner-2.txt")
 
@@ -104,7 +117,7 @@ export class DevCommand extends Command<DevCommandArgs, DevCommandOpts> {
     return true
   }
 
-  async prepare({ headerLog, footerLog }: PrepareParams<DevCommandArgs, DevCommandOpts>) {
+  async prepare({ headerLog, footerLog, args, opts, cloudApi }: PrepareParams<DevCommandArgs, DevCommandOpts>) {
     // print ANSI banner image
     if (chalk.supportsColor && chalk.supportsColor.level > 2) {
       const data = await readFile(ansiBannerPath)
@@ -114,7 +127,20 @@ export class DevCommand extends Command<DevCommandArgs, DevCommandOpts> {
     headerLog.info(chalk.gray.italic(`Good ${getGreetingTime()}! Let's get your environment wired up...`))
     headerLog.info("")
 
+    if (cloudApi) {
+      cloudApi.startWebSocketClient()
+    }
+
     this.server = await startServer({ log: footerLog })
+    const sessionSettings = prepareSessionSettings({
+      deployServiceNames: args.services || ["*"],
+      testModuleNames: opts["skip-tests"] ? [] : ["*"],
+      testConfigNames: opts["test-names"] || ["*"],
+      devModeServiceNames: args.services || ["*"],
+      hotReloadServiceNames: opts["hot-reload"] || [],
+    })
+
+    return { persistent: true, sessionSettings }
   }
 
   terminate() {
@@ -125,16 +151,19 @@ export class DevCommand extends Command<DevCommandArgs, DevCommandOpts> {
     garden,
     log,
     footerLog,
-    args,
-    opts,
+    sessionSettings,
   }: CommandParams<DevCommandArgs, DevCommandOpts>): Promise<CommandResult> {
     this.garden = garden
     this.server?.setGarden(garden)
 
+    const settings = <SessionSettings>sessionSettings
+
+    if (sessionSettings) {
+      garden.events.emit("sessionSettings", sessionSettings)
+    }
+
     const graph = await garden.getConfigGraph({ log, emit: true })
     const modules = graph.getModules()
-
-    const skipTests = opts["skip-tests"]
 
     if (modules.length === 0) {
       footerLog && footerLog.setState({ msg: "" })
@@ -143,7 +172,7 @@ export class DevCommand extends Command<DevCommandArgs, DevCommandOpts> {
       return {}
     }
 
-    const hotReloadServiceNames = getHotReloadServiceNames(opts["hot-reload"], graph)
+    const hotReloadServiceNames = getHotReloadServiceNames(settings.hotReloadServiceNames, graph)
     if (hotReloadServiceNames.length > 0) {
       const errMsg = validateHotReloadServiceNames(hotReloadServiceNames, graph)
       if (errMsg) {
@@ -152,24 +181,13 @@ export class DevCommand extends Command<DevCommandArgs, DevCommandOpts> {
       }
     }
 
-    const services = graph.getServices({ names: args.services })
-
-    const devModeServiceNames = services
-      .map((s) => s.name)
-      // Since dev mode is implicit when using this command, we consider explicitly enabling hot reloading to
-      // take precedence over dev mode.
-      .filter((name) => !hotReloadServiceNames.includes(name))
+    await wsConnect(garden)
 
     const initialTasks = await getDevCommandInitialTasks({
       garden,
       log,
       graph,
-      modules,
-      services,
-      devModeServiceNames,
-      hotReloadServiceNames,
-      skipTests,
-      forceDeploy: opts.force,
+      sessionSettings: settings,
     })
 
     const results = await processModules({
@@ -180,18 +198,15 @@ export class DevCommand extends Command<DevCommandArgs, DevCommandOpts> {
       modules,
       watch: true,
       initialTasks,
-      skipWatchModules: getDevModeModules(devModeServiceNames, graph),
+      skipWatchModules: getDevModeModules(getDevModeServiceNames(settings.devModeServiceNames, graph), graph),
+      sessionSettings: settings,
       changeHandler: async (updatedGraph: ConfigGraph, module: GardenModule) => {
         return getDevCommandWatchTasks({
           garden,
           log,
           updatedGraph,
           module,
-          servicesWatched: devModeServiceNames,
-          devModeServiceNames,
-          hotReloadServiceNames,
-          testNames: opts["test-names"],
-          skipTests,
+          sessionSettings: settings,
         })
       },
     })
@@ -204,23 +219,19 @@ export async function getDevCommandInitialTasks({
   garden,
   log,
   graph,
-  modules,
-  services,
-  devModeServiceNames,
-  hotReloadServiceNames,
-  skipTests,
-  forceDeploy,
+  sessionSettings,
 }: {
   garden: Garden
   log: LogEntry
   graph: ConfigGraph
-  modules: GardenModule[]
-  services: GardenService[]
-  devModeServiceNames: string[]
-  hotReloadServiceNames: string[]
-  skipTests: boolean
-  forceDeploy: boolean
+  sessionSettings: SessionSettings
 }) {
+  const { servicesToDeploy, hotReloadServiceNames, devModeServiceNames, testNames } = applySessionSettings(
+    graph,
+    sessionSettings
+  )
+  const modules = graph.getModules()
+
   const moduleTasks = flatten(
     await Bluebird.map(modules, async (module) => {
       // Build the module (in case there are no tests, tasks or services here that need to be run)
@@ -233,24 +244,25 @@ export async function getDevCommandInitialTasks({
       })
 
       // Run all tests in module
-      const testTasks = skipTests
-        ? []
-        : await getTestTasks({
+      const testTasks = moduleShouldBeTested(sessionSettings, module)
+        ? await getTestTasks({
             garden,
             graph,
             log,
             module,
             devModeServiceNames,
             hotReloadServiceNames,
-            force: forceDeploy,
+            filterNames: testNames,
+            force: false,
             forceBuild: false,
           })
+        : []
 
       return [...buildTasks, ...testTasks]
     })
   )
 
-  const serviceTasks = services
+  const serviceTasks = servicesToDeploy
     .filter((s) => !s.disabled)
     .map(
       (service) =>
@@ -275,53 +287,72 @@ export async function getDevCommandWatchTasks({
   log,
   updatedGraph,
   module,
-  servicesWatched,
-  devModeServiceNames,
-  hotReloadServiceNames,
-  testNames,
-  skipTests,
+  sessionSettings,
 }: {
   garden: Garden
   log: LogEntry
   updatedGraph: ConfigGraph
   module: GardenModule
-  servicesWatched: string[]
-  devModeServiceNames: string[]
-  hotReloadServiceNames: string[]
-  testNames: string[] | undefined
-  skipTests: boolean
+  sessionSettings: SessionSettings
 }) {
+  const { servicesToDeploy, hotReloadServiceNames, devModeServiceNames, testNames } = applySessionSettings(
+    updatedGraph,
+    sessionSettings
+  )
   const tasks = await getModuleWatchTasks({
     garden,
     log,
     graph: updatedGraph,
     module,
-    servicesWatched,
+    servicesWatched: servicesToDeploy.map((s) => s.name),
     devModeServiceNames,
     hotReloadServiceNames,
   })
 
-  if (!skipTests) {
-    const testModules: GardenModule[] = updatedGraph.withDependantModules([module])
-    tasks.push(
-      ...flatten(
-        await Bluebird.map(testModules, (m) =>
-          getTestTasks({
-            garden,
-            log,
-            module: m,
-            graph: updatedGraph,
-            filterNames: testNames,
-            fromWatch: true,
-            devModeServiceNames,
-            hotReloadServiceNames,
-          })
-        )
+  const testModules: GardenModule[] = updatedGraph.withDependantModules([module])
+  tasks.push(
+    ...flatten(
+      await Bluebird.map(testModules, (m) =>
+        moduleShouldBeTested(sessionSettings, m)
+          ? getTestTasks({
+              garden,
+              log,
+              module: m,
+              graph: updatedGraph,
+              filterNames: testNames,
+              devModeServiceNames,
+              hotReloadServiceNames,
+            })
+          : []
       )
     )
-  }
+  )
 
   return tasks
+}
+
+export function applySessionSettings(graph: ConfigGraph, sessionSettings: SessionSettings) {
+  const hotReloadServiceNames = getHotReloadServiceNames(sessionSettings.hotReloadServiceNames, graph)
+
+  const serviceNames = sessionSettings.deployServiceNames
+  const allServices = graph.getServices()
+  const servicesToDeploy = serviceNames[0] === "*" ? allServices : graph.getServices({ names: serviceNames })
+
+  let devModeServiceNames = getDevModeServiceNames(sessionSettings.devModeServiceNames, graph)
+
+  devModeServiceNames = servicesToDeploy
+    .map((s) => s.name)
+    // Since dev mode is implicit when using this command, we consider explicitly enabling hot reloading to
+    // take precedence over dev mode.
+    .filter((name) => devModeServiceNames.includes(name) && !hotReloadServiceNames.includes(name))
+  const testNames = isEmpty(sessionSettings.testConfigNames) ? undefined : sessionSettings.testConfigNames
+
+  return { servicesToDeploy, hotReloadServiceNames, devModeServiceNames, testNames }
+}
+
+function moduleShouldBeTested(sessionSettings: SessionSettings, module: GardenModule): boolean {
+  const testModuleNames = sessionSettings.testModuleNames
+  return testModuleNames[0] === "*" || !!testModuleNames.find((n) => n === module.name)
 }
 
 function getGreetingTime() {
@@ -336,4 +367,51 @@ function getGreetingTime() {
   } else {
     return "morning"
   }
+}
+
+async function wsConnect(garden: Garden) {
+  const validEvents = ["deployRequested", "buildRequested", "testRequested"]
+  const authToken = gardenEnv.GARDEN_AUTH_TOKEN
+  const tokenParam = !!gardenEnv.GARDEN_AUTH_TOKEN ? "ciToken" : "accessToken"
+  const wsUrl = `wss://ths.dev.enterprise.garden.io/ws/cli?${tokenParam}=${authToken}&sessionId=${garden.sessionId}`
+  console.log(`will connect ws: url ${wsUrl}`)
+  // if (garden.enterpriseApi) {
+  const ws = new WebSocket(wsUrl)
+  ws.on("open", () => {
+    // console.log("ws open")
+  })
+  ws.on("close", () => {
+    // console.log("ws closed")
+  })
+  ws.on("upgrade", () => {
+    // console.log("ws upgraded")
+  })
+  ws.on("ping", () => {
+    ws.pong()
+  })
+  ws.on("error", (err) => {
+    console.log("ws err", err)
+    console.log("ws err string", JSON.stringify(err))
+  })
+  ws.on("message", (msg) => {
+    const parsed = JSON.parse(msg.toString())
+    console.log(parsed)
+    if (validEvents.includes(parsed.event)) {
+      const payload = omit(parsed, "event")
+      garden.events.emit(parsed.event, payload)
+    }
+  })
+
+  garden.events.onAny((name, payload) => {
+    if (ws.readyState === 1) {
+      const content = { type: "event", body: { name, payload } }
+      // console.log(`sending event via ws: ${JSON.stringify(content, null, 2)}`)
+      ws.send(JSON.stringify(content))
+    }
+  })
+
+  // setInterval(() => {
+  //   ws.send(JSON.stringify({ type: "event", name: "foo", message: "ello ello" }))
+  // }, 1000)
+  // }
 }

--- a/core/src/config-graph.ts
+++ b/core/src/config-graph.ts
@@ -300,7 +300,7 @@ export class ConfigGraph {
   }
 
   /**
-   * Returns the Service with the specified name. Throws error if it doesn't exist.
+   * Returns the Module with the specified name. Throws error if it doesn't exist.
    */
   getModule(name: string, includeDisabled?: boolean): GardenModule {
     return this.getModules({ names: [name], includeDisabled })[0]

--- a/core/src/events.ts
+++ b/core/src/events.ts
@@ -17,6 +17,7 @@ import { AuthTokenResponse } from "./cloud/api"
 import { RenderedActionGraph } from "./config-graph"
 import { BuildState } from "./types/plugin/module/build"
 import { CommandInfo } from "./plugin-context"
+import { SessionSettings } from "./commands/base"
 
 export type GardenEventListener<T extends EventName> = (payload: Events[T]) => void
 
@@ -265,6 +266,43 @@ export interface Events extends LoggerEvents {
     index: number
     durationMsec: number
   }
+
+  // Cloud UI events
+  sessionSettings: SessionSettings
+  buildRequested: {
+    moduleName: string
+    force: boolean
+  }
+  deployRequested: {
+    serviceName: string
+    devMode: boolean
+    hotReload: boolean
+    force: boolean
+    forceBuild: boolean
+  }
+  testRequested: {
+    moduleName: string
+    force: boolean
+    forceBuild: boolean
+    testNames?: string[] // If not provided, run all tests for the module
+  }
+  taskRequested: {
+    taskName: string
+    force: boolean
+    forceBuild: boolean
+  }
+  setBuildOnWatch: {
+    moduleName: string
+    build: boolean
+  }
+  setDeployOnWatch: {
+    serviceName: string
+    deploy: boolean
+  }
+  setTestOnWatch: {
+    moduleName: string
+    test: boolean
+  }
 }
 
 export type EventName = keyof Events
@@ -308,4 +346,12 @@ export const pipedEventNames: EventName[] = [
   "workflowStepError",
   "workflowStepProcessing",
   "workflowStepSkipped",
+  "sessionSettings",
+  "buildRequested",
+  "deployRequested",
+  "testRequested",
+  "taskRequested",
+  "setBuildOnWatch",
+  "setDeployOnWatch",
+  "setTestOnWatch",
 ]

--- a/core/src/server/server.ts
+++ b/core/src/server/server.ts
@@ -250,9 +250,11 @@ export class GardenServer {
 
       const batch = ctx.request.body as ApiEventBatch
       this.debugLog.debug(`Received ${batch.events.length} events from session ${batch.sessionId}`)
+      this.debugLog.silly(JSON.stringify(batch.events, null, 2))
 
       // Pipe the events to the incoming stream, which websocket listeners will then receive
       batch.events.forEach((e) => this.incomingEvents.emit(e.name, e.payload))
+      // batch.events.forEach((e) => this.garden!.events.emit(e.name, e.payload))
 
       ctx.status = 200
     })

--- a/core/src/tasks/test.ts
+++ b/core/src/tasks/test.ts
@@ -23,6 +23,7 @@ import { BuildTask } from "./build"
 import { GraphResults } from "../task-graph"
 import { Profile } from "../util/profiling"
 import { GardenTest, testFromConfig } from "../types/test"
+import { ModuleConfig } from "../config/module"
 
 class TestError extends Error {
   toString() {
@@ -240,16 +241,8 @@ export async function getTestTasks({
   fromWatch?: boolean
   skipRuntimeDependencies?: boolean
 }) {
-  // If there are no filters we return the test otherwise
-  // we check if the test name matches against the filterNames array
-  const configs = module.testConfigs.filter(
-    (test) =>
-      !test.disabled &&
-      (!filterNames || filterNames.length === 0 || find(filterNames, (n: string) => minimatch(test.name, n)))
-  )
-
   return Bluebird.map(
-    configs,
+    filterTestConfigs(module.testConfigs, filterNames),
     (testConfig) =>
       new TestTask({
         garden,
@@ -263,5 +256,16 @@ export async function getTestTasks({
         hotReloadServiceNames,
         skipRuntimeDependencies,
       })
+  )
+}
+
+export function filterTestConfigs(
+  configs: ModuleConfig["testConfigs"],
+  filterNames?: string[]
+): ModuleConfig["testConfigs"] {
+  return configs.filter(
+    (test) =>
+      !test.disabled &&
+      (!filterNames || filterNames.length === 0 || find(filterNames, (n: string) => minimatch(test.name, n)))
   )
 }

--- a/core/test/unit/src/enterprise/event-handlers.ts
+++ b/core/test/unit/src/enterprise/event-handlers.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2018-2021 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import { prepareSessionSettings, SessionSettings } from "../../../../src/commands/base"
+import { ConfigGraph } from "../../../../src/config-graph"
+import { LogEntry } from "../../../../src/logger/log-entry"
+import { CloudEventHandlerCommonParams, cloudEventHandlers } from "../../../../src/process"
+import { makeTestGardenA, TestGarden } from "../../../helpers"
+
+describe("cloudEventHandlers", () => {
+  let garden: TestGarden
+  let graph: ConfigGraph
+  let log: LogEntry
+  let params: CloudEventHandlerCommonParams
+  let sessionSettings: SessionSettings
+
+  before(async () => {
+    garden = await makeTestGardenA()
+    log = garden.log
+    graph = await garden.getConfigGraph({ log, emit: false })
+    params = { garden, log, graph }
+  })
+
+  beforeEach(async () => {
+    sessionSettings = prepareSessionSettings({
+      deployServiceNames: ["*"],
+      testModuleNames: ["*"],
+      testConfigNames: ["*"],
+      devModeServiceNames: ["*"],
+      hotReloadServiceNames: [],
+    })
+  })
+
+  describe("buildRequested", () => {
+    it("should return a build task for the requested module", async () => {
+      const tasks = await cloudEventHandlers.buildRequested({
+        ...params,
+        request: { moduleName: "module-a", force: false },
+      })
+      expect(tasks.length).to.eql(1)
+      const buildTask = tasks.find((t) => t.type === "build")
+      expect(buildTask).to.exist
+      expect(buildTask!["module"].name).to.eql("module-a")
+      expect(buildTask!.force).to.eql(false)
+    })
+
+    it("should optionally return a build task with force = true for the requested module", async () => {
+      const tasks = await cloudEventHandlers.buildRequested({
+        ...params,
+        request: { moduleName: "module-a", force: true },
+      })
+      expect(tasks.length).to.eql(1)
+      const buildTask = tasks.find((t) => t.type === "build")
+      expect(buildTask).to.exist
+      expect(buildTask!["module"].name).to.eql("module-a")
+      expect(buildTask!.force).to.eql(true)
+    })
+  })
+
+  describe("deployRequested", () => {
+    it("should return a deploy task for the requested service and update the session settings", async () => {
+      const deployTask = await cloudEventHandlers.deployRequested({
+        ...params,
+        request: { serviceName: "service-a", force: false, forceBuild: false, devMode: false, hotReload: false },
+        sessionSettings,
+      })
+      expect(deployTask["hotReloadServiceNames"]).to.eql([])
+      expect(deployTask["devModeServiceNames"]).to.eql(["service-b", "service-c"])
+      expect(sessionSettings.devModeServiceNames).to.eql(["service-b", "service-c"])
+    })
+
+    it("should return a dev-mode deploy task for the requested service and update the session settings", async () => {
+      const deployTask = await cloudEventHandlers.deployRequested({
+        ...params,
+        request: { serviceName: "service-a", force: false, forceBuild: false, devMode: true, hotReload: false },
+        sessionSettings,
+      })
+      expect(deployTask["service"].name).to.eql("service-a")
+      expect(deployTask["hotReloadServiceNames"]).to.eql([])
+      expect(deployTask["devModeServiceNames"]).to.eql(["service-a", "service-b", "service-c"])
+      expect(sessionSettings.devModeServiceNames).to.eql(["*"])
+    })
+  })
+
+  describe("testRequested", () => {
+    it("should return test tasks for the requested module", async () => {
+      const testTasks = await cloudEventHandlers.testRequested({
+        ...params,
+        request: { moduleName: "module-a", force: false, forceBuild: false },
+        sessionSettings,
+      })
+      expect(testTasks.map((t) => t["test"].name).sort()).to.eql(["integration", "unit"])
+    })
+
+    it("should return test tasks for the requested module and test names", async () => {
+      const testTasks = await cloudEventHandlers.testRequested({
+        ...params,
+        request: { moduleName: "module-a", force: false, forceBuild: false, testNames: ["unit"] },
+        sessionSettings,
+      })
+      expect(testTasks.map((t) => t["test"].name).sort()).to.eql(["unit"])
+    })
+  })
+
+  describe("taskRequested", () => {
+    it("should return test tasks for the requested module", async () => {
+      const taskTask = await cloudEventHandlers.taskRequested({
+        ...params,
+        request: { taskName: "task-a", force: false, forceBuild: false },
+        sessionSettings,
+      })
+      expect(taskTask["task"].name).to.eql("task-a")
+    })
+  })
+
+  describe("setBuildOnWatch", () => {
+    it("should add a module to the list of modules rebuilt on source change", async () => {
+      sessionSettings.buildModuleNames = []
+      cloudEventHandlers.setBuildOnWatch(graph, "module-a", true, sessionSettings)
+      cloudEventHandlers.setBuildOnWatch(graph, "module-b", true, sessionSettings)
+      expect(sessionSettings.buildModuleNames).to.eql(["module-a", "module-b"])
+    })
+
+    it("should remove a module from the list of modules rebuilt on source change", async () => {
+      sessionSettings.buildModuleNames = []
+      cloudEventHandlers.setBuildOnWatch(graph, "module-a", true, sessionSettings)
+      cloudEventHandlers.setBuildOnWatch(graph, "module-b", true, sessionSettings)
+      cloudEventHandlers.setBuildOnWatch(graph, "module-a", false, sessionSettings)
+      expect(sessionSettings.buildModuleNames).to.eql(["module-b"])
+    })
+  })
+
+  describe("setDeployOnWatch", () => {
+    it("should add a service to the list of services redeployed on source change", async () => {
+      sessionSettings.deployServiceNames = []
+      cloudEventHandlers.setDeployOnWatch(graph, "service-a", true, sessionSettings)
+      cloudEventHandlers.setDeployOnWatch(graph, "service-b", true, sessionSettings)
+      expect(sessionSettings.deployServiceNames).to.eql(["service-a", "service-b"])
+    })
+
+    it("should remove a service from the list of services redeployed on source change", async () => {
+      sessionSettings.deployServiceNames = []
+      cloudEventHandlers.setDeployOnWatch(graph, "service-a", true, sessionSettings)
+      cloudEventHandlers.setDeployOnWatch(graph, "service-b", true, sessionSettings)
+      cloudEventHandlers.setDeployOnWatch(graph, "service-a", false, sessionSettings)
+      expect(sessionSettings.deployServiceNames).to.eql(["service-b"])
+    })
+
+    describe("setTestOnWatch", () => {
+      it("should add a module to the list of modules rebuilt on source change", async () => {
+        sessionSettings.testModuleNames = []
+        cloudEventHandlers.setTestOnWatch(graph, "module-a", true, sessionSettings)
+        cloudEventHandlers.setTestOnWatch(graph, "module-b", true, sessionSettings)
+        expect(sessionSettings.testModuleNames).to.eql(["module-a", "module-b"])
+      })
+
+      it("should remove a module from the list of modules rebuilt on source change", async () => {
+        sessionSettings.testModuleNames = []
+        cloudEventHandlers.setTestOnWatch(graph, "module-a", true, sessionSettings)
+        cloudEventHandlers.setTestOnWatch(graph, "module-b", true, sessionSettings)
+        cloudEventHandlers.setTestOnWatch(graph, "module-a", false, sessionSettings)
+        expect(sessionSettings.testModuleNames).to.eql(["module-b"])
+      })
+    })
+  })
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

The `dev` command can now be orchestrated from the Cloud UI via websocket events.

This includes:
* Requesting builds/deploys/tests/task runs (also toggling dev mode / hot reloading).
* Toggling whether a module/service should be rebuilt/retested/redeployed when sources change.

The default behavior of the `dev` command has not been changed, and all other commands are unchanged.

TODO:
- [ ] Add/finish websockets logic.