### PR TITLE
docs(cloud): removed "experimental" labels from cloud commands

### DIFF
--- a/core/src/commands/cloud/groups/groups.ts
+++ b/core/src/commands/cloud/groups/groups.ts
@@ -26,7 +26,7 @@ interface Groups {
 
 export class GroupsCommand extends CommandGroup {
   name = "groups"
-  help = "[EXPERIMENTAL] List groups."
+  help = "List groups."
 
   subCommands = [GroupsListCommand]
 }
@@ -41,7 +41,7 @@ type Opts = typeof groupsListOpts
 
 export class GroupsListCommand extends Command<{}, Opts> {
   name = "list"
-  help = "[EXPERIMENTAL] List groups."
+  help = "List groups."
   description = dedent`
     List all groups from Garden Cloud. This is useful for getting the group IDs when creating
     users via the \`garden cloud users create\` command.

--- a/core/src/commands/cloud/secrets/secrets-create.ts
+++ b/core/src/commands/cloud/secrets/secrets-create.ts
@@ -47,7 +47,7 @@ type Opts = typeof secretsCreateOpts
 
 export class SecretsCreateCommand extends Command<Args, Opts> {
   name = "create"
-  help = "[EXPERIMENTAL] Create secrets"
+  help = "Create secrets"
   description = dedent`
     Create secrets in Garden Cloud. You can create project wide secrets or optionally scope
     them to an environment, or an environment and a user.

--- a/core/src/commands/cloud/secrets/secrets-delete.ts
+++ b/core/src/commands/cloud/secrets/secrets-delete.ts
@@ -24,7 +24,7 @@ type Args = typeof secretsDeleteArgs
 
 export class SecretsDeleteCommand extends Command<Args> {
   name = "delete"
-  help = "[EXPERIMENTAL] Delete secrets."
+  help = "Delete secrets."
   description = dedent`
     Delete secrets in Garden Cloud. You will nee the IDs of the secrets you want to delete,
     which you which you can get from the \`garden cloud secrets list\` command.

--- a/core/src/commands/cloud/secrets/secrets-list.ts
+++ b/core/src/commands/cloud/secrets/secrets-list.ts
@@ -37,7 +37,7 @@ type Opts = typeof secretsListOpts
 
 export class SecretsListCommand extends Command<{}, Opts> {
   name = "list"
-  help = "[EXPERIMENTAL] List secrets."
+  help = "List secrets."
   description = dedent`
     List all secrets from Garden Cloud. Optionally filter on environment, user IDs, or secret names.
 

--- a/core/src/commands/cloud/secrets/secrets.ts
+++ b/core/src/commands/cloud/secrets/secrets.ts
@@ -13,7 +13,7 @@ import { SecretsListCommand } from "./secrets-list"
 
 export class SecretsCommand extends CommandGroup {
   name = "secrets"
-  help = "[EXPERIMENTAL] List, create, and delete secrets."
+  help = "List, create, and delete secrets."
 
   subCommands = [SecretsListCommand, SecretsCreateCommand, SecretsDeleteCommand]
 }

--- a/core/src/commands/cloud/users/users-create.ts
+++ b/core/src/commands/cloud/users/users-create.ts
@@ -47,7 +47,7 @@ type Opts = typeof secretsCreateOpts
 
 export class UsersCreateCommand extends Command<Args, Opts> {
   name = "create"
-  help = "[EXPERIMENTAL] Create users"
+  help = "Create users"
   description = dedent`
     Create users in Garden Cloud and optionally add the users to specific groups.
     You can get the group IDs from the \`garden cloud users list\` command.

--- a/core/src/commands/cloud/users/users-delete.ts
+++ b/core/src/commands/cloud/users/users-delete.ts
@@ -24,7 +24,7 @@ type Args = typeof usersDeleteArgs
 
 export class UsersDeleteCommand extends Command<Args> {
   name = "delete"
-  help = "[EXPERIMENTAL] Delete users."
+  help = "Delete users."
   description = dedent`
     Delete users in Garden Cloud. You will nee the IDs of the users you want to delete,
     which you which you can get from the \`garden cloud users list\` command.

--- a/core/src/commands/cloud/users/users-list.ts
+++ b/core/src/commands/cloud/users/users-list.ts
@@ -30,7 +30,7 @@ type Opts = typeof usersListOpts
 
 export class UsersListCommand extends Command<{}, Opts> {
   name = "list"
-  help = "[EXPERIMENTAL] List users."
+  help = "List users."
   description = dedent`
     List all users from Garden Cloud. Optionally filter on group names or user names.
 

--- a/core/src/commands/cloud/users/users.ts
+++ b/core/src/commands/cloud/users/users.ts
@@ -13,7 +13,7 @@ import { UsersListCommand } from "./users-list"
 
 export class UsersCommand extends CommandGroup {
   name = "users"
-  help = "[EXPERIMENTAL] List, create, and delete users."
+  help = "List, create, and delete users."
 
   subCommands = [UsersListCommand, UsersCreateCommand, UsersDeleteCommand]
 }

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -969,7 +969,7 @@ stderr:
 
 ### garden cloud secrets list
 
-**[EXPERIMENTAL] List secrets.**
+**List secrets.**
 
 List all secrets from Garden Cloud. Optionally filter on environment, user IDs, or secret names.
 
@@ -993,7 +993,7 @@ Examples:
 
 ### garden cloud secrets create
 
-**[EXPERIMENTAL] Create secrets**
+**Create secrets**
 
 Create secrets in Garden Cloud. You can create project wide secrets or optionally scope
 them to an environment, or an environment and a user.
@@ -1030,7 +1030,7 @@ Examples:
 
 ### garden cloud secrets delete
 
-**[EXPERIMENTAL] Delete secrets.**
+**Delete secrets.**
 
 Delete secrets in Garden Cloud. You will nee the IDs of the secrets you want to delete,
 which you which you can get from the `garden cloud secrets list` command.
@@ -1052,7 +1052,7 @@ Examples:
 
 ### garden cloud users list
 
-**[EXPERIMENTAL] List users.**
+**List users.**
 
 List all users from Garden Cloud. Optionally filter on group names or user names.
 
@@ -1075,7 +1075,7 @@ Examples:
 
 ### garden cloud users create
 
-**[EXPERIMENTAL] Create users**
+**Create users**
 
 Create users in Garden Cloud and optionally add the users to specific groups.
 You can get the group IDs from the `garden cloud users list` command.
@@ -1114,7 +1114,7 @@ Examples:
 
 ### garden cloud users delete
 
-**[EXPERIMENTAL] Delete users.**
+**Delete users.**
 
 Delete users in Garden Cloud. You will nee the IDs of the users you want to delete,
 which you which you can get from the `garden cloud users list` command.
@@ -1136,7 +1136,7 @@ Examples:
 
 ### garden cloud groups list
 
-**[EXPERIMENTAL] List groups.**
+**List groups.**
 
 List all groups from Garden Cloud. This is useful for getting the group IDs when creating
 users via the `garden cloud users create` command.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes some obsolete "experimental" labels from the Garden cloud commands' description.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
