### PR TITLE
feat(core): opt for deleting services in dep order

### DIFF
--- a/core/src/actions.ts
+++ b/core/src/actions.ts
@@ -850,6 +850,7 @@ export class ActionRouter implements TypeGuard {
     const servicesLog = log.info({ msg: chalk.white("Deleting services..."), status: "active" })
 
     const services = graph.getServices({ names })
+    const deleteServiceNames = services.map((s) => s.name)
 
     const deleteResults = await this.garden.processTasks(
       services.map((service) => {
@@ -858,7 +859,7 @@ export class ActionRouter implements TypeGuard {
           graph,
           service,
           log: servicesLog,
-          includeDependants: true,
+          deleteServiceNames,
         })
       })
     )

--- a/core/src/commands/delete.ts
+++ b/core/src/commands/delete.ts
@@ -9,14 +9,20 @@
 import { Command, CommandResult, CommandParams, CommandGroup } from "./base"
 import { NotFoundError } from "../exceptions"
 import dedent from "dedent"
-import { ServiceStatusMap, serviceStatusSchema } from "../types/service"
+import { ServiceStatus, ServiceStatusMap, serviceStatusSchema } from "../types/service"
 import { printHeader } from "../logger/util"
 import { DeleteSecretResult } from "../types/plugin/provider/deleteSecret"
 import { EnvironmentStatusMap } from "../types/plugin/provider/getEnvironmentStatus"
 import { DeleteServiceTask, deletedServiceStatuses } from "../tasks/delete-service"
 import { joi, joiIdentifierMap } from "../config/common"
 import { environmentStatusSchema } from "../config/status"
-import { StringParameter, StringsParameter } from "../cli/params"
+import { BooleanParameter, StringParameter, StringsParameter } from "../cli/params"
+import { deline } from "../util/string"
+import { Garden } from ".."
+import { ConfigGraph } from "../config-graph"
+import { LogEntry } from "../logger/log-entry"
+import { uniqByName } from "../util/util"
+import { flatten } from "lodash"
 
 export class DeleteCommand extends CommandGroup {
   name = "delete"
@@ -74,18 +80,34 @@ export class DeleteSecretCommand extends Command<typeof deleteSecretArgs> {
   }
 }
 
+const dependantsFirstOpt = {
+  "dependants-first": new BooleanParameter({
+    help: deline`
+      Delete services in reverse dependency order. That is, if service-a has a dependency on service-b, service-a
+      will be deleted before service-b when calling garden delete environment service-a,service-b --dependants-first.
+      When this flag is not used, all services in the project are deleted simultaneously.
+    `,
+  }),
+}
+
+const deleteEnvironmentOpts = dependantsFirstOpt
+
+type DeleteEnvironmentOpts = typeof dependantsFirstOpt
+
 interface DeleteEnvironmentResult {
   providerStatuses: EnvironmentStatusMap
   serviceStatuses: ServiceStatusMap
 }
 
-export class DeleteEnvironmentCommand extends Command {
+export class DeleteEnvironmentCommand extends Command<{}, DeleteEnvironmentOpts> {
   name = "environment"
   alias = "env"
   help = "Deletes a running environment."
 
   protected = true
   streamEvents = true
+
+  options = deleteEnvironmentOpts
 
   description = dedent`
     This will delete all services in the specified environment, and trigger providers to clear up any other resources
@@ -109,11 +131,19 @@ export class DeleteEnvironmentCommand extends Command {
     printHeader(headerLog, `Deleting environment`, "skull_and_crossbones")
   }
 
-  async action({ garden, log }: CommandParams): Promise<CommandResult<DeleteEnvironmentResult>> {
+  async action({
+    garden,
+    log,
+    opts,
+  }: CommandParams<{}, DeleteEnvironmentOpts>): Promise<CommandResult<DeleteEnvironmentResult>> {
     const actions = await garden.getActionRouter()
-
     const graph = await garden.getConfigGraph({ log, emit: true })
-    const serviceStatuses = await actions.deleteServices(graph, log)
+    const serviceStatuses = await deleteServices({
+      garden,
+      graph,
+      log,
+      dependantsFirst: opts["dependants-first"],
+    })
 
     log.info("")
 
@@ -123,14 +153,26 @@ export class DeleteEnvironmentCommand extends Command {
   }
 }
 
-export const deleteServiceArgs = {
+const deleteServiceArgs = {
   services: new StringsParameter({
     help: "The name(s) of the service(s) to delete. Use comma as a separator to specify multiple services.",
   }),
 }
 type DeleteServiceArgs = typeof deleteServiceArgs
 
-export class DeleteServiceCommand extends Command {
+const deleteServiceOpts = {
+  ...dependantsFirstOpt,
+  "with-dependants": new BooleanParameter({
+    help: deline`
+      Also delete services that have service dependencies on one of the services specified as CLI arguments
+      (recursively).  When used, this option implies --dependants-first. Note: This option has no effect unless a list
+      of service names is specified as CLI arguments (since then, every service in the project will be deleted).
+    `,
+  }),
+}
+type DeleteServiceOpts = typeof deleteServiceOpts
+
+export class DeleteServiceCommand extends Command<DeleteServiceArgs, DeleteServiceOpts> {
   name = "service"
   alias = "services"
   help = "Deletes running services."
@@ -158,21 +200,59 @@ export class DeleteServiceCommand extends Command {
     printHeader(headerLog, "Delete service", "skull_and_crossbones")
   }
 
-  async action({ garden, log, args }: CommandParams<DeleteServiceArgs>): Promise<CommandResult> {
+  async action({
+    garden,
+    log,
+    args,
+    opts,
+  }: CommandParams<DeleteServiceArgs, DeleteServiceOpts>): Promise<CommandResult> {
     const graph = await garden.getConfigGraph({ log, emit: true })
-    const services = graph.getServices({ names: args.services })
+    let services = graph.getServices({ names: args.services })
 
     if (services.length === 0) {
       log.warn({ msg: "No services found. Aborting." })
       return { result: {} }
     }
 
-    const deleteServiceTasks = services.map((service) => {
-      return new DeleteServiceTask({ garden, graph, log, service })
-    })
+    if (opts["with-dependants"]) {
+      // Then we include service dependants (recursively) in the list of services to delete
+      services = uniqByName([
+        ...services,
+        ...flatten(
+          services.map((s) => graph.getDependants({ nodeType: "deploy", name: s.name, recursive: true }).deploy)
+        ),
+      ])
+    }
 
-    const result = deletedServiceStatuses(await garden.processTasks(deleteServiceTasks))
+    // --with-dependants implies --dependants-first
+    const dependantsFirst = opts["dependants-first"] || opts["with-dependants"]
+    const serviceNames = services.map((s) => s.name)
+    const result = await deleteServices({ serviceNames, garden, graph, log, dependantsFirst })
 
     return { result }
   }
+}
+
+/**
+ * Note: If `serviceNames` is undefined, deletes all services.
+ */
+async function deleteServices({
+  serviceNames,
+  garden,
+  graph,
+  log,
+  dependantsFirst,
+}: {
+  serviceNames?: string[]
+  garden: Garden
+  graph: ConfigGraph
+  log: LogEntry
+  dependantsFirst: boolean
+}): Promise<{ [serviceName: string]: ServiceStatus }> {
+  const services = graph.getServices({ names: serviceNames })
+  const deleteServiceNames = services.map((s) => s.name)
+  const deleteServiceTasks = services.map((service) => {
+    return new DeleteServiceTask({ garden, graph, log, service, deleteServiceNames, dependantsFirst })
+  })
+  return deletedServiceStatuses(await garden.processTasks(deleteServiceTasks))
 }

--- a/core/src/commands/delete.ts
+++ b/core/src/commands/delete.ts
@@ -6,14 +6,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { Command, CommandResult, CommandParams, CommandGroup } from "./base"
+import { Command, CommandGroup, CommandParams, CommandResult } from "./base"
 import { NotFoundError } from "../exceptions"
 import dedent from "dedent"
 import { ServiceStatus, ServiceStatusMap, serviceStatusSchema } from "../types/service"
 import { printHeader } from "../logger/util"
 import { DeleteSecretResult } from "../types/plugin/provider/deleteSecret"
 import { EnvironmentStatusMap } from "../types/plugin/provider/getEnvironmentStatus"
-import { DeleteServiceTask, deletedServiceStatuses } from "../tasks/delete-service"
+import { deletedServiceStatuses, DeleteServiceTask } from "../tasks/delete-service"
 import { joi, joiIdentifierMap } from "../config/common"
 import { environmentStatusSchema } from "../config/status"
 import { BooleanParameter, StringParameter, StringsParameter } from "../cli/params"
@@ -22,7 +22,6 @@ import { Garden } from ".."
 import { ConfigGraph } from "../config-graph"
 import { LogEntry } from "../logger/log-entry"
 import { uniqByName } from "../util/util"
-import { flatten } from "lodash"
 
 export class DeleteCommand extends CommandGroup {
   name = "delete"
@@ -218,9 +217,7 @@ export class DeleteServiceCommand extends Command<DeleteServiceArgs, DeleteServi
       // Then we include service dependants (recursively) in the list of services to delete
       services = uniqByName([
         ...services,
-        ...flatten(
-          services.map((s) => graph.getDependants({ nodeType: "deploy", name: s.name, recursive: true }).deploy)
-        ),
+        ...services.flatMap((s) => graph.getDependants({ nodeType: "deploy", name: s.name, recursive: true }).deploy),
       ])
     }
 

--- a/core/src/tasks/delete-service.ts
+++ b/core/src/tasks/delete-service.ts
@@ -19,7 +19,14 @@ export interface DeleteServiceTaskParams {
   graph: ConfigGraph
   service: GardenService
   log: LogEntry
-  includeDependants?: boolean
+  /**
+   * If true, the task will include delete service tasks for its dependants in its list of dependencies.
+   */
+  dependantsFirst?: boolean
+  /**
+   * If not provided, defaults to just `[service.name]`.
+   */
+  deleteServiceNames?: string[]
 }
 
 export class DeleteServiceTask extends BaseTask {
@@ -27,13 +34,15 @@ export class DeleteServiceTask extends BaseTask {
   concurrencyLimit = 10
   graph: ConfigGraph
   service: GardenService
-  includeDependants: boolean
+  dependantsFirst: boolean
+  deleteServiceNames: string[]
 
-  constructor({ garden, graph, log, service, includeDependants = false }: DeleteServiceTaskParams) {
+  constructor({ garden, graph, log, service, deleteServiceNames, dependantsFirst = false }: DeleteServiceTaskParams) {
     super({ garden, log, force: false, version: service.version })
     this.graph = graph
     this.service = service
-    this.includeDependants = includeDependants
+    this.dependantsFirst = dependantsFirst
+    this.deleteServiceNames = deleteServiceNames || [service.name]
   }
 
   async resolveDependencies() {
@@ -45,12 +54,17 @@ export class DeleteServiceTask extends BaseTask {
       force: this.force,
     })
 
-    if (!this.includeDependants) {
+    if (!this.dependantsFirst) {
       return [stageBuildTask]
     }
 
     // Note: We delete in _reverse_ dependency order, so we query for dependants
-    const deps = this.graph.getDependants({ nodeType: "deploy", name: this.getName(), recursive: false })
+    const deps = this.graph.getDependants({
+      nodeType: "deploy",
+      name: this.getName(),
+      recursive: false,
+      filter: (depNode) => depNode.type === "deploy" && this.deleteServiceNames.includes(depNode.name),
+    })
 
     const dependants = deps.deploy.map((service) => {
       return new DeleteServiceTask({
@@ -58,7 +72,8 @@ export class DeleteServiceTask extends BaseTask {
         graph: this.graph,
         log: this.log,
         service,
-        includeDependants: this.includeDependants,
+        deleteServiceNames: this.deleteServiceNames,
+        dependantsFirst: true,
       })
     })
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -408,8 +408,13 @@ resources.
 
 #### Usage
 
-    garden delete environment 
+    garden delete environment [options]
 
+#### Options
+
+| Argument | Alias | Type | Description |
+| -------- | ----- | ---- | ----------- |
+  | `--dependants-first` |  | boolean | Delete services in reverse dependency order. That is, if service-a has a dependency on service-b, service-a will be deleted before service-b when calling garden delete environment service-a,service-b --dependants-first. When this flag is not used, all services in the project are deleted simultaneously.
 
 #### Outputs
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:

Added a `--dependants-first` option to the `delete service` and `delete environment` commands.

When used, services will be deleted in reverse dependency order. That is, service dependants will be    deleted before their dependencies.

Also added a `--with-dependants` option to the `delete service` command, which deletes any running      dependants of the requested service/services.

**Which issue(s) this PR fixes**:

Fixes #2782.

**Special notes for your reviewer**:

Note that the dependency logic here only uses service dependencies and doesn't traverse task dependencies to find transitive service dependencies.

This means that e.g. in the vote project, the `result` service won't be deleted before the `postgres` service, even though `result` transitively depends on `postgres` via the `db-init` task. Adding an explicit service dependency on `postgres` to the `result` service would change this.

If do we want to fully replicate the dependency behavior of `DeployTask` in reverse (which I think is probably unnecessary), we'd have to modify the dependency calculation logic there (which would be a bit fiddly, but not a big deal).