### PR TITLE
feat(k8s): add timeout to container services

### DIFF
--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -30,6 +30,7 @@ import { dedent, deline } from "../../util/string"
 import { getModuleTypeUrl } from "../../docs/common"
 import { ContainerModuleOutputs } from "./container"
 import { devModeGuideLink } from "../kubernetes/dev-mode"
+import { k8sDeploymentTimeoutSchema } from "../kubernetes/config"
 
 export const defaultContainerLimits: ServiceLimitSpec = {
   cpu: 1000, // = 1000 millicpu = 1 CPU
@@ -121,6 +122,7 @@ export interface ContainerServiceSpec extends CommonServiceSpec {
   healthCheck?: ServiceHealthCheckSpec
   hotReloadCommand?: string[]
   hotReloadArgs?: string[]
+  timeout?: number
   limits?: ServiceLimitSpec
   cpu: ContainerResourcesSpec["cpu"]
   memory: ContainerResourcesSpec["memory"]
@@ -610,6 +612,7 @@ const containerServiceSchema = () =>
         these arguments when the service is deployed with hot reloading enabled.`
       )
       .example(["npm", "run", "dev"]),
+    timeout: k8sDeploymentTimeoutSchema(),
     limits: limitsSchema()
       .description("Specify resource limits for the service.")
       .meta({ deprecated: "Please use the `cpu` and `memory` fields instead." }),

--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -38,6 +38,7 @@ import { ArtifactSpec } from "../../config/validation"
 import { V1Toleration } from "@kubernetes/client-node"
 import { runPodSpecIncludeFields } from "./run"
 import { KubernetesDevModeDefaults, kubernetesDevModeDefaultsSchema } from "./dev-mode"
+import { KUBECTL_DEFAULT_TIMEOUT } from "./kubectl"
 
 export const DEFAULT_KANIKO_IMAGE = "gcr.io/kaniko-project/executor:v1.6.0-debug"
 export interface ProviderSecretRef {
@@ -281,6 +282,12 @@ const storageSchema = (defaults: KubernetesStorageSpec, deprecated: boolean) =>
         .meta({ deprecated }),
     })
     .default(defaults)
+
+export const k8sDeploymentTimeoutSchema = () =>
+  joi
+    .number()
+    .default(KUBECTL_DEFAULT_TIMEOUT)
+    .description("The maximum duration (in seconds) to wait for resources to deploy and become healthy.")
 
 export const k8sContextSchema = () =>
   joi
@@ -838,7 +845,7 @@ export const portForwardsSchema = () =>
       "Manually specify port forwards that Garden should set up when deploying in dev or watch mode. If specified, these override the auto-detection of forwardable ports, so you'll need to specify the full list of port forwards to create."
     )
 
-const runPodSpecWhitelistDescription = runPodSpecIncludeFields.map((f) => `* \`${f}\``).join("\n")
+const runPodSpecWhitelistDescription = () => runPodSpecIncludeFields.map((f) => `* \`${f}\``).join("\n")
 
 export const kubernetesTaskSchema = () =>
   baseTaskSpecSchema()
@@ -851,7 +858,7 @@ export const kubernetesTaskSchema = () =>
         ${serviceResourceDescription}
 
         The following pod spec fields from the service resource will be used (if present) when executing the task:
-        ${runPodSpecWhitelistDescription}`
+        ${runPodSpecWhitelistDescription()}`
       ),
       cacheResult: cacheResultSchema(),
       command: joi
@@ -880,7 +887,7 @@ export const kubernetesTestSchema = () =>
         ${serviceResourceDescription}
 
         The following pod spec fields from the service resource will be used (if present) when executing the test suite:
-        ${runPodSpecWhitelistDescription}`
+        ${runPodSpecWhitelistDescription()}`
       ),
       command: joi
         .sparseArray()

--- a/core/src/plugins/kubernetes/container/deployment.ts
+++ b/core/src/plugins/kubernetes/container/deployment.ts
@@ -132,7 +132,7 @@ export async function deployContainerServiceRolling(params: DeployServiceParams<
     serviceName: service.name,
     resources: manifests,
     log,
-    timeoutSec: KUBECTL_DEFAULT_TIMEOUT,
+    timeoutSec: service.spec.timeout || KUBECTL_DEFAULT_TIMEOUT,
   })
 }
 

--- a/core/src/plugins/kubernetes/kubernetes-module/config.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/config.ts
@@ -27,10 +27,10 @@ import {
   serviceResourceDescription,
   portForwardsSchema,
   PortForwardSpec,
+  k8sDeploymentTimeoutSchema,
 } from "../config"
 import { ContainerModule } from "../../container/config"
 import { kubernetesDevModeSchema, KubernetesDevModeSpec } from "../dev-mode"
-import { KUBECTL_DEFAULT_TIMEOUT } from "../kubectl"
 
 // A Kubernetes Module always maps to a single Service
 export type KubernetesModuleSpec = KubernetesServiceSpec
