### PR TITLE
fix(k8s): escape spaces in local mutagen dests

### DIFF
--- a/core/src/plugins/kubernetes/dev-mode.ts
+++ b/core/src/plugins/kubernetes/dev-mode.ts
@@ -214,7 +214,7 @@ export async function startDevModeSync({
     for (const s of spec.sync) {
       const key = `${keyBase}-${i}`
 
-      const localPath = joinWithPosix(moduleRoot, s.source)
+      const localPath = joinWithPosix(moduleRoot, s.source).replace(/ /g, "\\ ") // Escape spaces in path
       const remoteDestination = await getKubectlExecDestination({
         ctx: k8sCtx,
         log,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:

This fixes an error that occurs when syncing to/from a local path that contains spaces.