### PR TITLE
improvement(logs): run and test commands error handling

### DIFF
--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -642,7 +642,7 @@ rm -rf ${tmpPath} >/dev/null || true
     const tmpDir = await tmp.dir({ unsafeCleanup: true })
 
     try {
-      await new Promise<void>((_resolve, reject) => {
+      await new Promise<void>((resolve, reject) => {
         // Create an extractor to receive the tarball we will stream from the container
         // and extract to the artifacts directory.
         let done = 0
@@ -656,7 +656,7 @@ rm -rf ${tmpPath} >/dev/null || true
         extractor.on("end", () => {
           // Need to make sure both processes are complete before resolving (may happen in either order)
           done++
-          done === 2 && _resolve()
+          done === 2 && resolve()
         })
         extractor.on("error", (err) => {
           reject(err)
@@ -675,7 +675,7 @@ rm -rf ${tmpPath} >/dev/null || true
           .then(() => {
             // Need to make sure both processes are complete before resolving (may happen in either order)
             done++
-            done === 2 && _resolve()
+            done === 2 && resolve()
           })
           .catch(reject)
       })
@@ -698,6 +698,7 @@ rm -rf ${tmpPath} >/dev/null || true
 
   return result
 }
+
 function makeTimeOutErrorLog(containerLogs: string) {
   return (
     "Command timed out." + (containerLogs ? ` Here are the logs until the timeout occurred:\n\n${containerLogs}` : "")

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -987,6 +987,22 @@ export class PodRunner extends PodRunnerParams {
       })
     }
 
+    if (result.exitCode === 137) {
+      const getDebugLogs = async () => {
+        try {
+          return this.getMainContainerLogs()
+        } catch (err) {
+          return ""
+        }
+      }
+
+      const msg = `Pod container was OOMKilled.`
+      throw new OutOfMemoryError(msg, {
+        logs: (await getDebugLogs()) || msg,
+        execParams: params,
+      })
+    }
+
     if (result.exitCode !== 0) {
       throw new PodRunnerError(`Command exited with code ${result.exitCode}:\n${result.allLogs}`, {
         result,

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -440,6 +440,7 @@ async function runWithoutArtifacts({
         startedAt,
         completedAt: new Date(),
         command: [...(command || []), ...(args || [])],
+        exitCode: err.detail.exitCode,
       }
     } else {
       throw err
@@ -624,6 +625,7 @@ ${cmd.join(" ")}
           startedAt,
           completedAt: new Date(),
           command: cmd,
+          exitCode: res.exitCode,
         }
       } else {
         throw err

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -429,6 +429,7 @@ async function runWithoutArtifacts({
         startedAt,
         completedAt: new Date(),
         command: runner.getFullCommand(),
+        exitCode: err.detail.exitCode,
       }
     } else if (err.type === "pod-runner") {
       // Command exited with non-zero code
@@ -614,6 +615,7 @@ ${cmd.join(" ")}
           startedAt,
           completedAt: new Date(),
           command: cmd,
+          exitCode: res.exitCode,
         }
       } else if (err.type === "pod-runner" && res && res.exitCode) {
         // Command exited with non-zero code
@@ -854,6 +856,7 @@ export class PodRunner extends PodRunnerParams {
           const msg = `Pod container was OOMKilled.`
           throw new OutOfMemoryError(msg, {
             logs: (await this.getDebugLogs()) || msg,
+            exitCode,
             serverPod,
           })
         }

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -979,8 +979,9 @@ export class PodRunner extends PodRunnerParams {
 
     if (result.timedOut) {
       throw new TimeoutError(`Command timed out after ${timeoutSec} seconds.`, {
-        result,
         logs: result.allLogs,
+        result,
+        execParams: params,
       })
     }
 
@@ -988,14 +989,16 @@ export class PodRunner extends PodRunnerParams {
       const msg = `Pod container was OOMKilled.`
       throw new OutOfMemoryError(msg, {
         logs: (await this.getDebugLogs()) || msg,
+        result,
         execParams: params,
       })
     }
 
     if (result.exitCode !== 0) {
       throw new PodRunnerError(`Command exited with code ${result.exitCode}:\n${result.allLogs}`, {
-        result,
         logs: result.allLogs,
+        result,
+        execParams: params,
       })
     }
 

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -617,7 +617,7 @@ ${cmd.join(" ")}
           command: cmd,
           exitCode: res.exitCode,
         }
-      } else if (err.type === "pod-runner" && res && res.exitCode) {
+      } else if (err.type === "pod-runner") {
         // Command exited with non-zero code
         result = {
           log: (await runner.getMainContainerLogs()).trim() || err.message,

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -127,7 +127,7 @@ export async function runAndCopy({
   privileged,
   addCapabilities,
   dropCapabilities,
-}: RunModuleParams<GardenModule> & {
+}: RunModuleParams & {
   image: string
   container?: V1Container
   podName?: string

--- a/core/src/plugins/kubernetes/status/pod.ts
+++ b/core/src/plugins/kubernetes/status/pod.ts
@@ -179,23 +179,18 @@ export async function getFormattedPodLogs(api: KubeApi, namespace: string, pods:
     .join("\n\n")
 }
 
-export function getExecExitCode(status: V1Status) {
-  if (!status) {
-    return 1
+export function getExecExitCode(status: V1Status): number {
+  // Status csn be either "Success" or "Failure"
+  if (status.status === "Success") {
+    return 0
   }
 
-  let exitCode = 0
+  const causes = status.details?.causes || []
+  const exitCodeCause = causes.find((c) => c.reason === "ExitCode")
 
-  if (status.status !== "Success") {
-    exitCode = 1
-
-    const causes = status.details?.causes || []
-    const exitCodeCause = causes.find((c) => c.reason === "ExitCode")
-
-    if (exitCodeCause && exitCodeCause.message) {
-      exitCode = parseInt(exitCodeCause.message, 10)
-    }
+  if (exitCodeCause && exitCodeCause.message) {
+    return parseInt(exitCodeCause.message, 10)
   }
 
-  return exitCode
+  return 1
 }

--- a/core/src/tasks/test.ts
+++ b/core/src/tasks/test.ts
@@ -194,11 +194,9 @@ export class TestTask extends BaseTask {
         append: true,
       })
     } else {
-      const msg = !!result.exitCode
-        ? `Failed with code ${result.exitCode}! (took ${log.getDuration(1)} sec)`
-        : `Failed! (took ${log.getDuration(1)} sec)`
+      const failedMsg = !!result.exitCode ? `Failed with code ${result.exitCode}!` : `Failed!`
       log.setError({
-        msg,
+        msg: `${failedMsg} (took ${log.getDuration(1)} sec)`,
         append: true,
       })
       throw new TestError(result.log)

--- a/core/src/tasks/test.ts
+++ b/core/src/tasks/test.ts
@@ -194,8 +194,11 @@ export class TestTask extends BaseTask {
         append: true,
       })
     } else {
+      const msg = !!result.exitCode
+        ? `Failed with code ${result.exitCode}! (took ${log.getDuration(1)} sec)`
+        : `Failed! (took ${log.getDuration(1)} sec)`
       log.setError({
-        msg: chalk.red(`Failed! (took ${log.getDuration(1)} sec)`),
+        msg,
         append: true,
       })
       throw new TestError(result.log)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR unifies error handling for `garden run` and `garden test` commands when running those with and without artifacts.

**Which issue(s) this PR fixes**:

Partially resolves #3297

**Special notes for your reviewer**:
