### PR TITLE
chore: check for requirements being installed

### DIFF
--- a/core/src/build-staging/rsync.ts
+++ b/core/src/build-staging/rsync.ts
@@ -6,67 +6,26 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import semver from "semver"
 import { relative, parse } from "path"
 import { ensureDir } from "fs-extra"
-import { RuntimeError } from "../exceptions"
 import { normalizeLocalRsyncPath, joinWithPosix } from "../util/fs"
-import { exec } from "../util/util"
-import { deline } from "../util/string"
 import { syncWithOptions } from "../util/sync"
 import { BuildStaging, SyncParams } from "./build-staging"
+import { validateInstall } from "../util/validateInstall"
 
 const minRsyncVersion = "3.1.0"
 const versionRegex = /rsync  version [v]*([\d\.]+)  /
-
-const versionDetectFailure = new RuntimeError(
-  deline`
-  Could not detect rsync version.
-  Please make sure rsync version ${minRsyncVersion} or later is installed and on your PATH.
-  `,
-  {}
-)
 
 /**
  * throws if no rsync is installed or version is too old
  */
 export async function validateRsyncInstall() {
-  let version: string | undefined = undefined
-
-  try {
-    const versionOutput = (await exec("rsync", ["--version"])).stdout
-    version = versionOutput.split("\n")[0].match(versionRegex)?.[1]
-  } catch (error) {
-    throw new RuntimeError(
-      deline`
-      Could not find rsync binary.
-      Please make sure rsync (version ${minRsyncVersion} or later) is installed and on your PATH.
-      `,
-      { error }
-    )
-  }
-
-  if (!version) {
-    throw versionDetectFailure
-  }
-
-  let versionGte = true
-
-  try {
-    versionGte = semver.gte(version, minRsyncVersion)
-  } catch (_) {
-    throw versionDetectFailure
-  }
-
-  if (!versionGte) {
-    throw new RuntimeError(
-      deline`
-      Found rsync binary but the version is too old (${version}).
-      Please install version ${minRsyncVersion} or later.
-      `,
-      { version }
-    )
-  }
+  await validateInstall({
+    minVersion: minRsyncVersion,
+    name: "rsync",
+    versionCommand: { cmd: "rsync", args: ["--version"] },
+    versionRegex,
+  })
 }
 
 export class BuildDirRsync extends BuildStaging {

--- a/core/src/cli/helpers.ts
+++ b/core/src/cli/helpers.ts
@@ -30,8 +30,8 @@ import { renderTable, tablePresets, naturalList } from "../util/string"
 import { globalOptions, GlobalOptions } from "./params"
 import { BuiltinArgs, Command, CommandGroup } from "../commands/base"
 import { DeepPrimitiveMap } from "../config/common"
-import { validateRsyncInstall } from "../build-staging/rsync"
 import { validateGitInstall } from "../vcs/vcs"
+import { validateRsyncInstall } from "../build-staging/rsync"
 
 let _cliStyles: any
 

--- a/core/src/cli/helpers.ts
+++ b/core/src/cli/helpers.ts
@@ -30,6 +30,8 @@ import { renderTable, tablePresets, naturalList } from "../util/string"
 import { globalOptions, GlobalOptions } from "./params"
 import { BuiltinArgs, Command, CommandGroup } from "../commands/base"
 import { DeepPrimitiveMap } from "../config/common"
+import { validateRsyncInstall } from "../build-staging/rsync"
+import { validateGitInstall } from "../vcs/vcs"
 
 let _cliStyles: any
 
@@ -67,6 +69,14 @@ export async function checkForStaticDir() {
       {}
     )
   }
+}
+
+/**
+ * checks if requirements to run garden are installed, throws if they are not
+ */
+export async function checkRequirements() {
+  await validateRsyncInstall()
+  await validateGitInstall()
 }
 
 export async function checkForUpdates(config: GlobalConfigStore, logger: LogEntry) {

--- a/core/src/config-store.ts
+++ b/core/src/config-store.ts
@@ -281,6 +281,7 @@ const requirementsCheckGlobalConfigSchema = () =>
       lastRunGardenVersion: joi.string().optional(),
       passed: joi.bool().optional(),
     })
+    .unknown(true)
     .meta({ internal: true })
 
 const globalConfigSchemaKeys = {

--- a/core/src/config-store.ts
+++ b/core/src/config-store.ts
@@ -240,6 +240,12 @@ export interface VersionCheckGlobalConfig {
   lastRun: Date
 }
 
+export interface RequirementsCheck {
+  lastRunDateUNIX?: number
+  lastRunGardenVersion?: string
+  passed?: boolean
+}
+
 export interface GlobalConfig {
   analytics?: AnalyticsGlobalConfig
   lastVersionCheck?: VersionCheckGlobalConfig
@@ -267,9 +273,20 @@ const versionCheckGlobalConfigSchema = () =>
     })
     .meta({ internal: true })
 
+const requirementsCheckGlobalConfigSchema = () =>
+  joi
+    .object()
+    .keys({
+      lastRunDateUNIX: joi.number().optional(),
+      lastRunGardenVersion: joi.string().optional(),
+      passed: joi.bool().optional(),
+    })
+    .meta({ internal: true })
+
 const globalConfigSchemaKeys = {
   analytics: analyticsGlobalConfigSchema(),
   lastVersionCheck: versionCheckGlobalConfigSchema(),
+  requirementsCheck: requirementsCheckGlobalConfigSchema(),
 }
 
 /* This contains a config key, key string pair to be used when setting/getting values in the store

--- a/core/src/util/validateInstall.ts
+++ b/core/src/util/validateInstall.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2018-2022 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import semver from "semver"
+import { RuntimeError } from "../exceptions"
+import { deline } from "./string"
+import { exec } from "./util"
+
+/**
+ * throws if version check fails or the version is too old
+ */
+export async function validateInstall(params: {
+  name: string
+  versionCommand: { cmd: string; args: string[] }
+  versionRegex: RegExp
+  minVersion: string
+}) {
+  let version: string | undefined = undefined
+  const versionDetectFailure = new RuntimeError(
+    deline`
+    Could not detect ${params.name} version.
+    Please make sure ${params.name} version ${params.minVersion} or later is installed and on your PATH.
+    `,
+    {}
+  )
+
+  try {
+    const versionOutput = (await exec(params.versionCommand.cmd, params.versionCommand.args)).stdout
+    version = versionOutput.split("\n")[0].match(params.versionRegex)?.[1]
+  } catch (error) {
+    throw new RuntimeError(
+      deline`
+      Could not find ${params.name} binary.
+      Please make sure ${params.name} (version ${params.minVersion} or later) is installed and on your PATH.
+      `,
+      { error }
+    )
+  }
+
+  if (!version) {
+    throw versionDetectFailure
+  }
+
+  let versionGte = true
+
+  try {
+    versionGte = semver.gte(version, params.minVersion)
+  } catch (_) {
+    throw versionDetectFailure
+  }
+
+  if (!versionGte) {
+    throw new RuntimeError(
+      deline`
+      Found ${params.name} binary but the version is too old (${version}).
+      Please install version ${params.minVersion} or later.
+      `,
+      { version }
+    )
+  }
+}

--- a/core/src/vcs/vcs.ts
+++ b/core/src/vcs/vcs.ts
@@ -14,12 +14,12 @@ import { validateSchema } from "../config/validation"
 import { join, relative, isAbsolute } from "path"
 import { GARDEN_VERSIONFILE_NAME as GARDEN_TREEVERSION_FILENAME } from "../constants"
 import { pathExists, readFile, writeFile } from "fs-extra"
-import { ConfigurationError, RuntimeError } from "../exceptions"
+import { ConfigurationError } from "../exceptions"
 import { ExternalSourceType, getRemoteSourcesDirname, getRemoteSourceRelPath } from "../util/ext-source-util"
 import { ModuleConfig, serializeConfig } from "../config/module"
 import { LogEntry } from "../logger/log-entry"
 import { treeVersionSchema, moduleVersionSchema } from "../config/common"
-import { dedent, deline } from "../util/string"
+import { dedent } from "../util/string"
 import { fixedProjectExcludes } from "../util/fs"
 import { TreeCache } from "../cache"
 import { getModuleCacheContext } from "../types/module"
@@ -28,8 +28,7 @@ import { TaskConfig } from "../config/task"
 import { TestConfig } from "../config/test"
 import { GardenModule } from "../types/module"
 import { emitWarning } from "../warnings"
-import { exec } from "../util/util"
-import semver from "semver"
+import { validateInstall } from "../util/validateInstall"
 
 const AsyncLock = require("async-lock")
 const scanLock = new AsyncLock()
@@ -41,54 +40,16 @@ const fileCountWarningThreshold = 10000
 const minGitVersion = "2.14.0"
 const versionRegex = /git version [v]*([\d\.]+)/
 
