### PR TITLE
Feat: Expose TTY setting on container modules

### DIFF
--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -129,6 +129,7 @@ export interface ContainerServiceSpec extends CommonServiceSpec {
   replicas?: number
   volumes: ContainerVolumeSpec[]
   privileged?: boolean
+  tty?: boolean
   addCapabilities?: string[]
   dropCapabilities?: string[]
 }
@@ -625,6 +626,12 @@ const containerServiceSchema = () =>
     `),
     volumes: getContainerVolumesSchema("service"),
     privileged: containerPrivilegedSchema("service"),
+    tty: joi
+      .boolean()
+      .default(false)
+      .description(
+        "Specify if containers in this module have TTY support enabled (which implies having stdin support enabled)."
+      ),
     addCapabilities: containerAddCapabilitiesSchema("service"),
     dropCapabilities: containerDropCapabilitiesSchema("service"),
   })

--- a/core/src/plugins/kubernetes/container/deployment.ts
+++ b/core/src/plugins/kubernetes/container/deployment.ts
@@ -421,6 +421,11 @@ export async function createWorkloadManifest({
     container.args = service.spec.args
   }
 
+  if (spec.tty) {
+    container.tty = true
+    container.stdin = true
+  }
+
   if (spec.healthCheck) {
     configureHealthCheck(container, spec, enableHotReload || enableDevMode)
   }

--- a/core/test/unit/src/commands/get/get-config.ts
+++ b/core/test/unit/src/commands/get/get-config.ts
@@ -493,6 +493,7 @@ describe("GetConfigCommand", () => {
             memory: defaultContainerResources.memory,
             ports: [],
             timeout: KUBECTL_DEFAULT_TIMEOUT,
+            tty: false,
             volumes: [],
           },
           hotReloadable: false,

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -4535,9 +4535,9 @@ describe("Garden", () => {
     })
 
     context("test against fixed version hashes", async () => {
-      const moduleAVersionString = "v-03ad0bf895"
-      const moduleBVersionString = "v-2ea060bd39"
-      const moduleCVersionString = "v-93f17bef44"
+      const moduleAVersionString = "v-2db99eee24"
+      const moduleBVersionString = "v-54d52a425f"
+      const moduleCVersionString = "v-dcb493917a"
 
       it("should return the same module versions between runtimes", async () => {
         const projectRoot = getDataDir("test-projects", "fixed-version-hashes-1")

--- a/core/test/unit/src/vcs/vcs.ts
+++ b/core/test/unit/src/vcs/vcs.ts
@@ -347,7 +347,7 @@ describe("getModuleVersionString", () => {
     const garden = await makeTestGarden(projectRoot, { noCache: true })
     const module = await garden.resolveModule("module-a")
 
-    const fixedVersionString = "v-03ad0bf895"
+    const fixedVersionString = "v-2db99eee24"
     expect(module.version.versionString).to.eql(fixedVersionString)
 
     delete process.env.TEST_ENV_VAR

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -459,6 +459,9 @@ services:
     # equivalent to root on the host. Defaults to false.
     privileged:
 
+    # Specify if containers in this module have TTY support enabled (which implies having stdin support enabled).
+    tty: false
+
     # POSIX capabilities to add to the running service's main container.
     addCapabilities:
 
@@ -1909,6 +1912,16 @@ If true, run the service's main container in privileged mode. Processes in privi
 | Type      | Required |
 | --------- | -------- |
 | `boolean` | No       |
+
+### `services[].tty`
+
+[services](#services) > tty
+
+Specify if containers in this module have TTY support enabled (which implies having stdin support enabled).
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `services[].addCapabilities[]`
 

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -480,6 +480,9 @@ services:
     # equivalent to root on the host. Defaults to false.
     privileged:
 
+    # Specify if containers in this module have TTY support enabled (which implies having stdin support enabled).
+    tty: false
+
     # POSIX capabilities to add to the running service's main container.
     addCapabilities:
 
@@ -1980,6 +1983,16 @@ If true, run the service's main container in privileged mode. Processes in privi
 | Type      | Required |
 | --------- | -------- |
 | `boolean` | No       |
+
+### `services[].tty`
+
+[services](#services) > tty
+
+Specify if containers in this module have TTY support enabled (which implies having stdin support enabled).
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `services[].addCapabilities[]`
 

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -459,6 +459,9 @@ services:
     # equivalent to root on the host. Defaults to false.
     privileged:
 
+    # Specify if containers in this module have TTY support enabled (which implies having stdin support enabled).
+    tty: false
+
     # POSIX capabilities to add to the running service's main container.
     addCapabilities:
 
@@ -1919,6 +1922,16 @@ If true, run the service's main container in privileged mode. Processes in privi
 | Type      | Required |
 | --------- | -------- |
 | `boolean` | No       |
+
+### `services[].tty`
+
+[services](#services) > tty
+
+Specify if containers in this module have TTY support enabled (which implies having stdin support enabled).
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `services[].addCapabilities[]`
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR exposes an optional `tty` property on container module configs. This property defaults to `false`, which used to be the only option before exposing it as a property in the config schema.

The benefit of being able to turn TTY/stdin on is to support attaching to a running container with TTY/stdin turned on. This comes into play when troubleshooting a service as it runs with a framework that supports interactive breakpoints. Interactive breakpoints require that you can send keyboard input to the service and interact with it via SSH.

As a companion to this configuration option, `garden attach` could potentially be added as a command, but even without that I find immense utility in being able to run commands like `kubectl attach -ti pod/my-pod-to-debug`.

This kind of debugging can already be done via `garden run --interactive ...`, but exposing the config enables some really nice developer workflows because the `tty` property can be tied to Garden config variables and, for example, turned on automatically when a service is started in dev-mode or when a deploy is not to a production environment. It also reduces mental overhead for a developer versus needing to either omit a service from a deploy or delete it from a current deploy and then separately use `garden run --interactive`.

**Which issue(s) this PR fixes**:

N/A; I recall mentioning this idea in Slack a while ago, but it doesn't look I created a ticket at the time 😊.

**Special notes for your reviewer**:
