### PR TITLE
fix(container): fix unneeded redeploys in dev mode

### DIFF
--- a/core/src/plugins/kubernetes/container/deployment.ts
+++ b/core/src/plugins/kubernetes/container/deployment.ts
@@ -47,14 +47,15 @@ export async function deployContainerService(
   params: DeployServiceParams<ContainerModule>
 ): Promise<ContainerServiceStatus> {
   const { ctx, service, log, devMode } = params
+  const deployWithDevMode = devMode && !!service.spec.devMode
   const { deploymentStrategy } = params.ctx.provider.config
   const k8sCtx = <KubernetesPluginContext>ctx
   const api = await KubeApi.factory(log, k8sCtx, k8sCtx.provider)
 
   if (deploymentStrategy === "blue-green") {
-    await deployContainerServiceBlueGreen({ ...params, api })
+    await deployContainerServiceBlueGreen({ ...params, devMode: deployWithDevMode, api })
   } else {
-    await deployContainerServiceRolling({ ...params, api })
+    await deployContainerServiceRolling({ ...params, devMode: deployWithDevMode, api })
   }
 
   const status = await getContainerServiceStatus(params)

--- a/core/src/plugins/kubernetes/container/status.ts
+++ b/core/src/plugins/kubernetes/container/status.ts
@@ -44,6 +44,7 @@ export async function getContainerServiceStatus({
   const api = await KubeApi.factory(log, ctx, provider)
   const namespaceStatus = await getAppNamespaceStatus(k8sCtx, log, k8sCtx.provider)
   const namespace = namespaceStatus.namespaceName
+  const enableDevMode = devMode && !!service.spec.devMode
 
   // FIXME: [objects, matched] and ingresses can be run in parallel
   const { workload, manifests } = await createContainerManifests({
@@ -52,7 +53,7 @@ export async function getContainerServiceStatus({
     log,
     service,
     runtimeContext,
-    enableDevMode: devMode,
+    enableDevMode,
     enableHotReload: hotReload,
     blueGreen: provider.config.deploymentStrategy === "blue-green",
   })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:

Before this fix, `container` services without dev mode configs would be redeployed when toggling dev mode (e.g. when running `garden dev` and then `garden deploy`). This led to unwanted and unnecessary redeploys in
certain scenarios.

The fix essentially consisted of applying the the same fix to `container` service deployments and status checks as were applied to `kubernetes` and `helm` services in 5bfb3d70.

**Which issue(s) this PR fixes**:

Fixes an issue that's been driving @eysi09 up the walls for months.