### PR TITLE
feat(core): debug logfiles

### DIFF
--- a/core/src/cli/debug-logs.ts
+++ b/core/src/cli/debug-logs.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2018-2022 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import Bluebird from "bluebird"
+import moment from "moment"
+import { lstat, pathExists, remove } from "fs-extra"
+import { join } from "path"
+import { LogEntry } from "../logger/log-entry"
+import { listDirectory } from "../util/fs"
+
+const logfileExpiryDays = 7
+
+/**
+ * Deletes any debug/JSON logfiles that are older than `logfileExpiryDays`, and returns the debug & silly
+ * logfile names for the currently executing command.
+ */
+export async function prepareDebugLogfiles(log: LogEntry, logsDirPath: string, commandFullName: string) {
+  try {
+    if (await pathExists(logsDirPath)) {
+      const filenames = await listDirectory(logsDirPath, { recursive: false })
+      // We don't want to slow down init, so we don't await this promise.
+      Bluebird.map(filenames, async (filename) => {
+        if (!filename.match(/debug.*\.log/) && !filename.match(/json.*\.log/)) {
+          return
+        }
+        const logfilePath = join(logsDirPath, filename)
+        const stat = await lstat(logfilePath)
+        // If the file is older than `logExpiryDays` days, delete it
+        if (moment(stat.birthtime).add(logfileExpiryDays, "days").isBefore(moment())) {
+          log.debug(`file ${filename} is older than ${logfileExpiryDays} days, deleting...`)
+          await remove(logfilePath)
+        }
+      }).catch((err) => {
+        log.warn(`An error occurred while cleaning up debug logfiles: ${err.message}`)
+      })
+    }
+  } catch (err) {
+    // We don't want control flow to stop if there's an error during logfile cleanup.
+    log.warn(`An error occurred while cleaning up debug logfiles: ${err.message}`)
+  }
+
+  return {
+    debugLogfileName: makeLogfileName("debug", commandFullName, "log"),
+    jsonLogfileName: makeLogfileName("silly", commandFullName, "jsonl"),
+  }
+}
+
+// Example: build.debug.2022-01-31T09:33:55.001Z.log
+function makeLogfileName(logLevel: string, commandFullName: string, extension: string): string {
+  return `${commandFullName.replace(" ", "-")}.${logLevel}.${new Date().toISOString()}.${extension}`
+}

