### PR TITLE
fix(k8s): allow any style of path for kubeconfig field

### DIFF
--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -724,9 +724,7 @@ export const configSchema = () =>
         .number()
         .default(443)
         .description("The external HTTPS port of the cluster's ingress controller."),
-      kubeconfig: joi
-        .posixPath()
-        .description("Path to kubeconfig file to use instead of the system default. Must be a POSIX-style path."),
+      kubeconfig: joi.string().description("Path to kubeconfig file to use instead of the system default."),
       namespace: namespaceSchema(),
       setupIngressController: joi
         .string()

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,9 +41,10 @@
 
 ## 🌺 Advanced
 
-* [Remote Sources](./advanced/using-remote-sources.md)
-* [Terraform](./advanced/terraform.md)
 * [cert-manager Integration](./advanced/cert-manager-integration.md)
+* [Terraform](./advanced/terraform.md)
+* [Using Remote Sources](./advanced/using-remote-sources.md)
+* [Minimal RBAC Configuration for Development Clusters](./advanced/rbac-config.md)
 
 ## ☘️ Reference
 

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -377,7 +377,7 @@ providers:
     # The external HTTPS port of the cluster's ingress controller.
     ingressHttpsPort: 443
 
-    # Path to kubeconfig file to use instead of the system default. Must be a POSIX-style path.
+    # Path to kubeconfig file to use instead of the system default.
     kubeconfig:
 
     # Specify which namespace to deploy services to, and optionally annotations/labels to apply to the namespace.
@@ -2012,11 +2012,11 @@ The external HTTPS port of the cluster's ingress controller.
 
 [providers](#providers) > kubeconfig
 
-Path to kubeconfig file to use instead of the system default. Must be a POSIX-style path.
+Path to kubeconfig file to use instead of the system default.
 
-| Type        | Required |
-| ----------- | -------- |
-| `posixPath` | No       |
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
 
 ### `providers[].namespace`
 


### PR DESCRIPTION
Fixes #2120
