### PR TITLE
fix(cloud): fix duplicate footer on config change

### DIFF
--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -419,7 +419,7 @@ ${renderCommands(commands)}
             )}
               ${nodeEmoji.link}  ${chalk.blueBright.underline(namespaceUrl)}
             `
-            footerLog.info(msg)
+            footerLog.setState(msg)
           }
 
           // TODO: "Tone down" dashboard link when connected to Garden Cloud.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:

Before this fix, a new log line with the Cloud NS link would be added every time a config was changed.

Just a quick fix for something I noticed in a demo the other day.