### PR TITLE
chore: Updated how Kubelogin is installed

### DIFF
--- a/support/azure.Dockerfile
+++ b/support/azure.Dockerfile
@@ -10,12 +10,7 @@ RUN apk add --virtual=build gcc libffi-dev musl-dev openssl-dev make readline li
 # Remove build dependencies
   && apk del --purge build
 
-# Ensure kubelogin is available
-ENV KUBELOGIN_VERSION="v0.0.9"
-RUN wget -O kubelogin-linux-amd64.zip https://github.com/Azure/kubelogin/releases/download/$KUBELOGIN_VERSION/kubelogin-linux-amd64.zip  \
- && unzip kubelogin-linux-amd64.zip \
- && cp bin/linux_amd64/kubelogin /usr/local/bin/ \
- && rm kubelogin-linux-amd64.zip
+RUN az aks install-cli # this will install the latest version of kubelogin if you need to pin to a specific version use --kubelogin-version v0.0.20
 
 # Required by Azure DevOps to tell the system where node is installed
 LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/local/bin/node"


### PR DESCRIPTION
Moved to the supported install method, microsoft ensure that a complaint version of kubectl and kubelogin are installed (Latest of each by default).

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
