### PR TITLE
feat(kubernetes): add sync helper commands

### DIFF
--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -20,6 +20,8 @@ export const STATIC_DIR = isPkg ? resolve(process.execPath, "..", "static") : re
 // We symlink to it the built dashboard to the core static directory during dev, and copy it there for dist builds
 export const DASHBOARD_STATIC_DIR = join(STATIC_DIR, "dashboard")
 export const DEFAULT_GARDEN_DIR_NAME = ".garden"
+export const MUTAGEN_DIR_NAME = "mutagen"
+export const LATEST_MUTAGEN_DATA_DIR_NAME = "latest"
 export const LOGS_DIR_NAME = "logs"
 export const GARDEN_GLOBAL_PATH = join(homedir(), DEFAULT_GARDEN_DIR_NAME)
 export const LOGS_DIR = join(DEFAULT_GARDEN_DIR_NAME, LOGS_DIR_NAME)

--- a/core/src/plugins/kubernetes/commands/sync.ts
+++ b/core/src/plugins/kubernetes/commands/sync.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2018-2022 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { PluginCommand } from "../../../types/plugin/command"
+import chalk from "chalk"
+import { getMutagenEnv, mutagenCliSpec, parseSyncListResult } from "../mutagen"
+import { LATEST_MUTAGEN_DATA_DIR_NAME, MUTAGEN_DIR_NAME } from "../../../constants"
+import { join } from "path"
+import { pathExists, readlink } from "fs-extra"
+import { dedent } from "../../../util/string"
+import { LogEntry } from "../../../logger/log-entry"
+import { PluginTool } from "../../../util/ext-tools"
+
+const logSuccess = (log: LogEntry) => log.info({ msg: chalk.green("\nDone!"), status: "success" })
+
+const commonDocs = `Only works if a Garden is already running in dev mode in a separate process in this project.`
+
+export const syncStatus: PluginCommand = {
+  name: "sync-status",
+  description: `Get the sync status for the current dev mode command. ${commonDocs}`,
+  title: "Get the current sync status",
+
+  handler: async ({ ctx, log }) => {
+    const dataDir = await getMutagenDataDir(ctx.gardenDirPath)
+    const mutagen = new PluginTool(mutagenCliSpec)
+
+    if (!(await pathExists(dataDir))) {
+      log.info(dedent`
+        No active sync session found.
+
+        Garden needs to be running in dev mode in this project for sync statuses to
+        be available.
+      `)
+
+      logSuccess(log)
+      return { result: [] }
+    }
+
+    const syncSessions = await getMutagenSyncSessions({ log, dataDir, mutagen })
+    const result = { syncSessions }
+
+    if (syncSessions.length === 0) {
+      log.info(`Found 0 syncs.`)
+    } else {
+      log.info(`Found ${syncSessions.length} syncs:`)
+      log.info({ data: syncSessions })
+    }
+
+    logSuccess(log)
+
+    return { result }
+  },
+}
+
+export const syncPause: PluginCommand = {
+  name: "sync-pause",
+  description: `Pause all active syncs. Can be resumed with the sync-resume command. ${commonDocs}`,
+  title: "Pause sync",
+
+  handler: async ({ ctx, log }) => {
+    const dataDir = await getMutagenDataDir(ctx.gardenDirPath)
+    const mutagen = new PluginTool(mutagenCliSpec)
+
+    if (!(await pathExists(dataDir))) {
+      log.info(dedent`
+        No active sync session found.
+
+        Garden needs to be running in dev mode in this project to be able to pause syncs.
+      `)
+
+      logSuccess(log)
+      return { result: [] }
+    }
+
+    const syncSessions = await getMutagenSyncSessions({ log, dataDir, mutagen })
+    const activeSyncSessionNames = syncSessions.filter((s) => !s.paused).map((s) => s.name)
+    const result = { pausedSessionNames: activeSyncSessionNames }
+
+    if (syncSessions.length === 0) {
+      log.info(`No syncs found.`)
+    } else if (activeSyncSessionNames.length === 0) {
+      log.info(`Sync are already paused.`)
+    } else {
+      log.info(`Pausing ${activeSyncSessionNames.length} syncs.`)
+      for (const sessionName of activeSyncSessionNames) {
+        log.debug(`Pausing sync session ${sessionName}`)
+        await mutagen.exec({ cwd: dataDir, log, env: getMutagenEnv(dataDir), args: ["sync", "pause", sessionName] })
+      }
+    }
+
+    logSuccess(log)
+    return { result }
+  },
+}
+
+export const syncResume: PluginCommand = {
+  name: "sync-resume",
+  description: `Resume all paused syncs. ${commonDocs}`,
+  title: "Resume sync",
+
+  handler: async ({ ctx, log }) => {
+    const dataDir = await getMutagenDataDir(ctx.gardenDirPath)
+    const mutagen = new PluginTool(mutagenCliSpec)
+
+    if (!(await pathExists(dataDir))) {
+      log.info(dedent`
+        No active sync session found.
+
+        Garden needs to be running in dev mode in this project to be able to resume syncs.
+      `)
+
+      logSuccess(log)
+      return { result: [] }
+    }
+
+    const syncSessions = await getMutagenSyncSessions({ log, dataDir, mutagen })
+    const pausedSyncSessionNames = syncSessions.filter((s) => s.paused).map((s) => s.name)
+    const result = { resumedSessionNames: pausedSyncSessionNames }
+
+    if (syncSessions.length === 0) {
+      log.info(`No syncs found.`)
+    } else if (pausedSyncSessionNames.length === 0) {
+      log.info(`Syncs are already active.`)
+    } else {
+      log.info(`Resuming ${pausedSyncSessionNames.length} syncs.`)
+      for (const sessionName of pausedSyncSessionNames) {
+        log.debug(`Resuming sync session ${sessionName}`)
+        await mutagen.exec({ cwd: dataDir, log, env: getMutagenEnv(dataDir), args: ["sync", "resume", sessionName] })
+      }
+    }
+
+    logSuccess(log)
+    return { result }
+  },
+}
+
+async function getMutagenSyncSessions({
+  mutagen,
+  dataDir,
+  log,
+}: {
+  mutagen: PluginTool
+  dataDir: string
+  log: LogEntry
+}) {
+  const res = await mutagen.exec({
+    cwd: dataDir,
+    log,
+    env: getMutagenEnv(dataDir),
+    args: ["sync", "list", "--template={{ json . }}"],
+  })
+  return parseSyncListResult(res)
+}
+
+/**
+ * Returns the "real" path to the Mutagen data dir for this project
+ * by reading it from the 'LATEST_MUTAGEN_DATA_DIR_NAME' symlink which
+ * is always created when the Mutagen daemon is started.
+ *
+ * This is based on the assumption that there's only a single Mutagen daemon
+ * running per project.
+ *
+ * It's a little hacky but works.
+ */
+async function getMutagenDataDir(gardenDirPath: string) {
+  const mutagenDataDirSymlink = join(gardenDirPath, MUTAGEN_DIR_NAME, LATEST_MUTAGEN_DATA_DIR_NAME)
+  return readlink(mutagenDataDirSymlink)
+}

