### PR TITLE
feat(k8s): arbitrary shared secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ node_modules
 *~
 *.swp
 *.swo
+tags
 
 # Runtime files
 .garden

--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -136,6 +136,7 @@ export interface KubernetesConfig extends BaseProviderConfig {
   }
   forceSsl: boolean
   imagePullSecrets: ProviderSecretRef[]
+  copySecrets: ProviderSecretRef[]
   ingressHttpPort: number
   ingressHttpsPort: number
   ingressClass?: string
@@ -314,6 +315,12 @@ const imagePullSecretsSchema = () =>
     References to \`docker-registry\` secrets to use for authenticating with remote registries when pulling
     images. This is necessary if you reference private images in your module configuration, and is required
     when configuring a remote Kubernetes environment with buildMode=local.
+  `)
+
+const copySecretsSchema = () =>
+  joiSparseArray(secretRef).description(dedent`
+    References to secrets you need to have copied into all namespaces deployed to. These secrets will be
+    ensured to exist in the namespace before deploying any service.
   `)
 
 const tlsCertificateSchema = () =>
@@ -496,6 +503,7 @@ export const kubernetesConfigBase = () =>
       )
       .meta({ internal: true }),
     imagePullSecrets: imagePullSecretsSchema(),
+    copySecrets: copySecretsSchema(),
     // TODO: invert the resources and storage config schemas
     resources: joi
       .object()

--- a/core/src/plugins/kubernetes/container/deployment.ts
+++ b/core/src/plugins/kubernetes/container/deployment.ts
@@ -30,7 +30,7 @@ import { gardenAnnotationKey, deline } from "../../../util/string"
 import { RuntimeContext } from "../../../runtime-context"
 import { resolve } from "path"
 import { killPortForwards } from "../port-forward"
-import { prepareImagePullSecrets } from "../secrets"
+import { prepareSecrets } from "../secrets"
 import { configureHotReload } from "../hot-reload/helpers"
 import { configureDevMode, startDevModeSync } from "../dev-mode"
 import { hotReloadableKinds, HotReloadableResource } from "../hot-reload/hot-reload"
