### PR TITLE
feat(core): --with-dependants option for build cmd

### DIFF
--- a/core/test/helpers.ts
+++ b/core/test/helpers.ts
@@ -330,6 +330,25 @@ export const makeTestModule = (params: Partial<ModuleConfig> = {}) => {
   return { ...defaultModuleConfig, ...params }
 }
 
+// Similar to `makeTestModule`, but uses a more minimal default config.
+export function makeModuleConfig(path: string, from: Partial<ModuleConfig>): ModuleConfig {
+  return {
+    apiVersion: DEFAULT_API_VERSION,
+    allowPublish: false,
+    build: { dependencies: [] },
+    disabled: false,
+    include: [],
+    name: "test",
+    path,
+    serviceConfigs: [],
+    taskConfigs: [],
+    spec: {},
+    testConfigs: [],
+    type: "test",
+    ...from,
+  }
+}
+
 export const testPlugins = () => [testPlugin(), testPluginB(), testPluginC()]
 
 export const makeTestGarden = async (projectRoot: string, opts: TestGardenOpts = {}): Promise<TestGarden> => {
@@ -577,24 +596,6 @@ export function getRuntimeStatusEvents(eventLog: EventLogEntry[]) {
       cloned.payload.status = pick(cloned.payload.status, ["state"])
       return cloned
     })
-}
-
-export function makeModuleConfig(path: string, from: Partial<ModuleConfig>): ModuleConfig {
-  return {
-    apiVersion: DEFAULT_API_VERSION,
-    allowPublish: false,
-    build: { dependencies: [] },
-    disabled: false,
-    include: [],
-    name: "test",
-    path,
-    serviceConfigs: [],
-    taskConfigs: [],
-    spec: {},
-    testConfigs: [],
-    type: "test",
-    ...from,
-  }
 }
 
 /**

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -69,6 +69,7 @@ Examples:
 | -------- | ----- | ---- | ----------- |
   | `--force` | `-f` | boolean | Force rebuild of module(s).
   | `--watch` | `-w` | boolean | Watch for changes in module(s) and auto-build.
+  | `--with-dependants` |  | boolean | Also rebuild modules that have build dependencies on one of the modules specified as CLI arguments (recursively). Note: This option has no effect unless a list of module names is specified as CLI arguments (since then, every module in the project will be rebuilt).
 
 #### Outputs
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:

Adds a `--with-dependants` option to the `build` command.

When used, build dependants of the modules provided as CLI arguments (and their build dependants, recursively) will also be rebuilt.

**Which issue(s) this PR fixes**:

Closes #2749.