### PR TITLE
improvement(core): better workflow error logging

### DIFF
--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -579,15 +579,17 @@ ${renderCommands(commands)}
 
     let code = 0
     if (gardenErrors.length > 0) {
-      for (const error of gardenErrors) {
-        const entry = logger.error({
-          msg: error.message,
-          error,
-        })
-        // Output error details to console when log level is silly
-        logger.silly({
-          msg: renderError(entry),
-        })
+      if (!command.skipCliErrorSummary) {
+        for (const error of gardenErrors) {
+          const entry = logger.error({
+            msg: error.message,
+            error,
+          })
+          // Output error details to console when log level is silly
+          logger.silly({
+            msg: renderError(entry),
+          })
+        }
       }
 
       if (logger.getWriters().find((w) => w instanceof FileWriter)) {

--- a/core/src/commands/base.ts
+++ b/core/src/commands/base.ts
@@ -89,6 +89,9 @@ export abstract class Command<T extends Parameters = {}, U extends Parameters = 
   hidden: boolean = false
   noProject: boolean = false
   protected: boolean = false
+  // Set to true to disable post-execution logging of command errors by the CLI class (e.g. to avoid duplicate logging
+  // when the command does its own error logging/formatting in its action method).
+  skipCliErrorSummary: boolean = false
   streamEvents: boolean = false // Set to true to stream events for the command
   streamLogEntries: boolean = false // Set to true to stream log entries for the command
   server: GardenServer | undefined = undefined


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:

We now log any errors that come up in a workflow step command in the body log. The `run workflow` command's error logging was also improved and cleaned up.

**Special notes for your reviewer**:

The optional `skipCliErrorSummary` field isn't ideal, but we need to assume a bit more manual control over the error output/formatting for the `run workflow` command (because we don't want to log the errors twice).