### PR TITLE
Added check chart without resources besides helm hook

### DIFF
--- a/core/src/plugins/kubernetes/helm/common.ts
+++ b/core/src/plugins/kubernetes/helm/common.ts
@@ -317,7 +317,7 @@ export async function renderHelmTemplateString(
  * `loadAll` in this context: https://github.com/kubeapps/kubeapps/issues/636.
  */
 export function loadTemplate(template: string) {
-  return loadAll(template, undefined, { json: true })
+  return loadAll(template || "", undefined, { json: true })
     .filter((obj) => obj !== null)
     .map((obj) => {
       if (isPlainObject(obj)) {

--- a/core/src/plugins/kubernetes/status/status.ts
+++ b/core/src/plugins/kubernetes/status/status.ts
@@ -197,6 +197,13 @@ export async function waitForResources({
   })
   emitLog(waitingMsg)
 
+  if (resources.length === 0) {
+    const readyMsg = `No resources to wait`
+    emitLog(readyMsg)
+    statusLine.setState({ symbol: "info", section: serviceName, msg: readyMsg })
+    return []
+  }
+
   const api = await KubeApi.factory(log, ctx, provider)
   let statuses: ResourceStatus[]
 

--- a/core/src/plugins/kubernetes/status/status.ts
+++ b/core/src/plugins/kubernetes/status/status.ts
@@ -198,9 +198,9 @@ export async function waitForResources({
   emitLog(waitingMsg)
 
   if (resources.length === 0) {
-    const readyMsg = `No resources to wait`
-    emitLog(readyMsg)
-    statusLine.setState({ symbol: "info", section: serviceName, msg: readyMsg })
+    const noResourcesMsg = `No resources to wait`
+    emitLog(noResourcesMsg)
+    statusLine.setState({ symbol: "info", section: serviceName, msg: noResourcesMsg })
     return []
   }
 


### PR DESCRIPTION
We have a scenario where our helm chart has only one single helm hook (db migration steps)

This ends up creating any resources from helm point of view, the issue is that garden tries to wait for resources with a list `["undefined"]` producing  a weird and unclear error message

```
[2021-12-09T16:58:36.315Z] TypeError: Cannot read property 'name' of undefined
    at KubeApi.<anonymous> (/home/janario/Projects/open/garden/core/src/plugins/kubernetes/api.ts:388:105)
    at Generator.next (<anonymous>)
    at /home/janario/Projects/open/garden/core/build/src/plugins/kubernetes/api.js:15:71
    at new Promise (<anonymous>)
    at __awaiter (/home/janario/Projects/open/garden/core/build/src/plugins/kubernetes/api.js:11:12)
    at KubeApi.readBySpec (/home/janario/Projects/open/garden/core/build/src/plugins/kubernetes/api.js:252:16)
    at /home/janario/Projects/open/garden/core/src/plugins/kubernetes/status/status.ts:143:26
    at Generator.next (<anonymous>)
    at /home/janario/Projects/open/garden/core/build/src/plugins/kubernetes/status/status.js:15:71
    at new Promise (<anonymous>)
    at __awaiter (/home/janario/Projects/open/garden/core/build/src/plugins/kubernetes/status/status.js:11:12)
    at checkResourceStatus (/home/janario/Projects/open/garden/core/build/src/plugins/kubernetes/status/status.js:92:12)
    at /home/janario/Projects/open/garden/core/src/plugins/kubernetes/status/status.ts:123:12
    at Generator.next (<anonymous>)
    at /home/janario/Projects/open/garden/core/build/src/plugins/kubernetes/status/status.js:15:71
    at new Promise (<anonymous>)
    at __awaiter (/home/janario/Projects/open/garden/core/build/src/plugins/kubernetes/status/status.js:11:12)
    at /home/janario/Projects/open/garden/core/src/plugins/kubernetes/status/status.ts:122:53
    at tryCatcher (/home/janario/Projects/open/garden/node_modules/bluebird/js/release/util.js:16:23)
    at MappingPromiseArray._promiseFulfilled (/home/janario/Projects/open/garden/node_modules/bluebird/js/release/map.js:68:38)
    at MappingPromiseArray.PromiseArray._iterate (/home/janario/Projects/open/garden/node_modules/bluebird/js/release/promise_array.js:115:31)
    at MappingPromiseArray.init (/home/janario/Projects/open/garden/node_modules/bluebird/js/release/promise_array.js:79:10)
    at MappingPromiseArray._asyncInit (/home/janario/Projects/open/garden/node_modules/bluebird/js/release/map.js:37:10)
    at _drainQueueStep (/home/janario/Projects/open/garden/node_modules/bluebird/js/release/async.js:97:12)
    at _drainQueue (/home/janario/Projects/open/garden/node_modules/bluebird/js/release/async.js:86:9)
    at Async._drainQueues (/home/janario/Projects/open/garden/node_modules/bluebird/js/release/async.js:102:5)
    at Immediate.Async.drainQueues (/home/janario/Projects/open/garden/node_modules/bluebird/js/release/async.js:15:14)
    at processImmediate (internal/timers.js:461:21)
```
With this changeset it will ignore in case there is no resources to wait and avoid this message.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
