### PR TITLE
fix(server): send better close codes on ws connection close

### DIFF
--- a/core/test/unit/src/server/server.ts
+++ b/core/test/unit/src/server/server.ts
@@ -224,40 +224,71 @@ describe("GardenServer", () => {
       ws.close()
     })
 
-    const onMessage = (cb: (req: object) => void) => {
-      ws.on("message", (msg) => cb(JSON.parse(msg.toString())))
+    const onFirstMsgAfterReadyMsg = (cb: (req: object) => void) => {
+      ws.on("message", (msg) => {
+        const parsed = JSON.parse(msg.toString())
+        // This message is always sent at the beginning and we skip it here
+        // to simplify testing.
+        if (parsed.type !== "serverReady") {
+          cb(parsed)
+        }
+      })
     }
 
     it("terminates the connection if auth query params are missing", (done) => {
       const badWs = new WebSocket(`ws://localhost:${port}/ws`)
-      badWs.on("close", () => {
+      badWs.on("close", (code, reason) => {
+        expect(code).to.eql(4401)
+        expect(reason).to.eql("Unauthorized")
         done()
       })
     })
 
     it("terminates the connection if key doesn't match and sessionId is missing", (done) => {
       const badWs = new WebSocket(`ws://localhost:${port}/ws?key=foo`)
-      badWs.on("close", () => {
+      badWs.on("close", (code, reason) => {
+        expect(code).to.eql(4401)
+        expect(reason).to.eql("Unauthorized")
         done()
       })
     })
 
     it("terminates the connection if sessionId doesn't match and key is missing", (done) => {
       const badWs = new WebSocket(`ws://localhost:${port}/ws?sessionId=foo`)
-      badWs.on("close", () => {
+      badWs.on("close", (code, reason) => {
+        expect(code).to.eql(4401)
+        expect(reason).to.eql("Unauthorized")
         done()
       })
     })
 
     it("terminates the connection if both sessionId and key are bad", (done) => {
       const badWs = new WebSocket(`ws://localhost:${port}/ws?sessionId=foo&key=bar`)
-      badWs.on("close", () => {
+      badWs.on("close", (code, reason) => {
+        expect(code).to.eql(4401)
+        expect(reason).to.eql("Unauthorized")
         done()
       })
     })
 
+    it("should send a serverReady event when the server is ready", (done) => {
+      let msgs: any[] = []
+      ws.on("message", (msg) => {
+        msgs.push(JSON.parse(msg.toString()))
+
+        if (msgs.length === 2) {
+          expect(msgs).to.eql([
+            { type: "serverReady", message: "Server ready" },
+            { type: "event", name: "_test", payload: "foo" },
+          ])
+          done()
+        }
+      })
+      garden.events.emit("_test", "foo")
+    })
+
     it("should emit events from the Garden event bus", (done) => {
-      onMessage((req) => {
+      onFirstMsgAfterReadyMsg((req) => {
         expect(req).to.eql({ type: "event", name: "_test", payload: "foo" })
         done()
       })
@@ -265,7 +296,7 @@ describe("GardenServer", () => {
     })
 
     it("should send error when a request is not valid JSON", (done) => {
-      onMessage((req) => {
+      onFirstMsgAfterReadyMsg((req) => {
         expect(req).to.eql({
           type: "error",
           message: "Could not parse message as JSON",
@@ -278,7 +309,7 @@ describe("GardenServer", () => {
     it("should send error when Garden instance is not set", (done) => {
       const id = uuidv4()
 
-      onMessage((req) => {
+      onFirstMsgAfterReadyMsg((req) => {
         expect(req).to.eql({
           type: "error",
           message: "Waiting for Garden instance to initialize",
@@ -299,7 +330,7 @@ describe("GardenServer", () => {
     })
 
     it("should error when a request is missing an ID", (done) => {
-      onMessage((req) => {
+      onFirstMsgAfterReadyMsg((req) => {
         expect(req).to.eql({
           type: "error",
           message: "Message should contain an `id` field with a UUID value",
@@ -310,7 +341,7 @@ describe("GardenServer", () => {
     })
 
     it("should error when a request has an invalid ID", (done) => {
-      onMessage((req) => {
+      onFirstMsgAfterReadyMsg((req) => {
         expect(req).to.eql({
           type: "error",
           requestId: "ksdhgalsdkjghalsjkg",
@@ -323,7 +354,7 @@ describe("GardenServer", () => {
 
     it("should error when a request has an invalid type", (done) => {
       const id = uuidv4()
-      onMessage((req) => {
+      onFirstMsgAfterReadyMsg((req) => {
         expect(req).to.eql({
           type: "error",
           requestId: id,
@@ -340,7 +371,7 @@ describe("GardenServer", () => {
       garden
         .dumpConfig({ log: garden.log })
         .then((config) => {
-          onMessage((req: any) => {
+          onFirstMsgAfterReadyMsg((req: any) => {
             if (req.type !== "commandResult") {
               return
             }
@@ -365,7 +396,7 @@ describe("GardenServer", () => {
 
     it("should correctly map arguments and options to commands", (done) => {
       const id = uuidv4()
-      onMessage((req) => {
+      onFirstMsgAfterReadyMsg((req) => {
         // Ignore other events such as taskPending and taskProcessing and wait for the command result
         if ((<any>req).type !== "commandResult") {
           return


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

These better websocket close / ready messages are helpful for Cloud (and future clients) when handling websocket connections.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
