### PR TITLE
refactor: removed deprecated options from garden commands

### DIFF
--- a/core/src/commands/logs.ts
+++ b/core/src/commands/logs.ts
@@ -70,12 +70,6 @@ const logsOpts = {
       unless \`--tail\` is set. Note that we don't recommend using a large value here when in follow mode.
     `,
   }),
-  // DEPRECATED: Remove in --original-color flag in v0.13 because we now always apply the original style to logs.
-  "original-color": new BooleanParameter({
-    help: "Show the original color output of the logs instead of color coding them.",
-    hidden: true,
-    defaultValue: false,
-  }),
   "hide-service": new BooleanParameter({
     help: "Hide the service name and render the logs directly.",
     defaultValue: false,

--- a/core/src/commands/publish.ts
+++ b/core/src/commands/publish.ts
@@ -41,9 +41,6 @@ export const publishOpts = {
   "force-build": new BooleanParameter({
     help: "Force rebuild of module(s) before publishing.",
   }),
-  "allow-dirty": new BooleanParameter({
-    help: "Allow publishing dirty builds (with untracked/uncommitted changes).",
-  }),
   "tag": new StringOption({
     help:
       "Override the tag on the built artifacts. You can use the same sorts of template " +
@@ -77,7 +74,6 @@ export class PublishCommand extends Command<Args, Opts> {
         garden publish                # publish artifacts for all modules in the project
         garden publish my-container   # only publish my-container
         garden publish --force-build  # force re-build of modules before publishing artifacts
-        garden publish --allow-dirty  # allow publishing dirty builds (which by default triggers error)
 
         # Publish my-container with a tag of v0.1
         garden publish my-container --tag "v0.1"
@@ -116,7 +112,6 @@ export class PublishCommand extends Command<Args, Opts> {
       log,
       modules,
       forceBuild: !!opts["force-build"],
-      allowDirty: !!opts["allow-dirty"],
       tagTemplate: opts.tag,
     })
 
@@ -138,7 +133,6 @@ export async function publishModules({
   log,
   modules,
   forceBuild,
-  allowDirty,
   tagTemplate,
 }: {
   garden: Garden
@@ -146,14 +140,8 @@ export async function publishModules({
   log: LogEntry
   modules: GardenModule<any>[]
   forceBuild: boolean
-  allowDirty: boolean
   tagTemplate?: string
 }): Promise<GraphResults> {
-  // TODO: remove in 0.13
-  if (!!allowDirty) {
-    log.warn(`The --allow-dirty flag has been deprecated. It no longer has an effect.`)
-  }
-
   const tasks = modules.map((module) => {
     return new PublishTask({ garden, graph, log, module, forceBuild, tagTemplate })
   })

--- a/core/test/unit/src/cli/helpers.ts
+++ b/core/test/unit/src/cli/helpers.ts
@@ -453,7 +453,7 @@ describe("processCliArgs", () => {
 
   it("parses args and opts for a PublishCommand", async () => {
     const cmd = new PublishCommand()
-    const { args, opts } = parseAndProcess(["module-a,module-b", "--allow-dirty"], cmd)
+    const { args, opts } = parseAndProcess(["module-a,module-b", "--force-build"], cmd)
     await cmd.action({
       ...defaultActionParams,
       args,

--- a/core/test/unit/src/commands/logs.ts
+++ b/core/test/unit/src/commands/logs.ts
@@ -260,17 +260,6 @@ describe("LogsCommand", () => {
 
       expect(out[0]).to.eql(msgColor("Yes, this is log"))
     })
-    it("should optionally show the container name", async () => {
-      const garden = await makeGarden(tmpDir, makeTestPlugin())
-      const command = new LogsCommand()
-      await command.action(makeCommandParams({ garden, opts: { "show-container": true } }))
-
-      const out = getLogOutput(garden, logMsg)
-
-      expect(out[0]).to.eql(
-        `${color.bold("test-service-a")} → ${color.bold("my-container")} → ${msgColor("Yes, this is log")}`
-      )
-    })
     it("should optionally show timestamps", async () => {
       const garden = await makeGarden(tmpDir, makeTestPlugin())
       const command = new LogsCommand()
@@ -399,15 +388,17 @@ describe("LogsCommand", () => {
         const colD = chalk[colors[3]]
         const dc = msgColor
         const command = new LogsCommand()
-        await command.action(makeCommandParams({ garden, opts: { "show-container": true } }))
+        await command.action(makeCommandParams({ garden, opts: { "show-tags": true } }))
 
         const out = getLogOutput(garden, logMsg, (entry) => entry.level === LogLevel.info)
 
-        expect(out[0]).to.eql(`${colA.bold("a-short")} → ${colA.bold("short")} → ${dc(logMsg)}`)
-        expect(out[1]).to.eql(`${colB.bold("b-not-short")} → ${colB.bold("not-short")} → ${dc(logMsg)}`)
-        expect(out[2]).to.eql(`${colA.bold("a-short    ")} → ${colA.bold("short    ")} → ${dc(logMsg)}`)
-        expect(out[3]).to.eql(`${colD.bold("d-very-very-long")} → ${colD.bold("very-very-long")} → ${dc(logMsg)}`)
-        expect(out[4]).to.eql(`${colA.bold("a-short         ")} → ${colA.bold("short         ")} → ${dc(logMsg)}`)
+        expect(out[0]).to.eql(`${colA.bold("a-short")} → ${chalk.gray("[container=short] ")}${dc(logMsg)}`)
+        expect(out[1]).to.eql(`${colB.bold("b-not-short")} → ${chalk.gray("[container=not-short] ")}${dc(logMsg)}`)
+        expect(out[2]).to.eql(`${colA.bold("a-short    ")} → ${chalk.gray("[container=short] ")}${dc(logMsg)}`)
+        expect(out[3]).to.eql(
+          `${colD.bold("d-very-very-long")} → ${chalk.gray("[container=very-very-long] ")}${dc(logMsg)}`
+        )
+        expect(out[4]).to.eql(`${colA.bold("a-short         ")} → ${chalk.gray("[container=short] ")}${dc(logMsg)}`)
       })
     })
     it("should assign the same color to each service, regardless of which service logs are streamed", async () => {

--- a/core/test/unit/src/commands/publish.ts
+++ b/core/test/unit/src/commands/publish.ts
@@ -78,7 +78,6 @@ describe("PublishCommand", () => {
         modules: undefined,
       },
       opts: withDefaultGlobalOpts({
-        "allow-dirty": false,
         "force-build": false,
         "tag": undefined,
       }),
@@ -150,7 +149,6 @@ describe("PublishCommand", () => {
         modules: undefined,
       },
       opts: withDefaultGlobalOpts({
-        "allow-dirty": false,
         "force-build": false,
         "tag": tag,
       }),
@@ -178,7 +176,6 @@ describe("PublishCommand", () => {
         modules: undefined,
       },
       opts: withDefaultGlobalOpts({
-        "allow-dirty": false,
         "force-build": false,
         "tag": tag,
       }),
@@ -205,7 +202,6 @@ describe("PublishCommand", () => {
         modules: undefined,
       },
       opts: withDefaultGlobalOpts({
-        "allow-dirty": false,
         "force-build": true,
         "tag": undefined,
       }),
@@ -235,7 +231,6 @@ describe("PublishCommand", () => {
         modules: ["module-a"],
       },
       opts: withDefaultGlobalOpts({
-        "allow-dirty": false,
         "force-build": false,
         "tag": undefined,
       }),
@@ -261,7 +256,6 @@ describe("PublishCommand", () => {
         modules: ["module-c"],
       },
       opts: withDefaultGlobalOpts({
-        "allow-dirty": false,
         "force-build": false,
         "tag": undefined,
       }),
@@ -285,7 +279,6 @@ describe("PublishCommand", () => {
         modules: ["module-a"],
       },
       opts: withDefaultGlobalOpts({
-        "allow-dirty": false,
         "force-build": false,
         "tag": undefined,
       }),

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -2871,7 +2871,6 @@ Examples:
     garden publish                # publish artifacts for all modules in the project
     garden publish my-container   # only publish my-container
     garden publish --force-build  # force re-build of modules before publishing artifacts
-    garden publish --allow-dirty  # allow publishing dirty builds (which by default triggers error)
 
     # Publish my-container with a tag of v0.1
     garden publish my-container --tag "v0.1"
@@ -2894,7 +2893,6 @@ Examples:
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
   | `--force-build` |  | boolean | Force rebuild of module(s) before publishing.
-  | `--allow-dirty` |  | boolean | Allow publishing dirty builds (with untracked/uncommitted changes).
   | `--tag` |  | string | Override the tag on the built artifacts. You can use the same sorts of template strings as when templating values in module configs, with the addition of ${module.*} tags, allowing you to reference the name and Garden version of the module being tagged.
 
 #### Outputs

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -2773,7 +2773,6 @@ Examples:
   | `--tag` |  | array:tag | Only show log lines that match the given tag, e.g. &#x60;--tag &#x27;container&#x3D;foo&#x27;&#x60;. If you specify multiple filters in a single tag option (e.g. &#x60;--tag &#x27;container&#x3D;foo,someOtherTag&#x3D;bar&#x27;&#x60;), they must all be matched. If you provide multiple &#x60;--tag&#x60; options (e.g. &#x60;--tag &#x27;container&#x3D;api&#x27; --tag &#x27;container&#x3D;frontend&#x27;&#x60;), they will be OR-ed together (i.e. if any of them match, the log line will be included). You can specify glob-style wildcards, e.g. &#x60;--tag &#x27;container&#x3D;prefix-*&#x27;&#x60;.
   | `--follow` | `-f` | boolean | Continuously stream new logs from the service(s).
   | `--tail` | `-t` | number | Number of lines to show for each service. Defaults to showing all log lines (up to a certain limit). Takes precedence over the &#x60;--since&#x60; flag if both are set. Note that we don&#x27;t recommend using a large value here when in follow mode.
-  | `--show-container` |  | boolean | Show the name of the container with log output. May not apply to all providers
   | `--show-tags` |  | boolean | Show any tags attached to each log line. May not apply to all providers
   | `--timestamps` |  | boolean | Show timestamps with log output.
   | `--since` |  | moment | Only show logs newer than a relative duration like 5s, 2m, or 3h. Defaults to &#x60;&quot;1m&quot;&#x60; when &#x60;--follow&#x60; is true unless &#x60;--tail&#x60; is set. Note that we don&#x27;t recommend using a large value here when in follow mode.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes deprecated opts from garden CLI commands.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
