### PR TITLE
Core-cloud Interactivity

### DIFF
--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -293,15 +293,15 @@ ${renderCommands(commands)}
     const footerLog = logger.placeholder()
 
     command.printHeader({ headerLog, args: parsedArgs, opts: parsedOpts })
+    const sessionId = uuidv4()
 
-    // Init enterprise API
+    // Init Cloud API
     let cloudApi: CloudApi | null = null
     if (!command.noProject) {
       cloudApi = await CloudApi.factory({ log, currentDirectory: workingDir })
     }
 
     // Init event & log streaming.
-    const sessionId = uuidv4()
     this.bufferedEventStream = new BufferedEventStream({
       log,
       cloudApi: cloudApi || undefined,
@@ -345,6 +345,8 @@ ${renderCommands(commands)}
       footerLog,
       args: parsedArgs,
       opts: parsedOpts,
+      // Commands that start a Garden server and want to open a websocket connection to the platform use this param.
+      cloudApi: cloudApi || undefined,
     }
 
     const persistent = command.isPersistent(prepareParams)

--- a/core/src/cloud/api.ts
+++ b/core/src/cloud/api.ts
@@ -138,12 +138,13 @@ export class CloudApi {
 
   constructor(log: LogEntry, enterpriseDomain: string, projectId: string) {
     this.log = log
+    // TODO: Replace all instances of "enterpriseDomain" with "cloudDomain".
     this.domain = enterpriseDomain
     this.projectId = projectId
   }
 
   /**
-   * Initialize the Enterprise API.
+   * Initialize the Cloud API.
    *
    * Returns null if the project is not configured for Garden Cloud or if the user is not logged in.
    * Throws if the user is logged in but the token is invalid and can't be refreshed.

--- a/core/src/cloud/buffered-event-stream.ts
+++ b/core/src/cloud/buffered-event-stream.ts
@@ -112,8 +112,8 @@ export class BufferedEventStream {
   private workflowRunUid: string | undefined
 
   /**
-   * We maintain this map to facilitate unsubscribing from a previously connected event bus
-   * when a new event bus is connected.
+   * We maintain this map to facilitate unsubscribing from a previous Garden instance's event bus
+   * when a new Garden instance is connected.
    */
   private gardenEventListeners: { [eventName: string]: (payload: any) => void }
 

--- a/core/src/config-graph.ts
+++ b/core/src/config-graph.ts
@@ -300,7 +300,7 @@ export class ConfigGraph {
   }
 
   /**
-   * Returns the Service with the specified name. Throws error if it doesn't exist.
+   * Returns the Module with the specified name. Throws error if it doesn't exist.
    */
   getModule(name: string, includeDisabled?: boolean): GardenModule {
     return this.getModules({ names: [name], includeDisabled })[0]

--- a/core/src/events.ts
+++ b/core/src/events.ts
@@ -266,9 +266,57 @@ export interface Events extends LoggerEvents {
     index: number
     durationMsec: number
   }
+
+  // Cloud UI events
+  buildRequested: {
+    moduleName: string
+    force: boolean
+  }
+  deployRequested: {
+    serviceName: string
+    devMode: boolean
+    hotReload: boolean
+    force: boolean
+    forceBuild: boolean
+    skipDependencies: boolean
+  }
+  testRequested: {
+    moduleName: string
+    force: boolean
+    forceBuild: boolean
+    testNames?: string[] // If not provided, run all tests for the module
+    skipDependencies: boolean
+  }
+  taskRequested: {
+    taskName: string
+    force: boolean
+    forceBuild: boolean
+  }
+  setBuildOnWatch: {
+    moduleName: string
+    build: boolean
+  }
+  setDeployOnWatch: {
+    serviceName: string
+    deploy: boolean
+  }
+  setTestOnWatch: {
+    moduleName: string
+    test: boolean
+  }
 }
 
 export type EventName = keyof Events
+
+/**
+ * These events indicate a request from Cloud to Core.
+ */
+export const cloudRequestEventNames: EventName[] = [
+  "buildRequested",
+  "deployRequested",
+  "testRequested",
+  "taskRequested",
+]
 
 // Note: Does not include logger events.
 export const pipedEventNames: EventName[] = [
@@ -309,4 +357,8 @@ export const pipedEventNames: EventName[] = [
   "workflowStepError",
   "workflowStepProcessing",
   "workflowStepSkipped",
+  "buildRequested",
+  "deployRequested",
+  "testRequested",
+  "taskRequested",
 ]

--- a/core/src/process.ts
+++ b/core/src/process.ts
@@ -15,12 +15,18 @@ import { BaseTask } from "./tasks/base"
 import { GraphResults } from "./task-graph"
 import { isModuleLinked } from "./util/ext-source-util"
 import { Garden } from "./garden"
-import { LogEntry } from "./logger/log-entry"
+import { EmojiName, LogEntry } from "./logger/log-entry"
 import { ConfigGraph } from "./config-graph"
-import { dedent } from "./util/string"
+import { dedent, naturalList } from "./util/string"
 import { ConfigurationError } from "./exceptions"
 import { uniqByName } from "./util/util"
 import { renderDivider } from "./logger/util"
+import { Events } from "./events"
+import { BuildTask } from "./tasks/build"
+import { DeployTask } from "./tasks/deploy"
+import { filterTestConfigs, TestTask } from "./tasks/test"
+import { testFromConfig } from "./types/test"
+import { TaskTask } from "./tasks/task"
 
 export type ProcessHandler = (graph: ConfigGraph, module: GardenModule) => Promise<BaseTask[]>
 
@@ -236,6 +242,79 @@ export async function processModules({
       await garden.processTasks(moduleTasks)
     })
 
+    // Handle Cloud events
+    const params = {
+      garden,
+      graph,
+      log,
+    }
+    garden.events.on("buildRequested", async (event: Events["buildRequested"]) => {
+      try {
+        graph = await garden.getConfigGraph({ log, emit: false })
+        log.info("")
+        log.info({ emoji: "hammer", msg: chalk.yellow(`Build requested for ${chalk.white(event.moduleName)}`) })
+        const tasks = await cloudEventHandlers.buildRequested({ ...params, request: event })
+        await garden.processTasks(tasks)
+      } catch (err) {
+        log.error(err.message)
+      }
+    })
+    garden.events.on("deployRequested", async (event: Events["deployRequested"]) => {
+      try {
+        graph = await garden.getConfigGraph({ log, emit: false })
+        let prefix: string
+        let emoji: EmojiName
+        if (event.hotReload) {
+          emoji = "fire"
+          prefix = `Hot reload-enabled deployment`
+        } else {
+          if (event.devMode) {
+            emoji = "zap"
+            prefix = `Dev-mode deployment`
+          } else {
+            emoji = "rocket"
+            prefix = "Deployment"
+          }
+        }
+        const msg = `${prefix} requested for ${chalk.white(event.serviceName)}`
+        log.info("")
+        log.info({ emoji, msg: chalk.yellow(msg) })
+        const deployTask = await cloudEventHandlers.deployRequested({ ...params, request: event })
+        await garden.processTasks([deployTask])
+      } catch (err) {
+        log.error(err.message)
+      }
+    })
+    garden.events.on("testRequested", async (event: Events["testRequested"]) => {
+      try {
+        graph = await garden.getConfigGraph({ log, emit: false })
+        const testNames = event.testNames
+        let suffix = ""
+        if (testNames) {
+          suffix = ` (only ${chalk.white(naturalList(testNames))})`
+        }
+        const msg = chalk.yellow(`Tests requested for ${chalk.white(event.moduleName)}${suffix}`)
+        log.info("")
+        log.info({ emoji: "thermometer", msg })
+        const testTasks = await cloudEventHandlers.testRequested({ ...params, request: event })
+        await garden.processTasks(testTasks)
+      } catch (err) {
+        log.error(err.message)
+      }
+    })
+    garden.events.on("taskRequested", async (event: Events["taskRequested"]) => {
+      try {
+        graph = await garden.getConfigGraph({ log, emit: false })
+        const msg = chalk.yellow(`Run requested for task ${chalk.white(event.taskName)}`)
+        log.info("")
+        log.info({ emoji: "runner", msg })
+        const taskTask = await cloudEventHandlers.taskRequested({ ...params, request: event })
+        await garden.processTasks([taskTask])
+      } catch (err) {
+        log.error(err.message)
+      }
+    })
+
     waiting()
   })
 
@@ -243,6 +322,77 @@ export async function processModules({
     taskResults: {}, // TODO: Return latest results for each task key processed between restarts?
     restartRequired,
   }
+}
+
+export interface CloudEventHandlerCommonParams {
+  garden: Garden
+  graph: ConfigGraph
+  log: LogEntry
+}
+
+export const cloudEventHandlers = {
+  buildRequested: async (params: CloudEventHandlerCommonParams & { request: Events["buildRequested"] }) => {
+    const { garden, graph, log } = params
+    const { moduleName, force } = params.request
+    const tasks = await BuildTask.factory({
+      garden,
+      log,
+      graph,
+      module: graph.getModule(moduleName),
+      force,
+    })
+    return tasks
+  },
+  testRequested: async (params: CloudEventHandlerCommonParams & { request: Events["testRequested"] }) => {
+    const { garden, graph, log } = params
+    const { moduleName, testNames, force, forceBuild } = params.request
+    const module = graph.getModule(moduleName)
+    return filterTestConfigs(module.testConfigs, testNames).map((config) => {
+      return new TestTask({
+        garden,
+        graph,
+        log,
+        force,
+        forceBuild,
+        test: testFromConfig(module, config, graph),
+        skipRuntimeDependencies: params.request.skipDependencies,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
+      })
+    })
+  },
+  deployRequested: async (params: CloudEventHandlerCommonParams & { request: Events["deployRequested"] }) => {
+    const { garden, graph, log } = params
+    const { serviceName, force, forceBuild } = params.request
+
+    const deployTask = new DeployTask({
+      garden,
+      log,
+      graph,
+      service: graph.getService(serviceName),
+      force,
+      forceBuild,
+      fromWatch: true,
+      skipRuntimeDependencies: params.request.skipDependencies,
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
+    })
+    return deployTask
+  },
+  taskRequested: async (params: CloudEventHandlerCommonParams & { request: Events["taskRequested"] }) => {
+    const { garden, graph, log } = params
+    const { taskName, force, forceBuild } = params.request
+    return new TaskTask({
+      garden,
+      log,
+      graph,
+      task: graph.getTask(taskName),
+      devModeServiceNames: [],
+      hotReloadServiceNames: [],
+      force,
+      forceBuild,
+    })
+  },
 }
 
 /**

--- a/core/src/process.ts
+++ b/core/src/process.ts
@@ -37,6 +37,10 @@ interface ProcessParams {
   footerLog?: LogEntry
   watch: boolean
   /**
+   * If provided, and if `watch === true`, will log this to the statusline when waiting for changes
+   */
+  overRideWatchStatusLine?: string
+  /**
    * If provided, and if `watch === true`, don't watch files in the module roots of these modules.
    */
   skipWatchModules?: GardenModule[]
@@ -68,6 +72,7 @@ export async function processModules({
   skipWatchModules,
   watch,
   changeHandler,
+  overRideWatchStatusLine,
 }: ProcessModulesParams): Promise<ProcessResults> {
   log.silly("Starting processModules")
 
@@ -148,7 +153,10 @@ export async function processModules({
 
   const waiting = () => {
     if (!!statusLine) {
-      statusLine.setState({ emoji: "clock2", msg: chalk.gray("Waiting for code changes...") })
+      statusLine.setState({
+        emoji: "clock2",
+        msg: chalk.gray(overRideWatchStatusLine || "Waiting for code changes..."),
+      })
     }
 
     garden.events.emit("watchingForChanges", {})

--- a/core/src/server/server.ts
+++ b/core/src/server/server.ts
@@ -24,7 +24,7 @@ import { DASHBOARD_STATIC_DIR, gardenEnv } from "../constants"
 import { LogEntry } from "../logger/log-entry"
 import { Command, CommandResult } from "../commands/base"
 import { toGardenError, GardenError } from "../exceptions"
-import { EventName, Events, EventBus, GardenEventListener } from "../events"
+import { EventName, Events, EventBus, GardenEventListener, cloudRequestEventNames } from "../events"
 import { uuidv4, ValueOf } from "../util/util"
 import { AnalyticsHandler } from "../analytics/analytics"
 import { joi } from "../config/common"
@@ -480,6 +480,8 @@ export class GardenServer {
           const req = this.activePersistentRequests[requestId]
           req && req.command.terminate()
           delete this.activePersistentRequests[requestId]
+        } else if (cloudRequestEventNames.find((e) => e === request.type)) {
+          this.garden?.events.emit(request.type, request)
         } else {
           return send("error", {
             requestId,

--- a/core/src/tasks/test.ts
+++ b/core/src/tasks/test.ts
@@ -23,6 +23,7 @@ import { BuildTask } from "./build"
 import { GraphResults } from "../task-graph"
 import { Profile } from "../util/profiling"
 import { GardenTest, testFromConfig } from "../types/test"
+import { ModuleConfig } from "../config/module"
 
 class TestError extends Error {
   toString() {
@@ -240,16 +241,8 @@ export async function getTestTasks({
   fromWatch?: boolean
   skipRuntimeDependencies?: boolean
 }) {
-  // If there are no filters we return the test otherwise
-  // we check if the test name matches against the filterNames array
-  const configs = module.testConfigs.filter(
-    (test) =>
-      !test.disabled &&
-      (!filterNames || filterNames.length === 0 || find(filterNames, (n: string) => minimatch(test.name, n)))
-  )
-
   return Bluebird.map(
-    configs,
+    filterTestConfigs(module.testConfigs, filterNames),
     (testConfig) =>
       new TestTask({
         garden,
@@ -263,5 +256,16 @@ export async function getTestTasks({
         hotReloadServiceNames,
         skipRuntimeDependencies,
       })
+  )
+}
+
+export function filterTestConfigs(
+  configs: ModuleConfig["testConfigs"],
+  filterNames?: string[]
+): ModuleConfig["testConfigs"] {
+  return configs.filter(
+    (test) =>
+      !test.disabled &&
+      (!filterNames || filterNames.length === 0 || find(filterNames, (n: string) => minimatch(test.name, n)))
   )
 }

--- a/core/test/unit/src/enterprise/event-handlers.ts
+++ b/core/test/unit/src/enterprise/event-handlers.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2018-2022 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import { ConfigGraph } from "../../../../src/config-graph"
+import { LogEntry } from "../../../../src/logger/log-entry"
+import { CloudEventHandlerCommonParams, cloudEventHandlers } from "../../../../src/process"
+import { makeTestGardenA, TestGarden } from "../../../helpers"
+
+describe("cloudEventHandlers", () => {
+  let garden: TestGarden
+  let graph: ConfigGraph
+  let log: LogEntry
+  let params: CloudEventHandlerCommonParams
+
+  before(async () => {
+    garden = await makeTestGardenA()
+    log = garden.log
+    graph = await garden.getConfigGraph({ log, emit: false })
+    params = { garden, log, graph }
+  })
+
+  describe("buildRequested", () => {
+    it("should return a build task for the requested module", async () => {
+      const tasks = await cloudEventHandlers.buildRequested({
+        ...params,
+        request: { moduleName: "module-a", force: false },
+      })
+      expect(tasks.length).to.eql(1)
+      const buildTask = tasks.find((t) => t.type === "build")
+      expect(buildTask).to.exist
+      expect(buildTask!["module"].name).to.eql("module-a")
+      expect(buildTask!.force).to.eql(false)
+    })
+
+    it("should optionally return a build task with force = true for the requested module", async () => {
+      const tasks = await cloudEventHandlers.buildRequested({
+        ...params,
+        request: { moduleName: "module-a", force: true },
+      })
+      expect(tasks.length).to.eql(1)
+      const buildTask = tasks.find((t) => t.type === "build")
+      expect(buildTask).to.exist
+      expect(buildTask!["module"].name).to.eql("module-a")
+      expect(buildTask!.force).to.eql(true)
+    })
+  })
+
+  describe("deployRequested", () => {
+    it("should return a deploy task for the requested service", async () => {
+      const deployTask = await cloudEventHandlers.deployRequested({
+        ...params,
+        request: {
+          serviceName: "service-a",
+          force: false,
+          forceBuild: false,
+          devMode: false,
+          hotReload: false,
+          skipDependencies: true,
+        },
+      })
+      expect(deployTask["hotReloadServiceNames"]).to.eql([])
+      expect(deployTask.service.name).to.eql("service-a")
+    })
+
+    it("should return a dev-mode deploy task for the requested service", async () => {
+      const deployTask = await cloudEventHandlers.deployRequested({
+        ...params,
+        request: {
+          serviceName: "service-a",
+          force: false,
+          forceBuild: false,
+          devMode: true,
+          hotReload: false,
+          skipDependencies: true,
+        },
+      })
+      expect(deployTask["service"].name).to.eql("service-a")
+    })
+  })
+
+  describe("testRequested", () => {
+    it("should return test tasks for the requested module", async () => {
+      const testTasks = await cloudEventHandlers.testRequested({
+        ...params,
+        request: { moduleName: "module-a", force: false, forceBuild: false, skipDependencies: true },
+      })
+      expect(testTasks.map((t) => t["test"].name).sort()).to.eql(["integration", "unit"])
+    })
+
+    it("should return test tasks for the requested module and test names", async () => {
+      const testTasks = await cloudEventHandlers.testRequested({
+        ...params,
+        request: {
+          moduleName: "module-a",
+          force: false,
+          forceBuild: false,
+          testNames: ["unit"],
+          skipDependencies: true,
+        },
+      })
+      expect(testTasks.map((t) => t["test"].name).sort()).to.eql(["unit"])
+    })
+  })
+
+  describe("taskRequested", () => {
+    it("should return test tasks for the requested module", async () => {
+      const taskTask = await cloudEventHandlers.taskRequested({
+        ...params,
+        request: { taskName: "task-a", force: false, forceBuild: false },
+      })
+      expect(taskTask["task"].name).to.eql("task-a")
+    })
+  })
+})


### PR DESCRIPTION
Listen to events from cloud and create tasks based on them. Also dashboard command can also be used for it.

Will leave as draft until this has been properly tested and combined with the Cloud implementation and the command palette.