--- a/core/src/logger/renderers.ts
+++ b/core/src/logger/renderers.ts
@@ -219,7 +219,8 @@ export function formatForJson(entry: LogEntry): JsonLogEntry {
   const msg = entry.getLatestMessage()
   const metadata = entry.getMetadata()
   const messages = chainMessages(entry.getMessages() || [])
-  return {
+  const errorDetail = entry.errorData && entry ? formatGardenErrorWithDetail(entry.errorData) : undefined
+  const jsonLogEntry: JsonLogEntry = {
     msg: cleanForJSON(messages),
     data: msg.data,
     metadata,
@@ -228,4 +229,8 @@ export function formatForJson(entry: LogEntry): JsonLogEntry {
     level: entry.getStringLevel(),
     allSections: getAllSections(entry, msg).map(cleanForJSON),
   }
+  if (errorDetail) {
+    jsonLogEntry.errorDetail = errorDetail
+  }
+  return jsonLogEntry
 }

--- a/core/src/logger/util.ts
+++ b/core/src/logger/util.ts
@@ -245,17 +245,22 @@ export function renderMessageWithDivider(prefix: string, msg: string, isError: b
   `
 }
 
-export function formatGardenErrorWithDetail(error: GardenError) {
-  const { detail, message, stack } = error
-  let out = stack || message || ""
-
-  // We recursively filter out internal fields (i.e. having names starting with _).
-  const filteredDetail = deepFilter(sanitizeObject(detail), (_val, key: string | number) => {
+// Recursively filters out internal fields (i.e. having names starting with `_`).
+export function withoutInternalFields(object: any): any {
+  return deepFilter(sanitizeObject(object), (_val, key: string | number) => {
     if (typeof key === "string") {
       return !key.startsWith("_")
     }
     return true
   })
+}
+
+export function formatGardenErrorWithDetail(error: GardenError) {
+  const { detail, message, stack } = error
+  let out = stack || message || ""
+
+  // We recursively filter out internal fields (i.e. having names starting with _).
+  const filteredDetail = withoutInternalFields(detail)
 
   if (!isEmpty(filteredDetail)) {
     try {

--- a/core/src/logger/writers/file-writer.ts
+++ b/core/src/logger/writers/file-writer.ts
@@ -21,6 +21,7 @@ export interface FileWriterConfig {
   level: LogLevel
   logFilePath: string
   fileTransportOptions?: {}
+  json?: boolean
   truncatePrevious?: boolean
 }
 
@@ -37,7 +38,7 @@ const DEFAULT_FILE_TRANSPORT_OPTIONS: FileTransportOptions = {
   maxFiles: 1,
 }
 
-const levelToStr = (lvl: LogLevel): string => LogLevel[lvl]
+export const levelToStr = (lvl: LogLevel): string => LogLevel[lvl]
 
 export function render(level: LogLevel, entry: LogEntry): string | null {
   if (level >= entry.level) {
@@ -50,9 +51,9 @@ export function render(level: LogLevel, entry: LogEntry): string | null {
 export class FileWriter extends Writer {
   type = "file"
 
-  private fileLogger: winston.Logger | null
-  private logFilePath: string
-  private fileTransportOptions: FileTransportOptions
+  protected fileLogger: winston.Logger | null
+  protected logFilePath: string
+  protected fileTransportOptions: FileTransportOptions
 
   constructor(logFilePath: string, config: FileWriterConfig) {
     super(config.level)
@@ -75,7 +76,7 @@ export class FileWriter extends Writer {
         await truncate(logFilePath)
       } catch (_) {}
     }
-    return new FileWriter(logFilePath, config)
+    return new this(logFilePath, config) // We use `this` in order for this factory method to work for subclasses
   }
 
   // Only init if needed to prevent unnecessary file writes

--- a/core/src/logger/writers/json-file-writer.ts
+++ b/core/src/logger/writers/json-file-writer.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2018-2022 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import winston from "winston"
+import { LogEntry } from "../log-entry"
+import { LogLevel } from "../logger"
+import { formatForJson } from "../renderers"
+import { FileWriter, levelToStr } from "./file-writer"
+
+export function renderAsJson(level: LogLevel, entry: LogEntry): string | null {
+  if (level >= entry.level) {
+    const jsonEntry = formatForJson(entry)
+    const empty = !(jsonEntry.msg || jsonEntry.data)
+    return empty ? null : JSON.stringify(jsonEntry)
+  }
+  return null
+}
+
+export class JsonFileWriter extends FileWriter {
+  type = "file-json"
+
+  // Only init if needed to prevent unnecessary file writes
+  initFileLogger() {
+    return winston.createLogger({
+      level: levelToStr(this.level),
+      transports: [
+        new winston.transports.File({
+          ...this.fileTransportOptions,
+          // We override the format here, since we want a pure JSON line (without a timestamp prefix).
+          format: winston.format.printf((info) => info.message),
+          filename: this.logFilePath,
+        }),
+      ],
+    })
+  }
+
+  render(entry: LogEntry): string | null {
+    return renderAsJson(this.level, entry)
+  }
+
+  onGraphChange(entry: LogEntry): void {
+    const out = this.render(entry)
+    if (out) {
+      if (!this.fileLogger) {
+        this.fileLogger = this.initFileLogger()
+      }
+      this.fileLogger.log(levelToStr(entry.level), out)
+    }
+  }
+}

--- a/core/src/logger/writers/json-terminal-writer.ts
+++ b/core/src/logger/writers/json-terminal-writer.ts
@@ -15,6 +15,7 @@ export interface JsonLogEntry {
   msg: string
   timestamp: string
   data?: any
+  errorDetail?: string
   section?: string
   metadata?: LogEntryMetadata
   level: string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko, @twelvemo and @s-chand.
-->

**What this PR does / why we need it**:

We now output all debug-level and silly-level logs into logfiles in the project's `.garden/logs` directory.

Debug-level logs are logged to a debug logfile using standard text formatting.

Silly-level logs are logged to a JSONL-formatted logfile (where each line is a JSON string). These can later be used to provide dynamic rendering of command logs via the CLI (e.g. allowing the user to select the log level, and then filtering the JSON entries before rendering them to the terminal).

The names of these logfiles include the command name, log level and the time the command was executed (as an ISO timestamp).

Logfiles older than 7 days are also automatically cleaned up by this logic.

This will be useful for gathering debug information when something goes wrong in a Garden command that was run at a lower (less verbose) log level.
