### PR TITLE
fix(cli): run exec commands from project root

### DIFF
--- a/core/src/commands/custom.ts
+++ b/core/src/commands/custom.ts
@@ -71,7 +71,6 @@ export class CustomCommandWrapper extends Command {
   name = "<custom>"
   help = ""
 
-  noProject = true
   allowUndefinedArguments = true
 
   constructor(public spec: CommandResource) {
@@ -138,6 +137,7 @@ export class CustomCommandWrapper extends Command {
           PKG_EXECPATH: "",
           ...(exec.env || {}),
         },
+        cwd: garden.projectRoot,
         reject: false,
       })
       const completedAt = new Date()


### PR DESCRIPTION
Closes https://github.com/garden-io/garden/issues/3151

Garden [custom commands](https://docs.garden.io/advanced/custom-commands) were run from the path the command was called from. Now garden project root is used for `cwd`.

Please note that I also removed the `noProject = true` property, which means that custom commands only work in garden projects now. I couldn't think of any reason why one would define a custom command without a garden project and it also aligns with doc which says
> As part of a Garden project, you can define custom commands

I spent a good 30min thinking how to test this but couldn't figure out any good solution, suggestions welcome. Existing unit tests are defined [here](https://github.com/garden-io/garden/blob/exec-dir/core/test/unit/src/commands/custom.ts)