### PR TITLE
feat: add skip-comments option to cli create command

### DIFF
--- a/core/src/commands/create/create-module.ts
+++ b/core/src/commands/create/create-module.ts
@@ -198,9 +198,9 @@ export class CreateModuleCommand extends Command<CreateModuleArgs, CreateModuleO
 
     const { yaml } = renderConfigReference(schema, {
       yamlOpts: {
-        commentOutEmpty: true,
+        onEmptyValue: opts.noComments ? "remove" : "comment out",
         filterMarkdown: true,
-        renderBasicDescription: true,
+        renderBasicDescription: !opts.noComments,
         renderFullDescription: false,
         renderValue: "preferExample",
         presetValues,

--- a/core/src/commands/create/create-module.ts
+++ b/core/src/commands/create/create-module.ts
@@ -198,9 +198,9 @@ export class CreateModuleCommand extends Command<CreateModuleArgs, CreateModuleO
 
     const { yaml } = renderConfigReference(schema, {
       yamlOpts: {
-        onEmptyValue: opts.noComments ? "remove" : "comment out",
+        onEmptyValue: opts["skip-comments"] ? "remove" : "comment out",
         filterMarkdown: true,
-        renderBasicDescription: !opts.noComments,
+        renderBasicDescription: !opts["skip-comments"],
         renderFullDescription: false,
         renderValue: "preferExample",
         presetValues,

--- a/core/src/commands/create/create-module.ts
+++ b/core/src/commands/create/create-module.ts
@@ -16,7 +16,7 @@ import { loadConfigResources, findProjectConfig } from "../../config/base"
 import { resolve, basename, relative, join } from "path"
 import { GardenBaseError, ParameterError } from "../../exceptions"
 import { getModuleTypes, getPluginBaseNames } from "../../plugins"
-import { addConfig } from "./helpers"
+import { addConfig, createBaseOpts } from "./helpers"
 import { getSupportedPlugins } from "../../plugins/plugins"
 import { baseModuleSpecSchema } from "../../config/module"
 import { renderConfigReference } from "../../docs/config"
@@ -35,6 +35,7 @@ import { userPrompt } from "../../util/util"
 
 const createModuleArgs = {}
 const createModuleOpts = {
+  ...createBaseOpts,
   dir: new PathParameter({
     help: "Directory to place the module in (defaults to current directory).",
     defaultValue: ".",

--- a/core/src/commands/create/create-project.ts
+++ b/core/src/commands/create/create-project.ts
@@ -16,7 +16,7 @@ import { loadConfigResources } from "../../config/base"
 import { resolve, basename, relative, join } from "path"
 import { GardenBaseError, ParameterError } from "../../exceptions"
 import { renderProjectConfigReference } from "../../docs/config"
-import { addConfig } from "./helpers"
+import { addConfig, createBaseOpts } from "./helpers"
 import { wordWrap } from "../../util/string"
 import { LoggerType } from "../../logger/logger"
 import { PathParameter, StringParameter, BooleanParameter, StringOption } from "../../cli/params"
@@ -33,6 +33,7 @@ export const defaultProjectConfigFilename = "project.garden.yml"
 
 const createProjectArgs = {}
 const createProjectOpts = {
+  ...createBaseOpts,
   dir: new PathParameter({
     help: "Directory to place the project in (defaults to current directory).",
     defaultValue: ".",

--- a/core/src/commands/create/create-project.ts
+++ b/core/src/commands/create/create-project.ts
@@ -141,9 +141,9 @@ export class CreateProjectCommand extends Command<CreateProjectArgs, CreateProje
 
     const { yaml } = renderProjectConfigReference({
       yamlOpts: {
-        commentOutEmpty: true,
+        onEmptyValue: opts.noComments ? "remove" : "comment out",
         filterMarkdown: true,
-        renderBasicDescription: true,
+        renderBasicDescription: !opts.noComments,
         renderFullDescription: false,
         renderValue: "preferExample",
         presetValues: {

--- a/core/src/commands/create/create-project.ts
+++ b/core/src/commands/create/create-project.ts
@@ -141,9 +141,9 @@ export class CreateProjectCommand extends Command<CreateProjectArgs, CreateProje
 
     const { yaml } = renderProjectConfigReference({
       yamlOpts: {
-        onEmptyValue: opts.noComments ? "remove" : "comment out",
+        onEmptyValue: opts["skip-comments"] ? "remove" : "comment out",
         filterMarkdown: true,
-        renderBasicDescription: !opts.noComments,
+        renderBasicDescription: !opts["skip-comments"],
         renderFullDescription: false,
         renderValue: "preferExample",
         presetValues: {

--- a/core/src/commands/create/helpers.ts
+++ b/core/src/commands/create/helpers.ts
@@ -7,6 +7,15 @@
  */
 
 import { pathExists, readFile, writeFile } from "fs-extra"
+import { BooleanParameter } from "../../cli/params"
+
+export const createBaseOpts = {
+  noComments: new BooleanParameter({
+    alias: "no-comments",
+    help: "Set to true to disable comment generation.",
+    defaultValue: false,
+  }),
+}
 
 export async function addConfig(configPath: string, yaml: string) {
   let output = yaml

--- a/core/src/commands/create/helpers.ts
+++ b/core/src/commands/create/helpers.ts
@@ -10,7 +10,7 @@ import { pathExists, readFile, writeFile } from "fs-extra"
 import { BooleanParameter } from "../../cli/params"
 
 export const createBaseOpts = {
-  noComments: new BooleanParameter({
+  "skip-comments": new BooleanParameter({
     help: "Set to true to disable comment generation.",
     defaultValue: false,
   }),

--- a/core/src/commands/create/helpers.ts
+++ b/core/src/commands/create/helpers.ts
@@ -11,7 +11,6 @@ import { BooleanParameter } from "../../cli/params"
 
 export const createBaseOpts = {
   noComments: new BooleanParameter({
-    alias: "no-comments",
     help: "Set to true to disable comment generation.",
     defaultValue: false,
   }),

--- a/core/test/unit/src/commands/create/create-module.ts
+++ b/core/test/unit/src/commands/create/create-module.ts
@@ -52,6 +52,7 @@ describe("CreateModuleCommand", () => {
         name: undefined,
         type: "exec",
         filename: defaultConfigFilename,
+        noComments: false,
       }),
     })
     const { name, configPath } = result!
@@ -84,6 +85,7 @@ describe("CreateModuleCommand", () => {
         name: "test",
         type: "exec",
         filename: "custom.garden.yml",
+        noComments: false,
       }),
     })
     const { configPath } = result!
@@ -105,6 +107,7 @@ describe("CreateModuleCommand", () => {
         name: "test",
         type: "exec",
         filename: defaultConfigFilename,
+        noComments: false,
       }),
     })
     const { name, configPath } = result!
@@ -140,6 +143,7 @@ describe("CreateModuleCommand", () => {
         name: "test",
         type: "exec",
         filename: defaultConfigFilename,
+        noComments: false,
       }),
     })
     const { name, configPath } = result!
@@ -178,6 +182,7 @@ describe("CreateModuleCommand", () => {
             name: "test",
             type: "exec",
             filename: defaultConfigFilename,
+            noComments: false,
           }),
         }),
       (err) => expect(stripAnsi(err.message)).to.equal("A Garden module named test already exists in " + configPath)
@@ -200,6 +205,7 @@ describe("CreateModuleCommand", () => {
             name: "test",
             type: "exec",
             filename: defaultConfigFilename,
+            noComments: false,
           }),
         }),
       (err) => expect(err.message).to.equal(`Path ${dir} does not exist`)
@@ -221,6 +227,7 @@ describe("CreateModuleCommand", () => {
             name: undefined,
             type: "foo",
             filename: defaultConfigFilename,
+            noComments: false,
           }),
         }),
       (err) => expect(stripAnsi(err.message)).to.equal("Could not find module type foo")

--- a/core/test/unit/src/commands/create/create-module.ts
+++ b/core/test/unit/src/commands/create/create-module.ts
@@ -48,11 +48,11 @@ describe("CreateModuleCommand", () => {
       args: {},
       opts: withDefaultGlobalOpts({
         dir,
-        interactive: false,
-        name: undefined,
-        type: "exec",
-        filename: defaultConfigFilename,
-        noComments: false,
+        "interactive": false,
+        "name": undefined,
+        "type": "exec",
+        "filename": defaultConfigFilename,
+        "skip-comments": false,
       }),
     })
     const { name, configPath } = result!
@@ -80,12 +80,12 @@ describe("CreateModuleCommand", () => {
       log: garden.log,
       args: {},
       opts: withDefaultGlobalOpts({
-        dir: tmp.path,
-        interactive: false,
-        name: "test",
-        type: "exec",
-        filename: "custom.garden.yml",
-        noComments: false,
+        "dir": tmp.path,
+        "interactive": false,
+        "name": "test",
+        "type": "exec",
+        "filename": "custom.garden.yml",
+        "skip-comments": false,
       }),
     })
     const { configPath } = result!
@@ -102,12 +102,12 @@ describe("CreateModuleCommand", () => {
       log: garden.log,
       args: {},
       opts: withDefaultGlobalOpts({
-        dir: tmp.path,
-        interactive: false,
-        name: "test",
-        type: "exec",
-        filename: defaultConfigFilename,
-        noComments: false,
+        "dir": tmp.path,
+        "interactive": false,
+        "name": "test",
+        "type": "exec",
+        "filename": defaultConfigFilename,
+        "skip-comments": false,
       }),
     })
     const { name, configPath } = result!
@@ -138,12 +138,12 @@ describe("CreateModuleCommand", () => {
       log: garden.log,
       args: {},
       opts: withDefaultGlobalOpts({
-        dir: tmp.path,
-        interactive: false,
-        name: "test",
-        type: "exec",
-        filename: defaultConfigFilename,
-        noComments: false,
+        "dir": tmp.path,
+        "interactive": false,
+        "name": "test",
+        "type": "exec",
+        "filename": defaultConfigFilename,
+        "skip-comments": false,
       }),
     })
     const { name, configPath } = result!
@@ -177,12 +177,12 @@ describe("CreateModuleCommand", () => {
           log: garden.log,
           args: {},
           opts: withDefaultGlobalOpts({
-            dir: tmp.path,
-            interactive: false,
-            name: "test",
-            type: "exec",
-            filename: defaultConfigFilename,
-            noComments: false,
+            "dir": tmp.path,
+            "interactive": false,
+            "name": "test",
+            "type": "exec",
+            "filename": defaultConfigFilename,
+            "skip-comments": false,
           }),
         }),
       (err) => expect(stripAnsi(err.message)).to.equal("A Garden module named test already exists in " + configPath)
@@ -201,11 +201,11 @@ describe("CreateModuleCommand", () => {
           args: {},
           opts: withDefaultGlobalOpts({
             dir,
-            interactive: false,
-            name: "test",
-            type: "exec",
-            filename: defaultConfigFilename,
-            noComments: false,
+            "interactive": false,
+            "name": "test",
+            "type": "exec",
+            "filename": defaultConfigFilename,
+            "skip-comments": false,
           }),
         }),
       (err) => expect(err.message).to.equal(`Path ${dir} does not exist`)
@@ -222,12 +222,12 @@ describe("CreateModuleCommand", () => {
           log: garden.log,
           args: {},
           opts: withDefaultGlobalOpts({
-            dir: tmp.path,
-            interactive: false,
-            name: undefined,
-            type: "foo",
-            filename: defaultConfigFilename,
-            noComments: false,
+            "dir": tmp.path,
+            "interactive": false,
+            "name": undefined,
+            "type": "foo",
+            "filename": defaultConfigFilename,
+            "skip-comments": false,
           }),
         }),
       (err) => expect(stripAnsi(err.message)).to.equal("Could not find module type foo")

--- a/core/test/unit/src/commands/create/create-project.ts
+++ b/core/test/unit/src/commands/create/create-project.ts
@@ -43,6 +43,7 @@ describe("CreateProjectCommand", () => {
         interactive: false,
         name: undefined,
         filename: defaultProjectConfigFilename,
+        noComments: false,
       }),
     })
     const { name, configPath, ignoreFileCreated, ignoreFilePath } = result!
@@ -81,6 +82,7 @@ describe("CreateProjectCommand", () => {
         interactive: false,
         name: undefined,
         filename: defaultProjectConfigFilename,
+        noComments: false,
       }),
     })
     const { ignoreFileCreated, ignoreFilePath } = result!
@@ -105,6 +107,7 @@ describe("CreateProjectCommand", () => {
         interactive: false,
         name: undefined,
         filename: defaultProjectConfigFilename,
+        noComments: false,
       }),
     })
     const { ignoreFileCreated, ignoreFilePath } = result!
@@ -126,6 +129,7 @@ describe("CreateProjectCommand", () => {
         interactive: false,
         name: "foo",
         filename: defaultProjectConfigFilename,
+        noComments: false,
       }),
     })
     const { name, configPath } = result!
@@ -161,6 +165,7 @@ describe("CreateProjectCommand", () => {
         interactive: false,
         name: undefined,
         filename: "garden.yml",
+        noComments: false,
       }),
     })
     const { name, configPath } = result!
@@ -189,6 +194,7 @@ describe("CreateProjectCommand", () => {
         interactive: false,
         name: undefined,
         filename: "custom.garden.yml",
+        noComments: false,
       }),
     })
     const { configPath } = result!
