### PR TITLE
improvement(jib): configurable gradle binary

### DIFF
--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -101,6 +101,8 @@ build:
 
   # Defines the location of the custom executable Maven binary.
   #
+  # If not provided, then Maven 3.8.5 will be downloaded and used.
+  #
   # **Note!** Either `jdkVersion` or `jdkPath` will be used to define `JAVA_HOME` environment variable for the custom
   # Maven.
   # To ensure a system JDK usage, please set `jdkPath` to `${local.env.JAVA_HOME}`.
@@ -993,6 +995,8 @@ To ensure a system JDK usage, please set `jdkPath` to `${local.env.JAVA_HOME}`.
 [build](#build) > mavenPath
 
 Defines the location of the custom executable Maven binary.
+
+If not provided, then Maven 3.8.5 will be downloaded and used.
 
 **Note!** Either `jdkVersion` or `jdkPath` will be used to define `JAVA_HOME` environment variable for the custom Maven.
 To ensure a system JDK usage, please set `jdkPath` to `${local.env.JAVA_HOME}`.

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -89,6 +89,16 @@ build:
   # Specify the image format in the resulting tar file. Only used if `tarOnly: true`.
   tarFormat: docker
 
+  # Defines the location of the custom executable Gradle binary.
+  #
+  # If not provided, then the Gradle binary available in the working directory will be used.
+  # If no Gradle binary found in the working dir, then Gradle 7.5.1 will be downloaded and used.
+  #
+  # **Note!** Either `jdkVersion` or `jdkPath` will be used to define `JAVA_HOME` environment variable for the custom
+  # Gradle.
+  # To ensure a system JDK usage, please set `jdkPath` to `${local.env.JAVA_HOME}`.
+  gradlePath:
+
   # Defines the location of the custom executable Maven binary.
   #
   # **Note!** Either `jdkVersion` or `jdkPath` will be used to define `JAVA_HOME` environment variable for the custom
@@ -961,6 +971,22 @@ Specify the image format in the resulting tar file. Only used if `tarOnly: true`
 | Type     | Allowed Values  | Default    | Required |
 | -------- | --------------- | ---------- | -------- |
 | `string` | "docker", "oci" | `"docker"` | Yes      |
+
+### `build.gradlePath`
+
+[build](#build) > gradlePath
+
+Defines the location of the custom executable Gradle binary.
+
+If not provided, then the Gradle binary available in the working directory will be used.
+If no Gradle binary found in the working dir, then Gradle 7.5.1 will be downloaded and used.
+
+**Note!** Either `jdkVersion` or `jdkPath` will be used to define `JAVA_HOME` environment variable for the custom Gradle.
+To ensure a system JDK usage, please set `jdkPath` to `${local.env.JAVA_HOME}`.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
 
 ### `build.mavenPath`
 

--- a/plugins/jib/index.ts
+++ b/plugins/jib/index.ts
@@ -11,7 +11,7 @@ import { createGardenPlugin } from "@garden-io/sdk"
 import { dedent } from "@garden-io/sdk/util/string"
 
 import { openJdkSpecs } from "./openjdk"
-import { mavenSpec, mvn } from "./maven"
+import { mavenSpec, mvn, mvnVersion } from "./maven"
 import { mavendSpec, mvnd } from "./mavend"
 import { gradle, gradleSpec, gradleVersion } from "./gradle"
 
@@ -104,6 +104,8 @@ const jibModuleSchema = () =>
       `),
       mavenPath: joi.string().optional().description(dedent`
         Defines the location of the custom executable Maven binary.
+
+        If not provided, then Maven ${mvnVersion} will be downloaded and used.
 
         **Note!** Either \`jdkVersion\` or \`jdkPath\` will be used to define \`JAVA_HOME\` environment variable for the custom Maven.
         To ensure a system JDK usage, please set \`jdkPath\` to \`${systemJdkGardenEnvVar}\`.

--- a/plugins/jib/index.ts
+++ b/plugins/jib/index.ts
@@ -13,7 +13,7 @@ import { dedent } from "@garden-io/sdk/util/string"
 import { openJdkSpecs } from "./openjdk"
 import { mavenSpec, mvn } from "./maven"
 import { mavendSpec, mvnd } from "./mavend"
-import { gradle, gradleSpec } from "./gradle"
+import { gradle, gradleSpec, gradleVersion } from "./gradle"
 
 // TODO: gradually get rid of these core dependencies, move some to SDK etc.
 import { providerConfigBaseSchema, GenericProviderConfig, Provider } from "@garden-io/core/build/src/config/provider"
@@ -93,6 +93,15 @@ const jibModuleSchema = () =>
         .valid("docker", "oci")
         .default("docker")
         .description("Specify the image format in the resulting tar file. Only used if `tarOnly: true`."),
+      gradlePath: joi.string().optional().description(dedent`
+        Defines the location of the custom executable Gradle binary.
+
+        If not provided, then the Gradle binary available in the working directory will be used.
+        If no Gradle binary found in the working dir, then Gradle ${gradleVersion} will be downloaded and used.
+
+        **Note!** Either \`jdkVersion\` or \`jdkPath\` will be used to define \`JAVA_HOME\` environment variable for the custom Gradle.
+        To ensure a system JDK usage, please set \`jdkPath\` to \`${systemJdkGardenEnvVar}\`.
+      `),
       mavenPath: joi.string().optional().description(dedent`
         Defines the location of the custom executable Maven binary.
 
@@ -262,6 +271,7 @@ export const gardenPlugin = () =>
                 cwd: module.path,
                 args,
                 openJdkPath,
+                gradlePath: module.spec.build.gradlePath,
                 outputStream,
               })
             }

--- a/plugins/jib/maven.ts
+++ b/plugins/jib/maven.ts
@@ -15,7 +15,7 @@ import execa from "execa"
 
 const buildLock = new AsyncLock()
 
-const mvnVersion = "3.8.5"
+export const mvnVersion = "3.8.5"
 
 const spec = {
   url: `https://archive.apache.org/dist/maven/maven-3/${mvnVersion}/binaries/apache-maven-${mvnVersion}-bin.tar.gz`,

--- a/plugins/jib/util.ts
+++ b/plugins/jib/util.ts
@@ -21,6 +21,7 @@ interface JibModuleBuildSpec extends ContainerBuildSpec {
   tarFormat: "docker" | "oci"
   mavenPath?: string
   mavenPhases: string[]
+  gradlePath?: string
 }
 
 interface JibModuleSpec extends ContainerModuleSpec {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an option to make the `gradle` binary path configurable.
A similar change was done for `maven` in #3173.

**Special notes for your reviewer**:
There is a lot of code duplication in [`maven.ts`](https://github.com/garden-io/garden/blob/improvement/configurable-gradle-binary/plugins/jib/maven.ts) and [`gradle.ts`](https://github.com/garden-io/garden/blob/improvement/configurable-gradle-binary/plugins/jib/gradle.ts). Those parts will be refactored in a separate PR.