### PR TITLE
improvement: bump alpine, node and gcloud SDK version in support

### DIFF
--- a/images/circleci-runner/Dockerfile
+++ b/images/circleci-runner/Dockerfile
@@ -2,7 +2,7 @@
 FROM google/cloud-sdk:331.0.0 as gcloud
 
 #### ldid utility ####
-FROM cimg/node:14.19.0 as ldid
+FROM cimg/node:14.19.3 as ldid
 
 RUN sudo apt-get update && sudo apt-get install -qq -y --no-install-recommends \
   git \
@@ -18,7 +18,7 @@ RUN cd /tmp && \
   sudo cp -f ./ldid /usr/local/bin/ldid
 
 #### main ####
-FROM cimg/node:14.19.0
+FROM cimg/node:14.19.3
 
 # install system deps
 RUN sudo apt-get update && sudo apt-get -y install rsync parallel python3

--- a/images/circleci-runner/Dockerfile
+++ b/images/circleci-runner/Dockerfile
@@ -1,5 +1,5 @@
 #### gcloud base image ####
-FROM google/cloud-sdk:331.0.0 as gcloud
+FROM google/cloud-sdk:390.0.0 as gcloud
 
 #### ldid utility ####
 FROM cimg/node:14.19.3 as ldid

--- a/images/circleci-runner/garden.yml
+++ b/images/circleci-runner/garden.yml
@@ -2,4 +2,4 @@ kind: Module
 type: container
 name: circleci-runner
 description: Used for the core pipeline in CircleCI
-image: gardendev/circleci-runner:14.19.0-1
+image: gardendev/circleci-runner:14.19.3-1

--- a/support/alpine-builder.Dockerfile
+++ b/support/alpine-builder.Dockerfile
@@ -1,5 +1,5 @@
 # Note: This is used by build-pkg.ts, and is not usable as a Garden container
-ARG NODE_VERSION=14.19.0-alpine3.14
+ARG NODE_VERSION=14.19.3-alpine3.16
 FROM node:${NODE_VERSION} as builder
 
 RUN apk add --no-cache \

--- a/support/alpine.Dockerfile
+++ b/support/alpine.Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_VERSION=14.19.0-alpine3.14
+ARG NODE_VERSION=14.19.3-alpine3.16
 FROM node:${NODE_VERSION}
 
 RUN apk add --no-cache \

--- a/support/buster.Dockerfile
+++ b/support/buster.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.19.0-buster
+FROM node:14.19.3-buster
 
 # system dependencies
 RUN set -ex; \

--- a/support/gcloud.Dockerfile
+++ b/support/gcloud.Dockerfile
@@ -1,5 +1,5 @@
 ARG TAG=latest
-FROM google/cloud-sdk:331.0.0-alpine as gcloud
+FROM google/cloud-sdk:390.0.0-alpine as gcloud
 
 RUN gcloud components install kubectl --quiet
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:

Update node, alpine and the gcloud SDK versions:

- node from 14.19.0 -> 14.19.3
- alpine from 3.14 -> 3.16
- GCloud SDK from 331.0.0 to 390.0.0. Note that there are some breaking changes detailed in the changelog: https://cloud.google.com/sdk/docs/release-notes

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
