### PR TITLE
chore: add garden image with ibmcloud cli tool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,6 +365,20 @@ jobs:
             TAG=gardendev/garden-aws-gcloud-azure:${CIRCLE_SHA1}
             docker build -t ${TAG} --build-arg TAG=${CIRCLE_SHA1} -f support/aws-gcloud-azure.Dockerfile dist/alpine-amd64
             docker push ${TAG}
+  build-docker-full:
+    <<: *node-config
+    steps:
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - checkout
+      - *attach-workspace
+      - docker_login
+      - run:
+          name: Build image and push to registry
+          command: |
+            TAG=gardendev/garden-full:${CIRCLE_SHA1}
+            docker build -t ${TAG} --build-arg TAG=${CIRCLE_SHA1} -f support/aws-gcloud-azure-ibmcloud.Dockerfile dist/alpine-amd64
+            docker push ${TAG}
   build-docker-buster:
     <<: *node-config
     steps:
@@ -833,6 +847,10 @@ workflows:
           context: docker
           requires: [build-docker-alpine]
       - build-docker-aws-gcloud-azure:
+          <<: *only-internal-prs
+          context: docker
+          requires: [build-docker-alpine]
+      - build-docker-full:
           <<: *only-internal-prs
           context: docker
           requires: [build-docker-alpine]

--- a/support/aws-gcloud-azure-ibmcloud.Dockerfile
+++ b/support/aws-gcloud-azure-ibmcloud.Dockerfile
@@ -1,0 +1,46 @@
+ARG TAG=latest
+FROM google/cloud-sdk:277.0.0-alpine as gcloud
+
+RUN gcloud components install kubectl
+
+FROM gardendev/garden:${TAG}
+
+ENV CLOUDSDK_PYTHON=python3
+ENV KUBELOGIN_VERSION=v0.0.9
+
+COPY --from=gcloud /google-cloud-sdk /google-cloud-sdk
+
+RUN apk add --no-cache python3 \
+  && ln -s /google-cloud-sdk/bin/* /usr/local/bin/ \
+  && chmod +x /usr/local/bin/*
+
+RUN apk add --no-cache python py-pip \
+  && pip install awscli==1.17.9 --upgrade \
+  && apk del py-pip
+
+RUN curl -o aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.15.10/2020-02-22/bin/linux/amd64/aws-iam-authenticator \
+  && chmod +x ./aws-iam-authenticator \
+  && mv ./aws-iam-authenticator /usr/bin/
+
+# Build dependencies
+RUN apk add --virtual=build gcc libffi-dev musl-dev openssl-dev make py3-pip \
+  # Runtime dependency
+  && apk add python3-dev \
+  && pip3 install virtualenv \
+  && python3 -m virtualenv /azure-cli \
+  && /azure-cli/bin/python -m pip --no-cache-dir install azure-cli \
+  && echo "#!/usr/bin/env sh" > /usr/bin/az \
+  && echo '/azure-cli/bin/python -m azure.cli "$@"' >> /usr/bin/az \
+  && chmod +x /usr/bin/az \
+  && wget https://github.com/Azure/kubelogin/releases/download/${KUBELOGIN_VERSION}/kubelogin-linux-amd64.zip \
+  && unzip kubelogin-linux-amd64.zip \
+  && cp bin/linux_amd64/kubelogin /usr/bin/
+
+RUN mkdir -p /opt/ibmcloud \
+  && cd /opt/ibmcloud \
+  && curl -o ibmcloud_installer.tar.gz https://download.clis.cloud.ibm.com/ibm-cloud-cli/2.2.0/IBM_Cloud_CLI_2.2.0_amd64.tar.gz \
+  && tar -zxf ibmcloud_installer.tar.gz \
+  && cd Bluemix_CLI/ \
+  && ./install \
+  && cd $HOME \
+  && ibmcloud plugin install container-service


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:
It adds a container image that also includes the ibmcloud cli tool. Some users are using ibmcloud and need this image for running workflows in Garden Cloud. Usually we also add an image just with Garden and the respective cloud provider tool, in this case i am not sure if there is demand for that. But I can easily add that, if it makes sense.
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
