### PR TITLE
improvement: optimized safety checks for git repos

### DIFF
--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -162,7 +162,7 @@ export class GitHandler extends VcsHandler {
       if (err.exitCode === 128 && err.stderr?.toLowerCase().includes("fatal: unsafe repository")) {
         log.warn(
           chalk.yellow(
-            `It looks like you're using Git 2.36.0 or newer and the Garden static directory "${path}" is owned by someone else. It will be added to safe.directory list in the .gitconfig.`
+            `It looks like you're using Git 2.36.0 or newer and the directory "${path}" is owned by someone else. It will be added to safe.directory list in the .gitconfig.`
           )
         )
 

--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -156,6 +156,7 @@ export class GitHandler extends VcsHandler {
 
     try {
       await git("status")
+      this.gitSafeDirs.add(path)
     } catch (err) {
       // Git has stricter repo ownerships checks since 2.36.0
       if (err.exitCode === 128 && err.stderr?.toLowerCase().includes("fatal: unsafe repository")) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR minimizes number of `git status` calls in the `GitHandler.ensureSafeDirGitRepo(log: LogEntry, path: string)` method. Every successful `git status` result is cached in memory.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
See https://github.com/garden-io/garden/pull/3012#discussion_r902252328 for more details.