### PR TITLE
chore(ci): remove in cluster image pull tests as too flaky

### DIFF
--- a/core/test/integ/src/plugins/kubernetes/commands/pull-image.ts
+++ b/core/test/integ/src/plugins/kubernetes/commands/pull-image.ts
@@ -88,31 +88,6 @@ describe("pull-image plugin command", () => {
     })
   })
 
-  grouped("kaniko").context("using the in cluster registry with kaniko", () => {
-    let module: GardenModule
-
-    before(async () => {
-      await init("kaniko")
-
-      module = graph.getModule("simple-service")
-
-      // build the image
-      await garden.buildStaging.syncFromSrc(module, garden.log)
-
-      await k8sBuildContainer({
-        ctx,
-        log: garden.log,
-        module,
-      })
-    })
-
-    it("should pull the image", async () => {
-      await removeImage(module)
-      await pullModule(ctx as KubernetesPluginContext, module, garden.log)
-      await ensureImagePulled(module)
-    })
-  })
-
   grouped("cluster-buildkit", "remote-only").context("using an external cluster registry with buildkit", () => {
     let module: GardenModule
 
@@ -120,31 +95,6 @@ describe("pull-image plugin command", () => {
       await init("cluster-buildkit-remote-registry")
 
       module = graph.getModule("remote-registry-test")
-
-      // build the image
-      await garden.buildStaging.syncFromSrc(module, garden.log)
-
-      await k8sBuildContainer({
-        ctx,
-        log: garden.log,
-        module,
-      })
-    })
-
-    it("should pull the image", async () => {
-      await removeImage(module)
-      await pullModule(ctx as KubernetesPluginContext, module, garden.log)
-      await ensureImagePulled(module)
-    })
-  })
-
-  grouped("cluster-buildkit").context("using the in cluster registry with buildkit", () => {
-    let module: GardenModule
-
-    before(async () => {
-      await init("cluster-buildkit")
-
-      module = graph.getModule("simple-service")
 
       // build the image
       await garden.buildStaging.syncFromSrc(module, garden.log)


### PR DESCRIPTION
**What this PR does / why we need it**:

Disables image pull tests for in-cluster image registry.

The in-cluster image registry is deprecated and removed in 0.13 anyway, and these tests are incredibly flaky and a major(ity?) chunk of our CI failures.

This solution is not ideal, but neither is our CI pipeline failing most of its runs.
Let's not let perfect be the enemy of good here.