-const versionDetectFailure = new RuntimeError(
-  deline`
-  Could not detect git version.
-  Please make sure git version ${minGitVersion} or later is installed and on your PATH.
-  `,
-  {}
-)
-
 /**
  * throws if no git is installed or version is too old
  */
 export async function validateGitInstall() {
-  let version: string | undefined = undefined
-
-  try {
-    const versionOutput = (await exec("git", ["--version"])).stdout
-    version = versionOutput.split("\n")[0].match(versionRegex)?.[1]
-  } catch (error) {
-    throw new RuntimeError(
-      deline`
-      Could not find git binary.
-      Please make sure git (version ${minGitVersion} or later) is installed and on your PATH.
-      `,
-      { error }
-    )
-  }
-
-  if (!version) {
-    throw versionDetectFailure
-  }
-
-  let versionGte = true
-
-  try {
-    versionGte = semver.gte(version, minGitVersion)
-  } catch (_) {
-    throw versionDetectFailure
-  }
-
-  if (!versionGte) {
-    throw new RuntimeError(
-      deline`
-      Found git binary but the version is too old (${version}).
-      Please install version ${minGitVersion} or later.
-      `,
-      { version }
-    )
-  }
+  await validateInstall({
+    minVersion: minGitVersion,
+    name: "git",
+    versionCommand: { cmd: "git", args: ["--version"] },
+    versionRegex,
+  })
 }
 
 export interface TreeVersion {

--- a/core/src/vcs/vcs.ts
+++ b/core/src/vcs/vcs.ts
@@ -38,7 +38,7 @@ export const NEW_MODULE_VERSION = "0000000000"
 const fileCountWarningThreshold = 10000
 
 const minGitVersion = "2.14.0"
-const versionRegex = /git version [v]*([\d\.]+)/
+export const gitVersionRegex = /git version [v]*([\d\.]+)/
 
 /**
  * throws if no git is installed or version is too old
@@ -48,7 +48,7 @@ export async function validateGitInstall() {
     minVersion: minGitVersion,
     name: "git",
     versionCommand: { cmd: "git", args: ["--version"] },
-    versionRegex,
+    versionRegex: gitVersionRegex,
   })
 }
 

--- a/core/test/unit/src/config-store.ts
+++ b/core/test/unit/src/config-store.ts
@@ -13,7 +13,7 @@ import { resolve } from "path"
 
 type ExecConfig = {}
 
-class ExecConfigStore extends ConfigStore<ExecConfig> {
+export class ExecConfigStore extends ConfigStore<ExecConfig> {
   getConfigPath(gardenDirPath: string): string {
     return resolve(gardenDirPath, "local-config.yml")
   }

--- a/core/test/unit/src/util/validateInstall.ts
+++ b/core/test/unit/src/util/validateInstall.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2018-2022 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import { describe } from "mocha"
+import { expectError } from "../../../../src/util/testing"
+import { validateInstall } from "../../../../src/util/validateInstall"
+import { gitVersionRegex } from "../../../../src/vcs/vcs"
+
+describe("validateInstall", () => {
+  it("should validate a binary version", async () => {
+    await validateInstall({
+      minVersion: "1.0.0",
+      name: "git",
+      versionCommand: { cmd: "git", args: ["--version"] },
+      versionRegex: gitVersionRegex,
+    })
+  })
+  it("should throw if a version is too old", async () => {
+    await expectError(
+      () =>
+        validateInstall({
+          minVersion: "100.0.0", // <--
+          name: "git",
+          versionCommand: { cmd: "git", args: ["--version"] },
+          versionRegex: gitVersionRegex,
+        }),
+      (err) => expect(err.message).to.include("version is too old")
+    )
+  })
+  it("should throw binary not installed", async () => {
+    await expectError(
+      () =>
+        validateInstall({
+          minVersion: "1.0.0",
+          name: "non existing thing",
+          versionCommand: { cmd: "this-binary-does-not-exist", args: ["--version"] }, // <--
+          versionRegex: gitVersionRegex,
+        }),
+      (err) => expect(err.message).to.include("is installed and on your PATH")
+    )
+  })
+  it("should include name in error message", async () => {
+    await expectError(
+      () =>
+        validateInstall({
+          minVersion: "1.0.0",
+          name: "name-of-the-thing",
+          versionCommand: { cmd: "this-binary-does-not-exist", args: ["--version"] }, // <--
+          versionRegex: gitVersionRegex,
+        }),
+      (err) => expect(err.message).to.include("Could not find name-of-the-thing binary.")
+    )
+  })
+})

--- a/core/test/unit/src/util/validateInstall.ts
+++ b/core/test/unit/src/util/validateInstall.ts
@@ -33,7 +33,7 @@ describe("validateInstall", () => {
       (err) => expect(err.message).to.include("version is too old")
     )
   })
-  it("should throw binary not installed", async () => {
+  it("should throw if binary is not installed", async () => {
     await expectError(
       () =>
         validateInstall({


### PR DESCRIPTION
checks if git and rsync are installed with valid versions
and gives readable error otherwise.

check results are cached and are not checked again once passed

I opted for the global config instead of the sqlite because connecting to the db and starting it took too long.
