### PR TITLE
Revert "ci(gke): clean up old namespaces"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,7 @@ commands:
             sudo ln -s "$NVM_DIR/versions/node/$(nvm version)/bin/npm" "/usr/local/bin/npm"
             sudo npm install -g yarn
 
-  configure_remote_cluster:
+  configure_kubectl_context:
     description: Configure the kubectl context via gcloud so that we can access our remote cluster. Used for e2e testing.
     steps:
       - run:
@@ -201,19 +201,6 @@ commands:
             gcloud --quiet config set compute/zone $GOOGLE_COMPUTE_ZONE
             gcloud --quiet container clusters get-credentials $GOOGLE_CLUSTER_ID --zone $GOOGLE_COMPUTE_ZONE
             gcloud --quiet auth configure-docker
-
-  cleanup_remote_cluster:
-    description: Clean up namespaces in the ci cluster on gcloud (to be used with configure_remote_cluster)
-    steps:
-      - run:
-          name: Delete current namespace
-          command: kubectl get ns | grep ${CIRCLE_BUILD_NUM} | awk '{print $1}' | xargs -n 1 kubectl delete namespace --wait=false || true
-          when: always
-      - run:
-          name: Delete namespaces older than 1 hour
-          # hack: find namespaces that contain '-ci' and their age ends with h or d, e.g. 1d5h or 24h
-          command: kubectl get ns | grep -E '(d|h)$' | grep -- '-ci' | awk '{print $1}' | xargs -n 1 kubectl delete namespace --wait=false || true
-          when: always
 
   build_dist:
     description: Package built code into executables and persist to dist directory
@@ -349,7 +336,7 @@ jobs:
     steps:
       - checkout
       - npm_install
-      - configure_remote_cluster
+      - configure_kubectl_context
       - docker_login
       - *attach-workspace
       - run:
@@ -359,7 +346,10 @@ jobs:
           name: Run e2e test
           command: |
             yarn e2e-project --project=<<parameters.project>> --env=<<parameters.environment>>
-      - cleanup_remote_cluster
+      - run:
+          name: Cleanup
+          command: kubectl delete --wait=false $(kubectl get ns -o name | grep $CIRCLE_BUILD_NUM) || true
+          when: always
 
   build-docker-alpine:
     <<: *node-config
@@ -475,13 +465,16 @@ jobs:
     steps:
       # Need to checkout to run example project
       - checkout
-      - configure_remote_cluster
+      - configure_kubectl_context
       - *attach-workspace
       - run:
           name: Deploy demo-project with container
           # overriding CIRCLE_BUILD_NUM to avoid conflict with other tests
           command: CIRCLE_BUILD_NUM=$CIRCLE_BUILD_NUM-docker /garden/garden build --root examples/demo-project --env remote --logger-type basic
-      - cleanup_remote_cluster
+      - run:
+          name: Cleanup
+          command: CIRCLE_BUILD_NUM=$CIRCLE_BUILD_NUM-docker kubectl delete --wait=false $(kubectl get ns -o name | grep demo-project-$CIRCLE_BUILD_NUM) || true
+          when: always
 
   release-service-docker:
     <<: *node-config
@@ -549,7 +542,7 @@ jobs:
     steps:
       # Need to checkout to run example project
       - checkout
-      - configure_remote_cluster
+      - configure_kubectl_context
       - *attach-workspace
       - run:
           name: Test that the binary works with the fancy logger enabled
@@ -565,7 +558,10 @@ jobs:
           name: Deploy demo-project with binary
           # overriding CIRCLE_BUILD_NUM to avoid conflict with other tests
           command: CIRCLE_BUILD_NUM=$CIRCLE_BUILD_NUM-dist dist/linux-amd64/garden deploy --root examples/demo-project --env remote --logger-type basic
-      - cleanup_remote_cluster
+      - run:
+          name: Cleanup
+          command: CIRCLE_BUILD_NUM=$CIRCLE_BUILD_NUM-dist kubectl delete --wait=false $(kubectl get ns -o name | grep demo-project-$CIRCLE_BUILD_NUM) || true
+          when: always
 
   test-plugins:
     machine:
@@ -794,11 +790,14 @@ jobs:
             tar xzf google-cloud-sdk-390.0.0-darwin-x86_64.tar.gz
             echo 'export PATH=$HOME/google-cloud-sdk/bin:$PATH' >> $BASH_ENV
       - docker_login
-      - configure_remote_cluster
+      - configure_kubectl_context
       - run:
           name: Deploy demo-project
           command: CIRCLE_BUILD_NUM=$CIRCLE_BUILD_NUM-macos dist/macos-amd64/garden deploy --root examples/demo-project --logger-type basic --env remote
-      - cleanup_remote_cluster
+      - run:
+          name: Cleanup
+          command: kubectl delete --wait=false $(kubectl get ns -o name | grep $CIRCLE_BUILD_NUM-macos) || true
+          when: always
 
   test-windows:
     executor: win/default


### PR DESCRIPTION
Reverts garden-io/garden#3392

Testing to see if this fixes our CI pipelines. Do not merge.
