### PR TITLE
feat(k8s): custom annotations for builder pods

### DIFF
--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -707,23 +707,23 @@ export const kubernetesConfigBase = () =>
           dedent`
             Exposes the \`nodeSelector\` field on the PodSpec of the Kaniko pods. This allows you to constrain the Kaniko pods to only run on particular nodes.
 
-            [See here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) for the official Kubernetes guide to assigning Pods to nodes.
+            [See here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) for the official Kubernetes guide to assigning pods to nodes.
           `
         ),
         tolerations: joiSparseArray(tolerationSchema()).description(
-          deline`Specify tolerations to apply to each Kaniko builder Pod. Useful to control which nodes in a cluster can run builds.
+          deline`Specify tolerations to apply to each Kaniko builder pod. Useful to control which nodes in a cluster can run builds.
           Same tolerations will be used for the util pod unless they are specifically set under \`util.tolerations\``
         ),
         annotations: annotationsSchema().description(
-          deline`Specify annotations to apply to each Kaniko builder Pod. Annotations may have an effect on the behaviour of certain components, for example autoscalers.
-          Same anotations will be used for the util pod unless they are specifically set under \`util.annotations\``
+          deline`Specify annotations to apply to each Kaniko builder pod. Annotations may have an effect on the behaviour of certain components, for example autoscalers.
+          Same anotations will be used for each util pod unless they are specifically set under \`util.annotations\``
         ),
         util: joi.object().keys({
           tolerations: joiSparseArray(tolerationSchema()).description(
-            "Specify tolerations to apply to the garden-util Pod."
+            "Specify tolerations to apply to each garden-util pod."
           ),
           annotations: annotationsSchema().description(
-            "Specify annotations to apply to the garden-util Pod and Deployment."
+            "Specify annotations to apply to each garden-util pod and deployments."
           ),
         }),
       })

--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -360,6 +360,7 @@ export function getBuildkitDeployment(
         app: buildkitDeploymentName,
       },
       name: buildkitDeploymentName,
