### PR TITLE
fix: remove deployment as default serviceresouce kind

### DIFF
--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -753,7 +753,6 @@ export const serviceResourceSchema = () =>
       kind: joi
         .string()
         .valid(...hotReloadableKinds)
-        .default("Deployment")
         .description("The type of Kubernetes resource to sync files to."),
       name: joi.string().description(
         deline`The name of the resource to sync to. If the module contains a single resource of the specified Kind,

--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -562,7 +562,7 @@ export async function getServiceResource({
 
   if (resourceSpec.podSelector && !isEmpty(resourceSpec.podSelector)) {
     const api = await KubeApi.factory(log, ctx, provider)
-    const namespace = await getAppNamespace(ctx, log, provider)
+    const namespace = module.spec.namespace || (await getAppNamespace(ctx, log, provider))
 
     const pods = await getReadyPods(api, namespace, resourceSpec.podSelector)
     const pod = sample(pods)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:
Currently `serviceResourceSchema.Kind`  has a default value of `Deployment`  set. This violates the  `oxor("podSelector", "kind")`  validation condition. This leads to the following error message `storage: Error validating Module 'storage': key .serviceResource contains a conflict between optional exclusive peers [podSelector, kind]`  when values are set for `serviceResource.podSelector`. This PR removes the default value.

Also `Kubernetes` and `Helm` Module types  has  `namespace`  field,  current the  `devMode` ignores this field if it is set. This PR give preference to this  property.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
