### PR TITLE
Separate resource and toleration configuration for garden-util pod

### DIFF
--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -158,17 +158,15 @@ export interface CertManagerConfig {
   acmeServer?: LetsEncryptServerType
 }
 
+export interface KuberetesResourceConfig {
+  cpu: number
+  memory: number
+  ephemeralStorage?: number
+}
+
 export interface KubernetesResourceSpec {
-  limits: {
-    cpu: number
-    memory: number
-    ephemeralStorage?: number
-  }
-  requests: {
-    cpu: number
-    memory: number
-    ephemeralStorage?: number
-  }
+  limits: KuberetesResourceConfig
+  requests: KuberetesResourceConfig
 }
 
 interface KubernetesResources {

--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -175,6 +175,7 @@ interface KubernetesResources {
   builder: KubernetesResourceSpec
   registry: KubernetesResourceSpec
   sync: KubernetesResourceSpec
+  util: KubernetesResourceSpec
 }
 
 interface KubernetesStorageSpec {
@@ -290,6 +291,16 @@ export const defaultResources: KubernetesResources = {
     requests: {
       cpu: 100,
       memory: 90,
+    },
+  },
+  util: {
+    limits: {
+      cpu: 256,
+      memory: 512,
+    },
+    requests: {
+      cpu: 256,
+      memory: 512,
     },
   },
 }
@@ -762,6 +773,12 @@ export const kubernetesConfigBase = () =>
 
             This is shared across all users and builds, so it should be resourced accordingly, factoring
             in how many concurrent builds you expect and how large your images tend to be.
+          `),
+        util: resourceSchema(defaultResources.util, false).description(dedent`
+            Resource requests and limits for the util pod for in-cluster builders.
+            This pod is used to get, start, stop and inquire the status of the builds.
+
+            This pod is created in each garden namespace.
           `),
         sync: resourceSchema(defaultResources.sync, true)
           .description(

--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -229,6 +229,9 @@ export interface KubernetesConfig extends BaseProviderConfig {
     namespace?: string | null
     nodeSelector?: StringMap
     tolerations?: V1Toleration[]
+    util?: {
+      tolerations?: V1Toleration[]
+    }
   }
   context: string
   defaultHostname?: string
@@ -704,8 +707,14 @@ export const kubernetesConfigBase = () =>
           `
         ),
         tolerations: joiSparseArray(tolerationSchema()).description(
-          "Specify tolerations to apply to each Kaniko Pod. Useful to control which nodes in a cluster can run builds."
+          deline`Specify tolerations to apply to each Kaniko builder Pod. Useful to control which nodes in a cluster can run builds.
+          Same tolerations will be used for the util pod unless they are specifically set under \`util.tolerations\``
         ),
+        util: joi.object().keys({
+          tolerations: joiSparseArray(tolerationSchema()).description(
+            "Specify tolerations to apply to each garden-util Pod."
+          ),
+        }),
       })
       .default(() => {})
       .description("Configuration options for the `kaniko` build mode."),

--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -158,7 +158,7 @@ export interface CertManagerConfig {
   acmeServer?: LetsEncryptServerType
 }
 
