### PR TITLE
fix(k8s): fix rollout status check for Recreate

### DIFF
--- a/core/src/plugins/kubernetes/status/workload.ts
+++ b/core/src/plugins/kubernetes/status/workload.ts
@@ -18,6 +18,7 @@ import {
   V1StatefulSetSpec,
   V1DeploymentStatus,
   CoreV1Event,
+  V1DeploymentSpec,
 } from "@kubernetes/client-node"
 import dedent = require("dedent")
 import { getCurrentWorkloadPods } from "../util"
@@ -224,8 +225,9 @@ async function getRolloutStatus(workload: Workload) {
     }
   } else {
     const status = <V1DeploymentStatus>workload.status
+    const deploymentSpec = <V1DeploymentSpec>workload.spec
 
-    const desired = status.replicas || 0
+    const desired = deploymentSpec.replicas || 1
     const updated = status.updatedReplicas || 0
     const replicas = status.replicas || 0
     const available = status.availableReplicas || 0

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -2551,7 +2551,7 @@ describe("Garden", () => {
       const garden = await makeTestGarden(projectRoot)
 
       const module = await garden.resolveModule("module-a")
-      const moduleCDep = { name: "module-c", copy: [] }
+      const moduleCDep = { name: "module-c", copy: [] }
       expect(module.build.dependencies).to.eql([moduleCDep])
       expect(module.spec.build.dependencies).to.eql([moduleCDep])
     })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

@twelvemo and I paired on this.

Before this fix, the rollout status of deployments using the `Recreate` strategy would be reported as ready before the new pods were fully ready.

This was fixed by copying/following the latest logic from kubectl's rollout status checking logic, comparing the requested number of replicas from the deployment spec with the actual updated pod count.

See the [corresponding logic in kubectl](https://github.com/kubernetes/kubectl/blob/24d21a0ee42ecb5e5bed731f36b2d2c9c0244c35/pkg/polymorphichelpers/rollout_status.go).

**Which issue(s) this PR fixes**:

Fixes #2630 and #2717.