### PR TITLE
ci(gke): clean up old namespaces

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,7 @@ commands:
             sudo ln -s "$NVM_DIR/versions/node/$(nvm version)/bin/npm" "/usr/local/bin/npm"
             sudo npm install -g yarn
 
-  configure_kubectl_context:
+  configure_remote_cluster:
     description: Configure the kubectl context via gcloud so that we can access our remote cluster. Used for e2e testing.
     steps:
       - run:
@@ -201,6 +201,19 @@ commands:
             gcloud --quiet config set compute/zone $GOOGLE_COMPUTE_ZONE
             gcloud --quiet container clusters get-credentials $GOOGLE_CLUSTER_ID --zone $GOOGLE_COMPUTE_ZONE
             gcloud --quiet auth configure-docker
+
+  cleanup_remote_cluster:
+    description: Clean up namespaces in the ci cluster on gcloud (to be used with configure_remote_cluster)
+    steps:
+      - run:
+          name: Delete current namespace
+          command: kubectl get ns | grep ${CIRCLE_BUILD_NUM} | awk '{print $1}' | xargs -n 1 kubectl delete namespace --wait=false || true
+          when: always
+      - run:
+          name: Delete namespaces older than 1 hour
+          # hack: find namespaces that contain '-ci' and their age ends with h or d, e.g. 1d5h or 24h
+          command: kubectl get ns | grep -E '(d|h)$' | grep -- '-ci' | awk '{print $1}' | xargs -n 1 kubectl delete namespace --wait=false || true
+          when: always
 
   build_dist:
     description: Package built code into executables and persist to dist directory
@@ -336,7 +349,7 @@ jobs:
     steps:
       - checkout
       - npm_install
-      - configure_kubectl_context
+      - configure_remote_cluster
       - docker_login
       - *attach-workspace
       - run:
@@ -346,10 +359,7 @@ jobs:
           name: Run e2e test
           command: |
             yarn e2e-project --project=<<parameters.project>> --env=<<parameters.environment>>
-      - run:
-          name: Cleanup
-          command: kubectl delete --wait=false $(kubectl get ns -o name | grep $CIRCLE_BUILD_NUM) || true
-          when: always
+      - cleanup_remote_cluster
 
   build-docker-alpine:
     <<: *node-config
@@ -465,16 +475,13 @@ jobs:
     steps:
       # Need to checkout to run example project
       - checkout
-      - configure_kubectl_context
+      - configure_remote_cluster
       - *attach-workspace
       - run:
           name: Deploy demo-project with container
           # overriding CIRCLE_BUILD_NUM to avoid conflict with other tests
           command: CIRCLE_BUILD_NUM=$CIRCLE_BUILD_NUM-docker /garden/garden build --root examples/demo-project --env remote --logger-type basic
-      - run:
-          name: Cleanup
-          command: CIRCLE_BUILD_NUM=$CIRCLE_BUILD_NUM-docker kubectl delete --wait=false $(kubectl get ns -o name | grep demo-project-$CIRCLE_BUILD_NUM) || true
-          when: always
+      - cleanup_remote_cluster
 
   release-service-docker:
     <<: *node-config
@@ -542,7 +549,7 @@ jobs:
     steps:
       # Need to checkout to run example project
       - checkout
-      - configure_kubectl_context
+      - configure_remote_cluster
       - *attach-workspace
       - run:
           name: Test that the binary works with the fancy logger enabled
@@ -558,10 +565,7 @@ jobs:
           name: Deploy demo-project with binary
           # overriding CIRCLE_BUILD_NUM to avoid conflict with other tests
           command: CIRCLE_BUILD_NUM=$CIRCLE_BUILD_NUM-dist dist/linux-amd64/garden deploy --root examples/demo-project --env remote --logger-type basic
-      - run:
-          name: Cleanup
-          command: CIRCLE_BUILD_NUM=$CIRCLE_BUILD_NUM-dist kubectl delete --wait=false $(kubectl get ns -o name | grep demo-project-$CIRCLE_BUILD_NUM) || true
-          when: always
+      - cleanup_remote_cluster
 
   test-plugins:
     machine:
@@ -790,14 +794,11 @@ jobs:
             tar xzf google-cloud-sdk-390.0.0-darwin-x86_64.tar.gz
             echo 'export PATH=$HOME/google-cloud-sdk/bin:$PATH' >> $BASH_ENV
       - docker_login
-      - configure_kubectl_context
+      - configure_remote_cluster
       - run:
           name: Deploy demo-project
           command: CIRCLE_BUILD_NUM=$CIRCLE_BUILD_NUM-macos dist/macos-amd64/garden deploy --root examples/demo-project --logger-type basic --env remote
-      - run:
-          name: Cleanup
-          command: kubectl delete --wait=false $(kubectl get ns -o name | grep $CIRCLE_BUILD_NUM-macos) || true
-          when: always
+      - cleanup_remote_cluster
 
   test-windows:
     executor: win/default


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

This enhances the cleanup routines for the shared ci cluster so
we actually remove namespaces that are older than 1h additionally to
the current build namespaces.

These old namespaces can pile up because the cleanup commands will not be executed by circleci, despite `when: always`. We often have auto-cancelled jobs when developer pushes a new commit while the workflows are still running.

<img width="2120" alt="Screenshot 2022-11-30 at 16 39 32" src="https://user-images.githubusercontent.com/139624/204842254-e466f9fe-47fd-45ec-89ff-77ef690492e9.png">

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
