### PR TITLE
chore: add more context for kubeconfig err

### DIFF
--- a/core/src/plugins/kubernetes/api.ts
+++ b/core/src/plugins/kubernetes/api.ts
@@ -895,8 +895,12 @@ async function getContextConfig(log: LogEntry, ctx: PluginContext, provider: Kub
   const kc = new KubeConfig()
 
   // There doesn't appear to be a method to just load the parsed config :/
-  kc.loadFromString(safeDumpYaml(rawConfig))
-  kc.setCurrentContext(context)
+  try {
+    kc.loadFromString(safeDumpYaml(rawConfig))
+    kc.setCurrentContext(context)
+  } catch (err) {
+    throw new Error("Could not parse kubeconfig, " + err)
+  }
 
   cachedConfigs[cacheKey] = kc
 


### PR DESCRIPTION
closes #2741

before: (see issue for why this is bad)
```
Failed resolving provider local-kubernetes. Here is the output:
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
contexts[0].name is missing
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Failed resolving one or more providers:
- local-kubernetes
```

after:
```
Failed resolving provider kubernetes. Here is the output:
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Could not parse kubeconfig, Error: contexts[0].name is missing
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Failed resolving one or more providers:
- kubernetes

See .garden/error.log for detailed error message
```