### PR TITLE
fix: add default ingress class for nginx ingress controller

### DIFF
--- a/static/kubernetes/system/ingress-controller/garden.yml
+++ b/static/kubernetes/system/ingress-controller/garden.yml
@@ -28,5 +28,9 @@ values:
     nodeSelector: ${var.system-node-selector}
     admissionWebhooks:
       enabled: false
+    ingressClassResource:
+      name: nginx
+      enabled: true
+      default: true
   defaultBackend:
     enabled: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:
The Garden shipped ingress controller sets it's own `ingressClass` to the default one, which makes it pick up ingresses that don't have the `ingressClass` param specified.
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
