### PR TITLE
feat(k8s): add service account and irsa support for in-cluster-builder

### DIFF
--- a/core/src/plugins/kubernetes/api.ts
+++ b/core/src/plugins/kubernetes/api.ts
@@ -31,6 +31,7 @@ import {
   V1Deployment,
   V1Secret,
   V1Service,
+  V1ServiceAccount,
   ServerConfiguration,
   createConfiguration,
 } from "@kubernetes/client-node"
@@ -128,6 +129,15 @@ const crudMap = {
     replace: null,
     delete: "deleteNamespacedService",
     patch: "patchNamespacedService",
+  },
+  ServiceAccount: {
+    cls: new V1ServiceAccount(),
+    group: "core",
+    read: "readNamespacedServiceAccount",
+    create: "createNamespacedServiceAccount",
+    replace: "replaceNamespacedServiceAccount",
+    delete: "deleteNamespacedServiceAccount",
+    patch: "patchNamespacedServiceAccount",
   },
 }
 

--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -534,6 +534,8 @@ export const kubernetesConfigBase = () =>
             .description(
               "In some cases you may need to push images built with Jib to the remote registry via Kubernetes cluster, e.g. if you don't have connectivity or access from where Garden is being run. In that case, set this flag to true, but do note that the build will take considerably take longer to complete! Only applies when using in-cluster building."
             ),