@@ -472,9 +472,11 @@ export async function createWorkloadManifest({
   }
 
   if (provider.config.imagePullSecrets.length > 0) {
-    // add any configured imagePullSecrets
-    workload.spec.template.spec!.imagePullSecrets = await prepareImagePullSecrets({ api, provider, namespace, log })
+    // add any configured imagePullSecrets.
+    const imagePullSecrets = await prepareSecrets({ api, namespace, secrets: provider.config.imagePullSecrets, log })
+    workload.spec.template.spec!.imagePullSecrets = imagePullSecrets
   }
+  await prepareSecrets({ api, namespace, secrets: provider.config.copySecrets, log })
 
   // this is important for status checks to work correctly, because how K8s normalizes resources
   if (!container.ports!.length) {

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -32,7 +32,7 @@ import { ContainerEnvVars, ContainerResourcesSpec, ContainerVolumeSpec } from ".
 import { prepareEnvVars, makePodName } from "./util"
 import { deline, randomString } from "../../util/string"
 import { ArtifactSpec } from "../../config/validation"
-import { prepareImagePullSecrets } from "./secrets"
+import { prepareSecrets } from "./secrets"
 import { configureVolumes } from "./container/deployment"
 import { PluginContext, PluginEventBroker } from "../../plugin-context"
 import { waitForResources, ResourceStatus } from "./status/status"
@@ -295,7 +295,8 @@ export async function prepareRunPodSpec({
     },
   ]
 
-  const imagePullSecrets = await prepareImagePullSecrets({ api, provider, namespace, log })
+  const imagePullSecrets = await prepareSecrets({ api, namespace, secrets: provider.config.imagePullSecrets, log })
+  await prepareSecrets({ api, namespace, secrets: provider.config.copySecrets, log })
 
   const preparedPodSpec = {
     ...pick(podSpec || {}, runPodSpecIncludeFields),

--- a/core/src/plugins/kubernetes/secrets.ts
+++ b/core/src/plugins/kubernetes/secrets.ts
@@ -7,7 +7,7 @@
  */
 
 import { KubeApi } from "./api"
-import { ProviderSecretRef, KubernetesPluginContext, KubernetesProvider } from "./config"
+import { ProviderSecretRef, KubernetesPluginContext } from "./config"
 import { ConfigurationError } from "../../exceptions"
 import { getAppNamespace } from "./namespace"
 import { GetSecretParams } from "../../types/plugin/provider/getSecret"
@@ -124,20 +124,20 @@ export async function ensureSecret(api: KubeApi, secretRef: ProviderSecretRef, t
 }
 
 /**
- * Prepare references to imagePullSecrets for use in Pod specs, and ensure they have been copied to the target
- * namespace.
+ * Prepare references to the secrets given by the array of ProviderSecretRefs passed in.
+ * These secrets will be copied to the given namespace if needed.
  */
-export async function prepareImagePullSecrets({
+export async function prepareSecrets({
   api,
-  provider,
   namespace,
+  secrets,
   log,
 }: {
   api: KubeApi
-  provider: KubernetesProvider
   namespace: string
+  secrets: Array<ProviderSecretRef>
   log: LogEntry
 }) {
-  await Promise.all(provider.config.imagePullSecrets.map((s) => ensureSecret(api, s, namespace, log)))
-  return provider.config.imagePullSecrets.map((s) => ({ name: s.name }))
+  await Promise.all(secrets.map((s) => ensureSecret(api, s, namespace, log)))
+  return secrets.map((s) => ({ name: s.name }))
 }

--- a/core/test/integ/src/plugins/kubernetes/container/ingress.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/ingress.ts
@@ -63,6 +63,7 @@ const basicConfig: PartialConfig = {
   forceSsl: false,
   gardenSystemNamespace: defaultSystemNamespace,
   imagePullSecrets: [],
+  copySecrets: [],
   ingressClass: "nginx",
   ingressHttpPort: 80,
   ingressHttpsPort: 443,

--- a/core/test/unit/src/plugins/kubernetes/init.ts
+++ b/core/test/unit/src/plugins/kubernetes/init.ts
@@ -51,6 +51,12 @@ const basicConfig: KubernetesConfig = {
       namespace: "default",
     },
   ],
+  copySecrets: [
+    {
+      name: "test-shared-secret",
+      namespace: "default",
+    },
+  ],
   ingressClass: "nginx",
   ingressHttpPort: 80,
   ingressHttpsPort: 443,

--- a/core/test/unit/src/plugins/kubernetes/kubernetes.ts
+++ b/core/test/unit/src/plugins/kubernetes/kubernetes.ts
@@ -24,6 +24,7 @@ describe("kubernetes configureProvider", () => {
     forceSsl: false,
     gardenSystemNamespace: defaultSystemNamespace,
     imagePullSecrets: [],
+    copySecrets: [],
     ingressClass: "nginx",
     ingressHttpPort: 80,
     ingressHttpsPort: 443,

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -184,6 +184,16 @@ providers:
         # namespace before use.
         namespace: default
 
+    # References to secrets you need to have copied into all namespaces deployed to. These secrets will be
+    # ensured to exist in the namespace before deploying any service.
+    copySecrets:
+      - # The name of the Kubernetes secret.
+        name:
+
+        # The namespace where the secret is stored. If necessary, the secret may be copied to the appropriate
+        # namespace before use.
+        namespace: default
+
     # Resource requests and limits for the in-cluster builder, container registry and code sync service. (which are
     # automatically installed and used when `buildMode` is `cluster-docker` or `kaniko`).
     resources:
@@ -846,6 +856,45 @@ providers:
 ### `providers[].imagePullSecrets[].namespace`
 
 [providers](#providers) > [imagePullSecrets](#providersimagepullsecrets) > namespace
+
+The namespace where the secret is stored. If necessary, the secret may be copied to the appropriate namespace before use.
+
+| Type     | Default     | Required |
+| -------- | ----------- | -------- |
+| `string` | `"default"` | No       |
+
+### `providers[].copySecrets[]`
+
+[providers](#providers) > copySecrets
+
+References to secrets you need to have copied into all namespaces deployed to. These secrets will be
+ensured to exist in the namespace before deploying any service.
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
+
+### `providers[].copySecrets[].name`
+
+[providers](#providers) > [copySecrets](#providerscopysecrets) > name
+
+The name of the Kubernetes secret.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | Yes      |
+
+Example:
+
+```yaml
+providers:
+  - copySecrets:
+      - name: "my-secret"
+```
+
+### `providers[].copySecrets[].namespace`
+
+[providers](#providers) > [copySecrets](#providerscopysecrets) > namespace
 
 The namespace where the secret is stored. If necessary, the secret may be copied to the appropriate namespace before use.
 

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -180,6 +180,16 @@ providers:
         # namespace before use.
         namespace: default
 
+    # References to secrets you need to have copied into all namespaces deployed to. These secrets will be
+    # ensured to exist in the namespace before deploying any service.
+    copySecrets:
+      - # The name of the Kubernetes secret.
+        name:
+
+        # The namespace where the secret is stored. If necessary, the secret may be copied to the appropriate
+        # namespace before use.
+        namespace: default
+
     # Resource requests and limits for the in-cluster builder, container registry and code sync service. (which are
     # automatically installed and used when `buildMode` is `cluster-docker` or `kaniko`).
     resources:
@@ -808,6 +818,45 @@ providers:
 ### `providers[].imagePullSecrets[].namespace`
 
 [providers](#providers) > [imagePullSecrets](#providersimagepullsecrets) > namespace
+
+The namespace where the secret is stored. If necessary, the secret may be copied to the appropriate namespace before use.
+
+| Type     | Default     | Required |
+| -------- | ----------- | -------- |
+| `string` | `"default"` | No       |
+
+### `providers[].copySecrets[]`
+
+[providers](#providers) > copySecrets
+
+References to secrets you need to have copied into all namespaces deployed to. These secrets will be
+ensured to exist in the namespace before deploying any service.
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
+
+### `providers[].copySecrets[].name`
+
+[providers](#providers) > [copySecrets](#providerscopysecrets) > name
+
+The name of the Kubernetes secret.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | Yes      |
+
+Example:
+
+```yaml
+providers:
+  - copySecrets:
+      - name: "my-secret"
+```
+
+### `providers[].copySecrets[].namespace`
+
+[providers](#providers) > [copySecrets](#providerscopysecrets) > namespace
 
 The namespace where the secret is stored. If necessary, the secret may be copied to the appropriate namespace before use.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:
This PR surfaces a new configuration field that can be used to specify arbitrary secrets that should be copied to each deployed environment. This is very similar to `imagePullSecrets` but it can be very useful to copy arbitrary secrets into namespaces  so that, for example, all developers can share a secret needed to authenticate with AWS S3 or Azure Blob Storage.
