### PR TITLE
feat: allow module overlap if one or both of them are disabled

### DIFF
--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -1132,7 +1132,7 @@ export class Garden {
       })
       .join("\n\n")
     const message = chalk.red(dedent`
-      There are multiple enabled modules that share the same garden.yml file or are nested within another:
+      Found multiple enabled modules that share the same garden.yml file or are nested within another:
 
       ${overlapList}
 

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -1132,11 +1132,18 @@ export class Garden {
       })
       .join("\n\n")
     const message = chalk.red(dedent`
-      Missing ${chalk.bold("include")} and/or ${chalk.bold("exclude")} directives on modules with overlapping paths.
-      Setting includes/excludes is required when modules have the same path (i.e. are in the same garden.yml file),
-      or when one module is nested within another.
+      There are multiple enabled modules that share the same garden.yml file or are nested within another:
 
       ${overlapList}
+
+      If this was intentional, there you have two options to resolve this error.
+
+      - You can add ${chalk.bold("include")} and/or ${chalk.bold("exclude")} directives on the affected modules.
+        With explicitly including / encluding files, the modules are actually allowed to overlap in case that is
+        what you want.
+      - You can use the ${chalk.bold("disabled")} directive to make sure that only one of the modules is enabled
+        in any given moment. For example, you can make sure that the modules are enabled only in their exclusive
+        environment.
     `)
     // Sanitize error details
     const overlappingModules = moduleOverlaps.map(({ module, overlaps }) => {

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -1136,7 +1136,7 @@ export class Garden {
 
       ${overlapList}
 
-      If this was intentional, there you have two options to resolve this error.
+      If this was intentional, there are two options to resolve this error:
 
       - You can add ${chalk.bold("include")} and/or ${chalk.bold("exclude")} directives on the affected modules.
         With explicitly including / encluding files, the modules are actually allowed to overlap in case that is

--- a/core/src/util/fs.ts
+++ b/core/src/util/fs.ts
@@ -83,12 +83,15 @@ export function detectModuleOverlap({
   gardenDirPath: string
   moduleConfigs: ModuleConfig[]
 }): ModuleOverlap[] {
+  // Don't consider overlap between disabled modules, or where one of the modules is disabled
+  const enabledModules = moduleConfigs.filter((m) => !m.disabled)
+
   let overlaps: ModuleOverlap[] = []
-  for (const config of moduleConfigs) {
+  for (const config of enabledModules) {
     if (!!config.include || !!config.exclude) {
       continue
     }
-    const matches = moduleConfigs
+    const matches = enabledModules
       .filter(
         (compare) =>
           config.name !== compare.name &&

--- a/core/test/unit/src/util/fs.ts
+++ b/core/test/unit/src/util/fs.ts
@@ -167,7 +167,7 @@ describe("detectModuleOverlap", () => {
       expect(detectModuleOverlap({ projectRoot, gardenDirPath, moduleConfigs: [moduleA, moduleB] })).to.be.empty
     })
 
-    it("should ignore modules that set excludes", () => {
+    it("should ignore modules that are disabled", () => {
       const moduleA = {
         name: "module-a",
         path: join(projectRoot, "foo"),

--- a/core/test/unit/src/util/fs.ts
+++ b/core/test/unit/src/util/fs.ts
@@ -126,6 +126,18 @@ describe("detectModuleOverlap", () => {
         },
       ])
     })
+    it("should ignore modules that are disabled", () => {
+      const moduleA = {
+        name: "module-a",
+        path: join(projectRoot, "foo"),
+        disabled: true,
+      } as ModuleConfig
+      const moduleB = {
+        name: "module-b",
+        path: join(projectRoot, "foo"),
+      } as ModuleConfig
+      expect(detectModuleOverlap({ projectRoot, gardenDirPath, moduleConfigs: [moduleA, moduleB] })).to.be.empty
+    })
   })
 
   context("nested modules", () => {
@@ -147,6 +159,19 @@ describe("detectModuleOverlap", () => {
         name: "module-a",
         path: join(projectRoot, "foo"),
         exclude: [""],
+      } as ModuleConfig
+      const moduleB = {
+        name: "module-b",
+        path: join(projectRoot, "foo", "bar"),
+      } as ModuleConfig
+      expect(detectModuleOverlap({ projectRoot, gardenDirPath, moduleConfigs: [moduleA, moduleB] })).to.be.empty
+    })
+
+    it("should ignore modules that set excludes", () => {
+      const moduleA = {
+        name: "module-a",
+        path: join(projectRoot, "foo"),
+        disabled: true,
       } as ModuleConfig
       const moduleB = {
         name: "module-b",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:
This fixes module validation to allow for modules to overlap, if
one of them is disabled. Example use case: one environment deploys
to kubernetes, the other environment deploys to a serverless env.

This also changes the error message: The goal was to make clear that
there are two ways to get rid of the error if the overlap is intentional.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
- [x] TODO: I failed running the tests locally, https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md#tests seems to be outdated: `error Command "test" not found. Did you mean "jest"?` – how can I run the fs.ts tests locally?