### PR TITLE
fix: fixed autoResolveIncludes for multi-stage dockerfiles

### DIFF
--- a/core/src/plugins/container/helpers.ts
+++ b/core/src/plugins/container/helpers.ts
@@ -372,12 +372,12 @@ const helpers = {
       flatten(
         commands.map((cmd) => {
           const args = cmd.args as string[]
-          if (args[0].startsWith("--chown")) {
-            // Ignore --chown args
-            return args.slice(1, -1)
-          } else if (args[0].startsWith("--from")) {
+          if (args.find((arg) => arg.startsWith("--from"))) {
             // Skip statements copying from another build stage
             return []
+          } else if (args[0].startsWith("--chown")) {
+            // Ignore --chown args
+            return args.slice(1, -1)
           } else {
             return args.slice(0, -1)
           }

--- a/core/test/unit/src/plugins/container/helpers.ts
+++ b/core/test/unit/src/plugins/container/helpers.ts
@@ -543,6 +543,19 @@ describe("containerHelpers", () => {
       expect(await helpers.autoResolveIncludes(config, log)).to.eql(["file-a", "Dockerfile"])
     })
 
+    it("should handle COPY statements with multiple arguments in any order", async () => {
+      await writeFile(
+        dockerfilePath,
+        dedent`
+        FROM foo
+        ADD --chown=bla file-a /
+        COPY --chown=bla --from=bla /file-b file-c /
+        COPY --from=bla --chown=bla  /file-c file-d /
+        `
+      )
+      expect(await helpers.autoResolveIncludes(config, log)).to.eql(["file-a", "Dockerfile"])
+    })
+
     it("should ignore paths containing a template string", async () => {
       await writeFile(dockerfilePath, "FROM foo\nADD file-a /\nCOPY file-${foo} file-c /")
       expect(await helpers.autoResolveIncludes(config, log)).to.be.undefined


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Fixes bug in auto-resolve logic for includes running on multi-stage Dockerfiles that has multiple arguments for COPY command.

**Which issue(s) this PR fixes**:

`autoResolveIncludes` logic was relying on having just one argument in ADD or COPY commands, and therefore filtering was done based only on the first argument (args[0]).

However, there are cases when both `--chown` and `--from` arguments can be used for COPY command (in multi-stage builds), and in such case Garden would handle includes successfully only if `--from` was the first argument. For cases when it's not, e.g. `COPY --chown=bla --from=bla file-b file-c`, existing logic would try to use `--from=bla` as an include parameter and fail with a cryptic message:
```
Error validating configure container output from provider kubernetes: 
key .moduleConfig.include[2] must be a relative sub-path (may not contain '..' segments or be an absolute path)
```