### PR TITLE
fix: ingress for microk8s and k8s 1.22

### DIFF
--- a/core/src/plugins/kubernetes/container/ingress.ts
+++ b/core/src/plugins/kubernetes/container/ingress.ts
@@ -22,9 +22,7 @@ import { LogEntry } from "../../../logger/log-entry"
 import chalk from "chalk"
 
 // Ingress API versions in descending order of preference
-// NOTE: We currently prefer the v1beta1 API version if available, since users may not have an IngressClass set up
-// correctly
-export const supportedIngressApiVersions = ["networking.k8s.io/v1beta1", "networking.k8s.io/v1", "extensions/v1beta1"]
+export const supportedIngressApiVersions = ["networking.k8s.io/v1", "networking.k8s.io/v1beta1", "extensions/v1beta1"]
 
 interface ServiceIngressWithCert extends ServiceIngress {
   spec: ContainerIngressSpec

--- a/core/src/plugins/kubernetes/container/ingress.ts
+++ b/core/src/plugins/kubernetes/container/ingress.ts
@@ -17,7 +17,7 @@ import { ConfigurationError, PluginError } from "../../../exceptions"
 import { ensureSecret } from "../secrets"
 import { getHostnamesFromPem } from "../../../util/tls"
 import { KubernetesResource } from "../types"
-import { ExtensionsV1beta1Ingress, V1Ingress, V1Secret } from "@kubernetes/client-node"
+import { ExtensionsV1beta1Ingress, V1Ingress, V1IngressClass, V1Secret } from "@kubernetes/client-node"
 import { LogEntry } from "../../../logger/log-entry"
 import chalk from "chalk"
 
@@ -70,6 +70,24 @@ export async function createIngressResources(
 
   const allIngresses = await getIngressesWithCert(service, api, provider)
 
+  if (apiVersion === "networking.k8s.io/v1") {
+    // Note: We do not create the IngressClass resource automatically here so add a warning if it's not there!
+    const ingressclasses = await api.listResources<KubernetesResource<V1IngressClass>>({
+      apiVersion,
+      kind: "IngressClass",
+      log,
+      namespace: "all",
+    })
+    const ingressclassWithCorrectName = ingressclasses.items.find(
+      (ic) => ic.metadata.name === provider.config.ingressClass
+    )
+    if (!ingressclassWithCorrectName) {
+      log.warn(
+        chalk.yellow(`ingressclass with name "${provider.config.ingressClass}" was not found, ingress might not work`)
+      )
+    }
+  }
+
   return Bluebird.map(allIngresses, async (ingress, index) => {
     const cert = ingress.certificate
 
@@ -80,7 +98,6 @@ export async function createIngressResources(
 
     if (apiVersion === "networking.k8s.io/v1") {
       // The V1 API has a different shape than the beta API
-      // Note: We do not create the IngressClass resource automatically here!
       const ingressResource: KubernetesResource<V1Ingress> = {
         apiVersion,
         kind: "Ingress",

--- a/core/src/plugins/kubernetes/local/config.ts
+++ b/core/src/plugins/kubernetes/local/config.ts
@@ -140,6 +140,7 @@ export async function configureProvider(params: ConfigureProviderParams<LocalKub
       log.debug("Using microk8s's ingress addon")
       addons.push("ingress")
       remove(_systemServices, (s) => nginxServices.includes(s))
+      _systemServices.push("nginx-ingress-class")
     }
 
     await configureMicrok8sAddons(log, addons)

--- a/static/kubernetes/system/ingress-class/garden.yml
+++ b/static/kubernetes/system/ingress-class/garden.yml
@@ -1,0 +1,11 @@
+kind: Module
+name: nginx-ingress-class
+description: Special manifests for installing nginx ingress class
+type: kubernetes
+manifests:
+  - apiVersion: networking.k8s.io/v1
+    kind: IngressClass
+    metadata:
+      name: nginx
+    spec:
+      controller: k8s.io/ingress-nginx


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:

* Fixes ingress not working for microk8s
* adds a warning if the networking api is at `networking.k8s.io/v1` and no ingressclass exists for the ingresses created by garden 

![image](https://user-images.githubusercontent.com/33936483/164446173-50867598-9460-4bf7-8aa6-fa4981fa5f5d.png)

(the warning appears twice because two containers are created which both have ingress)


**Special notes for your reviewer**:
