### PR TITLE
chore: update release url

### DIFF
--- a/.github/workflows/update-homebrew-action.yml
+++ b/.github/workflows/update-homebrew-action.yml
@@ -24,7 +24,7 @@ jobs:
         homebrew-tap: garden-io/homebrew-garden
         base-branch: master
         create-pullrequest: true
-        download-url: https://github.com/garden-io/garden/releases/download/${{ github.event.release.tag_name }}/garden-${{ github.event.release.tag_name }}-macos-amd64.tar.gz
+        download-url: https://download.garden.io/core/${{ github.event.release.tag_name }}/garden-${{ github.event.release.tag_name }}-macos-amd64.tar.gz
         commit-message: |
           Bump {{formulaName}} to {{version}}.
 

--- a/cli/src/build-pkg.ts
+++ b/cli/src/build-pkg.ts
@@ -54,6 +54,23 @@ const targets: { [name: string]: TargetSpec } = {
   "alpine-amd64": { pkgType: "node14-alpine-x64", handler: pkgAlpine, nodeBinaryPlatform: "linuxmusl" },
 }
 
+/**
+ * This function defines the filename format for release packages.
+ *
+ * The format SHOULD NOT be changed since other tools we use depend on it, unless you absolutely know what you're doing.
+ */
+function composePackageFilename(version: string, targetName: string, extension: string): string {
+  return `garden-${version}-${targetName}.${extension}`
+}
+
+export function getZipFilename(version: string, targetName: string): string {
+  return composePackageFilename(version, targetName, "zip")
+}
+
+export function getTarballFilename(version: string, targetName: string): string {
+  return composePackageFilename(version, targetName, "tar.gz")
+}
+
 async function buildBinaries(args: string[]) {
   const argv = minimist(args)
   const version = argv.version || getPackageVersion()
@@ -186,7 +203,8 @@ async function pkgWindows({ targetName, sourcePath, pkgType, version }: TargetHa
   })
 
   console.log(` - ${targetName} -> zip`)
-  await exec("zip", ["-q", "-r", `garden-${version}-${targetName}.zip`, targetName], { cwd: distPath })
+  const filename = getZipFilename(version, targetName)
+  await exec("zip", ["-q", "-r", filename, targetName], { cwd: distPath })
 }
 
 async function pkgAlpine({ targetName, version }: TargetHandlerParams) {
@@ -284,7 +302,7 @@ async function copyStatic(targetName: string) {
 }
 
 async function tarball(targetName: string, version: string): Promise<void> {
-  const filename = `garden-${version}-${targetName}.tar.gz`
+  const filename = getTarballFilename(version, targetName)
   console.log(` - ${targetName} -> tar (${filename})`)
 
   await exec("tar", ["-czf", filename, targetName], { cwd: distPath })

--- a/cli/test/unit/src/build-pkg.ts
+++ b/cli/test/unit/src/build-pkg.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2018-2022 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import { getTarballFilename, getZipFilename } from "../../../src/build-pkg"
+
+describe("build-pkg", () => {
+  const version = "0.12.44"
+  const errorMsg = (errDetails: string): string => {
+    return `The format of the release package name SHOULD NOT be changed since other tools we use depend on it, unless you absolutely know what you're doing. Test failed with error: ${errDetails}`
+  }
+
+  context("tarball-filenames", () => {
+    const errorDetails = "Tarball filename must be in kebab-case format `garden-${version}-${platform}.tar.gz`."
+
+    function expectTarballFilenameFormat(platformName: string) {
+      const tarballFilename = getTarballFilename(version, platformName)
+      expect(tarballFilename).to.equal(`garden-${version}-${platformName}.tar.gz`, errorMsg(errorDetails))
+    }
+
+    it("ensure filename format for tar packages", async () => {
+      expectTarballFilenameFormat("alpine-amd64")
+    })
+  })
+
+  context("zip-filenames", () => {
+    const errorDetails = "ZIP filename must be in kebab-case format `garden-${version}-${platform}.zip`."
+
+    function expectZipFilenameFormat(platformName: string) {
+      const tarballFilename = getZipFilename(version, platformName)
+      expect(tarballFilename).to.equal(`garden-${version}-${platformName}.zip`, errorMsg(errorDetails))
+    }
+
+    it("ensure filename format for alpine package", async () => {
+      expectZipFilenameFormat("windows-amd64")
+    })
+  })
+})

--- a/core/src/commands/self-update.ts
+++ b/core/src/commands/self-update.ts
@@ -76,7 +76,7 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
   options = selfUpdateOpts
 
   // Overridden during testing
-  _baseReleasesUrl = "https://github.com/garden-io/garden/releases/download/"
+  _baseReleasesUrl = "https://download.garden.io/core/"
 
   printHeader({ headerLog }) {
     printHeader(headerLog, "Update Garden", "rolled_up_newspaper")

--- a/scripts/test-release.sh
+++ b/scripts/test-release.sh
@@ -22,7 +22,7 @@ download_release() {
 
   platform=${os}-amd64
   filename="garden-${base_version}-${platform}.tar.gz"
-  url="https://github.com/garden-io/garden/releases/download/${version}/${filename}"
+  url="https://download.garden.io/core/${version}/${filename}"
   dir=${HOME}/.garden-release
   target_path=${dir}/bin
 

--- a/support/install.ps1
+++ b/support/install.ps1
@@ -98,7 +98,7 @@ $latestRelease = Invoke-WebRequest "https://github.com/garden-io/garden/releases
 $json = $latestRelease.Content | ConvertFrom-Json
 $latestVersion = $json.tag_name
 
-$url = "https://github.com/garden-io/garden/releases/download/$latestVersion/garden-$latestVersion-windows-amd64.zip"
+$url = "https://download.garden.io/core/$latestVersion/garden-$latestVersion-windows-amd64.zip"
 $zipPath = "$gardenTmpPath\garden-$latestVersion-windows-amd64.zip"
 
 Write-Host "-> Downloading $url..."

--- a/support/install.sh
+++ b/support/install.sh
@@ -38,7 +38,7 @@ fi
 PLATFORM=${OS}-amd64
 
 filename="garden-${GARDEN_VERSION}-${PLATFORM}.tar.gz"
-url="https://github.com/garden-io/garden/releases/download/${GARDEN_VERSION}/${filename}"
+url="https://download.garden.io/core/${GARDEN_VERSION}/${filename}"
 
 tmp=$(mktemp -d /tmp/garden-install.XXXXXX)
 (


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates Garden release packages' URLs. New URLs are connected to Scarf.sh to get better tracking of downloads.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
