### PR TITLE
Remove commented fields from create command outputs

### DIFF
--- a/core/src/commands/create/create-module.ts
+++ b/core/src/commands/create/create-module.ts
@@ -207,7 +207,7 @@ export class CreateModuleCommand extends Command<CreateModuleArgs, CreateModuleO
     })
 
     const moduleTypeUrl = getModuleTypeUrl(type)
-    yaml = `# Documentation about ${type} modules at ${moduleTypeUrl}\n\n${yaml}`
+    yaml = `# See the documentation and reference for ${type} modules at ${moduleTypeUrl}\n\n${yaml}`
     await addConfig(configPath, yaml)
 
     log.info(chalk.green(`-> Created new module config in ${chalk.bold.white(relative(process.cwd(), configPath))}`))

--- a/core/src/commands/create/create-module.ts
+++ b/core/src/commands/create/create-module.ts
@@ -16,7 +16,7 @@ import { loadConfigResources, findProjectConfig } from "../../config/base"
 import { resolve, basename, relative, join } from "path"
 import { GardenBaseError, ParameterError } from "../../exceptions"
 import { getModuleTypes, getPluginBaseNames } from "../../plugins"
-import { addConfig, createBaseOpts } from "./helpers"
+import { addConfig } from "./helpers"
 import { getSupportedPlugins } from "../../plugins/plugins"
 import { baseModuleSpecSchema } from "../../config/module"
 import { renderConfigReference } from "../../docs/config"
@@ -35,7 +35,6 @@ import { userPrompt } from "../../util/util"
 
 const createModuleArgs = {}
 const createModuleOpts = {
-  ...createBaseOpts,
   dir: new PathParameter({
     help: "Directory to place the module in (defaults to current directory).",
     defaultValue: ".",
@@ -196,9 +195,9 @@ export class CreateModuleCommand extends Command<CreateModuleArgs, CreateModuleO
       }
     )
 
-    const { yaml } = renderConfigReference(schema, {
+    let { yaml } = renderConfigReference(schema, {
       yamlOpts: {
-        onEmptyValue: opts["skip-comments"] ? "remove" : "comment out",
+        onEmptyValue: "remove",
         filterMarkdown: true,
         renderBasicDescription: !opts["skip-comments"],
         renderFullDescription: false,
@@ -207,6 +206,8 @@ export class CreateModuleCommand extends Command<CreateModuleArgs, CreateModuleO
       },
     })
 
+    const moduleTypeUrl = getModuleTypeUrl(type)
+    yaml = `# Documentation about ${type} modules at ${moduleTypeUrl}\n\n${yaml}`
     await addConfig(configPath, yaml)
 
     log.info(chalk.green(`-> Created new module config in ${chalk.bold.white(relative(process.cwd(), configPath))}`))
@@ -257,7 +258,7 @@ export class CreateModuleCommand extends Command<CreateModuleArgs, CreateModuleO
     }
 
     // This is to avoid `prettier` messing with the string formatting...
-    const moduleTypeUrl = chalk.cyan.underline(getModuleTypeUrl(type))
+    const moduleTypeUrlFormatted = chalk.cyan.underline(moduleTypeUrl)
     const providerUrl = chalk.cyan.underline(getProviderUrl(pluginName))
     const configFilesUrl = chalk.cyan.underline(`${DOCS_BASE_URL}/using-garden/configuration-overview`)
     const formattedType = chalk.bold(type)
@@ -267,9 +268,7 @@ export class CreateModuleCommand extends Command<CreateModuleArgs, CreateModuleO
       symbol: "info",
       msg: wordWrap(
         dedent`
-        We recommend reviewing the generated config, uncommenting fields that you'd like to configure, and cleaning up any commented fields that you don't need to use.
-
-        For more information about ${formattedType} modules, please check out ${moduleTypeUrl}, and the ${formattedPluginName} provider docs at ${providerUrl}. For general information about Garden configuration files, take a look at ${configFilesUrl}.
+        For more information about ${formattedType} modules, please check out ${moduleTypeUrlFormatted}, and the ${formattedPluginName} provider docs at ${providerUrl}. For general information about Garden configuration files, take a look at ${configFilesUrl}.
         `,
         120
       ),

--- a/core/src/commands/create/create-project.ts
+++ b/core/src/commands/create/create-project.ts
@@ -155,7 +155,11 @@ export class CreateProjectCommand extends Command<CreateProjectArgs, CreateProje
     })
 
     const projectDocURL = "https://docs.garden.io/using-garden/projects"
-    yaml = `# More info and documentation at ${projectDocURL}\n\n${yaml}`
+    const projectReferenceURL = "https://docs.garden.io/reference/project-config"
+    yaml =
+      dedent`
+    # Documentation about Garden projects can be found at ${projectDocURL}
+    # Reference for Garden projects can be found at ${projectReferenceURL}` + `\n\n${yaml}`
 
     await addConfig(configPath, yaml)
 
@@ -192,7 +196,7 @@ export class CreateProjectCommand extends Command<CreateProjectArgs, CreateProje
 
     // This is to avoid `prettier` messing with the string formatting...
     const configFilesUrl = chalk.cyan.underline("https://docs.garden.io/using-garden/configuration-overview")
-    const referenceUrl = chalk.cyan.underline("https://docs.garden.io/reference/config")
+    const referenceUrl = chalk.cyan.underline(projectReferenceURL)
 
     log.info({
       symbol: "info",

--- a/core/src/commands/create/helpers.ts
+++ b/core/src/commands/create/helpers.ts
@@ -7,14 +7,6 @@
  */
 
 import { pathExists, readFile, writeFile } from "fs-extra"
-import { BooleanParameter } from "../../cli/params"
-
-export const createBaseOpts = {
-  "skip-comments": new BooleanParameter({
-    help: "Set to true to disable comment generation.",
-    defaultValue: false,
-  }),
-}
 
 export async function addConfig(configPath: string, yaml: string) {
   let output = yaml

--- a/core/test/unit/src/commands/create/create-module.ts
+++ b/core/test/unit/src/commands/create/create-module.ts
@@ -48,11 +48,10 @@ describe("CreateModuleCommand", () => {
       args: {},
       opts: withDefaultGlobalOpts({
         dir,
-        "interactive": false,
-        "name": undefined,
-        "type": "exec",
-        "filename": defaultConfigFilename,
-        "skip-comments": false,
+        interactive: false,
+        name: undefined,
+        type: "exec",
+        filename: defaultConfigFilename,
       }),
     })
     const { name, configPath } = result!
@@ -80,12 +79,11 @@ describe("CreateModuleCommand", () => {
       log: garden.log,
       args: {},
       opts: withDefaultGlobalOpts({
-        "dir": tmp.path,
-        "interactive": false,
-        "name": "test",
-        "type": "exec",
-        "filename": "custom.garden.yml",
-        "skip-comments": false,
+        dir: tmp.path,
+        interactive: false,
+        name: "test",
+        type: "exec",
+        filename: "custom.garden.yml",
       }),
     })
     const { configPath } = result!
@@ -102,12 +100,11 @@ describe("CreateModuleCommand", () => {
       log: garden.log,
       args: {},
       opts: withDefaultGlobalOpts({
-        "dir": tmp.path,
-        "interactive": false,
-        "name": "test",
-        "type": "exec",
-        "filename": defaultConfigFilename,
-        "skip-comments": false,
+        dir: tmp.path,
+        interactive: false,
+        name: "test",
+        type: "exec",
+        filename: defaultConfigFilename,
       }),
     })
     const { name, configPath } = result!
@@ -138,12 +135,11 @@ describe("CreateModuleCommand", () => {
       log: garden.log,
       args: {},
       opts: withDefaultGlobalOpts({
-        "dir": tmp.path,
-        "interactive": false,
-        "name": "test",
-        "type": "exec",
-        "filename": defaultConfigFilename,
-        "skip-comments": false,
+        dir: tmp.path,
+        interactive: false,
+        name: "test",
+        type: "exec",
+        filename: defaultConfigFilename,
       }),
     })
     const { name, configPath } = result!
@@ -177,12 +173,11 @@ describe("CreateModuleCommand", () => {
           log: garden.log,
           args: {},
           opts: withDefaultGlobalOpts({
-            "dir": tmp.path,
-            "interactive": false,
-            "name": "test",
-            "type": "exec",
-            "filename": defaultConfigFilename,
-            "skip-comments": false,
+            dir: tmp.path,
+            interactive: false,
+            name: "test",
+            type: "exec",
+            filename: defaultConfigFilename,
           }),
         }),
       (err) => expect(stripAnsi(err.message)).to.equal("A Garden module named test already exists in " + configPath)
@@ -201,11 +196,10 @@ describe("CreateModuleCommand", () => {
           args: {},
           opts: withDefaultGlobalOpts({
             dir,
-            "interactive": false,
-            "name": "test",
-            "type": "exec",
-            "filename": defaultConfigFilename,
-            "skip-comments": false,
+            interactive: false,
+            name: "test",
+            type: "exec",
+            filename: defaultConfigFilename,
           }),
         }),
       (err) => expect(err.message).to.equal(`Path ${dir} does not exist`)
@@ -222,12 +216,11 @@ describe("CreateModuleCommand", () => {
           log: garden.log,
           args: {},
           opts: withDefaultGlobalOpts({
-            "dir": tmp.path,
-            "interactive": false,
-            "name": undefined,
-            "type": "foo",
-            "filename": defaultConfigFilename,
-            "skip-comments": false,
+            dir: tmp.path,
+            interactive: false,
+            name: undefined,
+            type: "foo",
+            filename: defaultConfigFilename,
           }),
         }),
       (err) => expect(stripAnsi(err.message)).to.equal("Could not find module type foo")

--- a/core/test/unit/src/commands/create/create-project.ts
+++ b/core/test/unit/src/commands/create/create-project.ts
@@ -39,11 +39,10 @@ describe("CreateProjectCommand", () => {
       log: garden.log,
       args: {},
       opts: withDefaultGlobalOpts({
-        "dir": tmp.path,
-        "interactive": false,
-        "name": undefined,
-        "filename": defaultProjectConfigFilename,
-        "skip-comments": false,
+        dir: tmp.path,
+        interactive: false,
+        name: undefined,
+        filename: defaultProjectConfigFilename,
       }),
     })
     const { name, configPath, ignoreFileCreated, ignoreFilePath } = result!
@@ -78,11 +77,10 @@ describe("CreateProjectCommand", () => {
       log: garden.log,
       args: {},
       opts: withDefaultGlobalOpts({
-        "dir": tmp.path,
-        "interactive": false,
-        "name": undefined,
-        "filename": defaultProjectConfigFilename,
-        "skip-comments": false,
+        dir: tmp.path,
+        interactive: false,
+        name: undefined,
+        filename: defaultProjectConfigFilename,
       }),
     })
     const { ignoreFileCreated, ignoreFilePath } = result!
@@ -103,11 +101,10 @@ describe("CreateProjectCommand", () => {
       log: garden.log,
       args: {},
       opts: withDefaultGlobalOpts({
-        "dir": tmp.path,
-        "interactive": false,
-        "name": undefined,
-        "filename": defaultProjectConfigFilename,
-        "skip-comments": false,
+        dir: tmp.path,
+        interactive: false,
+        name: undefined,
+        filename: defaultProjectConfigFilename,
       }),
     })
     const { ignoreFileCreated, ignoreFilePath } = result!
@@ -125,11 +122,10 @@ describe("CreateProjectCommand", () => {
       log: garden.log,
       args: {},
       opts: withDefaultGlobalOpts({
-        "dir": tmp.path,
-        "interactive": false,
-        "name": "foo",
-        "filename": defaultProjectConfigFilename,
-        "skip-comments": false,
+        dir: tmp.path,
+        interactive: false,
+        name: "foo",
+        filename: defaultProjectConfigFilename,
       }),
     })
     const { name, configPath } = result!
@@ -161,11 +157,10 @@ describe("CreateProjectCommand", () => {
       log: garden.log,
       args: {},
       opts: withDefaultGlobalOpts({
-        "dir": tmp.path,
-        "interactive": false,
-        "name": undefined,
-        "filename": "garden.yml",
-        "skip-comments": false,
+        dir: tmp.path,
+        interactive: false,
+        name: undefined,
+        filename: "garden.yml",
       }),
     })
     const { name, configPath } = result!
@@ -190,11 +185,10 @@ describe("CreateProjectCommand", () => {
       log: garden.log,
       args: {},
       opts: withDefaultGlobalOpts({
-        "dir": tmp.path,
-        "interactive": false,
-        "name": undefined,
-        "filename": "custom.garden.yml",
-        "skip-comments": false,
+        dir: tmp.path,
+        interactive: false,
+        name: undefined,
+        filename: "custom.garden.yml",
       }),
     })
     const { configPath } = result!
@@ -220,11 +214,10 @@ describe("CreateProjectCommand", () => {
           log: garden.log,
           args: {},
           opts: withDefaultGlobalOpts({
-            "dir": tmp.path,
-            "interactive": false,
-            "name": undefined,
-            "filename": defaultProjectConfigFilename,
-            "skip-comments": false,
+            dir: tmp.path,
+            interactive: false,
+            name: undefined,
+            filename: defaultProjectConfigFilename,
           }),
         }),
       (err) => expect(err.message).to.equal("A Garden project already exists in " + configPath)
@@ -243,10 +236,9 @@ describe("CreateProjectCommand", () => {
           args: {},
           opts: withDefaultGlobalOpts({
             dir,
-            "interactive": false,
-            "name": undefined,
-            "filename": defaultProjectConfigFilename,
-            "skip-comments": false,
+            interactive: false,
+            name: undefined,
+            filename: defaultProjectConfigFilename,
           }),
         }),
       (err) => expect(err.message).to.equal(`Path ${dir} does not exist`)

--- a/docs/getting-started/2-initialize-a-project.md
+++ b/docs/getting-started/2-initialize-a-project.md
@@ -14,7 +14,7 @@ This directory contains two directories, with one container service each, `backe
 To initialize the project, we can use a helper command:
 
 ```sh
-garden create project --skip-comments
+garden create project
 ```
 
 This will create a basic boilerplate project configuration in the current directory, making it our project root.
@@ -30,11 +30,11 @@ providers:
 
 We have one environment (`default`) and a single provider. We'll get back to this later.
 
-Next, let's create module configs for each of our two modules, starting with `backend`. You can omit the `--skip-comments` flag to create a module with commented-out fields, which reveal all the options available.
+Next, let's create module configs for each of our two modules, starting with `backend`.
 
 ```sh
 cd backend
-garden create module --skip-comments
+garden create module
 cd ..
 ```
 
@@ -42,7 +42,7 @@ You'll get a suggestion to make it a `container` module. Pick that, and give it 
 
 ```sh
 cd frontend
-garden create module --skip-comments
+garden create module
 cd ..
 ```
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -335,7 +335,6 @@ Examples:
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
-  | `--skip-comments` |  | boolean | Set to true to disable comment generation.
   | `--dir` |  | path | Directory to place the project in (defaults to current directory).
   | `--filename` |  | string | Filename to place the project config in (defaults to project.garden.yml).
   | `--interactive` | `-i` | boolean | Set to false to disable interactive prompts.
@@ -364,7 +363,6 @@ Examples:
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
-  | `--skip-comments` |  | boolean | Set to true to disable comment generation.
   | `--dir` |  | path | Directory to place the module in (defaults to current directory).
   | `--filename` |  | string | Filename to place the module config in (defaults to garden.yml).
   | `--interactive` | `-i` | boolean | Set to false to disable interactive prompts.


### PR DESCRIPTION
with this addition I'm undoing my very first contribution to garden (as an employee). #2904

* create commands no longer add empty commented fields
* remove `--skip-comments` flag
* update getting-started docs accordingly
* add links do docs on top of generated docs

![image](https://user-images.githubusercontent.com/33936483/180393342-fa55842b-1c37-48e8-82bd-f36a6dd4e9cb.png)


