### PR TITLE
WIP: refactor(k8s): use faux SSH command to switch away from Mutagen fork

### DIFF
--- a/core/src/plugins/kubernetes/mutagen/ssh/go.mod
+++ b/core/src/plugins/kubernetes/mutagen/ssh/go.mod
@@ -1,0 +1,3 @@
+module github.com/garden-io/garden/core/src/plugins/kubernetes/mutagen/ssh
+
+go 1.19

--- a/core/src/plugins/kubernetes/mutagen/ssh/main.go
+++ b/core/src/plugins/kubernetes/mutagen/ssh/main.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"syscall"
+	"unicode/utf8"
+)
+
+// KubectlParameters represents the JSON structure of kubectl parameters and
+// arguments that will be smuggled via the SSH hostname in Base64 encoding.
+type KubectlParameters struct {
+	// KubectlPath is the path to the kubectl executable.
+	KubectlPath string `json:"kubectlPath"`
+	// KubectlArgs are the arguments to be passed to kubectl.
+	KubectlArgs []string `json:"kubectlArgs"`
+}
+
+// fatal is a utility function to exit with an error message.
+func fatal(message string) {
+	fmt.Fprintln(os.Stderr, "error:", message)
+	os.Exit(1)
+}
+
+func main() {
+	// Identify the first non-flag argument, which should be the hostname. All
+	// of the flags that Mutagen passes to SSH will bind the value to the flag
+	// (e.g. -oConnectTimeout=X), with the exception of -p, which Mutagen won't
+	// specify in this case since all Garden URLs will use a default port.
+	// Likewise, no username will be specified and prepended to the hostname.
+	// Thus, the first non-flag argument will be the hostname field, through
+	// which we'll smuggle kubectl exec parameters. Mutagen will then provide
+	// the default agent path within the container, but we'll ignore that since
+	// the target agent path will be provided in the kubectl exec parameters
+	// that we receive.
+	var hostname string
+	for _, arg := range os.Args[1:] {
+		if !strings.HasPrefix(arg, "-") {
+			hostname = arg
+			break
+		}
+	}
+	if hostname == "" {
+		fatal("empty hostname specified")
+	}
+
+	// Replace all '_' in the hostname with '/' to undo the hack performed to
+	// work around Mutagen's local path detection heuristic.
+	hostname = strings.ReplaceAll(hostname, "_", "/")
+
+	// Decode the hostname specification into raw JSON bytes.
+	rawJSON, err := base64.StdEncoding.DecodeString(hostname)
+	if err != nil {
+		fatal(fmt.Errorf("invalid data: %w", err).Error())
+	} else if len(rawJSON) == 0 {
+		fatal("empty data")
+	} else if !utf8.Valid(rawJSON) {
+		fatal("non-UTF-8 data")
+	}
+
+	// Decode the kubectl parameters.
+	var parameters KubectlParameters
+	decoder := json.NewDecoder(bytes.NewReader(rawJSON))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&parameters); err != nil {
+		fatal(fmt.Errorf("unable to decode JSON data: %w", err).Error())
+	} else if decoder.More() {
+		fatal("extra JSON data provided")
+	}
+
+	// Set up termination signal handling so that we can forward signals to
+	// kubectl exec. Note that both of these signal types are emulated on
+	// Windows, so they are valid, though on Windows it will typically be the
+	// forwarded closure of standard input that signals termination because
+	// Mutagen can't trigger the emulated handling of these signals.
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+
+	// Set up the kubectl command.
+	kubectl := exec.Command(parameters.KubectlPath, parameters.KubectlArgs...)
+	kubectl.Stdin = os.Stdin
+	kubectl.Stdout = os.Stdout
+	kubectl.Stderr = os.Stderr
+
+	// Start the kubectl command.
+	if err := kubectl.Start(); err != nil {
+		fatal(fmt.Errorf("unable to start kubectl exec: %w", err).Error())
+	}
+
+	// Monitor for termination of the kubectl process.
+	termination := make(chan error, 1)
+	go func() {
+		termination <- kubectl.Wait()
+	}()
+
+	// Loop and forward signals until the kubectl process exits.
+	for {
+		select {
+		case s := <-signals:
+			kubectl.Process.Signal(s)
+		case err := <-termination:
+			if err != nil {
+				os.Exit(1)
+			}
+			return
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is a draft proposal for switching Garden back to the official Mutagen releases and dispensing with the Garden fork of Mutagen.  The last remaining blocker for this transition is Mutagen's lack of support for custom transports and Garden's need to use a `kubectl exec`-based transport.  To work around this limitation, this commit introduces a faux `ssh` executable (written in Go) that can be provided to the Mutagen daemon to serve as a transport.  This faux `ssh` command smuggles `kubectl exec` parameters through the SSH hostname argument (as Base64-encoded JSON) and then invokes `kubectl exec`, forwarding signals and standard input closure to ensure proper termination signaling from the Mutagen daemon.

**Special notes for your reviewer**:

This PR is fairly close to complete, but there are a few remaining questions:

1. Is this approach satisfactory overall?
2. Should the faux `ssh` command be rewritten in TypeScript?
3. How should the faux `ssh` command be source-controlled and distributed?
4. Are there any transition considerations for active `garden dev` commands?

Regarding (1), I think this is the best approach because it gets Garden back on the official Mutagen releases with the minimal amount of effort and the implementation strategy is very similar to what custom transports will eventually look like in Mutagen, meaning that the faux SSH command will probably be convertible to a `mutagen-transport-garden` (name TBD) command later on.

Regarding (2), that's a policy decision I'd leave to Garden.  The critical aspect is just the proper signal and standard input closure forwarding.

Regarding (3), that's probably a good point for discussion.  I would imagine it would be distributed/downloaded in a similar manner to the `mutagen` executable, but I don't know the best location to perform its build or serve its binaries.  There's also the consideration of its versioning w.r.t. Garden, especially if the format of the JSON changes, but that's likely to see very little churn once implemented, so manually managing its versioning as some external project might be suitable.  Once this is decided and implemented, the `MUTAGEN_SSH_PATH` environment variable will need to be set for `mutagen daemon run`; a TODO has been indicated for this in the code.

Regarding (4), the simple answer is that the project would probably just need to be restarted entirely.  If the same `MUTAGEN_DATA_DIRECTORY` is used, then the standard Mutagen daemon will just reject and ignore the prior `exec`-based sessions, but testing of this would be good before shipping.

CC @thsig @vvagaytsev

Fixes #5420 