### PR TITLE
chore: update links in cert-manager guide

### DIFF
--- a/docs/advanced/cert-manager-integration.md
+++ b/docs/advanced/cert-manager-integration.md
@@ -15,7 +15,7 @@ You also need make sure your DNS and routing are configured to point the domains
 cert-manager is currently under development. Currently we only support cert-manager v0.11.0, which requires Kubernetes v1.11 or higher.
 
 If you set `certManager.install: false` garden will expect to find a `cert-manager` installation in the `cert-manager` namespace.
-If you already have installed `cert-manager` please verify it's running by checking the status of the main pods as suggested in the [documentation](https://docs.cert-manager.io/en/latest/getting-started/install/kubernetes.html#verifying-the-installation).
+If you already have installed `cert-manager` please verify it's running by checking the status of the main pods as suggested in the [documentation](https://cert-manager.io/docs/installation/verify/)
 
 The integration currently only supports Let's Encrypt and HTTP-01 challenges. We also only support cert-manager ClusterIssuers and not namespace Issuers.
 
@@ -97,7 +97,7 @@ The above configuration will trigger the following workflow:
 
 All the steps above will happen at system startup/init. All your services will be built/tested/deployed after all the secrets have been populated.
 
-For advanced configuration, please take a look at the official [cert-manager documentation](https://docs.cert-manager.io/en/latest/tasks/index.html).
+For advanced configuration, please take a look at the official [cert-manager documentation](https://cert-manager.io/docs/usage/).
 
 ## Troubleshooting
 
@@ -119,7 +119,7 @@ and you can describe the failing Certificate with:
 $: kubectl describe Certificate certificate-name -n your-namespace
 ```
 
-Please find more info in the ["Issuing an ACME certificate using HTTP validation"](https://docs.cert-manager.io/en/release-0.11/tutorials/acme/http-validation.html#issuing-an-acme-certificate-using-http-validation) guide in the official cert-manager documentation.
+Please find more info in the ["Issuing an ACME certificate using HTTP validation"](https://cert-manager.io/docs/tutorials/acme/http-validation/#issuing-an-acme-certificate-using-http-validation) guide in the official cert-manager documentation.
 
 ---
 If have any issue, find a bug, or something is not clear from the documentation, please don't hesitate opening a new [GitHub issue](https://github.com/garden-io/garden/issues/new?template=BUG_REPORT.md) or ask us questions in our [Slack channel](https://chat.garden.io/).

--- a/markdown-link-check-config.json
+++ b/markdown-link-check-config.json
@@ -1,5 +1,6 @@
 {
   "retryOn429":true,
+  "timeout": "30s",
   "ignorePatterns": [
     {
       "pattern": "local.app.garden",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

Some of the links in the cert-manager guide were outdated (since the documentation site we link to has moved some pages around).

Also bumped the timeout for checking external links from 10 seconds (the default) to 30 seconds. In the past few months, GitBook has often exceeded the timeout during link checking, making our link checker falsely categorize it is a dead link.