### PR TITLE
fix: harbor error support

### DIFF
--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -268,7 +268,7 @@ export async function skopeoBuildStatus({
   }
 }
 
-export function skopeoManifestUnknown(errMsg: string | null | undefined) : boolean {
+export function skopeoManifestUnknown(errMsg: string | null | undefined): boolean {
   if (!errMsg) {
     return false
   }

--- a/core/test/unit/src/plugins/kubernetes/container/build/common.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/build/common.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2018-2021 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { skopeoManifestUnknown } from "../../../../../../../src/plugins/kubernetes/container/build/common"
+import { expect } from "chai"
+
+describe("common build", () => {
+  describe("manifest error", () => {
+    it("should result in manifest unknown for common registry error", () => {
+      const errorMessage = "ERROR: manifest unknown: manifest unknown"
+
+      expect(skopeoManifestUnknown(errorMessage)).to.be.true
+    })
+
+    it("should result in manifest unknown for Harbor registry error", () => {
+      const errorMessage =
+        'Unable to query registry for image status: time="2021-10-13T17:50:25Z" level=fatal msg="Error parsing image name "docker://registry.domain/namespace/image-name:v-1f160eadbb": Error reading manifest v-1f160eadbb in registry.domain/namespace/image-name: unknown: artifact namespace/image-name:v-1f160eadbb not found"'
+
+      expect(skopeoManifestUnknown(errorMessage)).to.be.true
+    })
+
+    it("should result in manifest not unknown for other errors", () => {
+      const errorMessage =
+        "unauthorized: unauthorized to access repository: namespace/image-name, action: push: unauthorized to access repository: namespace/image-name, action: push"
+
+      expect(skopeoManifestUnknown(errorMessage)).to.be.false
+    })
+  })
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

This PR addresses the issue I indirectly reported in this comment: https://github.com/garden-io/garden/issues/2418#issuecomment-942578508.

I am happy to open a new issue if that is desirable.

In short, the missing image error message given by Harbor used to happen to match the existing hard-coded check Garden performs. After updating the version of Harbor used for our internal image registry, my org started to see Garden fail to build images instead of recognizing that the image had just not been built at the current tag before.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

N/A