### PR TITLE
fix(k8s): backwards-compatible deployment logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -749,6 +749,14 @@ workflows:
   # variant and k8s version would be quite expensive, so we try and make sure each of the latest 6-7 k8s versions is
   # tested, and that the most recent versions are broadly tested. The kind tests are the cheapest to run so we use many
   # of those, but they currently don't test in-cluster building, so we do need a range of versions on minikube as well.
+  test-minikube-1.22:
+    jobs:
+      - test-minikube:
+          kubernetesVersion: "1.22.2"
+          minikubeVersion: "v1.23.2"
+          # OpenFaaS project fails without ingress, which doesn't work in CircleCI on minikube v1.12+, which is necessary
+          # for most recent k8s versions.
+          testOpenfaas: false
   test-minikube-1.20:
     jobs:
       - test-minikube:
@@ -761,12 +769,6 @@ workflows:
     jobs:
       - test-minikube:
           kubernetesVersion: "1.19.7"
-          minikubeVersion: "v1.16.0"
-          testOpenfaas: false
-  test-minikube-1.18:
-    jobs:
-      - test-minikube:
-          kubernetesVersion: "1.18.15"
           minikubeVersion: "v1.16.0"
           testOpenfaas: false
   test-minikube-1.14:

--- a/core/src/plugins/kubernetes/commands/cleanup-cluster-registry.ts
+++ b/core/src/plugins/kubernetes/commands/cleanup-cluster-registry.ts
@@ -255,6 +255,7 @@ async function runRegistryGarbageCollection(ctx: KubernetesPluginContext, api: K
   try {
     await apply({
       ctx,
+      api,
       log,
       provider,
       manifests: [modifiedDeployment],
@@ -301,6 +302,7 @@ async function runRegistryGarbageCollection(ctx: KubernetesPluginContext, api: K
 
         await apply({
           ctx,
+          api,
           log,
           provider,
           manifests: [writableRegistry],

--- a/core/src/plugins/kubernetes/container/ingress.ts
+++ b/core/src/plugins/kubernetes/container/ingress.ts
@@ -92,7 +92,7 @@ export async function createIngressResources(
                 paths: [
                   {
                     path: ingress.path,
-                    pathType: "prefix",
+                    pathType: "Prefix",
                     backend: {
                       service: {
                         name: service.name,

--- a/core/src/plugins/kubernetes/container/ingress.ts
+++ b/core/src/plugins/kubernetes/container/ingress.ts
@@ -33,6 +33,24 @@ interface ServiceIngressWithCert extends ServiceIngress {
 
 const certificateHostnames: { [name: string]: string[] } = {}
 
+/**
+ * Detects and returns the supported ingress version for the context (checking for api versions in the provided
+ * preference order).
+ */
+export async function getIngressApiVersion(
+  log: LogEntry,
+  api: KubeApi,
+  preferenceOrder: string[]
+): Promise<string | undefined> {
+  for (const version of preferenceOrder) {
+    const resourceInfo = await api.getApiResourceInfo(log, version, "Ingress")
+    if (resourceInfo) {
+      return version
+    }
+  }
+  return undefined
+}
+
 export async function createIngressResources(
   api: KubeApi,
   provider: KubernetesProvider,
@@ -45,14 +63,7 @@ export async function createIngressResources(
   }
 
   // Detect the supported ingress version for the context
-  let apiVersion: string | undefined = undefined
-
-  for (const version of supportedIngressApiVersions) {
-    const resourceInfo = await api.getApiResourceInfo(log, version, "Ingress")
-    if (resourceInfo) {
-      apiVersion = version
-    }
-  }
+  const apiVersion = await getIngressApiVersion(log, api, supportedIngressApiVersions)
 
   if (!apiVersion) {
     log.warn(chalk.yellow(`Could not find a supported Ingress API version in the target cluster`))

--- a/core/src/plugins/kubernetes/container/status.ts
+++ b/core/src/plugins/kubernetes/container/status.ts
@@ -48,6 +48,7 @@ export async function getContainerServiceStatus({
   // FIXME: [objects, matched] and ingresses can be run in parallel
   const { workload, manifests } = await createContainerManifests({
     ctx: k8sCtx,
+    api,
     log,
     service,
     runtimeContext,

--- a/core/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/src/plugins/kubernetes/helm/deployment.ts
@@ -22,6 +22,7 @@ import { getServiceResource, getServiceResourceSpec } from "../util"
 import { getModuleNamespace, getModuleNamespaceStatus } from "../namespace"
 import { getHotReloadSpec, configureHotReload, getHotReloadContainerName } from "../hot-reload/helpers"
 import { configureDevMode, startDevModeSync } from "../dev-mode"
+import { KubeApi } from "../api"
 
 export async function deployHelmService({
   ctx,
@@ -38,6 +39,7 @@ export async function deployHelmService({
 
   const k8sCtx = ctx as KubernetesPluginContext
   const provider = k8sCtx.provider
+  const api = await KubeApi.factory(log, ctx, provider)
 
   const namespaceStatus = await getModuleNamespaceStatus({
     ctx: k8sCtx,
@@ -104,7 +106,7 @@ export async function deployHelmService({
       spec: service.spec.devMode,
       containerName: service.spec.devMode?.containerName,
     })
-    await apply({ log, ctx, provider, manifests: [serviceResource], namespace })
+    await apply({ log, ctx, api, provider, manifests: [serviceResource], namespace })
   } else if (hotReload && hotReloadSpec && serviceResourceSpec && serviceResource) {
     configureHotReload({
       target: serviceResource,
@@ -112,7 +114,7 @@ export async function deployHelmService({
       hotReloadArgs: serviceResourceSpec.hotReloadArgs,
       containerName: getHotReloadContainerName(module),
     })
-    await apply({ log, ctx, provider, manifests: [serviceResource], namespace })
+    await apply({ log, ctx, api, provider, manifests: [serviceResource], namespace })
   }
 
   // FIXME: we should get these objects from the cluster, and not from the local `helm template` command, because

--- a/core/src/plugins/kubernetes/kubectl.ts
+++ b/core/src/plugins/kubernetes/kubectl.ts
@@ -16,15 +16,40 @@ import { gardenAnnotationKey } from "../../util/string"
 import { hashManifest } from "./util"
 import { PluginToolSpec } from "../../types/plugin/tools"
 import { PluginContext } from "../../plugin-context"
+import { KubeApi } from "./api"
+
+// Corresponds to the default prune whitelist in `kubectl`.
+// See: https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/apply/prune.go#L176-L192
+const versionedPruneKinds = [
+  { apiVersion: "v1", kind: "ConfigMap" },
+  { apiVersion: "v1", kind: "Endpoints" },
+  { apiVersion: "v1", kind: "Namespace" },
+  { apiVersion: "v1", kind: "PersistentVolumeClaim" },
+  { apiVersion: "v1", kind: "PersistentVolume" },
+  { apiVersion: "v1", kind: "Pod" },
+  { apiVersion: "v1", kind: "ReplicationController" },
+  { apiVersion: "v1", kind: "Secret" },
+  { apiVersion: "v1", kind: "Service" },
+  { apiVersion: "batch/v1", kind: "Job" },
+  { apiVersion: "batch/v1", kind: "CronJob" },
+  { apiVersion: "batch/v1beta1", kind: "CronJob" },
+  { apiVersion: "extensions/v1beta1", kind: "Ingress" },
+  { apiVersion: "networking.k8s.io/v1", kind: "Ingress" },
+  { apiVersion: "apps/v1", kind: "DaemonSet" },
+  { apiVersion: "apps/v1", kind: "Deployment" },
+  { apiVersion: "apps/v1", kind: "ReplicaSet" },
+  { apiVersion: "apps/v1", kind: "StatefulSet" },
+]
 
 export interface ApplyParams {
   log: LogEntry
   ctx: PluginContext
+  api: KubeApi
   provider: KubernetesProvider
   manifests: KubernetesResource[]
   namespace?: string
   dryRun?: boolean
-  pruneSelector?: string
+  pruneLabels?: { [label: string]: string }
   validate?: boolean
 }
 
@@ -33,11 +58,12 @@ export const KUBECTL_DEFAULT_TIMEOUT = 300
 export async function apply({
   log,
   ctx,
+  api,
   provider,
   manifests,
   dryRun = false,
   namespace,
-  pruneSelector,
+  pruneLabels,
   validate = true,
 }: ApplyParams) {
   // Hash the raw input and add as an annotation on each manifest (this is helpful beyond kubectl's own annotation,
@@ -53,15 +79,49 @@ export async function apply({
     manifest.metadata.annotations[gardenAnnotationKey("manifest-hash")] = await hashManifest(manifest)
   }
 
+  // The `--prune` option for `kubectl apply` currently isn't backwards-compatible, so here, we essentially
+  // reimplement the pruning logic. This enables us to prune resources in a way that works for newer and older
+  // versions of Kubernetes, while still being able to use an up-to-date version of `kubectl`.
+  //
+  // This really should be fixed in `kubectl` proper. In fact, simply including resource mappings for older/beta API
+  // versions and adding the appropriate error handling for missing API/resource versions to the pruning logic would
+  // be enough to make `kubectl apply --prune` backwards-compatible.
+  let resourcesToPrune: KubernetesResource[] = []
+  if (namespace && pruneLabels) {
+    // Fetch all deployed resources in the namesapce matching `pruneLabels` (for all resource kinds represented in
+    // `versionedPruneKinds` - see its definition above).
+    const resourcesForLabels = await api.listResourcesForKinds({
+      log,
+      namespace,
+      versionedKinds: versionedPruneKinds,
+      labelSelector: pruneLabels,
+    })
+
+    // We only prune resources that were created/updated via `kubectl apply (this is how `kubectl apply --prune` works)
+    // and that don't match any of the applied manifests by kind and name.
+    resourcesToPrune = resourcesForLabels
+      .filter((r) => r.metadata.annotations?.["kubectl.kubernetes.io/last-applied-configuration"])
+      .filter((r) => !manifests.find((m) => m.kind === r.kind && m.metadata.name === r.metadata.name))
+  }
+
   const input = Buffer.from(encodeYamlMulti(manifests))
 
   let args = ["apply"]
   dryRun && args.push("--dry-run")
-  pruneSelector && args.push("--prune", "--selector", pruneSelector)
   args.push("--output=json", "-f", "-")
   !validate && args.push("--validate=false")
 
   const result = await kubectl(ctx, provider).stdout({ log, namespace, args, input })
+
+  if (namespace && resourcesToPrune.length > 0) {
+    await deleteResources({
+      log,
+      ctx,
+      provider,
+      namespace,
+      resources: resourcesToPrune,
+    })
+  }
 
   try {
     return JSON.parse(result)
@@ -232,7 +292,7 @@ export const kubectlSpec: PluginToolSpec = {
       platform: "windows",
       architecture: "amd64",
       url: "https://storage.googleapis.com/kubernetes-release/release/v1.22.3/bin/windows/amd64/kubectl.exe",
-      sha256: "c1c148569b1aa500fc46151756c497d7fbbff0789f316d7be444ace1dc793593"
+      sha256: "c1c148569b1aa500fc46151756c497d7fbbff0789f316d7be444ace1dc793593",
     },
   ],
 }

--- a/core/src/plugins/kubernetes/kubectl.ts
+++ b/core/src/plugins/kubernetes/kubectl.ts
@@ -219,20 +219,20 @@ export const kubectlSpec: PluginToolSpec = {
     {
       platform: "darwin",
       architecture: "amd64",
-      url: "https://storage.googleapis.com/kubernetes-release/release/v1.20.2/bin/darwin/amd64/kubectl",
-      sha256: "c4b120ab1284222afbc15f28e4e7d8dfcfc3ad2435bd17e5bfec62e17036623c",
+      url: "https://storage.googleapis.com/kubernetes-release/release/v1.22.3/bin/darwin/amd64/kubectl",
+      sha256: "beea08a2a166a002603e2aa015223b5ba558d6e3f6a81098e3cc5d7d2b7a64d9",
     },
     {
       platform: "linux",
       architecture: "amd64",
-      url: "https://storage.googleapis.com/kubernetes-release/release/v1.20.2/bin/linux/amd64/kubectl",
-      sha256: "2583b1c9fbfc5443a722fb04cf0cc83df18e45880a2cf1f6b52d9f595c5beb88",
+      url: "https://storage.googleapis.com/kubernetes-release/release/v1.22.3/bin/linux/amd64/kubectl",
+      sha256: "0751808ca8d7daba56bf76b08848ef5df6b887e9d7e8a9030dd3711080e37b54",
     },
     {
       platform: "windows",
       architecture: "amd64",
-      url: "https://storage.googleapis.com/kubernetes-release/release/v1.20.2/bin/windows/amd64/kubectl.exe",
-      sha256: "d8731ac97166c506441e5d2f69e31d57356983ae15602ba12cc16981862bfdef",
+      url: "https://storage.googleapis.com/kubernetes-release/release/v1.22.3/bin/windows/amd64/kubectl.exe",
+      sha256: "c1c148569b1aa500fc46151756c497d7fbbff0789f316d7be444ace1dc793593"
     },
   ],
 }

--- a/core/src/types/plugin/tools.ts
+++ b/core/src/types/plugin/tools.ts
@@ -40,7 +40,7 @@ const toolBuildSchema = () =>
       .string()
       .required()
       .example("a81b23abe67e70f8395ff7a3659bea6610fba98cda1126ef19e0a995f0075d54")
-      .description("The SHA256 sum the target URL should have."),
+      .description("The SHA256 sum the target file should have."),
     extract: joi
       .object()
       .keys({

--- a/core/test/data/test-projects/helm/api/templates/ingress.yaml
+++ b/core/test/data/test-projects/helm/api/templates/ingress.yaml
@@ -1,6 +1,53 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "api.fullname" . -}}
 {{- $ingressPaths := .Values.ingress.paths -}}
+
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
+
+# Use the new Ingress manifest structure
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "api.name" . }}
+    helm.sh/chart: {{ include "api.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+	{{- range $ingressPaths }}
+          - path: {{ . }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: 80
+	{{- end }}
+  {{- end }}
+
+{{- else -}}
+
+# Use the old Ingress manifest structure
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -37,4 +84,7 @@ spec:
               servicePort: http
 	{{- end }}
   {{- end }}
+
+
+{{- end }}
 {{- end }}

--- a/core/test/integ/src/plugins/kubernetes/container/ingress.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/ingress.ts
@@ -475,7 +475,7 @@ describe("createIngressResources", () => {
 
     if (ingress.apiVersion === "networking.k8s.io/v1") {
       expect(ingress.spec.ingressClassName).to.equal("nginx")
-      expect(ingress.metadata.annotations?.["kubernetes.io/ingress.class"]).to.be.empty
+      expect(ingress.metadata.annotations?.["kubernetes.io/ingress.class"]).to.be.undefined
       expect(ingress.spec.rules).to.eql([
         {
           host: "my.domain.com",
@@ -483,7 +483,7 @@ describe("createIngressResources", () => {
             paths: [
               {
                 path: "/",
-                pathType: "prefix",
+                pathType: "Prefix",
                 backend: {
                   service: {
                     name: "my-service",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

This fixes an issue when using newer versions of `kubectl` with older cluster versions.

When `kubectl apply --prune` is used against a cluster with different API versions of certain resources (most commonly `Ingress` and `CronJob`), it will fail because `kubectl apply --prune` can only handle the resources hardcoded in the current version of `kubectl`.

See: https://github.com/kubernetes/kubectl/blob/0a152f10/pkg/cmd/apply/prune.go#L176-L192

Since the `--prune` option for `kubectl apply` currently isn't backwards-compatible, here we essentially reimplement the pruning logic in our Kubernetes plugin to be able to prune resources in a way that works for newer and older versions of Kubernetes.

This really should be fixed in `kubectl` proper. In fact, simply including resource mappings for older/beta API versions and adding the appropriate error handling for missing API/resource versions to the pruning logic would be enough to make `kubectl apply --prune` backwards-compatible.

If/when we have time, we should try to contribute a fix to `kubectl` along these lines.

Also updated to `kubectl` 1.22.3.

**Which issue(s) this PR fixes**:

Fixes #2636 and #2573.

**Special notes for your reviewer**:

The added integration test case should cover this, but do comment if you feel more testing is needed.

We rely heavily on pruning for both the `container` and `kubernetes` module types. That said, the changes implemented here should be relatively simple to reason about.