### PR TITLE
feat(core): add template string sha256 function

### DIFF
--- a/core/src/template-string/functions.ts
+++ b/core/src/template-string/functions.ts
@@ -7,6 +7,7 @@
  */
 
 import { v4 as uuidv4 } from "uuid"
+import { createHash } from "crypto"
 import { TemplateStringError } from "../exceptions"
 import { keyBy, mapValues, escapeRegExp, trim, isEmpty, camelCase, kebabCase, isArrayLike } from "lodash"
 import { joi, JoiDescription, joiPrimitive, Primitive } from "../config/common"
@@ -185,6 +186,18 @@ const helperFunctionSpecs: TemplateHelperFunction[] = [
     ],
     fn: (str: string, substring: string, replacement: string) =>
       str.replace(new RegExp(escapeRegExp(substring), "g"), replacement),
+  },
+  {
+    name: "sha256",
+    description: "Creates a SHA256 hash of the provided string.",
+    arguments: {
+      string: joi.string().required().description("The string to hash."),
+    },
+    outputSchema: joi.string(),
+    exampleArguments: [
+      { input: ["Some String"], output: "7f0fd64653ba0bb1a579ced2b6bf375e916cc60662109ee0c0b24f0a750c3a6c" },
+    ],
+    fn: (str: string) => createHash("sha256").update(str).digest("hex"),
   },
   {
     name: "slice",

--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -1066,6 +1066,11 @@ describe("resolveTemplateString", async () => {
       expect(res).to.equal("Zm9v")
     })
 
+    it("generates a correct hash with a string literal from the sha256 helper function", () => {
+      const res = resolveTemplateString("${sha256('This Is A Test String')}", new TestContext({}))
+      expect(res).to.equal("9a058284378d1cc6b4348aacb6ba847918376054b094bbe06eb5302defc52685")
+    })
+
     it("throws if an argument is missing", () => {
       expectError(
         () => resolveTemplateString("${base64Decode()}", new TestContext({})),

--- a/docs/reference/template-strings.md
+++ b/docs/reference/template-strings.md
@@ -137,6 +137,16 @@ Examples:
 * `${replace("string_with_underscores", "_", "-")}` -> `"string-with-underscores"`
 * `${replace("remove.these.dots", ".", "")}` -> `"removethesedots"`
 
+### sha256
+
+Creates a SHA256 hash of the provided string.
+
+Usage: `sha256(string)`
+
+Examples:
+
+* `${sha256("Some String")}` -> `"7f0fd64653ba0bb1a579ced2b6bf375e916cc60662109ee0c0b24f0a750c3a6c"`
+
 ### slice
 
 Slices a string or array at the specified start/end offsets. Note that you can use a negative number for the end offset to count backwards from the end.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:

We have the need for stable but unguessable identifiers for some aspects of our Garden stacks. Unfortunately uuidv4 as a template string function satisfies the latter requirement, but would presumably change on every deploy so we'll end up with a continually changing stack. Using a hashing function would satisfy both requirements.

This PR just adds a template string `sha256` based on the crypto package in the standard library.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:
