### PR TITLE
chore: always emit stack graph event in workflows

### DIFF
--- a/core/src/commands/run/workflow.ts
+++ b/core/src/commands/run/workflow.ts
@@ -79,6 +79,9 @@ export class RunWorkflowCommand extends Command<Args, {}> {
     }
 
     await registerAndSetUid(garden, log, workflow)
+    // This is to ensure that a stack graph event always gets emitted when a workflow is run, regardless of whether
+    // or not it has command steps that also emit it.
+    await garden.getConfigGraph({ log, emit: true })
     garden.events.emit("workflowRunning", {})
     const templateContext = new WorkflowConfigContext(garden, garden.variables)
     const files = resolveTemplateStrings(workflow.files || [], templateContext)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

This ensures that we also emit the stack graph event when the workflow only has script steps, or only has command steps that don't emit the stack graph event.