### PR TITLE
feat(k8s): add two-way-resolved-reverse option

### DIFF
--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -184,7 +184,14 @@ const hotReloadConfigSchema = () =>
     with this module as their \`sourceModule\`.
   `)
 
-export type SyncMode = "one-way" | "one-way-replica" | "one-way-reverse" | "one-way-replica-reverse" | "two-way"
+export type SyncMode =
+  | "one-way"
+  | "one-way-replica"
+  | "one-way-reverse"
+  | "one-way-replica-reverse"
+  | "two-way"
+  | "two-way-resolved"
+  | "two-way-resolved-reverse"
 
 export interface DevModeSyncSpec {
   source: string
@@ -259,7 +266,8 @@ const devModeSyncSchema = () =>
         "one-way-replica-reverse",
         "two-way",
         "two-way-safe",
-        "two-way-resolved"
+        "two-way-resolved",
+        "two-way-resolved-reverse"
       )
       .only()
       .default("one-way-safe")

--- a/core/src/plugins/kubernetes/dev-mode.ts
+++ b/core/src/plugins/kubernetes/dev-mode.ts
@@ -280,4 +280,6 @@ export function makeSyncConfig({
   }
 }
 
-const isReverseMode = (mode: string) => mode === "one-way-reverse" || mode === "one-way-replica-reverse"
+const reverseModeNames = ["one-way-reverse", "one-way-replica-reverse", "two-way-resolved-reverse"]
+
+const isReverseMode = (mode: string) => reverseModeNames.includes(mode)