-interface KubernetesResourceSpec {
+export interface KubernetesResourceSpec {
   limits: {
     cpu: number
     memory: number

--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -33,10 +33,11 @@ import { LogLevel } from "../../../../logger/logger"
 import { renderOutputStream, sleep } from "../../../../util/util"
 import { ContainerModule } from "../../../container/config"
 import { getDockerBuildArgs } from "../../../container/build"
-import { getRunningDeploymentPod, millicpuToString, megabytesToString, usingInClusterRegistry } from "../../util"
+import { getRunningDeploymentPod, usingInClusterRegistry } from "../../util"
 import { PodRunner } from "../../run"
 import { prepareSecrets } from "../../secrets"
 import { ContainerModuleOutputs } from "../../../container/container"
+import { stringifyResources } from "../util"
 
 export const buildkitImageName = "gardendev/buildkit:v0.10.5-1"
 export const buildkitDeploymentName = "garden-buildkit"
@@ -462,22 +463,7 @@ export function getBuildkitDeployment(
     }
   }
 
-  buildkitContainer.resources = {
-    limits: {
-      cpu: millicpuToString(provider.config.resources.builder.limits.cpu),
-      memory: megabytesToString(provider.config.resources.builder.limits.memory),
-      ...(provider.config.resources.builder.limits.ephemeralStorage
-        ? { "ephemeral-storage": megabytesToString(provider.config.resources.builder.limits.ephemeralStorage) }
-        : {}),
-    },
-    requests: {
-      cpu: millicpuToString(provider.config.resources.builder.requests.cpu),
-      memory: megabytesToString(provider.config.resources.builder.requests.memory),
-      ...(provider.config.resources.builder.requests.ephemeralStorage
-        ? { "ephemeral-storage": megabytesToString(provider.config.resources.builder.requests.ephemeralStorage) }
-        : {}),
-    },
-  }
+  buildkitContainer.resources = stringifyResources(provider.config.resources.builder)
 
   if (usingInClusterRegistry(provider)) {
     // We need a proxy sidecar to be able to reach the in-cluster registry from the Pod

--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -63,7 +63,7 @@ export const getBuildkitBuildStatus: BuildStatusHandler = async (params) => {
   return skopeoBuildStatus({
     namespace,
     deploymentName: buildkitDeploymentName,
-    containerName: getUtilContainer(authSecret.metadata.name).name,
+    containerName: getUtilContainer(authSecret.metadata.name, provider).name,
     log,
     api,
     ctx,
@@ -415,7 +415,7 @@ export function getBuildkitDeployment(
               ],
             },
             // Attach a util container for the rsync server and to use skopeo
-            getUtilContainer(authSecretName),
+            getUtilContainer(authSecretName, provider),
           ],
           imagePullSecrets,
           volumes: [

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -533,7 +533,10 @@ export function getUtilManifests(
   authSecretName: string,
   imagePullSecrets: { name: string }[]
 ) {
-  const kanikoTolerations = [...(provider.config.kaniko?.tolerations || []), builderToleration]
+  const kanikoTolerations = [
+    ...(provider.config.kaniko?.util?.tolerations || provider.config.kaniko?.tolerations || []),
+    builderToleration,
+  ]
   const deployment: KubernetesDeployment = {
     apiVersion: "apps/v1",
     kind: "Deployment",

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -11,7 +11,7 @@ import pRetry from "p-retry"
 import { ContainerModule, ContainerRegistryConfig } from "../../../container/config"
 import { GetBuildStatusParams, BuildStatus } from "../../../../types/plugin/module/getBuildStatus"
 import { BuildModuleParams, BuildResult } from "../../../../types/plugin/module/build"
-import { getRunningDeploymentPod, megabytesToString, millicpuToString, usingInClusterRegistry } from "../../util"
+import { getRunningDeploymentPod, usingInClusterRegistry } from "../../util"
 import {
   buildSyncVolumeName,
   dockerAuthSecretKey,
@@ -40,6 +40,7 @@ import { V1Container, V1Service } from "@kubernetes/client-node"
 import { cloneDeep, isEmpty } from "lodash"
 import { compareDeployedResources, waitForResources } from "../../status/status"
 import { KubernetesDeployment, KubernetesResource } from "../../types"
+import { stringifyResources } from "../util"
 
 const inClusterRegistryPort = 5000
 
@@ -505,22 +506,7 @@ export function getUtilContainer(authSecretName: string, provider: KubernetesPro
         },
       },
     },
-    resources: {
-      limits: {
-        cpu: millicpuToString(provider.config.resources.util.limits.cpu),
-        memory: megabytesToString(provider.config.resources.util.limits.memory),
-        ...(provider.config.resources.util.limits.ephemeralStorage
-          ? { "ephemeral-storage": megabytesToString(provider.config.resources.util.limits.ephemeralStorage) }
-          : {}),
-      },
-      requests: {
-        cpu: millicpuToString(provider.config.resources.util.requests.cpu),
-        memory: megabytesToString(provider.config.resources.util.requests.memory),
-        ...(provider.config.resources.util.requests.ephemeralStorage
-          ? { "ephemeral-storage": megabytesToString(provider.config.resources.util.requests.ephemeralStorage) }
-          : {}),
-      },
-    },
+    resources: stringifyResources(provider.config.resources.util),
     securityContext: {
       runAsUser: 1000,
       runAsGroup: 1000,

--- a/core/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/src/plugins/kubernetes/container/build/kaniko.ts
@@ -8,7 +8,7 @@
 
 import { V1PodSpec } from "@kubernetes/client-node"
 import { ContainerModule } from "../../../container/config"
-import { millicpuToString, megabytesToString, makePodName, usingInClusterRegistry } from "../../util"
+import { makePodName, usingInClusterRegistry } from "../../util"
 import { skopeoDaemonContainerName, dockerAuthSecretKey, k8sUtilImageName } from "../../constants"
 import { KubeApi } from "../../api"
 import { LogEntry } from "../../../../logger/log-entry"
@@ -40,6 +40,7 @@ import split2 from "split2"
 import { LogLevel } from "../../../../logger/logger"
 import { renderOutputStream } from "../../../../util/util"
 import { getDockerBuildFlags } from "../../../container/build"
+import { stringifyResources } from "../util"
 
 export const DEFAULT_KANIKO_FLAGS = ["--cache=true"]
 
@@ -337,22 +338,7 @@ async function runKaniko({
             mountPath: sharedMountPath,
           },
         ],
-        resources: {
-          limits: {
-            cpu: millicpuToString(provider.config.resources.builder.limits.cpu),
-            memory: megabytesToString(provider.config.resources.builder.limits.memory),
-            ...(provider.config.resources.builder.limits.ephemeralStorage
-              ? { "ephemeral-storage": megabytesToString(provider.config.resources.builder.limits.ephemeralStorage) }
-              : {}),
-          },
-          requests: {
-            cpu: millicpuToString(provider.config.resources.builder.requests.cpu),
-            memory: megabytesToString(provider.config.resources.builder.requests.memory),
-            ...(provider.config.resources.builder.requests.ephemeralStorage
-              ? { "ephemeral-storage": megabytesToString(provider.config.resources.builder.requests.ephemeralStorage) }
-              : {}),
-          },
-        },
+        resources: stringifyResources(provider.config.resources.builder),
       },
     ],
     tolerations: kanikoTolerations,

--- a/core/src/plugins/kubernetes/container/util.ts
+++ b/core/src/plugins/kubernetes/container/util.ts
@@ -10,12 +10,12 @@ import { resolve } from "url"
 import { getPortForward } from "../port-forward"
 import { CLUSTER_REGISTRY_DEPLOYMENT_NAME, CLUSTER_REGISTRY_PORT } from "../constants"
 import { LogEntry } from "../../../logger/log-entry"
-import { KubernetesPluginContext } from "../config"
+import { KubernetesPluginContext, KubernetesResourceSpec } from "../config"
 import { getSystemNamespace } from "../namespace"
 import { got, GotTextOptions } from "../../../util/http"
 import { ContainerResourcesSpec, ServiceLimitSpec } from "../../container/config"
 import { V1ResourceRequirements, V1SecurityContext } from "@kubernetes/client-node"
-import { kilobytesToString, millicpuToString } from "../util"
+import { kilobytesToString, megabytesToString, millicpuToString } from "../util"
 
 export async function queryRegistry(ctx: KubernetesPluginContext, log: LogEntry, path: string, opts?: GotTextOptions) {
   const registryFwd = await getRegistryPortForward(ctx, log)
@@ -82,4 +82,23 @@ export function getSecurityContext(
     ctx.capabilities = { ...(ctx.capabilities || {}), drop: dropCapabilities }
   }
   return ctx
+}
+
+export function stringifyResources(resources: KubernetesResourceSpec) {
+  return {
+    limits: {
+      cpu: millicpuToString(resources.limits.cpu),
+      memory: megabytesToString(resources.limits.memory),
+      ...(resources.limits.ephemeralStorage
+        ? { "ephemeral-storage": megabytesToString(resources.limits.ephemeralStorage) }
+        : {}),
+    },
+    requests: {
+      cpu: millicpuToString(resources.requests.cpu),
+      memory: megabytesToString(resources.requests.memory),
+      ...(resources.requests.ephemeralStorage
+        ? { "ephemeral-storage": megabytesToString(resources.requests.ephemeralStorage) }
+        : {}),
+    },
+  }
 }

--- a/core/src/plugins/kubernetes/container/util.ts
+++ b/core/src/plugins/kubernetes/container/util.ts
@@ -10,7 +10,7 @@ import { resolve } from "url"
 import { getPortForward } from "../port-forward"
 import { CLUSTER_REGISTRY_DEPLOYMENT_NAME, CLUSTER_REGISTRY_PORT } from "../constants"
 import { LogEntry } from "../../../logger/log-entry"
-import { KubernetesPluginContext, KubernetesResourceSpec } from "../config"
+import { KuberetesResourceConfig, KubernetesPluginContext, KubernetesResourceSpec } from "../config"
 import { getSystemNamespace } from "../namespace"
 import { got, GotTextOptions } from "../../../util/http"
 import { ContainerResourcesSpec, ServiceLimitSpec } from "../../container/config"
@@ -85,20 +85,14 @@ export function getSecurityContext(
 }
 
 export function stringifyResources(resources: KubernetesResourceSpec) {
+  const stringify = (r: KuberetesResourceConfig) => ({
+    cpu: millicpuToString(r.cpu),
+    memory: megabytesToString(r.memory),
+    ...(r.ephemeralStorage ? { "ephemeral-storage": megabytesToString(r.ephemeralStorage) } : {}),
+  })
+
   return {
-    limits: {
-      cpu: millicpuToString(resources.limits.cpu),
-      memory: megabytesToString(resources.limits.memory),
-      ...(resources.limits.ephemeralStorage
-        ? { "ephemeral-storage": megabytesToString(resources.limits.ephemeralStorage) }
-        : {}),
-    },
-    requests: {
-      cpu: millicpuToString(resources.requests.cpu),
-      memory: megabytesToString(resources.requests.memory),
-      ...(resources.requests.ephemeralStorage
-        ? { "ephemeral-storage": megabytesToString(resources.requests.ephemeralStorage) }
-        : {}),
-    },
+    limits: stringify(resources.limits),
+    requests: stringify(resources.requests),
   }
 }

--- a/core/test/unit/src/plugins/kubernetes/container/build/common.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/build/common.ts
@@ -6,8 +6,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { skopeoManifestUnknown } from "../../../../../../../src/plugins/kubernetes/container/build/common"
+import {
+  getUtilManifests,
+  skopeoManifestUnknown,
+} from "../../../../../../../src/plugins/kubernetes/container/build/common"
 import { expect } from "chai"
+import { defaultResources, KubernetesProvider } from "../../../../../../../src/plugins/kubernetes/config"
+import { DeepPartial } from "../../../../../../../src/util/util"
+import { k8sUtilImageName } from "../../../../../../../src/plugins/kubernetes/constants"
 
 describe("common build", () => {
   describe("manifest error", () => {
@@ -29,6 +35,136 @@ describe("common build", () => {
         "unauthorized: unauthorized to access repository: namespace/image-name, action: push: unauthorized to access repository: namespace/image-name, action: push"
 
       expect(skopeoManifestUnknown(errorMessage)).to.be.false
+    })
+  })
+
+  describe("getUtilManifests", () => {
+    const _provider: DeepPartial<KubernetesProvider> = {
+      config: {
+        resources: {
+          util: defaultResources.util,
+        },
+      },
+    }
+    let provider = _provider as KubernetesProvider
+    beforeEach(() => {
+      provider = _provider as KubernetesProvider
+    })
+
+    it("should return the manifest", () => {
+      const result = getUtilManifests(provider, "test", [])
+      expect(result).eql({
+        deployment: {
+          apiVersion: "apps/v1",
+          kind: "Deployment",
+          metadata: { labels: { app: "garden-util" }, name: "garden-util" },
+          spec: {
+            replicas: 1,
+            selector: { matchLabels: { app: "garden-util" } },
+            template: {
+              metadata: { labels: { app: "garden-util" } },
+              spec: {
+                containers: [
+                  {
+                    name: "util",
+                    image: k8sUtilImageName,
+                    imagePullPolicy: "IfNotPresent",
+                    command: ["/rsync-server.sh"],
+                    env: [
+                      { name: "ALLOW", value: "0.0.0.0/0" },
+                      { name: "RSYNC_PORT", value: "8730" },
+                    ],
+                    volumeMounts: [
+                      { name: "test", mountPath: "/home/user/.docker", readOnly: true },
+                      { name: "garden-sync", mountPath: "/data" },
+                    ],
+                    ports: [{ name: "garden-rsync", protocol: "TCP", containerPort: 8730 }],
+                    readinessProbe: {
+                      initialDelaySeconds: 1,
+                      periodSeconds: 1,
+                      timeoutSeconds: 3,
+                      successThreshold: 2,
+                      failureThreshold: 5,
+                      tcpSocket: { port: "garden-rsync" },
+                    },
+                    lifecycle: {
+                      preStop: {
+                        exec: {
+                          command: [
+                            "/bin/sh",
+                            "-c",
+                            "until test $(pgrep -fc '^[^ ]+rsync') = 1; do echo waiting for rsync to finish...; sleep 1; done",
+                          ],
+                        },
+                      },
+                    },
+                    resources: { limits: { cpu: "256m", memory: "512Mi" }, requests: { cpu: "256m", memory: "512Mi" } },
+                    securityContext: { runAsUser: 1000, runAsGroup: 1000 },
+                  },
+                ],
+                imagePullSecrets: [],
+                volumes: [
+                  {
+                    name: "test",
+                    secret: { secretName: "test", items: [{ key: ".dockerconfigjson", path: "config.json" }] },
+                  },
+                  { name: "garden-sync", emptyDir: {} },
+                ],
+                tolerations: [{ key: "garden-build", operator: "Equal", value: "true", effect: "NoSchedule" }],
+              },
+            },
+          },
+        },
+        service: {
+          apiVersion: "v1",
+          kind: "Service",
+          metadata: { name: "garden-util" },
+          spec: {
+            ports: [{ name: "rsync", protocol: "TCP", port: 8730, targetPort: 8730 }],
+            selector: { app: "garden-util" },
+            type: "ClusterIP",
+          },
+        },
+      })
+    })
+
+    it("should return the manifest with kaniko config tolerations if util tolerations are not specified", () => {
+      const toleration = { key: "custom-kaniko-toleration", operator: "Equal", value: "true", effect: "NoSchedule" }
+      provider.config.kaniko = {
+        tolerations: [toleration],
+      }
+      const result = getUtilManifests(provider, "test", [])
+      const tolerations = result.deployment.spec.template.spec?.tolerations
+
+      expect(tolerations?.find((t) => t.key === toleration.key)).to.eql(toleration)
+    })
+
+    it("should return the manifest with util config tolerations if util tolerations are specified", () => {
+      const tolerationUtil = { key: "util-toleration", operator: "Equal", value: "true", effect: "NoSchedule" }
+      provider.config.kaniko = {
+        util: {
+          tolerations: [tolerationUtil],
+        },
+      }
+      const result = getUtilManifests(provider, "test", [])
+      const tolerations = result.deployment.spec.template.spec?.tolerations
+
+      expect(tolerations?.find((t) => t.key === tolerationUtil.key)).to.eql(tolerationUtil)
+    })
+
+    it("should return the manifest with util tolerations only if kaniko has separate tolerations configured", () => {
+      const tolerationKaniko = { key: "kaniko-toleration", operator: "Equal", value: "true", effect: "NoSchedule" }
+      const tolerationUtil = { key: "util-toleration", operator: "Equal", value: "true", effect: "NoSchedule" }
+      provider.config.kaniko = {
+        tolerations: [tolerationKaniko],
+      }
+      provider.config.kaniko.util = {
+        tolerations: [tolerationUtil],
+      }
+      const result = getUtilManifests(provider, "test", [])
+      const tolerations = result.deployment.spec.template.spec?.tolerations
+
+      expect(tolerations?.findIndex((t) => t.key === tolerationKaniko.key)).to.eql(-1)
     })
   })
 })

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -232,7 +232,9 @@ providers:
       # guide to assigning Pods to nodes.
       nodeSelector:
 
-      # Specify tolerations to apply to each Kaniko Pod. Useful to control which nodes in a cluster can run builds.
+      # Specify tolerations to apply to each Kaniko builder Pod. Useful to control which nodes in a cluster can run
+      # builds. Same tolerations will be used for the util pod unless they are specifically set under
+      # `util.tolerations`
       tolerations:
         - # "Effect" indicates the taint effect to match. Empty means match all taint effects. When specified,
           # allowed values are "NoSchedule", "PreferNoSchedule" and "NoExecute".
@@ -258,6 +260,34 @@ providers:
           # empty,
           # otherwise just a regular string.
           value:
+
+      util:
+        # Specify tolerations to apply to each garden-util Pod.
+        tolerations:
+          - # "Effect" indicates the taint effect to match. Empty means match all taint effects. When specified,
+            # allowed values are "NoSchedule", "PreferNoSchedule" and "NoExecute".
+            effect:
+
+            # "Key" is the taint key that the toleration applies to. Empty means match all taint keys.
+            # If the key is empty, operator must be "Exists"; this combination means to match all values and all keys.
+            key:
+
+            # "Operator" represents a key's relationship to the value. Valid operators are "Exists" and "Equal".
+            # Defaults to
+            # "Equal". "Exists" is equivalent to wildcard for value, so that a pod can tolerate all taints of a
+            # particular category.
+            operator: Equal
+
+            # "TolerationSeconds" represents the period of time the toleration (which must be of effect "NoExecute",
+            # otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate
+            # the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately)
+            # by the system.
+            tolerationSeconds:
+
+            # "Value" is the taint value the toleration matches to. If the operator is "Exists", the value should be
+            # empty,
+            # otherwise just a regular string.
+            value:
 
     # A default hostname to use when no hostname is explicitly configured for a service.
     defaultHostname:
@@ -1075,7 +1105,7 @@ Exposes the `nodeSelector` field on the PodSpec of the Kaniko pods. This allows 
 
 [providers](#providers) > [kaniko](#providerskaniko) > tolerations
 
-Specify tolerations to apply to each Kaniko Pod. Useful to control which nodes in a cluster can run builds.
+Specify tolerations to apply to each Kaniko builder Pod. Useful to control which nodes in a cluster can run builds. Same tolerations will be used for the util pod unless they are specifically set under `util.tolerations`
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
@@ -1131,6 +1161,82 @@ by the system.
 ### `providers[].kaniko.tolerations[].value`
 
 [providers](#providers) > [kaniko](#providerskaniko) > [tolerations](#providerskanikotolerations) > value
+
+"Value" is the taint value the toleration matches to. If the operator is "Exists", the value should be empty,
+otherwise just a regular string.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.util`
+
+[providers](#providers) > [kaniko](#providerskaniko) > util
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.util.tolerations[]`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [util](#providerskanikoutil) > tolerations
+
+Specify tolerations to apply to each garden-util Pod.
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
+
+### `providers[].kaniko.util.tolerations[].effect`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [util](#providerskanikoutil) > [tolerations](#providerskanikoutiltolerations) > effect
+
+"Effect" indicates the taint effect to match. Empty means match all taint effects. When specified,
+allowed values are "NoSchedule", "PreferNoSchedule" and "NoExecute".
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.util.tolerations[].key`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [util](#providerskanikoutil) > [tolerations](#providerskanikoutiltolerations) > key
+
+"Key" is the taint key that the toleration applies to. Empty means match all taint keys.
+If the key is empty, operator must be "Exists"; this combination means to match all values and all keys.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.util.tolerations[].operator`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [util](#providerskanikoutil) > [tolerations](#providerskanikoutiltolerations) > operator
+
+"Operator" represents a key's relationship to the value. Valid operators are "Exists" and "Equal". Defaults to
+"Equal". "Exists" is equivalent to wildcard for value, so that a pod can tolerate all taints of a
+particular category.
+
+| Type     | Default   | Required |
+| -------- | --------- | -------- |
+| `string` | `"Equal"` | No       |
+
+### `providers[].kaniko.util.tolerations[].tolerationSeconds`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [util](#providerskanikoutil) > [tolerations](#providerskanikoutiltolerations) > tolerationSeconds
+
+"TolerationSeconds" represents the period of time the toleration (which must be of effect "NoExecute",
+otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate
+the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately)
+by the system.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.util.tolerations[].value`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [util](#providerskanikoutil) > [tolerations](#providerskanikoutiltolerations) > value
 
 "Value" is the taint value the toleration matches to. If the operator is "Exists", the value should be empty,
 otherwise just a regular string.

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -400,6 +400,31 @@ providers:
           # Ephemeral storage request in megabytes.
           ephemeralStorage:
 
+      # Resource requests and limits for the util pod for in-cluster builders.
+      # This pod is used to get, start, stop and inquire the status of the builds.
+      #
+      # This pod is created in each garden namespace.
+      util:
+        limits:
+          # CPU limit in millicpu.
+          cpu: 256
+
+          # Memory limit in megabytes.
+          memory: 512
+
+          # Ephemeral storage limit in megabytes.
+          ephemeralStorage:
+
+        requests:
+          # CPU request in millicpu.
+          cpu: 256
+
+          # Memory request in megabytes.
+          memory: 512
+
+          # Ephemeral storage request in megabytes.
+          ephemeralStorage:
+
     # Storage parameters to set for the in-cluster builder, container registry and code sync persistent volumes
     # (which are automatically installed and used when `buildMode` is `cluster-docker` or `kaniko`).
     #
@@ -1337,9 +1362,9 @@ The namespace where the secret is stored. If necessary, the secret may be copied
 
 Resource requests and limits for the in-cluster builder, container registry and code sync service. (which are automatically installed and used when `buildMode` is `cluster-docker` or `kaniko`).
 
-| Type     | Default                                                                                                                                                                                                                                                    | Required |
-| -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `object` | `{"builder":{"limits":{"cpu":4000,"memory":8192},"requests":{"cpu":100,"memory":512}},"registry":{"limits":{"cpu":2000,"memory":4096},"requests":{"cpu":200,"memory":512}},"sync":{"limits":{"cpu":500,"memory":512},"requests":{"cpu":100,"memory":90}}}` | No       |
+| Type     | Default                                                                                                                                                                                                                                                                                                                                   | Required |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `object` | `{"builder":{"limits":{"cpu":4000,"memory":8192},"requests":{"cpu":100,"memory":512}},"registry":{"limits":{"cpu":2000,"memory":4096},"requests":{"cpu":200,"memory":512}},"sync":{"limits":{"cpu":500,"memory":512},"requests":{"cpu":100,"memory":90}},"util":{"limits":{"cpu":256,"memory":512},"requests":{"cpu":256,"memory":512}}}` | No       |
 
 ### `providers[].resources.builder`
 
@@ -1673,6 +1698,173 @@ providers:
   - resources:
       ...
       registry:
+        ...
+        requests:
+          ...
+          ephemeralStorage: 8192
+```
+
+### `providers[].resources.util`
+
+[providers](#providers) > [resources](#providersresources) > util
+
+Resource requests and limits for the util pod for in-cluster builders.
+This pod is used to get, start, stop and inquire the status of the builds.
+
+This pod is created in each garden namespace.
+
+| Type     | Default                                                                   | Required |
+| -------- | ------------------------------------------------------------------------- | -------- |
+| `object` | `{"limits":{"cpu":256,"memory":512},"requests":{"cpu":256,"memory":512}}` | No       |
+
+### `providers[].resources.util.limits`
+
+[providers](#providers) > [resources](#providersresources) > [util](#providersresourcesutil) > limits
+
+| Type     | Default                    | Required |
+| -------- | -------------------------- | -------- |
+| `object` | `{"cpu":256,"memory":512}` | No       |
+
+### `providers[].resources.util.limits.cpu`
+
+[providers](#providers) > [resources](#providersresources) > [util](#providersresourcesutil) > [limits](#providersresourcesutillimits) > cpu
+
+CPU limit in millicpu.
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `256`   | No       |
+
+Example:
+
+```yaml
+providers:
+  - resources:
+      ...
+      util:
+        ...
+        limits:
+          ...
+          cpu: 256
+```
+
+### `providers[].resources.util.limits.memory`
+
+[providers](#providers) > [resources](#providersresources) > [util](#providersresourcesutil) > [limits](#providersresourcesutillimits) > memory
+
+Memory limit in megabytes.
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `512`   | No       |
+
+Example:
+
+```yaml
+providers:
+  - resources:
+      ...
+      util:
+        ...
+        limits:
+          ...
+          memory: 512
+```
+
+### `providers[].resources.util.limits.ephemeralStorage`
+
+[providers](#providers) > [resources](#providersresources) > [util](#providersresourcesutil) > [limits](#providersresourcesutillimits) > ephemeralStorage
+
+Ephemeral storage limit in megabytes.
+
+| Type     | Required |
+| -------- | -------- |
+| `number` | No       |
+
+Example:
+
+```yaml
+providers:
+  - resources:
+      ...
+      util:
+        ...
+        limits:
+          ...
+          ephemeralStorage: 8192
+```
+
+### `providers[].resources.util.requests`
+
+[providers](#providers) > [resources](#providersresources) > [util](#providersresourcesutil) > requests
+
+| Type     | Default                    | Required |
+| -------- | -------------------------- | -------- |
+| `object` | `{"cpu":256,"memory":512}` | No       |
+
+### `providers[].resources.util.requests.cpu`
+
+[providers](#providers) > [resources](#providersresources) > [util](#providersresourcesutil) > [requests](#providersresourcesutilrequests) > cpu
+
+CPU request in millicpu.
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `256`   | No       |
+
+Example:
+
+```yaml
+providers:
+  - resources:
+      ...
+      util:
+        ...
+        requests:
+          ...
+          cpu: 256
+```
+
+### `providers[].resources.util.requests.memory`
+
+[providers](#providers) > [resources](#providersresources) > [util](#providersresourcesutil) > [requests](#providersresourcesutilrequests) > memory
+
+Memory request in megabytes.
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `512`   | No       |
+
+Example:
+
+```yaml
+providers:
+  - resources:
+      ...
+      util:
+        ...
+        requests:
+          ...
+          memory: 512
+```
+
+### `providers[].resources.util.requests.ephemeralStorage`
+
+[providers](#providers) > [resources](#providersresources) > [util](#providersresourcesutil) > [requests](#providersresourcesutilrequests) > ephemeralStorage
+
+Ephemeral storage request in megabytes.
+
+| Type     | Required |
+| -------- | -------- |
+| `number` | No       |
+
+Example:
+
+```yaml
+providers:
+  - resources:
+      ...
+      util:
         ...
         requests:
           ...

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -396,6 +396,31 @@ providers:
           # Ephemeral storage request in megabytes.
           ephemeralStorage:
 
+      # Resource requests and limits for the util pod for in-cluster builders.
+      # This pod is used to get, start, stop and inquire the status of the builds.
+      #
+      # This pod is created in each garden namespace.
+      util:
+        limits:
+          # CPU limit in millicpu.
+          cpu: 256
+
+          # Memory limit in megabytes.
+          memory: 512
+
+          # Ephemeral storage limit in megabytes.
+          ephemeralStorage:
+
+        requests:
+          # CPU request in millicpu.
+          cpu: 256
+
+          # Memory request in megabytes.
+          memory: 512
+
+          # Ephemeral storage request in megabytes.
+          ephemeralStorage:
+
     # Storage parameters to set for the in-cluster builder, container registry and code sync persistent volumes
     # (which are automatically installed and used when `buildMode` is `cluster-docker` or `kaniko`).
     #
@@ -1286,9 +1311,9 @@ The namespace where the secret is stored. If necessary, the secret may be copied
 
 Resource requests and limits for the in-cluster builder, container registry and code sync service. (which are automatically installed and used when `buildMode` is `cluster-docker` or `kaniko`).
 
-| Type     | Default                                                                                                                                                                                                                                                    | Required |
-| -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `object` | `{"builder":{"limits":{"cpu":4000,"memory":8192},"requests":{"cpu":100,"memory":512}},"registry":{"limits":{"cpu":2000,"memory":4096},"requests":{"cpu":200,"memory":512}},"sync":{"limits":{"cpu":500,"memory":512},"requests":{"cpu":100,"memory":90}}}` | No       |
+| Type     | Default                                                                                                                                                                                                                                                                                                                                   | Required |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `object` | `{"builder":{"limits":{"cpu":4000,"memory":8192},"requests":{"cpu":100,"memory":512}},"registry":{"limits":{"cpu":2000,"memory":4096},"requests":{"cpu":200,"memory":512}},"sync":{"limits":{"cpu":500,"memory":512},"requests":{"cpu":100,"memory":90}},"util":{"limits":{"cpu":256,"memory":512},"requests":{"cpu":256,"memory":512}}}` | No       |
 
 ### `providers[].resources.builder`
 
@@ -1622,6 +1647,173 @@ providers:
   - resources:
       ...
       registry:
+        ...
+        requests:
+          ...
+          ephemeralStorage: 8192
+```
+
+### `providers[].resources.util`
+
+[providers](#providers) > [resources](#providersresources) > util
+
+Resource requests and limits for the util pod for in-cluster builders.
+This pod is used to get, start, stop and inquire the status of the builds.
+
+This pod is created in each garden namespace.
+
+| Type     | Default                                                                   | Required |
+| -------- | ------------------------------------------------------------------------- | -------- |
+| `object` | `{"limits":{"cpu":256,"memory":512},"requests":{"cpu":256,"memory":512}}` | No       |
+
+### `providers[].resources.util.limits`
+
+[providers](#providers) > [resources](#providersresources) > [util](#providersresourcesutil) > limits
+
+| Type     | Default                    | Required |
+| -------- | -------------------------- | -------- |
+| `object` | `{"cpu":256,"memory":512}` | No       |
+
+### `providers[].resources.util.limits.cpu`
+
+[providers](#providers) > [resources](#providersresources) > [util](#providersresourcesutil) > [limits](#providersresourcesutillimits) > cpu
+
+CPU limit in millicpu.
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `256`   | No       |
+
+Example:
+
+```yaml
+providers:
+  - resources:
+      ...
+      util:
+        ...
+        limits:
+          ...
+          cpu: 256
+```
+
+### `providers[].resources.util.limits.memory`
+
+[providers](#providers) > [resources](#providersresources) > [util](#providersresourcesutil) > [limits](#providersresourcesutillimits) > memory
+
+Memory limit in megabytes.
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `512`   | No       |
+
+Example:
+
+```yaml
+providers:
+  - resources:
+      ...
+      util:
+        ...
+        limits:
+          ...
+          memory: 512
+```
+
+### `providers[].resources.util.limits.ephemeralStorage`
+
+[providers](#providers) > [resources](#providersresources) > [util](#providersresourcesutil) > [limits](#providersresourcesutillimits) > ephemeralStorage
+
+Ephemeral storage limit in megabytes.
+
+| Type     | Required |
+| -------- | -------- |
+| `number` | No       |
+
+Example:
+
+```yaml
+providers:
+  - resources:
+      ...
+      util:
+        ...
+        limits:
+          ...
+          ephemeralStorage: 8192
+```
+
+### `providers[].resources.util.requests`
+
+[providers](#providers) > [resources](#providersresources) > [util](#providersresourcesutil) > requests
+
+| Type     | Default                    | Required |
+| -------- | -------------------------- | -------- |
+| `object` | `{"cpu":256,"memory":512}` | No       |
+
+### `providers[].resources.util.requests.cpu`
+
+[providers](#providers) > [resources](#providersresources) > [util](#providersresourcesutil) > [requests](#providersresourcesutilrequests) > cpu
+
+CPU request in millicpu.
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `256`   | No       |
+
+Example:
+
+```yaml
+providers:
+  - resources:
+      ...
+      util:
+        ...
+        requests:
+          ...
+          cpu: 256
+```
+
+### `providers[].resources.util.requests.memory`
+
+[providers](#providers) > [resources](#providersresources) > [util](#providersresourcesutil) > [requests](#providersresourcesutilrequests) > memory
+
+Memory request in megabytes.
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `number` | `512`   | No       |
+
+Example:
+
+```yaml
+providers:
+  - resources:
+      ...
+      util:
+        ...
+        requests:
+          ...
+          memory: 512
+```
+
+### `providers[].resources.util.requests.ephemeralStorage`
+
+[providers](#providers) > [resources](#providersresources) > [util](#providersresourcesutil) > [requests](#providersresourcesutilrequests) > ephemeralStorage
+
+Ephemeral storage request in megabytes.
+
+| Type     | Required |
+| -------- | -------- |
+| `number` | No       |
+
+Example:
+
+```yaml
+providers:
+  - resources:
+      ...
+      util:
         ...
         requests:
           ...

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -228,7 +228,9 @@ providers:
       # guide to assigning Pods to nodes.
       nodeSelector:
 
-      # Specify tolerations to apply to each Kaniko Pod. Useful to control which nodes in a cluster can run builds.
+      # Specify tolerations to apply to each Kaniko builder Pod. Useful to control which nodes in a cluster can run
+      # builds. Same tolerations will be used for the util pod unless they are specifically set under
+      # `util.tolerations`
       tolerations:
         - # "Effect" indicates the taint effect to match. Empty means match all taint effects. When specified,
           # allowed values are "NoSchedule", "PreferNoSchedule" and "NoExecute".
@@ -254,6 +256,34 @@ providers:
           # empty,
           # otherwise just a regular string.
           value:
+
+      util:
+        # Specify tolerations to apply to each garden-util Pod.
+        tolerations:
+          - # "Effect" indicates the taint effect to match. Empty means match all taint effects. When specified,
+            # allowed values are "NoSchedule", "PreferNoSchedule" and "NoExecute".
+            effect:
+
+            # "Key" is the taint key that the toleration applies to. Empty means match all taint keys.
+            # If the key is empty, operator must be "Exists"; this combination means to match all values and all keys.
+            key:
+
+            # "Operator" represents a key's relationship to the value. Valid operators are "Exists" and "Equal".
+            # Defaults to
+            # "Equal". "Exists" is equivalent to wildcard for value, so that a pod can tolerate all taints of a
+            # particular category.
+            operator: Equal
+
+            # "TolerationSeconds" represents the period of time the toleration (which must be of effect "NoExecute",
+            # otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate
+            # the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately)
+            # by the system.
+            tolerationSeconds:
+
+            # "Value" is the taint value the toleration matches to. If the operator is "Exists", the value should be
+            # empty,
+            # otherwise just a regular string.
+            value:
 
     # A default hostname to use when no hostname is explicitly configured for a service.
     defaultHostname:
@@ -1024,7 +1054,7 @@ Exposes the `nodeSelector` field on the PodSpec of the Kaniko pods. This allows 
 
 [providers](#providers) > [kaniko](#providerskaniko) > tolerations
 
-Specify tolerations to apply to each Kaniko Pod. Useful to control which nodes in a cluster can run builds.
+Specify tolerations to apply to each Kaniko builder Pod. Useful to control which nodes in a cluster can run builds. Same tolerations will be used for the util pod unless they are specifically set under `util.tolerations`
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
@@ -1080,6 +1110,82 @@ by the system.
 ### `providers[].kaniko.tolerations[].value`
 
 [providers](#providers) > [kaniko](#providerskaniko) > [tolerations](#providerskanikotolerations) > value
+
+"Value" is the taint value the toleration matches to. If the operator is "Exists", the value should be empty,
+otherwise just a regular string.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.util`
+
+[providers](#providers) > [kaniko](#providerskaniko) > util
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `providers[].kaniko.util.tolerations[]`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [util](#providerskanikoutil) > tolerations
+
+Specify tolerations to apply to each garden-util Pod.
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[object]` | `[]`    | No       |
+
+### `providers[].kaniko.util.tolerations[].effect`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [util](#providerskanikoutil) > [tolerations](#providerskanikoutiltolerations) > effect
+
+"Effect" indicates the taint effect to match. Empty means match all taint effects. When specified,
+allowed values are "NoSchedule", "PreferNoSchedule" and "NoExecute".
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.util.tolerations[].key`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [util](#providerskanikoutil) > [tolerations](#providerskanikoutiltolerations) > key
+
+"Key" is the taint key that the toleration applies to. Empty means match all taint keys.
+If the key is empty, operator must be "Exists"; this combination means to match all values and all keys.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.util.tolerations[].operator`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [util](#providerskanikoutil) > [tolerations](#providerskanikoutiltolerations) > operator
+
+"Operator" represents a key's relationship to the value. Valid operators are "Exists" and "Equal". Defaults to
+"Equal". "Exists" is equivalent to wildcard for value, so that a pod can tolerate all taints of a
+particular category.
+
+| Type     | Default   | Required |
+| -------- | --------- | -------- |
+| `string` | `"Equal"` | No       |
+
+### `providers[].kaniko.util.tolerations[].tolerationSeconds`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [util](#providerskanikoutil) > [tolerations](#providerskanikoutiltolerations) > tolerationSeconds
+
+"TolerationSeconds" represents the period of time the toleration (which must be of effect "NoExecute",
+otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate
+the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately)
+by the system.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `providers[].kaniko.util.tolerations[].value`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [util](#providerskanikoutil) > [tolerations](#providerskanikoutiltolerations) > value
 
 "Value" is the taint value the toleration matches to. If the operator is "Exists", the value should be empty,
 otherwise just a regular string.


### PR DESCRIPTION
closes #3197

Now custom resource limits and requests and tolerations can be set for the `garden-util` pod. See schema changes in the file diff.