### PR TITLE
refactor: update rbac api versions for kind resources

### DIFF
--- a/static/kubernetes/system/nginx-kind/garden.yml
+++ b/static/kubernetes/system/nginx-kind/garden.yml
@@ -70,7 +70,7 @@ manifests:
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
 
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       name: nginx-ingress-clusterrole
@@ -127,7 +127,7 @@ manifests:
         verbs:
           - update
 
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
       name: nginx-ingress-role
@@ -171,7 +171,7 @@ manifests:
         verbs:
           - get
 
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
       name: nginx-ingress-role-nisa-binding
@@ -188,7 +188,7 @@ manifests:
         name: nginx-ingress-serviceaccount
         namespace: ${var.namespace}
 
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
       name: nginx-ingress-clusterrole-nisa-binding


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:
The static resources deployed for kind were using the kubernetes api version `rbac.authorization.k8s.io/v1beta1` that have been deprecated in kubernetes 1.22. 
The api version `rbac.authorization.k8s.io/v1` is available since kubernetes 1.18.
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
