### PR TITLE
chore: fix string replacement in mutagen syncs

### DIFF
--- a/core/src/plugins/kubernetes/mutagen.ts
+++ b/core/src/plugins/kubernetes/mutagen.ts
@@ -578,7 +578,7 @@ export async function getKubectlExecDestination({
   targetPath: string
 }) {
   const kubectl = ctx.tools["kubernetes.kubectl"]
-  const kubectlPath = (await kubectl.getPath(log)).replaceAll(" ", "\\ ") // Escape spaces in path
+  const kubectlPath = (await kubectl.getPath(log)).replace(/ /g, "\\ ") // Escape spaces in path
 
   const connectionOpts = prepareConnectionOpts({
     provider: ctx.provider,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:

The `replaceAll` method isn't available on older Node versions. This didn't trigger any errors during CI, but was revealed during pre-release testing.