### PR TITLE
fix(core): ignore trailing slashes in project config domains

### DIFF
--- a/core/src/cloud/api.ts
+++ b/core/src/cloud/api.ts
@@ -94,12 +94,12 @@ export async function getEnterpriseConfig(currentDirectory: string) {
     })
   }
 
-  const domain = projectConfig.domain
   const projectId = projectConfig.id
-  if (!domain || !projectId) {
+  if (!projectId || !projectConfig.domain) {
     return
   }
 
+  const domain = new URL(projectConfig.domain).origin
   return { domain, projectId }
 }
 
@@ -204,7 +204,8 @@ export class CloudApi {
     enterpriseLog?.setSuccess({ msg: chalk.green("Done"), append: true })
     try {
       const project = await api.getProject()
-      enterpriseLog?.info({ symbol: "info", msg: `Visit project at ${api.domain}/projects/${project.id}` })
+      const url = new URL(`/projects/${project.id}`, api.domain)
+      enterpriseLog?.info({ symbol: "info", msg: `Visit project at ${url.href}` })
     } catch (err) {
       log.debug(`Getting project from API failed with error: err.message`)
     }
@@ -419,7 +420,8 @@ export class CloudApi {
       requestOptions.retry = 0 // Disables retry
     }
 
-    const res = await got<T>(`${this.domain}/${this.apiPrefix}/${path}`, requestOptions)
+    const url = new URL(`/${this.apiPrefix}/${path}`, this.domain)
+    const res = await got<T>(url.href, requestOptions)
 
     if (!isObject(res.body)) {
       throw new EnterpriseApiError(`Unexpected API response`, {
@@ -527,9 +529,8 @@ export class CloudApi {
   async checkClientAuthToken(): Promise<boolean> {
     let valid = false
     try {
-      this.log.debug(
-        `Checking client auth token with ${getCloudDistributionName(this.domain)}: ${this.domain}/token/verify`
-      )
+      const url = new URL("/token/verify", this.domain)
+      this.log.debug(`Checking client auth token with ${getCloudDistributionName(this.domain)}: ${url.href}`)
       await this.get("token/verify")
       valid = true
     } catch (err) {

--- a/core/src/cloud/auth.ts
+++ b/core/src/cloud/auth.ts
@@ -41,7 +41,8 @@ export class AuthRedirectServer {
     }
 
     await this.createApp()
-    await open(`${this.enterpriseDomain}/clilogin/${this.port}`)
+    const url = new URL(`/clilogin/${this.port}`, this.enterpriseDomain)
+    await open(url.href)
   }
 
   async close() {
@@ -63,6 +64,8 @@ export class AuthRedirectServer {
       this.log.debug("Received client auth token")
       this.events.emit("receivedToken", tokenResponse)
       ctx.redirect(`${this.enterpriseDomain}/clilogin/success`)
+      const url = new URL("/clilogin/success", this.enterpriseDomain)
+      ctx.redirect(url.href)
     })
 
     app.use(bodyParser())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:

Currently, if a domain contains a trailing slash in the project config it can cause garden to redirect to incorrect URLs, for example, attempting to log in with the domain set to `https://example.com/` will yield a login URL with two slashes after the origin (i.e. `https://example.com//clilogin/123`. This PR updates all the instances I found where this issue can occur using the `URL` builtin.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