@@ -105,10 +105,7 @@ export const kubernetesModuleSpecSchema = () =>
       }),
     tasks: joiSparseArray(kubernetesTaskSchema()),
     tests: joiSparseArray(kubernetesTestSchema()),
-    timeout: joi
-      .number()
-      .default(KUBECTL_DEFAULT_TIMEOUT)
-      .description("The maximum duration (in seconds) to wait for resources to deploy and become healthy."),
+    timeout: k8sDeploymentTimeoutSchema(),
   })
 
 export async function configureKubernetesModule({

--- a/core/test/unit/src/commands/get/get-config.ts
+++ b/core/test/unit/src/commands/get/get-config.ts
@@ -14,6 +14,7 @@ import { sortBy } from "lodash"
 import { DEFAULT_API_VERSION } from "../../../../../src/constants"
 import { defaultWorkflowResources, WorkflowConfig } from "../../../../../src/config/workflow"
 import { defaultContainerLimits, defaultContainerResources } from "../../../../../src/plugins/container/config"
+import { KUBECTL_DEFAULT_TIMEOUT } from "../../../../../src/plugins/kubernetes/kubectl"
 
 describe("GetConfigCommand", () => {
   it("should get the project configuration", async () => {
@@ -491,6 +492,7 @@ describe("GetConfigCommand", () => {
             cpu: defaultContainerResources.cpu,
             memory: defaultContainerResources.memory,
             ports: [],
+            timeout: KUBECTL_DEFAULT_TIMEOUT,
             volumes: [],
           },
           hotReloadable: false,

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -4454,9 +4454,9 @@ describe("Garden", () => {
     })
 
     context("test against fixed version hashes", async () => {
-      const moduleAVersionString = "v-02baf73977"
-      const moduleBVersionString = "v-2ef2ef79d3"
-      const moduleCVersionString = "v-dc9d7af247"
+      const moduleAVersionString = "v-f6743d2423"
+      const moduleBVersionString = "v-97a77e8414"
+      const moduleCVersionString = "v-afb847fa9a"
 
       it("should return the same module versions between runtimes", async () => {
         const projectRoot = getDataDir("test-projects", "fixed-version-hashes-1")

--- a/core/test/unit/src/vcs/vcs.ts
+++ b/core/test/unit/src/vcs/vcs.ts
@@ -423,7 +423,7 @@ describe("getModuleVersionString", () => {
     const garden = await makeTestGarden(projectRoot)
     const module = await garden.resolveModule("module-a")
 
-    const fixedVersionString = "v-02baf73977"
+    const fixedVersionString = "v-f6743d2423"
     expect(module.version.versionString).to.eql(fixedVersionString)
 
     delete process.env.TEST_ENV_VAR

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -344,6 +344,9 @@ services:
     # deployed with hot reloading enabled.
     hotReloadArgs:
 
+    # The maximum duration (in seconds) to wait for resources to deploy and become healthy.
+    timeout: 300
+
     cpu:
       # The minimum amount of CPU the service needs to be available for it to be deployed, in millicpus (i.e. 1000 = 1
       # CPU)
@@ -1549,6 +1552,16 @@ services:
       - run
       - dev
 ```
+
+### `services[].timeout`
+
+[services](#services) > timeout
+
+The maximum duration (in seconds) to wait for resources to deploy and become healthy.
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `300`   | No       |
 
 ### `services[].limits`
 

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -365,6 +365,9 @@ services:
     # deployed with hot reloading enabled.
     hotReloadArgs:
 
+    # The maximum duration (in seconds) to wait for resources to deploy and become healthy.
+    timeout: 300
+
     cpu:
       # The minimum amount of CPU the service needs to be available for it to be deployed, in millicpus (i.e. 1000 = 1
       # CPU)
@@ -1620,6 +1623,16 @@ services:
       - run
       - dev
 ```
+
+### `services[].timeout`
+
+[services](#services) > timeout
+
+The maximum duration (in seconds) to wait for resources to deploy and become healthy.
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `300`   | No       |
 
 ### `services[].limits`
 

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -344,6 +344,9 @@ services:
     # deployed with hot reloading enabled.
     hotReloadArgs:
 
+    # The maximum duration (in seconds) to wait for resources to deploy and become healthy.
+    timeout: 300
+
     cpu:
       # The minimum amount of CPU the service needs to be available for it to be deployed, in millicpus (i.e. 1000 = 1
       # CPU)
@@ -1559,6 +1562,16 @@ services:
       - run
       - dev
 ```
+
+### `services[].timeout`
+
+[services](#services) > timeout
+
+The maximum duration (in seconds) to wait for resources to deploy and become healthy.
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `300`   | No       |
 
 ### `services[].limits`
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

This has been requested by a few users. The deployment timeout for `container` services can now be configured.