### PR TITLE
fix(k8s): fixed error handling in image builders

### DIFF
--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -408,6 +408,7 @@ async function runWithoutArtifacts({
       events: ctx.events,
       timeoutSec: timeout || defaultTimeout,
       tty: interactive,
+      throwOnExitCode: true,
     })
     result = {
       ...res,
@@ -710,6 +711,8 @@ type RunParams = StartParams & {
   remove: boolean
   tty: boolean
   events: PluginEventBroker
+  // TODO: 0.13 consider removing this in the scope of https://github.com/garden-io/garden/issues/3254
+  throwOnExitCode?: boolean
 }
 
 class PodRunnerError extends GardenBaseError {
@@ -802,7 +805,7 @@ export class PodRunner extends PodRunnerParams {
    * @throws {KubernetesError}
    */
   async runAndWait(params: RunParams): Promise<RunAndWaitResult> {
-    const { log, remove, timeoutSec, tty } = params
+    const { log, remove, tty } = params
 
     const startedAt = new Date()
     const logsFollower = this.prepareLogsFollower(params)
@@ -816,7 +819,7 @@ export class PodRunner extends PodRunnerParams {
       await this.createPod({ log, tty })
 
       // Wait until main container terminates
-      const exitCode = await this.awaitRunningPod(startedAt, timeoutSec)
+      const exitCode = await this.awaitRunningPod(params, startedAt)
 
       // Retrieve logs after run
       const mainContainerLogs = await this.getMainContainerLogs()
@@ -842,7 +845,8 @@ export class PodRunner extends PodRunnerParams {
    * @throws {TimeoutError}
    * @throws {PodRunnerError}
    */
-  private async awaitRunningPod(startedAt: Date, timeoutSec: number | undefined): Promise<number | undefined> {
+  private async awaitRunningPod(params: RunParams, startedAt: Date): Promise<number | undefined> {
+    const { timeoutSec, throwOnExitCode } = params
     const { namespace, podName } = this
     const mainContainerName = this.getMainContainerName()
 
@@ -877,8 +881,12 @@ export class PodRunner extends PodRunnerParams {
           exitReason !== "StartError"
         ) {
           // Successfully ran the command in the main container, but returned non-zero exit code.
-          // Consider it as a task execution error inside the Pod.
-          throw newExitCodePodRunnerError(await errorDetails())
+          if (throwOnExitCode === true) {
+            // Consider it as a task execution error inside the Pod.
+            throw newExitCodePodRunnerError(await errorDetails())
+          } else {
+            return exitCode
+          }
         } else {
           throw new PodRunnerError(`Failed to start Pod ${podName}.`, await errorDetails())
         }
@@ -887,7 +895,11 @@ export class PodRunner extends PodRunnerParams {
       // reason "Completed" means main container is done, but sidecars or other containers possibly still alive
       if (state === "stopped" || exitReason === "Completed") {
         if (exitCode !== undefined && exitCode !== 0) {
-          throw newExitCodePodRunnerError(await errorDetails())
+          if (throwOnExitCode === true) {
+            throw newExitCodePodRunnerError(await errorDetails())
+          } else {
+            return exitCode
+          }
         }
         return exitCode
       }

--- a/core/test/integ/src/plugins/kubernetes/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/run.ts
@@ -257,7 +257,24 @@ describe("kubernetes Pod runner functions", () => {
         expect(res.success).to.be.true
       })
 
-      it("throws if Pod returns with non-zero exit code", async () => {
+      it("returns success=false if Pod returns with non-zero exit code when throwOnExitCode is not set", async () => {
+        const pod = makePod(["sh", "-c", "echo foo && exit 1"])
+
+        runner = new PodRunner({
+          ctx,
+          pod,
+          namespace,
+          api,
+          provider,
+        })
+
+        const res = await runner.runAndWait({ log, remove: true, tty: false, events: ctx.events })
+
+        expect(res.log.trim()).to.equal("foo")
+        expect(res.success).to.be.false
+      })
+
+      it("throws if Pod returns with non-zero exit code when throwOnExitCode=true", async () => {
         const pod = makePod(["sh", "-c", "echo foo && exit 1"])
 
         runner = new PodRunner({
@@ -269,7 +286,7 @@ describe("kubernetes Pod runner functions", () => {
         })
 
         await expectError(
-          () => runner.runAndWait({ log, remove: true, tty: false, events: ctx.events }),
+          () => runner.runAndWait({ log, remove: true, tty: false, events: ctx.events, throwOnExitCode: true }),
           (err) => expect(err.message.trim()).to.equal("Command exited with code 1:\nfoo")
         )
       })


### PR DESCRIPTION
This patches #3388. The method `PodRunner.runAndWait()` is used in a few places. Now it throws an error on non-zero exit code only when it's called from `runWithoutArtifacts(...)`, where the error can be handled correctly. In the rest places, it returns unsuccessful result w/o throwing any errors, just like it was before #3388.

The whole error handling and propagation flow can be revisited in #3254.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
