### PR TITLE
fix(kubernetes): fix bugs #3331 and #3535

### DIFF
--- a/core/src/actions.ts
+++ b/core/src/actions.ts
@@ -381,9 +381,9 @@ export class ActionRouter implements TypeGuard {
     const moduleName = params.module.name
     const moduleVersion = params.module.version.versionString
     const statusLine = params.log.placeholder({ level: LogLevel.verbose })
-    params.events.on("log", ({ timestamp, data }) => {
+    params.events.on("log", ({ timestamp, data, implementation }) => {
       const msg = data.toString()
-      statusLine.setState(renderOutputStream(msg, `build`))
+      statusLine.setState(renderOutputStream(msg, implementation))
       this.garden.events.emit("log", {
         timestamp,
         actionUid,
@@ -466,10 +466,11 @@ export class ActionRouter implements TypeGuard {
 
     try {
       // Annotate + emit log output
-      params.events.on("log", ({ timestamp, data }) => {
+      params.events.on("log", ({ timestamp, data, implementation }) => {
         const msg = data.toString()
         if (!params.interactive) {
-          statusLine.setState(renderOutputStream(msg, `test.${testName}`))
+          // XXX in the current implementation, user possibly cannot differentiate logs from different tests
+          statusLine.setState(renderOutputStream(msg, implementation))
         }
         this.garden.events.emit("log", {
           timestamp,
@@ -556,9 +557,9 @@ export class ActionRouter implements TypeGuard {
     const moduleVersion = params.service.module.version.versionString
     const moduleName = params.service.module.name
     const statusLine = params.log.placeholder({ level: LogLevel.verbose })
-    params.events.on("log", ({ timestamp, data }) => {
+    params.events.on("log", ({ timestamp, data, implementation }) => {
       const msg = data.toString()
-      statusLine.setState(renderOutputStream(msg, `deploy`))
+      statusLine.setState(renderOutputStream(msg, implementation))
       this.garden.events.emit("log", {
         timestamp,
         actionUid,
@@ -722,10 +723,11 @@ export class ActionRouter implements TypeGuard {
 
     try {
       // Annotate + emit log output
-      params.events.on("log", ({ timestamp, data }) => {
+      params.events.on("log", ({ timestamp, data, implementation }) => {
         const msg = data.toString()
         if (!params.interactive) {
-          statusLine.setState(renderOutputStream(msg, `task.${taskName}`))
+          // XXX in the current implementation, user possibly cannot differentiate logs from different tests
+          statusLine.setState(renderOutputStream(msg, implementation))
         }
         this.garden.events.emit("log", {
           timestamp,

--- a/core/src/commands/logs.ts
+++ b/core/src/commands/logs.ts
@@ -135,7 +135,7 @@ export class LogsCommand extends Command<Args, Opts> {
   }
 
   terminate() {
-    this.events?.emit("abort", {})
+    this.events?.emit("abort")
   }
 
   async action({ garden, log, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<ServiceLogEntry[]>> {

--- a/core/src/plugin-context.ts
+++ b/core/src/plugin-context.ts
@@ -92,9 +92,22 @@ export const pluginContextSchema = () =>
       cloudApi: joi.any().optional(),
     })
 
-interface PluginEvents {
-  abort: { reason?: string }
-  log: { data: Buffer }
+type LogMessage = {
+  // origin of the log message, e.g. tool that generated it
+  implementation: string
+
+  // number of milliseconds since the epoch
+  timestamp: number
+
+  // reveals the log message after conversion to string
+  data: Buffer
+}
+
+// Define your emitter's types like that:
+// Key: Event name; Value: Listener function signature
+type PluginEvents = {
+  abort: (reason?: string) => void
+  log: (msg: LogMessage) => void
 }
 
 type PluginEventType = keyof PluginEvents

--- a/core/src/plugins/container/build.ts
+++ b/core/src/plugins/container/build.ts
@@ -11,8 +11,6 @@ import { ContainerModule } from "./config"
 import { ConfigurationError } from "../../exceptions"
 import { GetBuildStatusParams } from "../../types/plugin/module/getBuildStatus"
 import { BuildModuleParams } from "../../types/plugin/module/build"
-import { LogLevel } from "../../logger/logger"
-import { renderOutputStream } from "../../util/util"
 import { PrimitiveMap } from "../../config/common"
 import split2 from "split2"
 
@@ -67,12 +65,9 @@ export async function buildContainerModule({ ctx, module, log }: BuildModulePara
 
   // Stream verbose log to a status line
   const outputStream = split2()
-  const statusLine = log.placeholder({ level: LogLevel.verbose })
-
   outputStream.on("error", () => {})
   outputStream.on("data", (line: Buffer) => {
     ctx.events.emit("log", { timestamp: new Date().getTime(), data: line })
-    statusLine.setState(renderOutputStream(line.toString(), "local-docker"))
   })
   const timeout = module.spec.build.timeout
   const res = await containerHelpers.dockerCli({

--- a/core/src/plugins/container/build.ts
+++ b/core/src/plugins/container/build.ts
@@ -67,7 +67,7 @@ export async function buildContainerModule({ ctx, module, log }: BuildModulePara
   const outputStream = split2()
   outputStream.on("error", () => {})
   outputStream.on("data", (line: Buffer) => {
-    ctx.events.emit("log", { timestamp: new Date().getTime(), data: line })
+    ctx.events.emit("log", { timestamp: new Date().getTime(), data: line, implementation: "local-docker" })
   })
   const timeout = module.spec.build.timeout
   const res = await containerHelpers.dockerCli({

--- a/core/src/plugins/exec/exec.ts
+++ b/core/src/plugins/exec/exec.ts
@@ -438,7 +438,7 @@ async function run({
 
   outputStream.on("error", () => {})
   outputStream.on("data", (line: Buffer) => {
-    ctx.events.emit("log", { timestamp: new Date().getTime(), data: line })
+    ctx.events.emit("log", { timestamp: new Date().getTime(), data: line, implementation: command[0] })
   })
 
   const res = await exec(command.join(" "), [], {

--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -29,8 +29,7 @@ import {
   builderToleration,
 } from "./common"
 import { getNamespaceStatus } from "../../namespace"
-import { LogLevel } from "../../../../logger/logger"
-import {  sleep } from "../../../../util/util"
+import { sleep } from "../../../../util/util"
 import { ContainerModule } from "../../../container/config"
 import { getDockerBuildArgs } from "../../../container/build"
 import { getRunningDeploymentPod, usingInClusterRegistry } from "../../util"
@@ -108,7 +107,7 @@ export const buildkitBuildHandler: BuildHandler = async (params) => {
 
   outputStream.on("error", () => {})
   outputStream.on("data", (line: Buffer) => {
-    ctx.events.emit("log", { timestamp: new Date().getTime(), data: line })
+    ctx.events.emit("log", { timestamp: new Date().getTime(), data: line, implementation: "buildkit" })
   })
 
   const command = [

--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -30,7 +30,7 @@ import {
 } from "./common"
 import { getNamespaceStatus } from "../../namespace"
 import { LogLevel } from "../../../../logger/logger"
-import { renderOutputStream, sleep } from "../../../../util/util"
+import {  sleep } from "../../../../util/util"
 import { ContainerModule } from "../../../container/config"
 import { getDockerBuildArgs } from "../../../container/build"
 import { getRunningDeploymentPod, usingInClusterRegistry } from "../../util"
@@ -105,12 +105,10 @@ export const buildkitBuildHandler: BuildHandler = async (params) => {
 
   // Stream verbose logs to a status line
   const outputStream = split2()
-  const statusLine = log.placeholder({ level: LogLevel.verbose })
 
   outputStream.on("error", () => {})
   outputStream.on("data", (line: Buffer) => {
     ctx.events.emit("log", { timestamp: new Date().getTime(), data: line })
-    statusLine.setState(renderOutputStream(line.toString(), "buildkit"))
   })
 
   const command = [

--- a/core/src/plugins/kubernetes/container/build/cluster-docker.ts
+++ b/core/src/plugins/kubernetes/container/build/cluster-docker.ts
@@ -94,7 +94,7 @@ export const clusterDockerBuild: BuildHandler = async (params) => {
 
   stdout.on("error", () => {})
   stdout.on("data", (line: Buffer) => {
-    ctx.events.emit("log", { timestamp: new Date().getTime(), data: line })
+    ctx.events.emit("log", { timestamp: new Date().getTime(), data: line, implementation: "cluster-docker" })
   })
 
   // Prepare the build command

--- a/core/src/plugins/kubernetes/container/build/cluster-docker.ts
+++ b/core/src/plugins/kubernetes/container/build/cluster-docker.ts
@@ -24,8 +24,6 @@ import {
 } from "./common"
 import { posix } from "path"
 import split2 = require("split2")
-import { LogLevel } from "../../../../logger/logger"
-import { renderOutputStream } from "../../../../util/util"
 import { getDockerBuildFlags } from "../../../container/build"
 
 export const getClusterDockerBuildStatus: BuildStatusHandler = async (params) => {
@@ -93,12 +91,10 @@ export const clusterDockerBuild: BuildHandler = async (params) => {
 
   // Stream verbose logs to a status line
   const stdout = split2()
-  const statusLine = log.placeholder({ level: LogLevel.verbose })
 
   stdout.on("error", () => {})
   stdout.on("data", (line: Buffer) => {
     ctx.events.emit("log", { timestamp: new Date().getTime(), data: line })
-    statusLine.setState(renderOutputStream(line.toString(), "cluster-docker"))
   })
 
   // Prepare the build command

--- a/core/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/src/plugins/kubernetes/container/build/kaniko.ts
@@ -103,8 +103,6 @@ export const kanikoBuild: BuildHandler = async (params) => {
 
   log.setState(`Building image ${localId}...`)
 
-  let buildLog = ""
-
   // Use the project namespace if set to null in config
   // TODO: change in 0.13 to default to project namespace
   let kanikoNamespace =
@@ -157,7 +155,7 @@ export const kanikoBuild: BuildHandler = async (params) => {
     args,
   })
 
-  buildLog = buildRes.log
+  const buildLog = buildRes.log
 
   if (kanikoBuildFailed(buildRes)) {
     throw new BuildError(`Failed building module ${chalk.bold(module.name)}:\n\n${buildLog}`, { buildLog })

--- a/core/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/src/plugins/kubernetes/container/build/kaniko.ts
@@ -36,9 +36,6 @@ import {
 } from "./common"
 import { differenceBy, isEmpty } from "lodash"
 import chalk from "chalk"
-import split2 from "split2"
-import { LogLevel } from "../../../../logger/logger"
-import { renderOutputStream } from "../../../../util/util"
 import { getDockerBuildFlags } from "../../../container/build"
 import { stringifyResources } from "../util"
 
@@ -107,15 +104,6 @@ export const kanikoBuild: BuildHandler = async (params) => {
   log.setState(`Building image ${localId}...`)
 
   let buildLog = ""
-
-  // Stream verbose logs to a status line
-  const outputStream = split2()
-  const statusLine = log.placeholder({ level: LogLevel.verbose })
-
-  outputStream.on("error", () => {})
-  outputStream.on("data", (line: Buffer) => {
-    statusLine.setState(renderOutputStream(line.toString(), "kaniko"))
-  })
 
   // Use the project namespace if set to null in config
   // TODO: change in 0.13 to default to project namespace

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -876,7 +876,7 @@ export class PodRunner extends PodRunnerParams {
         podEvents = undefined
       }
       return {
-        podEvents
+        podEvents,
       }
     }
 
@@ -889,7 +889,10 @@ export class PodRunner extends PodRunnerParams {
           // if the pod has been deleted during execution we might run into a 404 error.
           // Convert it to Garden NotFoundError and fetch the logs for more details.
           if (e.statusCode === 404) {
-            throw new NotFoundError("Pod disappeared while waiting for it to complete. The Pod might have been evicted or deleted.", await notFoundErrorDetails())
+            throw new NotFoundError(
+              "Pod disappeared while waiting for it to complete. The Pod might have been evicted or deleted.",
+              await notFoundErrorDetails()
+            )
           }
         }
 
@@ -1075,14 +1078,15 @@ export class PodRunner extends PodRunnerParams {
     }
   }
 
-async getPodEvents(): Promise<CoreV1EventList> {
-  return await this.api.core.listNamespacedEvent(
-    this.namespace,
-    undefined,
-    undefined,
-    undefined,
-    `involvedObject.name=${this.podName}`)
-}
+  async getPodEvents(): Promise<CoreV1EventList> {
+    return await this.api.core.listNamespacedEvent(
+      this.namespace,
+      undefined,
+      undefined,
+      undefined,
+      `involvedObject.name=${this.podName}`
+    )
+  }
 
   /**
    * Removes the Pod from the cluster, if it's running. You can safely call this even

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -833,11 +833,9 @@ export class PodRunner extends PodRunnerParams {
       const exitCode = await this.awaitRunningPod(params, startedAt)
 
       const events = await this.getPodEvents()
-      if (events !== undefined && events.items.length > 0) {
-        if (some(events.items, (event) => event.reason === "Killing")) {
-          const details: PodErrorDetails = { podEvents: events }
-          throw new NotFoundError("Pod has been killed or evicted.", details)
-        }
+      if (some(events.items, (event) => event.reason === "Killing")) {
+        const details: PodErrorDetails = { podEvents: events }
+        throw new NotFoundError("Pod has been killed or evicted.", details)
       }
 
       // Retrieve logs after run
@@ -1077,7 +1075,7 @@ export class PodRunner extends PodRunnerParams {
     }
   }
 
-async getPodEvents(): Promise<CoreV1EventList | undefined> {
+async getPodEvents(): Promise<CoreV1EventList> {
   return await this.api.core.listNamespacedEvent(
     this.namespace,
     undefined,

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -208,9 +208,18 @@ export async function runAndCopy({
   if (getArtifacts) {
     const outputStream = new PassThrough()
 
+    const statusLine = log.placeholder({ level: LogLevel.verbose })
+
     outputStream.on("error", () => {})
     outputStream.on("data", (data: Buffer) => {
       ctx.events.emit("log", { timestamp: new Date().getTime(), data })
+      if (!interactive) {
+        // TODO: At some point we should write task logs to our logger in the same location
+        // where the PluginEventBroker handles the `log` events, instead of repeating this logic
+        // all over the place.
+        // This is so easy to forget, and can lead to a degraded user experience if left out.
+        statusLine.setState(renderOutputStream(data.toString(), `${podName}`))
+      }
     })
 
     return runWithArtifacts({

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -209,7 +209,7 @@ export async function runAndCopy({
 
     outputStream.on("error", () => {})
     outputStream.on("data", (data: Buffer) => {
-      ctx.events.emit("log", { timestamp: new Date().getTime(), data })
+      ctx.events.emit("log", { timestamp: new Date().getTime(), data, implementation: command![0] })
     })
 
     return runWithArtifacts({
@@ -784,7 +784,11 @@ export class PodRunner extends PodRunnerParams {
 
     void stream.forEach((entry) => {
       const { msg, timestamp } = entry
-      events.emit("log", { timestamp, data: Buffer.from(msg) })
+      events.emit("log", {
+        timestamp: timestamp?.getTime() || new Date().getTime(),
+        data: Buffer.from(msg),
+        implementation: this.getFullCommand()[0],
+      })
       if (tty) {
         process.stdout.write(`${msg}\n`)
       }

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -816,7 +816,7 @@ export class PodRunner extends PodRunnerParams {
    * @throws {KubernetesError}
    */
   async runAndWait(params: RunParams): Promise<RunAndWaitResult> {
-    const { log, remove, tty, events } = params
+    const { log, remove, tty } = params
 
     const startedAt = new Date()
     const logsFollower = this.prepareLogsFollower(params)

--- a/core/src/plugins/kubernetes/status/events.ts
+++ b/core/src/plugins/kubernetes/status/events.ts
@@ -6,6 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import { sortBy } from "lodash"
 import { KubeApi } from "../api"
 import { KubernetesResource } from "../types"
 
@@ -30,5 +31,5 @@ export async function getResourceEvents(api: KubeApi, resource: KubernetesResour
         parseInt(e.involvedObject!.resourceVersion, 10) > minVersion
     )
 
-  return events
+  return sortBy(events, (e) => e.metadata.creationTimestamp)
 }

--- a/core/src/plugins/kubernetes/status/pod.ts
+++ b/core/src/plugins/kubernetes/status/pod.ts
@@ -136,7 +136,9 @@ export async function getPodLogs({
             timestamps
           )
         } catch (err) {
-          log = `[Could not retrieve previous logs for deleted pod ${pod.metadata!.name!}: ${err.message || "Unknown error occurred"}]`
+          log = `[Could not retrieve previous logs for deleted pod ${pod.metadata!.name!}: ${
+            err.message || "Unknown error occurred"
+          }]`
         }
       } else if (err instanceof KubernetesError && err.message.includes("waiting to start")) {
         log = ""

--- a/core/src/plugins/kubernetes/status/pod.ts
+++ b/core/src/plugins/kubernetes/status/pod.ts
@@ -136,7 +136,7 @@ export async function getPodLogs({
             timestamps
           )
         } catch (err) {
-          log = ""
+          log = `[Could not retrieve previous logs for deleted pod ${pod.metadata!.name!}: ${err.message || "Unknown error occurred"}]`
         }
       } else if (err instanceof KubernetesError && err.message.includes("waiting to start")) {
         log = ""

--- a/core/src/plugins/kubernetes/status/status.ts
+++ b/core/src/plugins/kubernetes/status/status.ts
@@ -187,7 +187,11 @@ export async function waitForResources({
   let lastMessage: string | undefined
   const startTime = new Date().getTime()
   const emitLog = (msg: string) =>
-    ctx.events.emit("log", { timestamp: new Date().getTime(), data: Buffer.from(msg, "utf-8") })
+    ctx.events.emit("log", {
+      timestamp: new Date().getTime(),
+      data: Buffer.from(msg, "utf-8"),
+      implementation: "plugin-kubernetes",
+    })
 
   const waitingMsg = `Waiting for resources to be ready...`
   const statusLine = log.info({

--- a/core/src/plugins/kubernetes/status/workload.ts
+++ b/core/src/plugins/kubernetes/status/workload.ts
@@ -21,7 +21,7 @@ import {
   V1DeploymentSpec,
 } from "@kubernetes/client-node"
 import dedent = require("dedent")
-import { getCurrentWorkloadPods } from "../util"
+import { getCurrentWorkloadPods, renderPodEvents } from "../util"
 import { getFormattedPodLogs, POD_LOG_LINES } from "./pod"
 import { ResourceStatus, StatusHandlerParams } from "./status"
 import { getResourceEvents } from "./events"
@@ -71,15 +71,7 @@ export async function checkWorkloadStatus({ api, namespace, resource }: StatusHa
     // List events
     const events = await getEvents()
     if (events.length > 0) {
-      logs += chalk.white("━━━ Events ━━━")
-      for (const event of events) {
-        const obj = event.involvedObject
-        const name = chalk.blueBright(`${obj.kind} ${obj.name}:`)
-        const msg = `${event.reason} - ${event.message}`
-        const colored =
-          event.type === "Error" ? chalk.red(msg) : event.type === "Warning" ? chalk.yellow(msg) : chalk.white(msg)
-        logs += `\n${name} ${colored}`
-      }
+      logs += renderPodEvents(events)
     }
 
     // Attach pod logs for debug output

--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -8,7 +8,7 @@
 
 import Bluebird from "bluebird"
 import { get, flatten, sortBy, omit, chain, sample, isEmpty, find, cloneDeep } from "lodash"
-import { V1Pod, V1EnvVar, V1Container, V1PodSpec, CoreV1EventList } from "@kubernetes/client-node"
+import { V1Pod, V1EnvVar, V1Container, V1PodSpec, CoreV1Event } from "@kubernetes/client-node"
 import { apply as jsonMerge } from "json-merge-patch"
 import chalk from "chalk"
 import hasha from "hasha"
@@ -759,8 +759,22 @@ export function usingInClusterRegistry(provider: KubernetesProvider) {
   return provider.config.deploymentRegistry?.hostname === inClusterRegistryHostname
 }
 
-export function renderPodEventsTable(events: CoreV1EventList["items"]): string {
-  return events
-    .map((event) => `Type=${event.type} Reason=${event.reason} Message=${event.message || "No message"}`)
-    .join("\n")
+export function renderPodEvents(events: CoreV1Event[]): string {
+  let text = ""
+
+  text += `${chalk.white("━━━ Events ━━━")}\n`
+  for (const event of events) {
+    const obj = event.involvedObject
+    const name = chalk.blueBright(`${obj.kind} ${obj.name}:`)
+    const msg = `${event.reason} - ${event.message}`
+    const colored =
+      event.type === "Error" ? chalk.red(msg) : event.type === "Warning" ? chalk.yellow(msg) : chalk.white(msg)
+    text += `${name} ${colored}\n`
+  }
+
+  if (events.length === 0) {
+    text += `${chalk.red("No matching events found")}\n`
+  }
+
+  return text
 }

--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -16,7 +16,7 @@ import hasha from "hasha"
 import { KubernetesResource, KubernetesWorkload, KubernetesPod, KubernetesServerResource, isPodResource } from "./types"
 import { splitLast, serializeValues, findByName, exec } from "../../util/util"
 import { KubeApi, KubernetesError } from "./api"
-import { gardenAnnotationKey, base64, deline, stableStringify, tablePresets } from "../../util/string"
+import { gardenAnnotationKey, base64, deline, stableStringify } from "../../util/string"
 import { inClusterRegistryHostname, MAX_CONFIGMAP_DATA_SIZE, systemDockerAuthSecretName } from "./constants"
 import { ContainerEnvVars } from "../container/config"
 import { ConfigurationError, DeploymentError, PluginError } from "../../exceptions"
@@ -760,7 +760,7 @@ export function usingInClusterRegistry(provider: KubernetesProvider) {
 }
 
 export function renderPodEventsTable(events: CoreV1EventList["items"]): string {
-  return events.map((event) => (
-    `Type=${event.type} Reason=${event.reason} Message=${event.message || "No message"}`
-  )).join("\n")
+  return events
+    .map((event) => `Type=${event.type} Reason=${event.reason} Message=${event.message || "No message"}`)
+    .join("\n")
 }

--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -8,7 +8,7 @@
 
 import Bluebird from "bluebird"
 import { get, flatten, sortBy, omit, chain, sample, isEmpty, find, cloneDeep } from "lodash"
-import { V1Pod, V1EnvVar, V1Container, V1PodSpec } from "@kubernetes/client-node"
+import { V1Pod, V1EnvVar, V1Container, V1PodSpec, CoreV1EventList } from "@kubernetes/client-node"
 import { apply as jsonMerge } from "json-merge-patch"
 import chalk from "chalk"
 import hasha from "hasha"
@@ -16,7 +16,7 @@ import hasha from "hasha"
 import { KubernetesResource, KubernetesWorkload, KubernetesPod, KubernetesServerResource, isPodResource } from "./types"
 import { splitLast, serializeValues, findByName, exec } from "../../util/util"
 import { KubeApi, KubernetesError } from "./api"
-import { gardenAnnotationKey, base64, deline, stableStringify } from "../../util/string"
+import { gardenAnnotationKey, base64, deline, stableStringify, tablePresets } from "../../util/string"
 import { inClusterRegistryHostname, MAX_CONFIGMAP_DATA_SIZE, systemDockerAuthSecretName } from "./constants"
 import { ContainerEnvVars } from "../container/config"
 import { ConfigurationError, DeploymentError, PluginError } from "../../exceptions"
@@ -757,4 +757,10 @@ export function getK8sProvider(providers: ProviderMap): KubernetesProvider {
  */
 export function usingInClusterRegistry(provider: KubernetesProvider) {
   return provider.config.deploymentRegistry?.hostname === inClusterRegistryHostname
+}
+
+export function renderPodEventsTable(events: CoreV1EventList["items"]): string {
+  return events.map((event) => (
+    `Type=${event.type} Reason=${event.reason} Message=${event.message || "No message"}`
+  )).join("\n")
 }

--- a/core/src/util/ext-tools.ts
+++ b/core/src/util/ext-tools.ts
@@ -151,7 +151,7 @@ export class CliWrapper {
     }
 
     logStream.on("data", (line: Buffer) => {
-      ctx.events.emit("log", { timestamp: new Date().getTime(), data: line })
+      ctx.events.emit("log", { timestamp: new Date().getTime(), data: line, implementation: this.name })
       const lineStr = line.toString()
       log.verbose(lineStr)
     })

--- a/core/src/util/util.ts
+++ b/core/src/util/util.ts
@@ -143,23 +143,6 @@ export function renderOutputStream(msg: string, command?: string) {
   return command ? chalk.gray(`[${command}]: ${msg}`) : chalk.gray(msg)
 }
 
-/**
- * Creates an output stream that updates a log entry on data events (in an opinionated way).
- *
- * Note that new entries are not created but rather the passed log entry gets updated.
- * It's therefore recommended to pass a placeholder entry, for example: `log.placeholder(LogLevel.debug)`
- */
-export function createOutputStream(log: LogEntry) {
-  const outputStream = split2()
-
-  outputStream.on("error", () => {})
-  outputStream.on("data", (line: Buffer) => {
-    log.setState(renderOutputStream(line.toString()))
-  })
-
-  return outputStream
-}
-
 export function makeErrorMsg({
   code,
   cmd,

--- a/core/test/unit/src/util/util.ts
+++ b/core/test/unit/src/util/util.ts
@@ -16,7 +16,6 @@ import {
   deepFilter,
   splitLast,
   exec,
-  createOutputStream,
   makeErrorMsg,
   renderOutputStream,
   spawn,
@@ -27,6 +26,8 @@ import { expectError } from "../../../helpers"
 import { splitFirst } from "../../../../src/util/util"
 import { getLogger } from "../../../../src/logger/logger"
 import { dedent } from "../../../../src/util/string"
+import split2 from "split2"
+import { LogEntry } from "../../../../src/logger/log-entry"
 
 function isLinuxOrDarwin() {
   return process.platform === "darwin" || process.platform === "linux"
@@ -388,3 +389,20 @@ describe("util", () => {
     })
   })
 })
+
+/**
+ * Creates an output stream that updates a log entry on data events (used in the tests above).
+ *
+ * Note that new entries are not created but rather the passed log entry gets updated.
+ * It's therefore recommended to pass a placeholder entry, for example: `log.placeholder(LogLevel.debug)`
+ */
+function createOutputStream(log: LogEntry) {
+  const outputStream = split2()
+
+  outputStream.on("error", () => {})
+  outputStream.on("data", (line: Buffer) => {
+    log.setState(renderOutputStream(line.toString()))
+  })
+
+  return outputStream
+}

--- a/plugins/jib/index.ts
+++ b/plugins/jib/index.ts
@@ -238,7 +238,8 @@ export const gardenPlugin = () =>
 
             outputStream.on("error", () => {})
             outputStream.on("data", (line: Buffer) => {
-              ctx.events.emit("log", { timestamp: new Date().getTime(), data: line })
+              const tool = ["maven", "mavend"].includes(projectType) ? projectType : "gradle"
+              ctx.events.emit("log", { timestamp: new Date().getTime(), data: line, implementation: tool })
               buildLog += line.toString()
             })
 

--- a/plugins/jib/index.ts
+++ b/plugins/jib/index.ts
@@ -238,9 +238,8 @@ export const gardenPlugin = () =>
 
             outputStream.on("error", () => {})
             outputStream.on("data", (line: Buffer) => {
-              const str = line.toString()
-              statusLine.setState({ section: module.name, msg: str })
-              buildLog += str
+              ctx.events.emit("log", { timestamp: new Date().getTime(), data: line })
+              buildLog += line.toString()
             })
 
             statusLine.setState({ section: module.name, msg: `Using JAVA_HOME=${openJdkPath}` })


### PR DESCRIPTION
**What this PR does / why we need it**:

For #3331:
- Stream logs to CLI to make them visible in verbose log level (`-l3`).

For #3535:
- Detect that pod has been killed by listing Pod events after the Pod
  has completed, and throwing an exception when the Pod has been killed
  to prevent reporting successful status in case the tests did not
  actually run to completion.

For #3331, #3535:
- improve the error message to be more on-point and convey more
  contextual information

co-authored-by: eysi09 <eysi09@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->


**Which issue(s) this PR fixes**:

Fixes #3331
Fixes #3535:

**Special notes for your reviewer**:
See the issues on how to reproduce this issue, but if you are just interested in how the errors look like:

<img width="1387" alt="Screenshot 2023-01-19 at 11 10 35" src="https://user-images.githubusercontent.com/139624/213415135-75744c56-e7e6-4fc8-aa97-b8fbc7d447f3.png">

This also changes how logs look like. E.g. for `garden test -f -l3`:

```diff
--- before.log	2023-01-23 15:02:49
+++ after.log	2023-01-23 15:18:17
@@ -6,8 +6,6 @@
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

 ℹ providers                 → Getting status...
-⚠️  A new version of Garden has been released (0.12.48).
-Please use the "garden self-update" command or run "brew upgrade garden-cli" to upgrade to the latest version.
 ✔ providers                 → Getting status... → Cached
 ℹ providers                 → Run with --force-refresh to force a refresh of provider statuses.
 ℹ graph                     → Resolving 2 modules...
@@ -22,20 +20,35 @@
 [verbose] All resources match.
 [verbose] Comparing expected and deployed resources...
 [verbose] All resources match.
-✔ frontend                  → Getting build status for v-2575c75f7b... → Already built
-ℹ frontend                  → Running unit tests
 ✔ backend                   → Getting build status for v-afcf6506f9... → Already built
 ℹ backend                   → Deploying version v-ea67a2a113...
 ✔ backend                   → Deploying version v-ea67a2a113... → Already deployed
 ℹ backend                   → Ingress: http://demo-project.local.app.garden/hello-backend
+✔ frontend                  → Getting build status for v-2575c75f7b... → Already built
+ℹ frontend                  → Running unit tests
 ℹ frontend                  → Deploying version v-cb2a872fe1...
 ✔ frontend                  → Deploying version v-cb2a872fe1... → Already deployed
 ℹ frontend                  → Ingress: http://demo-project.local.app.garden/hello-frontend
 ℹ frontend                  → Ingress: http://demo-project.local.app.garden/call-backend
 ℹ frontend                  → Running integ tests
-ℹ frontend [verbose]        → Starting Pod test-frontend-unit-faed07 with command 'npm test'
-ℹ frontend [verbose]        → Starting Pod test-frontend-integ-d72ddc with command 'npm run integ'
-✔ frontend                  → Running unit tests → Success (took 12.9 sec)
-✔ frontend                  → Running integ tests → Success (took 14 sec)
+ℹ frontend [verbose]        → Starting Pod test-frontend-unit-aebd05 with command 'npm test'
+ℹ frontend [verbose]        → Starting Pod test-frontend-integ-cb2b83 with command 'npm run integ'
+ℹ frontend [verbose]        → [npm]:
+ℹ frontend [verbose]        → [npm]: > frontend@1.0.0 test /app
+ℹ frontend [verbose]        → [npm]: > echo OK
+ℹ frontend [verbose]        → [npm]: OK
+ℹ frontend [verbose]        → [npm]:
+ℹ frontend [verbose]        → [npm]: > frontend@1.0.0 integ /app
+ℹ frontend [verbose]        → [npm]: > node_modules/mocha/bin/mocha test/integ.js
+ℹ frontend [verbose]        → [npm]:
+ℹ frontend [verbose]        → [npm]:
+ℹ frontend [verbose]        → [npm]:   GET /call-backend
+ℹ frontend [verbose]        → [npm]:     ✓ should respond with a message from the backend service
+ℹ frontend [verbose]        → [npm]:
+ℹ frontend [verbose]        → [npm]:
+ℹ frontend [verbose]        → [npm]:   1 passing (90ms)
+ℹ frontend [verbose]        → [npm]:
+✔ frontend                  → Running unit tests → Success (took 4.6 sec)
+✔ frontend                  → Running integ tests → Success (took 6 sec)

 Done! ✔️
```
 
 
For `garden build frontend -f -l3`:

```diff
 ```
 
 And for `garden deploy --force -l3`:
 
 ```diff
--- before.log	2023-01-23 15:21:43
+++ after.log	2023-01-23 15:22:01
@@ -12,29 +12,40 @@
 ✔ graph                     → Resolving 2 modules... → Done
 ℹ frontend [verbose]        → Syncing module sources (7 files)...
 ℹ backend [verbose]         → Syncing module sources (2 files)...
-✔ frontend [verbose]        → Syncing module sources (7 files)... → Done (took 0 sec)
-ℹ frontend                  → Getting build status for v-2575c75f7b...
 ✔ backend [verbose]         → Syncing module sources (2 files)... → Done (took 0 sec)
 ℹ backend                   → Getting build status for v-afcf6506f9...
+✔ frontend [verbose]        → Syncing module sources (7 files)... → Done (took 0 sec)
+ℹ frontend                  → Getting build status for v-2575c75f7b...
 [verbose] Comparing expected and deployed resources...
 [verbose] All resources match.
 [verbose] Comparing expected and deployed resources...
 [verbose] All resources match.
-✔ frontend                  → Getting build status for v-2575c75f7b... → Already built
 ✔ backend                   → Getting build status for v-afcf6506f9... → Already built
 ℹ backend                   → Deploying version v-ea67a2a113...
+✔ frontend                  → Getting build status for v-2575c75f7b... → Already built
 ℹ backend                   → Waiting for resources to be ready...
+ℹ backend [verbose]         → [plugin-kubernetes]: Waiting for resources to be ready...
+ℹ backend [verbose]         → [plugin-kubernetes]: Status of Deployment backend is "ready"
+ℹ backend [verbose]         → [plugin-kubernetes]: Status of Service backend is "ready"
+ℹ backend [verbose]         → [plugin-kubernetes]: Status of Ingress backend-0 is "ready"
+ℹ backend [verbose]         → [plugin-kubernetes]: Resources ready
 ℹ backend                   → Resources ready
 ℹ backend [verbose]         → Comparing expected and deployed resources...
 ℹ backend [verbose]         → All resources match.
-✔ backend                   → Deploying version v-ea67a2a113... → Done (took 3 sec)
+✔ backend                   → Deploying version v-ea67a2a113... → Done (took 2.7 sec)
 ℹ backend                   → Ingress: http://demo-project.local.app.garden/hello-backend
 ℹ frontend                  → Deploying version v-cb2a872fe1...
 ℹ frontend                  → Waiting for resources to be ready...
+ℹ frontend [verbose]        → [plugin-kubernetes]: Waiting for resources to be ready...
+ℹ frontend [verbose]        → [plugin-kubernetes]: Status of Deployment frontend is "ready"
+ℹ frontend [verbose]        → [plugin-kubernetes]: Status of Service frontend is "ready"
+ℹ frontend [verbose]        → [plugin-kubernetes]: Status of Ingress frontend-0 is "ready"
+ℹ frontend [verbose]        → [plugin-kubernetes]: Status of Ingress frontend-1 is "ready"
+ℹ frontend [verbose]        → [plugin-kubernetes]: Resources ready
 ℹ frontend                  → Resources ready
 ℹ frontend [verbose]        → Comparing expected and deployed resources...
 ℹ frontend [verbose]        → All resources match.
-✔ frontend                  → Deploying version v-cb2a872fe1... → Done (took 2.7 sec)
+✔ frontend                  → Deploying version v-cb2a872fe1... → Done (took 2.8 sec)
 ℹ frontend                  → Ingress: http://demo-project.local.app.garden/hello-frontend
 ℹ frontend                  → Ingress: http://demo-project.local.app.garden/call-backend
```
 
And finally for `garden run task test -l3`

```diff
--- before.log	2023-01-23 15:24:33
+++ after.log	2023-01-23 15:24:40
@@ -17,8 +17,9 @@
 ✔ test                      → Checking result... → Done
 ✔ backend                   → Getting build status for v-afcf6506f9... → Already built
 ℹ test                      → Running...
-ℹ test [verbose]            → Starting Pod task-backend-test-5771e6 with command 'sh -c echo task output'
-✔ test                      → Running... → Done (took 2.7 sec)
+ℹ test [verbose]            → Starting Pod task-backend-test-e66f0d with command 'sh -c echo task output'
+ℹ test [verbose]            → [sh]: task output
+✔ test                      → Running... → Done (took 2.8 sec)

 Task output:
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```