### PR TITLE
fix(template): error in && operator during partial initial resolution

### DIFF
--- a/core/src/template-string/parser.pegjs
+++ b/core/src/template-string/parser.pegjs
@@ -327,7 +327,7 @@ EqualityOperator
 LogicalANDExpression
   = head:EqualityExpression
     tail:(__ LogicalANDOperator __ EqualityExpression)*
-    { return buildLogicalExpression(head, tail); }
+    { return buildLogicalExpression(head, tail, options); }
 
 LogicalANDOperator
   = "&&"
@@ -335,7 +335,7 @@ LogicalANDOperator
 LogicalORExpression
   = head:LogicalANDExpression
     tail:(__ LogicalOROperator __ LogicalANDExpression)*
-    { return buildLogicalExpression(head, tail); }
+    { return buildLogicalExpression(head, tail, options); }
 
 LogicalOROperator
   = "||"

--- a/core/src/template-string/template-string.ts
+++ b/core/src/template-string/template-string.ts
@@ -557,7 +557,7 @@ function buildBinaryExpression(head: any, tail: any) {
   }, head)
 }
 
-function buildLogicalExpression(head: any, tail: any) {
+function buildLogicalExpression(head: any, tail: any, opts: ContextResolveOpts) {
   return tail.reduce((result: any, element: any) => {
     const operator = element[1]
     const leftRes = result
@@ -566,24 +566,28 @@ function buildLogicalExpression(head: any, tail: any) {
     switch (operator) {
       case "&&":
         if (leftRes && leftRes._error) {
-          if (leftRes._error.type === missingKeyExceptionType) {
+          if (!opts.allowPartial && leftRes._error.type === missingKeyExceptionType) {
             return false
           }
           return leftRes
         }
+
         const leftValue = getValue(leftRes)
+
         if (leftValue === undefined) {
           return { resolved: false }
         } else if (!leftValue) {
           return { resolved: leftValue }
         } else {
           if (rightRes && rightRes._error) {
-            if (rightRes._error.type === missingKeyExceptionType) {
+            if (!opts.allowPartial && rightRes._error.type === missingKeyExceptionType) {
               return false
             }
             return rightRes
           }
+
           const rightValue = getValue(rightRes)
+
           if (rightValue === undefined) {
             return { resolved: false }
           } else {

--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -340,35 +340,54 @@ describe("resolveTemplateString", async () => {
     expect(res).to.equal("b")
   })
 
-  it("should handle a logical AND between booleans", async () => {
-    const res = resolveTemplateString("${true && a}", new TestContext({ a: true }))
-    expect(res).to.equal(true)
-  })
+  context("logical AND (&& operator)", () => {
+    it("true literal and true variable reference", async () => {
+      const res = resolveTemplateString("${true && a}", new TestContext({ a: true }))
+      expect(res).to.equal(true)
+    })
 
-  it("should handle a logical AND where the first part is false but the second part is not resolvable", async () => {
-    // i.e. the 2nd clause should not need to be evaluated
-    const res = resolveTemplateString("${false && a}", new TestContext({}))
-    expect(res).to.equal(false)
-  })
+    it("two true variable references", async () => {
+      const res = resolveTemplateString("${var.a && var.b}", new TestContext({ var: { a: true, b: true } }))
+      expect(res).to.equal(true)
+    })
 
-  it("should handle a logical AND with an empty string as the first clause", async () => {
-    const res = resolveTemplateString("${'' && true}", new TestContext({}))
-    expect(res).to.equal("")
-  })
+    it("first part is false but the second part is not resolvable", async () => {
+      // i.e. the 2nd clause should not need to be evaluated
+      const res = resolveTemplateString("${false && a}", new TestContext({}))
+      expect(res).to.equal(false)
+    })
 
-  it("should handle a logical AND with an empty string as the second clause", async () => {
-    const res = resolveTemplateString("${true && ''}", new TestContext({}))
-    expect(res).to.equal("")
-  })
+    it("an empty string as the first clause", async () => {
+      const res = resolveTemplateString("${'' && true}", new TestContext({}))
+      expect(res).to.equal("")
+    })
 
-  it("should handle a logical AND with a missing reference as the first clause", async () => {
-    const res = resolveTemplateString("${var.foo && 'a'}", new TestContext({ var: {} }))
-    expect(res).to.equal(false)
-  })
+    it("an empty string as the second clause", async () => {
+      const res = resolveTemplateString("${true && ''}", new TestContext({}))
+      expect(res).to.equal("")
+    })
 
-  it("should handle a logical AND with a missing reference as the second clause", async () => {
-    const res = resolveTemplateString("${'a' && var.foo}", new TestContext({ var: {} }))
-    expect(res).to.equal(false)
+    it("a missing reference as the first clause", async () => {
+      const res = resolveTemplateString("${var.foo && 'a'}", new TestContext({ var: {} }))
+      expect(res).to.equal(false)
+    })
+
+    it("a missing reference as the second clause", async () => {
+      const res = resolveTemplateString("${'a' && var.foo}", new TestContext({ var: {} }))
+      expect(res).to.equal(false)
+    })
+
+    context("partial resolution", () => {
+      it("a missing reference as the first clause returns the original template", async () => {
+        const res = resolveTemplateString("${var.foo && 'a'}", new TestContext({ var: {} }), { allowPartial: true })
+        expect(res).to.equal("${var.foo && 'a'}")
+      })
+
+      it("a missing reference as the second clause returns the original template", async () => {
+        const res = resolveTemplateString("${'a' && var.foo}", new TestContext({ var: {} }), { allowPartial: true })
+        expect(res).to.equal("${'a' && var.foo}")
+      })
+    })
   })
 
   it("should handle a positive equality comparison between equal resolved values", async () => {


### PR DESCRIPTION
We would prematurely resolve a template string as false, where referenced
values would be resolvable later.
