### PR TITLE
fix(exec): properly handle empty lines in local service logs

### DIFF
--- a/core/src/plugins/exec/exec.ts
+++ b/core/src/plugins/exec/exec.ts
@@ -388,6 +388,7 @@ function runPersistent({
       transform(chunk, _encoding, cb) {
         const line = chunk.toString().trim()
         if (!line) {
+          cb(null)
           return
         }
         const entry = {

--- a/core/test/data/test-project-exec/module-local-persistent/garden.yml
+++ b/core/test/data/test-project-exec/module-local-persistent/garden.yml
@@ -11,6 +11,10 @@ services:
     devMode:
       command: [/bin/bash -c 'for((i=1;i<=5;i+=1)); do echo "Hello $i"; done']
     deployCommand: []
+  - name: dev-mode-with-empty-log-lines
+    devMode:
+      command: [/bin/bash -c 'for((i=1;i<=3;i+=1)); do printf "Hello\n\n$i\n"; done']
+    deployCommand: []
   - name: dev-mode-timeout
     persistent: true
     devMode:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:

Before this fix, log streaming would simply stop if a line was empty.
This could e.g. happen on double new-lines.

This commit fixes the issue and adds a unit test.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
