### PR TITLE
fix: re-initialize providers changing environments

### DIFF
--- a/core/src/tasks/resolve-provider.ts
+++ b/core/src/tasks/resolve-provider.ts
@@ -45,13 +45,11 @@ interface Params extends TaskParams {
 
 interface CachedStatus extends EnvironmentStatus {
   configHash: string
-  environmentName: string
   resolvedAt: Date
 }
 
 const cachedStatusSchema = environmentStatusSchema().keys({
   configHash: joi.string().required(),
-  environmentName: joi.string().required(),
   resolvedAt: joi.date().required(),
 })
 
@@ -283,11 +281,6 @@ export class ResolveProviderTask extends BaseTask {
       return null
     }
 
-    if (cachedStatus.environmentName !== this.garden.environmentName) {
-      this.log.silly(`Cached environment name at ${cachePath} does not match the current environmnent name`)
-      return null
-    }
-
     const configHash = this.hashConfig(config)
 
     if (cachedStatus.configHash !== configHash) {
@@ -303,7 +296,7 @@ export class ResolveProviderTask extends BaseTask {
       return null
     }
 
-    return omit(cachedStatus, ["configHash", "resolvedAt", "environmentName"])
+    return omit(cachedStatus, ["configHash", "resolvedAt"])
   }
 
   private async setCachedStatus(config: GenericProviderConfig, status: EnvironmentStatus) {

--- a/core/test/data/exec-provider-cache/.gitignore
+++ b/core/test/data/exec-provider-cache/.gitignore
@@ -1,0 +1,1 @@
+theFile

--- a/core/test/data/exec-provider-cache/project.garden.yml
+++ b/core/test/data/exec-provider-cache/project.garden.yml
@@ -1,0 +1,8 @@
+kind: Project
+name: incident-repro
+environments:
+  - name: one
+  - name: two
+providers:
+  - name: exec
+    initScript: "echo '${environment.name}' > theFile"

--- a/core/test/integ/src/plugins/exec/resolve.ts
+++ b/core/test/integ/src/plugins/exec/resolve.ts
@@ -14,49 +14,48 @@ import { getDataDir, makeTestGarden, TestGarden } from "../../../../helpers"
 describe("exec provider initialization cache behaviour", () => {
   let gardenOne: TestGarden
   let tmpDir: string
+  let fileLocation: string
 
   beforeEach(async () => {
     gardenOne = await makeTestGarden(getDataDir("exec-provider-cache"), { environmentName: "one" })
-    tmpDir = await gardenOne.getRepoRoot()
+
+    tmpDir = join(await gardenOne.getRepoRoot(), "project")
+    fileLocation = join(tmpDir, "theFile")
+
+    await gardenOne.resolveProvider(gardenOne.log, "exec")
   })
 
   it("writes the environment name to theFile as configured in the initScript", async () => {
-    await gardenOne.resolveProvider(gardenOne.log, "exec")
-
-    const contents = await readFile(join(tmpDir, "theFile"), { encoding: "utf-8" })
+    const contents = await readFile(fileLocation, { encoding: "utf-8" })
 
     expect(contents).equal("one\n")
   })
 
   it("overwrites theFile when changing environments", async () => {
-    await gardenOne.resolveProvider(gardenOne.log, "exec")
-
-    let contents = await readFile(join(tmpDir, "theFile"), { encoding: "utf-8" })
+    let contents = await readFile(fileLocation, { encoding: "utf-8" })
     expect(contents).equal("one\n")
 
     const gardenTwo = await makeTestGarden(tmpDir, { environmentName: "two", noTempDir: true })
     await gardenTwo.resolveProvider(gardenTwo.log, "exec")
 
-    contents = await readFile(join(tmpDir, "theFile"), { encoding: "utf-8" })
+    contents = await readFile(fileLocation, { encoding: "utf-8" })
     expect(contents).equal("two\n")
   })
 
   it("still overwrites theFile when changing environments back", async () => {
-    await gardenOne.resolveProvider(gardenOne.log, "exec")
-
-    let contents = await readFile(join(tmpDir, "theFile"), { encoding: "utf-8" })
+    let contents = await readFile(fileLocation, { encoding: "utf-8" })
     expect(contents).equal("one\n")
 
     const gardenTwo = await makeTestGarden(tmpDir, { environmentName: "two", noTempDir: true })
     await gardenTwo.resolveProvider(gardenTwo.log, "exec")
 
-    contents = await readFile(join(tmpDir, "theFile"), { encoding: "utf-8" })
+    contents = await readFile(fileLocation, { encoding: "utf-8" })
     expect(contents).equal("two\n")
 
     const gardenOneAgain = await makeTestGarden(tmpDir, { environmentName: "one", noTempDir: true })
     await gardenOneAgain.resolveProvider(gardenOneAgain.log, "exec")
 
-    contents = await readFile(join(tmpDir, "theFile"), { encoding: "utf-8" })
+    contents = await readFile(fileLocation, { encoding: "utf-8" })
     expect(contents).equal("one\n")
   })
 })

--- a/core/test/integ/src/plugins/exec/resolve.ts
+++ b/core/test/integ/src/plugins/exec/resolve.ts
@@ -1,6 +1,13 @@
+/*
+ * Copyright (C) 2018-2022 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
 import { expect } from "chai"
-import execa from "execa"
-import { remove, readFile } from "fs-extra"
+import { readFile } from "fs-extra"
 import { join } from "node:path"
 import { getDataDir, makeTestGarden, TestGarden } from "../../../../helpers"
 

--- a/core/test/integ/src/plugins/exec/resolve.ts
+++ b/core/test/integ/src/plugins/exec/resolve.ts
@@ -1,0 +1,55 @@
+import { expect } from "chai"
+import execa from "execa"
+import { remove, readFile } from "fs-extra"
+import { join } from "node:path"
+import { getDataDir, makeTestGarden, TestGarden } from "../../../../helpers"
+
+describe("exec provider initialization cache behaviour", () => {
+  let gardenOne: TestGarden
+  let tmpDir: string
+
+  beforeEach(async () => {
+    gardenOne = await makeTestGarden(getDataDir("exec-provider-cache"), { environmentName: "one" })
+    tmpDir = await gardenOne.getRepoRoot()
+  })
+
+  it("writes the environment name to theFile as configured in the initScript", async () => {
+    await gardenOne.resolveProvider(gardenOne.log, "exec")
+
+    const contents = await readFile(join(tmpDir, "theFile"), { encoding: "utf-8" })
+
+    expect(contents).equal("one\n")
+  })
+
+  it("overwrites theFile when changing environments", async () => {
+    await gardenOne.resolveProvider(gardenOne.log, "exec")
+
+    let contents = await readFile(join(tmpDir, "theFile"), { encoding: "utf-8" })
+    expect(contents).equal("one\n")
+
+    const gardenTwo = await makeTestGarden(tmpDir, { environmentName: "two", noTempDir: true })
+    await gardenTwo.resolveProvider(gardenTwo.log, "exec")
+
+    contents = await readFile(join(tmpDir, "theFile"), { encoding: "utf-8" })
+    expect(contents).equal("two\n")
+  })
+
+  it("still overwrites theFile when changing environments back", async () => {
+    await gardenOne.resolveProvider(gardenOne.log, "exec")
+
+    let contents = await readFile(join(tmpDir, "theFile"), { encoding: "utf-8" })
+    expect(contents).equal("one\n")
+
+    const gardenTwo = await makeTestGarden(tmpDir, { environmentName: "two", noTempDir: true })
+    await gardenTwo.resolveProvider(gardenTwo.log, "exec")
+
+    contents = await readFile(join(tmpDir, "theFile"), { encoding: "utf-8" })
+    expect(contents).equal("two\n")
+
+    const gardenOneAgain = await makeTestGarden(tmpDir, { environmentName: "one", noTempDir: true })
+    await gardenOneAgain.resolveProvider(gardenOneAgain.log, "exec")
+
+    contents = await readFile(join(tmpDir, "theFile"), { encoding: "utf-8" })
+    expect(contents).equal("one\n")
+  })
+})

--- a/plugins/terraform/commands.ts
+++ b/plugins/terraform/commands.ts
@@ -44,8 +44,7 @@ function makeRootCommand(commandName: string) {
       // Clear the provider status cache, to avoid any user confusion
       const cachePath = getProviderStatusCachePath({
         gardenDirPath: ctx.gardenDirPath,
-        pluginName: provider.name,
-        environmentName: ctx.environmentName,
+        pluginName: provider.name
       })
       await remove(cachePath)
 

--- a/plugins/terraform/commands.ts
+++ b/plugins/terraform/commands.ts
@@ -44,7 +44,7 @@ function makeRootCommand(commandName: string) {
       // Clear the provider status cache, to avoid any user confusion
       const cachePath = getProviderStatusCachePath({
         gardenDirPath: ctx.gardenDirPath,
-        pluginName: provider.name
+        pluginName: provider.name,
       })
       await remove(cachePath)
 


### PR DESCRIPTION
When users change environments, we need to re-initialize providers.

Let's consider the following example:

User has a provider config like so:
```
providers:
  - name: exec
    initScript: echo ${environment.name} > someFile
```

If user runs a garden command with --env foo, and then with --env bar,
and then again with --env foo we would expect `someFile` to contain `foo`. But
the file actually contains bar.

Reason for this is that garden skipped executing the initScript in the foo env,
because it has already been executed. But the cache logic is not aware that the
last command that ran was in the bar env.

This commit fixes that problem.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
