### PR TITLE
fix(cloud): handle "=" separator in named vars passed as command args

### DIFF
--- a/core/src/commands/cloud/users/users-create.ts
+++ b/core/src/commands/cloud/users/users-create.ts
@@ -8,16 +8,16 @@
 
 import { CommandError, ConfigurationError } from "../../../exceptions"
 import { CreateUserBulkRequest, CreateUserBulkResponse, UserResponse } from "@garden-io/platform-api-types"
-import dotenv = require("dotenv")
 import { readFile } from "fs-extra"
 
 import { printHeader } from "../../../logger/util"
 import { Command, CommandParams, CommandResult } from "../../base"
 import { ApiCommandError, handleBulkOperationResult, makeUserFromResponse, noApiMsg, UserResult } from "../helpers"
 import { dedent, deline } from "../../../util/string"
-import { StringsParameter, PathParameter } from "../../../cli/params"
+import { PathParameter, StringsParameter } from "../../../cli/params"
 import { StringMap } from "../../../config/common"
 import { chunk } from "lodash"
+import dotenv = require("dotenv")
 import Bluebird = require("bluebird")
 
 // This is the limit set by the API.
@@ -90,9 +90,16 @@ export class UsersCreateCommand extends Command<Args, Opts> {
       }
     } else if (args.users) {
       users = args.users.reduce((acc, keyValPair) => {
-        const parts = keyValPair.split("=")
-        acc[parts[0]] = parts[1]
-        return acc
+        try {
+          const user = dotenv.parse(keyValPair)
+          Object.assign(acc, user)
+          return acc
+        } catch (err) {
+          throw new CommandError(`Unable to read user from argument ${keyValPair}: ${err.message}`, {
+            args,
+            opts,
+          })
+        }
       }, {})
     } else {
       throw new CommandError(


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR ensures proper handling of the `=` separators when named variables are passed as command-line arguments. The fix addresses `garden enterprise secrets create` and `garden enterprise users create` commands.

**Which issue(s) this PR fixes**:

Fixes #2405

**Special notes for your reviewer**:
We do not have any tests for `commands.cloud` package yet, so no tests have been added.