### PR TITLE
Custom commands

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -52,12 +52,6 @@ export async function runCli({
     code = 1
   } finally {
     await processRecord.remove()
-
-    if (gardenEnv.GARDEN_ENABLE_PROFILING) {
-      // tslint:disable-next-line: no-console
-      console.log(getDefaultProfiler().report())
-    }
-
     await shutdown(code)
   }
 

--- a/core/package.json
+++ b/core/package.json
@@ -101,6 +101,7 @@
     "lodash": "^4.17.19",
     "log-symbols": "^4.0.0",
     "micromatch": "^4.0.4",
+    "mimic-fn": "^3.1.0",
     "minimatch": "^3.0.4",
     "minimist": "^1.2.5",
     "mocha-logger": "^1.0.6",
@@ -141,7 +142,6 @@
     "tough-cookie": "^4.0.0",
     "ts-stream": "^3.0.0",
     "typeorm-with-better-sqlite3": "^0.2.27",
-    "typescript-memoize": "^1.0.0-alpha.3",
     "uniqid": "^5.2.0",
     "unixify": "^1.0.0",
     "unzipper": "^0.10.11",
@@ -245,6 +245,7 @@
     "tslint-microsoft-contrib": "^6.2.0",
     "tslint-no-unused": "^0.2.0-alpha.1",
     "tslint-plugin-prettier": "^2.3.0",
+    "type-fest": "^2.5.4",
     "typescript": "^4.3.5"
   },
   "scripts": {

--- a/core/src/cli/params.ts
+++ b/core/src/cli/params.ts
@@ -52,6 +52,7 @@ export interface ParameterConstructor<T> {
   cliDefault?: T
   cliOnly?: boolean
   hidden?: boolean
+  spread?: boolean
 }
 
 export abstract class Parameter<T> {
@@ -68,6 +69,7 @@ export abstract class Parameter<T> {
   valueName: string
   overrides: string[]
   hidden: boolean
+  spread: boolean
 
   readonly cliDefault: T | undefined // Optionally specify a separate default for CLI invocation
   readonly cliOnly: boolean // If true, only expose in the CLI, and not in the HTTP/WS server.
@@ -83,6 +85,7 @@ export abstract class Parameter<T> {
     cliDefault,
     cliOnly,
     hidden,
+    spread,
   }: ParameterConstructor<T>) {
     this.help = help
     this.required = required || false
@@ -94,6 +97,7 @@ export abstract class Parameter<T> {
     this.cliDefault = cliDefault
     this.cliOnly = cliOnly || false
     this.hidden = hidden || false
+    this.spread = spread || false
   }
 
   // TODO: merge this and the parseString method?
@@ -355,7 +359,6 @@ export const globalOptions = {
     alias: "r",
     help:
       "Override project root directory (defaults to working directory). Can be absolute or relative to current directory.",
-    defaultValue: process.cwd(),
   }),
   "silent": new BooleanParameter({
     alias: "s",

--- a/core/src/commands/build.ts
+++ b/core/src/commands/build.ts
@@ -58,7 +58,6 @@ export class BuildCommand extends Command<Args, Opts> {
   help = "Build your modules."
 
   protected = true
-  workflows = true
   streamEvents = true
 
   description = dedent`
@@ -80,14 +79,14 @@ export class BuildCommand extends Command<Args, Opts> {
 
   outputsSchema = () => processCommandResultSchema()
 
-  async prepare({ footerLog, opts }: PrepareParams<Args, Opts>) {
-    const persistent = !!opts.watch
+  isPersistent({ opts }: PrepareParams<Args, Opts>) {
+    return !!opts.watch
+  }
 
-    if (persistent) {
-      this.server = await startServer({ log: footerLog })
+  async prepare(params: PrepareParams<Args, Opts>) {
+    if (this.isPersistent(params)) {
+      this.server = await startServer({ log: params.footerLog })
     }
-
-    return { persistent }
   }
 
   terminate() {

--- a/core/src/commands/cloud/cloud.ts
+++ b/core/src/commands/cloud/cloud.ts
@@ -16,8 +16,7 @@ export class CloudCommand extends CommandGroup {
   name = "cloud"
   alias = "enterprise"
   help = dedent`
-    [EXPERIMENTAL] Manage Garden Cloud resources such as users, groups and secrets.
-    Requires Garden Cloud 1.14.0 or higher.
+    Manage Garden Cloud/Enterprise resources such as users, groups and secrets.
   `
 
   subCommands = [SecretsCommand, UsersCommand, GroupsCommand]

--- a/core/src/commands/commands.ts
+++ b/core/src/commands/commands.ts
@@ -69,6 +69,6 @@ export const getCoreCommands = (): (Command | CommandGroup)[] => [
   new ValidateCommand(),
 ]
 
-export function getAllCommands() {
+export function getBuiltinCommands() {
   return getCoreCommands().flatMap((cmd) => (cmd instanceof CommandGroup ? [cmd, ...cmd.getSubCommands()] : [cmd]))
 }

--- a/core/src/commands/create/create-module.ts
+++ b/core/src/commands/create/create-module.ts
@@ -99,6 +99,11 @@ export class CreateModuleCommand extends Command<CreateModuleArgs, CreateModuleO
     printHeader(headerLog, "Create new module", "pencil2")
   }
 
+  // Defining it like this because it'll stall on waiting for user input.
+  isPersistent() {
+    return true
+  }
+
   async action({
     opts,
     log,

--- a/core/src/commands/create/create-project.ts
+++ b/core/src/commands/create/create-project.ts
@@ -95,6 +95,11 @@ export class CreateProjectCommand extends Command<CreateProjectArgs, CreateProje
     printHeader(headerLog, "Create new project", "pencil2")
   }
 
+  // Defining it like this because it'll stall on waiting for user input.
+  isPersistent() {
+    return true
+  }
+
   async action({
     opts,
     log,

--- a/core/src/commands/custom.ts
+++ b/core/src/commands/custom.ts
@@ -1,0 +1,271 @@
+/*
+ * Copyright (C) 2018-2021 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import Bluebird from "bluebird"
+import chalk from "chalk"
+import execa from "execa"
+import { apply as jsonMerge } from "json-merge-patch"
+import { cloneDeep, keyBy, mapValues, flatten } from "lodash"
+import { TreeCache } from "../cache"
+import { parseCliArgs, prepareMinimistOpts } from "../cli/helpers"
+import { BooleanParameter, globalOptions, IntegerParameter, Parameter, StringParameter } from "../cli/params"
+import { loadConfigResources } from "../config/base"
+import {
+  CommandResource,
+  customCommandExecSchema,
+  customCommandGardenCommandSchema,
+  CustomCommandOption,
+  customCommandSchema,
+} from "../config/command"
+import { joi } from "../config/common"
+import { CustomCommandContext } from "../config/template-contexts/custom-command"
+import { validateWithPath } from "../config/validation"
+import { ConfigurationError, GardenBaseError, InternalError, RuntimeError, toGardenError } from "../exceptions"
+import { VoidLogger } from "../logger/logger"
+import { resolveTemplateStrings } from "../template-string/template-string"
+import { findConfigPathsInPath, configFilenamePattern } from "../util/fs"
+import { GitHandler } from "../vcs/git"
+import { Command, CommandGroup, CommandParams, CommandResult, PrintHeaderParams } from "./base"
+import { customMinimist } from "../lib/minimist"
+import { removeSlice } from "../util/util"
+
+function convertArgSpec(spec: CustomCommandOption) {
+  const params = {
+    name: spec.name,
+    help: spec.description,
+    required: spec.required,
+  }
+
+  if (spec.type === "string") {
+    return new StringParameter(params)
+  } else if (spec.type === "integer") {
+    return new IntegerParameter(params)
+  } else if (spec.type === "boolean") {
+    return new BooleanParameter(params)
+  } else {
+    throw new ConfigurationError(`Unexpected parameter type '${spec.type}'`, { spec })
+  }
+}
+
+interface CustomCommandResult {
+  exec?: {
+    startedAt: Date
+    completedAt: Date
+    command: string[]
+    exitCode: number
+  }
+  gardenCommand?: {
+    startedAt: Date
+    completedAt: Date
+    command: string[]
+    result: any
+    errors: (Error | GardenBaseError)[]
+  }
+}
+
+export class CustomCommandWrapper extends Command {
+  // These are overridden in the constructor
+  name = "<custom>"
+  help = ""
+
+  noProject = true
+  allowUndefinedArguments = true
+
+  constructor(public spec: CommandResource) {
+    super()
+    this.name = spec.name
+    this.help = spec.description?.short
+    this.description = spec.description?.long
+
+    // Convert argument specs, so they'll be validated
+    this.arguments = spec.args ? mapValues(keyBy(spec.args, "name"), convertArgSpec) : undefined
+    this.options = mapValues(keyBy(spec.opts, "name"), convertArgSpec)
+  }
+
+  printHeader({ headerLog }: PrintHeaderParams) {
+    headerLog.info(chalk.cyan(this.name))
+  }
+
+  async action({ garden, cli, log, args, opts }: CommandParams<any, any>): Promise<CommandResult<CustomCommandResult>> {
+    // Prepare args/opts for the template context.
+    // Prepare the ${args.$rest} variable
+    // Note: The fork of minimist is a slightly unfortunate hack to be able to extract all unknown args and flags.
+    const parsed = customMinimist(
+      args.$all || [],
+      prepareMinimistOpts({
+        options: this.options || {},
+        cli: true,
+      })
+    )
+    // Strip the command name and any specified arguments off the $rest variable
+    const rest = removeSlice(parsed._unknown, this.getPath()).slice(Object.keys(this.arguments || {}).length)
+
+    // Render the command variables
+    const variablesContext = new CustomCommandContext({ ...garden, args, opts, rest })
+    const commandVariables = resolveTemplateStrings(this.spec.variables, variablesContext)
+    const variables: any = jsonMerge(cloneDeep(garden.variables), commandVariables)
+
+    // Make a new template context with the resolved variables
+    const commandContext = new CustomCommandContext({ ...garden, args, opts, variables, rest })
+
+    const result: CustomCommandResult = {}
+    const errors: GardenBaseError[] = []
+
+    // Run exec command
+    if (this.spec.exec) {
+      const startedAt = new Date()
+
+      const exec = validateWithPath({
+        config: resolveTemplateStrings(this.spec.exec, commandContext),
+        schema: customCommandExecSchema(),
+        path: this.spec.path,
+        projectRoot: garden.projectRoot,
+        configType: `exec field in custom Command '${this.name}'`,
+      })
+
+      const command = exec.command
+      log.debug(`Running exec command: ${command.join(" ")}`)
+
+      const res = await execa(command[0], command.slice(1), {
+        stdio: "inherit",
+        buffer: true,
+        env: exec.env,
+        reject: false,
+      })
+      const completedAt = new Date()
+
+      if (res.exitCode !== 0) {
+        return {
+          exitCode: res.exitCode,
+          errors: [new RuntimeError(`Command exited with code ${res.exitCode}`, { exitCode: res.exitCode, command })],
+        }
+      }
+
+      result.exec = {
+        command,
+        startedAt,
+        completedAt,
+        exitCode: res.exitCode,
+      }
+    }
+
+    // Run Garden command
+    if (this.spec.gardenCommand) {
+      const startedAt = new Date()
+
+      let gardenCommand = validateWithPath({
+        config: resolveTemplateStrings(this.spec.gardenCommand, commandContext),
+        schema: customCommandGardenCommandSchema(),
+        path: this.spec.path,
+        projectRoot: garden.projectRoot,
+        configType: `gardenCommand field in custom Command '${this.name}'`,
+      })
+
+      log.debug(`Running Garden command: ${gardenCommand.join(" ")}`)
+
+      // Doing runtime check to avoid updating hundreds of test invocations with a new required param, sorry. - JE
+      if (!cli) {
+        throw new InternalError(`Missing cli argument in custom command wrapper. This is a bug, please report it.`, {})
+      }
+
+      // Pass explicitly set global opts with the command, if they're not set in the command itself.
+      const parsedCommand = parseCliArgs({ stringArgs: gardenCommand, command: this, cli: false })
+
+      const globalFlags = Object.entries(opts)
+        .filter(([flag, value]) => {
+          const opt = <Parameter<any>>globalOptions[flag]
+          if (opt) {
+            if (!parsedCommand[flag] && value !== opt.getDefaultValue(true)) {
+              return true
+            }
+          }
+          return false
+        })
+        .flatMap(([flag, value]) => ["--" + flag, value + ""])
+
+      gardenCommand = [...globalFlags, ...gardenCommand]
+
+      const res = await cli.run({
+        args: gardenCommand,
+        exitOnError: false,
+        cwd: garden.projectRoot,
+      })
+
+      if (res.consoleOutput) {
+        if (res.code === 0) {
+          log.info(res.consoleOutput)
+        } else {
+          log.error(res.consoleOutput)
+        }
+      }
+
+      const completedAt = new Date()
+
+      errors.push(...res.errors.map((e) => toGardenError(e)))
+
+      result.gardenCommand = {
+        startedAt,
+        completedAt,
+        command: gardenCommand,
+        result: res.result,
+        errors: res.errors,
+      }
+    }
+
+    return { result, errors }
+  }
+}
+
+export async function getCustomCommands(builtinCommands: (Command | CommandGroup)[], projectRoot: string) {
+  // Look for Command resources in the project root directory
+  const paths = await findConfigPathsInPath({
+    vcs: new GitHandler(projectRoot, projectRoot, [], new TreeCache()),
+    dir: projectRoot,
+    include: [configFilenamePattern],
+    log: new VoidLogger().placeholder(),
+  })
+
+  const resources = flatten(await Bluebird.map(paths, (path) => loadConfigResources(projectRoot, path)))
+
+  const builtinNames = builtinCommands.flatMap((c) => c.getPaths().map((p) => p.join(" ")))
+
+  // Filter and validate the resources
+  const commandResources = <CommandResource[]>resources
+    .filter((r) => {
+      if (r.kind !== "Command") {
+        return false
+      }
+
+      if (builtinNames.includes(r.name)) {
+        // tslint:disable-next-line: no-console
+        console.log(
+          chalk.yellow(
+            `Ignoring custom command ${r.name} because it conflicts with a built-in command with the same name`
+          )
+        )
+        return false
+      }
+
+      return true
+    })
+    .map((config) =>
+      validateWithPath({
+        config,
+        schema: customCommandSchema().keys({
+          // Allowing any values here because they're fully resolved later
+          exec: joi.any(),
+          gardenCommand: joi.any(),
+        }),
+        path: config.path,
+        projectRoot,
+        configType: `custom Command '${config.name}'`,
+      })
+    )
+
+  return commandResources.map((spec) => new CustomCommandWrapper(spec))
+}

--- a/core/src/commands/dashboard.ts
+++ b/core/src/commands/dashboard.ts
@@ -51,6 +51,10 @@ export class DashboardCommand extends Command<Args, Opts> {
     printHeader(headerLog, "Dashboard", "bar_chart")
   }
 
+  isPersistent() {
+    return true
+  }
+
   async prepare({ log, footerLog, opts }: PrepareParams<Args, Opts>) {
     this.server = await startServer({ log: footerLog, port: opts.port })
 
@@ -68,8 +72,6 @@ export class DashboardCommand extends Command<Args, Opts> {
       }
       process.exit(1)
     })
-
-    return { persistent: true }
   }
 
   async action({ garden, log }: CommandParams<Args, Opts>): Promise<CommandResult<{}>> {

--- a/core/src/commands/delete.ts
+++ b/core/src/commands/delete.ts
@@ -85,7 +85,6 @@ export class DeleteEnvironmentCommand extends Command {
   help = "Deletes a running environment."
 
   protected = true
-  workflows = true
   streamEvents = true
 
   description = dedent`

--- a/core/src/commands/deploy.ts
+++ b/core/src/commands/deploy.ts
@@ -32,7 +32,7 @@ import {
 import { startServer } from "../server/server"
 import { DeployTask } from "../tasks/deploy"
 import { naturalList } from "../util/string"
-import { StringsParameter, BooleanParameter, ParameterValues } from "../cli/params"
+import { StringsParameter, BooleanParameter } from "../cli/params"
 import { Garden } from "../garden"
 
 export const deployArgs = {
@@ -92,7 +92,6 @@ export class DeployCommand extends Command<Args, Opts> {
   help = "Deploy service(s) to your environment."
 
   protected = true
-  workflows = true
   streamEvents = true
 
   description = dedent`
@@ -122,21 +121,18 @@ export class DeployCommand extends Command<Args, Opts> {
 
   outputsSchema = () => processCommandResultSchema()
 
-  private isPersistent = (opts: ParameterValues<Opts>) =>
-    !!opts.watch || !!opts["hot-reload"] || !!opts["dev-mode"] || !!opts.forward
+  isPersistent({ opts }: PrepareParams<Args, Opts>) {
+    return !!opts.watch || !!opts["hot-reload"] || !!opts["dev-mode"] || !!opts.forward
+  }
 
   printHeader({ headerLog }) {
     printHeader(headerLog, "Deploy", "rocket")
   }
 
-  async prepare({ footerLog, opts }: PrepareParams<Args, Opts>) {
-    const persistent = this.isPersistent(opts)
-
-    if (persistent) {
-      this.server = await startServer({ log: footerLog })
+  async prepare(params: PrepareParams<Args, Opts>) {
+    if (this.isPersistent(params)) {
+      this.server = await startServer({ log: params.footerLog })
     }
-
-    return { persistent }
   }
 
   terminate() {

--- a/core/src/commands/dev.ts
+++ b/core/src/commands/dev.ts
@@ -100,6 +100,10 @@ export class DevCommand extends Command<DevCommandArgs, DevCommandOpts> {
     printHeader(headerLog, "Dev", "keyboard")
   }
 
+  isPersistent() {
+    return true
+  }
+
   async prepare({ headerLog, footerLog }: PrepareParams<DevCommandArgs, DevCommandOpts>) {
     // print ANSI banner image
     if (chalk.supportsColor && chalk.supportsColor.level > 2) {
@@ -111,8 +115,6 @@ export class DevCommand extends Command<DevCommandArgs, DevCommandOpts> {
     headerLog.info("")
 
     this.server = await startServer({ log: footerLog })
-
-    return { persistent: true }
   }
 
   terminate() {

--- a/core/src/commands/exec.ts
+++ b/core/src/commands/exec.ts
@@ -42,8 +42,6 @@ export class ExecCommand extends Command<Args> {
   name = "exec"
   help = "Executes a command (such as an interactive shell) in a running service."
 
-  workflows = true
-
   description = dedent`
     Finds an active container for a deployed service and executes the given command within the container.
     Supports interactive shells.

--- a/core/src/commands/get/get-config.ts
+++ b/core/src/commands/get/get-config.ts
@@ -35,8 +35,6 @@ export class GetConfigCommand extends Command<{}, Opts> {
   name = "config"
   help = "Outputs the full configuration for this project and environment."
 
-  workflows = true
-
   outputsSchema = () =>
     joi.object().keys({
       allEnvironmentNames: joiArray(environmentNameSchema()).required(),

--- a/core/src/commands/get/get-outputs.ts
+++ b/core/src/commands/get/get-outputs.ts
@@ -18,8 +18,6 @@ export class GetOutputsCommand extends Command {
   name = "outputs"
   help = "Resolves and returns the outputs of the project."
 
-  workflows = true
-
   description = dedent`
     Resolves and returns the outputs of the project. If necessary, this may involve deploying services and/or running
     tasks referenced by the outputs in the project configuration.

--- a/core/src/commands/get/get-status.ts
+++ b/core/src/commands/get/get-status.ts
@@ -49,7 +49,6 @@ export class GetStatusCommand extends Command {
   name = "status"
   help = "Outputs the full status of your environment."
 
-  workflows = true
   streamEvents = true
 
   outputsSchema = () =>

--- a/core/src/commands/get/get-task-result.ts
+++ b/core/src/commands/get/get-task-result.ts
@@ -35,7 +35,6 @@ export class GetTaskResultCommand extends Command<Args> {
   name = "task-result"
   help = "Outputs the latest execution result of a provided task."
 
-  workflows = true
   streamEvents = true
 
   arguments = getTaskResultArgs

--- a/core/src/commands/get/get-test-result.ts
+++ b/core/src/commands/get/get-test-result.ts
@@ -38,7 +38,6 @@ export class GetTestResultCommand extends Command<Args> {
   name = "test-result"
   help = "Outputs the latest execution result of a provided test."
 
-  workflows = true
   streamEvents = true
 
   arguments = getTestResultArgs

--- a/core/src/commands/link/module.ts
+++ b/core/src/commands/link/module.ts
@@ -41,8 +41,6 @@ export class LinkModuleCommand extends Command<Args> {
   help = "Link a module to a local directory."
   arguments = linkModuleArguments
 
-  workflows = true
-
   outputsSchema = () =>
     joi.object().keys({
       sources: joiArray(linkedModuleSchema()).description("A list of all locally linked external modules."),

--- a/core/src/commands/link/source.ts
+++ b/core/src/commands/link/source.ts
@@ -42,8 +42,6 @@ export class LinkSourceCommand extends Command<Args> {
   help = "Link a remote source to a local directory."
   arguments = linkSourceArguments
 
-  workflows = true
-
   outputsSchema = () =>
     joi.object().keys({
       sources: joiArray(linkedSourceSchema()).description("A list of all locally linked external sources."),

--- a/core/src/commands/logs.ts
+++ b/core/src/commands/logs.ts
@@ -131,8 +131,8 @@ export class LogsCommand extends Command<Args, Opts> {
     printHeader(headerLog, "Logs", "scroll")
   }
 
-  async prepare({ opts }: PrepareParams<Args, Opts>) {
-    return { persistent: !!opts.follow }
+  isPersistent({ opts }: PrepareParams<Args, Opts>) {
+    return !!opts.follow
   }
 
   terminate() {

--- a/core/src/commands/plugins.ts
+++ b/core/src/commands/plugins.ts
@@ -90,7 +90,7 @@ export class PluginsCommand extends Command<Args> {
       }
     }
 
-    const commandArgs = args._ || []
+    const commandArgs = args["--"] || []
 
     if (command.title) {
       const environmentName = garden.environmentName

--- a/core/src/commands/publish.ts
+++ b/core/src/commands/publish.ts
@@ -64,7 +64,6 @@ export class PublishCommand extends Command<Args, Opts> {
   name = "publish"
   help = "Build and publish module(s) (e.g. container images) to a remote registry."
 
-  workflows = true
   streamEvents = true
 
   description = dedent`

--- a/core/src/commands/run/task.ts
+++ b/core/src/commands/run/task.ts
@@ -55,7 +55,6 @@ export class RunTaskCommand extends Command<Args, Opts> {
   alias = "t"
   help = "Run a task (in the context of its parent module)."
 
-  workflows = true
   streamEvents = true
 
   description = dedent`

--- a/core/src/commands/run/test.ts
+++ b/core/src/commands/run/test.ts
@@ -68,7 +68,6 @@ export class RunTestCommand extends Command<Args, Opts> {
   name = "test"
   help = "Run the specified module test."
 
-  workflows = true
   streamEvents = true
 
   description = dedent`

--- a/core/src/commands/test.ts
+++ b/core/src/commands/test.ts
@@ -79,7 +79,6 @@ export class TestCommand extends Command<Args, Opts> {
   help = "Test all or specified modules."
 
   protected = true
-  workflows = true
   streamEvents = true
 
   description = dedent`
@@ -111,14 +110,14 @@ export class TestCommand extends Command<Args, Opts> {
     printHeader(headerLog, `Running tests`, "thermometer")
   }
 
-  async prepare({ footerLog, opts }: PrepareParams<Args, Opts>) {
-    const persistent = !!opts.watch
+  isPersistent({ opts }: PrepareParams<Args, Opts>) {
+    return !!opts.watch
+  }
 
-    if (persistent) {
-      this.server = await startServer({ log: footerLog })
+  async prepare(params: PrepareParams<Args, Opts>) {
+    if (this.isPersistent(params)) {
+      this.server = await startServer({ log: params.footerLog })
     }
-
-    return { persistent }
   }
 
   terminate() {

--- a/core/src/commands/tools.ts
+++ b/core/src/commands/tools.ts
@@ -83,7 +83,6 @@ export class ToolsCommand extends Command<Args, Opts> {
     if (basicWriter) {
       basicWriter.output = process.stderr
     }
-    return { persistent: false }
   }
 
   async action({ garden, log, args, opts }: CommandParams<Args>) {
@@ -166,12 +165,12 @@ export class ToolsCommand extends Command<Args, Opts> {
     // We're running a binary
     if (opts.output) {
       // We collect the output and return
-      const result = await exec(path, args._ || [], { reject: false })
+      const result = await exec(path, args["--"] || [], { reject: false })
       return { result: { tools, path, stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode } }
     } else {
       // We attach stdout and stderr directly, and exit with the same code as we get from the command
       log.stop()
-      const result = await exec(path, args._ || [], { reject: false, stdio: "inherit" })
+      const result = await exec(path, args["--"] || [], { reject: false, stdio: "inherit" })
       await shutdown(result.exitCode)
       // Note: We never reach this line, just putting it here for the type-checker
       return { result: { tools, path, stdout: "", stderr: "", exitCode: result.exitCode } }

--- a/core/src/commands/update-remote/all.ts
+++ b/core/src/commands/update-remote/all.ts
@@ -24,8 +24,6 @@ export class UpdateRemoteAllCommand extends Command {
   name = "all"
   help = "Update all remote sources and modules."
 
-  workflows = true
-
   outputsSchema = () =>
     joi.object().keys({
       projectSources: joiArray(projectSourceSchema()).description("A list of all configured external project sources."),

--- a/core/src/commands/update-remote/modules.ts
+++ b/core/src/commands/update-remote/modules.ts
@@ -38,8 +38,6 @@ export class UpdateRemoteModulesCommand extends Command<Args> {
   help = "Update remote modules."
   arguments = updateRemoteModulesArguments
 
-  workflows = true
-
   outputsSchema = () =>
     joi.object().keys({
       sources: joiArray(moduleSourceSchema()).description("A list of all external module sources in the project."),

--- a/core/src/commands/update-remote/sources.ts
+++ b/core/src/commands/update-remote/sources.ts
@@ -37,8 +37,6 @@ export class UpdateRemoteSourcesCommand extends Command<Args> {
   help = "Update remote sources."
   arguments = updateRemoteSourcesArguments
 
-  workflows = true
-
   outputsSchema = () =>
     joi.object().keys({
       sources: joiArray(projectSourceSchema()).description("A list of all configured external project sources."),

--- a/core/src/config/command.ts
+++ b/core/src/config/command.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2018-2021 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { GardenResource } from "./base"
+import {
+  apiVersionSchema,
+  DeepPrimitiveMap,
+  joi,
+  joiArray,
+  joiEnvVars,
+  joiIdentifier,
+  joiUserIdentifier,
+  joiVariables,
+  StringMap,
+} from "./common"
+
+interface BaseParameter {
+  name: string
+  description: string
+  required?: boolean
+}
+
+export interface CustomCommandArgument extends BaseParameter {
+  type: "string" | "integer"
+}
+
+export interface CustomCommandOption extends BaseParameter {
+  type: CustomCommandArgument["type"] | "boolean"
+}
+
+export interface CommandResource extends GardenResource {
+  description: {
+    short: string
+    long?: string
+  }
+
+  args: CustomCommandArgument[]
+  opts: CustomCommandOption[]
+
+  exec?: {
+    command: string[]
+    env?: StringMap
+  }
+  gardenCommand?: string[]
+
+  variables: DeepPrimitiveMap
+}
+
+const argumentSchema = () =>
+  joi.object().keys({
+    name: joiIdentifier().required().description("Short name for the parameter."),
+    description: joi.string().required().description("Help text to describe the parameter."),
+    type: joi
+      .string()
+      .only()
+      .allow("string", "integer", "boolean")
+      .default("string")
+      .description("The value type, to use for validation."),
+    required: joi.boolean().default(false).description("Whether the parameter is required."),
+  })
+
+export const customCommandExecSchema = () =>
+  joi
+    .object()
+    .keys({
+      command: joi
+        .array()
+        .items(joi.string())
+        .required()
+        .description(
+          'The command to run. The first part of the array should be an executable available on a global PATH or a relative path to an executable. To run a shell script, you need to specify the shell as part of the command, e.g. `["sh", "-c", "<your sript>"]` or `["bash", "-s", "<your sript>"]`'
+        )
+        .example(["sh", "-c", "echo foo"]),
+      env: joiEnvVars().description("Environment variables to set when running the command."),
+    })
+    .description(
+      "A command to run. If both this and `gardenCommand` are specified, this command is run ahead of the Garden command."
+    )
+
+export const customCommandGardenCommandSchema = () =>
+  joi
+    .array()
+    .items(joi.string())
+    .description(
+      "Run the specified Garden command. If both this and `exec` are specified, the script is run ahead of this command."
+    )
+
+export const customCommandSchema = () =>
+  joi
+    .object()
+    .keys({
+      apiVersion: apiVersionSchema(),
+      kind: joi.string().default("Command").valid("Command").description("Indicate what kind of config this is."),
+      path: joi.string().meta({ internal: true }),
+      configPath: joi.string().meta({ internal: true }).description("The path to the project config file."),
+      name: joiUserIdentifier()
+        .required()
+        .description(
+          "The name of the command. Must be a valid DNS identifier, i.e. a kebab-cased string with no spaces."
+        ),
+      description: joi
+        .object()
+        .keys({
+          short: joi.string().required().max(100).description("A short help text, shown with `garden help`."),
+          long: joi
+            .string()
+            .description(
+              "A longer help text, printed when you run the command with the `--help` flag. If it's not provided, the short text is used."
+            ),
+        })
+        .required()
+        .description("The help text description for the command."),
+      args: joiArray(argumentSchema())
+        .description(
+          "A list of positional arguments that the command should expect. These can be referenced in the `script` and `gardenCommand` fields with `${args.<name>}`. They are parsed in the order given.\n\nNote that you can skip this if you just want to pass all arguments to the script or the Garden command with e.g. `${join(args.$all, ' ')}` or `${args.$all[0]}`. **Note that you cannot use templating in these argument specs themselves.**"
+        )
+        .unique("name"),
+      opts: joiArray(argumentSchema())
+        .description(
+          "A list of option flags that the command should expect. These can be referenced in the `script` and `gardenCommand` fields with `${opts.<name>}`. **Note that you cannot use templating in these option specs themselves.**"
+        )
+        .unique("name"),
+      exec: customCommandExecSchema(),
+      gardenCommand: customCommandGardenCommandSchema(),
+      variables: joiVariables().description("A map of variables that can be referenced in `exec` and `gardenCommand`."),
+    })
+    .or("exec", "gardenCommand")

--- a/core/src/config/template-contexts/custom-command.ts
+++ b/core/src/config/template-contexts/custom-command.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2018-2021 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { variableNameRegex, joiPrimitive, joiArray, DeepPrimitiveMap, joiVariables, joiIdentifierMap } from "../common"
+import { joi } from "../common"
+import { DefaultEnvironmentContext, DefaultEnvironmentContextParams } from "./project"
+import { schema } from "./base"
+
+interface ArgsSchema {
+  [name: string]: string | number | string[]
+}
+
+interface OptsSchema {
+  [name: string]: string | boolean | number
+}
+
+/**
+ * This context is available for template strings in `variables`, `exec` and `gardenCommand` fields in custom Commands.
+ */
+export class CustomCommandContext extends DefaultEnvironmentContext {
+  @schema(
+    joiVariables()
+      .description("A map of all variables defined in the command configuration.")
+      .meta({ keyPlaceholder: "<variable-name>" })
+  )
+  public variables: DeepPrimitiveMap
+
+  @schema(joiIdentifierMap(joiPrimitive()).description("Alias for the variables field."))
+  public var: DeepPrimitiveMap
+
+  @schema(
+    joi
+      .object()
+      .keys({
+        "$all": joiArray(joi.string()).description(
+          "Every argument passed to the command, except the name of the command itself."
+        ),
+        "$rest": joiArray(joi.string()).description(
+          "Every positional argument and option that isn't explicitly defined in the custom command, including any global Garden flags."
+        ),
+        "--": joiArray(joi.string()).description("Every argument following -- on the command line."),
+      })
+      .pattern(variableNameRegex, joiPrimitive())
+      .default(() => ({}))
+      .unknown(true)
+      .description(
+        "Map of all arguments, as defined in the Command spec. Also includes `$all`, `$rest` and `--` fields. See their description for details."
+      )
+  )
+  public args: ArgsSchema
+
+  @schema(
+    joi
+      .object()
+      .pattern(variableNameRegex, joiPrimitive())
+      .default(() => ({}))
+      .unknown(true)
+      .description("Map of all options, as defined in the Command spec.")
+  )
+  public opts: OptsSchema
+
+  constructor(
+    params: DefaultEnvironmentContextParams & {
+      args: ArgsSchema
+      opts: OptsSchema
+      variables: DeepPrimitiveMap
+      rest: string[]
+    }
+  ) {
+    super(params)
+    this.args = { "$all": [], "$rest": params.rest, "--": [], ...params.args }
+    this.opts = params.opts
+    this.var = this.variables = params.variables
+  }
+}

--- a/core/src/config/template-contexts/project.ts
+++ b/core/src/config/template-contexts/project.ts
@@ -221,7 +221,7 @@ class CommandContext extends ConfigContext {
   }
 }
 
-interface DefaultEnvironmentContextParams {
+export interface DefaultEnvironmentContextParams {
   projectName: string
   projectRoot: string
   artifactsPath: string

--- a/core/src/config/workflow.ts
+++ b/core/src/config/workflow.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { isEqual, merge, omit, take } from "lodash"
+import { omit } from "lodash"
 import {
   joi,
   joiUserIdentifier,
@@ -24,12 +24,8 @@ import { WorkflowConfigContext } from "./template-contexts/workflow"
 import { resolveTemplateStrings } from "../template-string/template-string"
 import { validateWithPath } from "./validation"
 import { ConfigurationError } from "../exceptions"
-import { getCoreCommands } from "../commands/commands"
-import { CommandGroup } from "../commands/base"
 import { EnvironmentConfig, getNamespace } from "./project"
-import { globalOptions } from "../cli/params"
-import { isTruthy, omitUndefined } from "../util/util"
-import { parseCliArgs, pickCommand } from "../cli/helpers"
+import { omitUndefined } from "../util/util"
 
 export const minimumWorkflowRequests = {
   cpu: 50, // 50 millicpu
@@ -206,13 +202,6 @@ export interface WorkflowStepSpec {
 }
 
 export const workflowStepSchema = () => {
-  const cmdConfigs = getStepCommands()
-  const cmdDescriptions = cmdConfigs
-    .map((c) => c.getPath().join(", "))
-    .sort()
-    .map((prefix) => `\`[${prefix}]\``)
-    .join("\n")
-
   return joi
     .object()
     .keys({
@@ -230,13 +219,10 @@ export const workflowStepSchema = () => {
         .description(
           dedent`
           A Garden command this step should run, followed by any required or optional arguments and flags.
-          Arguments and options for the commands may be templated, including references to previous steps, but for now
-          the commands themselves (as listed below) must be hard-coded.
 
-          Supported commands:
+          Note that commands that are _persistent_—e.g. the dev command, commands with a watch flag set, the logs command with following enabled etc.—are not supported. In general, workflow steps should run to completion.
 
-          ${cmdDescriptions}
-          \n
+          Global options like --env, --log-level etc. are currently not supported for built-in commands, since they are handled before the individual steps are run.
           `
         )
         .example(["run", "task", "my-task"]),
@@ -413,118 +399,10 @@ export function resolveWorkflowConfig(garden: Garden, config: WorkflowConfig) {
     resolvedConfig.resources.limits = resolvedConfig.limits
   }
 
-  validateSteps(resolvedConfig)
   validateTriggers(resolvedConfig, garden.environmentConfigs)
   populateNamespaceForTriggers(resolvedConfig, garden.environmentConfigs)
 
   return resolvedConfig
-}
-
-/**
- * Get all commands that are allowed in workflows
- */
-function getStepCommands() {
-  return getCoreCommands()
-    .flatMap((cmd) => {
-      if (cmd instanceof CommandGroup) {
-        return cmd.getSubCommands()
-      } else {
-        return [cmd]
-      }
-    })
-    .filter((cmd) => cmd.workflows)
-}
-
-const globalOptionNames = Object.keys(globalOptions).sort()
-
-/**
- * Throws if one or more steps refers to a command that is not supported in workflows, or one that uses CLI options
- * that are not supported for step commands.
- */
-function validateSteps(config: WorkflowConfig) {
-  const prefixErrors = validateStepCommandPrefixes(config)
-  const argumentErrors = validateStepCommandOptions(config)
-  const errors = [prefixErrors, argumentErrors].filter(isTruthy)
-  let errorMsg = errors.map(({ msg }) => msg).join("\n\n")
-  let errorDetail = merge({}, ...errors.map(({ detail }) => detail))
-
-  if (errorMsg) {
-    throw new ConfigurationError(errorMsg, errorDetail)
-  }
-}
-
-function validateStepCommandPrefixes(config: WorkflowConfig) {
-  const validStepCommandPrefixes = getStepCommands().map((c) => c.getPath())
-  const stepsWithInvalidPrefix: WorkflowStepSpec[] = config.steps.filter(
-    (step) =>
-      !!step.command && !validStepCommandPrefixes.find((valid) => isEqual(valid, take(step.command, valid.length)))
-  )
-
-  if (stepsWithInvalidPrefix.length > 0) {
-    const cmdString = stepsWithInvalidPrefix.length === 1 ? "command" : "commands"
-    const descriptions = stepsWithInvalidPrefix.map((step) => `[${step.command!.join(", ")}]`)
-    const validDescriptions = validStepCommandPrefixes.map((cmd) => `[${cmd.join(", ")}]`)
-    const msg = dedent`
-      Invalid step ${cmdString} for workflow ${config.name}:
-
-      ${descriptions.join("\n")}
-
-      Valid step commands:
-
-      ${validDescriptions.join("\n")}
-    `
-    return { msg, detail: { stepsWithInvalidPrefix } }
-  } else {
-    return null
-  }
-}
-
-/**
- * Finds usages of global CLI options in `step.commandSpec` (if present).
- *
- * These will be ignored when the step command is run, so we warn the user not to use them.
- *
- * TODO: Also detect invalid command args at validation time (these will result in exceptions when the workflow is run).
- */
-function findInvalidOptions(step: WorkflowStepSpec) {
-  if (!step.command) {
-    return null
-  }
-  const { command, rest } = pickCommand(getStepCommands(), step.command!)
-  const parsedArgs = parseCliArgs({ stringArgs: rest, command, cli: false, skipDefault: true })
-  const usedGlobalOptions = Object.entries(parsedArgs)
-    .filter(([name, value]) => globalOptionNames.find((optName) => optName === name) && !!value)
-    .map(([name, _]) => `--${name}`)
-  if (usedGlobalOptions.length > 0) {
-    const availableOptions = Object.keys(command!.options || {})
-    const availableDescription =
-      availableOptions.length > 0 ? `(available options: ${availableOptions.map((opt) => `--${opt}`).join(", ")})` : ""
-    const errorMsg = dedent`
-      Invalid options in step command [${step.command!.join(", ")}]: ${usedGlobalOptions.join(", ")}
-      ${availableDescription}
-    `
-    return { step, errorMsg }
-  } else {
-    return null
-  }
-}
-
-function validateStepCommandOptions(config: WorkflowConfig) {
-  const invalidSteps = config.steps.map((step) => findInvalidOptions(step)).filter(isTruthy)
-
-  if (invalidSteps.length > 0) {
-    const msgPrefix = `Invalid step command options for workflow ${config.name}:`
-    const msg = dedent`
-      ${msgPrefix}
-
-      ${invalidSteps.map((s) => s.errorMsg).join("\n\n")}
-
-      Global options (such as --env or --log-level) are not available in workflow step commands
-    `
-    return { msg, detail: { invalidStepCommands: invalidSteps.map((e) => e.step.command) } }
-  } else {
-    return null
-  }
 }
 
 /**

--- a/core/src/docs/template-strings.ts
+++ b/core/src/docs/template-strings.ts
@@ -22,6 +22,7 @@ import { WorkflowStepConfigContext } from "../config/template-contexts/workflow"
 import { getHelperFunctions } from "../template-string/functions"
 import { isEqual, sortBy } from "lodash"
 import { InternalError } from "../exceptions"
+import { CustomCommandContext } from "../config/template-contexts/custom-command"
 
 export function writeTemplateStringReferenceDocs(docsRoot: string) {
   const referenceDir = resolve(docsRoot, "reference")
@@ -53,6 +54,10 @@ export function writeTemplateStringReferenceDocs(docsRoot: string) {
 
   const workflowContext = renderTemplateStringReference({
     schema: WorkflowStepConfigContext.getSchema().required(),
+  })
+
+  const customCommandContext = renderTemplateStringReference({
+    schema: CustomCommandContext.getSchema().required(),
   })
 
   const templatePath = resolve(TEMPLATES_DIR, "template-strings.hbs")
@@ -95,6 +100,7 @@ export function writeTemplateStringReferenceDocs(docsRoot: string) {
     moduleContext,
     outputContext,
     workflowContext,
+    customCommandContext,
   })
 
   writeFileSync(outputPath, markdown)

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -79,7 +79,7 @@ import {
 import { ResolveProviderTask } from "./tasks/resolve-provider"
 import { ActionRouter } from "./actions"
 import { RuntimeContext } from "./runtime-context"
-import { loadPlugins, getDependencyOrder, getModuleTypes } from "./plugins"
+import { loadAndResolvePlugins, getDependencyOrder, getModuleTypes, loadPlugin } from "./plugins"
 import { deline, naturalList } from "./util/string"
 import { ensureConnected } from "./db/connection"
 import { DependencyValidationGraph } from "./util/validate-dependencies"
@@ -399,6 +399,10 @@ export class Garden {
     })
   }
 
+  async getRegisteredPlugins(): Promise<GardenPlugin[]> {
+    return Bluebird.map(this.registeredPlugins, (p) => loadPlugin(this.log, this.projectRoot, p))
+  }
+
   async getPlugin(pluginName: string): Promise<GardenPlugin> {
     const plugins = await this.getAllPlugins()
     const plugin = findByName(plugins, pluginName)
@@ -437,7 +441,7 @@ export class Garden {
       this.log.silly(`Loading plugins`)
       const rawConfigs = this.getRawProviderConfigs()
 
-      this.loadedPlugins = await loadPlugins(this.log, this.projectRoot, this.registeredPlugins, rawConfigs)
+      this.loadedPlugins = await loadAndResolvePlugins(this.log, this.projectRoot, this.registeredPlugins, rawConfigs)
 
       this.log.silly(`Loaded plugins: ${rawConfigs.map((c) => c.name).join(", ")}`)
     })

--- a/core/src/lib/README.md
+++ b/core/src/lib/README.md
@@ -1,0 +1,4 @@
+# libs
+
+Here we place 3rd party libraries that we can't install normally as packages, for whatever reason (e.g.
+incompatible package type).

--- a/core/src/lib/minimist.ts
+++ b/core/src/lib/minimist.ts
@@ -1,0 +1,400 @@
+/*
+ * Copyright (C) 2018-2021 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Forked and adapted from https://github.com/substack/minimist/blob/aeb3e27dae0412de5c0494e9563a5f10c82cc7a9/index.js
+ *
+ * Needed to extract unhandled options (added the _unknown output field).
+ */
+
+export function customMinimist(args, opts: minimist.Opts): minimist.ParsedArgs {
+  if (!opts) {
+    opts = {}
+  }
+
+  let flags = {
+    bools: <{ [key: string]: boolean }>{},
+    strings: <{ [key: string]: boolean }>{},
+    unknownFn: <minimist.Opts["unknown"] | null>null,
+    allBools: false,
+  }
+
+  if (typeof opts["unknown"] === "function") {
+    flags.unknownFn = opts["unknown"]
+  }
+
+  if (typeof opts["boolean"] === "boolean" && opts["boolean"]) {
+    flags.allBools = true
+  } else {
+    const booleans = typeof opts.boolean === "string" ? [opts.boolean] : opts.boolean || []
+
+    for (const key of booleans.filter(Boolean)) {
+      flags.bools[key] = true
+    }
+  }
+
+  let aliases = {}
+  Object.keys(opts.alias || {}).forEach(function (key) {
+    aliases[key] = typeof opts.alias?.[key] === "string" ? [opts.alias[key]] : opts.alias?.[key] || []
+    aliases[key].forEach(function (x) {
+      aliases[x] = [key].concat(
+        aliases[key].filter(function (y) {
+          return x !== y
+        })
+      )
+    })
+  })
+
+  const strings = typeof opts.string === "string" ? [opts.string] : opts.string || []
+
+  for (const key of strings.filter(Boolean)) {
+    flags.strings[key] = true
+    if (aliases[key]) {
+      flags.strings[aliases[key]] = true
+    }
+  }
+
+  let defaults = opts["default"] || {}
+
+  let argv = { _: <string[]>[], _unknown: <string[]>[] }
+  Object.keys(flags.bools).forEach(function (key) {
+    setArg(key, defaults[key] === undefined ? false : defaults[key])
+  })
+
+  let notFlags = []
+
+  if (args.indexOf("--") !== -1) {
+    notFlags = args.slice(args.indexOf("--") + 1)
+    args = args.slice(0, args.indexOf("--"))
+  }
+
+  function argDefined(key, arg) {
+    return (flags.allBools && /^--[^=]+$/.test(arg)) || flags.strings[key] || flags.bools[key] || aliases[key]
+  }
+
+  function setArg(key, val, arg?: string) {
+    if (arg && !argDefined(key, arg)) {
+      if (flags.unknownFn && flags.unknownFn(arg) === false) {
+        return
+      }
+    }
+
+    let value = !flags.strings[key] && isNumber(val) ? Number(val) : val
+    setKey(argv, key.split("."), value)
+
+    for (const x of aliases[key] || []) {
+      setKey(argv, x.split("."), value)
+    }
+  }
+
+  function setKey(obj, keys, value) {
+    let o = obj
+    for (let i = 0; i < keys.length - 1; i++) {
+      // tslint:disable-next-line: no-shadowed-variable
+      let key = keys[i]
+      if (key === "__proto__") {
+        return
+      }
+      if (o[key] === undefined) {
+        o[key] = {}
+      }
+      if (o[key] === Object.prototype || o[key] === Number.prototype || o[key] === String.prototype) {
+        o[key] = {}
+      }
+      if (o[key] === Array.prototype) {
+        o[key] = []
+      }
+      o = o[key]
+    }
+
+    let key = keys[keys.length - 1]
+    if (key === "__proto__") {
+      return
+    }
+    if (o === Object.prototype || o === Number.prototype || o === String.prototype) {
+      o = {}
+    }
+    if (o === Array.prototype) {
+      o = []
+    }
+    if (o[key] === undefined || flags.bools[key] || typeof o[key] === "boolean") {
+      o[key] = value
+    } else if (Array.isArray(o[key])) {
+      o[key].push(value)
+    } else {
+      o[key] = [o[key], value]
+    }
+  }
+
+  function aliasIsBoolean(key) {
+    return aliases[key].some(function (x) {
+      return flags.bools[x]
+    })
+  }
+
+  for (let i = 0; i < args.length; i++) {
+    let arg = args[i]
+
+    if (/^--.+=/.test(arg)) {
+      // Using [\s\S] instead of . because js doesn't support the
+      // 'dotall' regex modifier. See:
+      // http://stackoverflow.com/a/1068308/13216
+      let m = arg.match(/^--([^=]+)=([\s\S]*)$/)
+      let key = m[1]
+      let value = m[2]
+      if (flags.bools[key]) {
+        value = value !== "false"
+      }
+      if (!argDefined(key, arg)) {
+        argv._unknown.push(arg)
+      }
+      setArg(key, value, arg)
+    } else if (/^--no-.+/.test(arg)) {
+      let key = arg.match(/^--no-(.+)/)[1]
+      if (!argDefined(key, arg)) {
+        argv._unknown.push(arg)
+      }
+      setArg(key, false, arg)
+    } else if (/^--.+/.test(arg)) {
+      let key = arg.match(/^--(.+)/)[1]
+      let next = args[i + 1]
+      if (
+        next !== undefined &&
+        !/^-/.test(next) &&
+        !flags.bools[key] &&
+        !flags.allBools &&
+        (aliases[key] ? !aliasIsBoolean(key) : true)
+      ) {
+        if (!argDefined(key, arg)) {
+          argv._unknown.push(arg, next)
+        }
+        setArg(key, next, arg)
+        i++
+      } else if (/^(true|false)$/.test(next)) {
+        if (!argDefined(key, arg)) {
+          argv._unknown.push(arg, next)
+        }
+        setArg(key, next === "true", arg)
+        i++
+      } else {
+        if (!argDefined(key, arg)) {
+          argv._unknown.push(arg)
+        }
+        setArg(key, flags.strings[key] ? "" : true, arg)
+      }
+    } else if (/^-[^-]+/.test(arg)) {
+      let letters = arg.slice(1, -1).split("")
+
+      let broken = false
+      for (let j = 0; j < letters.length; j++) {
+        let next = arg.slice(j + 2)
+
+        if (next === "-") {
+          setArg(letters[j], next, arg)
+          continue
+        }
+
+        if (/[A-Za-z]/.test(letters[j]) && /=/.test(next)) {
+          setArg(letters[j], next.split("=")[1], arg)
+          broken = true
+          break
+        }
+
+        if (/[A-Za-z]/.test(letters[j]) && /-?\d+(\.\d*)?(e-?\d+)?$/.test(next)) {
+          setArg(letters[j], next, arg)
+          broken = true
+          break
+        }
+
+        if (letters[j + 1] && letters[j + 1].match(/\W/)) {
+          setArg(letters[j], arg.slice(j + 2), arg)
+          broken = true
+          break
+        } else {
+          setArg(letters[j], flags.strings[letters[j]] ? "" : true, arg)
+        }
+      }
+
+      let key = arg.slice(-1)[0]
+      if (!broken && key !== "-") {
+        if (
+          args[i + 1] &&
+          !/^(-|--)[^-]/.test(args[i + 1]) &&
+          !flags.bools[key] &&
+          (aliases[key] ? !aliasIsBoolean(key) : true)
+        ) {
+          if (!argDefined(key, arg)) {
+            argv._unknown.push(arg, args[i + 1])
+          }
+          setArg(key, args[i + 1], arg)
+          i++
+        } else if (args[i + 1] && /^(true|false)$/.test(args[i + 1])) {
+          if (!argDefined(key, arg)) {
+            argv._unknown.push(arg, args[i + 1])
+          }
+          setArg(key, args[i + 1] === "true", arg)
+          i++
+        } else {
+          if (!argDefined(key, arg)) {
+            argv._unknown.push(arg)
+          }
+          setArg(key, flags.strings[key] ? "" : true, arg)
+        }
+      }
+    } else {
+      if (!flags.unknownFn || flags.unknownFn(arg) !== false) {
+        const v = flags.strings["_"] || !isNumber(arg) ? arg : Number(arg)
+        argv._.push(v)
+        argv._unknown.push(v)
+      }
+      if (opts.stopEarly) {
+        argv._.push.apply(argv._, args.slice(i + 1))
+        argv._unknown.push.apply(argv._unknown, args.slice(i + 1))
+        break
+      }
+    }
+  }
+
+  Object.keys(defaults).forEach(function (key) {
+    if (!hasKey(argv, key.split("."))) {
+      setKey(argv, key.split("."), defaults[key])
+      for (const x of aliases[key] || []) {
+        setKey(argv, x.split("."), defaults[key])
+      }
+    }
+  })
+
+  argv._unknown.push(...notFlags)
+
+  if (opts["--"]) {
+    argv["--"] = new Array()
+    notFlags.forEach(function (key) {
+      argv["--"].push(key)
+    })
+  } else {
+    notFlags.forEach(function (key) {
+      argv._.push(key)
+    })
+  }
+
+  return argv
+}
+
+function hasKey(obj, keys) {
+  let o = obj
+  keys.slice(0, -1).forEach(function (k) {
+    o = o[k] || {}
+  })
+
+  let key = keys[keys.length - 1]
+  return key in o
+}
+
+function isNumber(x) {
+  if (typeof x === "number") {
+    return true
+  }
+  if (/^0x[0-9a-f]+$/i.test(x)) {
+    return true
+  }
+  return /^[-+]?(?:\d+(?:\.\d*)?|\.\d+)(e[-+]?\d+)?$/.test(x)
+}
+
+// Type definitions for minimist 1.2
+// Project: https://github.com/substack/minimist
+// Definitions by: Bart van der Schoor <https://github.com/Bartvds>
+//                 Necroskillz <https://github.com/Necroskillz>
+//                 kamranayub <https://github.com/kamranayub>
+//                 Piotr Błażejewicz <https://github.com/peterblazejewicz>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/**
+ * Return an argument object populated with the array arguments from args
+ *
+ * @param [args] An optional argument array (typically `process.argv.slice(2)`)
+ * @param [opts] An optional options object to customize the parsing
+ */
+declare function minimist(args?: string[], opts?: minimist.Opts): minimist.ParsedArgs
+
+/**
+ * Return an argument object populated with the array arguments from args. Strongly-typed
+ * to be the intersect of type T with minimist.ParsedArgs.
+ *
+ * `T` The type that will be intersected with minimist.ParsedArgs to represent the argument object
+ *
+ * @param [args] An optional argument array (typically `process.argv.slice(2)`)
+ * @param [opts] An optional options object to customize the parsing
+ */
+declare function minimist<T>(args?: string[], opts?: minimist.Opts): T & minimist.ParsedArgs
+
+/**
+ * Return an argument object populated with the array arguments from args. Strongly-typed
+ * to be the the type T which should extend minimist.ParsedArgs
+ *
+ * `T` The type that extends minimist.ParsedArgs and represents the argument object
+ *
+ * @param [args] An optional argument array (typically `process.argv.slice(2)`)
+ * @param [opts] An optional options object to customize the parsing
+ */
+declare function minimist<T extends minimist.ParsedArgs>(args?: string[], opts?: minimist.Opts): T
+
+declare namespace minimist {
+  interface Opts {
+    /**
+     * A string or array of strings argument names to always treat as strings
+     */
+    "string"?: string | string[] | undefined
+
+    /**
+     * A boolean, string or array of strings to always treat as booleans. If true will treat
+     * all double hyphenated arguments without equals signs as boolean (e.g. affects `--foo`, not `-f` or `--foo=bar`)
+     */
+    "boolean"?: boolean | string | string[] | undefined
+
+    /**
+     * An object mapping string names to strings or arrays of string argument names to use as aliases
+     */
+    "alias"?: { [key: string]: string | string[] } | undefined
+
+    /**
+     * An object mapping string argument names to default values
+     */
+    "default"?: { [key: string]: any } | undefined
+
+    /**
+     * When true, populate argv._ with everything after the first non-option
+     */
+    "stopEarly"?: boolean | undefined
+
+    /**
+     * A function which is invoked with a command line parameter not defined in the opts
+     * configuration object. If the function returns false, the unknown option is not added to argv
+     */
+    "unknown"?: ((arg: string) => boolean) | undefined
+
+    /**
+     * When true, populate argv._ with everything before the -- and argv['--'] with everything after the --.
+     * Note that with -- set, parsing for arguments still stops after the `--`.
+     */
+    "--"?: boolean | undefined
+  }
+
+  interface ParsedArgs {
+    [arg: string]: any
+
+    /**
+     * If opts['--'] is true, populated with everything after the --
+     */
+    "--"?: string[] | undefined
+
+    /**
+     * Contains all the arguments that didn't have an option associated with them
+     */
+    "_": string[]
+  }
+}

--- a/core/src/lib/p-memoize.ts
+++ b/core/src/lib/p-memoize.ts
@@ -1,0 +1,123 @@
+/**
+ * Copied from the sindresorhus/p-memoize npm package, v6.0.1.
+ * Had to do that because it's distributed as an ES module, which we can't support right now.
+ */
+
+import mimicFn from "mimic-fn"
+import type { AsyncReturnType } from "type-fest"
+
+// TODO: Use the one in `type-fest` when it's added there.
+type AnyAsyncFunction = (...args: readonly any[]) => Promise<unknown | void>
+
+const cacheStore = new WeakMap<AnyAsyncFunction, CacheStorage<any, any>>()
+const promiseCacheStore = new WeakMap<AnyAsyncFunction, Map<unknown, unknown>>()
+
+interface CacheStorage<KeyType, ValueType> {
+  has: (key: KeyType) => Promise<boolean> | boolean
+  get: (key: KeyType) => Promise<ValueType | undefined> | ValueType | undefined
+  set: (key: KeyType, value: ValueType) => void
+  delete: (key: KeyType) => void
+  clear?: () => void
+}
+
+interface Options<FunctionToMemoize extends AnyAsyncFunction, CacheKeyType> {
+  readonly cachePromiseRejection?: boolean
+  readonly cacheKey?: (args: Parameters<FunctionToMemoize>) => CacheKeyType
+  readonly cache?: CacheStorage<CacheKeyType, AsyncReturnType<FunctionToMemoize>>
+}
+
+export default function pMemoize<FunctionToMemoize extends AnyAsyncFunction, CacheKeyType>(
+  fn: FunctionToMemoize,
+  {
+    cachePromiseRejection = false,
+    cacheKey,
+    cache = new Map<CacheKeyType, AsyncReturnType<FunctionToMemoize>>(),
+  }: Options<FunctionToMemoize, CacheKeyType> = {}
+): FunctionToMemoize {
+  const promiseCache = new Map<CacheKeyType, Promise<AsyncReturnType<FunctionToMemoize>>>()
+
+  const memoized = async function (
+    this: any,
+    ...args: Parameters<FunctionToMemoize>
+  ): Promise<AsyncReturnType<FunctionToMemoize>> {
+    const key = cacheKey ? cacheKey(args) : (args[0] as CacheKeyType)
+
+    if (await cache.has(key)) {
+      if (promiseCache.has(key)) {
+        return promiseCache.get(key)!
+      }
+
+      return (await cache.get(key))!
+    }
+
+    const promise = fn.apply(this, args) as Promise<AsyncReturnType<FunctionToMemoize>>
+
+    promiseCache.set(key, promise)
+
+    try {
+      const result = await promise
+
+      cache.set(key, result)
+
+      return result
+    } catch (error: unknown) {
+      if (!cachePromiseRejection) {
+        promiseCache.delete(key)
+      }
+
+      throw error as Error
+    }
+  } as FunctionToMemoize
+
+  mimicFn(memoized, fn, {
+    ignoreNonConfigurable: true,
+  })
+
+  cacheStore.set(memoized, cache)
+  promiseCacheStore.set(memoized, promiseCache)
+
+  return memoized
+}
+
+export function pMemoizeDecorator<FunctionToMemoize extends AnyAsyncFunction, CacheKeyType>(
+  options: Options<FunctionToMemoize, CacheKeyType> = {}
+) {
+  const instanceMap = new WeakMap()
+
+  return (target: any, propertyKey: string, descriptor: PropertyDescriptor): void => {
+    // eslint-disable-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    const input = target[propertyKey]
+
+    if (typeof input !== "function") {
+      throw new TypeError("The decorated value must be a function")
+    }
+
+    delete descriptor.value
+    delete descriptor.writable
+
+    descriptor.get = function () {
+      // tslint:disable: no-invalid-this
+      if (!instanceMap.has(this)) {
+        const value = pMemoize(input, options) as FunctionToMemoize
+        instanceMap.set(this, value)
+        return value
+      }
+
+      return instanceMap.get(this) as FunctionToMemoize
+    }
+  }
+}
+
+export function pMemoizeClear(fn: AnyAsyncFunction): void {
+  const cache = cacheStore.get(fn)
+  if (!cache) {
+    throw new TypeError("Can't clear a function that was not memoized!")
+  }
+
+  if (typeof cache.clear !== "function") {
+    throw new TypeError("The cache Map can't be cleared!")
+  }
+
+  cache.clear()
+  promiseCacheStore.get(fn)!.clear()
+}

--- a/core/src/logger/logger.ts
+++ b/core/src/logger/logger.ts
@@ -313,6 +313,15 @@ export class Logger implements LogNode {
   }
 }
 
+/**
+ * Dummy Logger instance, just swallows log entries and prints nothing.
+ */
+export class VoidLogger extends Logger {
+  constructor() {
+    super({ writers: [], level: LogLevel.error, storeEntries: false })
+  }
+}
+
 export function getLogger() {
   return Logger.getInstance()
 }

--- a/core/src/plugins.ts
+++ b/core/src/plugins.ts
@@ -27,7 +27,7 @@ import { DependencyValidationGraph } from "./util/validate-dependencies"
 import { parse, resolve } from "path"
 import Bluebird from "bluebird"
 
-export async function loadPlugins(
+export async function loadAndResolvePlugins(
   log: LogEntry,
   projectRoot: string,
   registeredPlugins: RegisterPluginParam[],
@@ -115,7 +115,7 @@ export async function loadPlugins(
   return Object.values(resolveModuleDefinitions(resolvedPlugins, configs))
 }
 
-async function loadPlugin(log: LogEntry, projectRoot: string, nameOrPlugin: RegisterPluginParam) {
+export async function loadPlugin(log: LogEntry, projectRoot: string, nameOrPlugin: RegisterPluginParam) {
   let plugin: GardenPlugin
 
   if (isString(nameOrPlugin)) {

--- a/core/src/template-string/functions.ts
+++ b/core/src/template-string/functions.ts
@@ -355,7 +355,17 @@ export function getHelperFunctions(): HelperFunctions {
   return _helperFunctions
 }
 
-export function callHelperFunction(functionName: string, args: any[], text: string) {
+export function callHelperFunction({
+  functionName,
+  args,
+  text,
+  allowPartial,
+}: {
+  functionName: string
+  args: any[]
+  text: string
+  allowPartial: boolean
+}) {
   const helperFunctions = getHelperFunctions()
   const spec = helperFunctions[functionName]
 
@@ -405,7 +415,11 @@ export function callHelperFunction(functionName: string, args: any[], text: stri
         ErrorClass: TemplateStringError,
       })
     } catch (_error) {
-      return { _error }
+      if (allowPartial) {
+        return { resolved: text }
+      } else {
+        return { _error }
+      }
     }
 
     i++

--- a/core/src/template-string/functions.ts
+++ b/core/src/template-string/functions.ts
@@ -9,7 +9,7 @@
 import { v4 as uuidv4 } from "uuid"
 import { TemplateStringError } from "../exceptions"
 import { keyBy, mapValues, escapeRegExp, trim, isEmpty, camelCase, kebabCase, isArrayLike } from "lodash"
-import { joi, JoiDescription } from "../config/common"
+import { joi, JoiDescription, joiPrimitive, Primitive } from "../config/common"
 import Joi from "@hapi/joi"
 import { validateSchema } from "../config/validation"
 import { safeLoad, safeLoadAll } from "js-yaml"
@@ -98,6 +98,21 @@ const helperFunctionSpecs: TemplateHelperFunction[] = [
       { input: [null], output: true },
     ],
     fn: (value: any) => value === undefined || isEmpty(value),
+  },
+  {
+    name: "join",
+    description:
+      "Takes an array of strings (or other primitives) and concatenates them into a string, with the given separator",
+    arguments: {
+      input: joi.array().items(joiPrimitive()).required().description("The array to concatenate."),
+      separator: joi.string().required().description("The string to place between each item in the array."),
+    },
+    outputSchema: joi.string(),
+    exampleArguments: [
+      { input: [["some", "list", "of", "strings"], " "], output: "some list of strings" },
+      { input: [["some", "list", "of", "strings"], "."], output: "some.list.of.strings" },
+    ],
+    fn: (input: Primitive[], separator: string) => input.join(separator),
   },
   {
     name: "jsonDecode",

--- a/core/src/template-string/parser.pegjs
+++ b/core/src/template-string/parser.pegjs
@@ -178,7 +178,11 @@ MemberExpression
 
 CallExpression
   = callee:Identifier __ args:Arguments {
-      return callHelperFunction({ functionName: callee, args, text: text(), allowPartial: options.allowPartial })
+      // Workaround for parser issue (calling text() before referencing other values)
+      const functionName = callee
+      const _args = args
+
+      return callHelperFunction({ functionName, args: _args, text: text(), allowPartial: options.allowPartial })
     }
 
 Arguments

--- a/core/src/template-string/parser.pegjs
+++ b/core/src/template-string/parser.pegjs
@@ -178,7 +178,7 @@ MemberExpression
 
 CallExpression
   = callee:Identifier __ args:Arguments {
-      return callHelperFunction(callee, args)
+      return callHelperFunction({ functionName: callee, args, text: text(), allowPartial: options.allowPartial })
     }
 
 Arguments

--- a/core/src/util/fs.ts
+++ b/core/src/util/fs.ts
@@ -24,6 +24,7 @@ import { uuidv4, exec } from "./util"
 import micromatch from "micromatch"
 
 export const defaultConfigFilename = "garden.yml"
+export const configFilenamePattern = "*garden.y*ml"
 const metadataFilename = "metadata.json"
 export const defaultDotIgnoreFiles = [".gardenignore"]
 export const fixedProjectExcludes = [".git", ".gitmodules", ".garden/**/*", "debug-info*/**"]
@@ -159,13 +160,13 @@ export async function findConfigPathsInPath({
       if (last === "**" || last === "*") {
         // Swap out a general wildcard on the last path segment with one that will specifically match Garden configs,
         // to optimize the scan.
-        return split.slice(0, -1).concat(["*garden.y*ml"]).join(posix.sep)
+        return split.slice(0, -1).concat([configFilenamePattern]).join(posix.sep)
       } else {
         return path
       }
     })
   } else {
-    include = ["**/*garden.y*ml"]
+    include = ["**/" + configFilenamePattern]
   }
 
   const paths = await vcs.getFiles({

--- a/core/test/data/test-project-a/commands.garden.yml
+++ b/core/test/data/test-project-a/commands.garden.yml
@@ -1,0 +1,20 @@
+kind: Command
+name: echo
+description:
+  short: Just echo a string
+exec:
+  command:
+    - sh
+    - -c
+    - echo ${join(args.$rest, ' ')}
+
+---
+
+kind: Command
+name: run-task
+description:
+  short: Run the given task
+gardenCommand:
+  - run
+  - task
+  - $concat: ${args.$rest}

--- a/core/test/data/test-project-a/garden.yml
+++ b/core/test/data/test-project-a/garden.yml
@@ -5,7 +5,6 @@ environments:
   - name: other
 providers:
   - name: test-plugin
-    environments: [local]
   - name: test-plugin-b
     environments: [local]
 variables:

--- a/core/test/data/test-project-a/module-a/garden.yml
+++ b/core/test/data/test-project-a/module-a/garden.yml
@@ -17,3 +17,5 @@ tests:
 tasks:
   - name: task-a
     command: [echo, "${var.msg}"]
+  - name: task-a2
+    command: [echo, "${environment.name}-${var.msg}"]

--- a/core/test/data/test-projects/custom-commands-invalid/project.garden.yml
+++ b/core/test/data/test-projects/custom-commands-invalid/project.garden.yml
@@ -1,0 +1,20 @@
+kind: Project
+name: custom-commands-invalid
+providers:
+  - name: exec
+
+---
+kind: Command
+name: invalid
+floo: blorg
+
+---
+kind: Command
+name: echo
+description:
+  short: Just echo a string
+exec:
+  command:
+    - sh
+    - -c
+    - echo ${join(args.$all, ' ')}

--- a/core/test/data/test-projects/custom-commands/command.garden.yaml
+++ b/core/test/data/test-projects/custom-commands/command.garden.yaml
@@ -1,0 +1,9 @@
+kind: Command
+name: run-task
+description:
+  short: Run the specified task
+  long: An entirely unnecessary alias for garden run task
+gardenCommand:
+  - run
+  - task
+  - $concat: ${args.$all}

--- a/core/test/data/test-projects/custom-commands/nope.garden.yml
+++ b/core/test/data/test-projects/custom-commands/nope.garden.yml
@@ -1,0 +1,10 @@
+# These should be ignored because they conflict with built-in commands
+kind: Command
+name: plugins
+exec:
+  command: [echo, oops!]
+---
+kind: Command
+name: plugin
+exec:
+  command: [echo, oops!]

--- a/core/test/data/test-projects/custom-commands/nope/nope.garden.yml
+++ b/core/test/data/test-projects/custom-commands/nope/nope.garden.yml
@@ -1,0 +1,5 @@
+# This shouldn't get picked up
+kind: Command
+name: script
+exec:
+  command: [echo, oops!]

--- a/core/test/data/test-projects/custom-commands/project.garden.yml
+++ b/core/test/data/test-projects/custom-commands/project.garden.yml
@@ -1,0 +1,50 @@
+kind: Project
+name: custom-commands
+providers:
+  - name: exec
+variables:
+  project-level: a
+  command-level: overridden
+
+---
+
+kind: Module
+type: exec
+name: tasks
+tasks:
+  - name: test
+    command:
+      - echo test
+  - name: fail
+    command:
+      - sh
+      - -c
+      - echo "FAIL"; exit 1
+
+---
+kind: Command
+name: combo
+description:
+  short: A complete example using most available features
+  long: |
+    Ok, settle down. Let's really dig into this thing now.
+    So what this command will do is yeah ok you get the point...
+variables:
+  command-level: b
+args:
+  - name: task-name
+    description: The name of the task to run
+    required: true
+opts:
+  - name: foo
+    description: Some meaningless number?
+    type: integer
+exec:
+  command:
+    - sh
+    - -c
+    - echo Project=${project.name} task=${args.task-name} foo=${opts.foo || 123} command-var=${var.command-level}
+gardenCommand:
+  - run
+  - task
+  - ${args.task-name}

--- a/core/test/data/test-projects/custom-commands/script.garden.yml
+++ b/core/test/data/test-projects/custom-commands/script.garden.yml
@@ -1,0 +1,21 @@
+kind: Command
+name: echo
+description:
+  short: Just echo a string
+exec:
+  command:
+    - sh
+    - -c
+    - echo ${join(args.$rest, ' ')}
+
+---
+
+kind: Command
+name: script
+description:
+  short: Run a shell statement
+exec:
+  command:
+    - sh
+    - -c
+    - ${join(args.$rest, ' ')}

--- a/core/test/helpers.ts
+++ b/core/test/helpers.ts
@@ -22,7 +22,7 @@ import {
   RegisterPluginParam,
   ModuleAndRuntimeActionHandlers,
 } from "../src/types/plugin/plugin"
-import { Garden } from "../src/garden"
+import { Garden, GardenOpts } from "../src/garden"
 import { ModuleConfig } from "../src/config/module"
 import { mapValues, fromPairs } from "lodash"
 import { ModuleVersion } from "../src/vcs/vcs"
@@ -46,6 +46,7 @@ import { TestGarden, EventLogEntry, TestGardenOpts } from "../src/util/testing"
 import { Logger, LogLevel } from "../src/logger/logger"
 import { ExecInServiceParams, ExecInServiceResult } from "../src/types/plugin/service/execInService"
 import { ClientAuthToken } from "../src/db/entities/client-auth-token"
+import { GardenCli } from "../src/cli/cli"
 
 export { TempDirectory, makeTempDir } from "../src/util/fs"
 export { TestGarden, TestError, TestEventBus, expectError } from "../src/util/testing"
@@ -324,6 +325,12 @@ export const defaultModuleConfig: ModuleConfig = {
   ],
   testConfigs: [],
   taskConfigs: [],
+}
+
+export class TestGardenCli extends GardenCli {
+  async getGarden(workingDir: string, opts: GardenOpts) {
+    return makeTestGarden(workingDir, opts)
+  }
 }
 
 export const makeTestModule = (params: Partial<ModuleConfig> = {}) => {

--- a/core/test/unit/src/analytics/analytics.ts
+++ b/core/test/unit/src/analytics/analytics.ts
@@ -81,7 +81,7 @@ describe("AnalyticsHandler", () => {
           projectMetadata: {
             modulesCount: 3,
             moduleTypes: ["test"],
-            tasksCount: 3,
+            tasksCount: 4,
             servicesCount: 3,
             testsCount: 5,
           },
@@ -356,7 +356,7 @@ describe("AnalyticsHandler", () => {
             projectMetadata: {
               modulesCount: 3,
               moduleTypes: ["test"],
-              tasksCount: 3,
+              tasksCount: 4,
               servicesCount: 3,
               testsCount: 5,
             },

--- a/core/test/unit/src/commands/custom.ts
+++ b/core/test/unit/src/commands/custom.ts
@@ -1,0 +1,417 @@
+/*
+ * Copyright (C) 2018-2021 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import { GardenCli } from "../../../../src/cli/cli"
+import { BooleanParameter, IntegerParameter, StringParameter } from "../../../../src/cli/params"
+import { CustomCommandWrapper } from "../../../../src/commands/custom"
+import { DEFAULT_API_VERSION } from "../../../../src/constants"
+import { LogEntry } from "../../../../src/logger/log-entry"
+import { expectError, TestGarden } from "../../../../src/util/testing"
+import { makeTestGardenA, withDefaultGlobalOpts } from "../../../helpers"
+
+describe("CustomCommandWrapper", () => {
+  let garden: TestGarden
+  let log: LogEntry
+  const cli = new GardenCli()
+
+  before(async () => {
+    garden = await makeTestGardenA()
+    log = garden.log
+  })
+
+  it("correctly converts arguments from spec", () => {
+    const cmd = new CustomCommandWrapper({
+      apiVersion: DEFAULT_API_VERSION,
+      kind: "Command",
+      name: "test",
+      path: "/tmp",
+      description: {
+        short: "Test A",
+      },
+      args: [
+        { type: "string", name: "a", description: "Arg A", required: true },
+        { type: "integer", name: "b", description: "Arg B" },
+      ],
+      opts: [],
+      variables: {},
+    })
+
+    expect(Object.keys(cmd.arguments!)).to.eql(["a", "b"])
+    expect(cmd.arguments?.["a"]).to.be.instanceOf(StringParameter)
+    expect(cmd.arguments?.["a"].required).to.be.true
+    expect(cmd.arguments?.["b"]).to.be.instanceOf(IntegerParameter)
+    expect(cmd.arguments?.["b"].required).to.be.false
+  })
+
+  it("correctly converts options from spec", () => {
+    const cmd = new CustomCommandWrapper({
+      apiVersion: DEFAULT_API_VERSION,
+      kind: "Command",
+      name: "test",
+      path: "/tmp",
+      description: {
+        short: "Test A",
+      },
+      args: [],
+      opts: [
+        { type: "string", name: "a", description: "Arg A", required: true },
+        { type: "integer", name: "b", description: "Arg B" },
+        { type: "boolean", name: "c", description: "Arg C" },
+      ],
+      variables: {},
+    })
+
+    expect(Object.keys(cmd.options!)).to.eql(["a", "b", "c"])
+    expect(cmd.options?.["a"]).to.be.instanceOf(StringParameter)
+    expect(cmd.options?.["a"].required).to.be.true
+    expect(cmd.options?.["b"]).to.be.instanceOf(IntegerParameter)
+    expect(cmd.options?.["b"].required).to.be.false
+    expect(cmd.options?.["c"]).to.be.instanceOf(BooleanParameter)
+    expect(cmd.options?.["c"].required).to.be.false
+  })
+
+  it("sets name and help text from spec", () => {
+    const short = "Test"
+    const long = "Here's the full description"
+
+    const cmd = new CustomCommandWrapper({
+      apiVersion: DEFAULT_API_VERSION,
+      kind: "Command",
+      name: "test",
+      path: "/tmp",
+      description: {
+        short,
+        long,
+      },
+      args: [],
+      opts: [],
+      variables: {},
+    })
+
+    expect(cmd.name).to.equal("test")
+    expect(cmd.help).to.equal(short)
+    expect(cmd.description).to.equal(long)
+  })
+
+  it("sets the ${args.$rest} variable correctly", async () => {
+    const cmd = new CustomCommandWrapper({
+      apiVersion: DEFAULT_API_VERSION,
+      kind: "Command",
+      name: "test",
+      path: "/tmp",
+      description: {
+        short: "Test",
+      },
+      args: [
+        { type: "string", name: "a", description: "Arg A", required: true },
+        { type: "integer", name: "b", description: "Arg B" },
+      ],
+      opts: [
+        { type: "string", name: "a", description: "Opt A", required: true },
+        { type: "boolean", name: "b", description: "Opt B" },
+      ],
+      variables: {},
+      exec: {
+        command: ["echo", "${join(args.$rest, ' ')}"],
+      },
+    })
+
+    const { result } = await cmd.action({
+      cli,
+      garden,
+      log,
+      headerLog: log,
+      footerLog: log,
+      args: {
+        a: "A",
+        b: "B",
+        $all: ["test", "foo", "bar", "bla", "--bla=blop", "-c", "d"],
+      },
+      opts: withDefaultGlobalOpts({}),
+    })
+
+    expect(result?.exec?.command).to.eql(["echo", "bla --bla=blop -c d"])
+    expect(result?.exec?.exitCode).to.equal(0)
+  })
+
+  it("resolves template strings in command variables", async () => {
+    const cmd = new CustomCommandWrapper({
+      apiVersion: DEFAULT_API_VERSION,
+      kind: "Command",
+      name: "test",
+      path: "/tmp",
+      description: {
+        short: "Test",
+      },
+      args: [],
+      opts: [],
+      variables: {
+        foo: "${project.name}",
+      },
+      exec: {
+        command: ["echo", "${var.foo}"],
+      },
+    })
+
+    const { result } = await cmd.action({
+      cli,
+      garden,
+      log,
+      headerLog: log,
+      footerLog: log,
+      args: {},
+      opts: withDefaultGlobalOpts({}),
+    })
+
+    expect(result?.exec?.command).to.eql(["echo", "test-project-a"])
+    expect(result?.exec?.exitCode).to.equal(0)
+  })
+
+  it("runs an exec command with resolved templates", async () => {
+    const cmd = new CustomCommandWrapper({
+      apiVersion: DEFAULT_API_VERSION,
+      kind: "Command",
+      name: "test",
+      path: "/tmp",
+      description: {
+        short: "Test",
+      },
+      args: [],
+      opts: [],
+      variables: {
+        foo: "test",
+      },
+      exec: {
+        command: ["echo", "${project.name}-${var.foo}"],
+      },
+    })
+
+    const { result } = await cmd.action({
+      cli,
+      garden,
+      log,
+      headerLog: log,
+      footerLog: log,
+      args: {},
+      opts: withDefaultGlobalOpts({}),
+    })
+
+    expect(result?.exec?.command).to.eql(["echo", "test-project-a-test"])
+    expect(result?.exec?.exitCode).to.equal(0)
+  })
+
+  it("runs a Garden command with resolved templates", async () => {
+    const cmd = new CustomCommandWrapper({
+      apiVersion: DEFAULT_API_VERSION,
+      kind: "Command",
+      name: "test",
+      path: "/tmp",
+      description: {
+        short: "Test",
+      },
+      args: [],
+      opts: [],
+      variables: {
+        foo: "test",
+      },
+      gardenCommand: ["get", "doddi"],
+    })
+
+    const { result } = await cmd.action({
+      cli,
+      garden,
+      log,
+      headerLog: log,
+      footerLog: log,
+      args: {},
+      opts: withDefaultGlobalOpts({}),
+    })
+
+    expect(result?.gardenCommand?.command).to.eql(["get", "doddi"])
+    expect(result?.gardenCommand?.result.image).to.exist
+  })
+
+  it("runs exec command before Garden command if both are specified", async () => {
+    const cmd = new CustomCommandWrapper({
+      apiVersion: DEFAULT_API_VERSION,
+      kind: "Command",
+      name: "test",
+      path: "/tmp",
+      description: {
+        short: "Test",
+      },
+      args: [],
+      opts: [],
+      variables: {},
+      exec: {
+        command: ["sleep", "1"],
+      },
+      gardenCommand: ["get", "eysi"],
+    })
+
+    const { result } = await cmd.action({
+      cli,
+      garden,
+      log,
+      headerLog: log,
+      footerLog: log,
+      args: {},
+      opts: withDefaultGlobalOpts({}),
+    })
+
+    expect(result?.gardenCommand?.startedAt).to.be.greaterThan(result?.exec?.startedAt!)
+  })
+
+  it("exposes arguments and options correctly in command templates", async () => {
+    const cmd = new CustomCommandWrapper({
+      apiVersion: DEFAULT_API_VERSION,
+      kind: "Command",
+      name: "test",
+      path: "/tmp",
+      description: {
+        short: "Test",
+      },
+      args: [
+        { type: "string", name: "a", description: "Arg A", required: true },
+        { type: "integer", name: "b", description: "Arg B" },
+      ],
+      opts: [
+        { type: "string", name: "a", description: "Opt A", required: true },
+        { type: "boolean", name: "b", description: "Opt B" },
+      ],
+      variables: {
+        foo: "test",
+      },
+      exec: {
+        command: [
+          "sh",
+          "-c",
+          "echo ALL: ${args.$all}\necho ARG A: ${args.a}\necho ARG B: ${args.b}\necho OPT A: ${opts.a}\necho OPT B: ${opts.b}",
+        ],
+      },
+    })
+
+    const { result } = await cmd.action({
+      cli,
+      garden,
+      log,
+      headerLog: log,
+      footerLog: log,
+      args: { a: "test-a", b: 123 },
+      opts: withDefaultGlobalOpts({ a: "opt-a", b: true }),
+    })
+
+    expect(result?.exec?.command).to.eql([
+      "sh",
+      "-c",
+      "echo ALL: \necho ARG A: test-a\necho ARG B: 123\necho OPT A: opt-a\necho OPT B: true",
+    ])
+  })
+
+  it("defaults to global options passed in for Garden commands but allows overriding in the command spec", async () => {
+    const cmd = new CustomCommandWrapper({
+      apiVersion: DEFAULT_API_VERSION,
+      kind: "Command",
+      name: "test",
+      path: "/tmp",
+      description: {
+        short: "Test",
+      },
+      args: [],
+      opts: [],
+      variables: {},
+      gardenCommand: ["echo", "foo", "bar", "-l=5"],
+    })
+
+    const { result } = await cmd.action({
+      cli,
+      garden,
+      log,
+      headerLog: log,
+      footerLog: log,
+      args: {},
+      opts: withDefaultGlobalOpts({ "log-level": "error", "logger-type": "basic" }),
+    })
+
+    expect(result?.gardenCommand?.command).to.eql(["--logger-type", "basic", "echo", "foo", "bar", "-l=5"])
+  })
+
+  it("can run nested custom commands", async () => {
+    const cmd = new CustomCommandWrapper({
+      apiVersion: DEFAULT_API_VERSION,
+      kind: "Command",
+      name: "test",
+      path: "/tmp",
+      description: {
+        short: "Test",
+      },
+      args: [],
+      opts: [],
+      variables: {},
+      gardenCommand: ["echo", "foo", "bar"],
+    })
+
+    const { result } = await cmd.action({
+      cli,
+      garden,
+      log,
+      headerLog: log,
+      footerLog: log,
+      args: {},
+      opts: withDefaultGlobalOpts({}),
+    })
+
+    expect(result?.gardenCommand?.command).to.eql(["echo", "foo", "bar"])
+    expect(result?.gardenCommand?.result.exec.command).to.eql(["sh", "-c", "echo foo bar"])
+  })
+
+  it("throws on invalid argument type", () => {
+    expectError(
+      () =>
+        new CustomCommandWrapper({
+          apiVersion: DEFAULT_API_VERSION,
+          kind: "Command",
+          name: "test",
+          path: "/tmp",
+          description: {
+            short: "Test",
+          },
+          args: [<any>{ type: "blorg" }],
+          opts: [],
+          variables: {},
+          exec: {
+            command: ["sleep", "1"],
+          },
+        }),
+      (err) => expect(err.message).to.equal("Unexpected parameter type 'blorg'")
+    )
+  })
+
+  it("throws on invalid option type", () => {
+    expectError(
+      () =>
+        new CustomCommandWrapper({
+          apiVersion: DEFAULT_API_VERSION,
+          kind: "Command",
+          name: "test",
+          path: "/tmp",
+          description: {
+            short: "Test",
+          },
+          args: [],
+          opts: [<any>{ type: "blorg" }],
+          variables: {},
+          exec: {
+            command: ["sleep", "1"],
+          },
+        }),
+      (err) => expect(err.message).to.equal("Unexpected parameter type 'blorg'")
+    )
+  })
+})

--- a/core/test/unit/src/commands/deploy.ts
+++ b/core/test/unit/src/commands/deploy.ts
@@ -688,11 +688,11 @@ describe("DeployCommand", () => {
     expect(Object.keys(taskResultOutputs(result!)).includes("deploy.service-b")).to.be.false
   })
 
-  describe("prepare", () => {
+  describe("isPersistent", () => {
     it("should return persistent=true if --watch is set", async () => {
       const cmd = new DeployCommand()
       const log = getLogger().placeholder()
-      const { persistent } = await cmd.prepare({
+      const persistent = cmd.isPersistent({
         log,
         headerLog: log,
         footerLog: log,
@@ -716,7 +716,7 @@ describe("DeployCommand", () => {
     it("should return persistent=true if --dev is set", async () => {
       const cmd = new DeployCommand()
       const log = getLogger().placeholder()
-      const { persistent } = await cmd.prepare({
+      const persistent = cmd.isPersistent({
         log,
         headerLog: log,
         footerLog: log,
@@ -740,7 +740,7 @@ describe("DeployCommand", () => {
     it("should return persistent=true if --hot-reload is set", async () => {
       const cmd = new DeployCommand()
       const log = getLogger().placeholder()
-      const { persistent } = await cmd.prepare({
+      const persistent = cmd.isPersistent({
         log,
         headerLog: log,
         footerLog: log,
@@ -763,7 +763,7 @@ describe("DeployCommand", () => {
     it("should return persistent=true if --follow is set", async () => {
       const cmd = new DeployCommand()
       const log = getLogger().placeholder()
-      const { persistent } = await cmd.prepare({
+      const persistent = cmd.isPersistent({
         log,
         headerLog: log,
         footerLog: log,

--- a/core/test/unit/src/commands/plugins.ts
+++ b/core/test/unit/src/commands/plugins.ts
@@ -121,7 +121,7 @@ describe("PluginsCommand", () => {
       log,
       headerLog: log,
       footerLog: log,
-      args: { plugin: "test-plugin-a", command: "command-a", _: ["foo"] },
+      args: { "plugin": "test-plugin-a", "command": "command-a", "--": ["foo"] },
       opts: withDefaultGlobalOpts({}),
     })
 

--- a/core/test/unit/src/commands/tools.ts
+++ b/core/test/unit/src/commands/tools.ts
@@ -176,7 +176,7 @@ describe("ToolsCommand", () => {
       log,
       headerLog: log,
       footerLog: log,
-      args: { tool: "tool", _: ["0"] },
+      args: { "tool": "tool", "--": ["0"] },
       opts: withDefaultGlobalOpts({ "get-path": false, "output": "json" }),
     })
 
@@ -193,7 +193,7 @@ describe("ToolsCommand", () => {
           log,
           headerLog: log,
           footerLog: log,
-          args: { tool: "51616ok3xnnz....361.2362&123", _: ["0"] },
+          args: { "tool": "51616ok3xnnz....361.2362&123", "--": ["0"] },
           opts: withDefaultGlobalOpts({ "get-path": false, "output": "json" }),
         }),
       (err) =>
@@ -211,7 +211,7 @@ describe("ToolsCommand", () => {
           log,
           headerLog: log,
           footerLog: log,
-          args: { tool: "bla.tool", _: ["0"] },
+          args: { "tool": "bla.tool", "--": ["0"] },
           opts: withDefaultGlobalOpts({ "get-path": false, "output": "json" }),
         }),
       (err) => expect(err.message).to.equal("Could not find plugin bla.")
@@ -226,7 +226,7 @@ describe("ToolsCommand", () => {
           log,
           headerLog: log,
           footerLog: log,
-          args: { tool: "bla", _: ["0"] },
+          args: { "tool": "bla", "--": ["0"] },
           opts: withDefaultGlobalOpts({ "get-path": false, "output": "json" }),
         }),
       (err) => expect(err.message).to.equal("Could not find tool bla.")
@@ -245,7 +245,7 @@ describe("ToolsCommand", () => {
       log,
       headerLog: log,
       footerLog: log,
-      args: { tool: "tool", _: ["0"] },
+      args: { "tool": "tool", "--": ["0"] },
       opts: withDefaultGlobalOpts({ "get-path": false, "output": "json" }),
     })
 
@@ -260,7 +260,7 @@ describe("ToolsCommand", () => {
       log,
       headerLog: log,
       footerLog: log,
-      args: { tool: "test-b.tool", _: ["0"] },
+      args: { "tool": "test-b.tool", "--": ["0"] },
       opts: withDefaultGlobalOpts({ "get-path": false, "output": "json" }),
     })
 
@@ -307,7 +307,7 @@ describe("ToolsCommand", () => {
       log,
       headerLog: log,
       footerLog: log,
-      args: { tool: "tool", _: ["1"] },
+      args: { "tool": "tool", "--": ["1"] },
       opts: withDefaultGlobalOpts({ "get-path": false, "output": "json" }),
     })
 

--- a/core/test/unit/src/config-graph.ts
+++ b/core/test/unit/src/config-graph.ts
@@ -341,7 +341,7 @@ describe("ConfigGraph", () => {
   describe("getTasks", () => {
     it("should scan for modules and return all registered tasks in the context", async () => {
       const tasks = graphA.getTasks()
-      expect(getNames(tasks).sort()).to.eql(["task-a", "task-b", "task-c"])
+      expect(getNames(tasks).sort()).to.eql(["task-a", "task-a2", "task-b", "task-c"])
     })
 
     it("should optionally return specified tasks in the context", async () => {
@@ -946,7 +946,7 @@ describe("ConfigGraph", () => {
   describe("render", () => {
     it("should render config graph nodes with test names", () => {
       const rendered = graphA.render()
-      expect(rendered.nodes).to.have.deep.members([
+      expect(rendered.nodes).to.include.deep.members([
         {
           type: "build",
           name: "module-a",

--- a/core/test/unit/src/config/base.ts
+++ b/core/test/unit/src/config/base.ts
@@ -97,10 +97,7 @@ describe("loadConfigResources", () => {
             name: "other",
           },
         ],
-        providers: [
-          { name: "test-plugin", environments: ["local"] },
-          { name: "test-plugin-b", environments: ["local"] },
-        ],
+        providers: [{ name: "test-plugin" }, { name: "test-plugin-b", environments: ["local"] }],
         outputs: [
           {
             name: "taskName",
@@ -145,6 +142,10 @@ describe("loadConfigResources", () => {
             {
               name: "task-a",
               command: ["echo", "${var.msg}"],
+            },
+            {
+              name: "task-a2",
+              command: ["echo", "${environment.name}-${var.msg}"],
             },
           ],
           tests: [

--- a/core/test/unit/src/config/workflow.ts
+++ b/core/test/unit/src/config/workflow.ts
@@ -222,61 +222,6 @@ describe("resolveWorkflowConfig", () => {
     })
   })
 
-  it("should throw if a step uses an invalid/unsupported command", async () => {
-    const config: WorkflowConfig = {
-      ...defaults,
-      apiVersion: DEFAULT_API_VERSION,
-      kind: "Workflow",
-      name: "workflow-a",
-      path: "/tmp/foo",
-      description: "Sample workflow",
-      envVars: {},
-      steps: [
-        { description: "Do something silly", command: ["bork"] }, // <------
-        { command: ["test"] },
-      ],
-      triggers: [
-        {
-          environment: "local",
-          events: ["pull-request"],
-          branches: ["feature*"],
-          ignoreBranches: ["feature-ignored*"],
-        },
-      ],
-    }
-
-    await expectError(
-      () => resolveWorkflowConfig(garden, config),
-      (err) => expect(err.message).to.match(/Invalid step command for workflow workflow-a/)
-    )
-  })
-
-  it("should throw if a step command uses a global option", async () => {
-    const config: WorkflowConfig = {
-      ...defaults,
-      apiVersion: DEFAULT_API_VERSION,
-      kind: "Workflow",
-      name: "workflow-a",
-      path: "/tmp/foo",
-      description: "Sample workflow",
-      envVars: {},
-      steps: [{ command: ["test", "--env=foo", "-l", "4"] }, { command: ["test", "--silent"] }],
-      triggers: [
-        {
-          environment: "local",
-          events: ["pull-request"],
-          branches: ["feature*"],
-          ignoreBranches: ["feature-ignored*"],
-        },
-      ],
-    }
-
-    await expectError(
-      () => resolveWorkflowConfig(garden, config),
-      (err) => expect(err.message).to.match(/Invalid step command options for workflow workflow-a/)
-    )
-  })
-
   it("should throw if a trigger uses an environment that isn't defined in the project", async () => {
     const config: WorkflowConfig = {
       ...defaults,

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -117,7 +117,6 @@ describe("Garden", () => {
         config: {
           name: "test-plugin",
           dependencies: [],
-          environments: ["local"],
           path: projectRoot,
         },
         dependencies: {},
@@ -1442,7 +1441,6 @@ describe("Garden", () => {
         config: {
           name: "test-plugin",
           dependencies: [],
-          environments: ["local"],
           path: projectRoot,
         },
         dependencies: [],
@@ -2229,6 +2227,7 @@ describe("Garden", () => {
       const garden = await makeTestGardenA()
       const files = await garden.scanForConfigs(garden.projectRoot)
       expect(files).to.eql([
+        join(garden.projectRoot, "commands.garden.yml"),
         join(garden.projectRoot, "garden.yml"),
         join(garden.projectRoot, "module-a", "garden.yml"),
         join(garden.projectRoot, "module-b", "garden.yml"),
@@ -2248,6 +2247,7 @@ describe("Garden", () => {
       set(garden, "moduleExcludePatterns", ["module-a/**/*"])
       const files = await garden.scanForConfigs(garden.projectRoot)
       expect(files).to.eql([
+        join(garden.projectRoot, "commands.garden.yml"),
         join(garden.projectRoot, "garden.yml"),
         join(garden.projectRoot, "module-b", "garden.yml"),
         join(garden.projectRoot, "module-c", "garden.yml"),

--- a/core/test/unit/src/lib/minimist.ts
+++ b/core/test/unit/src/lib/minimist.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2018-2021 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import { customMinimist } from "../../../../src/lib/minimist"
+
+describe("customMinimist", () => {
+  it("collects unspecified options and arguments to _unknown", () => {
+    const args = ["pos-a", "pos-b", "--defined", "123", "--undefined", "foo", "--a=b"]
+    const parsed = customMinimist(args, { string: ["defined"] })
+    expect(parsed._unknown).to.eql(["pos-a", "pos-b", "--undefined", "foo", "--a=b"])
+  })
+})

--- a/core/test/unit/src/util/fs.ts
+++ b/core/test/unit/src/util/fs.ts
@@ -305,6 +305,7 @@ describe("findConfigPathsInPath", () => {
       log: garden.log,
     })
     expect(files).to.eql([
+      join(garden.projectRoot, "commands.garden.yml"),
       join(garden.projectRoot, "garden.yml"),
       join(garden.projectRoot, "module-a", "garden.yml"),
       join(garden.projectRoot, "module-b", "garden.yml"),
@@ -349,6 +350,7 @@ describe("findConfigPathsInPath", () => {
       exclude,
     })
     expect(files).to.eql([
+      join(garden.projectRoot, "commands.garden.yml"),
       join(garden.projectRoot, "garden.yml"),
       join(garden.projectRoot, "module-b", "garden.yml"),
       join(garden.projectRoot, "module-c", "garden.yml"),

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@
 * [Terraform](./advanced/terraform.md)
 * [Using Remote Sources](./advanced/using-remote-sources.md)
 * [Minimal RBAC Configuration for Development Clusters](./advanced/rbac-config.md)
+* [Custom Commands](./advanced/custom-commands.md)
 
 ## ☘️ Reference
 

--- a/docs/advanced/custom-commands.md
+++ b/docs/advanced/custom-commands.md
@@ -1,0 +1,151 @@
+# Custom Commands
+
+{% hint style="warning" %}
+This is currently considered experimental. Please try it out and post feedback via GitHub issues or in our community!
+{% endhint %}
+
+As part of a Garden project, you can define _custom commands_. You can think of these like Makefile targets, npm package scripts etc., except you have the full power of Garden's templating syntax to work with, and can easily declare the exact arguments and options the command accepts. The custom commands come up when you run `garden help`, which helps make your project easier to use and more self-documenting. You can also
+
+You'll find more examples and details below, but here's a simple example to illustrate the idea:
+
+```yaml
+kind: Command
+name: api-dev
+description:
+  short: Start garden with preconfigured options for API development
+exec:
+  command:
+    - sh
+    - -c
+    - git submodule update --recursive --remote  # Because we keep forgetting to update these, amirite?
+gardenCommand:
+  - deploy
+  - --dev
+  - api,worker
+  - --log-level
+  - debug
+  - $concat: ${args.$all}  # Allow any arguments/options on top of the fixed ones above
+```
+
+Here we imagine a basic day-to-day workflow for a certain group of developers. The user simply runs `garden api-dev`. Before the Garden command starts, we update the submodules in the repo, and then we start `garden deploy` with some parameters that we tend to use or prefer.
+
+Of course this is just an example, but no doubt you can imagine some commands, parameters etc. that you use a lot and which would be nice to codify for you and your team. And this example only uses a fraction of what's possible! Read on for more and see what ideas come up.
+
+## Limitations
+
+Before diving in, there are a few constraints and caveats to be aware of when defining your custom commands:
+
+* For performance reasons, we currently only pick custom commands from the project root folder. They can still be in any `*.garden.yml` file in that directory, much like other configs, but we deliberately avoid scanning the entire project structure for commands. By extension, commands cannot be defined in remote sources at this time.
+
+* Commands cannot have the same name as other Garden commands. This is by design, to avoid any potential confusion for users.
+
+* Only the `exec` and `gardenCommand` fields can be templated. Other fields need to be statically defined.
+
+* Project and environment variables cannot be referenced in command templates at this time, because the project configuration is by design not resolved before executing the command.
+
+We may later lift some of these limitations. Please post a [GitHub issue](https://github.com/garden-io/garden/issues) if any of the above is getting in your way!
+
+## Basics
+
+Each command has to define a `name`, which must be a valid identifier (following the same rules as module names etc.). A short description must also be provided with `description.short`, and you can also provide a longer description on `description.long` which is shown when you run the command with `--help`. For example:
+
+```yaml
+kind: Command
+name: api-dev
+description:
+  short: Short text to show when users run garden help
+  long: |
+    Some arbitrarily long paragraph that gets into more
+    detail and is shown then this command is run with
+    the --help flag.
+...
+```
+
+Then, you must define _one or both_ of `exec` and/or `gardenCommand`. The former simply executes some command on your system, e.g. a shell command. The latter, as you might have guessed, runs a Garden command.
+
+If you specify both `exec` and `gardenCommand`, the `exec` part is run before the `gardenCommand`.
+
+For the `exec` field, you must specify `exec.command` and can optionally set `exec.env` as well, to set any environment variables for the command execution.
+
+The `gardenCommand` field is a simple array, which normally should start with the command name to run, and then any flags and arguments you want to pass on.
+
+## Templating
+
+The `exec` and `gardenCommand` fields can be templated with many of the fields available for project and environment configuration. See [the reference](../reference/template-strings.md#custom-command-configuration-context) for all the fields available.
+
+Of special note are the `${args.*}` and `${opts.*}` variables. You can [see below](#defining-arguments-and-option-flags) how to explicitly define both positional arguments and option flags, but you can also use the following predefined variables:
+
+* `${args.$all}` is a list of every argument and flag passed to the command (only subtracting the name of the custom command itself). This includes all normal global Garden option flags, as well as the ones you explicitly specify.
+
+* `${args.$rest}` is a list of every positional argument and option that isn't explicitly defined in the custom command, including all global Garden flags.
+
+* `${args["--"]}` is a list of everything placed after `--` in the command line. For example, if you run `garden my-command -- foo --bar`, this variable will be an array containing `"foo"` and `"--bar"`.
+
+You can also reference any provided option flag under `${opts.*}`, even those that are not explicitly defined. Unspecified options won't be validated, but are still parsed and made available for templating.
+
+For example, if you just want to pass all arguments (beyond global options and the command name itself) to a shell script, you can do something like this:
+
+```yaml
+kind: Command
+name: my-script
+description:
+  short: Run that script we keep using
+exec:
+  command:
+    - sh
+    - -c
+    - |
+      echo "I'm a super important script, here we go!"
+      echo "We're in the ${project.name} project and you are ${local.username}, in case you forgot..."
+      ./scripts/foo.sh ${join(args.$rest, ' ')}
+```
+
+Here we use the `join` helper function to convert all extra arguments to a space separated string, and pass that to the imagined `foo.sh` script. Pretty much like using `"$@"` in a bash script. We also reference a couple of other common template variables (in this admittedly contrived example...).
+
+## Defining arguments and option flags
+
+You can explicitly define positional arguments and options that are expected or required for your command, using the `args` and `opts` fields. These are validated and parsed before running the command, and are also shown in the help text when running the command with `--help`. For example:
+
+```yaml
+kind: Command
+name: run-task
+description:
+  short: Run a task ad-hoc
+args:
+  - name: task-name
+    description: The name of the task to run
+    required: true
+opts:
+  - name: db
+    description: Override the database hostname
+    type: string
+gardenCommand:
+  - run
+  - task
+  - ${args.task-name}
+  - --var
+  - dbHostname=${opts.db || "db"}
+```
+
+Here we've made a wrapper command for running tasks in your project. We require one positional argument for the name of the task to run. Then we define an option for overriding a project variable. For the example, we imagine there's a project variable that's templated into the tasks that controls the hostname of a database they need to connect to. The last lines in the example override the variable and default to `"db"` if the option flag isn't set. To run this command, you could run e.g. `garden run-task my-task --db test`, which would run `my-task` with the `dbHostname` variable set to `test`.
+
+You might want to augment this example to further accept any additional arguments and append to the Garden command. To do that, you could add the following:
+
+```yaml
+...
+gardenCommand:
+  - run
+  - task
+  - ${args.task-name}
+  - --var
+  - dbHostname=${opts.db || "db"}
+  - $concat: ${args.$rest}  # <- pass any additional parameters through to the command without validation
+```
+
+Now you could, for example, run `garden run-task my-task --db test --force` and the additional `--force` parameter gets passed to the underlying Garden command.
+
+As you can see, you can do a whole lot here! Read on for more examples.
+
+## Using variables
+
+You can specify a `variables` field, and reference those in the `exec` and `gardenCommand` fields using `${var.*}`, similar to module variables. Note that _project variables_ are not available, since the Garden project is not resolved ahead of resolving the custom command.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -49,10 +49,6 @@ Examples:
     garden build --force    # force rebuild of modules
     garden build --watch    # watch for changes to code
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| Yes |                                                  |
-
 #### Usage
 
     garden build [modules] [options]
@@ -271,10 +267,6 @@ Examples:
 
 Note: Currently only supports simple GET requests for HTTP/HTTPS ingresses.
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
-
 #### Usage
 
     garden call <serviceAndPath> 
@@ -305,10 +297,6 @@ Examples:
     garden config analytics-enabled true   # enable analytics
     garden config analytics-enabled false  # disable analytics
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
-
 #### Usage
 
     garden config analytics-enabled [enable] 
@@ -335,10 +323,6 @@ Examples:
     garden create project --dir some-dir      # create a Garden project config in the ./some-dir directory
     garden create project --name my-project   # set the project name to my-project
     garden create project --interactive=false # don't prompt for user inputs when creating the config
-
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
 
 #### Usage
 
@@ -368,10 +352,6 @@ Examples:
     garden create module --name my-module     # set the module name to my-module
     garden create module --interactive=false  # don't prompt for user inputs when creating the module
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
-
 #### Usage
 
     garden create module [options]
@@ -398,10 +378,6 @@ Examples:
     garden delete secret kubernetes somekey
     garden del secret local-kubernetes some-other-key
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
-
 #### Usage
 
     garden delete secret <provider> <key> 
@@ -424,10 +400,6 @@ and reset it. When you then run `garden deploy`, the environment will be reconfi
 
 This can be useful if you find the environment to be in an inconsistent state, or need/want to free up
 resources.
-
-| Supported in workflows |   |
-| ---------------------- |---|
-| Yes |                                                  |
 
 #### Usage
 
@@ -561,10 +533,6 @@ Examples:
     garden delete service my-service # deletes my-service
     garden delete service            # deletes all deployed services in the project
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| Yes |                                                  |
-
 #### Usage
 
     garden delete service [services] 
@@ -683,10 +651,6 @@ Examples:
     garden deploy --dev                # deploys all compatible services with dev mode enabled
     garden deploy --env stage          # deploy your services to an environment called stage
     garden deploy --skip service-b     # deploy all services except service-b
-
-| Supported in workflows |   |
-| ---------------------- |---|
-| Yes |                                                  |
 
 #### Usage
 
@@ -915,10 +879,6 @@ Examples:
     garden dev --name integ                   # run all tests with the name 'integ' in the project
     garden test --name integ*                 # run all tests with the name starting with 'integ' in the project
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
-
 #### Usage
 
     garden dev [services] [options]
@@ -951,10 +911,6 @@ _NOTE: This command may not be supported for all module types._
 Examples:
 
      garden exec my-service /bin/sh   # runs a shell in the my-service container
-
-| Supported in workflows |   |
-| ---------------------- |---|
-| Yes |                                                  |
 
 #### Usage
 
@@ -1000,10 +956,6 @@ Examples:
     garden cloud secrets list --filter-envs dev                        # list all secrets from the dev environment
     garden cloud secrets list --filter-envs dev --filter-names *_DB_*  # list all secrets from the dev environment that have '_DB_' in their name.
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
-
 #### Usage
 
     garden cloud secrets list [options]
@@ -1035,10 +987,6 @@ Examples:
     garden cloud secrets create ACCESS_KEY=my-key --scope-to-env ci --scope-to-user 9  # create a secret and scope it to the ci environment and user with ID 9
     garden cloud secrets create --from-file /path/to/secrets.txt  # create secrets from the key value pairs in the secrets.txt file
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
-
 #### Usage
 
     garden cloud secrets create [secrets] [options]
@@ -1068,10 +1016,6 @@ which you which you can get from the `garden cloud secrets list` command.
 Examples:
     garden cloud secrets delete 1,2,3   # delete secrets with IDs 1,2, and 3.
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
-
 #### Usage
 
     garden cloud secrets delete [ids] 
@@ -1094,10 +1038,6 @@ Examples:
     garden cloud users list                            # list all users
     garden cloud users list --filter-names Gordon*     # list all the Gordons in Garden Cloud. Useful if you have a lot of Gordons.
     garden cloud users list --filter-groups devs-*     # list all users in groups that with names that start with 'dev-'
-
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
 
 #### Usage
 
@@ -1132,10 +1072,6 @@ Examples:
     garden cloud users create fatema_m="Fatema M" --add-to-groups 1,2  # create a user and add two groups with IDs 1,2
     garden cloud users create --from-file /path/to/users.txt           # create users from the key value pairs in the users.txt file
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
-
 #### Usage
 
     garden cloud users create [users] [options]
@@ -1164,10 +1100,6 @@ which you which you can get from the `garden cloud users list` command.
 Examples:
     garden cloud users delete 1,2,3   # delete users with IDs 1,2, and 3.
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
-
 #### Usage
 
     garden cloud users delete [ids] 
@@ -1191,10 +1123,6 @@ Examples:
     garden cloud groups list                       # list all groups
     garden cloud groups list --filter-names dev-*  # list all groups that start with 'dev-'
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
-
 #### Usage
 
     garden cloud groups list [options]
@@ -1211,10 +1139,6 @@ Examples:
 **Outputs the dependency relationships specified in this project's garden.yml files.**
 
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
-
 #### Usage
 
     garden get graph 
@@ -1225,10 +1149,6 @@ Examples:
 
 **Outputs the full configuration for this project and environment.**
 
-
-| Supported in workflows |   |
-| ---------------------- |---|
-| Yes |                                                  |
 
 #### Usage
 
@@ -1903,32 +1823,12 @@ workflowConfigs:
         name:
 
         # A Garden command this step should run, followed by any required or optional arguments and flags.
-        # Arguments and options for the commands may be templated, including references to previous steps, but for now
-        # the commands themselves (as listed below) must be hard-coded.
         #
-        # Supported commands:
+        # Note that commands that are _persistent_—e.g. the dev command, commands with a watch flag set, the logs
+        # command with following enabled etc.—are not supported. In general, workflow steps should run to completion.
         #
-        # `[build]`
-        # `[delete, environment]`
-        # `[delete, service]`
-        # `[deploy]`
-        # `[exec]`
-        # `[get, config]`
-        # `[get, outputs]`
-        # `[get, status]`
-        # `[get, task-result]`
-        # `[get, test-result]`
-        # `[link, module]`
-        # `[link, source]`
-        # `[publish]`
-        # `[run, task]`
-        # `[run, test]`
-        # `[test]`
-        # `[update-remote, all]`
-        # `[update-remote, modules]`
-        # `[update-remote, sources]`
-        #
-        #
+        # Global options like --env, --log-level etc. are currently not supported for built-in commands, since they
+        # are handled before the individual steps are run.
         command:
 
         # A description of the workflow step.
@@ -2030,10 +1930,6 @@ domain:
 **Outputs a list of all linked remote sources and modules for this project.**
 
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
-
 #### Usage
 
     garden get linked-repos 
@@ -2052,10 +1948,6 @@ Examples:
     garden get outputs                 # resolve and print the outputs from the project
     garden get outputs --env=prod      # resolve and print the outputs from the project for the prod environment
     garden get outputs --output=json   # resolve and return the project outputs in JSON format
-
-| Supported in workflows |   |
-| ---------------------- |---|
-| Yes |                                                  |
 
 #### Usage
 
@@ -2079,10 +1971,6 @@ Examples:
     garden get modules                                                # list all modules in the project
     garden get modules --exclude-disabled=true                        # skip disabled modules
     garden get modules -o=json | jq '.modules["my-module"].version'   # get version of my-module
-
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
 
 #### Usage
 
@@ -2410,10 +2298,6 @@ modules:
 **Outputs the full status of your environment.**
 
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| Yes |                                                  |
-
 #### Usage
 
     garden get status 
@@ -2560,10 +2444,6 @@ tests:
 **Lists the tasks defined in your project's modules.**
 
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
-
 #### Usage
 
     garden get tasks [tasks] 
@@ -2581,10 +2461,6 @@ tests:
 **Lists the tests defined in your project's modules.**
 
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
-
 #### Usage
 
     garden get tests [tests] 
@@ -2601,10 +2477,6 @@ tests:
 
 **Outputs the latest execution result of a provided task.**
 
-
-| Supported in workflows |   |
-| ---------------------- |---|
-| Yes |                                                  |
 
 #### Usage
 
@@ -2666,10 +2538,6 @@ artifacts:
 
 **Outputs the latest execution result of a provided test.**
 
-
-| Supported in workflows |   |
-| ---------------------- |---|
-| Yes |                                                  |
 
 #### Usage
 
@@ -2742,10 +2610,6 @@ garden get debug-info                    # create a zip file at the root of the 
 garden get debug-info --format yaml      # output provider info as YAML files (default is JSON)
 garden get debug-info --include-project  # include provider info for the project namespace (disabled by default)
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
-
 #### Usage
 
     garden get debug-info [options]
@@ -2767,10 +2631,6 @@ Check for openings at Berlin's vaccination centers at a 2
 second interval. If it finds one, you'll receive a notification
 with links to book an appointment.
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
-
 #### Usage
 
     garden get vaccine 
@@ -2788,10 +2648,6 @@ level `garden.yml` config.
 Examples:
 
     garden link source my-source path/to/my-source # links my-source to its local version at the given path
-
-| Supported in workflows |   |
-| ---------------------- |---|
-| Yes |                                                  |
 
 #### Usage
 
@@ -2828,10 +2684,6 @@ i.e. modules that specifiy a `repositoryUrl` in their `garden.yml` config file.
 Examples:
 
     garden link module my-module path/to/my-module # links my-module to its local version at the given path
-
-| Supported in workflows |   |
-| ---------------------- |---|
-| Yes |                                                  |
 
 #### Usage
 
@@ -2873,10 +2725,6 @@ Examples:
     garden logs --follow                   # keeps running and streams all incoming logs to the console
     garden logs --tag container=service-a  # only shows logs from containers with names matching the pattern
     garden logs --original-color           # interleaves logs from all services and prints the original output color
-
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
 
 #### Usage
 
@@ -2920,10 +2768,6 @@ Examples:
     garden migrate --write      # scans all garden.yml files and overwrites them with the updated versions.
     garden migrate ./garden.yml # scans the provided garden.yml file and prints the updated version.
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
-
 #### Usage
 
     garden migrate [configPaths] [options]
@@ -2946,10 +2790,6 @@ Examples:
 **Print global options.**
 
 Prints all global options (options that can be applied to any command).
-
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
 
 #### Usage
 
@@ -2975,10 +2815,6 @@ Examples:
 
     # List all the commands from the `kubernetes` plugin.
     garden plugins kubernetes
-
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
 
 #### Usage
 
@@ -3014,10 +2850,6 @@ Examples:
 
     # Publish my-container with a tag of v1.2-<hash> (e.g. v1.2-abcdef123)
     garden publish my-container --tag "v1.2-${module.hash}"
-
-| Supported in workflows |   |
-| ---------------------- |---|
-| Yes |                                                  |
 
 #### Usage
 
@@ -3262,10 +3094,6 @@ Examples:
     garden run module my-container /bin/sh                           # run an interactive shell in a new my-container container
     garden run module my-container --interactive=false /some/script  # execute a script in my-container and return the output
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
-
 #### Usage
 
     garden run module <module> [arguments] [options]
@@ -3296,10 +3124,6 @@ Examples:
 
     garden run service my-service   # run an ad-hoc instance of a my-service and attach to it
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
-
 #### Usage
 
     garden run service <service> [options]
@@ -3327,10 +3151,6 @@ This is useful for re-running tasks ad-hoc, for example after writing/modifying 
 Examples:
 
     garden run task my-db-migration   # run my-migration
-
-| Supported in workflows |   |
-| ---------------------- |---|
-| Yes |                                                  |
 
 #### Usage
 
@@ -3415,10 +3235,6 @@ Examples:
 
     garden run test my-module integ                      # run the test named 'integ' in my-module
     garden run test my-module integ --interactive=false  # do not attach to the test run, just output results when completed
-
-| Supported in workflows |   |
-| ---------------------- |---|
-| Yes |                                                  |
 
 #### Usage
 
@@ -3508,10 +3324,6 @@ Examples:
 
     garden run workflow my-workflow    # run my-workflow
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
-
 #### Usage
 
     garden run workflow <workflow> 
@@ -3529,10 +3341,6 @@ Examples:
 **Scans your project and outputs an overview of all modules.**
 
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
-
 #### Usage
 
     garden scan 
@@ -3548,10 +3356,6 @@ Starts the Garden dashboard for the current project, and your selected environme
 The dashboard will receive and display updates from other Garden processes that you run with the same Garden project, environment and namespace.
 
 Note: You must currently run one dashboard per-environment and namespace.
-
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
 
 #### Usage
 
@@ -3579,10 +3383,6 @@ Examples:
    garden self-update 0.12.24  # switch to the 0.12.24 version of the CLI
    garden self-update --force  # re-install even if the same version is detected
    garden self-update --install-dir ~/garden  # install to ~/garden instead of detecting the directory
-
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
 
 #### Usage
 
@@ -3622,10 +3422,6 @@ Examples:
     garden test -n unit -n lint   # run all tests called either 'unit' or 'lint' in the project
     garden test --force           # force tests to be re-run, even if they've already run successfully
     garden test --watch           # watch for changes to code
-
-| Supported in workflows |   |
-| ---------------------- |---|
-| Yes |                                                  |
 
 #### Usage
 
@@ -3860,10 +3656,6 @@ Examples:
     # List all available tools.
     garden tools
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
-
 #### Usage
 
     garden tools [tool] [options]
@@ -3892,10 +3684,6 @@ Examples:
 
     garden unlink source my-source  # unlinks my-source
     garden unlink source --all      # unlinks all sources
-
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
 
 #### Usage
 
@@ -3926,10 +3714,6 @@ Examples:
     garden unlink module my-module  # unlinks my-module
     garden unlink module --all      # unlink all modules
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
-
 #### Usage
 
     garden unlink module [modules] [options]
@@ -3957,10 +3741,6 @@ Examples:
 
     garden update-remote sources            # update all remote sources
     garden update-remote sources my-source  # update remote source my-source
-
-| Supported in workflows |   |
-| ---------------------- |---|
-| Yes |                                                  |
 
 #### Usage
 
@@ -3998,10 +3778,6 @@ Examples:
     garden update-remote modules            # update all remote modules in the project
     garden update-remote modules my-module  # update remote module my-module
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| Yes |                                                  |
-
 #### Usage
 
     garden update-remote modules [modules] 
@@ -4033,10 +3809,6 @@ sources:
 Examples:
 
     garden update-remote all # update all remote sources and modules in the project
-
-| Supported in workflows |   |
-| ---------------------- |---|
-| Yes |                                                  |
 
 #### Usage
 
@@ -4078,10 +3850,6 @@ Examples:
     garden util fetch-tools        # fetch for just the current project/env
     garden util fetch-tools --all  # fetch for all registered providers
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
-
 #### Usage
 
     garden util fetch-tools [options]
@@ -4098,10 +3866,6 @@ Examples:
 **Hide a specific warning message.**
 
 Hides the specified warning message. The command and key is generally provided along with displayed warning messages.
-
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
 
 #### Usage
 
@@ -4120,10 +3884,6 @@ Hides the specified warning message. The command and key is generally provided a
 **Check your garden configuration for errors.**
 
 Throws an error and exits with code 1 if something's not right in your garden.yml files.
-
-| Supported in workflows |   |
-| ---------------------- |---|
-| No |                                                  |
 
 #### Usage
 

--- a/docs/reference/template-strings.md
+++ b/docs/reference/template-strings.md
@@ -857,6 +857,367 @@ my-variable: ${environment.namespace}
 ```
 
 
+## Custom command configuration context
+
+The below keys are available in template strings for the `exec` and `gardenCommand` fields in [Custom Commands](../advanced/custom-commands.md).
+
+### `${local.*}`
+
+Context variables that are specific to the currently running environment/machine.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${local.artifactsPath}`
+
+The absolute path to the directory where exported artifacts from test and task runs are stored.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.artifactsPath}
+```
+
+### `${local.env.*}`
+
+A map of all local environment variables (see https://nodejs.org/api/process.html#process_process_env).
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${local.env.<env-var-name>}`
+
+The environment variable value.
+
+| Type     |
+| -------- |
+| `string` |
+
+### `${local.platform}`
+
+A string indicating the platform that the framework is running on (see https://nodejs.org/api/process.html#process_process_platform)
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.platform}
+```
+
+### `${local.projectPath}`
+
+The absolute path to the project root directory.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.projectPath}
+```
+
+### `${local.username}`
+
+The current username (as resolved by https://github.com/sindresorhus/username).
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.username}
+```
+
+### `${local.usernameLowerCase}`
+
+The current username (as resolved by https://github.com/sindresorhus/username), with any upper case characters converted to lower case.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${local.usernameLowerCase}
+```
+
+### `${command.*}`
+
+Information about the currently running command and its arguments.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${command.name}`
+
+The currently running Garden CLI command, without positional arguments or option flags. This can be handy to e.g. change some variables based on whether you're running `garden test` or some other specific command.
+
+Note that this will currently always resolve to `"run workflow"` when running Workflows, as opposed to individual workflow step commands. This may be revisited at a later time, but currently all configuration is resolved once for all workflow steps.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${command.name}
+```
+
+### `${command.params.*}`
+
+A map of all parameters set when calling the current command. This includes both positional arguments and option flags, and includes any default values set by the framework or specific command. This can be powerful if used right, but do take care since different parameters are only available in certain commands, some have array values etc.
+
+For example, to see if a service is in hot-reload mode, you might do something like `${command.params contains 'hot-reload' && command.params.hot-reload contains 'my-service'}`. Notice that you currently need to check both for the existence of the parameter, and also to correctly handle the array value.
+
+Option values can be referenced by the option's default name (e.g. `dev-mode`) or its alias (e.g. `dev`) if one is defined for that option.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${command.params.<name>}`
+
+| Type  |
+| ----- |
+| `any` |
+
+### `${datetime.*}`
+
+Information about the date/time at template resolution time.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${datetime.now}`
+
+The current UTC date and time, at time of template resolution, in ISO-8601 format.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${datetime.now}
+```
+
+### `${datetime.today}`
+
+The current UTC date, at time of template resolution, in ISO-8601 format.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${datetime.today}
+```
+
+### `${datetime.timestamp}`
+
+The current UTC Unix timestamp (in seconds), at time of template resolution.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${datetime.timestamp}
+```
+
+### `${project.*}`
+
+Information about the Garden project.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${project.name}`
+
+The name of the Garden project.
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${project.name}
+```
+
+### `${git.*}`
+
+Information about the current state of the project's Git repository.
+
+| Type     |
+| -------- |
+| `object` |
+
+### `${git.branch}`
+
+The current Git branch, if available. Resolves to an empty string if HEAD is in a detached state
+(e.g. when rebasing), or if the repository has no commits.
+
+When using remote sources, the branch used is that of the project/top-level repository (the one that contains
+the project configuration).
+
+The branch is resolved at the start of the Garden command's execution, and is not updated if the current branch changes during the command's execution (which could happen, for example, when using watch-mode commands).
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${git.branch}
+```
+
+### `${git.commitHash}`
+
+The current Git commit hash, if available. Resolves to an empty string if the repository has no commits.
+
+When using remote sources, the hash used is that of the project/top-level repository (the one that contains the project configuration).
+
+The hash is resolved at the start of the Garden command's execution, and is not updated if the current commit changes during the command's execution (which could happen, for example, when using watch-mode commands).
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${git.commitHash}
+```
+
+### `${git.originUrl}`
+
+The remote origin URL of the project Git repository.
+
+When using remote sources, the URL is that of the project/top-level repository (the one that contains the project configuration).
+
+| Type     |
+| -------- |
+| `string` |
+
+Example:
+
+```yaml
+my-variable: ${git.originUrl}
+```
+
+### `${variables.*}`
+
+A map of all variables defined in the command configuration.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${variables.<variable-name>}`
+
+| Type                                             |
+| ------------------------------------------------ |
+| `string | number | boolean | link | array[link]` |
+
+### `${var.*}`
+
+Alias for the variables field.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${var.<name>}`
+
+Number, string or boolean
+
+| Type                        |
+| --------------------------- |
+| `string | number | boolean` |
+
+### `${args.*}`
+
+Map of all arguments, as defined in the Command spec. Also includes `$all`, `$rest` and `--` fields. See their description for details.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${args.$all[]}`
+
+Every argument passed to the command, except the name of the command itself.
+
+| Type            | Default |
+| --------------- | ------- |
+| `array[string]` | `[]`    |
+
+### `${args.$rest[]}`
+
+Every positional argument and option that isn't explicitly defined in the custom command, including any global Garden flags.
+
+| Type            | Default |
+| --------------- | ------- |
+| `array[string]` | `[]`    |
+
+### `${args.--[]}`
+
+Every argument following -- on the command line.
+
+| Type            | Default |
+| --------------- | ------- |
+| `array[string]` | `[]`    |
+
+### `${args.<name>}`
+
+Number, string or boolean
+
+| Type                        |
+| --------------------------- |
+| `string | number | boolean` |
+
+### `${opts.*}`
+
+Map of all options, as defined in the Command spec.
+
+| Type     | Default |
+| -------- | ------- |
+| `object` | `{}`    |
+
+### `${opts.<name>}`
+
+Number, string or boolean
+
+| Type                        |
+| --------------------------- |
+| `string | number | boolean` |
+
+
 ## Environment configuration context
 
 The following keys are available in template strings under the `environments` key in project configs. Additional keys are available for the `environments[].providers` field, see the [Provider](#provider-configuration-context) section below for those.
@@ -2827,7 +3188,7 @@ my-variable: ${runtime.tasks.<task-name>.version}
 
 ## Workflow configuration context
 
-The below keys are available in template strings for Workflow configurations.
+The below keys are available in template strings for [Workflow](../using-garden/workflows.md) configurations, as well as the commands defined in [Custom Commands](../advanced/custom-commands.md).
 
 Note that the `{steps.*}` key is only available for the `steps[].command` and `steps[].script` fields in Workflow configs, and may only reference previous steps in the same workflow. See below for more details.
 

--- a/docs/reference/template-strings.md
+++ b/docs/reference/template-strings.md
@@ -70,6 +70,17 @@ Examples:
 * `${isEmpty("not empty")}` -> `false`
 * `${isEmpty(null)}` -> `true`
 
+### join
+
+Takes an array of strings (or other primitives) and concatenates them into a string, with the given separator
+
+Usage: `join(input, separator)`
+
+Examples:
+
+* `${join(["some","list","of","strings"], " ")}` -> `"some list of strings"`
+* `${join(["some","list","of","strings"], ".")}` -> `"some.list.of.strings"`
+
 ### jsonDecode
 
 Decodes the given JSON-encoded string.

--- a/docs/reference/workflow-config.md
+++ b/docs/reference/workflow-config.md
@@ -89,32 +89,12 @@ steps:
     name:
 
     # A Garden command this step should run, followed by any required or optional arguments and flags.
-    # Arguments and options for the commands may be templated, including references to previous steps, but for now
-    # the commands themselves (as listed below) must be hard-coded.
     #
-    # Supported commands:
+    # Note that commands that are _persistent_—e.g. the dev command, commands with a watch flag set, the logs command
+    # with following enabled etc.—are not supported. In general, workflow steps should run to completion.
     #
-    # `[build]`
-    # `[delete, environment]`
-    # `[delete, service]`
-    # `[deploy]`
-    # `[exec]`
-    # `[get, config]`
-    # `[get, outputs]`
-    # `[get, status]`
-    # `[get, task-result]`
-    # `[get, test-result]`
-    # `[link, module]`
-    # `[link, source]`
-    # `[publish]`
-    # `[run, task]`
-    # `[run, test]`
-    # `[test]`
-    # `[update-remote, all]`
-    # `[update-remote, modules]`
-    # `[update-remote, sources]`
-    #
-    #
+    # Global options like --env, --log-level etc. are currently not supported for built-in commands, since they are
+    # handled before the individual steps are run.
     command:
 
     # A description of the workflow step.
@@ -420,32 +400,10 @@ fields.
 [steps](#steps) > command
 
 A Garden command this step should run, followed by any required or optional arguments and flags.
-Arguments and options for the commands may be templated, including references to previous steps, but for now
-the commands themselves (as listed below) must be hard-coded.
 
-Supported commands:
+Note that commands that are _persistent_—e.g. the dev command, commands with a watch flag set, the logs command with following enabled etc.—are not supported. In general, workflow steps should run to completion.
 
-`[build]`
-`[delete, environment]`
-`[delete, service]`
-`[deploy]`
-`[exec]`
-`[get, config]`
-`[get, outputs]`
-`[get, status]`
-`[get, task-result]`
-`[get, test-result]`
-`[link, module]`
-`[link, source]`
-`[publish]`
-`[run, task]`
-`[run, test]`
-`[test]`
-`[update-remote, all]`
-`[update-remote, modules]`
-`[update-remote, sources]`
-
-
+Global options like --env, --log-level etc. are currently not supported for built-in commands, since they are handled before the individual steps are run.
 
 | Type            | Required |
 | --------------- | -------- |

--- a/static/docs/templates/commands.hbs
+++ b/static/docs/templates/commands.hbs
@@ -32,10 +32,6 @@ The following option flags can be used with any of the CLI commands:
 {{#if description}}{{{description}}}
 {{/if}}
 
-| Supported in workflows |   |
-| ---------------------- |---|
-| {{#if workflows}}Yes{{else}}No{{/if}} |                                                  |
-
 #### Usage
 
     garden {{fullName}} {{#each arguments}}{{{usageName}}} {{/each}}{{#if options}}[options]{{/if}}

--- a/static/docs/templates/template-strings.hbs
+++ b/static/docs/templates/template-strings.hbs
@@ -35,6 +35,11 @@ The following keys are available in any template strings within project definiti
 The following keys are available in template strings under the `sources` key in project configs.
 {{{remoteSourceContext}}}
 
+## Custom command configuration context
+
+The below keys are available in template strings for the `exec` and `gardenCommand` fields in [Custom Commands](../advanced/custom-commands.md).
+{{{customCommandContext}}}
+
 ## Environment configuration context
 
 The following keys are available in template strings under the `environments` key in project configs. Additional keys are available for the `environments[].providers` field, see the [Provider](#provider-configuration-context) section below for those.
@@ -69,7 +74,7 @@ For details on which outputs are available for a given module type, please refer
 
 ## Workflow configuration context
 
-The below keys are available in template strings for Workflow configurations.
+The below keys are available in template strings for [Workflow](../using-garden/workflows.md) configurations, as well as the commands defined in [Custom Commands](../advanced/custom-commands.md).
 
 Note that the `{steps.*}` key is only available for the `steps[].command` and `steps[].script` fields in Workflow configs, and may only reference previous steps in the same workflow. See below for more details.
 {{{workflowContext}}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12419,6 +12419,11 @@ mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
+mimic-fn@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-3.1.0.tgz#65755145bbf3e36954b949c16450427451d5ca74"
+  integrity sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==
+
 mimic-response@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
@@ -18276,6 +18281,11 @@ type-fest@^0.8.0, type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
+type-fest@^2.5.4:
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.5.4.tgz#1613bf29a172ff1c66c29325466af9096fe505b5"
+  integrity sha512-zyPomVvb6u7+gJ/GPYUH6/nLDNiTtVOqXVUHtxFv5PmZQh6skgfeRtFYzWC01T5KeNWNIx5/0P111rKFLlkFvA==
+
 type-is@^1.6.16, type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
@@ -18334,11 +18344,6 @@ typescript-formatter@^7.2.2:
   dependencies:
     commandpost "^1.0.0"
     editorconfig "^0.15.0"
-
-typescript-memoize@^1.0.0-alpha.3:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.0.0.tgz#ad3b0e7e5a411ca234be123f913a2a31302b7eb6"
-  integrity sha512-B1eufjs/mGzHqoGeI1VT/dnSBoZr2v3i3/Wm8NmdxlZflyVdleE8wO0QwUuj4NfundD7T5nU3I7HSKp/5BD9og==
 
 typescript@^4.3.5:
   version "4.3.5"


### PR DESCRIPTION
This adds the ability to define custom commands as part of any Garden project. See the added guide for details: https://github.com/garden-io/garden/blob/63b93ec60e62286b4fe7ecfd082e0065435dac7b/docs/advanced/custom-commands.md

When reviewing, please try making your own and see if you bump into any issues or get confused!

I'm flagging this as experimental just for the moment, since this sort of thing invites a fair number of edge cases and use cases we didn't consider up front, and getting real-world feedback will be important.

**Some additional notes on the PR:**

* As part of the process I started implementing a "spread" option for positional arguments, but went another way in the implementation, so finishing that will wait but I left those initial changes in.
* I had to remove the preemptive validation for workflow commands, and along the way I allowed more commands to run in workflows by making the criteria whether they're persistent or not.
* There are two separate smaller commits there, that I found necessary to get this done.