### PR TITLE
fix(k8s): fix port-forward error handling

### DIFF
--- a/core/src/proxy.ts
+++ b/core/src/proxy.ts
@@ -36,6 +36,8 @@ const activeProxies: { [key: string]: PortProxy } = {}
 registerCleanupFunction("kill-service-port-proxies", () => {
   for (const proxy of Object.values(activeProxies)) {
     try {
+      // Avoid EPIPE errors
+      proxy.server.on("error", () => {})
       stopPortProxy(proxy)
     } catch {}
   }
@@ -290,9 +292,6 @@ function stopPortProxy(proxy: PortProxy, log?: LogEntry) {
   delete activeProxies[proxy.key]
 
   try {
-    // Avoid EPIPE errors
-    proxy.server.on("error", () => {})
-
     proxy.server.close()
   } catch {}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

This should fix an error that some users have run into when using watch-mode commands when services are redeployed.