### PR TITLE
fix(k8s): make getRolloutStatus work with 0 replicas

### DIFF
--- a/core/src/plugins/kubernetes/status/workload.ts
+++ b/core/src/plugins/kubernetes/status/workload.ts
@@ -227,7 +227,7 @@ async function getRolloutStatus(workload: Workload) {
     const status = <V1DeploymentStatus>workload.status
     const deploymentSpec = <V1DeploymentSpec>workload.spec
 
-    const desired = deploymentSpec.replicas || 1
+    const desired = deploymentSpec.replicas === undefined ? 1 : deploymentSpec.replicas
     const updated = status.updatedReplicas || 0
     const replicas = status.replicas || 0
     const available = status.availableReplicas || 0


### PR DESCRIPTION
getRolloutStatus got stuck in an endless loop waiting for
1 replica when Deployment had zero desired replicas.

Fix was checking for undefined explicitly.

Fixes #3377

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
