### PR TITLE
docs: noted experimental status of the local mode feature in the docs

### DIFF
--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -394,7 +394,7 @@ export const containerLocalModeSchema = () =>
       ),
     restart: localModeRestartSchema(),
   }).description(dedent`
-    Configures the local application which will send and receive network requests instead of the target resource.
+    [EXPERIMENTAL] Configures the local application which will send and receive network requests instead of the target resource.
 
     The target service will be replaced by a proxy container which runs an SSH server to proxy requests.
     Reverse port-forwarding will be automatically configured to route traffic to the local service and back.
@@ -405,6 +405,8 @@ export const containerLocalModeSchema = () =>
     Health checks are disabled for services running in local mode.
 
     See the [Local Mode guide](${localModeGuideLink}) for more information.
+
+    Note! This feature is still experimental. Some incompatible changes can be made until the first non-experimental release.
   `)
 
 export type ContainerServiceConfig = ServiceConfig<ContainerServiceSpec>

--- a/docs/guides/running-service-in-local-mode.md
+++ b/docs/guides/running-service-in-local-mode.md
@@ -9,6 +9,14 @@
 * **Local service** - a locally deployed and running application which is supposed to replace a target Garden service
   configured in _local mode_.
 
+## Development status
+
+This feature is still **experimental**. We're still working on some open tasks to improve the feature
+stability and usability. It means that:
+
+* some **incompatible changes can be made** until the first non-experimental release
+* there are some functional limitations, see the **Current limitations** section below
+
 ## Introduction
 
 By configuring a Garden service in _local mode_, one can replace a target Kubernetes workload in a k8s cluster with a

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -300,7 +300,8 @@ services:
           # information.
           defaultGroup:
 
-    # Configures the local application which will send and receive network requests instead of the target resource.
+    # [EXPERIMENTAL] Configures the local application which will send and receive network requests instead of the
+    # target resource.
     #
     # The target service will be replaced by a proxy container which runs an SSH server to proxy requests.
     # Reverse port-forwarding will be automatically configured to route traffic to the local service and back.
@@ -311,6 +312,9 @@ services:
     # Health checks are disabled for services running in local mode.
     #
     # See the [Local Mode guide](https://docs.garden.io/guides/running-service-in-local-mode) for more information.
+    #
+    # Note! This feature is still experimental. Some incompatible changes can be made until the first non-experimental
+    # release.
     localMode:
       # The reverse port-forwards configuration for the local application.
       ports:
@@ -1402,7 +1406,7 @@ Set the default group on files and directories at the target. Specify either an 
 
 [services](#services) > localMode
 
-Configures the local application which will send and receive network requests instead of the target resource.
+[EXPERIMENTAL] Configures the local application which will send and receive network requests instead of the target resource.
 
 The target service will be replaced by a proxy container which runs an SSH server to proxy requests.
 Reverse port-forwarding will be automatically configured to route traffic to the local service and back.
@@ -1413,6 +1417,8 @@ Local mode always takes the precedence over dev mode if there are any conflictin
 Health checks are disabled for services running in local mode.
 
 See the [Local Mode guide](https://docs.garden.io/guides/running-service-in-local-mode) for more information.
+
+Note! This feature is still experimental. Some incompatible changes can be made until the first non-experimental release.
 
 | Type     | Required |
 | -------- | -------- |

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -341,7 +341,8 @@ services:
           # information.
           defaultGroup:
 
-    # Configures the local application which will send and receive network requests instead of the target resource.
+    # [EXPERIMENTAL] Configures the local application which will send and receive network requests instead of the
+    # target resource.
     #
     # The target service will be replaced by a proxy container which runs an SSH server to proxy requests.
     # Reverse port-forwarding will be automatically configured to route traffic to the local service and back.
@@ -352,6 +353,9 @@ services:
     # Health checks are disabled for services running in local mode.
     #
     # See the [Local Mode guide](https://docs.garden.io/guides/running-service-in-local-mode) for more information.
+    #
+    # Note! This feature is still experimental. Some incompatible changes can be made until the first non-experimental
+    # release.
     localMode:
       # The reverse port-forwards configuration for the local application.
       ports:
@@ -1540,7 +1544,7 @@ Set the default group on files and directories at the target. Specify either an 
 
 [services](#services) > localMode
 
-Configures the local application which will send and receive network requests instead of the target resource.
+[EXPERIMENTAL] Configures the local application which will send and receive network requests instead of the target resource.
 
 The target service will be replaced by a proxy container which runs an SSH server to proxy requests.
 Reverse port-forwarding will be automatically configured to route traffic to the local service and back.
@@ -1551,6 +1555,8 @@ Local mode always takes the precedence over dev mode if there are any conflictin
 Health checks are disabled for services running in local mode.
 
 See the [Local Mode guide](https://docs.garden.io/guides/running-service-in-local-mode) for more information.
+
+Note! This feature is still experimental. Some incompatible changes can be made until the first non-experimental release.
 
 | Type     | Required |
 | -------- | -------- |

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -300,7 +300,8 @@ services:
           # information.
           defaultGroup:
 
-    # Configures the local application which will send and receive network requests instead of the target resource.
+    # [EXPERIMENTAL] Configures the local application which will send and receive network requests instead of the
+    # target resource.
     #
     # The target service will be replaced by a proxy container which runs an SSH server to proxy requests.
     # Reverse port-forwarding will be automatically configured to route traffic to the local service and back.
@@ -311,6 +312,9 @@ services:
     # Health checks are disabled for services running in local mode.
     #
     # See the [Local Mode guide](https://docs.garden.io/guides/running-service-in-local-mode) for more information.
+    #
+    # Note! This feature is still experimental. Some incompatible changes can be made until the first non-experimental
+    # release.
     localMode:
       # The reverse port-forwards configuration for the local application.
       ports:
@@ -1412,7 +1416,7 @@ Set the default group on files and directories at the target. Specify either an 
 
 [services](#services) > localMode
 
-Configures the local application which will send and receive network requests instead of the target resource.
+[EXPERIMENTAL] Configures the local application which will send and receive network requests instead of the target resource.
 
 The target service will be replaced by a proxy container which runs an SSH server to proxy requests.
 Reverse port-forwarding will be automatically configured to route traffic to the local service and back.
@@ -1423,6 +1427,8 @@ Local mode always takes the precedence over dev mode if there are any conflictin
 Health checks are disabled for services running in local mode.
 
 See the [Local Mode guide](https://docs.garden.io/guides/running-service-in-local-mode) for more information.
+
+Note! This feature is still experimental. Some incompatible changes can be made until the first non-experimental release.
 
 | Type     | Required |
 | -------- | -------- |


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updated the local mode guide and module reference docs to explicitly note the experimental status of the local mode feature.

Caused by #3271.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
