### PR TITLE
feat(k8s): custom nodeSelector for util pods

### DIFF
--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -706,18 +706,18 @@ export const kubernetesConfigBase = () =>
           ),
         nodeSelector: joiStringMap(joi.string()).description(
           dedent`
-            Exposes the \`nodeSelector\` field on the PodSpec of the Kaniko pods. This allows you to constrain the Kaniko pods to only run on particular nodes.
+            Exposes the \`nodeSelector\` field on the PodSpec of the Kaniko pods. This allows you to constrain the Kaniko pods to only run on particular nodes. The same nodeSelector will be used for each util pod unless they are specifically set under \`util.nodeSelector\`.
 
             [See here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) for the official Kubernetes guide to assigning pods to nodes.
           `
         ),
         tolerations: joiSparseArray(tolerationSchema()).description(
           deline`Specify tolerations to apply to each Kaniko builder pod. Useful to control which nodes in a cluster can run builds.
-          Same tolerations will be used for the util pod unless they are specifically set under \`util.tolerations\``
+          The same tolerations will be used for each util pod unless they are specifically set under \`util.tolerations\``
         ),
         annotations: annotationsSchema().description(
           deline`Specify annotations to apply to each Kaniko builder pod. Annotations may have an effect on the behaviour of certain components, for example autoscalers.
-          Same annotations will be used for each util pod unless they are specifically set under \`util.annotations\``
+          The same annotations will be used for each util pod unless they are specifically set under \`util.annotations\``
         ),
         util: joi.object().keys({
           tolerations: joiSparseArray(tolerationSchema()).description(

--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -232,6 +232,7 @@ export interface KubernetesConfig extends BaseProviderConfig {
     util?: {
       tolerations?: V1Toleration[]
       annotations?: StringMap
+      nodeSelector?: StringMap
     }
   }
   context: string
@@ -716,7 +717,7 @@ export const kubernetesConfigBase = () =>
         ),
         annotations: annotationsSchema().description(
           deline`Specify annotations to apply to each Kaniko builder pod. Annotations may have an effect on the behaviour of certain components, for example autoscalers.
-          Same anotations will be used for each util pod unless they are specifically set under \`util.annotations\``
+          Same annotations will be used for each util pod unless they are specifically set under \`util.annotations\``
         ),
         util: joi.object().keys({
           tolerations: joiSparseArray(tolerationSchema()).description(
@@ -724,6 +725,9 @@ export const kubernetesConfigBase = () =>
           ),
           annotations: annotationsSchema().description(
             "Specify annotations to apply to each garden-util pod and deployments."
+          ),
+          nodeSelector: joiStringMap(joi.string()).description(
+            "Specify the nodeSelector constraints for each garden-util pod."
           ),
         }),
       })

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -583,8 +583,9 @@ export function getUtilManifests(
   }
 
   // Set the configured nodeSelector, if any
-  if (!isEmpty(provider.config.kaniko?.nodeSelector)) {
-    deployment.spec!.template.spec!.nodeSelector = provider.config.kaniko?.nodeSelector
+  const nodeSelector = provider.config.kaniko?.util?.nodeSelector || provider.config.kaniko?.nodeSelector
+  if (!isEmpty(nodeSelector)) {
+    deployment.spec!.template.spec!.nodeSelector = nodeSelector
   }
 
   return { deployment, service }

--- a/core/test/unit/src/plugins/kubernetes/container/build/common.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/build/common.ts
@@ -181,7 +181,8 @@ describe("common build", () => {
       const podAnnotations = result.deployment.spec.template.metadata?.annotations
       expect(podAnnotations).to.eql(provider.config.kaniko.annotations)
     })
-    it("should return the manifest with kaniko annotations when util annotations are specified", () => {
+
+    it("should return the manifest with util annotations when util annotations are specified", () => {
       provider.config.kaniko = {
         util: {
           annotations: {
@@ -196,6 +197,28 @@ describe("common build", () => {
 
       const podAnnotations = result.deployment.spec.template.metadata?.annotations
       expect(podAnnotations).to.eql(provider.config.kaniko.util?.annotations)
+    })
+
+    it("should return the manifest with kaniko nodeSelector when util nodeSelector is missing", () => {
+      provider.config.kaniko = {
+        nodeSelector: { "kubernetes.io/os": "linux" },
+      }
+      const result = getUtilManifests(provider, "test", [])
+
+      const podNodeSelector = result.deployment.spec.template.spec?.nodeSelector
+      expect(podNodeSelector).to.eql(provider.config.kaniko.nodeSelector)
+    })
+
+    it("should return the manifest with util nodeSelector when util nodeSelector is specified", () => {
+      provider.config.kaniko = {
+        util: {
+          nodeSelector: { "kubernetes.io/os": "linux" },
+        },
+      }
+      const result = getUtilManifests(provider, "test", [])
+
+      const podNodeSelector = result.deployment.spec.template.spec?.nodeSelector
+      expect(podNodeSelector).to.eql(provider.config.kaniko.util?.nodeSelector)
     })
   })
 })

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -230,14 +230,15 @@ providers:
       namespace: garden-system
 
       # Exposes the `nodeSelector` field on the PodSpec of the Kaniko pods. This allows you to constrain the Kaniko
-      # pods to only run on particular nodes.
+      # pods to only run on particular nodes. The same nodeSelector will be used for each util pod unless they are
+      # specifically set under `util.nodeSelector`.
       #
       # [See here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) for the official Kubernetes
       # guide to assigning pods to nodes.
       nodeSelector:
 
       # Specify tolerations to apply to each Kaniko builder pod. Useful to control which nodes in a cluster can run
-      # builds. Same tolerations will be used for the util pod unless they are specifically set under
+      # builds. The same tolerations will be used for each util pod unless they are specifically set under
       # `util.tolerations`
       tolerations:
         - # "Effect" indicates the taint effect to match. Empty means match all taint effects. When specified,
@@ -266,8 +267,8 @@ providers:
           value:
 
       # Specify annotations to apply to each Kaniko builder pod. Annotations may have an effect on the behaviour of
-      # certain components, for example autoscalers. Same annotations will be used for each util pod unless they are
-      # specifically set under `util.annotations`
+      # certain components, for example autoscalers. The same annotations will be used for each util pod unless they
+      # are specifically set under `util.annotations`
       annotations:
 
       util:
@@ -1128,7 +1129,7 @@ Choose the namespace where the Kaniko pods will be run. Set to `null` to use the
 
 [providers](#providers) > [kaniko](#providerskaniko) > nodeSelector
 
-Exposes the `nodeSelector` field on the PodSpec of the Kaniko pods. This allows you to constrain the Kaniko pods to only run on particular nodes.
+Exposes the `nodeSelector` field on the PodSpec of the Kaniko pods. This allows you to constrain the Kaniko pods to only run on particular nodes. The same nodeSelector will be used for each util pod unless they are specifically set under `util.nodeSelector`.
 
 [See here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) for the official Kubernetes guide to assigning pods to nodes.
 
@@ -1140,7 +1141,7 @@ Exposes the `nodeSelector` field on the PodSpec of the Kaniko pods. This allows 
 
 [providers](#providers) > [kaniko](#providerskaniko) > tolerations
 
-Specify tolerations to apply to each Kaniko builder pod. Useful to control which nodes in a cluster can run builds. Same tolerations will be used for the util pod unless they are specifically set under `util.tolerations`
+Specify tolerations to apply to each Kaniko builder pod. Useful to control which nodes in a cluster can run builds. The same tolerations will be used for each util pod unless they are specifically set under `util.tolerations`
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
@@ -1208,7 +1209,7 @@ otherwise just a regular string.
 
 [providers](#providers) > [kaniko](#providerskaniko) > annotations
 
-Specify annotations to apply to each Kaniko builder pod. Annotations may have an effect on the behaviour of certain components, for example autoscalers. Same annotations will be used for each util pod unless they are specifically set under `util.annotations`
+Specify annotations to apply to each Kaniko builder pod. Annotations may have an effect on the behaviour of certain components, for example autoscalers. The same annotations will be used for each util pod unless they are specifically set under `util.annotations`
 
 | Type     | Required |
 | -------- | -------- |

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -266,7 +266,7 @@ providers:
           value:
 
       # Specify annotations to apply to each Kaniko builder pod. Annotations may have an effect on the behaviour of
-      # certain components, for example autoscalers. Same anotations will be used for each util pod unless they are
+      # certain components, for example autoscalers. Same annotations will be used for each util pod unless they are
       # specifically set under `util.annotations`
       annotations:
 
@@ -300,6 +300,9 @@ providers:
 
         # Specify annotations to apply to each garden-util pod and deployments.
         annotations:
+
+        # Specify the nodeSelector constraints for each garden-util pod.
+        nodeSelector:
 
     # A default hostname to use when no hostname is explicitly configured for a service.
     defaultHostname:
@@ -1205,7 +1208,7 @@ otherwise just a regular string.
 
 [providers](#providers) > [kaniko](#providerskaniko) > annotations
 
-Specify annotations to apply to each Kaniko builder pod. Annotations may have an effect on the behaviour of certain components, for example autoscalers. Same anotations will be used for each util pod unless they are specifically set under `util.annotations`
+Specify annotations to apply to each Kaniko builder pod. Annotations may have an effect on the behaviour of certain components, for example autoscalers. Same annotations will be used for each util pod unless they are specifically set under `util.annotations`
 
 | Type     | Required |
 | -------- | -------- |
@@ -1318,6 +1321,16 @@ providers:
         annotations:
             cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
 ```
+
+### `providers[].kaniko.util.nodeSelector`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [util](#providerskanikoutil) > nodeSelector
+
+Specify the nodeSelector constraints for each garden-util pod.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
 
 ### `providers[].defaultHostname`
 

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -262,7 +262,7 @@ providers:
           value:
 
       # Specify annotations to apply to each Kaniko builder pod. Annotations may have an effect on the behaviour of
-      # certain components, for example autoscalers. Same anotations will be used for each util pod unless they are
+      # certain components, for example autoscalers. Same annotations will be used for each util pod unless they are
       # specifically set under `util.annotations`
       annotations:
 
@@ -296,6 +296,9 @@ providers:
 
         # Specify annotations to apply to each garden-util pod and deployments.
         annotations:
+
+        # Specify the nodeSelector constraints for each garden-util pod.
+        nodeSelector:
 
     # A default hostname to use when no hostname is explicitly configured for a service.
     defaultHostname:
@@ -1154,7 +1157,7 @@ otherwise just a regular string.
 
 [providers](#providers) > [kaniko](#providerskaniko) > annotations
 
-Specify annotations to apply to each Kaniko builder pod. Annotations may have an effect on the behaviour of certain components, for example autoscalers. Same anotations will be used for each util pod unless they are specifically set under `util.annotations`
+Specify annotations to apply to each Kaniko builder pod. Annotations may have an effect on the behaviour of certain components, for example autoscalers. Same annotations will be used for each util pod unless they are specifically set under `util.annotations`
 
 | Type     | Required |
 | -------- | -------- |
@@ -1267,6 +1270,16 @@ providers:
         annotations:
             cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
 ```
+
+### `providers[].kaniko.util.nodeSelector`
+
+[providers](#providers) > [kaniko](#providerskaniko) > [util](#providerskanikoutil) > nodeSelector
+
+Specify the nodeSelector constraints for each garden-util pod.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
 
 ### `providers[].defaultHostname`
 

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -226,14 +226,15 @@ providers:
       namespace: garden-system
 
       # Exposes the `nodeSelector` field on the PodSpec of the Kaniko pods. This allows you to constrain the Kaniko
-      # pods to only run on particular nodes.
+      # pods to only run on particular nodes. The same nodeSelector will be used for each util pod unless they are
+      # specifically set under `util.nodeSelector`.
       #
       # [See here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) for the official Kubernetes
       # guide to assigning pods to nodes.
       nodeSelector:
 
       # Specify tolerations to apply to each Kaniko builder pod. Useful to control which nodes in a cluster can run
-      # builds. Same tolerations will be used for the util pod unless they are specifically set under
+      # builds. The same tolerations will be used for each util pod unless they are specifically set under
       # `util.tolerations`
       tolerations:
         - # "Effect" indicates the taint effect to match. Empty means match all taint effects. When specified,
@@ -262,8 +263,8 @@ providers:
           value:
 
       # Specify annotations to apply to each Kaniko builder pod. Annotations may have an effect on the behaviour of
-      # certain components, for example autoscalers. Same annotations will be used for each util pod unless they are
-      # specifically set under `util.annotations`
+      # certain components, for example autoscalers. The same annotations will be used for each util pod unless they
+      # are specifically set under `util.annotations`
       annotations:
 
       util:
@@ -1077,7 +1078,7 @@ Choose the namespace where the Kaniko pods will be run. Set to `null` to use the
 
 [providers](#providers) > [kaniko](#providerskaniko) > nodeSelector
 
-Exposes the `nodeSelector` field on the PodSpec of the Kaniko pods. This allows you to constrain the Kaniko pods to only run on particular nodes.
+Exposes the `nodeSelector` field on the PodSpec of the Kaniko pods. This allows you to constrain the Kaniko pods to only run on particular nodes. The same nodeSelector will be used for each util pod unless they are specifically set under `util.nodeSelector`.
 
 [See here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) for the official Kubernetes guide to assigning pods to nodes.
 
@@ -1089,7 +1090,7 @@ Exposes the `nodeSelector` field on the PodSpec of the Kaniko pods. This allows 
 
 [providers](#providers) > [kaniko](#providerskaniko) > tolerations
 
-Specify tolerations to apply to each Kaniko builder pod. Useful to control which nodes in a cluster can run builds. Same tolerations will be used for the util pod unless they are specifically set under `util.tolerations`
+Specify tolerations to apply to each Kaniko builder pod. Useful to control which nodes in a cluster can run builds. The same tolerations will be used for each util pod unless they are specifically set under `util.tolerations`
 
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
@@ -1157,7 +1158,7 @@ otherwise just a regular string.
 
 [providers](#providers) > [kaniko](#providerskaniko) > annotations
 
-Specify annotations to apply to each Kaniko builder pod. Annotations may have an effect on the behaviour of certain components, for example autoscalers. Same annotations will be used for each util pod unless they are specifically set under `util.annotations`
+Specify annotations to apply to each Kaniko builder pod. Annotations may have an effect on the behaviour of certain components, for example autoscalers. The same annotations will be used for each util pod unless they are specifically set under `util.annotations`
 
 | Type     | Required |
 | -------- | -------- |


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables customizing `nodeSelector` requirements for the `garden-util` pods when using `kaniko` in kubernetes.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Taking inspiration from https://github.com/garden-io/garden/pull/3365.

This is currently implemented on top of existing code. This means that we configure `nodeSelector` for the `util` manifests in the `common.ts` file, even if we only expose the configuration options under `kaniko.util` specifically. If we want to, we can later refactor this, for example move the configuration logic to `kaniko.ts` specifically, or keep the configuration reading logic in `common.ts` and move the `util` configurations upwards in the configmap, or something else.

I've also verified the PR locally by editing the `examples/demo-project/garden.yml` file
```
providers:
  - name: local-kubernetes
    environments: [local]
    buildMode: kaniko
    kaniko:
      util:
        nodeSelector:
          "kubernetes.io/os": "linux"
```

- using `"kubernetes.io/os": "linux"` to verify a successful local deployment
- using `"kubernetes.io/os": "macos"` to verify an unsuccessful deployment due to no matching nodes being available.

---

Please let me know if I missed anything!