### PR TITLE
fix(jib): fixed jib module's include config

### DIFF
--- a/plugins/jib/index.ts
+++ b/plugins/jib/index.ts
@@ -29,6 +29,7 @@ import { LogLevel } from "@garden-io/core/build/src/logger/logger"
 import { detectProjectType, getBuildFlags, JibContainerModule } from "./util"
 
 export interface JibProviderConfig extends GenericProviderConfig {}
+
 export interface JibProvider extends Provider<JibProviderConfig> {}
 
 export const configSchema = () => providerConfigBaseSchema().unknown(false)
@@ -110,7 +111,7 @@ export const gardenPlugin = () =>
 
             // The base handler will either auto-detect or set include if there's no Dockerfile, so we need to
             // override that behavior.
-            const include = moduleConfig.include || []
+            const include = moduleConfig.include
             moduleConfig.include = []
 
             const configured = await base!({ ...params, moduleConfig: cloneDeep(moduleConfig) })
@@ -121,7 +122,7 @@ export const gardenPlugin = () =>
             moduleConfig.buildConfig!.jdkVersion = moduleConfig.spec.build.jdkVersion
 
             // FIXME: for now we need to set this value because various code paths decide if the module is built (as
-            // opposed to just fetched) by checking if a Dockerfile is found or specified.
+            //        opposed to just fetched) by checking if a Dockerfile is found or specified.
             moduleConfig.buildConfig!.dockerfile = moduleConfig.spec.dockerfile = "_jib"
 
             return { moduleConfig }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the issue with the Java source code updates in `jib-container` module.

**Which issue(s) this PR fixes**:
The issue can be reproduced with [https://github.com/garden-io/garden/tree/master/examples/jib-container/helloworld](jib-container helloworld example):
1. Locate to `garden/examples/jib-container`
2. Deploy `helloworld` service: `garden deploy helloworld`
3. Modify the source code in [https://github.com/garden-io/garden/blob/master/examples/jib-container/helloworld/src/main/java/example/HelloWorld.java](HelloWorld.java)
4. Redeploy `helloworld` service: `garden deploy helloworld`

**Expected behavior:**
- Garden rebuilds the service and deploys the new version

**Current behavior:**
- Garden doesn't rebuild the service and skips the deployment

Fixes #

**Special notes for your reviewer**:
