### PR TITLE
fix(core): fix task batch partitioning algorithm

### DIFF
--- a/core/test/unit/src/util/util.ts
+++ b/core/test/unit/src/util/util.ts
@@ -332,11 +332,12 @@ describe("util", () => {
 
   describe("relationshipClasses", () => {
     it("should correctly partition related items", () => {
-      const items = ["ab", "b", "c", "a", "cd"]
+      const items = ["a", "b", "c", "d", "e", "f", "g", "ab", "bc", "cd", "de", "fg"]
       const isRelated = (s1: string, s2: string) => includes(s1, s2) || includes(s2, s1)
+      // There's no "ef" element, so ["f", "fg", "g"] should be disjoint from the rest.
       expect(relationshipClasses(items, isRelated)).to.eql([
-        ["ab", "b", "a"],
-        ["c", "cd"],
+        ["a", "ab", "b", "bc", "c", "cd", "d", "de", "e"],
+        ["f", "fg", "g"],
       ])
     })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

The old batch partitioning algorithm wasn't correctly merging partition classes when transitive relationships with more than one "hop" were present.

This could lead to tasks being processed twice when using the `--force` flag for certain commands.