--- a/core/src/plugins/kubernetes/commands/sync.ts
+++ b/core/src/plugins/kubernetes/commands/sync.ts
@@ -18,7 +18,7 @@ import { PluginTool } from "../../../util/ext-tools"
 
 const logSuccess = (log: LogEntry) => log.info({ msg: chalk.green("\nDone!"), status: "success" })
 
-const commonDocs = `Only works if a Garden is already running in dev mode in a separate process in this project.`
+const commonDocs = `'garden dev' or 'garden deploy --dev' must be running in this project for this command to work.`
 
 export const syncStatus: PluginCommand = {
   name: "sync-status",

--- a/core/src/plugins/kubernetes/kubernetes.ts
+++ b/core/src/plugins/kubernetes/kubernetes.ts
@@ -46,6 +46,7 @@ import { jibContainerHandlers } from "./jib-container"
 import { emitWarning } from "../../warnings"
 import { kustomizeSpec } from "./kubernetes-module/kustomize"
 import { taskOutputsSchema } from "./task-results"
+import { syncPause, syncResume, syncStatus } from "./commands/sync"
 
 export async function configureProvider({
   log,
@@ -217,7 +218,15 @@ export const gardenPlugin = () =>
   `,
     configSchema: configSchema(),
     outputsSchema,
-    commands: [cleanupClusterRegistry, clusterInit, uninstallGardenServices, pullImage],
+    commands: [
+      cleanupClusterRegistry,
+      clusterInit,
+      uninstallGardenServices,
+      pullImage,
+      syncStatus,
+      syncPause,
+      syncResume,
+    ],
     handlers: {
       configureProvider,
       getEnvironmentStatus,

--- a/core/src/plugins/kubernetes/mutagen.ts
+++ b/core/src/plugins/kubernetes/mutagen.ts
@@ -62,17 +62,17 @@ export const mutagenModeMap = {
 // with an updated description to match Garden's context.
 const mutagenStatusDescriptions = {
   "disconnected": "Sync disconnected",
-  "halted-on-root-emptied": "Sync halted due to one-sided root emptying",
-  "halted-on-root-deletion": "Sync halted due to root deletion",
-  "halted-on-root-type-change": "Sync halted due to root type change",
-  "connecting-alpha": "Sync connected to alpha",
-  "connecting-beta": "Sync connected to beta",
+  "halted-on-root-emptied": "Sync halted because either the source or target directory was emptied",
+  "halted-on-root-deletion": "Sync halted because either the source or target was deleted",
+  "halted-on-root-type-change": "Sync halted because either the source or target changed type",
+  "connecting-alpha": "Sync connected to source",
+  "connecting-beta": "Sync connected to target",
   "watching": "Watching for changes",
   "scanning": "Scanning files to sync",
   "waiting-for-rescan": "Waiting 5 seconds for sync rescan",
   "reconciling": "Reconciling sync changes",
-  "staging-alpha": "Staging files to sync on alpha",
-  "staging-beta": "Staging files to sync on beta",
+  "staging-alpha": "Staging files to sync in source",
+  "staging-beta": "Staging files to sync in target",
   "transitioning": "Syncing changes...",
   "saving": "Saving sync archive",
 }
@@ -452,7 +452,7 @@ export class MutagenDaemon {
             symbol: "empty",
             section: mutagenLogSection,
             msg: chalk.gray(
-              `Could not flush mutagen session, retrying (attempt ${err.attemptNumber}/${err.retriesLeft})...`
+              `Could not flush synchronization changes, retrying (attempt ${err.attemptNumber}/${err.retriesLeft})...`
             ),
           })
         } else {
@@ -599,6 +599,7 @@ export class MutagenDaemon {
           const syncCount = session.successfulCycles || 0
           const description = `from ${sourceDescription} to ${targetDescription}`
           const isInitialSync = activeSync.lastSyncCount === 0
+          const syncLogPrefix = "[sync]:"
 
           // Mutagen resets the sync count to zero after resuming from a sync paused
           // so we keep track of whether the initial sync has completed so that we
@@ -607,7 +608,7 @@ export class MutagenDaemon {
             this.log.info({
               symbol: "success",
               section,
-              msg: chalk.gray(`Completed initial sync ${description}`),
+              msg: chalk.gray(`${syncLogPrefix} Completed initial sync ${description}`),
             })
             activeSync.initialSyncComplete = true
           }
@@ -632,7 +633,7 @@ export class MutagenDaemon {
             this.syncStatusLines[sessionName].setState({
               symbol: "info",
               section,
-              msg: chalk.gray(statusMsg),
+              msg: chalk.gray(`${syncLogPrefix} ${statusMsg}`),
             })
           }
 

--- a/core/test/integ/src/plugins/kubernetes/commands/sync.ts
+++ b/core/test/integ/src/plugins/kubernetes/commands/sync.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2018-2022 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import { Garden } from "../../../../../../src/garden"
+import { ConfigGraph } from "../../../../../../src/config-graph"
+import { getContainerTestGarden } from "../container/container"
+import { PluginContext } from "../../../../../../src/plugin-context"
+import { KubernetesProvider } from "../../../../../../src/plugins/kubernetes/config"
+import { MutagenDaemon } from "../../../../../../src/plugins/kubernetes/mutagen"
+import { syncPause, syncResume, syncStatus } from "../../../../../../src/plugins/kubernetes/commands/sync"
+import { LogEntry } from "../../../../../../src/logger/log-entry"
+import { DeployTask } from "../../../../../../src/tasks/deploy"
+
+describe("sync plugin commands", () => {
+  let garden: Garden
+  let graph: ConfigGraph
+  let provider: KubernetesProvider
+  let ctx: PluginContext
+  let log: LogEntry
+
+  before(async () => {
+    await init("local")
+  })
+
+  after(async () => {
+    if (garden) {
+      await garden.close()
+      await MutagenDaemon.clearInstance()
+    }
+  })
+
+  const init = async (environmentName: string) => {
+    garden = await getContainerTestGarden(environmentName)
+    graph = await garden.getConfigGraph({ log: garden.log, emit: false })
+    provider = <KubernetesProvider>await garden.resolveProvider(garden.log, "local-kubernetes")
+    ctx = await garden.getPluginContext(provider)
+    log = garden.log
+    const service = graph.getService("dev-mode")
+
+    // The deploy task actually creates the sync
+    const deployTask = new DeployTask({
+      garden,
+      graph,
+      log,
+      service,
+      force: true,
+      forceBuild: false,
+      devModeServiceNames: [service.name],
+      hotReloadServiceNames: [],
+      localModeServiceNames: [],
+    })
+
+    await garden.processTasks([deployTask], { throwOnError: true })
+
+    await MutagenDaemon.start({ ctx, log })
+  }
+
+  describe("sync-status", () => {
+    it("should print the Mutagen sync status", async () => {
+      const modules = graph.getModules()
+      const res = (await syncStatus.handler({ ctx, log, garden, modules, args: [] })) as any
+
+      expect(res.result.syncSessions.length).to.equal(1)
+      expect(res.result.syncSessions[0].alpha).to.exist
+      expect(res.result.syncSessions[0].beta).to.exist
+      expect(res.result.syncSessions[0].status).to.equal("watching")
+      expect(res.result.syncSessions[0].paused).to.equal(false)
+    })
+  })
+
+  describe("sync-pause and sync-resume", () => {
+    it("should pause all Mutagen syncs", async () => {
+      const modules = graph.getModules()
+      await syncPause.handler({ ctx, log, garden, modules, args: [] })
+      const pausedStatus = (await syncStatus.handler({ ctx, log, garden, modules, args: [] })) as any
+
+      await syncResume.handler({ ctx, log, garden, modules, args: [] })
+      const resumedStatus = (await syncStatus.handler({ ctx, log, garden, modules, args: [] })) as any
+
+      expect(pausedStatus.result.syncSessions[0].paused).to.equal(true)
+      expect(resumedStatus.result.syncSessions[0].paused).to.equal(false)
+    })
+  })
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

This commit adds Kubernetes plugin commands for getting the Mutagen sync status, pausing syncs, and resuming syncs.

I also refactored the Mutagen code to use a class which makes it a little easier to manage some of the daemon process life cycle logic.

The class is currently a singleton but should be refactored after v0.13 into a "normal" class that we can attach to the `garden` instance.

Finally, the new MutagenDaemon class also logs more information about what Mutagen is doing under the hood. This is e.g. useful when Mutagen is syncing large change sets because without the added logs it looks like nothing is happening.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
