### PR TITLE
chore(k8s): update to Mutagen v0.13.0

### DIFF
--- a/core/src/plugins/kubernetes/constants.ts
+++ b/core/src/plugins/kubernetes/constants.ts
@@ -24,7 +24,7 @@ export const inClusterRegistryHostname = "127.0.0.1:5000"
 export const gardenUtilDaemonDeploymentName = "garden-util-daemon"
 export const dockerDaemonDeploymentName = "garden-docker-daemon"
 
-export const k8sUtilImageName = "gardendev/k8s-util:0.5.1"
+export const k8sUtilImageName = "gardendev/k8s-util:0.5.2"
 export const dockerDaemonContainerName = "docker-daemon"
 export const skopeoDaemonContainerName = "util"
 

--- a/core/src/plugins/kubernetes/dev-mode.ts
+++ b/core/src/plugins/kubernetes/dev-mode.ts
@@ -36,7 +36,7 @@ import { joi, joiIdentifier } from "../../config/common"
 import { KubernetesPluginContext, KubernetesProvider } from "./config"
 import { isConfiguredForDevMode } from "./status/status"
 
-const syncUtilImageName = "gardendev/k8s-sync:0.1.1"
+const syncUtilImageName = "gardendev/k8s-sync:0.1.3"
 
 export const builtInExcludes = ["/**/*.git", "**/*.garden"]
 

--- a/core/src/plugins/kubernetes/mutagen.ts
+++ b/core/src/plugins/kubernetes/mutagen.ts
@@ -594,8 +594,8 @@ export const mutagenCliSpec: PluginToolSpec = {
       platform: "darwin",
       architecture: "amd64",
       url:
-        "https://github.com/garden-io/mutagen/releases/download/v0.12.0-garden-alpha2/mutagen_darwin_amd64_v0.12.0-beta3.tar.gz",
-      sha256: "e31cebb5c4cbd1a1320e56b111416389e9eed911233b40c93801547c1eec0563",
+        "https://github.com/garden-io/mutagen/releases/download/v0.13.0-garden-1/mutagen_darwin_amd64_v0.13.0.tar.gz",
+      sha256: "ef0642bfcd787ab20d30ab218f9f1cd92e51f035ab9fbaa38132bb0726abea74",
       extract: {
         format: "tar",
         targetPath: "mutagen",
@@ -604,9 +604,8 @@ export const mutagenCliSpec: PluginToolSpec = {
     {
       platform: "linux",
       architecture: "amd64",
-      url:
-        "https://github.com/garden-io/mutagen/releases/download/v0.12.0-garden-alpha2/mutagen_linux_amd64_v0.12.0-beta3.tar.gz",
-      sha256: "09a0dbccbbd784324707ba12002a6bc90395f0cd73daab83d6cda7432b4973f3",
+      url: "https://github.com/garden-io/mutagen/releases/download/v0.13.0-garden-1/mutagen_linux_amd64_v0.13.0.tar.gz",
+      sha256: "733d92d8d8eeab82ac4755df34c4a359eec3b600861b075b130bd8f954908640",
       extract: {
         format: "tar",
         targetPath: "mutagen",
@@ -615,9 +614,8 @@ export const mutagenCliSpec: PluginToolSpec = {
     {
       platform: "windows",
       architecture: "amd64",
-      url:
-        "https://github.com/garden-io/mutagen/releases/download/v0.12.0-garden-alpha2/mutagen_windows_amd64_v0.12.0-beta3.zip",
-      sha256: "9482646380a443b72aa38b3569c71c73d91ddde7c57a10de3d48b0b727cb8bff",
+      url: "https://github.com/garden-io/mutagen/releases/download/v0.13.0-garden-1/mutagen_windows_amd64_v0.13.0.zip",
+      sha256: "50235fb453d55e9c07a4f287c3afe7562b91786a288ef836bd58905f48d7be31",
       extract: {
         format: "zip",
         targetPath: "mutagen.exe",

--- a/core/src/plugins/kubernetes/mutagen.ts
+++ b/core/src/plugins/kubernetes/mutagen.ts
@@ -249,6 +249,7 @@ export async function execMutagenCommand(ctx: PluginContext, log: LogEntry, args
         log,
         env: {
           MUTAGEN_DATA_DIRECTORY: dataDir,
+          MUTAGEN_DISABLE_AUTOSTART: "1",
         },
       })
       startMutagenMonitor(ctx, log)
@@ -425,7 +426,7 @@ export function startMutagenMonitor(ctx: PluginContext, log: LogEntry) {
  * List the currently active syncs in the mutagen daemon.
  */
 export async function getActiveMutagenSyncs(ctx: PluginContext, log: LogEntry): Promise<SyncListEntry[]> {
-  const res = await execMutagenCommand(ctx, log, ["sync", "list", "--output=json", "--auto-start=false"])
+  const res = await execMutagenCommand(ctx, log, ["sync", "list", "--output=json"])
 
   // TODO: validate further
   let parsed: any = {}
@@ -477,7 +478,7 @@ export async function ensureMutagenSync({
 
       const ignoreFlags = ignore.flatMap((i) => ["-i", i])
       const syncMode = mutagenModeMap[mode]
-      const params = [alpha, beta, "--name", key, "--auto-start=false", "--sync-mode", syncMode, ...ignoreFlags]
+      const params = [alpha, beta, "--name", key, "--sync-mode", syncMode, ...ignoreFlags]
 
       if (defaultOwner) {
         params.push("--default-owner", defaultOwner.toString())
@@ -527,7 +528,7 @@ export async function terminateMutagenSync(ctx: PluginContext, log: LogEntry, ke
 
   return mutagenConfigLock.acquire("configure", async () => {
     try {
-      await execMutagenCommand(ctx, log, ["sync", "delete", key, "--auto-start=false"])
+      await execMutagenCommand(ctx, log, ["sync", "delete", key])
       delete activeSyncs[key]
     } catch (err) {
       // Ignore other errors, which should mean the sync wasn't found
@@ -541,7 +542,7 @@ export async function terminateMutagenSync(ctx: PluginContext, log: LogEntry, ke
  * Ensure a sync is completed.
  */
 export async function flushMutagenSync(ctx: PluginContext, log: LogEntry, key: string) {
-  await execMutagenCommand(ctx, log, ["sync", "flush", key, "--auto-start=false"])
+  await execMutagenCommand(ctx, log, ["sync", "flush", key])
 }
 
 export async function getKubectlExecDestination({

--- a/core/src/plugins/kubernetes/mutagen.ts
+++ b/core/src/plugins/kubernetes/mutagen.ts
@@ -528,7 +528,7 @@ export async function terminateMutagenSync(ctx: PluginContext, log: LogEntry, ke
 
   return mutagenConfigLock.acquire("configure", async () => {
     try {
-      await execMutagenCommand(ctx, log, ["sync", "delete", key])
+      await execMutagenCommand(ctx, log, ["sync", "terminate", key])
       delete activeSyncs[key]
     } catch (err) {
       // Ignore other errors, which should mean the sync wasn't found

--- a/core/test/integ/src/plugins/kubernetes/container/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/deployment.ts
@@ -270,7 +270,7 @@ describe("kubernetes container deployment handlers", () => {
       expect(resource.spec.template?.spec?.initContainers).to.eql([
         {
           name: "garden-dev-init",
-          image: "gardendev/k8s-sync:0.1.1",
+          image: "gardendev/k8s-sync:0.1.3",
           command: ["/bin/sh", "-c", "cp /usr/local/bin/mutagen-agent /.garden/mutagen-agent"],
           imagePullPolicy: "IfNotPresent",
           volumeMounts: [

--- a/images/k8s-sync/Dockerfile
+++ b/images/k8s-sync/Dockerfile
@@ -3,8 +3,9 @@ FROM alpine:3.13.5
 RUN apk add --no-cache curl
 
 # Get mutagen agent
-RUN curl -fsSL "https://github.com/garden-io/mutagen/releases/download/v0.12.0-garden-alpha2/agent_linux_amd64_v0.12.0-beta3.tar.gz" \
-  | tar xz --to-stdout mutagen-agent \
+RUN curl -fsSL "https://github.com/mutagen-io/mutagen/releases/download/v0.13.0/mutagen_linux_amd64_v0.13.0.tar.gz" \
+  | tar xz --to-stdout mutagen-agents.tar.gz \
+  | tar xz --to-stdout linux_amd64 \
   > /usr/local/bin/mutagen-agent && \
   chmod +x /usr/local/bin/mutagen-agent && \
   mkdir -p /.garden && \

--- a/images/k8s-sync/garden.yml
+++ b/images/k8s-sync/garden.yml
@@ -2,5 +2,5 @@ kind: Module
 type: container
 name: k8s-sync
 description: Used by the kubernetes provider for dev mode sync setup
-image: gardendev/k8s-sync:0.1.2
+image: gardendev/k8s-sync:0.1.3
 dockerfile: Dockerfile

--- a/images/k8s-util/garden.yml
+++ b/images/k8s-util/garden.yml
@@ -2,7 +2,7 @@ kind: Module
 type: container
 name: k8s-util
 description: Used by the kubernetes provider for build-related activities
-image: gardendev/k8s-util:0.5.1
+image: gardendev/k8s-util:0.5.2
 dockerfile: Dockerfile
 build:
   dependencies: [k8s-sync]


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates Garden to use Mutagen v0.13.0.  While this still uses a custom fork of the Mutagen CLI, it now switches to using the official Mutagen agent release binaries.  These changes are important for (a) bringing in fixes and enhancements added after Mutagen v0.12.0-beta3 (on which Garden's fork was previously based) and (b) moving Garden towards using official Mutagen release binaries.

This PR also fixes an incorrect command invocation in the Mutagen plugin and switches to using the more idiomatic `MUTAGEN_DISABLE_AUTOSTART` environment variable to prevent autostart of the Mutagen daemon when invoking commands (allowing for removal of the `--auto-start` flag in Garden's fork of Mutagen).

CC @edvald @thsig
