### PR TITLE
chore: require environments field in project configuration

### DIFF
--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -38,11 +38,11 @@ import {
 } from "./helpers"
 import { Parameters, globalOptions, OUTPUT_RENDERERS, GlobalOptions, ParameterValues } from "./params"
 import {
-  defaultEnvironments,
   ProjectConfig,
   defaultNamespace,
   parseEnvironment,
   ProjectResource,
+  EnvironmentConfig,
 } from "../config/project"
 import { ERROR_LOG_FILENAME, DEFAULT_API_VERSION, DEFAULT_GARDEN_DIR_NAME, LOGS_DIR_NAME } from "../constants"
 import { generateBasicDebugInfoReport } from "../commands/get/get-debug-info"
@@ -66,9 +66,9 @@ import { renderDivider } from "../logger/util"
 import { emoji as nodeEmoji } from "node-emoji"
 
 export async function makeDummyGarden(root: string, gardenOpts: GardenOpts) {
-  const environments = gardenOpts.environmentName
+  const environments: EnvironmentConfig[] = gardenOpts.environmentName
     ? [{ name: parseEnvironment(gardenOpts.environmentName).environment, defaultNamespace, variables: {} }]
-    : defaultEnvironments
+    : [{ defaultNamespace: "default", name: "dummy-env", variables: {} }]
 
   const config: ProjectConfig = {
     path: root,

--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -68,7 +68,7 @@ import { emoji as nodeEmoji } from "node-emoji"
 export async function makeDummyGarden(root: string, gardenOpts: GardenOpts) {
   const environments: EnvironmentConfig[] = gardenOpts.environmentName
     ? [{ name: parseEnvironment(gardenOpts.environmentName).environment, defaultNamespace, variables: {} }]
-    : [{ defaultNamespace: "default", name: "dummy-env", variables: {} }]
+    : [{ defaultNamespace: "default", name: "default", variables: {} }]
 
   const config: ProjectConfig = {
     path: root,

--- a/core/src/docs/config.ts
+++ b/core/src/docs/config.ts
@@ -10,7 +10,7 @@ import Joi from "@hapi/joi"
 import { readFileSync } from "fs"
 import linewrap from "linewrap"
 import { resolve } from "path"
-import { projectDocsSchema } from "../config/project"
+import { projectSchema } from "../config/project"
 import { get, isFunction, isString } from "lodash"
 import handlebars = require("handlebars")
 import { joi, JoiDescription } from "../config/common"
@@ -429,7 +429,7 @@ export function renderTemplateStringReference({
 
 export function renderProjectConfigReference(opts: RenderConfigOpts = {}) {
   return renderConfigReference(
-    projectDocsSchema().keys({
+    projectSchema().keys({
       // Hide this from docs until we actually use it
       apiVersion: joi.string().meta({ internal: true }),
     }),

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -49,7 +49,7 @@ import { TaskGraph, GraphResults, ProcessTasksOpts } from "./task-graph"
 import { getLogger } from "./logger/logger"
 import { PluginActionHandlers, GardenPlugin } from "./types/plugin/plugin"
 import { loadConfigResources, findProjectConfig, prepareModuleResource, GardenResource } from "./config/base"
-import { DeepPrimitiveMap, StringMap, PrimitiveMap, treeVersionSchema, joiSparseArray, joi } from "./config/common"
+import { DeepPrimitiveMap, StringMap, PrimitiveMap, treeVersionSchema, joi } from "./config/common"
 import { BaseTask } from "./tasks/base"
 import { LocalConfigStore, ConfigStore, GlobalConfigStore, LinkedSource } from "./config-store"
 import { getLinkedSources, ExternalSourceType } from "./util/ext-source-util"
@@ -1244,8 +1244,8 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
   // This prevents cryptic type errors when the user mistakely writes down e.g. a map instead of an array.
   validateWithPath({
     config: config.environments,
-    schema: joiSparseArray(joi.object()),
-    configType: "environments",
+    schema: joi.array().items(joi.object()).min(1).required(),
+    configType: "project environments",
     path: config.path,
     projectRoot: config.path,
   })

--- a/core/test/data/test-build-dependants/project.garden.yaml
+++ b/core/test/data/test-build-dependants/project.garden.yaml
@@ -1,2 +1,4 @@
 kind: Project
 name: test
+environments:
+  - name: local

--- a/core/test/data/test-projects/custom-commands-invalid/project.garden.yml
+++ b/core/test/data/test-projects/custom-commands-invalid/project.garden.yml
@@ -1,5 +1,7 @@
 kind: Project
 name: custom-commands-invalid
+environments:
+  - name: local
 providers:
   - name: exec
 

--- a/core/test/data/test-projects/custom-commands/project.garden.yml
+++ b/core/test/data/test-projects/custom-commands/project.garden.yml
@@ -1,5 +1,7 @@
 kind: Project
 name: custom-commands
+environments:
+  - name: local
 providers:
   - name: exec
 variables:

--- a/core/test/data/test-projects/empty-doc/garden.yml
+++ b/core/test/data/test-projects/empty-doc/garden.yml
@@ -1,4 +1,6 @@
 ---
 kind: Project
 name: foo
+environments:
+  - name: local
 ---

--- a/core/test/data/test-projects/exec-task-outputs/garden.yml
+++ b/core/test/data/test-projects/exec-task-outputs/garden.yml
@@ -1,2 +1,4 @@
 kind: Project
 name: exec-task-outputs
+environments:
+  - name: local

--- a/core/test/data/test-projects/helm/garden.yml
+++ b/core/test/data/test-projects/helm/garden.yml
@@ -1,4 +1,6 @@
 kind: Project
 name: helm-test
+environments:
+  - name: local
 providers:
   - name: local-kubernetes

--- a/core/test/data/test-projects/huge-project/garden.yml
+++ b/core/test/data/test-projects/huge-project/garden.yml
@@ -1,5 +1,7 @@
 kind: Project
 name: huge-project
 dotIgnoreFiles: [.gardenignore]
+environments:
+  - name: local
 modules:
   exclude: [dir0/**/*, dir1/**/*, dir2/**/*, dir3/**/*, dir4/**/*, dir5/**/*, dir6/**/*, dir7/**/*, dir8/**/*]

--- a/core/test/data/test-projects/kubernetes-module/garden.yml
+++ b/core/test/data/test-projects/kubernetes-module/garden.yml
@@ -1,4 +1,6 @@
 kind: Project
 name: kubernetes-module-test
+environments:
+  - name: local
 providers:
   - name: local-kubernetes

--- a/core/test/data/test-projects/persistentvolumeclaim/garden.yml
+++ b/core/test/data/test-projects/persistentvolumeclaim/garden.yml
@@ -1,5 +1,7 @@
 kind: Project
 name: persistentvolumeclaim
+environments:
+  - name: local
 providers:
   - name: local-kubernetes
 ---

--- a/core/test/data/validate/bad-module/garden.yml
+++ b/core/test/data/validate/bad-module/garden.yml
@@ -1,2 +1,4 @@
 kind: Project
 name: build-test-project
+environments:
+  - name: local

--- a/core/test/data/validate/bad-project/garden.yml
+++ b/core/test/data/validate/bad-project/garden.yml
@@ -1,2 +1,4 @@
 kind: Project
+environments:
+  - name: local
 # missing required name

--- a/core/test/data/validate/bad-workflow/garden.yml
+++ b/core/test/data/validate/bad-workflow/garden.yml
@@ -1,5 +1,7 @@
 kind: Project
 name: bad-workflow-project
+environments:
+  - name: local
 
 ---
 

--- a/core/test/unit/src/config/base.ts
+++ b/core/test/unit/src/config/base.ts
@@ -390,6 +390,7 @@ describe("loadConfigResources", () => {
         apiVersion: DEFAULT_API_VERSION,
         kind: "Project",
         name: "foo",
+        environments: [{ name: "local" }],
         path,
         configPath,
       },

--- a/core/test/unit/src/config/project.ts
+++ b/core/test/unit/src/config/project.ts
@@ -12,7 +12,6 @@ import tmp from "tmp-promise"
 import {
   ProjectConfig,
   resolveProjectConfig,
-  defaultEnvironments,
   pickEnvironment,
   defaultVarfilePath,
   defaultEnvVarfilePath,
@@ -40,15 +39,20 @@ const vcsInfo = {
 
 describe("resolveProjectConfig", () => {
   it("should pass through a canonical project config", async () => {
-    const defaultEnvironment = "default"
     const config: ProjectConfig = {
       apiVersion: DEFAULT_API_VERSION,
       kind: "Project",
       name: "my-project",
       path: "/tmp/foo",
-      defaultEnvironment,
+      defaultEnvironment: "default",
       dotIgnoreFiles: defaultDotIgnoreFiles,
-      environments: [{ name: "default", defaultNamespace, variables: {} }],
+      environments: [
+        {
+          name: "default",
+          defaultNamespace,
+          variables: {},
+        },
+      ],
       outputs: [],
       providers: [{ name: "some-provider", dependencies: [] }],
       variables: {},
@@ -56,7 +60,7 @@ describe("resolveProjectConfig", () => {
 
     expect(
       resolveProjectConfig({
-        defaultEnvironment,
+        defaultEnvironment: "default",
         config,
         artifactsPath: "/tmp",
         vcsInfo,
@@ -76,41 +80,6 @@ describe("resolveProjectConfig", () => {
         },
       ],
       sources: [],
-      varfile: defaultVarfilePath,
-    })
-  })
-
-  it("should inject a default environment if none is specified", async () => {
-    const defaultEnvironment = "local"
-    const config: ProjectConfig = {
-      apiVersion: DEFAULT_API_VERSION,
-      kind: "Project",
-      name: "my-project",
-      path: "/tmp/foo",
-      defaultEnvironment,
-      dotIgnoreFiles: defaultDotIgnoreFiles,
-      environments: [],
-      outputs: [],
-      providers: [{ name: "some-provider", dependencies: [] }],
-      variables: {},
-    }
-
-    expect(
-      resolveProjectConfig({
-        defaultEnvironment,
-        config,
-        artifactsPath: "/tmp",
-        vcsInfo,
-        username: "some-user",
-        loggedIn: true,
-        enterpriseDomain,
-        secrets: {},
-        commandInfo,
-      })
-    ).to.eql({
-      ...config,
-      sources: [],
-      environments: defaultEnvironments,
       varfile: defaultVarfilePath,
     })
   })
@@ -387,7 +356,7 @@ describe("resolveProjectConfig", () => {
       path: "/tmp/foo",
       defaultEnvironment,
       dotIgnoreFiles: defaultDotIgnoreFiles,
-      environments: [],
+      environments: [{ defaultNamespace: null, name: "first-env", variables: {} }],
       outputs: [],
       providers: [{ name: "some-provider", dependencies: [] }],
       variables: {},
@@ -407,8 +376,8 @@ describe("resolveProjectConfig", () => {
       })
     ).to.eql({
       ...config,
-      defaultEnvironment: "local",
-      environments: defaultEnvironments,
+      defaultEnvironment: "first-env",
+      environments: [{ defaultNamespace: null, name: "first-env", variables: {} }],
       sources: [],
       varfile: defaultVarfilePath,
     })
@@ -423,7 +392,7 @@ describe("resolveProjectConfig", () => {
       path: "/tmp/foo",
       defaultEnvironment,
       dotIgnoreFiles: defaultDotIgnoreFiles,
-      environments: [],
+      environments: [{ defaultNamespace: null, name: "default", variables: {} }],
       outputs: [],
       providers: [{ name: "some-provider", dependencies: [] }],
       variables: {},
@@ -443,8 +412,8 @@ describe("resolveProjectConfig", () => {
       })
     ).to.eql({
       ...config,
-      defaultEnvironment: "local",
-      environments: defaultEnvironments,
+      defaultEnvironment: "default",
+      environments: [{ defaultNamespace: null, name: "default", variables: {} }],
       sources: [],
       varfile: defaultVarfilePath,
     })

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -222,7 +222,26 @@ describe("Garden", () => {
       const projectRoot = join(dataDir, "test-project-malformed-environments")
       await expectError(
         async () => makeTestGarden(projectRoot),
-        (err) => expect(err.message).to.match(/Error validating environments: value must be an array/)
+        (err) => expect(err.message).to.match(/Error validating project environments: value must be an array/)
+      )
+    })
+
+    it("should throw if project.environments is an empty array", async () => {
+      const config: ProjectConfig = {
+        apiVersion: DEFAULT_API_VERSION,
+        kind: "Project",
+        name: "test",
+        path: pathFoo,
+        defaultEnvironment: "default",
+        dotIgnoreFiles: [],
+        environments: [], // <--
+        providers: [{ name: "foo" }],
+        variables: {},
+      }
+      await expectError(
+        async () => await TestGarden.factory(pathFoo, { config }),
+        (err) =>
+          expect(err.message).to.match(/Error validating project environments: value must contain at least 1 items/)
       )
     })
 
@@ -297,6 +316,8 @@ describe("Garden", () => {
           dedent`
           kind: Project
           name: foo
+          environments:
+            - name: local
         `
         )
         await expectError(

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -42,7 +42,7 @@ import {
 } from "../../../src/config/module"
 import { DEFAULT_API_VERSION } from "../../../src/constants"
 import { providerConfigBaseSchema } from "../../../src/config/provider"
-import { keyBy, set, mapValues } from "lodash"
+import { keyBy, set, mapValues, omit } from "lodash"
 import stripAnsi from "strip-ansi"
 import { joi } from "../../../src/config/common"
 import { defaultDotIgnoreFiles, makeTempDir } from "../../../src/util/fs"
@@ -242,6 +242,26 @@ describe("Garden", () => {
         async () => await TestGarden.factory(pathFoo, { config }),
         (err) =>
           expect(err.message).to.match(/Error validating project environments: value must contain at least 1 items/)
+      )
+    })
+
+    it("should throw if project.environments is not set", async () => {
+      let config: ProjectConfig = {
+        apiVersion: DEFAULT_API_VERSION,
+        kind: "Project",
+        name: "test",
+        path: pathFoo,
+        defaultEnvironment: "default",
+        dotIgnoreFiles: [],
+        environments: [], // this is omited later to simulate a config where envs are not set
+        providers: [{ name: "foo" }],
+        variables: {},
+      }
+
+      config = (omit(config, "environments") as any) as ProjectConfig
+      await expectError(
+        async () => await TestGarden.factory(pathFoo, { config }),
+        (err) => expect(err.message).to.include("Error validating project environments: value is required")
       )
     })
 

--- a/docs/reference/project-config.md
+++ b/docs/reference/project-config.md
@@ -226,7 +226,7 @@ A list of environments to configure for the project.
 
 | Type            | Required |
 | --------------- | -------- |
-| `array[object]` | No       |
+| `array[object]` | Yes      |
 
 ### `environments[].name`
 


### PR DESCRIPTION
Now environment field is required in project configs.
This also eliminates the need for an internal default env (used to be "local"), now if default env is not set just the first one will be selected (as before) and error is thrown if envs is undefined or an empty array.