### PR TITLE
improvement(cli): trim binary size by approx 1/3

### DIFF
--- a/cli/src/build-pkg.ts
+++ b/cli/src/build-pkg.ts
@@ -258,6 +258,8 @@ async function pkgCommon({
       "--target",
       pkgType,
       sourcePath,
+      "--compress",
+      "Brotli",
       "--public",
       "--options",
       nodeOptions.join(","),

--- a/support/alpine-builder.Dockerfile
+++ b/support/alpine-builder.Dockerfile
@@ -39,6 +39,6 @@ ADD static /garden/static
 
 # Create the binary
 RUN mkdir -p /garden \
-  && node_modules/.bin/pkg --target node14-alpine-x64 . --output /garden/garden \
+  && node_modules/.bin/pkg --compress Brotli --target node14-alpine-x64 . --output /garden/garden \
   && cp node_modules/better-sqlite3/build/Release/better_sqlite3.node /garden \
   && /garden/garden version


### PR DESCRIPTION
This is a cheap improvement enabled by a compression feature in pkg.

pkg docs suggest this would generally improve startup time but in my manual testing I could find no meaningful changes on that front in either direction, but that's all good.
