### PR TITLE
fix: rename `master` to `main`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ orbs:
     GARDEN_LOGGER_TYPE: basic
 
   shared-machine-config: &shared-machine-config
-    image: 'ubuntu-2004:202010-01'
+    image: "ubuntu-2004:202010-01"
     docker_layer_caching: true
 
   remote-docker: &remote-docker
@@ -43,11 +43,11 @@ orbs:
     attach_workspace:
       at: ./
 
-  # Only run jobs on master
-  only-master: &only-master
+  # Only run jobs on main
+  only-main: &only-main
     filters:
       branches:
-        only: master
+        only: main
       tags:
         ignore: /.*/
 
@@ -81,8 +81,8 @@ commands:
     steps:
       - restore_cache:
           keys:
-          - yarn-v4-<<parameters.context>>-{{ checksum "yarn.lock" }}
-          - yarn-v4-<<parameters.context>>
+            - yarn-v4-<<parameters.context>>-{{ checksum "yarn.lock" }}
+            - yarn-v4-<<parameters.context>>
 
       - run: yarn
 
@@ -99,7 +99,6 @@ commands:
           command: |
             git config --global user.name "Garden CI"
             git config --global user.email "admin@garden.io"
-
 
   install_kubectl:
     description: Install kubectl
@@ -489,8 +488,8 @@ jobs:
       - deploy:
           name: Release docker images
           command: |
-            # Switches between git tag and master for releases
-            TAG=${CIRCLE_TAG:-master}
+            # Switches between git tag and main for releases
+            TAG=${CIRCLE_TAG:-main}
             # Push the container
             ./scripts/push-containers.sh $TAG
             # Push again with latest tag for non-pre-release tags
@@ -588,7 +587,7 @@ jobs:
       # Restore Maven cache
       - restore_cache:
           keys:
-          - m2-v1
+            - m2-v1
       # Run tests
       - run:
           name: Plugin tests
@@ -1024,18 +1023,18 @@ workflows:
           requires: [build]
           kindNodeImage: kindest/node:v1.21.2
 
-      ### MASTER ONLY ###
+      ### MAIN ONLY ###
 
       # TODO: Re-enable this if we can figure out a way to not spam users who have starred the repo.
       # - build-dist-edge:
-      #     <<: *only-master
+      #     <<: *only-main
       #     requires: [build]
       # - release-service-docker:
-      #     <<: *only-master
+      #     <<: *only-main
       #     context: docker
       #     requires: [build-dist-edge]
       # - release-service-dist-edge:
-      #     <<: *only-master
+      #     <<: *only-main
       #     requires: [build-dist-edge]
 
   tags:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--  Thanks for sending a pull request!  Here are some tips for you:
 
-1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md file.
+1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
 2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
 3. Ensure you have added or run the appropriate tests for your PR.
 4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -3,9 +3,9 @@ on:
   # Only the default branch is supported.
   branch_protection_rule:
   schedule:
-    - cron: '31 20 * * 0'
+    - cron: "31 20 * * 0"
   push:
-    branches: [ "master" ]
+    branches: ["main"]
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -22,7 +22,7 @@ jobs:
       # Needs for private repositories.
       contents: read
       actions: read
-    
+
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@dd2c410b088af7c0dc8046f3ac9a8f4148492a95
@@ -53,8 +53,8 @@ jobs:
           # repo_token: ${{ secrets.SCORECARD_READ_TOKEN }}
 
           # Publish the results for public repositories to enable scorecard badges. For more details, see
-          # https://github.com/ossf/scorecard-action#publishing-results. 
-          # For private repositories, `publish_results` will automatically be set to `false`, regardless 
+          # https://github.com/ossf/scorecard-action#publishing-results.
+          # For private repositories, `publish_results` will automatically be set to `false`, regardless
           # of the value entered here.
           publish_results: true
 
@@ -66,7 +66,7 @@ jobs:
           name: SARIF file
           path: results.sarif
           retention-days: 5
-      
+
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
         uses: github/codeql-action/upload-sarif@5f532563584d71fdef14ee64d17bafb34f751ce5 # v1.0.26

--- a/.github/workflows/update-homebrew-action.yml
+++ b/.github/workflows/update-homebrew-action.yml
@@ -4,41 +4,40 @@ on:
   release:
     types: [published]
 
-permissions:  # added using https://github.com/step-security/secure-workflows
+permissions: # added using https://github.com/step-security/secure-workflows
   contents: read
 
 jobs:
   homebrew-release:
-
-    runs-on: macOS-latest
+    runs-on: macos-latest
 
     steps:
-    - name: Checks if pre-release
-      if: github.event.release.prerelease == true
-      run: |
-        echo This is running against a pre-release.
-        echo Skipping all the next steps.
-    - name: Release Homebrew Formula
-      if: github.event.release.prerelease != true
-      uses: mislav/bump-homebrew-formula-action@21991dc8f899341b552c9842957677139a340980
-      with:
-        formula-name: garden-cli
-        formula-path: Formula/garden-cli.rb
-        homebrew-tap: garden-io/homebrew-garden
-        base-branch: master
-        create-pullrequest: true
-        download-url: https://download.garden.io/core/${{ github.event.release.tag_name }}/garden-${{ github.event.release.tag_name }}-macos-amd64.tar.gz
-        commit-message: |
-          Bump {{formulaName}} to {{version}}.
+      - name: Checks if pre-release
+        if: github.event.release.prerelease == true
+        run: |
+          echo This is running against a pre-release.
+          echo Skipping all the next steps.
+      - name: Release Homebrew Formula
+        if: github.event.release.prerelease != true
+        uses: mislav/bump-homebrew-formula-action@21991dc8f899341b552c9842957677139a340980
+        with:
+          formula-name: garden-cli
+          formula-path: Formula/garden-cli.rb
+          homebrew-tap: garden-io/homebrew-garden
+          base-branch: main
+          create-pullrequest: true
+          download-url: https://download.garden.io/core/${{ github.event.release.tag_name }}/garden-${{ github.event.release.tag_name }}-macos-amd64.tar.gz
+          commit-message: |
+            Bump {{formulaName}} to {{version}}.
 
