### PR TITLE
improve(k8s): pick up ingresses from kubernetes and helm modules

### DIFF
--- a/core/src/plugins/kubernetes/kubernetes-module/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/handlers.ts
@@ -27,6 +27,7 @@ import { apply, deleteObjectsBySelector, KUBECTL_DEFAULT_TIMEOUT } from "../kube
 import { streamK8sLogs } from "../logs"
 import { getModuleNamespace, getModuleNamespaceStatus } from "../namespace"
 import { getForwardablePorts, getPortForwardHandler, killPortForwards } from "../port-forward"
+import { getK8sIngresses } from "../status/ingress"
 import { compareDeployedResources, isConfiguredForDevMode, waitForResources } from "../status/status"
 import { getTaskResult } from "../task-results"
 import { getTestResult } from "../test-results"
@@ -136,6 +137,7 @@ export async function getKubernetesServiceStatus({
     detail: { remoteResources },
     devMode: deployedWithDevMode || deployedWithHotReloading,
     namespaceStatuses: [namespaceStatus],
+    ingresses: getK8sIngresses(remoteResources),
   }
 }
 

--- a/core/src/plugins/kubernetes/status/ingress.ts
+++ b/core/src/plugins/kubernetes/status/ingress.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2018-2022 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { ServiceIngress } from "../../../types/service"
+import { KubernetesIngress, KubernetesResource } from "../types"
+
+/**
+ * Returns a list of ServiceIngresses found in a list of k8s resources.
+ *
+ * Does a best-effort extraction based on known ingress resource types.
+ */
+export function getK8sIngresses(resources: KubernetesResource[]): ServiceIngress[] {
+  const output: ServiceIngress[] = []
+
+  for (const r of resources.filter(isIngressResource)) {
+    const tlsHosts = r.spec.tls?.flatMap((t) => t.hosts || []) || []
+
+    for (const rule of r.spec.rules || []) {
+      if (!rule.host) {
+        continue
+      }
+
+      // TODO: handle wildcards more specifically
+      for (const path of rule.http?.paths || []) {
+        let stringPath: string
+
+        if (typeof path !== "string") {
+          // Handle extensions/v1beta1
+          if (!path.path) {
+            // There should always be a path, but the type doesn't guarantee it, skip if missing
+            continue
+          }
+          stringPath = path.path
+        } else {
+          stringPath = path
+        }
+
+        output.push({
+          hostname: rule.host,
+          protocol: tlsHosts.includes(rule.host) ? "https" : "http",
+          path: stringPath,
+        })
+      }
+    }
+  }
+
+  return output
+}
+
+export function isIngressResource(resource: KubernetesResource): resource is KubernetesIngress {
+  if (resource.kind === "Ingress") {
+    if (
+      resource.apiVersion === "networking.k8s.io/v1" ||
+      resource.apiVersion === "networking.k8s.io/v1beta1" ||
+      resource.apiVersion === "extensions/v1beta1"
+    ) {
+      return true
+    }
+  }
+  return false
+}

--- a/core/src/plugins/kubernetes/types.ts
+++ b/core/src/plugins/kubernetes/types.ts
@@ -15,6 +15,9 @@ import {
   V1StatefulSet,
   V1Pod,
   V1ListMeta,
+  V1Ingress,
+  NetworkingV1beta1Ingress,
+  ExtensionsV1beta1Ingress,
 } from "@kubernetes/client-node"
 
 import { Omit } from "../../util/util"
@@ -77,6 +80,7 @@ export type KubernetesStatefulSet = KubernetesResource<V1StatefulSet>
 export type KubernetesPod = KubernetesResource<V1Pod>
 
 export type KubernetesWorkload = KubernetesResource<V1DaemonSet | V1Deployment | V1ReplicaSet | V1StatefulSet>
