### PR TITLE
chore(k8s): update Mutagen to v0.14.0

### DIFF
--- a/core/src/plugins/kubernetes/constants.ts
+++ b/core/src/plugins/kubernetes/constants.ts
@@ -24,7 +24,7 @@ export const inClusterRegistryHostname = "127.0.0.1:5000"
 export const gardenUtilDaemonDeploymentName = "garden-util-daemon"
 export const dockerDaemonDeploymentName = "garden-docker-daemon"
 
-export const k8sUtilImageName = "gardendev/k8s-util:0.5.2"
+export const k8sUtilImageName = "gardendev/k8s-util:0.5.3"
 export const k8sSyncUtilImageName = "gardendev/k8s-sync:0.1.4"
 
 export const dockerDaemonContainerName = "docker-daemon"

--- a/core/src/plugins/kubernetes/constants.ts
+++ b/core/src/plugins/kubernetes/constants.ts
@@ -25,6 +25,8 @@ export const gardenUtilDaemonDeploymentName = "garden-util-daemon"
 export const dockerDaemonDeploymentName = "garden-docker-daemon"
 
 export const k8sUtilImageName = "gardendev/k8s-util:0.5.2"
+export const k8sSyncUtilImageName = "gardendev/k8s-sync:0.1.4"
+
 export const dockerDaemonContainerName = "docker-daemon"
 export const skopeoDaemonContainerName = "util"
 

--- a/core/src/plugins/kubernetes/dev-mode.ts
+++ b/core/src/plugins/kubernetes/dev-mode.ts
@@ -36,7 +36,7 @@ import { joi, joiIdentifier } from "../../config/common"
 import { KubernetesPluginContext, KubernetesProvider } from "./config"
 import { isConfiguredForDevMode } from "./status/status"
 
-const syncUtilImageName = "gardendev/k8s-sync:0.1.3"
+const syncUtilImageName = "gardendev/k8s-sync:0.1.4"
 
 export const builtInExcludes = ["/**/*.git", "**/*.garden"]
 

--- a/core/src/plugins/kubernetes/dev-mode.ts
+++ b/core/src/plugins/kubernetes/dev-mode.ts
@@ -36,7 +36,7 @@ import { joi, joiIdentifier } from "../../config/common"
 import { KubernetesPluginContext, KubernetesProvider } from "./config"
 import { isConfiguredForDevMode } from "./status/status"
 
-const syncUtilImageName = "gardendev/k8s-sync:0.1.4"
+export const syncUtilImageName = "gardendev/k8s-sync:0.1.4"
 
 export const builtInExcludes = ["/**/*.git", "**/*.garden"]
 

