### PR TITLE
feat(core): add --skip-dependencies CLI option

### DIFF
--- a/core/src/commands/test.ts
+++ b/core/src/commands/test.ts
@@ -55,6 +55,14 @@ export const testOpts = {
     alias: "w",
     cliOnly: true,
   }),
+  "skip-dependencies": new BooleanParameter({
+    help: deline`Don't deploy any services or run any tasks that the requested tests depend on.
+    This can be useful e.g. when your stack has already been deployed, and you want to run tests with runtime
+    dependencies without redeploying any service dependencies that may have changed since you last deployed.
+    Warning: Take great care when using this option in CI, since Garden won't ensure that the runtime dependencies of
+    your test suites are up to date when this option is used.`,
+    alias: "no-deps",
+  }),
   "skip-dependants": new BooleanParameter({
     help: deline`
       When using the modules argument, only run tests for those modules (and skip tests in other modules with
@@ -145,6 +153,7 @@ export class TestCommand extends Command<Args, Opts> {
     const filterNames = opts.name || []
     const force = opts.force
     const forceBuild = opts["force-build"]
+    const skipRuntimeDependencies = opts["skip-dependencies"]
 
     const initialTasks = flatten(
       await Bluebird.map(modules, (module) =>
@@ -158,6 +167,7 @@ export class TestCommand extends Command<Args, Opts> {
           forceBuild,
           devModeServiceNames: [],
           hotReloadServiceNames: [],
+          skipRuntimeDependencies,
         })
       )
     )

--- a/core/src/tasks/build.ts
+++ b/core/src/tasks/build.ts
@@ -30,9 +30,8 @@ export interface BuildTaskParams {
 export class BuildTask extends BaseTask {
   type: TaskType = "build"
   concurrencyLimit = 5
-
-  private graph: ConfigGraph
-  private module: GardenModule
+  graph: ConfigGraph
+  module: GardenModule
 
   constructor({ garden, graph, log, module, force }: BuildTaskParams & { _guard: true }) {
     // Note: The _guard attribute is to prevent accidentally bypassing the factory method

--- a/core/src/tasks/delete-service.ts
+++ b/core/src/tasks/delete-service.ts
@@ -25,10 +25,9 @@ export interface DeleteServiceTaskParams {
 export class DeleteServiceTask extends BaseTask {
   type: TaskType = "delete-service"
   concurrencyLimit = 10
-
-  private graph: ConfigGraph
-  private service: GardenService
-  private includeDependants: boolean
+  graph: ConfigGraph
+  service: GardenService
+  includeDependants: boolean
 
   constructor({ garden, graph, log, service, includeDependants = false }: DeleteServiceTaskParams) {
     super({ garden, log, force: false, version: service.version })

--- a/core/src/tasks/get-service-status.ts
+++ b/core/src/tasks/get-service-status.ts
@@ -33,11 +33,10 @@ export interface GetServiceStatusTaskParams {
 export class GetServiceStatusTask extends BaseTask {
   type: TaskType = "get-service-status"
   concurrencyLimit = 20
-
-  private graph: ConfigGraph
-  private service: GardenService
-  private devModeServiceNames: string[]
-  private hotReloadServiceNames: string[]
+  graph: ConfigGraph
+  service: GardenService
+  devModeServiceNames: string[]
+  hotReloadServiceNames: string[]
 
   constructor({
     garden,

--- a/core/src/tasks/get-task-result.ts
+++ b/core/src/tasks/get-task-result.ts
@@ -27,9 +27,8 @@ export interface GetTaskResultTaskParams {
 export class GetTaskResultTask extends BaseTask {
   type: TaskType = "get-task-result"
   concurrencyLimit = 20
-
-  private graph: ConfigGraph
-  private task: GardenTask
+  graph: ConfigGraph
+  task: GardenTask
 
   constructor(params: GetTaskResultTaskParams) {
     super({ ...params, version: params.task.version })

--- a/core/src/tasks/helpers.ts
+++ b/core/src/tasks/helpers.ts
@@ -10,10 +10,14 @@ import { uniqBy } from "lodash"
 import { DeployTask } from "./deploy"
 import { Garden } from "../garden"
 import { GardenModule } from "../types/module"
-import { ConfigGraph } from "../config-graph"
+import { ConfigGraph, DependencyRelations } from "../config-graph"
 import { LogEntry } from "../logger/log-entry"
 import { BaseTask } from "./base"
 import { HotReloadTask } from "./hot-reload"
+import { TestTask } from "./test"
+import { TaskTask } from "./task"
+import { GetServiceStatusTask } from "./get-service-status"
+import { GetTaskResultTask } from "./get-task-result"
 
 /**
  * Helper used by the `garden dev` and `garden deploy --watch` commands, to get all the tasks that should be
@@ -77,6 +81,66 @@ export async function getModuleWatchTasks({
   const deduplicated = uniqBy(outputTasks, (t) => t.getKey())
 
   return deduplicated
+}
+
+type RuntimeTask = DeployTask | TestTask
+
+export function getServiceStatusDeps(task: RuntimeTask, deps: DependencyRelations): GetServiceStatusTask[] {
+  return deps.deploy.map((service) => {
+    return new GetServiceStatusTask({
+      garden: task.garden,
+      graph: task.graph,
+      log: task.log,
+      service,
+      force: false,
+      devModeServiceNames: task.devModeServiceNames,
+      hotReloadServiceNames: task.hotReloadServiceNames,
+    })
+  })
+}
+
+export function getTaskResultDeps(task: RuntimeTask, deps: DependencyRelations): GetTaskResultTask[] {
+  return deps.run.map((dep) => {
+    return new GetTaskResultTask({
+      garden: task.garden,
+      graph: task.graph,
+      log: task.log,
+      task: dep,
+      force: false,
+    })
+  })
+}
+
+export function getTaskDeps(task: RuntimeTask, deps: DependencyRelations, force: boolean): TaskTask[] {
+  return deps.run.map((dep) => {
+    return new TaskTask({
+      task: dep,
+      garden: task.garden,
+      log: task.log,
+      graph: task.graph,
+      force,
+      forceBuild: task.forceBuild,
+      devModeServiceNames: task.devModeServiceNames,
+      hotReloadServiceNames: task.hotReloadServiceNames,
+    })
+  })
+}
+
+export function getDeployDeps(task: RuntimeTask, deps: DependencyRelations, force: boolean): DeployTask[] {
+  return deps.deploy.map(
+    (service) =>
+      new DeployTask({
+        garden: task.garden,
+        graph: task.graph,
+        log: task.log,
+        service,
+        force,
+        forceBuild: task.forceBuild,
+        skipRuntimeDependencies: task.skipRuntimeDependencies,
+        devModeServiceNames: task.devModeServiceNames,
+        hotReloadServiceNames: task.hotReloadServiceNames,
+      })
+  )
 }
 
 export function makeTestTaskName(moduleName: string, testConfigName: string) {

--- a/core/src/tasks/hot-reload.ts
+++ b/core/src/tasks/hot-reload.ts
@@ -28,9 +28,9 @@ export class HotReloadTask extends BaseTask {
   type: TaskType = "hot-reload"
   concurrencyLimit = 10
 
-  private graph: ConfigGraph
-  // private hotReloadServiceNames: string[]
-  private service: GardenService
+  graph: ConfigGraph
+  // hotReloadServiceNames: string[]
+  service: GardenService
 
   constructor(params: Params) {
     super({ ...params, version: params.service.version })

--- a/core/src/tasks/publish.ts
+++ b/core/src/tasks/publish.ts
@@ -34,10 +34,10 @@ export class PublishTask extends BaseTask {
   type: TaskType = "publish"
   concurrencyLimit = 5
 
-  private graph: ConfigGraph
-  private module: GardenModule
-  private forceBuild: boolean
-  private tagTemplate?: string
+  graph: ConfigGraph
+  module: GardenModule
+  forceBuild: boolean
+  tagTemplate?: string
 
   constructor({ garden, graph, log, module, forceBuild, tagTemplate }: PublishTaskParams) {
     super({ garden, log, version: module.version.versionString })

--- a/core/src/tasks/stage-build.ts
+++ b/core/src/tasks/stage-build.ts
@@ -31,9 +31,9 @@ export class StageBuildTask extends BaseTask {
   type: TaskType = "stage-build"
   concurrencyLimit = 10
 
-  private graph: ConfigGraph
-  private module: GardenModule
-  private extraDependencies: BaseTask[]
+  graph: ConfigGraph
+  module: GardenModule
+  extraDependencies: BaseTask[]
 
   constructor({ garden, graph, log, module, force, dependencies }: StageBuildTaskParams) {
     super({ garden, log, force, version: module.version.versionString })

--- a/core/src/tasks/task.ts
+++ b/core/src/tasks/task.ts
@@ -42,12 +42,11 @@ class RunTaskError extends Error {
 export class TaskTask extends BaseTask {
   // ... to be renamed soon.
   type: TaskType = "task"
-
-  private graph: ConfigGraph
-  private task: GardenTask
-  private forceBuild: boolean
-  private devModeServiceNames: string[]
-  private hotReloadServiceNames: string[]
+  graph: ConfigGraph
+  task: GardenTask
+  forceBuild: boolean
+  devModeServiceNames: string[]
+  hotReloadServiceNames: string[]
 
   constructor({
     garden,

--- a/core/test/helpers.ts
+++ b/core/test/helpers.ts
@@ -579,6 +579,24 @@ export function getRuntimeStatusEvents(eventLog: EventLogEntry[]) {
     })
 }
 
+export function makeModuleConfig(path: string, from: Partial<ModuleConfig>): ModuleConfig {
+  return {
+    apiVersion: DEFAULT_API_VERSION,
+    allowPublish: false,
+    build: { dependencies: [] },
+    disabled: false,
+    include: [],
+    name: "test",
+    path,
+    serviceConfigs: [],
+    taskConfigs: [],
+    spec: {},
+    testConfigs: [],
+    type: "test",
+    ...from,
+  }
+}
+
 /**
  * Initialise test logger.
  *

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -2551,7 +2551,7 @@ describe("Garden", () => {
       const garden = await makeTestGarden(projectRoot)
 
       const module = await garden.resolveModule("module-a")
-      const moduleCDep = { name: "module-c", copy: [] }
+      const moduleCDep = { name: "module-c", copy: [] }
       expect(module.build.dependencies).to.eql([moduleCDep])
       expect(module.spec.build.dependencies).to.eql([moduleCDep])
     })

--- a/core/test/unit/src/tasks/test.ts
+++ b/core/test/unit/src/tasks/test.ts
@@ -45,5 +45,27 @@ describe("TestTask", () => {
 
       expect(deps.map((d) => d.getKey())).to.eql(["build.module-a", "deploy.service-b", "task.task-a"])
     })
+
+    context("when skipRuntimeDependencies = true", () => {
+      it("doesn't return deploy or task dependencies", async () => {
+        const moduleA = graph.getModule("module-a")
+        const testConfig = moduleA.testConfigs[0]
+
+        const task = new TestTask({
+          garden,
+          log,
+          graph,
+          test: testFromConfig(moduleA, testConfig, graph),
+          force: true,
+          forceBuild: false,
+          skipRuntimeDependencies: true, // <-----
+          devModeServiceNames: [],
+          hotReloadServiceNames: [],
+        })
+
+        const deps = await task.resolveDependencies()
+        expect(deps.find((dep) => dep.type === "deploy" || dep.type === "task")).to.be.undefined
+      })
+    })
   })
 })

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -707,6 +707,7 @@ Examples:
   | `--dev-mode` | `-dev` | array:string | [EXPERIMENTAL] The name(s) of the service(s) to deploy with dev mode enabled. Use comma as a separator to specify multiple services. Use * to deploy all services with dev mode enabled. When this option is used, the command is run in watch mode (i.e. implicitly sets the --watch/-w flag).
   | `--hot-reload` | `-hot` | array:string | The name(s) of the service(s) to deploy with hot reloading enabled. Use comma as a separator to specify multiple services. Use * to deploy all services with hot reloading enabled (ignores services belonging to modules that don&#x27;t support or haven&#x27;t configured hot reloading). When this option is used, the command is run in watch mode (i.e. implicitly sets the --watch/-w flag).
   | `--skip` |  | array:string | The name(s) of services you&#x27;d like to skip when deploying.
+  | `--skip-dependencies` | `-no-deps` | boolean | Deploy the specified services, but don&#x27;t deploy any additional services that they depend on or run any tasks that they depend on. This option can only be used when a list of service names is passed as CLI arguments. This can be useful e.g. when your stack has already been deployed, and you want to deploy a subset of services in dev mode without redeploying any service dependencies that may have changed since you last deployed.
   | `--forward` |  | boolean | Create port forwards and leave process running without watching for changes. Ignored if --watch/-w flag is set or when in dev or hot-reload mode.
 
 #### Outputs
@@ -3643,6 +3644,7 @@ Examples:
   | `--force` | `-f` | boolean | Force re-test of module(s).
   | `--force-build` |  | boolean | Force rebuild of module(s).
   | `--watch` | `-w` | boolean | Watch for changes in module(s) and auto-test.
+  | `--skip-dependencies` | `-no-deps` | boolean | Don&#x27;t deploy any services or run any tasks that the requested tests depend on. This can be useful e.g. when your stack has already been deployed, and you want to run tests with runtime dependencies without redeploying any service dependencies that may have changed since you last deployed. Warning: Take great care when using this option in CI, since Garden won&#x27;t ensure that the runtime dependencies of your test suites are up to date when this option is used.
   | `--skip-dependants` |  | boolean | When using the modules argument, only run tests for those modules (and skip tests in other modules with dependencies on those modules).
 
 #### Outputs


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

Added a `--skip-dependencies` CLI option for the `deploy` and `test` commands.

When used with the `deploy` command, the specified services are deployed, but any additional services or tasks that they depend on are skipped.

This can be useful e.g. when your stack has already been deployed, and you want to deploy a subset of services in dev mode without redeploying any service dependencies that may have changed since you last deployed.

Similarly, for the `test` command, this option skips deploying/running any runtime dependencies of the requested test suites (not recommended for CI, but can be useful during inner-loop development in certain scenarios).