### PR TITLE
improvement(template): allow empty string separator in `join` function

### DIFF
--- a/core/src/template-string/functions.ts
+++ b/core/src/template-string/functions.ts
@@ -132,7 +132,7 @@ const helperFunctionSpecs: TemplateHelperFunction[] = [
       "Takes an array of strings (or other primitives) and concatenates them into a string, with the given separator",
     arguments: {
       input: joi.array().items(joiPrimitive()).required().description("The array to concatenate."),
-      separator: joi.string().required().description("The string to place between each item in the array."),
+      separator: joi.string().allow("").required().description("The string to place between each item in the array."),
     },
     outputSchema: joi.string(),
     exampleArguments: [

--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -1163,6 +1163,11 @@ describe("resolveTemplateString", async () => {
       const res = resolveTemplateString("${join(['foo', 'bar'], ',')}", new TestContext({}))
       expect(res).to.eql("foo,bar")
     })
+
+    it("allows empty string separator in join helper function", () => {
+      const res = resolveTemplateString("${join(['foo', 'bar'], '')}", new TestContext({}))
+      expect(res).to.eql("foobar")
+    })
   })
 })
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows using empty string (`""`) as a separator in the `join helper function in the template strings.

Without this PR Garden fails with an error like this:
```
Invalid template string (${join(["a", "b"], "")}): Error validating argument 'separator' for join helper function: value is not allowed to be empty
```

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
