### PR TITLE
feat(core): module varfiles

### DIFF
--- a/core/src/config/base.ts
+++ b/core/src/config/base.ts
@@ -187,6 +187,7 @@ export function prepareModuleResource(spec: any, configPath: string, projectRoot
     type: spec.type,
     taskConfigs: [],
     variables: spec.variables,
+    varfile: spec.varfile,
   }
 
   validateWithPath({

--- a/core/src/config/module.ts
+++ b/core/src/config/module.ts
@@ -23,6 +23,7 @@ import { TestConfig, testConfigSchema } from "./test"
 import { TaskConfig, taskConfigSchema } from "./task"
 import { dedent, stableStringify } from "../util/string"
 import { templateKind } from "./module-template"
+import { varfileDescription } from "./project"
 
 export const defaultBuildTimeout = 1200
 
@@ -91,6 +92,7 @@ interface ModuleSpecCommon {
   repositoryUrl?: string
   type: string
   variables?: DeepPrimitiveMap
+  varfile?: string
 }
 
 export interface AddModuleSpec extends ModuleSpecCommon {
@@ -230,6 +232,21 @@ export const baseModuleSpecKeys = () => ({
   variables: joiVariables().default(() => undefined).description(dedent`
     A map of variables scoped to this particular module. These are resolved before any other parts of the module configuration and take precedence over project-scoped variables. They may reference project-scoped variables, and generally use any template strings normally allowed when resolving modules.
   `),
+  varfile: joi
+    .posixPath()
+    .description(
+      dedent`
+      Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+      module-level \`variables\` field.
+
+      ${varfileDescription}
+
+      To use different module-level varfiles in different environments, you can template in the environment name
+      to the varfile name, e.g. \`varfile: "my-module.\$\{environment.name\}.env\` (this assumes that the corresponding
+      varfiles exist).
+    `
+    )
+    .example("my-module.env"),
 })
 
 export const baseModuleSpecSchema = () => coreModuleSpecSchema().keys(baseModuleSpecKeys())

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -174,6 +174,7 @@ export interface GardenParams {
   projectSources?: SourceConfig[]
   providerConfigs: GenericProviderConfig[]
   variables: DeepPrimitiveMap
+  cliVariables: DeepPrimitiveMap
   secrets: StringMap
   sessionId: string
   username: string | undefined
@@ -215,6 +216,9 @@ export class Garden {
   public readonly environmentConfigs: EnvironmentConfig[]
   public readonly namespace: string
   public readonly variables: DeepPrimitiveMap
+  // Any variables passed via the `--var` CLI option (maintained here so that they can be used during module resolution
+  // to override module variables and module varfiles).
+  public readonly cliVariables: DeepPrimitiveMap
   public readonly secrets: StringMap
   private readonly projectSources: SourceConfig[]
   public readonly buildStaging: BuildStaging
@@ -257,6 +261,7 @@ export class Garden {
     this.projectSources = params.projectSources || []
     this.providerConfigs = params.providerConfigs
     this.variables = params.variables
+    this.cliVariables = params.cliVariables
     this.secrets = params.secrets
     this.workingCopyId = params.workingCopyId
     this.dotIgnoreFiles = params.dotIgnoreFiles
@@ -1321,7 +1326,8 @@ export async function resolveGardenParams(currentDirectory: string, opts: Garden
   })
 
   // Allow overriding variables
-  variables = { ...variables, ...(opts.variables || {}) }
+  const cliVariables = opts.variables || {}
+  variables = { ...variables, ...cliVariables }
 
   // Use the legacy build sync mode if
   // A) GARDEN_LEGACY_BUILD_STAGE=true is set or
@@ -1356,6 +1362,7 @@ export async function resolveGardenParams(currentDirectory: string, opts: Garden
     environmentConfigs: config.environments,
     namespace,
     variables,
+    cliVariables,
     secrets,
     projectSources,
     buildStaging: buildDir,

--- a/core/test/data/test-projects/module-varfiles/garden.module-a.default.env
+++ b/core/test/data/test-projects/module-varfiles/garden.module-a.default.env
@@ -1,0 +1,2 @@
+c=from-module-varfile
+d=from-module-varfile

--- a/core/test/data/test-projects/module-varfiles/garden.project.env
+++ b/core/test/data/test-projects/module-varfiles/garden.project.env
@@ -1,0 +1,4 @@
+a=from-project-varfile
+b=from-project-varfile
+c=from-project-varfile
+d=from-project-varfile

--- a/core/test/data/test-projects/module-varfiles/garden.yml
+++ b/core/test/data/test-projects/module-varfiles/garden.yml
@@ -1,0 +1,20 @@
+kind: Project
+name: module-varfiles
+varfile: garden.project.env
+environments:
+  - name: default
+providers:
+  - name: test-plugin
+
+---
+
+kind: Module
+name: module-a
+type: test
+varfile: "garden.module-a.${environment.name}.env"
+variables:
+  b: from-module-vars
+  c: from-module-vars # should be overridden by module-level varfile
+  d: from-module-vars # should be overridden by var passed as a CLI option
+build:
+  command: [echo, A]

--- a/core/test/integ/src/plugins/kubernetes/helm/config.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/config.ts
@@ -119,7 +119,8 @@ describe("configureHelmModule", () => {
       testConfigs: [],
       type: "helm",
       taskConfigs: [],
-      variables: undefined,
+      variables: {},
+      varfile: undefined,
     })
   })
 

--- a/core/test/unit/src/config/base.ts
+++ b/core/test/unit/src/config/base.ts
@@ -133,6 +133,7 @@ describe("loadConfigResources", () => {
         build: { dependencies: [] },
         path: modulePathA,
         variables: { msg: "OK" },
+        varfile: undefined,
 
         spec: {
           build: {
@@ -276,6 +277,7 @@ describe("loadConfigResources", () => {
         testConfigs: [],
         taskConfigs: [],
         variables: undefined,
+        varfile: undefined,
       },
     ])
   })
@@ -315,6 +317,7 @@ describe("loadConfigResources", () => {
         testConfigs: [],
         taskConfigs: [],
         variables: undefined,
+        varfile: undefined,
       },
       {
         apiVersion: "garden.io/v0",
@@ -344,6 +347,7 @@ describe("loadConfigResources", () => {
         testConfigs: [],
         taskConfigs: [],
         variables: undefined,
+        varfile: undefined,
       },
     ])
   })

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -271,6 +271,22 @@ describe("Garden", () => {
       })
     })
 
+    it("should respect the module variables < module varfile < CLI var precedence order", async () => {
+      const projectRoot = join(dataDir, "test-projects", "module-varfiles")
+
+      const garden = await makeTestGarden(projectRoot)
+      // In the normal flow, `garden.cliVariables` is populated with variables passed via the `--var` CLI option.
+      garden.cliVariables["d"] = "from-cli-var"
+      const graph = await garden.getConfigGraph({ log: garden.log, emit: false })
+      const module = graph.getModule("module-a")
+      expect({ ...garden.variables, ...module.variables }).to.eql({
+        a: "from-project-varfile",
+        b: "from-module-vars",
+        c: "from-module-varfile",
+        d: "from-cli-var",
+      })
+    })
+
     it("should throw if project root is not in a git repo root", async () => {
       const dir = await tmp.dir({ unsafeCleanup: true })
 
@@ -4462,9 +4478,9 @@ describe("Garden", () => {
     })
 
     context("test against fixed version hashes", async () => {
-      const moduleAVersionString = "v-f6743d2423"
-      const moduleBVersionString = "v-97a77e8414"
-      const moduleCVersionString = "v-afb847fa9a"
+      const moduleAVersionString = "v-3b072717eb"
+      const moduleBVersionString = "v-b9e3153900"
+      const moduleCVersionString = "v-371a6bbdec"
 
       it("should return the same module versions between runtimes", async () => {
         const projectRoot = getDataDir("test-projects", "fixed-version-hashes-1")

--- a/core/test/unit/src/vcs/vcs.ts
+++ b/core/test/unit/src/vcs/vcs.ts
@@ -423,7 +423,7 @@ describe("getModuleVersionString", () => {
     const garden = await makeTestGarden(projectRoot)
     const module = await garden.resolveModule("module-a")
 
-    const fixedVersionString = "v-f6743d2423"
+    const fixedVersionString = "v-3b072717eb"
     expect(module.version.versionString).to.eql(fixedVersionString)
 
     delete process.env.TEST_ENV_VAR

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1367,6 +1367,25 @@ providers:
         variables:
           <name>:
 
+        # Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+        # module-level `variables` field.
+        #
+        # The format of the files is determined by the configured file's extension:
+        #
+        # * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+        # * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys
+        # may contain any value type.
+        # * `.json` - JSON. Must contain a single JSON _object_ (not an array).
+        #
+        # _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of
+        # nested objects and arrays._
+        #
+        # To use different module-level varfiles in different environments, you can template in the environment name
+        # to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the
+        # corresponding
+        # varfiles exist).
+        varfile:
+
         # The filesystem path of the module.
         path:
 
@@ -1646,6 +1665,24 @@ moduleConfigs:
     # and generally use any template strings normally allowed when resolving modules.
     variables:
       <name>:
+
+    # Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+    # module-level `variables` field.
+    #
+    # The format of the files is determined by the configured file's extension:
+    #
+    # * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+    # * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
+    # contain any value type.
+    # * `.json` - JSON. Must contain a single JSON _object_ (not an array).
+    #
+    # _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of
+    # nested objects and arrays._
+    #
+    # To use different module-level varfiles in different environments, you can template in the environment name
+    # to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+    # varfiles exist).
+    varfile:
 
     # The filesystem path of the module.
     path:
@@ -2158,6 +2195,24 @@ modules:
     # and generally use any template strings normally allowed when resolving modules.
     variables:
       <name>:
+
+    # Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+    # module-level `variables` field.
+    #
+    # The format of the files is determined by the configured file's extension:
+    #
+    # * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+    # * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
+    # contain any value type.
+    # * `.json` - JSON. Must contain a single JSON _object_ (not an array).
+    #
+    # _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of
+    # nested objects and arrays._
+    #
+    # To use different module-level varfiles in different environments, you can template in the environment name
+    # to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+    # varfiles exist).
+    varfile:
 
     # The filesystem path of the module.
     path:

--- a/docs/reference/module-template-config.md
+++ b/docs/reference/module-template-config.md
@@ -160,6 +160,24 @@ modules:
     # and generally use any template strings normally allowed when resolving modules.
     variables:
 
+    # Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+    # module-level `variables` field.
+    #
+    # The format of the files is determined by the configured file's extension:
+    #
+    # * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+    # * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
+    # contain any value type.
+    # * `.json` - JSON. Must contain a single JSON _object_ (not an array).
+    #
+    # _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of
+    # nested objects and arrays._
+    #
+    # To use different module-level varfiles in different environments, you can template in the environment name
+    # to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+    # varfiles exist).
+    varfile:
+
     # POSIX-style path of a sub-directory to set as the module root. If the directory does not exist, it is
     # automatically created.
     path:
@@ -504,6 +522,36 @@ A map of variables scoped to this particular module. These are resolved before a
 | Type     | Required |
 | -------- | -------- |
 | `object` | No       |
+
+### `modules[].varfile`
+
+[modules](#modules) > varfile
+
+Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+module-level `variables` field.
+
+The format of the files is determined by the configured file's extension:
+
+* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+
+_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+
+To use different module-level varfiles in different environments, you can template in the environment name
+to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+varfiles exist).
+
+| Type        | Required |
+| ----------- | -------- |
+| `posixPath` | No       |
+
+Example:
+
+```yaml
+modules:
+  - varfile: "my-module.env"
+```
 
 ### `modules[].path`
 

--- a/docs/reference/module-types/configmap.md
+++ b/docs/reference/module-types/configmap.md
@@ -135,6 +135,24 @@ generateFiles:
 # generally use any template strings normally allowed when resolving modules.
 variables:
 
+# Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+# module-level `variables` field.
+#
+# The format of the files is determined by the configured file's extension:
+#
+# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+# * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
+# contain any value type.
+# * `.json` - JSON. Must contain a single JSON _object_ (not an array).
+#
+# _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested
+# objects and arrays._
+#
+# To use different module-level varfiles in different environments, you can template in the environment name
+# to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+# varfiles exist).
+varfile:
+
 # List of services and tasks to deploy/run before deploying this ConfigMap.
 dependencies: []
 
@@ -410,6 +428,33 @@ A map of variables scoped to this particular module. These are resolved before a
 | Type     | Required |
 | -------- | -------- |
 | `object` | No       |
+
+### `varfile`
+
+Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+module-level `variables` field.
+
+The format of the files is determined by the configured file's extension:
+
+* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+
+_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+
+To use different module-level varfiles in different environments, you can template in the environment name
+to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+varfiles exist).
+
+| Type        | Required |
+| ----------- | -------- |
+| `posixPath` | No       |
+
+Example:
+
+```yaml
+varfile: "my-module.env"
+```
 
 ### `dependencies[]`
 

--- a/docs/reference/module-types/conftest.md
+++ b/docs/reference/module-types/conftest.md
@@ -138,6 +138,24 @@ generateFiles:
 # generally use any template strings normally allowed when resolving modules.
 variables:
 
+# Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+# module-level `variables` field.
+#
+# The format of the files is determined by the configured file's extension:
+#
+# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+# * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
+# contain any value type.
+# * `.json` - JSON. Must contain a single JSON _object_ (not an array).
+#
+# _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested
+# objects and arrays._
+#
+# To use different module-level varfiles in different environments, you can template in the environment name
+# to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+# varfiles exist).
+varfile:
+
 # Specify a module whose sources we want to test.
 sourceModule:
 
@@ -421,6 +439,33 @@ A map of variables scoped to this particular module. These are resolved before a
 | Type     | Required |
 | -------- | -------- |
 | `object` | No       |
+
+### `varfile`
+
+Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+module-level `variables` field.
+
+The format of the files is determined by the configured file's extension:
+
+* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+
+_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+
+To use different module-level varfiles in different environments, you can template in the environment name
+to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+varfiles exist).
+
+| Type        | Required |
+| ----------- | -------- |
+| `posixPath` | No       |
+
+Example:
+
+```yaml
+varfile: "my-module.env"
+```
 
 ### `sourceModule`
 

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -150,6 +150,24 @@ generateFiles:
 # generally use any template strings normally allowed when resolving modules.
 variables:
 
+# Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+# module-level `variables` field.
+#
+# The format of the files is determined by the configured file's extension:
+#
+# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+# * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
+# contain any value type.
+# * `.json` - JSON. Must contain a single JSON _object_ (not an array).
+#
+# _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested
+# objects and arrays._
+#
+# To use different module-level varfiles in different environments, you can template in the environment name
+# to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+# varfiles exist).
+varfile:
+
 # Specify build arguments to use when building the container image.
 #
 # Note: Garden will always set a `GARDEN_MODULE_VERSION` argument with the module version at build time.
@@ -939,6 +957,33 @@ A map of variables scoped to this particular module. These are resolved before a
 | Type     | Required |
 | -------- | -------- |
 | `object` | No       |
+
+### `varfile`
+
+Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+module-level `variables` field.
+
+The format of the files is determined by the configured file's extension:
+
+* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+
+_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+
+To use different module-level varfiles in different environments, you can template in the environment name
+to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+varfiles exist).
+
+| Type        | Required |
+| ----------- | -------- |
+| `posixPath` | No       |
+
+Example:
+
+```yaml
+varfile: "my-module.env"
+```
 
 ### `buildArgs`
 

--- a/docs/reference/module-types/exec.md
+++ b/docs/reference/module-types/exec.md
@@ -148,6 +148,24 @@ generateFiles:
 # generally use any template strings normally allowed when resolving modules.
 variables:
 
+# Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+# module-level `variables` field.
+#
+# The format of the files is determined by the configured file's extension:
+#
+# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+# * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
+# contain any value type.
+# * `.json` - JSON. Must contain a single JSON _object_ (not an array).
+#
+# _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested
+# objects and arrays._
+#
+# To use different module-level varfiles in different environments, you can template in the environment name
+# to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+# varfiles exist).
+varfile:
+
 # If set to true, Garden will run the build command, services, tests, and tasks in the module source directory,
 # instead of in the Garden build directory (under .garden/build/<module-name>).
 #
@@ -580,6 +598,33 @@ A map of variables scoped to this particular module. These are resolved before a
 | Type     | Required |
 | -------- | -------- |
 | `object` | No       |
+
+### `varfile`
+
+Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+module-level `variables` field.
+
+The format of the files is determined by the configured file's extension:
+
+* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+
+_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+
+To use different module-level varfiles in different environments, you can template in the environment name
+to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+varfiles exist).
+
+| Type        | Required |
+| ----------- | -------- |
+| `posixPath` | No       |
+
+Example:
+
+```yaml
+varfile: "my-module.env"
+```
 
 ### `local`
 

--- a/docs/reference/module-types/hadolint.md
+++ b/docs/reference/module-types/hadolint.md
@@ -141,6 +141,24 @@ generateFiles:
 # generally use any template strings normally allowed when resolving modules.
 variables:
 
+# Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+# module-level `variables` field.
+#
+# The format of the files is determined by the configured file's extension:
+#
+# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+# * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
+# contain any value type.
+# * `.json` - JSON. Must contain a single JSON _object_ (not an array).
+#
+# _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested
+# objects and arrays._
+#
+# To use different module-level varfiles in different environments, you can template in the environment name
+# to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+# varfiles exist).
+varfile:
+
 # POSIX-style path to a Dockerfile that you want to lint with `hadolint`.
 dockerfilePath:
 ```
@@ -409,6 +427,33 @@ A map of variables scoped to this particular module. These are resolved before a
 | Type     | Required |
 | -------- | -------- |
 | `object` | No       |
+
+### `varfile`
+
+Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+module-level `variables` field.
+
+The format of the files is determined by the configured file's extension:
+
+* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+
+_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+
+To use different module-level varfiles in different environments, you can template in the environment name
+to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+varfiles exist).
+
+| Type        | Required |
+| ----------- | -------- |
+| `posixPath` | No       |
+
+Example:
+
+```yaml
+varfile: "my-module.env"
+```
 
 ### `dockerfilePath`
 

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -140,6 +140,24 @@ generateFiles:
 # generally use any template strings normally allowed when resolving modules.
 variables:
 
+# Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+# module-level `variables` field.
+#
+# The format of the files is determined by the configured file's extension:
+#
+# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+# * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
+# contain any value type.
+# * `.json` - JSON. Must contain a single JSON _object_ (not an array).
+#
+# _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested
+# objects and arrays._
+#
+# To use different module-level varfiles in different environments, you can template in the environment name
+# to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+# varfiles exist).
+varfile:
+
 # Whether to set the --atomic flag during installs and upgrades. Set to false if e.g. you want to see more information
 # about failures and then manually roll back, instead of having Helm do it automatically on failure.
 atomicInstall: true
@@ -821,6 +839,33 @@ A map of variables scoped to this particular module. These are resolved before a
 | Type     | Required |
 | -------- | -------- |
 | `object` | No       |
+
+### `varfile`
+
+Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+module-level `variables` field.
+
+The format of the files is determined by the configured file's extension:
+
+* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+
+_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+
+To use different module-level varfiles in different environments, you can template in the environment name
+to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+varfiles exist).
+
+| Type        | Required |
+| ----------- | -------- |
+| `posixPath` | No       |
+
+Example:
+
+```yaml
+varfile: "my-module.env"
+```
 
 ### `atomicInstall`
 

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -171,6 +171,24 @@ generateFiles:
 # generally use any template strings normally allowed when resolving modules.
 variables:
 
+# Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+# module-level `variables` field.
+#
+# The format of the files is determined by the configured file's extension:
+#
+# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+# * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
+# contain any value type.
+# * `.json` - JSON. Must contain a single JSON _object_ (not an array).
+#
+# _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested
+# objects and arrays._
+#
+# To use different module-level varfiles in different environments, you can template in the environment name
+# to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+# varfiles exist).
+varfile:
+
 # Specify build arguments to use when building the container image.
 #
 # Note: Garden will always set a `GARDEN_MODULE_VERSION` argument with the module version at build time.
@@ -1010,6 +1028,33 @@ A map of variables scoped to this particular module. These are resolved before a
 | Type     | Required |
 | -------- | -------- |
 | `object` | No       |
+
+### `varfile`
+
+Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+module-level `variables` field.
+
+The format of the files is determined by the configured file's extension:
+
+* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+
+_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+
+To use different module-level varfiles in different environments, you can template in the environment name
+to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+varfiles exist).
+
+| Type        | Required |
+| ----------- | -------- |
+| `posixPath` | No       |
+
+Example:
+
+```yaml
+varfile: "my-module.env"
+```
 
 ### `buildArgs`
 

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -144,6 +144,24 @@ generateFiles:
 # generally use any template strings normally allowed when resolving modules.
 variables:
 
+# Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+# module-level `variables` field.
+#
+# The format of the files is determined by the configured file's extension:
+#
+# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+# * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
+# contain any value type.
+# * `.json` - JSON. Must contain a single JSON _object_ (not an array).
+#
+# _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested
+# objects and arrays._
+#
+# To use different module-level varfiles in different environments, you can template in the environment name
+# to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+# varfiles exist).
+varfile:
+
 # The names of any services that this service depends on at runtime, and the names of any tasks that should be
 # executed before this service is deployed.
 dependencies: []
@@ -750,6 +768,33 @@ A map of variables scoped to this particular module. These are resolved before a
 | Type     | Required |
 | -------- | -------- |
 | `object` | No       |
+
+### `varfile`
+
+Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+module-level `variables` field.
+
+The format of the files is determined by the configured file's extension:
+
+* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+
+_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+
+To use different module-level varfiles in different environments, you can template in the environment name
+to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+varfiles exist).
+
+| Type        | Required |
+| ----------- | -------- |
+| `posixPath` | No       |
+
+Example:
+
+```yaml
+varfile: "my-module.env"
+```
 
 ### `dependencies[]`
 

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -150,6 +150,24 @@ generateFiles:
 # generally use any template strings normally allowed when resolving modules.
 variables:
 
+# Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+# module-level `variables` field.
+#
+# The format of the files is determined by the configured file's extension:
+#
+# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+# * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
+# contain any value type.
+# * `.json` - JSON. Must contain a single JSON _object_ (not an array).
+#
+# _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested
+# objects and arrays._
+#
+# To use different module-level varfiles in different environments, you can template in the environment name
+# to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+# varfiles exist).
+varfile:
+
 # Specify build arguments to use when building the container image.
 #
 # Note: Garden will always set a `GARDEN_MODULE_VERSION` argument with the module version at build time.
@@ -949,6 +967,33 @@ A map of variables scoped to this particular module. These are resolved before a
 | Type     | Required |
 | -------- | -------- |
 | `object` | No       |
+
+### `varfile`
+
+Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+module-level `variables` field.
+
+The format of the files is determined by the configured file's extension:
+
+* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+
+_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+
+To use different module-level varfiles in different environments, you can template in the environment name
+to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+varfiles exist).
+
+| Type        | Required |
+| ----------- | -------- |
+| `posixPath` | No       |
+
+Example:
+
+```yaml
+varfile: "my-module.env"
+```
 
 ### `buildArgs`
 

--- a/docs/reference/module-types/openfaas.md
+++ b/docs/reference/module-types/openfaas.md
@@ -134,6 +134,24 @@ generateFiles:
 # generally use any template strings normally allowed when resolving modules.
 variables:
 
+# Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+# module-level `variables` field.
+#
+# The format of the files is determined by the configured file's extension:
+#
+# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+# * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
+# contain any value type.
+# * `.json` - JSON. Must contain a single JSON _object_ (not an array).
+#
+# _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested
+# objects and arrays._
+#
+# To use different module-level varfiles in different environments, you can template in the environment name
+# to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+# varfiles exist).
+varfile:
+
 # The names of services/functions that this function depends on at runtime.
 dependencies: []
 
@@ -440,6 +458,33 @@ A map of variables scoped to this particular module. These are resolved before a
 | Type     | Required |
 | -------- | -------- |
 | `object` | No       |
+
+### `varfile`
+
+Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+module-level `variables` field.
+
+The format of the files is determined by the configured file's extension:
+
+* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+
+_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+
+To use different module-level varfiles in different environments, you can template in the environment name
+to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+varfiles exist).
+
+| Type        | Required |
+| ----------- | -------- |
+| `posixPath` | No       |
+
+Example:
+
+```yaml
+varfile: "my-module.env"
+```
 
 ### `dependencies[]`
 

--- a/docs/reference/module-types/persistentvolumeclaim.md
+++ b/docs/reference/module-types/persistentvolumeclaim.md
@@ -135,6 +135,24 @@ generateFiles:
 # generally use any template strings normally allowed when resolving modules.
 variables:
 
+# Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+# module-level `variables` field.
+#
+# The format of the files is determined by the configured file's extension:
+#
+# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+# * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
+# contain any value type.
+# * `.json` - JSON. Must contain a single JSON _object_ (not an array).
+#
+# _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested
+# objects and arrays._
+#
+# To use different module-level varfiles in different environments, you can template in the environment name
+# to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+# varfiles exist).
+varfile:
+
 # List of services and tasks to deploy/run before deploying this PVC.
 dependencies: []
 
@@ -462,6 +480,33 @@ A map of variables scoped to this particular module. These are resolved before a
 | Type     | Required |
 | -------- | -------- |
 | `object` | No       |
+
+### `varfile`
+
+Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+module-level `variables` field.
+
+The format of the files is determined by the configured file's extension:
+
+* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+
+_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+
+To use different module-level varfiles in different environments, you can template in the environment name
+to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+varfiles exist).
+
+| Type        | Required |
+| ----------- | -------- |
+| `posixPath` | No       |
+
+Example:
+
+```yaml
+varfile: "my-module.env"
+```
 
 ### `dependencies[]`
 

--- a/docs/reference/module-types/templated.md
+++ b/docs/reference/module-types/templated.md
@@ -12,7 +12,7 @@ A special module type, for rendering [module templates](../../using-garden/modul
 Specify the name of a ModuleTemplate with the `template` field, and provide any expected inputs using the `inputs` field. The generated modules becomes sub-modules of this module.
 
 Note that the following common Module configuration fields are disallowed for this module type:
-`build`, `description`, `include`, `exclude`, `repositoryUrl`, `allowPublish`, `generateFiles` and `variables`
+`build`, `description`, `include`, `exclude`, `repositoryUrl`, `allowPublish`, `generateFiles`, `variables` and `varfile`
 
 Below is the full schema reference. For an introduction to configuring Garden modules, please look at our [Configuration
 guide](../../using-garden/configuration-overview.md).
@@ -137,6 +137,24 @@ generateFiles:
 # configuration and take precedence over project-scoped variables. They may reference project-scoped variables, and
 # generally use any template strings normally allowed when resolving modules.
 variables:
+
+# Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+# module-level `variables` field.
+#
+# The format of the files is determined by the configured file's extension:
+#
+# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+# * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
+# contain any value type.
+# * `.json` - JSON. Must contain a single JSON _object_ (not an array).
+#
+# _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested
+# objects and arrays._
+#
+# To use different module-level varfiles in different environments, you can template in the environment name
+# to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+# varfiles exist).
+varfile:
 
 # The ModuleTemplate to use to generate the sub-modules of this module.
 template:
@@ -415,6 +433,33 @@ A map of variables scoped to this particular module. These are resolved before a
 | Type     | Required |
 | -------- | -------- |
 | `object` | No       |
+
+### `varfile`
+
+Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+module-level `variables` field.
+
+The format of the files is determined by the configured file's extension:
+
+* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+
+_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+
+To use different module-level varfiles in different environments, you can template in the environment name
+to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+varfiles exist).
+
+| Type        | Required |
+| ----------- | -------- |
+| `posixPath` | No       |
+
+Example:
+
+```yaml
+varfile: "my-module.env"
+```
 
 ### `template`
 

--- a/docs/reference/module-types/terraform.md
+++ b/docs/reference/module-types/terraform.md
@@ -143,6 +143,24 @@ generateFiles:
 # specified here take precedence.
 variables:
 
+# Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+# module-level `variables` field.
+#
+# The format of the files is determined by the configured file's extension:
+#
+# * `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+# * `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may
+# contain any value type.
+# * `.json` - JSON. Must contain a single JSON _object_ (not an array).
+#
+# _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested
+# objects and arrays._
+#
+# To use different module-level varfiles in different environments, you can template in the environment name
+# to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+# varfiles exist).
+varfile:
+
 # If set to true, Garden will run `terraform destroy` on the stack when calling `garden delete env` or `garden delete
 # service <module name>`.
 allowDestroy: false
@@ -439,6 +457,33 @@ specified here take precedence.
 | Type     | Required |
 | -------- | -------- |
 | `object` | No       |
+
+### `varfile`
+
+Specify a path (relative to the module root) to a file containing variables, that we apply on top of the
+module-level `variables` field.
+
+The format of the files is determined by the configured file's extension:
+
+* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+
+_NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
+
+To use different module-level varfiles in different environments, you can template in the environment name
+to the varfile name, e.g. `varfile: "my-module.\$\{environment.name\}.env` (this assumes that the corresponding
+varfiles exist).
+
+| Type        | Required |
+| ----------- | -------- |
+| `posixPath` | No       |
+
+Example:
+
+```yaml
+varfile: "my-module.env"
+```
 
 ### `allowDestroy`
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

Added support for module varfiles. These are located at or under the module root, and take precedence over module variables (thus having the second-highest precedence behind CLI vars).

The path to the module varfile is set via the optional `module.varfile` field.

Also fixed an issue where CLI variables were overridden by module variables. CLI variables now correctly have the highest precedence.

**Which issue(s) this PR fixes**:

Fixes #2687.
Fixes #2676.