### PR TITLE
fix(dev-mode): proper support of absolute source paths

### DIFF
--- a/core/src/plugins/kubernetes/dev-mode.ts
+++ b/core/src/plugins/kubernetes/dev-mode.ts
@@ -27,6 +27,7 @@ import { KubernetesDevModeDefaults, KubernetesPluginContext, KubernetesProvider 
 import { isConfiguredForDevMode } from "./status/status"
 import { k8sSyncUtilImageName } from "./constants"
 import { isAbsolute } from "path"
+import { enumerate } from "../../util/enumerate"
 
 export const builtInExcludes = ["/**/*.git", "**/*.garden"]
 
@@ -151,9 +152,7 @@ export async function startDevModeSync({
     const k8sProvider = <KubernetesProvider>k8sCtx.provider
     const defaults = k8sProvider.config.devMode?.defaults || {}
 
-    let i = 0
-
-    for (const s of spec.sync) {
+    for (const [i, s] of enumerate(spec.sync)) {
       const key = `${keyBase}-${i}`
 
       const localPath = getLocalSyncPath(s.source, moduleRoot)
@@ -192,8 +191,6 @@ export async function startDevModeSync({
         targetDescription,
         config: makeSyncConfig({ defaults, spec: s, localPath, remoteDestination }),
       })
-
-      i++
     }
   })
 }

--- a/core/src/util/enumerate.ts
+++ b/core/src/util/enumerate.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2018-2022 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Analogue of the Python's {@code enumerate} function.
+ * See https://docs.python.org/3/library/functions.html#enumerate
+ *
+ * NOTE: based on the pure JS implementation suggested in https://stackoverflow.com/a/34347308/2753863
+ *
+ * @template T
+ *
+ * @param {Iterable<T>} it
+ * @param {number} start
+ *
+ * @returns  {[number, {T}]}
+ *
+ * @module    enumerate
+ * @function  default
+ */
+export function* enumerate<T>(it: Iterable<T>, start: number = 0) {
+  let i = start
+  for (const x of it) {
+    const tuple: [number, T] = [i++, x]
+    yield tuple
+  }
+}

--- a/core/test/unit/src/plugins/kubernetes/dev-mode.ts
+++ b/core/test/unit/src/plugins/kubernetes/dev-mode.ts
@@ -7,14 +7,35 @@
  */
 
 import { expect } from "chai"
-import { builtInExcludes, makeSyncConfig } from "../../../../../src/plugins/kubernetes/dev-mode"
+import { builtInExcludes, getLocalSyncPath, makeSyncConfig } from "../../../../../src/plugins/kubernetes/dev-mode"
 
 describe("k8s dev mode helpers", () => {
-  const localPath = "/path/to/module/src"
-  const remoteDestination = "exec:'various fun connection parameters'"
-  const source = "src"
-  const target = "/app/src"
+  describe("getLocalSyncPath", () => {
+    context("relative source path", () => {
+      it("should join the module root path with the source path", () => {
+        const relativeSourcePath = "../relative/path"
+        const moduleRoot = "/this/is/module/path"
+        const localPath = getLocalSyncPath(relativeSourcePath, moduleRoot)
+        expect(localPath).to.equal("/this/is/module/relative/path")
+      })
+    })
+
+    context("absolute source path", () => {
+      it("should ignore the module root path and return the absolute source path", () => {
+        const absoluteSourcePath = "/absolute/path"
+        const moduleRoot = "/this/is/module/path"
+        const localPath = getLocalSyncPath(absoluteSourcePath, moduleRoot)
+        expect(localPath).to.equal(absoluteSourcePath)
+      })
+    })
+  })
+
   describe("makeSyncConfig", () => {
+    const localPath = "/path/to/module/src"
+    const remoteDestination = "exec:'various fun connection parameters'"
+    const source = "src"
+    const target = "/app/src"
+
     it("should generate a simple sync config", () => {
       const config = makeSyncConfig({
         localPath,

--- a/core/test/unit/src/util/enumerate.ts
+++ b/core/test/unit/src/util/enumerate.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2018-2022 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { enumerate } from "../../../../src/util/enumerate"
+import { expect } from "chai"
+
+describe("enumerate", () => {
+  const list = ["a", "b", "c"]
+  it("counts from 0 if no start parameter defined", () => {
+    const enumeratedArray = Array.from(enumerate(list))
+    expect(enumeratedArray).to.deep.equal([
+      [0, "a"],
+      [1, "b"],
+      [2, "c"],
+    ])
+  })
+
+  it("counts from custom start value if it's defined", () => {
+    const start = 5
+    let counter = start
+    const enumeratedArray = Array.from(enumerate(list, start))
+    expect(enumeratedArray).to.deep.equal([
+      [counter++, "a"],
+      [counter++, "b"],
+      [counter, "c"],
+    ])
+  })
+
+  it("returns empty array for empty input", () => {
+    const enumeratedArray = Array.from(enumerate([]))
+    expect(enumeratedArray).to.deep.equal([])
+  })
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
Patch for #3145.

As a bonus track, it introduces a new [helper function](https://github.com/garden-io/garden/pull/3447/commits/048f8ea31a875300a380960db6b7f9dcb81ece62) - an analog of the [Pythonic `enumerate`](https://docs.python.org/3/library/functions.html#enumerate).

**Which issue(s) this PR fixes**:

Fixes the [Mutagen file sync in devMode using absolute paths appears to not be working](https://discord.com/channels/817392104711651328/1051879220789399612) issue from our public Discord.

**Special notes for your reviewer**:
