### PR TITLE
feat(core): render module command

### DIFF
--- a/core/src/commands/commands.ts
+++ b/core/src/commands/commands.ts
@@ -9,56 +9,58 @@
 import { Command, CommandGroup } from "./base"
 import { BuildCommand } from "./build"
 import { CallCommand } from "./call"
+import { ConfigCommand } from "./config/config"
 import { CreateCommand } from "./create/create"
+import { DashboardCommand } from "./dashboard"
 import { DeleteCommand } from "./delete"
 import { DeployCommand } from "./deploy"
 import { DevCommand } from "./dev"
-import { GetCommand } from "./get/get"
 import { EnterpriseCommand } from "./enterprise/enterprise"
+import { ExecCommand } from "./exec"
+import { GetCommand } from "./get/get"
 import { LinkCommand } from "./link/link"
+import { LogOutCommand } from "./logout"
+import { LoginCommand } from "./login"
 import { LogsCommand } from "./logs"
 import { MigrateCommand } from "./migrate"
+import { OptionsCommand } from "./options"
+import { PluginsCommand } from "./plugins"
 import { PublishCommand } from "./publish"
+import { RenderCommand } from "./render/render"
 import { RunCommand } from "./run/run"
 import { ScanCommand } from "./scan"
+import { SelfUpdateCommand } from "./self-update"
 import { SetCommand } from "./set"
 import { TestCommand } from "./test"
+import { ToolsCommand } from "./tools"
 import { UnlinkCommand } from "./unlink/unlink"
 import { UpdateRemoteCommand } from "./update-remote/update-remote"
-import { ValidateCommand } from "./validate"
-import { ExecCommand } from "./exec"
-import { DashboardCommand } from "./dashboard"
-import { OptionsCommand } from "./options"
-import { ConfigCommand } from "./config/config"
-import { PluginsCommand } from "./plugins"
-import { LoginCommand } from "./login"
-import { LogOutCommand } from "./logout"
-import { ToolsCommand } from "./tools"
 import { UtilCommand } from "./util/util"
-import { SelfUpdateCommand } from "./self-update"
+import { ValidateCommand } from "./validate"
 
 export const getCoreCommands = (): (Command | CommandGroup)[] => [
   new BuildCommand(),
   new CallCommand(),
   new ConfigCommand(),
   new CreateCommand(),
+  new DashboardCommand(),
   new DeleteCommand(),
   new DeployCommand(),
   new DevCommand(),
-  new ExecCommand(),
   new EnterpriseCommand(),
+  new ExecCommand(),
   new GetCommand(),
   new LinkCommand(),
-  new LoginCommand(),
   new LogOutCommand(),
+  new LoginCommand(),
   new LogsCommand(),
   new MigrateCommand(),
   new OptionsCommand(),
   new PluginsCommand(),
   new PublishCommand(),
+  new RenderCommand(),
   new RunCommand(),
   new ScanCommand(),
-  new DashboardCommand(),
   new SelfUpdateCommand(),
   new SetCommand(),
   new TestCommand(),

--- a/core/src/commands/render/render.ts
+++ b/core/src/commands/render/render.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2018-2021 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { omit } from "lodash"
+import chalk from "chalk"
+import { StringParameter } from "../../cli/params"
+import { StringMap } from "../../config/common"
+import { printHeader } from "../../logger/util"
+import { GardenModule } from "../../types/module"
+import { dedent } from "../../util/string"
+import { deepMap, highlightYaml, safeDumpYaml } from "../../util/util"
+import { Command, CommandGroup, CommandParams, CommandResult } from "../base"
+
+export class RenderCommand extends CommandGroup {
+  name = "render"
+  help = "Render and output Garden configuration."
+
+  subCommands = [RenderModuleCommand]
+}
+
+const renderModuleArgs = {
+  module: new StringParameter({
+    help: "The name of the module to render.",
+    required: true,
+  }),
+}
+
+type RenderModuleArgs = typeof renderModuleArgs
+type RenderModuleOpts = {}
+
+export class RenderModuleCommand extends Command<RenderModuleArgs, RenderModuleOpts> {
+  name = "module"
+  help = "Outputs a fully resolved configuration for the requested module."
+  description = dedent`
+    Outputs the fully resolved module configuration. Resolves all template strings and includes the module's current
+    version. This is useful for debugging template strings.
+
+    Examples:
+      garden render module my-module          # Renders my-module as YAML
+      garden render module my-module -o json  # Renders my-module as JSON
+  `
+
+  arguments = renderModuleArgs
+
+  printHeader({ headerLog, args }) {
+    printHeader(headerLog, `Rendering module ${chalk.white(args.module)}`, "spiral_note_pad")
+  }
+
+  async action({
+    garden,
+    log,
+    args,
+  }: CommandParams<RenderModuleArgs, RenderModuleOpts>): Promise<CommandResult<RenderedModule>> {
+    const graph = await garden.getConfigGraph({ log, emit: false })
+    const module = graph.getModule(args.module)
+    const rendered = renderModule(module, garden.secrets)
+    const yaml = safeDumpYaml(rendered, { noRefs: true, sortKeys: true })
+    log.info("")
+    log.info(highlightYaml(yaml))
+    return { result: rendered }
+  }
+}
+
+type RenderedModule = Omit<
+  GardenModule,
+  | "_config"
+  | "variables"
+  | "path"
+  | "plugin"
+  | "version"
+  | "buildDependencies"
+  | "serviceConfigs"
+  | "testConfigs"
+  | "taskConfigs"
+> & {
+  version: string
+  buildDependencies: string[]
+}
+
+export function renderModule(module: GardenModule, secrets: StringMap): RenderedModule {
+  const version = module.version.versionString
+  const buildDependencies = Object.keys(module.buildDependencies)
+  const filtered = omit(
+    module,
+    "_config",
+    "variables",
+    "path",
+    "plugin",
+    "serviceConfigs",
+    "testConfigs",
+    "taskConfigs"
+  )
+  return filterSecrets(
+    {
+      ...filtered,
+      version,
+      buildDependencies,
+    },
+    secrets
+  )
+}
+
+/**
+ * Replaces any string value in `object` that matches one of the values in `secrets` with a placeholder.
+ *
+ * Used for sanitizing output that may contain secret values.
+ */
+export function filterSecrets<T extends object>(object: T, secrets: StringMap): T {
+  const secretValues = new Set(Object.values(secrets))
+  const secretNames = Object.keys(secrets)
+  const sanitized = <T>deepMap(object, (value) => {
+    if (secretValues.has(value)) {
+      const name = secretNames.find((n) => secrets[n] === value)!
+      return `[filtered secret: ${name}]`
+    } else {
+      return value
+    }
+  })
+  return sanitized
+}

--- a/core/test/unit/src/commands/render/render-module.ts
+++ b/core/test/unit/src/commands/render/render-module.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2018-2021 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import { ensureDir } from "fs-extra"
+import { join } from "path"
+import { RenderModuleCommand } from "../../../../../src/commands/render/render"
+import { DEFAULT_API_VERSION, GARDEN_CORE_ROOT } from "../../../../../src/constants"
+import { makeTestGardenA, withDefaultGlobalOpts } from "../../../../helpers"
+
+describe("RenderModuleCommand", () => {
+  let tmpPath: string
+
+  before(async () => {
+    tmpPath = join(GARDEN_CORE_ROOT, "tmp")
+    await ensureDir(tmpPath)
+  })
+
+  it("should filter secrets from the rendered output", async () => {
+    const garden = await makeTestGardenA()
+    garden.secrets = {
+      big_secret: "there is no spoon",
+    }
+    garden.setModuleConfigs([
+      {
+        apiVersion: DEFAULT_API_VERSION,
+        allowPublish: false,
+        build: { dependencies: [] },
+        disabled: false,
+        name: "foo",
+        path: tmpPath,
+        serviceConfigs: [],
+        taskConfigs: [],
+        spec: {
+          services: [
+            {
+              name: "disabled-service",
+              dependencies: [],
+              disabled: true,
+              hotReloadable: false,
+              spec: {},
+              env: { some_field: "there is no spoon" },
+            },
+          ],
+        },
+        testConfigs: [],
+        type: "test",
+      },
+    ])
+    const command = new RenderModuleCommand()
+    const log = garden.log
+    const result = await command.action({
+      garden,
+      log,
+      headerLog: log,
+      footerLog: log,
+      args: { module: "foo" },
+      opts: withDefaultGlobalOpts({}),
+    })
+    expect(result.result?.spec.services[0]["env"]["some_field"]).to.eql("[filtered secret: big_secret]")
+  })
+})

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -386,6 +386,31 @@ Examples:
   | `--type` |  | string | The module type to create. Required if --interactive&#x3D;false.
 
 
+### garden dashboard
+
+**Starts the Garden dashboard for the current project and environment.**
+
+Starts the Garden dashboard for the current project, and your selected environment+namespace. The dashboard can be used to monitor your Garden project, look at logs, provider-specific dashboard pages and more.
+
+The dashboard will receive and display updates from other Garden processes that you run with the same Garden project, environment and namespace.
+
+Note: You must currently run one dashboard per-environment and namespace.
+
+| Supported in workflows |   |
+| ---------------------- |---|
+| No |                                                  |
+
+#### Usage
+
+    garden dashboard [options]
+
+#### Options
+
+| Argument | Alias | Type | Description |
+| -------- | ----- | ---- | ----------- |
+  | `--port` |  | number | The port number for the Garden dashboard to listen on.
+
+
 ### garden delete secret
 
 **Delete a secret from the environment.**
@@ -937,56 +962,6 @@ Examples:
   | `--test-names` | `-tn` | array:string | Filter the tests to run by test name across all modules (leave unset to run all tests). Accepts glob patterns (e.g. integ* would run both &#x27;integ&#x27; and &#x27;integration&#x27;).
 
 
-### garden exec
-
-**Executes a command (such as an interactive shell) in a running service.**
-
-Finds an active container for a deployed service and executes the given command within the container.
-Supports interactive shells.
-
-_NOTE: This command may not be supported for all module types._
-
-Examples:
-
-     garden exec my-service /bin/sh   # runs a shell in the my-service container
-
-| Supported in workflows |   |
-| ---------------------- |---|
-| Yes |                                                  |
-
-#### Usage
-
-    garden exec <service> <command> [options]
-
-#### Arguments
-
-| Argument | Required | Description |
-| -------- | -------- | ----------- |
-  | `service` | Yes | The service to exec the command in.
-  | `command` | Yes | The command to run.
-
-#### Options
-
-| Argument | Alias | Type | Description |
-| -------- | ----- | ---- | ----------- |
-  | `--interactive` |  | boolean | Set to false to skip interactive mode and just output the command result
-
-#### Outputs
-
-```yaml
-# The exit code of the command executed in the service container.
-code:
-
-# The output of the executed command.
-output:
-
-# The stdout output of the executed command (if available).
-stdout:
-
-# The stderr output of the executed command (if available).
-stderr:
-```
-
 ### garden enterprise secrets list
 
 **[EXPERIMENTAL] List secrets.**
@@ -1203,6 +1178,56 @@ Examples:
 | -------- | ----- | ---- | ----------- |
   | `--filter-names` |  | array:string | Filter on group name. Use comma as a separator to filter on multiple names. Accepts glob patterns.
 
+
+### garden exec
+
+**Executes a command (such as an interactive shell) in a running service.**
+
+Finds an active container for a deployed service and executes the given command within the container.
+Supports interactive shells.
+
+_NOTE: This command may not be supported for all module types._
+
+Examples:
+
+     garden exec my-service /bin/sh   # runs a shell in the my-service container
+
+| Supported in workflows |   |
+| ---------------------- |---|
+| Yes |                                                  |
+
+#### Usage
+
+    garden exec <service> <command> [options]
+
+#### Arguments
+
+| Argument | Required | Description |
+| -------- | -------- | ----------- |
+  | `service` | Yes | The service to exec the command in.
+  | `command` | Yes | The command to run.
+
+#### Options
+
+| Argument | Alias | Type | Description |
+| -------- | ----- | ---- | ----------- |
+  | `--interactive` |  | boolean | Set to false to skip interactive mode and just output the command result
+
+#### Outputs
+
+```yaml
+# The exit code of the command executed in the service container.
+code:
+
+# The output of the executed command.
+output:
+
+# The stdout output of the executed command (if available).
+stdout:
+
+# The stderr output of the executed command (if available).
+stderr:
+```
 
 ### garden get graph
 
@@ -3193,6 +3218,33 @@ published:
     version:
 ```
 
+### garden render module
+
+**Outputs a fully resolved configuration for the requested module.**
+
+Outputs the fully resolved module configuration. Resolves all template strings and includes the module's current
+version. This is useful for debugging template strings.
+
+Examples:
+  garden render module my-module          # Renders my-module as YAML
+  garden render module my-module -o json  # Renders my-module as JSON
+
+| Supported in workflows |   |
+| ---------------------- |---|
+| No |                                                  |
+
+#### Usage
+
+    garden render module <module> 
+
+#### Arguments
+
+| Argument | Required | Description |
+| -------- | -------- | ----------- |
+  | `module` | Yes | The name of the module to render.
+
+
+
 ### garden run module
 
 **Run an ad-hoc instance of a module.**
@@ -3480,31 +3532,6 @@ Examples:
 
     garden scan 
 
-
-
-### garden dashboard
-
-**Starts the Garden dashboard for the current project and environment.**
-
-Starts the Garden dashboard for the current project, and your selected environment+namespace. The dashboard can be used to monitor your Garden project, look at logs, provider-specific dashboard pages and more.
-
-The dashboard will receive and display updates from other Garden processes that you run with the same Garden project, environment and namespace.
-
-Note: You must currently run one dashboard per-environment and namespace.
-
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
-
-#### Usage
-
-    garden dashboard [options]
-
-#### Options
-
-| Argument | Alias | Type | Description |
-| -------- | ----- | ---- | ----------- |
-  | `--port` |  | number | The port number for the Garden dashboard to listen on.
 
 
 ### garden self-update


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

Added a new command: `garden render module`.

This command resolves all template strings in the module, and outputs the full module configuration (which includes the resolved module version).

This is useful for debugging/writing template strings for modules, and for reasoning about which files/variables factor into the  module's version calculation.

Note: Garden Cloud/Enterprise secrets are filtered from the rendered output.