### PR TITLE
improvement(k8s): bump buildkit image to v0.10.5

### DIFF
--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -38,7 +38,7 @@ import { PodRunner } from "../../run"
 import { prepareSecrets } from "../../secrets"
 import { ContainerModuleOutputs } from "../../../container/container"
 
-export const buildkitImageName = "gardendev/buildkit:v0.9.3-1"
+export const buildkitImageName = "gardendev/buildkit:v0.10.5-1"
 export const buildkitDeploymentName = "garden-buildkit"
 const buildkitContainerName = "buildkitd"
 

--- a/images/buildkit/Dockerfile
+++ b/images/buildkit/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE_SUFFIX
-ARG BUILDKIT_VERSION=v0.9.3
+ARG BUILDKIT_VERSION=v0.10.5
 FROM moby/buildkit:${BUILDKIT_VERSION} as deps
 
 RUN apk add --no-cache curl

--- a/images/buildkit/garden.yml
+++ b/images/buildkit/garden.yml
@@ -2,7 +2,7 @@ kind: Module
 type: container
 name: buildkit
 description: Used for the cluster-buildkit build mode in the kubernetes provider
-image: gardendev/buildkit:v0.9.3-1
+image: gardendev/buildkit:v0.10.5-1
 dockerfile: Dockerfile
 build:
   targetImage: output
@@ -11,7 +11,7 @@ kind: Module
 type: container
 name: buildkit-rootless
 description: Used for the cluster-buildkit build mode in the kubernetes provider, rootless variant
-image: gardendev/buildkit:v0.9.3-1-rootless
+image: gardendev/buildkit:v0.10.5-1-rootless
 dockerfile: Dockerfile
 build:
   dependencies:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Updates the buildkit image to use v0.10.5.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
