### PR TITLE
fix: increased num of retries and timeouts for rsync

### DIFF
--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -178,10 +178,10 @@ export async function syncToBuildSync(params: SyncToSharedBuildSyncParams) {
     const syncArgs = [...commonSyncArgs, "--relative", "--delete", "--temp-dir", "/tmp", src, destination]
 
     log.debug(`Syncing from ${src} to ${destination}`)
-    // We retry a couple of times, because we may get intermittent connection issues or concurrency issues
+    // We retry a few times, because we may get intermittent connection issues or concurrency issues
     await pRetry(() => exec("rsync", syncArgs), {
-      retries: 3,
-      minTimeout: 500,
+      retries: 5,
+      minTimeout: 1000,
     })
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Increased timeout and number of retries for the `rsync` command call.

**Which issue(s) this PR fixes**:

Fixes #2944

**Special notes for your reviewer**:
This _should_ fix https://github.com/garden-io/garden/issues/2944. The reporter hasn't verified the fix yet. The link to the edge release was posted in the original issue.