@@ -218,6 +224,7 @@ describe("CreateProjectCommand", () => {
             interactive: false,
             name: undefined,
             filename: defaultProjectConfigFilename,
+            noComments: false,
           }),
         }),
       (err) => expect(err.message).to.equal("A Garden project already exists in " + configPath)
@@ -239,6 +246,7 @@ describe("CreateProjectCommand", () => {
             interactive: false,
             name: undefined,
             filename: defaultProjectConfigFilename,
+            noComments: false,
           }),
         }),
       (err) => expect(err.message).to.equal(`Path ${dir} does not exist`)

--- a/core/test/unit/src/commands/create/create-project.ts
+++ b/core/test/unit/src/commands/create/create-project.ts
@@ -39,11 +39,11 @@ describe("CreateProjectCommand", () => {
       log: garden.log,
       args: {},
       opts: withDefaultGlobalOpts({
-        dir: tmp.path,
-        interactive: false,
-        name: undefined,
-        filename: defaultProjectConfigFilename,
-        noComments: false,
+        "dir": tmp.path,
+        "interactive": false,
+        "name": undefined,
+        "filename": defaultProjectConfigFilename,
+        "skip-comments": false,
       }),
     })
     const { name, configPath, ignoreFileCreated, ignoreFilePath } = result!
@@ -78,11 +78,11 @@ describe("CreateProjectCommand", () => {
       log: garden.log,
       args: {},
       opts: withDefaultGlobalOpts({
-        dir: tmp.path,
-        interactive: false,
-        name: undefined,
-        filename: defaultProjectConfigFilename,
-        noComments: false,
+        "dir": tmp.path,
+        "interactive": false,
+        "name": undefined,
+        "filename": defaultProjectConfigFilename,
+        "skip-comments": false,
       }),
     })
     const { ignoreFileCreated, ignoreFilePath } = result!
@@ -103,11 +103,11 @@ describe("CreateProjectCommand", () => {
       log: garden.log,
       args: {},
       opts: withDefaultGlobalOpts({
-        dir: tmp.path,
-        interactive: false,
-        name: undefined,
-        filename: defaultProjectConfigFilename,
-        noComments: false,
+        "dir": tmp.path,
+        "interactive": false,
+        "name": undefined,
+        "filename": defaultProjectConfigFilename,
+        "skip-comments": false,
       }),
     })
     const { ignoreFileCreated, ignoreFilePath } = result!
@@ -125,11 +125,11 @@ describe("CreateProjectCommand", () => {
       log: garden.log,
       args: {},
       opts: withDefaultGlobalOpts({
-        dir: tmp.path,
-        interactive: false,
-        name: "foo",
-        filename: defaultProjectConfigFilename,
-        noComments: false,
+        "dir": tmp.path,
+        "interactive": false,
+        "name": "foo",
+        "filename": defaultProjectConfigFilename,
+        "skip-comments": false,
       }),
     })
     const { name, configPath } = result!
@@ -161,11 +161,11 @@ describe("CreateProjectCommand", () => {
       log: garden.log,
       args: {},
       opts: withDefaultGlobalOpts({
-        dir: tmp.path,
-        interactive: false,
-        name: undefined,
-        filename: "garden.yml",
-        noComments: false,
+        "dir": tmp.path,
+        "interactive": false,
+        "name": undefined,
+        "filename": "garden.yml",
+        "skip-comments": false,
       }),
     })
     const { name, configPath } = result!
@@ -190,11 +190,11 @@ describe("CreateProjectCommand", () => {
       log: garden.log,
       args: {},
       opts: withDefaultGlobalOpts({
-        dir: tmp.path,
-        interactive: false,
-        name: undefined,
-        filename: "custom.garden.yml",
-        noComments: false,
+        "dir": tmp.path,
+        "interactive": false,
+        "name": undefined,
+        "filename": "custom.garden.yml",
+        "skip-comments": false,
       }),
     })
     const { configPath } = result!
@@ -220,11 +220,11 @@ describe("CreateProjectCommand", () => {
           log: garden.log,
           args: {},
           opts: withDefaultGlobalOpts({
-            dir: tmp.path,
-            interactive: false,
-            name: undefined,
-            filename: defaultProjectConfigFilename,
-            noComments: false,
+            "dir": tmp.path,
+            "interactive": false,
+            "name": undefined,
+            "filename": defaultProjectConfigFilename,
+            "skip-comments": false,
           }),
         }),
       (err) => expect(err.message).to.equal("A Garden project already exists in " + configPath)