+export type KubernetesIngress = KubernetesResource<V1Ingress | NetworkingV1beta1Ingress | ExtensionsV1beta1Ingress>
 
 export function isPodResource(resource: KubernetesWorkload | KubernetesPod): resource is KubernetesPod {
   return resource.kind === "Pod"

--- a/core/src/types/service.ts
+++ b/core/src/types/service.ts
@@ -111,8 +111,12 @@ export interface ServiceIngressSpec {
   protocol: ServiceProtocol
 }
 
-export interface ServiceIngress extends ServiceIngressSpec {
+export interface ServiceIngress {
   hostname: string
+  linkUrl?: string
+  path: string
+  port?: number
+  protocol: ServiceProtocol
 }
 
 export const ingressHostnameSchema = () =>
@@ -149,7 +153,6 @@ export const serviceIngressSchema = () =>
   serviceIngressSpecSchema()
     .keys({
       hostname: joi.string().required().description("The hostname where the service can be accessed."),
-      port: portSchema().required(),
     })
     .unknown(true)
     .description("A description of a deployed service ingress.")

--- a/core/test/unit/src/plugins/kubernetes/status/ingress.ts
+++ b/core/test/unit/src/plugins/kubernetes/status/ingress.ts
@@ -1,0 +1,342 @@
+/*
+ * Copyright (C) 2018-2022 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { ExtensionsV1beta1Ingress, NetworkingV1beta1Ingress, V1Ingress } from "@kubernetes/client-node"
+import { expect } from "chai"
+import { getK8sIngresses } from "../../../../../../src/plugins/kubernetes/status/ingress"
+import { KubernetesResource } from "../../../../../../src/plugins/kubernetes/types"
+
+describe("getK8sIngresses", () => {
+  it("ignores non-Ingress resources", () => {
+    const resources: KubernetesResource[] = [
+      {
+        apiVersion: "v1",
+        kind: "Service",
+        metadata: {
+          name: "foo",
+        },
+        spec: {},
+      },
+      {
+        apiVersion: "v1",
+        kind: "Deployment",
+        metadata: {
+          name: "foo",
+        },
+        spec: {},
+      },
+    ]
+    expect(getK8sIngresses(resources)).to.eql([])
+  })
+
+  it("picks up extensions/v1beta1 Ingress resource", () => {
+    const ingress: KubernetesResource<ExtensionsV1beta1Ingress> = {
+      apiVersion: "extensions/v1beta1",
+      kind: "Ingress",
+      metadata: {
+        name: "foo",
+      },
+      spec: {
+        rules: [
+          {
+            host: "a.com",
+            http: {
+              paths: [
+                { path: "/a1", backend: { serviceName: "one" } },
+                { path: "/a2", backend: { serviceName: "two" } },
+              ],
+            },
+          },
+          {
+            host: "b.com",
+            http: {
+              paths: [
+                { path: "/b1", backend: { serviceName: "one" } },
+                { path: "/b2", backend: { serviceName: "two" } },
+              ],
+            },
+          },
+        ],
+      },
+    }
+    expect(getK8sIngresses([ingress])).to.eql([
+      {
+        hostname: "a.com",
+        path: "/a1",
+        protocol: "http",
+      },
+      {
+        hostname: "a.com",
+        path: "/a2",
+        protocol: "http",
+      },
+      {
+        hostname: "b.com",
+        path: "/b1",
+        protocol: "http",
+      },
+      {
+        hostname: "b.com",
+        path: "/b2",
+        protocol: "http",
+      },
+    ])
+  })
+
+  it("picks up networking.k8s.io/v1beta1 Ingress resource", () => {
+    const ingress: KubernetesResource<NetworkingV1beta1Ingress> = {
+      apiVersion: "networking.k8s.io/v1beta1",
+      kind: "Ingress",
+      metadata: {
+        name: "foo",
+      },
+      spec: {
+        rules: [
+          {
+            host: "a.com",
+            http: {
+              paths: [
+                { path: "/a1", backend: { serviceName: "one" } },
+                { path: "/a2", backend: { serviceName: "two" } },
+              ],
+            },
+          },
+          {
+            host: "b.com",
+            http: {
+              paths: [
+                { path: "/b1", backend: { serviceName: "one" } },
+                { path: "/b2", backend: { serviceName: "two" } },
+              ],
+            },
+          },
+        ],
+      },
+    }
+    expect(getK8sIngresses([ingress])).to.eql([
+      {
+        hostname: "a.com",
+        path: "/a1",
+        protocol: "http",
+      },
+      {
+        hostname: "a.com",
+        path: "/a2",
+        protocol: "http",
+      },
+      {
+        hostname: "b.com",
+        path: "/b1",
+        protocol: "http",
+      },
+      {
+        hostname: "b.com",
+        path: "/b2",
+        protocol: "http",
+      },
+    ])
+  })
+
+  it("picks up networking.k8s.io/v1 Ingress resource", () => {
+    const ingress: KubernetesResource<V1Ingress> = {
+      apiVersion: "networking.k8s.io/v1beta1",
+      kind: "Ingress",
+      metadata: {
+        name: "foo",
+      },
+      spec: {
+        rules: [
+          {
+            host: "a.com",
+            http: {
+              paths: [
+                { path: "/a1", backend: { service: { name: "one" } } },
+                { path: "/a2", backend: { service: { name: "two" } } },
+              ],
+            },
+          },
+          {
+            host: "b.com",
+            http: {
+              paths: [
+                { path: "/b1", backend: { service: { name: "one" } } },
+                { path: "/b2", backend: { service: { name: "two" } } },
+              ],
+            },
+          },
+        ],
+      },
+    }
+    expect(getK8sIngresses([ingress])).to.eql([
+      {
+        hostname: "a.com",
+        path: "/a1",
+        protocol: "http",
+      },
+      {
+        hostname: "a.com",
+        path: "/a2",
+        protocol: "http",
+      },
+      {
+        hostname: "b.com",
+        path: "/b1",
+        protocol: "http",
+      },
+      {
+        hostname: "b.com",
+        path: "/b2",
+        protocol: "http",
+      },
+    ])
+  })
+
+  it("sets https protocol if host is in tls.hosts", () => {
+    const ingress: KubernetesResource<V1Ingress> = {
+      apiVersion: "networking.k8s.io/v1beta1",
+      kind: "Ingress",
+      metadata: {
+        name: "foo",
+      },
+      spec: {
+        rules: [
+          {
+            host: "a.com",
+            http: {
+              paths: [
+                { path: "/a1", backend: { service: { name: "one" } } },
+                { path: "/a2", backend: { service: { name: "two" } } },
+              ],
+            },
+          },
+          {
+            host: "b.com",
+            http: {
+              paths: [
+                { path: "/b1", backend: { service: { name: "one" } } },
+                { path: "/b2", backend: { service: { name: "two" } } },
+              ],
+            },
+          },
+        ],
+        tls: [{ hosts: ["b.com", "c.com"] }],
+      },
+    }
+    expect(getK8sIngresses([ingress])).to.eql([
+      {
+        hostname: "a.com",
+        path: "/a1",
+        protocol: "http",
+      },
+      {
+        hostname: "a.com",
+        path: "/a2",
+        protocol: "http",
+      },
+      {
+        hostname: "b.com",
+        path: "/b1",
+        protocol: "https",
+      },
+      {
+        hostname: "b.com",
+        path: "/b2",
+        protocol: "https",
+      },
+    ])
+  })
+
+  it("ignores rule without hosts set", () => {
+    const ingress: KubernetesResource<V1Ingress> = {
+      apiVersion: "networking.k8s.io/v1beta1",
+      kind: "Ingress",
+      metadata: {
+        name: "foo",
+      },
+      spec: {
+        rules: [
+          {
+            host: "a.com",
+            http: {
+              paths: [
+                { path: "/a1", backend: { service: { name: "one" } } },
+                { path: "/a2", backend: { service: { name: "two" } } },
+              ],
+            },
+          },
+          {
+            // host: "b.com", <---
+            http: {
+              paths: [
+                { path: "/b1", backend: { service: { name: "one" } } },
+                { path: "/b2", backend: { service: { name: "two" } } },
+              ],
+            },
+          },
+        ],
+      },
+    }
+    expect(getK8sIngresses([ingress])).to.eql([
+      {
+        hostname: "a.com",
+        path: "/a1",
+        protocol: "http",
+      },
+      {
+        hostname: "a.com",
+        path: "/a2",
+        protocol: "http",
+      },
+    ])
+  })
+
+  it("ignores rule path without path field set", () => {
+    const ingress: KubernetesResource<V1Ingress> = {
+      apiVersion: "networking.k8s.io/v1beta1",
+      kind: "Ingress",
+      metadata: {
+        name: "foo",
+      },
+      spec: {
+        rules: [
+          {
+            host: "a.com",
+            http: {
+              paths: [
+                { path: "/a1", backend: { service: { name: "one" } } },
+                { backend: { service: { name: "two" } } }, // <---
+              ],
+            },
+          },
+          {
+            host: "b.com",
+            http: {
+              paths: [
+                { backend: { service: { name: "one" } } }, // <---
+                { path: "/b2", backend: { service: { name: "two" } } },
+              ],
+            },
+          },
+        ],
+        tls: [{ hosts: ["b.com", "c.com"] }],
+      },
+    }
+    expect(getK8sIngresses([ingress])).to.eql([
+      {
+        hostname: "a.com",
+        path: "/a1",
+        protocol: "http",
+      },
+      {
+        hostname: "b.com",
+        path: "/b2",
+        protocol: "https",
+      },
+    ])
+  })
+})

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -149,7 +149,11 @@ deployments:
 
     # List of currently deployed ingress endpoints for the service.
     ingresses:
-      - # The ingress path that should be matched to route to this service.
+      - # The port number that the service is exposed on internally.
+        # This defaults to the first specified port for the service.
+        port:
+
+        # The ingress path that should be matched to route to this service.
         path:
 
         # The protocol to use for the ingress.
@@ -157,10 +161,6 @@ deployments:
 
         # The hostname where the service can be accessed.
         hostname:
-
-        # The port number that the service is exposed on internally.
-        # This defaults to the first specified port for the service.
-        port:
 
     # Latest status message of the service (if any).
     lastMessage:
@@ -484,7 +484,11 @@ serviceStatuses:
 
     # List of currently deployed ingress endpoints for the service.
     ingresses:
-      - # The ingress path that should be matched to route to this service.
+      - # The port number that the service is exposed on internally.
+        # This defaults to the first specified port for the service.
+        port:
+
+        # The ingress path that should be matched to route to this service.
         path:
 
         # The protocol to use for the ingress.
@@ -492,10 +496,6 @@ serviceStatuses:
 
         # The hostname where the service can be accessed.
         hostname:
-
-        # The port number that the service is exposed on internally.
-        # This defaults to the first specified port for the service.
-        port:
 
     # Latest status message of the service (if any).
     lastMessage:
@@ -594,7 +594,11 @@ Examples:
 
   # List of currently deployed ingress endpoints for the service.
   ingresses:
-    - # The ingress path that should be matched to route to this service.
+    - # The port number that the service is exposed on internally.
+      # This defaults to the first specified port for the service.
+      port:
+
+      # The ingress path that should be matched to route to this service.
       path:
 
       # The protocol to use for the ingress.
@@ -602,10 +606,6 @@ Examples:
 
       # The hostname where the service can be accessed.
       hostname:
-
-      # The port number that the service is exposed on internally.
-      # This defaults to the first specified port for the service.
-      port:
 
   # Latest status message of the service (if any).
   lastMessage:
@@ -757,7 +757,11 @@ deployments:
 
     # List of currently deployed ingress endpoints for the service.
     ingresses:
-      - # The ingress path that should be matched to route to this service.
+      - # The port number that the service is exposed on internally.
+        # This defaults to the first specified port for the service.
+        port:
+
+        # The ingress path that should be matched to route to this service.
         path:
 
         # The protocol to use for the ingress.
@@ -765,10 +769,6 @@ deployments:
 
         # The hostname where the service can be accessed.
         hostname:
-
-        # The port number that the service is exposed on internally.
-        # This defaults to the first specified port for the service.
-        port:
 
     # Latest status message of the service (if any).
     lastMessage:
@@ -2381,7 +2381,11 @@ services:
 
     # List of currently deployed ingress endpoints for the service.
     ingresses:
-      - # The ingress path that should be matched to route to this service.
+      - # The port number that the service is exposed on internally.
+        # This defaults to the first specified port for the service.
+        port:
+
+        # The ingress path that should be matched to route to this service.
         path:
 
         # The protocol to use for the ingress.
@@ -2389,10 +2393,6 @@ services:
 
         # The hostname where the service can be accessed.
         hostname:
-
-        # The port number that the service is exposed on internally.
-        # This defaults to the first specified port for the service.
-        port:
 
     # Latest status message of the service (if any).
     lastMessage:
@@ -2949,7 +2949,11 @@ deployments:
 
     # List of currently deployed ingress endpoints for the service.
     ingresses:
-      - # The ingress path that should be matched to route to this service.
+      - # The port number that the service is exposed on internally.
+        # This defaults to the first specified port for the service.
+        port:
+
+        # The ingress path that should be matched to route to this service.
         path:
 
         # The protocol to use for the ingress.
@@ -2957,10 +2961,6 @@ deployments:
 
         # The hostname where the service can be accessed.
         hostname:
-
-        # The port number that the service is exposed on internally.
-        # This defaults to the first specified port for the service.
-        port:
 
     # Latest status message of the service (if any).
     lastMessage:
@@ -3524,7 +3524,11 @@ deployments:
 
     # List of currently deployed ingress endpoints for the service.
     ingresses:
-      - # The ingress path that should be matched to route to this service.
+      - # The port number that the service is exposed on internally.
+        # This defaults to the first specified port for the service.
+        port:
+
+        # The ingress path that should be matched to route to this service.
         path:
 
         # The protocol to use for the ingress.
@@ -3532,10 +3536,6 @@ deployments:
 
         # The hostname where the service can be accessed.
         hostname:
-
-        # The port number that the service is exposed on internally.
-        # This defaults to the first specified port for the service.
-        port:
 
     # Latest status message of the service (if any).
     lastMessage:


### PR DESCRIPTION
This adds a best-effort extraction of ingresses from the resources generated
in `kubernetes` and `helm` modules.
