### PR TITLE
fix(cli): avoid unnecessary git scan at startup

### DIFF
--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -496,6 +496,10 @@ ${renderCommands(commands)}
       return done(1, chalk.red(`Could not find specified root path (${argv.root})`))
     }
 
+    if (argv._.length === 0 || argv._[0] === "help") {
+      return done(0, await this.renderHelp(workingDir))
+    }
+
     let projectConfig: ProjectResource | undefined
 
     // First look for native Garden commands
@@ -514,7 +518,7 @@ ${renderCommands(commands)}
     }
 
     if (!command) {
-      const exitCode = argv.h || argv.help || argv._[0] === "help" ? 0 : 1
+      const exitCode = argv.h || argv.help ? 0 : 1
       return done(exitCode, await this.renderHelp(workingDir))
     }
 

--- a/core/test/unit/src/cli/cli.ts
+++ b/core/test/unit/src/cli/cli.ts
@@ -59,7 +59,7 @@ describe("cli", () => {
     it("aborts with help text if no positional argument is provided", async () => {
       const { code, consoleOutput } = await cli.run({ args: [], exitOnError: false })
 
-      expect(code).to.equal(1)
+      expect(code).to.equal(0)
       expect(consoleOutput).to.equal(await cli.renderHelp("/"))
     })
 


### PR DESCRIPTION
This was both inefficient and unnecessary, and could cause issues in some edge cases (as discovered by a user).