### PR TITLE
fix: update nginx ingress controller for kind

### DIFF
--- a/static/kubernetes/system/nginx-kind/garden.yml
+++ b/static/kubernetes/system/nginx-kind/garden.yml
@@ -2,317 +2,634 @@ kind: Module
 name: nginx-kind
 description: Special manifests for installing nginx on KinD clusters
 type: kubernetes
+variables:
+  namespace: ingress-nginx
 manifests:
   - apiVersion: v1
     kind: Service
     metadata:
-      name: ingress-nginx
-      namespace: ${var.namespace}
       labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.1.3
+      name: ingress-nginx-controller
+      namespace: ${var.namespace}
     spec:
-      type: NodePort
       ports:
-        - name: http
-          port: 80
-          targetPort: 80
-          protocol: TCP
-        - name: https
-          port: 443
-          targetPort: 443
-          protocol: TCP
+      - appProtocol: http
+        name: http
+        port: 80
+        protocol: TCP
+        targetPort: http
+      - appProtocol: https
+        name: https
+        port: 443
+        protocol: TCP
+        targetPort: https
       selector:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: ingress-nginx
+        app.kubernetes.io/name: ingress-nginx
+      type: NodePort
+
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.1.3
+      name: ingress-nginx-controller-admission
+      namespace: ${var.namespace}
+    spec:
+      ports:
+      - appProtocol: https
+        name: https-webhook
+        port: 443
+        targetPort: webhook
+      selector:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: ingress-nginx
+        app.kubernetes.io/name: ingress-nginx
+      type: ClusterIP
 
   - apiVersion: v1
     kind: Namespace
     metadata:
+      labels:
+        app.kubernetes.io/instance: ingress-nginx
+        app.kubernetes.io/name: ingress-nginx
+      name: ${var.namespace}
+
+  - apiVersion: v1
+    data:
+      allow-snippet-annotations: "true"
+    kind: ConfigMap
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: ingress-nginx
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.1.3
+      name: ingress-nginx-controller
+      namespace: ${var.namespace}
+
+  - apiVersion: v1
+    automountServiceAccountToken: true
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: ingress-nginx
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.1.3
       name: ingress-nginx
-      labels:
-        app.kubernetes.io/name: ingress-nginx
-        app.kubernetes.io/part-of: ingress-nginx
-
-  - kind: ConfigMap
-    apiVersion: v1
-    metadata:
-      name: nginx-configuration
       namespace: ${var.namespace}
-      labels:
-        app.kubernetes.io/name: ingress-nginx
-        app.kubernetes.io/part-of: ingress-nginx
-
-  - kind: ConfigMap
-    apiVersion: v1
-    metadata:
-      name: tcp-services
-      namespace: ${var.namespace}
-      labels:
-        app.kubernetes.io/name: ingress-nginx
-        app.kubernetes.io/part-of: ingress-nginx
-
-  - kind: ConfigMap
-    apiVersion: v1
-    metadata:
-      name: udp-services
-      namespace: ${var.namespace}
-      labels:
-        app.kubernetes.io/name: ingress-nginx
-        app.kubernetes.io/part-of: ingress-nginx
 
   - apiVersion: v1
     kind: ServiceAccount
     metadata:
-      name: nginx-ingress-serviceaccount
-      namespace: ${var.namespace}
       labels:
+        app.kubernetes.io/component: admission-webhook
+        app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.1.3
+      name: ingress-nginx-admission
+      namespace: ${var.namespace}
 
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
-      name: nginx-ingress-clusterrole
       labels:
+        app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.1.3
+      name: ingress-nginx
     rules:
-      - apiGroups:
-          - ""
-        resources:
-          - configmaps
-          - endpoints
-          - nodes
-          - pods
-          - secrets
-        verbs:
-          - list
-          - watch
-      - apiGroups:
-          - ""
-        resources:
-          - nodes
-        verbs:
-          - get
-      - apiGroups:
-          - ""
-        resources:
-          - services
-        verbs:
-          - get
-          - list
-          - watch
-      - apiGroups:
-          - ""
-        resources:
-          - events
-        verbs:
-          - create
-          - patch
-      - apiGroups:
-          - "extensions"
-          - "networking.k8s.io"
-        resources:
-          - ingresses
-        verbs:
-          - get
-          - list
-          - watch
-      - apiGroups:
-          - "extensions"
-          - "networking.k8s.io"
-        resources:
-          - ingresses/status
-        verbs:
-          - update
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      - endpoints
+      - nodes
+      - pods
+      - secrets
+      - namespaces
+      verbs:
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - services
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - networking.k8s.io
+      resources:
+      - ingresses
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - create
+      - patch
+    - apiGroups:
+      - networking.k8s.io
+      resources:
+      - ingresses/status
+      verbs:
+      - update
+    - apiGroups:
+      - networking.k8s.io
+      resources:
+      - ingressclasses
+      verbs:
+      - get
+      - list
+      - watch
 
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      labels:
+        app.kubernetes.io/component: admission-webhook
+        app.kubernetes.io/instance: ingress-nginx
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.1.3
+      name: ingress-nginx-admission
+    rules:
+    - apiGroups:
+      - admissionregistration.k8s.io
+      resources:
+      - validatingwebhookconfigurations
+      verbs:
+      - get
+      - update
+
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
-      name: nginx-ingress-role
-      namespace: ${var.namespace}
       labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.1.3
