### PR TITLE
2023 01 03 tiny fixes

### DIFF
--- a/core/src/plugins/kubernetes/logs.ts
+++ b/core/src/plugins/kubernetes/logs.ts
@@ -231,6 +231,7 @@ export class K8sLogFollower<T> {
     await this.createConnections(opts)
 
     this.intervalId = setInterval(async () => {
+      this.log.silly(`calling createConnections again with retryIntervalMs: ${this.retryIntervalMs}`)
       await this.createConnections(opts)
     }, this.retryIntervalMs)
 

--- a/core/src/plugins/kubernetes/logs.ts
+++ b/core/src/plugins/kubernetes/logs.ts
@@ -265,11 +265,13 @@ export class K8sLogFollower<T> {
     }
 
     // There's no need to log the closed event that happens after an error event
-    if (!(prevStatus === "error" && status === "closed")) {
-      this.log.silly(
-        `<Lost connection to container '${conn.containerName}' in Pod '${conn.pod.metadata.name}'. Reason: ${reason}. Will retry in background...>`
-      )
+    if (prevStatus === "error" && status === "closed") {
+      return
     }
+
+    this.log.silly(
+      `<Lost connection to container '${conn.containerName}' in Pod '${conn.pod.metadata.name}'. Reason: ${reason}. Will retry in background...>`
+    )
   }
 
   private async createConnections({ tail, since, limitBytes }: LogOpts) {

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -785,7 +785,7 @@ export class PodRunner extends PodRunnerParams {
     })
     return new K8sLogFollower({
       defaultNamespace: this.namespace,
-      retryIntervalMs: 10,
+      retryIntervalMs: 10000,
       stream,
       log,
       entryConverter: makeRunLogEntry,


### PR DESCRIPTION
**What this PR does / why we need it**:

Small improvements to kubernetes logging. This should make reading CI logs and other `-l5` level logs much easier, and significantly reduce the amount of requests we are making to the kubernetes api for the logs during service startup.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

WIP do not merge yet