### PR TITLE
improvement(examples): update ingress specs in example garden projects

### DIFF
--- a/examples/conftest/helm-chart/templates/ingress.yaml
+++ b/examples/conftest/helm-chart/templates/ingress.yaml
@@ -1,11 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "helm-chart.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -33,9 +29,12 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/examples/hot-reload-k8s/node-service/garden.yml
+++ b/examples/hot-reload-k8s/node-service/garden.yml
@@ -73,7 +73,7 @@ manifests:
         protocol: TCP
         targetPort: 8080
       type: ClusterIP
-  - apiVersion: extensions/v1beta1
+  - apiVersion: networking.k8s.io/v1
     kind: Ingress
     metadata:
       labels:
@@ -84,7 +84,10 @@ manifests:
       - host: ${var.default-hostname}
         http:
           paths:
-          - backend:
-              serviceName: node-service
-              servicePort: 8080
-            path: /hello
+          - path: /hello
+            pathType: Prefix
+            backend:
+              service:
+                name: node-service
+                port:
+                  number: 8080

--- a/examples/vote-helm/base-chart/templates/ingress.yaml
+++ b/examples/vote-helm/base-chart/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "base-chart.fullname" . -}}
 {{- $ingressPaths := .Values.ingress.paths -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -32,9 +32,12 @@ spec:
         paths:
 	{{- range $ingressPaths }}
           - path: {{ . }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: 80
 	{{- end }}
   {{- end }}
 {{- end }}

--- a/examples/vote-helm/vote/templates/ingress.yaml
+++ b/examples/vote-helm/vote/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "vote.fullname" . -}}
 {{- $ingressPaths := .Values.ingress.paths -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -32,9 +32,12 @@ spec:
         paths:
 	{{- range $ingressPaths }}
           - path: {{ . }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: 80
 	{{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:

Update the ingress spec in our examples to use `networking.k8s.io/v1`. The examples still using `extensions/v1beta1` or 
`networking.k8s.io/v1beta1` stopped working in Kubernetes 1.22.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