-          For more info: https://github.com/garden-io/garden
-      env:
-        COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
-    - name: Test Homebrew package
-      if: github.event.release.prerelease != true
-      run: |
-        echo 'Testing brew install'
-        brew tap garden-io/garden
-        brew install garden-cli
-        echo 'Running garden --version'
-        garden --version
+            For more info: https://github.com/garden-io/garden
+        env:
+          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+      - name: Test Homebrew package
+        if: github.event.release.prerelease != true
+        run: |
+          echo 'Testing brew install'
+          brew tap garden-io/garden
+          brew install garden-cli
+          echo 'Running garden --version'
+          garden --version

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://docs.garden.io/?utm_source=github">Docs</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://github.com/garden-io/garden/tree/master/examples">Examples</a>
+  <a href="https://github.com/garden-io/garden/tree/main/examples">Examples</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://garden.io/blog/?utm_source=github">Blog</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
@@ -32,7 +32,7 @@ With Garden you can:
 
 This is the repo for the open source Garden Core. To learn more about Garden Cloud [click here](https://cloud.docs.garden.io/).
 
-*If you’re using Garden or if you like the project, please ★ star this repository to show your support 💖*
+_If you’re using Garden or if you like the project, please ★ star this repository to show your support 💖_
 
 ### **Getting started**
 
@@ -70,7 +70,7 @@ With the Stack Graph, each part of your stack describes itself using simple, int
 
 ![Stack Graph](docs/stack-graph-drawing.png)
 
-Garden then leverages your *existing tools and infrastructure* to execute this graph, allowing you to go **from zero to a running system in a single command**. And thanks to smart caching, it’s fast!
+Garden then leverages your _existing tools and infrastructure_ to execute this graph, allowing you to go **from zero to a running system in a single command**. And thanks to smart caching, it’s fast!
 
 For example, to create a preview environment on every pull request, simply add the following to your CI pipeline:
 
@@ -130,7 +130,7 @@ You can also head to our [community forum](https://community.garden.io/) for Qs 
 
 If you find a security issue in Garden, please follow responsible disclosure practices and send information about security issues directly to security@garden.io.
 
-For more details [see here](https://github.com/garden-io/garden/blob/master/SECURITY.md).
+For more details [see here](https://github.com/garden-io/garden/blob/main/SECURITY.md).
 
 ### **Telemetry**
 
@@ -142,4 +142,4 @@ If you are curious to see an example of the data we collect or if you would like
 
 ### **License**
 
-Garden is licensed according to [Mozilla Public License 2.0 (MPL-2.0)](https://github.com/garden-io/garden/blob/master/LICENSE.md).
+Garden is licensed according to [Mozilla Public License 2.0 (MPL-2.0)](https://github.com/garden-io/garden/blob/main/LICENSE.md).

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,23 +1,25 @@
 # Release process
 
-We have a dedicated release branch, `latest-release`, off of which we create our releases using our [release script](https://github.com/garden-io/garden/blob/master/scripts/release.ts). Once we're ready to release, we reset the `latest-release` branch to `master` and create a pre-release with the script. If there are issues with the pre-release, we merge the fixes to `master` and cherry-pick them to the `latest-release` branch. We repeat this process until all issues have been resolved and we can make a proper release.
+We have a dedicated release branch, `latest-release`, off of which we create our releases using our [release script](https://github.com/garden-io/garden/blob/main/scripts/release.ts). Once we're ready to release, we reset the `latest-release` branch to `main` and create a pre-release with the script. If there are issues with the pre-release, we merge the fixes to `main` and cherry-pick them to the `latest-release` branch. We repeat this process until all issues have been resolved and we can make a proper release.
 
-This procedure allows us to continue merging features into `master` without them being included in the release.
+This procedure allows us to continue merging features into `main` without them being included in the release.
 
-On every merge to `master` we also publish an **unstable** release with the version `edge` that is always flagged as a pre-release.
+On every merge to `main` we also publish an **unstable** release with the version `edge` that is always flagged as a pre-release.
 
 ## Release script
 
-The [release script](https://github.com/garden-io/garden/blob/master/scripts/release.ts) has the signature:
+The [release script](https://github.com/garden-io/garden/blob/main/scripts/release.ts) has the signature:
+
 ```sh
 ./scripts/release.ts <minor | patch | preminor | prepatch | prerelease> [--force] [--dry-run]
 ```
+
 and does the following:
 
-* Checks out a branch named `release-<version>`.
-* Updates `core/package.json`, `core/yarn.lock` and `CHANGELOG.md`.
-* Commits the changes, tags the commit, and pushes the tag and branch.
-* Pushing the tag triggers a CI process that creates the release artifacts and publishes them to GitHub. If the release is not a pre-release, we create a draft instead of actually publishing.
+- Checks out a branch named `release-<version>`.
+- Updates `core/package.json`, `core/yarn.lock` and `CHANGELOG.md`.
+- Commits the changes, tags the commit, and pushes the tag and branch.
+- Pushing the tag triggers a CI process that creates the release artifacts and publishes them to GitHub. If the release is not a pre-release, we create a draft instead of actually publishing.
 
 ## Steps
 
@@ -25,39 +27,39 @@ To make a new release, set your current working directory to the garden root dir
 
 1. **Checkout to the `latest-release` branch**.
 2. Make the first pre-release:
-  * Reset `latest-release` to `master` with `git reset --hard origin/master`.
-  * Run `git log` to make sure that the latest commit is the expected one and there are no unwanted changes from master included in the release.
-  * Run `./scripts/release.ts preminor|prepatch`.
-  * Wait for the CI build job to get the binaries from the [Github Releases page](https://github.com/garden-io/garden/releases).
+   - Reset `latest-release` to `main` with `git reset --hard origin/main`.
+   - Run `git log` to make sure that the latest commit is the expected one and there are no unwanted changes from `main` included in the release.
+   - Run `./scripts/release.ts preminor|prepatch`.
+   - Wait for the CI build job to get the binaries from the [Github Releases page](https://github.com/garden-io/garden/releases).
 3. Manual testing (using the pre-release/release binary)
-  * On **macOS** or **Linux**, run the `./scripts/test-release.sh <version>` script, where `<version>` should have the format `<major>.<minor>.<patch>-<preReleaseCounter>`, e.g. `0.12.38-0`. The script runs some simple tests to sanity check the release.
-  * On a **Windows** machine, run `garden deploy --dev vote --env remote` in the `vote` example project.
-    * If there are any issues with syncing, consider changing the `services[].devMode.sync[].mode` value(s) to `one-way-replica` and restarting Garden.
-    * Change a file in the `vote` service and verify that the code synchronization was successful.
-    * Open the dashboard, verify that the initial page loads without errors.
-4. You might need to include some additional commits here. For example, if any other fix(es) should be included from master, or if there are any test failures. In that case ypou need a new pre-release:
-    * Checkout to the most recent pre-release branch, e.g. `1.2.3-0`, and cherry-pick the appropriate commits from `master`.
-    * Run `./scripts/release.ts prerelease` - it will generate a new pre-release `1.2.3-1`.
-    * Repeat the manual testing.
+   - On **macOS** or **Linux**, run the `./scripts/test-release.sh <version>` script, where `<version>` should have the format `<major>.<minor>.<patch>-<preReleaseCounter>`, e.g. `0.12.38-0`. The script runs some simple tests to sanity check the release.
+   - On a **Windows** machine, run `garden deploy --dev vote --env remote` in the `vote` example project.
+   - If there are any issues with syncing, consider changing the `services[].devMode.sync[].mode` value(s) to `one-way-replica` and restarting Garden.
+   - Change a file in the `vote` service and verify that the code synchronization was successful.
+   - Open the dashboard, verify that the initial page loads without errors.
+4. You might need to include some additional commits here. For example, if any other fix(es) should be included from `main`, or if there are any test failures. In that case ypou need a new pre-release:
+   - Checkout to the most recent pre-release branch, e.g. `1.2.3-0`, and cherry-pick the appropriate commits from `main`.
+   - Run `./scripts/release.ts prerelease` - it will generate a new pre-release `1.2.3-1`.
+   - Repeat the manual testing.
 5. If you’re ready to make a proper release, do the following:
-    * Checkout to the most recent pre-release branch, e.g. `1.2.3-1`.
-    * Remove all the `bump version...` commits. E.g. by using `git rebase -i <hash-before-first-version-bump>` and `drop`-ing the commits. In this case we drop `chore(release): bump version to 1.2.3-0` and `chore(release): bump version to v.1.2.3-1`.
-    * Run `./scripts/release.ts minor | patch`. This way, the version bump commits and changelog entries created by the pre-releases are omitted from the final history.
-7. Go to our GitHub [Releases page](https://github.com/garden-io/garden/releases) and click the **Edit** button for the draft just created from CI. Note that for drafts, a new one is always created instead of replacing a previous one.
-8. Write release notes. The notes should give an overview of the release and mention all relevant features. They should also **acknowledge all external contributors** and contain the changelog for that release.
-    * Automated release notes generation:
-      * Run `./scripts/draft-release-notes.ts <previous-tag> <current-tag>`, the filename with the draft notes will be printed in the console
-      * Open the draft file (it's named `release-notes-${version}-draft.txt`, e.g. `release-notes-0.12.38-draft.txt`) and resolve all suggested TODO items
-    * Old way of release notes generation (if the automated way fails for some reason):
-      * To generate a changelog for just that tag, run `git-chglog <previous-release-tag-name>..<tag-name>`
-      * To get a list of all contributors between releases, ordered by count, run: `./scripts/show-contributors.sh <previous-tag> <current-tag>`. Note that authors of squashed commits won't show up, so it might be good to do a quick sanity check on Github as well.
-      * Take the previous release notes for GitHub as a template and apply the necessary updates.
-      * Remember to put the list of features on top of the list of bug fixes in the changelog.
-9. Click the **Publish release** button.
-10. Make a pull request for the branch that was pushed by the script and make sure it's merged as soon as possible.
-11. Make sure the `latest-release` branch contains the released version, and push it to the remote. **This branch is used for our documentation, so this step is important.**
-12. Check the `update-homebrew` GitHub Action run successfully and merge the relevant PR in the [homebrew repo](https://github.com/garden-io/homebrew-garden/pulls).
-13. Install the Homebrew package and make sure it works okay:
-    * `brew tap garden-io/garden && brew install garden-cli || true && brew update && brew upgrade garden-cli`
-    * Run `$(brew --prefix garden-cli)/bin/garden dev` (to make sure you're using the packaged release) in an example project and see if all looks well.
-14. Prepare the release announcement and publish it in our channels (Slack and Twitter). If not possible, delegate the task to an available contributor.
+   - Checkout to the most recent pre-release branch, e.g. `1.2.3-1`.
+   - Remove all the `bump version...` commits. E.g. by using `git rebase -i <hash-before-first-version-bump>` and `drop`-ing the commits. In this case we drop `chore(release): bump version to 1.2.3-0` and `chore(release): bump version to v.1.2.3-1`.
+   - Run `./scripts/release.ts minor | patch`. This way, the version bump commits and changelog entries created by the pre-releases are omitted from the final history.
+6. Go to our GitHub [Releases page](https://github.com/garden-io/garden/releases) and click the **Edit** button for the draft just created from CI. Note that for drafts, a new one is always created instead of replacing a previous one.
+7. Write release notes. The notes should give an overview of the release and mention all relevant features. They should also **acknowledge all external contributors** and contain the changelog for that release.
+   - Automated release notes generation:
+     - Run `./scripts/draft-release-notes.ts <previous-tag> <current-tag>`, the filename with the draft notes will be printed in the console
+     - Open the draft file (it's named `release-notes-${version}-draft.txt`, e.g. `release-notes-0.12.38-draft.txt`) and resolve all suggested TODO items
+   - Old way of release notes generation (if the automated way fails for some reason):
+     - To generate a changelog for just that tag, run `git-chglog <previous-release-tag-name>..<tag-name>`
+     - To get a list of all contributors between releases, ordered by count, run: `./scripts/show-contributors.sh <previous-tag> <current-tag>`. Note that authors of squashed commits won't show up, so it might be good to do a quick sanity check on Github as well.
+     - Take the previous release notes for GitHub as a template and apply the necessary updates.
+     - Remember to put the list of features on top of the list of bug fixes in the changelog.
+8. Click the **Publish release** button.
+9. Make a pull request for the branch that was pushed by the script and make sure it's merged as soon as possible.
+10. Make sure the `latest-release` branch contains the released version, and push it to the remote. **This branch is used for our documentation, so this step is important.**
+11. Check the `update-homebrew` GitHub Action run successfully and merge the relevant PR in the [homebrew repo](https://github.com/garden-io/homebrew-garden/pulls).
+12. Install the Homebrew package and make sure it works okay:
+    - `brew tap garden-io/garden && brew install garden-cli || true && brew update && brew upgrade garden-cli`
+    - Run `$(brew --prefix garden-cli)/bin/garden dev` (to make sure you're using the packaged release) in an example project and see if all looks well.
+13. Prepare the release announcement and publish it in our channels (Slack and Twitter). If not possible, delegate the task to an available contributor.

--- a/core/src/plugins/kubernetes/local-mode.ts
+++ b/core/src/plugins/kubernetes/local-mode.ts
@@ -39,7 +39,7 @@ import touch = require("touch")
 
 // export const localModeGuideLink = "https://docs.garden.io/guides/running-service-in-local-mode.md"
 export const localModeGuideLink =
-  "https://github.com/garden-io/garden/blob/master/docs/guides/running-service-in-local-mode.md"
+  "https://github.com/garden-io/garden/blob/main/docs/guides/running-service-in-local-mode.md"
 
 const localhost = "127.0.0.1"
 

--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -53,7 +53,7 @@ export function parseGitUrl(url: string) {
     throw new ConfigurationError(
       deline`
         Repository URLs must contain a hash part pointing to a specific branch or tag
-        (e.g. https://github.com/org/repo.git#master)`,
+        (e.g. https://github.com/org/repo.git#main)`,
       { repositoryUrl: url }
     )
   }

--- a/core/test/data/test-project-ext-module-sources/module-a/garden.yml
+++ b/core/test/data/test-project-ext-module-sources/module-a/garden.yml
@@ -1,6 +1,6 @@
 kind: Module
 name: module-a
-repositoryUrl: https://my-git-server.com/my-repo.git#master
+repositoryUrl: https://my-git-server.com/my-repo.git#main
 type: test
 services:
   - name: service-a

--- a/core/test/data/test-project-ext-module-sources/module-b/garden.yml
+++ b/core/test/data/test-project-ext-module-sources/module-b/garden.yml
@@ -1,6 +1,6 @@
 kind: Module
 name: module-b
-repositoryUrl: https://my-git-server.com/my-repo.git#master
+repositoryUrl: https://my-git-server.com/my-repo.git#main
 type: test
 services:
   - name: service-b

--- a/core/test/data/test-project-ext-module-sources/module-c/garden.yml
+++ b/core/test/data/test-project-ext-module-sources/module-c/garden.yml
@@ -1,6 +1,6 @@
 kind: Module
 name: module-c
-repositoryUrl: https://my-git-server.com/my-repo.git#master
+repositoryUrl: https://my-git-server.com/my-repo.git#main
 type: test
 services:
   - name: service-c

--- a/core/test/data/test-project-ext-project-sources/garden.yml
+++ b/core/test/data/test-project-ext-project-sources/garden.yml
@@ -2,11 +2,11 @@ kind: Project
 name: test-project-ext-project-sources
 sources:
   - name: source-a
-    repositoryUrl: https://my-git-server.com/my-repo.git#master
+    repositoryUrl: https://my-git-server.com/my-repo.git#main
   - name: source-b
-    repositoryUrl: https://my-git-server.com/my-repo.git#master
+    repositoryUrl: https://my-git-server.com/my-repo.git#main
   - name: source-c
-    repositoryUrl: https://my-git-server.com/my-repo.git#master
+    repositoryUrl: https://my-git-server.com/my-repo.git#main
 environments:
   - name: local
   - name: other

--- a/core/test/helpers.ts
+++ b/core/test/helpers.ts
@@ -62,7 +62,7 @@ export const testModuleVersion: ModuleVersion = {
 }
 
 // All test projects use this git URL
-export const testGitUrl = "https://my-git-server.com/my-repo.git#master"
+export const testGitUrl = "https://my-git-server.com/my-repo.git#main"
 export const testGitUrlHash = hashRepoUrl(testGitUrl)
 
 export function getDataDir(...names: string[]) {

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -2351,7 +2351,7 @@ describe("Garden", () => {
         await exec("git", ["add", "."], { cwd: repoPath })
         await exec("git", ["commit", "-m", "foo"], { cwd: repoPath })
 
-        garden.variables.sourceBranch = "master"
+        garden.variables.sourceBranch = "main"
 
         const _garden = garden as any
         _garden["projectSources"] = [
@@ -3289,7 +3289,7 @@ describe("Garden", () => {
             taskConfigs: [],
             testConfigs: [],
             spec: {},
-            repositoryUrl: "file://" + tmpRepo.path + "#master",
+            repositoryUrl: "file://" + tmpRepo.path + "#main",
             generateFiles: [
               {
                 sourcePath,
@@ -3354,7 +3354,7 @@ describe("Garden", () => {
             taskConfigs: [],
             testConfigs: [],
             spec: {},
-            repositoryUrl: "file://" + tmpRepo.path + "#master",
+            repositoryUrl: "file://" + tmpRepo.path + "#main",
             generateFiles: [
               {
                 sourcePath,
@@ -3421,7 +3421,7 @@ describe("Garden", () => {
             dotIgnoreFiles: [],
             environments: [{ name: "default", defaultNamespace, variables: {} }],
             providers: [{ name: "test-plugin" }],
-            sources: [{ name: "remote-module", repositoryUrl: "file://" + tmpRepo.path + "#master" }],
+            sources: [{ name: "remote-module", repositoryUrl: "file://" + tmpRepo.path + "#main" }],
             variables: {},
           },
         })
@@ -3478,7 +3478,7 @@ describe("Garden", () => {
             dotIgnoreFiles: [],
             environments: [{ name: "default", defaultNamespace, variables: {} }],
             providers: [{ name: "test-plugin" }],
-            sources: [{ name: "remote-module", repositoryUrl: "file://" + tmpRepo.path + "#master" }],
+            sources: [{ name: "remote-module", repositoryUrl: "file://" + tmpRepo.path + "#main" }],
             variables: {},
           },
         })

--- a/core/test/unit/src/vcs/git.ts
+++ b/core/test/unit/src/vcs/git.ts
@@ -28,7 +28,7 @@ async function getCommitMsg(repoPath: string) {
 }
 
 async function commit(msg: string, repoPath: string) {
-  // Ensure master contains changes when committing
+  // Ensure main contains changes when committing
   const uniqueFilename = `${uuidv4()}.txt`
   const filePath = join(repoPath, uniqueFilename)
   await createFile(filePath)
@@ -132,7 +132,7 @@ describe("GitHandler", () => {
       const path = tmpPath
       await commit("init", tmpPath)
       const { branch } = await handler.getPathInfo(log, path)
-      expect(branch).to.equal("master")
+      expect(branch).to.equal("main")
     })
 
     it("should return empty strings when given a path outside of a repo", async () => {
@@ -764,7 +764,7 @@ describe("GitHandler", () => {
       tmpRepoPathA = await realpath(tmpRepoA.path)
       await commit("test commit A", tmpRepoPathA)
 
-      repositoryUrlA = `file://${tmpRepoPathA}#master`
+      repositoryUrlA = `file://${tmpRepoPathA}#main`
 
       tmpRepoB = await makeTempGitRepo()
       tmpRepoPathB = await realpath(tmpRepoB.path)
@@ -967,15 +967,15 @@ describe("GitHandler", () => {
 describe("git", () => {
   describe("getCommitIdFromRefList", () => {
     it("should get the commit id from a list of commit ids and refs", () => {
-      const refList = ["abcde	ref/heads/master", "1234	ref/heads/master", "foobar	ref/heads/master"]
+      const refList = ["abcde	ref/heads/main", "1234	ref/heads/main", "foobar	ref/heads/main"]
       expect(getCommitIdFromRefList(refList)).to.equal("abcde")
     })
     it("should get the commit id from a list of commit ids without refs", () => {
-      const refList = ["abcde", "1234	ref/heads/master", "foobar	ref/heads/master"]
+      const refList = ["abcde", "1234	ref/heads/main", "foobar	ref/heads/main"]
       expect(getCommitIdFromRefList(refList)).to.equal("abcde")
     })
     it("should get the commit id from a single commit id / ref pair", () => {
-      const refList = ["abcde	ref/heads/master"]
+      const refList = ["abcde	ref/heads/main"]
       expect(getCommitIdFromRefList(refList)).to.equal("abcde")
     })
     it("should get the commit id from single commit id without a ref", () => {

--- a/docs/advanced/using-remote-sources.md
+++ b/docs/advanced/using-remote-sources.md
@@ -27,8 +27,8 @@ sources:
   - name: web-services
     repositoryUrl: https://github.com/garden-io/garden-example-remote-sources-web-services.git
   - name: db-services
-  # use #your-branch to specify a branch or #v0.3.0 to configure git version
-    repositoryUrl: https://github.com/garden-io/garden-example-remote-sources-db-services.git#master
+    # use #your-branch to specify a branch or #v0.3.0 to configure git version
+    repositoryUrl: https://github.com/garden-io/garden-example-remote-sources-db-services.git#main
 ```
 
 Note that the URL must point to a specific branch or tag.
@@ -108,7 +108,7 @@ Notice that it only contains the `garden.yml` file, all the source code is in th
 You can also import sources and modules from your local file system by setting the `repositoryUrl` to a local file path:
 
 ```yaml
-repositoryUrl: file:///my/local/project/path#master
+repositoryUrl: file:///my/local/project/path#main
 ```
 
 As usual, the URL must point to a specific branch or tag.
@@ -137,7 +137,7 @@ garden unlink source web-services
 
 Garden will only update a remote source if explicitly asked to do so via the `update-remote sources|modules` command.
 
-For example, if we had pointed the repository URL of the `web-services` source from above to something like a `master` branch, and we now wanted to pull the latest code from the remote, we would run:
+For example, if we had pointed the repository URL of the `web-services` source from above to something like a `main` branch, and we now wanted to pull the latest code from the remote, we would run:
 
 ```console
 garden update-remote source web-services

--- a/docs/getting-started/1-installation.md
+++ b/docs/getting-started/1-installation.md
@@ -4,21 +4,21 @@ This guide will walk you through setting up the Garden framework.
 
 Please follow the guide for your operating system:
 
-* [macOS](#macos)
-* [Windows](#windows)
-* [Linux](#linux)
+- [macOS](#macos)
+- [Windows](#windows)
+- [Linux](#linux)
 
 If you'd like to run Kubernetes locally, please see our [local Kubernetes guide](../guides/local-kubernetes.md)
 for installation and usage information.
 
-If you want to install Garden from source, see the instructions in our [contributor guide](https://github.com/garden-io/garden/tree/master/CONTRIBUTING.md).
+If you want to install Garden from source, see the instructions in our [contributor guide](https://github.com/garden-io/garden/tree/main/CONTRIBUTING.md).
 
 ## Requirements
 
 You need the following dependencies on your local machine to use Garden:
 
-* Git (v2.14 or newer)
-* rsync (v3.1.0 or newer)
+- Git (v2.14 or newer)
+- rsync (v3.1.0 or newer)
 
 And if you'd like to build and run services locally, you need [a local installation of Kubernetes](https://kubernetes.io/docs/tutorials/hello-minikube/). Garden is committed to supporting [the _latest six_ stable versions (i.e. if the latest stable version is v1.23.x, Garden supports v1.18.x and newer)](https://kubernetes.io/releases/).
 
@@ -82,20 +82,22 @@ _Note: The Home edition doesn't support virtualization, but you can still use Ga
 To install the Garden CLI and its dependencies, please use our installation script. To run the script, open PowerShell as an administrator and run:
 
 ```PowerShell
-Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/garden-io/garden/master/support/install.ps1'))
+Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/garden-io/garden/main/support/install.ps1'))
 ```
 
 The things the script will check for are the following:
 
-* The [Chocolatey](https://chocolatey.org) package manager. The script installs it automatically if necessary.
-* _git_ and _rsync_ . The script will install or upgrade those via Chocolatey.
+- The [Chocolatey](https://chocolatey.org) package manager. The script installs it automatically if necessary.
+- _git_ and _rsync_ . The script will install or upgrade those via Chocolatey.
 
 To later upgrade to the newest version, simply re-run the above script.
 
 We also recommend adding an exclusion folder for the `.garden` directory in your repository root to Windows Defender:
+
 ```powershell
 Add-MpPreference -ExclusionPath "C:\Path\To\Your\Repo\.garden"
 ```
+
 This will significantly speed up the first Garden build of large projects on Windows machines.
 
 Note that you must run Powershell with elevated permissions when you execute this command.
@@ -138,7 +140,7 @@ for installation and usage information.
 If you're running Garden behind a firewall, you may need to use a proxy to route external requests. To do this,
 you need to set the `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables. For example:
 
- ```sh
+```sh
 export HTTP_PROXY=http://localhost:9999               # <- Replace with your proxy address.
 export HTTPS_PROXY=$HTTP_PROXY                        # <- Replace if you use a separate proxy for HTTPS.
 export NO_PROXY=local.app.garden,localhost,127.0.0.1  # <- This is important! See below.

--- a/docs/guides/using-garden-in-ci.md
+++ b/docs/guides/using-garden-in-ci.md
@@ -2,10 +2,10 @@
 
 In this guide we'll demonstrate how Garden can fit into your continuous integration (CI) pipeline. Simply by adding extra environments to the project configuration, you can use Garden for local development _and_ for testing and deploying your project in CI. This approach has several benefits:
 
-* Use the same tool and the same set of commands for the entire development cycle, from source to finish.
-* No need to change your CI configuration when you change your stack since Garden holds the entire stack graph.
-* The only thing you need to install in CI is the Garden CLI and its dependencies (or use a ready-made Garden container image).
-* When using [in-cluster building](../guides/in-cluster-building.md) your CI also uses the same build and test result cache as you and your team, which makes for a much faster pipeline.
+- Use the same tool and the same set of commands for the entire development cycle, from source to finish.
+- No need to change your CI configuration when you change your stack since Garden holds the entire stack graph.
+- The only thing you need to install in CI is the Garden CLI and its dependencies (or use a ready-made Garden container image).
+- When using [in-cluster building](../guides/in-cluster-building.md) your CI also uses the same build and test result cache as you and your team, which makes for a much faster pipeline.
 
 To use Garden in your CI pipeline you need the following:
 
@@ -18,14 +18,14 @@ The guide is based on the [Remote Kubernetes](https://docs.garden.io/guides/remo
 
 ## Prerequisites
 
-* A [CircleCI account](https://circleci.com/)
-* A running Kubernetes cluster that you have API access to
+- A [CircleCI account](https://circleci.com/)
+- A running Kubernetes cluster that you have API access to
 
 ## Project overview
 
 The project is based on our basic [demo-project](https://github.com/garden-io/garden/tree/0.12.44/examples/demo-project) example, but configured for multiple environments. Additionally it contains a CircleCI config file. You'll find the entire source code [here](https://github.com/garden-io/ci-demo-project).
 
-The CI pipeline is configured so that Garden tests the project and deploys it to a **preview** environment on every pull request. Additionally, it tests the project and deploys it to a separate **staging** environment on every merge to the `master` branch.
+The CI pipeline is configured so that Garden tests the project and deploys it to a **preview** environment on every pull request. Additionally, it tests the project and deploys it to a separate **staging** environment on every merge to the `main` branch.
 
 To see it in action, you can fork the repository and follow the set-up steps below. Once you've set everything up, you can submit a pull request to the fork to trigger a CircleCI job which in turns deploys the project to your remote Kubernetes cluster.
 
@@ -55,9 +55,9 @@ providers:
 
 Notice that we're using the `CIRCLE_BRANCH` environment variable to label the project namespace. This ensures that each pull request gets deployed into its own namespace.
 
-The `staging` environment is configured in a similar manner. The relevant CI job is triggered on merges to the `master` branch.
+The `staging` environment is configured in a similar manner. The relevant CI job is triggered on merges to the `main` branch.
 
-You'll find the rest of the config [here](https://github.com/garden-io/ci-demo-project/blob/master/garden.yml).
+You'll find the rest of the config [here](https://github.com/garden-io/ci-demo-project/blob/main/garden.yml).
 
 ## Configure the kubectl context
 
@@ -88,13 +88,13 @@ commands:
 
 The commands use the following environment variables that you can set on the **Project Environment Variables** page (see [here](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project)) in the CircleCI dashboard:
 
-* `GCLOUD_SERVICE_KEY`: Follow [these instructions](https://cloud.google.com/sdk/docs/authorizing#authorizing_with_a_service_account) to get a service account key.
-* `GCLOUD_PROJECT_ID`, `GCLOUD_COMPUTE_ZONE`,  and `GCLOUD_CLUSTER_ID`: These you'll find under the relevant project in your Google Cloud Platform console.
+- `GCLOUD_SERVICE_KEY`: Follow [these instructions](https://cloud.google.com/sdk/docs/authorizing#authorizing_with_a_service_account) to get a service account key.
+- `GCLOUD_PROJECT_ID`, `GCLOUD_COMPUTE_ZONE`, and `GCLOUD_CLUSTER_ID`: These you'll find under the relevant project in your Google Cloud Platform console.
 
 Please refer to this [doc](https://circleci.com/docs/2.0/google-auth/) for more information on using the Google Cloud SDK in CircleCI.
 
 You'll find the entire CircleCI config for this project
-[here](https://github.com/garden-io/ci-demo-project/blob/master/.circleci/config.yml).
+[here](https://github.com/garden-io/ci-demo-project/blob/main/.circleci/config.yml).
 
 ## Running Garden commands in CircleCI
 
@@ -109,8 +109,8 @@ jobs:
     docker:
       - image: gardendev/garden-gcloud:v0.10.0-1
     environment:
-      GARDEN_LOG_LEVEL: debug     # set the log level to your preference here
-      GARDEN_LOGGER_TYPE: basic   # this is important, since the default logger doesn't play nice with CI :)
+      GARDEN_LOG_LEVEL: debug # set the log level to your preference here
+      GARDEN_LOGGER_TYPE: basic # this is important, since the default logger doesn't play nice with CI :)
     steps:
       - checkout
       - configure_kubectl_context

--- a/docs/misc/faq.md
+++ b/docs/misc/faq.md
@@ -33,7 +33,7 @@ Both, actually.
 
 We aim to change to this behavior and make it more user-friendly with our next major release.
 
-### When should I use the module-level `include`/`exclude` fields? How are they different from the project-level  `module.include/module.exclude` fields? What about ignore files?
+### When should I use the module-level `include`/`exclude` fields? How are they different from the project-level `module.include/module.exclude` fields? What about ignore files?
 
 Read all about it in [this section](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) of our docs.
 
@@ -69,7 +69,7 @@ See [this example project](https://github.com/garden-io/garden/tree/0.12.44/exam
 
 ### Can I use runtime variables in container builds (e.g. from tasks)?
 
-No, only *modules* can be build dependencies and runtime outputs come from *tasks*, *tests*, and *services*.
+No, only _modules_ can be build dependencies and runtime outputs come from _tasks_, _tests_, and _services_.
 
 ### How do I view container build logs?
 
@@ -103,7 +103,6 @@ dockerfile: dockerfiles/api.Dockerfile
 include: [api/**/*]
 
 ---
-
 kind: Module
 name: frontend
 dockerfile: dockerfiles/frontend.Dockerfile
@@ -120,7 +119,7 @@ See [this example project](https://github.com/garden-io/garden/tree/0.12.44/exam
 
 ### How do I add Docker specific flags to the build command?
 
-Use the module-level  [`extraFlags` field](https://docs.garden.io/module-types/container#extraflags).
+Use the module-level [`extraFlags` field](https://docs.garden.io/module-types/container#extraflags).
 
 ### How do I use different Dockerfiles for different environments?
 
@@ -298,7 +297,7 @@ Garden also optionally installs Nginx. The `local-kubernetes` provider defaults 
 
 Furthermore, the `openfaas` provider installs some components necessary for OpenFaas to work.
 
-Of course, we use Garden to install these components, and you’ll find the Garden modules for them in [in our source code](https://github.com/garden-io/garden/tree/master/static) under `kubernetes/system` and `openfaas/system`.
+Of course, we use Garden to install these components, and you’ll find the Garden modules for them in [in our source code](https://github.com/garden-io/garden/tree/main/static) under `kubernetes/system` and `openfaas/system`.
 
 ### How does Garden resolve the `*.local.app.garden` domain?
 

--- a/docs/reference/module-template-config.md
+++ b/docs/reference/module-template-config.md
@@ -8,8 +8,9 @@ title: Module Template Configuration
 Below is the schema reference for `ModuleTemplate` configuration files. To learn more about module templates, see the [Module Templates guide](../using-garden/module-templates.md).
 
 The reference is divided into two sections:
-* [YAML Schema](#yaml-schema) contains the config YAML schema
-* [Configuration keys](#configuration-keys) describes each individual schema key for the configuration files.
+
+- [YAML Schema](#yaml-schema) contains the config YAML schema
+- [Configuration keys](#configuration-keys) describes each individual schema key for the configuration files.
 
 Also check out the [`templated` module type reference](./module-types/templated.md).
 
@@ -184,7 +185,6 @@ modules:
 
 ## Configuration Keys
 
-
 ### `apiVersion`
 
 The schema version of this config (currently not used).
@@ -219,9 +219,9 @@ Path to a JSON schema file describing the expected inputs for the template. Must
 
 A list of modules this template will output. The schema for each is the same as when you create modules normally in configuration files, with the addition of a `path` field, which allows you to specify a sub-directory to set as the module root.
 
-In addition to any template strings you can normally use for modules (see [the reference](./template-strings/modules.md)), you can reference the inputs described by the inputs schema for the template, using ${inputs.*} template strings, as well as ${parent.name} and ${template.name}, to reference the name of the module using the template, and the name of the template itself, respectively. This also applies to file contents specified under the `files` key.
+In addition to any template strings you can normally use for modules (see [the reference](./template-strings/modules.md)), you can reference the inputs described by the inputs schema for the template, using ${inputs.\*} template strings, as well as ${parent.name} and ${template.name}, to reference the name of the module using the template, and the name of the template itself, respectively. This also applies to file contents specified under the `files` key.
 
-**Important: Make sure you use templates for any identifiers that must be unique, such as module names, service names and task names. Otherwise you'll inevitably run into configuration errors. The module names can reference the ${inputs.*}, ${parent.name} and ${template.name} keys. Other identifiers can also reference those, plus any other keys available for module templates (see [the module context reference](./template-strings/modules.md)).**
+**Important: Make sure you use templates for any identifiers that must be unique, such as module names, service names and task names. Otherwise you'll inevitably run into configuration errors. The module names can reference the ${inputs.\*}, ${parent.name} and ${template.name} keys. Other identifiers can also reference those, plus any other keys available for module templates (see [the module context reference](./template-strings/modules.md)).**
 
 | Type            | Required |
 | --------------- | -------- |
@@ -388,7 +388,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 [modules](#modules) > include
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do _not_ match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
 Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
@@ -427,7 +427,7 @@ Example:
 modules:
   - exclude:
       - tmp/**/*
-      - '*.log'
+      - "*.log"
 ```
 
 ### `modules[].repositoryUrl`
@@ -438,9 +438,9 @@ A remote repository URL. Currently only supports git servers. Must contain a has
 
 Garden will import the repository source code into this module, but read the module's config from the local garden.yml file.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `gitUrl | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `gitUrl \| string` | No       |
 
 Example:
 
@@ -531,9 +531,9 @@ module-level `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
-* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
-* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+- `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+- `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+- `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
 _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
@@ -561,4 +561,3 @@ POSIX-style path of a sub-directory to set as the module root. If the directory 
 | Type        | Required |
 | ----------- | -------- |
 | `posixPath` | No       |
-

--- a/docs/reference/module-types/configmap.md
+++ b/docs/reference/module-types/configmap.md
@@ -308,7 +308,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 ### `include[]`
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do _not_ match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
 Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
@@ -343,7 +343,7 @@ Example:
 ```yaml
 exclude:
   - tmp/**/*
-  - '*.log'
+  - "*.log"
 ```
 
 ### `repositoryUrl`
@@ -352,9 +352,9 @@ A remote repository URL. Currently only supports git servers. Must contain a has
 
 Garden will import the repository source code into this module, but read the module's config from the local garden.yml file.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `gitUrl | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `gitUrl \| string` | No       |
 
 Example:
 
@@ -436,9 +436,9 @@ module-level `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
-* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
-* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+- `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+- `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+- `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
 _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
@@ -479,7 +479,6 @@ The ConfigMap data, as a key/value map of string values.
 | Type     | Required |
 | -------- | -------- |
 | `object` | Yes      |
-
 
 ## Outputs
 
@@ -534,9 +533,9 @@ A map of all variables defined in the module.
 
 ### `${modules.<module-name>.var.<variable-name>}`
 
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
+| Type                                                 |
+| ---------------------------------------------------- |
+| `string \| number \| boolean \| link \| array[link]` |
 
 ### `${modules.<module-name>.version}`
 
@@ -551,7 +550,6 @@ Example:
 ```yaml
 my-variable: ${modules.my-module.version}
 ```
-
 
 ### Service Outputs
 
@@ -572,7 +570,6 @@ Example:
 my-variable: ${runtime.services.my-service.version}
 ```
 
-
 ### Task Outputs
 
 The following keys are available via the `${runtime.tasks.<task-name>}` template string key for `configmap` module tasks.
@@ -591,4 +588,3 @@ Example:
 ```yaml
 my-variable: ${runtime.tasks.my-tasks.version}
 ```
-

--- a/docs/reference/module-types/conftest.md
+++ b/docs/reference/module-types/conftest.md
@@ -319,7 +319,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 ### `include[]`
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do _not_ match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
 Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
@@ -354,7 +354,7 @@ Example:
 ```yaml
 exclude:
   - tmp/**/*
-  - '*.log'
+  - "*.log"
 ```
 
 ### `repositoryUrl`
@@ -363,9 +363,9 @@ A remote repository URL. Currently only supports git servers. Must contain a has
 
 Garden will import the repository source code into this module, but read the module's config from the local garden.yml file.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `gitUrl | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `gitUrl \| string` | No       |
 
 Example:
 
@@ -447,9 +447,9 @@ module-level `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
-* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
-* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+- `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+- `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+- `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
 _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
@@ -510,7 +510,6 @@ A list of files to test with the given policy. Must be POSIX-style paths, and ma
 | ------------------ | -------- |
 | `array[posixPath]` | Yes      |
 
-
 ## Outputs
 
 ### Module Outputs
@@ -564,9 +563,9 @@ A map of all variables defined in the module.
 
 ### `${modules.<module-name>.var.<variable-name>}`
 
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
+| Type                                                 |
+| ---------------------------------------------------- |
+| `string \| number \| boolean \| link \| array[link]` |
 
 ### `${modules.<module-name>.version}`
 
@@ -581,7 +580,6 @@ Example:
 ```yaml
 my-variable: ${modules.my-module.version}
 ```
-
 
 ### Service Outputs
 
@@ -602,7 +600,6 @@ Example:
 my-variable: ${runtime.services.my-service.version}
 ```
 
-
 ### Task Outputs
 
 The following keys are available via the `${runtime.tasks.<task-name>}` template string key for `conftest` module tasks.
@@ -621,4 +618,3 @@ Example:
 ```yaml
 my-variable: ${runtime.tasks.my-tasks.version}
 ```
-

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -311,7 +311,7 @@ services:
     # Health checks are disabled for services running in local mode.
     #
     # See the [Local Mode
-    # guide](https://github.com/garden-io/garden/blob/master/docs/guides/running-service-in-local-mode.md) for more
+    # guide](https://github.com/garden-io/garden/blob/main/docs/guides/running-service-in-local-mode.md) for more
     # information.
     localMode:
       # The working port of the local application.
@@ -863,7 +863,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 ### `include[]`
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do _not_ match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
 Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
@@ -905,7 +905,7 @@ Example:
 ```yaml
 exclude:
   - tmp/**/*
-  - '*.log'
+  - "*.log"
 ```
 
 ### `repositoryUrl`
@@ -914,9 +914,9 @@ A remote repository URL. Currently only supports git servers. Must contain a has
 
 Garden will import the repository source code into this module, but read the module's config from the local garden.yml file.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `gitUrl | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `gitUrl \| string` | No       |
 
 Example:
 
@@ -998,9 +998,9 @@ module-level `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
-* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
-* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+- `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+- `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+- `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
 _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
@@ -1186,7 +1186,7 @@ Example:
 ```yaml
 services:
   - annotations:
-        nginx.ingress.kubernetes.io/proxy-body-size: '0'
+      nginx.ingress.kubernetes.io/proxy-body-size: "0"
 ```
 
 ### `services[].command[]`
@@ -1205,7 +1205,7 @@ Example:
 services:
   - command:
       - /bin/sh
-      - '-c'
+      - "-c"
 ```
 
 ### `services[].args[]`
@@ -1381,9 +1381,9 @@ The default permission bits, specified as an octal, to set on directories at the
 
 Set the default owner of files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `number | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `number \| string` | No       |
 
 ### `services[].devMode.sync[].defaultGroup`
 
@@ -1391,9 +1391,9 @@ Set the default owner of files and directories at the target. Specify either an 
 
 Set the default group on files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `number | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `number \| string` | No       |
 
 ### `services[].localMode`
 
@@ -1409,7 +1409,7 @@ Local mode always takes the precedence over dev mode if there are any conflictin
 
 Health checks are disabled for services running in local mode.
 
-See the [Local Mode guide](https://github.com/garden-io/garden/blob/master/docs/guides/running-service-in-local-mode.md) for more information.
+See the [Local Mode guide](https://github.com/garden-io/garden/blob/main/docs/guides/running-service-in-local-mode.md) for more information.
 
 | Type     | Required |
 | -------- | -------- |
@@ -1502,7 +1502,7 @@ services:
       - path: /api
         port: http
       - annotations:
-            nginx.ingress.kubernetes.io/proxy-body-size: '0'
+          nginx.ingress.kubernetes.io/proxy-body-size: "0"
 ```
 
 ### `services[].ingresses[].hostname`
@@ -1566,12 +1566,12 @@ Example:
 ```yaml
 services:
   - env:
-        - MY_VAR: some-value
-          MY_SECRET_VAR:
-            secretRef:
-              name: my-secret
-              key: some-key
-        - {}
+      - MY_VAR: some-value
+        MY_SECRET_VAR:
+          secretRef:
+            name: my-secret
+            key: some-key
+      - {}
 ```
 
 ### `services[].healthCheck`
@@ -1678,7 +1678,7 @@ Example:
 services:
   - hotReloadCommand:
       - /bin/sh
-      - '-c'
+      - "-c"
 ```
 
 ### `services[].hotReloadArgs[]`
@@ -2187,7 +2187,7 @@ Example:
 tests:
   - command:
       - /bin/sh
-      - '-c'
+      - "-c"
 ```
 
 ### `tests[].env`
@@ -2205,12 +2205,12 @@ Example:
 ```yaml
 tests:
   - env:
-        - MY_VAR: some-value
-          MY_SECRET_VAR:
-            secretRef:
-              name: my-secret
-              key: some-key
-        - {}
+      - MY_VAR: some-value
+        MY_SECRET_VAR:
+          secretRef:
+            name: my-secret
+            key: some-key
+      - {}
 ```
 
 ### `tests[].cpu`
@@ -2445,7 +2445,7 @@ Example:
 tasks:
   - args:
       - rake
-      - 'db:migrate'
+      - "db:migrate"
 ```
 
 ### `tasks[].artifacts[]`
@@ -2532,7 +2532,7 @@ Example:
 tasks:
   - command:
       - /bin/sh
-      - '-c'
+      - "-c"
 ```
 
 ### `tasks[].env`
@@ -2550,12 +2550,12 @@ Example:
 ```yaml
 tasks:
   - env:
-        - MY_VAR: some-value
-          MY_SECRET_VAR:
-            secretRef:
-              name: my-secret
-              key: some-key
-        - {}
+      - MY_VAR: some-value
+        MY_SECRET_VAR:
+          secretRef:
+            name: my-secret
+            key: some-key
+      - {}
 ```
 
 ### `tasks[].cpu`
@@ -2712,7 +2712,6 @@ POSIX capabilities to remove from the running task's main container.
 | --------------- | -------- |
 | `array[string]` | No       |
 
-
 ## Outputs
 
 ### Module Outputs
@@ -2766,9 +2765,9 @@ A map of all variables defined in the module.
 
 ### `${modules.<module-name>.var.<variable-name>}`
 
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
+| Type                                                 |
+| ---------------------------------------------------- |
+| `string \| number \| boolean \| link \| array[link]` |
 
 ### `${modules.<module-name>.version}`
 
@@ -2840,7 +2839,6 @@ Example:
 my-variable: ${modules.my-module.outputs.deployment-image-id}
 ```
 
-
 ### Service Outputs
 
 The following keys are available via the `${runtime.services.<service-name>}` template string key for `container` module services.
@@ -2859,7 +2857,6 @@ Example:
 ```yaml
 my-variable: ${runtime.services.my-service.version}
 ```
-
 
 ### Task Outputs
 
@@ -2887,4 +2884,3 @@ The full log from the executed task. (Pro-tip: Make it machine readable so it ca
 | Type     | Default |
 | -------- | ------- |
 | `string` | `""`    |
-

--- a/docs/reference/module-types/exec.md
+++ b/docs/reference/module-types/exec.md
@@ -506,7 +506,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 ### `include[]`
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do _not_ match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
 Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
@@ -541,7 +541,7 @@ Example:
 ```yaml
 exclude:
   - tmp/**/*
-  - '*.log'
+  - "*.log"
 ```
 
 ### `repositoryUrl`
@@ -550,9 +550,9 @@ A remote repository URL. Currently only supports git servers. Must contain a has
 
 Garden will import the repository source code into this module, but read the module's config from the local garden.yml file.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `gitUrl | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `gitUrl \| string` | No       |
 
 Example:
 
@@ -634,9 +634,9 @@ module-level `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
-* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
-* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+- `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+- `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+- `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
 _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
@@ -1052,7 +1052,6 @@ A POSIX-style path to copy the artifacts to, relative to the project artifacts d
 | ----------- | ------- | -------- |
 | `posixPath` | `"."`   | No       |
 
-
 ## Outputs
 
 ### Module Outputs
@@ -1106,9 +1105,9 @@ A map of all variables defined in the module.
 
 ### `${modules.<module-name>.var.<variable-name>}`
 
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
+| Type                                                 |
+| ---------------------------------------------------- |
+| `string \| number \| boolean \| link \| array[link]` |
 
 ### `${modules.<module-name>.version}`
 
@@ -1123,7 +1122,6 @@ Example:
 ```yaml
 my-variable: ${modules.my-module.version}
 ```
-
 
 ### Service Outputs
 
@@ -1143,7 +1141,6 @@ Example:
 ```yaml
 my-variable: ${runtime.services.my-service.version}
 ```
-
 
 ### Task Outputs
 
@@ -1171,4 +1168,3 @@ The full log from the executed task. (Pro-tip: Make it machine readable so it ca
 | Type     | Default |
 | -------- | ------- |
 | `string` | `""`    |
-

--- a/docs/reference/module-types/hadolint.md
+++ b/docs/reference/module-types/hadolint.md
@@ -307,7 +307,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 ### `include[]`
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do _not_ match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
 Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
@@ -342,7 +342,7 @@ Example:
 ```yaml
 exclude:
   - tmp/**/*
-  - '*.log'
+  - "*.log"
 ```
 
 ### `repositoryUrl`
@@ -351,9 +351,9 @@ A remote repository URL. Currently only supports git servers. Must contain a has
 
 Garden will import the repository source code into this module, but read the module's config from the local garden.yml file.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `gitUrl | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `gitUrl \| string` | No       |
 
 Example:
 
@@ -435,9 +435,9 @@ module-level `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
-* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
-* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+- `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+- `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+- `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
 _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
@@ -462,7 +462,6 @@ POSIX-style path to a Dockerfile that you want to lint with `hadolint`.
 | Type        | Required |
 | ----------- | -------- |
 | `posixPath` | Yes      |
-
 
 ## Outputs
 
@@ -517,9 +516,9 @@ A map of all variables defined in the module.
 
 ### `${modules.<module-name>.var.<variable-name>}`
 
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
+| Type                                                 |
+| ---------------------------------------------------- |
+| `string \| number \| boolean \| link \| array[link]` |
 
 ### `${modules.<module-name>.version}`
 
@@ -534,7 +533,6 @@ Example:
 ```yaml
 my-variable: ${modules.my-module.version}
 ```
-
 
 ### Service Outputs
 
@@ -555,7 +553,6 @@ Example:
 my-variable: ${runtime.services.my-service.version}
 ```
 
-
 ### Task Outputs
 
 The following keys are available via the `${runtime.tasks.<task-name>}` template string key for `hadolint` module tasks.
@@ -574,4 +571,3 @@ Example:
 ```yaml
 my-variable: ${runtime.tasks.my-tasks.version}
 ```
-

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -261,7 +261,7 @@ devMode:
 # Health checks are disabled for services running in local mode.
 #
 # See the [Local Mode
-# guide](https://github.com/garden-io/garden/blob/master/docs/guides/running-service-in-local-mode.md) for more
+# guide](https://github.com/garden-io/garden/blob/main/docs/guides/running-service-in-local-mode.md) for more
 # information.
 localMode:
   # The working port of the local application.
@@ -755,7 +755,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 ### `include[]`
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do _not_ match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
 Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
@@ -796,7 +796,7 @@ Example:
 ```yaml
 exclude:
   - tmp/**/*
-  - '*.log'
+  - "*.log"
 ```
 
 ### `repositoryUrl`
@@ -805,9 +805,9 @@ A remote repository URL. Currently only supports git servers. Must contain a has
 
 Garden will import the repository source code into this module, but read the module's config from the local garden.yml file.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `gitUrl | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `gitUrl \| string` | No       |
 
 Example:
 
@@ -889,9 +889,9 @@ module-level `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
-* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
-* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+- `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+- `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+- `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
 _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
@@ -1104,9 +1104,9 @@ The default permission bits, specified as an octal, to set on directories at the
 
 Set the default owner of files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `number | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `number \| string` | No       |
 
 ### `devMode.sync[].defaultGroup`
 
@@ -1114,9 +1114,9 @@ Set the default owner of files and directories at the target. Specify either an 
 
 Set the default group on files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `number | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `number \| string` | No       |
 
 ### `devMode.containerName`
 
@@ -1145,7 +1145,7 @@ Local mode always takes the precedence over dev mode if there are any conflictin
 
 Health checks are disabled for services running in local mode.
 
-See the [Local Mode guide](https://github.com/garden-io/garden/blob/master/docs/guides/running-service-in-local-mode.md) for more information.
+See the [Local Mode guide](https://github.com/garden-io/garden/blob/main/docs/guides/running-service-in-local-mode.md) for more information.
 
 | Type     | Required |
 | -------- | -------- |
@@ -1479,7 +1479,7 @@ Example:
 tasks:
   - command:
       - /bin/sh
-      - '-c'
+      - "-c"
 ```
 
 ### `tasks[].args[]`
@@ -1498,7 +1498,7 @@ Example:
 tasks:
   - args:
       - rake
-      - 'db:migrate'
+      - "db:migrate"
 ```
 
 ### `tasks[].env`
@@ -1516,12 +1516,12 @@ Example:
 ```yaml
 tasks:
   - env:
-        - MY_VAR: some-value
-          MY_SECRET_VAR:
-            secretRef:
-              name: my-secret
-              key: some-key
-        - {}
+      - MY_VAR: some-value
+        MY_SECRET_VAR:
+          secretRef:
+            name: my-secret
+            key: some-key
+      - {}
 ```
 
 ### `tasks[].artifacts[]`
@@ -1582,34 +1582,35 @@ an error will be thrown.
 This can either reference a workload (i.e. a Deployment, DaemonSet or StatefulSet) via the `kind` and `name` fields, or a Pod via the `podSelector` field.
 
 The following pod spec fields from the service resource will be used (if present) when executing the task:
-* `affinity`
-* `automountServiceAccountToken`
-* `containers`
-* `dnsConfig`
-* `dnsPolicy`
-* `enableServiceLinks`
-* `hostAliases`
-* `hostIPC`
-* `hostNetwork`
-* `hostPID`
-* `hostname`
-* `imagePullSecrets`
-* `nodeName`
-* `nodeSelector`
-* `overhead`
-* `preemptionPolicy`
-* `priority`
-* `priorityClassName`
-* `runtimeClassName`
-* `schedulerName`
-* `securityContext`
-* `serviceAccount`
-* `serviceAccountName`
-* `shareProcessNamespace`
-* `subdomain`
-* `tolerations`
-* `topologySpreadConstraints`
-* `volumes`
+
+- `affinity`
+- `automountServiceAccountToken`
+- `containers`
+- `dnsConfig`
+- `dnsPolicy`
+- `enableServiceLinks`
+- `hostAliases`
+- `hostIPC`
+- `hostNetwork`
+- `hostPID`
+- `hostname`
+- `imagePullSecrets`
+- `nodeName`
+- `nodeSelector`
+- `overhead`
+- `preemptionPolicy`
+- `priority`
+- `priorityClassName`
+- `runtimeClassName`
+- `schedulerName`
+- `securityContext`
+- `serviceAccount`
+- `serviceAccountName`
+- `shareProcessNamespace`
+- `subdomain`
+- `tolerations`
+- `topologySpreadConstraints`
+- `volumes`
 
 | Type     | Required |
 | -------- | -------- |
@@ -1772,7 +1773,7 @@ Example:
 tests:
   - command:
       - /bin/sh
-      - '-c'
+      - "-c"
 ```
 
 ### `tests[].args[]`
@@ -1809,12 +1810,12 @@ Example:
 ```yaml
 tests:
   - env:
-        - MY_VAR: some-value
-          MY_SECRET_VAR:
-            secretRef:
-              name: my-secret
-              key: some-key
-        - {}
+      - MY_VAR: some-value
+        MY_SECRET_VAR:
+          secretRef:
+            name: my-secret
+            key: some-key
+      - {}
 ```
 
 ### `tests[].artifacts[]`
@@ -1875,34 +1876,35 @@ an error will be thrown.
 This can either reference a workload (i.e. a Deployment, DaemonSet or StatefulSet) via the `kind` and `name` fields, or a Pod via the `podSelector` field.
 
 The following pod spec fields from the service resource will be used (if present) when executing the test suite:
-* `affinity`
-* `automountServiceAccountToken`
-* `containers`
-* `dnsConfig`
-* `dnsPolicy`
-* `enableServiceLinks`
-* `hostAliases`
-* `hostIPC`
-* `hostNetwork`
-* `hostPID`
-* `hostname`
-* `imagePullSecrets`
-* `nodeName`
-* `nodeSelector`
-* `overhead`
-* `preemptionPolicy`
-* `priority`
-* `priorityClassName`
-* `runtimeClassName`
-* `schedulerName`
-* `securityContext`
-* `serviceAccount`
-* `serviceAccountName`
-* `shareProcessNamespace`
-* `subdomain`
-* `tolerations`
-* `topologySpreadConstraints`
-* `volumes`
+
+- `affinity`
+- `automountServiceAccountToken`
+- `containers`
+- `dnsConfig`
+- `dnsPolicy`
+- `enableServiceLinks`
+- `hostAliases`
+- `hostIPC`
+- `hostNetwork`
+- `hostPID`
+- `hostname`
+- `imagePullSecrets`
+- `nodeName`
+- `nodeSelector`
+- `overhead`
+- `preemptionPolicy`
+- `priority`
+- `priorityClassName`
+- `runtimeClassName`
+- `schedulerName`
+- `securityContext`
+- `serviceAccount`
+- `serviceAccountName`
+- `shareProcessNamespace`
+- `subdomain`
+- `tolerations`
+- `topologySpreadConstraints`
+- `volumes`
 
 | Type     | Required |
 | -------- | -------- |
@@ -2038,7 +2040,6 @@ your module directory.
 | ------------------ | ------- | -------- |
 | `array[posixPath]` | `[]`    | No       |
 
-
 ## Outputs
 
 ### Module Outputs
@@ -2092,9 +2093,9 @@ A map of all variables defined in the module.
 
 ### `${modules.<module-name>.var.<variable-name>}`
 
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
+| Type                                                 |
+| ---------------------------------------------------- |
+| `string \| number \| boolean \| link \| array[link]` |
 
 ### `${modules.<module-name>.version}`
 
@@ -2118,7 +2119,6 @@ The Helm release name of the service.
 | -------- |
 | `string` |
 
-
 ### Service Outputs
 
 The following keys are available via the `${runtime.services.<service-name>}` template string key for `helm` module services.
@@ -2138,7 +2138,6 @@ Example:
 my-variable: ${runtime.services.my-service.version}
 ```
 
-
 ### Task Outputs
 
 The following keys are available via the `${runtime.tasks.<task-name>}` template string key for `helm` module tasks.
@@ -2157,4 +2156,3 @@ Example:
 ```yaml
 my-variable: ${runtime.tasks.my-tasks.version}
 ```
-

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -352,7 +352,7 @@ services:
     # Health checks are disabled for services running in local mode.
     #
     # See the [Local Mode
-    # guide](https://github.com/garden-io/garden/blob/master/docs/guides/running-service-in-local-mode.md) for more
+    # guide](https://github.com/garden-io/garden/blob/main/docs/guides/running-service-in-local-mode.md) for more
     # information.
     localMode:
       # The working port of the local application.
@@ -1001,7 +1001,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 ### `include[]`
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do _not_ match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
 Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
@@ -1043,7 +1043,7 @@ Example:
 ```yaml
 exclude:
   - tmp/**/*
-  - '*.log'
+  - "*.log"
 ```
 
 ### `repositoryUrl`
@@ -1052,9 +1052,9 @@ A remote repository URL. Currently only supports git servers. Must contain a has
 
 Garden will import the repository source code into this module, but read the module's config from the local garden.yml file.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `gitUrl | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `gitUrl \| string` | No       |
 
 Example:
 
@@ -1136,9 +1136,9 @@ module-level `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
-* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
-* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+- `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+- `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+- `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
 _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
@@ -1324,7 +1324,7 @@ Example:
 ```yaml
 services:
   - annotations:
-        nginx.ingress.kubernetes.io/proxy-body-size: '0'
+      nginx.ingress.kubernetes.io/proxy-body-size: "0"
 ```
 
 ### `services[].command[]`
@@ -1343,7 +1343,7 @@ Example:
 services:
   - command:
       - /bin/sh
-      - '-c'
+      - "-c"
 ```
 
 ### `services[].args[]`
@@ -1519,9 +1519,9 @@ The default permission bits, specified as an octal, to set on directories at the
 
 Set the default owner of files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `number | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `number \| string` | No       |
 
 ### `services[].devMode.sync[].defaultGroup`
 
@@ -1529,9 +1529,9 @@ Set the default owner of files and directories at the target. Specify either an 
 
 Set the default group on files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `number | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `number \| string` | No       |
 
 ### `services[].localMode`
 
@@ -1547,7 +1547,7 @@ Local mode always takes the precedence over dev mode if there are any conflictin
 
 Health checks are disabled for services running in local mode.
 
-See the [Local Mode guide](https://github.com/garden-io/garden/blob/master/docs/guides/running-service-in-local-mode.md) for more information.
+See the [Local Mode guide](https://github.com/garden-io/garden/blob/main/docs/guides/running-service-in-local-mode.md) for more information.
 
 | Type     | Required |
 | -------- | -------- |
@@ -1640,7 +1640,7 @@ services:
       - path: /api
         port: http
       - annotations:
-            nginx.ingress.kubernetes.io/proxy-body-size: '0'
+          nginx.ingress.kubernetes.io/proxy-body-size: "0"
 ```
 
 ### `services[].ingresses[].hostname`
@@ -1704,12 +1704,12 @@ Example:
 ```yaml
 services:
   - env:
-        - MY_VAR: some-value
-          MY_SECRET_VAR:
-            secretRef:
-              name: my-secret
-              key: some-key
-        - {}
+      - MY_VAR: some-value
+        MY_SECRET_VAR:
+          secretRef:
+            name: my-secret
+            key: some-key
+      - {}
 ```
 
 ### `services[].healthCheck`
@@ -1816,7 +1816,7 @@ Example:
 services:
   - hotReloadCommand:
       - /bin/sh
-      - '-c'
+      - "-c"
 ```
 
 ### `services[].hotReloadArgs[]`
@@ -2325,7 +2325,7 @@ Example:
 tests:
   - command:
       - /bin/sh
-      - '-c'
+      - "-c"
 ```
 
 ### `tests[].env`
@@ -2343,12 +2343,12 @@ Example:
 ```yaml
 tests:
   - env:
-        - MY_VAR: some-value
-          MY_SECRET_VAR:
-            secretRef:
-              name: my-secret
-              key: some-key
-        - {}
+      - MY_VAR: some-value
+        MY_SECRET_VAR:
+          secretRef:
+            name: my-secret
+            key: some-key
+      - {}
 ```
 
 ### `tests[].cpu`
@@ -2583,7 +2583,7 @@ Example:
 tasks:
   - args:
       - rake
-      - 'db:migrate'
+      - "db:migrate"
 ```
 
 ### `tasks[].artifacts[]`
@@ -2670,7 +2670,7 @@ Example:
 tasks:
   - command:
       - /bin/sh
-      - '-c'
+      - "-c"
 ```
 
 ### `tasks[].env`
@@ -2688,12 +2688,12 @@ Example:
 ```yaml
 tasks:
   - env:
-        - MY_VAR: some-value
-          MY_SECRET_VAR:
-            secretRef:
-              name: my-secret
-              key: some-key
-        - {}
+      - MY_VAR: some-value
+        MY_SECRET_VAR:
+          secretRef:
+            name: my-secret
+            key: some-key
+      - {}
 ```
 
 ### `tasks[].cpu`
@@ -2850,7 +2850,6 @@ POSIX capabilities to remove from the running task's main container.
 | --------------- | -------- |
 | `array[string]` | No       |
 
-
 ## Outputs
 
 ### Module Outputs
@@ -2904,9 +2903,9 @@ A map of all variables defined in the module.
 
 ### `${modules.<module-name>.var.<variable-name>}`
 
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
+| Type                                                 |
+| ---------------------------------------------------- |
+| `string \| number \| boolean \| link \| array[link]` |
 
 ### `${modules.<module-name>.version}`
 
@@ -2921,7 +2920,6 @@ Example:
 ```yaml
 my-variable: ${modules.my-module.version}
 ```
-
 
 ### Service Outputs
 
@@ -2942,7 +2940,6 @@ Example:
 my-variable: ${runtime.services.my-service.version}
 ```
 
-
 ### Task Outputs
 
 The following keys are available via the `${runtime.tasks.<task-name>}` template string key for `jib-container` module tasks.
@@ -2961,4 +2958,3 @@ Example:
 ```yaml
 my-variable: ${runtime.tasks.my-tasks.version}
 ```
-

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -247,7 +247,7 @@ devMode:
 # Health checks are disabled for services running in local mode.
 #
 # See the [Local Mode
-# guide](https://github.com/garden-io/garden/blob/master/docs/guides/running-service-in-local-mode.md) for more
+# guide](https://github.com/garden-io/garden/blob/main/docs/guides/running-service-in-local-mode.md) for more
 # information.
 localMode:
   # The working port of the local application.
@@ -699,7 +699,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 ### `include[]`
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do _not_ match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
 Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
@@ -737,7 +737,7 @@ Example:
 ```yaml
 exclude:
   - tmp/**/*
-  - '*.log'
+  - "*.log"
 ```
 
 ### `repositoryUrl`
@@ -746,9 +746,9 @@ A remote repository URL. Currently only supports git servers. Must contain a has
 
 Garden will import the repository source code into this module, but read the module's config from the local garden.yml file.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `gitUrl | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `gitUrl \| string` | No       |
 
 Example:
 
@@ -830,9 +830,9 @@ module-level `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
-* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
-* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+- `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+- `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+- `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
 _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
@@ -999,9 +999,9 @@ The default permission bits, specified as an octal, to set on directories at the
 
 Set the default owner of files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `number | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `number \| string` | No       |
 
 ### `devMode.sync[].defaultGroup`
 
@@ -1009,9 +1009,9 @@ Set the default owner of files and directories at the target. Specify either an 
 
 Set the default group on files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `number | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `number \| string` | No       |
 
 ### `devMode.containerName`
 
@@ -1040,7 +1040,7 @@ Local mode always takes the precedence over dev mode if there are any conflictin
 
 Health checks are disabled for services running in local mode.
 
-See the [Local Mode guide](https://github.com/garden-io/garden/blob/master/docs/guides/running-service-in-local-mode.md) for more information.
+See the [Local Mode guide](https://github.com/garden-io/garden/blob/main/docs/guides/running-service-in-local-mode.md) for more information.
 
 | Type     | Required |
 | -------- | -------- |
@@ -1128,9 +1128,9 @@ Resolve the specified kustomization and include the resulting resources. Note th
 
 The directory path where the desired kustomization.yaml is, or a git repository URL. This could be the path to an overlay directory, for example. If it's a path, must be a relative POSIX-style path and must be within the module root. Defaults to the module root. If you set this to null, kustomize will not be run.
 
-| Type                 | Default | Required |
-| -------------------- | ------- | -------- |
-| `posixPath | string` | `"."`   | No       |
+| Type                  | Default | Required |
+| --------------------- | ------- | -------- |
+| `posixPath \| string` | `"."`   | No       |
 
 ### `kustomize.extraArgs[]`
 
@@ -1409,34 +1409,35 @@ an error will be thrown.
 This can either reference a workload (i.e. a Deployment, DaemonSet or StatefulSet) via the `kind` and `name` fields, or a Pod via the `podSelector` field.
 
 The following pod spec fields from the service resource will be used (if present) when executing the task:
-* `affinity`
-* `automountServiceAccountToken`
-* `containers`
-* `dnsConfig`
-* `dnsPolicy`
-* `enableServiceLinks`
-* `hostAliases`
-* `hostIPC`
-* `hostNetwork`
-* `hostPID`
-* `hostname`
-* `imagePullSecrets`
-* `nodeName`
-* `nodeSelector`
-* `overhead`
-* `preemptionPolicy`
-* `priority`
-* `priorityClassName`
-* `runtimeClassName`
-* `schedulerName`
-* `securityContext`
-* `serviceAccount`
-* `serviceAccountName`
-* `shareProcessNamespace`
-* `subdomain`
-* `tolerations`
-* `topologySpreadConstraints`
-* `volumes`
+
+- `affinity`
+- `automountServiceAccountToken`
+- `containers`
+- `dnsConfig`
+- `dnsPolicy`
+- `enableServiceLinks`
+- `hostAliases`
+- `hostIPC`
+- `hostNetwork`
+- `hostPID`
+- `hostname`
+- `imagePullSecrets`
+- `nodeName`
+- `nodeSelector`
+- `overhead`
+- `preemptionPolicy`
+- `priority`
+- `priorityClassName`
+- `runtimeClassName`
+- `schedulerName`
+- `securityContext`
+- `serviceAccount`
+- `serviceAccountName`
+- `shareProcessNamespace`
+- `subdomain`
+- `tolerations`
+- `topologySpreadConstraints`
+- `volumes`
 
 | Type     | Required |
 | -------- | -------- |
@@ -1508,7 +1509,7 @@ Example:
 tasks:
   - command:
       - /bin/sh
-      - '-c'
+      - "-c"
 ```
 
 ### `tasks[].args[]`
@@ -1527,7 +1528,7 @@ Example:
 tasks:
   - args:
       - rake
-      - 'db:migrate'
+      - "db:migrate"
 ```
 
 ### `tasks[].env`
@@ -1545,12 +1546,12 @@ Example:
 ```yaml
 tasks:
   - env:
-        - MY_VAR: some-value
-          MY_SECRET_VAR:
-            secretRef:
-              name: my-secret
-              key: some-key
-        - {}
+      - MY_VAR: some-value
+        MY_SECRET_VAR:
+          secretRef:
+            name: my-secret
+            key: some-key
+      - {}
 ```
 
 ### `tasks[].artifacts[]`
@@ -1660,34 +1661,35 @@ an error will be thrown.
 This can either reference a workload (i.e. a Deployment, DaemonSet or StatefulSet) via the `kind` and `name` fields, or a Pod via the `podSelector` field.
 
 The following pod spec fields from the service resource will be used (if present) when executing the test suite:
-* `affinity`
-* `automountServiceAccountToken`
-* `containers`
-* `dnsConfig`
-* `dnsPolicy`
-* `enableServiceLinks`
-* `hostAliases`
-* `hostIPC`
-* `hostNetwork`
-* `hostPID`
-* `hostname`
-* `imagePullSecrets`
-* `nodeName`
-* `nodeSelector`
-* `overhead`
-* `preemptionPolicy`
-* `priority`
-* `priorityClassName`
-* `runtimeClassName`
-* `schedulerName`
-* `securityContext`
-* `serviceAccount`
-* `serviceAccountName`
-* `shareProcessNamespace`
-* `subdomain`
-* `tolerations`
-* `topologySpreadConstraints`
-* `volumes`
+
+- `affinity`
+- `automountServiceAccountToken`
+- `containers`
+- `dnsConfig`
+- `dnsPolicy`
+- `enableServiceLinks`
+- `hostAliases`
+- `hostIPC`
+- `hostNetwork`
+- `hostPID`
+- `hostname`
+- `imagePullSecrets`
+- `nodeName`
+- `nodeSelector`
+- `overhead`
+- `preemptionPolicy`
+- `priority`
+- `priorityClassName`
+- `runtimeClassName`
+- `schedulerName`
+- `securityContext`
+- `serviceAccount`
+- `serviceAccountName`
+- `shareProcessNamespace`
+- `subdomain`
+- `tolerations`
+- `topologySpreadConstraints`
+- `volumes`
 
 | Type     | Required |
 | -------- | -------- |
@@ -1749,7 +1751,7 @@ Example:
 tests:
   - command:
       - /bin/sh
-      - '-c'
+      - "-c"
 ```
 
 ### `tests[].args[]`
@@ -1786,12 +1788,12 @@ Example:
 ```yaml
 tests:
   - env:
-        - MY_VAR: some-value
-          MY_SECRET_VAR:
-            secretRef:
-              name: my-secret
-              key: some-key
-        - {}
+      - MY_VAR: some-value
+        MY_SECRET_VAR:
+          secretRef:
+            name: my-secret
+            key: some-key
+      - {}
 ```
 
 ### `tests[].artifacts[]`
@@ -1849,7 +1851,6 @@ The maximum duration (in seconds) to wait for resources to deploy and become hea
 | -------- | ------- | -------- |
 | `number` | `300`   | No       |
 
-
 ## Outputs
 
 ### Module Outputs
@@ -1903,9 +1904,9 @@ A map of all variables defined in the module.
 
 ### `${modules.<module-name>.var.<variable-name>}`
 
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
+| Type                                                 |
+| ---------------------------------------------------- |
+| `string \| number \| boolean \| link \| array[link]` |
 
 ### `${modules.<module-name>.version}`
 
@@ -1920,7 +1921,6 @@ Example:
 ```yaml
 my-variable: ${modules.my-module.version}
 ```
-
 
 ### Service Outputs
 
@@ -1941,7 +1941,6 @@ Example:
 my-variable: ${runtime.services.my-service.version}
 ```
 
-
 ### Task Outputs
 
 The following keys are available via the `${runtime.tasks.<task-name>}` template string key for `kubernetes` module tasks.
@@ -1960,4 +1959,3 @@ Example:
 ```yaml
 my-variable: ${runtime.tasks.my-tasks.version}
 ```
-

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -311,7 +311,7 @@ services:
     # Health checks are disabled for services running in local mode.
     #
     # See the [Local Mode
-    # guide](https://github.com/garden-io/garden/blob/master/docs/guides/running-service-in-local-mode.md) for more
+    # guide](https://github.com/garden-io/garden/blob/main/docs/guides/running-service-in-local-mode.md) for more
     # information.
     localMode:
       # The working port of the local application.
@@ -880,7 +880,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 ### `include[]`
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do _not_ match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
 Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
@@ -915,7 +915,7 @@ Example:
 ```yaml
 exclude:
   - tmp/**/*
-  - '*.log'
+  - "*.log"
 ```
 
 ### `repositoryUrl`
@@ -924,9 +924,9 @@ A remote repository URL. Currently only supports git servers. Must contain a has
 
 Garden will import the repository source code into this module, but read the module's config from the local garden.yml file.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `gitUrl | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `gitUrl \| string` | No       |
 
 Example:
 
@@ -1008,9 +1008,9 @@ module-level `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
-* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
-* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+- `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+- `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+- `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
 _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
@@ -1196,7 +1196,7 @@ Example:
 ```yaml
 services:
   - annotations:
-        nginx.ingress.kubernetes.io/proxy-body-size: '0'
+      nginx.ingress.kubernetes.io/proxy-body-size: "0"
 ```
 
 ### `services[].command[]`
@@ -1215,7 +1215,7 @@ Example:
 services:
   - command:
       - /bin/sh
-      - '-c'
+      - "-c"
 ```
 
 ### `services[].args[]`
@@ -1391,9 +1391,9 @@ The default permission bits, specified as an octal, to set on directories at the
 
 Set the default owner of files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `number | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `number \| string` | No       |
 
 ### `services[].devMode.sync[].defaultGroup`
 
@@ -1401,9 +1401,9 @@ Set the default owner of files and directories at the target. Specify either an 
 
 Set the default group on files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `number | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `number \| string` | No       |
 
 ### `services[].localMode`
 
@@ -1419,7 +1419,7 @@ Local mode always takes the precedence over dev mode if there are any conflictin
 
 Health checks are disabled for services running in local mode.
 
-See the [Local Mode guide](https://github.com/garden-io/garden/blob/master/docs/guides/running-service-in-local-mode.md) for more information.
+See the [Local Mode guide](https://github.com/garden-io/garden/blob/main/docs/guides/running-service-in-local-mode.md) for more information.
 
 | Type     | Required |
 | -------- | -------- |
@@ -1512,7 +1512,7 @@ services:
       - path: /api
         port: http
       - annotations:
-            nginx.ingress.kubernetes.io/proxy-body-size: '0'
+          nginx.ingress.kubernetes.io/proxy-body-size: "0"
 ```
 
 ### `services[].ingresses[].hostname`
@@ -1576,12 +1576,12 @@ Example:
 ```yaml
 services:
   - env:
-        - MY_VAR: some-value
-          MY_SECRET_VAR:
-            secretRef:
-              name: my-secret
-              key: some-key
-        - {}
+      - MY_VAR: some-value
+        MY_SECRET_VAR:
+          secretRef:
+            name: my-secret
+            key: some-key
+      - {}
 ```
 
 ### `services[].healthCheck`
@@ -1688,7 +1688,7 @@ Example:
 services:
   - hotReloadCommand:
       - /bin/sh
-      - '-c'
+      - "-c"
 ```
 
 ### `services[].hotReloadArgs[]`
@@ -2197,7 +2197,7 @@ Example:
 tests:
   - command:
       - /bin/sh
-      - '-c'
+      - "-c"
 ```
 
 ### `tests[].env`
@@ -2215,12 +2215,12 @@ Example:
 ```yaml
 tests:
   - env:
-        - MY_VAR: some-value
-          MY_SECRET_VAR:
-            secretRef:
-              name: my-secret
-              key: some-key
-        - {}
+      - MY_VAR: some-value
+        MY_SECRET_VAR:
+          secretRef:
+            name: my-secret
+            key: some-key
+      - {}
 ```
 
 ### `tests[].cpu`
@@ -2455,7 +2455,7 @@ Example:
 tasks:
   - args:
       - rake
-      - 'db:migrate'
+      - "db:migrate"
 ```
 
 ### `tasks[].artifacts[]`
@@ -2542,7 +2542,7 @@ Example:
 tasks:
   - command:
       - /bin/sh
-      - '-c'
+      - "-c"
 ```
 
 ### `tasks[].env`
@@ -2560,12 +2560,12 @@ Example:
 ```yaml
 tasks:
   - env:
-        - MY_VAR: some-value
-          MY_SECRET_VAR:
-            secretRef:
-              name: my-secret
-              key: some-key
-        - {}
+      - MY_VAR: some-value
+        MY_SECRET_VAR:
+          secretRef:
+            name: my-secret
+            key: some-key
+      - {}
 ```
 
 ### `tasks[].cpu`
@@ -2775,7 +2775,6 @@ Use the default Dockerfile provided with this module. If set to `false` and no D
 | --------- | ------- | -------- |
 | `boolean` | `true`  | No       |
 
-
 ## Outputs
 
 ### Module Outputs
@@ -2829,9 +2828,9 @@ A map of all variables defined in the module.
 
 ### `${modules.<module-name>.var.<variable-name>}`
 
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
+| Type                                                 |
+| ---------------------------------------------------- |
+| `string \| number \| boolean \| link \| array[link]` |
 
 ### `${modules.<module-name>.version}`
 
@@ -2903,7 +2902,6 @@ Example:
 my-variable: ${modules.my-module.outputs.deployment-image-id}
 ```
 
-
 ### Service Outputs
 
 The following keys are available via the `${runtime.services.<service-name>}` template string key for `maven-container` module services.
@@ -2923,7 +2921,6 @@ Example:
 my-variable: ${runtime.services.my-service.version}
 ```
 
-
 ### Task Outputs
 
 The following keys are available via the `${runtime.tasks.<task-name>}` template string key for `maven-container` module tasks.
@@ -2942,4 +2939,3 @@ Example:
 ```yaml
 my-variable: ${runtime.tasks.my-tasks.version}
 ```
-

--- a/docs/reference/module-types/openfaas.md
+++ b/docs/reference/module-types/openfaas.md
@@ -338,7 +338,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 ### `include[]`
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do _not_ match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
 Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
@@ -373,7 +373,7 @@ Example:
 ```yaml
 exclude:
   - tmp/**/*
-  - '*.log'
+  - "*.log"
 ```
 
 ### `repositoryUrl`
@@ -382,9 +382,9 @@ A remote repository URL. Currently only supports git servers. Must contain a has
 
 Garden will import the repository source code into this module, but read the module's config from the local garden.yml file.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `gitUrl | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `gitUrl \| string` | No       |
 
 Example:
 
@@ -466,9 +466,9 @@ module-level `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
-* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
-* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+- `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+- `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+- `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
 _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
@@ -597,7 +597,6 @@ Key/value map of environment variables. Keys must be valid POSIX environment var
 | -------- | ------- | -------- |
 | `object` | `{}`    | No       |
 
-
 ## Outputs
 
 ### Module Outputs
@@ -651,9 +650,9 @@ A map of all variables defined in the module.
 
 ### `${modules.<module-name>.var.<variable-name>}`
 
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
+| Type                                                 |
+| ---------------------------------------------------- |
+| `string \| number \| boolean \| link \| array[link]` |
 
 ### `${modules.<module-name>.version}`
 
@@ -677,7 +676,6 @@ The full URL to query this service _from within_ the cluster.
 | -------- |
 | `string` |
 
-
 ### Service Outputs
 
 The following keys are available via the `${runtime.services.<service-name>}` template string key for `openfaas` module services.
@@ -697,7 +695,6 @@ Example:
 my-variable: ${runtime.services.my-service.version}
 ```
 
-
 ### Task Outputs
 
 The following keys are available via the `${runtime.tasks.<task-name>}` template string key for `openfaas` module tasks.
@@ -716,4 +713,3 @@ Example:
 ```yaml
 my-variable: ${runtime.tasks.my-tasks.version}
 ```
-

--- a/docs/reference/module-types/persistentvolumeclaim.md
+++ b/docs/reference/module-types/persistentvolumeclaim.md
@@ -360,7 +360,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 ### `include[]`
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do _not_ match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
 Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
@@ -395,7 +395,7 @@ Example:
 ```yaml
 exclude:
   - tmp/**/*
-  - '*.log'
+  - "*.log"
 ```
 
 ### `repositoryUrl`
@@ -404,9 +404,9 @@ A remote repository URL. Currently only supports git servers. Must contain a has
 
 Garden will import the repository source code into this module, but read the module's config from the local garden.yml file.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `gitUrl | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `gitUrl \| string` | No       |
 
 Example:
 
@@ -488,9 +488,9 @@ module-level `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
-* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
-* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+- `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+- `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+- `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
 _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
@@ -672,7 +672,6 @@ VolumeName is the binding reference to the PersistentVolume backing this claim.
 | -------- | -------- |
 | `string` | No       |
 
-
 ## Outputs
 
 ### Module Outputs
@@ -726,9 +725,9 @@ A map of all variables defined in the module.
 
 ### `${modules.<module-name>.var.<variable-name>}`
 
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
+| Type                                                 |
+| ---------------------------------------------------- |
+| `string \| number \| boolean \| link \| array[link]` |
 
 ### `${modules.<module-name>.version}`
 
@@ -743,7 +742,6 @@ Example:
 ```yaml
 my-variable: ${modules.my-module.version}
 ```
-
 
 ### Service Outputs
 
@@ -764,7 +762,6 @@ Example:
 my-variable: ${runtime.services.my-service.version}
 ```
 
-
 ### Task Outputs
 
 The following keys are available via the `${runtime.tasks.<task-name>}` template string key for `persistentvolumeclaim` module tasks.
@@ -783,4 +780,3 @@ Example:
 ```yaml
 my-variable: ${runtime.tasks.my-tasks.version}
 ```
-

--- a/docs/reference/module-types/pulumi.md
+++ b/docs/reference/module-types/pulumi.md
@@ -385,7 +385,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 ### `include[]`
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do _not_ match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
 Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
@@ -420,7 +420,7 @@ Example:
 ```yaml
 exclude:
   - tmp/**/*
-  - '*.log'
+  - "*.log"
 ```
 
 ### `repositoryUrl`
@@ -429,9 +429,9 @@ A remote repository URL. Currently only supports git servers. Must contain a has
 
 Garden will import the repository source code into this module, but read the module's config from the local garden.yml file.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `gitUrl | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `gitUrl \| string` | No       |
 
 Example:
 
@@ -513,9 +513,9 @@ module-level `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
-* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
-* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+- `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+- `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+- `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
 _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
@@ -651,8 +651,8 @@ Example:
 
 ```yaml
 stackReferences:
-  - '${runtime.services.some-pulumi-module.outputs.ip-address}'
-  - '${runtime.services.some-other-pulumi-module.outputs.database-url}'
+  - "${runtime.services.some-pulumi-module.outputs.ip-address}"
+  - "${runtime.services.some-other-pulumi-module.outputs.database-url}"
 ```
 
 ### `deployFromPreview`
@@ -678,7 +678,6 @@ The name of the pulumi stack to use. Defaults to the current environment name.
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
-
 
 ## Outputs
 
@@ -733,9 +732,9 @@ A map of all variables defined in the module.
 
 ### `${modules.<module-name>.var.<variable-name>}`
 
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
+| Type                                                 |
+| ---------------------------------------------------- |
+| `string \| number \| boolean \| link \| array[link]` |
 
 ### `${modules.<module-name>.version}`
 
@@ -750,7 +749,6 @@ Example:
 ```yaml
 my-variable: ${modules.my-module.version}
 ```
-
 
 ### Service Outputs
 
@@ -781,10 +779,9 @@ A map of all the outputs returned by the Pulumi stack.
 
 ### `${runtime.services.<service-name>.outputs.<name>}`
 
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
-
+| Type                                                 |
+| ---------------------------------------------------- |
+| `string \| number \| boolean \| link \| array[link]` |
 
 ### Task Outputs
 
@@ -804,4 +801,3 @@ Example:
 ```yaml
 my-variable: ${runtime.tasks.my-tasks.version}
 ```
-

--- a/docs/reference/module-types/templated.md
+++ b/docs/reference/module-types/templated.md
@@ -313,7 +313,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 ### `include[]`
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do _not_ match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
 Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
@@ -348,7 +348,7 @@ Example:
 ```yaml
 exclude:
   - tmp/**/*
-  - '*.log'
+  - "*.log"
 ```
 
 ### `repositoryUrl`
@@ -357,9 +357,9 @@ A remote repository URL. Currently only supports git servers. Must contain a has
 
 Garden will import the repository source code into this module, but read the module's config from the local garden.yml file.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `gitUrl | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `gitUrl \| string` | No       |
 
 Example:
 
@@ -441,9 +441,9 @@ module-level `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
-* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
-* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+- `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+- `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+- `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
 _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
@@ -478,7 +478,6 @@ Note: You can use template strings for the inputs, but be aware that inputs that
 | Type     | Required |
 | -------- | -------- |
 | `object` | No       |
-
 
 ## Outputs
 
@@ -533,9 +532,9 @@ A map of all variables defined in the module.
 
 ### `${modules.<module-name>.var.<variable-name>}`
 
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
+| Type                                                 |
+| ---------------------------------------------------- |
+| `string \| number \| boolean \| link \| array[link]` |
 
 ### `${modules.<module-name>.version}`
 
@@ -550,7 +549,6 @@ Example:
 ```yaml
 my-variable: ${modules.my-module.version}
 ```
-
 
 ### Service Outputs
 
@@ -571,7 +569,6 @@ Example:
 my-variable: ${runtime.services.my-service.version}
 ```
 
-
 ### Task Outputs
 
 The following keys are available via the `${runtime.tasks.<task-name>}` template string key for `templated` module tasks.
@@ -590,4 +587,3 @@ Example:
 ```yaml
 my-variable: ${runtime.tasks.my-tasks.version}
 ```
-

--- a/docs/reference/module-types/terraform.md
+++ b/docs/reference/module-types/terraform.md
@@ -333,7 +333,7 @@ If you disable the module, and its services, tasks or tests are referenced as _r
 
 ### `include[]`
 
-Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do *not* match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
+Specify a list of POSIX-style paths or globs that should be regarded as the source files for this module. Files that do _not_ match these paths or globs are excluded when computing the version of the module, when responding to filesystem watch events, and when staging builds.
 
 Note that you can also _exclude_ files using the `exclude` field or by placing `.gardenignore` files in your source tree, which use the same format as `.gitignore` files. See the [Configuration Files guide](https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories) for details.
 
@@ -368,7 +368,7 @@ Example:
 ```yaml
 exclude:
   - tmp/**/*
-  - '*.log'
+  - "*.log"
 ```
 
 ### `repositoryUrl`
@@ -377,9 +377,9 @@ A remote repository URL. Currently only supports git servers. Must contain a has
 
 Garden will import the repository source code into this module, but read the module's config from the local garden.yml file.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `gitUrl | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `gitUrl \| string` | No       |
 
 Example:
 
@@ -465,9 +465,9 @@ module-level `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
-* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
-* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+- `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+- `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+- `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
 _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
@@ -540,7 +540,6 @@ Use the specified Terraform workspace.
 | -------- | -------- |
 | `string` | No       |
 
-
 ## Outputs
 
 ### Module Outputs
@@ -594,9 +593,9 @@ A map of all variables defined in the module.
 
 ### `${modules.<module-name>.var.<variable-name>}`
 
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
+| Type                                                 |
+| ---------------------------------------------------- |
+| `string \| number \| boolean \| link \| array[link]` |
 
 ### `${modules.<module-name>.version}`
 
@@ -611,7 +610,6 @@ Example:
 ```yaml
 my-variable: ${modules.my-module.version}
 ```
-
 
 ### Service Outputs
 
@@ -642,10 +640,9 @@ A map of all the outputs defined in the Terraform stack.
 
 ### `${runtime.services.<service-name>.outputs.<name>}`
 
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
-
+| Type                                                 |
+| ---------------------------------------------------- |
+| `string \| number \| boolean \| link \| array[link]` |
 
 ### Task Outputs
 
@@ -665,4 +662,3 @@ Example:
 ```yaml
 my-variable: ${runtime.tasks.my-tasks.version}
 ```
-

--- a/docs/reference/project-config.md
+++ b/docs/reference/project-config.md
@@ -8,8 +8,9 @@ title: Project Configuration
 Below is the schema reference for [Project](../using-garden/projects.md) configuration files. For an introduction to configuring a Garden project, please look at our [configuration guide](../using-garden/configuration-overview.md).
 
 The reference is divided into two sections:
-* [YAML Schema](#yaml-schema) contains the Project config YAML schema
-* [Configuration keys](#configuration-keys) describes each individual schema key for Project configuration files.
+
+- [YAML Schema](#yaml-schema) contains the Project config YAML schema
+- [Configuration keys](#configuration-keys) describes each individual schema key for Project configuration files.
 
 Note that individual providers, e.g. `kubernetes`, add their own project level configuration keys. The provider types are listed on the [Providers page](../reference/providers/README.md).
 
@@ -197,7 +198,6 @@ variables: {}
 
 ## Configuration Keys
 
-
 ### `kind`
 
 Indicate what kind of config this is.
@@ -367,9 +367,9 @@ _environment-specific_ `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
-* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
-* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+- `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+- `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+- `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
 _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
@@ -591,9 +591,9 @@ outputs:
 The value for the output. Must be a primitive (string, number, boolean or null). May also be any valid template
 string.
 
-| Type                        | Required |
-| --------------------------- | -------- |
-| `string | number | boolean` | Yes      |
+| Type                          | Required |
+| ----------------------------- | -------- |
+| `string \| number \| boolean` | Yes      |
 
 Example:
 
@@ -633,9 +633,9 @@ sources:
 
 A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific branch or tag, with the format: <git remote url>#<branch|tag>
 
-| Type              | Required |
-| ----------------- | -------- |
-| `gitUrl | string` | Yes      |
+| Type               | Required |
+| ------------------ | -------- |
+| `gitUrl \| string` | Yes      |
 
 Example:
 
@@ -651,9 +651,9 @@ project-wide `variables` field.
 
 The format of the files is determined by the configured file's extension:
 
-* `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
-* `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
-* `.json` - JSON. Must contain a single JSON _object_ (not an array).
+- `.env` - Standard "dotenv" format, as defined by [dotenv](https://github.com/motdotla/dotenv#rules).
+- `.yaml`/`.yml` - YAML. The file must consist of a YAML document, which must be a map (dictionary). Keys may contain any value type.
+- `.json` - JSON. Must contain a single JSON _object_ (not an array).
 
 _NOTE: The default varfile format will change to YAML in Garden v0.13, since YAML allows for definition of nested objects and arrays._
 
@@ -680,4 +680,3 @@ Key/value map of variables to configure for all environments. Keys may contain l
 | Type     | Default | Required |
 | -------- | ------- | -------- |
 | `object` | `{}`    | No       |
-

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -68,10 +68,10 @@ providers:
       # See the following table for details on our detection mechanism:
       #
       # | Registry Name                   | Detection string | Assumed `mode=max` support |
-      # |---------------------------------|------------------|------------------------------|
-      # | AWS Elastic Container Registry  | `.dkr.ecr.`    | No                           |
-      # | Google Cloud Container Registry | `gcr.io`       | No                           |
-      # | Any other registry              | -                | Yes                          |
+      # |---------------------------------|------------------|----------------------------|
+      # | AWS Elastic Container Registry  | `.dkr.ecr.`      | No                         |
+      # | Google Cloud Container Registry | `gcr.io`         | No                         |
+      # | Any other registry              | -                | Yes                        |
       #
       # In case you need to override the defaults for your registry, you can do it like so:
       #
@@ -541,6 +541,7 @@ providers:
     # Set this to `nginx` to install/enable the NGINX ingress controller.
     setupIngressController: false
 ```
+
 ## Configuration Keys
 
 ### `providers[]`
@@ -617,6 +618,7 @@ Configuration options for the `cluster-buildkit` build mode.
 Use the `cache` configuration to customize the default cluster-buildkit cache behaviour.
 
 The default value is:
+
 ```yaml
 clusterBuildkit:
   cache:
@@ -625,6 +627,7 @@ clusterBuildkit:
 ```
 
 For every build, this will
+
 - import cached layers from a docker image tag named `_buildcache`
 - when the build is finished, upload cache information to `_buildcache`
 
@@ -637,10 +640,10 @@ we will avoid using `mode=max` with them.
 See the following table for details on our detection mechanism:
 
 | Registry Name                   | Detection string | Assumed `mode=max` support |
-|---------------------------------|------------------|------------------------------|
-| AWS Elastic Container Registry  | `.dkr.ecr.`    | No                           |
-| Google Cloud Container Registry | `gcr.io`       | No                           |
-| Any other registry              | -                | Yes                          |
+| ------------------------------- | ---------------- | -------------------------- |
+| AWS Elastic Container Registry  | `.dkr.ecr.`      | No                         |
+| Google Cloud Container Registry | `gcr.io`         | No                         |
+| Any other registry              | -                | Yes                        |
 
 In case you need to override the defaults for your registry, you can do it like so:
 
@@ -785,7 +788,7 @@ The values `min` and `max` ensure that garden passes the `mode=max` or `mode=min
 stored stored in the configured `tag`.
 
 `auto` is the same as `max` for most registries. Some popular registries do not support `max` and garden will fall back to `inline` for them.
- See the [clusterBuildkit cache option](#providers-.clusterbuildkit.cache) for a description of the detection mechanism.
+See the [clusterBuildkit cache option](#providers-.clusterbuildkit.cache) for a description of the detection mechanism.
 
 See also the [buildkit export cache documentation](https://github.com/moby/buildkit#export-cache)
 
@@ -1047,7 +1050,7 @@ Sets the deployment strategy for `container` services.
 
 The default is `"rolling"`, which performs rolling updates. There is also experimental support for blue/green deployments (via the `"blue-green"` strategy).
 
-Note that this setting only applies to `container` services (and not, for example,  `kubernetes` or `helm` services).
+Note that this setting only applies to `container` services (and not, for example, `kubernetes` or `helm` services).
 
 | Type     | Default     | Required |
 | -------- | ----------- | -------- |
@@ -1132,9 +1135,9 @@ The default permission bits, specified as an octal, to set on directories at the
 
 Set the default owner of files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `number | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `number \| string` | No       |
 
 ### `providers[].devMode.defaults.group`
 
@@ -1142,9 +1145,9 @@ Set the default owner of files and directories at the target. Specify either an 
 
 Set the default group on files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `number | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `number \| string` | No       |
 
 ### `providers[].forceSsl`
 
@@ -2019,8 +2022,8 @@ Example:
 providers:
   - tlsCertificates:
       - secretRef:
-            name: my-tls-secret
-            namespace: default
+          name: my-tls-secret
+          namespace: default
 ```
 
 ### `providers[].tlsCertificates[].secretRef.name`
@@ -2190,7 +2193,7 @@ Example:
 ```yaml
 providers:
   - systemNodeSelector:
-        disktype: ssd
+      disktype: ssd
 ```
 
 ### `providers[].registryProxyTolerations[]`
@@ -2434,9 +2437,9 @@ You can specify a string as a shorthand for `name: <name>`. Defaults to `<projec
 
 Note that the framework may generate other namespaces as well with this name as a prefix. Also note that if the namespace previously exists, Garden will attempt to add the specified labels and annotations. If the user does not have permissions to do so, a warning is shown.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `object | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `object \| string` | No       |
 
 ### `providers[].namespace.name`
 
@@ -2477,7 +2480,6 @@ Set this to `nginx` to install/enable the NGINX ingress controller.
 | Type     | Default | Required |
 | -------- | ------- | -------- |
 | `string` | `false` | No       |
-
 
 ## Outputs
 

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -65,8 +65,8 @@ providers:
       #
       # | Registry Name                   | Detection string | Assumed `mode=max` support |
       # |---------------------------------|------------------|------------------------------|
-      # | AWS Elastic Container Registry  | `.dkr.ecr.`    | No                           |
-      # | Google Cloud Container Registry | `gcr.io`       | No                           |
+      # | AWS Elastic Container Registry  | `.dkr.ecr.`      | No                           |
+      # | Google Cloud Container Registry | `gcr.io`         | No                           |
       # | Any other registry              | -                | Yes                          |
       #
       # In case you need to override the defaults for your registry, you can do it like so:
@@ -490,6 +490,7 @@ providers:
     # Set this to null or false to skip installing/enabling the `nginx` ingress controller.
     setupIngressController: nginx
 ```
+
 ## Configuration Keys
 
 ### `providers[]`
@@ -566,6 +567,7 @@ Configuration options for the `cluster-buildkit` build mode.
 Use the `cache` configuration to customize the default cluster-buildkit cache behaviour.
 
 The default value is:
+
 ```yaml
 clusterBuildkit:
   cache:
@@ -574,6 +576,7 @@ clusterBuildkit:
 ```
 
 For every build, this will
+
 - import cached layers from a docker image tag named `_buildcache`
 - when the build is finished, upload cache information to `_buildcache`
 
@@ -586,10 +589,10 @@ we will avoid using `mode=max` with them.
 See the following table for details on our detection mechanism:
 
 | Registry Name                   | Detection string | Assumed `mode=max` support |
-|---------------------------------|------------------|------------------------------|
-| AWS Elastic Container Registry  | `.dkr.ecr.`    | No                           |
-| Google Cloud Container Registry | `gcr.io`       | No                           |
-| Any other registry              | -                | Yes                          |
+| ------------------------------- | ---------------- | -------------------------- |
+| AWS Elastic Container Registry  | `.dkr.ecr.`      | No                         |
+| Google Cloud Container Registry | `gcr.io`         | No                         |
+| Any other registry              | -                | Yes                        |
 
 In case you need to override the defaults for your registry, you can do it like so:
 
@@ -734,7 +737,7 @@ The values `min` and `max` ensure that garden passes the `mode=max` or `mode=min
 stored stored in the configured `tag`.
 
 `auto` is the same as `max` for most registries. Some popular registries do not support `max` and garden will fall back to `inline` for them.
- See the [clusterBuildkit cache option](#providers-.clusterbuildkit.cache) for a description of the detection mechanism.
+See the [clusterBuildkit cache option](#providers-.clusterbuildkit.cache) for a description of the detection mechanism.
 
 See also the [buildkit export cache documentation](https://github.com/moby/buildkit#export-cache)
 
@@ -996,7 +999,7 @@ Sets the deployment strategy for `container` services.
 
 The default is `"rolling"`, which performs rolling updates. There is also experimental support for blue/green deployments (via the `"blue-green"` strategy).
 
-Note that this setting only applies to `container` services (and not, for example,  `kubernetes` or `helm` services).
+Note that this setting only applies to `container` services (and not, for example, `kubernetes` or `helm` services).
 
 | Type     | Default     | Required |
 | -------- | ----------- | -------- |
@@ -1081,9 +1084,9 @@ The default permission bits, specified as an octal, to set on directories at the
 
 Set the default owner of files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `number | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `number \| string` | No       |
 
 ### `providers[].devMode.defaults.group`
 
@@ -1091,9 +1094,9 @@ Set the default owner of files and directories at the target. Specify either an 
 
 Set the default group on files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `number | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `number \| string` | No       |
 
 ### `providers[].forceSsl`
 
@@ -1968,8 +1971,8 @@ Example:
 providers:
   - tlsCertificates:
       - secretRef:
-            name: my-tls-secret
-            namespace: default
+          name: my-tls-secret
+          namespace: default
 ```
 
 ### `providers[].tlsCertificates[].secretRef.name`
@@ -2139,7 +2142,7 @@ Example:
 ```yaml
 providers:
   - systemNodeSelector:
-        disktype: ssd
+      disktype: ssd
 ```
 
 ### `providers[].registryProxyTolerations[]`
@@ -2254,9 +2257,9 @@ providers:
 
 Specify which namespace to deploy services to (defaults to the project name). Note that the framework generates other namespaces as well with this name as a prefix.
 
-| Type              | Required |
-| ----------------- | -------- |
-| `object | string` | No       |
+| Type               | Required |
+| ------------------ | -------- |
+| `object \| string` | No       |
 
 ### `providers[].namespace.name`
 
@@ -2297,4 +2300,3 @@ Set this to null or false to skip installing/enabling the `nginx` ingress contro
 | Type     | Default   | Required |
 | -------- | --------- | -------- |
 | `string` | `"nginx"` | No       |
-

--- a/docs/reference/template-strings/custom-commands.md
+++ b/docs/reference/template-strings/custom-commands.md
@@ -301,9 +301,9 @@ A map of all variables defined in the command configuration.
 
 ### `${variables.<variable-name>}`
 
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
+| Type                                                 |
+| ---------------------------------------------------- |
+| `string \| number \| boolean \| link \| array[link]` |
 
 ### `${var.*}`
 
@@ -317,9 +317,9 @@ Alias for the variables field.
 
 Number, string or boolean
 
-| Type                        |
-| --------------------------- |
-| `string | number | boolean` |
+| Type                          |
+| ----------------------------- |
+| `string \| number \| boolean` |
 
 ### `${args.*}`
 
@@ -357,9 +357,9 @@ Every argument following -- on the command line.
 
 Number, string or boolean
 
-| Type                        |
-| --------------------------- |
-| `string | number | boolean` |
+| Type                          |
+| ----------------------------- |
+| `string \| number \| boolean` |
 
 ### `${opts.*}`
 
@@ -373,7 +373,6 @@ Map of all options, as defined in the Command spec.
 
 Number, string or boolean
 
-| Type                        |
-| --------------------------- |
-| `string | number | boolean` |
-
+| Type                          |
+| ----------------------------- |
+| `string \| number \| boolean` |

--- a/docs/reference/template-strings/environments.md
+++ b/docs/reference/template-strings/environments.md
@@ -309,9 +309,9 @@ A map of all variables defined in the project configuration.
 
 ### `${variables.<variable-name>}`
 
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
+| Type                                                 |
+| ---------------------------------------------------- |
+| `string \| number \| boolean \| link \| array[link]` |
 
 ### `${var.*}`
 
@@ -325,7 +325,6 @@ Alias for the variables field.
 
 Number, string or boolean
 
-| Type                        |
-| --------------------------- |
-| `string | number | boolean` |
-
+| Type                          |
+| ----------------------------- |
+| `string \| number \| boolean` |

--- a/docs/reference/template-strings/modules.md
+++ b/docs/reference/template-strings/modules.md
@@ -315,9 +315,9 @@ A map of all variables defined in the project configuration, including environme
 
 ### `${variables.<variable-name>}`
 
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
+| Type                                                 |
+| ---------------------------------------------------- |
+| `string \| number \| boolean \| link \| array[link]` |
 
 ### `${var.*}`
 
@@ -331,9 +331,9 @@ Alias for the variables field.
 
 Number, string or boolean
 
-| Type                        |
-| --------------------------- |
-| `string | number | boolean` |
+| Type                          |
+| ----------------------------- |
+| `string \| number \| boolean` |
 
 ### `${environment.*}`
 
@@ -405,9 +405,9 @@ The resolved configuration for the provider.
 
 The provider config key value. Refer to individual [provider references](https://docs.garden.io/reference/providers) for details.
 
-| Type                        |
-| --------------------------- |
-| `string | number | boolean` |
+| Type                          |
+| ----------------------------- |
+| `string \| number \| boolean` |
 
 ### `${providers.<provider-name>.outputs.*}`
 
@@ -421,9 +421,9 @@ The outputs defined by the provider (see individual plugin docs for details).
 
 The provider output value. Refer to individual [provider references](https://docs.garden.io/reference/providers) for details.
 
-| Type                        |
-| --------------------------- |
-| `string | number | boolean` |
+| Type                          |
+| ----------------------------- |
+| `string \| number \| boolean` |
 
 ### `${modules.*}`
 
@@ -481,9 +481,9 @@ The outputs defined by the module (see individual module type [references](https
 
 The module output value. Refer to individual [module type references](https://docs.garden.io/reference/module-types) for details.
 
-| Type                        |
-| --------------------------- |
-| `string | number | boolean` |
+| Type                          |
+| ----------------------------- |
+| `string \| number \| boolean` |
 
 ### `${modules.<module-name>.var.*}`
 
@@ -495,9 +495,9 @@ A map of all variables defined in the module.
 
 ### `${modules.<module-name>.var.<variable-name>}`
 
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
+| Type                                                 |
+| ---------------------------------------------------- |
+| `string \| number \| boolean \| link \| array[link]` |
 
 ### `${modules.<module-name>.version}`
 
@@ -541,9 +541,9 @@ The runtime outputs defined by the service (see individual module type [referenc
 
 The service output value. Refer to individual [module type references](https://docs.garden.io/reference/module-types) for details.
 
-| Type                        |
-| --------------------------- |
-| `string | number | boolean` |
+| Type                          |
+| ----------------------------- |
+| `string \| number \| boolean` |
 
 ### `${runtime.services.<service-name>.version}`
 
@@ -579,9 +579,9 @@ The runtime outputs defined by the task (see individual module type [references]
 
 The task output value. Refer to individual [module type references](https://docs.garden.io/reference/module-types) for details.
 
-| Type                        |
-| --------------------------- |
-| `string | number | boolean` |
+| Type                          |
+| ----------------------------- |
+| `string \| number \| boolean` |
 
 ### `${runtime.tasks.<task-name>.version}`
 
@@ -607,9 +607,9 @@ The inputs provided to the module through a undefined, if applicable.
 
 ### `${inputs.<input-key>}`
 
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
+| Type                                                 |
+| ---------------------------------------------------- |
+| `string \| number \| boolean \| link \| array[link]` |
 
 ### `${parent.*}`
 
@@ -686,4 +686,3 @@ Example:
 ```yaml
 my-variable: ${this.path}
 ```
-

--- a/docs/reference/template-strings/project-outputs.md
+++ b/docs/reference/template-strings/project-outputs.md
@@ -315,9 +315,9 @@ A map of all variables defined in the project configuration, including environme
 
 ### `${variables.<variable-name>}`
 
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
+| Type                                                 |
+| ---------------------------------------------------- |
+| `string \| number \| boolean \| link \| array[link]` |
 
 ### `${var.*}`
 
@@ -331,9 +331,9 @@ Alias for the variables field.
 
 Number, string or boolean
 
-| Type                        |
-| --------------------------- |
-| `string | number | boolean` |
+| Type                          |
+| ----------------------------- |
+| `string \| number \| boolean` |
 
 ### `${environment.*}`
 
@@ -405,9 +405,9 @@ The resolved configuration for the provider.
 
 The provider config key value. Refer to individual [provider references](https://docs.garden.io/reference/providers) for details.
 
-| Type                        |
-| --------------------------- |
-| `string | number | boolean` |
+| Type                          |
+| ----------------------------- |
+| `string \| number \| boolean` |
 
 ### `${providers.<provider-name>.outputs.*}`
 
@@ -421,9 +421,9 @@ The outputs defined by the provider (see individual plugin docs for details).
 
 The provider output value. Refer to individual [provider references](https://docs.garden.io/reference/providers) for details.
 
-| Type                        |
-| --------------------------- |
-| `string | number | boolean` |
+| Type                          |
+| ----------------------------- |
+| `string \| number \| boolean` |
 
 ### `${modules.*}`
 
@@ -481,9 +481,9 @@ The outputs defined by the module (see individual module type [references](https
 
 The module output value. Refer to individual [module type references](https://docs.garden.io/reference/module-types) for details.
 
-| Type                        |
-| --------------------------- |
-| `string | number | boolean` |
+| Type                          |
+| ----------------------------- |
+| `string \| number \| boolean` |
 
 ### `${modules.<module-name>.var.*}`
 
@@ -495,9 +495,9 @@ A map of all variables defined in the module.
 
 ### `${modules.<module-name>.var.<variable-name>}`
 
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
+| Type                                                 |
+| ---------------------------------------------------- |
+| `string \| number \| boolean \| link \| array[link]` |
 
 ### `${modules.<module-name>.version}`
 
@@ -541,9 +541,9 @@ The runtime outputs defined by the service (see individual module type [referenc
 
 The service output value. Refer to individual [module type references](https://docs.garden.io/reference/module-types) for details.
 
-| Type                        |
-| --------------------------- |
-| `string | number | boolean` |
+| Type                          |
+| ----------------------------- |
+| `string \| number \| boolean` |
 
 ### `${runtime.services.<service-name>.version}`
 
@@ -579,9 +579,9 @@ The runtime outputs defined by the task (see individual module type [references]
 
 The task output value. Refer to individual [module type references](https://docs.garden.io/reference/module-types) for details.
 
-| Type                        |
-| --------------------------- |
-| `string | number | boolean` |
+| Type                          |
+| ----------------------------- |
+| `string \| number \| boolean` |
 
 ### `${runtime.tasks.<task-name>.version}`
 
@@ -596,4 +596,3 @@ Example:
 ```yaml
 my-variable: ${runtime.tasks.<task-name>.version}
 ```
-

--- a/docs/reference/template-strings/providers.md
+++ b/docs/reference/template-strings/providers.md
@@ -311,9 +311,9 @@ A map of all variables defined in the project configuration, including environme
 
 ### `${variables.<variable-name>}`
 
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
+| Type                                                 |
+| ---------------------------------------------------- |
+| `string \| number \| boolean \| link \| array[link]` |
 
 ### `${var.*}`
 
@@ -327,9 +327,9 @@ Alias for the variables field.
 
 Number, string or boolean
 
-| Type                        |
-| --------------------------- |
-| `string | number | boolean` |
+| Type                          |
+| ----------------------------- |
+| `string \| number \| boolean` |
 
 ### `${environment.*}`
 
@@ -401,9 +401,9 @@ The resolved configuration for the provider.
 
 The provider config key value. Refer to individual [provider references](https://docs.garden.io/reference/providers) for details.
 
-| Type                        |
-| --------------------------- |
-| `string | number | boolean` |
+| Type                          |
+| ----------------------------- |
+| `string \| number \| boolean` |
 
 ### `${providers.<provider-name>.outputs.*}`
 
@@ -417,7 +417,6 @@ The outputs defined by the provider (see individual plugin docs for details).
 
 The provider output value. Refer to individual [provider references](https://docs.garden.io/reference/providers) for details.
 
-| Type                        |
-| --------------------------- |
-| `string | number | boolean` |
-
+| Type                          |
+| ----------------------------- |
+| `string \| number \| boolean` |

--- a/docs/reference/template-strings/remote-sources.md
+++ b/docs/reference/template-strings/remote-sources.md
@@ -309,9 +309,9 @@ A map of all variables defined in the project configuration, including environme
 
 ### `${variables.<variable-name>}`
 
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
+| Type                                                 |
+| ---------------------------------------------------- |
+| `string \| number \| boolean \| link \| array[link]` |
 
 ### `${var.*}`
 
@@ -325,9 +325,9 @@ Alias for the variables field.
 
 Number, string or boolean
 
-| Type                        |
-| --------------------------- |
-| `string | number | boolean` |
+| Type                          |
+| ----------------------------- |
+| `string \| number \| boolean` |
 
 ### `${environment.*}`
 
@@ -378,4 +378,3 @@ Example:
 ```yaml
 my-variable: ${environment.namespace}
 ```
-

--- a/docs/reference/template-strings/workflows.md
+++ b/docs/reference/template-strings/workflows.md
@@ -311,9 +311,9 @@ A map of all variables defined in the project configuration, including environme
 
 ### `${variables.<variable-name>}`
 
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
+| Type                                                 |
+| ---------------------------------------------------- |
+| `string \| number \| boolean \| link \| array[link]` |
 
 ### `${var.*}`
 
@@ -327,9 +327,9 @@ Alias for the variables field.
 
 Number, string or boolean
 
-| Type                        |
-| --------------------------- |
-| `string | number | boolean` |
+| Type                          |
+| ----------------------------- |
+| `string \| number \| boolean` |
 
 ### `${environment.*}`
 
@@ -411,7 +411,6 @@ for its output schema.
 
 ### `${steps.<step-name>.outputs.<output-key>}`
 
-| Type                                             |
-| ------------------------------------------------ |
-| `string | number | boolean | link | array[link]` |
-
+| Type                                                 |
+| ---------------------------------------------------- |
+| `string \| number \| boolean \| link \| array[link]` |

--- a/examples/disabled-configs/README.md
+++ b/examples/disabled-configs/README.md
@@ -1,6 +1,6 @@
 # Disabled configs example project
 
-A simple variation on the [demo-project](https://github.com/garden-io/garden/blob/master/examples/demo-project/README.md) where the `backend` module, and the `integ` test in the `frontend` module, are disabled for the `local` environment.
+A simple variation on the [demo-project](https://github.com/garden-io/garden/blob/main/examples/demo-project/README.md) where the `backend` module, and the `integ` test in the `frontend` module, are disabled for the `local` environment.
 
 The `backend` config then looks like this:
 

--- a/examples/local-exec/backend/go.mod
+++ b/examples/local-exec/backend/go.mod
@@ -1,3 +1,3 @@
-module github.com/garden-io/garden/tree/master/examples/local-exec/backend
+module github.com/garden-io/garden/tree/main/examples/local-exec/backend
 
 go 1.18

--- a/examples/local-service/README.md
+++ b/examples/local-service/README.md
@@ -5,7 +5,7 @@ remotely but frontend services locally.
 
 ## Project Structure
 
-This project is based on the [demo-project](https://github.com/garden-io/garden/tree/master/examples/demo-project) and contains a `backend` module, a
+This project is based on the [demo-project](https://github.com/garden-io/garden/tree/main/examples/demo-project) and contains a `backend` module, a
 `frontend` module and a `frontend-local` module.
 
 Here's an excerpt from the `frontend` config:
@@ -23,7 +23,6 @@ variables:
 # ...
 
 ---
-
 kind: Module
 name: frontend-local
 type: exec # <--- This is a "local exec module"
@@ -65,4 +64,3 @@ You can now stream logs from both the local and remote services with the logs co
 ```console
 garden logs --follow
 ```
-

--- a/examples/remote-sources/garden.yml
+++ b/examples/remote-sources/garden.yml
@@ -5,7 +5,7 @@ sources:
     # use #your-branch to specify a branch or #v0.3.0 to specify a tag
     repositoryUrl: https://github.com/garden-io/garden-example-remote-sources-web-services.git#v0.4.0
   - name: db-services
-    repositoryUrl: https://github.com/garden-io/garden-example-remote-sources-db-services.git#master
+    repositoryUrl: https://github.com/garden-io/garden-example-remote-sources-db-services.git#main
 environments:
   - name: local
     variables:
@@ -24,8 +24,8 @@ providers:
     defaultHostname: ${var.baseHostname}
     buildMode: kaniko
     deploymentRegistry:
-      hostname: eu.gcr.io    # <- set this according to the region your cluster runs in
-      namespace: garden-ci   # <- set this to the project ID of the target cluster
+      hostname: eu.gcr.io # <- set this according to the region your cluster runs in
+      namespace: garden-ci # <- set this to the project ID of the target cluster
     imagePullSecrets:
       # Make sure this matches the name and namespace of the imagePullSecret you've created
       # to authenticate with your registry (if needed)

--- a/examples/spring-boot-hot-reload/README.md
+++ b/examples/spring-boot-hot-reload/README.md
@@ -8,7 +8,7 @@ You'll need to have Java and [Maven](https://maven.apache.org/install.html) inst
 
 ## Overview
 
-This project consists of a single module (in the `devtools` directory), which is a minimally modified version of the [Spring Boot devtools sample project found here](https://github.com/spring-projects/spring-boot/tree/master/spring-boot-project/spring-boot-devtools).
+This project consists of a single module (in the `devtools` directory), which is a minimally modified version of the [Spring Boot devtools sample project found here](https://github.com/spring-projects/spring-boot/tree/main/spring-boot-project/spring-boot-devtools).
 
 We've changed the parent pom from `spring-boot-samples` to `spring-boot-starter-parent`, and added a dependency on `spring-boot-starter-actuator` (to enable the health check endpoint for k8s readiness and liveness probes). We've also removed the artificial 5 second delay that was added by the `slowRestart` method in `MyController`.
 
@@ -38,6 +38,7 @@ took 67 sec)
 
 🕑  Waiting for code changes
 ```
+
 Open the ingress URL (http://spring-boot-hot-reload.local.app.garden above) in a web browser.
 
 Now, change the value of the `MESSAGE` constant in `devtools/src/main/java/sample/devtools/Message.java` to something else than `"Message"`, and run `mvn compile` (again in the `devtools` directory).

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -6,8 +6,8 @@ yarn run generate-docs
 git diff --quiet HEAD -- docs/ || (echo 'generated docs are not up-to-date! run \"yarn generate-docs\" and commit the changes\n' && exit 1)
 
 # Use "|| true" so we don't exit on empty
-modified_docs=$(git diff --name-status master docs README.md) || true
-modified_examples=$(git diff --name-status master examples | grep "examples.*\README.md$") || true
+modified_docs=$(git diff --name-status main docs README.md) || true
+modified_examples=$(git diff --name-status main examples | grep "examples.*\README.md$") || true
 
 found_dead_links=false
 check_links() {

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -221,7 +221,7 @@ async function release() {
       https://github.com/garden-io/garden/pull/new/${branchName}\n
 
     Please refer to our contributing docs for the next steps:
-    https://github.com/garden-io/garden/blob/master/CONTRIBUTING.md
+    https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md
   `);
   }
 }

--- a/support/install.ps1
+++ b/support/install.ps1
@@ -7,7 +7,7 @@
 # 3. Installs or updates the garden binary.
 #
 # To execute it run the following command in PowerShell:
-# Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/garden-io/garden/master/support/install.ps1'))
+# Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/garden-io/garden/main/support/install.ps1'))
 #
 # For more information visit https://docs.garden.io/
 


### PR DESCRIPTION
- rename `master` to `main` in a lot of documentation and configuration
- semantic fixes to docs markdown tables, fixes the rendering of multi-option fields
- various tiny formatting fixes with `prettier` and format-on-save