### PR TITLE
docs: add backend injection to terraform doc

### DIFF
--- a/docs/advanced/terraform.md
+++ b/docs/advanced/terraform.md
@@ -107,6 +107,48 @@ Here we imagine a Terraform stack that has a `my-database-uri` output, that we t
 
 Much like other modules, you can also reference Terraform definitions in other repositories using the `repositoryUrl` key. See the [Remote Sources](./using-remote-sources.md) guide for details.
 
+## Injecting Environment Variables Into Backend Manifests
+
+[Terraform does not interpolate named values in backend manifests](https://www.terraform.io/language/settings/backends/configuration). Below are two solutions (using an `exec` provider and using both an `exec` and a `teraform` module).
+
+### Exec Provider
+
+One way to inject variables into new terraform manifests is to add an [exec provider](https://docs.garden.io/reference/providers/exec) that calls an [initScript](https://docs.garden.io/reference/providers/exec#providers-.initscript) in the project.garden.yaml file. Exec providers allow us to run scripts while initiating other providers. An `initScript` runs in the project root when initializing those providers.
+
+In this sample `terraform/backend.tf` manifest, we need to replace the `key` based on which environment we are building.
+
+```
+terraform {
+  backend "s3" {
+    bucket  = "state-bucket"
+    key     = "projects/my-project/terraform.tfstate"
+    region  = "us-west-2"
+  }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+```
+
+In the `project.garden.yaml` file for this sample, the exec provider calls an initScript that replaces in-place the pre-existing state file with a copy that substitutes the s3 bucket name with the environment name in the `backend.tf` file.
+
+```yaml
+...
+providers:
+  - name: exec
+    initScript: rm -rf terraform/.terraform* && sed -i .bak 's;key *= *"projects/[a-zA-Z0-9]*/terraform.tfstate";key = "projects/${environment.name}/terraform.tfstate";g' terraform/backend.tf
+  - name: terraform
+    initRoot: "./terraform"
+    variables:
+      project: ${environment.name}
+    dependencies: [exec]
+```
+
+Now when you deploy a new Terraformed environment, the new backend statefile will know where to go.
+
 ## Next steps
 
 Check out the [terraform-gke example](https://github.com/garden-io/garden/tree/0.12.41/examples/terraform-gke) project. Also take a look at the [Terraform provider reference](../reference/providers/terraform.md) and the [Terraform module type reference](../reference/module-types/terraform.md) for details on all the configuration parameters.


### PR DESCRIPTION

**What this PR does / why we need it**: This PR explains how to use an exec module to inject environment variables into backend terraform files