### PR TITLE
fix: git repository ownership issue

### DIFF
--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -32,6 +32,9 @@ import chalk = require("chalk")
 import hasha = require("hasha")
 import { pMemoizeDecorator } from "../lib/p-memoize"
 
+const AsyncLock = require("async-lock")
+const gitConfigAsyncLock = new AsyncLock()
+
 const submoduleErrorSuggestion = `Perhaps you need to run ${chalk.underline(`git submodule update --recursive`)}?`
 const hashConcurrencyLimit = 50
 const currentPlatformName = process.platform
@@ -78,12 +81,14 @@ export class GitHandler extends VcsHandler {
   name = "git"
   repoRoots = new Map()
   profiler: Profiler
-  private readonly gitSafeDirs: Record<string, boolean>
+  private readonly gitSafeDirs: Set<string>
+  private gitSafeDirsRead: boolean
 
   constructor(...args: [string, string, string[], TreeCache]) {
     super(...args)
     this.profiler = getDefaultProfiler()
-    this.gitSafeDirs = {}
+    this.gitSafeDirs = new Set<string>()
+    this.gitSafeDirsRead = false
   }
 
   gitCli(log: LogEntry, cwd: string): GitCli {
@@ -127,11 +132,28 @@ export class GitHandler extends VcsHandler {
    * see https://github.blog/2022-04-18-highlights-from-git-2-36/ for more details.
    */
   private async ensureSafeDirGitRepo(log: LogEntry, path: string): Promise<void> {
-    if (this.gitSafeDirs[path]) {
+    if (this.gitSafeDirs.has(path)) {
       return
     }
 
     const git = this.gitCli(log, path)
+
+    if (!this.gitSafeDirsRead) {
+      await gitConfigAsyncLock.acquire(".gitconfig", async () => {
+        if (!this.gitSafeDirsRead) {
+          const gitCli = this.gitCli(log, path)
+          try {
+            const safeDirectories = await gitCli("config", "--get-all", "safe.directory")
+            safeDirectories.forEach((safeDir) => this.gitSafeDirs.add(safeDir))
+          } catch (err) {
+            // ignore the error if there are no safe directories defined
+            log.debug(`Error reading safe directories from the .gitconfig: ${err}`)
+          }
+          this.gitSafeDirsRead = true
+        }
+      })
+    }
+
     try {
       await git("status")
     } catch (err) {
@@ -142,12 +164,20 @@ export class GitHandler extends VcsHandler {
             `It looks like you're using Git 2.36.0 or newer and the Garden static directory "${path}" is owned by someone else. It will be added to safe.directory list in the .gitconfig.`
           )
         )
-        const gitConfigCompatiblePath = this.toGitConfigCompatiblePath(path, currentPlatformName)
-        // Add the safe directory globally to be able to run git command outside a (trusted) git repo
-        // Wrap the path in quotes to pass it as a single argument in case if it contains any whitespaces
-        await git("config", "--global", "--add", "safe.directory", `'${gitConfigCompatiblePath}'`)
-        this.gitSafeDirs[path] = true
-        log.debug(`Configured git to trust repository in ${path}`)
+
+        if (!this.gitSafeDirs.has(path)) {
+          await gitConfigAsyncLock.acquire(".gitconfig", async () => {
+            if (!this.gitSafeDirs.has(path)) {
+              const gitConfigCompatiblePath = this.toGitConfigCompatiblePath(path, currentPlatformName)
+              // Add the safe directory globally to be able to run git command outside a (trusted) git repo
+              // Wrap the path in quotes to pass it as a single argument in case if it contains any whitespaces
+              await git("config", "--global", "--add", "safe.directory", `'${gitConfigCompatiblePath}'`)
+              this.gitSafeDirs.add(path)
+              log.debug(`Configured git to trust repository in ${path}`)
+            }
+          })
+        }
+
         return
       } else if (err.exitCode === 128 && err.stderr?.toLowerCase().includes("fatal: not a git repository")) {
         throw new RuntimeError(notInRepoRootErrorMessage(path), { path })
@@ -158,7 +188,7 @@ export class GitHandler extends VcsHandler {
         throw err
       }
     }
-    this.gitSafeDirs[path] = true
+    this.gitSafeDirs.add(path)
   }
 
   async getRepoRoot(log: LogEntry, path: string) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This is an additional fix for #2905. The same issue happened with some sub-folder of the git repo in the Garden Cloud testing.

The suggested solution is to always consider any working directory in a git repository as a safe one.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
