### PR TITLE
fix(container): propagate privileged flag

### DIFF
--- a/core/src/plugins/kubernetes/container/deployment.ts
+++ b/core/src/plugins/kubernetes/container/deployment.ts
@@ -401,7 +401,7 @@ export async function createWorkloadManifest({
     resources: getResourceRequirements({ cpu, memory }, limits),
     imagePullPolicy: "IfNotPresent",
     securityContext: {
-      allowPrivilegeEscalation: false,
+      allowPrivilegeEscalation: spec.privileged || false,
       ...getSecurityContext(spec.privileged, spec.addCapabilities, spec.dropCapabilities),
     },
   }

--- a/core/test/integ/src/plugins/kubernetes/container/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/deployment.ts
@@ -198,7 +198,7 @@ describe("kubernetes container deployment handlers", () => {
       })
 
       expect(resource.spec.template?.spec?.containers[0].securityContext).to.eql({
-        allowPrivilegeEscalation: false,
+        allowPrivilegeEscalation: true,
         privileged: true,
         capabilities: {
           add: ["SYS_TIME"],


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

The `privileged` config flag for `container` services wasn't resulting in the `allowPrivilegeEscalation` flag being set too. This is fixed here.