### PR TITLE
chore: replace update-homebrew-action with bump-homebrew-formula-action

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -15,39 +15,22 @@ jobs:
       run: |
         echo This is running against a pre-release.
         echo Skipping all the next steps.
-    - uses: actions/checkout@v1
-      if: github.event.release.prerelease != true
-    - name: Use Node.js 12.x
-      uses: actions/setup-node@v1
-      if: github.event.release.prerelease != true
-      with:
-        node-version: 12.x
-    - name: Setup git
-      if: github.event.release.prerelease != true
-      run: |
-        eval "$(ssh-agent -s)"
-        mkdir -p ~/.ssh
-        ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
-        echo "${{ secrets.DEPLOY_KEY_HOMEBREW_GARDEN }}" > ~/.ssh/homebrew_id
-        chmod 600 ~/.ssh/homebrew_id
-        ssh-add -K ~/.ssh/homebrew_id
-        git config --global user.email "e.libralato@gmail.com"
-        git config --global user.name "Github Actions"
-        tee -a ~/.ssh/config << END
-        Host github.com
-            AddKeysToAgent yes
-            UseKeychain yes
-            IdentityFile ~/.ssh/homebrew_id
-        END
     - name: Release Homebrew Formula
       if: github.event.release.prerelease != true
-      uses: garden-io/update-homebrew-action@v1
+      uses: mislav/bump-homebrew-formula-action@v1.16
       with:
-        packageName: 'garden-cli'
-        templatePath: 'support/homebrew-formula.rb'
-        tapRepo: 'garden-io/homebrew-garden'
-        srcRepo: 'garden-io/garden'
-        authToken: ${{ secrets.GITHUB_TOKEN }}
+        formula-name: garden-cli
+        formula-path: Formula/garden-cli.rb
+        homebrew-tap: garden-io/homebrew-garden
+        base-branch: master
+        create-pullrequest: true
+        download-url: https://github.com/garden-io/garden/releases/download/${{ github.event.release.tag_name }}/garden-${{ github.event.release.tag_name }}-macos-amd64.tar.gz
+        commit-message: |
+          Bump {{formulaName}} to {{version}}.
+
+          For more info: https://github.com/garden-io/garden
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Test Homebrew package
       if: github.event.release.prerelease != true
       run: |


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:

Updates the GitHub action for updating the Homebrew formula to account for the [homebrew-garden ](https://github.com/garden-io/homebrew-garden) branch protection.

It turns out some nice folks have been maintaining and updating a nice [GitHub Action](https://github.com/mislav/bump-homebrew-formula-action) that's very similar to our own [update-homebrew-action](https://github.com/garden-io/update-homebrew-action) and it has all the functionalities we need. 

In the spirit of not reinventing the wheel, I updated our release workflow to use said action.

We will deprecate our own action (PR on the respective repo will follow).

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

