### PR TITLE
chore: fix cli build-pkg

### DIFF
--- a/cli/src/build-pkg.ts
+++ b/cli/src/build-pkg.ts
@@ -256,7 +256,6 @@ async function pkgCommon({
 }) {
   const targetPath = resolve(distPath, targetName)
   await remove(targetPath)
-  await mkdirp(targetPath)
 
   console.log(` - ${targetName} -> pkg`)
   await exec(pkgPath, [


### PR DESCRIPTION
`pkg` creates the output directory automatically and will fail
if the directory already exists.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Fixes CI, allows actually building artifacts.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
