### PR TITLE
refactor: renamed delete commands

### DIFF
--- a/core/src/commands/delete.ts
+++ b/core/src/commands/delete.ts
@@ -23,6 +23,7 @@ import { ConfigGraph } from "../config-graph"
 import { LogEntry } from "../logger/log-entry"
 import { uniqByName } from "../util/util"
 
+// TODO-G2 rename this to CleanupCommand, and do the same for all related classes, constants, variables and functions
 export class DeleteCommand extends CommandGroup {
   name = "cleanup"
   alias = "delete"
@@ -100,6 +101,7 @@ interface DeleteEnvironmentResult {
 
 export class DeleteEnvironmentCommand extends Command<{}, DeleteEnvironmentOpts> {
   name = "namespace"
+  // TODO-G2 add `environment` and `env` as aliases here
   alias = "ns"
   help = "Deletes a running namespace."
 

--- a/core/src/commands/delete.ts
+++ b/core/src/commands/delete.ts
@@ -25,6 +25,7 @@ import { uniqByName } from "../util/util"
 
 export class DeleteCommand extends CommandGroup {
   name = "cleanup"
+  alias = "delete"
   help = "Delete/cleanup configuration or objects."
 
   subCommands = [DeleteSecretCommand, DeleteEnvironmentCommand, DeleteServiceCommand]

--- a/core/src/commands/delete.ts
+++ b/core/src/commands/delete.ts
@@ -24,9 +24,8 @@ import { LogEntry } from "../logger/log-entry"
 import { uniqByName } from "../util/util"
 
 export class DeleteCommand extends CommandGroup {
-  name = "delete"
-  alias = "del"
-  help = "Delete configuration or objects."
+  name = "cleanup"
+  help = "Delete/cleanup configuration or objects."
 
   subCommands = [DeleteSecretCommand, DeleteEnvironmentCommand, DeleteServiceCommand]
 }
@@ -54,14 +53,14 @@ export class DeleteSecretCommand extends Command<typeof deleteSecretArgs> {
 
     Examples:
 
-        garden delete secret kubernetes somekey
-        garden del secret local-kubernetes some-other-key
+        garden cleanup secret kubernetes somekey
+        garden cleanup secret local-kubernetes some-other-key
   `
 
   arguments = deleteSecretArgs
 
   printHeader({ headerLog }) {
-    printHeader(headerLog, "Delete secrete", "skull_and_crossbones")
+    printHeader(headerLog, "Cleanup secret", "skull_and_crossbones")
   }
 
   async action({ garden, log, args }: CommandParams<DeleteSecretArgs>): Promise<CommandResult<DeleteSecretResult>> {
@@ -83,7 +82,7 @@ const dependantsFirstOpt = {
   "dependants-first": new BooleanParameter({
     help: deline`
       Delete services in reverse dependency order. That is, if service-a has a dependency on service-b, service-a
-      will be deleted before service-b when calling garden delete environment service-a,service-b --dependants-first.
+      will be deleted before service-b when calling \`garden cleanup environment service-a,service-b --dependants-first\`.
       When this flag is not used, all services in the project are deleted simultaneously.
     `,
   }),
@@ -127,7 +126,7 @@ export class DeleteEnvironmentCommand extends Command<{}, DeleteEnvironmentOpts>
     })
 
   printHeader({ headerLog }) {
-    printHeader(headerLog, `Deleting environment`, "skull_and_crossbones")
+    printHeader(headerLog, `Cleanup environment`, "skull_and_crossbones")
   }
 
   async action({
@@ -188,15 +187,15 @@ export class DeleteServiceCommand extends Command<DeleteServiceArgs, DeleteServi
 
     Examples:
 
-        garden delete service my-service # deletes my-service
-        garden delete service            # deletes all deployed services in the project
+        garden cleanup service my-service # deletes my-service
+        garden cleanup service            # deletes all deployed services in the project
   `
 
   outputsSchema = () =>
     joiIdentifierMap(serviceStatusSchema()).description("A map of statuses for all the deleted services.")
 
   printHeader({ headerLog }) {
-    printHeader(headerLog, "Delete service", "skull_and_crossbones")
+    printHeader(headerLog, "Cleanup service", "skull_and_crossbones")
   }
 
   async action({

--- a/core/src/commands/delete.ts
+++ b/core/src/commands/delete.ts
@@ -45,7 +45,7 @@ type DeleteSecretArgs = typeof deleteSecretArgs
 
 export class DeleteSecretCommand extends Command<typeof deleteSecretArgs> {
   name = "secret"
-  help = "Delete a secret from the environment."
+  help = "Delete a secret from the namespace."
   protected = true
 
   description = dedent`
@@ -82,7 +82,7 @@ const dependantsFirstOpt = {
   "dependants-first": new BooleanParameter({
     help: deline`
       Delete services in reverse dependency order. That is, if service-a has a dependency on service-b, service-a
-      will be deleted before service-b when calling \`garden cleanup environment service-a,service-b --dependants-first\`.
+      will be deleted before service-b when calling \`garden cleanup namespace service-a,service-b --dependants-first\`.
       When this flag is not used, all services in the project are deleted simultaneously.
     `,
   }),
@@ -98,9 +98,9 @@ interface DeleteEnvironmentResult {
 }
 
 export class DeleteEnvironmentCommand extends Command<{}, DeleteEnvironmentOpts> {
-  name = "environment"
-  alias = "env"
-  help = "Deletes a running environment."
+  name = "namespace"
+  alias = "ns"
+  help = "Deletes a running namespace."
 
   protected = true
   streamEvents = true
@@ -108,25 +108,24 @@ export class DeleteEnvironmentCommand extends Command<{}, DeleteEnvironmentOpts>
   options = deleteEnvironmentOpts
 
   description = dedent`
-    This will delete all services in the specified environment, and trigger providers to clear up any other resources
-    and reset it. When you then run \`garden deploy\`, the environment will be reconfigured.
+    This will delete all services in the specified namespace, and trigger providers to clear up any other resources
+    and reset it. When you then run \`garden deploy\`, the namespace will be reconfigured.
 
-    This can be useful if you find the environment to be in an inconsistent state, or need/want to free up
-    resources.
+    This can be useful if you find the namespace to be in an inconsistent state, or need/want to free up resources.
   `
 
   outputsSchema = () =>
     joi.object().keys({
       providerStatuses: joiIdentifierMap(environmentStatusSchema()).description(
-        "The status of each provider in the environment."
+        "The status of each provider in the namespace."
       ),
       serviceStatuses: joiIdentifierMap(serviceStatusSchema()).description(
-        "The status of each service in the environment."
+        "The status of each service in the namespace."
       ),
     })
 
   printHeader({ headerLog }) {
-    printHeader(headerLog, `Cleanup environment`, "skull_and_crossbones")
+    printHeader(headerLog, `Cleanup namespace`, "skull_and_crossbones")
   }
 
   async action({

--- a/core/test/unit/src/cli/helpers.ts
+++ b/core/test/unit/src/cli/helpers.ts
@@ -81,7 +81,7 @@ describe("pickCommand", () => {
   })
 
   it("picks a command with an alias", () => {
-    const { command, rest } = pickCommand(commands, ["cleanup", "ns", "foo", "--force"])
+    const { command, rest } = pickCommand(commands, ["delete", "ns", "foo", "--force"])
     expect(command?.getPath()).to.eql(["cleanup", "namespace"])
     expect(rest).to.eql(["foo", "--force"])
   })

--- a/core/test/unit/src/cli/helpers.ts
+++ b/core/test/unit/src/cli/helpers.ts
@@ -81,8 +81,8 @@ describe("pickCommand", () => {
   })
 
   it("picks a command with an alias", () => {
-    const { command, rest } = pickCommand(commands, ["del", "env", "foo", "--force"])
-    expect(command?.getPath()).to.eql(["delete", "environment"])
+    const { command, rest } = pickCommand(commands, ["cleanup", "ns", "foo", "--force"])
+    expect(command?.getPath()).to.eql(["cleanup", "namespace"])
     expect(rest).to.eql(["foo", "--force"])
   })
 

--- a/core/test/unit/src/commands/run/workflow.ts
+++ b/core/test/unit/src/commands/run/workflow.ts
@@ -65,8 +65,8 @@ describe("RunWorkflowCommand", () => {
           { command: ["deploy", "${var.foo}"] }, // <-- the second (null) element should get filtered out
           { command: ["run", "test", "module-a", "unit"] },
           { command: ["run", "task", "task-a"] },
-          { command: ["delete", "service", "service-a"] },
-          { command: ["delete", "environment"] },
+          { command: ["cleanup", "service", "service-a"] },
+          { command: ["cleanup", "namespace"] },
           { command: ["publish"] },
         ],
       },

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -374,7 +374,7 @@ Examples:
 
 ### garden cleanup secret
 
-**Delete a secret from the environment.**
+**Delete a secret from the namespace.**
 
 Returns with an error if the provided key could not be found by the provider.
 
@@ -396,30 +396,29 @@ Examples:
 
 
 
-### garden cleanup environment
+### garden cleanup namespace
 
-**Deletes a running environment.**
+**Deletes a running namespace.**
 
-This will delete all services in the specified environment, and trigger providers to clear up any other resources
-and reset it. When you then run `garden deploy`, the environment will be reconfigured.
+This will delete all services in the specified namespace, and trigger providers to clear up any other resources
+and reset it. When you then run `garden deploy`, the namespace will be reconfigured.
 
-This can be useful if you find the environment to be in an inconsistent state, or need/want to free up
-resources.
+This can be useful if you find the namespace to be in an inconsistent state, or need/want to free up resources.
 
 #### Usage
 
-    garden cleanup environment [options]
+    garden cleanup namespace [options]
 
 #### Options
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
-  | `--dependants-first` |  | boolean | Delete services in reverse dependency order. That is, if service-a has a dependency on service-b, service-a will be deleted before service-b when calling &#x60;garden cleanup environment service-a,service-b --dependants-first&#x60;. When this flag is not used, all services in the project are deleted simultaneously.
+  | `--dependants-first` |  | boolean | Delete services in reverse dependency order. That is, if service-a has a dependency on service-b, service-a will be deleted before service-b when calling &#x60;garden cleanup namespace service-a,service-b --dependants-first&#x60;. When this flag is not used, all services in the project are deleted simultaneously.
 
 #### Outputs
 
 ```yaml
-# The status of each provider in the environment.
+# The status of each provider in the namespace.
 providerStatuses:
   # Description of an environment's status for a provider.
   <name>:
@@ -445,7 +444,7 @@ providerStatuses:
     # Set to true to disable caching of the status.
     disableCache:
 
-# The status of each service in the environment.
+# The status of each service in the namespace.
 serviceStatuses:
   <name>:
     # When the service was first deployed by the provider.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -372,7 +372,7 @@ Examples:
   | `--type` |  | string | The module type to create. Required if --interactive&#x3D;false.
 
 
-### garden delete secret
+### garden cleanup secret
 
 **Delete a secret from the environment.**
 
@@ -380,12 +380,12 @@ Returns with an error if the provided key could not be found by the provider.
 
 Examples:
 
-    garden delete secret kubernetes somekey
-    garden del secret local-kubernetes some-other-key
+    garden cleanup secret kubernetes somekey
+    garden cleanup secret local-kubernetes some-other-key
 
 #### Usage
 
-    garden delete secret <provider> <key> 
+    garden cleanup secret <provider> <key> 
 
 #### Arguments
 
@@ -396,7 +396,7 @@ Examples:
 
 
 
-### garden delete environment
+### garden cleanup environment
 
 **Deletes a running environment.**
 
@@ -408,13 +408,13 @@ resources.
 
 #### Usage
 
-    garden delete environment [options]
+    garden cleanup environment [options]
 
 #### Options
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
-  | `--dependants-first` |  | boolean | Delete services in reverse dependency order. That is, if service-a has a dependency on service-b, service-a will be deleted before service-b when calling garden delete environment service-a,service-b --dependants-first. When this flag is not used, all services in the project are deleted simultaneously.
+  | `--dependants-first` |  | boolean | Delete services in reverse dependency order. That is, if service-a has a dependency on service-b, service-a will be deleted before service-b when calling &#x60;garden cleanup environment service-a,service-b --dependants-first&#x60;. When this flag is not used, all services in the project are deleted simultaneously.
 
 #### Outputs
 
@@ -533,7 +533,7 @@ serviceStatuses:
     version:
 ```
 
-### garden delete service
+### garden cleanup service
 
 **Deletes running services.**
 
@@ -543,12 +543,12 @@ therefore leave the project in an unstable state. Running `garden deploy` will r
 
 Examples:
 
-    garden delete service my-service # deletes my-service
-    garden delete service            # deletes all deployed services in the project
+    garden cleanup service my-service # deletes my-service
+    garden cleanup service            # deletes all deployed services in the project
 
 #### Usage
 
-    garden delete service [services] 
+    garden cleanup service [services] 
 
 #### Arguments
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR only contains the user-facing parts for now. We can rename internals later. The internal includes the classes like `DeleteXxx[Command|Params|Result]`, some handlers, methods and functions in the action router, local variables, etc.

Changing the internal now can cause extra conflicts with https://github.com/garden-io/garden/tree/graph-v2.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
