### PR TITLE
improvement(template): support string concatenation with `+` operator

### DIFF
--- a/core/src/template-string/template-string.ts
+++ b/core/src/template-string/template-string.ts
@@ -15,7 +15,7 @@ import {
   ContextKeySegment,
   GenericContext,
 } from "../config/template-contexts/base"
-import { difference, uniq, isPlainObject, isNumber, cloneDeep } from "lodash"
+import { difference, uniq, isPlainObject, isNumber, isString, cloneDeep } from "lodash"
 import {
   Primitive,
   StringMap,
@@ -540,11 +540,13 @@ function buildBinaryExpression(head: any, tail: any) {
     if (operator === "+") {
       if (isNumber(left) && isNumber(right)) {
         return left + right
+      } else if (isString(left) && isString(right)) {
+        return left + right
       } else if (Array.isArray(left) && Array.isArray(right)) {
         return left.concat(right)
       } else {
         const err = new TemplateStringError(
-          `Both terms need to be either arrays or numbers for + operator (got ${typeof left} and ${typeof right}).`,
+          `Both terms need to be either arrays or strings or numbers for + operator (got ${typeof left} and ${typeof right}).`,
           { left, right, operator }
         )
         return { _error: err }

--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -530,6 +530,11 @@ describe("resolveTemplateString", async () => {
     expect(res).to.eql([1, 2, 3])
   })
 
+  it("should concatenate two strings", async () => {
+    const res = resolveTemplateString("${a + b}", new TestContext({ a: "foo", b: "bar" }))
+    expect(res).to.eql("foobar")
+  })
+
   it("should add two numbers together", async () => {
     const res = resolveTemplateString("${1 + a}", new TestContext({ a: 2 }))
     expect(res).to.equal(3)
@@ -540,7 +545,7 @@ describe("resolveTemplateString", async () => {
       () => resolveTemplateString("${a + b}", new TestContext({ a: 123, b: ["a"] })),
       (err) =>
         expect(stripAnsi(err.message)).to.equal(
-          "Invalid template string (${a + b}): Both terms need to be either arrays or numbers for + operator (got number and object)."
+          "Invalid template string (${a + b}): Both terms need to be either arrays or strings or numbers for + operator (got number and object)."
         )
     )
   })

--- a/docs/using-garden/variables-and-templating.md
+++ b/docs/using-garden/variables-and-templating.md
@@ -40,7 +40,7 @@ Note that while this syntax looks similar to template strings in Javascript, we 
 
 In addition to referencing variables from template contexts, you can include a variety of _literals_ in template strings:
 
-* _Strings_ enclosed with either double or single quotes: `${"foo"}`, `${'bar'}`.
+* _Strings_, including concatenated ones, enclosed with either double or single quotes: `${"foo"}`, `${'bar'}`, `${'bar' + 'foo}`.
 * _Numbers_: `${123}`
 * _Booleans_: `${true}`, `${false}`
 * _Null_: `${null}`
@@ -59,8 +59,9 @@ You can use a variety of operators in template string expressions:
 * Unary: `!` (negation), `typeof` (returns the type of the following value as a string, e.g. `"boolean"` or `"number"`)
 * Relational: `contains` (to see if an array contains a value, an object contains a key, or a string contains a substring)
 * Arrays: `+`
+* Strings: `+`
 
-The arithmetic and numeric comparison operators can only be used for numeric literals and keys that resolve to numbers, except the `+` operator which can be used to concatenate two array references. The equality and logical operators work with any term (but be warned that arrays and complex objects aren't currently compared in-depth).
+The arithmetic and numeric comparison operators can only be used for numeric literals and keys that resolve to numbers, except the `+` operator which can be used to concatenate two strings or array references. The equality and logical operators work with any term (but be warned that arrays and complex objects aren't currently compared in-depth).
 
 Clauses are evaluated in standard precedence order, but you can also use parentheses to control evaluation order (e.g. `${(1 + 2) * (3 + 4)}` evaluates to 21).
 
@@ -130,7 +131,7 @@ services:
   ...
 ```
 
-And the `+` operator can also be used to concatenate two arrays:
+And the `+` operator can also be used to concatenate two arrays or strings:
 
 ```yaml
 kind: Project
@@ -138,12 +139,15 @@ kind: Project
 variables:
   some-values: ["a", "b"]
   other-values: ["c", "d"]
+  str1: "foo"
+  str2: "bar"
 ---
 kind: Module
 type: helm
 # ...
 values:
   some-array: ${var.some-values + var.other-values}
+  str12: ${var.str1 + var.str2}
   ...
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows using `+` operator for string concatenation in template strings.

Without this PR Garden fails with an error like this:
```
Invalid template string (${"a" + "b"}): Both terms need to be either arrays or numbers for + operator (got string and string).
```
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
