### PR TITLE
chore: mark cert-manager integration as deprecated

### DIFF
--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -470,7 +470,8 @@ const tlsCertificateSchema = () =>
     `
       )
       .allow("cert-manager")
-      .example("cert-manager"),
+      .example("cert-manager")
+      .meta({ deprecated: "The cert-manager integration is deprecated and will be removed in a future release" }),
   })
 
 const buildkitCacheConfigurationSchema = () =>
@@ -894,21 +895,29 @@ export const kubernetesConfigBase = () =>
       .object()
       .optional()
       .keys({
-        install: joi.bool().default(false).description(dedent`
+        install: joi
+          .bool()
+          .default(false)
+          .description(
+            dedent`
           Automatically install \`cert-manager\` on initialization. See the
           [cert-manager integration guide](https://docs.garden.io/advanced/cert-manager-integration) for details.
-        `),
+        `
+          )
+          .meta({ deprecated: "The cert-manager integration is deprecated and will be removed in a future release" }),
         email: joi
           .string()
           .required()
           .description("The email to use when requesting Let's Encrypt certificates.")
-          .example("yourname@example.com"),
+          .example("yourname@example.com")
+          .meta({ deprecated: "The cert-manager integration is deprecated and will be removed in a future release" }),
         issuer: joi
           .string()
           .allow("acme")
           .default("acme")
           .description("The type of issuer for the certificate (only ACME is supported for now).")
-          .example("acme"),
+          .example("acme")
+          .meta({ deprecated: "The cert-manager integration is deprecated and will be removed in a future release" }),
         acmeServer: joi
           .string()
           .allow("letsencrypt-staging", "letsencrypt-prod")
@@ -917,7 +926,8 @@ export const kubernetesConfigBase = () =>
             deline`Specify which ACME server to request certificates from. Currently Let's Encrypt staging and prod
           servers are supported.`
           )
-          .example("letsencrypt-staging"),
+          .example("letsencrypt-staging")
+          .meta({ deprecated: "The cert-manager integration is deprecated and will be removed in a future release" }),
         acmeChallengeType: joi
           .string()
           .allow("HTTP-01")
@@ -926,9 +936,14 @@ export const kubernetesConfigBase = () =>
             deline`The type of ACME challenge used to validate hostnames and generate the certificates
           (only HTTP-01 is supported for now).`
           )
-          .example("HTTP-01"),
-      }).description(dedent`cert-manager configuration, for creating and managing TLS certificates. See the
-        [cert-manager guide](https://docs.garden.io/advanced/cert-manager-integration) for details.`),
+          .example("HTTP-01")
+          .meta({ deprecated: "The cert-manager integration is deprecated and will be removed in a future release" }),
+      })
+      .description(
+        dedent`cert-manager configuration, for creating and managing TLS certificates. See the
+        [cert-manager guide](https://docs.garden.io/advanced/cert-manager-integration) for details.`
+      )
+      .meta({ deprecated: "The cert-manager integration is deprecated and will be removed in a future release" }),
     _systemServices: joiArray(joiIdentifier()).meta({ internal: true }),
     systemNodeSelector: joiStringMap(joi.string())
       .description(

--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -471,7 +471,7 @@ const tlsCertificateSchema = () =>
       )
       .allow("cert-manager")
       .example("cert-manager")
-      .meta({ deprecated: "The cert-manager integration is deprecated and will be removed in a future release" }),
+      .meta({ deprecated: "The cert-manager integration is deprecated and will be removed in the 0.13 release" }),
   })
 
 const buildkitCacheConfigurationSchema = () =>
@@ -904,20 +904,20 @@ export const kubernetesConfigBase = () =>
           [cert-manager integration guide](https://docs.garden.io/advanced/cert-manager-integration) for details.
         `
           )
-          .meta({ deprecated: "The cert-manager integration is deprecated and will be removed in a future release" }),
+          .meta({ deprecated: "The cert-manager integration is deprecated and will be removed in the 0.13 release" }),
         email: joi
           .string()
           .required()
           .description("The email to use when requesting Let's Encrypt certificates.")
           .example("yourname@example.com")
-          .meta({ deprecated: "The cert-manager integration is deprecated and will be removed in a future release" }),
+          .meta({ deprecated: "The cert-manager integration is deprecated and will be removed in the 0.13 release" }),
         issuer: joi
           .string()
           .allow("acme")
           .default("acme")
           .description("The type of issuer for the certificate (only ACME is supported for now).")
           .example("acme")
-          .meta({ deprecated: "The cert-manager integration is deprecated and will be removed in a future release" }),
+          .meta({ deprecated: "The cert-manager integration is deprecated and will be removed in the 0.13 release" }),
         acmeServer: joi
           .string()
           .allow("letsencrypt-staging", "letsencrypt-prod")
@@ -927,7 +927,7 @@ export const kubernetesConfigBase = () =>
           servers are supported.`
           )
           .example("letsencrypt-staging")
