### PR TITLE
fix(k8s): fix status comparison when K8s specs have empty env values

### DIFF
--- a/core/test/data/test-projects/kubernetes-module/module-simple/garden.yml
+++ b/core/test/data/test-projects/kubernetes-module/module-simple/garden.yml
@@ -23,6 +23,13 @@ manifests:
             - name: busybox
               image: busybox:1.31.1
               args: [sleep, "100"]
+              env:
+                - name: FOO
+                  value: banana
+                - name: BAR
+                  value: ""
+                - name: BAZ
+                  value: null
               ports:
                 - containerPort: 80
 serviceResource:

--- a/core/test/integ/src/plugins/kubernetes/kubernetes-module/config.ts
+++ b/core/test/integ/src/plugins/kubernetes/kubernetes-module/config.ts
@@ -99,6 +99,11 @@ describe("configureKubernetesModule", () => {
                         name: "busybox",
                         image: "busybox:1.31.1",
                         args: ["sleep", "100"],
+                        env: [
+                          { name: "FOO", value: "banana" },
+                          { name: "BAR", value: "" },
+                          { name: "BAZ", value: null },
+                        ],
                         ports: [
                           {
                             containerPort: 80,

--- a/core/test/integ/src/plugins/kubernetes/kubernetes-module/handlers.ts
+++ b/core/test/integ/src/plugins/kubernetes/kubernetes-module/handlers.ts
@@ -163,6 +163,7 @@ describe("kubernetes-module handlers", () => {
         runtimeContext: emptyRuntimeContext,
       }
       const status = await deployKubernetesService(deployParams)
+      expect(status.state).to.eql("ready")
       expect(status.namespaceStatuses).to.eql([
         {
           pluginName: "local-kubernetes",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

If a deployed K8s resource has a container spec with env vars with an
empty value, K8s will return the env as something like `{ name: "FOO"
}` whereas we expect it to be `{ name: "FOO", value: ""}`.

This PR ensures we normalize manifests.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
