### PR TITLE
fix: maven download for windows

### DIFF
--- a/plugins/jib/maven.ts
+++ b/plugins/jib/maven.ts
@@ -43,9 +43,11 @@ export const mavenSpec: PluginToolSpec = {
       platform: "windows",
       architecture: "amd64",
       ...spec,
+      url: "https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip",
+      sha256: "444522b0af3a85e966f25c50adfcd00a1a6fc5fce79f503bff096e02b9977c2e",
       extract: {
         format: "zip",
-        targetPath: spec.extract.targetPath + ".bat",
+        targetPath: spec.extract.targetPath + ".cmd",
       },
     },
   ],


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:
It fixes an issue where garden tries to extract a downloaded maven tarball with zip on windows.
**Which issue(s) this PR fixes**:

Fixes #2849 

**Special notes for your reviewer**:
