### PR TITLE
fix: include stderr for outputs from commands returning an artifact

### DIFF
--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -560,7 +560,7 @@ async function runWithArtifacts({
       const res = await runner.exec({
         // Pipe the output from the command to the /tmp/output pipe, including stderr. Some shell voodoo happening
         // here, but this was the only working approach I could find after a lot of trial and error.
-        command: ["sh", "-c", `exec >/tmp/output; ${cmd.join(" ")}`],
+        command: ["sh", "-c", `exec &>/tmp/output; ${cmd.join(" ")}`],
         containerName: mainContainerName,
         log,
         stdout,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:

When running tests that return artifacts, the K8S runner needs to take a different path compared to the case without artifacts. In this case the log output is diverted into a named pipe. Due to how the output was passed to the named pipe (using `exec`), stderr was not included. This PR tries to ensure that stderr is included in the log output. 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
