### PR TITLE
chore: ensure ANALYTICS_DEV env var has the right type

### DIFF
--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -50,7 +50,7 @@ export const VERSION_CHECK_URL = "https://get.garden.io/version"
  * We set this up as a map to facilitate overriding values in tests.
  */
 export const gardenEnv = {
-  ANALYTICS_DEV: env.get("ANALYTICS_DEV").required(false).asString(),
+  ANALYTICS_DEV: env.get("ANALYTICS_DEV").required(false).asBool(),
   GARDEN_AUTH_TOKEN: env.get("GARDEN_AUTH_TOKEN").required(false).asString(),
   GARDEN_CACHE_TTL: env.get("GARDEN_CACHE_TTL").required(false).asInt(),
   GARDEN_DB_DIR: env.get("GARDEN_DB_DIR").required(false).default(GARDEN_GLOBAL_PATH).asString(),

--- a/core/test/helpers.ts
+++ b/core/test/helpers.ts
@@ -554,7 +554,7 @@ export async function enableAnalytics(garden: TestGarden) {
   await garden.globalConfigStore.set(["analytics", "optedIn"], true)
   gardenEnv.GARDEN_DISABLE_ANALYTICS = false
   // Set the analytics mode to dev for good measure
-  gardenEnv.ANALYTICS_DEV = "1"
+  gardenEnv.ANALYTICS_DEV = true
 
   const resetConfig = async () => {
     if (originalAnalyticsConfig) {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

Before this fix, setting ANALYTICS_DEV=false would be interpreted as
truthy because it was being evaluated as a string. Only the dev team
uses this so it was basically a none issue, but incorrect none the less.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
