### PR TITLE
fix(k8s): validation fix in serviceResource schema

### DIFF
--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -770,7 +770,6 @@ export const serviceResourceSchema = () =>
         `
       ),
     })
-    .oxor("podSelector", "kind")
     .oxor("podSelector", "name")
 
 export const containerModuleSchema = () =>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

Before this fix, the `kind` field of a `serviceResource` could not be set/overridden when also providing a `podSelector` in a `serviceResource`.

**Which issue(s) this PR fixes**:

Fixes the issue reported in #2635.