### PR TITLE
chore(k8s): update Mutagen to v0.14.0

### DIFF
--- a/core/src/plugins/kubernetes/dev-mode.ts
+++ b/core/src/plugins/kubernetes/dev-mode.ts
@@ -36,7 +36,7 @@ import { joi, joiIdentifier } from "../../config/common"
 import { KubernetesPluginContext, KubernetesProvider } from "./config"
 import { isConfiguredForDevMode } from "./status/status"
 
-const syncUtilImageName = "gardendev/k8s-sync:0.1.3"
+const syncUtilImageName = "gardendev/k8s-sync:0.1.4"
 
 export const builtInExcludes = ["/**/*.git", "**/*.garden"]
 

--- a/core/src/plugins/kubernetes/mutagen.ts
+++ b/core/src/plugins/kubernetes/mutagen.ts
@@ -611,8 +611,8 @@ export const mutagenCliSpec: PluginToolSpec = {
       platform: "darwin",
       architecture: "amd64",
       url:
-        "https://github.com/garden-io/mutagen/releases/download/v0.13.0-garden-2/mutagen_darwin_amd64_v0.13.0.tar.gz",
-      sha256: "cbcf52f653081606c48e0886f3c0755544c1fa0a1d981e899c913c91e757570f",
+        "https://github.com/garden-io/mutagen/releases/download/v0.14.0-garden-1/mutagen_darwin_amd64_v0.14.0.tar.gz",
+      sha256: "53abc7dadef14d3cb90b72e2afa79622d72d5aa4c3ff70189da3f29249651d55",
       extract: {
         format: "tar",
         targetPath: "mutagen",
@@ -622,8 +622,8 @@ export const mutagenCliSpec: PluginToolSpec = {
       platform: "darwin",
       architecture: "arm64",
       url:
-        "https://github.com/mutagen-io/mutagen/releases/download/v0.13.0-garden-2/mutagen_darwin_arm64_v0.13.0.tar.gz",
-      sha256: "186408d720188393354d7f517e16541dc0fac1e90a6e6e74a3d2a2729a6c9942",
+        "https://github.com/mutagen-io/mutagen/releases/download/v0.14.0-garden-1/mutagen_darwin_arm64_v0.14.0.tar.gz",
+      sha256: "684de1c76cdf5893b1973cf57bd09792b66a7c8a3ae8e7e20286d440f875800c",
       extract: {
         format: "tar",
         targetPath: "mutagen",
@@ -632,8 +632,8 @@ export const mutagenCliSpec: PluginToolSpec = {
     {
       platform: "linux",
       architecture: "amd64",
-      url: "https://github.com/garden-io/mutagen/releases/download/v0.13.0-garden-2/mutagen_linux_amd64_v0.13.0.tar.gz",
-      sha256: "6a5c4f61fa7302ce450f0c8f3005d7dc76cf9cba53191d14f8810d6b45e9ed05",
+      url: "https://github.com/garden-io/mutagen/releases/download/v0.14.0-garden-1/mutagen_linux_amd64_v0.14.0.tar.gz",
+      sha256: "3529ee4b2b836fc8cdf9bd3678d211cadaa916f3e24d6e1337f5ce6f25d46ca6",
       extract: {
         format: "tar",
         targetPath: "mutagen",
@@ -642,8 +642,8 @@ export const mutagenCliSpec: PluginToolSpec = {
     {
       platform: "windows",
       architecture: "amd64",
-      url: "https://github.com/garden-io/mutagen/releases/download/v0.13.0-garden-2/mutagen_windows_amd64_v0.13.0.zip",
-      sha256: "b753534e2a291be69759929691987a720ec6060184d5c9556c362a2648b3a49e",
+      url: "https://github.com/garden-io/mutagen/releases/download/v0.14.0-garden-1/mutagen_windows_amd64_v0.14.0.zip",
+      sha256: "6a09d990e5d74fbfd50edce25182e5786922af74f5f5ad00b33c30fa562fae9a",
       extract: {
         format: "zip",
         targetPath: "mutagen.exe",

--- a/core/test/integ/src/plugins/kubernetes/container/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/deployment.ts
@@ -270,7 +270,7 @@ describe("kubernetes container deployment handlers", () => {
       expect(resource.spec.template?.spec?.initContainers).to.eql([
         {
           name: "garden-dev-init",
-          image: "gardendev/k8s-sync:0.1.3",
+          image: "gardendev/k8s-sync:0.1.4",
           command: ["/bin/sh", "-c", "cp /usr/local/bin/mutagen-agent /.garden/mutagen-agent"],
           imagePullPolicy: "IfNotPresent",
           volumeMounts: [

--- a/images/k8s-sync/Dockerfile
+++ b/images/k8s-sync/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:3.13.5
+FROM alpine:3.15.4
 
 RUN apk add --no-cache curl
 
 # Get mutagen agent
-RUN curl -fsSL "https://github.com/mutagen-io/mutagen/releases/download/v0.13.0/mutagen_linux_amd64_v0.13.0.tar.gz" \
+RUN curl -fsSL "https://github.com/mutagen-io/mutagen/releases/download/v0.14.0/mutagen_linux_amd64_v0.14.0.tar.gz" \
   | tar xz --to-stdout mutagen-agents.tar.gz \
   | tar xz --to-stdout linux_amd64 \
   > /usr/local/bin/mutagen-agent && \

--- a/images/k8s-sync/garden.yml
+++ b/images/k8s-sync/garden.yml
@@ -2,5 +2,5 @@ kind: Module
 type: container
 name: k8s-sync
 description: Used by the kubernetes provider for dev mode sync setup
-image: gardendev/k8s-sync:0.1.3
+image: gardendev/k8s-sync:0.1.4
 dockerfile: Dockerfile


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request updates the k8s-sync functionality to use Mutagen v0.14.0 (or, rather, Garden's Mutagen fork rebased atop Mutagen v0.14.0).  The [v0.14.0](https://github.com/mutagen-io/mutagen/releases/tag/v0.14.0) release brings some important optimizations to synchronization and filesystem watching.  This should hopefully be the last of the fork-based updates to Mutagen in Garden.

**Which issue(s) this PR fixes**:

No specific issues are fixed by this PR.

**Special notes for your reviewer**:

This PR is not yet complete, because a corresponding `gardendev/k8s-sync` tag needs to be built manually using `images/k8s-sync/Dockerfile`.  Once that's done, another commit will be necessary as part of this PR to reference the updated image.

It may be worth considering an update of the `alpine` base image being used, but I wasn't sure about Garden's policy regarding image version updates.  I can quickly amend this commit to update the base image to a more recent `alpine` tag if desired. It should have essentially no impact on the Mutagen functionality of the container.

CC @edvald @thsig 