### PR TITLE
chore(ci): longer timeouts in conftest + terraform plugin tests

### DIFF
--- a/plugins/conftest/.mocharc.yml
+++ b/plugins/conftest/.mocharc.yml
@@ -1,6 +1,6 @@
 reporter: spec
 spec: test/**/*.js
-timeout: 10000
+timeout: 100000
 watch-files:
   - "*.js"
   - "test/*.js"

--- a/plugins/terraform/.mocharc.yml
+++ b/plugins/terraform/.mocharc.yml
@@ -1,6 +1,6 @@
 reporter: spec
 spec: test/**/*.js
-timeout: 10000
+timeout: 100000
 require:
   - source-map-support/register
 watch-files:


### PR DESCRIPTION
This was causing some CI flakiness.