### PR TITLE
feat: allow to set no resource limits

### DIFF
--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -539,7 +539,8 @@ export const containerCpuSchema = (targetType: string) =>
         The minimum amount of CPU the ${targetType} needs to be available for it to be deployed, in millicpus
         (i.e. 1000 = 1 CPU)
       `),
-    max: joi.number().default(defaultContainerResources.cpu.max).min(10).allow(null).description(deline`
+    max: joi.number().default(defaultContainerResources.cpu.max).min(defaultContainerResources.cpu.min).allow(null)
+      .description(deline`
         The maximum amount of CPU the ${targetType} can use, in millicpus (i.e. 1000 = 1 CPU).
         If set to null will result in no limit being set.
       `),

--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -99,11 +99,11 @@ export interface ServiceLimitSpec {
 export interface ContainerResourcesSpec {
   cpu: {
     min: number
-    max: number
+    max: number | null
   }
   memory: {
     min: number
-    max: number
+    max: number | null
   }
 }
 
@@ -536,14 +536,13 @@ const limitsSchema = () =>
 export const containerCpuSchema = (targetType: string) =>
   joi.object().keys({
     min: joi.number().default(defaultContainerResources.cpu.min).description(deline`
-          The minimum amount of CPU the ${targetType} needs to be available for it to be deployed, in millicpus
-          (i.e. 1000 = 1 CPU)
-        `),
-    max: joi
-      .number()
-      .default(defaultContainerResources.cpu.max)
-      .min(10)
-      .description(`The maximum amount of CPU the ${targetType} can use, in millicpus (i.e. 1000 = 1 CPU)`),
+        The minimum amount of CPU the ${targetType} needs to be available for it to be deployed, in millicpus
+        (i.e. 1000 = 1 CPU)
+      `),
+    max: joi.number().default(defaultContainerResources.cpu.max).min(10).allow(null).description(deline`
+        The maximum amount of CPU the ${targetType} can use, in millicpus (i.e. 1000 = 1 CPU).
+        If set to null will result in no limit being set.
+      `),
   })
 
 export const containerMemorySchema = (targetType: string) =>
@@ -552,11 +551,10 @@ export const containerMemorySchema = (targetType: string) =>
         The minimum amount of RAM the ${targetType} needs to be available for it to be deployed, in megabytes
         (i.e. 1024 = 1 GB)
       `),
-    max: joi
-      .number()
-      .default(defaultContainerResources.memory.min)
-      .min(64)
-      .description(`The maximum amount of RAM the ${targetType} can use, in megabytes (i.e. 1024 = 1 GB)`),
+    max: joi.number().default(defaultContainerResources.memory.max).allow(null).min(64).description(deline`
+        The maximum amount of RAM the ${targetType} can use, in megabytes (i.e. 1024 = 1 GB)
+        If set to null will result in no limit being set.
+      `),
   })
 
 export const portSchema = () =>