+      annotations: provider.config.clusterBuildkit?.annotations,
     },
     spec: {
       replicas: 1,
@@ -373,6 +374,7 @@ export function getBuildkitDeployment(
           labels: {
             app: buildkitDeploymentName,
           },
+          annotations: provider.config.clusterBuildkit?.annotations,
         },
         spec: {
           containers: [

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -523,6 +523,7 @@ export function getUtilManifests(
     ...(provider.config.kaniko?.util?.tolerations || provider.config.kaniko?.tolerations || []),
     builderToleration,
   ]
+  const kanikoAnnotations = provider.config.kaniko?.util?.annotations || provider.config.kaniko?.annotations
   const deployment: KubernetesDeployment = {
     apiVersion: "apps/v1",
     kind: "Deployment",
@@ -531,6 +532,7 @@ export function getUtilManifests(
         app: utilDeploymentName,
       },
       name: utilDeploymentName,
+      annotations: kanikoAnnotations,
     },
     spec: {
       replicas: 1,
@@ -544,6 +546,7 @@ export function getUtilManifests(
           labels: {
             app: utilDeploymentName,
           },
+          annotations: kanikoAnnotations,
         },
         spec: {
           containers: [getUtilContainer(authSecretName, provider)],

--- a/core/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/src/plugins/kubernetes/container/build/kaniko.ts
@@ -211,7 +211,16 @@ export function kanikoBuildFailed(buildRes: RunResult) {
   )
 }
 
-interface GetKanikoBuilderPodManifestParams {
+export function getKanikoBuilderPodManifest({
+  provider,
+  kanikoNamespace,
+  authSecretName,
+  syncArgs,
+  imagePullSecrets,
+  sourceUrl,
+  podName,
+  commandStr,
+}: {
   provider: KubernetesProvider
   kanikoNamespace: string
   authSecretName: string
@@ -222,18 +231,7 @@ interface GetKanikoBuilderPodManifestParams {
   sourceUrl: string
   podName: string
   commandStr: string
-}
-
-export function getKanikoBuilderPodManifest({
-  provider,
-  kanikoNamespace,
-  authSecretName,
-  syncArgs,
-  imagePullSecrets,
-  sourceUrl,
-  podName,
-  commandStr,
-}: GetKanikoBuilderPodManifestParams) {
+}) {
   const kanikoImage = provider.config.kaniko?.image || DEFAULT_KANIKO_IMAGE
   const kanikoTolerations = [...(provider.config.kaniko?.tolerations || []), builderToleration]
 
@@ -361,17 +359,6 @@ export function getKanikoBuilderPodManifest({
   return pod
 }
 
-interface RunKanikoParams {
-  ctx: PluginContext
-  provider: KubernetesProvider
-  kanikoNamespace: string
-  utilNamespace: string
-  authSecretName: string
-  log: LogEntry
-  module: ContainerModule
-  args: string[]
-}
-
 async function runKaniko({
   ctx,
   provider,
@@ -381,7 +368,16 @@ async function runKaniko({
   log,
   module,
   args,
-}: RunKanikoParams): Promise<RunResult> {
+}: {
+  ctx: PluginContext
+  provider: KubernetesProvider
+  kanikoNamespace: string
+  utilNamespace: string
+  authSecretName: string
+  log: LogEntry
+  module: ContainerModule
+  args: string[]
+}): Promise<RunResult> {
   const api = await KubeApi.factory(log, ctx, provider)
 
   const podName = makePodName("kaniko", module.name)

--- a/core/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/src/plugins/kubernetes/container/build/kaniko.ts
@@ -390,6 +390,7 @@ async function runKaniko({
     metadata: {
       name: podName,
       namespace: kanikoNamespace,
+      annotations: provider.config.kaniko?.annotations,
     },
     spec,
   }

--- a/core/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/src/plugins/kubernetes/container/build/kaniko.ts
@@ -211,68 +211,31 @@ export function kanikoBuildFailed(buildRes: RunResult) {
   )
 }
 
-interface RunKanikoParams {
-  ctx: PluginContext
+interface GetKanikoBuilderPodManifestParams {
   provider: KubernetesProvider
   kanikoNamespace: string
-  utilNamespace: string
   authSecretName: string
-  log: LogEntry
-  module: ContainerModule
-  args: string[]
+  syncArgs: string[]
+  imagePullSecrets: {
+    name: string
+  }[]
+  sourceUrl: string
+  podName: string
+  commandStr: string
 }
 
-async function runKaniko({
-  ctx,
+export function getKanikoBuilderPodManifest({
   provider,
   kanikoNamespace,
-  utilNamespace,
   authSecretName,
-  log,
-  module,
-  args,
-}: RunKanikoParams): Promise<RunResult> {
-  const api = await KubeApi.factory(log, ctx, provider)
-
-  const podName = makePodName("kaniko", module.name)
-
-  // Escape the args so that we can safely interpolate them into the kaniko command
-  const argsStr = args.map((arg) => JSON.stringify(arg)).join(" ")
-
-  let commandStr = dedent`
-    /kaniko/executor ${argsStr};
-    export exitcode=$?;
-    touch ${sharedMountPath}/done;
-    exit $exitcode;
-  `
-
-  if (usingInClusterRegistry(provider)) {
-    // This may seem kind of insane but we have to wait until the socat proxy is up (because Kaniko immediately tries to
-    // reach the registry we plan on pushing to). See the support container in the Pod spec below for more on this
-    // hackery.
-    commandStr = dedent`
-      while true; do
-        if ls ${sharedMountPath}/socatStarted 2> /dev/null; then
-          ${commandStr}
-        else
-          sleep 0.3;
-        fi
-      done
-    `
-  }
-
+  syncArgs,
+  imagePullSecrets,
+  sourceUrl,
+  podName,
+  commandStr,
+}: GetKanikoBuilderPodManifestParams) {
   const kanikoImage = provider.config.kaniko?.image || DEFAULT_KANIKO_IMAGE
   const kanikoTolerations = [...(provider.config.kaniko?.tolerations || []), builderToleration]
-  const utilHostname = `${utilDeploymentName}.${utilNamespace}.svc.cluster.local`
-  const sourceUrl = `rsync://${utilHostname}:${utilRsyncPort}/volume/${ctx.workingCopyId}/${module.name}/`
-  const imagePullSecrets = await prepareSecrets({
-    api,
-    namespace: kanikoNamespace,
-    secrets: provider.config.imagePullSecrets,
-    log,
-  })
-
-  const syncArgs = [...commonSyncArgs, sourceUrl, contextPath]
 
   const spec: V1PodSpec = {
     shareProcessNamespace: true,
@@ -394,6 +357,81 @@ async function runKaniko({
     },
     spec,
   }
+
+  return pod
+}
+
+interface RunKanikoParams {
+  ctx: PluginContext
+  provider: KubernetesProvider
+  kanikoNamespace: string
+  utilNamespace: string
+  authSecretName: string
+  log: LogEntry
+  module: ContainerModule
+  args: string[]
+}
+
+async function runKaniko({
+  ctx,
+  provider,
+  kanikoNamespace,
+  utilNamespace,
+  authSecretName,
+  log,
+  module,
+  args,
+}: RunKanikoParams): Promise<RunResult> {
+  const api = await KubeApi.factory(log, ctx, provider)
+
+  const podName = makePodName("kaniko", module.name)
+
+  // Escape the args so that we can safely interpolate them into the kaniko command
+  const argsStr = args.map((arg) => JSON.stringify(arg)).join(" ")
+
+  let commandStr = dedent`
+    /kaniko/executor ${argsStr};
+    export exitcode=$?;
+    touch ${sharedMountPath}/done;
+    exit $exitcode;
+  `
+
+  if (usingInClusterRegistry(provider)) {
+    // This may seem kind of insane but we have to wait until the socat proxy is up (because Kaniko immediately tries to
+    // reach the registry we plan on pushing to). See the support container in the Pod spec below for more on this
+    // hackery.
+    commandStr = dedent`
+      while true; do
+        if ls ${sharedMountPath}/socatStarted 2> /dev/null; then
+          ${commandStr}
+        else
+          sleep 0.3;
+        fi
+      done
+    `
+  }
+
+  const utilHostname = `${utilDeploymentName}.${utilNamespace}.svc.cluster.local`
+  const sourceUrl = `rsync://${utilHostname}:${utilRsyncPort}/volume/${ctx.workingCopyId}/${module.name}/`
+  const imagePullSecrets = await prepareSecrets({
+    api,
+    namespace: kanikoNamespace,
+    secrets: provider.config.imagePullSecrets,
+    log,
+  })
+
+  const syncArgs = [...commonSyncArgs, sourceUrl, contextPath]
+
+  const pod = getKanikoBuilderPodManifest({
+    provider,
+    podName,
+    sourceUrl,
+    syncArgs,
+    imagePullSecrets,
+    commandStr,
+    kanikoNamespace,
+    authSecretName,
+  })
 
   // Set the configured nodeSelector, if any
   if (!isEmpty(provider.config.kaniko?.nodeSelector)) {

--- a/core/src/plugins/kubernetes/status/status.ts
+++ b/core/src/plugins/kubernetes/status/status.ts
@@ -430,8 +430,8 @@ export async function compareDeployedResources(
       }
     }
 
-    // clean null values
-    manifest = <KubernetesResource>removeNull(manifest)
+    // clean null and undefined values
+    manifest = <KubernetesResource>removeNullAndUndefined(manifest)
     // The Kubernetes API currently strips out environment variables values so we remove them
     // from the manifests as well
     manifest = removeEmptyEnvValues(manifest)
@@ -492,15 +492,15 @@ export async function getDeployedResource(
 }
 
 /**
- * Recursively removes all null value properties from objects
+ * Recursively removes all null and undefined value properties from objects
  */
-function removeNull<T>(value: T | Iterable<T>): T | Iterable<T> | { [K in keyof T]: T[K] } {
+function removeNullAndUndefined<T>(value: T | Iterable<T>): T | Iterable<T> | { [K in keyof T]: T[K] } {
   if (isArray(value)) {
-    return value.map(removeNull)
+    return value.map(removeNullAndUndefined)
   } else if (isPlainObject(value)) {
     return <{ [K in keyof T]: T[K] }>mapValues(
-      pickBy(<any>value, (v) => v !== null),
-      removeNull
+      pickBy(<any>value, (v) => v !== null && v !== undefined),
+      removeNullAndUndefined
     )
   } else {
     return value

--- a/core/test/integ/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/build/buildkit.ts
@@ -153,6 +153,30 @@ grouped("cluster-buildkit").describe("ensureBuildkit", () => {
       })
       expect(updated).to.be.false
     })
+
+    it("returns false if buildkit is already deployed with annotations", async () => {
+      provider.config.clusterBuildkit = {
+        cache: [],
+        annotations: {
+          testAnnotation: "is-there",
+        },
+      }
+      await ensureBuildkit({
+        ctx,
+        provider,
+        log: garden.log,
+        api,
+        namespace,
+      })
+      const { updated } = await ensureBuildkit({
+        ctx,
+        provider,
+        log: garden.log,
+        api,
+        namespace,
+      })
+      expect(updated).to.be.false
+    })
   })
 
   grouped("cluster-buildkit-rootless").context("cluster-buildkit-rootless mode", () => {

--- a/core/test/unit/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/build/buildkit.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { expect, util } from "chai"
+import { expect } from "chai"
 import { DeepPartial } from "typeorm-with-better-sqlite3"
 import {
   ClusterBuildkitCacheConfig,

--- a/core/test/unit/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/build/buildkit.ts
@@ -6,117 +6,322 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { expect } from "chai"
-import { ClusterBuildkitCacheConfig } from "../../../../../../../src/plugins/kubernetes/config"
-import { inClusterRegistryHostname } from "../../../../../../../src/plugins/kubernetes/constants"
+import { expect, util } from "chai"
+import { DeepPartial } from "typeorm-with-better-sqlite3"
 import {
+  ClusterBuildkitCacheConfig,
+  defaultResources,
+  KubernetesProvider,
+} from "../../../../../../../src/plugins/kubernetes/config"
+import { inClusterRegistryHostname, k8sUtilImageName } from "../../../../../../../src/plugins/kubernetes/constants"
+import {
+  buildkitImageName,
+  getBuildkitDeployment,
   getBuildkitImageFlags,
   getBuildkitModuleFlags,
 } from "../../../../../../../src/plugins/kubernetes/container/build/buildkit"
 import { getDataDir, makeTestGarden } from "../../../../../../helpers"
 
-describe("getBuildkitModuleFlags", () => {
-  it("should correctly format the build target option", async () => {
-    const projectRoot = getDataDir("test-project-container")
-    const garden = await makeTestGarden(projectRoot)
-    const graph = await garden.getConfigGraph({ log: garden.log, emit: false })
-    const module = graph.getModule("module-a")
+describe("buildkit build", () => {
+  describe("getBuildkitDeployment", () => {
+    const _provider: DeepPartial<KubernetesProvider> = {
+      config: {
+        resources: defaultResources,
+      },
+    }
+    let provider = _provider as KubernetesProvider
+    beforeEach(() => {
+      provider = _provider as KubernetesProvider
+    })
 
-    module.spec.build.targetImage = "foo"
+    it("should return a Kubernetes Deployment manifest for buildkit in-cluster-builder", () => {
+      const result = getBuildkitDeployment(provider, "authSecretName", [{ name: "imagePullSecretName" }])
+      expect(result.kind).eql("Deployment")
+      expect(result.metadata).eql({
+        annotations: undefined,
+        labels: {
+          app: "garden-buildkit",
+        },
+        name: "garden-buildkit",
+      })
+      expect(result.spec.template.metadata).eql({
+        annotations: undefined,
+        labels: {
+          app: "garden-buildkit",
+        },
+      })
 
-    const flags = getBuildkitModuleFlags(module)
+      expect(result.spec.template.spec?.containers.length === 2)
 
-    expect(flags).to.eql([
-      "--opt",
-      "build-arg:GARDEN_MODULE_VERSION=" + module.version.versionString,
-      "--opt",
-      "target=foo",
-    ])
+      expect(result.spec.template.spec?.containers[0]).eql({
+        args: ["--addr", "unix:///run/buildkit/buildkitd.sock"],
+        env: [
+          {
+            name: "DOCKER_CONFIG",
+            value: "/.docker",
+          },
+        ],
+        image: buildkitImageName,
+        livenessProbe: {
+          exec: {
+            command: ["buildctl", "debug", "workers"],
+          },
+          initialDelaySeconds: 5,
+          periodSeconds: 30,
+        },
+        name: "buildkitd",
+        readinessProbe: {
+          exec: {
+            command: ["buildctl", "debug", "workers"],
+          },
+          initialDelaySeconds: 3,
+          periodSeconds: 5,
+        },
+        resources: {
+          limits: {
+            cpu: "4",
+            memory: "8Gi",
+          },
+          requests: {
+            cpu: "100m",
+            memory: "512Mi",
+          },
+        },
+        securityContext: {
+          privileged: true,
+        },
+        volumeMounts: [
+          {
+            mountPath: "/.docker",
+            name: "authSecretName",
+            readOnly: true,
+          },
+          {
+            mountPath: "/garden-build",
+            name: "garden-sync",
+          },
+        ],
+      })
+
+      expect(result.spec.template.spec?.containers[1]).eql({
+        command: ["/rsync-server.sh"],
+        env: [
+          {
+            name: "ALLOW",
+            value: "0.0.0.0/0",
+          },
+          {
+            name: "RSYNC_PORT",
+            value: "8730",
+          },
+        ],
+        image: k8sUtilImageName,
+        imagePullPolicy: "IfNotPresent",
+        lifecycle: {
+          preStop: {
+            exec: {
+              command: [
+                "/bin/sh",
+                "-c",
+                "until test $(pgrep -fc '^[^ ]+rsync') = 1; do echo waiting for rsync to finish...; sleep 1; done",
+              ],
+            },
+          },
+        },
+        name: "util",
+        ports: [
+          {
+            containerPort: 8730,
+            name: "garden-rsync",
+            protocol: "TCP",
+          },
+        ],
+        readinessProbe: {
+          failureThreshold: 5,
+          initialDelaySeconds: 1,
+          periodSeconds: 1,
+          successThreshold: 2,
+          tcpSocket: {
+            port: "garden-rsync",
+          },
+          timeoutSeconds: 3,
+        },
+        resources: {
+          limits: {
+            cpu: "256m",
+            memory: "512Mi",
+          },
+          requests: {
+            cpu: "256m",
+            memory: "512Mi",
+          },
+        },
+        securityContext: {
+          runAsGroup: 1000,
+          runAsUser: 1000,
+        },
+        volumeMounts: [
+          {
+            mountPath: "/home/user/.docker",
+            name: "authSecretName",
+            readOnly: true,
+          },
+          {
+            mountPath: "/data",
+            name: "garden-sync",
+          },
+        ],
+      })
+    })
+
+    it("should return a Kubernetes Deployment with the configured annotations", () => {
+      provider.config.clusterBuildkit = {
+        cache: [],
+        annotations: {
+          buildkitAnnotation: "is-there",
+        },
+      }
+      const result = getBuildkitDeployment(provider, "authSecretName", [{ name: "imagePullSecretName" }])
+      expect(result.metadata.annotations).eql(provider.config.clusterBuildkit.annotations)
+      expect(result.spec.template.metadata?.annotations).eql(provider.config.clusterBuildkit.annotations)
+    })
   })
-})
 
-describe("getBuildkitImageFlags()", () => {
-  const defaultConfig: ClusterBuildkitCacheConfig[] = [
-    {
-      type: "registry",
-      mode: "auto",
-      tag: "_buildcache",
-      export: true,
-    },
-  ]
+  describe("getBuildkitModuleFlags", () => {
+    it("should correctly format the build target option", async () => {
+      const projectRoot = getDataDir("test-project-container")
+      const garden = await makeTestGarden(projectRoot)
+      const graph = await garden.getConfigGraph({ log: garden.log, emit: false })
+      const module = graph.getModule("module-a")
 
-  // test autodetection for mode=inline
-  const expectedInline = [
-    // The following registries are actually known NOT to support mode=max
-    "eu.gcr.io",
-    "gcr.io",
-    "aws_account_id.dkr.ecr.region.amazonaws.com",
-    "keks.dkr.ecr.bla.amazonaws.com",
-    // Most self-hosted registries actually support mode=max, but because
-    // Harbor actually doesn't, we need to default to inline.
-    "anyOtherRegistry",
-    "127.0.0.1",
-  ]
-  for (const registry of expectedInline) {
-    it(`returns type=inline cache flags with default config with registry ${registry}`, async () => {
-      const moduleOutputs = {
-        "local-image-id": "name:v-xxxxxx",
-        "local-image-name": "name",
-        "deployment-image-id": `${registry}/namespace/name:v-xxxxxx`,
-        "deployment-image-name": `${registry}/namespace/name`,
-      }
+      module.spec.build.targetImage = "foo"
 
-      const flags = getBuildkitImageFlags(defaultConfig, moduleOutputs, false)
+      const flags = getBuildkitModuleFlags(module)
 
       expect(flags).to.eql([
-        "--export-cache",
-        "type=inline",
-        "--output",
-        `type=image,"name=${registry}/namespace/name:v-xxxxxx,${registry}/namespace/name:_buildcache",push=true`,
-        "--import-cache",
-        `type=registry,ref=${registry}/namespace/name:_buildcache`,
+        "--opt",
+        "build-arg:GARDEN_MODULE_VERSION=" + module.version.versionString,
+        "--opt",
+        "target=foo",
       ])
     })
-  }
+  })
 
-  // test autodetection for mode=max
-  const expectedMax = [
-    // The following registries are known to actually support mode=max
-    "hub.docker.com",
-    "pkg.dev",
-    "some.subdomain.pkg.dev",
-    "ghcr.io",
-    "GHCR.io",
-    "azurecr.io",
-    "some.subdomain.azurecr.io",
-  ]
-  for (const registry of expectedMax) {
-    it(`returns mode=max cache flags with default config with registry ${registry}`, async () => {
-      const moduleOutputs = {
-        "local-image-id": "name:v-xxxxxx",
-        "local-image-name": "name",
-        "deployment-image-id": `${registry}/namespace/name:v-xxxxxx`,
-        "deployment-image-name": `${registry}/namespace/name`,
-      }
+  describe("getBuildkitImageFlags()", () => {
+    const defaultConfig: ClusterBuildkitCacheConfig[] = [
+      {
+        type: "registry",
+        mode: "auto",
+        tag: "_buildcache",
+        export: true,
+      },
+    ]
 
-      const flags = getBuildkitImageFlags(defaultConfig, moduleOutputs, false)
+    // test autodetection for mode=inline
+    const expectedInline = [
+      // The following registries are actually known NOT to support mode=max
+      "eu.gcr.io",
+      "gcr.io",
+      "aws_account_id.dkr.ecr.region.amazonaws.com",
+      "keks.dkr.ecr.bla.amazonaws.com",
+      // Most self-hosted registries actually support mode=max, but because
+      // Harbor actually doesn't, we need to default to inline.
+      "anyOtherRegistry",
+      "127.0.0.1",
+    ]
+    for (const registry of expectedInline) {
+      it(`returns type=inline cache flags with default config with registry ${registry}`, async () => {
+        const moduleOutputs = {
+          "local-image-id": "name:v-xxxxxx",
+          "local-image-name": "name",
+          "deployment-image-id": `${registry}/namespace/name:v-xxxxxx`,
+          "deployment-image-name": `${registry}/namespace/name`,
+        }
 
-      expect(flags).to.eql([
-        "--output",
-        `type=image,"name=${registry}/namespace/name:v-xxxxxx",push=true`,
-        "--import-cache",
-        `type=registry,ref=${registry}/namespace/name:_buildcache`,
-        "--export-cache",
-        `type=registry,ref=${registry}/namespace/name:_buildcache,mode=max`,
-      ])
-    })
-  }
+        const flags = getBuildkitImageFlags(defaultConfig, moduleOutputs, false)
 
-  // explicit min / max
-  const explicitModes: ClusterBuildkitCacheConfig["mode"][] = ["min", "max"]
-  for (const mode of explicitModes) {
-    it(`returns mode=${mode} cache flags if explicitly configured`, async () => {
-      const registry = "explicitTeamRegistry"
+        expect(flags).to.eql([
+          "--export-cache",
+          "type=inline",
+          "--output",
+          `type=image,"name=${registry}/namespace/name:v-xxxxxx,${registry}/namespace/name:_buildcache",push=true`,
+          "--import-cache",
+          `type=registry,ref=${registry}/namespace/name:_buildcache`,
+        ])
+      })
+    }
+
+    // test autodetection for mode=max
+    const expectedMax = [
+      // The following registries are known to actually support mode=max
+      "hub.docker.com",
+      "pkg.dev",
+      "some.subdomain.pkg.dev",
+      "ghcr.io",
+      "GHCR.io",
+      "azurecr.io",
+      "some.subdomain.azurecr.io",
+    ]
+    for (const registry of expectedMax) {
+      it(`returns mode=max cache flags with default config with registry ${registry}`, async () => {
+        const moduleOutputs = {
+          "local-image-id": "name:v-xxxxxx",
+          "local-image-name": "name",
+          "deployment-image-id": `${registry}/namespace/name:v-xxxxxx`,
+          "deployment-image-name": `${registry}/namespace/name`,
+        }
+
+        const flags = getBuildkitImageFlags(defaultConfig, moduleOutputs, false)
+
+        expect(flags).to.eql([
+          "--output",
+          `type=image,"name=${registry}/namespace/name:v-xxxxxx",push=true`,
+          "--import-cache",
+          `type=registry,ref=${registry}/namespace/name:_buildcache`,
+          "--export-cache",
+          `type=registry,ref=${registry}/namespace/name:_buildcache,mode=max`,
+        ])
+      })
+    }
+
+    // explicit min / max
+    const explicitModes: ClusterBuildkitCacheConfig["mode"][] = ["min", "max"]
+    for (const mode of explicitModes) {
+      it(`returns mode=${mode} cache flags if explicitly configured`, async () => {
+        const registry = "explicitTeamRegistry"
+
+        const moduleOutputs = {
+          "local-image-id": "name:v-xxxxxx",
+          "local-image-name": "name",
+          "deployment-image-id": `${registry}/namespace/name:v-xxxxxx`,
+          "deployment-image-name": `${registry}/namespace/name`,
+        }
+
+        const config: ClusterBuildkitCacheConfig[] = [
+          {
+            type: "registry",
+            mode,
+            tag: "_buildcache",
+            export: true,
+          },
+        ]
+
+        const flags = getBuildkitImageFlags(config, moduleOutputs, false)
+
+        expect(flags).to.eql([
+          "--output",
+          `type=image,"name=${registry}/namespace/name:v-xxxxxx",push=true`,
+          "--import-cache",
+          `type=registry,ref=${registry}/namespace/name:_buildcache`,
+          "--export-cache",
+          `type=registry,ref=${registry}/namespace/name:_buildcache,mode=${mode}`,
+        ])
+      })
+    }
+
+    // explicit inline
+    it(`returns type=inline cache flags when explicitly configured`, async () => {
+      const registry = "someExplicitInlineRegistry"
 
       const moduleOutputs = {
         "local-image-id": "name:v-xxxxxx",
@@ -128,7 +333,7 @@ describe("getBuildkitImageFlags()", () => {
       const config: ClusterBuildkitCacheConfig[] = [
         {
           type: "registry",
-          mode,
+          mode: "inline",
           tag: "_buildcache",
           export: true,
         },
@@ -137,164 +342,132 @@ describe("getBuildkitImageFlags()", () => {
       const flags = getBuildkitImageFlags(config, moduleOutputs, false)
 
       expect(flags).to.eql([
+        "--export-cache",
+        "type=inline",
         "--output",
-        `type=image,"name=${registry}/namespace/name:v-xxxxxx",push=true`,
+        `type=image,"name=${registry}/namespace/name:v-xxxxxx,${registry}/namespace/name:_buildcache",push=true`,
         "--import-cache",
         `type=registry,ref=${registry}/namespace/name:_buildcache`,
-        "--export-cache",
-        `type=registry,ref=${registry}/namespace/name:_buildcache,mode=${mode}`,
       ])
     })
-  }
 
-  // explicit inline
-  it(`returns type=inline cache flags when explicitly configured`, async () => {
-    const registry = "someExplicitInlineRegistry"
+    it("uses registry.insecure=true with the in-cluster registry", async () => {
+      const registry = inClusterRegistryHostname
 
-    const moduleOutputs = {
-      "local-image-id": "name:v-xxxxxx",
-      "local-image-name": "name",
-      "deployment-image-id": `${registry}/namespace/name:v-xxxxxx`,
-      "deployment-image-name": `${registry}/namespace/name`,
-    }
+      const moduleOutputs = {
+        "local-image-id": "name:v-xxxxxx",
+        "local-image-name": "name",
+        "deployment-image-id": `${registry}/namespace/name:v-xxxxxx`,
+        "deployment-image-name": `${registry}/namespace/name`,
+      }
 
-    const config: ClusterBuildkitCacheConfig[] = [
-      {
-        type: "registry",
-        mode: "inline",
-        tag: "_buildcache",
-        export: true,
-      },
-    ]
+      const flags = getBuildkitImageFlags(
+        defaultConfig,
+        moduleOutputs,
+        true // deploymentRegistryInsecure
+      )
 
-    const flags = getBuildkitImageFlags(config, moduleOutputs, false)
+      expect(flags).to.eql([
+        "--output",
+        `type=image,"name=${registry}/namespace/name:v-xxxxxx",push=true,registry.insecure=true`,
+        "--import-cache",
+        `type=registry,ref=${registry}/namespace/name:_buildcache,registry.insecure=true`,
+        "--export-cache",
+        `type=registry,ref=${registry}/namespace/name:_buildcache,mode=max,registry.insecure=true`,
+      ])
+    })
 
-    expect(flags).to.eql([
-      "--export-cache",
-      "type=inline",
-      "--output",
-      `type=image,"name=${registry}/namespace/name:v-xxxxxx,${registry}/namespace/name:_buildcache",push=true`,
-      "--import-cache",
-      `type=registry,ref=${registry}/namespace/name:_buildcache`,
-    ])
-  })
+    it("returns correct flags with separate cache registry", async () => {
+      const deploymentRegistry = "gcr.io/deploymentRegistry"
+      const cacheRegistry = "pkg.dev/cacheRegistry"
 
-  it("uses registry.insecure=true with the in-cluster registry", async () => {
-    const registry = inClusterRegistryHostname
+      const moduleOutputs = {
+        "local-image-id": "name:v-xxxxxx",
+        "local-image-name": "name",
+        "deployment-image-id": `${deploymentRegistry}/namespace/name:v-xxxxxx`,
+        "deployment-image-name": `${deploymentRegistry}/namespace/name`,
+      }
 
-    const moduleOutputs = {
-      "local-image-id": "name:v-xxxxxx",
-      "local-image-name": "name",
-      "deployment-image-id": `${registry}/namespace/name:v-xxxxxx`,
-      "deployment-image-name": `${registry}/namespace/name`,
-    }
-
-    const flags = getBuildkitImageFlags(
-      defaultConfig,
-      moduleOutputs,
-      true // deploymentRegistryInsecure
-    )
-
-    expect(flags).to.eql([
-      "--output",
-      `type=image,"name=${registry}/namespace/name:v-xxxxxx",push=true,registry.insecure=true`,
-      "--import-cache",
-      `type=registry,ref=${registry}/namespace/name:_buildcache,registry.insecure=true`,
-      "--export-cache",
-      `type=registry,ref=${registry}/namespace/name:_buildcache,mode=max,registry.insecure=true`,
-    ])
-  })
-
-  it("returns correct flags with separate cache registry", async () => {
-    const deploymentRegistry = "gcr.io/deploymentRegistry"
-    const cacheRegistry = "pkg.dev/cacheRegistry"
-
-    const moduleOutputs = {
-      "local-image-id": "name:v-xxxxxx",
-      "local-image-name": "name",
-      "deployment-image-id": `${deploymentRegistry}/namespace/name:v-xxxxxx`,
-      "deployment-image-name": `${deploymentRegistry}/namespace/name`,
-    }
-
-    const config: ClusterBuildkitCacheConfig[] = [
-      {
-        type: "registry",
-        registry: {
-          hostname: cacheRegistry,
-          namespace: "namespace",
-          insecure: false,
+      const config: ClusterBuildkitCacheConfig[] = [
+        {
+          type: "registry",
+          registry: {
+            hostname: cacheRegistry,
+            namespace: "namespace",
+            insecure: false,
+          },
+          mode: "auto",
+          tag: "_buildcache",
+          export: true,
         },
-        mode: "auto",
-        tag: "_buildcache",
-        export: true,
-      },
-    ]
+      ]
 
-    const flags = getBuildkitImageFlags(config, moduleOutputs, false)
+      const flags = getBuildkitImageFlags(config, moduleOutputs, false)
 
-    expect(flags).to.eql([
-      // output to deploymentRegistry
-      "--output",
-      `type=image,"name=${deploymentRegistry}/namespace/name:v-xxxxxx",push=true`,
+      expect(flags).to.eql([
+        // output to deploymentRegistry
+        "--output",
+        `type=image,"name=${deploymentRegistry}/namespace/name:v-xxxxxx",push=true`,
 
-      // import and export to cacheRegistry with mode=max
-      "--import-cache",
-      `type=registry,ref=${cacheRegistry}/namespace/name:_buildcache`,
-      "--export-cache",
-      `type=registry,ref=${cacheRegistry}/namespace/name:_buildcache,mode=max`,
-    ])
-  })
+        // import and export to cacheRegistry with mode=max
+        "--import-cache",
+        `type=registry,ref=${cacheRegistry}/namespace/name:_buildcache`,
+        "--export-cache",
+        `type=registry,ref=${cacheRegistry}/namespace/name:_buildcache,mode=max`,
+      ])
+    })
 
-  it("returns correct flags for complex feautureBranch / Main branch + separate cache registry use case", async () => {
-    const deploymentRegistry = "gcr.io/someBigTeamDeploymentRegistry"
-    const cacheRegistry = "pkg.dev/someBigTeamCacheRegistry"
+    it("returns correct flags for complex cache registry use case", async () => {
+      const deploymentRegistry = "gcr.io/someBigTeamDeploymentRegistry"
+      const cacheRegistry = "pkg.dev/someBigTeamCacheRegistry"
 
-    const moduleOutputs = {
-      "local-image-id": "name:v-xxxxxx",
-      "local-image-name": "name",
-      "deployment-image-id": `${deploymentRegistry}/namespace/name:v-xxxxxx`,
-      "deployment-image-name": `${deploymentRegistry}/namespace/name`,
-    }
+      const moduleOutputs = {
+        "local-image-id": "name:v-xxxxxx",
+        "local-image-name": "name",
+        "deployment-image-id": `${deploymentRegistry}/namespace/name:v-xxxxxx`,
+        "deployment-image-name": `${deploymentRegistry}/namespace/name`,
+      }
 
-    const config: ClusterBuildkitCacheConfig[] = [
-      {
-        type: "registry",
-        registry: {
-          hostname: cacheRegistry,
-          namespace: "namespace",
-          insecure: false,
+      const config: ClusterBuildkitCacheConfig[] = [
+        {
+          type: "registry",
+          registry: {
+            hostname: cacheRegistry,
+            namespace: "namespace",
+            insecure: false,
+          },
+          mode: "auto",
+          tag: "_buildcache-featureBranch",
+          export: true,
         },
-        mode: "auto",
-        tag: "_buildcache-featureBranch",
-        export: true,
-      },
-      {
-        type: "registry",
-        registry: {
-          hostname: cacheRegistry,
-          namespace: "namespace",
-          insecure: false,
+        {
+          type: "registry",
+          registry: {
+            hostname: cacheRegistry,
+            namespace: "namespace",
+            insecure: false,
+          },
+          mode: "auto",
+          tag: "_buildcache-main",
+          export: false,
         },
-        mode: "auto",
-        tag: "_buildcache-main",
-        export: false,
-      },
-    ]
+      ]
 
-    const flags = getBuildkitImageFlags(config, moduleOutputs, false)
+      const flags = getBuildkitImageFlags(config, moduleOutputs, false)
 
-    expect(flags).to.eql([
-      // output to deploymentRegistry
-      "--output",
-      `type=image,"name=${deploymentRegistry}/namespace/name:v-xxxxxx",push=true`,
-      // import and export to cacheRegistry with mode=max
-      // import first _buildcache-featureBranch, then _buildcache-main
-      "--import-cache",
-      `type=registry,ref=${cacheRegistry}/namespace/name:_buildcache-featureBranch`,
-      "--export-cache",
-      `type=registry,ref=${cacheRegistry}/namespace/name:_buildcache-featureBranch,mode=max`,
-      "--import-cache",
-      `type=registry,ref=${cacheRegistry}/namespace/name:_buildcache-main`,
-    ])
+      expect(flags).to.eql([
+        // output to deploymentRegistry
+        "--output",
+        `type=image,"name=${deploymentRegistry}/namespace/name:v-xxxxxx",push=true`,
+        // import and export to cacheRegistry with mode=max
+        // import first _buildcache-featureBranch, then _buildcache-main
+        "--import-cache",
+        `type=registry,ref=${cacheRegistry}/namespace/name:_buildcache-featureBranch`,
+        "--export-cache",
+        `type=registry,ref=${cacheRegistry}/namespace/name:_buildcache-featureBranch,mode=max`,
+        "--import-cache",
+        `type=registry,ref=${cacheRegistry}/namespace/name:_buildcache-main`,
+      ])
+    })
   })
 })

--- a/core/test/unit/src/plugins/kubernetes/container/build/common.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/build/common.ts
@@ -57,12 +57,12 @@ describe("common build", () => {
         deployment: {
           apiVersion: "apps/v1",
           kind: "Deployment",
-          metadata: { labels: { app: "garden-util" }, name: "garden-util" },
+          metadata: { labels: { app: "garden-util" }, name: "garden-util", annotations: undefined },
           spec: {
             replicas: 1,
             selector: { matchLabels: { app: "garden-util" } },
             template: {
-              metadata: { labels: { app: "garden-util" } },
+              metadata: { labels: { app: "garden-util" }, annotations: undefined },
               spec: {
                 containers: [
                   {
@@ -165,6 +165,37 @@ describe("common build", () => {
       const tolerations = result.deployment.spec.template.spec?.tolerations
 
       expect(tolerations?.findIndex((t) => t.key === tolerationKaniko.key)).to.eql(-1)
+    })
+
+    it("should return the manifest with kaniko annotations when util annotations are missing", () => {
+      provider.config.kaniko = {
+        annotations: {
+          testAnnotation: "its-there",
+        },
+      }
+      const result = getUtilManifests(provider, "test", [])
+
+      const deploymentAnnotations = result.deployment.metadata?.annotations
+      expect(deploymentAnnotations).to.eql(provider.config.kaniko.annotations)
+
+      const podAnnotations = result.deployment.spec.template.metadata?.annotations
+      expect(podAnnotations).to.eql(provider.config.kaniko.annotations)
+    })
+    it("should return the manifest with kaniko annotations when util annotations are specified", () => {
+      provider.config.kaniko = {
+        util: {
+          annotations: {
+            testAnnotation: "its-there",
+          },
+        },
+      }
+      const result = getUtilManifests(provider, "test", [])
+
+      const deploymentAnnotations = result.deployment.metadata?.annotations
+      expect(deploymentAnnotations).to.eql(provider.config.kaniko.util?.annotations)
+
+      const podAnnotations = result.deployment.spec.template.metadata?.annotations
+      expect(podAnnotations).to.eql(provider.config.kaniko.util?.annotations)
     })
   })
 })

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -233,10 +233,10 @@ providers:
       # pods to only run on particular nodes.
       #
       # [See here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) for the official Kubernetes
-      # guide to assigning Pods to nodes.
+      # guide to assigning pods to nodes.
       nodeSelector:
 
-      # Specify tolerations to apply to each Kaniko builder Pod. Useful to control which nodes in a cluster can run
+      # Specify tolerations to apply to each Kaniko builder pod. Useful to control which nodes in a cluster can run
       # builds. Same tolerations will be used for the util pod unless they are specifically set under
       # `util.tolerations`
       tolerations:
@@ -265,13 +265,13 @@ providers:
           # otherwise just a regular string.
           value:
 
-      # Specify annotations to apply to each Kaniko builder Pod. Annotations may have an effect on the behaviour of
-      # certain components, for example autoscalers. Same anotations will be used for the util pod unless they are
+      # Specify annotations to apply to each Kaniko builder pod. Annotations may have an effect on the behaviour of
+      # certain components, for example autoscalers. Same anotations will be used for each util pod unless they are
       # specifically set under `util.annotations`
       annotations:
 
       util:
-        # Specify tolerations to apply to the garden-util Pod.
+        # Specify tolerations to apply to each garden-util pod.
         tolerations:
           - # "Effect" indicates the taint effect to match. Empty means match all taint effects. When specified,
             # allowed values are "NoSchedule", "PreferNoSchedule" and "NoExecute".
@@ -298,7 +298,7 @@ providers:
             # otherwise just a regular string.
             value:
 
-        # Specify annotations to apply to the garden-util Pod and Deployment.
+        # Specify annotations to apply to each garden-util pod and deployments.
         annotations:
 
     # A default hostname to use when no hostname is explicitly configured for a service.
@@ -1127,7 +1127,7 @@ Choose the namespace where the Kaniko pods will be run. Set to `null` to use the
 
 Exposes the `nodeSelector` field on the PodSpec of the Kaniko pods. This allows you to constrain the Kaniko pods to only run on particular nodes.
 
-[See here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) for the official Kubernetes guide to assigning Pods to nodes.
+[See here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) for the official Kubernetes guide to assigning pods to nodes.
 
 | Type     | Required |
 | -------- | -------- |
@@ -1137,7 +1137,7 @@ Exposes the `nodeSelector` field on the PodSpec of the Kaniko pods. This allows 
 
 [providers](#providers) > [kaniko](#providerskaniko) > tolerations
 
-Specify tolerations to apply to each Kaniko builder Pod. Useful to control which nodes in a cluster can run builds. Same tolerations will be used for the util pod unless they are specifically set under `util.tolerations`
+Specify tolerations to apply to each Kaniko builder pod. Useful to control which nodes in a cluster can run builds. Same tolerations will be used for the util pod unless they are specifically set under `util.tolerations`
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
@@ -1205,7 +1205,7 @@ otherwise just a regular string.
 
 [providers](#providers) > [kaniko](#providerskaniko) > annotations
 
-Specify annotations to apply to each Kaniko builder Pod. Annotations may have an effect on the behaviour of certain components, for example autoscalers. Same anotations will be used for the util pod unless they are specifically set under `util.annotations`
+Specify annotations to apply to each Kaniko builder pod. Annotations may have an effect on the behaviour of certain components, for example autoscalers. Same anotations will be used for each util pod unless they are specifically set under `util.annotations`
 
 | Type     | Required |
 | -------- | -------- |
@@ -1233,7 +1233,7 @@ providers:
 
 [providers](#providers) > [kaniko](#providerskaniko) > [util](#providerskanikoutil) > tolerations
 
-Specify tolerations to apply to the garden-util Pod.
+Specify tolerations to apply to each garden-util pod.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
@@ -1301,7 +1301,7 @@ otherwise just a regular string.
 
 [providers](#providers) > [kaniko](#providerskaniko) > [util](#providerskanikoutil) > annotations
 
-Specify annotations to apply to the garden-util Pod and Deployment.
+Specify annotations to apply to each garden-util pod and deployments.
 
 | Type     | Required |
 | -------- | -------- |

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -202,6 +202,10 @@ providers:
           # otherwise just a regular string.
           value:
 
+      # Specify annotations to apply to both the Pod and Deployment resources associated with cluster-buildkit.
+      # Annotations may have an effect on the behaviour of certain components, for example autoscalers.
+      annotations:
+
     # Setting related to Jib image builds.
     jib:
       # In some cases you may need to push images built with Jib to the remote registry via Kubernetes cluster, e.g.
@@ -261,8 +265,13 @@ providers:
           # otherwise just a regular string.
           value:
 
+      # Specify annotations to apply to each Kaniko builder Pod. Annotations may have an effect on the behaviour of
+      # certain components, for example autoscalers. Same anotations will be used for the util pod unless they are
+      # specifically set under `util.annotations`
+      annotations:
+
       util:
-        # Specify tolerations to apply to each garden-util Pod.
+        # Specify tolerations to apply to the garden-util Pod.
         tolerations:
           - # "Effect" indicates the taint effect to match. Empty means match all taint effects. When specified,
             # allowed values are "NoSchedule", "PreferNoSchedule" and "NoExecute".
@@ -288,6 +297,9 @@ providers:
             # empty,
             # otherwise just a regular string.
             value:
+
+        # Specify annotations to apply to the garden-util Pod and Deployment.
+        annotations:
 
     # A default hostname to use when no hostname is explicitly configured for a service.
     defaultHostname:
@@ -999,6 +1011,26 @@ otherwise just a regular string.
 | -------- | -------- |
 | `string` | No       |
 
+### `providers[].clusterBuildkit.annotations`
+
+[providers](#providers) > [clusterBuildkit](#providersclusterbuildkit) > annotations
+
+Specify annotations to apply to both the Pod and Deployment resources associated with cluster-buildkit. Annotations may have an effect on the behaviour of certain components, for example autoscalers.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+Example:
+
+```yaml
+providers:
+  - clusterBuildkit:
+      ...
+      annotations:
+          cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
+```
+
 ### `providers[].clusterDocker`
 
 [providers](#providers) > clusterDocker
@@ -1169,6 +1201,26 @@ otherwise just a regular string.
 | -------- | -------- |
 | `string` | No       |
 
+### `providers[].kaniko.annotations`
+
+[providers](#providers) > [kaniko](#providerskaniko) > annotations
+
+Specify annotations to apply to each Kaniko builder Pod. Annotations may have an effect on the behaviour of certain components, for example autoscalers. Same anotations will be used for the util pod unless they are specifically set under `util.annotations`
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+Example:
+
+```yaml
+providers:
+  - kaniko:
+      ...
+      annotations:
+          cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
+```
+
 ### `providers[].kaniko.util`
 
 [providers](#providers) > [kaniko](#providerskaniko) > util
@@ -1181,7 +1233,7 @@ otherwise just a regular string.
 
 [providers](#providers) > [kaniko](#providerskaniko) > [util](#providerskanikoutil) > tolerations
 
-Specify tolerations to apply to each garden-util Pod.
+Specify tolerations to apply to the garden-util Pod.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
@@ -1244,6 +1296,28 @@ otherwise just a regular string.
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
+
+### `providers[].kaniko.util.annotations`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [util](#providerskanikoutil) > annotations
+
+Specify annotations to apply to the garden-util Pod and Deployment.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+Example:
+
+```yaml
+providers:
+  - kaniko:
+      ...
+      util:
+        ...
+        annotations:
+            cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
+```
 
 ### `providers[].defaultHostname`
 
@@ -2851,6 +2925,16 @@ Map of annotations to apply to the namespace when creating it.
 | Type     | Required |
 | -------- | -------- |
 | `object` | No       |
+
+Example:
+
+```yaml
+providers:
+  - namespace: ''
+      ...
+      annotations:
+          cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
+```
 
 ### `providers[].namespace.labels`
 

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -229,10 +229,10 @@ providers:
       # pods to only run on particular nodes.
       #
       # [See here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) for the official Kubernetes
-      # guide to assigning Pods to nodes.
+      # guide to assigning pods to nodes.
       nodeSelector:
 
-      # Specify tolerations to apply to each Kaniko builder Pod. Useful to control which nodes in a cluster can run
+      # Specify tolerations to apply to each Kaniko builder pod. Useful to control which nodes in a cluster can run
       # builds. Same tolerations will be used for the util pod unless they are specifically set under
       # `util.tolerations`
       tolerations:
@@ -261,13 +261,13 @@ providers:
           # otherwise just a regular string.
           value:
 
-      # Specify annotations to apply to each Kaniko builder Pod. Annotations may have an effect on the behaviour of
-      # certain components, for example autoscalers. Same anotations will be used for the util pod unless they are
+      # Specify annotations to apply to each Kaniko builder pod. Annotations may have an effect on the behaviour of
+      # certain components, for example autoscalers. Same anotations will be used for each util pod unless they are
       # specifically set under `util.annotations`
       annotations:
 
       util:
-        # Specify tolerations to apply to the garden-util Pod.
+        # Specify tolerations to apply to each garden-util pod.
         tolerations:
           - # "Effect" indicates the taint effect to match. Empty means match all taint effects. When specified,
             # allowed values are "NoSchedule", "PreferNoSchedule" and "NoExecute".
@@ -294,7 +294,7 @@ providers:
             # otherwise just a regular string.
             value:
 
-        # Specify annotations to apply to the garden-util Pod and Deployment.
+        # Specify annotations to apply to each garden-util pod and deployments.
         annotations:
 
     # A default hostname to use when no hostname is explicitly configured for a service.
@@ -1076,7 +1076,7 @@ Choose the namespace where the Kaniko pods will be run. Set to `null` to use the
 
 Exposes the `nodeSelector` field on the PodSpec of the Kaniko pods. This allows you to constrain the Kaniko pods to only run on particular nodes.
 
-[See here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) for the official Kubernetes guide to assigning Pods to nodes.
+[See here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) for the official Kubernetes guide to assigning pods to nodes.
 
 | Type     | Required |
 | -------- | -------- |
@@ -1086,7 +1086,7 @@ Exposes the `nodeSelector` field on the PodSpec of the Kaniko pods. This allows 
 
 [providers](#providers) > [kaniko](#providerskaniko) > tolerations
 
-Specify tolerations to apply to each Kaniko builder Pod. Useful to control which nodes in a cluster can run builds. Same tolerations will be used for the util pod unless they are specifically set under `util.tolerations`
+Specify tolerations to apply to each Kaniko builder pod. Useful to control which nodes in a cluster can run builds. Same tolerations will be used for the util pod unless they are specifically set under `util.tolerations`
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
@@ -1154,7 +1154,7 @@ otherwise just a regular string.
 
 [providers](#providers) > [kaniko](#providerskaniko) > annotations
 
-Specify annotations to apply to each Kaniko builder Pod. Annotations may have an effect on the behaviour of certain components, for example autoscalers. Same anotations will be used for the util pod unless they are specifically set under `util.annotations`
+Specify annotations to apply to each Kaniko builder pod. Annotations may have an effect on the behaviour of certain components, for example autoscalers. Same anotations will be used for each util pod unless they are specifically set under `util.annotations`
 
 | Type     | Required |
 | -------- | -------- |
@@ -1182,7 +1182,7 @@ providers:
 
 [providers](#providers) > [kaniko](#providerskaniko) > [util](#providerskanikoutil) > tolerations
 
-Specify tolerations to apply to the garden-util Pod.
+Specify tolerations to apply to each garden-util pod.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
@@ -1250,7 +1250,7 @@ otherwise just a regular string.
 
 [providers](#providers) > [kaniko](#providerskaniko) > [util](#providerskanikoutil) > annotations
 
-Specify annotations to apply to the garden-util Pod and Deployment.
+Specify annotations to apply to each garden-util pod and deployments.
 
 | Type     | Required |
 | -------- | -------- |

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -198,6 +198,10 @@ providers:
           # otherwise just a regular string.
           value:
 
+      # Specify annotations to apply to both the Pod and Deployment resources associated with cluster-buildkit.
+      # Annotations may have an effect on the behaviour of certain components, for example autoscalers.
+      annotations:
+
     # Setting related to Jib image builds.
     jib:
       # In some cases you may need to push images built with Jib to the remote registry via Kubernetes cluster, e.g.
@@ -257,8 +261,13 @@ providers:
           # otherwise just a regular string.
           value:
 
+      # Specify annotations to apply to each Kaniko builder Pod. Annotations may have an effect on the behaviour of
+      # certain components, for example autoscalers. Same anotations will be used for the util pod unless they are
+      # specifically set under `util.annotations`
+      annotations:
+
       util:
-        # Specify tolerations to apply to each garden-util Pod.
+        # Specify tolerations to apply to the garden-util Pod.
         tolerations:
           - # "Effect" indicates the taint effect to match. Empty means match all taint effects. When specified,
             # allowed values are "NoSchedule", "PreferNoSchedule" and "NoExecute".
@@ -284,6 +293,9 @@ providers:
             # empty,
             # otherwise just a regular string.
             value:
+
+        # Specify annotations to apply to the garden-util Pod and Deployment.
+        annotations:
 
     # A default hostname to use when no hostname is explicitly configured for a service.
     defaultHostname:
@@ -948,6 +960,26 @@ otherwise just a regular string.
 | -------- | -------- |
 | `string` | No       |
 
+### `providers[].clusterBuildkit.annotations`
+
+[providers](#providers) > [clusterBuildkit](#providersclusterbuildkit) > annotations
+
+Specify annotations to apply to both the Pod and Deployment resources associated with cluster-buildkit. Annotations may have an effect on the behaviour of certain components, for example autoscalers.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+Example:
+
+```yaml
+providers:
+  - clusterBuildkit:
+      ...
+      annotations:
+          cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
+```
+
 ### `providers[].clusterDocker`
 
 [providers](#providers) > clusterDocker
@@ -1118,6 +1150,26 @@ otherwise just a regular string.
 | -------- | -------- |
 | `string` | No       |
 
+### `providers[].kaniko.annotations`
+
+[providers](#providers) > [kaniko](#providerskaniko) > annotations
+
+Specify annotations to apply to each Kaniko builder Pod. Annotations may have an effect on the behaviour of certain components, for example autoscalers. Same anotations will be used for the util pod unless they are specifically set under `util.annotations`
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+Example:
+
+```yaml
+providers:
+  - kaniko:
+      ...
+      annotations:
+          cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
+```
+
 ### `providers[].kaniko.util`
 
 [providers](#providers) > [kaniko](#providerskaniko) > util
@@ -1130,7 +1182,7 @@ otherwise just a regular string.
 
 [providers](#providers) > [kaniko](#providerskaniko) > [util](#providerskanikoutil) > tolerations
 
-Specify tolerations to apply to each garden-util Pod.
+Specify tolerations to apply to the garden-util Pod.
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
@@ -1193,6 +1245,28 @@ otherwise just a regular string.
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
+
+### `providers[].kaniko.util.annotations`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [util](#providerskanikoutil) > annotations
+
+Specify annotations to apply to the garden-util Pod and Deployment.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+Example:
+
+```yaml
+providers:
+  - kaniko:
+      ...
+      util:
+        ...
+        annotations:
+            cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
+```
 
 ### `providers[].defaultHostname`
 
@@ -2671,6 +2745,16 @@ Map of annotations to apply to the namespace when creating it.
 | Type     | Required |
 | -------- | -------- |
 | `object` | No       |
+
+Example:
+
+```yaml
+providers:
+  - namespace: ''
+      ...
+      annotations:
+          cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
+```
 
 ### `providers[].namespace.labels`
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow specifying custom annotations for garden-
managed pods when using in-cluster building with
buildkit or kaniko.

This is useful when users want to alter how certain
components, like the cluster-autoscaler treat these
pods.

**Which issue(s) this PR fixes**:

Fixes #2628

**Special notes for your reviewer**:
