### PR TITLE
Dev mode fixes

### DIFF
--- a/core/src/commands/serve.ts
+++ b/core/src/commands/serve.ts
@@ -92,7 +92,7 @@ export class ServeCommand extends Command<Args, Opts> {
     this.server!.setGarden(garden)
 
     const allModules = graph.getModules()
-    const allActions = graph.getActions()
+    const allDeployActions = graph.getActionsByKind("Deploy")
 
     await processActions({
       garden,
@@ -102,7 +102,7 @@ export class ServeCommand extends Command<Args, Opts> {
       watch: true,
       actions: [],
       initialTasks: [],
-      skipWatch: allActions,
+      skipWatch: allDeployActions,
       skipWatchModules: allModules,
       changeHandler: async () => [],
     })

--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -24,7 +24,7 @@ import { ingressHostnameSchema, linkUrlSchema } from "../../types/service"
 import { DEFAULT_PORT_PROTOCOL } from "../../constants"
 import { cacheResultSchema } from "../../config/task"
 import { dedent, deline } from "../../util/string"
-import { devModeGuideLink } from "../kubernetes/dev-mode"
+import { devModeGuideLink, kubernetesDeployDevModeSchema, KubernetesDeployDevModeSpec } from "../kubernetes/dev-mode"
 import { k8sDeploymentTimeoutSchema } from "../kubernetes/config"
 import { localModeGuideLink } from "../kubernetes/local-mode"
 import { BuildAction, BuildActionConfig } from "../../actions/build"
@@ -651,7 +651,6 @@ interface ContainerCommonRuntimeSpec {
 export interface ContainerCommonDeploySpec extends ContainerCommonRuntimeSpec {
   annotations: Annotations
   daemon: boolean
-  devMode?: ContainerDevModeSpec
   localMode?: ContainerLocalModeSpec
   ingresses: ContainerIngressSpec[]
   healthCheck?: ServiceHealthCheckSpec
@@ -663,6 +662,7 @@ export interface ContainerCommonDeploySpec extends ContainerCommonRuntimeSpec {
 }
 
 export interface ContainerDeploySpec extends ContainerCommonDeploySpec {
+  devMode?: KubernetesDeployDevModeSpec
   volumes: ContainerVolumeSpec[]
   image?: string
 }
@@ -728,7 +728,6 @@ export const containerDeploySchemaKeys = () => ({
       Whether to run the service as a daemon (to ensure exactly one instance runs per node).
       May not be supported by all providers.
     `),
-  devMode: containerDevModeSchema(),
   localMode: containerLocalModeSchema(),
   image: containerImageSchema(),
   ingresses: joiSparseArray(ingressSchema())
@@ -750,7 +749,11 @@ export const containerDeploySchemaKeys = () => ({
   `),
 })
 
-export const containerDeploySchema = () => joi.object().keys(containerDeploySchemaKeys())
+export const containerDeploySchema = () =>
+  joi.object().keys({
+    ...containerDeploySchemaKeys(),
+    devMode: kubernetesDeployDevModeSchema(),
+  })
 
 export interface ContainerRegistryConfig {
   hostname: string

--- a/core/src/plugins/container/moduleConfig.ts
+++ b/core/src/plugins/container/moduleConfig.ts
@@ -19,6 +19,8 @@ import {
   containerCommonBuildSpecKeys,
   ContainerCommonDeploySpec,
   containerDeploySchemaKeys,
+  containerDevModeSchema,
+  ContainerDevModeSpec,
   ContainerRunActionSpec,
   containerRunSpecKeys,
   ContainerTestActionSpec,
@@ -43,6 +45,7 @@ interface ContainerModuleVolumeSpec extends ContainerVolumeSpecBase {
 
 export type ContainerServiceSpec = CommonServiceSpec &
   ContainerCommonDeploySpec & {
+    devMode?: ContainerDevModeSpec
     volumes: ContainerModuleVolumeSpec[]
   }
 export type ContainerServiceConfig = ServiceConfig<ContainerServiceSpec>
@@ -95,6 +98,7 @@ const containerBuildSpecSchema = () =>
 const containerServiceSchema = () =>
   baseServiceSpecSchema().keys({
     ...containerDeploySchemaKeys(),
+    devMode: containerDevModeSchema(),
     volumes: getContainerVolumesSchema(
       volumeSchemaBase()
         .keys({

--- a/core/src/plugins/kubernetes/dev-mode.ts
+++ b/core/src/plugins/kubernetes/dev-mode.ts
@@ -506,7 +506,7 @@ export async function startDevModeSyncs({
       })
 
       const localPathDescription = chalk.white(s.sourcePath)
-      const remoteDestinationDescription = `${chalk.white(s.target)} in ${chalk.white(resourceName)}`
+      const remoteDestinationDescription = `${chalk.white(s.containerPath)} in ${chalk.white(resourceName)}`
 
       let sourceDescription: string
       let targetDescription: string

--- a/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
@@ -14,7 +14,7 @@ import { serviceStateToActionState, ServiceStatus } from "../../../types/service
 import { gardenAnnotationKey } from "../../../util/string"
 import { KubeApi } from "../api"
 import type { KubernetesPluginContext } from "../config"
-import { configureDevMode, startDevModeSyncs } from "../dev-mode"
+import { configureDevMode, convertDevModeSpec, convertKubernetesDevModeSpec, startDevModeSyncs } from "../dev-mode"
 import { apply, deleteObjectsBySelector, KUBECTL_DEFAULT_TIMEOUT } from "../kubectl"
 import { streamK8sLogs } from "../logs"
 import { getActionNamespace, getActionNamespaceStatus } from "../namespace"
@@ -28,7 +28,6 @@ import { configureLocalMode, startServiceInLocalMode } from "../local-mode"
 import type { ExecBuildConfig } from "../../exec/config"
 import type { KubernetesActionConfig, KubernetesDeployAction, KubernetesDeployActionConfig } from "./config"
 import type { DeployActionHandler } from "../../../plugin/action-types"
-import { convertKubernetesDevModeSpec } from "../helm/handlers"
 import { getTargetResource } from "../util"
 import type { LogEntry } from "../../../logger/log-entry"
 import type { Resolved } from "../../../actions/types"
@@ -59,10 +58,10 @@ export const kubernetesHandlers: Partial<ModuleActionHandlers<KubernetesModule>>
       include: module.spec.files,
 
       spec: {
-        ...omit(module.spec, ["name", "dependencies", "serviceResource", "tasks", "tests"]),
+        ...omit(module.spec, ["name", "dependencies", "serviceResource", "tasks", "tests", "devMode"]),
         files: module.spec.files || [],
         manifests: module.spec.manifests || [],
-        devMode: convertKubernetesDevModeSpec(module, service, serviceResource),
+        devMode: convertKubernetesDevModeSpec(module, service, serviceResource)
       },
     }
 

--- a/core/src/process.ts
+++ b/core/src/process.ts
@@ -22,6 +22,7 @@ import { Action } from "./actions/types"
 import { actionReferenceToString } from "./actions/base"
 import { GraphResults } from "./graph/results"
 import { GardenModule } from "./types/module"
+import { DeployAction } from "./actions/deploy"
 
 export type ProcessHandler = (graph: ConfigGraph, action: Action) => Promise<BaseTask[]>
 
@@ -38,7 +39,7 @@ interface ProcessParams {
   /**
    * If provided, and if `watch === true`, don't watch files in the roots of these actions and modules.
    */
-  skipWatch?: Action[]
+  skipWatch?: DeployAction[]
   skipWatchModules?: GardenModule[]
   initialTasks: BaseTask[]
   /**

--- a/docs/reference/action-types/Deploy/container.md
+++ b/docs/reference/action-types/Deploy/container.md
@@ -236,59 +236,6 @@ spec:
   # providers.
   daemon: false
 
-  # Specifies which files or directories to sync to which paths inside the running containers of the service when it's
-  # in dev mode, and overrides for the container command and/or arguments.
-  #
-  # Dev mode is enabled when running the `garden dev` command, and by setting the `--dev` flag on the `garden deploy`
-  # command.
-  #
-  # See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for more
-  # information.
-  devMode:
-    # Override the default container arguments when in dev mode.
-    args:
-
-    # Override the default container command (i.e. entrypoint) when in dev mode.
-    command:
-
-    # Specify one or more source files or directories to automatically sync with the running container.
-    sync:
-      - # POSIX-style path of the directory to sync to the target, relative to the config's directory. Must be a
-        # relative path. Defaults to the config's directory if no value is provided.
-        source: .
-
-        # POSIX-style absolute path to sync to inside the container. The root path (i.e. "/") is not allowed.
-        target:
-
-        # Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
-        #
-        # `.git` directories and `.garden` directories are always ignored.
-        exclude:
-
-        # The sync mode to use for the given paths. See the [Dev Mode
-        # guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
-        mode: one-way-safe
-
-        # The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600
-        # (user read/write). See the [Mutagen
-        # docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
-        defaultFileMode:
-
-        # The default permission bits, specified as an octal, to set on directories at the sync target. Defaults to
-        # 0700 (user read/write). See the [Mutagen
-        # docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
-        defaultDirectoryMode:
-
-        # Set the default owner of files and directories at the target. Specify either an integer ID or a string name.
-        # See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for
-        # more information.
-        defaultOwner:
-
-        # Set the default group on files and directories at the target. Specify either an integer ID or a string name.
-        # See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for
-        # more information.
-        defaultGroup:
-
   # [EXPERIMENTAL] Configures the local application which will send and receive network requests instead of the target
   # resource.
   #
@@ -423,6 +370,140 @@ spec:
   # Note: This setting may be overridden or ignored in some cases. For example, when running with `daemon: true` or if
   # the provider doesn't support multiple replicas.
   replicas:
+
+  # Configure dev mode syncs for the resources in this Deploy.
+  #
+  # If you have multiple syncs for the Deploy, you can use the `defaults` field to set common configuration for every
+  # individual sync.
+  devMode:
+    # Defaults to set across every sync for this Deploy. If you use the `exclude` field here, it will be merged with
+    # any excludes set in individual syncs. These are applied on top of any defaults set in the provider
+    # configuration.
+    defaults:
+      # Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+      #
+      # Any exclusion patterns defined in individual dev mode sync specs will be applied in addition to these
+      # patterns.
+      #
+      # `.git` directories and `.garden` directories are always ignored.
+      exclude:
+
+      # The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600 (user
+      # read/write). See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#permissions)
+      # for more information.
+      fileMode:
+
+      # The default permission bits, specified as an octal, to set on directories at the sync target. Defaults to 0700
+      # (user read/write). See the [Mutagen
+      # docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
+      directoryMode:
+
+      # Set the default owner of files and directories at the target. Specify either an integer ID or a string name.
+      # See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for
+      # more information.
+      owner:
+
+      # Set the default group on files and directories at the target. Specify either an integer ID or a string name.
+      # See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for
+      # more information.
+      group:
+
+    # A list of syncs to start once the Deploy is successfully started.
+    syncs:
+      - # The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600
+        # (user read/write). See the [Mutagen
+        # docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
+        fileMode:
+
+        # The default permission bits, specified as an octal, to set on directories at the sync target. Defaults to
+        # 0700 (user read/write). See the [Mutagen
+        # docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
+        directoryMode:
+
+        # Set the default owner of files and directories at the target. Specify either an integer ID or a string name.
+        # See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for
+        # more information.
+        owner:
+
+        # Set the default group on files and directories at the target. Specify either an integer ID or a string name.
+        # See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for
+        # more information.
+        group:
+
+        # The Kubernetes resource to sync to. If specified, this is used instead of `spec.defaultTarget`.
+        target:
+          # The kind of Kubernetes resource to find.
+          kind:
+
+          # The name of the resource, of the specified `kind`. If specified, you must also specify `kind`.
+          name:
+
+          # A map of string key/value labels to match on any Pods in the namespace. When specified, a random ready Pod
+          # with matching labels will be picked as a target, so make sure the labels will always match a specific Pod
+          # type.
+          podSelector:
+
+          # The name of a container in the target. Specify this if the target contains more than one container and the
+          # main container is not the first container in the spec.
+          containerName:
+
+        # The local path to sync from, either absolute or relative to the source directory where the Deploy action is
+        # defined.
+        #
+        # This should generally be a templated path to another action's source path (e.g.
+        # `${build.my-container-image.sourcePath}`), or a relative path. If a path is hard-coded, you must make sure
+        # the path exists, and that it is reliably the correct path for every user.
+        sourcePath: .
+
+        # POSIX-style absolute path to sync to inside the container. The root path (i.e. "/") is not allowed.
+        containerPath:
+
+        # Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+        #
+        # `.git` directories and `.garden` directories are always ignored.
+        exclude:
+
+        # The sync mode to use for the given paths. See the [Dev Mode
+        # guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
+        mode: one-way-safe
+
+        # The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600
+        # (user read/write). See the [Mutagen
+        # docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
+        defaultFileMode:
+
+        # The default permission bits, specified as an octal, to set on directories at the sync target. Defaults to
+        # 0700 (user read/write). See the [Mutagen
+        # docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
+        defaultDirectoryMode:
+
+        # Set the default owner of files and directories at the target. Specify either an integer ID or a string name.
+        # See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for
+        # more information.
+        defaultOwner:
+
+        # Set the default group on files and directories at the target. Specify either an integer ID or a string name.
+        # See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for
+        # more information.
+        defaultGroup:
+
+    overrides:
+      - target:
+          # The kind of the Kubernetes resource to modify.
+          kind:
+
+          # The name of the resource.
+          name:
+
+          # The name of a container in the target. Specify this if the target contains more than one container and the
+          # main container is not the first container in the spec.
+          containerName:
+
+        # Override the command/entrypoint in the matched container.
+        command:
+
+        # Override the args in the matched container.
+        args:
 ```
 
 ## Configuration Keys
@@ -918,167 +999,6 @@ Whether to run the service as a daemon (to ensure exactly one instance runs per 
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
-### `spec.devMode`
-
-[spec](#spec) > devMode
-
-Specifies which files or directories to sync to which paths inside the running containers of the service when it's in dev mode, and overrides for the container command and/or arguments.
-
-Dev mode is enabled when running the `garden dev` command, and by setting the `--dev` flag on the `garden deploy` command.
-
-See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for more information.
-
-| Type     | Required |
-| -------- | -------- |
-| `object` | No       |
-
-### `spec.devMode.args[]`
-
-[spec](#spec) > [devMode](#specdevmode) > args
-
-Override the default container arguments when in dev mode.
-
-| Type            | Required |
-| --------------- | -------- |
-| `array[string]` | No       |
-
-### `spec.devMode.command[]`
-
-[spec](#spec) > [devMode](#specdevmode) > command
-
-Override the default container command (i.e. entrypoint) when in dev mode.
-
-| Type            | Required |
-| --------------- | -------- |
-| `array[string]` | No       |
-
-### `spec.devMode.sync[]`
-
-[spec](#spec) > [devMode](#specdevmode) > sync
-
-Specify one or more source files or directories to automatically sync with the running container.
-
-| Type            | Required |
-| --------------- | -------- |
-| `array[object]` | No       |
-
-### `spec.devMode.sync[].source`
-
-[spec](#spec) > [devMode](#specdevmode) > [sync](#specdevmodesync) > source
-
-POSIX-style path of the directory to sync to the target, relative to the config's directory. Must be a relative path. Defaults to the config's directory if no value is provided.
-
-| Type        | Default | Required |
-| ----------- | ------- | -------- |
-| `posixPath` | `"."`   | No       |
-
-Example:
-
-```yaml
-spec:
-  ...
-  devMode:
-    ...
-    sync:
-      - source: "src"
-```
-
-### `spec.devMode.sync[].target`
-
-[spec](#spec) > [devMode](#specdevmode) > [sync](#specdevmodesync) > target
-
-POSIX-style absolute path to sync to inside the container. The root path (i.e. "/") is not allowed.
-
-| Type        | Required |
-| ----------- | -------- |
-| `posixPath` | Yes      |
-
-Example:
-
-```yaml
-spec:
-  ...
-  devMode:
-    ...
-    sync:
-      - target: "/app/src"
-```
-
-### `spec.devMode.sync[].exclude[]`
-
-[spec](#spec) > [devMode](#specdevmode) > [sync](#specdevmodesync) > exclude
-
-Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
-
-`.git` directories and `.garden` directories are always ignored.
-
-| Type               | Required |
-| ------------------ | -------- |
-| `array[posixPath]` | No       |
-
-Example:
-
-```yaml
-spec:
-  ...
-  devMode:
-    ...
-    sync:
-      - exclude:
-          - dist/**/*
-          - '*.log'
-```
-
-### `spec.devMode.sync[].mode`
-
-[spec](#spec) > [devMode](#specdevmode) > [sync](#specdevmodesync) > mode
-
-The sync mode to use for the given paths. See the [Dev Mode guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
-
-| Type     | Allowed Values                                                                                                                            | Default          | Required |
-| -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
-| `string` | "one-way", "one-way-safe", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way", "two-way-safe", "two-way-resolved" | `"one-way-safe"` | Yes      |
-
-### `spec.devMode.sync[].defaultFileMode`
-
-[spec](#spec) > [devMode](#specdevmode) > [sync](#specdevmodesync) > defaultFileMode
-
-The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600 (user read/write). See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
-
-| Type     | Required |
-| -------- | -------- |
-| `number` | No       |
-
-### `spec.devMode.sync[].defaultDirectoryMode`
-
-[spec](#spec) > [devMode](#specdevmode) > [sync](#specdevmodesync) > defaultDirectoryMode
-
-The default permission bits, specified as an octal, to set on directories at the sync target. Defaults to 0700 (user read/write). See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
-
-| Type     | Required |
-| -------- | -------- |
-| `number` | No       |
-
-### `spec.devMode.sync[].defaultOwner`
-
-[spec](#spec) > [devMode](#specdevmode) > [sync](#specdevmodesync) > defaultOwner
-
-Set the default owner of files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
-
-| Type               | Required |
-| ------------------ | -------- |
-| `number \| string` | No       |
-
-### `spec.devMode.sync[].defaultGroup`
-
-[spec](#spec) > [devMode](#specdevmode) > [sync](#specdevmodesync) > defaultGroup
-
-Set the default group on files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
-
-| Type               | Required |
-| ------------------ | -------- |
-| `number \| string` | No       |
-
 ### `spec.localMode`
 
 [spec](#spec) > localMode
@@ -1537,6 +1457,370 @@ Note: This setting may be overridden or ignored in some cases. For example, when
 | Type     | Required |
 | -------- | -------- |
 | `number` | No       |
+
+### `spec.devMode`
+
+[spec](#spec) > devMode
+
+Configure dev mode syncs for the resources in this Deploy.
+
+If you have multiple syncs for the Deploy, you can use the `defaults` field to set common configuration for every individual sync.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `spec.devMode.defaults`
+
+[spec](#spec) > [devMode](#specdevmode) > defaults
+
+Defaults to set across every sync for this Deploy. If you use the `exclude` field here, it will be merged with any excludes set in individual syncs. These are applied on top of any defaults set in the provider configuration.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `spec.devMode.defaults.exclude[]`
+
+[spec](#spec) > [devMode](#specdevmode) > [defaults](#specdevmodedefaults) > exclude
+
+Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+
+Any exclusion patterns defined in individual dev mode sync specs will be applied in addition to these patterns.
+
+`.git` directories and `.garden` directories are always ignored.
+
+| Type               | Required |
+| ------------------ | -------- |
+| `array[posixPath]` | No       |
+
+Example:
+
+```yaml
+spec:
+  ...
+  devMode:
+    ...
+    defaults:
+      ...
+      exclude:
+        - dist/**/*
+        - '*.log'
+```
+
+### `spec.devMode.defaults.fileMode`
+
+[spec](#spec) > [devMode](#specdevmode) > [defaults](#specdevmodedefaults) > fileMode
+
+The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600 (user read/write). See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
+
+| Type     | Required |
+| -------- | -------- |
+| `number` | No       |
+
+### `spec.devMode.defaults.directoryMode`
+
+[spec](#spec) > [devMode](#specdevmode) > [defaults](#specdevmodedefaults) > directoryMode
+
+The default permission bits, specified as an octal, to set on directories at the sync target. Defaults to 0700 (user read/write). See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
+
+| Type     | Required |
+| -------- | -------- |
+| `number` | No       |
+
+### `spec.devMode.defaults.owner`
+
+[spec](#spec) > [devMode](#specdevmode) > [defaults](#specdevmodedefaults) > owner
+
+Set the default owner of files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
+
+| Type               | Required |
+| ------------------ | -------- |
+| `number \| string` | No       |
+
+### `spec.devMode.defaults.group`
+
+[spec](#spec) > [devMode](#specdevmode) > [defaults](#specdevmodedefaults) > group
+
+Set the default group on files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
+
+| Type               | Required |
+| ------------------ | -------- |
+| `number \| string` | No       |
+
+### `spec.devMode.syncs[]`
+
+[spec](#spec) > [devMode](#specdevmode) > syncs
+
+A list of syncs to start once the Deploy is successfully started.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[object]` | No       |
+
+### `spec.devMode.syncs[].fileMode`
+
+[spec](#spec) > [devMode](#specdevmode) > [syncs](#specdevmodesyncs) > fileMode
+
+The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600 (user read/write). See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
+
+| Type     | Required |
+| -------- | -------- |
+| `number` | No       |
+
+### `spec.devMode.syncs[].directoryMode`
+
+[spec](#spec) > [devMode](#specdevmode) > [syncs](#specdevmodesyncs) > directoryMode
+
+The default permission bits, specified as an octal, to set on directories at the sync target. Defaults to 0700 (user read/write). See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
+
+| Type     | Required |
+| -------- | -------- |
+| `number` | No       |
+
+### `spec.devMode.syncs[].owner`
+
+[spec](#spec) > [devMode](#specdevmode) > [syncs](#specdevmodesyncs) > owner
+
+Set the default owner of files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
+
+| Type               | Required |
+| ------------------ | -------- |
+| `number \| string` | No       |
+
+### `spec.devMode.syncs[].group`
+
+[spec](#spec) > [devMode](#specdevmode) > [syncs](#specdevmodesyncs) > group
+
+Set the default group on files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
+
+| Type               | Required |
+| ------------------ | -------- |
+| `number \| string` | No       |
+
+### `spec.devMode.syncs[].target`
+
+[spec](#spec) > [devMode](#specdevmode) > [syncs](#specdevmodesyncs) > target
+
+The Kubernetes resource to sync to. If specified, this is used instead of `spec.defaultTarget`.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `spec.devMode.syncs[].target.kind`
+
+[spec](#spec) > [devMode](#specdevmode) > [syncs](#specdevmodesyncs) > [target](#specdevmodesyncstarget) > kind
+
+The kind of Kubernetes resource to find.
+
+| Type     | Allowed Values                           | Required |
+| -------- | ---------------------------------------- | -------- |
+| `string` | "Deployment", "DaemonSet", "StatefulSet" | Yes      |
+
+### `spec.devMode.syncs[].target.name`
+
+[spec](#spec) > [devMode](#specdevmode) > [syncs](#specdevmodesyncs) > [target](#specdevmodesyncstarget) > name
+
+The name of the resource, of the specified `kind`. If specified, you must also specify `kind`.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `spec.devMode.syncs[].target.podSelector`
+
+[spec](#spec) > [devMode](#specdevmode) > [syncs](#specdevmodesyncs) > [target](#specdevmodesyncstarget) > podSelector
+
+A map of string key/value labels to match on any Pods in the namespace. When specified, a random ready Pod with matching labels will be picked as a target, so make sure the labels will always match a specific Pod type.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `spec.devMode.syncs[].target.containerName`
+
+[spec](#spec) > [devMode](#specdevmode) > [syncs](#specdevmodesyncs) > [target](#specdevmodesyncstarget) > containerName
+
+The name of a container in the target. Specify this if the target contains more than one container and the main container is not the first container in the spec.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `spec.devMode.syncs[].sourcePath`
+
+[spec](#spec) > [devMode](#specdevmode) > [syncs](#specdevmodesyncs) > sourcePath
+
+The local path to sync from, either absolute or relative to the source directory where the Deploy action is defined.
+
+This should generally be a templated path to another action's source path (e.g. `${build.my-container-image.sourcePath}`), or a relative path. If a path is hard-coded, you must make sure the path exists, and that it is reliably the correct path for every user.
+
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `"."`   | No       |
+
+### `spec.devMode.syncs[].containerPath`
+
+[spec](#spec) > [devMode](#specdevmode) > [syncs](#specdevmodesyncs) > containerPath
+
+POSIX-style absolute path to sync to inside the container. The root path (i.e. "/") is not allowed.
+
+| Type        | Required |
+| ----------- | -------- |
+| `posixPath` | Yes      |
+
+Example:
+
+```yaml
+spec:
+  ...
+  devMode:
+    ...
+    syncs:
+      - containerPath: "/app/src"
+```
+
+### `spec.devMode.syncs[].exclude[]`
+
+[spec](#spec) > [devMode](#specdevmode) > [syncs](#specdevmodesyncs) > exclude
+
+Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+
+`.git` directories and `.garden` directories are always ignored.
+
+| Type               | Required |
+| ------------------ | -------- |
+| `array[posixPath]` | No       |
+
+Example:
+
+```yaml
+spec:
+  ...
+  devMode:
+    ...
+    syncs:
+      - exclude:
+          - dist/**/*
+          - '*.log'
+```
+
+### `spec.devMode.syncs[].mode`
+
+[spec](#spec) > [devMode](#specdevmode) > [syncs](#specdevmodesyncs) > mode
+
+The sync mode to use for the given paths. See the [Dev Mode guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
+
+| Type     | Allowed Values                                                                                                                            | Default          | Required |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
+| `string` | "one-way", "one-way-safe", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way", "two-way-safe", "two-way-resolved" | `"one-way-safe"` | Yes      |
+
+### `spec.devMode.syncs[].defaultFileMode`
+
+[spec](#spec) > [devMode](#specdevmode) > [syncs](#specdevmodesyncs) > defaultFileMode
+
+The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600 (user read/write). See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
+
+| Type     | Required |
+| -------- | -------- |
+| `number` | No       |
+
+### `spec.devMode.syncs[].defaultDirectoryMode`
+
+[spec](#spec) > [devMode](#specdevmode) > [syncs](#specdevmodesyncs) > defaultDirectoryMode
+
+The default permission bits, specified as an octal, to set on directories at the sync target. Defaults to 0700 (user read/write). See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
+
+| Type     | Required |
+| -------- | -------- |
+| `number` | No       |
+
+### `spec.devMode.syncs[].defaultOwner`
+
+[spec](#spec) > [devMode](#specdevmode) > [syncs](#specdevmodesyncs) > defaultOwner
+
+Set the default owner of files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
+
+| Type               | Required |
+| ------------------ | -------- |
+| `number \| string` | No       |
+
+### `spec.devMode.syncs[].defaultGroup`
+
+[spec](#spec) > [devMode](#specdevmode) > [syncs](#specdevmodesyncs) > defaultGroup
+
+Set the default group on files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
+
+| Type               | Required |
+| ------------------ | -------- |
+| `number \| string` | No       |
+
+### `spec.devMode.overrides[]`
+
+[spec](#spec) > [devMode](#specdevmode) > overrides
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[object]` | No       |
+
+### `spec.devMode.overrides[].target`
+
+[spec](#spec) > [devMode](#specdevmode) > [overrides](#specdevmodeoverrides) > target
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `spec.devMode.overrides[].target.kind`
+
+[spec](#spec) > [devMode](#specdevmode) > [overrides](#specdevmodeoverrides) > [target](#specdevmodeoverridestarget) > kind
+
+The kind of the Kubernetes resource to modify.
+
+| Type     | Allowed Values                           | Required |
+| -------- | ---------------------------------------- | -------- |
+| `string` | "Deployment", "DaemonSet", "StatefulSet" | Yes      |
+
+### `spec.devMode.overrides[].target.name`
+
+[spec](#spec) > [devMode](#specdevmode) > [overrides](#specdevmodeoverrides) > [target](#specdevmodeoverridestarget) > name
+
+The name of the resource.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | Yes      |
+
+### `spec.devMode.overrides[].target.containerName`
+
+[spec](#spec) > [devMode](#specdevmode) > [overrides](#specdevmodeoverrides) > [target](#specdevmodeoverridestarget) > containerName
+
+The name of a container in the target. Specify this if the target contains more than one container and the main container is not the first container in the spec.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
+
+### `spec.devMode.overrides[].command[]`
+
+[spec](#spec) > [devMode](#specdevmode) > [overrides](#specdevmodeoverrides) > command
+
+Override the command/entrypoint in the matched container.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
+### `spec.devMode.overrides[].args[]`
+
+[spec](#spec) > [devMode](#specdevmode) > [overrides](#specdevmodeoverrides) > args
+
+Override the args in the matched container.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
 
 
 ## Outputs

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -296,61 +296,6 @@ services:
     # all providers.
     daemon: false
 
-    # Specifies which files or directories to sync to which paths inside the running containers of the service when
-    # it's in dev mode, and overrides for the container command and/or arguments.
-    #
-    # Dev mode is enabled when running the `garden dev` command, and by setting the `--dev` flag on the `garden
-    # deploy` command.
-    #
-    # See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for more
-    # information.
-    devMode:
-      # Override the default container arguments when in dev mode.
-      args:
-
-      # Override the default container command (i.e. entrypoint) when in dev mode.
-      command:
-
-      # Specify one or more source files or directories to automatically sync with the running container.
-      sync:
-        - # POSIX-style path of the directory to sync to the target, relative to the config's directory. Must be a
-          # relative path. Defaults to the config's directory if no value is provided.
-          source: .
-
-          # POSIX-style absolute path to sync to inside the container. The root path (i.e. "/") is not allowed.
-          target:
-
-          # Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
-          #
-          # `.git` directories and `.garden` directories are always ignored.
-          exclude:
-
-          # The sync mode to use for the given paths. See the [Dev Mode
-          # guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
-          mode: one-way-safe
-
-          # The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600
-          # (user read/write). See the [Mutagen
-          # docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
-          defaultFileMode:
-
-          # The default permission bits, specified as an octal, to set on directories at the sync target. Defaults to
-          # 0700 (user read/write). See the [Mutagen
-          # docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
-          defaultDirectoryMode:
-
-          # Set the default owner of files and directories at the target. Specify either an integer ID or a string
-          # name. See the [Mutagen
-          # docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more
-          # information.
-          defaultOwner:
-
-          # Set the default group on files and directories at the target. Specify either an integer ID or a string
-          # name. See the [Mutagen
-          # docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more
-          # information.
-          defaultGroup:
-
     # [EXPERIMENTAL] Configures the local application which will send and receive network requests instead of the
     # target resource.
     #
@@ -487,6 +432,61 @@ services:
     # Note: This setting may be overridden or ignored in some cases. For example, when running with `daemon: true` or
     # if the provider doesn't support multiple replicas.
     replicas:
+
+    # Specifies which files or directories to sync to which paths inside the running containers of the service when
+    # it's in dev mode, and overrides for the container command and/or arguments.
+    #
+    # Dev mode is enabled when running the `garden dev` command, and by setting the `--dev` flag on the `garden
+    # deploy` command.
+    #
+    # See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for more
+    # information.
+    devMode:
+      # Override the default container arguments when in dev mode.
+      args:
+
+      # Override the default container command (i.e. entrypoint) when in dev mode.
+      command:
+
+      # Specify one or more source files or directories to automatically sync with the running container.
+      sync:
+        - # POSIX-style path of the directory to sync to the target, relative to the config's directory. Must be a
+          # relative path. Defaults to the config's directory if no value is provided.
+          source: .
+
+          # POSIX-style absolute path to sync to inside the container. The root path (i.e. "/") is not allowed.
+          target:
+
+          # Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+          #
+          # `.git` directories and `.garden` directories are always ignored.
+          exclude:
+
+          # The sync mode to use for the given paths. See the [Dev Mode
+          # guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
+          mode: one-way-safe
+
+          # The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600
+          # (user read/write). See the [Mutagen
+          # docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
+          defaultFileMode:
+
+          # The default permission bits, specified as an octal, to set on directories at the sync target. Defaults to
+          # 0700 (user read/write). See the [Mutagen
+          # docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
+          defaultDirectoryMode:
+
+          # Set the default owner of files and directories at the target. Specify either an integer ID or a string
+          # name. See the [Mutagen
+          # docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more
+          # information.
+          defaultOwner:
+
+          # Set the default group on files and directories at the target. Specify either an integer ID or a string
+          # name. See the [Mutagen
+          # docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more
+          # information.
+          defaultGroup:
 
 # A list of tests to run in the module.
 tests:
@@ -1361,164 +1361,6 @@ Whether to run the service as a daemon (to ensure exactly one instance runs per 
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
-### `services[].devMode`
-
-[services](#services) > devMode
-
-Specifies which files or directories to sync to which paths inside the running containers of the service when it's in dev mode, and overrides for the container command and/or arguments.
-
-Dev mode is enabled when running the `garden dev` command, and by setting the `--dev` flag on the `garden deploy` command.
-
-See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for more information.
-
-| Type     | Required |
-| -------- | -------- |
-| `object` | No       |
-
-### `services[].devMode.args[]`
-
-[services](#services) > [devMode](#servicesdevmode) > args
-
-Override the default container arguments when in dev mode.
-
-| Type            | Required |
-| --------------- | -------- |
-| `array[string]` | No       |
-
-### `services[].devMode.command[]`
-
-[services](#services) > [devMode](#servicesdevmode) > command
-
-Override the default container command (i.e. entrypoint) when in dev mode.
-
-| Type            | Required |
-| --------------- | -------- |
-| `array[string]` | No       |
-
-### `services[].devMode.sync[]`
-
-[services](#services) > [devMode](#servicesdevmode) > sync
-
-Specify one or more source files or directories to automatically sync with the running container.
-
-| Type            | Required |
-| --------------- | -------- |
-| `array[object]` | No       |
-
-### `services[].devMode.sync[].source`
-
-[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > source
-
-POSIX-style path of the directory to sync to the target, relative to the config's directory. Must be a relative path. Defaults to the config's directory if no value is provided.
-
-| Type        | Default | Required |
-| ----------- | ------- | -------- |
-| `posixPath` | `"."`   | No       |
-
-Example:
-
-```yaml
-services:
-  - devMode:
-      ...
-      sync:
-        - source: "src"
-```
-
-### `services[].devMode.sync[].target`
-
-[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > target
-
-POSIX-style absolute path to sync to inside the container. The root path (i.e. "/") is not allowed.
-
-| Type        | Required |
-| ----------- | -------- |
-| `posixPath` | Yes      |
-
-Example:
-
-```yaml
-services:
-  - devMode:
-      ...
-      sync:
-        - target: "/app/src"
-```
-
-### `services[].devMode.sync[].exclude[]`
-
-[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > exclude
-
-Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
-
-`.git` directories and `.garden` directories are always ignored.
-
-| Type               | Required |
-| ------------------ | -------- |
-| `array[posixPath]` | No       |
-
-Example:
-
-```yaml
-services:
-  - devMode:
-      ...
-      sync:
-        - exclude:
-            - dist/**/*
-            - '*.log'
-```
-
-### `services[].devMode.sync[].mode`
-
-[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > mode
-
-The sync mode to use for the given paths. See the [Dev Mode guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
-
-| Type     | Allowed Values                                                                                                                            | Default          | Required |
-| -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
-| `string` | "one-way", "one-way-safe", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way", "two-way-safe", "two-way-resolved" | `"one-way-safe"` | Yes      |
-
-### `services[].devMode.sync[].defaultFileMode`
-
-[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > defaultFileMode
-
-The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600 (user read/write). See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
-
-| Type     | Required |
-| -------- | -------- |
-| `number` | No       |
-
-### `services[].devMode.sync[].defaultDirectoryMode`
-
-[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > defaultDirectoryMode
-
-The default permission bits, specified as an octal, to set on directories at the sync target. Defaults to 0700 (user read/write). See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
-
-| Type     | Required |
-| -------- | -------- |
-| `number` | No       |
-
-### `services[].devMode.sync[].defaultOwner`
-
-[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > defaultOwner
-
-Set the default owner of files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
-
-| Type               | Required |
-| ------------------ | -------- |
-| `number \| string` | No       |
-
-### `services[].devMode.sync[].defaultGroup`
-
-[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > defaultGroup
-
-Set the default group on files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
-
-| Type               | Required |
-| ------------------ | -------- |
-| `number \| string` | No       |
-
 ### `services[].localMode`
 
 [services](#services) > localMode
@@ -1972,6 +1814,164 @@ Note: This setting may be overridden or ignored in some cases. For example, when
 | Type     | Required |
 | -------- | -------- |
 | `number` | No       |
+
+### `services[].devMode`
+
+[services](#services) > devMode
+
+Specifies which files or directories to sync to which paths inside the running containers of the service when it's in dev mode, and overrides for the container command and/or arguments.
+
+Dev mode is enabled when running the `garden dev` command, and by setting the `--dev` flag on the `garden deploy` command.
+
+See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for more information.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `services[].devMode.args[]`
+
+[services](#services) > [devMode](#servicesdevmode) > args
+
+Override the default container arguments when in dev mode.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
+### `services[].devMode.command[]`
+
+[services](#services) > [devMode](#servicesdevmode) > command
+
+Override the default container command (i.e. entrypoint) when in dev mode.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
+### `services[].devMode.sync[]`
+
+[services](#services) > [devMode](#servicesdevmode) > sync
+
+Specify one or more source files or directories to automatically sync with the running container.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[object]` | No       |
+
+### `services[].devMode.sync[].source`
+
+[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > source
+
+POSIX-style path of the directory to sync to the target, relative to the config's directory. Must be a relative path. Defaults to the config's directory if no value is provided.
+
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `"."`   | No       |
+
+Example:
+
+```yaml
+services:
+  - devMode:
+      ...
+      sync:
+        - source: "src"
+```
+
+### `services[].devMode.sync[].target`
+
+[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > target
+
+POSIX-style absolute path to sync to inside the container. The root path (i.e. "/") is not allowed.
+
+| Type        | Required |
+| ----------- | -------- |
+| `posixPath` | Yes      |
+
+Example:
+
+```yaml
+services:
+  - devMode:
+      ...
+      sync:
+        - target: "/app/src"
+```
+
+### `services[].devMode.sync[].exclude[]`
+
+[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > exclude
+
+Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+
+`.git` directories and `.garden` directories are always ignored.
+
+| Type               | Required |
+| ------------------ | -------- |
+| `array[posixPath]` | No       |
+
+Example:
+
+```yaml
+services:
+  - devMode:
+      ...
+      sync:
+        - exclude:
+            - dist/**/*
+            - '*.log'
+```
+
+### `services[].devMode.sync[].mode`
+
+[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > mode
+
+The sync mode to use for the given paths. See the [Dev Mode guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
+
+| Type     | Allowed Values                                                                                                                            | Default          | Required |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
+| `string` | "one-way", "one-way-safe", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way", "two-way-safe", "two-way-resolved" | `"one-way-safe"` | Yes      |
+
+### `services[].devMode.sync[].defaultFileMode`
+
+[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > defaultFileMode
+
+The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600 (user read/write). See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
+
+| Type     | Required |
+| -------- | -------- |
+| `number` | No       |
+
+### `services[].devMode.sync[].defaultDirectoryMode`
+
+[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > defaultDirectoryMode
+
+The default permission bits, specified as an octal, to set on directories at the sync target. Defaults to 0700 (user read/write). See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
+
+| Type     | Required |
+| -------- | -------- |
+| `number` | No       |
+
+### `services[].devMode.sync[].defaultOwner`
+
+[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > defaultOwner
+
+Set the default owner of files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
+
+| Type               | Required |
+| ------------------ | -------- |
+| `number \| string` | No       |
+
+### `services[].devMode.sync[].defaultGroup`
+
+[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > defaultGroup
+
+Set the default group on files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
+
+| Type               | Required |
+| ------------------ | -------- |
+| `number \| string` | No       |
 
 ### `tests[]`
 

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -349,61 +349,6 @@ services:
     # all providers.
     daemon: false
 
-    # Specifies which files or directories to sync to which paths inside the running containers of the service when
-    # it's in dev mode, and overrides for the container command and/or arguments.
-    #
-    # Dev mode is enabled when running the `garden dev` command, and by setting the `--dev` flag on the `garden
-    # deploy` command.
-    #
-    # See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for more
-    # information.
-    devMode:
-      # Override the default container arguments when in dev mode.
-      args:
-
-      # Override the default container command (i.e. entrypoint) when in dev mode.
-      command:
-
-      # Specify one or more source files or directories to automatically sync with the running container.
-      sync:
-        - # POSIX-style path of the directory to sync to the target, relative to the config's directory. Must be a
-          # relative path. Defaults to the config's directory if no value is provided.
-          source: .
-
-          # POSIX-style absolute path to sync to inside the container. The root path (i.e. "/") is not allowed.
-          target:
-
-          # Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
-          #
-          # `.git` directories and `.garden` directories are always ignored.
-          exclude:
-
-          # The sync mode to use for the given paths. See the [Dev Mode
-          # guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
-          mode: one-way-safe
-
-          # The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600
-          # (user read/write). See the [Mutagen
-          # docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
-          defaultFileMode:
-
-          # The default permission bits, specified as an octal, to set on directories at the sync target. Defaults to
-          # 0700 (user read/write). See the [Mutagen
-          # docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
-          defaultDirectoryMode:
-
-          # Set the default owner of files and directories at the target. Specify either an integer ID or a string
-          # name. See the [Mutagen
-          # docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more
-          # information.
-          defaultOwner:
-
-          # Set the default group on files and directories at the target. Specify either an integer ID or a string
-          # name. See the [Mutagen
-          # docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more
-          # information.
-          defaultGroup:
-
     # [EXPERIMENTAL] Configures the local application which will send and receive network requests instead of the
     # target resource.
     #
@@ -540,6 +485,61 @@ services:
     # Note: This setting may be overridden or ignored in some cases. For example, when running with `daemon: true` or
     # if the provider doesn't support multiple replicas.
     replicas:
+
+    # Specifies which files or directories to sync to which paths inside the running containers of the service when
+    # it's in dev mode, and overrides for the container command and/or arguments.
+    #
+    # Dev mode is enabled when running the `garden dev` command, and by setting the `--dev` flag on the `garden
+    # deploy` command.
+    #
+    # See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for more
+    # information.
+    devMode:
+      # Override the default container arguments when in dev mode.
+      args:
+
+      # Override the default container command (i.e. entrypoint) when in dev mode.
+      command:
+
+      # Specify one or more source files or directories to automatically sync with the running container.
+      sync:
+        - # POSIX-style path of the directory to sync to the target, relative to the config's directory. Must be a
+          # relative path. Defaults to the config's directory if no value is provided.
+          source: .
+
+          # POSIX-style absolute path to sync to inside the container. The root path (i.e. "/") is not allowed.
+          target:
+
+          # Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+          #
+          # `.git` directories and `.garden` directories are always ignored.
+          exclude:
+
+          # The sync mode to use for the given paths. See the [Dev Mode
+          # guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
+          mode: one-way-safe
+
+          # The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600
+          # (user read/write). See the [Mutagen
+          # docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
+          defaultFileMode:
+
+          # The default permission bits, specified as an octal, to set on directories at the sync target. Defaults to
+          # 0700 (user read/write). See the [Mutagen
+          # docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
+          defaultDirectoryMode:
+
+          # Set the default owner of files and directories at the target. Specify either an integer ID or a string
+          # name. See the [Mutagen
+          # docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more
+          # information.
+          defaultOwner:
+
+          # Set the default group on files and directories at the target. Specify either an integer ID or a string
+          # name. See the [Mutagen
+          # docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more
+          # information.
+          defaultGroup:
 
 # A list of tests to run in the module.
 tests:
@@ -1529,164 +1529,6 @@ Whether to run the service as a daemon (to ensure exactly one instance runs per 
 | --------- | ------- | -------- |
 | `boolean` | `false` | No       |
 
-### `services[].devMode`
-
-[services](#services) > devMode
-
-Specifies which files or directories to sync to which paths inside the running containers of the service when it's in dev mode, and overrides for the container command and/or arguments.
-
-Dev mode is enabled when running the `garden dev` command, and by setting the `--dev` flag on the `garden deploy` command.
-
-See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for more information.
-
-| Type     | Required |
-| -------- | -------- |
-| `object` | No       |
-
-### `services[].devMode.args[]`
-
-[services](#services) > [devMode](#servicesdevmode) > args
-
-Override the default container arguments when in dev mode.
-
-| Type            | Required |
-| --------------- | -------- |
-| `array[string]` | No       |
-
-### `services[].devMode.command[]`
-
-[services](#services) > [devMode](#servicesdevmode) > command
-
-Override the default container command (i.e. entrypoint) when in dev mode.
-
-| Type            | Required |
-| --------------- | -------- |
-| `array[string]` | No       |
-
-### `services[].devMode.sync[]`
-
-[services](#services) > [devMode](#servicesdevmode) > sync
-
-Specify one or more source files or directories to automatically sync with the running container.
-
-| Type            | Required |
-| --------------- | -------- |
-| `array[object]` | No       |
-
-### `services[].devMode.sync[].source`
-
-[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > source
-
-POSIX-style path of the directory to sync to the target, relative to the config's directory. Must be a relative path. Defaults to the config's directory if no value is provided.
-
-| Type        | Default | Required |
-| ----------- | ------- | -------- |
-| `posixPath` | `"."`   | No       |
-
-Example:
-
-```yaml
-services:
-  - devMode:
-      ...
-      sync:
-        - source: "src"
-```
-
-### `services[].devMode.sync[].target`
-
-[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > target
-
-POSIX-style absolute path to sync to inside the container. The root path (i.e. "/") is not allowed.
-
-| Type        | Required |
-| ----------- | -------- |
-| `posixPath` | Yes      |
-
-Example:
-
-```yaml
-services:
-  - devMode:
-      ...
-      sync:
-        - target: "/app/src"
-```
-
-### `services[].devMode.sync[].exclude[]`
-
-[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > exclude
-
-Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
-
-`.git` directories and `.garden` directories are always ignored.
-
-| Type               | Required |
-| ------------------ | -------- |
-| `array[posixPath]` | No       |
-
-Example:
-
-```yaml
-services:
-  - devMode:
-      ...
-      sync:
-        - exclude:
-            - dist/**/*
-            - '*.log'
-```
-
-### `services[].devMode.sync[].mode`
-
-[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > mode
-
-The sync mode to use for the given paths. See the [Dev Mode guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
-
-| Type     | Allowed Values                                                                                                                            | Default          | Required |
-| -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
-| `string` | "one-way", "one-way-safe", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way", "two-way-safe", "two-way-resolved" | `"one-way-safe"` | Yes      |
-
-### `services[].devMode.sync[].defaultFileMode`
-
-[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > defaultFileMode
-
-The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600 (user read/write). See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
-
-| Type     | Required |
-| -------- | -------- |
-| `number` | No       |
-
-### `services[].devMode.sync[].defaultDirectoryMode`
-
-[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > defaultDirectoryMode
-
-The default permission bits, specified as an octal, to set on directories at the sync target. Defaults to 0700 (user read/write). See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
-
-| Type     | Required |
-| -------- | -------- |
-| `number` | No       |
-
-### `services[].devMode.sync[].defaultOwner`
-
-[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > defaultOwner
-
-Set the default owner of files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
-
-| Type               | Required |
-| ------------------ | -------- |
-| `number \| string` | No       |
-
-### `services[].devMode.sync[].defaultGroup`
-
-[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > defaultGroup
-
-Set the default group on files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
-
-| Type               | Required |
-| ------------------ | -------- |
-| `number \| string` | No       |
-
 ### `services[].localMode`
 
 [services](#services) > localMode
@@ -2140,6 +1982,164 @@ Note: This setting may be overridden or ignored in some cases. For example, when
 | Type     | Required |
 | -------- | -------- |
 | `number` | No       |
+
+### `services[].devMode`
+
+[services](#services) > devMode
+
+Specifies which files or directories to sync to which paths inside the running containers of the service when it's in dev mode, and overrides for the container command and/or arguments.
+
+Dev mode is enabled when running the `garden dev` command, and by setting the `--dev` flag on the `garden deploy` command.
+
+See the [Code Synchronization guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for more information.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `services[].devMode.args[]`
+
+[services](#services) > [devMode](#servicesdevmode) > args
+
+Override the default container arguments when in dev mode.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
+### `services[].devMode.command[]`
+
+[services](#services) > [devMode](#servicesdevmode) > command
+
+Override the default container command (i.e. entrypoint) when in dev mode.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[string]` | No       |
+
+### `services[].devMode.sync[]`
+
+[services](#services) > [devMode](#servicesdevmode) > sync
+
+Specify one or more source files or directories to automatically sync with the running container.
+
+| Type            | Required |
+| --------------- | -------- |
+| `array[object]` | No       |
+
+### `services[].devMode.sync[].source`
+
+[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > source
+
+POSIX-style path of the directory to sync to the target, relative to the config's directory. Must be a relative path. Defaults to the config's directory if no value is provided.
+
+| Type        | Default | Required |
+| ----------- | ------- | -------- |
+| `posixPath` | `"."`   | No       |
+
+Example:
+
+```yaml
+services:
+  - devMode:
+      ...
+      sync:
+        - source: "src"
+```
+
+### `services[].devMode.sync[].target`
+
+[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > target
+
+POSIX-style absolute path to sync to inside the container. The root path (i.e. "/") is not allowed.
+
+| Type        | Required |
+| ----------- | -------- |
+| `posixPath` | Yes      |
+
+Example:
+
+```yaml
+services:
+  - devMode:
+      ...
+      sync:
+        - target: "/app/src"
+```
+
+### `services[].devMode.sync[].exclude[]`
+
+[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > exclude
+
+Specify a list of POSIX-style paths or glob patterns that should be excluded from the sync.
+
+`.git` directories and `.garden` directories are always ignored.
+
+| Type               | Required |
+| ------------------ | -------- |
+| `array[posixPath]` | No       |
+
+Example:
+
+```yaml
+services:
+  - devMode:
+      ...
+      sync:
+        - exclude:
+            - dist/**/*
+            - '*.log'
+```
+
+### `services[].devMode.sync[].mode`
+
+[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > mode
+
+The sync mode to use for the given paths. See the [Dev Mode guide](https://docs.garden.io/guides/code-synchronization-dev-mode) for details.
+
+| Type     | Allowed Values                                                                                                                            | Default          | Required |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
+| `string` | "one-way", "one-way-safe", "one-way-replica", "one-way-reverse", "one-way-replica-reverse", "two-way", "two-way-safe", "two-way-resolved" | `"one-way-safe"` | Yes      |
+
+### `services[].devMode.sync[].defaultFileMode`
+
+[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > defaultFileMode
+
+The default permission bits, specified as an octal, to set on files at the sync target. Defaults to 0600 (user read/write). See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
+
+| Type     | Required |
+| -------- | -------- |
+| `number` | No       |
+
+### `services[].devMode.sync[].defaultDirectoryMode`
+
+[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > defaultDirectoryMode
+
+The default permission bits, specified as an octal, to set on directories at the sync target. Defaults to 0700 (user read/write). See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#permissions) for more information.
+
+| Type     | Required |
+| -------- | -------- |
+| `number` | No       |
+
+### `services[].devMode.sync[].defaultOwner`
+
+[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > defaultOwner
+
+Set the default owner of files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
+
+| Type               | Required |
+| ------------------ | -------- |
+| `number \| string` | No       |
+
+### `services[].devMode.sync[].defaultGroup`
+
+[services](#services) > [devMode](#servicesdevmode) > [sync](#servicesdevmodesync) > defaultGroup
+
+Set the default group on files and directories at the target. Specify either an integer ID or a string name. See the [Mutagen docs](https://mutagen.io/documentation/synchronization/permissions#owners-and-groups) for more information.
+
+| Type               | Required |
+| ------------------ | -------- |
+| `number \| string` | No       |
 
 ### `tests[]`
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

**fix(k8s): fixed dev mode for `container` services**

A few changes were needed to make dev mode work for `container` services in 0.13, mostly to use the same helper function to convert from the old-style dev mode sync specs to the new style.

**fix(core): correctly ignore watches in dev mode**

This fixes a regression in 0.13 where an `actionSourcesChanged` event would get fired when sources are changd for a Deploy that's deployed with dev mode enabled. This caused several problems, but is now fixed.

The problem lay in the way we were calculating the paths to skip/ignore, which are passed to the `Watcher` class.

**fix(k8s): fix sync destination formatting issue**

Before this fix, the path in the remote sync desination would get rendered as `[object Object]` - a simple change.

**Special notes for your reviewer**:

I haven't tested these changes on `kubernetes` modules yet, but I think dev mode should be working there now—and if not, the fixes needed should be quite straightforward at this point.