### PR TITLE
fix(cli): uncaught promise error when version check fails

### DIFF
--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -403,8 +403,11 @@ ${renderCommands(commands)}
         analytics = await AnalyticsHandler.init(garden, log)
         analytics.trackCommand(command.getFullName())
 
-        // tslint:disable-next-line: no-floating-promises
-        checkForUpdates(garden.globalConfigStore, headerLog)
+        // Note: No reason to await the check
+        checkForUpdates(garden.globalConfigStore, headerLog).catch((err) => {
+          headerLog.verbose("Something went wrong while checking for the latest Garden version.")
+          headerLog.verbose(err)
+        })
 
         await checkForStaticDir()
 


### PR DESCRIPTION
Users would see some log spam upon certain errors during the version check. This cleans that up.

As a general note, let's _please_ not allow floating promises and do this type of catching instead.