### PR TITLE
fix(template): ignore errors in skipped ternary clause

### DIFF
--- a/core/src/template-string/parser.pegjs
+++ b/core/src/template-string/parser.pegjs
@@ -344,13 +344,6 @@ ConditionalExpression
       if (test && test._error) {
         return test
       }
-      if (consequent && consequent._error) {
-        return consequent
-      }
-      if (alternate && alternate._error) {
-        return alternate
-      }
-
       return getValue(test) ? consequent : alternate
     }
   / LogicalORExpression

--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -629,6 +629,11 @@ describe("resolveTemplateString", async () => {
     expect(res).to.equal(true)
   })
 
+  it("should ignore errors in a value not returned by a ternary", async () => {
+    const res = resolveTemplateString("${var.foo ? replace(var.foo, ' ', ',') : null}", new TestContext({ var: {} }))
+    expect(res).to.equal(null)
+  })
+
   it("should handle a ternary expression with an object as a test", async () => {
     const res = resolveTemplateString("${a ? a.value : b}", new TestContext({ a: { value: true }, b: false }))
     expect(res).to.equal(true)


### PR DESCRIPTION
Fixes #2678
