### PR TITLE
fix: correct port number when open multiple dashboards

### DIFF
--- a/core/src/db/entities/garden-process.ts
+++ b/core/src/db/entities/garden-process.ts
@@ -8,7 +8,7 @@
 
 import { Entity, Column } from "typeorm-with-better-sqlite3"
 import { GardenEntity } from "../base-entity"
-import { partition, find, isMatch } from "lodash"
+import { partition, filter, isMatch } from "lodash"
 
 /**
  * Each GardenProcess entry maps to a running Garden process. We use this to keep track of active processes,
@@ -87,12 +87,13 @@ export class GardenProcess extends GardenEntity {
   }
 
   /**
-   * Finds a running dashboard process for the given project, environment and namespace, returns undefined otherwise.
+   * Finds all running dashboard processes for the given project, environment and namespace,
+   * or returns an empty array otherwise.
    *
-   * @param runningProcesses - List of running processes, as returned by `getActiveProcesses()`
+   * @param runningProcesses - List of running processes, as returned by {@link getActiveProcesses()}
    * @param scope - Project information to match on
    */
-  static getDashboardProcess(
+  static getDashboardProcesses(
     runningProcesses: GardenProcess[],
     scope: {
       projectRoot: string
@@ -100,8 +101,8 @@ export class GardenProcess extends GardenEntity {
       environmentName: string
       namespace: string
     }
-  ): GardenProcess | undefined {
-    return find(
+  ): GardenProcess[] {
+    return filter(
       runningProcesses,
       (p) => !!p.serverHost && !!p.serverAuthKey && isMatch(p, { ...scope, command: "dashboard", persistent: true })
     )

--- a/core/test/unit/src/db/entities/garden-process.ts
+++ b/core/test/unit/src/db/entities/garden-process.ts
@@ -98,7 +98,7 @@ describe("GardenProcess", () => {
     })
   })
 
-  describe("getDashboardProcess", () => {
+  describe("getDashboardProcesses", () => {
     const scope = {
       projectRoot: "/tmp",
       projectName: testCommand + "-project",
@@ -147,17 +147,18 @@ describe("GardenProcess", () => {
         GardenProcess.create(spec)
       )
 
-      const result = GardenProcess.getDashboardProcess(commands, scope)
-      expect(result?.pid).to.equal(2)
+      const result = GardenProcess.getDashboardProcesses(commands, scope)
+      expect(result.length).to.equal(1)
+      expect(result[0].pid).to.equal(2)
     })
 
-    it("returns undefined if no running Garden process is found for the project+env", async () => {
+    it("returns empty array if no running Garden process is found for the project+env", async () => {
       const commands = [buildCommand, otherProjectDashboard, otherNamespaceDashboard].map((spec) =>
         GardenProcess.create(spec)
       )
 
-      const result = GardenProcess.getDashboardProcess(commands, scope)
-      expect(result).to.be.undefined
+      const result = GardenProcess.getDashboardProcesses(commands, scope)
+      expect(result).to.eql([])
     })
   })
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR ensures that the displayed URL of the currently running dashboard process is correct.

Previously the method [`GP.getDashboardProcess`](https://github.com/garden-io/garden/blob/master/core/src/db/entities/garden-process.ts#L95) did not rely on the base URL (i.e. the hostname and the port) of the target dashboard process. There might be several dashboards running on the different ports. In that case, we need to apply extra filtering by the command's base URL (which includes the port).

**Which issue(s) this PR fixes**:

Fixes #2188

**Special notes for your reviewer**:
There are no integration tests for [`cli.ts`](https://github.com/garden-io/garden/blob/master/core/src/cli/cli.ts) yet. An integration test for this case assumes starting 2 garden CLI processes and monitoring the logs of each process. The corresponding unit tests were fixed respectively.
