### PR TITLE
Update link from project stack to commands

### DIFF
--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -419,7 +419,7 @@ ${renderCommands(commands)}
           let namespaceUrl: string | undefined
           if (cloudApi && cloudApi.environmentId && cloudApi.namespaceId) {
             const project = await cloudApi.getProject()
-            const path = `/projects/${project.id}/environments/${cloudApi.environmentId}/namespaces/${cloudApi.namespaceId}/stack`
+            const path = `/projects/${project.id}/commands`
             const url = new URL(path, cloudApi.domain)
             namespaceUrl = url.href
           }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

This PR updates the link to Cloud that is logged from the old Stack page to the current Commands page. We're already redirecting internally in Cloud from the current URL that is logged, and we'll have to keep that redirect for the foreseeable future.

This PR depends on https://github.com/garden-io/garden-platform/pull/1812.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
