### PR TITLE
Fixed `--parallel` flag implementation in `garden update-remote sources` sub-command

### DIFF
--- a/core/src/commands/update-remote/all.ts
+++ b/core/src/commands/update-remote/all.ts
@@ -14,7 +14,7 @@ import { updateRemoteModules } from "./modules"
 import { SourceConfig, projectSourceSchema, moduleSourceSchema } from "../../config/project"
 import { printHeader } from "../../logger/util"
 import { joi, joiArray } from "../../config/common"
-import { BooleanParameter } from "../../cli/params"
+import { updateRemoteSharedOptions } from "./helpers"
 
 export interface UpdateRemoteAllResult {
   projectSources: SourceConfig[]
@@ -22,10 +22,7 @@ export interface UpdateRemoteAllResult {
 }
 
 const updateRemoteAllOptions = {
-  parallel: new BooleanParameter({
-    help: "Allow git updates to happen in parallel",
-    defaultValue: false,
-  }),
+  ...updateRemoteSharedOptions,
 }
 
 type Opts = typeof updateRemoteAllOptions

--- a/core/src/commands/update-remote/all.ts
+++ b/core/src/commands/update-remote/all.ts
@@ -47,7 +47,8 @@ export class UpdateRemoteAllCommand extends Command<{}, Opts> {
   description = dedent`
     Examples:
 
-        garden update-remote all # update all remote sources and modules in the project
+        garden update-remote all --parallel # update all remote sources and modules in the project in parallel mode
+        garden update-remote all            # update all remote sources and modules in the project
   `
 
   printHeader({ headerLog }) {

--- a/core/src/commands/update-remote/helpers.ts
+++ b/core/src/commands/update-remote/helpers.ts
@@ -13,6 +13,15 @@ import { remove, pathExists } from "fs-extra"
 import { getChildDirNames } from "../../util/fs"
 import { ExternalSourceType, getRemoteSourcesDirname, getRemoteSourceRelPath } from "../../util/ext-source-util"
 import { SourceConfig } from "../../config/project"
+import { BooleanParameter } from "../../cli/params"
+
+export const updateRemoteSharedOptions = {
+  parallel: new BooleanParameter({
+    help:
+      "Allow git updates to happen in parallel. This will automatically reject any Git prompt, such as username / password.",
+    defaultValue: false,
+  }),
+}
 
 export async function pruneRemoteSources({
   gardenDirPath,

--- a/core/src/commands/update-remote/modules.ts
+++ b/core/src/commands/update-remote/modules.ts
@@ -13,13 +13,13 @@ import chalk from "chalk"
 import { Command, CommandResult, CommandParams } from "../base"
 import { SourceConfig, moduleSourceSchema } from "../../config/project"
 import { ParameterError } from "../../exceptions"
-import { pruneRemoteSources } from "./helpers"
+import { pruneRemoteSources, updateRemoteSharedOptions } from "./helpers"
 import { hasRemoteSource } from "../../util/ext-source-util"
 import { printHeader } from "../../logger/util"
 import { Garden } from "../../garden"
 import { LogEntry } from "../../logger/log-entry"
 import { joiArray, joi } from "../../config/common"
-import { StringsParameter, ParameterValues, BooleanParameter } from "../../cli/params"
+import { StringsParameter, ParameterValues } from "../../cli/params"
 
 const updateRemoteModulesArguments = {
   modules: new StringsParameter({
@@ -30,11 +30,7 @@ const updateRemoteModulesArguments = {
 type Args = typeof updateRemoteModulesArguments
 
 const updateRemoteModulesOptions = {
-  parallel: new BooleanParameter({
-    help:
-      "Allow git updates to happen in parallel. This will automatically reject any Git prompt, such as username / password",
-    defaultValue: false,
-  }),
+  ...updateRemoteSharedOptions,
 }
 
 type Opts = typeof updateRemoteModulesOptions

--- a/core/src/commands/update-remote/modules.ts
+++ b/core/src/commands/update-remote/modules.ts
@@ -60,6 +60,7 @@ export class UpdateRemoteModulesCommand extends Command<Args, Opts> {
 
     Examples:
 
+        garden update-remote modules --parallel # update all remote modules in parallel mode
         garden update-remote modules            # update all remote modules in the project
         garden update-remote modules my-module  # update remote module my-module
   `

--- a/core/src/commands/update-remote/sources.ts
+++ b/core/src/commands/update-remote/sources.ts
@@ -12,13 +12,13 @@ import chalk from "chalk"
 
 import { Command, CommandResult, CommandParams } from "../base"
 import { ParameterError } from "../../exceptions"
-import { pruneRemoteSources } from "./helpers"
+import { pruneRemoteSources, updateRemoteSharedOptions } from "./helpers"
 import { SourceConfig, projectSourceSchema } from "../../config/project"
 import { printHeader } from "../../logger/util"
 import { Garden } from "../../garden"
 import { LogEntry } from "../../logger/log-entry"
 import { joiArray, joi } from "../../config/common"
-import { StringsParameter, ParameterValues, BooleanParameter } from "../../cli/params"
+import { StringsParameter, ParameterValues } from "../../cli/params"
 
 const updateRemoteSourcesArguments = {
   sources: new StringsParameter({
@@ -29,11 +29,7 @@ const updateRemoteSourcesArguments = {
 type Args = typeof updateRemoteSourcesArguments
 
 const updateRemoteSourcesOptions = {
-  parallel: new BooleanParameter({
-    help:
-      "Allow git updates to happen in parallel. This will automatically reject any Git prompt, such as username / password",
-    defaultValue: false,
-  }),
+  ...updateRemoteSharedOptions,
 }
 
 type Opts = typeof updateRemoteSourcesOptions

--- a/core/src/commands/update-remote/sources.ts
+++ b/core/src/commands/update-remote/sources.ts
@@ -46,7 +46,7 @@ export class UpdateRemoteSourcesCommand extends Command<Args, Opts> {
   name = "sources"
   help = "Update remote sources."
   arguments = updateRemoteSourcesArguments
-  opts = updateRemoteSourcesOptions
+  options = updateRemoteSourcesOptions
 
   outputsSchema = () =>
     joi.object().keys({

--- a/core/src/commands/update-remote/sources.ts
+++ b/core/src/commands/update-remote/sources.ts
@@ -58,6 +58,7 @@ export class UpdateRemoteSourcesCommand extends Command<Args, Opts> {
 
     Examples:
 
+        garden update-remote sources --parallel # update all remote sources in parallel mode
         garden update-remote sources            # update all remote sources
         garden update-remote sources my-source  # update remote source my-source
   `

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -3799,7 +3799,7 @@ Examples:
 
 #### Usage
 
-    garden update-remote sources [sources] 
+    garden update-remote sources [sources] [options]
 
 #### Arguments
 
@@ -3807,6 +3807,11 @@ Examples:
 | -------- | -------- | ----------- |
   | `sources` | No | The name(s) of the remote source(s) to update. Use comma as a separator to specify multiple sources.
 
+#### Options
+
+| Argument | Alias | Type | Description |
+| -------- | ----- | ---- | ----------- |
+  | `--parallel` |  | boolean | Allow git updates to happen in parallel. This will automatically reject any Git prompt, such as username / password
 
 #### Outputs
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -3794,6 +3794,7 @@ Updates the remote sources declared in the project level `garden.yml` config fil
 
 Examples:
 
+    garden update-remote sources --parallel # update all remote sources in parallel mode
     garden update-remote sources            # update all remote sources
     garden update-remote sources my-source  # update remote source my-source
 
@@ -3835,6 +3836,7 @@ in their `garden.yml` config that points to a remote repository.
 
 Examples:
 
+    garden update-remote modules --parallel # update all remote modules in parallel mode
     garden update-remote modules            # update all remote modules in the project
     garden update-remote modules my-module  # update remote module my-module
 
@@ -3873,7 +3875,8 @@ sources:
 
 Examples:
 
-    garden update-remote all # update all remote sources and modules in the project
+    garden update-remote all --parallel # update all remote sources and modules in the project in parallel mode
+    garden update-remote all            # update all remote sources and modules in the project
 
 #### Usage
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -3812,7 +3812,7 @@ Examples:
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
-  | `--parallel` |  | boolean | Allow git updates to happen in parallel. This will automatically reject any Git prompt, such as username / password
+  | `--parallel` |  | boolean | Allow git updates to happen in parallel. This will automatically reject any Git prompt, such as username / password.
 
 #### Outputs
 
@@ -3854,7 +3854,7 @@ Examples:
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
-  | `--parallel` |  | boolean | Allow git updates to happen in parallel. This will automatically reject any Git prompt, such as username / password
+  | `--parallel` |  | boolean | Allow git updates to happen in parallel. This will automatically reject any Git prompt, such as username / password.
 
 #### Outputs
 
@@ -3886,7 +3886,7 @@ Examples:
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
-  | `--parallel` |  | boolean | Allow git updates to happen in parallel
+  | `--parallel` |  | boolean | Allow git updates to happen in parallel. This will automatically reject any Git prompt, such as username / password.
 
 #### Outputs
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The `--parallel` flag of the `garden update-remote sources` sub-command was not defined properly. This PR fixes that issue.

This patches #3206.

**Which issue(s) this PR fixes**:

Fixes #3269

**Special notes for your reviewer**:
