### PR TITLE
Fix publish tests

### DIFF
--- a/core/src/actions/build.ts
+++ b/core/src/actions/build.ts
@@ -143,11 +143,6 @@ export class BuildAction<
       return join(this.baseBuildDirectory, this.name)
     }
   }
-
-  // TODO-G2: see if we actually need/want this
-  getBuildMetadataPath() {
-    return join(this.baseBuildDirectory, this.name + ".metadata")
-  }
 }
 
 // TODO: see if we can avoid the duplication here with ResolvedRuntimeAction

--- a/core/src/build-staging/build-staging.ts
+++ b/core/src/build-staging/build-staging.ts
@@ -43,13 +43,11 @@ export interface SyncParams {
 @Profile()
 export class BuildStaging {
   public buildDirPath: string
-  public buildMetadataDirPath: string
 
   private createdPaths: Set<string>
 
   constructor(protected projectRoot: string, gardenDirPath: string) {
     this.buildDirPath = join(gardenDirPath, "build")
-    this.buildMetadataDirPath = join(gardenDirPath, "build-metadata")
     this.createdPaths = new Set()
   }
 
@@ -137,20 +135,6 @@ export class BuildStaging {
 
   async ensureBuildPath(config: BuildActionConfig<string, any>): Promise<string> {
     const path = this.getBuildPath(config)
-    await this.ensureDir(path)
-    return path
-  }
-
-  /**
-   * This directory can be used to store build-related metadata for a given module, for example the last built
-   * version for exec modules.
-   */
-  getBuildMetadataPath(moduleName: string) {
-    return join(this.buildMetadataDirPath, moduleName)
-  }
-
-  async ensureBuildMetadataPath(moduleName: string): Promise<string> {
-    const path = this.getBuildMetadataPath(moduleName)
     await this.ensureDir(path)
     return path
   }

--- a/core/src/commands/get/get-modules.ts
+++ b/core/src/commands/get/get-modules.ts
@@ -102,7 +102,6 @@ function logFull(garden: Garden, modules: GardenModule[], log: LogEntry) {
         "_config",
         "variables",
         "buildPath",
-        "buildMetadataPath",
         "configPath",
         "plugin",
         "serviceConfigs",

--- a/core/src/commands/publish.ts
+++ b/core/src/commands/publish.ts
@@ -57,13 +57,18 @@ export class PublishCommand extends Command<Args, Opts> {
   description = dedent`
     Publishes built artifacts for all or specified builds. Also builds dependencies if needed.
 
-    By default the artifacts/images are tagged with the Garden action version, but you can also specify the \`--tag\` option to specify a specific string tag _or_ a templated tag. Any template values that can be used on the build being tagged are available, in addition to ${"${build.name}"}, ${"${build.version}"} and ${"${build.hash}"} tags that allows referencing the name of the build being tagged, as well as its Garden version. ${"${build.version}"} includes the "v-" prefix normally used for Garden versions, and ${"${build.hash}"} doesn't.
+    By default the artifacts/images are tagged with the Garden action version,
+    but you can also specify the \`--tag\` option to specify a specific string tag _or_ a templated tag.
+    Any template values that can be used on the build being tagged are available,
+    in addition to ${"${build.name}"}, ${"${build.version}"} and ${"${build.hash}"}
+    tags that allows referencing the name of the build being tagged, as well as its Garden version.
+    ${"${build.version}"} includes the "v-" prefix normally used for Garden versions, ${"${build.hash}"} doesn't.
 
     Examples:
 
-        garden publish                # publish artifacts for all modules in the project
+        garden publish                # publish artifacts for all builds in the project
         garden publish my-container   # only publish my-container
-        garden publish --force-build  # force re-build of modules before publishing artifacts
+        garden publish --force-build  # force re-build before publishing artifacts
 
         # Publish my-container with a tag of v0.1
         garden publish my-container --tag "v0.1"
@@ -78,12 +83,12 @@ export class PublishCommand extends Command<Args, Opts> {
   outputsSchema = () =>
     processCommandResultSchema().keys({
       published: joiIdentifierMap(publishResultSchema().keys(processCommandResultKeys())).description(
-        "A map of all modules that were published (or scheduled/attempted for publishing) and the results."
+        "A map of all builds that were published (or scheduled/attempted for publishing) and the results."
       ),
     })
 
   printHeader({ headerLog }) {
-    printHeader(headerLog, "Publish modules", "rocket")
+    printHeader(headerLog, "Publish builds", "rocket")
   }
 
   async action({

--- a/core/src/plugin/handlers/build/publish.ts
+++ b/core/src/plugin/handlers/build/publish.ts
@@ -12,6 +12,7 @@ import { joi } from "../../../config/common"
 import { BuildAction } from "../../../actions/build"
 import { ActionTypeHandlerSpec } from "../base/base"
 import { ActionStatus, Executed } from "../../../actions/types"
+import { actionStatusSchema } from "../../../actions/base"
 
 interface PublishActionParams<T extends BuildAction = BuildAction> extends PluginBuildActionParamsBase<T> {
   tag?: string
@@ -26,10 +27,12 @@ interface PublishActionDetail {
 export type PublishActionResult = ActionStatus<BuildAction, PublishActionDetail>
 
 export const publishResultSchema = () =>
-  joi.object().keys({
-    published: joi.boolean().required().description("Set to true if the build was published."),
-    message: joi.string().description("Optional result message from the provider."),
-    identifier: joi.string().description("The published artifact identifier, if applicable."),
+  actionStatusSchema().keys({
+    detail: joi.object().keys({
+      published: joi.boolean().required().description("Set to true if the build was published."),
+      message: joi.string().description("Optional result message from the provider."),
+      identifier: joi.string().description("The published artifact identifier, if applicable."),
+    }),
   })
 
 export class PublishBuildAction<T extends BuildAction = BuildAction> extends ActionTypeHandlerSpec<

--- a/core/src/plugins/exec/exec.ts
+++ b/core/src/plugins/exec/exec.ts
@@ -195,7 +195,7 @@ export const buildExecAction: BuildActionHandler<"build", ExecBuild> = async ({ 
   }
 
   if (output.detail?.buildLog) {
-    const prefix = `Finished building module ${chalk.white(action.name)}. Here is the full output:`
+    const prefix = `Finished building action ${chalk.white(action.name)}. Here is the full output:`
     log.verbose(renderMessageWithDivider(prefix, output.detail?.buildLog, false, chalk.gray))
   }
 

--- a/core/src/plugins/exec/exec.ts
+++ b/core/src/plugins/exec/exec.ts
@@ -198,9 +198,6 @@ export const buildExecAction: BuildActionHandler<"build", ExecBuild> = async ({ 
     const prefix = `Finished building module ${chalk.white(action.name)}. Here is the full output:`
     log.verbose(renderMessageWithDivider(prefix, output.detail?.buildLog, false, chalk.gray))
   }
-  // keep track of which version has been built
-  const buildVersionFilePath = join(action.getBuildMetadataPath(), GARDEN_BUILD_VERSION_FILENAME)
-  await writeModuleVersionFile(buildVersionFilePath, action.getFullVersion())
 
   return output
 }

--- a/core/src/plugins/exec/exec.ts
+++ b/core/src/plugins/exec/exec.ts
@@ -195,7 +195,7 @@ export const buildExecAction: BuildActionHandler<"build", ExecBuild> = async ({ 
   }
 
   if (output.detail?.buildLog) {
-    const prefix = `Finished building action ${chalk.white(action.name)}. Here is the full output:`
+    const prefix = `Finished building ${chalk.white(action.name)}. Here is the full output:`
     log.verbose(renderMessageWithDivider(prefix, output.detail?.buildLog, false, chalk.gray))
   }
 

--- a/core/src/tasks/base.ts
+++ b/core/src/tasks/base.ts
@@ -295,7 +295,7 @@ export abstract class BaseActionTask<
       )
     }
 
-    return <Executed<T>>result.outputs.resolvedAction
+    return <Executed<T>>result.result?.executedAction
   }
 
   /**

--- a/core/src/tasks/publish.ts
+++ b/core/src/tasks/publish.ts
@@ -59,7 +59,7 @@ export class PublishTask extends BaseActionTask<BuildAction, PublishActionResult
     if (this.action.getConfig("allowPublish") === false) {
       this.log.info({
         section: this.action.key(),
-        msg: "Publishing disabled (allowPublish=false set on action)",
+        msg: "Publishing disabled (allowPublish=false set on build)",
         status: "active",
       })
       return { state: <ActionState>"ready", detail: { published: false }, outputs: {} }

--- a/core/src/tasks/publish.ts
+++ b/core/src/tasks/publish.ts
@@ -62,7 +62,7 @@ export class PublishTask extends BaseActionTask<BuildAction, PublishActionResult
         msg: "Publishing disabled (allowPublish=false set on action)",
         status: "active",
       })
-      return { state: <ActionState>"ready", detail: { published: false, outputs: {} }, outputs: {} }
+      return { state: <ActionState>"ready", detail: { published: false }, outputs: {} }
     }
 
     const action = this.getExecutedAction(this.action, dependencyResults)

--- a/core/src/tasks/publish.ts
+++ b/core/src/tasks/publish.ts
@@ -59,7 +59,7 @@ export class PublishTask extends BaseActionTask<BuildAction, PublishActionResult
     if (this.action.getConfig("allowPublish") === false) {
       this.log.info({
         section: this.action.key(),
-        msg: "Publishing disabled (allowPublish=false set on module)",
+        msg: "Publishing disabled (allowPublish=false set on action)",
         status: "active",
       })
       return { state: <ActionState>"ready", detail: { published: false, outputs: {} }, outputs: {} }

--- a/core/src/types/module.ts
+++ b/core/src/types/module.ts
@@ -45,7 +45,6 @@ export interface GardenModule<
   O extends {} = any
 > extends ModuleConfig<M, S, T, W> {
   buildPath: string
-  buildMetadataPath: string
   needsBuild: boolean
 
   version: ModuleVersion
@@ -68,7 +67,6 @@ export interface GardenModule<
 export const moduleSchema = () =>
   moduleConfigSchema().keys({
     buildPath: joi.string().required().description("The path to the build staging directory for the module."),
-    buildMetadataPath: joi.string().required().description("The path to the build metadata directory for the module."),
     compatibleTypes: joiArray(joiIdentifier())
       .required()
       .description("A list of types that this module is compatible with (i.e. the module type itself + all bases)."),
@@ -133,7 +131,6 @@ export async function moduleFromConfig({
     ...cloneDeep(config),
 
     buildPath,
-    buildMetadataPath: await garden.buildStaging.ensureBuildMetadataPath(config.name),
 
     version,
     needsBuild: moduleNeedsBuild(config, moduleTypes[config.type]),

--- a/core/test/unit/src/plugins/exec/exec.ts
+++ b/core/test/unit/src/plugins/exec/exec.ts
@@ -401,21 +401,6 @@ describe("exec plugin", () => {
   })
 
   describe("build", () => {
-    it("should write a build version file after building", async () => {
-      const action = graph.getBuild(moduleName)
-      const buildMetadataPath = action.getBuildMetadataPath()
-      const versionFilePath = join(buildMetadataPath, GARDEN_BUILD_VERSION_FILENAME)
-
-      await garden.buildStaging.syncFromSrc(action, log)
-      const actions = await garden.getActionRouter()
-      const resolvedAction = await garden.resolveAction({ action, graph, log })
-      await actions.build.build({ log, action: resolvedAction, graph })
-
-      const versionFileContents = await readModuleVersionFile(versionFilePath)
-
-      expect(versionFileContents).to.eql(action.versionString())
-    })
-
     it("should run the build command in the module dir if local true", async () => {
       const action = graph.getBuild("module-local")
       const actions = await garden.getActionRouter()


### PR DESCRIPTION
Fixes all but one tests for the publish command. The one remaining tests fails due to I bug in the solver I think?

Currently no builds are being triggered by the publish task. I'm not sure if that's a deliberate change or not.

Also removed build metadata logic.
