### PR TITLE
improvement: allow mutagen code sync outside subpath

### DIFF
--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -253,15 +253,14 @@ export const syncDefaultGroupSchema = () =>
 const devModeSyncSchema = () =>
   hotReloadSyncSchema().keys({
     exclude: syncExcludeSchema(),
-    source: joi // same as hotReloadSyncSchema but no subPathOnly
+    source: joi // same as hotReloadSyncSchema but no subPathOnly and relativeOnly
       .posixPath()
-      .relativeOnly()
       .allowGlobs()
       .default(".")
       .description(
         deline`
-      POSIX-style path of the directory to sync to the target, relative to the module's top-level directory.
-      Must be a relative path. Defaults to the module's top-level directory if no value is provided.`
+      POSIX-style path of the directory to sync to the target. Can be either a relative or an absolute path.
+      Defaults to the module's top-level directory if no value is provided.`
       )
       .example("src"),
     mode: joi

--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -253,6 +253,17 @@ export const syncDefaultGroupSchema = () =>
 const devModeSyncSchema = () =>
   hotReloadSyncSchema().keys({
     exclude: syncExcludeSchema(),
+    source: joi // same as hotReloadSyncSchema but no subPathOnly
+      .posixPath()
+      .relativeOnly()
+      .allowGlobs()
+      .default(".")
+      .description(
+        deline`
+      POSIX-style path of the directory to sync to the target, relative to the module's top-level directory.
+      Must be a relative path. Defaults to the module's top-level directory if no value is provided.`
+      )
+      .example("src"),
     mode: joi
       .string()
       .allow(

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -270,8 +270,8 @@ services:
           # `.git` directories and `.garden` directories are always ignored.
           exclude:
 
-          # POSIX-style path of the directory to sync to the target, relative to the module's top-level directory.
-          # Must be a relative path. Defaults to the module's top-level directory if no value is provided.
+          # POSIX-style path of the directory to sync to the target. Can be either a relative or an absolute path.
+          # Defaults to the module's top-level directory if no value is provided.
           source: .
 
           # The sync mode to use for the given paths. See the [Dev Mode
@@ -1329,7 +1329,7 @@ services:
 
 [services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > source
 
-POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be a relative path. Defaults to the module's top-level directory if no value is provided.
+POSIX-style path of the directory to sync to the target. Can be either a relative or an absolute path. Defaults to the module's top-level directory if no value is provided.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -261,11 +261,7 @@ services:
 
       # Specify one or more source files or directories to automatically sync with the running container.
       sync:
-        - # POSIX-style path of the directory to sync to the target, relative to the module's top-level directory.
-          # Must be a relative path. Defaults to the module's top-level directory if no value is provided.
-          source: .
-
-          # POSIX-style absolute path to sync the directory to inside the container. The root path (i.e. "/") is not
+        - # POSIX-style absolute path to sync the directory to inside the container. The root path (i.e. "/") is not
           # allowed.
           target:
 
@@ -273,6 +269,10 @@ services:
           #
           # `.git` directories and `.garden` directories are always ignored.
           exclude:
+
+          # POSIX-style path of the directory to sync to the target, relative to the module's top-level directory.
+          # Must be a relative path. Defaults to the module's top-level directory if no value is provided.
+          source: .
 
           # The sync mode to use for the given paths. See the [Dev Mode
           # guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
@@ -1281,26 +1281,6 @@ Specify one or more source files or directories to automatically sync with the r
 | --------------- | -------- |
 | `array[object]` | No       |
 
-### `services[].devMode.sync[].source`
-
-[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > source
-
-POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be a relative path. Defaults to the module's top-level directory if no value is provided.
-
-| Type        | Default | Required |
-| ----------- | ------- | -------- |
-| `posixPath` | `"."`   | No       |
-
-Example:
-
-```yaml
-services:
-  - devMode:
-      ...
-      sync:
-        - source: "src"
-```
-
 ### `services[].devMode.sync[].target`
 
 [services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > target
@@ -1343,6 +1323,26 @@ services:
         - exclude:
             - dist/**/*
             - '*.log'
+```
+
+### `services[].devMode.sync[].source`
+
+[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > source
+
+POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be a relative path. Defaults to the module's top-level directory if no value is provided.
+
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `"."`   | No       |
+
+Example:
+
+```yaml
+services:
+  - devMode:
+      ...
+      sync:
+        - source: "src"
 ```
 
 ### `services[].devMode.sync[].mode`

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -208,8 +208,8 @@ devMode:
       # `.git` directories and `.garden` directories are always ignored.
       exclude:
 
-      # POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be
-      # a relative path. Defaults to the module's top-level directory if no value is provided.
+      # POSIX-style path of the directory to sync to the target. Can be either a relative or an absolute path.
+      # Defaults to the module's top-level directory if no value is provided.
       source: .
 
       # The sync mode to use for the given paths. See the [Dev Mode
@@ -1053,7 +1053,7 @@ devMode:
 
 [devMode](#devmode) > [sync](#devmodesync) > source
 
-POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be a relative path. Defaults to the module's top-level directory if no value is provided.
+POSIX-style path of the directory to sync to the target. Can be either a relative or an absolute path. Defaults to the module's top-level directory if no value is provided.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -199,11 +199,7 @@ devMode:
 
   # Specify one or more source files or directories to automatically sync with the running container.
   sync:
-    - # POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be
-      # a relative path. Defaults to the module's top-level directory if no value is provided.
-      source: .
-
-      # POSIX-style absolute path to sync the directory to inside the container. The root path (i.e. "/") is not
+    - # POSIX-style absolute path to sync the directory to inside the container. The root path (i.e. "/") is not
       # allowed.
       target:
 
@@ -211,6 +207,10 @@ devMode:
       #
       # `.git` directories and `.garden` directories are always ignored.
       exclude:
+
+      # POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be
+      # a relative path. Defaults to the module's top-level directory if no value is provided.
+      source: .
 
       # The sync mode to use for the given paths. See the [Dev Mode
       # guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
@@ -1007,25 +1007,6 @@ Specify one or more source files or directories to automatically sync with the r
 | --------------- | -------- |
 | `array[object]` | No       |
 
-### `devMode.sync[].source`
-
-[devMode](#devmode) > [sync](#devmodesync) > source
-
-POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be a relative path. Defaults to the module's top-level directory if no value is provided.
-
-| Type        | Default | Required |
-| ----------- | ------- | -------- |
-| `posixPath` | `"."`   | No       |
-
-Example:
-
-```yaml
-devMode:
-  ...
-  sync:
-    - source: "src"
-```
-
 ### `devMode.sync[].target`
 
 [devMode](#devmode) > [sync](#devmodesync) > target
@@ -1066,6 +1047,25 @@ devMode:
     - exclude:
         - dist/**/*
         - '*.log'
+```
+
+### `devMode.sync[].source`
+
+[devMode](#devmode) > [sync](#devmodesync) > source
+
+POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be a relative path. Defaults to the module's top-level directory if no value is provided.
+
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `"."`   | No       |
+
+Example:
+
+```yaml
+devMode:
+  ...
+  sync:
+    - source: "src"
 ```
 
 ### `devMode.sync[].mode`

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -291,8 +291,8 @@ services:
           # `.git` directories and `.garden` directories are always ignored.
           exclude:
 
-          # POSIX-style path of the directory to sync to the target, relative to the module's top-level directory.
-          # Must be a relative path. Defaults to the module's top-level directory if no value is provided.
+          # POSIX-style path of the directory to sync to the target. Can be either a relative or an absolute path.
+          # Defaults to the module's top-level directory if no value is provided.
           source: .
 
           # The sync mode to use for the given paths. See the [Dev Mode
@@ -1400,7 +1400,7 @@ services:
 
 [services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > source
 
-POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be a relative path. Defaults to the module's top-level directory if no value is provided.
+POSIX-style path of the directory to sync to the target. Can be either a relative or an absolute path. Defaults to the module's top-level directory if no value is provided.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -282,11 +282,7 @@ services:
 
       # Specify one or more source files or directories to automatically sync with the running container.
       sync:
-        - # POSIX-style path of the directory to sync to the target, relative to the module's top-level directory.
-          # Must be a relative path. Defaults to the module's top-level directory if no value is provided.
-          source: .
-
-          # POSIX-style absolute path to sync the directory to inside the container. The root path (i.e. "/") is not
+        - # POSIX-style absolute path to sync the directory to inside the container. The root path (i.e. "/") is not
           # allowed.
           target:
 
@@ -294,6 +290,10 @@ services:
           #
           # `.git` directories and `.garden` directories are always ignored.
           exclude:
+
+          # POSIX-style path of the directory to sync to the target, relative to the module's top-level directory.
+          # Must be a relative path. Defaults to the module's top-level directory if no value is provided.
+          source: .
 
           # The sync mode to use for the given paths. See the [Dev Mode
           # guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
@@ -1352,26 +1352,6 @@ Specify one or more source files or directories to automatically sync with the r
 | --------------- | -------- |
 | `array[object]` | No       |
 
-### `services[].devMode.sync[].source`
-
-[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > source
-
-POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be a relative path. Defaults to the module's top-level directory if no value is provided.
-
-| Type        | Default | Required |
-| ----------- | ------- | -------- |
-| `posixPath` | `"."`   | No       |
-
-Example:
-
-```yaml
-services:
-  - devMode:
-      ...
-      sync:
-        - source: "src"
-```
-
 ### `services[].devMode.sync[].target`
 
 [services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > target
@@ -1414,6 +1394,26 @@ services:
         - exclude:
             - dist/**/*
             - '*.log'
+```
+
+### `services[].devMode.sync[].source`
+
+[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > source
+
+POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be a relative path. Defaults to the module's top-level directory if no value is provided.
+
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `"."`   | No       |
+
+Example:
+
+```yaml
+services:
+  - devMode:
+      ...
+      sync:
+        - source: "src"
 ```
 
 ### `services[].devMode.sync[].mode`

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -185,11 +185,7 @@ devMode:
 
   # Specify one or more source files or directories to automatically sync with the running container.
   sync:
-    - # POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be
-      # a relative path. Defaults to the module's top-level directory if no value is provided.
-      source: .
-
-      # POSIX-style absolute path to sync the directory to inside the container. The root path (i.e. "/") is not
+    - # POSIX-style absolute path to sync the directory to inside the container. The root path (i.e. "/") is not
       # allowed.
       target:
 
@@ -197,6 +193,10 @@ devMode:
       #
       # `.git` directories and `.garden` directories are always ignored.
       exclude:
+
+      # POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be
+      # a relative path. Defaults to the module's top-level directory if no value is provided.
+      source: .
 
       # The sync mode to use for the given paths. See the [Dev Mode
       # guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
@@ -902,25 +902,6 @@ Specify one or more source files or directories to automatically sync with the r
 | --------------- | -------- |
 | `array[object]` | No       |
 
-### `devMode.sync[].source`
-
-[devMode](#devmode) > [sync](#devmodesync) > source
-
-POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be a relative path. Defaults to the module's top-level directory if no value is provided.
-
-| Type        | Default | Required |
-| ----------- | ------- | -------- |
-| `posixPath` | `"."`   | No       |
-
-Example:
-
-```yaml
-devMode:
-  ...
-  sync:
-    - source: "src"
-```
-
 ### `devMode.sync[].target`
 
 [devMode](#devmode) > [sync](#devmodesync) > target
@@ -961,6 +942,25 @@ devMode:
     - exclude:
         - dist/**/*
         - '*.log'
+```
+
+### `devMode.sync[].source`
+
+[devMode](#devmode) > [sync](#devmodesync) > source
+
+POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be a relative path. Defaults to the module's top-level directory if no value is provided.
+
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `"."`   | No       |
+
+Example:
+
+```yaml
+devMode:
+  ...
+  sync:
+    - source: "src"
 ```
 
 ### `devMode.sync[].mode`

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -194,8 +194,8 @@ devMode:
       # `.git` directories and `.garden` directories are always ignored.
       exclude:
 
-      # POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be
-      # a relative path. Defaults to the module's top-level directory if no value is provided.
+      # POSIX-style path of the directory to sync to the target. Can be either a relative or an absolute path.
+      # Defaults to the module's top-level directory if no value is provided.
       source: .
 
       # The sync mode to use for the given paths. See the [Dev Mode
@@ -948,7 +948,7 @@ devMode:
 
 [devMode](#devmode) > [sync](#devmodesync) > source
 
-POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be a relative path. Defaults to the module's top-level directory if no value is provided.
+POSIX-style path of the directory to sync to the target. Can be either a relative or an absolute path. Defaults to the module's top-level directory if no value is provided.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -261,11 +261,7 @@ services:
 
       # Specify one or more source files or directories to automatically sync with the running container.
       sync:
-        - # POSIX-style path of the directory to sync to the target, relative to the module's top-level directory.
-          # Must be a relative path. Defaults to the module's top-level directory if no value is provided.
-          source: .
-
-          # POSIX-style absolute path to sync the directory to inside the container. The root path (i.e. "/") is not
+        - # POSIX-style absolute path to sync the directory to inside the container. The root path (i.e. "/") is not
           # allowed.
           target:
 
@@ -273,6 +269,10 @@ services:
           #
           # `.git` directories and `.garden` directories are always ignored.
           exclude:
+
+          # POSIX-style path of the directory to sync to the target, relative to the module's top-level directory.
+          # Must be a relative path. Defaults to the module's top-level directory if no value is provided.
+          source: .
 
           # The sync mode to use for the given paths. See the [Dev Mode
           # guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
@@ -1291,26 +1291,6 @@ Specify one or more source files or directories to automatically sync with the r
 | --------------- | -------- |
 | `array[object]` | No       |
 
-### `services[].devMode.sync[].source`
-
-[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > source
-
-POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be a relative path. Defaults to the module's top-level directory if no value is provided.
-
-| Type        | Default | Required |
-| ----------- | ------- | -------- |
-| `posixPath` | `"."`   | No       |
-
-Example:
-
-```yaml
-services:
-  - devMode:
-      ...
-      sync:
-        - source: "src"
-```
-
 ### `services[].devMode.sync[].target`
 
 [services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > target
@@ -1353,6 +1333,26 @@ services:
         - exclude:
             - dist/**/*
             - '*.log'
+```
+
+### `services[].devMode.sync[].source`
+
+[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > source
+
+POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be a relative path. Defaults to the module's top-level directory if no value is provided.
+
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `"."`   | No       |
+
+Example:
+
+```yaml
+services:
+  - devMode:
+      ...
+      sync:
+        - source: "src"
 ```
 
 ### `services[].devMode.sync[].mode`

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -270,8 +270,8 @@ services:
           # `.git` directories and `.garden` directories are always ignored.
           exclude:
 
-          # POSIX-style path of the directory to sync to the target, relative to the module's top-level directory.
-          # Must be a relative path. Defaults to the module's top-level directory if no value is provided.
+          # POSIX-style path of the directory to sync to the target. Can be either a relative or an absolute path.
+          # Defaults to the module's top-level directory if no value is provided.
           source: .
 
           # The sync mode to use for the given paths. See the [Dev Mode
@@ -1339,7 +1339,7 @@ services:
 
 [services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > source
 
-POSIX-style path of the directory to sync to the target, relative to the module's top-level directory. Must be a relative path. Defaults to the module's top-level directory if no value is provided.
+POSIX-style path of the directory to sync to the target. Can be either a relative or an absolute path. Defaults to the module's top-level directory if no value is provided.
 
 | Type        | Default | Required |
 | ----------- | ------- | -------- |

--- a/examples/build-dependencies/README.md
+++ b/examples/build-dependencies/README.md
@@ -1,8 +1,12 @@
 # Build Dependencies
 
-This example project demonstrates how to use build dependencies to include files and directories from outside a module's root with its build context. For example, some .NET and Java projects that are split up into multiple modules need a shared configuration file at build time for each module.
+This example project demonstrates how to use build dependencies to include files and directories from outside a module's root with its build context.
+The frontend module is also [configured for dev-mode](frontend/garden.yml#L13-L23) to show how to synchronize the dependancy with the rest of the code.
 
-Another common use case is to use build dependencies to include shared libraries with multiple modules. Our [`openfaas` example project](../openfaas) demonstrates this same pattern with an NPM package.
+Benefits of this feature can be utilized by .NET or Java projects that are split up into multiple modules need a shared configuration file at build time for each module.
+
+Another common use case for build dependencies is to include shared config files or libraries with multiple modules.
+Our [`openfaas` example project](../openfaas) demonstrates this same pattern with an NPM package.
 
 To achieve this, we:
 
@@ -13,7 +17,7 @@ To achieve this, we:
 
 The project consists of a `shared-config` module of type `exec`, and two container modules, `frontend` and `backend`, that have a build dependency on the `shared-config` module.
 
-The `shared-config` module contains a single `config.env` file and the following Garden config:
+The `shared-config` module contains a single [config.json](shared-config/config.json) file and the following [Garden config](shared-config/garden.yml):
 
 ```yaml
 # shared-config/garden.yml
@@ -43,7 +47,7 @@ $ tree .garden/build/frontend -L 2
 
 .garden/build/frontend
 ├── config
-│   └── config.env # <--- The shared config file
+│   └── config.json # <--- The shared config file
 ├── Dockerfile
 ├── app.js
 ├── ...
@@ -61,7 +65,7 @@ Run `garden deploy` to deploy the project. You can verify that it works by runni
 garden call frontend
 ```
 
-It'll print the contents of the `shared-config/config.env` file:
+It'll print the contents of the `shared-config/config.json` file:
 
 ```sh
 Call 📞
@@ -71,5 +75,5 @@ Call 📞
 
 200 OK
 
-Config says: Hello World
+Config says: This message comes from the shared config file!
 ```

--- a/examples/build-dependencies/backend/Dockerfile
+++ b/examples/build-dependencies/backend/Dockerfile
@@ -4,7 +4,7 @@ ENV PORT=8080
 EXPOSE ${PORT}
 WORKDIR /app
 
-COPY main.go .
+COPY . /app
 
 RUN go mod init main && go build -o main .
 

--- a/examples/build-dependencies/backend/garden.yml
+++ b/examples/build-dependencies/backend/garden.yml
@@ -6,7 +6,7 @@ build:
   dependencies:
     - name: shared-config
       copy:
-        - source: "config.env"
+        - source: "config.json"
           target: "config/"
 services:
   - name: backend

--- a/examples/build-dependencies/backend/main.go
+++ b/examples/build-dependencies/backend/main.go
@@ -1,12 +1,37 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"log"
 	"net/http"
 )
 
+type Config struct {
+	SharedConfigMessage string
+}
+
+func readConfig() Config {
+	content, err := ioutil.ReadFile("./config/config.json")
+	if err != nil {
+		log.Fatal("Error when opening file: ", err)
+	}
+
+	var payload Config
+	err = json.Unmarshal(content, &payload)
+	if err != nil {
+		log.Fatal("Error during Unmarshal(): ", err)
+	}
+
+	log.Printf("shared config loaded: %s\n", payload.SharedConfigMessage)
+	return payload
+}
+
 func handler(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprint(w, "Hello from Go!")
+	config := readConfig()
+
+	fmt.Fprint(w, "Hello from Go! "+config.SharedConfigMessage)
 }
 
 func main() {
@@ -18,4 +43,3 @@ func main() {
 		panic(err)
 	}
 }
-

--- a/examples/build-dependencies/frontend/app.js
+++ b/examples/build-dependencies/frontend/app.js
@@ -1,13 +1,14 @@
 const express = require('express');
 const request = require('request-promise')
-const path = require('path')
-const dotenv = require('dotenv')
+const fs = require('fs');
 const app = express();
 
-const config = dotenv.config({ path: path.resolve(process.cwd(), "config", "config.env") })
+const rawdata = fs.readFileSync('./config/config.json');
+const config = JSON.parse(rawdata);
+
 const backendServiceEndpoint = `http://backend/hello-backend`
 
-app.get('/hello-frontend', (req, res) => res.send(`Config says: ${config.parsed.MESSAGE}`));
+app.get('/hello-frontend', (req, res) => res.send(`Config says: ${config.sharedConfigMessage}`));
 
 app.get('/call-backend', (req, res) => {
   // Query the backend and return the response

--- a/examples/build-dependencies/frontend/garden.yml
+++ b/examples/build-dependencies/frontend/garden.yml
@@ -10,6 +10,17 @@ build:
           target: "config/"
 services:
   - name: frontend
+    devMode:
+      command: [npm, run, dev]
+      sync:
+        - source: .
+          target: /app
+          exclude: [node_modules]
+          mode: one-way # do not set to one-way-replica, otherwise it will remove the /config dir
+        - source: ../shared-config/
+          target: /app/config/
+          exclude: [garden.yml]
+          mode: one-way-replica
     ports:
       - name: http
         containerPort: 8080

--- a/examples/build-dependencies/frontend/garden.yml
+++ b/examples/build-dependencies/frontend/garden.yml
@@ -6,7 +6,7 @@ build:
   dependencies:
     - name: shared-config
       copy:
-        - source: "config.env"
+        - source: "config.json"
           target: "config/"
 services:
   - name: frontend

--- a/examples/build-dependencies/frontend/package-lock.json
+++ b/examples/build-dependencies/frontend/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -22,6 +28,16 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      }
+    },
+    "anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
       }
     },
     "array-flatten": {
@@ -71,6 +87,12 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -103,6 +125,15 @@
         "concat-map": "0.0.1"
       }
     },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
@@ -118,6 +149,22 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      }
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -308,6 +355,15 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
     "finalhandler": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -359,6 +415,13 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -379,6 +442,15 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
       }
     },
     "growl": {
@@ -443,6 +515,12 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -462,6 +540,36 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -612,6 +720,65 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
+    "nodemon": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.19.tgz",
+      "integrity": "sha512-4pv1f2bMDj0Eeg/MhGqxrtveeQ5/G/UVe9iO6uTZzjnRluSA4PVWf8CW99LUPwGB3eNIA7zUFoP77YuI7hOc0A==",
+      "dev": true,
+      "requires": {
+        "chokidar": "^3.5.2",
+        "debug": "^3.2.7",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.0.4",
+        "pstree.remy": "^1.1.8",
+        "semver": "^5.7.1",
+        "simple-update-notifier": "^1.0.7",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -655,6 +822,12 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -674,6 +847,12 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
       "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
+    },
+    "pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true
     },
     "punycode": {
       "version": "2.1.1",
@@ -714,6 +893,15 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
+      }
+    },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
       }
     },
     "request": {
@@ -779,6 +967,12 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
+    },
     "send": {
       "version": "0.17.1",
       "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
@@ -821,6 +1015,23 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+    },
+    "simple-update-notifier": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.0.7.tgz",
+      "integrity": "sha512-BBKgR84BJQJm6WjWFMHgLVuo61FBDSj1z/xSFUIozqO6wO7ii0JxCqlIud7Enr/+LhlbNI0whErq96P2qHNWew==",
+      "dev": true,
+      "requires": {
+        "semver": "~7.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+          "dev": true
+        }
+      }
     },
     "sshpk": {
       "version": "1.16.1",
@@ -911,10 +1122,28 @@
         "has-flag": "^3.0.0"
       }
     },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
+    "touch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
+      "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
+      "dev": true,
+      "requires": {
+        "nopt": "~1.0.10"
+      }
     },
     "tough-cookie": {
       "version": "2.5.0",
@@ -946,6 +1175,12 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",

--- a/examples/build-dependencies/frontend/package-lock.json
+++ b/examples/build-dependencies/frontend/package-lock.json
@@ -216,11 +216,6 @@
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
-    "dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
-    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",

--- a/examples/build-dependencies/frontend/package.json
+++ b/examples/build-dependencies/frontend/package.json
@@ -11,7 +11,6 @@
   "author": "garden.io <info@garden.io>",
   "license": "ISC",
   "dependencies": {
-    "dotenv": "^8.2.0",
     "express": "^4.16.2",
     "request": "^2.83.0",
     "request-promise": "^4.2.2"

--- a/examples/build-dependencies/frontend/package.json
+++ b/examples/build-dependencies/frontend/package.json
@@ -5,6 +5,7 @@
   "main": "main.js",
   "scripts": {
     "start": "node main.js",
+    "dev": "nodemon src/main.js",
     "test": "echo OK",
     "integ": "node_modules/mocha/bin/mocha test/integ.js"
   },
@@ -17,6 +18,7 @@
   },
   "devDependencies": {
     "mocha": "^5.1.1",
+    "nodemon": "^2.0.19",
     "supertest": "^3.0.0"
   }
 }

--- a/examples/build-dependencies/shared-config/config.env
+++ b/examples/build-dependencies/shared-config/config.env
@@ -1,1 +1,0 @@
-MESSAGE=Hello World

--- a/examples/build-dependencies/shared-config/config.json
+++ b/examples/build-dependencies/shared-config/config.json
@@ -1,0 +1,3 @@
+{
+  "sharedConfigMessage": "This message comes from the shared config file!"
+}


### PR DESCRIPTION
allow mutagen code sync outside subpath and add dev-mode to the [build dependencies example](https://github.com/garden-io/garden/tree/sync-build-deps/examples/build-dependencies)