### PR TITLE
chore: add runtime.tasks.<task-name>.outputs.log schema to helm and kubernetes modules

### DIFF
--- a/core/src/plugins/container/container.ts
+++ b/core/src/plugins/container/container.ts
@@ -24,6 +24,7 @@ import { dedent } from "../../util/string"
 import { Provider, GenericProviderConfig, providerConfigBaseSchema } from "../../config/provider"
 import { isSubdir } from "../../util/util"
 import { GetModuleOutputsParams } from "../../types/plugin/module/getModuleOutputs"
+import { taskOutputsSchema } from "../kubernetes/task-results"
 
 export interface ContainerProviderConfig extends GenericProviderConfig {}
 export type ContainerProvider = Provider<ContainerProviderConfig>
@@ -60,17 +61,6 @@ export const containerModuleOutputsSchema = () =>
       .description("The full ID of the image (incl. tag/version) that the module will use during deployment.")
       .example("my-deployment-registry.io/my-org/my-module:v-abf3f8dca"),
   })
-
-const taskOutputsSchema = joi.object().keys({
-  log: joi
-    .string()
-    .allow("")
-    .default("")
-    .description(
-      "The full log from the executed task. " +
-        "(Pro-tip: Make it machine readable so it can be parsed by dependant tasks and services!)"
-    ),
-})
 
 export async function configureContainerModule({ log, moduleConfig }: ConfigureModuleParams<ContainerModule>) {
   // validate hot reload configuration

--- a/core/src/plugins/exec/exec.ts
+++ b/core/src/plugins/exec/exec.ts
@@ -47,6 +47,7 @@ import { GetServiceStatusParams } from "../../types/plugin/service/getServiceSta
 import { DeleteServiceParams } from "../../types/plugin/service/deleteService"
 import { PluginContext } from "../../plugin-context"
 import { ServiceStatus } from "../../types/service"
+import { taskOutputsSchema } from "../kubernetes/task-results"
 
 const execPathDoc = dedent`
   By default, the command is run inside the Garden build directory (under .garden/build/<module-name>).
@@ -814,16 +815,7 @@ export const execPlugin = () =>
     `,
         moduleOutputsSchema: joi.object().keys({}),
         schema: execModuleSpecSchema(),
-        taskOutputsSchema: joi.object().keys({
-          log: joi
-            .string()
-            .allow("")
-            .default("")
-            .description(
-              "The full log from the executed task. " +
-                "(Pro-tip: Make it machine readable so it can be parsed by dependant tasks and services!)"
-            ),
-        }),
+        taskOutputsSchema,
         handlers: {
           configure: configureExecModule,
           build: buildExecModule,

--- a/core/src/plugins/kubernetes/kubernetes.ts
+++ b/core/src/plugins/kubernetes/kubernetes.ts
@@ -45,6 +45,7 @@ import { configMapModuleDefinition } from "./volumes/configmap"
 import { jibContainerHandlers } from "./jib-container"
 import { emitWarning } from "../../warnings"
 import { kustomizeSpec } from "./kubernetes-module/kustomize"
+import { taskOutputsSchema } from "./task-results"
 
 export async function configureProvider({
   log,
@@ -236,6 +237,7 @@ export const gardenPlugin = () =>
       `,
         moduleOutputsSchema: helmModuleOutputsSchema(),
         schema: helmModuleSpecSchema(),
+        taskOutputsSchema,
         handlers: helmHandlers,
       },
       {

--- a/core/src/plugins/kubernetes/kubernetes.ts
+++ b/core/src/plugins/kubernetes/kubernetes.ts
@@ -255,6 +255,7 @@ export const gardenPlugin = () =>
       `,
         moduleOutputsSchema: joi.object().keys({}),
         schema: kubernetesModuleSpecSchema(),
+        taskOutputsSchema,
         handlers: kubernetesHandlers,
       },
       pvcModuleDefinition(),

--- a/core/src/plugins/kubernetes/task-results.ts
+++ b/core/src/plugins/kubernetes/task-results.ts
@@ -25,6 +25,18 @@ import { trimRunOutput } from "./helm/common"
 import { MAX_RUN_RESULT_LOG_LENGTH } from "./constants"
 import chalk from "chalk"
 import { GardenTask } from "../../types/task"
+import { joi } from "../../config/common"
+
+export const taskOutputsSchema = joi.object().keys({
+  log: joi
+    .string()
+    .allow("")
+    .default("")
+    .description(
+      "The full log from the executed task. " +
+        "(Pro-tip: Make it machine readable so it can be parsed by dependant tasks and services!)"
+    ),
+})
 
 export async function getTaskResult({
   ctx,

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -2181,3 +2181,11 @@ Example:
 my-variable: ${runtime.tasks.my-tasks.version}
 ```
 
+### `${runtime.tasks.<task-name>.outputs.log}`
+
+The full log from the executed task. (Pro-tip: Make it machine readable so it can be parsed by dependant tasks and services!)
+
+| Type     | Default |
+| -------- | ------- |
+| `string` | `""`    |
+

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -1984,3 +1984,11 @@ Example:
 my-variable: ${runtime.tasks.my-tasks.version}
 ```
 
+### `${runtime.tasks.<task-name>.outputs.log}`
+
+The full log from the executed task. (Pro-tip: Make it machine readable so it can be parsed by dependant tasks and services!)
+
+| Type     | Default |
+| -------- | ------- |
+| `string` | `""`    |
+


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the `joi` schema for `runtime.tasks.<task-name>.outputs.log` for both `helm` and `kubernetes` module types.
The necessary code for passing the logs already exists for both [helm](https://github.com/garden-io/garden/blob/7ba352815890ebcf727ae5731dd06bd3599aa866/core/src/plugins/kubernetes/helm/run.ts#L185) as well as [kubernetes](https://github.com/garden-io/garden/blob/7ba352815890ebcf727ae5731dd06bd3599aa866/core/src/plugins/kubernetes/kubernetes-module/run.ts#L73), but they were not documented correctly.

**Which issue(s) this PR fixes**:

Fixes #3378 

**Special notes for your reviewer**:
