### PR TITLE
fix: do not log failed log connection attempt

### DIFF
--- a/core/src/plugins/kubernetes/logs.ts
+++ b/core/src/plugins/kubernetes/logs.ts
@@ -360,9 +360,12 @@ export class K8sLogFollower<T> {
         this.log.silly(`<Connected to container '${containerName}' in Pod '${pod.metadata.name}'>`)
       } catch (err) {
         // Log the error and keep trying.
-        this.log.debug(
-          `<Getting logs for container '${containerName}' in Pod '${pod.metadata.name}' failed with error: ${err?.message}>`
-        )
+        // If the error is "HTTP request failed" most likely the pod is just not up yet
+        if (err.message !== "HTTP request failed") {
+          this.log.debug(
+            `<Getting logs for container '${containerName}' in Pod '${pod.metadata.name}' failed with error: ${err?.message}>`
+          )
+        }
         return
       }
       this.connections[connectionId] = {


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/garden-io/garden/pull/3374 where each time garden attempts to follow logs from newly deployed service about 20-200 lines of debug level logs are printed with the same message.

The logic is meant to retry the connection until it succeeds and it doesn't make sense to log the generic http error as it means the pod is just not up yet.

Before the kubernetes client library update there was a separate callback for connection failed, now it's all the same promise rejection so it has to be handled separately.