### PR TITLE
improvement(core): evaluate null|false as undefined for dockerfile field

### DIFF
--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -832,7 +832,12 @@ export const containerModuleSpecSchema = () =>
         specifies a remote image, Garden automatically sets \`include\` to \`[]\`.
       `),
       hotReload: hotReloadConfigSchema(),
-      dockerfile: joi.posixPath().subPathOnly().description("POSIX-style name of Dockerfile, relative to module root."),
+      dockerfile: joi
+        .posixPath()
+        .subPathOnly()
+        .allow(false, null)
+        .empty([false, null])
+        .description("POSIX-style name of Dockerfile, relative to module root."),
       services: joiSparseArray(containerServiceSchema())
         .unique("name")
         .description("A list of services to deploy from this container module."),


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:

We want to better handle optional strings in general at the schema
validation level by  mapping null and false to undefined.
However that's a bigger change that requires proper testing and
documentation.

We'll do that in a follow up PR but just getting this small fix out now
to unblock some users.


**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