@@ -243,10 +243,10 @@ describe("CreateProjectCommand", () => {
           args: {},
           opts: withDefaultGlobalOpts({
             dir,
-            interactive: false,
-            name: undefined,
-            filename: defaultProjectConfigFilename,
-            noComments: false,
+            "interactive": false,
+            "name": undefined,
+            "filename": defaultProjectConfigFilename,
+            "skip-comments": false,
           }),
         }),
       (err) => expect(err.message).to.equal(`Path ${dir} does not exist`)

--- a/core/test/unit/src/docs/config.ts
+++ b/core/test/unit/src/docs/config.ts
@@ -328,7 +328,7 @@ describe("docs config module", () => {
 
       const schemaDescriptions = normalizeJoiSchemaDescription(schema.describe() as JoiDescription)
       const yaml = renderSchemaDescriptionYaml(schemaDescriptions, {
-        commentOutEmpty: true,
+        onEmptyValue: "comment out",
         filterMarkdown: true,
         presetValues: { keyC: "foo" },
         renderBasicDescription: false,

--- a/core/test/unit/src/docs/config.ts
+++ b/core/test/unit/src/docs/config.ts
@@ -318,7 +318,23 @@ describe("docs config module", () => {
         keyC: foo
       `)
     })
-
+    it("should optionally remove keys without preset values", () => {
+      const schema = joi.object().keys({
+        keyA: joi.string(),
+        keyB: joi.string().default("default-value"),
+        keyC: joi.number().example(4),
+        keyD: joi.number().description("foobar"),
+      })
+      const schemaDescriptions = normalizeJoiSchemaDescription(schema.describe() as JoiDescription)
+      const yaml = renderSchemaDescriptionYaml(schemaDescriptions, {
+        renderFullDescription: false,
+        presetValues: { keyA: "foo" },
+        onEmptyValue: "remove",
+      })
+      expect(yaml).to.equal(dedent`
+        keyA: foo
+      `)
+    })
     it("should optionally comment out keys without preset values", () => {
       const schema = joi.object().keys({
         keyA: joi.string(),

--- a/docs/getting-started/2-initialize-a-project.md
+++ b/docs/getting-started/2-initialize-a-project.md
@@ -14,10 +14,10 @@ This directory contains two directories, with one container service each, `backe
 To initialize the project, we can use a helper command:
 
 ```sh
-garden create project
+garden create project --skip-comments
 ```
 
-This will create a basic boilerplate project configuration in the current directory, making it our project root. With the comments stripped out, it should look something like this:
+This will create a basic boilerplate project configuration in the current directory, making it our project root.
 
 ```yaml
 kind: Project
@@ -30,11 +30,11 @@ providers:
 
 We have one environment (`default`) and a single provider. We'll get back to this later.
 
-Next, let's create module configs for each of our two modules, starting with `backend`:
+Next, let's create module configs for each of our two modules, starting with `backend`. You can omit the `--skip-comments` flag to create a module with commented-out fields, which reveal all the options available.
 
 ```sh
 cd backend
-garden create module
+garden create module --skip-comments
 cd ..
 ```
 
@@ -42,13 +42,13 @@ You'll get a suggestion to make it a `container` module. Pick that, and give it 
 
 ```sh
 cd frontend
-garden create module
+garden create module --skip-comments
 cd ..
 ```
 
 This is now enough configuration to build the project. Before we can deploy, we need to configure `services` in each module configuration, as well as set up a local cluster or connect to a remote cluster.
 
-Starting with the former, go ahead and open the newly created `backend/garden.yml` file. You'll find a number of commented-out fields, which reveal all the options available for the `container` module type. One of them is the `services` field. Just to keep things simple for now, go ahead and replace that block (or append to the file) the following:
+Starting with the former, go ahead and open the newly created `backend/garden.yml` file. Just to keep things simple for now, go ahead and append to the file the following:
 
 ```yaml
 services:

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -332,7 +332,7 @@ Examples:
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
-  | `--noComments` | `-no-comments` | boolean | Set to true to disable comment generation.
+  | `--skip-comments` |  | boolean | Set to true to disable comment generation.
   | `--dir` |  | path | Directory to place the project in (defaults to current directory).
   | `--filename` |  | string | Filename to place the project config in (defaults to project.garden.yml).
   | `--interactive` | `-i` | boolean | Set to false to disable interactive prompts.
@@ -361,7 +361,7 @@ Examples:
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
-  | `--noComments` | `-no-comments` | boolean | Set to true to disable comment generation.
+  | `--skip-comments` |  | boolean | Set to true to disable comment generation.
   | `--dir` |  | path | Directory to place the module in (defaults to current directory).
   | `--filename` |  | string | Filename to place the module config in (defaults to garden.yml).
   | `--interactive` | `-i` | boolean | Set to false to disable interactive prompts.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -332,6 +332,7 @@ Examples:
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
+  | `--noComments` | `-no-comments` | boolean | Set to true to disable comment generation.
   | `--dir` |  | path | Directory to place the project in (defaults to current directory).
   | `--filename` |  | string | Filename to place the project config in (defaults to project.garden.yml).
   | `--interactive` | `-i` | boolean | Set to false to disable interactive prompts.
@@ -360,6 +361,7 @@ Examples:
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
+  | `--noComments` | `-no-comments` | boolean | Set to true to disable comment generation.
   | `--dir` |  | path | Directory to place the module in (defaults to current directory).
   | `--filename` |  | string | Filename to place the module config in (defaults to garden.yml).
   | `--interactive` | `-i` | boolean | Set to false to disable interactive prompts.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:
This pr adds a `--skip-comments` flag to create commands which removes all commented out sections from the generated files.
Motivation for the change is that the [getting started guide](https://docs.garden.io/getting-started/2-initialize-a-project) has all the comments removed so it would make sense to add that option to the cli as well.

![Peek 2022-04-19 14-37](https://user-images.githubusercontent.com/33936483/164005705-3349cd9a-2f4d-46a4-907d-de924b00a8c1.gif)


**Special notes for your reviewer**:
* Please note if I need to update any documentation or add a note about the flag to the [getting started guide](https://docs.garden.io/getting-started/2-initialize-a-project)
* I gave up on adding this as an interactive option as current logic doesn't differentiate between boolean parameters being undefined or false. That change would require a bit of a bigger rewrite
