### PR TITLE
chore(test): reverted test config for `GitHandler`

### DIFF
--- a/core/test/unit/src/vcs/git.ts
+++ b/core/test/unit/src/vcs/git.ts
@@ -70,13 +70,7 @@ describe("GitHandler", () => {
     log = garden.log
     tmpDir = await makeTempGitRepo()
     tmpPath = await realpath(tmpDir.path)
-    handler = new GitHandler(
-      tmpPath,
-      join(tmpPath, ".garden"),
-      // allow to use file protocol for the tests
-      [defaultIgnoreFilename, "-c", "protocol.file.allow=always"],
-      garden.cache
-    )
+    handler = new GitHandler(tmpPath, join(tmpPath, ".garden"), [defaultIgnoreFilename], garden.cache)
     git = (<any>handler).gitCli(log, tmpPath)
   })
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This reverts the test config for `GitHandler`.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
See https://github.com/garden-io/garden/pull/3498#discussion_r1072311317 for the details.