### PR TITLE
fix(k8s): use mode=inline for buildkit in-cluster builder as default

### DIFF
--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -492,7 +492,7 @@ const buildkitCacheConfigurationSchema = () =>
         The values \`min\` and \`max\` ensure that garden passes the \`mode=max\` or \`mode=min\` modifiers to the buildkit \`--export-cache\` option. Cache manifests will only be
         stored stored in the configured \`tag\`.
 
-        \`auto\` is the same as \`max\` for most registries. Some popular registries do not support \`max\` and garden will fall back to \`inline\` for them.
+        \`auto\` is the same as \`max\` for some registries that are known to support it. Garden will fall back to \`inline\` for all other registries.
          See the [clusterBuildkit cache option](#providers-.clusterbuildkit.cache) for a description of the detection mechanism.
 
         See also the [buildkit export cache documentation](https://github.com/moby/buildkit#export-cache)
@@ -559,16 +559,16 @@ export const kubernetesConfigBase = () =>
             For registries that support it, \`mode: auto\` (the default) will enable the buildkit \`mode=max\`
             option.
 
-            Some registries are known not to support the cache manifests needed for the \`mode=max\` option, so
-            we will avoid using \`mode=max\` with them.
-
             See the following table for details on our detection mechanism:
 
-            | Registry Name                   | Detection string | Assumed \`mode=max\` support |
-            |---------------------------------|------------------|------------------------------|
-            | AWS Elastic Container Registry  | \`.dkr.ecr.\`    | No                           |
-            | Google Cloud Container Registry | \`gcr.io\`       | No                           |
-            | Any other registry              | -                | Yes                          |
+            | Registry Name                   | Registry Domain         | Assumed \`mode=max\` support |
+            |---------------------------------|-------------------------|------------------------------|
+            | Google Cloud Artifact Registry  | \`pkg.dev\`             | Yes                          |
+            | Azure Container Registry        | \`azurecr.io\`          | Yes                          |
+            | GitHub Container Registry       | \`ghcr.io\`             | Yes                          |
+            | DockerHub                       | \`hub.docker.com\`     | Yes                          |
+            | Garden In-Cluster Registry      |                         | Yes                          |
+            | Any other registry              |                         | No                           |
 
             In case you need to override the defaults for your registry, you can do it like so:
 
@@ -576,7 +576,7 @@ export const kubernetesConfigBase = () =>
             clusterBuildkit:
               cache:
                 - type: registry
-                  mode: inline
+                  mode: max
             \`\`\`
 
             When you add multiple caches, we will make sure to pass the \`--import-cache\` options to buildkit in the same

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -62,23 +62,23 @@ providers:
       # For registries that support it, `mode: auto` (the default) will enable the buildkit `mode=max`
       # option.
       #
-      # Some registries are known not to support the cache manifests needed for the `mode=max` option, so
-      # we will avoid using `mode=max` with them.
-      #
       # See the following table for details on our detection mechanism:
       #
-      # | Registry Name                   | Detection string | Assumed `mode=max` support |
-      # |---------------------------------|------------------|------------------------------|
-      # | AWS Elastic Container Registry  | `.dkr.ecr.`    | No                           |
-      # | Google Cloud Container Registry | `gcr.io`       | No                           |
-      # | Any other registry              | -                | Yes                          |
+      # | Registry Name                   | Registry Domain         | Assumed `mode=max` support |
+      # |---------------------------------|-------------------------|------------------------------|
+      # | Google Cloud Artifact Registry  | `pkg.dev`             | Yes                          |
+      # | Azure Container Registry        | `azurecr.io`          | Yes                          |
+      # | GitHub Container Registry       | `ghcr.io`             | Yes                          |
+      # | DockerHub                       | `hub.docker.com`     | Yes                          |
+      # | Garden In-Cluster Registry      |                         | Yes                          |
+      # | Any other registry              |                         | No                           |
       #
       # In case you need to override the defaults for your registry, you can do it like so:
       #
       # clusterBuildkit:
       #   cache:
       #     - type: registry
-      #       mode: inline
+      #       mode: max
       #
       # When you add multiple caches, we will make sure to pass the `--import-cache` options to buildkit in the same
       # order as provided in the cache configuration. This is because buildkit will not actually use all imported
@@ -144,8 +144,8 @@ providers:
           # buildkit `--export-cache` option. Cache manifests will only be
           # stored stored in the configured `tag`.
           #
-          # `auto` is the same as `max` for most registries. Some popular registries do not support `max` and garden
-          # will fall back to `inline` for them.
+          # `auto` is the same as `max` for some registries that are known to support it. Garden will fall back to
+          # `inline` for all other registries.
           #  See the [clusterBuildkit cache option](#providers-.clusterbuildkit.cache) for a description of the
           # detection mechanism.
           #
@@ -659,16 +659,16 @@ For every build, this will
 For registries that support it, `mode: auto` (the default) will enable the buildkit `mode=max`
 option.
 
-Some registries are known not to support the cache manifests needed for the `mode=max` option, so
-we will avoid using `mode=max` with them.
-
 See the following table for details on our detection mechanism:
 
-| Registry Name                   | Detection string | Assumed `mode=max` support |
-|---------------------------------|------------------|------------------------------|
-| AWS Elastic Container Registry  | `.dkr.ecr.`    | No                           |
-| Google Cloud Container Registry | `gcr.io`       | No                           |
-| Any other registry              | -                | Yes                          |
+| Registry Name                   | Registry Domain         | Assumed `mode=max` support |
+|---------------------------------|-------------------------|------------------------------|
+| Google Cloud Artifact Registry  | `pkg.dev`             | Yes                          |
+| Azure Container Registry        | `azurecr.io`          | Yes                          |
+| GitHub Container Registry       | `ghcr.io`             | Yes                          |
+| DockerHub                       | `hub.docker.com`     | Yes                          |
+| Garden In-Cluster Registry      |                         | Yes                          |
+| Any other registry              |                         | No                           |
 
 In case you need to override the defaults for your registry, you can do it like so:
 
@@ -676,7 +676,7 @@ In case you need to override the defaults for your registry, you can do it like 
 clusterBuildkit:
   cache:
     - type: registry
-      mode: inline
+      mode: max
 ```
 
 When you add multiple caches, we will make sure to pass the `--import-cache` options to buildkit in the same
