### PR TITLE
chore: update TypeScript to 4.7.4

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -51,7 +51,7 @@
     "tslint-microsoft-contrib": "^6.2.0",
     "tslint-no-unused": "^0.2.0-alpha.1",
     "tslint-plugin-prettier": "^2.3.0",
-    "typescript": "^4.3.5",
+    "typescript": "^4.7.4",
     "username": "^5.1.0"
   },
   "scripts": {

--- a/core/package.json
+++ b/core/package.json
@@ -247,7 +247,7 @@
     "tslint-no-unused": "^0.2.0-alpha.1",
     "tslint-plugin-prettier": "^2.3.0",
     "type-fest": "^2.5.4",
-    "typescript": "^4.3.5"
+    "typescript": "^4.7.4"
   },
   "scripts": {
     "build": "gulp pegjs",

--- a/core/src/actions.ts
+++ b/core/src/actions.ts
@@ -1329,7 +1329,7 @@ export class ActionRouter implements TypeGuard {
       handlers[actionType][moduleType] = {}
     }
 
-    this.moduleActionHandlers[actionType][moduleType][pluginName] = wrapped
+    this.moduleActionHandlers[actionType][moduleType][pluginName] = <any>wrapped
   }
 
   /**

--- a/core/src/config-store.ts
+++ b/core/src/config-store.ts
@@ -51,7 +51,7 @@ export abstract class ConfigStore<T extends object = any> {
     }
 
     for (const { keyPath, value } of entries) {
-      config = this.updateConfig(config, keyPath, value)
+      config = await this.updateConfig(config, keyPath, value)
     }
 
     await this.saveConfig(config)
@@ -99,7 +99,7 @@ export abstract class ConfigStore<T extends object = any> {
       await this.loadConfig()
     }
     // Spreading does not work on generic types, see: https://github.com/Microsoft/TypeScript/issues/13557
-    return Object.assign(this.config, {})
+    return <T>Object.assign(<T>this.config, {})
   }
 
   private updateConfig(config: T, keyPath: string[], value: ConfigValue): T {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -24,7 +24,7 @@
     "tslint-no-unused": "^0.2.0-alpha.1",
     "tslint-plugin-prettier": "^2.3.0",
     "tslint-react": "^5.0.0",
-    "typescript": "^4.3.5"
+    "typescript": "^4.7.4"
   },
   "dependencies": {
     "@emotion/core": "^10.0.28",

--- a/dashboard/src/api/actions.ts
+++ b/dashboard/src/api/actions.ts
@@ -16,29 +16,30 @@ import { ConfigDump } from "@garden-io/core/build/src/garden"
 import { GetTestResultCommandResult } from "@garden-io/core/build/src/commands/get/get-test-result"
 import { GraphOutput } from "@garden-io/core/build/src/commands/get/get-graph"
 import {
+  ApiDispatch,
+  defaultRunStatus,
+  defaultServiceStatus,
+  defaultTaskState,
   Entities,
   ModuleEntity,
   ServiceEntity,
   TaskEntity,
   TestEntity,
-  ApiDispatch,
-  defaultTaskState,
-  defaultServiceStatus,
-  defaultRunStatus,
 } from "../contexts/api"
 import {
+  fetchConfig,
+  fetchGraph,
   fetchLogs,
   fetchStatus,
   fetchTaskResult,
-  fetchConfig,
-  fetchTestResult,
-  fetchGraph,
   FetchTaskResultParams,
+  fetchTestResult,
   FetchTestResultParams,
 } from "./api"
 import { getAuthKey, getTestKey } from "../util/helpers"
 import { ProviderMap } from "@garden-io/core/build/src/config/provider"
 import { DashboardPage } from "@garden-io/core/build/src/types/plugin/provider/getDashboardPage"
+import { AxiosError } from "axios"
 
 // This file contains the API action functions.
 // The actions are responsible for dispatching the appropriate action types and normalising the
@@ -87,7 +88,7 @@ async function loadConfig(dispatch: ApiDispatch) {
   try {
     res = await fetchConfig()
   } catch (error) {
-    dispatch({ requestKey, type: "fetchFailure", error })
+    dispatch({ requestKey, type: "fetchFailure", error: error as AxiosError })
     return
   }
 
@@ -182,7 +183,7 @@ export async function loadStatus(dispatch: ApiDispatch) {
   try {
     res = await fetchStatus()
   } catch (error) {
-    dispatch({ requestKey, type: "fetchFailure", error })
+    dispatch({ requestKey, type: "fetchFailure", error: error as AxiosError })
     return
   }
 
@@ -227,7 +228,7 @@ export async function loadLogs(dispatch: ApiDispatch, serviceNames: string[]) {
   try {
     res = await fetchLogs({ serviceNames })
   } catch (error) {
-    dispatch({ requestKey, type: "fetchFailure", error })
+    dispatch({ requestKey, type: "fetchFailure", error: error as AxiosError })
     return
   }
 
@@ -255,7 +256,7 @@ export async function loadTaskResult({ dispatch, ...fetchParams }: LoadTaskResul
   try {
     res = await fetchTaskResult(fetchParams)
   } catch (error) {
-    dispatch({ requestKey, type: "fetchFailure", error })
+    dispatch({ requestKey, type: "fetchFailure", error: error as AxiosError })
     return
   }
 
@@ -285,7 +286,7 @@ export async function loadTestResult({ dispatch, ...fetchParams }: LoadTestResul
   try {
     res = await fetchTestResult(fetchParams)
   } catch (error) {
-    dispatch({ requestKey, type: "fetchFailure", error })
+    dispatch({ requestKey, type: "fetchFailure", error: error as AxiosError })
     return
   }
 
@@ -313,7 +314,7 @@ export async function loadGraph(dispatch: ApiDispatch) {
   try {
     res = await fetchGraph()
   } catch (error) {
-    dispatch({ requestKey, type: "fetchFailure", error })
+    dispatch({ requestKey, type: "fetchFailure", error: error as AxiosError })
     return
   }
 

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -37,7 +37,7 @@
     "mocha": "^9.2.0",
     "prettier": "^2.1.1",
     "split2": "^4.1.0",
-    "ts-node": "^10.5.0",
+    "ts-node": "^10.8.2",
     "tslint": "^6.1.3",
     "tslint-config-prettier": "^1.18.0",
     "tslint-microsoft-contrib": "^6.2.0",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -43,7 +43,7 @@
     "tslint-microsoft-contrib": "^6.2.0",
     "tslint-no-unused": "^0.2.0-alpha.1",
     "tslint-plugin-prettier": "^2.3.0",
-    "typescript": "^4.3.5"
+    "typescript": "^4.7.4"
   },
   "scripts": {
     "check-package-lock": "git diff-index --quiet HEAD -- yarn.lock || (echo 'yarn.lock is dirty!' && exit 1)",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "shx": "^0.3.2",
     "strip-ansi": "^6.0.0",
     "treeify": "^1.1.0",
-    "ts-node": "^8.10.1",
+    "ts-node": "^10.8.2",
     "tslint": "^6.1.3",
     "tslint-microsoft-contrib": "^6.2.0",
     "tslint-no-focused-test": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "tslint-no-focused-test": "^0.5.0",
     "tslint-no-unused": "^0.2.0-alpha.1",
     "tslint-plugin-prettier": "^2.3.0",
-    "typescript": "^4.3.5",
+    "typescript": "^4.7.4",
     "typescript-formatter": "^7.2.2",
     "wrap-ansi": "^7.0.0"
   },

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -30,7 +30,7 @@
     "tslint-microsoft-contrib": "^6.2.0",
     "tslint-no-unused": "^0.2.0-alpha.1",
     "tslint-plugin-prettier": "^2.3.0",
-    "typescript": "^4.3.5"
+    "typescript": "^4.7.4"
   },
   "scripts": {
     "check-package-lock": "git diff-index --quiet HEAD -- yarn.lock || (echo 'yarn.lock is dirty!' && exit 1)",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18544,10 +18544,10 @@ typescript-formatter@^7.2.2:
     commandpost "^1.0.0"
     editorconfig "^0.15.0"
 
-typescript@^4.3.5:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+typescript@^4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 uglify-js@^3.1.4:
   version "3.12.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1314,17 +1314,12 @@
   dependencies:
     find-up "^4.0.0"
 
-"@cspotcode/source-map-consumer@0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"
-  integrity sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==
-
-"@cspotcode/source-map-support@0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz#4789840aa859e46d2f3173727ab707c66bf344f5"
-  integrity sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
   dependencies:
-    "@cspotcode/source-map-consumer" "0.8.0"
+    "@jridgewell/trace-mapping" "0.3.9"
 
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"
@@ -1723,6 +1718,24 @@
     "@types/node" "*"
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
+
+"@jridgewell/resolve-uri@^3.0.3":
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.0.8.tgz#687cc2bbf243f4e9a868ecf2262318e2658873a1"
+  integrity sha512-YK5G9LaddzGbcucK4c8h5tWFmMPBvRZ/uyWmN1/SbBdIvqGUdWGkJ5BAaccgs6XbzVLsqbPJrBSFwKv3kT9i7w==
+
+"@jridgewell/sourcemap-codec@^1.4.10":
+  version "1.4.14"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
+  integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@jsdevtools/file-path-filter@^3.0.2":
   version "3.0.2"
@@ -17136,7 +17149,7 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.17, source-map-support@^0.5.19, source-map-support@^0.5.6, source-map-support@~0.5.12:
+source-map-support@^0.5.19, source-map-support@^0.5.6, source-map-support@~0.5.12:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -18281,12 +18294,12 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
-ts-node@^10.5.0:
-  version "10.5.0"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.5.0.tgz#618bef5854c1fbbedf5e31465cbb224a1d524ef9"
-  integrity sha512-6kEJKwVxAJ35W4akuiysfKwKmjkbYxwQMTBaAxo9KKAx/Yd26mPUyhGz3ji+EsJoAgrLqVsYHNuuYwQe22lbtw==
+ts-node@^10.8.2:
+  version "10.8.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.8.2.tgz#3185b75228cef116bf82ffe8762594f54b2a23f2"
+  integrity sha512-LYdGnoGddf1D6v8REPtIH+5iq/gTDuZqv2/UJUU7tKjuEU8xVZorBM+buCGNjj+pGEud+sOoM4CX3/YzINpENA==
   dependencies:
-    "@cspotcode/source-map-support" "0.7.0"
+    "@cspotcode/source-map-support" "^0.8.0"
     "@tsconfig/node10" "^1.0.7"
     "@tsconfig/node12" "^1.0.7"
     "@tsconfig/node14" "^1.0.0"
@@ -18297,18 +18310,7 @@ ts-node@^10.5.0:
     create-require "^1.1.0"
     diff "^4.0.1"
     make-error "^1.1.1"
-    v8-compile-cache-lib "^3.0.0"
-    yn "3.1.1"
-
-ts-node@^8.10.1:
-  version "8.10.2"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.10.2.tgz#eee03764633b1234ddd37f8db9ec10b75ec7fb8d"
-  integrity sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==
-  dependencies:
-    arg "^4.1.0"
-    diff "^4.0.1"
-    make-error "^1.1.1"
-    source-map-support "^0.5.17"
+    v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
 ts-pnp@1.1.6:
@@ -18947,10 +18949,10 @@ uuid@^8.1.0, uuid@^8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
-v8-compile-cache-lib@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz#0582bcb1c74f3a2ee46487ceecf372e46bce53e8"
-  integrity sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-compile-cache@^2.0.3:
   version "2.2.0"


### PR DESCRIPTION
This paves the way for an update to Node 16 and supporting ES modules.

See more on TS 4.7 here:
https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/
