### PR TITLE
improvement(jib): updated LTS JDK binaries to the latest releases

### DIFF
--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -876,7 +876,7 @@ The JDK version to use.
 
 | Type     | Allowed Values | Default | Required |
 | -------- | -------------- | ------- | -------- |
-| `number` | 8, 11, 13      | `11`    | Yes      |
+| `number` | 8, 11, 13, 17  | `11`    | Yes      |
 
 ### `build.dockerBuild`
 

--- a/plugins/jib/index.ts
+++ b/plugins/jib/index.ts
@@ -48,7 +48,7 @@ const jibModuleSchema = () =>
             The type of project to build. Defaults to auto-detecting between gradle and maven (based on which files/directories are found in the module root), but in some cases you may need to specify it.
             `
         ),
-      jdkVersion: joi.number().integer().valid(8, 11, 13).default(11).description("The JDK version to use."),
+      jdkVersion: joi.number().integer().valid(8, 11, 13, 17).default(11).description("The JDK version to use."),
       dockerBuild: joi
         .boolean()
         .default(false)

--- a/plugins/jib/openjdk.ts
+++ b/plugins/jib/openjdk.ts
@@ -9,6 +9,7 @@
 // FIXME: figure out why the hell this causes builds to fail
 // import { PluginToolSpec } from "@garden-io/sdk/types"
 import { posix } from "path"
+import { PluginToolSpec } from "@garden-io/core/build/src/types/plugin/tools"
 
 interface JdkBinary {
   filename: string
@@ -16,6 +17,8 @@ interface JdkBinary {
 }
 
 interface JdkVersion {
+  lookupName: string
+  description: string
   baseUrl: string
   versionName: string
   mac: JdkBinary
@@ -24,6 +27,8 @@ interface JdkVersion {
 }
 
 const jdk8Version: JdkVersion = {
+  lookupName: "openjdk-8",
+  description: "The OpenJDK 8 library.",
   baseUrl: "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u292-b10/",
   versionName: "jdk8u292-b10",
   mac: {
@@ -41,6 +46,8 @@ const jdk8Version: JdkVersion = {
 }
 
 const jdk11Version: JdkVersion = {
+  lookupName: "openjdk-11",
+  description: "The OpenJDK 11 library.",
   baseUrl: "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.9.1%2B1/",
   versionName: "jdk-11.0.9.1+1",
   mac: {
@@ -58,186 +65,86 @@ const jdk11Version: JdkVersion = {
 }
 
 const jdk13Version: JdkVersion = {
+  lookupName: "openjdk-13",
+  description: "The OpenJDK 13 library.",
   baseUrl: "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33/",
   versionName: "jdk-13+33",
   mac: {
     filename: "OpenJDK13U-jdk_x64_mac_hotspot_13_33.tar.gz",
-    sha256: "f948be96daba250b6695e22cb51372d2ba3060e4d778dd09c89548889783099f"
+    sha256: "f948be96daba250b6695e22cb51372d2ba3060e4d778dd09c89548889783099f",
   },
   linux: {
     filename: "OpenJDK13U-jdk_x64_linux_hotspot_13_33.tar.gz",
-    sha256: "e562caeffa89c834a69a44242d802eae3523875e427f07c05b1902c152638368"
+    sha256: "e562caeffa89c834a69a44242d802eae3523875e427f07c05b1902c152638368",
   },
   windows: {
     filename: "OpenJDK13U-jdk_x64_windows_hotspot_13_33.zip",
-    sha256: "65d71a954167d538c7a260e64d9868ceffe60edd1108817a9c44fddf60d13569"
+    sha256: "65d71a954167d538c7a260e64d9868ceffe60edd1108817a9c44fddf60d13569",
   },
 }
 
 const jdk17Version: JdkVersion = {
+  lookupName: "openjdk-17",
+  description: "The OpenJDK 17 library.",
   baseUrl: "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/",
   versionName: "jdk-17.0.4.1+1",
   mac: {
     filename: "OpenJDK17U-jdk_x64_mac_hotspot_17.0.4.1_1.tar.gz",
-    sha256: "ac21a5a87f7cfa00212ab7c41f7eb80ca33640d83b63ad850be811c24095d61a"
+    sha256: "ac21a5a87f7cfa00212ab7c41f7eb80ca33640d83b63ad850be811c24095d61a",
   },
   linux: {
     filename: "OpenJDK17U-jdk_x64_linux_hotspot_17.0.4.1_1.tar.gz",
-    sha256: "5fbf8b62c44f10be2efab97c5f5dbf15b74fae31e451ec10abbc74e54a04ff44"
+    sha256: "5fbf8b62c44f10be2efab97c5f5dbf15b74fae31e451ec10abbc74e54a04ff44",
   },
   windows: {
     filename: "OpenJDK17U-jdk_x64_windows_hotspot_17.0.4.1_1.zip",
-    sha256: "3860d2ed7405674baeb0f9f4c71377421716759fe4301e92bdd4dd43c0442dc3"
+    sha256: "3860d2ed7405674baeb0f9f4c71377421716759fe4301e92bdd4dd43c0442dc3",
   },
 }
 
-export const openJdkSpecs: any = [
-  {
-    name: "openjdk-8",
-    description: "The OpenJDK 8 library.",
+function openJdkSpec(jdkVersion: JdkVersion): PluginToolSpec {
+  return {
+    name: jdkVersion.lookupName,
+    description: jdkVersion.description,
     type: "library",
     builds: [
       {
         platform: "darwin",
         architecture: "amd64",
-        url: jdk8Version.baseUrl + jdk8Version.mac.filename,
-        sha256: jdk8Version.mac.sha256,
+        url: jdkVersion.baseUrl + jdkVersion.mac.filename,
+        sha256: jdkVersion.mac.sha256,
         extract: {
           format: "tar",
-          targetPath: posix.join(jdk8Version.versionName, "Contents", "Home"),
+          targetPath: posix.join(jdkVersion.versionName, "Contents", "Home"),
         },
       },
       {
         platform: "linux",
         architecture: "amd64",
-        url: jdk8Version.baseUrl + jdk8Version.linux.filename,
-        sha256: jdk8Version.linux.sha256,
+        url: jdkVersion.baseUrl + jdkVersion.linux.filename,
+        sha256: jdkVersion.linux.sha256,
         extract: {
           format: "tar",
-          targetPath: jdk8Version.versionName,
+          targetPath: jdkVersion.versionName,
         },
       },
       {
         platform: "windows",
         architecture: "amd64",
-        url: jdk8Version.baseUrl + jdk8Version.windows.filename,
-        sha256: jdk8Version.windows.sha256,
+        url: jdkVersion.baseUrl + jdkVersion.windows.filename,
+        sha256: jdkVersion.windows.sha256,
         extract: {
           format: "zip",
-          targetPath: jdk8Version.versionName,
+          targetPath: jdkVersion.versionName,
         },
       },
     ],
-  },
-  {
-    name: "openjdk-11",
-    description: "The OpenJDK 11 library.",
-    type: "library",
-    builds: [
-      {
-        platform: "darwin",
-        architecture: "amd64",
-        url: jdk11Version.baseUrl + jdk11Version.mac.filename,
-        sha256: jdk11Version.mac.sha256,
-        extract: {
-          format: "tar",
-          targetPath: posix.join(jdk11Version.versionName, "Contents", "Home"),
-        },
-      },
-      {
-        platform: "linux",
-        architecture: "amd64",
-        url: jdk11Version.baseUrl + jdk11Version.linux.filename,
-        sha256: jdk11Version.linux.sha256,
-        extract: {
-          format: "tar",
-          targetPath: jdk11Version.versionName,
-        },
-      },
-      {
-        platform: "windows",
-        architecture: "amd64",
-        url: jdk11Version.baseUrl + jdk11Version.windows.filename,
-        sha256: jdk11Version.windows.sha256,
-        extract: {
-          format: "zip",
-          targetPath: jdk11Version.versionName,
-        },
-      },
-    ],
-  },
-  {
-    name: "openjdk-13",
-    description: "The OpenJDK 13 library.",
-    type: "library",
-    builds: [
-      {
-        platform: "darwin",
-        architecture: "amd64",
-        url: jdk13Version.baseUrl + jdk13Version.mac.filename,
-        sha256: jdk13Version.mac.sha256,
-        extract: {
-          format: "tar",
-          targetPath: posix.join(jdk13Version.versionName, "Contents", "Home"),
-        },
-      },
-      {
-        platform: "linux",
-        architecture: "amd64",
-        url: jdk13Version.baseUrl + jdk13Version.linux.filename,
-        sha256: jdk13Version.linux.sha256,
-        extract: {
-          format: "tar",
-          targetPath: jdk13Version.versionName,
-        },
-      },
-      {
-        platform: "windows",
-        architecture: "amd64",
-        url: jdk13Version.baseUrl + jdk13Version.windows.filename,
-        sha256: jdk13Version.windows.sha256,
-        extract: {
-          format: "zip",
-          targetPath: jdk13Version.versionName,
-        },
-      },
-    ],
-  },
-  {
-    name: "openjdk-17",
-    description: "The OpenJDK 17 library.",
-    type: "library",
-    builds: [
-      {
-        platform: "darwin",
-        architecture: "amd64",
-        url: jdk17Version.baseUrl + jdk17Version.mac.filename,
-        sha256: jdk17Version.mac.sha256,
-        extract: {
-          format: "tar",
-          targetPath: posix.join(jdk17Version.versionName, "Contents", "Home"),
-        },
-      },
-      {
-        platform: "linux",
-        architecture: "amd64",
-        url: jdk17Version.baseUrl + jdk17Version.linux.filename,
-        sha256: jdk17Version.linux.sha256,
-        extract: {
-          format: "tar",
-          targetPath: jdk17Version.versionName,
-        },
-      },
-      {
-        platform: "windows",
-        architecture: "amd64",
-        url: jdk17Version.baseUrl + jdk17Version.windows.filename,
-        sha256: jdk17Version.windows.sha256,
-        extract: {
-          format: "zip",
-          targetPath: jdk17Version.versionName,
-        },
-      },
-    ],
-  },
+  }
+}
+
+export const openJdkSpecs: PluginToolSpec[] = [
+  openJdkSpec(jdk8Version),
+  openJdkSpec(jdk11Version),
+  openJdkSpec(jdk13Version),
+  openJdkSpec(jdk17Version),
 ]

--- a/plugins/jib/openjdk.ts
+++ b/plugins/jib/openjdk.ts
@@ -13,10 +13,12 @@ import { posix } from "path"
 const jdk8Version = "jdk8u292-b10"
 const jdk11Version = "jdk-11.0.9.1+1"
 const jdk13Version = "jdk-13+33"
+const jdk17Version = "jdk-17.0.4.1+1"
 
 const jdk8Base = `https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/${jdk8Version}/`
 const jdk11Base = "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.9.1%2B1/"
 const jdk13Base = "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33/"
+const jdk17Base = "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/"
 
 export const openJdkSpecs: any = [
   {
@@ -126,6 +128,43 @@ export const openJdkSpecs: any = [
         extract: {
           format: "zip",
           targetPath: jdk13Version,
+        },
+      },
+    ],
+  },
+  {
+    name: "openjdk-17",
+    description: "The OpenJDK 17 library.",
+    type: "library",
+    builds: [
+      {
+        platform: "darwin",
+        architecture: "amd64",
+        url: jdk17Base + "OpenJDK17U-jdk_x64_mac_hotspot_17.0.4.1_1.tar.gz",
+        sha256: "ac21a5a87f7cfa00212ab7c41f7eb80ca33640d83b63ad850be811c24095d61a",
+        extract: {
+          format: "tar",
+          targetPath: posix.join(jdk17Version, "Contents", "Home"),
+        },
+      },
+      {
+        platform: "linux",
+        architecture: "amd64",
+        url: jdk17Base + "OpenJDK17U-jdk_x64_linux_hotspot_17.0.4.1_1.tar.gz",
+        sha256: "5fbf8b62c44f10be2efab97c5f5dbf15b74fae31e451ec10abbc74e54a04ff44",
+        extract: {
+          format: "tar",
+          targetPath: jdk17Version,
+        },
+      },
+      {
+        platform: "windows",
+        architecture: "amd64",
+        url: jdk17Base + "OpenJDK17U-jdk_x64_windows_hotspot_17.0.4.1_1.zip",
+        sha256: "3860d2ed7405674baeb0f9f4c71377421716759fe4301e92bdd4dd43c0442dc3",
+        extract: {
+          format: "zip",
+          targetPath: jdk17Version,
         },
       },
     ],

--- a/plugins/jib/openjdk.ts
+++ b/plugins/jib/openjdk.ts
@@ -10,12 +10,12 @@
 // import { PluginToolSpec } from "@garden-io/sdk/types"
 import { posix } from "path"
 
-const jdk8Version = "jdk8u202-b08"
-const jdk11Version = "jdk-11.0.2+9"
+const jdk8Version = "jdk8u292-b10"
+const jdk11Version = "jdk-11.0.9.1+1"
 const jdk13Version = "jdk-13+33"
 
 const jdk8Base = `https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/${jdk8Version}/`
-const jdk11Base = "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.2%2B9/"
+const jdk11Base = "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.9.1%2B1/"
 const jdk13Base = "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33/"
 
 export const openJdkSpecs: any = [
@@ -27,8 +27,8 @@ export const openJdkSpecs: any = [
       {
         platform: "darwin",
         architecture: "amd64",
-        url: jdk8Base + "OpenJDK8U-jdk_x64_mac_hotspot_8u202b08.tar.gz",
-        sha256: "059f7c18faa6722aa636bbd79bcdff3aee6a6da5b34940b072ea6e3af85bbe1d",
+        url: jdk8Base + "OpenJDK8U-jdk_x64_mac_hotspot_8u292b10.tar.gz",
+        sha256: "5646fbe9e4138c902c910bb7014d41463976598097ad03919e4848634c7e8007",
         extract: {
           format: "tar",
           targetPath: posix.join(jdk8Version, "Contents", "Home"),
@@ -37,8 +37,8 @@ export const openJdkSpecs: any = [
       {
         platform: "linux",
         architecture: "amd64",
-        url: jdk8Base + "OpenJDK8U-jdk_x64_linux_hotspot_8u202b08.tar.gz",
-        sha256: "f5a1c9836beb3ca933ec3b1d39568ecbb68bd7e7ca6a9989a21ff16a74d910ab",
+        url: jdk8Base + "OpenJDK8U-jdk_x64_linux_hotspot_8u292b10.tar.gz",
+        sha256: "0949505fcf42a1765558048451bb2a22e84b3635b1a31dd6191780eeccaa4ada",
         extract: {
           format: "tar",
           targetPath: jdk8Version,
@@ -47,8 +47,8 @@ export const openJdkSpecs: any = [
       {
         platform: "windows",
         architecture: "amd64",
-        url: jdk8Base + "OpenJDK8U-jdk_x64_windows_hotspot_8u202b08.zip",
-        sha256: "2637dab3bc81274e19991eebc27684276b482dd71d0f84fedf703d4fba3576e5",
+        url: jdk8Base + "OpenJDK8U-jdk_x64_windows_hotspot_8u292b10.zip",
+        sha256: "2405e11f9f3603e506cf7ab01fcb67a3e3a1cf3e7858e14d629a72c9a24c6c42",
         extract: {
           format: "zip",
           targetPath: jdk8Version,
@@ -64,8 +64,8 @@ export const openJdkSpecs: any = [
       {
         platform: "darwin",
         architecture: "amd64",
-        url: jdk11Base + "OpenJDK11U-jdk_x64_mac_hotspot_11.0.2_9.tar.gz",
-        sha256: "fffd4ed283e5cd443760a8ec8af215c8ca4d33ec5050c24c1277ba64b5b5e81a",
+        url: jdk11Base + "OpenJDK11U-jdk_x64_mac_hotspot_11.0.9.1_1.tar.gz",
+        sha256: "96bc469f9b02a3b84382a0685b0bd7935e1ad1bd82a0aab9befb5b42a17cbd77",
         extract: {
           format: "tar",
           targetPath: posix.join(jdk11Version, "Contents", "Home"),
@@ -74,8 +74,8 @@ export const openJdkSpecs: any = [
       {
         platform: "linux",
         architecture: "amd64",
-        url: jdk11Base + "OpenJDK11U-jdk_x64_linux_hotspot_11.0.2_9.tar.gz",
-        sha256: "d02089d834f7702ac1a9776d8d0d13ee174d0656cf036c6b68b9ffb71a6f610e",
+        url: jdk11Base + "OpenJDK11U-jdk_x64_linux_hotspot_11.0.9.1_1.tar.gz",
+        sha256: "e388fd7f3f2503856d0b04fde6e151cbaa91a1df3bcebf1deddfc3729d677ca3",
         extract: {
           format: "tar",
           targetPath: jdk11Version,
@@ -84,8 +84,8 @@ export const openJdkSpecs: any = [
       {
         platform: "windows",
         architecture: "amd64",
-        url: jdk11Base + "OpenJDK11U-jdk_x64_windows_hotspot_11.0.2_9.zip",
-        sha256: "bde1648333abaf49c7175c9ee8ba9115a55fc160838ff5091f07d10c4bb50b3a",
+        url: jdk11Base + "OpenJDK11U-jdk_x64_windows_hotspot_11.0.9.1_1.zip",
+        sha256: "fea633dc37f007cb6b1e1af1874da63ad3d5e31817e583048287c67010dce5c8",
         extract: {
           format: "zip",
           targetPath: jdk11Version,

--- a/plugins/jib/openjdk.ts
+++ b/plugins/jib/openjdk.ts
@@ -10,15 +10,86 @@
 // import { PluginToolSpec } from "@garden-io/sdk/types"
 import { posix } from "path"
 
-const jdk8Version = "jdk8u292-b10"
-const jdk11Version = "jdk-11.0.9.1+1"
-const jdk13Version = "jdk-13+33"
-const jdk17Version = "jdk-17.0.4.1+1"
+interface JdkBinary {
+  filename: string
+  sha256: string
+}
 
-const jdk8Base = `https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/${jdk8Version}/`
-const jdk11Base = "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.9.1%2B1/"
-const jdk13Base = "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33/"
-const jdk17Base = "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/"
+interface JdkVersion {
+  baseUrl: string
+  versionName: string
+  mac: JdkBinary
+  linux: JdkBinary
+  windows: JdkBinary
+}
+
+const jdk8Version: JdkVersion = {
+  baseUrl: "https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u292-b10/",
+  versionName: "jdk8u292-b10",
+  mac: {
+    filename: "OpenJDK8U-jdk_x64_mac_hotspot_8u292b10.tar.gz",
+    sha256: "5646fbe9e4138c902c910bb7014d41463976598097ad03919e4848634c7e8007",
+  },
+  linux: {
+    filename: "OpenJDK8U-jdk_x64_linux_hotspot_8u292b10.tar.gz",
+    sha256: "0949505fcf42a1765558048451bb2a22e84b3635b1a31dd6191780eeccaa4ada",
+  },
+  windows: {
+    filename: "OpenJDK8U-jdk_x64_windows_hotspot_8u292b10.zip",
+    sha256: "2405e11f9f3603e506cf7ab01fcb67a3e3a1cf3e7858e14d629a72c9a24c6c42",
+  },
+}
+
+const jdk11Version: JdkVersion = {
+  baseUrl: "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.9.1%2B1/",
+  versionName: "jdk-11.0.9.1+1",
+  mac: {
+    filename: "OpenJDK11U-jdk_x64_mac_hotspot_11.0.9.1_1.tar.gz",
+    sha256: "96bc469f9b02a3b84382a0685b0bd7935e1ad1bd82a0aab9befb5b42a17cbd77",
+  },
+  linux: {
+    filename: "OpenJDK11U-jdk_x64_linux_hotspot_11.0.9.1_1.tar.gz",
+    sha256: "e388fd7f3f2503856d0b04fde6e151cbaa91a1df3bcebf1deddfc3729d677ca3",
+  },
+  windows: {
+    filename: "OpenJDK11U-jdk_x64_windows_hotspot_11.0.9.1_1.zip",
+    sha256: "fea633dc37f007cb6b1e1af1874da63ad3d5e31817e583048287c67010dce5c8",
+  },
+}
+
+const jdk13Version: JdkVersion = {
+  baseUrl: "https://github.com/AdoptOpenJDK/openjdk13-binaries/releases/download/jdk-13%2B33/",
+  versionName: "jdk-13+33",
+  mac: {
+    filename: "OpenJDK13U-jdk_x64_mac_hotspot_13_33.tar.gz",
+    sha256: "f948be96daba250b6695e22cb51372d2ba3060e4d778dd09c89548889783099f"
+  },
+  linux: {
+    filename: "OpenJDK13U-jdk_x64_linux_hotspot_13_33.tar.gz",
+    sha256: "e562caeffa89c834a69a44242d802eae3523875e427f07c05b1902c152638368"
+  },
+  windows: {
+    filename: "OpenJDK13U-jdk_x64_windows_hotspot_13_33.zip",
+    sha256: "65d71a954167d538c7a260e64d9868ceffe60edd1108817a9c44fddf60d13569"
+  },
+}
+
+const jdk17Version: JdkVersion = {
+  baseUrl: "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1%2B1/",
+  versionName: "jdk-17.0.4.1+1",
+  mac: {
+    filename: "OpenJDK17U-jdk_x64_mac_hotspot_17.0.4.1_1.tar.gz",
+    sha256: "ac21a5a87f7cfa00212ab7c41f7eb80ca33640d83b63ad850be811c24095d61a"
+  },
+  linux: {
+    filename: "OpenJDK17U-jdk_x64_linux_hotspot_17.0.4.1_1.tar.gz",
+    sha256: "5fbf8b62c44f10be2efab97c5f5dbf15b74fae31e451ec10abbc74e54a04ff44"
+  },
+  windows: {
+    filename: "OpenJDK17U-jdk_x64_windows_hotspot_17.0.4.1_1.zip",
+    sha256: "3860d2ed7405674baeb0f9f4c71377421716759fe4301e92bdd4dd43c0442dc3"
+  },
+}
 
 export const openJdkSpecs: any = [
   {
@@ -29,31 +100,31 @@ export const openJdkSpecs: any = [
       {
         platform: "darwin",
         architecture: "amd64",
-        url: jdk8Base + "OpenJDK8U-jdk_x64_mac_hotspot_8u292b10.tar.gz",
-        sha256: "5646fbe9e4138c902c910bb7014d41463976598097ad03919e4848634c7e8007",
+        url: jdk8Version.baseUrl + jdk8Version.mac.filename,
+        sha256: jdk8Version.mac.sha256,
         extract: {
           format: "tar",
-          targetPath: posix.join(jdk8Version, "Contents", "Home"),
+          targetPath: posix.join(jdk8Version.versionName, "Contents", "Home"),
         },
       },
       {
         platform: "linux",
         architecture: "amd64",
-        url: jdk8Base + "OpenJDK8U-jdk_x64_linux_hotspot_8u292b10.tar.gz",
-        sha256: "0949505fcf42a1765558048451bb2a22e84b3635b1a31dd6191780eeccaa4ada",
+        url: jdk8Version.baseUrl + jdk8Version.linux.filename,
+        sha256: jdk8Version.linux.sha256,
         extract: {
           format: "tar",
-          targetPath: jdk8Version,
+          targetPath: jdk8Version.versionName,
         },
       },
       {
         platform: "windows",
         architecture: "amd64",
-        url: jdk8Base + "OpenJDK8U-jdk_x64_windows_hotspot_8u292b10.zip",
-        sha256: "2405e11f9f3603e506cf7ab01fcb67a3e3a1cf3e7858e14d629a72c9a24c6c42",
+        url: jdk8Version.baseUrl + jdk8Version.windows.filename,
+        sha256: jdk8Version.windows.sha256,
         extract: {
           format: "zip",
-          targetPath: jdk8Version,
+          targetPath: jdk8Version.versionName,
         },
       },
     ],
@@ -66,31 +137,31 @@ export const openJdkSpecs: any = [
       {
         platform: "darwin",
         architecture: "amd64",
-        url: jdk11Base + "OpenJDK11U-jdk_x64_mac_hotspot_11.0.9.1_1.tar.gz",
-        sha256: "96bc469f9b02a3b84382a0685b0bd7935e1ad1bd82a0aab9befb5b42a17cbd77",
+        url: jdk11Version.baseUrl + jdk11Version.mac.filename,
+        sha256: jdk11Version.mac.sha256,
         extract: {
           format: "tar",
-          targetPath: posix.join(jdk11Version, "Contents", "Home"),
+          targetPath: posix.join(jdk11Version.versionName, "Contents", "Home"),
         },
       },
       {
         platform: "linux",
         architecture: "amd64",
-        url: jdk11Base + "OpenJDK11U-jdk_x64_linux_hotspot_11.0.9.1_1.tar.gz",
-        sha256: "e388fd7f3f2503856d0b04fde6e151cbaa91a1df3bcebf1deddfc3729d677ca3",
+        url: jdk11Version.baseUrl + jdk11Version.linux.filename,
+        sha256: jdk11Version.linux.sha256,
         extract: {
           format: "tar",
-          targetPath: jdk11Version,
+          targetPath: jdk11Version.versionName,
         },
       },
       {
         platform: "windows",
         architecture: "amd64",
-        url: jdk11Base + "OpenJDK11U-jdk_x64_windows_hotspot_11.0.9.1_1.zip",
-        sha256: "fea633dc37f007cb6b1e1af1874da63ad3d5e31817e583048287c67010dce5c8",
+        url: jdk11Version.baseUrl + jdk11Version.windows.filename,
+        sha256: jdk11Version.windows.sha256,
         extract: {
           format: "zip",
-          targetPath: jdk11Version,
+          targetPath: jdk11Version.versionName,
         },
       },
     ],
@@ -103,31 +174,31 @@ export const openJdkSpecs: any = [
       {
         platform: "darwin",
         architecture: "amd64",
-        url: jdk13Base + "OpenJDK13U-jdk_x64_mac_hotspot_13_33.tar.gz",
-        sha256: "f948be96daba250b6695e22cb51372d2ba3060e4d778dd09c89548889783099f",
+        url: jdk13Version.baseUrl + jdk13Version.mac.filename,
+        sha256: jdk13Version.mac.sha256,
         extract: {
           format: "tar",
-          targetPath: posix.join(jdk13Version, "Contents", "Home"),
+          targetPath: posix.join(jdk13Version.versionName, "Contents", "Home"),
         },
       },
       {
         platform: "linux",
         architecture: "amd64",
-        url: jdk13Base + "OpenJDK13U-jdk_x64_linux_hotspot_13_33.tar.gz",
-        sha256: "e562caeffa89c834a69a44242d802eae3523875e427f07c05b1902c152638368",
+        url: jdk13Version.baseUrl + jdk13Version.linux.filename,
+        sha256: jdk13Version.linux.sha256,
         extract: {
           format: "tar",
-          targetPath: jdk13Version,
+          targetPath: jdk13Version.versionName,
         },
       },
       {
         platform: "windows",
         architecture: "amd64",
-        url: jdk13Base + "OpenJDK13U-jdk_x64_windows_hotspot_13_33.zip",
-        sha256: "65d71a954167d538c7a260e64d9868ceffe60edd1108817a9c44fddf60d13569",
+        url: jdk13Version.baseUrl + jdk13Version.windows.filename,
+        sha256: jdk13Version.windows.sha256,
         extract: {
           format: "zip",
-          targetPath: jdk13Version,
+          targetPath: jdk13Version.versionName,
         },
       },
     ],
@@ -140,31 +211,31 @@ export const openJdkSpecs: any = [
       {
         platform: "darwin",
         architecture: "amd64",
-        url: jdk17Base + "OpenJDK17U-jdk_x64_mac_hotspot_17.0.4.1_1.tar.gz",
-        sha256: "ac21a5a87f7cfa00212ab7c41f7eb80ca33640d83b63ad850be811c24095d61a",
+        url: jdk17Version.baseUrl + jdk17Version.mac.filename,
+        sha256: jdk17Version.mac.sha256,
         extract: {
           format: "tar",
-          targetPath: posix.join(jdk17Version, "Contents", "Home"),
+          targetPath: posix.join(jdk17Version.versionName, "Contents", "Home"),
         },
       },
       {
         platform: "linux",
         architecture: "amd64",
-        url: jdk17Base + "OpenJDK17U-jdk_x64_linux_hotspot_17.0.4.1_1.tar.gz",
-        sha256: "5fbf8b62c44f10be2efab97c5f5dbf15b74fae31e451ec10abbc74e54a04ff44",
+        url: jdk17Version.baseUrl + jdk17Version.linux.filename,
+        sha256: jdk17Version.linux.sha256,
         extract: {
           format: "tar",
-          targetPath: jdk17Version,
+          targetPath: jdk17Version.versionName,
         },
       },
       {
         platform: "windows",
         architecture: "amd64",
-        url: jdk17Base + "OpenJDK17U-jdk_x64_windows_hotspot_17.0.4.1_1.zip",
-        sha256: "3860d2ed7405674baeb0f9f4c71377421716759fe4301e92bdd4dd43c0442dc3",
+        url: jdk17Version.baseUrl + jdk17Version.windows.filename,
+        sha256: jdk17Version.windows.sha256,
         extract: {
           format: "zip",
-          targetPath: jdk17Version,
+          targetPath: jdk17Version.versionName,
         },
       },
     ],


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates LTS JDK versions (8 and 11) to the latest releases and adds the latest LTS JDK 17 to the list of the supported ones.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
* Older non-LTS versions 9, 10, 12-16 are EOL ones, see the [Java version history](https://en.wikipedia.org/wiki/Java_version_history).
* Support of the latest non-LTS JDK 18 was intentionally omitted. An ability to use custom JDK will be implemented in https://github.com/garden-io/garden/issues/3152. This looks like a better alternative to the continuous support of short-term releases.
* OpenJDK binaries [have been moved](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/) to [Eclipse Adoptium repo](https://github.com/adoptium/) since the version 17.
* OpenJDK 13 support can be removed in the Garden `0.13` release.