### PR TITLE
feat(template): add indent helper function

### DIFF
--- a/docs/reference/template-strings.md
+++ b/docs/reference/template-strings.md
@@ -18,6 +18,7 @@ Decodes the given base64-encoded string.
 Usage: `base64Decode(string)`
 
 Examples:
+
 * `${base64Decode("bXkgdmFsdWU=")}` -> `"my value"`
 
 ### base64Encode
@@ -27,6 +28,7 @@ Encodes the given string as base64.
 Usage: `base64Encode(string)`
 
 Examples:
+
 * `${base64Encode("my value")}` -> `"bXkgdmFsdWU="`
 
 ### camelCase
@@ -36,9 +38,21 @@ Converts the given string to a valid camelCase identifier, changing the casing a
 Usage: `camelCase(string)`
 
 Examples:
+
 * `${camelCase("Foo Bar")}` -> `"fooBar"`
 * `${camelCase("--foo-bar--")}` -> `"fooBar"`
 * `${camelCase("__FOO_BAR__")}` -> `"fooBar"`
+
+### indent
+
+Indents each line in the given string with the specified number of spaces.
+
+Usage: `indent(string, spaces)`
+
+Examples:
+
+* `${indent("some: multiline\nyaml: document", 2)}` -> `"  some: multiline\n  yaml: document"`
+* `${indent("My\nblock\nof\ntext", 4)}` -> `"    My\n    block\n    of\n    text"`
 
 ### isEmpty
 
@@ -47,6 +61,7 @@ Returns true if the given value is an empty string, object, array, null or undef
 Usage: `isEmpty([value])`
 
 Examples:
+
 * `${isEmpty({})}` -> `true`
 * `${isEmpty({"not":"empty"})}` -> `false`
 * `${isEmpty([])}` -> `true`
@@ -62,6 +77,7 @@ Decodes the given JSON-encoded string.
 Usage: `jsonDecode(string)`
 
 Examples:
+
 * `${jsonDecode("{\"foo\": \"bar\"}")}` -> `{"foo":"bar"}`
 * `${jsonDecode("\"JSON encoded string\"")}` -> `"JSON encoded string"`
 * `${jsonDecode("[\"my\", \"json\", \"array\"]")}` -> `["my","json","array"]`
@@ -73,6 +89,7 @@ Encodes the given value as JSON.
 Usage: `jsonEncode(value)`
 
 Examples:
+
 * `${jsonEncode(["some","array"])}` -> `"[\"some\",\"array\"]"`
 * `${jsonEncode({"some":"object"})}` -> `"{\"some\":\"object\"}"`
 
@@ -83,6 +100,7 @@ Converts the given string to a valid kebab-case identifier, changing to all lowe
 Usage: `kebabCase(string)`
 
 Examples:
+
 * `${kebabCase("Foo Bar")}` -> `"foo-bar"`
 * `${kebabCase("fooBar")}` -> `"foo-bar"`
 * `${kebabCase("__FOO_BAR__")}` -> `"foo-bar"`
@@ -94,6 +112,7 @@ Convert the given string to all lowercase.
 Usage: `lower(string)`
 
 Examples:
+
 * `${lower("Some String")}` -> `"some string"`
 
 ### replace
@@ -103,6 +122,7 @@ Replaces all occurrences of a given substring in a string.
 Usage: `replace(string, substring, replacement)`
 
 Examples:
+
 * `${replace("string_with_underscores", "_", "-")}` -> `"string-with-underscores"`
 * `${replace("remove.these.dots", ".", "")}` -> `"removethesedots"`
 
@@ -113,6 +133,7 @@ Slices a string or array at the specified start/end offsets. Note that you can u
 Usage: `slice(input, start, [end])`
 
 Examples:
+
 * `${slice("ThisIsALongStringThatINeedAPartOf", 11, -7)}` -> `"StringThatINeed"`
 * `${slice(".foo", 1)}` -> `"foo"`
 
@@ -123,6 +144,7 @@ Splits the given string by a substring (e.g. a comma, colon etc.).
 Usage: `split(string, separator)`
 
 Examples:
+
 * `${split("a,b,c", ",")}` -> `["a","b","c"]`
 * `${split("1:2:3:4", ":")}` -> `["1","2","3","4"]`
 
@@ -133,6 +155,7 @@ Trims whitespace (or other specified characters) off the ends of the given strin
 Usage: `trim(string, [characters])`
 
 Examples:
+
 * `${trim("   some string with surrounding whitespace ")}` -> `"some string with surrounding whitespace"`
 
 ### upper
@@ -142,6 +165,7 @@ Converts the given string to all uppercase.
 Usage: `upper(string)`
 
 Examples:
+
 * `${upper("Some String")}` -> `"SOME STRING"`
 
 ### uuidv4
@@ -151,7 +175,8 @@ Generates a random v4 UUID.
 Usage: `uuidv4()`
 
 Examples:
-* `${uuidv4()}` -> `1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed`
+
+* `${uuidv4()}` -> `"1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed"`
 
 ### yamlDecode
 
@@ -160,6 +185,7 @@ Decodes the given YAML-encoded string. Note that for multi-document YAML strings
 Usage: `yamlDecode(string, [multiDocument])`
 
 Examples:
+
 * `${yamlDecode("a: 1\nb: 2\n")}` -> `{"a":1,"b":2}`
 * `${yamlDecode("a: 1\nb: 2\n---\na: 3\nb: 4\n", true)}` -> `[{"a":1,"b":2},{"a":3,"b":4}]`
 
@@ -170,6 +196,7 @@ Encodes the given value as YAML.
 Usage: `yamlEncode(value, [multiDocument])`
 
 Examples:
+
 * `${yamlEncode({"my":"simple document"})}` -> `"my: simple document\n"`
 * `${yamlEncode([{"a":1,"b":2},{"a":3,"b":4}], true)}` -> `"---a: 1\nb: 2\n---a: 3\nb: 4\n"`
 

--- a/static/docs/templates/template-strings.hbs
+++ b/static/docs/templates/template-strings.hbs
@@ -19,6 +19,7 @@ Note that there are multiple sections below, since different configuration secti
 Usage: `{{{usage}}}`
 
 Examples:
+
 {{#each examples}}
 * `{{{template}}}` -> `{{{result}}}`
 {{/each}}


### PR DESCRIPTION
This is useful for indenting YAML strings, for example:

`${indent("some: multiline\nyaml: document", 2)}`

 ->

```
  some: multiline
  yaml: document
```

Closes #2659
