### PR TITLE
test: updated some old helm charts to the newer versions

### DIFF
--- a/core/test/data/test-projects/helm/postgres/garden.yml
+++ b/core/test/data/test-projects/helm/postgres/garden.yml
@@ -4,7 +4,7 @@ type: helm
 name: postgres
 chart: postgresql
 repo: https://charts.bitnami.com/bitnami
-version: "8.10.5"
+version: "10.16.1"
 serviceResource:
   kind: StatefulSet
   name: postgres

--- a/core/test/integ/src/plugins/kubernetes/util.ts
+++ b/core/test/integ/src/plugins/kubernetes/util.ts
@@ -367,7 +367,7 @@ describe("util", () => {
         log,
         version: module.version.versionString,
       })
-      module.spec.serviceResource.name = `{{ template "postgresql.master.fullname" . }}`
+      module.spec.serviceResource.name = `{{ template "postgresql.primary.fullname" . }}`
       const result = await getServiceResource({
         ctx,
         log,

--- a/docs/guides/using-helm-charts.md
+++ b/docs/guides/using-helm-charts.md
@@ -30,7 +30,7 @@ type: helm
 name: redis
 repo: https://charts.bitnami.com/bitnami
 chart: redis
-version: "10.5.7"
+version: "16.0.0"
 values:
   usePassword: false
 ```

--- a/examples/tasks/postgres/garden.yml
+++ b/examples/tasks/postgres/garden.yml
@@ -4,7 +4,7 @@ type: helm
 name: postgres
 chart: postgresql
 repo: https://charts.bitnami.com/bitnami
-version: "8.10.5"
+version: "10.16.1"
 serviceResource:
   kind: StatefulSet
   name: postgres

--- a/examples/vote-helm/api-image/app.py
+++ b/examples/vote-helm/api-image/app.py
@@ -6,6 +6,8 @@ import socket
 import random
 import json
 
+REDIS_HOST = 'redis-master'
+
 option_a = os.getenv('OPTION_A', "Cats")
 option_b = os.getenv('OPTION_B', "Dogs")
 hostname = socket.gethostname()
@@ -15,7 +17,7 @@ CORS(app)
 
 def get_redis():
     if not hasattr(g, 'redis'):
-        g.redis = Redis(host="redis-master", db=0, socket_timeout=5)
+        g.redis = Redis(host=REDIS_HOST, db=0, socket_timeout=5)
     return g.redis
 
 @app.route("/api", methods=['GET'])

--- a/examples/vote-helm/postgres/garden.yml
+++ b/examples/vote-helm/postgres/garden.yml
@@ -4,7 +4,7 @@ type: helm
 name: postgres
 chart: postgresql
 repo: https://charts.bitnami.com/bitnami
-version: "8.10.5"
+version: "10.16.1"
 serviceResource:
   kind: StatefulSet
   name: postgres

--- a/examples/vote-helm/redis/garden.yml
+++ b/examples/vote-helm/redis/garden.yml
@@ -4,6 +4,7 @@ type: helm
 name: redis
 repo: https://charts.bitnami.com/bitnami
 chart: redis
-version: "10.5.7"
+version: "16.0.0"
 values:
-  usePassword: false
+  auth:
+    enabled: false

--- a/examples/vote-helm/worker-image/src/main/java/worker/Worker.java
+++ b/examples/vote-helm/worker-image/src/main/java/worker/Worker.java
@@ -14,17 +14,27 @@ class Worker {
       System.err.println("Watching vote queue");
 
       while (true) {
-        String voteJSON = redis.blpop(0, "votes").get(1);
-        JSONObject voteData = new JSONObject(voteJSON);
-        String voterID = voteData.getString("voter_id");
-        String vote = voteData.getString("vote");
-
-        System.err.printf("Processing vote for '%s' by '%s'\n", vote, voterID);
-        updateVote(dbConn, voterID, vote);
+        getVoteFromQueue(dbConn, redis);
       }
     } catch (SQLException e) {
       e.printStackTrace();
       System.exit(1);
+    }
+  }
+
+  static void getVoteFromQueue(Connection dbConn, Jedis redis) throws SQLException {
+    String voteJSON = redis.blpop(0, "votes").get(1);
+
+    try {
+      JSONObject voteData = new JSONObject(voteJSON);
+      String voterID = voteData.getString("voter_id");
+      String vote = voteData.getString("vote");
+
+      System.err.printf("Processing vote for '%s' by '%s'\n", vote, voterID);
+      updateVote(dbConn, voterID, vote);
+    } catch (Exception e) {
+      System.err.printf("Error when processing vote from queue: " + e);
+      return;
     }
   }
 

--- a/examples/vote-helm/worker-image/src/main/resources/application.properties
+++ b/examples/vote-helm/worker-image/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+redis.host: redis-master
+
+postgres.host: postgres
+postgres.db: postgres
+postgres.username: postgres
+postgres.password: postgres

--- a/plugins/conftest-kubernetes/test/test-project/helm/garden.yml
+++ b/plugins/conftest-kubernetes/test/test-project/helm/garden.yml
@@ -4,7 +4,7 @@ type: helm
 name: helm
 chart: postgresql
 repo: https://charts.bitnami.com/bitnami
-version: "8.10.5"
+version: "10.16.1"
 dependencies: [kubernetes]
 values:
   foo: ${runtime.services.kubernetes.outputs}


### PR DESCRIPTION
**What this PR does / why we need it**:
Some tests fail with errors:
```
Error: chart "postgresql" version "8.10.5" not found in https://charts.bitnami.com/bitnami repository
Error: chart "redis" version "10.5.7" not found in https://charts.bitnami.com/bitnami repository
```

The charts older than 6 months are not available in the [standard bitnami charts repo](https://charts.bitnami.com/bitnami) since June 1st.  The index file was too heavy and some older versions were removed from the index. Too heavy index file caused some CloudFront traffic limitations and errors like this:
```
failed to generate YAML for specified Helm chart: failed to pull chart: looks like "https://charts.bitnami.com/bitnami" is not a valid chart repository or cannot be reached: stream error: stream ID 1; INTERNAL_ERROR; received from peer
```
We observed the error above in our test failures. See https://github.com/bitnami/charts/issues/10539 and https://github.com/bitnami/charts/issues/8433 for more details.

There is still a way to use the old chart versions by explicitly specifying the repo https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
But that's not a recommended way, because it can cause test failures again (because of the heavy index file and the traffic issue described above).

This PR updates the `postgres` and `redis` helm charts the latest versions compatible with Kubernetes 1.12+:
- [postgres 10.16.1](https://staging.artifacthub.io/packages/helm/bitnami/postgresql/10.16.1)
- [redis 16.0.0](https://staging.artifacthub.io/packages/helm/bitnami/redis/16.0.0)

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
