### PR TITLE
fix(k8s): update ecr-cred-helper for imdsv2 support

### DIFF
--- a/core/src/plugins/kubernetes/constants.ts
+++ b/core/src/plugins/kubernetes/constants.ts
@@ -28,7 +28,7 @@ export const inClusterRegistryHostname = "127.0.0.1:5000"
 export const gardenUtilDaemonDeploymentName = "garden-util-daemon"
 export const dockerDaemonDeploymentName = "garden-docker-daemon"
 
-export const k8sUtilImageName = "gardendev/k8s-util:0.5.4"
+export const k8sUtilImageName = "gardendev/k8s-util:0.5.4-1"
 export const k8sSyncUtilImageName = "gardendev/k8s-sync:0.1.5"
 export const k8sReverseProxyImageName = "gardendev/k8s-reverse-proxy:0.1.0"
 

--- a/core/src/plugins/kubernetes/constants.ts
+++ b/core/src/plugins/kubernetes/constants.ts
@@ -28,7 +28,7 @@ export const inClusterRegistryHostname = "127.0.0.1:5000"
 export const gardenUtilDaemonDeploymentName = "garden-util-daemon"
 export const dockerDaemonDeploymentName = "garden-docker-daemon"
 
-export const k8sUtilImageName = "gardendev/k8s-util:0.5.5"
+export const k8sUtilImageName = "gardendev/k8s-util:0.5.6"
 export const k8sSyncUtilImageName = "gardendev/k8s-sync:0.1.5"
 export const k8sReverseProxyImageName = "gardendev/k8s-reverse-proxy:0.1.0"
 

--- a/core/src/plugins/kubernetes/constants.ts
+++ b/core/src/plugins/kubernetes/constants.ts
@@ -28,7 +28,7 @@ export const inClusterRegistryHostname = "127.0.0.1:5000"
 export const gardenUtilDaemonDeploymentName = "garden-util-daemon"
 export const dockerDaemonDeploymentName = "garden-docker-daemon"
 
-export const k8sUtilImageName = "gardendev/k8s-util:0.5.4-1"
+export const k8sUtilImageName = "gardendev/k8s-util:0.5.5"
 export const k8sSyncUtilImageName = "gardendev/k8s-sync:0.1.5"
 export const k8sReverseProxyImageName = "gardendev/k8s-reverse-proxy:0.1.0"
 

--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -39,7 +39,7 @@ import { prepareSecrets } from "../../secrets"
 import { ContainerModuleOutputs } from "../../../container/container"
 import { stringifyResources } from "../util"
 
-export const buildkitImageName = "gardendev/buildkit:v0.10.5-1"
+export const buildkitImageName = "gardendev/buildkit:v0.10.5-2"
 export const buildkitDeploymentName = "garden-buildkit"
 const buildkitContainerName = "buildkitd"
 

--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -33,7 +33,7 @@ import { isSubset } from "../../util/is-subset"
 import { checkPodStatus } from "./status/pod"
 import { getModuleNamespace } from "./namespace"
 
-export const skopeoImage = "gardendev/skopeo:1.41.0-2"
+export const skopeoImage = "gardendev/skopeo:1.41.0-3"
 
 const STATIC_LABEL_REGEX = /[0-9]/g
 export const workloadTypes = ["Deployment", "DaemonSet", "ReplicaSet", "StatefulSet"]

--- a/images/buildkit/Dockerfile
+++ b/images/buildkit/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache curl
 
 # ECR credential helper
 RUN cd /tmp && \
-  curl -O https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.4.0/linux-amd64/docker-credential-ecr-login && \
+  curl -O https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.6.0/linux-amd64/docker-credential-ecr-login && \
   chmod +x docker-credential-ecr-login
 
 # GCR credential helper

--- a/images/buildkit/garden.yml
+++ b/images/buildkit/garden.yml
@@ -2,7 +2,7 @@ kind: Module
 type: container
 name: buildkit
 description: Used for the cluster-buildkit build mode in the kubernetes provider
-image: gardendev/buildkit:v0.10.5-1
+image: gardendev/buildkit:v0.10.5-2
 dockerfile: Dockerfile
 build:
   targetImage: output
@@ -11,7 +11,7 @@ kind: Module
 type: container
 name: buildkit-rootless
 description: Used for the cluster-buildkit build mode in the kubernetes provider, rootless variant
-image: gardendev/buildkit:v0.10.5-1-rootless
+image: gardendev/buildkit:v0.10.5-2-rootless
 dockerfile: Dockerfile
 build:
   dependencies:

--- a/images/docker-dind/Dockerfile
+++ b/images/docker-dind/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache curl
 
 # Install ECR credential helper
 RUN cd /usr/local/bin && \
