### PR TITLE
fix(core): properly handle sparse build deps

### DIFF
--- a/core/test/data/test-projects/dynamic-build-dependencies/garden.yml
+++ b/core/test/data/test-projects/dynamic-build-dependencies/garden.yml
@@ -1,0 +1,8 @@
+kind: Project
+name: dynamic-build-dependencies
+environments:
+  - name: local
+providers:
+  - name: test-plugin
+variables:
+  banana: "exists"

--- a/core/test/data/test-projects/dynamic-build-dependencies/module-a/garden.yml
+++ b/core/test/data/test-projects/dynamic-build-dependencies/module-a/garden.yml
@@ -1,0 +1,7 @@
+kind: Module
+name: module-a
+type: test
+build:
+  dependencies:
+    - "${var.missing ? 'module-b' : null}"
+    - module-c

--- a/core/test/data/test-projects/dynamic-build-dependencies/module-b/garden.yml
+++ b/core/test/data/test-projects/dynamic-build-dependencies/module-b/garden.yml
@@ -1,0 +1,3 @@
+kind: Module
+name: module-b
+type: test

--- a/core/test/data/test-projects/dynamic-build-dependencies/module-c/garden.yml
+++ b/core/test/data/test-projects/dynamic-build-dependencies/module-c/garden.yml
@@ -1,0 +1,3 @@
+kind: Module
+name: module-c
+type: test

--- a/core/test/unit/src/config/base.ts
+++ b/core/test/unit/src/config/base.ts
@@ -7,7 +7,7 @@
  */
 
 import { expect } from "chai"
-import { loadConfigResources, findProjectConfig } from "../../../../src/config/base"
+import { loadConfigResources, findProjectConfig, prepareModuleResource } from "../../../../src/config/base"
 import { resolve, join } from "path"
 import { dataDir, expectError, getDataDir } from "../../../helpers"
 import { DEFAULT_API_VERSION } from "../../../../src/constants"
@@ -392,6 +392,19 @@ describe("loadConfigResources", () => {
         path,
         configPath,
       },
+    ])
+  })
+})
+
+describe("prepareModuleResource", () => {
+  it("should normalize build dependencies", async () => {
+    const moduleConfigPath = resolve(modulePathA, "garden.yml")
+    const parsed: any = (await loadConfigResources(projectPathA, moduleConfigPath))[0]
+    parsed.build!.dependencies = [{ name: "apple" }, "banana", null]
+    const prepared = prepareModuleResource(parsed, moduleConfigPath, projectPathA)
+    expect(prepared.build!.dependencies).to.eql([
+      { name: "apple", copy: [] },
+      { name: "banana", copy: [] },
     ])
   })
 })

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -2546,6 +2546,16 @@ describe("Garden", () => {
       expect(module.allowPublish).to.equal(false)
     })
 
+    it("should filter out null build dependencies after resolving template strings", async () => {
+      const projectRoot = getDataDir("test-projects", "dynamic-build-dependencies")
+      const garden = await makeTestGarden(projectRoot)
+
+      const module = await garden.resolveModule("module-a")
+      const moduleCDep = { name: "module-c", copy: [] }
+      expect(module.build.dependencies).to.eql([moduleCDep])
+      expect(module.spec.build.dependencies).to.eql([moduleCDep])
+    })
+
     it("should correctly resolve template strings referencing nested variables", async () => {
       const test = createGardenPlugin({
         name: "test",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

Previously, adding an optional build dependency via a template string that sometimes resolves to null would throw an error when the string resolved to null.

The build dependencies array was always intended to be a sparse array, but due to the special handling we have to support both the shorthand (module name only) and the full (a map with the module name and other fields) formats, we needed to add a bit of extra logic to account for this use case.

**Which issue(s) this PR fixes**:

Fixes #2685.

**Special notes for your reviewer**:

It's a bit awkward that we have to normalize / clean up the shape of the build dependencies array in two separate places, but it's perhaps acceptable given the incremental nature of the module resolution flow.