### PR TITLE
fix(core): resolve runtime values in test configs

### DIFF
--- a/core/src/tasks/test.ts
+++ b/core/src/tasks/test.ts
@@ -155,7 +155,7 @@ export class TestTask extends BaseTask {
 
     const dependencies = this.graph.getDependencies({
       nodeType: "test",
-      name: this.test.name,
+      name: this.getName(),
       recursive: false,
     })
     const serviceStatuses = getServiceStatuses(dependencyResults)

--- a/core/test/data/test-project-test-deps/module-a/garden.yml
+++ b/core/test/data/test-project-test-deps/module-a/garden.yml
@@ -6,10 +6,10 @@ services:
     command: [echo, OK]
 tasks:
   - name: task-a
-    command: [echo, OK]
+    command: [echo, "task-a-ok"]
 tests:
   - name: integ
     dependencies:
       - service-b
       - task-a
-    command: [echo, OK]
+    command: [echo, "${runtime.tasks.task-a.outputs.log}"]

--- a/core/test/unit/src/tasks/test.ts
+++ b/core/test/unit/src/tasks/test.ts
@@ -25,6 +25,30 @@ describe("TestTask", () => {
     log = garden.log
   })
 
+  describe("process", () => {
+    it("should correctly resolve runtime outputs from tasks", async () => {
+      const moduleA = graph.getModule("module-a")
+      const testConfig = moduleA.testConfigs[0]
+
+      const testTask = new TestTask({
+        garden,
+        log,
+        graph,
+        test: testFromConfig(moduleA, testConfig, graph),
+        force: true,
+        forceBuild: false,
+        devModeServiceNames: [],
+        hotReloadServiceNames: [],
+        localModeServiceNames: [],
+      })
+
+      const key = testTask.getKey()
+      const { [key]: result } = await garden.processTasks([testTask], { throwOnError: true })
+
+      expect(result!.output.log).to.eql("echo task-a-ok")
+    })
+  })
+
   describe("getDependencies", () => {
     it("should include task dependencies", async () => {
       const moduleA = graph.getModule("module-a")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:

Before this fix, `${runtime.*}` values were not resolved in test configs before calling the plugin handlers for `getTestStatus` and `testModule`.

This was fixed by applying a similar runtime resolution flow as is used for service and task actions to test actions.

For consistency, a few interfaces and types were added to correspond with how these things are laid out for service and task handlers.

**Which issue(s) this PR fixes**:

Fixes #2862.
