### PR TITLE
fix(jib): fixed broken Maven Daemon support in  0.13

### DIFF
--- a/plugins/jib/index.ts
+++ b/plugins/jib/index.ts
@@ -12,7 +12,7 @@ import { dedent } from "@garden-io/sdk/util/string"
 
 import { openJdkSpecs } from "./openjdk"
 import { mavenSpec, mvn } from "./maven"
-import { mavendSpec } from "./mavend"
+import { mavendSpec, mvnd } from "./mavend"
 import { gradle, gradleSpec } from "./gradle"
 
 // TODO: gradually get rid of these core dependencies, move some to SDK etc.
@@ -199,6 +199,15 @@ export const gardenPlugin = () =>
                   args: [...mavenPhases, ...args],
                   openJdkPath,
                   mavenPath,
+                  outputStream,
+                })
+              } else if (projectType === "mavend") {
+                await mvnd({
+                  ctx,
+                  log,
+                  cwd: action.basePath(),
+                  args: [...mavenPhases, ...args],
+                  openJdkPath,
                   outputStream,
                 })
               } else {


### PR DESCRIPTION
Fixes the `mvnd` support for jib module type that was initially implemented in #3361.

**Special notes for your reviewer**:
The feature was accidentally broken while merging `main` into `0.13` (see https://github.com/garden-io/garden/commit/5f2a54afe5ade93553bd19ea17f2b02c76b47274#diff-b3bbd18a1db370349e20a629ca82693b5349d847b24cf167d6ca726406160f8b, https://github.com/garden-io/garden/commit/f433568fe82e98dbd01bd4f54361e29145cc7646#diff-b3bbd18a1db370349e20a629ca82693b5349d847b24cf167d6ca726406160f8b, and https://github.com/garden-io/garden/commit/db432a464670c34a1d53fe5b822e5cac51772f05)
