### PR TITLE
fix(docs): re-generated docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@
 * [Cloud Provider Set-up](./guides/cloud-provider-setup.md)
 * [Code Synchronization (Dev Mode)](./guides/code-synchronization-dev-mode.md)
 * [Container Modules](./guides/container-modules.md)
-* [Namespaces](./guides/namespaces.md)
+* [Environments and namespaces](./guides/namespaces.md)
 * [Helm Charts](./guides/using-helm-charts.md)
 * [Hot Reload](./guides/hot-reload.md)
 * [In-Cluster Building](./guides/in-cluster-building.md)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates auto-generated docs introduced in https://github.com/garden-io/garden/pull/2873
