### PR TITLE
refactor(pulumi): remove dead code

### DIFF
--- a/plugins/pulumi/handlers.ts
+++ b/plugins/pulumi/handlers.ts
@@ -76,7 +76,7 @@ export const getPulumiServiceStatus: ServiceActionHandlers["getServiceStatus"] =
   const provider = ctx.provider as PulumiProvider
   const pulumiModule: PulumiModule = module
   const pulumiParams = { log, ctx, provider, module: pulumiModule }
-  const { deployFromPreview, cacheStatus } = pulumiModule.spec
+  const { cacheStatus } = pulumiModule.spec
   const serviceVersion = service.version
 
   if (!cacheStatus) {
@@ -90,14 +90,6 @@ export const getPulumiServiceStatus: ServiceActionHandlers["getServiceStatus"] =
 
   await selectStack(pulumiParams)
   const stackStatus = await getStackStatusFromTag({ ...pulumiParams, serviceVersion })
-  if (deployFromPreview && stackStatus === "up-to-date") {
-    return {
-      state: "ready",
-      version: serviceVersion,
-      outputs: await getStackOutputs(pulumiParams),
-      detail: {},
-    }
-  }
 
   const serviceStatus: ServiceStatus = {
     state: stackStatus === "up-to-date" ? "ready" : "outdated",


### PR DESCRIPTION
tiny cleanup, the `serviceStatus` block below handles the same case in the same way.

found this while reading through the code when debugging https://github.com/garden-io/garden/issues/3468 and thought might as well remove it, even if it doesn't really matter. we can also let it be, if we prefer.