### PR TITLE
fix(core): fix test dependencies for dev command

### DIFF
--- a/core/src/commands/dev.ts
+++ b/core/src/commands/dev.ts
@@ -300,7 +300,7 @@ export async function getDevCommandWatchTasks({
   })
 
   if (!skipTests) {
-    const testModules: GardenModule[] = await updatedGraph.withDependantModules([module])
+    const testModules: GardenModule[] = updatedGraph.withDependantModules([module])
     tasks.push(
       ...flatten(
         await Bluebird.map(testModules, (m) =>
@@ -310,6 +310,7 @@ export async function getDevCommandWatchTasks({
             module: m,
             graph: updatedGraph,
             filterNames: testNames,
+            fromWatch: true,
             devModeServiceNames,
             hotReloadServiceNames,
           })

--- a/core/src/commands/test.ts
+++ b/core/src/commands/test.ts
@@ -171,7 +171,7 @@ export class TestCommand extends Command<Args, Opts> {
       initialTasks,
       watch: opts.watch,
       changeHandler: async (updatedGraph, module) => {
-        const modulesToProcess = await updatedGraph.withDependantModules([module])
+        const modulesToProcess = updatedGraph.withDependantModules([module])
         return flatten(
           await Bluebird.map(modulesToProcess, (m) =>
             getTestTasks({
@@ -182,6 +182,7 @@ export class TestCommand extends Command<Args, Opts> {
               filterNames,
               force,
               forceBuild,
+              fromWatch: true,
               devModeServiceNames: [],
               hotReloadServiceNames: [],
             })

--- a/core/src/plugins/kubernetes/container/status.ts
+++ b/core/src/plugins/kubernetes/container/status.ts
@@ -55,7 +55,13 @@ export async function getContainerServiceStatus({
     enableHotReload: hotReload,
     blueGreen: provider.config.deploymentStrategy === "blue-green",
   })
-  const { state, remoteResources } = await compareDeployedResources(k8sCtx, api, namespace, manifests, log)
+  const { state, remoteResources, deployedWithDevMode, deployedWithHotReloading } = await compareDeployedResources(
+    k8sCtx,
+    api,
+    namespace,
+    manifests,
+    log
+  )
   const ingresses = await getIngresses(service, api, provider)
 
   const forwardablePorts: ForwardablePort[] = service.spec.ports
@@ -78,6 +84,7 @@ export async function getContainerServiceStatus({
     namespaceStatuses: [namespaceStatus],
     version: state === "ready" ? service.version : undefined,
     detail: { remoteResources, workload },
+    devMode: deployedWithDevMode || deployedWithHotReloading,
   }
 
   if (state === "ready" && devMode) {

--- a/core/src/plugins/kubernetes/dev-mode.ts
+++ b/core/src/plugins/kubernetes/dev-mode.ts
@@ -34,6 +34,7 @@ import {
 } from "./mutagen"
 import { joi, joiIdentifier } from "../../config/common"
 import { KubernetesPluginContext, KubernetesProvider } from "./config"
+import { isConfiguredForDevMode } from "./status/status"
 
 const syncUtilImageName = "gardendev/k8s-sync:0.1.1"
 
@@ -188,7 +189,7 @@ export async function startDevModeSync({
 
   return mutagenConfigLock.acquire("start-sync", async () => {
     // Validate the target
-    if (target.metadata.annotations?.[gardenAnnotationKey("dev-mode")] !== "true") {
+    if (!isConfiguredForDevMode(target)) {
       throw new ConfigurationError(`Resource ${resourceName} is not deployed in dev mode`, {
         target,
       })

--- a/core/src/plugins/kubernetes/hot-reload/hot-reload.ts
+++ b/core/src/plugins/kubernetes/hot-reload/hot-reload.ts
@@ -25,6 +25,7 @@ import { getManifests } from "../kubernetes-module/common"
 import { KubernetesModule, KubernetesService } from "../kubernetes-module/config"
 import { getHotReloadSpec, syncToService } from "./helpers"
 import { GardenModule } from "../../../types/module"
+import { isConfiguredForHotReloading } from "../status/status"
 
 export type HotReloadableResource = KubernetesWorkload | KubernetesPod
 export type HotReloadableKind = "Deployment" | "DaemonSet" | "StatefulSet"
@@ -142,7 +143,7 @@ export async function hotReloadContainer({
     },
   })
 
-  const list = res.items.filter((r) => r.metadata.annotations![gardenAnnotationKey("hot-reload")] === "true")
+  const list = res.items.filter((r) => isConfiguredForHotReloading(r))
 
   if (list.length === 0) {
     throw new RuntimeError(`Unable to find deployed instance of service ${service.name} with hot-reloading enabled`, {

--- a/core/src/tasks/deploy.ts
+++ b/core/src/tasks/deploy.ts
@@ -192,6 +192,7 @@ export class DeployTask extends BaseTask {
     const actions = await this.garden.getActionRouter()
 
     let status = serviceStatuses[this.service.name]
+    const devModeSkipRedeploy = status.devMode && (devMode || hotReload)
 
     const log = this.log.info({
       status: "active",
@@ -199,7 +200,7 @@ export class DeployTask extends BaseTask {
       msg: `Deploying version ${version}...`,
     })
 
-    if (!this.force && version === status.version && status.state === "ready") {
+    if (!this.force && status.state === "ready" && (version === status.version || devModeSkipRedeploy)) {
       // already deployed and ready
       log.setSuccess({
         msg: chalk.green("Already deployed"),

--- a/core/src/tasks/test.ts
+++ b/core/src/tasks/test.ts
@@ -39,6 +39,7 @@ export interface TestTaskParams {
   test: GardenTest
   force: boolean
   forceBuild: boolean
+  fromWatch?: boolean
   devModeServiceNames: string[]
   hotReloadServiceNames: string[]
   silent?: boolean
@@ -52,6 +53,7 @@ export class TestTask extends BaseTask {
   private test: GardenTest
   private graph: ConfigGraph
   private forceBuild: boolean
+  private fromWatch: boolean
   private devModeServiceNames: string[]
   private hotReloadServiceNames: string[]
   private silent: boolean
@@ -63,6 +65,7 @@ export class TestTask extends BaseTask {
     test,
     force,
     forceBuild,
+    fromWatch = false,
     devModeServiceNames,
     hotReloadServiceNames,
     silent = true,
@@ -73,6 +76,7 @@ export class TestTask extends BaseTask {
     this.graph = graph
     this.force = force
     this.forceBuild = forceBuild
+    this.fromWatch = fromWatch
     this.devModeServiceNames = devModeServiceNames
     this.hotReloadServiceNames = hotReloadServiceNames
     this.silent = silent
@@ -92,6 +96,7 @@ export class TestTask extends BaseTask {
       recursive: false,
       filter: (depNode) =>
         !(
+          this.fromWatch &&
           depNode.type === "deploy" &&
           includes([...this.devModeServiceNames, ...this.hotReloadServiceNames], depNode.name)
         ),
@@ -242,6 +247,7 @@ export async function getTestTasks({
   hotReloadServiceNames,
   force = false,
   forceBuild = false,
+  fromWatch = false,
 }: {
   garden: Garden
   log: LogEntry
@@ -252,6 +258,7 @@ export async function getTestTasks({
   hotReloadServiceNames: string[]
   force?: boolean
   forceBuild?: boolean
+  fromWatch?: boolean
 }) {
   // If there are no filters we return the test otherwise
   // we check if the test name matches against the filterNames array
@@ -270,6 +277,7 @@ export async function getTestTasks({
         log,
         force,
         forceBuild,
+        fromWatch,
         test: testFromConfig(module, testConfig, graph),
         devModeServiceNames,
         hotReloadServiceNames,

--- a/core/src/types/service.ts
+++ b/core/src/types/service.ts
@@ -182,6 +182,7 @@ const forwardablePortSchema = () => joi.object().keys(forwardablePortKeys())
 export interface ServiceStatus<T = any> {
   createdAt?: string
   detail: T
+  devMode?: boolean
   namespaceStatuses?: NamespaceStatus[]
   externalId?: string
   externalVersion?: string
@@ -204,6 +205,7 @@ export const serviceStatusSchema = () =>
   joi.object().keys({
     createdAt: joi.string().description("When the service was first deployed by the provider."),
     detail: joi.object().meta({ extendable: true }).description("Additional detail, specific to the provider."),
+    devMode: joi.boolean().description("Whether the service was deployed with dev mode enabled."),
     namespaceStatuses: namespaceStatusesSchema().optional(),
     externalId: joi
       .string()

--- a/core/test/integ/src/plugins/kubernetes/container/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/deployment.ts
@@ -21,9 +21,9 @@ import { DeployTask } from "../../../../../../src/tasks/deploy"
 import { getServiceStatuses } from "../../../../../../src/tasks/base"
 import { expectError, grouped } from "../../../../../helpers"
 import stripAnsi = require("strip-ansi")
-import { gardenAnnotationKey } from "../../../../../../src/util/string"
 import { kilobytesToString, millicpuToString } from "../../../../../../src/plugins/kubernetes/util"
 import { getResourceRequirements } from "../../../../../../src/plugins/kubernetes/container/util"
+import { isConfiguredForDevMode } from "../../../../../../src/plugins/kubernetes/status/status"
 
 describe("kubernetes container deployment handlers", () => {
   let garden: Garden
@@ -255,7 +255,7 @@ describe("kubernetes container deployment handlers", () => {
         blueGreen: false,
       })
 
-      expect(resource.metadata.annotations![gardenAnnotationKey("dev-mode")]).to.eq("true")
+      expect(isConfiguredForDevMode(resource)).to.eq(true)
 
       const initContainer = resource.spec.template?.spec?.initContainers![0]
       expect(initContainer).to.exist

--- a/core/test/integ/src/plugins/kubernetes/dev-mode.ts
+++ b/core/test/integ/src/plugins/kubernetes/dev-mode.ts
@@ -88,6 +88,7 @@ describe("dev mode deployments and sync behavior", () => {
       devMode: true,
       hotReload: false,
     })
+    expect(status.devMode).to.eql(true)
 
     const workload = status.detail.workload!
 

--- a/core/test/unit/src/commands/dev.ts
+++ b/core/test/unit/src/commands/dev.ts
@@ -79,6 +79,7 @@ describe("DevCommand", () => {
     const args = { services: undefined }
     const opts = withDefaultGlobalOpts({
       "force-build": false,
+      "force": false,
       "hot-reload": undefined,
       "skip-tests": false,
       "test-names": undefined,
@@ -134,6 +135,7 @@ describe("DevCommand", () => {
       // hot reloading don't request non-hot-reload-enabled deploys for those same services.
       hotReloadServiceNames: ["service-a"],
       skipTests: false,
+      forceDeploy: false,
     })
 
     const withDeps = async (task: BaseTask) => {
@@ -159,6 +161,7 @@ describe("DevCommand", () => {
     const args = { services: undefined }
     const opts = withDefaultGlobalOpts({
       "force-build": false,
+      "force": false,
       "hot-reload": undefined,
       "skip-tests": false,
       "test-names": undefined,
@@ -180,6 +183,7 @@ describe("DevCommand", () => {
     const args = { services: undefined }
     const opts = withDefaultGlobalOpts({
       "force-build": false,
+      "force": false,
       "hot-reload": undefined,
       "skip-tests": false,
       "test-names": undefined,
@@ -201,6 +205,7 @@ describe("DevCommand", () => {
     const args = { services: undefined }
     const opts = withDefaultGlobalOpts({
       "force-build": false,
+      "force": false,
       "hot-reload": undefined,
       "skip-tests": false,
       "test-names": undefined,
@@ -222,6 +227,7 @@ describe("DevCommand", () => {
     const args = { services: undefined }
     const opts = withDefaultGlobalOpts({
       "force-build": false,
+      "force": false,
       "hot-reload": undefined,
       "skip-tests": false,
       "test-names": undefined,
@@ -243,6 +249,7 @@ describe("DevCommand", () => {
     const args = { services: undefined }
     const opts = withDefaultGlobalOpts({
       "force-build": false,
+      "force": false,
       "hot-reload": undefined,
       "skip-tests": false,
       "test-names": undefined,
@@ -264,6 +271,7 @@ describe("DevCommand", () => {
     const args = { services: undefined }
     const opts = withDefaultGlobalOpts({
       "force-build": false,
+      "force": false,
       "hot-reload": undefined,
       "skip-tests": false,
       "test-names": undefined,

--- a/core/test/unit/src/tasks/test.ts
+++ b/core/test/unit/src/tasks/test.ts
@@ -46,25 +46,4 @@ describe("TestTask", () => {
       expect(deps.map((d) => d.getKey())).to.eql(["build.module-a", "deploy.service-b", "task.task-a"])
     })
   })
-
-  describe("getTestTasks", () => {
-    it("should not return test tasks with deploy dependencies on services deployed with hot reloading", async () => {
-      const moduleA = graph.getModule("module-a")
-
-      const tasks = await getTestTasks({
-        garden,
-        log,
-        graph,
-        module: moduleA,
-        devModeServiceNames: [],
-        hotReloadServiceNames: ["service-b"],
-      })
-
-      const testTask = tasks[0]
-      const deps = await testTask.resolveDependencies()
-
-      expect(tasks.length).to.eql(1)
-      expect(deps.map((d) => d.getKey())).to.eql(["build.module-a", "task.task-a"])
-    })
-  })
 })

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -112,6 +112,9 @@ deployments:
     # Additional detail, specific to the provider.
     detail:
 
+    # Whether the service was deployed with dev mode enabled.
+    devMode:
+
     namespaceStatuses:
       - pluginName:
 
@@ -468,6 +471,9 @@ serviceStatuses:
     # Additional detail, specific to the provider.
     detail:
 
+    # Whether the service was deployed with dev mode enabled.
+    devMode:
+
     namespaceStatuses:
       - pluginName:
 
@@ -578,6 +584,9 @@ Examples:
 
   # Additional detail, specific to the provider.
   detail:
+
+  # Whether the service was deployed with dev mode enabled.
+  devMode:
 
   namespaceStatuses:
     - pluginName:
@@ -741,6 +750,9 @@ deployments:
 
     # Additional detail, specific to the provider.
     detail:
+
+    # Whether the service was deployed with dev mode enabled.
+    devMode:
 
     namespaceStatuses:
       - pluginName:
@@ -2388,6 +2400,9 @@ services:
     # Additional detail, specific to the provider.
     detail:
 
+    # Whether the service was deployed with dev mode enabled.
+    devMode:
+
     namespaceStatuses:
       - pluginName:
 
@@ -3007,6 +3022,9 @@ deployments:
     # Additional detail, specific to the provider.
     detail:
 
+    # Whether the service was deployed with dev mode enabled.
+    devMode:
+
     namespaceStatuses:
       - pluginName:
 
@@ -3613,6 +3631,9 @@ deployments:
 
     # Additional detail, specific to the provider.
     detail:
+
+    # Whether the service was deployed with dev mode enabled.
+    devMode:
 
     namespaceStatuses:
       - pluginName:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

This fixes a minor regression introduced when we fixed the task graph's batching algorithm (see commit `5625e79d`).

Here, we also add an optional `devMode` field to service statuses (currently implemented/used by `container`, `kubernetes` and `helm` services), which will eventually enable us to start `garden dev` or `garden deploy --dev` without rebuilding dev-mode modules.

This is done in preparation for planned changes/improvements in how the task graph works (which will introduce more dynamic dependency resolution, enabling us to skip unnecessary tasks in many situations).

Also added a `--force` flag to the `garden dev` command.

This flag force-deploys services when the command starts (but after that, doesn't force-deploy them on source changes).