### PR TITLE
chore: allow unknown keys in config-store

### DIFF
--- a/core/src/config-store.ts
+++ b/core/src/config-store.ts
@@ -265,6 +265,7 @@ const versionCheckGlobalConfigSchema = () =>
     .keys({
       lastRun: joi.date().optional(),
     })
+    .unknown(true)
     .meta({ internal: true })
 
 const globalConfigSchemaKeys = {
@@ -286,7 +287,7 @@ export const globalConfigKeys = Object.keys(globalConfigSchemaKeys).reduce((acc,
   return acc
 }, {}) as { [K in keyof typeof globalConfigSchemaKeys]: K }
 
-const globalConfigSchema = () => joi.object().keys(globalConfigSchemaKeys).meta({ internal: true })
+const globalConfigSchema = () => joi.object().keys(globalConfigSchemaKeys).unknown(true).meta({ internal: true })
 
 export class GlobalConfigStore extends ConfigStore<GlobalConfig> {
   constructor() {


### PR DESCRIPTION
needed for backwards compatibility (if user downgrades from a garden version which has new keys garden would stop working otherwise).

Needs to be merged before #3097 