+      name: ingress-nginx
+      namespace: ${var.namespace}
     rules:
-      - apiGroups:
-          - ""
-        resources:
-          - configmaps
-          - pods
-          - secrets
-          - namespaces
-        verbs:
-          - get
-      - apiGroups:
-          - ""
-        resources:
-          - configmaps
-        resourceNames:
-          # Defaults to "<election-id>-<ingress-class>"
-          # Here: "<ingress-controller-leader>-<nginx>"
-          # This has to be adapted if you change either parameter
-          # when launching the nginx-ingress-controller.
-          - "ingress-controller-leader-nginx"
-        verbs:
-          - get
-          - update
-      - apiGroups:
-          - ""
-        resources:
-          - configmaps
-        verbs:
-          - create
-      - apiGroups:
-          - ""
-        resources:
-          - endpoints
-        verbs:
-          - get
+    - apiGroups:
+      - ""
+      resources:
+      - namespaces
+      verbs:
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      - pods
+      - secrets
+      - endpoints
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - services
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - networking.k8s.io
+      resources:
+      - ingresses
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - networking.k8s.io
+      resources:
+      - ingresses/status
+      verbs:
+      - update
+    - apiGroups:
+      - networking.k8s.io
+      resources:
+      - ingressclasses
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resourceNames:
+      - ingress-controller-leader
+      resources:
+      - configmaps
+      verbs:
+      - get
+      - update
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - create
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - create
+      - patch
 
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      labels:
+        app.kubernetes.io/component: admission-webhook
+        app.kubernetes.io/instance: ingress-nginx
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.1.3
+      name: ingress-nginx-admission
+      namespace: ${var.namespace}
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - secrets
+      verbs:
+      - get
+      - create
+
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
-      name: nginx-ingress-role-nisa-binding
-      namespace: ${var.namespace}
       labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.1.3
+      name: ingress-nginx
+      namespace: ${var.namespace}
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: Role
-      name: nginx-ingress-role
+      name: ingress-nginx
     subjects:
-      - kind: ServiceAccount
-        name: nginx-ingress-serviceaccount
-        namespace: ${var.namespace}
+    - kind: ServiceAccount
+      name: ingress-nginx
+      namespace: ${var.namespace}
 
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
-    kind: ClusterRoleBinding
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
     metadata:
-      name: nginx-ingress-clusterrole-nisa-binding
       labels:
+        app.kubernetes.io/component: admission-webhook
+        app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.1.3
+      name: ingress-nginx-admission
+      namespace: ${var.namespace}
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: ingress-nginx-admission
+    subjects:
+    - kind: ServiceAccount
+      name: ingress-nginx-admission
+      namespace: ${var.namespace}
+
+
+
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        app.kubernetes.io/instance: ingress-nginx
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.1.3
+      name: ingress-nginx
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: ClusterRole
-      name: nginx-ingress-clusterrole
+      name: ingress-nginx
     subjects:
-      - kind: ServiceAccount
-        name: nginx-ingress-serviceaccount
-        namespace: ${var.namespace}
+    - kind: ServiceAccount
+      name: ingress-nginx
+      namespace: ${var.namespace}
+
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      labels:
+        app.kubernetes.io/component: admission-webhook
+        app.kubernetes.io/instance: ingress-nginx
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.1.3
+      name: ingress-nginx-admission
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: ingress-nginx-admission
+    subjects:
+    - kind: ServiceAccount
+      name: ingress-nginx-admission
+      namespace: ${var.namespace}
 
   - apiVersion: apps/v1
     kind: Deployment
     metadata:
-      name: nginx-ingress-controller
-      namespace: ${var.namespace}
       labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.1.3
+      name: ingress-nginx-controller
+      namespace: ${var.namespace}
     spec:
-      replicas: 1
-      strategy:
-        # We only want one instance at a time, because we otherwise get a port conflict
-        type: Recreate
+      minReadySeconds: 0
+      revisionHistoryLimit: 10
       selector:
         matchLabels:
+          app.kubernetes.io/component: controller
+          app.kubernetes.io/instance: ingress-nginx
           app.kubernetes.io/name: ingress-nginx
-          app.kubernetes.io/part-of: ingress-nginx
+      strategy:
+        rollingUpdate:
+          maxUnavailable: 1
+        type: RollingUpdate
       template:
         metadata:
           labels:
+            app.kubernetes.io/component: controller
+            app.kubernetes.io/instance: ingress-nginx
             app.kubernetes.io/name: ingress-nginx
-            app.kubernetes.io/part-of: ingress-nginx
-          annotations:
-            prometheus.io/port: "10254"
-            prometheus.io/scrape: "true"
         spec:
-          # wait up to five minutes for the drain of connections
-          terminationGracePeriodSeconds: 300
-          serviceAccountName: nginx-ingress-serviceaccount
-          nodeSelector:
-            kubernetes.io/os: linux
-            ingress-ready: "true" # <- kind customization
-          tolerations: # <- kind customization
-            - key: node-role.kubernetes.io/master
-              operator: Equal
-              effect: NoSchedule
           containers:
-            - name: nginx-ingress-controller
-              image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.30.0
-              args:
-                - /nginx-ingress-controller
-                - --configmap=$(POD_NAMESPACE)/nginx-configuration
-                - --tcp-services-configmap=$(POD_NAMESPACE)/tcp-services
-                - --udp-services-configmap=$(POD_NAMESPACE)/udp-services
-                - --publish-service=$(POD_NAMESPACE)/ingress-nginx
-                - --annotations-prefix=nginx.ingress.kubernetes.io
-              securityContext:
-                allowPrivilegeEscalation: true
-                capabilities:
-                  drop:
-                    - ALL
-                  add:
-                    - NET_BIND_SERVICE
-                # www-data -> 101
-                runAsUser: 101
-              env:
-                - name: POD_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.name
-                - name: POD_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.namespace
-              ports:
-                - name: http
-                  containerPort: 80
-                  hostPort: 80  # <- kind customization
-                  protocol: TCP
-                - name: https
-                  containerPort: 443
-                  hostPort: 443  # <- kind customization
-                  protocol: TCP
-              livenessProbe:
-                failureThreshold: 3
-                httpGet:
-                  path: /healthz
-                  port: 10254
-                  scheme: HTTP
-                initialDelaySeconds: 10
-                periodSeconds: 10
-                successThreshold: 1
-                timeoutSeconds: 10
-              readinessProbe:
-                failureThreshold: 3
-                httpGet:
-                  path: /healthz
-                  port: 10254
-                  scheme: HTTP
-                periodSeconds: 10
-                successThreshold: 1
-                timeoutSeconds: 10
-              lifecycle:
-                preStop:
-                  exec:
-                    command:
-                      - /wait-shutdown
-
-  - apiVersion: v1
-    kind: LimitRange
+          - args:
+            - /nginx-ingress-controller
+            - --election-id=ingress-controller-leader
+            - --controller-class=k8s.io/ingress-nginx
+            - --ingress-class=nginx
+            - --configmap=$(POD_NAMESPACE)/ingress-nginx-controller
+            - --validating-webhook=:8443
+            - --validating-webhook-certificate=/usr/local/certificates/cert
+            - --validating-webhook-key=/usr/local/certificates/key
+            - --watch-ingress-without-class=true
+            - --publish-status-address=localhost
+            env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: LD_PRELOAD
+              value: /usr/local/lib/libmimalloc.so
+            image: k8s.gcr.io/ingress-nginx/controller:v1.1.3@sha256:31f47c1e202b39fadecf822a9b76370bd4baed199a005b3e7d4d1455f4fd3fe2
+            imagePullPolicy: IfNotPresent
+            lifecycle:
+              preStop:
+                exec:
+                  command:
+                  - /wait-shutdown
+            livenessProbe:
+              failureThreshold: 5
+              httpGet:
+                path: /healthz
+                port: 10254
+                scheme: HTTP
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              successThreshold: 1
+              timeoutSeconds: 1
+            name: controller
+            ports:
+            - containerPort: 80
+              hostPort: 80
+              name: http
+              protocol: TCP
+            - containerPort: 443
+              hostPort: 443
+              name: https
+              protocol: TCP
+            - containerPort: 8443
+              name: webhook
+              protocol: TCP
+            readinessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /healthz
+                port: 10254
+                scheme: HTTP
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              successThreshold: 1
+              timeoutSeconds: 1
+            resources:
+              requests:
+                cpu: 100m
+                memory: 90Mi
+            securityContext:
+              allowPrivilegeEscalation: true
+              capabilities:
+                add:
+                - NET_BIND_SERVICE
+                drop:
+                - ALL
+              runAsUser: 101
+            volumeMounts:
+            - mountPath: /usr/local/certificates/
+              name: webhook-cert
+              readOnly: true
+          dnsPolicy: ClusterFirst
+          nodeSelector:
+            ingress-ready: "true"
+            kubernetes.io/os: linux
+          serviceAccountName: ingress-nginx
+          terminationGracePeriodSeconds: 0
+          tolerations:
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/master
+            operator: Equal
+          volumes:
+          - name: webhook-cert
+            secret:
+              secretName: ingress-nginx-admission
+  - apiVersion: batch/v1
+    kind: Job
     metadata:
-      name: ingress-nginx
-      namespace: ${var.namespace}
       labels:
+        app.kubernetes.io/component: admission-webhook
+        app.kubernetes.io/instance: ingress-nginx
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.1.3
+      name: ingress-nginx-admission-create
+      namespace: ${var.namespace}
     spec:
-      limits:
-      - min:
-          memory: 90Mi
-          cpu: 100m
-        type: Container
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: admission-webhook
+            app.kubernetes.io/instance: ingress-nginx
+            app.kubernetes.io/name: ingress-nginx
+            app.kubernetes.io/part-of: ingress-nginx
+            app.kubernetes.io/version: 1.1.3
+          name: ingress-nginx-admission-create
+        spec:
+          containers:
+          - args:
+            - create
+            - --host=ingress-nginx-controller-admission,ingress-nginx-controller-admission.$(POD_NAMESPACE).svc
+            - --namespace=$(POD_NAMESPACE)
+            - --secret-name=ingress-nginx-admission
+            env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660
+            imagePullPolicy: IfNotPresent
+            name: create
+            securityContext:
+              allowPrivilegeEscalation: false
+          nodeSelector:
+            kubernetes.io/os: linux
+          restartPolicy: OnFailure
+          securityContext:
+            fsGroup: 2000
+            runAsNonRoot: true
+            runAsUser: 2000
+          serviceAccountName: ingress-nginx-admission
+  - apiVersion: batch/v1
+    kind: Job
+    metadata:
+      labels:
+        app.kubernetes.io/component: admission-webhook
+        app.kubernetes.io/instance: ingress-nginx
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.1.3
+      name: ingress-nginx-admission-patch
+      namespace: ${var.namespace}
+    spec:
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: admission-webhook
+            app.kubernetes.io/instance: ingress-nginx
+            app.kubernetes.io/name: ingress-nginx
+            app.kubernetes.io/part-of: ingress-nginx
+            app.kubernetes.io/version: 1.1.3
+          name: ingress-nginx-admission-patch
+        spec:
+          containers:
+          - args:
+            - patch
+            - --webhook-name=ingress-nginx-admission
+            - --namespace=$(POD_NAMESPACE)
+            - --patch-mutating=false
+            - --secret-name=ingress-nginx-admission
+            - --patch-failure-policy=Fail
+            env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660
+            imagePullPolicy: IfNotPresent
+            name: patch
+            securityContext:
+              allowPrivilegeEscalation: false
+          nodeSelector:
+            kubernetes.io/os: linux
+          restartPolicy: OnFailure
+          securityContext:
+            fsGroup: 2000
+            runAsNonRoot: true
+            runAsUser: 2000
+          serviceAccountName: ingress-nginx-admission
+  - apiVersion: networking.k8s.io/v1
+    kind: IngressClass
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: ingress-nginx
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.1.3
+      annotations:
+        ingressclass.kubernetes.io/is-default-class: "true"
+      name: nginx
+    spec:
+      controller: k8s.io/ingress-nginx
+  - apiVersion: admissionregistration.k8s.io/v1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      labels:
+        app.kubernetes.io/component: admission-webhook
+        app.kubernetes.io/instance: ingress-nginx
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.1.3
+      name: ingress-nginx-admission
+    webhooks:
+    - admissionReviewVersions:
+      - v1
+      clientConfig:
+        service:
+          name: ingress-nginx-controller-admission
+          namespace: ${var.namespace}
+          path: /networking/v1/ingresses
+      failurePolicy: Fail
+      matchPolicy: Equivalent
+      name: validate.nginx.ingress.kubernetes.io
+      rules:
+      - apiGroups:
+        - networking.k8s.io
+        apiVersions:
+        - v1
+        operations:
+        - CREATE
+        - UPDATE
+        resources:
+        - ingresses
+      sideEffects: None


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:
The NGINX ingress controller deployed for Kind clusters was out of date and contained several incompatible API types to Kubernetes versions >= 1.22. 
This PR updates the resource to the [latest manifests](https://kind.sigs.k8s.io/docs/user/ingress/#ingress-nginx) as proposed by the kind team. 
The updated manifests work for Kind clusters >= 1.21. In case we are looking for backward compatibility, we can look into adjusting the API versions of `batch/v1` to `batch/v1beta1`.
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
