### PR TITLE
chore: clarify documentation on varfiles

### DIFF
--- a/docs/using-garden/variables-and-templating.md
+++ b/docs/using-garden/variables-and-templating.md
@@ -521,7 +521,7 @@ name: my-service
 # Here, we use per-environment module varfiles as an optional override for variables (these have a higher precedence
 # than those in the `variables` field below).
 #
-# If no varfile exists, no error is thrown (we simply don't override any variables).
+# If a varfile is defined but not found, an error is thrown in order to prevent misconfigurations silently passing.
 varfile: my-service.${environment.name}.yaml
 variables:
   # This overrides the project-level hostname variable


### PR DESCRIPTION
**What this PR does / why we need it**:

Clarifies the documentation on the `varfile` field, to make it match the expected behavior and current code implementation.

**Which issue(s) this PR fixes**:

Fixes #3150 

**Special notes for your reviewer**:

Relevant code at https://github.com/garden-io/garden/blob/35fdae0560536b3480e05b50766d635a941e52d5/core/src/config/base.ts#L243-L302
