### PR TITLE
fix(autoResolve): handle unknown Dockerfile flags

### DIFF
--- a/core/src/plugins/container/helpers.ts
+++ b/core/src/plugins/container/helpers.ts
@@ -23,7 +23,7 @@ import {
 } from "./config"
 import { Writable } from "stream"
 import Bluebird from "bluebird"
-import { flatten, uniq, fromPairs } from "lodash"
+import { flatten, uniq, fromPairs, reduce } from "lodash"
 import { LogEntry } from "../../logger/log-entry"
 import chalk from "chalk"
 import isUrl from "is-url"
@@ -371,16 +371,30 @@ const helpers = {
     const paths: string[] = uniq(
       flatten(
         commands.map((cmd) => {
-          const args = cmd.args as string[]
-          if (args.find((arg) => arg.startsWith("--from"))) {
+          const parsed = reduce(
+            cmd.args as string[],
+            (state, current) => {
+              // starts with -- and we did not parse any files yet?
+              // must be a flag!
+              if (current.startsWith("--") && !state.files.length) {
+                state.flags.push(current)
+              } else {
+                // must be a file
+                state.files.push(current)
+              }
+
+              return state
+            },
+            { flags: [] as string[], files: [] as string[] }
+          )
+
+          if (parsed.flags.find((f) => f.startsWith("--from"))) {
             // Skip statements copying from another build stage
             return []
-          } else if (args[0].startsWith("--chown")) {
-            // Ignore --chown args
-            return args.slice(1, -1)
-          } else {
-            return args.slice(0, -1)
           }
+
+          // skip the COPY destination
+          return parsed.files.slice(0, -1)
         })
       )
         // Strip quotes from quoted paths

--- a/core/test/unit/src/plugins/container/helpers.ts
+++ b/core/test/unit/src/plugins/container/helpers.ts
@@ -556,6 +556,26 @@ describe("containerHelpers", () => {
       expect(await helpers.autoResolveIncludes(config, log)).to.eql(["file-a", "Dockerfile"])
     })
 
+    it("should ignore unknown flag arguments", async () => {
+      await writeFile(
+        dockerfilePath,
+        dedent`
+        FROM foo
+        ADD --foo=bla file-a /destination-a
+        COPY --bar=bla --keks file-b file-c file-d /destination-b
+        COPY --crazynewarg --yes  file-e /destination-c
+        `
+      )
+      expect(await helpers.autoResolveIncludes(config, log)).to.eql([
+        "file-a",
+        "file-b",
+        "file-c",
+        "file-d",
+        "file-e",
+        "Dockerfile",
+      ])
+    })
+
     it("should ignore paths containing a template string", async () => {
       await writeFile(dockerfilePath, "FROM foo\nADD file-a /\nCOPY file-${foo} file-c /")
       expect(await helpers.autoResolveIncludes(config, log)).to.be.undefined


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
This fixes the `autoResolveIncludes` function so it ignores
all unknown ADD/COPY flags. That way users do not receive
strange looking error messages like

```
Error validating configure container output from provider kubernetes:
key .moduleConfig.include[2] must be a relative sub-path (may not contain '..' segments or be an absolute path)
```

This improves further upon the bug fix in #3354

Thanks again to @ivanbabenko to bring this up.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
