### PR TITLE
feat: use m1 native tools where available

### DIFF
--- a/core/src/plugins/container/container.ts
+++ b/core/src/plugins/container/container.ts
@@ -310,6 +310,16 @@ export const gardenPlugin = () =>
             },
           },
           {
+            platform: "darwin",
+            architecture: "arm64",
+            url: "https://download.docker.com/mac/static/stable/aarch64/docker-20.10.9.tgz",
+            sha256: "e41cc3b53b9907ee038c7a1ab82c5961815241180fefb49359d820d629658e6b",
+            extract: {
+              format: "tar",
+              targetPath: "docker/docker",
+            },
+          },
+          {
             platform: "linux",
             architecture: "amd64",
             url: "https://download.docker.com/linux/static/stable/x86_64/docker-20.10.9.tgz",

--- a/core/src/plugins/hadolint/hadolint.ts
+++ b/core/src/plugins/hadolint/hadolint.ts
@@ -260,6 +260,7 @@ export const gardenPlugin = () =>
         type: "binary",
         _includeInGardenImage: false,
         builds: [
+          // this version has no arm support yet. If you add a later release, please add the "arm64" architecture.
           {
             platform: "darwin",
             architecture: "amd64",

--- a/core/src/plugins/kubernetes/helm/helm-cli.ts
+++ b/core/src/plugins/kubernetes/helm/helm-cli.ts
@@ -32,7 +32,7 @@ export const helm3Spec: PluginToolSpec = {
     },
     {
       platform: "darwin",
-      architecture: "amd64",
+      architecture: "arm64",
       url: "https://get.helm.sh/helm-v3.7.2-darwin-arm64.tar.gz",
       sha256: "260d4b8bffcebc6562ea344dfe88efe252cf9511dd6da3cccebf783773d42aec",
       extract: {

--- a/core/src/plugins/kubernetes/helm/helm-cli.ts
+++ b/core/src/plugins/kubernetes/helm/helm-cli.ts
@@ -31,6 +31,16 @@ export const helm3Spec: PluginToolSpec = {
       },
     },
     {
+      platform: "darwin",
+      architecture: "amd64",
+      url: "https://get.helm.sh/helm-v3.7.2-darwin-arm64.tar.gz",
+      sha256: "260d4b8bffcebc6562ea344dfe88efe252cf9511dd6da3cccebf783773d42aec",
+      extract: {
+        format: "tar",
+        targetPath: "darwin-arm64/helm",
+      },
+    },
+    {
       platform: "linux",
       architecture: "amd64",
       url: "https://get.helm.sh/helm-v3.7.2-linux-amd64.tar.gz",

--- a/core/src/plugins/kubernetes/kubectl.ts
+++ b/core/src/plugins/kubernetes/kubectl.ts
@@ -301,6 +301,12 @@ export const kubectlSpec: PluginToolSpec = {
       sha256: "ecc91cd2f92184630912f9dcd8c47443b50ebfa4b1da431fb28fa7b462dd70ab",
     },
     {
+      platform: "darwin",
+      architecture: "arm64",
+      url: "https://storage.googleapis.com/kubernetes-release/release/v1.23.3/bin/darwin/arm64/kubectl",
+      sha256: "e43303daa6e99de6e182f0c3b3113e45ea0015bc84abd2485f0dde5770163f63",
+    },
+    {
       platform: "linux",
       architecture: "amd64",
       url: "https://storage.googleapis.com/kubernetes-release/release/v1.23.3/bin/linux/amd64/kubectl",

--- a/core/src/plugins/kubernetes/kubernetes-module/kustomize.ts
+++ b/core/src/plugins/kubernetes/kubernetes-module/kustomize.ts
@@ -51,6 +51,17 @@ export const kustomizeSpec: PluginToolSpec = {
       },
     },
     {
+      platform: "darwin",
+      architecture: "arm64",
+      url:
+        "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.5.2/kustomize_v4.5.2_darwin_arm64.tar.gz",
+      sha256: "4ee7ef099b8f59d65cb393d9c1b8fa49a392529dbefcd469359cc51094dad517",
+      extract: {
+        format: "tar",
+        targetPath: "kustomize",
+      },
+    },
+    {
       platform: "linux",
       architecture: "amd64",
       url:

--- a/core/src/plugins/kubernetes/logs.ts
+++ b/core/src/plugins/kubernetes/logs.ts
@@ -525,6 +525,7 @@ export const sternSpec: PluginToolSpec = {
   type: "binary",
   _includeInGardenImage: true,
   builds: [
+    // this version has no arm support yet. If you add a later release, please add the "arm64" architecture.
     {
       platform: "darwin",
       architecture: "amd64",

--- a/core/src/plugins/octant/octant.ts
+++ b/core/src/plugins/octant/octant.ts
@@ -87,6 +87,7 @@ export const gardenPlugin = () =>
         type: "binary",
         _includeInGardenImage: false,
         builds: [
+          // this version has no arm support yet. If you add a later release, please add the "arm64" architecture.
           {
             platform: "darwin",
             architecture: "amd64",

--- a/core/src/plugins/openfaas/faas-cli.ts
+++ b/core/src/plugins/openfaas/faas-cli.ts
@@ -14,6 +14,7 @@ export const faasCliSpec: PluginToolSpec = {
   type: "binary",
   _includeInGardenImage: false,
   builds: [
+    // this version has no arm support yet. If you add a later release, please add the "arm64" architecture.
     {
       platform: "darwin",
       architecture: "amd64",

--- a/core/src/util/ext-tools.ts
+++ b/core/src/util/ext-tools.ts
@@ -250,8 +250,6 @@ export class PluginTool extends CliWrapper {
     const architecture = getArchitecture()
     const isEmulated = isRosetta()
 
-    console.log("===================", { _platform, architecture, isEmulated })
-
     let buildSpec: ToolBuildSpec
     // first look for native arch, if not found, then try (potentially emulated) arch
     if (isEmulated) {

--- a/core/src/util/ext-tools.ts
+++ b/core/src/util/ext-tools.ts
@@ -234,7 +234,6 @@ export class PluginTool extends CliWrapper {
     const architecture = getArchitecture()
     const darwinARM = isDarwinARM()
 
-    let buildSpec: ToolBuildSpec
     if (darwinARM) {
       // first look for native arch, if not found, then try (potentially emulated) arch
       this.buildSpec = findBuildSpec(spec, platform, "arm64") || findBuildSpec(spec, platform, "amd64")
@@ -328,9 +327,9 @@ export class PluginTool extends CliWrapper {
       protocol === "file:"
         ? createReadStream(parsed.path!)
         : got.stream({
-          method: "GET",
-          url: this.buildSpec.url,
-        })
+            method: "GET",
+            url: this.buildSpec.url,
+          })
 
     // compute the sha256 checksum
     const hash = createHash("sha256")

--- a/core/src/util/ext-tools.ts
+++ b/core/src/util/ext-tools.ts
@@ -234,14 +234,16 @@ export class PluginTool extends CliWrapper {
     const architecture = getArchitecture()
     const darwinARM = isDarwinARM()
 
+    let buildSpec: ToolBuildSpec | undefined
+
     if (darwinARM) {
       // first look for native arch, if not found, then try (potentially emulated) arch
-      this.buildSpec = findBuildSpec(spec, platform, "arm64")! || findBuildSpec(spec, platform, "amd64")!
+      buildSpec = findBuildSpec(spec, platform, "arm64") || findBuildSpec(spec, platform, "amd64")
     } else {
-      this.buildSpec = findBuildSpec(spec, platform, architecture)!
+      buildSpec = findBuildSpec(spec, platform, architecture)!
     }
 
-    if (!this.buildSpec) {
+    if (!buildSpec) {
       throw new ConfigurationError(
         `Command ${spec.name} doesn't have a spec for this platform/architecture (${platform}-${architecture})`,
         {
@@ -252,6 +254,8 @@ export class PluginTool extends CliWrapper {
         }
       )
     }
+
+    this.buildSpec = buildSpec
 
     this.name = spec.name
     this.type = spec.type

--- a/core/src/util/ext-tools.ts
+++ b/core/src/util/ext-tools.ts
@@ -231,12 +231,10 @@ export class PluginTool extends CliWrapper {
     const architecture = getArchitecture()
     const nativeArchitecture = getNativeArchitecture()
 
-    function findMatchingSpec(p: string, a: string) {
-      return spec.builds.find((build) => build.platform === p && build.architecture === a)!
-    }
-
     // first look for native arch, if not found, try (potentially emulated) arch
-    this.buildSpec = findMatchingSpec(_platform, nativeArchitecture) || findMatchingSpec(_platform, architecture)
+    this.buildSpec = spec.builds.find((build) => {
+      return build.platform === _platform && [architecture, nativeArchitecture].includes(build.architecture)
+    })!
 
     if (!this.buildSpec) {
       const testedArchs = new Set(["${_platform}-${architecture}", "${_platform}-${nativeArchitecture}"])

--- a/core/src/util/ext-tools.ts
+++ b/core/src/util/ext-tools.ts
@@ -245,18 +245,18 @@ export class PluginTool extends CliWrapper {
   private chmodDone: boolean
 
   constructor(spec: PluginToolSpec) {
-    const _platform = getPlatform()
+    const platform = getPlatform()
     const architecture = getArchitecture()
-    const _isDarwinARM = isDarwinARM()
+    const darwinARM = isDarwinARM()
 
     let buildSpec: ToolBuildSpec
     let darwinPreferredArch: string | undefined
-    if (_isDarwinARM) {
+    if (darwinARM) {
       // first look for native arch, if not found, then try (potentially emulated) arch
-      buildSpec = findBuildSpec(spec, _platform, "arm64") || findBuildSpec(spec, _platform, "amd64")
+      buildSpec = findBuildSpec(spec, platform, "arm64") || findBuildSpec(spec, platform, "amd64")
       darwinPreferredArch = buildSpec?.architecture
     } else {
-      buildSpec = findBuildSpec(spec, _platform, architecture)
+      buildSpec = findBuildSpec(spec, platform, architecture)
     }
 
     super(spec.name, "", darwinPreferredArch)
@@ -265,12 +265,12 @@ export class PluginTool extends CliWrapper {
 
     if (!this.buildSpec) {
       throw new ConfigurationError(
-        `Command ${spec.name} doesn't have a spec for this platform/architecture (${_platform}-${architecture})`,
+        `Command ${spec.name} doesn't have a spec for this platform/architecture (${platform}-${architecture})`,
         {
           spec,
-          platform: _platform,
+          platform,
           architecture,
-          isDarwinARM: _isDarwinARM,
+          darwinARM,
         }
       )
     }

--- a/core/src/util/ext-tools.ts
+++ b/core/src/util/ext-tools.ts
@@ -202,7 +202,7 @@ export class CliWrapper {
 }
 
 const findBuildSpec = (spec: PluginToolSpec, plat: string, arch: string) => {
-  return spec.builds.find((build) => build.platform === plat && build.architecture === arch)!
+  return spec.builds.find((build) => build.platform === plat && build.architecture === arch)
 }
 
 export interface PluginTools {
@@ -236,9 +236,9 @@ export class PluginTool extends CliWrapper {
 
     if (darwinARM) {
       // first look for native arch, if not found, then try (potentially emulated) arch
-      this.buildSpec = findBuildSpec(spec, platform, "arm64") || findBuildSpec(spec, platform, "amd64")
+      this.buildSpec = findBuildSpec(spec, platform, "arm64")! || findBuildSpec(spec, platform, "amd64")!
     } else {
-      this.buildSpec = findBuildSpec(spec, platform, architecture)
+      this.buildSpec = findBuildSpec(spec, platform, architecture)!
     }
 
     if (!this.buildSpec) {

--- a/core/src/util/ext-tools.ts
+++ b/core/src/util/ext-tools.ts
@@ -250,8 +250,8 @@ export class PluginTool extends CliWrapper {
     const architecture = getArchitecture()
 
     let buildSpec: ToolBuildSpec
-    // first look for native arch, if not found, then try (potentially emulated) arch
     if (isDarwinARM()) {
+      // first look for native arch, if not found, then try (potentially emulated) arch
       buildSpec = findBuildSpec(spec, _platform, "arm64") || findBuildSpec(spec, _platform, "amd64")
     } else {
       buildSpec = findBuildSpec(spec, _platform, architecture)

--- a/core/src/util/util.ts
+++ b/core/src/util/util.ts
@@ -15,6 +15,7 @@ import {
   isArray,
   isPlainObject,
   mapValues,
+  memoize,
   omit,
   pick,
   pickBy,
@@ -704,11 +705,11 @@ export function getArchitecture() {
   return archMap[arch] || arch
 }
 
-export function isRosetta() {
+export const isRosetta = memoize(() => {
   // detect rosetta on Apple M cpu family macs
   // see also https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment
   if (process.arch === "x64" && process.platform === "darwin") {
-    // Use execSync here, because getNativeArch is called in a constructor
+    // Use execSync here, because this function is called in a constructor
     // otherwise we'd make the function async and call `spawn`
     const stdout = execSync("sysctl -n sysctl.proc_translated", { encoding: "utf-8" })
     if (stdout === "1\n") {
@@ -717,7 +718,7 @@ export function isRosetta() {
   }
 
   return false
-}
+})
 
 export function getDurationMsec(start: Date, end: Date): number {
   return Math.round(end.getTime() - start.getTime())

--- a/core/src/util/util.ts
+++ b/core/src/util/util.ts
@@ -705,11 +705,17 @@ export function getArchitecture() {
   return archMap[arch] || arch
 }
 
-export const isRosetta = memoize(() => {
-  // detect rosetta on Apple M cpu family macs
-  // see also https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment
-  if (process.arch === "x64" && process.platform === "darwin") {
-    // Use execSync here, because this function is called in a constructor
+export const isDarwinARM = memoize(() => {
+  if (process.platform !== "darwin") {
+    return false
+  }
+
+  if (process.arch === "arm64") {
+    return true
+  } else if (process.arch === "x64") {
+    // detect rosetta on Apple M cpu family macs
+    // see also https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment
+    // We use execSync here, because this function is called in a constructor
     // otherwise we'd make the function async and call `spawn`
     const stdout = execSync("sysctl -n sysctl.proc_translated", { encoding: "utf-8" })
     if (stdout === "1\n") {

--- a/core/src/util/util.ts
+++ b/core/src/util/util.ts
@@ -704,21 +704,19 @@ export function getArchitecture() {
   return archMap[arch] || arch
 }
 
-export function getNativeArchitecture() {
-  const arch = getArchitecture()
-
+export function isRosetta() {
   // detect rosetta on Apple M cpu family macs
   // see also https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment
-  if (arch === "x64" && process.platform === "darwin") {
+  if (process.arch === "x64" && process.platform === "darwin") {
     // Use execSync here, because getNativeArch is called in a constructor
-    // otherwise we should make the function async and call `spawn`
+    // otherwise we'd make the function async and call `spawn`
     const stdout = execSync("sysctl -n sysctl.proc_translated", { encoding: "utf-8" })
-    if (stdout === "1") {
-      return "arm64"
+    if (stdout === "1\n") {
+      return true
     }
   }
 
-  return arch
+  return false
 }
 
 export function getDurationMsec(start: Date, end: Date): number {

--- a/plugins/conftest/index.ts
+++ b/plugins/conftest/index.ts
@@ -272,6 +272,7 @@ export const gardenPlugin = () =>
         type: "binary",
         _includeInGardenImage: true,
         builds: [
+          // this version has no arm support yet. If you add a later release, please add the "arm64" architecture.
           {
             platform: "darwin",
             architecture: "amd64",

--- a/plugins/jib/gradle.ts
+++ b/plugins/jib/gradle.ts
@@ -37,6 +37,11 @@ export const gradleSpec: any = {
       ...spec,
     },
     {
+      platform: "darwin",
+      architecture: "arm64",
+      ...spec,
+    },
+    {
       platform: "linux",
       architecture: "amd64",
       ...spec,

--- a/plugins/jib/maven.ts
+++ b/plugins/jib/maven.ts
@@ -37,6 +37,11 @@ export const mavenSpec: PluginToolSpec = {
       ...spec,
     },
     {
+      platform: "darwin",
+      architecture: "arm64",
+      ...spec,
+    },
+    {
       platform: "linux",
       architecture: "amd64",
       ...spec,

--- a/plugins/jib/openjdk.ts
+++ b/plugins/jib/openjdk.ts
@@ -159,7 +159,7 @@ function openJdkSpec(jdkVersion: JdkVersion): PluginToolSpec {
           targetPath: jdkVersion.versionName,
         },
       },
-      ...macBuilds
+      ...macBuilds,
     ],
   }
 }

--- a/plugins/jib/openjdk.ts
+++ b/plugins/jib/openjdk.ts
@@ -125,8 +125,8 @@ function openJdkSpec(jdkVersion: JdkVersion): PluginToolSpec {
     macBuilds.push({
       platform: "darwin",
       architecture: "arm64",
-      url: jdkVersion.baseUrl + jdkVersion.mac_amd64.filename,
-      sha256: jdkVersion.mac_amd64.sha256,
+      url: jdkVersion.baseUrl + jdkVersion.mac_arm64.filename,
+      sha256: jdkVersion.mac_arm64.sha256,
       extract: {
         format: "tar",
         targetPath: posix.join(jdkVersion.versionName, "Contents", "Home"),

--- a/plugins/pulumi/cli.ts
+++ b/plugins/pulumi/cli.ts
@@ -77,7 +77,7 @@ export const pulumiCliSPecs: { [version: string]: PluginToolSpec } = {
       },
       {
         platform: "darwin",
-        architecture: "amd64",
+        architecture: "arm64",
         url: "https://github.com/pulumi/pulumi/releases/download/v3.25.1/pulumi-v3.25.1-darwin-arm64.tar.gz",
         sha256: "a5ab29db86733b5f730a0f352b407aed64b82337a222a0c7cd1492b55189e6c1",
         extract: {
@@ -126,7 +126,7 @@ export const pulumiCliSPecs: { [version: string]: PluginToolSpec } = {
       {
         platform: "darwin",
         architecture: "arm64",
-        url: "https://github.com/pulumi/pulumi/releases/download/v3.24.1/pulumi-v3.24.1-darwin-x64.tar.gz",
+        url: "https://github.com/pulumi/pulumi/releases/download/v3.24.1/pulumi-v3.24.1-darwin-arm64.tar.gz",
         sha256: "cdfd2d05beb66380b7eb2354ef45abbce17865441a465294cf8e5448a534eb7f",
         extract: {
           format: "tar",

--- a/plugins/pulumi/cli.ts
+++ b/plugins/pulumi/cli.ts
@@ -76,6 +76,16 @@ export const pulumiCliSPecs: { [version: string]: PluginToolSpec } = {
         },
       },
       {
+        platform: "darwin",
+        architecture: "amd64",
+        url: "https://github.com/pulumi/pulumi/releases/download/v3.25.1/pulumi-v3.25.1-darwin-arm64.tar.gz",
+        sha256: "a5ab29db86733b5f730a0f352b407aed64b82337a222a0c7cd1492b55189e6c1",
+        extract: {
+          format: "tar",
+          targetPath: "pulumi/pulumi",
+        },
+      },
+      {
         platform: "linux",
         architecture: "amd64",
         url: "https://github.com/pulumi/pulumi/releases/download/v3.25.1/pulumi-v3.25.1-linux-x64.tar.gz",
@@ -108,6 +118,16 @@ export const pulumiCliSPecs: { [version: string]: PluginToolSpec } = {
         architecture: "amd64",
         url: "https://github.com/pulumi/pulumi/releases/download/v3.24.1/pulumi-v3.24.1-darwin-x64.tar.gz",
         sha256: "1bfafd10f189c4e57b9961ddf899055efb55649e7403fc1bdd33c89e5a9cce1c",
+        extract: {
+          format: "tar",
+          targetPath: "pulumi/pulumi",
+        },
+      },
+      {
+        platform: "darwin",
+        architecture: "arm64",
+        url: "https://github.com/pulumi/pulumi/releases/download/v3.24.1/pulumi-v3.24.1-darwin-x64.tar.gz",
+        sha256: "cdfd2d05beb66380b7eb2354ef45abbce17865441a465294cf8e5448a534eb7f",
         extract: {
           format: "tar",
           targetPath: "pulumi/pulumi",

--- a/plugins/terraform/cli.ts
+++ b/plugins/terraform/cli.ts
@@ -174,6 +174,16 @@ export const terraformCliSpecs: { [version: string]: PluginToolSpec } = {
         },
       },
       {
+        platform: "darwin",
+        architecture: "arm64",
+        url: "https://releases.hashicorp.com/terraform/1.0.5/terraform_1.0.5_darwin_arm64.zip",
+        sha256: "3de4b9f167392622ef49d807e438a166e6c86c631afa730ff3189cf72cc950e2",
+        extract: {
+          format: "zip",
+          targetPath: "terraform",
+        },
+      },
+      {
         platform: "linux",
         architecture: "amd64",
         url: "https://releases.hashicorp.com/terraform/1.0.5/terraform_1.0.5_linux_amd64.zip",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:

Use M1 native tools where upstream provides official builds.

The idea of this PR is to already download and call native M1 tools where available.

We should actually change our build processes to provide native ARM Garden builds for Linux and MacOS, but this change is simpler and already relieves some pain for tools with ARM incompatibilities (like with terraform, see #3166).

Also in case of Java, users can benefit from faster builds with native execution.

**Which issue(s) this PR fixes**:

Implements #3166

**Special notes for your reviewer**:

I gave my best to make sure that all the hashes and instances of the string `arm64`/`aarch64` are correct. I smoke tested using this command:

```
garden tools 2>&1 | grep -E '\[(binary|library)\]' | awk -F' ' '{print $1}' | xargs -I'{}' -n 1 -P 20 garden tools '{}' -- version
```

all the downloads succeeded on my M1 mac.

If you want, I can add unit tests for this stuff, but it would take some time

