### PR TITLE
fix(k8s): better handling for long log lines

### DIFF
--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -810,7 +810,8 @@ export class PodRunner extends PodRunnerParams {
       resources: [this.pod],
       k8sApi: this.api,
     })
-    logsFollower.followLogs().catch((_err) => {
+    const limitBytes = 1000 * 1024 // 1MB
+    logsFollower.followLogs({ limitBytes }).catch((_err) => {
       // Errors in `followLogs` are logged there, so all we need to do here is to ensure that the follower is closed.
       logsFollower.close()
     })

--- a/core/test/integ/src/plugins/kubernetes/container/logs.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/logs.ts
@@ -135,7 +135,7 @@ describe("kubernetes", () => {
         setTimeout(() => {
           logsFollower.close()
         }, 2500)
-        await logsFollower.followLogs()
+        await logsFollower.followLogs({ limitBytes: null })
 
         expect(ctx.log.toString()).to.match(/Connected to container 'simple-service'/)
 
@@ -210,7 +210,7 @@ describe("kubernetes", () => {
         // Start following logs even when no services is deployed
         // (we don't wait for the Promise since it won't resolve unless we close the connection)
         // tslint:disable-next-line: no-floating-promises
-        logsFollower.followLogs()
+        logsFollower.followLogs({ limitBytes: null })
         await sleep(1500)
 
         // Deploy the service


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

Here, we remove the byte limit when streaming k8s logs directly (e.g. via the `logs` command), and greatly increase the byte limit when streaming logs for buids/tests/tasks.

**Which issue(s) this PR fixes**:

Fixes #2716.

**Special notes for your reviewer**:

I've tested this with extremely long log lines, and with test suites where we previously saw lines being truncated. Everything is looking good.