### PR TITLE
improvement(core): add --skip flag to test command

### DIFF
--- a/core/test/unit/src/commands/test.ts
+++ b/core/test/unit/src/commands/test.ts
@@ -31,6 +31,7 @@ describe("TestCommand", () => {
         "force": true,
         "force-build": true,
         "watch": false,
+        "skip": [],
         "skip-dependencies": false,
         "skip-dependants": false,
       }),
@@ -166,6 +167,7 @@ describe("TestCommand", () => {
         "force": true,
         "force-build": true,
         "watch": false,
+        "skip": [],
         "skip-dependencies": false,
         "skip-dependants": false,
       }),
@@ -178,6 +180,58 @@ describe("TestCommand", () => {
           buildLog: "A",
         },
         "test.module-a.unit": {
+          success: true,
+          log: "OK",
+        },
+      })
+    ).to.be.true
+  })
+
+  it("should optionally skip tests by name", async () => {
+    const garden = await makeTestGardenA()
+    const log = garden.log
+
+    const { result } = await command.action({
+      garden,
+      log,
+      headerLog: log,
+      footerLog: log,
+      args: { modules: ["module-a"] },
+      opts: withDefaultGlobalOpts({
+        "name": undefined,
+        "force": true,
+        "force-build": true,
+        "watch": false,
+        "skip": ["int*"],
+        "skip-dependencies": false,
+        "skip-dependants": false,
+      }),
+    })
+
+    expect(
+      isSubset(taskResultOutputs(result!), {
+        "build.module-a": {
+          fresh: true,
+          buildLog: "A",
+        },
+        "test.module-a.integration": {
+          success: true,
+          log: "OK",
+        },
+        "test.module-c.integ": {
+          success: true,
+          log: "OK",
+        },
+      })
+    ).to.be.false
+
+    expect(
+      isSubset(taskResultOutputs(result!), {
+        "test.module-a.unit": {
+          success: true,
+          log: "OK",
+        },
+        "test.module-c.unit": {
           success: true,
           log: "OK",
         },
@@ -199,6 +253,7 @@ describe("TestCommand", () => {
         "name": ["int*"],
         "force": true,
         "force-build": true,
+        "skip": [],
         "watch": false,
         "skip-dependencies": false,
         "skip-dependants": false,
@@ -258,6 +313,7 @@ describe("TestCommand", () => {
         "force": true,
         "force-build": false,
         "watch": false,
+        "skip": [],
         "skip-dependencies": false,
         "skip-dependants": false,
       }),
@@ -296,6 +352,7 @@ describe("TestCommand", () => {
         "force": true,
         "force-build": false,
         "watch": false,
+        "skip": [],
         "skip-dependencies": false,
         "skip-dependants": false,
       }),
@@ -365,6 +422,7 @@ describe("TestCommand", () => {
           "force": true,
           "force-build": false,
           "watch": false,
+          "skip": [],
           "skip-dependencies": true, // <----
           "skip-dependants": false,
         }),
@@ -432,6 +490,7 @@ describe("TestCommand", () => {
         "force": true,
         "force-build": false,
         "watch": false,
+        "skip": [],
         "skip-dependencies": false,
         "skip-dependants": true, // <----
       }),

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -3441,6 +3441,7 @@ Examples:
   | `--force` | `-f` | boolean | Force re-test of module(s).
   | `--force-build` |  | boolean | Force rebuild of module(s).
   | `--watch` | `-w` | boolean | Watch for changes in module(s) and auto-test.
+  | `--skip` |  | array:string | The name(s) of tests you&#x27;d like to skip. Accepts glob patterns (e.g. integ* would skip both &#x27;integ&#x27; and &#x27;integration&#x27;). Applied after the &#x27;name&#x27; filter.
   | `--skip-dependencies` | `-no-deps` | boolean | Don&#x27;t deploy any services or run any tasks that the requested tests depend on. This can be useful e.g. when your stack has already been deployed, and you want to run tests with runtime dependencies without redeploying any service dependencies that may have changed since you last deployed. Warning: Take great care when using this option in CI, since Garden won&#x27;t ensure that the runtime dependencies of your test suites are up to date when this option is used.
   | `--skip-dependants` |  | boolean | When using the modules argument, only run tests for those modules (and skip tests in other modules with dependencies on those modules).
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:

The test command was missing a `--skip` flag (similar to what the deploy command has). This PR fixes that (needed by a user). 

More on the meta level, but it would be great to have more consistency in command arguments and options and ideally enforce that somehow. E.g., all commands that operate on lists should be guaranteed to have a filter / omitter and the logic would ideally be re-used so that we don't need to test each one in isolation. 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
