### PR TITLE
improve(k8s): add symlink to mutagen data directory to .garden/mutagen

### DIFF
--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -126,6 +126,7 @@ export async function syncToBuildSync(params: SyncToSharedBuildSyncParams) {
 
       // -> Create the sync
       await ensureMutagenSync({
+        ctx,
         log,
         key,
         logSection: module.name,
@@ -147,11 +148,11 @@ export async function syncToBuildSync(params: SyncToSharedBuildSyncParams) {
       })
 
       // -> Flush the sync once
-      await flushMutagenSync(log, key)
+      await flushMutagenSync(ctx, log, key)
       log.debug(`Sync from ${sourcePath} to ${resourceName} completed`)
     } finally {
       // -> Terminate the sync
-      await terminateMutagenSync(log, key)
+      await terminateMutagenSync(ctx, log, key)
       log.debug(`Sync connection terminated`)
     }
   } else {

--- a/core/src/plugins/kubernetes/dev-mode.ts
+++ b/core/src/plugins/kubernetes/dev-mode.ts
@@ -241,6 +241,7 @@ export async function startDevModeSync({
       log.info({ symbol: "info", section: serviceName, msg: chalk.gray(`Syncing ${description} (${s.mode})`) })
 
       await ensureMutagenSync({
+        ctx,
         // Prefer to log to the main view instead of the handler log context
         log,
         key,

--- a/docs/guides/code-synchronization-dev-mode.md
+++ b/docs/guides/code-synchronization-dev-mode.md
@@ -142,6 +142,7 @@ This is done to grant you more control over precisely which files and directorie
 For example, you might want to ignore `dist` or `build` directories (not version control them, not include them in builds or module versions), but still be able to sync them from your local machine to the running container (or from the running container to your local machine). This is easy to achieve with dev mode.
 
 Exclusion rules can be specified on individual sync configs:
+
 ```yaml
 kind: Module
 name: node-service
@@ -158,7 +159,9 @@ services:
           mode: two-way
   ...
 ```
+
 Project-wide exclusion rules can be set on the `local-kubernetes` and `kubernetes` providers:
+
 ```yaml
 kind: Project
 ...
@@ -172,6 +175,7 @@ providers:
         exclude:
           - "/**/node_modules" # <--- with this, we don't have to specify `node_modules` on individual sync specs
 ```
+
 This is great to reduce repetition in your excludes.
 
 See the reference documentation for the [`kubernetes` provider](../reference/providers/kubernetes.md#providersdevmode)) for a full list of provider-level options for dev mode when using the `kubernetes` provider. The same dev-mode options are also available when using `local-kubernetes`.
@@ -207,6 +211,7 @@ These options are passed directly to Mutagen. For more information, please see t
 ### An advanced example
 
 This example demonstrates several of the more advanced options that dev mode offers. For more details on the options available, see the sections above.
+
 ```yaml
 kind: Project
 ...
@@ -254,4 +259,16 @@ services:
           # description of each available sync mode.
           mode: one-way-replica-reverse
   ...
+```
+
+## Troubleshooting
+
+Every so often something comes up in the underlying Mutagen synchronization process, which may not be visible in the Garden CLI logs. To figure out what the issue may be (say, ahead of reporting a GitHub issue for Garden), it's useful to be able to use the `mutagen` CLI directly.
+
+Because Garden creates a temporary data directory for Mutagen for every Garden CLI instance, you can't use the `mutagen` CLI without additional context. However, to make this easier, a symlink to the temporary directory is automatically created under `<project root>/.garden/mutagen/<random ID>`, as well as a `mutagen.sh` helper script within that directory that sets the appropriate context and links to the automatically installed Mutagen CLI.
+
+To, for example, get the current list of active syncs in an active Garden process, you could run the following from the project root directory:
+
+```sh
+.garden/mutagen/<session ID>/mutagen.sh sync list
 ```


### PR DESCRIPTION
This is just to ease troubleshooting, since otherwise the directory is
difficult to find. The symlink is named with the Garden session ID, e.g.
`.garden/mutagen/f98b8d43-baf0-448d-98d7-bc3a295beb8a`.

We also add a `mutagen.sh` script into the data directory which makes
it easier to call the mutagen CLI with the right env vars set.

So from the Garden project root, you can run e.g.
`.garden/mutagen/<session UUID>/mutagen.sh sync list`
