### PR TITLE
improvement: used async sleeps between retries in recoverable process

### DIFF
--- a/core/src/plugins/kubernetes/local-mode.ts
+++ b/core/src/plugins/kubernetes/local-mode.ts
@@ -775,7 +775,7 @@ function composeSshTunnelProcessTree(
   log: LogEntry
 ): RecoverableProcess {
   const root = sshTunnel
-  root.addDescendantProcesses(reversePortForward)
+  root.addDescendants(reversePortForward)
   root.setFailureHandler(async () => {
     log.error("Local mode failed, shutting down...")
     await shutdown(1)

--- a/core/src/plugins/kubernetes/local-mode.ts
+++ b/core/src/plugins/kubernetes/local-mode.ts
@@ -215,18 +215,22 @@ export class ProxySshKeystore {
   }
 }
 
+export type LocalModeProcessRegistryState = "ready" | "running" | "closed"
+
 /*
  * This can be changed to a "global" registry for all processes,
  * but now recoverable processes are used in local mode only.
  */
 export class LocalModeProcessRegistry {
   private recoverableProcesses: RecoverableProcess[]
+  private state: LocalModeProcessRegistryState
 
   private constructor() {
     if (!!LocalModeProcessRegistry.instance) {
       throw new RuntimeError("Cannot init singleton twice, use LocalModeProcessRegistry.getInstance()", {})
     }
     this.recoverableProcesses = []
+    this.state = "ready"
   }
 
   private static instance?: LocalModeProcessRegistry = undefined
@@ -240,8 +244,22 @@ export class LocalModeProcessRegistry {
     return LocalModeProcessRegistry.instance
   }
 
-  public register(process: RecoverableProcess): void {
+  /**
+   * Attempts to register and start a recoverable process.
+   * If the registry is closed, then it can not accept any processes.
+   *
+   * @return {@code true} if the process has been registered or {@code false} otherwise
+   */
+  public submit(process: RecoverableProcess): boolean {
+    if (this.state === "closed") {
+      return false
+    }
+    if (this.state !== "running") {
+      this.state = "running"
+    }
     this.recoverableProcesses.push(process.getTreeRoot())
+    process.startAll()
+    return true
   }
 
   public shutdown(): void {
@@ -804,15 +822,24 @@ export async function startServiceInLocalMode(configParams: StartLocalModeParams
   const localSshPort = await getPort()
   ProxySshKeystore.getInstance(log).registerLocalPort(localSshPort, log)
 
+  const localModeProcessRegistry = LocalModeProcessRegistry.getInstance()
+
   const localApp = getLocalAppProcess(configParams)
   if (!!localApp) {
-    LocalModeProcessRegistry.getInstance().register(localApp)
     log.info({
       status: "active",
       section: gardenService.name,
       msg: chalk.white("Starting local app, this can take a while"),
     })
-    localApp.startAll()
+    const localAppStatus = localModeProcessRegistry.submit(localApp)
+    if (!localAppStatus) {
+      log.warn({
+        status: "warn",
+        symbol: "warning",
+        section: gardenService.name,
+        msg: chalk.yellow("Unable to start local app. Reason: rejected by the registry"),
+      })
+    }
   }
 
   const targetNamespace = targetResource.metadata.namespace || namespace
@@ -827,12 +854,27 @@ export async function startServiceInLocalMode(configParams: StartLocalModeParams
   const reversePortForward = await getReversePortForwardProcess(configParams, localSshPort, targetContainer)
 
   const compositeSshTunnel = composeSshTunnelProcessTree(kubectlPortForward, reversePortForward, log)
-  log.debug(`Starting local mode ssh tunnels:\n` + `${chalk.white(`${compositeSshTunnel.renderProcessTree()}`)}`)
   log.info({
     status: "active",
     section: gardenService.name,
     msg: chalk.white("Starting local mode ssh tunnels, some failures and retries are possible"),
   })
-  LocalModeProcessRegistry.getInstance().register(compositeSshTunnel)
-  compositeSshTunnel.startAll()
+  const sshTunnelCmdRenderer = (command: OsCommand) => `${command.command} ${command.args?.join(" ")}`
+  log.verbose({
+    status: "active",
+    section: gardenService.name,
+    msg: chalk.grey(
+      `Starting the process tree for the local mode ssh tunnels:\n` +
+        `${compositeSshTunnel.renderProcessTree(sshTunnelCmdRenderer)}`
+    ),
+  })
+  const localTunnelsStatus = localModeProcessRegistry.submit(compositeSshTunnel)
+  if (!localTunnelsStatus) {
+    log.warn({
+      status: "warn",
+      symbol: "warning",
+      section: gardenService.name,
+      msg: chalk.yellow("Unable to local mode ssh tunnels. Reason: rejected by the registry"),
+    })
+  }
 }

--- a/core/src/plugins/kubernetes/local-mode.ts
+++ b/core/src/plugins/kubernetes/local-mode.ts
@@ -775,7 +775,7 @@ function composeSshTunnelProcessTree(
   log: LogEntry
 ): RecoverableProcess {
   const root = sshTunnel
-  root.addDescendantProcess(reversePortForward)
+  root.addDescendantProcesses(reversePortForward)
   root.setFailureHandler(async () => {
     log.error("Local mode failed, shutting down...")
     await shutdown(1)

--- a/core/src/util/recoverable-process.ts
+++ b/core/src/util/recoverable-process.ts
@@ -17,7 +17,7 @@ export interface OsCommand {
   readonly cwd?: string
 }
 
-const renderOsCommand = (cmd: OsCommand): string => JSON.stringify(cmd)
+export const renderOsCommand = (cmd: OsCommand): string => JSON.stringify(cmd)
 
 export interface ProcessMessage {
   readonly pid: number
@@ -456,17 +456,21 @@ export class RecoverableProcess {
     return descendants
   }
 
-  private renderProcessTreeRecursively(indent: string, output: string): string {
-    output += indent + `-> '${renderOsCommand(this.command)}'\n`
+  private renderProcessTreeRecursively(
+    indent: string,
+    output: string,
+    renderer: (command: OsCommand) => string
+  ): string {
+    output += indent + `-> '${renderer(this.command)}'\n`
     for (const descendant of this.descendants) {
-      output = descendant.renderProcessTreeRecursively(indent + "..", output)
+      output = descendant.renderProcessTreeRecursively(indent + "..", output, renderer)
     }
     return output
   }
 
-  public renderProcessTree(): string {
+  public renderProcessTree(renderer: (command: OsCommand) => string = renderOsCommand): string {
     const output = ""
-    return this.renderProcessTreeRecursively("", output)
+    return this.renderProcessTreeRecursively("", output, renderer)
   }
 
   public getTreeRoot() {

--- a/core/src/util/recoverable-process.ts
+++ b/core/src/util/recoverable-process.ts
@@ -446,7 +446,7 @@ export class RecoverableProcess {
     }
   }
 
-  public addDescendantProcess(descendant: RecoverableProcess): RecoverableProcess {
+  private addDescendantProcess(descendant: RecoverableProcess): RecoverableProcess {
     if (this.state !== "runnable") {
       throw new RuntimeError("Cannot attach a descendant to already running, stopped or failed process.", this)
     }

--- a/core/src/util/recoverable-process.ts
+++ b/core/src/util/recoverable-process.ts
@@ -448,7 +448,7 @@ export class RecoverableProcess {
 
   public addDescendantProcess(descendant: RecoverableProcess): RecoverableProcess {
     if (this.state !== "runnable") {
-      throw new RuntimeError("Cannot attach a descendant to already running process", this)
+      throw new RuntimeError("Cannot attach a descendant to already running, stopped or failed process.", this)
     }
 
     descendant.parent = this

--- a/core/src/util/recoverable-process.ts
+++ b/core/src/util/recoverable-process.ts
@@ -446,7 +446,7 @@ export class RecoverableProcess {
     }
   }
 
-  private addDescendantProcess(descendant: RecoverableProcess): RecoverableProcess {
+  private addDescendant(descendant: RecoverableProcess): RecoverableProcess {
     if (this.state !== "runnable") {
       throw new RuntimeError("Cannot attach a descendant to already running, stopped or failed process.", this)
     }
@@ -456,9 +456,9 @@ export class RecoverableProcess {
     return descendant
   }
 
-  public addDescendantProcesses(...descendants: RecoverableProcess[]): RecoverableProcess[] {
+  public addDescendants(...descendants: RecoverableProcess[]): RecoverableProcess[] {
     for (const descendant of descendants) {
-      this.addDescendantProcess(descendant)
+      this.addDescendant(descendant)
     }
     return descendants
   }

--- a/core/src/util/recoverable-process.ts
+++ b/core/src/util/recoverable-process.ts
@@ -8,7 +8,7 @@
 
 import { ChildProcess, execFile, spawn } from "child_process"
 import { LogEntry } from "../logger/log-entry"
-import { sleepSync } from "./util"
+import { sleep } from "./util"
 import { ConfigurationError, RuntimeError } from "../exceptions"
 
 export interface OsCommand {
@@ -428,9 +428,8 @@ export class RecoverableProcess {
     this.unregisterSubTreeListeners()
     this.stopSubTree()
     if (this.retriesLeft > 0) {
-      // sleep synchronously to avoid pre-mature retry attempts
       if (this.retryConfig.minTimeoutMs > 0) {
-        sleepSync(this.retryConfig.minTimeoutMs)
+        await sleep(this.retryConfig.minTimeoutMs)
       }
       this.retriesLeft--
       this.state = "retrying"

--- a/core/src/util/recoverable-process.ts
+++ b/core/src/util/recoverable-process.ts
@@ -125,6 +125,12 @@ export type ActiveProcessState = "running" | "retrying"
  * Both "stopped" and ""failed" are final states.
  */
 export type InactiveProcessState = "stopped" | "failed"
+/**
+ * Special set of states to be used with {@link RecoverableProcess#stopNode()}.
+ * State "retrying" is used to stop the process temporarily while doing a retry.
+ * State "stopped" is used to stop the process permanently.
+ */
+export type InterruptedProcessState = "retrying" | "stopped"
 export type RecoverableProcessState = InitialProcessState | ActiveProcessState | InactiveProcessState
 
 /**
@@ -262,7 +268,7 @@ export class RecoverableProcess {
     node.descendants.forEach((descendant) => RecoverableProcess.recursiveAction(descendant, action))
   }
 
-  private stopNode(state: RecoverableProcessState): void {
+  private stopNode(state: InterruptedProcessState): void {
     this.state = state
     const proc = this.proc
     if (!proc) {
@@ -273,7 +279,7 @@ export class RecoverableProcess {
     this.proc = undefined
   }
 
-  private stopSubTree(state: RecoverableProcessState): void {
+  private stopSubTree(state: InterruptedProcessState): void {
     RecoverableProcess.recursiveAction(this, (node) => node.stopNode(state))
   }
 

--- a/core/src/util/util.ts
+++ b/core/src/util/util.ts
@@ -40,7 +40,6 @@ import { PrimitiveMap } from "../config/common"
 import { isAbsolute, relative } from "path"
 import { getDefaultProfiler } from "./profiling"
 import { gardenEnv } from "../constants"
-import { spawnSync } from "child_process"
 import split2 = require("split2")
 import Bluebird = require("bluebird")
 import execa = require("execa")
@@ -119,11 +118,6 @@ export function getCloudDistributionName(domain: string) {
 
 export async function sleep(msec: number) {
   return new Promise((resolve) => setTimeout(resolve, msec))
-}
-
-export function sleepSync(msec: number) {
-  // it seems to be the best available solution to sleep synchronously, see https://stackoverflow.com/a/50098685/2753863
-  spawnSync(process.argv[0], ["-e", "setTimeout(function(){}," + msec + ")"])
 }
 
 /**

--- a/core/test/integ/src/plugins/kubernetes/container/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/deployment.ts
@@ -37,7 +37,11 @@ import {
   PROXY_CONTAINER_SSH_TUNNEL_PORT_NAME,
   PROXY_CONTAINER_USER_NAME,
 } from "../../../../../../src/plugins/kubernetes/constants"
-import { LocalModeEnv } from "../../../../../../src/plugins/kubernetes/local-mode"
+import {
+  LocalModeEnv,
+  LocalModeProcessRegistry,
+  ProxySshKeystore,
+} from "../../../../../../src/plugins/kubernetes/local-mode"
 import stripAnsi = require("strip-ansi")
 
 describe("kubernetes container deployment handlers", () => {
@@ -67,6 +71,11 @@ describe("kubernetes container deployment handlers", () => {
   describe("createContainerManifests", () => {
     before(async () => {
       await init("local")
+    })
+
+    afterEach(async () => {
+      LocalModeProcessRegistry.getInstance().shutdown()
+      ProxySshKeystore.getInstance(garden.log).shutdown(garden.log)
     })
 
     function expectSshContainerPort(workload: KubernetesWorkload) {

--- a/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
@@ -26,7 +26,7 @@ import Bluebird from "bluebird"
 import { CloudApi } from "../../../../../../src/cloud/api"
 import { resolve } from "path"
 import { getLogger } from "../../../../../../src/logger/logger"
-import { LocalModeProcessRegistry } from "../../../../../../src/plugins/kubernetes/local-mode"
+import { LocalModeProcessRegistry, ProxySshKeystore } from "../../../../../../src/plugins/kubernetes/local-mode"
 
 describe("deployHelmService in local-mode", () => {
   let garden: TestGarden
@@ -43,13 +43,18 @@ describe("deployHelmService in local-mode", () => {
   })
 
   after(async () => {
-    // shut down local app and tunnels to avoid retrying after redeploy
     LocalModeProcessRegistry.getInstance().shutdown()
+    ProxySshKeystore.getInstance(garden.log).shutdown(garden.log)
     const actions = await garden.getActionRouter()
     await actions.deleteServices(graph, garden.log)
     if (garden) {
       await garden.close()
     }
+  })
+
+  afterEach(async () => {
+    // shut down local app and tunnels to avoid retrying after redeploy
+    LocalModeProcessRegistry.getInstance().shutdown()
   })
 
   it("should deploy a chart with localMode enabled", async () => {

--- a/core/test/integ/src/plugins/kubernetes/kubernetes-module/handlers.ts
+++ b/core/test/integ/src/plugins/kubernetes/kubernetes-module/handlers.ts
@@ -32,7 +32,7 @@ import Bluebird from "bluebird"
 import { buildHelmModules } from "../helm/common"
 import { gardenAnnotationKey } from "../../../../../../src/util/string"
 import { getServiceStatuses } from "../../../../../../src/tasks/base"
-import { LocalModeProcessRegistry } from "../../../../../../src/plugins/kubernetes/local-mode"
+import { LocalModeProcessRegistry, ProxySshKeystore } from "../../../../../../src/plugins/kubernetes/local-mode"
 
 describe("kubernetes-module handlers", () => {
   let tmpDir: tmp.DirectoryResult
@@ -309,6 +309,7 @@ describe("kubernetes-module handlers", () => {
       const res2 = await findDeployedResources(manifests, log)
       // shut down local app and tunnels to avoid retrying after redeploy
       LocalModeProcessRegistry.getInstance().shutdown()
+      ProxySshKeystore.getInstance(log).shutdown(log)
 
       // Deploy without local mode again
       await deployKubernetesService(deployParams)
@@ -358,6 +359,7 @@ describe("kubernetes-module handlers", () => {
       const res2 = await findDeployedResources(manifests, log)
       // shut down local app and tunnels to avoid retrying after redeploy
       LocalModeProcessRegistry.getInstance().shutdown()
+      ProxySshKeystore.getInstance(log).shutdown(log)
 
       // Deploy without local mode again
       await deployKubernetesService(deployParams)

--- a/core/test/integ/src/plugins/kubernetes/local-mode.ts
+++ b/core/test/integ/src/plugins/kubernetes/local-mode.ts
@@ -32,16 +32,13 @@ describe("local mode deployments and ssh tunneling behavior", () => {
     await init("local")
   })
 
-  after(() => {
-    LocalModeProcessRegistry.getInstance().shutdown()
-    ProxySshKeystore.getInstance(garden.log).shutdown(garden.log)
-  })
-
   beforeEach(async () => {
     graph = await garden.getConfigGraph({ log: garden.log, emit: false })
   })
 
   afterEach(async () => {
+    LocalModeProcessRegistry.getInstance().shutdown()
+    ProxySshKeystore.getInstance(garden.log).shutdown(garden.log)
     if (garden) {
       await garden.close()
     }

--- a/core/test/unit/src/util/recoverable-process.ts
+++ b/core/test/unit/src/util/recoverable-process.ts
@@ -553,7 +553,7 @@ describe("RecoverableProcess", async () => {
     const right = failingProcess(maxRetries, minTimeoutMs)
     const rightChild = longSleepingProcess(maxRetries, minTimeoutMs)
     root.addDescendantProcesses(left, right)
-    right.addDescendantProcess(rightChild)
+    right.addDescendantProcesses(rightChild)
 
     root.startAll()
 
@@ -575,7 +575,7 @@ describe("RecoverableProcess", async () => {
     const right = longSleepingProcess(maxRetries, minTimeoutMs)
     const rightChild = failingProcess(maxRetries, minTimeoutMs)
     root.addDescendantProcesses(left, right)
-    right.addDescendantProcess(rightChild)
+    right.addDescendantProcesses(rightChild)
 
     root.startAll()
 

--- a/core/test/unit/src/util/recoverable-process.ts
+++ b/core/test/unit/src/util/recoverable-process.ts
@@ -533,4 +533,15 @@ describe("RecoverableProcess", async () => {
 
     expect(() => root.startAll()).to.throw("Cannot start the process tree. Some processes failed with no retries left.")
   })
+
+  it("failed process cannot be started", async () => {
+    const maxRetries = 0
+    const minTimeoutMs = 500
+    const root = infiniteProcess(maxRetries, minTimeoutMs)
+
+    root.startAll()
+    root.stopAll()
+
+    expect(() => root.startAll()).to.throw("Cannot start already stopped process.")
+  })
 })

--- a/core/test/unit/src/util/recoverable-process.ts
+++ b/core/test/unit/src/util/recoverable-process.ts
@@ -138,8 +138,8 @@ describe("RecoverableProcess", async () => {
     const rightChild1 = infiniteProcess(maxRetries, minTimeoutMs)
     const rightChild2 = infiniteProcess(maxRetries, minTimeoutMs)
 
-    root.addDescendantProcesses(left, right)
-    right.addDescendantProcesses(rightChild1, rightChild2)
+    root.addDescendants(left, right)
+    right.addDescendants(rightChild1, rightChild2)
 
     return [root, left, right, rightChild1, rightChild2]
   }
@@ -151,8 +151,8 @@ describe("RecoverableProcess", async () => {
     const rightChild1 = longSleepingProcess(maxRetries, minTimeoutMs)
     const rightChild2 = longSleepingProcess(maxRetries, minTimeoutMs)
 
-    root.addDescendantProcesses(left, right)
-    right.addDescendantProcesses(rightChild1, rightChild2)
+    root.addDescendants(left, right)
+    right.addDescendants(rightChild1, rightChild2)
 
     return [root, left, right, rightChild1, rightChild2]
   }
@@ -214,7 +214,7 @@ describe("RecoverableProcess", async () => {
     })
 
     function expectDescendantRejection(parentProc: RecoverableProcess, childProc: RecoverableProcess) {
-      expect(() => parentProc.addDescendantProcesses(childProc)).to.throw(
+      expect(() => parentProc.addDescendants(childProc)).to.throw(
         "Cannot attach a descendant to already running, stopped or failed process."
       )
       expectRunnable(childProc)
@@ -225,7 +225,7 @@ describe("RecoverableProcess", async () => {
     }
 
     it('child processes can be added to a "runnable" parent', () => {
-      expect(() => parent.addDescendantProcesses(child)).to.not.throw()
+      expect(() => parent.addDescendants(child)).to.not.throw()
 
       expectRunnable(parent)
       expectRunnable(child)
@@ -377,8 +377,8 @@ describe("RecoverableProcess", async () => {
     const right = infiniteProcess(maxRetries, minTimeoutMs)
     const rightChild1 = infiniteProcess(maxRetries, minTimeoutMs)
     const rightChild2 = infiniteProcess(maxRetries, minTimeoutMs)
-    root.addDescendantProcesses(left, right)
-    right.addDescendantProcesses(rightChild1, rightChild2)
+    root.addDescendants(left, right)
+    right.addDescendants(rightChild1, rightChild2)
 
     root.startAll()
     expectRunning(root)
@@ -532,7 +532,7 @@ describe("RecoverableProcess", async () => {
     const root = failingProcess(maxRetries, minTimeoutMs)
     const left = longSleepingProcess(maxRetries, minTimeoutMs)
     const right = longSleepingProcess(maxRetries, minTimeoutMs)
-    root.addDescendantProcesses(left, right)
+    root.addDescendants(left, right)
 
     root.startAll()
 
@@ -552,8 +552,8 @@ describe("RecoverableProcess", async () => {
     const left = longSleepingProcess(maxRetries, minTimeoutMs)
     const right = failingProcess(maxRetries, minTimeoutMs)
     const rightChild = longSleepingProcess(maxRetries, minTimeoutMs)
-    root.addDescendantProcesses(left, right)
-    right.addDescendantProcesses(rightChild)
+    root.addDescendants(left, right)
+    right.addDescendants(rightChild)
 
     root.startAll()
 
@@ -574,8 +574,8 @@ describe("RecoverableProcess", async () => {
     const left = longSleepingProcess(maxRetries, minTimeoutMs)
     const right = longSleepingProcess(maxRetries, minTimeoutMs)
     const rightChild = failingProcess(maxRetries, minTimeoutMs)
-    root.addDescendantProcesses(left, right)
-    right.addDescendantProcesses(rightChild)
+    root.addDescendants(left, right)
+    right.addDescendants(rightChild)
 
     root.startAll()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
I've noticed that sleep periods between retries do not work well when I use Garden binaries built by CI pipeline. Local builds work fine. I'm not sure if it's related to the sync sleeping implementation, but it makes sense to use async sleep like anywhere else in the project codebase.

Async sleep won't spawn a new OS process, it will use `Promise` instead.
Also, sleep is called from the [async function](https://github.com/garden-io/garden/blob/master/core/src/util/recoverable-process.ts#L423), so it makes sense to keep the sleep call async too.

This PR also fixes state management in `RecoverableProcess` class. Now both `"stopped"` and `failed"` are the valid final states. The former stands for forced process tree stop, the latter -- for the failure after all retries have been used.

If necessary, it is possible to introduce an intermediate `"stopped"` state later, and define `"terminated"` and `"failed"` states as the final ones. But now it's not the case, the recoverable process trees should last for the duration of the Garden session.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
