### PR TITLE
fix(core): fix git submodules usage

### DIFF
--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -199,8 +199,8 @@ export class GitHandler extends VcsHandler {
           )
     )
 
-    // List all submodule paths in the current repo
-    const submodules = await this.getSubmodules(gitRoot)
+    // List all submodule paths in the current path
+    const submodules = await this.getSubmodules(path)
     const submodulePaths = submodules.map((s) => join(gitRoot, s.path))
     if (submodules.length > 0) {
       log.silly(`Submodules listed at ${submodules.map((s) => `${s.path} (${s.url})`).join(", ")}`)
@@ -591,12 +591,12 @@ export class GitHandler extends VcsHandler {
     }
   }
 
-  private async getSubmodules(gitRoot: string) {
+  private async getSubmodules(gitModulesConfigPath: string) {
     const submodules: Submodule[] = []
-    const gitmodulesPath = join(gitRoot, ".gitmodules")
+    const gitmodulesPath = join(gitModulesConfigPath, ".gitmodules")
 
     if (await pathExists(gitmodulesPath)) {
-      const parsed = await parseGitConfig({ cwd: gitRoot, path: ".gitmodules" })
+      const parsed = await parseGitConfig({ cwd: gitModulesConfigPath, path: ".gitmodules" })
 
       for (const [key, spec] of Object.entries(parsed || {}) as any) {
         if (!key.startsWith("submodule")) {

--- a/core/test/unit/src/vcs/git.ts
+++ b/core/test/unit/src/vcs/git.ts
@@ -485,6 +485,23 @@ describe("GitHandler", () => {
         expect(paths).to.eql([".gitmodules", join("sub", initFile)])
       })
 
+      it("should work if submodule is not initialized and not include any files", async () => {
+        await execa("git", ["submodule", "deinit", "--all"], { cwd: tmpPath })
+        const files = await handler.getFiles({ path: tmpPath, log })
+        const paths = files.map((f) => relative(tmpPath, f.path))
+
+        expect(paths).to.eql([".gitmodules", "sub"])
+      })
+
+      it("should work if submodule is initialized but not updated", async () => {
+        await execa("git", ["submodule", "deinit", "--all"], { cwd: tmpPath })
+        await execa("git", ["submodule", "init"], { cwd: tmpPath })
+        const files = await handler.getFiles({ path: tmpPath, log })
+        const paths = files.map((f) => relative(tmpPath, f.path))
+
+        expect(paths).to.eql([".gitmodules", "sub"])
+      })
+
       it("should include tracked files in submodules when multiple dotignore files are set", async () => {
         const _handler = new GitHandler(
           tmpPath,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**: Fixes handling of uninitialized or not-updated git submodules. Previously having an empty git submodule resulted in garden getting stuck and eventually running into stack overflow.

**Which issue(s) this PR fixes**:

Fixes #2119

**Special notes for your reviewer**:
Explanation of the bug:
the recursive [getFiles](https://github.com/garden-io/garden/blob/git-submodule-fixes/core/src/vcs/git.ts#L130) function calls itself for each git submodule. If a submodule is initialized it acts as it's own git project and thus the [gitRoot](https://github.com/garden-io/garden/blob/git-submodule-fixes/core/src/vcs/git.ts#L204) changes to that module's own path. This change will stop the recursion if the submodule doesn't have a submodule of it's own. But when a module is not initialized&pulled the path will stay as project root and the function will keep on calling itself.

Passing the path that the [getFiles](https://github.com/garden-io/garden/blob/git-submodule-fixes/core/src/vcs/git.ts#L130) function gets fixes this problem and kills the recursion even if the submodule is uninitialized.