### PR TITLE
chore: disable edge releases on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1010,16 +1010,17 @@ workflows:
 
       ### MASTER ONLY ###
 
-      - build-dist-edge:
-          <<: *only-master
-          requires: [build]
-      - release-service-docker:
-          <<: *only-master
-          context: docker
-          requires: [build-dist-edge]
-      - release-service-dist-edge:
-          <<: *only-master
-          requires: [build-dist-edge]
+      # TODO: Re-enable this if we can figure out a way to not spam users who have starred the repo.
+      # - build-dist-edge:
+      #     <<: *only-master
+      #     requires: [build]
+      # - release-service-docker:
+      #     <<: *only-master
+      #     context: docker
+      #     requires: [build-dist-edge]
+      # - release-service-dist-edge:
+      #     <<: *only-master
+      #     requires: [build-dist-edge]
 
   tags:
     jobs:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @10ko and @twelvemo.
-->

**What this PR does / why we need it**:

We've started getting complaints from users that they're being spammed with release notifications for every edge release.

For the time being, we'll disable edge releasees on merges to master. We may re-enable them once we've had a closer look and found a way to do this in a less noisy way.