--- a/core/src/plugins/kubernetes/mutagen.ts
+++ b/core/src/plugins/kubernetes/mutagen.ts
@@ -40,6 +40,7 @@ export const mutagenModeMap = {
   "two-way": "two-way-safe",
   "two-way-safe": "two-way-safe",
   "two-way-resolved": "two-way-resolved",
+  "two-way-resolved-reverse": "two-way-resolved",
 }
 
 export interface SyncConfig {

--- a/core/test/unit/src/plugins/kubernetes/dev-mode.ts
+++ b/core/test/unit/src/plugins/kubernetes/dev-mode.ts
@@ -105,7 +105,7 @@ describe("k8s dev mode helpers", () => {
     })
 
     it("should return a remote alpha and a local beta when called with a reverse sync mode", () => {
-      const config = makeSyncConfig({
+      const oneWayConfig = makeSyncConfig({
         localPath,
         remoteDestination,
         defaults: {},
@@ -116,11 +116,33 @@ describe("k8s dev mode helpers", () => {
         },
       })
 
-      expect(config).to.eql({
+      expect(oneWayConfig).to.eql({
         alpha: remoteDestination, // <----
         beta: localPath, // <----
         ignore: [...builtInExcludes],
         mode: "one-way-replica-reverse",
+        defaultOwner: undefined,
+        defaultGroup: undefined,
+        defaultDirectoryMode: undefined,
+        defaultFileMode: undefined,
+      })
+
+      const twoWayConfig = makeSyncConfig({
+        localPath,
+        remoteDestination,
+        defaults: {},
+        spec: {
+          source,
+          target,
+          mode: "two-way-resolved-reverse",
+        },
+      })
+
+      expect(twoWayConfig).to.eql({
+        alpha: remoteDestination, // <----
+        beta: localPath, // <----
+        ignore: [...builtInExcludes],
+        mode: "two-way-resolved-reverse",
         defaultOwner: undefined,
         defaultGroup: undefined,
         defaultDirectoryMode: undefined,

--- a/docs/guides/code-synchronization-dev-mode.md
+++ b/docs/guides/code-synchronization-dev-mode.md
@@ -122,7 +122,13 @@ In brief: It's generally easiest to get started with the `one-way` or `two-way` 
 
 Same as `two-way-safe` except:
 
-  * Changes made in the local `source` will always win any conflict. This includes cases where alpha’s deletions would overwrite beta’s modifications or creations
+  * Changes made in the local `source` will always win any conflict. This includes cases where deletions at the local `source` would overwrite modifications or creations at the remote `target`.
+  * No conflicts can occur in this synchronization mode.
+
+### `two-way-resolved-reverse`
+Same as `two-way-resolved`, except the direction of the sync is reversed:
+
+  * Changes made in the remote `target` will always win any conflict. This includes cases where deletions at the remote `target` would overwrite modifications or creations at the local `source`.
   * No conflicts can occur in this synchronization mode.
 
 In addition to the above, please check out the [Mutagen docs on synchronization](https://mutagen.io/documentation/synchronization) for more info.

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -1270,9 +1270,9 @@ services:
 
 The sync mode to use for the given paths. See the [Dev Mode guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
 
-| Type     | Allowed Values                                                                                                                            | Default          | Required |
-| -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
-| `string` | "one-way", "one-way-safe", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way", "two-way-safe", "two-way-resolved" | `"one-way-safe"` | Yes      |
+| Type     | Allowed Values                                                                                                                                                        | Default          | Required |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
+| `string` | "one-way", "one-way-safe", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way", "two-way-safe", "two-way-resolved", "two-way-resolved-reverse" | `"one-way-safe"` | Yes      |
 
 ### `services[].devMode.sync[].defaultFileMode`
 

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -987,9 +987,9 @@ devMode:
 
 The sync mode to use for the given paths. See the [Dev Mode guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
 
-| Type     | Allowed Values                                                                                                                            | Default          | Required |
-| -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
-| `string` | "one-way", "one-way-safe", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way", "two-way-safe", "two-way-resolved" | `"one-way-safe"` | Yes      |
+| Type     | Allowed Values                                                                                                                                                        | Default          | Required |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
+| `string` | "one-way", "one-way-safe", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way", "two-way-safe", "two-way-resolved", "two-way-resolved-reverse" | `"one-way-safe"` | Yes      |
 
 ### `devMode.sync[].defaultFileMode`
 

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -1328,9 +1328,9 @@ services:
 
 The sync mode to use for the given paths. See the [Dev Mode guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
 
-| Type     | Allowed Values                                                                                                                            | Default          | Required |
-| -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
-| `string` | "one-way", "one-way-safe", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way", "two-way-safe", "two-way-resolved" | `"one-way-safe"` | Yes      |
+| Type     | Allowed Values                                                                                                                                                        | Default          | Required |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
+| `string` | "one-way", "one-way-safe", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way", "two-way-safe", "two-way-resolved", "two-way-resolved-reverse" | `"one-way-safe"` | Yes      |
 
 ### `services[].devMode.sync[].defaultFileMode`
 

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -870,9 +870,9 @@ devMode:
 
 The sync mode to use for the given paths. See the [Dev Mode guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
 
-| Type     | Allowed Values                                                                                                                            | Default          | Required |
-| -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
-| `string` | "one-way", "one-way-safe", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way", "two-way-safe", "two-way-resolved" | `"one-way-safe"` | Yes      |
+| Type     | Allowed Values                                                                                                                                                        | Default          | Required |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
+| `string` | "one-way", "one-way-safe", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way", "two-way-safe", "two-way-resolved", "two-way-resolved-reverse" | `"one-way-safe"` | Yes      |
 
 ### `devMode.sync[].defaultFileMode`
 

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -1280,9 +1280,9 @@ services:
 
 The sync mode to use for the given paths. See the [Dev Mode guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
 
-| Type     | Allowed Values                                                                                                                            | Default          | Required |
-| -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
-| `string` | "one-way", "one-way-safe", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way", "two-way-safe", "two-way-resolved" | `"one-way-safe"` | Yes      |
+| Type     | Allowed Values                                                                                                                                                        | Default          | Required |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
+| `string` | "one-way", "one-way-safe", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way", "two-way-safe", "two-way-resolved", "two-way-resolved-reverse" | `"one-way-safe"` | Yes      |
 
 ### `services[].devMode.sync[].defaultFileMode`
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

This should be the last Mutagen sync mode we'll have to add.

When using a resolved two-way sync, it's useful to be able to decide which endpoint is used as the primary. With this sync mode, the user now has every combination of options when using the resolved one/two-way sync modes.