### PR TITLE
fix(server): terminate ws connection if server not ready

### DIFF
--- a/core/src/server/server.ts
+++ b/core/src/server/server.ts
@@ -299,14 +299,16 @@ export class GardenServer {
     const wsRouter = new Router()
 
     wsRouter.get("/ws", async (ctx) => {
+      // The typing for koa-websocket isn't working currently
+      const websocket: Koa.Context["ws"] = ctx["websocket"]
+
       if (!this.garden) {
-        return this.notReady(ctx)
+        this.log.debug("Server not ready.")
+        websocket.terminate()
+        return
       }
 
       const connId = uuidv4()
-
-      // The typing for koa-websocket isn't working currently
-      const websocket: Koa.Context["ws"] = ctx["websocket"]
 
       // Helper to make JSON messages, make them type-safe, and to log errors.
       const send = <T extends ServerWebsocketMessageType>(type: T, payload: ServerWebsocketMessages[T]) => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Previously we were exiting early from the websocket connection handler if the server wasn't ready but not terminating the actual connection.

This meant that a client could be connected but websocket messages were otherwise not handled.

Now we simply terminate the connection so that clients can retry.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
