### PR TITLE
fix(k8s): avoid unnecessary namespace patch no-op on init

### DIFF
--- a/core/src/plugins/kubernetes/namespace.ts
+++ b/core/src/plugins/kubernetes/namespace.ts
@@ -116,8 +116,8 @@ export async function ensureNamespace(
 function namespaceNeedsUpdate(resource: KubernetesServerResource<V1Namespace> | undefined, config: NamespaceConfig) {
   return (
     resource &&
-    (!isSubset(resource.metadata?.annotations, config.annotations) ||
-      !isSubset(resource.metadata?.labels, config.labels))
+    (!isSubset(resource.metadata?.annotations || {}, config.annotations || {}) ||
+      !isSubset(resource.metadata?.labels || {}, config.labels || {}))
   )
 }
 


### PR DESCRIPTION
Just a minor thing I happened to come across, some no-op k8s API calls being made on provider init.