### PR TITLE
feat(exec): live log streaming for exec modules

### DIFF
--- a/core/src/plugins/exec/exec.ts
+++ b/core/src/plugins/exec/exec.ts
@@ -26,7 +26,7 @@ import { BuildModuleParams, BuildResult } from "../../types/plugin/module/build"
 import { TestModuleParams } from "../../types/plugin/module/testModule"
 import { TestResult } from "../../types/plugin/module/getTestResult"
 import { RunTaskParams, RunTaskResult } from "../../types/plugin/task/runTask"
-import { createOutputStream, exec, ExecOpts, runScript, sleep } from "../../util/util"
+import { exec, ExecOpts, renderOutputStream, runScript, sleep } from "../../util/util"
 import { ConfigurationError, RuntimeError, TimeoutError } from "../../exceptions"
 import { LogEntry } from "../../logger/log-entry"
 import { providerConfigBaseSchema } from "../../config/provider"
@@ -423,19 +423,28 @@ function runPersistent({
 async function run({
   command,
   module,
+  ctx,
   log,
   env,
   opts = {},
 }: {
   command: string[]
   module: ExecModule
+  ctx: PluginContext
   log: LogEntry
   env?: PrimitiveMap
   opts?: ExecOpts
 }) {
-  const stdout = createOutputStream(log.placeholder({ level: LogLevel.verbose }))
+  const outputStream = split2()
 
-  return exec(command.join(" "), [], {
+  outputStream.on("error", () => {})
+  outputStream.on("data", (line: Buffer) => {
+    log.setState(renderOutputStream(line.toString()))
+    ctx.events.emit("log", { timestamp: new Date().getTime(), data: line })
+  })
+
+  const res = await exec(command.join(" "), [], {
+    ...opts,
     cwd: module.buildPath,
     env: {
       ...getDefaultEnvVars(module),
@@ -443,18 +452,18 @@ async function run({
     },
     // TODO: remove this in 0.13 and alert users to use e.g. sh -c '<script>' instead.
     shell: true,
-    stdout,
-    stderr: stdout,
-    ...opts,
+    stdout: outputStream,
+    stderr: outputStream,
   })
+  return res
 }
 
-export async function buildExecModule({ module, log }: BuildModuleParams<ExecModule>): Promise<BuildResult> {
+export async function buildExecModule({ module, ctx, log }: BuildModuleParams<ExecModule>): Promise<BuildResult> {
   const output: BuildResult = {}
   const { command } = module.spec.build
 
   if (command.length) {
-    const result = await run({ command, module, log })
+    const result = await run({ command, module, ctx, log })
 
     output.fresh = true
     output.buildLog = result.stdout + result.stderr
@@ -474,13 +483,14 @@ export async function buildExecModule({ module, log }: BuildModuleParams<ExecMod
 export async function testExecModule({
   log,
   module,
+  ctx,
   test,
   artifactsPath,
 }: TestModuleParams<ExecModule>): Promise<TestResult> {
   const startedAt = new Date()
   const { command } = test.config.spec
 
-  const result = await run({ command, module, log, env: test.config.spec.env, opts: { reject: false } })
+  const result = await run({ command, module, ctx, log, env: test.config.spec.env, opts: { reject: false } })
 
   await copyArtifacts(log, test.config.spec.artifacts, module.buildPath, artifactsPath)
 
@@ -503,7 +513,7 @@ export async function testExecModule({
 }
 
 export async function runExecTask(params: RunTaskParams<ExecModule>): Promise<RunTaskResult> {
-  const { artifactsPath, log, task } = params
+  const { artifactsPath, log, task, ctx } = params
   const module = task.module
   const command = task.spec.command
   const startedAt = new Date()
@@ -513,7 +523,7 @@ export async function runExecTask(params: RunTaskParams<ExecModule>): Promise<Ru
   let success = true
 
   if (command && command.length) {
-    const commandResult = await run({ command, module, log, env: task.spec.env, opts: { reject: false } })
+    const commandResult = await run({ command, module, ctx, log, env: task.spec.env, opts: { reject: false } })
 
     completedAt = new Date()
     outputLog = (commandResult.stdout + commandResult.stderr).trim()
@@ -546,7 +556,7 @@ export async function runExecTask(params: RunTaskParams<ExecModule>): Promise<Ru
 }
 
 export async function runExecModule(params: RunModuleParams<ExecModule>): Promise<RunResult> {
-  const { module, args, interactive, log } = params
+  const { module, ctx, args, interactive, log } = params
   const startedAt = new Date()
 
   let completedAt: Date
@@ -557,6 +567,7 @@ export async function runExecModule(params: RunModuleParams<ExecModule>): Promis
     const commandResult = await run({
       command: args,
       module,
+      ctx,
       log,
       env: module.spec.env,
       opts: { reject: false, stdio: interactive ? "inherit" : undefined },
@@ -586,12 +597,13 @@ export async function runExecModule(params: RunModuleParams<ExecModule>): Promis
 export const getExecServiceStatus: ServiceActionHandlers["getServiceStatus"] = async (
   params: GetServiceStatusParams<ExecModule>
 ) => {
-  const { module, service, log } = params
+  const { module, ctx, service, log } = params
 
   if (service.spec.statusCommand) {
     const result = await run({
       command: service.spec.statusCommand,
       module,
+      ctx,
       log,
       env: service.spec.env,
       opts: { reject: false },
@@ -646,6 +658,7 @@ export const deployExecService: ServiceActionHandlers["deployService"] = async (
     const result = await run({
       command: serviceSpec.deployCommand,
       module,
+      ctx,
       log,
       env,
       opts: { reject: true },
@@ -728,6 +741,7 @@ async function deployPersistentExecService({
       const result = await run({
         command: devModeSpec.statusCommand,
         module,
+        ctx,
         log,
         env,
         opts: { reject: false },
@@ -743,12 +757,13 @@ async function deployPersistentExecService({
 export const deleteExecService: ServiceActionHandlers["deleteService"] = async (
   params: DeleteServiceParams<ExecModule>
 ) => {
-  const { module, service, log } = params
+  const { module, ctx, service, log } = params
 
   if (service.spec.cleanupCommand) {
     const result = await run({
       command: service.spec.cleanupCommand,
       module,
+      ctx,
       log,
       env: service.spec.env,
       opts: { reject: true },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

We now stream build, deploy, test, task and service logs for `exec` modules.

This brings the Cloud logging experience for `exec` modules to full parity with our k8s-based module types.

**Special notes for your reviewer**:

I've verified that build, test, deploy, task and service log events are emitted, and that they show up in the logging UI in Cloud.

Would be nice to have proper automated testing for the end-to-end flow here, but since this log event emission logic is rarely changed after its initial implementation, it may not be worth the effort right now.