### PR TITLE
improve(exec): stream logs from exec module on verbose log level

### DIFF
--- a/core/src/util/util.ts
+++ b/core/src/util/util.ts
@@ -155,7 +155,7 @@ export function makeErrorMsg({
   return msg
 }
 
-interface ExecOpts extends execa.Options {
+export interface ExecOpts extends execa.Options {
   stdout?: Writable
   stderr?: Writable
 }

--- a/core/test/unit/src/util/util.ts
+++ b/core/test/unit/src/util/util.ts
@@ -140,6 +140,15 @@ describe("util", () => {
       expect(entry.getLatestMessage().msg).to.equal(renderOutputStream("hello"))
     })
 
+    it("should buffer outputs when piping to stream", async () => {
+      const logger = getLogger()
+      const entry = logger.placeholder()
+
+      const res = await exec("echo", ["hello"], { stdout: createOutputStream(entry) })
+
+      expect(res.stdout).to.equal("hello")
+    })
+
     it("should throw a standardised error message on error", async () => {
       try {
         // Using "sh -c" to get consistent output between operating systems


### PR DESCRIPTION
This replicates the behavior in e.g. container builds. Behavior stays
the same on the default log level.

Closes #2669

cc @tedchang77