### PR TITLE
ci: harden egress for scorecard workflow

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -24,10 +24,17 @@ jobs:
       actions: read
     
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@dd2c410b088af7c0dc8046f3ac9a8f4148492a95
-        with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+    - name: Harden Runner
+      uses: step-security/harden-runner@dd2c410b088af7c0dc8046f3ac9a8f4148492a95
+      with:
+        egress-policy: block
+        allowed-endpoints: >
+          api.github.com:443
+          api.osv.dev:443
+          bestpractices.coreinfrastructure.org:443
+          codeload.github.com:443
+          github.com:443
+          pipelines.actions.githubusercontent.com:443
 
       - name: "Checkout code"
         uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3.0.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:
we can now block other egress to make it harder to exfiltrate secrets for third
party dependencies and actions

**Which issue(s) this PR fixes**:
none really, it just hardens the scorecard workflow, because we can (basically as a canary for hopefully our release workflows in the future, when we migrate them from macOS to Linux)

**Special notes for your reviewer**:
Stepsecurity audit log

      https://app.stepsecurity.io/github/garden-io/garden/actions/runs/2918784935

