### PR TITLE
fix(k8s): refactor and bug fix for Mutagen v0.13.0 rebase

### DIFF
--- a/core/src/plugins/kubernetes/mutagen.ts
+++ b/core/src/plugins/kubernetes/mutagen.ts
@@ -249,6 +249,7 @@ export async function execMutagenCommand(ctx: PluginContext, log: LogEntry, args
         log,
         env: {
           MUTAGEN_DATA_DIRECTORY: dataDir,
+          MUTAGEN_DISABLE_AUTOSTART: "1",
         },
       })
       startMutagenMonitor(ctx, log)
@@ -425,7 +426,7 @@ export function startMutagenMonitor(ctx: PluginContext, log: LogEntry) {
  * List the currently active syncs in the mutagen daemon.
  */
 export async function getActiveMutagenSyncs(ctx: PluginContext, log: LogEntry): Promise<SyncListEntry[]> {
-  const res = await execMutagenCommand(ctx, log, ["sync", "list", "--output=json", "--auto-start=false"])
+  const res = await execMutagenCommand(ctx, log, ["sync", "list", "--output=json"])
 
   // TODO: validate further
   let parsed: any = {}
@@ -477,7 +478,7 @@ export async function ensureMutagenSync({
 
       const ignoreFlags = ignore.flatMap((i) => ["-i", i])
       const syncMode = mutagenModeMap[mode]
-      const params = [alpha, beta, "--name", key, "--auto-start=false", "--sync-mode", syncMode, ...ignoreFlags]
+      const params = [alpha, beta, "--name", key, "--sync-mode", syncMode, ...ignoreFlags]
 
       if (defaultOwner) {
         params.push("--default-owner", defaultOwner.toString())
@@ -527,7 +528,7 @@ export async function terminateMutagenSync(ctx: PluginContext, log: LogEntry, ke
 
   return mutagenConfigLock.acquire("configure", async () => {
     try {
-      await execMutagenCommand(ctx, log, ["sync", "delete", key, "--auto-start=false"])
+      await execMutagenCommand(ctx, log, ["sync", "delete", key])
       delete activeSyncs[key]
     } catch (err) {
       // Ignore other errors, which should mean the sync wasn't found
@@ -541,7 +542,7 @@ export async function terminateMutagenSync(ctx: PluginContext, log: LogEntry, ke
  * Ensure a sync is completed.
  */
 export async function flushMutagenSync(ctx: PluginContext, log: LogEntry, key: string) {
-  await execMutagenCommand(ctx, log, ["sync", "flush", key, "--auto-start=false"])
+  await execMutagenCommand(ctx, log, ["sync", "flush", key])
 }
 
 export async function getKubectlExecDestination({

--- a/core/src/plugins/kubernetes/mutagen.ts
+++ b/core/src/plugins/kubernetes/mutagen.ts
@@ -528,7 +528,7 @@ export async function terminateMutagenSync(ctx: PluginContext, log: LogEntry, ke
 
   return mutagenConfigLock.acquire("configure", async () => {
     try {
-      await execMutagenCommand(ctx, log, ["sync", "delete", key])
+      await execMutagenCommand(ctx, log, ["sync", "terminate", key])
       delete activeSyncs[key]
     } catch (err) {
       // Ignore other errors, which should mean the sync wasn't found


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit fixes an incorrect command invocation in the Mutagen plugin.  It also switches to using the more idiomatic `MUTAGEN_DISABLE_AUTOSTART` environment variable to prevent autostart of the Mutagen daemon when invoking commands.

This commit is a prerequisite for updating Garden's Mutagen fork to v0.13.0.  It is backwards-compatible with Garden's existing Mutagen fork based on Mutagen v0.12.0-beta3.

CC @edvald @thsig 