### PR TITLE
chore(ingress-nginx): update ingress-nginx to latest versio

### DIFF
--- a/static/kubernetes/system/ingress-controller/garden.yml
+++ b/static/kubernetes/system/ingress-controller/garden.yml
@@ -7,7 +7,7 @@ chart: ingress-nginx
 releaseName: garden-nginx
 dependencies:
   - default-backend
-version: 3.19.0
+version: 4.0.13
 values:
   name: ingress-controller
   controller:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:
The nginx ingress controller version 0.43.0 currently installed by the helm chart 3.19.0 does not support Kubernetes 1.22. Updating the chart to version 4.0.13 installs the controller in version 1.1.0, which is compatible with Kubernetes 1.19 to 1.22.
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
