### PR TITLE
fix(framework): idempotent config store deletes

### DIFF
--- a/core/src/config-store.ts
+++ b/core/src/config-store.ts
@@ -82,7 +82,8 @@ export abstract class ConfigStore<T extends object = any> {
   public async delete(keyPath: string[]) {
     let config = await this.getConfig()
     if (get(config, keyPath) === undefined) {
-      this.throwKeyNotFound(config, keyPath)
+      // Nothing to do
+      return
     }
     const success = unset(config, keyPath)
     if (!success) {

--- a/core/test/unit/src/config-store.ts
+++ b/core/test/unit/src/config-store.ts
@@ -141,15 +141,9 @@ describe("ConfigStore", () => {
       throw new Error("Expected error, got " + res)
     })
 
-    it("should throw if key is not found", async () => {
-      let res
-      try {
-        res = await config.delete(["key"])
-      } catch (err) {
-        expect(err.type).to.equal("local-config")
-        return
-      }
-      throw new Error("Expected error, got " + res)
+    it("should return undefined if key is not found", async () => {
+      const res = await config.delete(["key"])
+      expect(res).to.be.undefined
     })
   })
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Previously the ConfigStore class would throw if attempting to delete an entry with a key that doesn't exist.

So e.g. running delete twice on the same key would fail the second time.

I'm 99.9% sure this that is just a mistake that was made years ago and hasn't surfaced before.

This fix is needed to handle a test error on a different branch.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
