### PR TITLE
WIP: try to fix getPublicImageId helper tests

### DIFF
--- a/core/test/helpers.ts
+++ b/core/test/helpers.ts
@@ -719,3 +719,16 @@ export async function assertAsyncError(action: () => Promise<any>, ...expectedEr
     expectedErrorMessages.forEach((msg) => expect(errorString).to.contain(msg))
   }
 }
+
+// https://stackoverflow.com/a/66836940
+// useful for typesafe stubbing
+export function getPropertyName<T>(
+  obj: T,
+  expression: (x: { [Property in keyof T]: () => string }) => () => string
+): string {
+  const res: { [Property in keyof T]: () => string } = {} as { [Property in keyof T]: () => string }
+
+  Object.keys(obj).map((k) => (res[k as keyof T] = () => k))
+
+  return expression(res)()
+}

--- a/core/test/helpers.ts
+++ b/core/test/helpers.ts
@@ -35,7 +35,7 @@ import { Logger, LogLevel } from "../src/logger/logger"
 import { ClientAuthToken } from "../src/db/entities/client-auth-token"
 import { GardenCli } from "../src/cli/cli"
 import { profileAsync } from "../src/util/profiling"
-import { makeTempDir } from "../src/util/fs"
+import { defaultDotIgnoreFile, makeTempDir } from "../src/util/fs"
 import { DirectoryResult } from "tmp-promise"
 import { ConfigurationError } from "../src/exceptions"
 import { assert, expect } from "chai"
@@ -55,6 +55,7 @@ import { ActionKind, RunActionHandler, TestActionHandler } from "../src/plugin/a
 import { GetRunResult } from "../src/plugin/handlers/run/get-result"
 import { WrappedActionRouterHandlers } from "../src/router/base"
 import { Resolved } from "../src/actions/types"
+import { defaultNamespace, ProjectConfig } from "../src/config/project"
 
 export { TempDirectory, makeTempDir } from "../src/util/fs"
 export { TestGarden, TestError, TestEventBus, expectError, expectFuzzyMatch } from "../src/util/testing"
@@ -328,6 +329,18 @@ export const testPluginC = () => {
       },
     ],
   })
+}
+
+export const defaultProjectConfig: ProjectConfig = {
+  apiVersion: DEFAULT_API_VERSION,
+  kind: "Project",
+  name: "test",
+  path: "tmp",
+  defaultEnvironment: "default",
+  dotIgnoreFile: defaultDotIgnoreFile,
+  environments: [{ name: "default", defaultNamespace, variables: {} }],
+  providers: [],
+  variables: {},
 }
 
 export const defaultModuleConfig: ModuleConfig = {

--- a/core/test/unit/src/plugins/container/helpers.ts
+++ b/core/test/unit/src/plugins/container/helpers.ts
@@ -16,7 +16,7 @@ import { writeFile, mkdir } from "fs-extra"
 import { Garden } from "../../../../../src/garden"
 import { PluginContext } from "../../../../../src/plugin-context"
 import { gardenPlugin } from "../../../../../src/plugins/container/container"
-import { dataDir, expectError, makeTestGarden } from "../../../../helpers"
+import { dataDir, expectError, getPropertyName, makeTestGarden } from "../../../../helpers"
 import { moduleFromConfig } from "../../../../../src/types/module"
 import { ModuleConfig } from "../../../../../src/config/module"
 import { LogEntry } from "../../../../../src/logger/log-entry"
@@ -76,6 +76,7 @@ describe("containerHelpers", () => {
   let garden: Garden
   let ctx: PluginContext
   let log: LogEntry
+  const moduleHasDockerfile = getPropertyName(helpers, (x) => x.moduleHasDockerfile)
 
   beforeEach(async () => {
     garden = await makeTestGarden(projectRoot, { plugins: [gardenPlugin()] })
@@ -121,7 +122,7 @@ describe("containerHelpers", () => {
 
   describe("getLocalImageName", () => {
     it("should return explicit image name with no version if specified", async () => {
-      td.replace(helpers, "hasDockerfile", () => false)
+      td.replace(helpers, moduleHasDockerfile, () => false)
 
       const config = cloneDeep(baseConfig)
       config.spec.image = "some/image:1.1"
@@ -130,7 +131,7 @@ describe("containerHelpers", () => {
     })
 
     it("should return build name if no image name is specified", async () => {
-      td.replace(helpers, "hasDockerfile", () => true)
+      td.replace(helpers, moduleHasDockerfile, () => true)
 
       const config = cloneDeep(baseConfig)
 
@@ -140,7 +141,7 @@ describe("containerHelpers", () => {
 
   describe("getDeploymentImageId", () => {
     it("should return module name with module version if there is a Dockerfile and no image name set", async () => {
-      td.replace(helpers, "hasDockerfile", () => true)
+      td.replace(helpers, moduleHasDockerfile, () => true)
 
       const config = cloneDeep(baseConfig)
       const module = await getTestModule(config)
@@ -149,7 +150,7 @@ describe("containerHelpers", () => {
     })
 
     it("should return image name with module version if there is a Dockerfile and image name is set", async () => {
-      td.replace(helpers, "hasDockerfile", () => true)
+      td.replace(helpers, moduleHasDockerfile, () => true)
 
       const config = cloneDeep(baseConfig)
       config.spec.image = "some/image:1.1"
@@ -159,7 +160,7 @@ describe("containerHelpers", () => {
     })
 
     it("should return configured image tag if there is no Dockerfile", async () => {
-      td.replace(helpers, "hasDockerfile", () => false)
+      td.replace(helpers, moduleHasDockerfile, () => false)
 
       const config = cloneDeep(baseConfig)
       config.spec.image = "some/image:1.1"
@@ -171,7 +172,7 @@ describe("containerHelpers", () => {
     it("should throw if no image name is set and there is no Dockerfile", async () => {
       const config = cloneDeep(baseConfig)
 
-      td.replace(helpers, "hasDockerfile", () => false)
+      td.replace(helpers, moduleHasDockerfile, () => false)
 
       await expectError(() => helpers.getModuleDeploymentImageId(config, dummyVersion, undefined), "configuration")
     })
@@ -220,7 +221,7 @@ describe("containerHelpers", () => {
     })
 
     it("should use local id if no image name is set", async () => {
-      td.replace(helpers, "hasDockerfile", () => true)
+      td.replace(helpers, moduleHasDockerfile, () => true)
 
       const action = await getResolvedTestBuildAction(baseConfig)
 
@@ -337,7 +338,7 @@ describe("containerHelpers", () => {
 
   describe("hasDockerfile", () => {
     it("should return true if module config explicitly sets a Dockerfile", async () => {
-      td.replace(helpers, "hasDockerfile", () => true)
+      td.replace(helpers, moduleHasDockerfile, () => true)
 
       const graph = await garden.getConfigGraph({ log: garden.log, emit: false })
       const module = graph.getModule("module-a")

--- a/core/test/unit/src/types/test.ts
+++ b/core/test/unit/src/types/test.ts
@@ -55,24 +55,24 @@ describe("testFromConfig", () => {
     let moduleA = graph.getModule("module-a")
     const testConfig = moduleA.testConfigs[0]
     const versionBeforeChange = testFromConfig(moduleA, testConfig, graph.moduleGraph).version
-    const backup = cloneDeep(graph["modules"]["module-b"])
+    const backup = cloneDeep(graph.moduleGraph.getModule("module-b"))
 
     // Verify that changed build version is reflected in the test version
-    graph["modules"]["module-b"].version.versionString = "12345"
+    graph.moduleGraph["modules"]["module-b"].version.versionString = "12345"
     moduleA = graph.getModule("module-a")
     const testAfterBuildChange = testFromConfig(moduleA, testConfig, graph.moduleGraph)
     expect(versionBeforeChange).to.not.eql(testAfterBuildChange.version)
 
     // Verify that changed service dependency config is reflected in the test version
-    graph["modules"]["module-b"] = backup
-    graph["serviceConfigs"]["service-b"].config.spec["command"] = ["echo", "something-else"]
+    graph.moduleGraph["modules"]["module-b"] = backup
+    graph.moduleGraph["serviceConfigs"]["service-b"].config.spec["command"] = ["echo", "something-else"]
     moduleA = graph.getModule("module-a")
     const testAfterServiceConfigChange = testFromConfig(moduleA, testConfig, graph.moduleGraph)
     expect(versionBeforeChange).to.not.eql(testAfterServiceConfigChange.version)
 
     // Verify that changed task dependency config is reflected in the test version
-    graph["modules"]["module-b"] = backup
-    graph["taskConfigs"]["task-a"].config.spec["command"] = ["echo", "something-else"]
+    graph.moduleGraph["modules"]["module-b"] = backup
+    graph.moduleGraph["taskConfigs"]["task-a"].config.spec["command"] = ["echo", "something-else"]
     moduleA = graph.getModule("module-a")
     const testAfterTaskConfigChange = testFromConfig(moduleA, testConfig, graph.moduleGraph)
     expect(versionBeforeChange).to.not.eql(testAfterTaskConfigChange.version)


### PR DESCRIPTION
WIP

Attempt to fix tests for the docker getPublicImageId helper. Instead of a module, create an action dynamically. Current issue: `garden.resolveAction` with the dynamic action passed returns undefined.