-  curl -O https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.4.0/linux-amd64/docker-credential-ecr-login && \
+  curl -O https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.6.0/linux-amd64/docker-credential-ecr-login && \
   chmod +x docker-credential-ecr-login
 
 # Install GCR credential helper

--- a/images/docker-dind/garden.yml
+++ b/images/docker-dind/garden.yml
@@ -2,5 +2,5 @@ kind: Module
 type: container
 name: docker-dind
 description: The image used for the in-cluster docker daemon. Extending the base image to add credential helpers.
-image: gardendev/docker-dind:19.03.8-1
+image: gardendev/docker-dind:19.03.8-2
 dockerfile: Dockerfile

--- a/images/k8s-util/Dockerfile
+++ b/images/k8s-util/Dockerfile
@@ -3,7 +3,7 @@ FROM ${BASE_IMAGE}
 
 RUN apk add --no-cache rsync skopeo
 RUN cd /usr/local/bin && \
-  curl -O https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.4.0/linux-amd64/docker-credential-ecr-login && \
+  curl -O https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.6.0/linux-amd64/docker-credential-ecr-login && \
   chmod +x docker-credential-ecr-login
 
 RUN adduser -g 1000 -D user && \

--- a/images/k8s-util/garden.yml
+++ b/images/k8s-util/garden.yml
@@ -2,7 +2,7 @@ kind: Module
 type: container
 name: k8s-util
 description: Used by the kubernetes provider for build-related activities
-image: gardendev/k8s-util:0.5.4
+image: gardendev/k8s-util:0.5.4-1
 dockerfile: Dockerfile
 build:
   dependencies: [k8s-sync]

--- a/images/k8s-util/garden.yml
+++ b/images/k8s-util/garden.yml
@@ -2,7 +2,7 @@ kind: Module
 type: container
 name: k8s-util
 description: Used by the kubernetes provider for build-related activities
-image: gardendev/k8s-util:0.5.4-1
+image: gardendev/k8s-util:0.5.5
 dockerfile: Dockerfile
 build:
   dependencies: [k8s-sync]

--- a/images/k8s-util/garden.yml
+++ b/images/k8s-util/garden.yml
@@ -2,7 +2,7 @@ kind: Module
 type: container
 name: k8s-util
 description: Used by the kubernetes provider for build-related activities
-image: gardendev/k8s-util:0.5.5
+image: gardendev/k8s-util:0.5.6
 dockerfile: Dockerfile
 build:
   dependencies: [k8s-sync]

--- a/images/skopeo/Dockerfile
+++ b/images/skopeo/Dockerfile
@@ -2,7 +2,7 @@ FROM danifernandezs/skopeo:1.41.0-alpine3.10.3
 
 RUN apk add --no-cache curl
 RUN cd /usr/local/bin && \
-  curl -O https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.4.0/linux-amd64/docker-credential-ecr-login && \
+  curl -O https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.6.0/linux-amd64/docker-credential-ecr-login && \
   chmod +x docker-credential-ecr-login
 
 RUN curl -fsSL "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.0.1/docker-credential-gcr_linux_amd64-2.0.1.tar.gz" \

--- a/images/skopeo/garden.yml
+++ b/images/skopeo/garden.yml
@@ -2,5 +2,5 @@ kind: Module
 type: container
 name: skopeo
 description: Used by the kubernetes provider for interacting with container registries within a cluster
-image: gardendev/skopeo:1.41.0-2
+image: gardendev/skopeo:1.41.0-3
 dockerfile: Dockerfile

--- a/static/kubernetes/system/docker-daemon/values.yaml
+++ b/static/kubernetes/system/docker-daemon/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: gardendev/docker-dind
-  tag: "19.03.8-1"
+  tag: "19.03.8-2"
   pullPolicy: IfNotPresent
 
 nameOverride: "garden-docker-daemon"

--- a/static/kubernetes/system/util/values.yaml
+++ b/static/kubernetes/system/util/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: gardendev/skopeo
-  tag: "1.41.0-2"
+  tag: "1.41.0-3"
   pullPolicy: IfNotPresent
 
 nameOverride: "garden-util-daemon"


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
amazon-ecr-credential-helper version 0.4.0 has no imdsv2
support (instance metadata service v2). AWS recmmends
disabling imdsv1 for security reasons, so EKS clusters
that follow this recommendation aren't usable with some
garden features anymore.

This PR updates amazon-ecr-credential-helper to 0.6.0 as
imdsv2 support has been introduced in 0.5.0

**Which issue(s) this PR fixes**:

Fixes #3368

**Special notes for your reviewer**:
