### PR TITLE
improve(core): faster module resolution for certain scenarios

### DIFF
--- a/core/src/actions.ts
+++ b/core/src/actions.ts
@@ -214,7 +214,7 @@ export class ActionRouter implements TypeGuard {
       actionType: "augmentGraph",
       pluginName,
       params: omit(params, ["pluginName"]),
-      defaultHandler: async () => ({ addBuildDependencies: [], addRuntimeDependencies: [], addModules: [] }),
+      defaultHandler: async () => ({ addRuntimeDependencies: [], addModules: [] }),
     })
   }
 

--- a/core/src/types/module.ts
+++ b/core/src/types/module.ts
@@ -106,7 +106,7 @@ export async function moduleFromConfig({
   buildDependencies: GardenModule[]
   forceVersion?: boolean
 }): Promise<GardenModule> {
-  const version = await garden.resolveModuleVersion(config, config.build.dependencies, forceVersion)
+  const version = await garden.resolveModuleVersion(log, config, config.build.dependencies, forceVersion)
   const actions = await garden.getActionRouter()
   const { outputs } = await actions.getModuleOutputs({ log, moduleConfig: config, version })
   const moduleTypes = await garden.getModuleTypes()

--- a/core/src/types/plugin/provider/augmentGraph.ts
+++ b/core/src/types/plugin/provider/augmentGraph.ts
@@ -24,7 +24,6 @@ interface AddDependency {
 }
 
 export interface AugmentGraphResult {
-  addBuildDependencies?: AddDependency[]
   addRuntimeDependencies?: AddDependency[]
   addModules?: AddModuleSpec[]
 }
@@ -54,30 +53,6 @@ export const augmentGraph = () => ({
     providers: joiIdentifierMap(providerSchema()).description("Map of all configured providers in the project."),
   }),
   resultSchema: joi.object().keys({
-    addBuildDependencies: joi
-      .array()
-      .items(
-        joi
-          .object()
-          .optional()
-          .keys({
-            by: joiIdentifier().description(
-              "The _dependant_, i.e. the module that should have a build dependency on `on`."
-            ),
-            on: joiIdentifier().description("The _dependency, i.e. the module that `by` should depend on."),
-          })
-      )
-      .description(
-        dedent`
-        Add build dependencies between two modules, where \`by\` depends on \`on\`.
-
-        Both modules must be previously defined in the project, added by one of the providers that this provider depends
-        on, _or_ it can be one of the modules specified in \`addModules\`.
-
-        The most common use case for this field is to make an existing module depend on one of the modules specified
-        in \`addModules\`.
-      `
-      ),
     addRuntimeDependencies: joi
       .array()
       .items(
@@ -111,8 +86,7 @@ export const augmentGraph = () => ({
           a normal module specified in a \`garden.yml\` config file (which will later be passed to the appropriate
           \`configure\` handler(s) for the module type).
 
-          The added modules can be referenced in \`addBuildDependencies\`, and their services/tasks can be referenced
-          in \`addRuntimeDependencies\`.
+          Added services/tasks can be referenced in \`addRuntimeDependencies\`.
         `
       ),
   }),

--- a/core/src/vcs/vcs.ts
+++ b/core/src/vcs/vcs.ts
@@ -119,7 +119,7 @@ export abstract class VcsHandler {
     // Make sure we don't concurrently scan the exact same context
     await scanLock.acquire(cacheKey.join(":"), async () => {
       if (!force) {
-        const cached = this.cache.get(cacheKey)
+        const cached = this.cache.get(log, cacheKey)
         if (cached) {
           log.silly(`Got cached tree version for module ${moduleConfig.name} (key ${cacheKey})`)
           result = cached
@@ -156,7 +156,7 @@ export abstract class VcsHandler {
         result.files = files.map((f) => f.path)
       }
 
-      this.cache.set(cacheKey, result, getModuleCacheContext(moduleConfig))
+      this.cache.set(log, cacheKey, result, getModuleCacheContext(moduleConfig))
     })
 
     return result

--- a/core/src/watch.ts
+++ b/core/src/watch.ts
@@ -422,7 +422,7 @@ export class Watcher extends EventEmitter {
     // invalidate the cache for anything attached to the module path or upwards in the directory tree
     for (const module of modules) {
       const cacheContext = pathToCacheContext(module.path)
-      this.garden.cache.invalidateUp(cacheContext)
+      this.garden.cache.invalidateUp(this.log, cacheContext)
     }
   }
 }

--- a/core/test/unit/src/actions.ts
+++ b/core/test/unit/src/actions.ts
@@ -143,7 +143,6 @@ describe("ActionRouter", () => {
         const name = "added-by-test-plugin"
 
         expect(result).to.eql({
-          addBuildDependencies: [{ by: name, on: "module-b" }],
           addRuntimeDependencies: [{ by: name, on: "service-b" }],
           addModules: [
             {
@@ -2171,7 +2170,6 @@ const testPlugin = createGardenPlugin({
       const moduleName = "added-by-" + params.ctx.provider.name
 
       return {
-        addBuildDependencies: [{ by: moduleName, on: "module-b" }],
         addRuntimeDependencies: [{ by: moduleName, on: "service-b" }],
         addModules: [
           {

--- a/core/test/unit/src/cache.ts
+++ b/core/test/unit/src/cache.ts
@@ -9,9 +9,11 @@
 import { TreeCache } from "../../../src/cache"
 import { expect } from "chai"
 import { expectError } from "../../helpers"
+import { getLogger } from "../../../src/logger/logger"
 
 describe("TreeCache", () => {
   let cache: TreeCache
+  const log = getLogger().placeholder()
 
   beforeEach(() => {
     cache = new TreeCache()
@@ -24,9 +26,9 @@ describe("TreeCache", () => {
     const value = "my-value"
     const context = ["some", "context"]
 
-    cache.set(key, value, context)
+    cache.set(log, key, value, context)
 
-    expect(cache.get(key)).to.equal(value)
+    expect(cache.get(log, key)).to.equal(value)
   })
 
   it("should store and retrieve a multi-part key", () => {
@@ -34,9 +36,9 @@ describe("TreeCache", () => {
     const value = "my-value"
     const context = ["some", "context"]
 
-    cache.set(key, value, context)
+    cache.set(log, key, value, context)
 
-    expect(cache.get(key)).to.equal(value)
+    expect(cache.get(log, key)).to.equal(value)
   })
 
   describe("set", () => {
@@ -46,9 +48,9 @@ describe("TreeCache", () => {
       const contextA = ["context", "a"]
       const contextB = ["context", "b"]
 
-      cache.set(key, value, contextA, contextB)
+      cache.set(log, key, value, contextA, contextB)
 
-      expect(cache.get(key)).to.equal(value)
+      expect(cache.get(log, key)).to.equal(value)
       expect(mapToPairs(cache.getByContext(contextA))).to.eql([[key, value]])
       expect(mapToPairs(cache.getByContext(contextB))).to.eql([[key, value]])
     })
@@ -59,10 +61,10 @@ describe("TreeCache", () => {
       const contextA = ["context", "a"]
       const contextB = ["context", "b"]
 
-      cache.set(key, value, contextA)
-      cache.set(key, value, contextB)
+      cache.set(log, key, value, contextA)
+      cache.set(log, key, value, contextB)
 
-      expect(cache.get(key)).to.equal(value)
+      expect(cache.get(log, key)).to.equal(value)
       expect(mapToPairs(cache.getByContext(contextA))).to.eql([[key, value]])
       expect(mapToPairs(cache.getByContext(contextB))).to.eql([[key, value]])
     })
@@ -73,10 +75,10 @@ describe("TreeCache", () => {
       const valueB = "my-new-value"
       const context = ["context", "a"]
 
-      cache.set(key, value, context)
-      cache.set(key, valueB, context)
+      cache.set(log, key, value, context)
+      cache.set(log, key, valueB, context)
 
-      expect(cache.get(key)).to.equal(valueB)
+      expect(cache.get(log, key)).to.equal(valueB)
     })
 
     it("should throw with an empty key", async () => {
@@ -84,14 +86,14 @@ describe("TreeCache", () => {
       const value = "my-value"
       const context = ["some", "context"]
 
-      await expectError(() => cache.set(key, value, context), "parameter")
+      await expectError(() => cache.set(log, key, value, context), "parameter")
     })
 
     it("should throw with no context", async () => {
       const key = ["my-key"]
       const value = "my-value"
 
-      await expectError(() => cache.set(key, value), "parameter")
+      await expectError(() => cache.set(log, key, value), "parameter")
     })
 
     it("should throw with an empty context", async () => {
@@ -99,19 +101,19 @@ describe("TreeCache", () => {
       const value = "my-value"
       const context = []
 
-      await expectError(() => cache.set(key, value, context), "parameter")
+      await expectError(() => cache.set(log, key, value, context), "parameter")
     })
   })
 
   describe("get", () => {
     it("should return undefined when key does not exist", () => {
-      expect(cache.get(["bla"])).to.be.undefined
+      expect(cache.get(log, ["bla"])).to.be.undefined
     })
   })
 
   describe("getOrThrow", () => {
     it("should throw when key does not exist", async () => {
-      await expectError(() => cache.getOrThrow(["bla"]), "not-found")
+      await expectError(() => cache.getOrThrow(log, ["bla"]), "not-found")
     })
   })
 
@@ -121,10 +123,10 @@ describe("TreeCache", () => {
       const value = "my-value"
       const context = ["context", "a"]
 
-      cache.set(key, value, context)
-      cache.delete(key)
+      cache.set(log, key, value, context)
+      cache.delete(log, key)
 
-      expect(cache.get(key)).to.be.undefined
+      expect(cache.get(log, key)).to.be.undefined
       expect(cache.getByContext(context).size).to.equal(0)
     })
   })
@@ -135,18 +137,18 @@ describe("TreeCache", () => {
       const valueA = "value-a"
       const contextA = ["context", "a"]
 
-      cache.set(keyA, valueA, contextA)
+      cache.set(log, keyA, valueA, contextA)
 
       const keyB = ["key", "b"]
       const valueB = "value-b"
       const contextB = ["context", "b"]
 
-      cache.set(keyB, valueB, contextB)
+      cache.set(log, keyB, valueB, contextB)
 
-      cache.invalidate(contextA)
+      cache.invalidate(log, contextA)
 
-      expect(cache.get(keyA)).to.be.undefined
-      expect(cache.get(keyB)).to.equal(valueB)
+      expect(cache.get(log, keyA)).to.be.undefined
+      expect(cache.get(log, keyB)).to.equal(valueB)
     })
 
     it("should remove entry from all associated contexts", () => {
@@ -155,16 +157,16 @@ describe("TreeCache", () => {
       const contextA = ["some", "context"]
       const contextB = ["other", "context"]
 
-      cache.set(key, value, contextA, contextB)
-      cache.invalidate(contextB)
+      cache.set(log, key, value, contextA, contextB)
+      cache.invalidate(log, contextB)
 
-      expect(cache.get(key)).to.be.undefined
+      expect(cache.get(log, key)).to.be.undefined
       expect(mapToPairs(cache.getByContext(contextA))).to.eql([])
       expect(mapToPairs(cache.getByContext(contextB))).to.eql([])
     })
 
     it("should return if the specified context cannot be found", () => {
-      cache.invalidate(["bla"])
+      cache.invalidate(log, ["bla"])
     })
   })
 
@@ -174,29 +176,29 @@ describe("TreeCache", () => {
       const valueA = "value-a"
       const contextA = ["section-a", "a"]
 
-      cache.set(keyA, valueA, contextA)
+      cache.set(log, keyA, valueA, contextA)
 
       const keyB = ["key", "b"]
       const valueB = "value-b"
       const contextB = ["section-a", "a", "nested"]
 
-      cache.set(keyB, valueB, contextB)
+      cache.set(log, keyB, valueB, contextB)
 
       const keyC = ["key", "c"]
       const valueC = "value-c"
       const contextC = ["section-b", "c"]
 
-      cache.set(keyC, valueC, contextC)
+      cache.set(log, keyC, valueC, contextC)
 
-      cache.invalidateUp(contextB)
+      cache.invalidateUp(log, contextB)
 
-      expect(cache.get(keyA)).to.be.undefined
-      expect(cache.get(keyB)).to.be.undefined
-      expect(cache.get(keyC)).to.equal(valueC)
+      expect(cache.get(log, keyA)).to.be.undefined
+      expect(cache.get(log, keyB)).to.be.undefined
+      expect(cache.get(log, keyC)).to.equal(valueC)
     })
 
     it("should return if the specified context cannot be found", () => {
-      cache.invalidateUp(["bla"])
+      cache.invalidateUp(log, ["bla"])
     })
   })
 
@@ -206,29 +208,29 @@ describe("TreeCache", () => {
       const valueA = "value-a"
       const contextA = ["section-a", "a"]
 
-      cache.set(keyA, valueA, contextA)
+      cache.set(log, keyA, valueA, contextA)
 
       const keyB = ["key", "b"]
       const valueB = "value-b"
       const contextB = ["section-a", "a", "nested"]
 
-      cache.set(keyB, valueB, contextB)
+      cache.set(log, keyB, valueB, contextB)
 
       const keyC = ["key", "c"]
       const valueC = "value-c"
       const contextC = ["section-b", "c"]
 
-      cache.set(keyC, valueC, contextC)
+      cache.set(log, keyC, valueC, contextC)
 
-      cache.invalidateDown(["section-a"])
+      cache.invalidateDown(log, ["section-a"])
 
-      expect(cache.get(keyA)).to.be.undefined
-      expect(cache.get(keyB)).to.be.undefined
-      expect(cache.get(keyC)).to.equal(valueC)
+      expect(cache.get(log, keyA)).to.be.undefined
+      expect(cache.get(log, keyB)).to.be.undefined
+      expect(cache.get(log, keyC)).to.equal(valueC)
     })
 
     it("should return if the specified context cannot be found", () => {
-      cache.invalidateDown(["bla"])
+      cache.invalidateDown(log, ["bla"])
     })
   })
 })

--- a/core/test/unit/src/vcs/vcs.ts
+++ b/core/test/unit/src/vcs/vcs.ts
@@ -220,7 +220,7 @@ describe("VcsHandler", () => {
       const cacheKey = getModuleTreeCacheKey(moduleConfig)
 
       const cachedResult = { contentHash: "abcdef", files: ["foo"] }
-      handlerA["cache"].set(cacheKey, cachedResult, ["foo", "bar"])
+      handlerA["cache"].set(gardenA.log, cacheKey, cachedResult, ["foo", "bar"])
 
       const result = await handlerA.getTreeVersion(gardenA.log, gardenA.projectName, moduleConfig)
       expect(result).to.eql(cachedResult)
@@ -231,7 +231,7 @@ describe("VcsHandler", () => {
       const cacheKey = getModuleTreeCacheKey(moduleConfig)
 
       const result = await handlerA.getTreeVersion(gardenA.log, gardenA.projectName, moduleConfig)
-      const cachedResult = handlerA["cache"].get(cacheKey)
+      const cachedResult = handlerA["cache"].get(gardenA.log, cacheKey)
 
       expect(result).to.eql(cachedResult)
     })


### PR DESCRIPTION
This combines two things:

1. Avoid unnecessary cache invalidation when using `generateFiles`
2. Drop an unused and soon-to-be-superseded plugin framework feature that
   prompted an unnecessary extra set of version resolution and file scanning.

Also threw in some extra debug logs for when we might need to dig further.

This should provide a small boost for most/all projects, but potentially
substantial improvements for larger projects, especially when using module
templates and `generateFiles`.

