### PR TITLE
fix(core): avoid type error when active request not found

### DIFF
--- a/core/src/server/server.ts
+++ b/core/src/server/server.ts
@@ -478,7 +478,7 @@ export class GardenServer {
           })
         } else if (request.type === "abortCommand") {
           const req = this.activePersistentRequests[requestId]
-          req.command.terminate()
+          req && req.command.terminate()
           delete this.activePersistentRequests[requestId]
         } else {
           return send("error", {


### PR DESCRIPTION
Every now and then we see the following error at this code path:

Cannot read property 'command' of undefined

This fix avoids that by checking whether the request exists before
calling the command.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
