### PR TITLE
fix(logger): ensure fancy logger doesn't erease new entries

### DIFF
--- a/core/src/logger/writers/fancy-terminal-writer.ts
+++ b/core/src/logger/writers/fancy-terminal-writer.ts
@@ -132,8 +132,9 @@ export class FancyTerminalWriter extends Writer {
     const nextEntryLineNumber = allLines.length >= this.prevOutput.length ? nextEntry.lineNumber : 0
     const terminalHeight = process.stdout.rows
     const nextEntryIsInViewport = nextEntryLineNumber >= allLines.length - terminalHeight - 1
+    const nextEntryIsNew = nextEntryLineNumber >= this.prevOutput.length - 1
 
-    // If the next entry is in the viewport, we clear the terminal from the bottom
+    // If the next entry is new, or in the viewport, we clear the terminal from the bottom
     // and up towards the entry, and then render it alongside the subsequent entries.
     //
     // This applies to entries that are being updated and have content below them
@@ -142,7 +143,7 @@ export class FancyTerminalWriter extends Writer {
     // This is the "legacy" render method.
     //
     // Terminal height may not always be defined, in which case we also fallback to this method.
-    if (nextEntryIsInViewport || !terminalHeight || gardenEnv.GARDEN_LEGACY_FANCY_LOG_RENDER) {
+    if (nextEntryIsNew || nextEntryIsInViewport || !terminalHeight || gardenEnv.GARDEN_LEGACY_FANCY_LOG_RENDER) {
       const nLinesToErase = this.prevOutput.length - nextEntryLineNumber
       out += ansiEscapes.eraseLines(nLinesToErase)
       out += allLines.slice(nextEntryLineNumber).join("\n")


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Fixes an edge case bug where the fancy logger used ansi escape codes to erase new entries that where much longer then the full terminal viewport.

Now we explicitly ensure that new lines get rendered at the bottom of the terminal without any ansi escape tricks.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
