### PR TITLE
fix(k8s): add preStop command for rsync containers

### DIFF
--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -490,6 +490,21 @@ export function getUtilContainer(authSecretName: string): V1Container {
       failureThreshold: 5,
       tcpSocket: { port: <object>(<unknown>rsyncPortName) },
     },
+    lifecycle: {
+      preStop: {
+        exec: {
+          // this preStop command makes sure that we wait for some time if an rsync is still ongoing, before
+          // actually killing the pod. If the transfer takes more than 30 seconds, which is unlikely, the pod
+          // will be killed anyway. The command works by counting the number of rsync processes. This works
+          // because rsync forks for every connection.
+          command: [
+            "/bin/sh",
+            "-c",
+            "until test $(pgrep -fc '^[^ ]+rsync') = 1; do echo waiting for rsync to finish...; sleep 1; done",
+          ],
+        },
+      },
+    },
     resources: {
       // This should be ample
       limits: {

--- a/core/src/plugins/kubernetes/hot-reload/helpers.ts
+++ b/core/src/plugins/kubernetes/hot-reload/helpers.ts
@@ -162,6 +162,21 @@ export function configureHotReload({
       failureThreshold: 5,
       tcpSocket: { port: <object>(<unknown>rsyncPortName) },
     },
+    lifecycle: {
+      preStop: {
+        exec: {
+          // this preStop command makes sure that we wait for some time if an rsync is still ongoing, before
+          // actually killing the pod. If the transfer takes more than 30 seconds, which is unlikely, the pod
+          // will be killed anyway. The command works by counting the number of rsync processes. This works
+          // because rsync forks for every connection.
+          command: [
+            "/bin/sh",
+            "-c",
+            "until test $(pgrep -fc '^[^ ]+rsync') = 1; do echo waiting for rsync to finish...; sleep 1; done",
+          ],
+        },
+      },
+    },
   })
 }
 

--- a/core/test/unit/src/plugins/kubernetes/hot-reload.ts
+++ b/core/test/unit/src/plugins/kubernetes/hot-reload.ts
@@ -102,6 +102,17 @@ describe("configureHotReload", () => {
                   failureThreshold: 5,
                   tcpSocket: { port: <object>(<unknown>rsyncPortName) },
                 },
+                lifecycle: {
+                  preStop: {
+                    exec: {
+                      command: [
+                        "/bin/sh",
+                        "-c",
+                        "until test $(pgrep -fc '^[^ ]+rsync') = 1; do echo waiting for rsync to finish...; sleep 1; done",
+                      ],
+                    },
+                  },
+                },
                 volumeMounts: [
                   {
                     name: "garden-sync",
@@ -218,6 +229,21 @@ describe("configureHotReload", () => {
               successThreshold: 1,
               failureThreshold: 5,
               tcpSocket: { port: <object>(<unknown>rsyncPortName) },
+            },
+            lifecycle: {
+              preStop: {
+                exec: {
+                  // this preStop command makes sure that we wait for some time if an rsync is still ongoing, before
+                  // actually killing the pod. If the transfer takes more than 30 seconds, which is unlikely, the pod
+                  // will be killed anyway. The command works by counting the number of rsync processes. This works
+                  // because rsync forks for every connection.
+                  command: [
+                    "/bin/sh",
+                    "-c",
+                    "until test $(pgrep -fc '^[^ ]+rsync') = 1; do echo waiting for rsync to finish...; sleep 1; done",
+                  ],
+                },
+              },
             },
             volumeMounts: [
               {

--- a/static/kubernetes/system/build-sync/templates/deployment.yaml
+++ b/static/kubernetes/system/build-sync/templates/deployment.yaml
@@ -54,6 +54,15 @@ spec:
               command: [stat, /data]
             initialDelaySeconds: 20
             periodSeconds: 2
+          lifecycle:
+            preStop:
+              exec:
+                # this preStop command makes sure that we wait for some time if an rsync is still ongoing, before
+                # this preStop command makes sure that we wait for some time if an rsync is still ongoing, before
+                # actually killing the pod. If the transfer takes more than 30 seconds, which is unlikely, the pod
+                # will be killed anyway. The command works by counting the number of rsync processes. This works
+                # because rsync forks for every connection.
+                command: ["/bin/sh", "-c", "until test $(pgrep -fc '^[^ ]+rsync') = 1; do echo waiting for rsync to finish...; sleep 1; done"]
           volumeMounts:
             - mountPath: /data
               name: garden-build-sync


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Add a preStop command for rsync containers to make sure that an ongoing
rsync is not interrupted (or at least make it unlikely, as transfers
usually are quicker than 30 seconds)

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
