### PR TITLE
ci: restrictive permissions for update-homebrew-deprecated.yml

### DIFF
--- a/.github/workflows/update-homebrew-deprecated.yml
+++ b/.github/workflows/update-homebrew-deprecated.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   homebrew-release:
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:
We reduce permissions to make it unlikely that third party actions
do something weird with out GITHUB_TOKEN – the token is accessible
by third party actions by default and could be misused.

Fixes code-scanning alert 12

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
