### PR TITLE
fix: use modulespec namespace value

### DIFF
--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -562,7 +562,7 @@ export async function getServiceResource({
 
   if (resourceSpec.podSelector && !isEmpty(resourceSpec.podSelector)) {
     const api = await KubeApi.factory(log, ctx, provider)
-    const namespace = await getAppNamespace(ctx, log, provider)
+    const namespace = module.spec.namespace || (await getAppNamespace(ctx, log, provider))
 
     const pods = await getReadyPods(api, namespace, resourceSpec.podSelector)
     const pod = sample(pods)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

 Kubernetes and Helm Module types have namespace fields, current the devMode ignores this field if it is set. This PR gives preference to this property.
 
 When the namespace field is set, it uses that instead of the default namespace set on the provider config.
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
