### PR TITLE
feat(k8s): add two-way-resolved option for dev mode syncs

### DIFF
--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -251,11 +251,20 @@ const devModeSyncSchema = () =>
     exclude: syncExcludeSchema(),
     mode: joi
       .string()
-      .allow("one-way", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way")
+      .allow(
+        "one-way",
+        "one-way-safe",
+        "one-way-replica",
+        "one-way-reverse",
+        "one-way-replica-reverse",
+        "two-way",
+        "two-way-safe",
+        "two-way-resolved"
+      )
       .only()
-      .default("one-way")
+      .default("one-way-safe")
       .description(
-        "The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `one-way-reverse`, `one-way-replica-reverse` and `two-way`."
+        "The sync mode to use for the given paths. See the [Dev Mode guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details."
       ),
     defaultFileMode: syncDefaultFileModeSchema(),
     defaultDirectoryMode: syncDefaultDirectoryModeSchema(),

--- a/core/src/plugins/kubernetes/mutagen.ts
+++ b/core/src/plugins/kubernetes/mutagen.ts
@@ -33,10 +33,13 @@ let mutagenTmp: TempDirectory
 
 export const mutagenModeMap = {
   "one-way": "one-way-safe",
+  "one-way-safe": "one-way-safe",
   "one-way-reverse": "one-way-safe",
   "one-way-replica": "one-way-replica",
   "one-way-replica-reverse": "one-way-replica",
   "two-way": "two-way-safe",
+  "two-way-safe": "two-way-safe",
+  "two-way-resolved": "two-way-resolved",
 }
 
 export interface SyncConfig {

--- a/docs/guides/code-synchronization-dev-mode.md
+++ b/docs/guides/code-synchronization-dev-mode.md
@@ -87,7 +87,8 @@ Garden's dev mode supports several sync modes, each of which maps onto a Mutagen
 
 In brief: It's generally easiest to get started with the `one-way` or `two-way` sync modes, and then graduate to a more fine-grained setup based on `one-way-replica` and/or `one-way-replica-reverse` once you're ready to specify exactly which paths to sync and which files/directories to ignore from the sync.
 
-### `one-way` (shorthand for `one-way-safe`)
+### `one-way-safe` (or alias `one-way`)
+
 * Syncs a local `source` path to a remote `target` path.
 * When there are conflicts, does not replace/delete files in the remote `target` path.
 * Simple to use, especially when there are files/directories inside the remote `target` that you don't want to override with the contents of the local `source`.
@@ -109,13 +110,20 @@ In brief: It's generally easiest to get started with the `one-way` or `two-way` 
   * Syncs a remote `target` path to a local `source` path, such that `source` is always an exact mirror of `target` (with the exception of excluded paths).
   * When using this mode, there can be no conflicts—the contents of `target` always override the contents of `source`.
 
-### `two-way` (maps to Mutagen's `two-way-safe`)
+### `two-way-safe` (or alias `two-way`)
   * Bidirectionally syncs a local `source` to a remote `target` path.
   * Changes made in the local `source` will be synced to the remote `target`.
   * Changes made in the remote `target` will be synced to the local `source`.
   * When there are conflicts on either side, does not replace/delete the corresponding conflicting paths on the other side.
   * Similarly to `one-way`, this mode is simple to configure when there are files in either `source` or `target` that you don't want overriden on the other side when files change or are added/deleted.
   * Setting up several `one-way-replica` and `one-way-replica-reverse` syncs instead of `one-way` and `two-way` is generally the best approach long-term, but may require more fine-grained configuration (more sync specs for specific subpaths and more specific exclusion rules, to make sure things don't get overwritten/deleted in unwanted ways).
+
+### `two-way-resolved`
+
+Same as `two-way-safe` except:
+
+  * Changes made in the local `source` will always win any conflict. This includes cases where alpha’s deletions would overwrite beta’s modifications or creations
+  * No conflicts can occur in this synchronization mode.
 
 In addition to the above, please check out the [Mutagen docs on synchronization](https://mutagen.io/documentation/synchronization) for more info.
 

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -256,9 +256,9 @@ services:
           # `.git` directories and `.garden` directories are always ignored.
           exclude:
 
-          # The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`,
-          # `one-way-reverse`, `one-way-replica-reverse` and `two-way`.
-          mode: one-way
+          # The sync mode to use for the given paths. See the [Dev Mode
+          # guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
+          mode: one-way-safe
 
           # The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600
           # (user read/write). See the [Mutagen
@@ -1268,11 +1268,11 @@ services:
 
 [services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > mode
 
-The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `one-way-reverse`, `one-way-replica-reverse` and `two-way`.
+The sync mode to use for the given paths. See the [Dev Mode guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
 
-| Type     | Allowed Values                                                                        | Default     | Required |
-| -------- | ------------------------------------------------------------------------------------- | ----------- | -------- |
-| `string` | "one-way", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way" | `"one-way"` | Yes      |
+| Type     | Allowed Values                                                                                                                            | Default          | Required |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
+| `string` | "one-way", "one-way-safe", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way", "two-way-safe", "two-way-resolved" | `"one-way-safe"` | Yes      |
 
 ### `services[].devMode.sync[].defaultFileMode`
 

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -194,9 +194,9 @@ devMode:
       # `.git` directories and `.garden` directories are always ignored.
       exclude:
 
-      # The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `one-way-reverse`,
-      # `one-way-replica-reverse` and `two-way`.
-      mode: one-way
+      # The sync mode to use for the given paths. See the [Dev Mode
+      # guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
+      mode: one-way-safe
 
       # The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600 (user
       # read/write). See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#permissions)
@@ -985,11 +985,11 @@ devMode:
 
 [devMode](#devmode) > [sync](#devmodesync) > mode
 
-The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `one-way-reverse`, `one-way-replica-reverse` and `two-way`.
+The sync mode to use for the given paths. See the [Dev Mode guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
 
-| Type     | Allowed Values                                                                        | Default     | Required |
-| -------- | ------------------------------------------------------------------------------------- | ----------- | -------- |
-| `string` | "one-way", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way" | `"one-way"` | Yes      |
+| Type     | Allowed Values                                                                                                                            | Default          | Required |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
+| `string` | "one-way", "one-way-safe", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way", "two-way-safe", "two-way-resolved" | `"one-way-safe"` | Yes      |
 
 ### `devMode.sync[].defaultFileMode`
 

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -274,9 +274,9 @@ services:
           # `.git` directories and `.garden` directories are always ignored.
           exclude:
 
-          # The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`,
-          # `one-way-reverse`, `one-way-replica-reverse` and `two-way`.
-          mode: one-way
+          # The sync mode to use for the given paths. See the [Dev Mode
+          # guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
+          mode: one-way-safe
 
           # The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600
           # (user read/write). See the [Mutagen
@@ -1326,11 +1326,11 @@ services:
 
 [services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > mode
 
-The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `one-way-reverse`, `one-way-replica-reverse` and `two-way`.
+The sync mode to use for the given paths. See the [Dev Mode guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
 
-| Type     | Allowed Values                                                                        | Default     | Required |
-| -------- | ------------------------------------------------------------------------------------- | ----------- | -------- |
-| `string` | "one-way", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way" | `"one-way"` | Yes      |
+| Type     | Allowed Values                                                                                                                            | Default          | Required |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
+| `string` | "one-way", "one-way-safe", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way", "two-way-safe", "two-way-resolved" | `"one-way-safe"` | Yes      |
 
 ### `services[].devMode.sync[].defaultFileMode`
 

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -180,9 +180,9 @@ devMode:
       # `.git` directories and `.garden` directories are always ignored.
       exclude:
 
-      # The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `one-way-reverse`,
-      # `one-way-replica-reverse` and `two-way`.
-      mode: one-way
+      # The sync mode to use for the given paths. See the [Dev Mode
+      # guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
+      mode: one-way-safe
 
       # The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600 (user
       # read/write). See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#permissions)
@@ -868,11 +868,11 @@ devMode:
 
 [devMode](#devmode) > [sync](#devmodesync) > mode
 
-The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `one-way-reverse`, `one-way-replica-reverse` and `two-way`.
+The sync mode to use for the given paths. See the [Dev Mode guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
 
-| Type     | Allowed Values                                                                        | Default     | Required |
-| -------- | ------------------------------------------------------------------------------------- | ----------- | -------- |
-| `string` | "one-way", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way" | `"one-way"` | Yes      |
+| Type     | Allowed Values                                                                                                                            | Default          | Required |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
+| `string` | "one-way", "one-way-safe", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way", "two-way-safe", "two-way-resolved" | `"one-way-safe"` | Yes      |
 
 ### `devMode.sync[].defaultFileMode`
 

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -256,9 +256,9 @@ services:
           # `.git` directories and `.garden` directories are always ignored.
           exclude:
 
-          # The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`,
-          # `one-way-reverse`, `one-way-replica-reverse` and `two-way`.
-          mode: one-way
+          # The sync mode to use for the given paths. See the [Dev Mode
+          # guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
+          mode: one-way-safe
 
           # The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600
           # (user read/write). See the [Mutagen
@@ -1278,11 +1278,11 @@ services:
 
 [services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > mode
 
-The sync mode to use for the given paths. Allowed options: `one-way`, `one-way-replica`, `one-way-reverse`, `one-way-replica-reverse` and `two-way`.
+The sync mode to use for the given paths. See the [Dev Mode guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
 
-| Type     | Allowed Values                                                                        | Default     | Required |
-| -------- | ------------------------------------------------------------------------------------- | ----------- | -------- |
-| `string` | "one-way", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way" | `"one-way"` | Yes      |
+| Type     | Allowed Values                                                                                                                            | Default          | Required |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
+| `string` | "one-way", "one-way-safe", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way", "two-way-safe", "two-way-resolved" | `"one-way-safe"` | Yes      |
 
 ### `services[].devMode.sync[].defaultFileMode`
 


### PR DESCRIPTION
Nice and easy. Also allow entering `one-way-safe` and `two-way-safe`
instead of just the alias (which in hindsight was unnecessary).

