### PR TITLE
fix a few ci problems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -627,9 +627,6 @@ jobs:
       - run:
           name: Deploy demo-project
           command: ./bin/garden deploy --root examples/demo-project --logger-type basic
-      - run:
-          name: Deploy openfaas
-          command: ./bin/garden deploy --root examples/openfaas --logger-type basic
 
   test-microk8s:
     machine:
@@ -688,9 +685,6 @@ jobs:
       - run:
           name: Deploy demo-project
           command: sudo -E ./bin/garden deploy --root examples/demo-project --logger-type basic
-      - run:
-          name: Deploy openfaas
-          command: sudo -E ./bin/garden deploy --root examples/openfaas --logger-type basic
 
   test-minikube:
     machine:
@@ -708,10 +702,6 @@ jobs:
         description: Integ test groups to skip
         type: string
         default: "cluster-docker kaniko remote-only"
-      testOpenfaas:
-        description: Whether to test the openfaas project
-        type: boolean
-        default: true
     environment:
       <<: *shared-env-config
       K8S_VERSION: <<parameters.kubernetesVersion>>
@@ -760,12 +750,6 @@ jobs:
       - run:
           name: Deploy demo-project
           command: sudo -E ./bin/garden deploy --root examples/demo-project
-      - when:
-          condition: <<parameters.testOpenfaas>>
-          steps:
-            - run:
-                name: Deploy openfaas
-                command: sudo -E ./bin/garden deploy --root examples/openfaas
       - run:
           name: Run cluster cleanup
           command: |
@@ -937,11 +921,6 @@ workflows:
           requires: [build]
       - e2e-project:
           <<: *only-internal-prs
-          name: e2e-openfaas
-          project: openfaas
-          requires: [build]
-      - e2e-project:
-          <<: *only-internal-prs
           name: e2e-project-variables
           project: project-variables
           requires: [build]
@@ -986,23 +965,16 @@ workflows:
           # This is sort of fine, since we don't _really_ support in-cluster building on minikube, just been using it for
           # integration tests.
           skipTests: cluster-docker cluster-buildkit kaniko remote-only
-          # OpenFaaS project fails without ingress, which doesn't work in CircleCI on minikube v1.12+, which is necessary
-          # for most recent k8s versions.
-          testOpenfaas: false
       - test-minikube:
           name: vm-1.23-minikube
           requires: [build]
           kubernetesVersion: "1.23.3"
           minikubeVersion: "v1.25.2"
-          # OpenFaaS project fails without ingress, which doesn't work in CircleCI on minikube v1.12+, which is necessary
-          # for most recent k8s versions.
-          testOpenfaas: false
       - test-minikube:
           name: vm-1.19-minikube
           requires: [build]
           kubernetesVersion: "1.19.7"
           minikubeVersion: "v1.16.0"
-          testOpenfaas: false
       - test-microk8s:
           name: vm-1.24-microk8s
           requires: [build]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -978,7 +978,7 @@ workflows:
       # tested, and that the most recent versions are broadly tested. The kind tests are the cheapest to run so we use many
       # of those, but they currently don't test in-cluster building, so we do need a range of versions on minikube as well.
       - test-minikube:
-          name: minikube-1.22
+          name: vm-1.22-minikube
           requires: [build]
           kubernetesVersion: "1.22.2"
           minikubeVersion: "v1.25.2"
@@ -990,7 +990,7 @@ workflows:
           # for most recent k8s versions.
           testOpenfaas: false
       - test-minikube:
-          name: minikube-1.23
+          name: vm-1.23-minikube
           requires: [build]
           kubernetesVersion: "1.23.3"
           minikubeVersion: "v1.25.2"
@@ -998,33 +998,33 @@ workflows:
           # for most recent k8s versions.
           testOpenfaas: false
       - test-minikube:
-          name: minikube-1.19
+          name: vm-1.19-minikube
           requires: [build]
-          kubernetesVersion: "1.22.2"
-          minikubeVersion: "v1.25.2"
+          kubernetesVersion: "1.19.7"
+          minikubeVersion: "v1.16.0"
           testOpenfaas: false
       - test-microk8s:
