### PR TITLE
chore: updated circleci ubuntu image to 20.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 orbs:
-  win: circleci/windows@1.0.0
+  win: circleci/windows@2.2.0
   rok8s-scripts: fairwinds/rok8s-scripts@11.1.3
 
 # Shared config to use between jobs
@@ -800,7 +800,7 @@ jobs:
           when: always
 
   test-windows:
-    executor: win/vs2019
+    executor: win/default
     steps:
       - checkout
       - *attach-workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,10 @@ orbs:
     GARDEN_K8S_BUILD_SYNC_MODE: "mutagen"
     GARDEN_LOGGER_TYPE: basic
 
+  shared-machine-config: &shared-machine-config
+    image: 'ubuntu-2004:202010-01'
+    docker_layer_caching: true
+
   remote-docker: &remote-docker
     setup_remote_docker:
       version: 20.10.11
@@ -557,8 +561,7 @@ jobs:
 
   test-plugins:
     machine:
-      image: 'ubuntu-1604:201903-01'
-      docker_layer_caching: true
+      <<: *shared-machine-config
     parameters:
       kindNodeImage:
         description: The kind node image to use
@@ -593,8 +596,7 @@ jobs:
 
   test-kind:
     machine:
-      image: 'ubuntu-1604:201903-01'
-      docker_layer_caching: true
+      <<: *shared-machine-config
     parameters:
       kindNodeImage:
         description: The kind node image to use
@@ -630,8 +632,7 @@ jobs:
 
   test-microk8s:
     machine:
-      image: 'ubuntu-1604:202004-01'
-      docker_layer_caching: true
+      <<: *shared-machine-config
     parameters:
       kubernetesVersion:
         description: The Kubernetes version to run
@@ -692,8 +693,7 @@ jobs:
 
   test-minikube:
     machine:
-      image: 'ubuntu-1604:202004-01'
-      docker_layer_caching: true
+      <<: *shared-machine-config
     resource_class: large
     parameters:
       minikubeVersion:


### PR DESCRIPTION
**What this PR does / why we need it**:
It looks like our CircleCI containers are using old Ubuntu 16 images. Recently I (and likely many of us) received an email about the deprecation of old Ubuntu images.

The same warning can be found in [CircleCI logs](https://app.circleci.com/pipelines/github/garden-io/garden/11466/workflows/4c6334c4-6cd8-4baa-b411-1acc412c65cc/jobs/177831):

> This job is either using an Ubuntu 14.04 image, an Ubuntu 16.04 image, or the default Ubuntu 14.04-based image by specifying machine:true in config. These images (including the default image) [will be removed on May 31, 2022. ](https://circleci.com/blog/ubuntu-14-16-image-deprecation/)Upgrade your image from Ubuntu [14.04 ](https://circleci.com/docs/2.0/images/linux-vm/14.04-to-20.04-migration/)or [16.04](https://circleci.com/docs/2.0/images/linux-vm/16.04-to-20.04-migration/).

The Ubuntu 16 images also have too old OpenSSH 7.2 (from March 2016) which does not support option `-oStrictHostKeyChecking=accept-new`. This causes [test failures](https://app.circleci.com/pipelines/github/garden-io/garden/11460/workflows/9d9c8cb8-612f-485c-b914-65059fd5f52e/jobs/177604) in [reverse proxy PR](https://github.com/garden-io/garden/pull/2880).

So, the best way is to upgrade our build jobs to use [newer Ubuntu images](https://circleci.com/docs/2.0/executor-intro/#machine).

**Special notes for your reviewer**:
