### PR TITLE
improvement(template): string concatenation with `concat` function

### DIFF
--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -1136,6 +1136,55 @@ describe("resolveTemplateString", async () => {
           )
       )
     })
+
+    context("concat", () => {
+      it("allows empty strings", () => {
+        const res = resolveTemplateString("${concat('', '')}", new TestContext({}))
+        expect(res).to.equal("")
+      })
+
+      context("throws when", () => {
+        function expectArgTypeError({
+          template,
+          testContextVars = {},
+          errorMessage,
+        }: {
+          template: string
+          testContextVars?: object
+          errorMessage: string
+        }) {
+          return expectError(
+            () => resolveTemplateString(template, new TestContext(testContextVars)),
+            (err) =>
+              expect(stripAnsi(err.message)).to.equal(`Invalid template string (\${concat(a, b)}): ${errorMessage}`)
+          )
+        }
+
+        it("using on incompatible argument types (string and object)", async () => {
+          return expectArgTypeError({
+            template: "${concat(a, b)}",
+            testContextVars: {
+              a: "123",
+              b: ["a"],
+            },
+            errorMessage:
+              "Error from helper function concat: Both terms need to be either arrays or strings (got string and object).",
+          })
+        })
+
+        it("using on unsupported argument types (number and object)", async () => {
+          return expectArgTypeError({
+            template: "${concat(a, b)}",
+            testContextVars: {
+              a: 123,
+              b: ["a"],
+            },
+            errorMessage:
+              "Error validating argument 'arg1' for concat helper function: value must be one of [array, string]",
+          })
+        })
+      })
+    })
   })
 
   context("array literals", () => {
@@ -1290,7 +1339,7 @@ describe("resolveTemplateStrings", () => {
   })
 
   context("$concat", () => {
-    it("handles array concetenation", () => {
+    it("handles array concatenation", () => {
       const obj = {
         foo: ["a", { $concat: ["b", "c"] }, "d"],
       }

--- a/docs/reference/template-strings/functions.md
+++ b/docs/reference/template-strings/functions.md
@@ -41,14 +41,15 @@ Examples:
 
 ## concat
 
-Concatenates two arrays.
+Concatenates two arrays or strings.
 
-Usage: `concat(array1, array2)`
+Usage: `concat(arg1, arg2)`
 
 Examples:
 
 * `${concat(["first","two"], ["second","list"])}` -> `["first","two","second","list"]`
 * `${concat([1,2,3], [4,5])}` -> `[1,2,3,4,5]`
+* `${concat("string1", "string2")}` -> `"string1string2"`
 
 ## indent
 

--- a/docs/using-garden/variables-and-templating.md
+++ b/docs/using-garden/variables-and-templating.md
@@ -44,7 +44,7 @@ In addition to referencing variables from template contexts, you can include a v
 * _Numbers_: `${123}`
 * _Booleans_: `${true}`, `${false}`
 * _Null_: `${null}`
-* _Arrays_: `${[1, 2, 3]}`, `${["foo", "bar"]}`, `${[var.someKey, var.someOtherKey]}`, `${join(["foo", "bar"], ",")}`
+* _Arrays_: `${[1, 2, 3]}`, `${["foo", "bar"]}`, `${[var.someKey, var.someOtherKey]}`, `${concat(["foo", "bar"], ["baz"])}`, `${join(["foo", "bar"], ",")}`
 
 These can be used with [operators](#operators), as [helper function arguments](#helper-functions) and more.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows using the `concat` helper function to concatenate strings, and not only arrays.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
