### PR TITLE
improvement(jib): enhanced schema validation

### DIFF
--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -858,9 +858,9 @@ Maximum time in seconds to wait for build to finish.
 
 The type of project to build. Defaults to auto-detecting between gradle and maven (based on which files/directories are found in the module root), but in some cases you may need to specify it.
 
-| Type     | Default  | Required |
-| -------- | -------- | -------- |
-| `string` | `"auto"` | No       |
+| Type     | Allowed Values                   | Default  | Required |
+| -------- | -------------------------------- | -------- | -------- |
+| `string` | "gradle", "maven", "jib", "auto" | `"auto"` | Yes      |
 
 ### `build.jdkVersion`
 
@@ -868,9 +868,9 @@ The type of project to build. Defaults to auto-detecting between gradle and mave
 
 The JDK version to use.
 
-| Type     | Default | Required |
-| -------- | ------- | -------- |
-| `number` | `11`    | No       |
+| Type     | Allowed Values | Default | Required |
+| -------- | -------------- | ------- | -------- |
+| `number` | 8, 11, 13      | `11`    | Yes      |
 
 ### `build.dockerBuild`
 
@@ -898,9 +898,9 @@ Don't load or push the resulting image to a Docker daemon or registry, only buil
 
 Specify the image format in the resulting tar file. Only used if `tarOnly: true`.
 
-| Type     | Default    | Required |
-| -------- | ---------- | -------- |
-| `string` | `"docker"` | No       |
+| Type     | Allowed Values  | Default    | Required |
+| -------- | --------------- | ---------- | -------- |
+| `string` | "docker", "oci" | `"docker"` | Yes      |
 
 ### `build.extraFlags[]`
 

--- a/plugins/jib/index.ts
+++ b/plugins/jib/index.ts
@@ -41,14 +41,14 @@ const jibModuleSchema = () =>
     build: baseBuildSpecSchema().keys({
       projectType: joi
         .string()
-        .allow("gradle", "maven", "jib", "auto")
+        .valid("gradle", "maven", "jib", "auto")
         .default("auto")
         .description(
           dedent`
             The type of project to build. Defaults to auto-detecting between gradle and maven (based on which files/directories are found in the module root), but in some cases you may need to specify it.
             `
         ),
-      jdkVersion: joi.number().integer().allow(8, 11).default(11).description("The JDK version to use."),
+      jdkVersion: joi.number().integer().valid(8, 11).default(11).description("The JDK version to use."),
       dockerBuild: joi
         .boolean()
         .default(false)
@@ -63,7 +63,7 @@ const jibModuleSchema = () =>
         ),
       tarFormat: joi
         .string()
-        .allow("docker", "oci")
+        .valid("docker", "oci")
         .default("docker")
         .description("Specify the image format in the resulting tar file. Only used if `tarOnly: true`."),
       extraFlags: joi

--- a/plugins/jib/index.ts
+++ b/plugins/jib/index.ts
@@ -48,7 +48,7 @@ const jibModuleSchema = () =>
             The type of project to build. Defaults to auto-detecting between gradle and maven (based on which files/directories are found in the module root), but in some cases you may need to specify it.
             `
         ),
-      jdkVersion: joi.number().integer().valid(8, 11).default(11).description("The JDK version to use."),
+      jdkVersion: joi.number().integer().valid(8, 11, 13).default(11).description("The JDK version to use."),
       dockerBuild: joi
         .boolean()
         .default(false)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the config schema validation for `jib-module` module type.

Prior to this PR, the validation did not work properly for the `jdkVersion`, `projectType` and `tarFormat` config fields. This happened because `joi.allow()` method itself doesn't raise an error in an invalid value is passed in. To make it work, it should be used with `.only()` method like `joi.string().allow("a", "the").only()`. Alternatively, a single `.valid()` method can be used (this approach was chosen to fix the issue).

Without the changes made in this PR the jib plugin failed with the error below if any incorrect values were passed to the fields validated with `.allow()` method:
```
Failed building {module-name}. Here is the output:
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Cannot read property 'getPath' of undefined
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```

This PR also adds openjdk-13 to the list of allowed JDK versions, because the JDK 13 itself was already presented in the list of the supported JDKs, see https://github.com/garden-io/garden/blob/master/plugins/jib/openjdk.ts#L97.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
We need to check the other config schemas too. That can be done in a separate PR.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202808257019395