### PR TITLE
fix(cli): potential OOM error for large projects

### DIFF
--- a/cli/bin/garden
+++ b/cli/bin/garden
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --max-old-space-size=4096
 
 if (process.env.GARDEN_ENABLE_PROFILING === "1" || process.env.GARDEN_ENABLE_PROFILING === "true") {
   // Patch require to profile module loading

--- a/cli/bin/garden-debug
+++ b/cli/bin/garden-debug
@@ -1,3 +1,3 @@
-#!/usr/bin/env node --inspect
+#!/usr/bin/env node --inspect --max-old-space-size=4096
 
 require("./garden")

--- a/cli/src/build-pkg.ts
+++ b/cli/src/build-pkg.ts
@@ -28,6 +28,9 @@ const pkgFetchPath = resolve(repoRoot, "node_modules", ".bin", "pkg-fetch")
 const distPath = resolve(repoRoot, "dist")
 const sqliteBinFilename = "better_sqlite3.node"
 
+// Allow larger heap size than default
+const nodeOptions = ["max-old-space-size=4096"]
+
 // tslint:disable: no-console
 
 interface TargetHandlerParams {
@@ -232,7 +235,15 @@ async function pkgCommon({
   await mkdirp(targetPath)
 
   console.log(` - ${targetName} -> pkg`)
-  await exec(pkgPath, ["--target", pkgType, sourcePath, "--output", resolve(targetPath, binFilename)])
+  await exec(pkgPath, [
+    "--target",
+    pkgType,
+    sourcePath,
+    "--options",
+    nodeOptions.join(","),
+    "--output",
+    resolve(targetPath, binFilename),
+  ])
 
   console.log(` - ${targetName} -> ${sqliteBinFilename}`)
   await copy(


### PR DESCRIPTION
This raises the maximum heap size for uncollected objects in the process, which may be necessary for large projects.