### PR TITLE
Fix exec error log streaming

### DIFF
--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -819,7 +819,7 @@ export const containerModuleSpecSchema = () =>
         Specify extra flags to use when building the container image.
         Note that arguments may not be portable across implementations.`),
       // TODO: validate the image name format
-      image: joi.string().description(deline`
+      image: joi.string().allow(false, null).empty([false, null]).description(deline`
         Specify the image name for the container. Should be a valid Docker image identifier. If specified and
         the module does not contain a Dockerfile, this image will be used to deploy services for this module.
         If specified and the module does contain a Dockerfile, this identifier is used when pushing the built image.`),

--- a/core/src/plugins/exec/logs.ts
+++ b/core/src/plugins/exec/logs.ts
@@ -39,7 +39,7 @@ export type LocalServiceLogEntry = ServiceLogEntry & {
 }
 
 function isValidServiceLogEntry(entry: any): entry is LocalServiceLogEntry {
-  if (!entry.timestamp || !entry.level) {
+  if (!entry.timestamp || isNaN(entry.level)) {
     return false
   }
 

--- a/core/test/unit/src/plugins/exec/logs.ts
+++ b/core/test/unit/src/plugins/exec/logs.ts
@@ -86,6 +86,31 @@ describe("ExecLogsFollower", () => {
       expect(logs).to.eql(entries)
     })
 
+    it("should include error entries", async () => {
+      const logFilePath = join(tmpDir.path, `log-${randomString(8)}.jsonl`)
+      const [stream, logs] = getStream()
+
+      const execLogsFollower = new ExecLogsFollower({
+        stream,
+        serviceName: "foo",
+        log,
+        logFilePath,
+      })
+
+      const entries = range(10).map((el) => ({
+        msg: String(el),
+        timestamp: new Date(),
+        serviceName: "foo",
+        level: 0,
+      }))
+
+      await writeLogFile(logFilePath, entries)
+
+      await execLogsFollower.streamLogs({ follow: false })
+
+      expect(logs).to.eql(entries)
+    })
+
     it("should optionally stream last N entries", async () => {
       const logFilePath = join(tmpDir.path, `log-${randomString(8)}.jsonl`)
       const [stream, logs] = getStream()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:

From individual commits:

[fix(core): treat null/false as undefined for container image field](https://github.com/garden-io/garden/commit/df9c3c64a27549700e31d90d078d4a6c9f854a74) 

We want to add a Joi schema that treats null/false values as undefined
for optional strings in general but this is just a quick fix to unblock
a user.

And:

[fix(core): treat null/false as undefined for container image field](https://github.com/garden-io/garden/commit/df9c3c64a27549700e31d90d078d4a6c9f854a74) 

We want to add a Joi schema that treats null/false values as undefined
for optional strings in general but this is just a quick fix to unblock
a user.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
