### PR TITLE
fix: ensure semver format in git/rsync version regex

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -770,7 +770,19 @@ jobs:
       #     command: nvm install 14 && nvm alias default 14
       - run:
           name: brew install
-          command: brew install docker kubectl
+          command: brew install docker kubectl git rsync
+      # Garden has 2 main pre-requisites: git and rsync
+      # Upgrade rsync to the latest version.
+      # The default version is too old, Garden requires 3.1.0+.
+      # This step ensures that Garden is always tested to be compatible with the latest rsync.
+      - run:
+          name: Upgrade rsync
+          command: brew upgrade rsync
+      # Upgrade git to the latest version.
+      # This step ensures that Garden is always tested to be compatible with the latest git.
+      - run:
+          name: Upgrade git
+          command: brew upgrade git
       - run:
           name: Install gcloud SDK
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -808,7 +808,9 @@ jobs:
       - run:
           name: Install Deps
           command: |
-            choco upgrade -y rsync gcloudsdk kubernetes-cli
+            choco install -y git
+            choco install -y rsync
+            choco upgrade -y git rsync gcloudsdk kubernetes-cli
             refreshenv
       - run:
           name: Write gcloud credentials to file

--- a/core/src/build-staging/rsync.ts
+++ b/core/src/build-staging/rsync.ts
@@ -14,7 +14,7 @@ import { BuildStaging, SyncParams } from "./build-staging"
 import { validateInstall } from "../util/validateInstall"
 
 const minRsyncVersion = "3.1.0"
-const versionRegex = /rsync  version [v]*([\d\.]+)  /
+const versionRegex = /rsync\s+version\s+v?(\d+.\d+.\d+)/
 
 /**
  * throws if no rsync is installed or version is too old

--- a/core/src/vcs/vcs.ts
+++ b/core/src/vcs/vcs.ts
@@ -38,7 +38,7 @@ export const NEW_MODULE_VERSION = "0000000000"
 const fileCountWarningThreshold = 10000
 
 const minGitVersion = "2.14.0"
-export const gitVersionRegex = /git version [v]*([\d\.]+)/
+export const gitVersionRegex = /git\s+version\s+v?(\d+.\d+.\d+)/
 
 /**
  * throws if no git is installed or version is too old


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the regex patterns for `git` and `rsync` version checks. The previous pattern was not accurate enough. Fow Windows output it grabbed the whole version like `2.37.0.windows.1` instead of semver-only sub-part like `2.37.0`.

Now it's fixed. The relevant error message was not informative enough. The error handling will be fixed in a separate PR.

This PR also ensures that `git` and `rsync` are installed and up-to-date in `test-macos` and `test-windows` steps of the CircleCI pipeline.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
