### PR TITLE
fix: subcommand help listing

### DIFF
--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -606,10 +606,6 @@ ${renderCommands(commands)}
       return done(1, chalk.red(`Could not find specified root path (${argv.root})`))
     }
 
-    if (argv._.length === 0 || argv._[0] === "help") {
-      return done(0, await this.renderHelp(workingDir))
-    }
-
     let projectConfig: ProjectResource | undefined
 
     // First look for native Garden commands
@@ -627,8 +623,9 @@ ${renderCommands(commands)}
       }
     }
 
+    // If we still haven't found a valid command, print help
     if (!command) {
-      const exitCode = argv.h || argv.help ? 0 : 1
+      const exitCode = argv._.length === 0 || argv._[0] === "help" ? 0 : 1
       return done(exitCode, await this.renderHelp(workingDir))
     }
 

--- a/core/test/unit/src/cli/cli.ts
+++ b/core/test/unit/src/cli/cli.ts
@@ -41,6 +41,7 @@ import { expectError } from "../../../../src/util/testing"
 import { GlobalConfigStore, RequirementsCheck } from "../../../../src/config-store"
 import { ExecConfigStore } from "../config-store"
 import tmp from "tmp-promise"
+import { CloudCommand } from "../../../../src/commands/cloud/cloud"
 
 describe("cli", () => {
   let cli: GardenCli
@@ -297,6 +298,38 @@ describe("cli", () => {
 
       expect(code).to.equal(0)
       expect(consoleOutput).to.equal(cmd.renderHelp())
+    })
+
+    it("shows nested subcommand help text if provided subcommand is a group", async () => {
+      const cmd = new CloudCommand()
+      const secrets = new cmd.subCommands[0]()
+      const { code, consoleOutput } = await cli.run({ args: ["cloud", "secrets"], exitOnError: false })
+
+      expect(code).to.equal(0)
+      expect(consoleOutput).to.equal(secrets.renderHelp())
+    })
+
+    it("shows nested subcommand help text if requested", async () => {
+      const cmd = new CloudCommand()
+      const secrets = new cmd.subCommands[0]()
+      const { code, consoleOutput } = await cli.run({ args: ["cloud", "secrets", "--help"], exitOnError: false })
+
+      expect(code).to.equal(0)
+      expect(consoleOutput).to.equal(secrets.renderHelp())
+    })
+
+    it("errors and shows general help if nonexistent command is given", async () => {
+      const { code, consoleOutput } = await cli.run({ args: ["nonexistent"], exitOnError: false })
+
+      expect(code).to.equal(1)
+      expect(consoleOutput).to.equal(await cli.renderHelp("/"))
+    })
+
+    it("errors and shows general help if nonexistent command is given with --help", async () => {
+      const { code, consoleOutput } = await cli.run({ args: ["nonexistent", "--help"], exitOnError: false })
+
+      expect(code).to.equal(1)
+      expect(consoleOutput).to.equal(await cli.renderHelp("/"))
     })
 
     it("picks and runs a command", async () => {


### PR DESCRIPTION
# Subcommand help listing fix

Fixes https://github.com/garden-io/garden/issues/3256
Tiny simplifications to `cli.ts` help handling while at it.
Slightly more correct return values for nonexistent commands even with `-h` passed.

## Before:

```
garden cloud

USAGE
  garden cloud <command> [options]

COMMANDS
  cloud groups   List groups.
  cloud secrets  List, create, and delete secrets.
  cloud users    List, create, and delete users.
```

```
garden cloud users

USAGE
  garden cloud <command> [options]

COMMANDS
  cloud groups   List groups.
  cloud secrets  List, create, and delete secrets.
  cloud users    List, create, and delete users.
```

| command                         | return |
| ------------------------------- | ------ |
| garden; echo $?;                | 0      |
| garden help; echo $?;           | 0      |
| garden -h; echo $?;             | 0      |
| garden cloud; echo $?;          | 0      |
| garden cloud users; echo $?;    | 0      |
| garden nonexistent; echo $?;    | 1      |
| garden nonexistent -h; echo $?; | 0      |

## After:

```
garden cloud

USAGE
  garden cloud <command> [options]

COMMANDS
  cloud groups   List groups.
  cloud secrets  List, create, and delete secrets.
  cloud users    List, create, and delete users.
```

```
garden cloud users

USAGE
  garden users <command> [options]

COMMANDS
  users create  Create users
  users delete  Delete users.
  users list    List users.
```

| command                         | return |
| ------------------------------- | ------ |
| garden; echo $?;                | 0      |
| garden help; echo $?;           | 0      |
| garden -h; echo $?;             | 0      |
| garden cloud; echo $?;          | 0      |
| garden cloud users; echo $?;    | 0      |
| garden nonexistent; echo $?;    | 1      |
| garden nonexistent -h; echo $?; | 1      |
