### PR TITLE
improvement(k8s): bump BuildKit version to 0.9.3

### DIFF
--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -36,7 +36,7 @@ import { getDockerBuildArgs } from "../../../container/build"
 import { getRunningDeploymentPod, millicpuToString, megabytesToString, usingInClusterRegistry } from "../../util"
 import { PodRunner } from "../../run"
 
-export const buildkitImageName = "gardendev/buildkit:v0.8.1-4"
+export const buildkitImageName = "gardendev/buildkit:v0.9.3-1"
 export const buildkitDeploymentName = "garden-buildkit"
 const buildkitContainerName = "buildkitd"
 

--- a/images/buildkit/Dockerfile
+++ b/images/buildkit/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE_SUFFIX
-ARG BUILDKIT_VERSION=v0.8.1
+ARG BUILDKIT_VERSION=v0.9.3
 FROM moby/buildkit:${BUILDKIT_VERSION} as deps
 
 RUN apk add --no-cache curl

--- a/images/buildkit/garden.yml
+++ b/images/buildkit/garden.yml
@@ -2,7 +2,7 @@ kind: Module
 type: container
 name: buildkit
 description: Used for the cluster-buildkit build mode in the kubernetes provider
-image: gardendev/buildkit:v0.8.1-4
+image: gardendev/buildkit:v0.9.3-1
 dockerfile: Dockerfile
 build:
   targetImage: output
@@ -11,7 +11,7 @@ kind: Module
 type: container
 name: buildkit-rootless
 description: Used for the cluster-buildkit build mode in the kubernetes provider, rootless variant
-image: gardendev/buildkit:v0.8.1-4-rootless
+image: gardendev/buildkit:v0.9.3-1-rootless
 dockerfile: Dockerfile
 build:
   dependencies:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:

Updates the version of BuildKit used for the `cluster-buildkit` build mode from 0.8.1 to 0.9.3.

The accompanying Docker images have been built and published.

**Which issue(s) this PR fixes**:

Fixes #2815.