@@ -812,7 +812,7 @@ The value `inline` ensures that garden is using the buildkit option `--export-ca
 The values `min` and `max` ensure that garden passes the `mode=max` or `mode=min` modifiers to the buildkit `--export-cache` option. Cache manifests will only be
 stored stored in the configured `tag`.
 
-`auto` is the same as `max` for most registries. Some popular registries do not support `max` and garden will fall back to `inline` for them.
+`auto` is the same as `max` for some registries that are known to support it. Garden will fall back to `inline` for all other registries.
  See the [clusterBuildkit cache option](#providers-.clusterbuildkit.cache) for a description of the detection mechanism.
 
 See also the [buildkit export cache documentation](https://github.com/moby/buildkit#export-cache)

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -58,23 +58,23 @@ providers:
       # For registries that support it, `mode: auto` (the default) will enable the buildkit `mode=max`
       # option.
       #
-      # Some registries are known not to support the cache manifests needed for the `mode=max` option, so
-      # we will avoid using `mode=max` with them.
-      #
       # See the following table for details on our detection mechanism:
       #
-      # | Registry Name                   | Detection string | Assumed `mode=max` support |
-      # |---------------------------------|------------------|------------------------------|
-      # | AWS Elastic Container Registry  | `.dkr.ecr.`    | No                           |
-      # | Google Cloud Container Registry | `gcr.io`       | No                           |
-      # | Any other registry              | -                | Yes                          |
+      # | Registry Name                   | Registry Domain         | Assumed `mode=max` support |
+      # |---------------------------------|-------------------------|------------------------------|
+      # | Google Cloud Artifact Registry  | `pkg.dev`             | Yes                          |
+      # | Azure Container Registry        | `azurecr.io`          | Yes                          |
+      # | GitHub Container Registry       | `ghcr.io`             | Yes                          |
+      # | DockerHub                       | `hub.docker.com`     | Yes                          |
+      # | Garden In-Cluster Registry      |                         | Yes                          |
+      # | Any other registry              |                         | No                           |
       #
       # In case you need to override the defaults for your registry, you can do it like so:
       #
       # clusterBuildkit:
       #   cache:
       #     - type: registry
-      #       mode: inline
+      #       mode: max
       #
       # When you add multiple caches, we will make sure to pass the `--import-cache` options to buildkit in the same
       # order as provided in the cache configuration. This is because buildkit will not actually use all imported
@@ -140,8 +140,8 @@ providers:
           # buildkit `--export-cache` option. Cache manifests will only be
           # stored stored in the configured `tag`.
           #
-          # `auto` is the same as `max` for most registries. Some popular registries do not support `max` and garden
-          # will fall back to `inline` for them.
+          # `auto` is the same as `max` for some registries that are known to support it. Garden will fall back to
+          # `inline` for all other registries.
           #  See the [clusterBuildkit cache option](#providers-.clusterbuildkit.cache) for a description of the
           # detection mechanism.
           #
@@ -608,16 +608,16 @@ For every build, this will
 For registries that support it, `mode: auto` (the default) will enable the buildkit `mode=max`
 option.
 
-Some registries are known not to support the cache manifests needed for the `mode=max` option, so
-we will avoid using `mode=max` with them.
-
 See the following table for details on our detection mechanism:
 
-| Registry Name                   | Detection string | Assumed `mode=max` support |
-|---------------------------------|------------------|------------------------------|
-| AWS Elastic Container Registry  | `.dkr.ecr.`    | No                           |
-| Google Cloud Container Registry | `gcr.io`       | No                           |
-| Any other registry              | -                | Yes                          |
+| Registry Name                   | Registry Domain         | Assumed `mode=max` support |
+|---------------------------------|-------------------------|------------------------------|
+| Google Cloud Artifact Registry  | `pkg.dev`             | Yes                          |
+| Azure Container Registry        | `azurecr.io`          | Yes                          |
+| GitHub Container Registry       | `ghcr.io`             | Yes                          |
+| DockerHub                       | `hub.docker.com`     | Yes                          |
+| Garden In-Cluster Registry      |                         | Yes                          |
+| Any other registry              |                         | No                           |
 
 In case you need to override the defaults for your registry, you can do it like so:
 
@@ -625,7 +625,7 @@ In case you need to override the defaults for your registry, you can do it like 
 clusterBuildkit:
   cache:
     - type: registry
-      mode: inline
+      mode: max
 ```
 
 When you add multiple caches, we will make sure to pass the `--import-cache` options to buildkit in the same
@@ -761,7 +761,7 @@ The value `inline` ensures that garden is using the buildkit option `--export-ca
 The values `min` and `max` ensure that garden passes the `mode=max` or `mode=min` modifiers to the buildkit `--export-cache` option. Cache manifests will only be
 stored stored in the configured `tag`.
 
-`auto` is the same as `max` for most registries. Some popular registries do not support `max` and garden will fall back to `inline` for them.
+`auto` is the same as `max` for some registries that are known to support it. Garden will fall back to `inline` for all other registries.
  See the [clusterBuildkit cache option](#providers-.clusterbuildkit.cache) for a description of the detection mechanism.
 
 See also the [buildkit export cache documentation](https://github.com/moby/buildkit#export-cache)


### PR DESCRIPTION
**What this PR does / why we need it**:

While most self-hosted registries do support buildkits mode=max,
harbor doesnt and so we can't use mode=max as a default unless we find
a way to autodetect the support for an unknown registry.

**Which issue(s) this PR fixes**:

Fixes #3279

**Special notes for your reviewer**:
