### PR TITLE
fix(k8s): delete env command would recreate namespace after delete

### DIFF
--- a/core/src/actions.ts
+++ b/core/src/actions.ts
@@ -878,7 +878,7 @@ export class ActionRouter implements TypeGuard {
     const providers = await this.garden.resolveProviders(log)
     await Bluebird.each(Object.values(providers), async (provider) => {
       await this.cleanupEnvironment({ pluginName: provider.name, log: envLog })
-      environmentStatuses[provider.name] = await this.getEnvironmentStatus({ pluginName: provider.name, log: envLog })
+      environmentStatuses[provider.name] = { ready: false, outputs: {} }
     })
 
     envLog.setSuccess()


### PR DESCRIPTION
We were calling the environment status handler unnecessarily, which
might implicitly create a k8s namespace during execution.
