### PR TITLE
fix(scripts): fixed deps installation script

### DIFF
--- a/scripts/install-osx-dependencies.sh
+++ b/scripts/install-osx-dependencies.sh
@@ -14,11 +14,19 @@ brew install --cask google-cloud-sdk
 gcloud components update
 gcloud components install beta
 
-# install nvm and node
+# install nvm
 curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.35.1/install.sh | bash
+# make nvm command active without terminal reopening
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+# install node
 nvm install 12
 nvm alias default 12
 nvm use default
 
 # install/update global packages
 npm install -g gulp-cli ts-node typescript
+
+# install yarn
+npm install --global yarn


### PR DESCRIPTION
**What this PR does / why we need it:**
`nvm` command fails in the `install-osx-dependencies.sh` script because it is not visible in the script after the installation. The fix is based on the suggestion from the installer.
 
This PR also adds `yarn` installation command to the `install-osx-dependencies.sh`.