### PR TITLE
fix(core): improve project config validation

### DIFF
--- a/core/src/config/common.ts
+++ b/core/src/config/common.ts
@@ -10,7 +10,7 @@ import Joi from "@hapi/joi"
 import Ajv from "ajv"
 import { splitLast } from "../util/util"
 import { deline, dedent } from "../util/string"
-import { cloneDeep } from "lodash"
+import { cloneDeep, isArray } from "lodash"
 import { joiPathPlaceholder } from "./validation"
 import { DEFAULT_API_VERSION } from "../constants"
 
@@ -415,7 +415,7 @@ joi = joi.extend({
   type: "sparseArray",
   coerce: {
     method(value) {
-      return { value: value && value.filter((v: any) => v !== undefined && v !== null) }
+      return { value: isArray(value) && value.filter((v: any) => v !== undefined && v !== null) }
     },
   },
 })

--- a/core/src/config/project.ts
+++ b/core/src/config/project.ts
@@ -133,13 +133,7 @@ export const environmentSchema = () =>
   })
 
 export const environmentsSchema = () =>
-  joi
-    .alternatives(
-      joiSparseArray(environmentSchema()).unique("name"),
-      // Allow a string as a shorthand for { name: foo }
-      joiSparseArray(joiUserIdentifier())
-    )
-    .description("A list of environments to configure for the project.")
+  joiSparseArray(environmentSchema()).unique("name").description("A list of environments to configure for the project.")
 
 export interface SourceConfig {
   name: string

--- a/core/test/data/test-project-malformed-environments/garden.yml
+++ b/core/test/data/test-project-malformed-environments/garden.yml
@@ -1,0 +1,6 @@
+kind: Project
+name: test-project-malformed-environments
+environments:
+  name: local # This should result in an exception, because `environments` is a map instead of a array.
+providers:
+  - name: test-plugin

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -218,6 +218,14 @@ describe("Garden", () => {
       await expectError(async () => TestGarden.factory(projectRootA, { environmentName: "garden-bla" }), "parameter")
     })
 
+    it("should throw if project.environments is not an array", async () => {
+      const projectRoot = join(dataDir, "test-project-malformed-environments")
+      await expectError(
+        async () => TestGarden.factory(projectRoot),
+        (err) => expect(err.message).to.match(/Error validating environments: value must be an array/)
+      )
+    })
+
     it("should set .garden as the default cache dir", async () => {
       const projectRoot = join(dataDir, "test-project-empty")
       const garden = await TestGarden.factory(projectRoot, { plugins: [testPlugin] })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

We now validate that `project.environments` is an array and throw an informative error if it isn't.

Previously, if `project.environments` was mistakenly formatted as a map instead of an array, a cryptic type error would be printed (e.g. "Cannot read property name of undefined"). We now clearly indicate the problem
to the user.

Additionally, the `joiSparseArray` schema can now properly handle non-array inputs without failing cryptically.

**Which issue(s) this PR fixes**:

Fixes #2653.

**Special notes for your reviewer**:

You'll note that I removed support for defining an environment with a string instead of an object. For example something like the following was allowed by `environmentsSchema`
```
environments
- someEnvName
- name: someOtherEnv
  variables:
   ...
```
but would have thrown an error during the resolution process. We could also keep the `- environmentName` format as an option, but fix it so that it's actually usable (i.e. doesn't just result in an error).