### PR TITLE
fix: workflows fail silently and don't output script logs with --output option

### DIFF
--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -699,17 +699,15 @@ ${renderCommands(commands)}
 
     let code = 0
     if (gardenErrors.length > 0) {
-      if (!command.skipCliErrorSummary) {
-        for (const error of gardenErrors) {
-          const entry = logger.error({
-            msg: error.message,
-            error,
-          })
-          // Output error details to console when log level is silly
-          logger.silly({
-            msg: renderError(entry),
-          })
-        }
+      for (const error of gardenErrors) {
+        const entry = logger.error({
+          msg: error.message,
+          error,
+        })
+        // Output error details to console when log level is silly
+        logger.silly({
+          msg: renderError(entry),
+        })
       }
 
       if (logger.getWriters().find((w) => w instanceof FileWriter)) {

--- a/core/src/commands/base.ts
+++ b/core/src/commands/base.ts
@@ -89,9 +89,6 @@ export abstract class Command<T extends Parameters = {}, U extends Parameters = 
   hidden: boolean = false
   noProject: boolean = false
   protected: boolean = false
-  // Set to true to disable post-execution logging of command errors by the CLI class (e.g. to avoid duplicate logging
-  // when the command does its own error logging/formatting in its action method).
-  skipCliErrorSummary: boolean = false
   streamEvents: boolean = false // Set to true to stream events for the command
   streamLogEntries: boolean = false // Set to true to stream log entries for the command
   server: GardenServer | undefined = undefined

--- a/core/src/commands/run/workflow.ts
+++ b/core/src/commands/run/workflow.ts
@@ -184,7 +184,7 @@ export class RunWorkflowCommand extends Command<Args, {}> {
       }
       stepBodyLog.root.storeEntries = initSaveLogState
 
-      if (stepResult.errors) {
+      if (stepResult.errors && stepResult.errors.length > 0) {
         garden.events.emit("workflowStepError", getStepEndEvent(index, stepStartedAt))
         logErrors(outerLog, stepResult.errors, index, steps.length, step.description)
         stepErrors[index] = stepResult.errors

--- a/core/src/commands/run/workflow.ts
+++ b/core/src/commands/run/workflow.ts
@@ -152,6 +152,8 @@ export class RunWorkflowCommand extends Command<Args, {}> {
 
       const stepStartedAt = new Date()
 
+      const initSaveLogState = stepBodyLog.root.storeEntries
+      stepBodyLog.root.storeEntries = true
       try {
         if (step.command) {
           step.command = resolveTemplateStrings(step.command, stepTemplateContext).filter((arg) => !!arg)
@@ -180,6 +182,7 @@ export class RunWorkflowCommand extends Command<Args, {}> {
         outputs: stepResult.result || {},
         log: stepLog,
       }
+      stepBodyLog.root.storeEntries = initSaveLogState
 
       if (stepResult.errors) {
         garden.events.emit("workflowStepError", getStepEndEvent(index, stepStartedAt))

--- a/core/src/commands/run/workflow.ts
+++ b/core/src/commands/run/workflow.ts
@@ -55,7 +55,6 @@ export class RunWorkflowCommand extends Command<Args, {}> {
 
   streamEvents = true
   streamLogEntries = true
-  skipCliErrorSummary = true
 
   description = dedent`
     Runs the commands and/or scripts defined in the workflow's steps, in sequence.
@@ -197,7 +196,17 @@ export class RunWorkflowCommand extends Command<Args, {}> {
     if (size(stepErrors) > 0) {
       printResult({ startedAt, log: outerLog, workflow, success: false })
       garden.events.emit("workflowError", {})
-      return { result, errors: flatten(Object.values(stepErrors)) }
+      const errors = flatten(Object.values(stepErrors))
+      const finalError = opts.output
+        ? errors
+        : [
+            new Error(
+              `workflow failed with ${errors.length} ${
+                errors.length > 1 ? "errors" : "error"
+              }, see logs above for more info`
+            ),
+          ]
+      return { result, errors: finalError }
     }
 
     printResult({ startedAt, log: outerLog, workflow, success: true })

--- a/core/test/unit/src/commands/run/workflow.ts
+++ b/core/test/unit/src/commands/run/workflow.ts
@@ -507,7 +507,7 @@ describe("RunWorkflowCommand", () => {
     const { result, errors } = await cmd.action({ ...defaultParams, args: { workflow: "workflow-a" } })
 
     expect(result).to.exist
-    expect(errors).to.eql([])
+    expect(errors).to.eql(undefined)
     expect(result?.steps["step-1"].outputs.exec?.["command"]).to.eql(["sh", "-c", "echo foo"])
   })
 
@@ -528,7 +528,7 @@ describe("RunWorkflowCommand", () => {
     const { result, errors } = await cmd.action({ ...defaultParams, args: { workflow: "workflow-a" } })
 
     expect(result).to.exist
-    expect(errors).to.eql([])
+    expect(errors).to.eql(undefined)
     expect(result?.steps["step-1"].outputs.gardenCommand?.["result"].result.log).to.equal("echo other-YEP")
     expect(result?.steps["step-1"].outputs.gardenCommand?.["command"]).to.eql([
       "run",
@@ -758,8 +758,9 @@ describe("RunWorkflowCommand", () => {
 
     const { errors } = await cmd.action({ ...defaultParams, args: { workflow: "workflow-a" } })
 
-    expect(errors![0].message).to.equal("Script exited with code 1")
-    expect(errors![0].detail.stdout).to.equal("boo!")
+    expect(errors![0].message).to.equal("workflow failed with 1 error, see logs above for more info")
+    // no details because log is set to human-readable output and details are logged above
+    expect(errors![0].detail).to.equal(undefined)
   })
 
   it("should include outputs from steps in the command output", async () => {


### PR DESCRIPTION
Fixes the issue introduced in https://github.com/garden-io/garden/pull/2754 where workflows will fail silently if they fail outside of the steps (e.g. invalid workflow config) issue: #2883

Also fixes scripts logs not being visible with the `--output` option, issue: #2898

closes: #2883 and #2898

With this logic:
1. If `--output` is not specified and error(s) occur in the workflow steps themselves they will be printed while running the task and generic aggregated error will be printed at the bottom.
![image](https://user-images.githubusercontent.com/33936483/170211006-f94be7b4-8234-4331-8d90-43cdb976de80.png)

2. If `--output` is not specified and error occurs *outside* the workflow steps it will be printed immediately
![image](https://user-images.githubusercontent.com/33936483/170212214-e4276d91-a6bf-4f3d-8509-f893e5c37ea0.png)

The `--output` option also works now and the `.garden/error.log` gets properly populated as well.
