### PR TITLE
fix(k8s): change kaniko default image to 1.8.1

### DIFF
--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -40,7 +40,7 @@ import { runPodSpecIncludeFields } from "./run"
 import { KubernetesDevModeDefaults, kubernetesDevModeDefaultsSchema } from "./dev-mode"
 import { KUBECTL_DEFAULT_TIMEOUT } from "./kubectl"
 
-export const DEFAULT_KANIKO_IMAGE = "gcr.io/kaniko-project/executor:v1.6.0-debug"
+export const DEFAULT_KANIKO_IMAGE = "gcr.io/kaniko-project/executor:v1.8.1-debug"
 export interface ProviderSecretRef {
   name: string
   namespace: string

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -74,7 +74,7 @@ providers:
       extraFlags:
 
       # Change the kaniko image (repository/image:tag) to use when building in kaniko mode.
-      image: 'gcr.io/kaniko-project/executor:v1.6.0-debug'
+      image: 'gcr.io/kaniko-project/executor:v1.8.1-debug'
 
       # Choose the namespace where the Kaniko pods will be run. Set to `null` to use the project namespace.
       #
@@ -600,7 +600,7 @@ Change the kaniko image (repository/image:tag) to use when building in kaniko mo
 
 | Type     | Default                                         | Required |
 | -------- | ----------------------------------------------- | -------- |
-| `string` | `"gcr.io/kaniko-project/executor:v1.6.0-debug"` | No       |
+| `string` | `"gcr.io/kaniko-project/executor:v1.8.1-debug"` | No       |
 
 ### `providers[].kaniko.namespace`
 

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -70,7 +70,7 @@ providers:
       extraFlags:
 
       # Change the kaniko image (repository/image:tag) to use when building in kaniko mode.
-      image: 'gcr.io/kaniko-project/executor:v1.6.0-debug'
+      image: 'gcr.io/kaniko-project/executor:v1.8.1-debug'
 
       # Choose the namespace where the Kaniko pods will be run. Set to `null` to use the project namespace.
       #
@@ -553,7 +553,7 @@ Change the kaniko image (repository/image:tag) to use when building in kaniko mo
 
 | Type     | Default                                         | Required |
 | -------- | ----------------------------------------------- | -------- |
-| `string` | `"gcr.io/kaniko-project/executor:v1.6.0-debug"` | No       |
+| `string` | `"gcr.io/kaniko-project/executor:v1.8.1-debug"` | No       |
 
 ### `providers[].kaniko.namespace`
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Kaniko has a bug with not computing the correct cache keys when running multistage builds yielding images with outdated files inside. This version fixes the issue.