-          .meta({ deprecated: "The cert-manager integration is deprecated and will be removed in a future release" }),
+          .meta({ deprecated: "The cert-manager integration is deprecated and will be removed in the 0.13 release" }),
         acmeChallengeType: joi
           .string()
           .allow("HTTP-01")
@@ -937,13 +937,13 @@ export const kubernetesConfigBase = () =>
           (only HTTP-01 is supported for now).`
           )
           .example("HTTP-01")
-          .meta({ deprecated: "The cert-manager integration is deprecated and will be removed in a future release" }),
+          .meta({ deprecated: "The cert-manager integration is deprecated and will be removed in the 0.13 release" }),
       })
       .description(
         dedent`cert-manager configuration, for creating and managing TLS certificates. See the
         [cert-manager guide](https://docs.garden.io/advanced/cert-manager-integration) for details.`
       )
-      .meta({ deprecated: "The cert-manager integration is deprecated and will be removed in a future release" }),
+      .meta({ deprecated: "The cert-manager integration is deprecated and will be removed in the 0.13 release" }),
     _systemServices: joiArray(joiIdentifier()).meta({ internal: true }),
     systemNodeSelector: joiStringMap(joi.string())
       .description(

--- a/core/src/plugins/kubernetes/integrations/cert-manager.ts
+++ b/core/src/plugins/kubernetes/integrations/cert-manager.ts
@@ -176,6 +176,11 @@ export async function checkCertManagerStatus({
   provider: KubernetesProvider
   namespace?: string
 }): Promise<ServiceState> {
+  log.warn({
+    symbol: "warning",
+    msg: "The cert-manager integration is deprecated and will be removed in a future release",
+  })
+
   const api = await KubeApi.factory(log, ctx, provider)
   const systemPods = await api.core.listNamespacedPod(namespace)
   const certManagerPods: KubernetesServerResource<V1Pod>[] = []

--- a/core/src/plugins/kubernetes/integrations/cert-manager.ts
+++ b/core/src/plugins/kubernetes/integrations/cert-manager.ts
@@ -26,6 +26,7 @@ import { EnvironmentStatus } from "../../../types/plugin/provider/getEnvironment
 import { PrimitiveMap } from "../../../config/common"
 import chalk from "chalk"
 import { defaultIngressClass } from "../constants"
+import { emitWarning } from "../../../warnings"
 
 /**
  * Given an array of certificate names, check if they are all existing and Ready.
@@ -176,9 +177,10 @@ export async function checkCertManagerStatus({
   provider: KubernetesProvider
   namespace?: string
 }): Promise<ServiceState> {
-  log.warn({
-    symbol: "warning",
-    msg: "The cert-manager integration is deprecated and will be removed in a future release",
+  await emitWarning({
+    key: "cert-manager-deprecated",
+    log,
+    message: "The cert-manager integration is deprecated and will be removed in the 0.13 release",
   })
 
   const api = await KubeApi.factory(log, ctx, provider)

--- a/docs/advanced/cert-manager-integration.md
+++ b/docs/advanced/cert-manager-integration.md
@@ -5,6 +5,10 @@ title: cert-manager Integration
 
 # cert-manager Integration
 
+{% hint style="warning" %}
+The cert-manager integration is deprecated and will be removed in a future release.
+{% endhint %}
+
 When starting a new Kubernetes project or when maintaining your existing ones, dealing with the creation and renewal of TLS certificates can easily become a headache. A popular tool to help automate certficate generation and renewal is [cert-manager](https://github.com/jetstack/cert-manager).
 
 The [kubernetes](../k8s-plugins/remote-k8s/README.md) and [local-kubernetes](../k8s-plugins/local-k8s/README.md) providers include an integration with cert-manager. The goal of the integration is to give you a head start when setting up TLS certificates for your project, providing an easy way to install it, and some sensible defaults.
@@ -53,6 +57,7 @@ To enable cert-manager, you'll need to configure it in the `kubernetes` provider
 ```
 
 Unless you want to use your own installation of cert-manager, you will need to set the option `install: true`. Garden will then install cert-manager for you under the `cert-manager` namespace.
+
 > Note: Garden will wait until all the pods required by cert-manager will be up and running. This might take more than 2 minutes depending on the cluster.
 
 If nothing is specified or `install: false`, Garden will assume you already have a valid and running cert-manager installation in the `cert-manager` namespace.
@@ -127,4 +132,5 @@ $: kubectl describe Certificate certificate-name -n your-namespace
 Please find more info in the ["Issuing an ACME certificate using HTTP validation"](https://cert-manager.io/docs/tutorials/acme/http-validation/#issuing-an-acme-certificate-using-http-validation) guide in the official cert-manager documentation.
 
 ---
+
 If have any issue, find a bug, or something is not clear from the documentation, please don't hesitate opening a new [GitHub issue](https://github.com/garden-io/garden/issues/new?template=BUG_REPORT.md) or ask us questions in [our Discord community](https://discord.gg/gxeuDgp6Xt).

--- a/docs/advanced/cert-manager-integration.md
+++ b/docs/advanced/cert-manager-integration.md
@@ -6,7 +6,7 @@ title: cert-manager Integration
 # cert-manager Integration
 
 {% hint style="warning" %}
-The cert-manager integration is deprecated and will be removed in a future release.
+The cert-manager integration is deprecated and will be removed in the 0.13 release.
 {% endhint %}
 
 When starting a new Kubernetes project or when maintaining your existing ones, dealing with the creation and renewal of TLS certificates can easily become a headache. A popular tool to help automate certficate generation and renewal is [cert-manager](https://github.com/jetstack/cert-manager).

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -506,32 +506,6 @@ providers:
           # namespace before use.
           namespace: default
 
-        # Set to `cert-manager` to configure [cert-manager](https://github.com/jetstack/cert-manager) to manage this
-        # certificate. See our
-        # [cert-manager integration guide](https://docs.garden.io/advanced/cert-manager-integration) for details.
-        managedBy:
-
-    # cert-manager configuration, for creating and managing TLS certificates. See the
-    # [cert-manager guide](https://docs.garden.io/advanced/cert-manager-integration) for details.
-    certManager:
-      # Automatically install `cert-manager` on initialization. See the
-      # [cert-manager integration guide](https://docs.garden.io/advanced/cert-manager-integration) for details.
-      install: false
-
-      # The email to use when requesting Let's Encrypt certificates.
-      email:
-
-      # The type of issuer for the certificate (only ACME is supported for now).
-      issuer: acme
-
-      # Specify which ACME server to request certificates from. Currently Let's Encrypt staging and prod servers are
-      # supported.
-      acmeServer: letsencrypt-staging
-
-      # The type of ACME challenge used to validate hostnames and generate the certificates (only HTTP-01 is supported
-      # for now).
-      acmeChallengeType: HTTP-01
-
     # Exposes the `nodeSelector` field on the PodSpec of system services. This allows you to constrain the system
     # services to only run on particular nodes.
     #
@@ -2541,6 +2515,10 @@ The namespace where the secret is stored. If necessary, the secret may be copied
 
 [providers](#providers) > [tlsCertificates](#providerstlscertificates) > managedBy
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Set to `cert-manager` to configure [cert-manager](https://github.com/jetstack/cert-manager) to manage this
 certificate. See our
 [cert-manager integration guide](https://docs.garden.io/advanced/cert-manager-integration) for details.
@@ -2561,6 +2539,10 @@ providers:
 
 [providers](#providers) > certManager
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 cert-manager configuration, for creating and managing TLS certificates. See the
 [cert-manager guide](https://docs.garden.io/advanced/cert-manager-integration) for details.
 
@@ -2572,6 +2554,10 @@ cert-manager configuration, for creating and managing TLS certificates. See the
 
 [providers](#providers) > [certManager](#providerscertmanager) > install
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Automatically install `cert-manager` on initialization. See the
 [cert-manager integration guide](https://docs.garden.io/advanced/cert-manager-integration) for details.
 
@@ -2582,6 +2568,10 @@ Automatically install `cert-manager` on initialization. See the
 ### `providers[].certManager.email`
 
 [providers](#providers) > [certManager](#providerscertmanager) > email
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The email to use when requesting Let's Encrypt certificates.
 
@@ -2602,6 +2592,10 @@ providers:
 
 [providers](#providers) > [certManager](#providerscertmanager) > issuer
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 The type of issuer for the certificate (only ACME is supported for now).
 
 | Type     | Default  | Required |
@@ -2621,6 +2615,10 @@ providers:
 
 [providers](#providers) > [certManager](#providerscertmanager) > acmeServer
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Specify which ACME server to request certificates from. Currently Let's Encrypt staging and prod servers are supported.
 
 | Type     | Default                 | Required |
@@ -2639,6 +2637,10 @@ providers:
 ### `providers[].certManager.acmeChallengeType`
 
 [providers](#providers) > [certManager](#providerscertmanager) > acmeChallengeType
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The type of ACME challenge used to validate hostnames and generate the certificates (only HTTP-01 is supported for now).
 

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -502,32 +502,6 @@ providers:
           # namespace before use.
           namespace: default
 
-        # Set to `cert-manager` to configure [cert-manager](https://github.com/jetstack/cert-manager) to manage this
-        # certificate. See our
-        # [cert-manager integration guide](https://docs.garden.io/advanced/cert-manager-integration) for details.
-        managedBy:
-
-    # cert-manager configuration, for creating and managing TLS certificates. See the
-    # [cert-manager guide](https://docs.garden.io/advanced/cert-manager-integration) for details.
-    certManager:
-      # Automatically install `cert-manager` on initialization. See the
-      # [cert-manager integration guide](https://docs.garden.io/advanced/cert-manager-integration) for details.
-      install: false
-
-      # The email to use when requesting Let's Encrypt certificates.
-      email:
-
-      # The type of issuer for the certificate (only ACME is supported for now).
-      issuer: acme
-
-      # Specify which ACME server to request certificates from. Currently Let's Encrypt staging and prod servers are
-      # supported.
-      acmeServer: letsencrypt-staging
-
-      # The type of ACME challenge used to validate hostnames and generate the certificates (only HTTP-01 is supported
-      # for now).
-      acmeChallengeType: HTTP-01
-
     # Exposes the `nodeSelector` field on the PodSpec of system services. This allows you to constrain the system
     # services to only run on particular nodes.
     #
@@ -2490,6 +2464,10 @@ The namespace where the secret is stored. If necessary, the secret may be copied
 
 [providers](#providers) > [tlsCertificates](#providerstlscertificates) > managedBy
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Set to `cert-manager` to configure [cert-manager](https://github.com/jetstack/cert-manager) to manage this
 certificate. See our
 [cert-manager integration guide](https://docs.garden.io/advanced/cert-manager-integration) for details.
@@ -2510,6 +2488,10 @@ providers:
 
 [providers](#providers) > certManager
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 cert-manager configuration, for creating and managing TLS certificates. See the
 [cert-manager guide](https://docs.garden.io/advanced/cert-manager-integration) for details.
 
@@ -2521,6 +2503,10 @@ cert-manager configuration, for creating and managing TLS certificates. See the
 
 [providers](#providers) > [certManager](#providerscertmanager) > install
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Automatically install `cert-manager` on initialization. See the
 [cert-manager integration guide](https://docs.garden.io/advanced/cert-manager-integration) for details.
 
@@ -2531,6 +2517,10 @@ Automatically install `cert-manager` on initialization. See the
 ### `providers[].certManager.email`
 
 [providers](#providers) > [certManager](#providerscertmanager) > email
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The email to use when requesting Let's Encrypt certificates.
 
@@ -2551,6 +2541,10 @@ providers:
 
 [providers](#providers) > [certManager](#providerscertmanager) > issuer
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 The type of issuer for the certificate (only ACME is supported for now).
 
 | Type     | Default  | Required |
@@ -2570,6 +2564,10 @@ providers:
 
 [providers](#providers) > [certManager](#providerscertmanager) > acmeServer
 
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
+
 Specify which ACME server to request certificates from. Currently Let's Encrypt staging and prod servers are supported.
 
 | Type     | Default                 | Required |
@@ -2588,6 +2586,10 @@ providers:
 ### `providers[].certManager.acmeChallengeType`
 
 [providers](#providers) > [certManager](#providerscertmanager) > acmeChallengeType
+
+{% hint style="warning" %}
+**Deprecated**: This field will be removed in a future release.
+{% endhint %}
 
 The type of ACME challenge used to validate hostnames and generate the certificates (only HTTP-01 is supported for now).
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Marking `cert-manager` as deprecated and warning on the use of it.

**Which issue(s) this PR fixes**:

Related to https://github.com/garden-io/garden/issues/2551 but not closing it.
Let's close it during 0.13 when it will be actually removed.

**Special notes for your reviewer**:

This has been asked about in the community Discord as well, so we should definitely get these docs up to date.

