### PR TITLE
ci: fix the edge release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ orbs:
       docker_layer_caching: true
 
   runner-image: &runner-image
-    image: gardendev/circleci-runner:14.19.3-3
+    image: gardendev/circleci-runner:14.19.3-4
 
   # Configuration for our node jobs
   node-config: &node-config

--- a/images/circleci-runner/Dockerfile
+++ b/images/circleci-runner/Dockerfile
@@ -33,11 +33,9 @@ COPY --from=ldid /usr/local/bin/ldid /usr/local/bin
 COPY --from=ghr /usr/bin/ghr /usr/bin/
 
 # install gh
-RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /usr/share/keyrings/githubcli-archive-keyring.gpg > /dev/null \
-  && sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
-  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-  && sudo apt-get update \
-  && sudo apt-get install gh -y
+# NOTE: We pin to this version because the latest version does not support the fine-grained access tokens for editing issues (https://github.com/cli/cli/issues/6680)
+# When the issue has been resolved, we can go back to installing the latest version of gh.
+RUN wget https://github.com/cli/cli/releases/download/v2.14.7/gh_2.14.7_linux_amd64.deb && sudo dpkg -i gh_2.14.7_linux_amd64.deb && rm gh_2.14.7_linux_amd64.deb
 
 # install gcloud
 ENV CLOUDSDK_PYTHON=python3

--- a/images/circleci-runner/garden.yml
+++ b/images/circleci-runner/garden.yml
@@ -2,5 +2,5 @@ kind: Module
 type: container
 name: circleci-runner
 description: Used for the core pipeline in CircleCI
-image: gardendev/circleci-runner:14.19.3-3
+image: gardendev/circleci-runner:14.19.3-4
 extraFlags: [ "--platform", "linux/amd64" ]


### PR DESCRIPTION
The latest version of the gh utility fails with this error message:

```
non-200 OK status code: 401 Unauthorized body: "{\"message\":\"Personal access tokens with fine grained access do not support the GraphQL API\",\"documentation_url\":\"https://docs.github.com/graphql/guides/forming-calls-with-graphql#authenticating-with-graphql\"}"
```

But when downgrading gh it works.

We can update to the latest version again once GitHub resolved https://github.com/cli/cli/issues/6680

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
