### PR TITLE
fix(core): always show dashboard link

### DIFF
--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -402,7 +402,7 @@ ${renderCommands(commands)}
             namespaceUrl = url.href
           }
 
-          // Print a different header and footer when persistent and connected to Garden Cloud.
+          // Print a specific header and footer when persistent and connected to Garden Cloud.
           if (persistent && namespaceUrl) {
             const distroName = getCloudDistributionName(cloudApi?.domain || "")
             nsLog.setState(
@@ -414,14 +414,14 @@ ${renderCommands(commands)}
               })
             )
             const msg = dedent`
-              ${chalk.cyan(`Connected to ${distroName}! Visit your namespace to stream logs and more.`)}
+              \n${nodeEmoji.lightning}   ${chalk.cyan(`Connected to ${distroName}! Visit your namespace to stream logs and more.`)}
               ${nodeEmoji.link}  ${chalk.blueBright.underline(namespaceUrl)}
             `
-            footerLog.info({
-              emoji: "sunflower",
-              msg,
-            })
-          } else if (persistent && command.server) {
+            footerLog.info(msg)
+          }
+
+          // TODO: "Tone down" dashboard link when connected to Garden Cloud.
+          if (persistent && command.server) {
             // If there is an explicit `garden dashboard` process running for the current project+env, and a server
             // is started in this Command, we show the URL to the external dashboard. Otherwise the built-in one.
 
@@ -439,6 +439,7 @@ ${renderCommands(commands)}
             if (dashboardProcess) {
               url = `${dashboardProcess.serverHost}?key=${dashboardProcess.serverAuthKey}`
             }
+
             command.server.showUrl(url)
           }
         }

--- a/core/src/server/server.ts
+++ b/core/src/server/server.ts
@@ -132,7 +132,7 @@ export class GardenServer {
   showUrl(url?: string) {
     this.statusLog.setState({
       emoji: "sunflower",
-      msg: chalk.cyan("Garden dashboard running at ") + (url || this.getUrl()),
+      msg: chalk.cyan("Garden dashboard running at ") + chalk.blueBright(url || this.getUrl()),
     })
   }
 


### PR DESCRIPTION
We removed the dashboard link in favour of a link to the Garden Cloud
namespace for Cloud users, but in hindsight we should also print the
dashboard link for them.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
