### PR TITLE
fix: deploy --force flag

### DIFF
--- a/core/src/tasks/deploy.ts
+++ b/core/src/tasks/deploy.ts
@@ -105,7 +105,7 @@ export class DeployTask extends BaseTask {
         // statuses and results.
         return [statusTask, ...buildTasks, ...getServiceStatusDeps(this, deps), ...getTaskResultDeps(this, deps)]
       } else {
-        return [statusTask, ...buildTasks, ...getDeployDeps(this, deps, false), ...getTaskDeps(this, deps, false)]
+        return [statusTask, ...buildTasks, ...getDeployDeps(this, deps, this.force), ...getTaskDeps(this, deps, false)]
       }
     }
   }

--- a/core/src/tasks/deploy.ts
+++ b/core/src/tasks/deploy.ts
@@ -59,6 +59,10 @@ export class DeployTask extends BaseTask {
     hotReloadServiceNames,
   }: DeployTaskParams) {
     super({ garden, log, force, version: service.version })
+    log.info({
+      section: service.name,
+      msg: `new DeployTask(uid=${this.uid}, force=${force}, serviceName=${service.name})`,
+    })
     this.graph = graph
     this.service = service
     this.forceBuild = forceBuild
@@ -159,6 +163,11 @@ export class DeployTask extends BaseTask {
       status: "active",
       section: this.service.name,
       msg: `Deploying version ${version}...`,
+    })
+
+    log.info({
+      section: this.service.name,
+      msg: `DeployTask(uid=${this.uid}, force=${this.force}, serviceName=${this.service.name}).process()`,
     })
 
     if (!this.force && status.state === "ready" && (version === status.version || devModeSkipRedeploy)) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes issue with `garden deploy --force` command when some deploy-level dependant services are not re-deployed in force mode.

The issue can be reproduced with [demo-project example](https://github.com/garden-io/garden/tree/master/examples/demo-project) by running the command `garden deploy --force`.

Here is the example output (with some extra logging):
```
✔ providers                 → Getting status... → Cached
   ℹ Run with --force-refresh to force a refresh of provider statuses.
frontend                  → new DeployTask(uid=b467dac0-d057-11ec-9efe-8352ecdfe161, force=true, serviceName=frontend)
backend                   → new DeployTask(uid=b4687700-d057-11ec-9efe-8352ecdfe161, force=true, serviceName=backend)
backend                   → new DeployTask(uid=b468ec34-d057-11ec-9efe-8352ecdfe161, force=false, serviceName=backend)
✔ backend                   → Getting build status for v-05b195be19... → Already built
✔ frontend                  → Getting build status for v-9f87fc75ef... → Already built
✔ backend                   → Deploying version v-2a8c9419c1... → Already deployed
   backend                   → DeployTask(uid=b468ec34-d057-11ec-9efe-8352ecdfe161, force=false, serviceName=backend).process()
   → Ingress: http://demo-project.local.app.garden/hello-backend
✔ frontend                  → Deploying version v-13c6cf9522... → Done (took 3.8 sec)
   frontend                  → DeployTask(uid=b467dac0-d057-11ec-9efe-8352ecdfe161, force=true, serviceName=frontend).process()
   ℹ frontend                  → Resources ready
   → Ingress: http://demo-project.local.app.garden/hello-frontend
   → Ingress: http://demo-project.local.app.garden/call-backend
```

The "backend" deploy-task is created twice:
1. First one (`new DeployTask(uid=b4687700-d057-11ec-9efe-8352ecdfe161, force=true, serviceName=backend)`) is created in [`initialTasks`](https://github.com/garden-io/garden/blob/latest-release/core/src/commands/deploy.ts#L208) in the method `DeployCommand.action()`.
2. Second one (`new DeployTask(uid=b468ec34-d057-11ec-9efe-8352ecdfe161, force=false, serviceName=backend)`) is created as a deploy-level dependency of a "frontend" deploy-task in the method [`DeployTask.resolveDependencies()`](https://github.com/garden-io/garden/blob/latest-release/core/src/tasks/deploy.ts#L104).

It looks like the second task replaces the original one, is it expected behavior @edvald @thsig?

If yes, then the fix is just to propagate the original task's `force` flag to the dependant deploy-tasks, as [we do for `TestTask`s](https://github.com/garden-io/garden/blob/latest-release/core/src/tasks/test.ts#L117).

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
Note, there is some extra debug logging in the PR, it will be removed before merging.