### PR TITLE
fix: kubernetes endpoints over plain http

### DIFF
--- a/core/src/plugins/kubernetes/api.ts
+++ b/core/src/plugins/kubernetes/api.ts
@@ -9,7 +9,6 @@
 // No idea why tslint complains over this line
 // tslint:disable-next-line:no-unused
 import { IncomingMessage } from "http"
-import { Agent } from "https"
 import { ReadStream } from "tty"
 import Bluebird from "bluebird"
 import chalk from "chalk"
@@ -79,8 +78,6 @@ const cachedConfigs: { [context: string]: KubeConfig } = {}
 const cachedApiInfo: { [context: string]: ApiInfo } = {}
 const cachedApiResourceInfo: { [context: string]: ApiResourceMap } = {}
 const apiInfoLock = new AsyncLock()
-
-const requestAgent = new Agent({})
 
 // NOTE: be warned, the API of the client library is very likely to change
 
@@ -333,7 +330,6 @@ export class KubeApi {
       method: "get",
       json: true,
       resolveWithFullResponse: true,
-      agent: requestAgent,
       ...opts,
     }
 
@@ -644,10 +640,6 @@ export class KubeApi {
    */
   private wrapApi<T extends K8sApi>(log: LogEntry, api: T, config: KubeConfig): T {
     api.setDefaultAuthentication(config)
-
-    api.addInterceptor((opts) => {
-      opts.agent = requestAgent
-    })
 
     return new Proxy(api, {
       get: (target: T, name: string, receiver) => {


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the https agent in kubernetes `api.ts`.

The request library now picks the protocol automatically - previously this required the use of `https` protocol.

This agent and its use and removal has some interactions with other recent PRs as well. The global agent initialization used to be forced before #3374. After the PR, the local `https` agent created in this `api.ts` was used instead of a global one, and required the use of `https` protocol. This regressed the ability to use `http` endpoints for kubernetes.

The original reason for using the local agent here was to provide a dns lookup cache for it with the use of `dns-lookup-cache` library, but that was removed in #3389. Thus, there is no reason to keep this local agent anymore and it can be removed entirely.

**Which issue(s) this PR fixes**:

Fixes #3411 

**Special notes for your reviewer**:

