### PR TITLE
fix(exec): error when calling garden CLI within exec module tasks

### DIFF
--- a/core/src/plugins/exec.ts
+++ b/core/src/plugins/exec.ts
@@ -280,6 +280,8 @@ function getDefaultEnvVars(module: ExecModule) {
   return {
     ...process.env,
     GARDEN_MODULE_VERSION: module.version.versionString,
+    // Workaround for https://github.com/vercel/pkg/issues/897
+    PKG_EXECPATH: "",
     ...mapValues(module.spec.env, (v) => v.toString()),
   }
 }


### PR DESCRIPTION
This fixes that pkg issue we had previously fixed for workflow steps,
but left out of the exec module type.
