### PR TITLE
fix(cli): get rid of EPIPE error and OOM check

### DIFF
--- a/cli/bin/garden
+++ b/cli/bin/garden
@@ -1,42 +1,7 @@
 #!/usr/bin/env node
 
-const cluster = require("cluster")
+require("source-map-support").install()
+const cli = require("../build/src/cli")
 
-// Wrapping and forking, to catch OOM errors and print helpful message
-// See https://medium.com/@evgeni.leonti/detect-heap-overflow-on-node-js-javascript-heap-out-of-memory-41cb649c6b33
-if (cluster.isMaster) {
-  cluster.fork()
-  cluster.on("exit", (_, workerExitCode) => {
-    process.exit(workerExitCode)
-  })
-} else {
-  const v8 = require("v8")
-  require("source-map-support").install()
-
-  const cli = require("../build/src/cli")
-  const chalk = require("chalk")
-
-  // Worker process
-  const totalHeapSizeThreshold = (v8.getHeapStatistics().heap_size_limit * 85) / 100
-
-  let detectHeapOverflow = () => {
-    let stats = v8.getHeapStatistics()
-
-    if (stats.total_heap_size > totalHeapSizeThreshold) {
-      // tslint:disable-next-line: no-console
-      console.error(
-        chalk.red.bold(`
-Process memory threshold reached. This most likely means there are too many files in the project, and that you need to exclude large dependency directories. Please see https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories for information on how to do that.
-
-If this keeps occurring after configuring exclusions, please file an issue at https://github.com/garden-io/garden/issues.
-        `)
-      )
-
-      process.exit(137)
-    }
-  }
-  setInterval(detectHeapOverflow, 1000)
-
-  // tslint:disable-next-line: no-floating-promises
-  cli.runCli()
-}
+// tslint:disable-next-line: no-floating-promises
+cli.runCli()

--- a/core/src/proxy.ts
+++ b/core/src/proxy.ts
@@ -305,7 +305,7 @@ function stopPortProxy(proxy: PortProxy, log?: LogEntry) {
   delete activeProxies[proxy.key]
 
   try {
-    proxy.server.close()
+    proxy.server.close(() => {})
   } catch {}
 }
 


### PR DESCRIPTION
The OOM check (which involves forking the main process and monitoring
it) is causing more problems than it solves, and may also be slowing
down the overall execution.

We should test this well but my sense is this will be a net improvement.