--- a/core/src/plugins/kubernetes/dev-mode.ts
+++ b/core/src/plugins/kubernetes/dev-mode.ts
@@ -35,8 +35,7 @@ import {
 import { joi, joiIdentifier } from "../../config/common"
 import { KubernetesPluginContext, KubernetesProvider } from "./config"
 import { isConfiguredForDevMode } from "./status/status"
-
-export const syncUtilImageName = "gardendev/k8s-sync:0.1.4"
+import { k8sSyncUtilImageName } from "./constants"
 
 export const builtInExcludes = ["/**/*.git", "**/*.garden"]
 
@@ -144,7 +143,7 @@ export function configureDevMode({ target, spec, containerName }: ConfigureDevMo
 
   const initContainer = {
     name: "garden-dev-init",
-    image: syncUtilImageName,
+    image: k8sSyncUtilImageName,
     command: ["/bin/sh", "-c", "cp /usr/local/bin/mutagen-agent " + mutagenAgentPath],
     imagePullPolicy: "IfNotPresent",
     volumeMounts: [gardenVolumeMount],

--- a/core/src/plugins/kubernetes/mutagen.ts
+++ b/core/src/plugins/kubernetes/mutagen.ts
@@ -611,8 +611,8 @@ export const mutagenCliSpec: PluginToolSpec = {
       platform: "darwin",
       architecture: "amd64",
       url:
-        "https://github.com/garden-io/mutagen/releases/download/v0.13.0-garden-2/mutagen_darwin_amd64_v0.13.0.tar.gz",
-      sha256: "cbcf52f653081606c48e0886f3c0755544c1fa0a1d981e899c913c91e757570f",
+        "https://github.com/garden-io/mutagen/releases/download/v0.14.0-garden-1/mutagen_darwin_amd64_v0.14.0.tar.gz",
+      sha256: "53abc7dadef14d3cb90b72e2afa79622d72d5aa4c3ff70189da3f29249651d55",
       extract: {
         format: "tar",
         targetPath: "mutagen",
@@ -622,8 +622,8 @@ export const mutagenCliSpec: PluginToolSpec = {
       platform: "darwin",
       architecture: "arm64",
       url:
-        "https://github.com/mutagen-io/mutagen/releases/download/v0.13.0-garden-2/mutagen_darwin_arm64_v0.13.0.tar.gz",
-      sha256: "186408d720188393354d7f517e16541dc0fac1e90a6e6e74a3d2a2729a6c9942",
+        "https://github.com/mutagen-io/mutagen/releases/download/v0.14.0-garden-1/mutagen_darwin_arm64_v0.14.0.tar.gz",
+      sha256: "684de1c76cdf5893b1973cf57bd09792b66a7c8a3ae8e7e20286d440f875800c",
       extract: {
         format: "tar",
         targetPath: "mutagen",
@@ -632,8 +632,8 @@ export const mutagenCliSpec: PluginToolSpec = {
     {
       platform: "linux",
       architecture: "amd64",
-      url: "https://github.com/garden-io/mutagen/releases/download/v0.13.0-garden-2/mutagen_linux_amd64_v0.13.0.tar.gz",
-      sha256: "6a5c4f61fa7302ce450f0c8f3005d7dc76cf9cba53191d14f8810d6b45e9ed05",
+      url: "https://github.com/garden-io/mutagen/releases/download/v0.14.0-garden-1/mutagen_linux_amd64_v0.14.0.tar.gz",
+      sha256: "3529ee4b2b836fc8cdf9bd3678d211cadaa916f3e24d6e1337f5ce6f25d46ca6",
       extract: {
         format: "tar",
         targetPath: "mutagen",
@@ -642,8 +642,8 @@ export const mutagenCliSpec: PluginToolSpec = {
     {
       platform: "windows",
       architecture: "amd64",
-      url: "https://github.com/garden-io/mutagen/releases/download/v0.13.0-garden-2/mutagen_windows_amd64_v0.13.0.zip",
-      sha256: "b753534e2a291be69759929691987a720ec6060184d5c9556c362a2648b3a49e",
+      url: "https://github.com/garden-io/mutagen/releases/download/v0.14.0-garden-1/mutagen_windows_amd64_v0.14.0.zip",
+      sha256: "6a09d990e5d74fbfd50edce25182e5786922af74f5f5ad00b33c30fa562fae9a",
       extract: {
         format: "zip",
         targetPath: "mutagen.exe",

--- a/core/test/integ/src/plugins/kubernetes/container/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/deployment.ts
@@ -270,7 +270,7 @@ describe("kubernetes container deployment handlers", () => {
       expect(resource.spec.template?.spec?.initContainers).to.eql([
         {
           name: "garden-dev-init",
-          image: "gardendev/k8s-sync:0.1.3",
+          image: "gardendev/k8s-sync:0.1.4",
           command: ["/bin/sh", "-c", "cp /usr/local/bin/mutagen-agent /.garden/mutagen-agent"],
           imagePullPolicy: "IfNotPresent",
           volumeMounts: [

--- a/core/test/integ/src/plugins/kubernetes/container/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/deployment.ts
@@ -28,6 +28,7 @@ import { ContainerService } from "../../../../../../src/plugins/container/config
 import { apply } from "../../../../../../src/plugins/kubernetes/kubectl"
 import { getAppNamespace } from "../../../../../../src/plugins/kubernetes/namespace"
 import { gardenAnnotationKey } from "../../../../../../src/util/string"
+import { syncUtilImageName } from "../../../../../../src/plugins/kubernetes/dev-mode"
 
 describe("kubernetes container deployment handlers", () => {
   let garden: Garden
@@ -270,7 +271,7 @@ describe("kubernetes container deployment handlers", () => {
       expect(resource.spec.template?.spec?.initContainers).to.eql([
         {
           name: "garden-dev-init",
-          image: "gardendev/k8s-sync:0.1.4",
+          image: syncUtilImageName,
           command: ["/bin/sh", "-c", "cp /usr/local/bin/mutagen-agent /.garden/mutagen-agent"],
           imagePullPolicy: "IfNotPresent",
           volumeMounts: [

--- a/core/test/integ/src/plugins/kubernetes/container/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/deployment.ts
@@ -28,7 +28,7 @@ import { ContainerService } from "../../../../../../src/plugins/container/config
 import { apply } from "../../../../../../src/plugins/kubernetes/kubectl"
 import { getAppNamespace } from "../../../../../../src/plugins/kubernetes/namespace"
 import { gardenAnnotationKey } from "../../../../../../src/util/string"
-import { syncUtilImageName } from "../../../../../../src/plugins/kubernetes/dev-mode"
+import { k8sSyncUtilImageName } from "../../../../../../src/plugins/kubernetes/constants"
 
 describe("kubernetes container deployment handlers", () => {
   let garden: Garden
@@ -271,7 +271,7 @@ describe("kubernetes container deployment handlers", () => {
       expect(resource.spec.template?.spec?.initContainers).to.eql([
         {
           name: "garden-dev-init",
-          image: syncUtilImageName,
+          image: k8sSyncUtilImageName,
           command: ["/bin/sh", "-c", "cp /usr/local/bin/mutagen-agent /.garden/mutagen-agent"],
           imagePullPolicy: "IfNotPresent",
           volumeMounts: [

--- a/images/README.md
+++ b/images/README.md
@@ -1,4 +1,4 @@
-# images
+# Images
 
 Here we place container images that we maintain and reference when using Garden.
 

--- a/images/k8s-sync/Dockerfile
+++ b/images/k8s-sync/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:3.13.5
+FROM alpine:3.15.4
 
 RUN apk add --no-cache curl
 
 # Get mutagen agent
-RUN curl -fsSL "https://github.com/mutagen-io/mutagen/releases/download/v0.13.0/mutagen_linux_amd64_v0.13.0.tar.gz" \
+RUN curl -fsSL "https://github.com/mutagen-io/mutagen/releases/download/v0.14.0/mutagen_linux_amd64_v0.14.0.tar.gz" \
   | tar xz --to-stdout mutagen-agents.tar.gz \
   | tar xz --to-stdout linux_amd64 \
   > /usr/local/bin/mutagen-agent && \

--- a/images/k8s-sync/README.md
+++ b/images/k8s-sync/README.md
@@ -1,0 +1,32 @@
+# Image `k8s-sync`
+
+This image is used for code-synchronization in dev mode. It's based on the [Alpine Linux](https://www.alpinelinux.org/)
+and [Mutagen](https://github.com/mutagen-io/mutagen).
+
+## Mutagen version upgrade
+
+To update the mutagen version, two following steps must be done:
+
+1. Publish new Docker images
+2. Implement code changes
+
+### Publish new Docker images
+
+1. Upgrade the [Dockerfile](./Dockerfile) to use the new mutagen binaries and update the image name.
+   in [garden.yml](./garden.yml).
+2. Build and publish the new `k8s-sync` image.
+3. Increment the version of [k8s-util](../k8s-util) image by updating its [Dockerfile](../k8s-util/Dockerfile)
+   and [garden.yml](../k8s-util/garden.yml).
+4. Build and publish the new `k8s-util` image, because it depends on the `k8s-sync` image.
+
+### Implement code changes
+
+1. Upgrade the constant `mutagenCliSpec` object in the [mutagen.ts](../../core/src/plugins/kubernetes/mutagen.ts).
+2. Search for the `gardendev/k8s-sync` string in the code and change the old version to the new one.
+3. Implement the necessary code chnages to address the mutagen's breaking changes if any.
+
+If the constant `mutagenCliSpec` cannot be found in the location specified above, then try a full-text search for the
+old mutagen version in the source code, and change all occurrences to the new mutagen version.
+
+If any duplicates are found for the `gardendev/k8s-sync` image name string, then refactor the code to use a single
+public constant.

--- a/images/k8s-sync/README.md
+++ b/images/k8s-sync/README.md
@@ -3,16 +3,16 @@
 This image is used for code-synchronization in dev mode. It's based on the [Alpine Linux](https://www.alpinelinux.org/)
 and [Mutagen](https://github.com/mutagen-io/mutagen).
 
-## Mutagen version upgrade
+## Mutagen version update
 
-To update the mutagen version, two following steps must be done:
+To update the mutagen version:
 
 1. Publish new Docker images
 2. Implement code changes
 
 ### Publish new Docker images
 
-1. Upgrade the [Dockerfile](./Dockerfile) to use the new mutagen binaries and update the image name.
+1. Update the [Dockerfile](./Dockerfile) to use the new mutagen binaries and update the image name.
    in [garden.yml](./garden.yml).
 2. Build and publish the new `k8s-sync` image.
 3. Increment the version of [k8s-util](../k8s-util) image by updating its [Dockerfile](../k8s-util/Dockerfile)
@@ -21,9 +21,9 @@ To update the mutagen version, two following steps must be done:
 
 ### Implement code changes
 
-1. Upgrade the constant `mutagenCliSpec` object in the [mutagen.ts](../../core/src/plugins/kubernetes/mutagen.ts).
+1. Update the constant `mutagenCliSpec` object in the [mutagen.ts](../../core/src/plugins/kubernetes/mutagen.ts).
 2. Search for the `gardendev/k8s-sync` string in the code and change the old version to the new one.
-3. Implement the necessary code chnages to address the mutagen's breaking changes if any.
+3. Implement the necessary code changes to address the mutagen's breaking changes if any.
 
 If the constant `mutagenCliSpec` cannot be found in the location specified above, then try a full-text search for the
 old mutagen version in the source code, and change all occurrences to the new mutagen version.

--- a/images/k8s-sync/garden.yml
+++ b/images/k8s-sync/garden.yml
@@ -2,5 +2,5 @@ kind: Module
 type: container
 name: k8s-sync
 description: Used by the kubernetes provider for dev mode sync setup
-image: gardendev/k8s-sync:0.1.3
+image: gardendev/k8s-sync:0.1.4
 dockerfile: Dockerfile

--- a/images/k8s-util/README.md
+++ b/images/k8s-util/README.md
@@ -1,0 +1,19 @@
+# Image `k8s-util`
+
+This utility image is used to set up a sync between a local Garden project's sources and its target k8s container when
+the in-cluster build mode (`kaniko` or `cluster-buildkit`) is used.
+
+It also mounts a volume that’s shared with the builder pods (both when using `kaniko` or `cluster-buildkit` build modes)
+. That is, the build context is synced from the local machine to the volume that the util pod mounts, which is then also
+mounted by the builders. This shared volume is how we provide an up-to-date build context to the builder pods.
+
+t’s also used to run [skopeo](../skopeo), which is used to check if an image has already been built (which is why it
+mounts a secret that enables it to communicate with the container registry).
+
+## Dependencies
+
+This image depends on [k8s-sync](../k8s-sync).
+
+## Version update
+
+See the [k8s-sync README.md](../k8s-sync/README.md) to get more information about the version update.

--- a/images/k8s-util/garden.yml
+++ b/images/k8s-util/garden.yml
@@ -2,7 +2,7 @@ kind: Module
 type: container
 name: k8s-util
 description: Used by the kubernetes provider for build-related activities
-image: gardendev/k8s-util:0.5.2
+image: gardendev/k8s-util:0.5.3
 dockerfile: Dockerfile
 build:
   dependencies: [k8s-sync]


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request updates the k8s-sync functionality to use Mutagen v0.14.0 (or, rather, Garden's Mutagen fork rebased atop Mutagen v0.14.0).  The [v0.14.0](https://github.com/mutagen-io/mutagen/releases/tag/v0.14.0) release brings some important optimizations to synchronization and filesystem watching.  This should hopefully be the last of the fork-based updates to Mutagen in Garden.

**Which issue(s) this PR fixes**:

No specific issues are fixed by this PR.

**Special notes for your reviewer**:
This reopens #2929 
CC @edvald @thsig 