### PR TITLE
fix(docs): fixed multi-char aliases in commands' descriptions

### DIFF
--- a/core/src/cli/helpers.ts
+++ b/core/src/cli/helpers.ts
@@ -374,8 +374,15 @@ export function renderArguments(params: Parameters) {
 
 export function renderOptions(params: Parameters) {
   return renderParameters(params, (name, param) => {
-    const alias = param.alias ? `-${param.alias}, ` : ""
-    return chalk.green(` ${alias}--${name} `)
+    const renderAlias = (alias: string | undefined): string => {
+      if (!alias) {
+        return ""
+      }
+      const prefix = alias.length === 1 ? "-" : "--"
+      return `${prefix}${alias}, `
+    }
+    const renderedAlias = renderAlias(param.alias)
+    return chalk.green(` ${renderedAlias}--${name} `)
   })
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the displayed values of multi-char aliases in Garden commands' descriptions.

**Which issue(s) this PR fixes**:

Fixes #3084

**Special notes for your reviewer**:
