### PR TITLE
chore(update): update kubelogin version to v0.0.24

### DIFF
--- a/support/aws-gcloud-azure.Dockerfile
+++ b/support/aws-gcloud-azure.Dockerfile
@@ -1,7 +1,7 @@
 ARG TAG=latest
 FROM gardendev/garden-gcloud:${TAG}
 
-ENV KUBELOGIN_VERSION=v0.0.9
+ENV KUBELOGIN_VERSION=v0.0.24
 
 RUN pip install awscli==1.22.77 --upgrade
 

--- a/support/azure.Dockerfile
+++ b/support/azure.Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --virtual=build gcc libffi-dev musl-dev openssl-dev make readline li
   && apk del --purge build
 
 # Ensure kubelogin is available
-ENV KUBELOGIN_VERSION="v0.0.9"
+ENV KUBELOGIN_VERSION="v0.0.24"
 RUN wget -O kubelogin-linux-amd64.zip https://github.com/Azure/kubelogin/releases/download/$KUBELOGIN_VERSION/kubelogin-linux-amd64.zip  \
  && unzip kubelogin-linux-amd64.zip \
  && cp bin/linux_amd64/kubelogin /usr/local/bin/ \


### PR DESCRIPTION
**What this PR does / why we need it**:
Helps with bumping the version of `kubelogin` binary used in Azure based images

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
happy to pair and test locally.