--- a/core/src/plugins/kubernetes/container/util.ts
+++ b/core/src/plugins/kubernetes/container/util.ts
@@ -43,16 +43,24 @@ export function getResourceRequirements(
 ): V1ResourceRequirements {
   const maxCpu = limits?.cpu || resources.cpu.max
   const maxMemory = limits?.memory || resources.memory.max
-  return {
+
+  const resourceReq: V1ResourceRequirements = {
     requests: {
       cpu: millicpuToString(resources.cpu.min),
       memory: kilobytesToString(resources.memory.min * 1024),
     },
-    limits: {
-      cpu: millicpuToString(maxCpu),
-      memory: kilobytesToString(maxMemory * 1024),
-    },
   }
+  if (maxMemory || maxCpu) {
+    resourceReq.limits = {}
+  }
+  if (maxMemory) {
+    resourceReq.limits!.memory = kilobytesToString(maxMemory * 1024)
+  }
+  if (maxCpu) {
+    resourceReq.limits!.cpu = millicpuToString(maxCpu)
+  }
+
+  return resourceReq
 }
 
 export function getSecurityContext(

--- a/core/test/unit/src/plugins/kubernetes/container/util.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/util.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2018-2022 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import { getResourceRequirements } from "../../../../../../src/plugins/kubernetes/container/util"
+
+describe("getResourceRequirements", () => {
+  it("should return resources", () => {
+    expect(getResourceRequirements({ cpu: { max: 1, min: 1 }, memory: { max: 1, min: 1 } })).to.eql({
+      requests: {
+        cpu: "1m",
+        memory: "1Mi",
+      },
+      limits: {
+        cpu: "1m",
+        memory: "1Mi",
+      },
+    })
+  })
+
+  it("should return resources without limits if max values are null", () => {
+    expect(getResourceRequirements({ cpu: { max: null, min: 1 }, memory: { max: null, min: 1 } })).to.eql({
+      requests: {
+        cpu: "1m",
+        memory: "1Mi",
+      },
+    })
+  })
+
+  it("should return resources with one limit if one max value is set", () => {
+    expect(getResourceRequirements({ cpu: { max: 1, min: 1 }, memory: { max: null, min: 1 } })).to.eql({
+      requests: {
+        cpu: "1m",
+        memory: "1Mi",
+      },
+      limits: {
+        cpu: "1m",
+      },
+    })
+  })
+
+  it("shoudl prioritize deprecated limits param", () => {
+    expect(
+      getResourceRequirements({ cpu: { max: 1, min: 1 }, memory: { max: null, min: 1 } }, { cpu: 50, memory: 50 })
+    ).to.eql({
+      requests: {
+        cpu: "1m",
+        memory: "1Mi",
+      },
+      limits: {
+        cpu: "50m",
+        memory: "50Mi",
+      },
+    })
+  })
+})

--- a/core/test/unit/src/plugins/kubernetes/container/util.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/util.ts
@@ -44,7 +44,7 @@ describe("getResourceRequirements", () => {
     })
   })
 
