### PR TITLE
improvement: decoupled the cloud api login from project configuration and verification

### DIFF
--- a/core/src/cloud/api.ts
+++ b/core/src/cloud/api.ts
@@ -108,7 +108,7 @@ export function getGardenCloudDomain(projectConfig?: ProjectResource): string | 
   if (gardenEnv.GARDEN_CLOUD_DOMAIN) {
     cloudDomain = new URL(gardenEnv.GARDEN_CLOUD_DOMAIN).origin
   } else if (projectConfig?.domain) {
-    cloudDomain = new URL(projectConfig?.domain).origin
+    cloudDomain = new URL(projectConfig.domain).origin
   }
 
   return cloudDomain

--- a/core/src/cloud/api.ts
+++ b/core/src/cloud/api.ts
@@ -107,7 +107,7 @@ export function getGardenCloudDomain(projectConfig?: ProjectResource): string | 
 
   if (gardenEnv.GARDEN_CLOUD_DOMAIN) {
     cloudDomain = new URL(gardenEnv.GARDEN_CLOUD_DOMAIN).origin
-  } else if (projectConfig?.domain) {
+  } else if (projectConfig.domain) {
     cloudDomain = new URL(projectConfig.domain).origin
   }
 
@@ -558,7 +558,11 @@ export class CloudApi {
   }
 
   async getProject() {
-    if (this._project) {
+    // If we are using a new project ID, retrieve again from the API
+    // NOTE: If we wan't to use this with multiple project IDs we need
+    // a cache supporting that + check if the remote project metadata
+    // was updated.
+    if (this._project && this._project.uid === this.projectId) {
       return this._project
     }
 

--- a/core/src/cloud/api.ts
+++ b/core/src/cloud/api.ts
@@ -9,8 +9,7 @@
 import { IncomingHttpHeaders } from "http"
 
 import { got, GotHeaders, GotHttpError, GotJsonOptions, GotResponse } from "../util/http"
-import { findProjectConfig } from "../config/base"
-import { CommandError, EnterpriseApiError } from "../exceptions"
+import { EnterpriseApiError } from "../exceptions"
 import { LogEntry } from "../logger/log-entry"
 import { gardenEnv } from "../constants"
 import type { ClientAuthToken as ClientAuthTokenType } from "../db/entities/client-auth-token"
@@ -21,6 +20,7 @@ import chalk from "chalk"
 import { GetProjectResponse, GetUserResponse } from "@garden-io/platform-api-types"
 import { getCloudDistributionName, getPackageVersion } from "../util/util"
 import { CommandInfo } from "../plugin-context"
+import { ProjectResource } from "../config/project"
 
 const gardenClientName = "garden-core"
 const gardenClientVersion = getPackageVersion()
@@ -95,24 +95,23 @@ export interface RegisterSessionResponse {
 }
 
 /**
- * A helper function that finds a project without resolving template strings and returns the enterprise
- * config. Needed since the EnterpriseApi is generally used before initializing the Garden class.
+ * A helper function to get the cloud domain from a project config. Uses the env var
+ * GARDEN_CLOUD_DOMAIN to override a configured domain.
  */
-export async function getEnterpriseConfig(currentDirectory: string) {
-  const projectConfig = await findProjectConfig(currentDirectory)
+export function getGardenCloudDomain(projectConfig?: ProjectResource): string | undefined {
   if (!projectConfig) {
-    throw new CommandError(`Not a project directory (or any of the parent directories): ${currentDirectory}`, {
-      currentDirectory,
-    })
+    return undefined
   }
 
-  const projectId = projectConfig.id
-  if (!projectId || !projectConfig.domain) {
-    return
+  let cloudDomain: string | undefined
+
+  if (gardenEnv.GARDEN_CLOUD_DOMAIN) {
+    cloudDomain = new URL(gardenEnv.GARDEN_CLOUD_DOMAIN).origin
+  } else if (projectConfig?.domain) {
+    cloudDomain = new URL(projectConfig?.domain).origin
   }
 
-  const domain = new URL(projectConfig.domain).origin
-  return { domain, projectId }
+  return cloudDomain
 }
 
 /**
@@ -129,18 +128,17 @@ export class CloudApi {
   private _project?: GetProjectResponse["data"]
   private _profile?: GetUserResponse["data"]
   public domain: string
-  public projectId: string
+  public projectId: string | undefined
 
   // Set when/if the Core session is registered with Cloud
   public environmentId?: number
   public namespaceId?: number
   public sessionRegistered = false
 
-  constructor(log: LogEntry, enterpriseDomain: string, projectId: string) {
+  constructor(log: LogEntry, enterpriseDomain: string) {
     this.log = log
     // TODO: Replace all instances of "enterpriseDomain" with "cloudDomain".
     this.domain = enterpriseDomain
-    this.projectId = projectId
   }
 
   /**
@@ -154,20 +152,14 @@ export class CloudApi {
    */
   static async factory({
     log,
-    currentDirectory,
+    cloudDomain,
     skipLogging = false,
   }: {
     log: LogEntry
-    currentDirectory: string
+    cloudDomain: string
     skipLogging?: boolean
   }) {
     log.debug("Initializing Garden Cloud API client.")
-
-    const config = await getEnterpriseConfig(currentDirectory)
-    if (!config) {
-      log.debug("Cloud/Enterprise domain and/or project ID missing. Aborting.")
-      return null
-    }
 
     const token = await CloudApi.getClientAuthTokenFromDb(log)
     if (!token && !gardenEnv.GARDEN_AUTH_TOKEN) {
@@ -175,10 +167,10 @@ export class CloudApi {
       return null
     }
 
-    const api = new CloudApi(log, config.domain, config.projectId)
+    const api = new CloudApi(log, cloudDomain)
     const tokenIsValid = await api.checkClientAuthToken()
 
-    const distroName = getCloudDistributionName(config.domain)
+    const distroName = getCloudDistributionName(api.domain)
     const section = distroName === "Garden Enterprise" ? "garden-enterprise" : "garden-cloud"
 
     const enterpriseLog = skipLogging ? null : log.info({ section, msg: "Authorizing...", status: "active" })
@@ -217,13 +209,6 @@ export class CloudApi {
     }
 
     enterpriseLog?.setSuccess({ msg: chalk.green("Done"), append: true })
-    try {
-      const project = await api.getProject()
-      const url = new URL(`/projects/${project.id}`, api.domain)
-      enterpriseLog?.info({ symbol: "info", msg: `Visit project at ${url.href}` })
-    } catch (err) {
-      log.debug(`Getting project from API failed with error: ${err.message}`)
-    }
 
     return api
   }
@@ -335,6 +320,17 @@ export class CloudApi {
     if (this.intervalId) {
       clearInterval(this.intervalId)
       this.intervalId = null
+    }
+  }
+
+  async ensureProject(projectId: string) {
+    try {
+      this.projectId = projectId
+      const project = await this.getProject()
+      return new URL(`/projects/${project.id}`, this.domain)
+    } catch (err) {
+      this.projectId = undefined
+      throw err
     }
   }
 

--- a/core/src/cloud/get-secrets.ts
+++ b/core/src/cloud/get-secrets.ts
@@ -15,16 +15,17 @@ import { getCloudDistributionName } from "../util/util"
 
 export interface GetSecretsParams {
   log: LogEntry
+  projectId: string
   environmentName: string
   cloudApi: CloudApi
 }
 
-export async function getSecrets({ log, environmentName, cloudApi }: GetSecretsParams): Promise<StringMap> {
+export async function getSecrets({ log, projectId, environmentName, cloudApi }: GetSecretsParams): Promise<StringMap> {
   let secrets: StringMap = {}
   const distroName = getCloudDistributionName(cloudApi.domain)
 
   try {
-    const res = await cloudApi.get<BaseResponse>(`/secrets/projectUid/${cloudApi.projectId}/env/${environmentName}`)
+    const res = await cloudApi.get<BaseResponse>(`/secrets/projectUid/${projectId}/env/${environmentName}`)
     secrets = res.data
   } catch (err) {
     if (isGotError(err, 404)) {

--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -79,4 +79,5 @@ export const gardenEnv = {
   // Allow users to fallback to "legacy" fancy writer render logic in case recent changes introduce
   // issues on terminals we haven't tested. We can remove again in v0.13.
   GARDEN_LEGACY_FANCY_LOG_RENDER: env.get("GARDEN_LEGACY_FANCY_LOG_RENDER").required(false).asBool(),
+  GARDEN_CLOUD_DOMAIN: env.get("GARDEN_CLOUD_DOMAIN").required(false).asUrlString(),
 }

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -108,7 +108,7 @@ import {
 } from "./config/module-template"
 import { TemplatedModuleConfig } from "./plugins/templated"
 import { BuildDirRsync } from "./build-staging/rsync"
-import { CloudApi } from "./cloud/api"
+import { CloudApi, getGardenCloudDomain } from "./cloud/api"
 import { DefaultEnvironmentContext, RemoteSourceConfigContext } from "./config/template-contexts/project"
 import { OutputConfigContext } from "./config/template-contexts/module"
 import { ProviderConfigContext } from "./config/template-contexts/provider"
@@ -1281,7 +1281,12 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
 
   let secrets: StringMap = {}
   const cloudApi = opts.cloudApi || null
-  const cloudDomain = cloudApi?.domain
+  // fall back to get the domain from config if the cloudApi instance failed
+  // to login or was not defined
+  const cloudDomain = cloudApi?.domain || getGardenCloudDomain(config)
+
+  // The cloudApi instance only has a project ID when the configured ID has
+  // been verified against the cloud instance.
   const cloudProjectId: string | undefined = config.id
 
   if (!opts.noEnterprise && cloudApi) {
@@ -1360,8 +1365,8 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
     vcsInfo,
     sessionId,
     disablePortForwards,
-    projectId: cloudApi?.projectId,
-    enterpriseDomain: config.domain,
+    projectId: cloudProjectId,
+    enterpriseDomain: cloudDomain,
     projectRoot,
     projectName,
     environmentName,

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -1304,10 +1304,10 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
         cloudLog.debug(`Getting project from API failed with error: ${err.message}`)
       }
 
-      // Only fetch secrets if the projectId existed in the cloud instance
+      // Only fetch secrets if the projectId exists in the cloud API instance
       if (cloudApi.projectId) {
         try {
-          secrets = await getSecrets({ log: cloudLog, projectId: cloudApi.projectId, environmentName, cloudApi })
+          secrets = await getSecrets({ log: cloudLog, projectId: cloudProjectId, environmentName, cloudApi })
           cloudLog.setSuccess({ msg: chalk.green("Ready"), append: true })
           cloudLog.silly(`Fetched ${Object.keys(secrets).length} secrets from ${cloudDomain}`)
         } catch (err) {

--- a/core/test/data/test-projects/login/has-domain/garden.yml
+++ b/core/test/data/test-projects/login/has-domain/garden.yml
@@ -2,4 +2,4 @@ kind: Project
 name: login
 domain: http://dummy-domain.com
 environments:
-  - test
+  - name: test

--- a/core/test/data/test-projects/login/missing-domain/garden.yml
+++ b/core/test/data/test-projects/login/missing-domain/garden.yml
@@ -1,4 +1,4 @@
 kind: Project
 name: login
 environments:
-  - test
+  - name: test

--- a/core/test/data/test-projects/login/secret-in-project-variables/garden.yml
+++ b/core/test/data/test-projects/login/secret-in-project-variables/garden.yml
@@ -3,6 +3,6 @@ name: login
 domain: http://dummy-domain.com
 id: dummy-id
 environments:
-  - test
+  - name: test
 variables:
   foo: ${secrets.foo}

--- a/core/test/helpers.ts
+++ b/core/test/helpers.ts
@@ -654,16 +654,19 @@ export async function cleanupAuthTokens() {
 }
 
 export function makeCommandParams<T extends Parameters = {}, U extends Parameters = {}>({
+  cli,
   garden,
   args,
   opts,
 }: {
+  cli?: GardenCli
   garden: Garden
   args: T
   opts: U
 }): CommandParams<T, U> {
   const log = garden.log
   return {
+    cli,
     garden,
     log,
     headerLog: log,

--- a/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
@@ -318,7 +318,7 @@ describe("deployHelmService", () => {
   })
 
   it("should mark a chart that has been paused by Garden Cloud AEC as outdated", async () => {
-    const fakeCloudApi = new CloudApi(getLogger().placeholder(), "https://test.cloud.garden.io", "project-id")
+    const fakeCloudApi = new CloudApi(getLogger().placeholder(), "https://test.cloud.garden.io")
     const projectRoot = resolve(dataDir, "test-projects", "helm")
     const gardenWithCloudApi = await makeTestGarden(projectRoot, { cloudApi: fakeCloudApi, noCache: true })
 

--- a/core/test/unit/src/analytics/analytics.ts
+++ b/core/test/unit/src/analytics/analytics.ts
@@ -18,10 +18,11 @@ import { CloudApi } from "../../../../src/cloud/api"
 import { LogEntry } from "../../../../src/logger/log-entry"
 import { Logger, LogLevel } from "../../../../src/logger/logger"
 import { AnalyticsGlobalConfig } from "../../../../src/config-store"
+import { ProjectResource } from "../../../../src/config/project"
 
 class FakeCloudApi extends CloudApi {
-  static async factory(params: { log: LogEntry; currentDirectory: string; skipLogging?: boolean }) {
-    return new FakeCloudApi(params.log, "my-project-id-1234", "https://garden.io")
+  static async factory(params: { log: LogEntry; projectConfig?: ProjectResource; skipLogging?: boolean }) {
+    return new FakeCloudApi(params.log, "https://garden.io")
   }
   async getProfile() {
     return {
@@ -266,7 +267,7 @@ describe("AnalyticsHandler", () => {
         writers: [],
         storeEntries: false,
       })
-      const cloudApi = await FakeCloudApi.factory({ log: logger.placeholder(), currentDirectory: "" })
+      const cloudApi = await FakeCloudApi.factory({ log: logger.placeholder() })
       garden = await makeTestGardenA(undefined, { cloudApi })
       garden.vcsInfo.originUrl = remoteOriginUrl
       await enableAnalytics(garden)

--- a/core/test/unit/src/commands/logout.ts
+++ b/core/test/unit/src/commands/logout.ts
@@ -8,7 +8,7 @@
 
 import { expect } from "chai"
 import td from "testdouble"
-import { getDataDir, cleanupAuthTokens, makeCommandParams } from "../../../helpers"
+import { getDataDir, cleanupAuthTokens, makeCommandParams, TestGardenCli } from "../../../helpers"
 import { makeDummyGarden } from "../../../../src/cli/cli"
 import { ClientAuthToken } from "../../../../src/db/entities/client-auth-token"
 import { randomString } from "../../../../src/util/string"
@@ -16,9 +16,11 @@ import { CloudApi } from "../../../../src/cloud/api"
 import { LogLevel } from "../../../../src/logger/logger"
 import { LogOutCommand } from "../../../../src/commands/logout"
 import { getLogMessages } from "../../../../src/util/testing"
+import { ensureConnected } from "../../../../src/db/connection"
 
 describe("LogoutCommand", () => {
   beforeEach(async () => {
+    await ensureConnected()
     await cleanupAuthTokens()
   })
 
@@ -35,6 +37,7 @@ describe("LogoutCommand", () => {
     }
 
     const command = new LogOutCommand()
+    const cli = new TestGardenCli()
     const garden = await makeDummyGarden(getDataDir("test-projects", "login", "has-domain-and-id"), {
       noEnterprise: false,
       commandInfo: { name: "foo", args: {}, opts: {} },
@@ -51,7 +54,7 @@ describe("LogoutCommand", () => {
     expect(savedToken!.token).to.eql(testToken.token)
     expect(savedToken!.refreshToken).to.eql(testToken.refreshToken)
 
-    await command.action(makeCommandParams({ garden, args: {}, opts: {} }))
+    await command.action(makeCommandParams({ cli, garden, args: {}, opts: {} }))
 
     const tokenAfterLogout = await ClientAuthToken.findOne()
     const logOutput = getLogMessages(garden.log, (entry) => entry.level === LogLevel.info).join("\n")
@@ -62,12 +65,13 @@ describe("LogoutCommand", () => {
 
   it("should be a no-op if the user is already logged out", async () => {
     const command = new LogOutCommand()
+    const cli = new TestGardenCli()
     const garden = await makeDummyGarden(getDataDir("test-projects", "login", "has-domain-and-id"), {
       noEnterprise: false,
       commandInfo: { name: "foo", args: {}, opts: {} },
     })
 
-    await command.action(makeCommandParams({ garden, args: {}, opts: {} }))
+    await command.action(makeCommandParams({ cli, garden, args: {}, opts: {} }))
 
     const logOutput = getLogMessages(garden.log, (entry) => entry.level === LogLevel.info).join("\n")
     expect(logOutput).to.include("You're already logged out from Garden Enterprise.")
@@ -82,6 +86,7 @@ describe("LogoutCommand", () => {
     }
 
     const command = new LogOutCommand()
+    const cli = new TestGardenCli()
     const garden = await makeDummyGarden(getDataDir("test-projects", "login", "has-domain-and-id"), {
       noEnterprise: false,
       commandInfo: { name: "foo", args: {}, opts: {} },
@@ -99,7 +104,7 @@ describe("LogoutCommand", () => {
     expect(savedToken!.token).to.eql(testToken.token)
     expect(savedToken!.refreshToken).to.eql(testToken.refreshToken)
 
-    await command.action(makeCommandParams({ garden, args: {}, opts: {} }))
+    await command.action(makeCommandParams({ cli, garden, args: {}, opts: {} }))
 
     const tokenAfterLogout = await ClientAuthToken.findOne()
     const logOutput = getLogMessages(garden.log, (entry) => entry.level === LogLevel.info).join("\n")
@@ -117,6 +122,7 @@ describe("LogoutCommand", () => {
     }
 
     const command = new LogOutCommand()
+    const cli = new TestGardenCli()
     const garden = await makeDummyGarden(getDataDir("test-projects", "login", "has-domain-and-id"), {
       noEnterprise: false,
       commandInfo: { name: "foo", args: {}, opts: {} },
@@ -134,7 +140,7 @@ describe("LogoutCommand", () => {
     expect(savedToken!.token).to.eql(testToken.token)
     expect(savedToken!.refreshToken).to.eql(testToken.refreshToken)
 
-    await command.action(makeCommandParams({ garden, args: {}, opts: {} }))
+    await command.action(makeCommandParams({ cli, garden, args: {}, opts: {} }))
 
     const tokenAfterLogout = await ClientAuthToken.findOne()
     const logOutput = getLogMessages(garden.log, (entry) => entry.level === LogLevel.info).join("\n")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

The cloud API required both a `domain` and a `projectId` to be initialised. This PR removes the requirement of a `projectId` which makes it possible to implement new cloud commands that does not need a `projectId`. An example would be a command to create garden cloud projects.

A new environment variable `GARDEN_CLOUD_DOMAIN` is introduced that makes it possible to override a cloud domain configured in the project for easier configuration/testing.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
