### PR TITLE
improvement(k8s): better error handling and logging in `PodRunner`

### DIFF
--- a/core/src/plugins/kubernetes/api.ts
+++ b/core/src/plugins/kubernetes/api.ts
@@ -1004,7 +1004,7 @@ const statusCodesForRetry: number[] = [
   httpStatusCodes.SERVICE_UNAVAILABLE,
   httpStatusCodes.GATEWAY_TIMEOUT,
 
-  // Clouflare-specific status codes
+  // Cloudflare-specific status codes
   521, // Web Server Is Down
   522, // Connection Timed Out
   524, // A Timeout Occurred

--- a/core/src/plugins/kubernetes/api.ts
+++ b/core/src/plugins/kubernetes/api.ts
@@ -838,6 +838,7 @@ export class KubeApi {
 
   /**
    * Create an ad-hoc Pod. Use this method to handle race-condition cases when creating Pods.
+   * @throws {KubernetesError}
    */
   async createPod(namespace: string, pod: KubernetesPod) {
     try {

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -432,7 +432,7 @@ async function runWithoutArtifacts({
  * See https://stackoverflow.com/a/20564208
  * @param cmd the command to wrap
  */
-function commandExecutionScript(cmd: string[]) {
+function getCommandExecutionScript(cmd: string[]) {
   return `
 exec 1<&-
 exec 2<&-
@@ -451,7 +451,7 @@ ${cmd.join(" ")}
  *   4. Tarball the directory and pipe to stdout
  * @param artifacts the artifacts to be processed
  */
-function artifactsTarScript(artifacts: ArtifactSpec[]) {
+function getArtifactsTarScript(artifacts: ArtifactSpec[]) {
   // TODO: only interpret target as directory if it ends with a slash (breaking change, so slated for 0.13)
   const directoriesToCreate = artifacts.map((a) => a.target).filter((target) => !!target && target !== ".")
   const tmpPath = "/tmp/.garden-artifacts-" + randomString(8)
@@ -590,7 +590,7 @@ async function runWithArtifacts({
     const cmd = [...command!, ...(args || [])].map((s) => JSON.stringify(s))
 
     try {
-      const commandScript = commandExecutionScript(cmd)
+      const commandScript = getCommandExecutionScript(cmd)
 
       const res = await runner.exec({
         // Pipe the output from the command to the /tmp/output pipe, including stderr. Some shell voodoo happening
@@ -619,7 +619,7 @@ async function runWithArtifacts({
       })
     }
 
-    const tarScript = artifactsTarScript(artifacts)
+    const tarScript = getArtifactsTarScript(artifacts)
 
     // Copy the artifacts
     const tmpDir = await tmp.dir({ unsafeCleanup: true })

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -407,7 +407,7 @@ async function runWithoutArtifacts({
       remove: true,
       events: ctx.events,
       timeoutSec: timeout || defaultTimeout,
-      tty: !!interactive,
+      tty: interactive,
     })
     result = {
       ...res,

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -725,7 +725,7 @@ interface RunAndWaitResult {
   exitCode?: number
 }
 
-interface PodErrorDetails {
+export interface PodErrorDetails {
   logs: string
   // optional details
   exitCode?: number

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -1019,7 +1019,6 @@ export class PodRunner extends PodRunnerParams {
       throw new TimeoutError(`Command timed out after ${timeoutSec} seconds.`, {
         logs: result.allLogs,
         result,
-        execParams: params,
       })
     }
 
@@ -1028,7 +1027,6 @@ export class PodRunner extends PodRunnerParams {
       throw new OutOfMemoryError(msg, {
         logs: (await this.getMainContainerLogs()) || msg,
         result,
-        execParams: params,
       })
     }
 
@@ -1036,7 +1034,6 @@ export class PodRunner extends PodRunnerParams {
       throw new PodRunnerError(`Command exited with code ${result.exitCode}:\n${result.allLogs}`, {
         logs: result.allLogs,
         result,
-        execParams: params,
       })
     }
 

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -827,7 +827,7 @@ export class PodRunner extends PodRunnerParams {
         completedAt: new Date(),
         log: mainContainerLogs,
         exitCode,
-        success: exitCode === 0,
+        success: exitCode === undefined || exitCode === 0,
       }
     } finally {
       logsFollower.close()
@@ -886,7 +886,7 @@ export class PodRunner extends PodRunnerParams {
 
       // reason "Completed" means main container is done, but sidecars or other containers possibly still alive
       if (state === "stopped" || exitReason === "Completed") {
-        if (!!exitCode) {
+        if (exitCode !== undefined && exitCode !== 0) {
           throw newExitCodePodRunnerError(await errorDetails())
         }
         return exitCode

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -416,14 +416,12 @@ async function runWithoutArtifacts({
     }
   } catch (err) {
     const containerLogs = err.detail.logs
-    const exitCode = err.detail.exitCode
 
     result = handlePodError({
       err,
       containerLogs,
       command: runner.getFullCommand(),
       startedAt,
-      exitCode,
       version,
       moduleName: module.name,
     })
@@ -616,14 +614,12 @@ async function runWithArtifacts({
       }
     } catch (err) {
       const containerLogs = await runner.getMainContainerLogs()
-      const exitCode = err.detail.exitCode
 
       result = handlePodError({
         err,
         containerLogs,
         command: cmd,
         startedAt,
-        exitCode,
         version,
         moduleName: module.name,
       })
@@ -697,7 +693,6 @@ function handlePodError({
   containerLogs,
   command,
   startedAt,
-  exitCode,
   version,
   moduleName,
 }: {
@@ -705,10 +700,12 @@ function handlePodError({
   containerLogs: string
   command: string[]
   startedAt: Date
-  exitCode: number
   version: string
   moduleName
 }) {
+  const errorDetail = <PodErrorDetails>err.detail
+  const exitCode = errorDetail.exitCode
+
   if (err.type === "out-of-memory" || err.type === "timeout") {
     // Command timed out or the pod container exceeded its memory limits
     const errorLog =

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -795,6 +795,11 @@ export class PodRunner extends PodRunnerParams {
    * Returns the logs for the first container in the Pod. Returns success=false if Pod exited with non-zero code.
    *
    * If tty=true, we attach to the process stdio during execution.
+   *
+   * @throws {OutOfMemoryError}
+   * @throws {TimeoutError}
+   * @throws {PodRunnerError}
+   * @throws {KubernetesError}
    */
   async runAndWait(params: RunParams): Promise<RunAndWaitResult> {
     const { log, remove, timeoutSec, tty } = params
@@ -832,6 +837,11 @@ export class PodRunner extends PodRunnerParams {
     }
   }
 
+  /**
+   * @throws {OutOfMemoryError}
+   * @throws {TimeoutError}
+   * @throws {PodRunnerError}
+   */
   private async awaitRunningPod(startedAt: Date, timeoutSec: number | undefined): Promise<number | undefined> {
     const { namespace, podName } = this
     const mainContainerName = this.getMainContainerName()
@@ -893,9 +903,9 @@ export class PodRunner extends PodRunnerParams {
   }
 
   /**
-   * Starts the Pod and leaves it running. Use this along with the `exec()` method when you need to run multiple
-   * commands in the same Pod. Note that you *must manually call `stop()`* when you're done. Otherwise the Pod will
-   * stay running in the cluster until the process exits.
+   * Starts the Pod and leaves it running. Use this along with the {@link #exec()} method when you need to run multiple
+   * commands in the same Pod. Note that you *must manually call {@link #stop()}* when you're done.
+   * Otherwise, the Pod will stay running in the cluster until the process exits.
    */
   async start({ log, timeoutSec = KUBECTL_DEFAULT_TIMEOUT }: StartParams) {
     const { ctx, provider, pod, namespace } = this
@@ -909,7 +919,11 @@ export class PodRunner extends PodRunnerParams {
   }
 
   /**
-   * Executes a command in the running Pod. Must be called after `start()`.
+   * Executes a command in the running Pod. Must be called after {@link start()}.
+   *
+   * @throws {OutOfMemoryError}
+   * @throws {TimeoutError}
+   * @throws {PodRunnerError}
    */
   async exec(params: ExecParams) {
     const { command, containerName: container, timeoutSec, tty = false, log, buffer = true } = params

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -982,12 +982,15 @@ export class PodRunner extends PodRunnerParams {
   }
 
   async getMainContainerLogs(): Promise<string> {
+    const mainContainerName = this.getMainContainerName()
     try {
       const allLogs = await this.getLogs()
-      const containerLogs = allLogs.find((l) => l.containerName === this.getMainContainerName())?.log || ""
-      return containerLogs.trim()
+      const containerLogs = allLogs.find((l) => l.containerName === mainContainerName)?.log?.trim()
+      return containerLogs || ""
     } catch (err) {
-      return ""
+      return `[Could not retrieve logs for container '${mainContainerName}': ${
+        err.message || "unknown error occurred"
+      }]`
     }
   }
 

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -1135,7 +1135,7 @@ export class PodRunner extends PodRunnerParams {
 
           return errorDesc
         case "kubernetes":
-          return `Unable to start command execution. Kubernetes cluster returned error:\n${error.message}\n\nPlease check the cluster health.`
+          return `Unable to start command execution. Failed to initiate a runner pod with error:\n${error.message}\n\nPlease check the cluster health and network connectivity.`
         default:
           const _exhaustiveCheck: never = error.type
           return _exhaustiveCheck

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -1077,14 +1077,14 @@ export class PodRunner extends PodRunnerParams {
             terminationDesc = terminationDesc.trim()
 
             if (!!terminationDesc) {
-              errorDesc += terminationDesc + "\n"
+              errorDesc += terminationDesc + "\n\n"
             }
           }
           // Print Pod status if case of too generic and non-informative error in the terminated state
           if (!terminatedContainerState?.message && terminatedContainerState?.reason === "Error") {
             if (!!podStatus) {
               const podStatusDesc = "PodStatus:\n" + JSON.stringify(podStatus, null, 2)
-              errorDesc += podStatusDesc + "\n"
+              errorDesc += podStatusDesc + "\n\n"
             }
           }
 

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -709,10 +709,13 @@ function handlePodError({
     switch (error.type) {
       // The pod container exceeded its memory limits
       case "out-of-memory":
-        return makeOutOfMemoryErrorLog(containerLogs)
+        return (
+          err.message +
+          (containerLogs ? ` Here are the logs until the out-of-memory event occurred:\n\n${containerLogs}` : "")
+        )
       // Command timed out
       case "timeout":
-        return makeTimeOutErrorLog(containerLogs)
+        return err.message + (containerLogs ? ` Here are the logs until the timeout occurred:\n\n${containerLogs}` : "")
       // Command exited with non-zero code
       case "pod-runner":
         return containerLogs || error.message
@@ -733,19 +736,6 @@ function handlePodError({
     command,
     exitCode: errorDetail.exitCode,
   }
-}
-
-function makeTimeOutErrorLog(containerLogs: string) {
-  return (
-    "Command timed out." + (containerLogs ? ` Here are the logs until the timeout occurred:\n\n${containerLogs}` : "")
-  )
-}
-
-function makeOutOfMemoryErrorLog(containerLogs?: string) {
-  return (
-    "The Pod container was OOMKilled." +
-    (containerLogs ? ` Here are the logs until the out-of-memory event occurred:\n\n${containerLogs}` : "")
-  )
 }
 
 class PodRunnerParams {

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -415,11 +415,8 @@ async function runWithoutArtifacts({
       version,
     }
   } catch (err) {
-    const containerLogs = err.detail.logs
-
     result = await runner.handlePodError({
       err,
-      containerLogs,
       command: runner.getFullCommand(),
       startedAt,
       version,
@@ -613,11 +610,8 @@ async function runWithArtifacts({
         version,
       }
     } catch (err) {
-      const containerLogs = await runner.getMainContainerLogs()
-
       result = await runner.handlePodError({
         err,
-        containerLogs,
         command: cmd,
         startedAt,
         version,
@@ -1036,14 +1030,12 @@ export class PodRunner extends PodRunnerParams {
 
   async handlePodError({
     err,
-    containerLogs,
     command,
     startedAt,
     version,
     moduleName,
   }: {
     err: any
-    containerLogs: string
     command: string[]
     startedAt: Date
     version: string
@@ -1051,7 +1043,7 @@ export class PodRunner extends PodRunnerParams {
   }) {
     const errorDetail = <PodErrorDetails>err.detail
     // Error detail may already contain container logs
-    const logs = errorDetail.logs || containerLogs
+    const logs = errorDetail.logs || (await this.getMainContainerLogs())
 
     const renderError = (error: any, podErrorDetails: PodErrorDetails) => {
       switch (error.type) {

--- a/core/test/integ/src/plugins/kubernetes/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/run.ts
@@ -257,7 +257,7 @@ describe("kubernetes Pod runner functions", () => {
         expect(res.success).to.be.true
       })
 
-      it("returns success=false if Pod returns with non-zero exit code", async () => {
+      it("throws if Pod returns with non-zero exit code", async () => {
         const pod = makePod(["sh", "-c", "echo foo && exit 1"])
 
         runner = new PodRunner({
@@ -268,10 +268,10 @@ describe("kubernetes Pod runner functions", () => {
           provider,
         })
 
-        const res = await runner.runAndWait({ log, remove: true, tty: false, events: ctx.events })
-
-        expect(res.log.trim()).to.equal("foo")
-        expect(res.success).to.be.false
+        await expectError(
+          () => runner.runAndWait({ log, remove: true, tty: false, events: ctx.events }),
+          (err) => expect(err.message.trim()).to.equal("Command exited with code 1:\nfoo")
+        )
       })
 
       it("throws if Pod is invalid", async () => {

--- a/core/test/integ/src/plugins/kubernetes/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/run.ts
@@ -990,6 +990,7 @@ describe("kubernetes Pod runner functions", () => {
       const task = graph.getTask("artifacts-task")
       const module = task.module
 
+      const timeout = 4
       const result = await runAndCopy({
         ctx: await garden.getPluginContext(provider),
         log: garden.log,
@@ -1000,12 +1001,12 @@ describe("kubernetes Pod runner functions", () => {
         namespace,
         runtimeContext: { envVars: {}, dependencies: [] },
         image,
-        timeout: 4,
+        timeout,
         version: module.version.versionString,
       })
 
       // Note: Kubernetes doesn't always return the logs when commands time out.
-      expect(result.log.trim()).to.include("Command timed out.")
+      expect(result.log.trim()).to.include(`Command timed out after ${timeout} seconds.`)
       expect(result.success).to.be.false
     })
 
@@ -1161,6 +1162,7 @@ describe("kubernetes Pod runner functions", () => {
         const task = graph.getTask("artifacts-task")
         const module = task.module
 
+        const timeout = 3
         const result = await runAndCopy({
           ctx: await garden.getPluginContext(provider),
           log: garden.log,
@@ -1173,11 +1175,13 @@ describe("kubernetes Pod runner functions", () => {
           artifacts: task.spec.artifacts,
           artifactsPath: tmpDir.path,
           image,
-          timeout: 3,
+          timeout,
           version: module.version.versionString,
         })
 
-        expect(result.log.trim()).to.equal("Command timed out. Here are the logs until the timeout occurred:\n\nbanana")
+        expect(result.log.trim()).to.equal(
+          `Command timed out after ${timeout} seconds. Here are the logs until the timeout occurred:\n\nbanana`
+        )
         expect(result.success).to.be.false
       })
 
@@ -1185,6 +1189,7 @@ describe("kubernetes Pod runner functions", () => {
         const task = graph.getTask("artifacts-task")
         const module = task.module
 
+        const timeout = 3
         const result = await runAndCopy({
           ctx: await garden.getPluginContext(provider),
           log: garden.log,
@@ -1197,11 +1202,11 @@ describe("kubernetes Pod runner functions", () => {
           artifacts: task.spec.artifacts,
           artifactsPath: tmpDir.path,
           image,
-          timeout: 3,
+          timeout,
           version: module.version.versionString,
         })
 
-        expect(result.log.trim()).to.equal("Command timed out.")
+        expect(result.log.trim()).to.equal(`Command timed out after ${timeout} seconds.`)
         expect(await pathExists(join(tmpDir.path, "task.txt"))).to.be.true
         expect(result.success).to.be.false
       })


### PR DESCRIPTION
**What this PR does / why we need it**:
* Refactored error handling and log retrieval for `garden run` and `garden test` commands.
* Aligned error code handling for running tests with and without artifacts.
* Extracted a number of helper functions to avoid too long function bodies

See individual commits for more details.

**Which issue(s) this PR fixes**:

Fixes #3330.

This should partially resolve the issues reported in #3330. The error messages now are more structured and should be more informative. However, mappings between K8s errors and suggested solutions haven't been implemented yet. It's expected to be done in #3254.

Partially resolves #3297.

This PR also fixes flaky-tests like [this](https://app.circleci.com/pipelines/github/garden-io/garden/13888/workflows/f3ae8d4e-48f3-4bc3-a604-7016d52d4012/jobs/232512) (https://github.com/garden-io/garden/commit/9de010466794b220a664c8260751403998797bbf).

**Special notes for your reviewer**:
Note, that there is still an issue with duplicate logs printed on failures of the `garden run` command. Verified with `garden run task` and `garden run test` sub-commands.

There are some open discussions to clarify the ideas behind the changes made.

Manual tests can be found in [this branch](https://github.com/garden-io/garden/tree/refactor/run-and-test-logs-manual-test).