### PR TITLE
feat(jib-container): add maven daemon support as project type

### DIFF
--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -888,9 +888,9 @@ Maximum time in seconds to wait for build to finish.
 
 The type of project to build. Defaults to auto-detecting between gradle and maven (based on which files/directories are found in the module root), but in some cases you may need to specify it.
 
-| Type     | Allowed Values                   | Default  | Required |
-| -------- | -------------------------------- | -------- | -------- |
-| `string` | "gradle", "maven", "jib", "auto" | `"auto"` | Yes      |
+| Type     | Allowed Values                             | Default  | Required |
+| -------- | ------------------------------------------ | -------- | -------- |
+| `string` | "gradle", "maven", "jib", "auto", "mavend" | `"auto"` | Yes      |
 
 ### `build.jdkVersion`
 

--- a/plugins/jib/index.ts
+++ b/plugins/jib/index.ts
@@ -12,6 +12,7 @@ import { dedent } from "@garden-io/sdk/util/string"
 
 import { openJdkSpecs } from "./openjdk"
 import { mavenSpec, mvn } from "./maven"
+import {mavendSpec, mvnd} from "./mavend"
 import { gradle, gradleSpec } from "./gradle"
 
 // TODO: gradually get rid of these core dependencies, move some to SDK etc.
@@ -43,7 +44,7 @@ const jibModuleSchema = () =>
     build: baseBuildSpecSchema().keys({
       projectType: joi
         .string()
-        .valid("gradle", "maven", "jib", "auto")
+        .valid("gradle", "maven", "jib", "auto","mavend")
         .default("auto")
         .description(
           dedent`
@@ -245,6 +246,15 @@ export const gardenPlugin = () =>
                 mavenPath: module.spec.build.mavenPath,
                 outputStream,
               })
+            }else if (projectType === "mavend"){
+              await mvnd({
+                ctx,
+                log,
+                cwd: module.path,
+                args: [...mavenPhases, ...args],
+                openJdkPath,
+                outputStream,
+              })
             } else {
               await gradle({
                 ctx,
@@ -267,5 +277,5 @@ export const gardenPlugin = () =>
         },
       },
     ],
-    tools: [mavenSpec, gradleSpec, ...openJdkSpecs],
+    tools: [mavenSpec, gradleSpec,mavendSpec, ...openJdkSpecs],
   })

--- a/plugins/jib/index.ts
+++ b/plugins/jib/index.ts
@@ -12,7 +12,7 @@ import { dedent } from "@garden-io/sdk/util/string"
 
 import { openJdkSpecs } from "./openjdk"
 import { mavenSpec, mvn } from "./maven"
-import {mavendSpec, mvnd} from "./mavend"
+import { mavendSpec, mvnd } from "./mavend"
 import { gradle, gradleSpec } from "./gradle"
 
 // TODO: gradually get rid of these core dependencies, move some to SDK etc.
@@ -44,7 +44,7 @@ const jibModuleSchema = () =>
     build: baseBuildSpecSchema().keys({
       projectType: joi
         .string()
-        .valid("gradle", "maven", "jib", "auto","mavend")
+        .valid("gradle", "maven", "jib", "auto", "mavend")
         .default("auto")
         .description(
           dedent`
@@ -246,7 +246,7 @@ export const gardenPlugin = () =>
                 mavenPath: module.spec.build.mavenPath,
                 outputStream,
               })
-            }else if (projectType === "mavend"){
+            } else if (projectType === "mavend") {
               await mvnd({
                 ctx,
                 log,
@@ -277,5 +277,5 @@ export const gardenPlugin = () =>
         },
       },
     ],
-    tools: [mavenSpec, gradleSpec,mavendSpec, ...openJdkSpecs],
+    tools: [mavenSpec, gradleSpec, mavendSpec, ...openJdkSpecs],
   })

--- a/plugins/jib/mavend.ts
+++ b/plugins/jib/mavend.ts
@@ -20,9 +20,9 @@ const mvndSpec = {
   description: "The Maven Daemon CLI.",
   baseUrl: `https://github.com/apache/maven-mvnd/releases/download/${mvndVersion}/`,
   linux: {
-    filename: `maven-mvnd-${mvndVersion}-darwin-amd64.tar.gz`,
+    filename: `maven-mvnd-${mvndVersion}-linux-amd64.tar.gz`,
     sha256: "5bcd4c3e45b767d562aa8d81583461abeb4fd6626ea1b8a1d961f34ef472f115",
-    targetPath: `maven-mvnd-${mvndVersion}-darwin-amd64/bin/mvnd`,
+    targetPath: `maven-mvnd-${mvndVersion}-linux-amd64/bin/mvnd`,
   },
   darwin_aarch64: {
     filename: `maven-mvnd-${mvndVersion}-darwin-aarch64.tar.gz`,
@@ -36,7 +36,7 @@ const mvndSpec = {
   },
   windows: {
     filename: `maven-mvnd-${mvndVersion}-windows-amd64.zip`,
-    sha256: "1991f977d9f73b8fa13a21c062e0fa3bd850e874f2f5682dca1f567548024bc6",
+    sha256: "bfe6115b643ecb54b52a46df9e5b790035e54e67e21c10f964c7d58f633b7f22",
     targetPath: `maven-mvnd-${mvndVersion}-windows-amd64/bin/mvnd.cmd`,
   },
 }

--- a/plugins/jib/mavend.ts
+++ b/plugins/jib/mavend.ts
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2018-2022 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import AsyncLock from "async-lock"
+import { LogEntry, PluginContext, PluginToolSpec } from "@garden-io/sdk/types"
+import { find } from "lodash"
+import { PluginError, RuntimeError } from "@garden-io/core/build/src/exceptions"
+import { Writable } from "node:stream"
+import execa from "execa"
+
+const buildLock = new AsyncLock()
+
+const mvndVersion = "0.8.2"
+const mvndSpec = {
+  description: "The Maven Daemon CLI.",
+  baseUrl: `https://github.com/apache/maven-mvnd/releases/download/${mvndVersion}/`,
+  linux: {
+    filename: `maven-mvnd-${mvndVersion}-linux-amd64.tar.gz`,
+    sha256: "5bcd4c3e45b767d562aa8d81583461abeb4fd6626ea1b8a1d961f34ef472f115",
+    targetPath: `maven-mvnd-${mvndVersion}-linux-amd64/bin/mvnd`
+  },
+  darwin_aarch64: {
+    filename: `maven-mvnd-${mvndVersion}-darwin-aarch64.tar.gz`,
+    sha256: "0949505fcf42a1765558048451bb2a22e84b3635b1a31dd6191780eeccaa4ada",
+    targetPath: `maven-mvnd-${mvndVersion}-darwin-aarch64/bin/mvnd`
+  },
+  darwin_amd64: {
+    filename: `maven-mvnd-${mvndVersion}-darwin-amd64.tar.gz`,
+    sha256: "0949505fcf42a1765558048451bb2a22e84b3635b1a31dd6191780eeccaa4ada",
+    targetPath: `maven-mvnd-${mvndVersion}-darwin-amd64/bin/mvnd`
+  },
+  windows: {
+    filename: `maven-mvnd-${mvndVersion}-windows-amd64.zip`,
+    sha256: "2405e11f9f3603e506cf7ab01fcb67a3e3a1cf3e7858e14d629a72c9a24c6c42",
+    targetPath: `maven-mvnd-${mvndVersion}-windows-amd64/bin/mvnd.cmd`
+  },
+}
+
+
+/*
+const spec = {
+  sha256: "d53e045bc5c02aad179fae2fbc565d953354880db6661a8fab31f3a718d7b62c",
+  extract: {
+    format: "tar",
+    targetPath: `maven-mvnd-${mvndSpec.versionName}-linux-amd64/bin/mvnd`,
+  },
+}*/
+
+export const mavendSpec: PluginToolSpec = {
+  name: "mavend",
+  description: "The Maven Daemon CLI.",
+  type: "binary",
+  builds: [
+    {
+      platform: "linux",
+      architecture: "amd64",
+      sha256: mvndSpec.linux.sha256,
+      url: `${mvndSpec.baseUrl}${mvndSpec.linux.filename}`,
+      extract: {
+        format: "tar",
+        targetPath: mvndSpec.linux.targetPath,
+      },
+    },
+    {
+      platform: "darwin",
+      architecture: "amd64",
+      sha256: mvndSpec.linux.sha256,
+      url: `${mvndSpec.baseUrl}${mvndSpec.darwin_amd64.filename}`,
+      extract: {
+        format: "tar",
+        targetPath: mvndSpec.darwin_amd64.targetPath,
+      },
+    },
+    {
+      platform: "darwin",
+      architecture: "aarch64",
+      sha256: mvndSpec.linux.sha256,
+      url: `${mvndSpec.baseUrl}${mvndSpec.darwin_aarch64.filename}`,
+      extract: {
+        format: "tar",
+        targetPath: mvndSpec.darwin_aarch64.targetPath,
+      },
+    },
+    {
+      platform: "windows",
+      architecture: "amd64",
+      url: `${mvndSpec.baseUrl}${mvndSpec.windows.filename}`,
+      sha256: "d53e045bc5c02aad179fae2fbc565d953354880db6661a8fab31f3a718d7b62c",
+      extract: {
+        format: "zip",
+        targetPath: mvndSpec.windows.targetPath
+      },
+    },
+  ],
+}
+
+export function getMvndTool(ctx: PluginContext) {
+  
+  const tool = find(ctx.tools, (_, k) => k.endsWith(".mavend"))
+
+  if (!tool) {
+    throw new PluginError(`Could not find configured maven daemon tool`, { tools: ctx.tools })
+  }
+
+  return tool
+}
+
+/**
+ * Run mavend with the specified args in the specified directory.
+ */
+export async function mvnd({
+  ctx,
+  args,
+  cwd,
+  log,
+  openJdkPath,
+  outputStream,
+}: {
+  ctx: PluginContext
+  args: string[]
+  cwd: string
+  log: LogEntry
+  openJdkPath: string
+  outputStream?: Writable
+}) {
+  let mvndPath: string
+  log.verbose(`The Maven Daemon binary hasn't been specified explicitly. Maven ${mvndVersion} will be used by default.`)
+
+  const tool = getMvndTool(ctx)
+  mvndPath = await tool.getPath(log)
+
+  return buildLock.acquire("mvnd", async () => {
+    log.debug(`Execing ${mvndPath} ${args.join(" ")}`)
+
+    const res = execa(mvndPath, args, {
+      cwd,
+      env: {
+        JAVA_HOME: openJdkPath,
+      },
+    })
+
+    if (outputStream) {
+      res.stdout?.pipe(outputStream)
+      res.stderr?.pipe(outputStream)
+    }
+
+    return res
+  })
+}

--- a/plugins/jib/mavend.ts
+++ b/plugins/jib/mavend.ts
@@ -9,7 +9,7 @@
 import AsyncLock from "async-lock"
 import { LogEntry, PluginContext, PluginToolSpec } from "@garden-io/sdk/types"
 import { find } from "lodash"
-import { PluginError, RuntimeError } from "@garden-io/core/build/src/exceptions"
+import { PluginError } from "@garden-io/core/build/src/exceptions"
 import { Writable } from "node:stream"
 import execa from "execa"
 
@@ -22,34 +22,24 @@ const mvndSpec = {
   linux: {
     filename: `maven-mvnd-${mvndVersion}-linux-amd64.tar.gz`,
     sha256: "5bcd4c3e45b767d562aa8d81583461abeb4fd6626ea1b8a1d961f34ef472f115",
-    targetPath: `maven-mvnd-${mvndVersion}-linux-amd64/bin/mvnd`
+    targetPath: `maven-mvnd-${mvndVersion}-linux-amd64/bin/mvnd`,
   },
   darwin_aarch64: {
     filename: `maven-mvnd-${mvndVersion}-darwin-aarch64.tar.gz`,
     sha256: "0949505fcf42a1765558048451bb2a22e84b3635b1a31dd6191780eeccaa4ada",
-    targetPath: `maven-mvnd-${mvndVersion}-darwin-aarch64/bin/mvnd`
+    targetPath: `maven-mvnd-${mvndVersion}-darwin-aarch64/bin/mvnd`,
   },
   darwin_amd64: {
     filename: `maven-mvnd-${mvndVersion}-darwin-amd64.tar.gz`,
     sha256: "0949505fcf42a1765558048451bb2a22e84b3635b1a31dd6191780eeccaa4ada",
-    targetPath: `maven-mvnd-${mvndVersion}-darwin-amd64/bin/mvnd`
+    targetPath: `maven-mvnd-${mvndVersion}-darwin-amd64/bin/mvnd`,
   },
   windows: {
     filename: `maven-mvnd-${mvndVersion}-windows-amd64.zip`,
     sha256: "2405e11f9f3603e506cf7ab01fcb67a3e3a1cf3e7858e14d629a72c9a24c6c42",
-    targetPath: `maven-mvnd-${mvndVersion}-windows-amd64/bin/mvnd.cmd`
+    targetPath: `maven-mvnd-${mvndVersion}-windows-amd64/bin/mvnd.cmd`,
   },
 }
-
-
-/*
-const spec = {
-  sha256: "d53e045bc5c02aad179fae2fbc565d953354880db6661a8fab31f3a718d7b62c",
-  extract: {
-    format: "tar",
-    targetPath: `maven-mvnd-${mvndSpec.versionName}-linux-amd64/bin/mvnd`,
-  },
-}*/
 
 export const mavendSpec: PluginToolSpec = {
   name: "mavend",
@@ -93,14 +83,13 @@ export const mavendSpec: PluginToolSpec = {
       sha256: "d53e045bc5c02aad179fae2fbc565d953354880db6661a8fab31f3a718d7b62c",
       extract: {
         format: "zip",
-        targetPath: mvndSpec.windows.targetPath
+        targetPath: mvndSpec.windows.targetPath,
       },
     },
   ],
 }
 
 export function getMvndTool(ctx: PluginContext) {
-  
   const tool = find(ctx.tools, (_, k) => k.endsWith(".mavend"))
 
   if (!tool) {

--- a/plugins/jib/mavend.ts
+++ b/plugins/jib/mavend.ts
@@ -20,23 +20,23 @@ const mvndSpec = {
   description: "The Maven Daemon CLI.",
   baseUrl: `https://github.com/apache/maven-mvnd/releases/download/${mvndVersion}/`,
   linux: {
-    filename: `maven-mvnd-${mvndVersion}-linux-amd64.tar.gz`,
+    filename: `maven-mvnd-${mvndVersion}-darwin-amd64.tar.gz`,
     sha256: "5bcd4c3e45b767d562aa8d81583461abeb4fd6626ea1b8a1d961f34ef472f115",
-    targetPath: `maven-mvnd-${mvndVersion}-linux-amd64/bin/mvnd`,
+    targetPath: `maven-mvnd-${mvndVersion}-darwin-amd64/bin/mvnd`,
   },
   darwin_aarch64: {
     filename: `maven-mvnd-${mvndVersion}-darwin-aarch64.tar.gz`,
-    sha256: "0949505fcf42a1765558048451bb2a22e84b3635b1a31dd6191780eeccaa4ada",
+    sha256: "b3fab0126188072ea80784c4bcc726bf398e0115ed37f3e243e14c84a2fe7e45",
     targetPath: `maven-mvnd-${mvndVersion}-darwin-aarch64/bin/mvnd`,
   },
   darwin_amd64: {
     filename: `maven-mvnd-${mvndVersion}-darwin-amd64.tar.gz`,
-    sha256: "0949505fcf42a1765558048451bb2a22e84b3635b1a31dd6191780eeccaa4ada",
+    sha256: "889278f2e2a88450dcb074558a136fe06f9874db9b8d224674a5163a92ef2b69",
     targetPath: `maven-mvnd-${mvndVersion}-darwin-amd64/bin/mvnd`,
   },
   windows: {
     filename: `maven-mvnd-${mvndVersion}-windows-amd64.zip`,
-    sha256: "2405e11f9f3603e506cf7ab01fcb67a3e3a1cf3e7858e14d629a72c9a24c6c42",
+    sha256: "1991f977d9f73b8fa13a21c062e0fa3bd850e874f2f5682dca1f567548024bc6",
     targetPath: `maven-mvnd-${mvndVersion}-windows-amd64/bin/mvnd.cmd`,
   },
 }

--- a/plugins/jib/util.ts
+++ b/plugins/jib/util.ts
@@ -14,7 +14,7 @@ import { ContainerBuildSpec, ContainerModuleSpec } from "@garden-io/core/build/s
 
 interface JibModuleBuildSpec extends ContainerBuildSpec {
   dockerBuild?: boolean
-  projectType: "gradle" | "maven" | "auto"
+  projectType: "gradle" | "maven" | "mavend" | "auto"
   jdkVersion: number
   jdkPath?: string
   tarOnly?: boolean
@@ -69,7 +69,7 @@ export function getBuildFlags(module: JibContainerModule, projectType: JibModule
   let targetDir: string
   let target: string
 
-  if (projectType === "maven") {
+  if (projectType === "maven" || projectType === "mavend") {
     targetDir = "target"
     if (tarOnly) {
       target = "jib:buildTar"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
Added one more build option in `type:jib-container` to use [Mavend](https://github.com/apache/maven-mvnd#introduction) for faster build processes of maven projects.

User can now use `mavend` to specify in `projectType` for `jib-container` modules.

Eg.
```
kind: Module
type: jib-container
name: spring-boot
build:
  projectType: mavend
```

This is useful for maven based projects and aims at providing faster Maven builds, when using jib container module.
 