### PR TITLE
0.13 partially fix some `plugins/exec` tests

### DIFF
--- a/core/src/plugin/handlers/deploy/delete.ts
+++ b/core/src/plugin/handlers/deploy/delete.ts
@@ -12,10 +12,20 @@ import { dedent } from "../../../util/string"
 import { ServiceStatus, serviceStatusSchema } from "../../../types/service"
 import { ActionTypeHandlerSpec } from "../base/base"
 import type { ActionStatus, Resolved } from "../../../actions/types"
+import { createSchema } from "../../../config/common"
+import { actionStatusSchema } from "../../../actions/base"
 
 interface DeleteDeployParams<T extends DeployAction> extends PluginDeployActionParamsBase<T> {}
 
 type DeleteDeployStatus<T extends DeployAction = DeployAction> = ActionStatus<T, ServiceStatus, {}>
+
+export const getDeleteDeployResultSchema = createSchema({
+  name: "delete-deploy-result",
+  keys: {
+    detail: serviceStatusSchema,
+  },
+  extend: actionStatusSchema,
+})
 
 export class DeleteDeploy<T extends DeployAction = DeployAction> extends ActionTypeHandlerSpec<
   "Deploy",
@@ -29,5 +39,5 @@ export class DeleteDeploy<T extends DeployAction = DeployAction> extends ActionT
   `
 
   paramsSchema = () => actionParamsSchema()
-  resultSchema = () => serviceStatusSchema()
+  resultSchema = () => getDeleteDeployResultSchema()
 }

--- a/core/src/types/service.ts
+++ b/core/src/types/service.ts
@@ -71,16 +71,8 @@ export function serviceFromConfig<M extends GardenModule = GardenModule>(
   }
 }
 
-export type ServiceState = "ready" | "deploying" | "stopped" | "unhealthy" | "unknown" | "outdated" | "missing"
-export const serviceStates: ServiceState[] = [
-  "ready",
-  "deploying",
-  "stopped",
-  "unhealthy",
-  "unknown",
-  "outdated",
-  "missing",
-]
+export const serviceStates = ["ready", "deploying", "stopped", "unhealthy", "unknown", "outdated", "missing"] as const
+export type ServiceState = typeof serviceStates[number]
 
 const serviceStateMap: { [key in ServiceState]: ActionState } = {
   ready: "ready",
@@ -248,7 +240,7 @@ export const serviceStatusSchema = () =>
     runningReplicas: joi.number().description("How many replicas of the service are currently running."),
     state: joi
       .string()
-      .valid("ready", "deploying", "stopped", "unhealthy", "unknown", "outdated", "missing")
+      .valid(...serviceStates)
       .default("unknown")
       .description("The current deployment status of the service."),
     updatedAt: joi.string().description("When the service was last updated by the provider."),

--- a/core/test/unit/src/plugins/exec/exec.ts
+++ b/core/test/unit/src/plugins/exec/exec.ts
@@ -620,7 +620,9 @@ describe("exec plugin", () => {
           action,
           graph,
         })
-        expect(res.detail?.outputs).to.eql("deployed echo service")
+        expect(res.state).to.eql("ready")
+        expect(res.detail?.state).to.eql("ready")
+        expect(res.detail?.detail.deployCommandOutput).to.eql("deployed echo service")
       })
 
       it("skips deploying if deploy command is empty but does not throw", async () => {

--- a/core/test/unit/src/plugins/exec/exec.ts
+++ b/core/test/unit/src/plugins/exec/exec.ts
@@ -878,7 +878,8 @@ describe("exec plugin", () => {
 
     describe("getExecServiceStatus", async () => {
       it("returns 'unknown' if no statusCommand is set", async () => {
-        const rawAction = graph.getDeploy("error")
+        const actionName = "error"
+        const rawAction = graph.getDeploy(actionName)
         const router = await garden.getActionRouter()
         const action = await garden.resolveAction({ graph, log, action: rawAction })
         const res = await router.getDeployStatuses({
@@ -886,11 +887,18 @@ describe("exec plugin", () => {
           graph,
           names: [action.name],
         })
-        expect(res.state).to.equal("unknown")
+
+        const actionRes = res[actionName]
+        expect(actionRes.state).to.equal("unknown")
+        const detail = actionRes.detail!
+        expect(detail.state).to.equal("unknown")
+        expect(detail.version).to.equal(action.versionString())
+        expect(detail.detail).to.be.empty
       })
 
       it("returns 'ready' if statusCommand returns zero exit code", async () => {
-        const rawAction = graph.getDeploy("touch")
+        const actionName = "touch"
+        const rawAction = graph.getDeploy(actionName)
         const router = await garden.getActionRouter()
         const action = await garden.resolveAction({ graph, log, action: rawAction })
         await router.deploy.deploy({
@@ -907,13 +915,18 @@ describe("exec plugin", () => {
           graph,
           names: [action.name],
         })
-        expect(res.state).to.equal("ready")
-        expect(res.version).to.equal(action.versionString())
-        // expect(res.detail.statusCommandOutput).to.equal("already deployed") TODO-G2
+
+        const actionRes = res[actionName]
+        expect(actionRes.state).to.equal("ready")
+        const detail = actionRes.detail!
+        expect(detail.state).to.equal("ready")
+        expect(detail.version).to.equal(action.versionString())
+        expect(detail.detail.statusCommandOutput).to.equal("already deployed")
       })
 
       it("returns 'outdated' if statusCommand returns non-zero exit code", async () => {
-        const rawAction = graph.getDeploy("touch")
+        const actionName = "touch"
+        const rawAction = graph.getDeploy(actionName)
         const router = await garden.getActionRouter()
         const action = await garden.resolveAction({ graph, log, action: rawAction })
         const res = await router.getDeployStatuses({
@@ -921,8 +934,13 @@ describe("exec plugin", () => {
           log,
           names: [action.name],
         })
-        expect(res.state).to.equal("outdated")
-        expect(res.version).to.equal(action.versionString())
+
+        const actionRes = res[actionName]
+        expect(actionRes.state).to.equal("outdated")
+        const detail = actionRes.detail!
+        expect(detail.state).to.equal("outdated")
+        expect(detail.version).to.equal(action.versionString())
+        expect(detail.detail.statusCommandOutput).to.be.empty
       })
     })
 

--- a/core/test/unit/src/plugins/exec/exec.ts
+++ b/core/test/unit/src/plugins/exec/exec.ts
@@ -497,7 +497,12 @@ describe("exec plugin", () => {
         interactive: true,
         graph,
       })
-      expect(res.outputs).to.eql(join(garden.projectRoot, "module-local"))
+
+      const expectedLogPath = join(garden.projectRoot, "module-local")
+      // TODO-G2: there is also `res.detail.outputs` field existing in runtime here,
+      //  which does not exist in the `RunResult` type declaration.
+      //  Is it a bug? Reference `res.detail?.outputs` causes a TS compilation error.
+      expect(res.detail?.log).to.eql(expectedLogPath)
     })
 
     it("should receive module version as an env var", async () => {
@@ -514,7 +519,8 @@ describe("exec plugin", () => {
         graph,
       })
 
-      expect(res.outputs).to.equal(action.versionString())
+      // TODO-G2: see the comment is the previous spec
+      expect(res.detail?.log).to.equal(action.versionString())
     })
   })
 

--- a/core/test/unit/src/plugins/exec/exec.ts
+++ b/core/test/unit/src/plugins/exec/exec.ts
@@ -309,7 +309,6 @@ describe("exec plugin", () => {
       force: false,
       forceBuild: false,
       devModeDeployNames: [],
-
       localModeDeployNames: [],
     })
     const results = await _garden.processTasks({ tasks: [taskTask], throwOnError: false })
@@ -336,7 +335,6 @@ describe("exec plugin", () => {
       force: false,
       forceBuild: false,
       devModeDeployNames: [],
-
       localModeDeployNames: [],
     })
 
@@ -361,7 +359,6 @@ describe("exec plugin", () => {
       force: false,
       forceBuild: false,
       devModeDeployNames: [],
-
       localModeDeployNames: [],
     })
 

--- a/core/test/unit/src/plugins/exec/exec.ts
+++ b/core/test/unit/src/plugins/exec/exec.ts
@@ -348,7 +348,7 @@ describe("exec plugin", () => {
   it("should copy artifacts after test runs", async () => {
     const _garden = await makeTestGarden(getDataDir("test-projects", "exec-artifacts"))
     const _graph = await _garden.getConfigGraph({ log: _garden.log, emit: false })
-    const test = _graph.getTest("module-a.test-a")
+    const test = _graph.getTest("module-a-test-a")
 
     const testTask = new TestTask({
       garden: _garden,

--- a/core/test/unit/src/plugins/exec/exec.ts
+++ b/core/test/unit/src/plugins/exec/exec.ts
@@ -399,8 +399,9 @@ describe("exec plugin", () => {
       const actions = await garden.getActionRouter()
       const resolvedAction = await garden.resolveAction({ action, log, graph })
       const res = await actions.build.build({ log, action: resolvedAction, graph })
-      // TODO-G2 figure the expect out here
-      expect(res.detail).to.eql(join(garden.projectRoot, "module-local"))
+
+      const expectedBuildLog = join(garden.projectRoot, "module-local")
+      expect(res.detail).to.eql({ buildLog: expectedBuildLog, fresh: true })
     })
 
     it("should receive module version as an env var", async () => {
@@ -411,8 +412,7 @@ describe("exec plugin", () => {
       const resolvedAction = await garden.resolveAction({ log, graph, action })
       const res = await actions.build.build({ log, action: resolvedAction, graph })
 
-      // TODO-G2 figure the expect out here
-      expect(res.outputs).to.equal(action.versionString())
+      expect(res.detail).to.eql({ buildLog: action.versionString(), fresh: true })
     })
   })
 

--- a/core/test/unit/src/plugins/exec/exec.ts
+++ b/core/test/unit/src/plugins/exec/exec.ts
@@ -963,8 +963,11 @@ describe("exec plugin", () => {
           graph,
           action,
         })
-        expect(res.state).to.equal("missing")
-        // expect(res.detail.cleanupCommandOutput).to.equal("cleaned up") TODO-G2
+
+        expect(res.state).to.equal("not-ready")
+        const detail = res.detail!
+        expect(detail.state).to.equal("missing")
+        expect(detail.detail.cleanupCommandOutput).to.equal("cleaned up")
       })
 
       it("returns 'unknown' state if no cleanupCommand is set", async () => {
@@ -976,7 +979,9 @@ describe("exec plugin", () => {
           graph,
           action,
         })
+
         expect(res.state).to.equal("unknown")
+        expect(res.detail?.state).to.equal("unknown")
       })
 
       it("throws if cleanupCommand returns with non-zero code", async () => {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes some tests in `plugins/exec/exec.ts`.

**Which issue(s) this PR fixes**:

Partially addresses #3549 

**Special notes for your reviewer**:
Please check the new `TODO-G2` comments.