### PR TITLE
refactor(k8s): update Mutagen to v0.15.0

### DIFF
--- a/core/src/plugins/kubernetes/constants.ts
+++ b/core/src/plugins/kubernetes/constants.ts
@@ -28,8 +28,8 @@ export const inClusterRegistryHostname = "127.0.0.1:5000"
 export const gardenUtilDaemonDeploymentName = "garden-util-daemon"
 export const dockerDaemonDeploymentName = "garden-docker-daemon"
 
-export const k8sUtilImageName = "gardendev/k8s-util:0.5.3"
-export const k8sSyncUtilImageName = "gardendev/k8s-sync:0.1.4"
+export const k8sUtilImageName = "gardendev/k8s-util:0.5.4"
+export const k8sSyncUtilImageName = "gardendev/k8s-sync:0.1.5"
 export const reverseProxyImageName = "gardendev/k8s-reverse-proxy:0.0.1"
 
 export const dockerDaemonContainerName = "docker-daemon"

--- a/core/src/plugins/kubernetes/mutagen.ts
+++ b/core/src/plugins/kubernetes/mutagen.ts
@@ -637,8 +637,8 @@ export const mutagenCliSpec: PluginToolSpec = {
       platform: "darwin",
       architecture: "amd64",
       url:
-        "https://github.com/garden-io/mutagen/releases/download/v0.14.0-garden-1/mutagen_darwin_amd64_v0.14.0.tar.gz",
-      sha256: "53abc7dadef14d3cb90b72e2afa79622d72d5aa4c3ff70189da3f29249651d55",
+        "https://github.com/garden-io/mutagen/releases/download/v0.15.0-garden-1/mutagen_darwin_amd64_v0.15.0.tar.gz",
+      sha256: "370bf71e28f94002453921fda83282280162df7192bd07042bf622bf54507e3f",
       extract: {
         format: "tar",
         targetPath: "mutagen",
@@ -648,8 +648,8 @@ export const mutagenCliSpec: PluginToolSpec = {
       platform: "darwin",
       architecture: "arm64",
       url:
-        "https://github.com/mutagen-io/mutagen/releases/download/v0.14.0-garden-1/mutagen_darwin_arm64_v0.14.0.tar.gz",
-      sha256: "684de1c76cdf5893b1973cf57bd09792b66a7c8a3ae8e7e20286d440f875800c",
+        "https://github.com/garden-io/mutagen/releases/download/v0.15.0-garden-1/mutagen_darwin_arm64_v0.15.0.tar.gz",
+      sha256: "a0a7be8bb37266ea184cb580004e1741a17c8165b2032ce4b191f23fead821a0",
       extract: {
         format: "tar",
         targetPath: "mutagen",
@@ -658,8 +658,8 @@ export const mutagenCliSpec: PluginToolSpec = {
     {
       platform: "linux",
       architecture: "amd64",
-      url: "https://github.com/garden-io/mutagen/releases/download/v0.14.0-garden-1/mutagen_linux_amd64_v0.14.0.tar.gz",
-      sha256: "3529ee4b2b836fc8cdf9bd3678d211cadaa916f3e24d6e1337f5ce6f25d46ca6",
+      url: "https://github.com/garden-io/mutagen/releases/download/v0.15.0-garden-1/mutagen_linux_amd64_v0.15.0.tar.gz",
+      sha256: "e8c0708258ddd6d574f1b8f514fb214f9ab5d82aed38dd8db49ec10956e5063a",
       extract: {
         format: "tar",
         targetPath: "mutagen",
@@ -668,8 +668,8 @@ export const mutagenCliSpec: PluginToolSpec = {
     {
       platform: "windows",
       architecture: "amd64",
-      url: "https://github.com/garden-io/mutagen/releases/download/v0.14.0-garden-1/mutagen_windows_amd64_v0.14.0.zip",
-      sha256: "6a09d990e5d74fbfd50edce25182e5786922af74f5f5ad00b33c30fa562fae9a",
+      url: "https://github.com/garden-io/mutagen/releases/download/v0.15.0-garden-1/mutagen_windows_amd64_v0.15.0.zip",
+      sha256: "fdae26b43cc418b2525a937a1613bba36e74ea3dde4dbec3512a9abd004def95",
       extract: {
         format: "zip",
         targetPath: "mutagen.exe",

--- a/images/k8s-sync/Dockerfile
+++ b/images/k8s-sync/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.15.4
 RUN apk add --no-cache curl
 
 # Get mutagen agent
-RUN curl -fsSL "https://github.com/mutagen-io/mutagen/releases/download/v0.14.0/mutagen_linux_amd64_v0.14.0.tar.gz" \
+RUN curl -fsSL "https://github.com/mutagen-io/mutagen/releases/download/v0.15.0/mutagen_linux_amd64_v0.15.0.tar.gz" \
   | tar xz --to-stdout mutagen-agents.tar.gz \
   | tar xz --to-stdout linux_amd64 \
   > /usr/local/bin/mutagen-agent && \

--- a/images/k8s-sync/garden.yml
+++ b/images/k8s-sync/garden.yml
@@ -2,5 +2,5 @@ kind: Module
 type: container
 name: k8s-sync
 description: Used by the kubernetes provider for dev mode sync setup
-image: gardendev/k8s-sync:0.1.4
+image: gardendev/k8s-sync:0.1.5
 dockerfile: Dockerfile

--- a/images/k8s-util/garden.yml
+++ b/images/k8s-util/garden.yml
@@ -2,7 +2,7 @@ kind: Module
 type: container
 name: k8s-util
 description: Used by the kubernetes provider for build-related activities
-image: gardendev/k8s-util:0.5.3
+image: gardendev/k8s-util:0.5.4
 dockerfile: Dockerfile
 build:
   dependencies: [k8s-sync]


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request updates Garden to use Mutagen v0.15.0 for dev mode.  It makes use of the JSON output added in Mutagen v0.15.0, obviating the need for part of Garden's Mutagen fork.  The custom Garden exec transport is still implemented via the fork.

While this PR doesn't include any user-visible changes to Garden's behavior (except when using the `mutagen.sh` wrapper script), it does make additional synchronization session statistics and metadata available to Garden internally, which can be presented to users in future updates. For now this information is available via the `mutagen.sh` script.

**Special notes for your reviewer**:

The `k8s-sync` and `k8s-util` images will need to be manually regenerated before CI will succeed.

I'm not sure of the correct numbering scheme for `k8s-util`; please let me know if you'd prefer a different tag for that.

CC @edvald @thsig @vvagaytsev