### PR TITLE
improvement(local-mode): don't watch files in local-mode modules

### DIFF
--- a/core/src/commands/deploy.ts
+++ b/core/src/commands/deploy.ts
@@ -24,7 +24,7 @@ import { processModules } from "../process"
 import { printHeader } from "../logger/util"
 import { BaseTask } from "../tasks/base"
 import {
-  getDevModeModules,
+  getModulesByServiceNames,
   getMatchingServiceNames,
   getHotReloadServiceNames,
   validateHotReloadServiceNames,
@@ -245,7 +245,10 @@ export class DeployCommand extends Command<Args, Opts> {
       footerLog,
       modules,
       initialTasks,
-      skipWatchModules: getDevModeModules(devModeServiceNames, initGraph),
+      skipWatchModules: [
+        ...getModulesByServiceNames(devModeServiceNames, initGraph),
+        ...getModulesByServiceNames(localModeServiceNames, initGraph),
+      ],
       watch,
       changeHandler: async (graph, module) => {
         const tasks: BaseTask[] = await getModuleWatchTasks({

--- a/core/src/commands/dev.ts
+++ b/core/src/commands/dev.ts
@@ -20,7 +20,7 @@ import { GardenModule } from "../types/module"
 import { getTestTasks } from "../tasks/test"
 import { ConfigGraph } from "../config-graph"
 import {
-  getDevModeModules,
+  getModulesByServiceNames,
   getHotReloadServiceNames,
   getMatchingServiceNames,
   validateHotReloadServiceNames,
@@ -201,7 +201,10 @@ export class DevCommand extends Command<DevCommandArgs, DevCommandOpts> {
       modules,
       watch: true,
       initialTasks,
-      skipWatchModules: getDevModeModules(devModeServiceNames, graph),
+      skipWatchModules: [
+        ...getModulesByServiceNames(devModeServiceNames, graph),
+        ...getModulesByServiceNames(localModeServiceNames, graph),
+      ],
       changeHandler: async (updatedGraph: ConfigGraph, module: GardenModule) => {
         return getDevCommandWatchTasks({
           garden,

--- a/core/src/commands/helpers.ts
+++ b/core/src/commands/helpers.ts
@@ -39,8 +39,8 @@ export function getHotReloadServiceNames(namesFromOpt: string[] | undefined, con
   }
 }
 
-export function getDevModeModules(devModeServiceNames: string[], graph: ConfigGraph): GardenModule[] {
-  return uniqByName(graph.getServices({ names: devModeServiceNames }).map((s) => s.module))
+export function getModulesByServiceNames(serviceNames: string[], graph: ConfigGraph): GardenModule[] {
+  return uniqByName(graph.getServices({ names: serviceNames }).map((s) => s.module))
 }
 
 /**


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR ensures that modules deployed in `local-mode` are skipped by the file watcher.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
No tests have been added because there are no similar tests for `dev-mode`. Test coverage can be improved later, for instance, in `0.13` branch.