-  it("shoudl prioritize deprecated limits param", () => {
+  it("should prioritize deprecated limits param", () => {
     expect(
       getResourceRequirements({ cpu: { max: 1, min: 1 }, memory: { max: null, min: 1 } }, { cpu: 50, memory: 50 })
     ).to.eql({

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -407,7 +407,8 @@ services:
       # CPU)
       min: 10
 
-      # The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)
+      # The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU). If set to null will result in
+      # no limit being set.
       max: 1000
 
     memory:
@@ -415,8 +416,9 @@ services:
       # GB)
       min: 90
 
-      # The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB)
-      max: 90
+      # The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB) If set to null will result in
+      # no limit being set.
+      max: 1024
 
     # List of ports that the service container exposes.
     ports:
@@ -554,7 +556,8 @@ tests:
       # CPU)
       min: 10
 
-      # The maximum amount of CPU the test can use, in millicpus (i.e. 1000 = 1 CPU)
+      # The maximum amount of CPU the test can use, in millicpus (i.e. 1000 = 1 CPU). If set to null will result in no
+      # limit being set.
       max: 1000
 
     memory:
@@ -562,8 +565,9 @@ tests:
       # GB)
       min: 90
 
-      # The maximum amount of RAM the test can use, in megabytes (i.e. 1024 = 1 GB)
-      max: 90
+      # The maximum amount of RAM the test can use, in megabytes (i.e. 1024 = 1 GB) If set to null will result in no
+      # limit being set.
+      max: 1024
 
     # List of volumes that should be mounted when deploying the test.
     #
@@ -667,7 +671,8 @@ tasks:
       # CPU)
       min: 10
 
-      # The maximum amount of CPU the task can use, in millicpus (i.e. 1000 = 1 CPU)
+      # The maximum amount of CPU the task can use, in millicpus (i.e. 1000 = 1 CPU). If set to null will result in no
+      # limit being set.
       max: 1000
 
     memory:
@@ -675,8 +680,9 @@ tasks:
       # GB)
       min: 90
 
-      # The maximum amount of RAM the task can use, in megabytes (i.e. 1024 = 1 GB)
-      max: 90
+      # The maximum amount of RAM the task can use, in megabytes (i.e. 1024 = 1 GB) If set to null will result in no
+      # limit being set.
+      max: 1024
 
     # List of volumes that should be mounted when deploying the task.
     #
@@ -1807,7 +1813,7 @@ The minimum amount of CPU the service needs to be available for it to be deploye
 
 [services](#services) > [cpu](#servicescpu) > max
 
-The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)
+The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU). If set to null will result in no limit being set.
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |
@@ -1835,11 +1841,11 @@ The minimum amount of RAM the service needs to be available for it to be deploye
 
 [services](#services) > [memory](#servicesmemory) > max
 
-The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB)
+The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB) If set to null will result in no limit being set.
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |
-| `number` | `90`    | No       |
+| `number` | `1024`  | No       |
 
 ### `services[].ports[]`
 
@@ -2277,7 +2283,7 @@ The minimum amount of CPU the test needs to be available for it to be deployed, 
 
 [tests](#tests) > [cpu](#testscpu) > max
 
-The maximum amount of CPU the test can use, in millicpus (i.e. 1000 = 1 CPU)
+The maximum amount of CPU the test can use, in millicpus (i.e. 1000 = 1 CPU). If set to null will result in no limit being set.
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |
@@ -2305,11 +2311,11 @@ The minimum amount of RAM the test needs to be available for it to be deployed, 
 
 [tests](#tests) > [memory](#testsmemory) > max
 
-The maximum amount of RAM the test can use, in megabytes (i.e. 1024 = 1 GB)
+The maximum amount of RAM the test can use, in megabytes (i.e. 1024 = 1 GB) If set to null will result in no limit being set.
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |
-| `number` | `90`    | No       |
+| `number` | `1024`  | No       |
 
 ### `tests[].volumes[]`
 
@@ -2622,7 +2628,7 @@ The minimum amount of CPU the task needs to be available for it to be deployed, 
 
 [tasks](#tasks) > [cpu](#taskscpu) > max
 
-The maximum amount of CPU the task can use, in millicpus (i.e. 1000 = 1 CPU)
+The maximum amount of CPU the task can use, in millicpus (i.e. 1000 = 1 CPU). If set to null will result in no limit being set.
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |
@@ -2650,11 +2656,11 @@ The minimum amount of RAM the task needs to be available for it to be deployed, 
 
 [tasks](#tasks) > [memory](#tasksmemory) > max
 
-The maximum amount of RAM the task can use, in megabytes (i.e. 1024 = 1 GB)
+The maximum amount of RAM the task can use, in megabytes (i.e. 1024 = 1 GB) If set to null will result in no limit being set.
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |
-| `number` | `90`    | No       |
+| `number` | `1024`  | No       |
 
 ### `tasks[].volumes[]`
 

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -448,7 +448,8 @@ services:
       # CPU)
       min: 10
 
-      # The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)
+      # The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU). If set to null will result in
+      # no limit being set.
       max: 1000
 
     memory:
@@ -456,8 +457,9 @@ services:
       # GB)
       min: 90
 
-      # The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB)
-      max: 90
+      # The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB) If set to null will result in
+      # no limit being set.
+      max: 1024
 
     # List of ports that the service container exposes.
     ports:
@@ -595,7 +597,8 @@ tests:
       # CPU)
       min: 10
 
-      # The maximum amount of CPU the test can use, in millicpus (i.e. 1000 = 1 CPU)
+      # The maximum amount of CPU the test can use, in millicpus (i.e. 1000 = 1 CPU). If set to null will result in no
+      # limit being set.
       max: 1000
 
     memory:
@@ -603,8 +606,9 @@ tests:
       # GB)
       min: 90
 
-      # The maximum amount of RAM the test can use, in megabytes (i.e. 1024 = 1 GB)
-      max: 90
+      # The maximum amount of RAM the test can use, in megabytes (i.e. 1024 = 1 GB) If set to null will result in no
+      # limit being set.
+      max: 1024
 
     # List of volumes that should be mounted when deploying the test.
     #
@@ -708,7 +712,8 @@ tasks:
       # CPU)
       min: 10
 
-      # The maximum amount of CPU the task can use, in millicpus (i.e. 1000 = 1 CPU)
+      # The maximum amount of CPU the task can use, in millicpus (i.e. 1000 = 1 CPU). If set to null will result in no
+      # limit being set.
       max: 1000
 
     memory:
@@ -716,8 +721,9 @@ tasks:
       # GB)
       min: 90
 
-      # The maximum amount of RAM the task can use, in megabytes (i.e. 1024 = 1 GB)
-      max: 90
+      # The maximum amount of RAM the task can use, in megabytes (i.e. 1024 = 1 GB) If set to null will result in no
+      # limit being set.
+      max: 1024
 
     # List of volumes that should be mounted when deploying the task.
     #
@@ -1945,7 +1951,7 @@ The minimum amount of CPU the service needs to be available for it to be deploye
 
 [services](#services) > [cpu](#servicescpu) > max
 
-The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)
+The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU). If set to null will result in no limit being set.
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |
@@ -1973,11 +1979,11 @@ The minimum amount of RAM the service needs to be available for it to be deploye
 
 [services](#services) > [memory](#servicesmemory) > max
 
-The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB)
+The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB) If set to null will result in no limit being set.
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |
-| `number` | `90`    | No       |
+| `number` | `1024`  | No       |
 
 ### `services[].ports[]`
 
@@ -2415,7 +2421,7 @@ The minimum amount of CPU the test needs to be available for it to be deployed, 
 
 [tests](#tests) > [cpu](#testscpu) > max
 
-The maximum amount of CPU the test can use, in millicpus (i.e. 1000 = 1 CPU)
+The maximum amount of CPU the test can use, in millicpus (i.e. 1000 = 1 CPU). If set to null will result in no limit being set.
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |
@@ -2443,11 +2449,11 @@ The minimum amount of RAM the test needs to be available for it to be deployed, 
 
 [tests](#tests) > [memory](#testsmemory) > max
 
-The maximum amount of RAM the test can use, in megabytes (i.e. 1024 = 1 GB)
+The maximum amount of RAM the test can use, in megabytes (i.e. 1024 = 1 GB) If set to null will result in no limit being set.
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |
-| `number` | `90`    | No       |
+| `number` | `1024`  | No       |
 
 ### `tests[].volumes[]`
 
@@ -2760,7 +2766,7 @@ The minimum amount of CPU the task needs to be available for it to be deployed, 
 
 [tasks](#tasks) > [cpu](#taskscpu) > max
 
-The maximum amount of CPU the task can use, in millicpus (i.e. 1000 = 1 CPU)
+The maximum amount of CPU the task can use, in millicpus (i.e. 1000 = 1 CPU). If set to null will result in no limit being set.
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |
@@ -2788,11 +2794,11 @@ The minimum amount of RAM the task needs to be available for it to be deployed, 
 
 [tasks](#tasks) > [memory](#tasksmemory) > max
 
-The maximum amount of RAM the task can use, in megabytes (i.e. 1024 = 1 GB)
+The maximum amount of RAM the task can use, in megabytes (i.e. 1024 = 1 GB) If set to null will result in no limit being set.
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |
-| `number` | `90`    | No       |
+| `number` | `1024`  | No       |
 
 ### `tasks[].volumes[]`
 

--- a/docs/reference/module-types/maven-container.md
+++ b/docs/reference/module-types/maven-container.md
@@ -407,7 +407,8 @@ services:
       # CPU)
       min: 10
 
-      # The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)
+      # The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU). If set to null will result in
+      # no limit being set.
       max: 1000
 
     memory:
@@ -415,8 +416,9 @@ services:
       # GB)
       min: 90
 
-      # The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB)
-      max: 90
+      # The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB) If set to null will result in
+      # no limit being set.
+      max: 1024
 
     # List of ports that the service container exposes.
     ports:
@@ -554,7 +556,8 @@ tests:
       # CPU)
       min: 10
 
-      # The maximum amount of CPU the test can use, in millicpus (i.e. 1000 = 1 CPU)
+      # The maximum amount of CPU the test can use, in millicpus (i.e. 1000 = 1 CPU). If set to null will result in no
+      # limit being set.
       max: 1000
 
     memory:
@@ -562,8 +565,9 @@ tests:
       # GB)
       min: 90
 
-      # The maximum amount of RAM the test can use, in megabytes (i.e. 1024 = 1 GB)
-      max: 90
+      # The maximum amount of RAM the test can use, in megabytes (i.e. 1024 = 1 GB) If set to null will result in no
+      # limit being set.
+      max: 1024
 
     # List of volumes that should be mounted when deploying the test.
     #
@@ -667,7 +671,8 @@ tasks:
       # CPU)
       min: 10
 
-      # The maximum amount of CPU the task can use, in millicpus (i.e. 1000 = 1 CPU)
+      # The maximum amount of CPU the task can use, in millicpus (i.e. 1000 = 1 CPU). If set to null will result in no
+      # limit being set.
       max: 1000
 
     memory:
@@ -675,8 +680,9 @@ tasks:
       # GB)
       min: 90
 
-      # The maximum amount of RAM the task can use, in megabytes (i.e. 1024 = 1 GB)
-      max: 90
+      # The maximum amount of RAM the task can use, in megabytes (i.e. 1024 = 1 GB) If set to null will result in no
+      # limit being set.
+      max: 1024
 
     # List of volumes that should be mounted when deploying the task.
     #
@@ -1817,7 +1823,7 @@ The minimum amount of CPU the service needs to be available for it to be deploye
 
 [services](#services) > [cpu](#servicescpu) > max
 
-The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU)
+The maximum amount of CPU the service can use, in millicpus (i.e. 1000 = 1 CPU). If set to null will result in no limit being set.
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |
@@ -1845,11 +1851,11 @@ The minimum amount of RAM the service needs to be available for it to be deploye
 
 [services](#services) > [memory](#servicesmemory) > max
 
-The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB)
+The maximum amount of RAM the service can use, in megabytes (i.e. 1024 = 1 GB) If set to null will result in no limit being set.
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |
-| `number` | `90`    | No       |
+| `number` | `1024`  | No       |
 
 ### `services[].ports[]`
 
@@ -2287,7 +2293,7 @@ The minimum amount of CPU the test needs to be available for it to be deployed, 
 
 [tests](#tests) > [cpu](#testscpu) > max
 
-The maximum amount of CPU the test can use, in millicpus (i.e. 1000 = 1 CPU)
+The maximum amount of CPU the test can use, in millicpus (i.e. 1000 = 1 CPU). If set to null will result in no limit being set.
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |
@@ -2315,11 +2321,11 @@ The minimum amount of RAM the test needs to be available for it to be deployed, 
 
 [tests](#tests) > [memory](#testsmemory) > max
 
-The maximum amount of RAM the test can use, in megabytes (i.e. 1024 = 1 GB)
+The maximum amount of RAM the test can use, in megabytes (i.e. 1024 = 1 GB) If set to null will result in no limit being set.
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |
-| `number` | `90`    | No       |
+| `number` | `1024`  | No       |
 
 ### `tests[].volumes[]`
 
@@ -2632,7 +2638,7 @@ The minimum amount of CPU the task needs to be available for it to be deployed, 
 
 [tasks](#tasks) > [cpu](#taskscpu) > max
 
-The maximum amount of CPU the task can use, in millicpus (i.e. 1000 = 1 CPU)
+The maximum amount of CPU the task can use, in millicpus (i.e. 1000 = 1 CPU). If set to null will result in no limit being set.
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |
@@ -2660,11 +2666,11 @@ The minimum amount of RAM the task needs to be available for it to be deployed, 
 
 [tasks](#tasks) > [memory](#tasksmemory) > max
 
-The maximum amount of RAM the task can use, in megabytes (i.e. 1024 = 1 GB)
+The maximum amount of RAM the task can use, in megabytes (i.e. 1024 = 1 GB) If set to null will result in no limit being set.
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |
-| `number` | `90`    | No       |
+| `number` | `1024`  | No       |
 
 ### `tasks[].volumes[]`
 


### PR DESCRIPTION
closes #3337

If the max value of memory or cpu under the container service is set to
null, no resource limit will be set. If they are NOT set to anything at
all (undefined), a default value is used like before.