-          name: microk8s-1.24
+          name: vm-1.24-microk8s
           requires: [build]
           kubernetesVersion: "1.24"
       - test-kind:
-          name: kind-1.19
+          name: vm-1.19-kind
           requires: [build]
           kindNodeImage: kindest/node:v1.19.4
       - test-kind:
-          name: kind-1.20
+          name: vm-1.20-kind
           requires: [build]
           kindNodeImage: kindest/node:v1.20.2
       - test-kind:
-          name: kind-1.21
+          name: vm-1.21-kind
           requires: [build]
           kindNodeImage: kindest/node:v1.21.2
       - test-kind:
-          name: kind-1.22
+          name: vm-1.22-kind
           requires: [build]
           kindNodeImage: kindest/node:v1.22.9@sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105
       - test-kind:
-          name: kind-1.23
+          name: vm-1.23-kind
           requires: [build]
           kindNodeImage: kindest/node:v1.23.6@sha256:b1fa224cc6c7ff32455e0b1fd9cbfd3d3bc87ecaa8fcb06961ed1afb3db0f9ae
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -981,7 +981,7 @@ workflows:
           name: minikube-1.22
           requires: [build]
           kubernetesVersion: "1.22.2"
-          minikubeVersion: "v1.23.2"
+          minikubeVersion: "v1.25.2"
           # cluster-buildkit works on other minikube versions, but the in-cluster registry has issues on the latest version
           # This is sort of fine, since we don't _really_ support in-cluster building on minikube, just been using it for
           # integration tests.
@@ -990,34 +990,23 @@ workflows:
           # for most recent k8s versions.
           testOpenfaas: false
       - test-minikube:
-          name: minikube-1.20
+          name: minikube-1.23
           requires: [build]
-          kubernetesVersion: "1.20.2"
-          minikubeVersion: "v1.16.0"
+          kubernetesVersion: "1.23.3"
+          minikubeVersion: "v1.25.2"
           # OpenFaaS project fails without ingress, which doesn't work in CircleCI on minikube v1.12+, which is necessary
           # for most recent k8s versions.
           testOpenfaas: false
       - test-minikube:
           name: minikube-1.19
           requires: [build]
-          kubernetesVersion: "1.19.7"
-          minikubeVersion: "v1.16.0"
+          kubernetesVersion: "1.22.2"
+          minikubeVersion: "v1.25.2"
           testOpenfaas: false
       - test-microk8s:
+          name: microk8s-1.24
           requires: [build]
-          kubernetesVersion: "1.19"
-      - test-kind:
-          name: kind-1.15
-          requires: [build]
-          kindNodeImage: kindest/node:v1.15.12
-      - test-kind:
-          name: kind-1.16
-          requires: [build]
-          kindNodeImage: kindest/node:v1.16.15
-      - test-kind:
-          name: kind-1.17
-          requires: [build]
-          kindNodeImage: kindest/node:v1.17.11
+          kubernetesVersion: "1.24"
       - test-kind:
           name: kind-1.19
           requires: [build]
@@ -1030,6 +1019,14 @@ workflows:
           name: kind-1.21
           requires: [build]
           kindNodeImage: kindest/node:v1.21.2
+      - test-kind:
+          name: kind-1.22
+          requires: [build]
+          kindNodeImage: kindest/node:v1.22.9@sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105
+      - test-kind:
+          name: kind-1.23
+          requires: [build]
+          kindNodeImage: kindest/node:v1.23.6@sha256:b1fa224cc6c7ff32455e0b1fd9cbfd3d3bc87ecaa8fcb06961ed1afb3db0f9ae
 
       - test-plugins:
           requires: [build]

--- a/cli/package.json
+++ b/cli/package.json
@@ -28,8 +28,8 @@
     "@garden-io/garden-conftest-kubernetes": "*",
     "@garden-io/garden-jib": "*",
     "@garden-io/garden-maven-container": "*",
-    "@garden-io/garden-terraform": "*",
     "@garden-io/garden-pulumi": "*",
+    "@garden-io/garden-terraform": "*",
     "chalk": "^4.1.0"
   },
   "devDependencies": {
@@ -42,7 +42,7 @@
     "minimist": "^1.2.6",
     "mocha": "^8.1.1",
     "patch-package": "^6.4.7",
-    "pkg": "5.6.0",
+    "pkg": "5.7.0",
     "postinstall-postinstall": "^2.1.0",
     "prettier": "^2.1.0",
     "split2": "^3.2.2",

--- a/cli/patches/pkg+5.7.0.patch
+++ b/cli/patches/pkg+5.7.0.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/pkg/prelude/bootstrap.js b/node_modules/pkg/prelude/bootstrap.js
-index 9c2ad55..f8304de 100644
+index 8627ea5..bde7122 100644
 --- a/node_modules/pkg/prelude/bootstrap.js
 +++ b/node_modules/pkg/prelude/bootstrap.js
-@@ -1963,7 +1963,7 @@ function payloadFileSync(pointer) {
+@@ -2006,7 +2006,7 @@ function payloadFileSync(pointer) {
      }
      const opts = args[pos];
      if (!opts.env) opts.env = _extend({}, process.env);

--- a/cli/src/build-pkg.ts
+++ b/cli/src/build-pkg.ts
@@ -242,7 +242,6 @@ async function pkgCommon({
 
   console.log(` - ${targetName} -> pkg`)
   await exec(pkgPath, [
-    "-d", // it seems to fix a concurrency big in pkg if this is added :(
     "--target",
     pkgType,
     sourcePath,

--- a/docs/advanced/pulumi.md
+++ b/docs/advanced/pulumi.md
@@ -111,7 +111,7 @@ garden plugins pulumi preview -- my-pulumi-module my-other-pulumi-module
 
 ## Next steps
 
-Check out the [`pulumi` example]((https://github.com/garden-io/garden/tree/0.12.41/examples/pulumi)) project.
+Check out the [`pulumi` example](https://github.com/garden-io/garden/tree/0.12.41/examples/pulumi) project.
 
 Also take a look at the [pulumi provider reference]() and the [pulumi module type reference] for details on all the configuration parameters.
 

--- a/docs/guides/remote-kubernetes.md
+++ b/docs/guides/remote-kubernetes.md
@@ -92,13 +92,11 @@ images when deploying. This should generally be a _private_ container registry, 
 public registry.
 
 Similarly to the below TLS configuration, you may also need to set up auth for the registry using K8s Secrets, in this
-case via the `kubectl create secret docker-registry` helper.
+case via the `kubectl create secret docker-registry` helper. You can read more about using and setting up private 
+registries [here](https://kubernetes.io/docs/concepts/containers/images/#using-a-private-registry).
 
 _Note that you do not need to configure the authentication and imagePullSecrets when using GKE along with GCR,
 as long as your deployment registry is in the same project as the GKE cluster._
-
-The lovely folks at Heptio have prepared good guides on how to configure private registries
-for Kubernetes, which you can find [here](http://docs.heptio.com/content/private-registries.html).
 
 Once you've created the auth secret in the cluster, you can configure the registry and the secrets in your
 `garden.yml` project config like this:
@@ -131,7 +129,7 @@ to your registry's documentation on how to do that (for Docker Hub you simply ru
 
 ### Ingress, TLS and DNS
 
-By default, Garden will not install an ingress controller for remote environments. This can be toggled by setting the [`setupIngressController` flag](../reference/providers/kubernetes.md#providerssetupingresscontroller) to `nginx`. Alternatively, you can set up your own ingress controller, e.g. using [Traefik](https://traefik.io/), [Ambassador](https://www.getambassador.io/) or [Istio](https://istio.io/). You can find examples for [using Garden with Ambassador](https://github.com/garden-io/garden/tree/0.12.41/examples/ambassador) and [with Istio](https://github.com/garden-io/garden/tree/0.12.41/examples/istio) in our [examples directory](https://github.com/garden-io/garden/tree/0.12.41/examples).
+By default, Garden will not install an ingress controller for remote environments. This can be toggled by setting the [`setupIngressController` flag](../reference/providers/kubernetes.md#providerssetupingresscontroller) to `nginx`. Alternatively, you can set up your own ingress controller, e.g. using [Traefik](https://traefik.io/), [Ambassador](https://www.getambassador.io/) or [Istio](https://istio.io/). You can find an example for [using Garden with Istio](https://github.com/garden-io/garden/tree/0.12.41/examples/istio) in our [examples directory](https://github.com/garden-io/garden/tree/0.12.41/examples).
 
 You'll also need to point one or more DNS entries to your cluster, and configure a TLS certificate for the hostnames
 you will expose for ingress.

--- a/plugins/jib/test/index.ts
+++ b/plugins/jib/test/index.ts
@@ -14,7 +14,10 @@ import { makeTestGarden, TestGarden } from "@garden-io/sdk/testing"
 import { defaultApiVersion, defaultNamespace } from "@garden-io/sdk/constants"
 import { gardenPlugin } from ".."
 
-describe("jib-container", () => {
+describe("jib-container", function () {
+  // tslint:disable-next-line: no-invalid-this
+  this.timeout(180 * 1000) // initial jib build can take a long time
+
   const projectRoot = join(__dirname, "test-project")
 
   const projectConfig: ProjectConfig = {

--- a/static/kubernetes/system/cert-manager/cert-manager-crd.yaml
+++ b/static/kubernetes/system/cert-manager/cert-manager-crd.yaml
@@ -5402,7 +5402,7 @@ metadata:
     helm.sh/chart: cert-manager-v0.11.0
 ---
 # Source: cert-manager/charts/cainjector/templates/rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cert-manager-cainjector
@@ -5432,7 +5432,7 @@ rules:
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "watch", "update"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cert-manager-cainjector
@@ -5453,7 +5453,7 @@ subjects:
 
 ---
 # leader election rules
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: cert-manager-cainjector:leaderelection
@@ -5475,7 +5475,7 @@ rules:
 
 # grant cert-manager permission to manage the leaderelection configmap in the
 # leader election namespace
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: cert-manager-cainjector:leaderelection
@@ -5501,7 +5501,7 @@ subjects:
 ---
 # apiserver gets the auth-delegator role to delegate auth decisions to
 # the core apiserver
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cert-manager-webhook:auth-delegator
@@ -5526,7 +5526,7 @@ subjects:
 # apiserver gets the ability to read authentication. This allows it to
 # read the specific configmap that has the requestheader-* entries to
 # api agg
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: cert-manager-webhook:webhook-authentication-reader
@@ -5571,7 +5571,7 @@ rules:
   - create
 ---
 # Source: cert-manager/templates/rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: cert-manager:leaderelection
@@ -5593,7 +5593,7 @@ rules:
 
 # grant cert-manager permission to manage the leaderelection configmap in the
 # leader election namespace
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: cert-manager:leaderelection
@@ -5617,7 +5617,7 @@ subjects:
 ---
 
 # Issuer controller role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cert-manager-controller-issuers
@@ -5644,7 +5644,7 @@ rules:
 ---
 
 # ClusterIssuer controller role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cert-manager-controller-clusterissuers
@@ -5671,7 +5671,7 @@ rules:
 ---
 
 # Certificates controller role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cert-manager-controller-certificates
@@ -5707,7 +5707,7 @@ rules:
 ---
 
 # Orders controller role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cert-manager-controller-orders
@@ -5746,7 +5746,7 @@ rules:
 ---
 
 # Challenges controller role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cert-manager-controller-challenges
@@ -5798,7 +5798,7 @@ rules:
 ---
 
 # ingress-shim controller role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cert-manager-controller-ingress-shim
@@ -5830,7 +5830,7 @@ rules:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cert-manager-leaderelection
@@ -5851,7 +5851,7 @@ subjects:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cert-manager-controller-issuers
@@ -5872,7 +5872,7 @@ subjects:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cert-manager-controller-clusterissuers
@@ -5893,7 +5893,7 @@ subjects:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cert-manager-controller-certificates
@@ -5914,7 +5914,7 @@ subjects:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cert-manager-controller-orders
@@ -5935,7 +5935,7 @@ subjects:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cert-manager-controller-challenges
@@ -5956,7 +5956,7 @@ subjects:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cert-manager-controller-ingress-shim

--- a/static/kubernetes/system/nginx-kind/nginx-kind-old.garden.yml
+++ b/static/kubernetes/system/nginx-kind/nginx-kind-old.garden.yml
@@ -70,7 +70,7 @@ manifests:
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/part-of: ingress-nginx
 
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole
     metadata:
       name: nginx-ingress-clusterrole
@@ -127,7 +127,7 @@ manifests:
         verbs:
           - update
 
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
       name: nginx-ingress-role
@@ -171,7 +171,7 @@ manifests:
         verbs:
           - get
 
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
       name: nginx-ingress-role-nisa-binding
@@ -188,7 +188,7 @@ manifests:
         name: nginx-ingress-serviceaccount
         namespace: ${var.namespace}
 
-  - apiVersion: rbac.authorization.k8s.io/v1beta1
+  - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
       name: nginx-ingress-clusterrole-nisa-binding

--- a/support/alpine-builder.Dockerfile
+++ b/support/alpine-builder.Dockerfile
@@ -19,7 +19,7 @@ RUN apk add --no-cache \
 WORKDIR /garden-tmp/pkg
 
 # Pre-fetch the node binary for pkg
-RUN yarn add pkg@5.6.0 && \
+RUN yarn add pkg@5.7.0 && \
   node_modules/.bin/pkg-fetch node14 alpine x64
 
 # Add all the packages

--- a/support/gcloud.Dockerfile
+++ b/support/gcloud.Dockerfile
@@ -1,7 +1,7 @@
 ARG TAG=latest
 FROM google/cloud-sdk:331.0.0-alpine as gcloud
 
-RUN gcloud components install kubectl
+RUN gcloud components install kubectl --quiet
 
 FROM gardendev/garden:${TAG}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -257,7 +257,7 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz#6654d171b2024f6d8ee151bf2509699919131d48"
   integrity sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==
 
-"@babel/helper-validator-identifier@^7.15.7":
+"@babel/helper-validator-identifier@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
   integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
@@ -304,10 +304,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@7.16.2":
-  version "7.16.2"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.2.tgz#3723cd5c8d8773eef96ce57ea1d9b7faaccd12ac"
-  integrity sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw==
+"@babel/parser@7.17.10":
+  version "7.17.10"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.10.tgz#873b16db82a8909e0fbd7f115772f4b739f6ce78"
+  integrity sha512-n2Q6i+fnJqzOaq2VkdXxy2TCPCWQZHiCo0XqmrCvDWcZQKRyZzYi4Z0yxlBuN0w+r2ZHmre+Q087DSrw3pbJDQ==
 
 "@babel/parser@^7.1.0", "@babel/parser@^7.12.13", "@babel/parser@^7.12.17", "@babel/parser@^7.4.3", "@babel/parser@^7.7.0", "@babel/parser@^7.9.0":
   version "7.12.17"
@@ -1151,12 +1151,12 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
-"@babel/types@7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.16.0.tgz#db3b313804f96aadd0b776c4823e127ad67289ba"
-  integrity sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==
+"@babel/types@7.17.10":
+  version "7.17.10"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.17.10.tgz#d35d7b4467e439fcf06d195f8100e0fea7fc82c4"
+  integrity sha512-9O26jG0mBYfGkUYCYZRnBwbVLd1UZOICEr2Em6InB6jVfsAv1GKgwXHmrSg+WFWDmeKTA6vyTZiN8tCSM5Oo3A==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.15.7"
+    "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
 
 "@babel/types@^7.0.0", "@babel/types@^7.12.1", "@babel/types@^7.12.13", "@babel/types@^7.12.17", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.7.0", "@babel/types@^7.9.0":
@@ -9006,7 +9006,7 @@ globby@^11.0.1:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-globby@^11.0.4:
+globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
@@ -10204,6 +10204,13 @@ is-color-stop@^1.0.0:
     hsla-regex "^1.0.0"
     rgb-regex "^1.0.1"
     rgba-regex "^1.0.0"
+
+is-core-module@2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.9.0.tgz#e1c34429cd51c6dd9e09e0799e396e27b19a9c69"
+  integrity sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==
+  dependencies:
+    has "^1.0.3"
 
 is-core-module@^2.2.0:
   version "2.2.0"
@@ -14318,10 +14325,10 @@ pkg-dir@^5.0.0:
   dependencies:
     find-up "^5.0.0"
 
-pkg-fetch@3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/pkg-fetch/-/pkg-fetch-3.3.0.tgz#3afc2fb7a19219839cf75654fa8b54a2630df891"
-  integrity sha512-xJnIZ1KP+8rNN+VLafwu4tEeV4m8IkFBDdCFqmAJz9K1aiXEtbARmdbEe6HlXWGSVuShSHjFXpfkKRkDBQ5kiA==
+pkg-fetch@3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/pkg-fetch/-/pkg-fetch-3.4.1.tgz#be68bb9f7fdb0f6ed995abc518ab2e35aa64d2fd"
+  integrity sha512-fS4cdayCa1r4jHkOKGPJKnS9PEs6OWZst+s+m0+CmhmPZObMnxoRnf9T9yUWl+lzM2b5aJF7cnQIySCT7Hq8Dg==
   dependencies:
     chalk "^4.1.2"
     fs-extra "^9.1.0"
@@ -14339,26 +14346,25 @@ pkg-up@3.1.0, pkg-up@^3.1.0:
   dependencies:
     find-up "^3.0.0"
 
-pkg@5.6.0:
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/pkg/-/pkg-5.6.0.tgz#53d2616491e429db293d93d474e69ca3dc0f281d"
-  integrity sha512-mHrAVSQWmHA41RnUmRpC7pK9lNnMfdA16CF3cqOI22a8LZxOQzF7M8YWtA2nfs+d7I0MTDXOtkDsAsFXeCpYjg==
+pkg@5.7.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/pkg/-/pkg-5.7.0.tgz#6422df05e8aa147764be6ef912921d0fa719ea95"
+  integrity sha512-PTiAjNq/CGAtK5qUBR6pjheqnipTFjeecgSgIKEcAOJA4GpmZeOZC8pMOoT0rfes5vHsmcFo7wbSRTAmXQurrg==
   dependencies:
-    "@babel/parser" "7.16.2"
-    "@babel/types" "7.16.0"
+    "@babel/parser" "7.17.10"
+    "@babel/types" "7.17.10"
     chalk "^4.1.2"
     escodegen "^2.0.0"
     fs-extra "^9.1.0"
-    globby "^11.0.4"
+    globby "^11.1.0"
     into-stream "^6.0.0"
-    minimist "^1.2.5"
+    is-core-module "2.9.0"
+    minimist "^1.2.6"
     multistream "^4.1.0"
-    pkg-fetch "3.3.0"
+    pkg-fetch "3.4.1"
     prebuild-install "6.1.4"
-    progress "^2.0.3"
-    resolve "^1.20.0"
+    resolve "^1.22.0"
     stream-meter "^1.0.4"
-    tslib "2.3.1"
 
 pkijs@^1.3.27:
   version "1.3.33"
@@ -16446,7 +16452,7 @@ resolve@^1.1.7, resolve@^1.10.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13
     is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
-resolve@^1.20.0:
+resolve@^1.22.0:
   version "1.22.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.0.tgz#5e0b8c67c15df57a89bdbabe603a002f21731198"
   integrity sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
@@ -18333,11 +18339,6 @@ ts-stream@^3.0.0:
   integrity sha512-inSYkFNWYRDKu+fEriDeTV8KP6BLx/CujUb047sIuMH1YUZcUdjYpwiGsXVyWIEREOFb02e0z6b/cK8lG1i4cw==
   dependencies:
     "@types/node" "*"
-
-tslib@2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
-  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tslib@^1.10.0, tslib@^1.13.0, tslib@^1.6.0, tslib@^1.7.1, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"


### PR DESCRIPTION
FIx a bunch of small things that were messing up ci + add new k8s versions and remove old unsupported ones.

Please review this commit by commit (they have a lot of extra info in them)

Stuff that still sometimes fails (don't have any more time to spend on debugging, maybe will do so later)
* build step will still occasionally fail due to the concurrency issue in pkg. The delays seemed to help, but not completely fix (more info in the pkg commits)
* in vm e2e runs sometimes mutagen fails to sync stuff and crashes ([example](https://app.circleci.com/pipelines/github/garden-io/garden/12104/workflows/7e760b32-0793-46e7-8182-91b19118599c/jobs/196256))