### PR TITLE
chore(server): remove debug logs for ws ping pongs

### DIFF
--- a/core/src/server/server.ts
+++ b/core/src/server/server.ts
@@ -363,11 +363,10 @@ export class GardenServer {
         return
       }
 
-      // Set up heartbeat to detect dead connections
-      let isAlive = true
-
       send("serverReady", { message: "Server ready" })
 
+      // Set up heartbeat to detect dead connections
+      let isAlive = true
       let heartbeatInterval = setInterval(() => {
         if (!isAlive) {
           this.log.debug(`Connection ${connId} timed out.`)
@@ -375,12 +374,10 @@ export class GardenServer {
         }
 
         isAlive = false
-        this.log.debug(`Connection ${connId} ping.`)
         websocket.ping(() => {})
       }, 1000)
 
       websocket.on("pong", () => {
-        this.log.debug(`Connection ${connId} pong.`)
         isAlive = true
       })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Previously we were logging websocket ping/pongs at the debug level. A user pointed out that this was adding a lot of noise to their logs. 

This PR removes the logs altogether since they'll add noise at any level. We do log when the connection times out which is based on the ping/pongs and should be enough. 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
