### PR TITLE
Better basic logger

### DIFF
--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -423,12 +423,6 @@ ${renderCommands(commands)}
           // Print a specific header and footer when connected to Garden Cloud.
           if (namespaceUrl) {
             const distroName = getCloudDistributionName(cloudApi?.domain || "")
-            nsLog.setState(
-              renderHeader({
-                namespaceName: garden.namespace,
-                environmentName: garden.environmentName,
-              })
-            )
             const msg = dedent`
               \n${nodeEmoji.lightning}   ${chalk.cyan(
               `Connected to ${distroName}! Click the link below to view logs and more.`

--- a/core/src/logger/util.ts
+++ b/core/src/logger/util.ts
@@ -120,6 +120,21 @@ export function tailChildEntries(node: Logger | LogEntry, level: LogLevel, lines
 }
 
 /**
+ * Returns the entry's section or first parent section it finds.
+ */
+export function findSection(entry: LogEntry): string | null {
+  const section = entry.getLatestMessage().section
+  if (section) {
+    return section
+  }
+  if (entry.parent) {
+    return findSection(entry.parent)
+  }
+
+  return null
+}
+
+/**
  * Get the log entry preceding the given `entry` in its tree, given the minimum log `level`.
  */
 export function getPrecedingEntry(entry: LogEntry) {

--- a/core/src/plugins/container/build.ts
+++ b/core/src/plugins/container/build.ts
@@ -72,7 +72,7 @@ export async function buildContainerModule({ ctx, module, log }: BuildModulePara
   outputStream.on("error", () => {})
   outputStream.on("data", (line: Buffer) => {
     ctx.events.emit("log", { timestamp: new Date().getTime(), data: line })
-    statusLine.setState(renderOutputStream(line.toString()))
+    statusLine.setState(renderOutputStream(line.toString(), "local-docker"))
   })
   const timeout = module.spec.build.timeout
   const res = await containerHelpers.dockerCli({

--- a/core/src/plugins/exec/exec.ts
+++ b/core/src/plugins/exec/exec.ts
@@ -440,7 +440,8 @@ async function run({
 
   outputStream.on("error", () => {})
   outputStream.on("data", (line: Buffer) => {
-    log.setState(renderOutputStream(line.toString()))
+    const cmdName = command[0]
+    log.setState(renderOutputStream(line.toString(), cmdName))
     ctx.events.emit("log", { timestamp: new Date().getTime(), data: line })
   })
 

--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -110,7 +110,7 @@ export const buildkitBuildHandler: BuildHandler = async (params) => {
   outputStream.on("error", () => {})
   outputStream.on("data", (line: Buffer) => {
     ctx.events.emit("log", { timestamp: new Date().getTime(), data: line })
-    statusLine.setState(renderOutputStream(line.toString()))
+    statusLine.setState(renderOutputStream(line.toString(), "buildkit"))
   })
 
   const command = [

--- a/core/src/plugins/kubernetes/container/build/cluster-docker.ts
+++ b/core/src/plugins/kubernetes/container/build/cluster-docker.ts
@@ -98,7 +98,7 @@ export const clusterDockerBuild: BuildHandler = async (params) => {
   stdout.on("error", () => {})
   stdout.on("data", (line: Buffer) => {
     ctx.events.emit("log", { timestamp: new Date().getTime(), data: line })
-    statusLine.setState(renderOutputStream(line.toString()))
+    statusLine.setState(renderOutputStream(line.toString(), "cluster-docker"))
   })
 
   // Prepare the build command

--- a/core/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/src/plugins/kubernetes/container/build/kaniko.ts
@@ -114,7 +114,7 @@ export const kanikoBuild: BuildHandler = async (params) => {
 
   outputStream.on("error", () => {})
   outputStream.on("data", (line: Buffer) => {
-    statusLine.setState(renderOutputStream(line.toString()))
+    statusLine.setState(renderOutputStream(line.toString(), "kaniko"))
   })
 
   // Use the project namespace if set to null in config

--- a/core/src/plugins/kubernetes/container/deployment.ts
+++ b/core/src/plugins/kubernetes/container/deployment.ts
@@ -102,6 +102,9 @@ export async function startContainerDevSync({
 
   log.info({
     section: service.name,
+    // FIXME: Not sure why we need to explicitly set the symbol here, but if we don't
+    // it's not rendered.
+    symbol: "info",
     msg: chalk.grey(`Deploying in dev mode`),
   })
 

--- a/core/src/tasks/deploy.ts
+++ b/core/src/tasks/deploy.ts
@@ -202,7 +202,7 @@ export class DeployTask extends BaseTask {
     }
 
     for (const ingress of status.ingresses || []) {
-      log.info(chalk.gray("→ Ingress: ") + chalk.underline.gray(getLinkUrl(ingress)))
+      log.info(chalk.gray("Ingress: ") + chalk.underline.gray(getLinkUrl(ingress)))
     }
 
     if (this.garden.persistent) {
@@ -219,7 +219,7 @@ export class DeployTask extends BaseTask {
 
         log.info(
           chalk.gray(
-            `→ Forward: ` +
+            `Port forward: ` +
               chalk.underline(proxy.localUrl) +
               ` → ${targetHost}:${proxy.spec.targetPort}` +
               (proxy.spec.name ? ` (${proxy.spec.name})` : "")

--- a/core/src/util/util.ts
+++ b/core/src/util/util.ts
@@ -139,8 +139,8 @@ export function defer<T>() {
 /**
  * Extracting to a separate function so that we can test output streams
  */
-export function renderOutputStream(msg: string) {
-  return chalk.gray("  → " + msg)
+export function renderOutputStream(msg: string, command?: string) {
+  return command ? chalk.gray(`[${command}]: ${msg}`) : chalk.gray(msg)
 }
 
 /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

From the commit message:

Before this fix, basic logger entries would regularly be 'orphaned'
because the parent section wasn't printed. This made it very hard to
tell what section a given log entry would belong to.

E.g. when the log level is set to verbose, it's hard to tell if build
logs belong to one module or the other.

Furthermore, the commit also:

- Prints the name of the command when rendering output streams.
- Ensures the header isn't rendered twice with the basic logger.
- Removes superfluous arrows from some log strings which don't render
  nicely with the basic logger.
- Prints the log level if using the basic logger and the level is higher
  than 'info'.
- Skip left padding for basic logger.

**Which issue(s) this PR fixes**:

Partially address #3254 

**Special notes for your reviewer**:

This is probably best explained with a bit of a before and after. 

**Before:**

```
 vote-demo  main .  GARDEN_SERVER_PORT=9778 garden deploy -l3                                                                                                                   INT ✘ 
Deploy 🚀 


━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🌍  Running in namespace vote-demo-eysi in environment dev
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

ℹ providers                 → Getting status...
Comparing expected and deployed resources...
All resources match.
ℹ postgres                  → Deploying version v-fd26509fc2...
✔ postgres                  → Deploying version v-fd26509fc2... → Already deployed
✔ db-init                   → Already run
Comparing expected and deployed resources...
All resources match.
ℹ redis                     → Deploying version v-8dd1ace6b1...
✔ redis                     → Deploying version v-8dd1ace6b1... → Already deployed
All resources match.
Comparing expected and deployed resources...
All resources match.
✔ result                    → Deploying version v-458785fb69... → Already deployed
Comparing expected and deployed resources...
ℹ vote                      → Building image vote:v-3e4e59008c...
  → #1 [internal] load .dockerignore
  → #1 transferring context: 2B 0.0s done
  → #1 DONE 0.0s
  → 
  → #2 DONE 0.0s
  → 
  → #3 [internal] load metadata for docker.io/library/node:10-alpine
  → #3 DONE 0.6s
  → #14 DONE 2.7s
✔ api                       → Building image api:v-9d07676cdb... → Done (took 13.5 sec)
ℹ api                       → Deploying version v-84e1c7a5d9...
  → #13 pushing manifest for ***** 1.1s done
  → #13 DONE 2.8s
✔ vote                      → Building image vote:v-3e4e59008c... → Done (took 13.6 sec)
   ℹ api                       → Waiting for resources to be ready...
   ℹ api                       → Deployment/api: Started container api
   ℹ api                       → Resources ready
   Comparing expected and deployed resources...
   All resources match.
✔ api                       → Deploying version v-84e1c7a5d9... → Done (took 9.5 sec)
   → Ingress: **** 
ℹ vote                      → Deploying version v-357aeccc8c...
   ℹ vote                      → Waiting for resources to be ready...
   ℹ vote                      → Deployment/vote: Started container vote
   ℹ vote                      → Resources ready
   Comparing expected and deployed resources...
   All resources match.
```

**After:**

```
 vote-demo  main .  garden deploy -l3                                                                                                                   INT ✘ 
Deploy 🚀 


━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🌍  Running in namespace vote-demo-eysi in environment dev
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

ℹ providers                 → Getting status...
✔ providers                 → Getting status... → Cached
[verbose] Comparing expected and deployed resources...
[verbose] Comparing expected and deployed resources...
[verbose] All resources match.
[verbose] All resources match.
ℹ redis                     → Deploying version v-8dd1ace6b1...
✔ redis                     → Deploying version v-8dd1ace6b1... → Already deployed
ℹ postgres                  → Deploying version v-fd26509fc2...
✔ postgres                  → Deploying version v-fd26509fc2... → Already deployed
✔ db-init                   → Already run
ℹ api                       → Syncing files to cluster...
ℹ vote [verbose]            → Comparing expected and deployed resources...
ℹ vote [verbose]            → All resources match.
ℹ vote                      → Syncing files to cluster...
ℹ api                       → File sync to cluster complete
ℹ api                       → Building image api:v-b40a87f556...
ℹ vote                      → File sync to cluster complete
ℹ vote                      → Building image vote:v-7ff442a927...
ℹ api [verbose]             → [buildkit]: #1 [internal] load .dockerignore
ℹ api [verbose]             → [buildkit]: #1 transferring context: 2B done
ℹ api [verbose]             → [buildkit]: #3 [internal] load metadata for docker.io/library/python:2.7-alpine
ℹ vote [verbose]            → [buildkit]: #1 [internal] load build definition from Dockerfile
ℹ vote [verbose]            → [buildkit]: 
ℹ vote [verbose]            → [buildkit]: #3 [internal] load metadata for docker.io/library/node:10-alpine
ℹ api [verbose]             → [buildkit]: #3 DONE 0.7s
ℹ vote [verbose]            → [buildkit]: #3 DONE 0.7s
ℹ api [verbose]             → [buildkit]: 
ℹ api [verbose]             → [buildkit]: #4 [internal] load build context
ℹ api [verbose]             → [buildkit]: #15 DONE 3.3s
✔ api                       → Building image api:v-b40a87f556... → Done (took 13.8 sec)
ℹ api                       → Deploying version v-b87e4f72f7...
ℹ vote [verbose]            → All resources match.
✔ vote                      → Deploying version v-4053a82c86... → Done (took 20.8 sec)

Done! ✔️ 
```

Notice how in the "after" version:

- Build logs aren't orphaned and you can tell what module they belong to.
- You can see what's executing the build. In this case it's buildkit but it works for other builders and many other commands. E.g. an exec module may print something like: `[yarn]: ....`. 
- The verbosity is visible. 
- Everything's aligned to the left. In the "before" version an entry may be indented under an entry that's not its actual parent. 

Finally, it's a little awkward to print the verbosity after the section, but printing it before really messes up the alignment. Also, we'll be re-doing this with #3254, so I'd rather just err on being informative for now and not worry too much about where we place things. 