### PR TITLE
chore(helm): relax path validation requirements for valueFiles

### DIFF
--- a/core/src/plugins/kubernetes/helm/config.ts
+++ b/core/src/plugins/kubernetes/helm/config.ts
@@ -225,7 +225,7 @@ export const helmModuleSpecSchema = () =>
       When specified, these take precedence over the values in the \`values.yaml\` file (or the files specified
       in \`valueFiles\`).
     `),
-    valueFiles: joiSparseArray(joi.posixPath().subPathOnly()).description(dedent`
+    valueFiles: joiSparseArray(joi.posixPath()).description(dedent`
       Specify value files to use when rendering the Helm chart. These will take precedence over the \`values.yaml\` file
       bundled in the Helm chart, and should be specified in ascending order of precedence. Meaning, the last file in
       this list will have the highest precedence.

--- a/core/test/integ/src/plugins/kubernetes/helm/common.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/common.ts
@@ -654,6 +654,19 @@ ${expectedIngressOutput}
         gardenValuesPath,
       ])
     })
+
+    it("should allow relative paths for valueFiles", async () => {
+      const module = graph.getModule("api")
+      module.spec.valueFiles = ["../relative.yaml"]
+      const gardenValuesPath = getGardenValuesPath(module.buildPath)
+
+      expect(await getValueArgs(module, false, false, false)).to.eql([
+        "--values",
+        resolve(module.buildPath, "../relative.yaml"),
+        "--values",
+        gardenValuesPath,
+      ])
+    })
   })
 
   describe("getReleaseName", () => {


### PR DESCRIPTION
**What this PR does / why we need it**:

Relaxes the path validation requirements for `valueFiles` field in helm modules.

**Which issue(s) this PR fixes**:

Fixes https://github.com/garden-io/garden/issues/3367
Introduces https://github.com/garden-io/garden/issues/3487

**Special notes for your reviewer**:

Based on internal conversations, we're essentially trading issues here: allow users to specify the valueFiles in a bit more flexible manner to unblock them, while introducing the slight risk of possible version/cache invalidation issues.