### PR TITLE
improvement(cloud): handle AEC for Helm services

### DIFF
--- a/core/src/plugin-context.ts
+++ b/core/src/plugin-context.ts
@@ -24,6 +24,7 @@ type WrappedFromGarden = Pick<
   | "projectRoot"
   | "gardenDirPath"
   | "workingCopyId"
+  | "cloudApi"
   // TODO: remove this from the interface
   | "environmentName"
   | "production"
@@ -88,6 +89,7 @@ export const pluginContextSchema = () =>
       sessionId: joi.string().description("The unique ID of the currently active session."),
       tools: joiStringMap(joi.object()),
       workingCopyId: joi.string().description("A unique ID assigned to the current project working copy."),
+      cloudApi: joi.any().optional(),
     })
 
 interface PluginEvents {
@@ -123,5 +125,6 @@ export async function createPluginContext(
     sessionId: garden.sessionId,
     tools: await garden.getTools(),
     workingCopyId: garden.workingCopyId,
+    cloudApi: garden.cloudApi,
   }
 }

--- a/core/src/plugins/kubernetes/helm/logs.ts
+++ b/core/src/plugins/kubernetes/helm/logs.ts
@@ -12,7 +12,7 @@ import { HelmModule } from "./config"
 import { KubernetesPluginContext } from "../config"
 import { getReleaseName } from "./common"
 import { getModuleNamespace } from "../namespace"
-import { getDeployedResources } from "./status"
+import { getRenderedResources } from "./status"
 import { sleep } from "../../../util/util"
 
 export async function getServiceLogs(params: GetServiceLogsParams<HelmModule>) {
@@ -38,7 +38,7 @@ export async function getServiceLogs(params: GetServiceLogsParams<HelmModule>) {
     //    terminated when the command exits.
     while (true) {
       try {
-        resources = await getDeployedResources({ ctx: k8sCtx, module, releaseName, log })
+        resources = await getRenderedResources({ ctx: k8sCtx, module, releaseName, log })
         break
       } catch (err) {
         log.debug(`Failed getting deployed resources. Retrying...`)
@@ -47,7 +47,7 @@ export async function getServiceLogs(params: GetServiceLogsParams<HelmModule>) {
       await sleep(2000)
     }
   } else {
-    resources = await getDeployedResources({ ctx: k8sCtx, module, releaseName, log })
+    resources = await getRenderedResources({ ctx: k8sCtx, module, releaseName, log })
   }
   return streamK8sLogs({ ...params, provider, defaultNamespace: namespace, resources: resources! })
 }

--- a/core/src/plugins/kubernetes/helm/status.ts
+++ b/core/src/plugins/kubernetes/helm/status.ts
@@ -16,9 +16,13 @@ import { KubernetesPluginContext } from "../config"
 import { getForwardablePorts } from "../port-forward"
 import { KubernetesServerResource } from "../types"
 import { getModuleNamespace, getModuleNamespaceStatus } from "../namespace"
-import { getServiceResource, getServiceResourceSpec } from "../util"
+import { getServiceResource, getServiceResourceSpec, isWorkload } from "../util"
 import { startDevModeSync } from "../dev-mode"
 import { isConfiguredForDevMode } from "../status/status"
+import { KubeApi } from "../api"
+import Bluebird from "bluebird"
+
+export const gardenCloudAECPauseAnnotation = "garden.io/aec-status"
 
 const helmStatusMap: { [status: string]: ServiceState } = {
   unknown: "unknown",
@@ -60,7 +64,7 @@ export async function getServiceStatus({
   let deployedWithDevModeOrHotReloading: boolean | undefined
 
   try {
-    helmStatus = await getReleaseStatus({ ctx: k8sCtx, service, releaseName, log, devMode, hotReload })
+    helmStatus = await getReleaseStatus({ ctx: k8sCtx, module, service, releaseName, log, devMode, hotReload })
     state = helmStatus.state
     deployedWithDevModeOrHotReloading = helmStatus.devMode
   } catch (err) {
@@ -70,7 +74,7 @@ export async function getServiceStatus({
   let forwardablePorts: ForwardablePort[] = []
 
   if (state !== "missing") {
-    const deployedResources = await getDeployedResources({ ctx: k8sCtx, module, releaseName, log })
+    const deployedResources = await getRenderedResources({ ctx: k8sCtx, module, releaseName, log })
     forwardablePorts = getForwardablePorts(deployedResources, service)
 
     if (state === "ready" && devMode && service.spec.devMode) {
@@ -124,7 +128,7 @@ export async function getServiceStatus({
   }
 }
 
-export async function getDeployedResources({
+export async function getRenderedResources({
   ctx,
   releaseName,
   log,
@@ -154,6 +158,7 @@ export async function getDeployedResources({
 
 export async function getReleaseStatus({
   ctx,
+  module,
   service,
   releaseName,
   log,
@@ -161,6 +166,7 @@ export async function getReleaseStatus({
   hotReload,
 }: {
   ctx: KubernetesPluginContext
+  module: HelmModule
   service: GardenService
   releaseName: string
   log: LogEntry
@@ -194,6 +200,7 @@ export async function getReleaseStatus({
           args: ["get", "values", releaseName, "--output", "json"],
         })
       )
+
       const deployedVersion = values[".garden"] && values[".garden"].version
       devModeEnabled = values[".garden"] && values[".garden"].devMode === true
       hotReloadEnabled = values[".garden"] && values[".garden"].hotReload === true
@@ -204,6 +211,13 @@ export async function getReleaseStatus({
         !deployedVersion ||
         deployedVersion !== service.version
       ) {
+        state = "outdated"
+      }
+
+      // If ctx.cloudApi is defined, the user is logged in and they might be trying to deploy to an environment
+      // that could have been paused by Garden Cloud's AEC functionality. We therefore make sure to check for
+      // the annotations Garden Cloud adds to Helm Deployments and StatefulSets when pausing an environment.
+      if (ctx.cloudApi && (await isPaused({ ctx, namespace, module, releaseName, log }))) {
         state = "outdated"
       }
     }
@@ -220,4 +234,49 @@ export async function getReleaseStatus({
       throw err
     }
   }
+}
+
+/**
+ *  Returns Helm workload resources that have been marked as "paused" by Garden Cloud's AEC functionality
+ */
+export async function getPausedResources({
+  ctx,
+  module,
+  namespace,
+  releaseName,
+  log,
+}: {
+  ctx: KubernetesPluginContext
+  namespace: string
+  module: HelmModule
+  releaseName: string
+  log: LogEntry
+}) {
+  const api = await KubeApi.factory(log, ctx, ctx.provider)
+  const renderedResources = await getRenderedResources({ ctx, module, releaseName, log })
+  const workloads = renderedResources.filter(isWorkload)
+  const deployedResources = await Bluebird.all(
+    workloads.map((workload) => api.readBySpec({ log, namespace, manifest: workload }))
+  )
+
+  const pausedWorkloads = deployedResources.filter((resource) => {
+    return resource?.metadata?.annotations?.[gardenCloudAECPauseAnnotation] === "paused"
+  })
+  return pausedWorkloads
+}
+
+async function isPaused({
+  ctx,
+  module,
+  namespace,
+  releaseName,
+  log,
+}: {
+  ctx: KubernetesPluginContext
+  namespace: string
+  module: HelmModule
+  releaseName: string
+  log: LogEntry
+}) {
+  return (await getPausedResources({ ctx, module, namespace, releaseName, log })).length > 0
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:
This PR changes the status check for the Helm plugin to mark resources that have been deployed via Helm and paused by Garden Cloud AEC functionality as `outdated`.
This is needed because when we scale down Helm workload resources from the CleanupRunners, Helm stays unaware of those changes and always returns the `ready` status.

Note: I might need help with testing this @thsig and we were also wondering how to pass a `gardenCloudContext` to plugin handlers in order to call this logic only if the user is logged in Garden Cloud and avoid unnecessary checks otherwise.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
cc @twelvemo 