### PR TITLE
chore: remove dns-lookup-cache

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -59,7 +59,6 @@
     "deline": "^1.0.4",
     "dependency-graph": "^0.9.0",
     "directory-tree": "^2.2.4",
-    "dns-lookup-cache": "^1.0.4",
     "docker-file-parser": "^1.0.4",
     "dockerode": "^3.2.0",
     "dotenv": "^16.0.0",

--- a/core/src/plugins/kubernetes/api.ts
+++ b/core/src/plugins/kubernetes/api.ts
@@ -40,7 +40,6 @@ import request = require("request-promise")
 import requestErrors = require("request-promise/errors")
 import { safeLoad } from "js-yaml"
 import { readFile } from "fs-extra"
-import { lookup } from "dns-lookup-cache"
 
 import { Omit, safeDumpYaml, StringCollector, sleep } from "../../util/util"
 import { omitBy, isObject, isPlainObject, keyBy, flatten } from "lodash"
@@ -82,7 +81,7 @@ const cachedApiInfo: { [context: string]: ApiInfo } = {}
 const cachedApiResourceInfo: { [context: string]: ApiResourceMap } = {}
 const apiInfoLock = new AsyncLock()
 
-const requestAgent = new Agent({ lookup })
+const requestAgent = new Agent({})
 
 // NOTE: be warned, the API of the client library is very likely to change
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6892,14 +6892,6 @@ dns-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d"
   integrity sha1-s55/HabrCnW6nBcySzR1PEfgZU0=
 
-dns-lookup-cache@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/dns-lookup-cache/-/dns-lookup-cache-1.0.4.tgz#fab28a97ef320215d9255ce866b7dc769acf1762"
-  integrity sha512-528ydOnvZQ+a0f+BfmBU4A5zGb05uvwxN/u96/yQdSA7Z8uwDXHXJ+FEPl5UI91Ga7SNyDT4csL9x4pWMHMCyg==
-  dependencies:
-    lodash "^4.17.11"
-    rr "^0.1.0"
-
 dns-packet@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-1.3.1.tgz#12aa426981075be500b910eedcd0b47dd7deda5a"
@@ -16304,11 +16296,6 @@ roarr@^2.15.3:
     json-stringify-safe "^5.0.1"
     semver-compare "^1.0.0"
     sprintf-js "^1.1.2"
-
-rr@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/rr/-/rr-0.1.0.tgz#a18ec25ec94a67c35f210bb3a85d17914e79cd1e"
-  integrity sha1-oY7CXslKZ8NfIQuzqF0XkU55zR4=
 
 rsvp@^4.8.4:
   version "4.8.5"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Fixes the regression in local Docker Desktop Kubernetes introduced in https://github.com/garden-io/garden/pull/3374 due to some adverse interaction with the DNS caching library we used.

**Which issue(s) this PR fixes**:

Replaces the need to revert the changes with https://github.com/garden-io/garden/pull/3387

**Special notes for your reviewer**:

The `dns-lookup-cache` library has its latest commit at nearly 3 years ago, so we should remove it anyway. If we absolutely need a DNS caching solution, we should figure out an alternative.