### PR TITLE
Stricter validation

### DIFF
--- a/docs/reference/providers/pulumi.md
+++ b/docs/reference/providers/pulumi.md
@@ -120,9 +120,9 @@ providers:
 
 The version of pulumi to use. Set to `null` to use whichever version of `pulumi` is on your PATH.
 
-| Type     | Default    | Required |
-| -------- | ---------- | -------- |
-| `string` | `"3.25.1"` | No       |
+| Type     | Allowed Values           | Default    | Required |
+| -------- | ------------------------ | ---------- | -------- |
+| `string` | "3.25.1", "3.24.1", null | `"3.25.1"` | Yes      |
 
 ### `providers[].previewDir`
 

--- a/docs/reference/providers/terraform.md
+++ b/docs/reference/providers/terraform.md
@@ -167,9 +167,9 @@ A map of variables to use when applying Terraform stacks. You can define these h
 
 The version of Terraform to use. Set to `null` to use whichever version of `terraform` that is on your PATH.
 
-| Type     | Default   | Required |
-| -------- | --------- | -------- |
-| `string` | `"1.2.9"` | No       |
+| Type     | Allowed Values                                        | Default   | Required |
+| -------- | ----------------------------------------------------- | --------- | -------- |
+| `string` | "0.12.26", "0.13.3", "0.14.7", "1.0.5", "1.2.9", null | `"1.2.9"` | Yes      |
 
 ### `providers[].workspace`
 

--- a/plugins/pulumi/config.ts
+++ b/plugins/pulumi/config.ts
@@ -29,6 +29,7 @@ export const pulumiProviderConfigSchema = providerConfigBaseSchema()
     version: joi
       .string()
       .allow(...supportedVersions, null)
+      .only()
       .default(defaultPulumiVersion).description(dedent`
         The version of pulumi to use. Set to \`null\` to use whichever version of \`pulumi\` is on your PATH.
       `),

--- a/plugins/terraform/index.ts
+++ b/plugins/terraform/index.ts
@@ -60,6 +60,7 @@ const configSchema = providerConfigBaseSchema()
     version: joi
       .string()
       .allow(...supportedVersions, null)
+      .only()
       .default(defaultTerraformVersion).description(dedent`
         The version of Terraform to use. Set to \`null\` to use whichever version of \`terraform\` that is on your PATH.
       `),


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the version validation for Terraform and Pulumi plugins. The validation is now more strict, and the error messages are more informative.

**Before:**
```
Failed resolving provider terraform. Here is the output:
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Unsupported Terraform version: 0.13.0
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Failed resolving one or more providers:
- terraform
```

**After:**
```
Failed resolving provider terraform. Here is the output:
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Error validating provider configuration: key .version must be one of [0.12.26, 0.13.3, 0.14.7, 1.0.5, 1.2.9, null]
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Failed resolving one or more providers:
- terraform
```

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