+        })
+        .description("Setting related to Jib image builds."),
       kaniko: joi
         .object()
         .keys({
@@ -604,7 +606,7 @@ export const kubernetesConfigBase = () =>
           The experimental support for blue/green deployments (via the \`"blue-green"\` strategy) has been removed.
 
           Note that this setting only applies to \`container\` deploy actions (and not, for example,  \`kubernetes\` or \`helm\` deploy actions).
-          `
+        `
         )
         .meta({
           experimental: true,

--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -132,6 +132,7 @@ export interface KubernetesConfig extends BaseProviderConfig {
     nodeSelector?: StringMap
     tolerations?: V1Toleration[]
     annotations?: StringMap
+    serviceAccountAnnotations?: StringMap
   }
   jib?: {
     pushViaCluster?: boolean
@@ -143,6 +144,7 @@ export interface KubernetesConfig extends BaseProviderConfig {
     nodeSelector?: StringMap
     tolerations?: V1Toleration[]
     annotations?: StringMap
+    serviceAccountAnnotations?: StringMap
     util?: {
       tolerations?: V1Toleration[]
       annotations?: StringMap
@@ -517,9 +519,29 @@ export const kubernetesConfigBase = () =>
           annotations: annotationsSchema().description(
             "Specify annotations to apply to both the Pod and Deployment resources associated with cluster-buildkit. Annotations may have an effect on the behaviour of certain components, for example autoscalers."
           ),
+          serviceAccountAnnotations: annotationsSchema().description(
+            "Specify annotations to apply to the Kubernetes service account used by cluster-buildkit. This can be useful to set up IRSA with in-cluster building."
+          ),
         })
         .default(() => ({}))
         .description("Configuration options for the `cluster-buildkit` build mode."),
+      clusterDocker: joi
+        .object()
+        .keys({
+          enableBuildKit: joi
+            .boolean()
+            .default(false)
+            .description(
+              deline`
+            Enable [BuildKit](https://github.com/moby/buildkit) support. This should in most cases work well and be
+            more performant, but we're opting to keep it optional until it's enabled by default in Docker.
+          `
+            )
+            .meta({ deprecated: true }),
+        })
+        .default(() => ({}))
+        .description("Configuration options for the `cluster-docker` build mode.")
+        .meta({ deprecated: "The cluster-docker build mode has been deprecated." }),
       jib: joi
         .object()
         .keys({
@@ -529,8 +551,12 @@ export const kubernetesConfigBase = () =>
             .description(
               "In some cases you may need to push images built with Jib to the remote registry via Kubernetes cluster, e.g. if you don't have connectivity or access from where Garden is being run. In that case, set this flag to true, but do note that the build will take considerably take longer to complete! Only applies when using in-cluster building."
             ),
+          annotations: annotationsSchema().description(
+            "Specify annotations to apply to both the Pod and Deployment resources associated with cluster-buildkit. Annotations may have an effect on the behaviour of certain components, for example autoscalers."
+          ),
         })
-        .description("Setting related to Jib image builds."),
+        .default(() => ({}))
+        .description("Configuration options for the `cluster-buildkit` build mode."),
       kaniko: joi
         .object()
         .keys({

--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -519,7 +519,7 @@ export const kubernetesConfigBase = () =>
           annotations: annotationsSchema().description(
             "Specify annotations to apply to both the Pod and Deployment resources associated with cluster-buildkit. Annotations may have an effect on the behaviour of certain components, for example autoscalers."
           ),
-          serviceAccountAnnotations: annotationsSchema().description(
+          serviceAccountAnnotations: serviceAccountAnnotationsSchema().description(
             "Specify annotations to apply to the Kubernetes service account used by cluster-buildkit. This can be useful to set up IRSA with in-cluster building."
           ),
         })
@@ -593,6 +593,9 @@ export const kubernetesConfigBase = () =>
             deline`Specify annotations to apply to each Kaniko builder pod. Annotations may have an effect on the behaviour of certain components, for example autoscalers.
           The same annotations will be used for each util pod unless they are specifically set under \`util.annotations\``
           ),
+          serviceAccountAnnotations: serviceAccountAnnotationsSchema().description(
+            "Specify annotations to apply to the Kubernetes service account used by kaniko. This can be useful to set up IRSA with in-cluster building."
+          ),
           util: joi.object().keys({
             tolerations: joiSparseArray(tolerationSchema()).description(
               "Specify tolerations to apply to each garden-util pod."
@@ -617,14 +620,14 @@ export const kubernetesConfigBase = () =>
         .allow("rolling", "blue-green")
         .description(
           dedent`
-          Sets the deployment strategy for \`container\` deploy actions.
-
-          Note that this field has been deprecated since 0.13, and has no effect.
-          The \`"rolling"\` will be applied in all cases.
-          The experimental support for blue/green deployments (via the \`"blue-green"\` strategy) has been removed.
-
-          Note that this setting only applies to \`container\` deploy actions (and not, for example,  \`kubernetes\` or \`helm\` deploy actions).
-        `
+            Sets the deployment strategy for \`container\` services.
+  
+            Note that this field has been deprecated since 0.13, and has no effect.
+            The \`"rolling"\` will be applied in all cases.
+            The experimental support for blue/green deployments (via the \`"blue-green"\` strategy) has been removed.
+  
+            Note that this setting only applies to \`container\` deploy actions (and not, for example,  \`kubernetes\` or \`helm\` deploy actions).
+          `
         )
         .meta({
           experimental: true,
@@ -704,6 +707,13 @@ const annotationsSchema = () =>
   joiStringMap(joi.string())
     .example({
       "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
+    })
+    .optional()
+
+const serviceAccountAnnotationsSchema = () =>
+  joiStringMap(joi.string())
+    .example({
+      "eks.amazonaws.com/role-arn": "arn:aws:iam::111122223333:role/my-role",
     })
     .optional()
 

--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -525,23 +525,6 @@ export const kubernetesConfigBase = () =>
         })
         .default(() => ({}))
         .description("Configuration options for the `cluster-buildkit` build mode."),
-      clusterDocker: joi
-        .object()
-        .keys({
-          enableBuildKit: joi
-            .boolean()
-            .default(false)
-            .description(
-              deline`
-            Enable [BuildKit](https://github.com/moby/buildkit) support. This should in most cases work well and be
-            more performant, but we're opting to keep it optional until it's enabled by default in Docker.
-          `
-            )
-            .meta({ deprecated: true }),
-        })
-        .default(() => ({}))
-        .description("Configuration options for the `cluster-docker` build mode.")
-        .meta({ deprecated: "The cluster-docker build mode has been deprecated." }),
       jib: joi
         .object()
         .keys({
@@ -551,12 +534,6 @@ export const kubernetesConfigBase = () =>
             .description(
               "In some cases you may need to push images built with Jib to the remote registry via Kubernetes cluster, e.g. if you don't have connectivity or access from where Garden is being run. In that case, set this flag to true, but do note that the build will take considerably take longer to complete! Only applies when using in-cluster building."
             ),
-          annotations: annotationsSchema().description(
-            "Specify annotations to apply to both the Pod and Deployment resources associated with cluster-buildkit. Annotations may have an effect on the behaviour of certain components, for example autoscalers."
-          ),
-        })
-        .default(() => ({}))
-        .description("Configuration options for the `cluster-buildkit` build mode."),
       kaniko: joi
         .object()
         .keys({
@@ -620,13 +597,13 @@ export const kubernetesConfigBase = () =>
         .allow("rolling", "blue-green")
         .description(
           dedent`
-            Sets the deployment strategy for \`container\` services.
-  
-            Note that this field has been deprecated since 0.13, and has no effect.
-            The \`"rolling"\` will be applied in all cases.
-            The experimental support for blue/green deployments (via the \`"blue-green"\` strategy) has been removed.
-  
-            Note that this setting only applies to \`container\` deploy actions (and not, for example,  \`kubernetes\` or \`helm\` deploy actions).
+          Sets the deployment strategy for \`container\` deploy actions.
+
+          Note that this field has been deprecated since 0.13, and has no effect.
+          The \`"rolling"\` will be applied in all cases.
+          The experimental support for blue/green deployments (via the \`"blue-green"\` strategy) has been removed.
+
+          Note that this setting only applies to \`container\` deploy actions (and not, for example,  \`kubernetes\` or \`helm\` deploy actions).
           `
         )
         .meta({

--- a/core/src/plugins/kubernetes/constants.ts
+++ b/core/src/plugins/kubernetes/constants.ts
@@ -31,15 +31,15 @@ export const defaultIngressClass = "nginx"
 
 // Docker images that Garden ships with
 export const k8sUtilImageName: DockerImageWithDigest =
-  "gardendev/k8s-util:0.5.6@sha256:dce403dc7951e3f714fbb0157aaa08d010601049ea939517957e46ac332073ad"
+  "gardendev/k8s-util:0.5.7@sha256:522da245a5e6ae7c711aa94f84fc83f82a8fdffbf6d8bc48f4d80fee0e0e631b"
 export const k8sSyncUtilImageName: DockerImageWithDigest =
   "gardendev/k8s-sync:0.1.5@sha256:28263cee5ac41acebb8c08f852c4496b15e18c0c94797d7a949a4453b5f91578"
 export const k8sReverseProxyImageName: DockerImageWithDigest =
   "gardendev/k8s-reverse-proxy:0.1.0@sha256:df2976dc67c237114bd9c70e32bfe4d7131af98e140adf6dac29b47b85e07232"
 export const buildkitImageName: DockerImageWithDigest =
-  "gardendev/buildkit:v0.12.2@sha256:2e40f645994b55e03b75b07fbb574dac3d08463a7dda31a958a8619ed011aed6"
+  "gardendev/buildkit:v0.12.2-1@sha256:5b30f6fa46e1fdb89b2255b4290dd3f9072b8f91fd6927b8d428e92498fbf8d0"
 export const buildkitRootlessImageName: DockerImageWithDigest =
-  "gardendev/buildkit:v0.12.2-rootless@sha256:e30b7830078d51e66f1a861024dcc91f2ae5cb1108789c74d0e43ffe0d065b20"
+  "gardendev/buildkit:v0.12.2-1-rootless@sha256:d60e79c66832a95b89f67b1dbee255a561b20105f4d3ec9903dcc7dc4c40f19b"
 export const defaultKanikoImageName: DockerImageWithDigest =
   "gcr.io/kaniko-project/executor:v1.11.0-debug@sha256:32ba2214921892c2fa7b5f9c4ae6f8f026538ce6b2105a93a36a8b5ee50fe517"
 export const defaultGardenIngressControllerDefaultBackendImage: DockerImageWithDigest =

--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -223,8 +223,8 @@ export async function ensureBuildkit({
 
     // if the service account changed, all pods part of the deployment must be restarted
     // so that they receive new credentials (e.g. for IRSA)
-    if (status.remoteResources.length && serviceAccountChanged) {
-      await cycleDeployment({ ctx, provider, deployment: manifest, api, namespace, deployLog })
+    if (status.remoteResources.length > 0 && serviceAccountChanged) {
+      await cycleDeployment({ ctx, provider, deployment, api, namespace, deployLog })
     }
 
     if (status.state === "ready") {

--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -224,7 +224,7 @@ export async function ensureBuildkit({
     // if the service account changed, all pods part of the deployment must be restarted
     // so that they receive new credentials (e.g. for IRSA)
     if (status.remoteResources.length > 0 && serviceAccountChanged) {
-      await cycleDeployment({ ctx, provider, deployment, api, namespace, deployLog })
+      await cycleDeployment({ ctx, provider, deployment: manifest, api, namespace, deployLog })
     }
 
     if (status.state === "ready") {

--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -30,6 +30,9 @@ import {
   getUtilContainer,
   ensureBuilderSecret,
   builderToleration,
+  inClusterBuilderServiceAccount,
+  ensureServiceAccount,
+  cycleDeployment,
 } from "./common.js"
 import { getNamespaceStatus } from "../../namespace.js"
 import { sleep } from "../../../../util/util.js"
@@ -187,6 +190,14 @@ export async function ensureBuildkit({
   api: KubeApi
   namespace: string
 }) {
+  const serviceAccountChanged = await ensureServiceAccount({
+    ctx,
+    log,
+    api,
+    namespace,
+    annotations: provider.config.clusterBuildkit?.serviceAccountAnnotations,
+  })
+
   return deployLock.acquire(namespace, async () => {
     const deployLog = log.createLog()
 
@@ -210,12 +221,18 @@ export async function ensureBuildkit({
       log: deployLog,
     })
 
+    // if the service account changed, all pods part of the deployment must be restarted
+    // so that they receive new credentials (e.g. for IRSA)
+    if (status.remoteResources.length && serviceAccountChanged) {
+      await cycleDeployment({ ctx, provider, deployment: manifest, api, namespace, deployLog })
+    }
+
     if (status.state === "ready") {
       // Need to wait a little to ensure the secret is updated in the deployment
       if (secretUpdated) {
         await sleep(1000)
       }
-      return { authSecret, updated: false }
+      return { authSecret, updated: serviceAccountChanged }
     }
 
     // Deploy the buildkit daemon
@@ -397,6 +414,7 @@ export function getBuildkitDeployment(
           annotations: provider.config.clusterBuildkit?.annotations,
         },
         spec: {
+          serviceAccountName: inClusterBuilderServiceAccount,
           containers: [
             {
               name: buildkitContainerName,

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -365,7 +365,7 @@ export async function ensureUtilDeployment({
 
     // if the service account changed, all pods part of the deployment must be restarted
     // so that they receive new credentials (e.g. for IRSA)
-    if (status.remoteResources.length && serviceAccountChanged) {
+    if (status.remoteResources.length > 0 && serviceAccountChanged) {
       await cycleDeployment({ ctx, provider, deployment, api, namespace, deployLog })
     }
 

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -192,7 +192,7 @@ export async function skopeoBuildStatus({
   const outputs = k8sGetContainerBuildActionOutputs({ action, provider })
 
   const remoteId = outputs.deploymentImageId
-  const skopeoCommand = ["skopeo", "--command-timeout=30s", "inspect", "--raw", "--authfile", "/.docker/config.json"]
+  const skopeoCommand = ["skopeo", "--command-timeout=30s", "inspect", "--raw", "--authfile", "~/.docker/config.json"]
 
   if (deploymentRegistry?.insecure === true) {
     skopeoCommand.push("--tls-verify=false")
@@ -280,6 +280,11 @@ export async function ensureServiceAccount({
 }): Promise<boolean> {
   return deployLock.acquire(namespace, async () => {
     const serviceAccount = getBuilderServiceAccountSpec(annotations)
+
+    // the manifest does not contain the namespace, so we need to set it here
+    // otherwise the comparison with deployed resources returns success if the
+    // serviceAccount exists in any namespace
+    serviceAccount.metadata.namespace = namespace
 
     const status = await compareDeployedResources({
       ctx: ctx as KubernetesPluginContext,

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -290,7 +290,7 @@ export async function ensureServiceAccount({
     })
 
     // NOTE: This is here to make sure that we remove annotations in case they are removed in the garden config.
-    // `compareDeployedResources` as of today only checks wether the manifest is a subset of the deployed manifest.
+    // `compareDeployedResources` as of today only checks whether the manifest is a subset of the deployed manifest.
     // The manifest is still a subset of the deployed manifest, if an annotation has been removed. But we want the
     // annotation to be actually removed.
     // NOTE(steffen): I tried to change the behaviour of `compareDeployedResources` to return "outdated" when the

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -354,7 +354,7 @@ export async function ensureUtilDeployment({
     const imagePullSecrets = await prepareSecrets({ api, namespace, secrets: provider.config.imagePullSecrets, log })
 
     // Check status of the util deployment
-    const { deployment, service } = getUtilManifests(provider, authSecret.metadata.name, imagePullSecrets, namespace)
+    const { deployment, service } = getUtilManifests(provider, authSecret.metadata.name, imagePullSecrets)
     const status = await compareDeployedResources({
       ctx: ctx as KubernetesPluginContext,
       api,
@@ -576,8 +576,7 @@ export function getUtilContainer(authSecretName: string, provider: KubernetesPro
 export function getUtilManifests(
   provider: KubernetesProvider,
   authSecretName: string,
-  imagePullSecrets: { name: string }[],
-  namespace?: string
+  imagePullSecrets: { name: string }[]
 ) {
   const kanikoTolerations = [
     ...(provider.config.kaniko?.util?.tolerations || provider.config.kaniko?.tolerations || []),
@@ -594,7 +593,6 @@ export function getUtilManifests(
       },
       name: utilDeploymentName,
       annotations: kanikoAnnotations,
-      namespace,
     },
     spec: {
       replicas: 1,
@@ -644,7 +642,6 @@ export function getUtilManifests(
   }
 
   const service = cloneDeep(baseUtilService)
-  service.metadata.namespace = namespace
 
   // Set the configured nodeSelector, if any
   const nodeSelector = provider.config.kaniko?.util?.nodeSelector || provider.config.kaniko?.nodeSelector

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -22,7 +22,7 @@ import { randomString } from "../../../../util/string.js"
 import type { V1Container, V1Service } from "@kubernetes/client-node"
 import { cloneDeep, isEmpty } from "lodash-es"
 import { compareDeployedResources, waitForResources } from "../../status/status.js"
-import type { KubernetesDeployment, KubernetesResource } from "../../types.js"
+import type { KubernetesDeployment, KubernetesResource, KubernetesServiceAccount } from "../../types.js"
 import type { BuildActionHandler, BuildActionResults } from "../../../../plugin/action-types.js"
 import { k8sGetContainerBuildActionOutputs } from "../handlers.js"
 import type { Resolved } from "../../../../actions/types.js"
@@ -31,7 +31,10 @@ import { getKubectlExecDestination } from "../../sync.js"
 import { getRunningDeploymentPod } from "../../util.js"
 import { buildSyncVolumeName, dockerAuthSecretKey, k8sUtilImageName, rsyncPortName } from "../../constants.js"
 import { styles } from "../../../../logger/styles.js"
+import type { StringMap } from "../../../../config/common.js"
 
+export const inClusterBuilderServiceAccount = "garden-in-cluster-builder"
+export const sharedBuildSyncDeploymentName = "garden-build-sync"
 export const utilContainerName = "util"
 export const utilRsyncPort = 8730
 export const utilDeploymentName = "garden-util"
@@ -262,6 +265,57 @@ export function skopeoManifestUnknown(errMsg: string | null | undefined): boolea
   )
 }
 
+export async function ensureServiceAccount({
+  ctx,
+  log,
+  api,
+  namespace,
+  annotations,
+}: {
+  ctx: PluginContext
+  log: Log
+  api: KubeApi
+  namespace: string
+  annotations?: StringMap
+}): Promise<boolean> {
+  return deployLock.acquire(namespace, async () => {
+    const serviceAccount = getBuilderServiceAccountSpec(annotations)
+
+    const status = await compareDeployedResources({
+      ctx: ctx as KubernetesPluginContext,
+      api,
+      namespace,
+      manifests: [serviceAccount],
+      log,
+    })
+
+    // NOTE: This is here to make sure that we remove annotations in case they are removed in the garden config.
+    // `compareDeployedResources` as of today only checks wether the manifest is a subset of the deployed manifest.
+    // The manifest is still a subset of the deployed manifest, if an annotation has been removed. But we want the
+    // annotation to be actually removed.
+    // NOTE(steffen): I tried to change the behaviour of `compareDeployedResources` to return "outdated" when the
+    // annotations have changed. But a lot of code actually depends on the behaviour of it with missing annotations.
+    const annotationsNeedUpdate =
+      status.remoteResources.length > 0 && !isEqualAnnotations(serviceAccount, status.remoteResources[0])
+
+    const needUpsert = status.state !== "ready" || annotationsNeedUpdate
+
+    if (needUpsert) {
+      await api.upsert({ kind: "ServiceAccount", namespace, log, obj: serviceAccount })
+      return true
+    }
+
+    return false
+  })
+}
+
+function isEqualAnnotations(r1: KubernetesResource, r2: KubernetesResource): boolean {
+  // normalize annotations before comparison
+  const a1 = r1.metadata.annotations !== undefined ? r1.metadata.annotations : {}
+  const a2 = r2.metadata.annotations !== undefined ? r2.metadata.annotations : {}
+  return JSON.stringify(a1) === JSON.stringify(a2)
+}
+
 /**
  * Ensures that a garden-util deployment exists in the specified namespace.
  * Returns the docker auth secret that's generated and mounted in the deployment.
@@ -279,6 +333,14 @@ export async function ensureUtilDeployment({
   api: KubeApi
   namespace: string
 }) {
+  const serviceAccountChanged = await ensureServiceAccount({
+    ctx,
+    log,
+    api,
+    namespace,
+    annotations: provider.config.kaniko?.serviceAccountAnnotations,
+  })
+
   return deployLock.acquire(namespace, async () => {
     const deployLog = log.createLog()
 
@@ -301,12 +363,18 @@ export async function ensureUtilDeployment({
       log: deployLog,
     })
 
+    // if the service account changed, all pods part of the deployment must be restarted
+    // so that they receive new credentials (e.g. for IRSA)
+    if (status.remoteResources.length && serviceAccountChanged) {
+      await cycleDeployment({ ctx, provider, deployment, api, namespace, deployLog })
+    }
+
     if (status.state === "ready") {
       // Need to wait a little to ensure the secret is updated in the deployment
       if (secretUpdated) {
         await sleep(1000)
       }
-      return { authSecret, updated: false }
+      return { authSecret, updated: serviceAccountChanged }
     }
 
     // Deploy the service
@@ -330,6 +398,46 @@ export async function ensureUtilDeployment({
     deployLog.info("Done!")
 
     return { authSecret, updated: true }
+  })
+}
+
+export async function cycleDeployment({
+  ctx,
+  provider,
+  deployment,
+  api,
+  namespace,
+  deployLog,
+}: {
+  ctx: PluginContext
+  provider: KubernetesProvider
+  deployment: KubernetesDeployment
+  api: KubeApi
+  namespace: string
+  deployLog: Log
+}) {
+  const originalReplicas = deployment.spec.replicas
+
+  deployment.spec.replicas = 0
+  await api.upsert({ kind: "Deployment", namespace, log: deployLog, obj: deployment })
+  await waitForResources({
+    namespace,
+    ctx,
+    provider,
+    resources: [deployment],
+    log: deployLog,
+    timeoutSec: 600,
+  })
+
+  deployment.spec.replicas = originalReplicas
+  await api.upsert({ kind: "Deployment", namespace, log: deployLog, obj: deployment })
+  await waitForResources({
+    namespace,
+    ctx,
+    provider,
+    resources: [deployment],
+    log: deployLog,
+    timeoutSec: 600,
   })
 }
 
@@ -384,6 +492,20 @@ export async function ensureBuilderSecret({
   }
 
   return { authSecret, updated }
+}
+
+export function getBuilderServiceAccountSpec(annotations?: StringMap) {
+  const serviceAccount: KubernetesServiceAccount = {
+    apiVersion: "v1",
+    kind: "ServiceAccount",
+    metadata: {
+      name: inClusterBuilderServiceAccount,
+      // ensure we clear old annotations if config flags are removed
+      annotations: annotations || {},
+    },
+  }
+
+  return serviceAccount
 }
 
 export function getUtilContainer(authSecretName: string, provider: KubernetesProvider): V1Container {
@@ -491,6 +613,7 @@ export function getUtilManifests(
           annotations: kanikoAnnotations,
         },
         spec: {
+          serviceAccountName: inClusterBuilderServiceAccount,
           containers: [utilContainer],
           imagePullSecrets,
           volumes: [

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -20,7 +20,7 @@ import { prepareSecrets } from "../../secrets.js"
 import { Mutagen } from "../../../../mutagen.js"
 import { randomString } from "../../../../util/string.js"
 import type { V1Container, V1Service } from "@kubernetes/client-node"
-import { cloneDeep, isEmpty } from "lodash-es"
+import { cloneDeep, isEmpty, isEqual } from "lodash-es"
 import { compareDeployedResources, waitForResources } from "../../status/status.js"
 import type { KubernetesDeployment, KubernetesResource, KubernetesServiceAccount } from "../../types.js"
 import type { BuildActionHandler, BuildActionResults } from "../../../../plugin/action-types.js"
@@ -313,7 +313,7 @@ export function isEqualAnnotations(r1: KubernetesResource, r2: KubernetesResourc
   // normalize annotations before comparison
   const a1 = r1.metadata.annotations !== undefined ? r1.metadata.annotations : {}
   const a2 = r2.metadata.annotations !== undefined ? r2.metadata.annotations : {}
-  return JSON.stringify(a1) === JSON.stringify(a2)
+  return isEqual(a1, a2)
 }
 
 /**

--- a/core/src/plugins/kubernetes/jib-container.ts
+++ b/core/src/plugins/kubernetes/jib-container.ts
@@ -110,7 +110,6 @@ async function buildAndPushViaRemote(params: BuildActionParams<"build", Containe
 
     // Make sure the sync target is up
     if (buildMode === "kaniko") {
-      // Make sure the garden-util deployment is up
       await ensureUtilDeployment({
         ctx,
         provider,
@@ -120,7 +119,6 @@ async function buildAndPushViaRemote(params: BuildActionParams<"build", Containe
       })
       deploymentName = utilDeploymentName
     } else if (buildMode === "cluster-buildkit") {
-      // Make sure the buildkit deployment is up
       await ensureBuildkit({
         ctx,
         provider,

--- a/core/src/plugins/kubernetes/status/status.ts
+++ b/core/src/plugins/kubernetes/status/status.ts
@@ -541,6 +541,7 @@ export async function compareDeployedResources({
     manifest = removeEmptyEnvValues(manifest)
     // ...and from the deployedResource for good measure, in case the K8s API changes.
     deployedResource = removeEmptyEnvValues(deployedResource)
+    const isItSubset = isSubset(deployedResource, manifest)
 
     if (!isSubset(deployedResource, manifest)) {
       if (manifest) {

--- a/core/src/plugins/kubernetes/status/status.ts
+++ b/core/src/plugins/kubernetes/status/status.ts
@@ -541,7 +541,6 @@ export async function compareDeployedResources({
     manifest = removeEmptyEnvValues(manifest)
     // ...and from the deployedResource for good measure, in case the K8s API changes.
     deployedResource = removeEmptyEnvValues(deployedResource)
-    const isItSubset = isSubset(deployedResource, manifest)
 
     if (!isSubset(deployedResource, manifest)) {
       if (manifest) {

--- a/core/src/plugins/kubernetes/types.ts
+++ b/core/src/plugins/kubernetes/types.ts
@@ -10,6 +10,7 @@ import type {
   KubernetesObject,
   V1DaemonSet,
   V1Deployment,
+  V1ServiceAccount,
   V1ObjectMeta,
   V1ReplicaSet,
   V1StatefulSet,
@@ -92,6 +93,7 @@ export type KubernetesReplicaSet = KubernetesResource<V1ReplicaSet>
 export type KubernetesStatefulSet = KubernetesResource<V1StatefulSet>
 export type KubernetesPod = KubernetesResource<V1Pod>
 export type KubernetesService = KubernetesResource<V1Service>
+export type KubernetesServiceAccount = KubernetesResource<V1ServiceAccount>
 
 export type KubernetesWorkload = KubernetesResource<V1DaemonSet | V1Deployment | V1ReplicaSet | V1StatefulSet>
 export type KubernetesIngress = KubernetesResource<V1Ingress>

--- a/core/test/integ/src/plugins/kubernetes/container/build/build.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/build/build.ts
@@ -583,7 +583,7 @@ describe("Kubernetes Container Build Extension", () => {
 
   grouped("kaniko").context("kaniko service account annotations", () => {
     beforeEach(async () => {
-      await init("local")
+      await init("kaniko")
     })
 
     afterEach(async () => {
@@ -671,7 +671,7 @@ describe("Kubernetes Container Build Extension", () => {
 
   grouped("cluster-buildkit").context("cluster-buildkit service account annotations", () => {
     beforeEach(async () => {
-      await init("local")
+      await init("cluster-buildkit")
     })
 
     afterEach(async () => {

--- a/core/test/integ/src/plugins/kubernetes/container/build/build.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/build/build.ts
@@ -642,7 +642,7 @@ describe("Ensure serviceAccount annotations for in-cluster building", () => {
         log,
       })
       // Both annotations should be present
-      expect(isEqualAnnotations(originalServiceAccount, status.remoteResources[0]))
+      expect(isEqualAnnotations(originalServiceAccount, status.remoteResources[0])).to.be.true
 
       const reducedAnnotations = {
         "iam.gke.io/gcp-service-account": "workload-identity-gar@garden-ci.iam.gserviceaccount.com",
@@ -660,7 +660,7 @@ describe("Ensure serviceAccount annotations for in-cluster building", () => {
         log,
       })
       // Only reduced annotations should be present
-      expect(isEqualAnnotations(updatedServiceAccount, updatedStatus.remoteResources[0]))
+      expect(isEqualAnnotations(updatedServiceAccount, updatedStatus.remoteResources[0])).to.be.true
     })
     it("should cycle the util deployment when the serviceAccount annotations changed", async () => {
       const originalAnnotations = {
@@ -678,7 +678,7 @@ describe("Ensure serviceAccount annotations for in-cluster building", () => {
       provider.config.kaniko = { serviceAccountAnnotations: updatedAnnotations }
       const { updated } = await ensureUtilDeployment({ ctx, provider, log, api, namespace: projectNamespace })
 
-      expect(updated)
+      expect(updated).to.be.true
     })
   })
 
@@ -740,7 +740,7 @@ describe("Ensure serviceAccount annotations for in-cluster building", () => {
       provider.config.clusterBuildkit = { serviceAccountAnnotations: updatedAnnotations, cache: defaultCacheConfig }
       const { updated } = await ensureBuildkit({ ctx, provider, log: garden.log, api, namespace: projectNamespace })
 
-      expect(updated)
+      expect(updated).to.be.true
     })
   })
 })

--- a/core/test/integ/src/plugins/kubernetes/container/build/build.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/build/build.ts
@@ -642,7 +642,7 @@ describe("Ensure serviceAccount annotations for in-cluster building", () => {
         log,
       })
       // Both annotations should be present
-      expect(isEqualAnnotations(originalServiceAccount, status.remoteResources[0])).to.be.true
+      expect(isEqualAnnotations(originalServiceAccount)).to.equal(status.remoteResources[0])
 
       const reducedAnnotations = {
         "iam.gke.io/gcp-service-account": "workload-identity-gar@garden-ci.iam.gserviceaccount.com",

--- a/core/test/integ/src/plugins/kubernetes/container/build/build.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/build/build.ts
@@ -44,7 +44,6 @@ describe.skip("Kubernetes Container Build Extension", () => {
   let graph: ConfigGraph
   let provider: KubernetesProvider
   let ctx: PluginContext
-  let api: KubeApi
 
   after(async () => {
     if (garden) {
@@ -58,7 +57,6 @@ describe.skip("Kubernetes Container Build Extension", () => {
     graph = await garden.getConfigGraph({ log: garden.log, emit: false })
     provider = <KubernetesProvider>await garden.resolveProvider(garden.log, "local-kubernetes")
     ctx = await garden.getPluginContext({ provider, templateContext: undefined, events: undefined })
-    api = await KubeApi.factory(log, ctx, provider)
   }
 
   async function executeBuild(buildActionName: string) {

--- a/core/test/integ/src/plugins/kubernetes/container/build/build.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/build/build.ts
@@ -29,7 +29,6 @@ import {
   ensureServiceAccount,
   ensureUtilDeployment,
   getBuilderServiceAccountSpec,
-  isEqualAnnotations,
 } from "../../../../../../../src/plugins/kubernetes/container/build/common.js"
 import { compareDeployedResources } from "../../../../../../../src/plugins/kubernetes/status/status.js"
 import { KubeApi } from "../../../../../../../src/plugins/kubernetes/api.js"
@@ -642,7 +641,7 @@ describe("Ensure serviceAccount annotations for in-cluster building", () => {
         log,
       })
       // Both annotations should be present
-      expect(isEqualAnnotations(originalServiceAccount)).to.equal(status.remoteResources[0])
+      expect(originalServiceAccount.metadata.annotations).to.deep.equal(status.remoteResources[0].metadata.annotations)
 
       const reducedAnnotations = {
         "iam.gke.io/gcp-service-account": "workload-identity-gar@garden-ci.iam.gserviceaccount.com",
@@ -660,7 +659,9 @@ describe("Ensure serviceAccount annotations for in-cluster building", () => {
         log,
       })
       // Only reduced annotations should be present
-      expect(isEqualAnnotations(updatedServiceAccount, updatedStatus.remoteResources[0])).to.be.true
+      expect(updatedServiceAccount.metadata.annotations).to.deep.equal(
+        updatedStatus.remoteResources[0].metadata.annotations
+      )
     })
     it("should cycle the util deployment when the serviceAccount annotations changed", async () => {
       const originalAnnotations = {

--- a/core/test/unit/src/plugins/kubernetes/container/build/common.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/build/common.ts
@@ -51,19 +51,20 @@ describe("common build", () => {
   describe("getBuilderServiceAccountSpec", () => {
     it("should return the manifest", () => {
       const annotation = { "some-annotation": "annotation-value" }
-      const result = getBuilderServiceAccountSpec(annotation)
+      const result = getBuilderServiceAccountSpec("random-namespace", annotation)
       expect(result).eql({
         apiVersion: "v1",
         kind: "ServiceAccount",
         metadata: {
           name: inClusterBuilderServiceAccount,
           annotations: annotation,
+          namespace: "random-namespace",
         },
       })
     })
 
     it("should return empty annotations when no annotations are provided", () => {
-      const result = getBuilderServiceAccountSpec()
+      const result = getBuilderServiceAccountSpec("random-namespace")
       expect(result.metadata.annotations).eql({})
     })
   })

--- a/core/test/unit/src/plugins/kubernetes/container/build/common.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/build/common.ts
@@ -50,13 +50,14 @@ describe("common build", () => {
 
   describe("getBuilderServiceAccountSpec", () => {
     it("should return the manifest", () => {
-      const result = getBuilderServiceAccountSpec({ "some-annotation": "annotation-value" })
+      const annotation = { "some-annotation": "annotation-value" }
+      const result = getBuilderServiceAccountSpec(annotation)
       expect(result).eql({
         apiVersion: "v1",
         kind: "ServiceAccount",
         metadata: {
           name: inClusterBuilderServiceAccount,
-          annotations: { "some-annotations": "annotation-value" },
+          annotations: annotation,
         },
       })
     })

--- a/core/test/unit/src/plugins/kubernetes/container/build/common.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/build/common.ts
@@ -7,7 +7,9 @@
  */
 
 import {
+  getBuilderServiceAccountSpec,
   getUtilManifests,
+  inClusterBuilderServiceAccount,
   skopeoManifestUnknown,
 } from "../../../../../../../src/plugins/kubernetes/container/build/common.js"
 import { expect } from "chai"
@@ -46,6 +48,25 @@ describe("common build", () => {
     })
   })
 
+  describe("getBuilderServiceAccountSpec", () => {
+    it("should return the manifest", () => {
+      const result = getBuilderServiceAccountSpec({ "some-annotation": "annotation-value" })
+      expect(result).eql({
+        apiVersion: "v1",
+        kind: "ServiceAccount",
+        metadata: {
+          name: inClusterBuilderServiceAccount,
+          annotations: { "some-annotations": "annotation-value" },
+        },
+      })
+    })
+
+    it("should return empty annotations when no annotations are provided", () => {
+      const result = getBuilderServiceAccountSpec()
+      expect(result.metadata.annotations).eql({})
+    })
+  })
+
   describe("getUtilManifests", () => {
     const _provider: DeepPartial<KubernetesProvider> = {
       config: {
@@ -75,6 +96,7 @@ describe("common build", () => {
             template: {
               metadata: { labels: { app: "garden-util" }, annotations: undefined },
               spec: {
+                serviceAccountName: inClusterBuilderServiceAccount,
                 containers: [
                   {
                     name: "util",

--- a/core/test/unit/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/build/kaniko.ts
@@ -139,6 +139,7 @@ describe("kaniko build", () => {
             },
           ],
           shareProcessNamespace: true,
+          serviceAccountName: "garden-in-cluster-builder",
           tolerations: [
             {
               effect: "NoSchedule",

--- a/core/test/unit/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/build/kaniko.ts
@@ -17,6 +17,7 @@ import type { KubernetesProvider } from "../../../../../../../src/plugins/kubern
 import { defaultResources } from "../../../../../../../src/plugins/kubernetes/config.js"
 import { defaultKanikoImageName, k8sUtilImageName } from "../../../../../../../src/plugins/kubernetes/constants.js"
 import type { DeepPartial } from "utility-types"
+import { inClusterBuilderServiceAccount } from "../../../../../../../src/plugins/kubernetes/container/build/common.js"
 
 describe("kaniko build", () => {
   it("should return as successful when immutable tag already exists in destination", () => {
@@ -139,7 +140,7 @@ describe("kaniko build", () => {
             },
           ],
           shareProcessNamespace: true,
-          serviceAccountName: "garden-in-cluster-builder",
+          serviceAccountName: inClusterBuilderServiceAccount,
           tolerations: [
             {
               effect: "NoSchedule",

--- a/docs/k8s-plugins/advanced/in-cluster-building.md
+++ b/docs/k8s-plugins/advanced/in-cluster-building.md
@@ -662,13 +662,13 @@ providers:
     buildMode: kaniko
     kaniko:
       serviceAccountAnnotations:
-        iam.gke.io/gcp-service-account: gar-access@${PROJECT}.iam.gserviceaccount.com
+        iam.gke.io/gcp-service-account: gar-access@${PROJECT_ID}.iam.gserviceaccount.com
 
     # If you use the buildkit build mode
     buildMode: buildkit
     clusterBuildkit:
       serviceAccountAnnotations:
-        iam.gke.io/gcp-service-account: gar-access@${PROJECT}.iam.gserviceaccount.com
+        iam.gke.io/gcp-service-account: gar-access@${PROJECT_ID}.iam.gserviceaccount.com
 ```
 
 ## Publishing images

--- a/docs/k8s-plugins/advanced/in-cluster-building.md
+++ b/docs/k8s-plugins/advanced/in-cluster-building.md
@@ -298,9 +298,118 @@ See below for specific instructions for working with ECR.
 
 ### Using in-cluster building with ECR
 
-For AWS ECR (Elastic Container Registry), you need to enable the ECR credential helper once for the repository by adding an `imagePullSecret` for you ECR repository.
+### Using in-cluster building with ECR
 
-First create a `config.json` somewhere with the following contents (`<aws_account_id>` and `<region>` are placeholders that you need to replace for your repo):
+For using Garden with AWS ECR (Elastic Container Registry) we need to
+
+1. Create an IAM policy that allows your Kubernetes worker nodes to pull images from the ECR registry
+2. Create a [web identity IAM role](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_oidc.html), allowing the `garden-in-cluster-builder` service accounts managed by Garden to push images to the ECR registry
+3. Create a Kubernetes secret of type `kubernetes.io/dockerconfigjson` and reference it in the Garden configuration
+
+#### IAM policies and roles
+
+To allow access to the Docker images in your ECR repositories from the Kubernetes worker nodes and from the Garden in-cluster builder Pods, you need to configure an IAM policy and a [web identity IAM role](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_oidc.html). To learn more about ECR IAM policies, please refer to [the AWS documentation](https://docs.aws.amazon.com/AmazonECR/latest/userguide/security_iam_id-based-policy-examples.html).
+
+Create this IAM policy to allow the Kubernetes nodes to pull images from your ECR repositories:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "GardenAllowPull",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": ["arn:aws:iam::<account-id>:role/<k8s-worker-iam-role>"]
+            },
+            "Action": [
+                "ecr:BatchGetImage",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetDownloadUrlForLayer",
+            ]
+            "Resource": "arn:aws:ecr:<region>:<account-id>:repository/<ecr-repository>"
+        },
+        {
+            "Sid": "GetAuthorizationToken",
+            "Effect": "Allow",
+            "Action": [
+                "ecr:GetAuthorizationToken"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+
+Create a [web identity role](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_oidc.html) to allow pushing images, with the following trust relationship:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Federated": "arn:aws:iam::<account-id>:oidc-provider/oidc.eks.<region>.amazonaws.com/id/<oidc-provider-id>"
+            },
+            "Action": "sts:AssumeRoleWithWebIdentity",
+            "Condition": {
+                "StringEquals": {
+                    "oidc.eks.<region>.amazonaws.com/id/<oidc-provider-id>:sub": "system:serviceaccount:*:garden-in-cluster-builder",
+                    "oidc.eks.<region>.amazonaws.com/id/<oidc-provider-id>:aud": "sts.amazonaws.com"
+                }
+            }
+        }
+    ]
+}
+```
+
+Note that this trust relationship allows the Pods associated with the `garden-in-cluster-builder` serviceaccount in all namespaces (`*`) to push images.
+
+Configure the following IAM policy with the web identity role:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "GardenAllowPushPull",
+            "Effect": "Allow",
+            "Action": [
+                "ecr:BatchGetImage",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:CompleteLayerUpload",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:InitiateLayerUpload",
+                "ecr:PutImage",
+                "ecr:UploadLayerPart"
+            ],
+            "Resource": "arn:aws:ecr:<region>:<account-id>:repository/<ecr-repository>"
+        },
+        {
+            "Sid": "GetAuthorizationToken",
+            "Effect": "Allow",
+            "Action": [
+                "ecr:GetAuthorizationToken"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+
+NOTE: You need to replace the following placeholders:
+- `<account-id>` is your AWS Account ID
+- `<k8s-worker-iam-role>` is the Node IAM role name (You can find it in your EKS node group)
+- `<region>` AWS region
+- `<ecr-repository>` name of the ECR repositories ([matching multiple names using wildcards](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html#reference_policies_elements_resource_wildcards) is allowed)
+- `<oidc-provider-id>` Part of the OpenID Connect provider URL
+
+#### Kubernetes Image pull secret
+
+The Kubernetes image pull secret
+
+Create a `config.json` somewhere with the following contents (`<aws-account-id>` and `<region>` are placeholders that you need to replace for your repo):
 
 ```json
 {
@@ -310,7 +419,7 @@ First create a `config.json` somewhere with the following contents (`<aws_accoun
 }
 ```
 
-Next create the _imagePullSecret_ in your cluster (feel free to replace the default namespace, just make sure it's correctly referenced in the config below):
+Next create the _imagePullSecret_ in your cluster (feel free to use a different namespace, just make sure it's correctly referenced in the config below):
 
 ```sh
 kubectl --namespace default create secret generic ecr-config \
@@ -318,7 +427,9 @@ kubectl --namespace default create secret generic ecr-config \
   --type=kubernetes.io/dockerconfigjson
 ```
 
-Finally, add the secret reference to your `kubernetes` provider configuration:
+#### Garden kubernetes provider configuration
+
+Add a reference to the secret in your `kubernetes` provider configuration:
 
 ```yaml
 apiVersion: garden.io/v1
@@ -328,41 +439,21 @@ name: my-project
 providers:
   - name: kubernetes
     ...
+    # If you use the kaniko build mode
+    buildMode: kaniko
+    kaniko:
+      serviceAccountAnnotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::<account-id>:role/<web-identity-role-name>
+    # If you use the buildkit build mode
+    buildMode: buildkit
+    clusterBuildkit:
+      serviceAccountAnnotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::<account-id>:role/<web-identity-role-name>
+
     imagePullSecrets:
       - name: ecr-config
         namespace: default
 ```
-
-#### Configuring Access
-
-To grant your service account the right permission to push to ECR, add this policy to each of the repositories in the container registry that you want to use with in-cluster building:
-
-```json
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "AllowPushPull",
-            "Effect": "Allow",
-            "Principal": {
-                "AWS": [
-                    "arn:aws:iam::<account-id>:role/<k8s_worker_iam_role>"                ]
-            },
-            "Action": [
-                "ecr:BatchGetImage",
-                "ecr:BatchCheckLayerAvailability",
-                "ecr:CompleteLayerUpload",
-                "ecr:GetDownloadUrlForLayer",
-                "ecr:InitiateLayerUpload",
-                "ecr:PutImage",
-                "ecr:UploadLayerPart"
-            ]
-        }
-    ]
-}
-```
-
-To grant developers permission to push and pull directly from a repository, see [the AWS documentation](https://docs.aws.amazon.com/AmazonECR/latest/userguide/security_iam_id-based-policy-examples.html).
 
 ### Using in-cluster building with GCR
 

--- a/docs/reference/action-types/Deploy/pulumi.md
+++ b/docs/reference/action-types/Deploy/pulumi.md
@@ -11,7 +11,7 @@ Deploys a Pulumi stack and either creates/updates it automatically (if `autoAppl
 
 **Note: It is not recommended to set `autoApply` to `true` for production or shared environments, since this may result in accidental or conflicting changes to the stack.** Instead, it is recommended to manually preview and update using the provided plugin commands. Run `garden plugins pulumi` for details. Note that not all Pulumi CLI commands are wrapped by the plugin, only the ones where it's important to apply any variables defined in the action. For others, simply run the Pulumi CLI as usual from the project root.
 
-Stack outputs are made available as action outputs. These can then be referenced by other actions under `${actions.<action-kind>.<action-name>.outputs.<key>}`. You can template in those values as e.g. command arguments or environment variables for other services.
+Stack outputs are made available as action outputs. These can then be referenced by other actions under `${actions.<name>.outputs.<key>}`. You can template in those values as e.g. command arguments or environment variables for other services.
 
 Below is the full schema reference for the action. For an introduction to configuring Garden, please look at our [Configuration
 guide](../../../using-garden/configuration-overview.md).

--- a/docs/reference/action-types/Deploy/pulumi.md
+++ b/docs/reference/action-types/Deploy/pulumi.md
@@ -11,7 +11,7 @@ Deploys a Pulumi stack and either creates/updates it automatically (if `autoAppl
 
 **Note: It is not recommended to set `autoApply` to `true` for production or shared environments, since this may result in accidental or conflicting changes to the stack.** Instead, it is recommended to manually preview and update using the provided plugin commands. Run `garden plugins pulumi` for details. Note that not all Pulumi CLI commands are wrapped by the plugin, only the ones where it's important to apply any variables defined in the action. For others, simply run the Pulumi CLI as usual from the project root.
 
-Stack outputs are made available as action outputs. These can then be referenced by other actions under `${actions.<name>.outputs.<key>}`. You can template in those values as e.g. command arguments or environment variables for other services.
+Stack outputs are made available as action outputs. These can then be referenced by other actions under `${actions.<action-kind>.<action-name>.outputs.<key>}`. You can template in those values as e.g. command arguments or environment variables for other services.
 
 Below is the full schema reference for the action. For an introduction to configuring Garden, please look at our [Configuration
 guide](../../../using-garden/configuration-overview.md).

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -202,6 +202,10 @@ providers:
       # Annotations may have an effect on the behaviour of certain components, for example autoscalers.
       annotations:
 
+      # Specify annotations to apply to the Kubernetes service account used by cluster-buildkit. This can be useful to
+      # set up IRSA with in-cluster building.
+      serviceAccountAnnotations:
+
     # Setting related to Jib image builds.
     jib:
       # In some cases you may need to push images built with Jib to the remote registry via Kubernetes cluster, e.g.
@@ -298,6 +302,10 @@ providers:
 
         # Specify the nodeSelector constraints for each garden-util pod.
         nodeSelector:
+
+      # Specify annotations to apply to the Kubernetes service account used by kaniko. This can be useful to set up
+      # IRSA with in-cluster building.
+      serviceAccountAnnotations:
 
     # A default hostname to use when no hostname is explicitly configured for a service.
     defaultHostname:
@@ -908,6 +916,54 @@ providers:
           cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
 ```
 
+### `providers[].clusterBuildkit.serviceAccountAnnotations`
+
+[providers](#providers) > [clusterBuildkit](#providersclusterbuildkit) > serviceAccountAnnotations
+
+Specify annotations to apply to the Kubernetes service account used by cluster-buildkit. This can be useful to set up IRSA with in-cluster building.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+Example:
+
+```yaml
+providers:
+  - clusterBuildkit:
+      ...
+      serviceAccountAnnotations:
+          eks.amazonaws.com/role-arn: 'arn:aws:iam::111122223333:role/my-role'
+```
+
+### `providers[].clusterDocker`
+
+[providers](#providers) > clusterDocker
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
+Configuration options for the `cluster-docker` build mode.
+
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `object` | `{}`    | No       |
+
+### `providers[].clusterDocker.enableBuildKit`
+
+[providers](#providers) > [clusterDocker](#providersclusterdocker) > enableBuildKit
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
+Enable [BuildKit](https://github.com/moby/buildkit) support. This should in most cases work well and be more performant, but we're opting to keep it optional until it's enabled by default in Docker.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
+
 ### `providers[].jib`
 
 [providers](#providers) > jib
@@ -1175,6 +1231,26 @@ Specify the nodeSelector constraints for each garden-util pod.
 | Type     | Required |
 | -------- | -------- |
 | `object` | No       |
+
+### `providers[].kaniko.serviceAccountAnnotations`
+
+[providers](#providers) > [kaniko](#providerskaniko) > serviceAccountAnnotations
+
+Specify annotations to apply to the Kubernetes service account used by kaniko. This can be useful to set up IRSA with in-cluster building.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+Example:
+
+```yaml
+providers:
+  - kaniko:
+      ...
+      serviceAccountAnnotations:
+          eks.amazonaws.com/role-arn: 'arn:aws:iam::111122223333:role/my-role'
+```
 
 ### `providers[].defaultHostname`
 

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -269,6 +269,10 @@ providers:
       # are specifically set under `util.annotations`
       annotations:
 
+      # Specify annotations to apply to the Kubernetes service account used by kaniko. This can be useful to set up
+      # IRSA with in-cluster building.
+      serviceAccountAnnotations:
+
       util:
         # Specify tolerations to apply to each garden-util pod.
         tolerations:
@@ -302,10 +306,6 @@ providers:
 
         # Specify the nodeSelector constraints for each garden-util pod.
         nodeSelector:
-
-      # Specify annotations to apply to the Kubernetes service account used by kaniko. This can be useful to set up
-      # IRSA with in-cluster building.
-      serviceAccountAnnotations:
 
     # A default hostname to use when no hostname is explicitly configured for a service.
     defaultHostname:
@@ -933,36 +933,8 @@ providers:
   - clusterBuildkit:
       ...
       serviceAccountAnnotations:
-          eks.amazonaws.com/role-arn: 'arn:aws:iam::111122223333:role/my-role'
+          eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/my-role
 ```
-
-### `providers[].clusterDocker`
-
-[providers](#providers) > clusterDocker
-
-{% hint style="warning" %}
-**Deprecated**: This field will be removed in a future release.
-{% endhint %}
-
-Configuration options for the `cluster-docker` build mode.
-
-| Type     | Default | Required |
-| -------- | ------- | -------- |
-| `object` | `{}`    | No       |
-
-### `providers[].clusterDocker.enableBuildKit`
-
-[providers](#providers) > [clusterDocker](#providersclusterdocker) > enableBuildKit
-
-{% hint style="warning" %}
-**Deprecated**: This field will be removed in a future release.
-{% endhint %}
-
-Enable [BuildKit](https://github.com/moby/buildkit) support. This should in most cases work well and be more performant, but we're opting to keep it optional until it's enabled by default in Docker.
-
-| Type      | Default | Required |
-| --------- | ------- | -------- |
-| `boolean` | `false` | No       |
 
 ### `providers[].jib`
 
@@ -1124,6 +1096,26 @@ providers:
           cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
 ```
 
+### `providers[].kaniko.serviceAccountAnnotations`
+
+[providers](#providers) > [kaniko](#providerskaniko) > serviceAccountAnnotations
+
+Specify annotations to apply to the Kubernetes service account used by kaniko. This can be useful to set up IRSA with in-cluster building.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+Example:
+
+```yaml
+providers:
+  - kaniko:
+      ...
+      serviceAccountAnnotations:
+          eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/my-role
+```
+
 ### `providers[].kaniko.util`
 
 [providers](#providers) > [kaniko](#providerskaniko) > util
@@ -1231,26 +1223,6 @@ Specify the nodeSelector constraints for each garden-util pod.
 | Type     | Required |
 | -------- | -------- |
 | `object` | No       |
-
-### `providers[].kaniko.serviceAccountAnnotations`
-
-[providers](#providers) > [kaniko](#providerskaniko) > serviceAccountAnnotations
-
-Specify annotations to apply to the Kubernetes service account used by kaniko. This can be useful to set up IRSA with in-cluster building.
-
-| Type     | Required |
-| -------- | -------- |
-| `object` | No       |
-
-Example:
-
-```yaml
-providers:
-  - kaniko:
-      ...
-      serviceAccountAnnotations:
-          eks.amazonaws.com/role-arn: 'arn:aws:iam::111122223333:role/my-role'
-```
 
 ### `providers[].defaultHostname`
 

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -198,6 +198,10 @@ providers:
       # Annotations may have an effect on the behaviour of certain components, for example autoscalers.
       annotations:
 
+      # Specify annotations to apply to the Kubernetes service account used by cluster-buildkit. This can be useful to
+      # set up IRSA with in-cluster building.
+      serviceAccountAnnotations:
+
     # Setting related to Jib image builds.
     jib:
       # In some cases you may need to push images built with Jib to the remote registry via Kubernetes cluster, e.g.
@@ -294,6 +298,10 @@ providers:
 
         # Specify the nodeSelector constraints for each garden-util pod.
         nodeSelector:
+
+      # Specify annotations to apply to the Kubernetes service account used by kaniko. This can be useful to set up
+      # IRSA with in-cluster building.
+      serviceAccountAnnotations:
 
     # A default hostname to use when no hostname is explicitly configured for a service.
     defaultHostname:
@@ -1123,6 +1131,26 @@ Specify the nodeSelector constraints for each garden-util pod.
 | Type     | Required |
 | -------- | -------- |
 | `object` | No       |
+
+### `providers[].kaniko.serviceAccountAnnotations`
+
+[providers](#providers) > [kaniko](#providerskaniko) > serviceAccountAnnotations
+
+Specify annotations to apply to the Kubernetes service account used by kaniko. This can be useful to set up IRSA with in-cluster building.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+Example:
+
+```yaml
+providers:
+  - kaniko:
+      ...
+      serviceAccountAnnotations:
+          eks.amazonaws.com/role-arn: 'arn:aws:iam::111122223333:role/my-role'
+```
 
 ### `providers[].defaultHostname`
 

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -265,6 +265,10 @@ providers:
       # are specifically set under `util.annotations`
       annotations:
 
+      # Specify annotations to apply to the Kubernetes service account used by kaniko. This can be useful to set up
+      # IRSA with in-cluster building.
+      serviceAccountAnnotations:
+
       util:
         # Specify tolerations to apply to each garden-util pod.
         tolerations:
@@ -298,10 +302,6 @@ providers:
 
         # Specify the nodeSelector constraints for each garden-util pod.
         nodeSelector:
-
-      # Specify annotations to apply to the Kubernetes service account used by kaniko. This can be useful to set up
-      # IRSA with in-cluster building.
-      serviceAccountAnnotations:
 
     # A default hostname to use when no hostname is explicitly configured for a service.
     defaultHostname:
@@ -864,6 +864,26 @@ providers:
           cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
 ```
 
+### `providers[].clusterBuildkit.serviceAccountAnnotations`
+
+[providers](#providers) > [clusterBuildkit](#providersclusterbuildkit) > serviceAccountAnnotations
+
+Specify annotations to apply to the Kubernetes service account used by cluster-buildkit. This can be useful to set up IRSA with in-cluster building.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+Example:
+
+```yaml
+providers:
+  - clusterBuildkit:
+      ...
+      serviceAccountAnnotations:
+          eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/my-role
+```
+
 ### `providers[].jib`
 
 [providers](#providers) > jib
@@ -1024,6 +1044,26 @@ providers:
           cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
 ```
 
+### `providers[].kaniko.serviceAccountAnnotations`
+
+[providers](#providers) > [kaniko](#providerskaniko) > serviceAccountAnnotations
+
+Specify annotations to apply to the Kubernetes service account used by kaniko. This can be useful to set up IRSA with in-cluster building.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+Example:
+
+```yaml
+providers:
+  - kaniko:
+      ...
+      serviceAccountAnnotations:
+          eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/my-role
+```
+
 ### `providers[].kaniko.util`
 
 [providers](#providers) > [kaniko](#providerskaniko) > util
@@ -1131,26 +1171,6 @@ Specify the nodeSelector constraints for each garden-util pod.
 | Type     | Required |
 | -------- | -------- |
 | `object` | No       |
-
-### `providers[].kaniko.serviceAccountAnnotations`
-
-[providers](#providers) > [kaniko](#providerskaniko) > serviceAccountAnnotations
-
-Specify annotations to apply to the Kubernetes service account used by kaniko. This can be useful to set up IRSA with in-cluster building.
-
-| Type     | Required |
-| -------- | -------- |
-| `object` | No       |
-
-Example:
-
-```yaml
-providers:
-  - kaniko:
-      ...
-      serviceAccountAnnotations:
-          eks.amazonaws.com/role-arn: 'arn:aws:iam::111122223333:role/my-role'
-```
 
 ### `providers[].defaultHostname`
 

--- a/images/buildkit/Dockerfile
+++ b/images/buildkit/Dockerfile
@@ -9,12 +9,12 @@ RUN cd /usr/local/bin && \
   chmod +x docker-credential-ecr-login
 
 # GCR credential helper
-RUN wget "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.0.1/docker-credential-gcr_linux_amd64-2.0.1.tar.gz" && \
-  echo "90837d1d9cf16809a60d5c7891d7d0b8445b1978ad43187032a0ca93bda49ed5  docker-credential-gcr_linux_amd64-2.0.1.tar.gz" | sha256sum -c && \
-  tar xzf docker-credential-gcr_linux_amd64-2.0.1.tar.gz --to-stdout ./docker-credential-gcr \
-  > /usr/local/bin/docker-credential-gcr && \
-  chmod +x /usr/local/bin/docker-credential-gcr && \
-  rm docker-credential-gcr_linux_amd64-2.0.1.tar.gz
+RUN cd /usr/local/bin && \
+  wget "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.1.14/docker-credential-gcr_linux_amd64-2.1.14.tar.gz" && \
+  echo "81f2d215466ab5bf6a350aadab42b42ad29590d16eab39f28014e4a6563c848a  docker-credential-gcr_linux_amd64-2.1.14.tar.gz" | sha256sum -c && \
+  tar xzf docker-credential-gcr_linux_amd64-2.1.14.tar.gz && \
+  rm docker-credential-gcr_linux_amd64-2.1.14.tar.gz && \
+  chmod +x docker-credential-gcr
 
 FROM moby/buildkit:v0.12.2-rootless@sha256:0919807170af622451887366c17408dc9a946d04c6fe4fcca3071f9637f8598f as buildkit-rootless
 

--- a/images/buildkit/garden.yml
+++ b/images/buildkit/garden.yml
@@ -2,7 +2,7 @@ kind: Module
 type: container
 name: buildkit
 description: Used for the cluster-buildkit build mode in the kubernetes provider
-image: gardendev/buildkit:v0.12.2
+image: gardendev/buildkit:v0.12.2-1
 dockerfile: Dockerfile
 build:
   targetImage: buildkit
@@ -14,7 +14,7 @@ kind: Module
 type: container
 name: buildkit-rootless
 description: Used for the cluster-buildkit build mode in the kubernetes provider, rootless variant
-image: gardendev/buildkit:v0.12.2-rootless
+image: gardendev/buildkit:v0.12.2-1-rootless
 dockerfile: Dockerfile
 build:
   dependencies:

--- a/images/k8s-util/Dockerfile
+++ b/images/k8s-util/Dockerfile
@@ -7,6 +7,13 @@ RUN cd /usr/local/bin && \
   echo "af805202cb5d627dde2e6d4be1f519b195fd5a3a35ddc88d5010b4a4e5a98dd8  docker-credential-ecr-login" | sha256sum -c && \
   chmod +x docker-credential-ecr-login
 
+RUN cd /usr/local/bin && \
+  wget "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.1.14/docker-credential-gcr_linux_amd64-2.1.14.tar.gz" && \
+  echo "81f2d215466ab5bf6a350aadab42b42ad29590d16eab39f28014e4a6563c848a  docker-credential-gcr_linux_amd64-2.1.14.tar.gz" | sha256sum -c && \
+  tar xzf docker-credential-gcr_linux_amd64-2.1.14.tar.gz && \
+  rm docker-credential-gcr_linux_amd64-2.1.14.tar.gz && \
+  chmod +x docker-credential-gcr
+
 RUN adduser -g 1000 -D user && \
   mkdir -p /data && \
   chown -R user:user /data

--- a/images/k8s-util/garden.yml
+++ b/images/k8s-util/garden.yml
@@ -2,7 +2,7 @@ kind: Module
 type: container
 name: k8s-util
 description: Used by the kubernetes provider for build-related activities
-image: gardendev/k8s-util:0.5.6
+image: gardendev/k8s-util:0.5.7
 dockerfile: Dockerfile
 build:
   dependencies: [k8s-sync]

--- a/images/skopeo/Dockerfile
+++ b/images/skopeo/Dockerfile
@@ -6,9 +6,9 @@ RUN cd /usr/local/bin && \
   echo "af805202cb5d627dde2e6d4be1f519b195fd5a3a35ddc88d5010b4a4e5a98dd8  docker-credential-ecr-login" | sha256sum -c && \
   chmod +x docker-credential-ecr-login
 
-RUN wget "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.0.1/docker-credential-gcr_linux_amd64-2.0.1.tar.gz" && \
-  echo "90837d1d9cf16809a60d5c7891d7d0b8445b1978ad43187032a0ca93bda49ed5  docker-credential-gcr_linux_amd64-2.0.1.tar.gz" | sha256sum -c && \
-  tar xzf docker-credential-gcr_linux_amd64-2.0.1.tar.gz --to-stdout ./docker-credential-gcr \
-  > /usr/local/bin/docker-credential-gcr && \
-  chmod +x /usr/local/bin/docker-credential-gcr && \
-  rm docker-credential-gcr_linux_amd64-2.0.1.tar.gz
+RUN cd /usr/local/bin && \
+  wget "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v2.1.14/docker-credential-gcr_linux_amd64-2.1.14.tar.gz" && \
+  echo "81f2d215466ab5bf6a350aadab42b42ad29590d16eab39f28014e4a6563c848a  docker-credential-gcr_linux_amd64-2.1.14.tar.gz" | sha256sum -c && \
+  tar xzf docker-credential-gcr_linux_amd64-2.1.14.tar.gz && \
+  rm docker-credential-gcr_linux_amd64-2.1.14.tar.gz && \
+  chmod +x docker-credential-gcr

--- a/images/skopeo/garden.yml
+++ b/images/skopeo/garden.yml
@@ -2,6 +2,6 @@ kind: Module
 type: container
 name: skopeo
 description: Used by the kubernetes provider for interacting with container registries within a cluster
-image: gardendev/skopeo:1.41.0-3
+image: gardendev/skopeo:1.41.0-4
 dockerfile: Dockerfile
 extraFlags: [ "--platform", "linux/amd64" ]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
1. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
1. Ensure you have added or run the appropriate tests for your PR.
1. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
1. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, Orzelius and vvagaytsev.
-->

**What this PR does / why we need it**:
This PR introduces a new service account, and makes the annotations
configurable in kaniko and buildkit in-cluster-builders.

This change enables the use of IRSA for in-cluter-building which makes
in-cluster building more secure.

**Which issue(s) this PR fixes**:

Fixes #2931

**Special notes for your reviewer**:

