### PR TITLE
fix(k8s): fixed error detail format in `PodRunner.exec()`

### DIFF
--- a/core/src/plugins/kubernetes/api.ts
+++ b/core/src/plugins/kubernetes/api.ts
@@ -170,6 +170,14 @@ type WrappedApi<T> = {
   T[P]
 }
 
+export interface ExecInPodResult {
+  exitCode?: number
+  allLogs: string
+  stdout: string
+  stderr: string
+  timedOut: boolean
+}
+
 export class KubeApi {
   public apis: WrappedApi<ApisApi>
   public apps: WrappedApi<AppsV1Api>
@@ -720,7 +728,7 @@ export class KubeApi {
     stdin?: Readable
     tty: boolean
     timeoutSec?: number
-  }): Promise<{ exitCode?: number; allLogs: string; stdout: string; stderr: string; timedOut: boolean }> {
+  }): Promise<ExecInPodResult> {
     const stdoutCollector = new StringCollector()
     const stderrCollector = new StringCollector()
     const combinedCollector = new StringCollector()

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -24,7 +24,7 @@ import {
 import { KubernetesProvider } from "./config"
 import { Writable, Readable, PassThrough } from "stream"
 import { uniqByName, sleep } from "../../util/util"
-import { KubeApi } from "./api"
+import { ExecInPodResult, KubeApi } from "./api"
 import { getPodLogs, checkPodStatus } from "./status/pod"
 import { KubernetesResource, KubernetesPod, KubernetesServerResource } from "./types"
 import { RunModuleParams } from "../../types/plugin/module/runModule"
@@ -742,7 +742,7 @@ export interface PodErrorDetails {
   exitCode?: number
   containerStatus?: V1ContainerStatus
   podStatus?: V1PodStatus
-  result?: any
+  result?: ExecInPodResult
 }
 
 export class PodRunner extends PodRunnerParams {

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -742,6 +742,7 @@ export interface PodErrorDetails {
   exitCode?: number
   containerStatus?: V1ContainerStatus
   podStatus?: V1PodStatus
+  result?: any
 }
 
 export class PodRunner extends PodRunnerParams {
@@ -977,7 +978,7 @@ export class PodRunner extends PodRunnerParams {
     const collectLogs = async () => result.allLogs || (await this.getMainContainerLogs())
 
     if (result.timedOut) {
-      const errorDetails: PodErrorDetails = { logs: await collectLogs() }
+      const errorDetails: PodErrorDetails = { logs: await collectLogs(), result }
       throw new TimeoutError(`Command timed out after ${timeoutSec} seconds.`, errorDetails)
     }
 
@@ -985,6 +986,7 @@ export class PodRunner extends PodRunnerParams {
       const errorDetails: PodErrorDetails = {
         logs: await collectLogs(),
         exitCode: result.exitCode,
+        result,
       }
       throw new OutOfMemoryError("Pod container was OOMKilled.", errorDetails)
     }
@@ -993,6 +995,7 @@ export class PodRunner extends PodRunnerParams {
       const errorDetails: PodErrorDetails = {
         logs: await collectLogs(),
         exitCode: result.exitCode,
+        result,
       }
       throw newExitCodePodRunnerError(errorDetails)
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
This patches https://github.com/garden-io/garden/pull/3388. If the method `PodRunner.exec()` throws an error, then the error's `detail` field must contain the `result` field to ensure the proper error handling in [`skopeoBuildStatus`](https://github.com/garden-io/garden/blob/main/core/src/plugins/kubernetes/container/build/common.ts#L198) function.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
