### PR TITLE
feat(commands): allow disabling watch in dev mode

### DIFF
--- a/core/src/commands/helpers.ts
+++ b/core/src/commands/helpers.ts
@@ -16,6 +16,7 @@ import { GardenModule } from "../types/module"
 import { GardenService } from "../types/service"
 import { GardenTask } from "../types/task"
 import { GardenTest } from "../types/test"
+import { deline, naturalList } from "../util/string"
 import { uniqByName } from "../util/util"
 
 export function getMatchingServiceNames(namesFromOpt: string[] | undefined, configGraph: ConfigGraph) {
@@ -100,6 +101,16 @@ export function makeGetTestOrTaskLog(
     logStr += `${type} in module ${chalk.green(m.name)}` + "\n" + logStrForTasks + "\n"
   }
   return logStr
+}
+
+export function makeSkipWatchErrorMsg(hotReloadServiceNames: string[]) {
+  return deline`
+    The --skip-watch flag cannot be used if hot reloading is enabled.
+
+    Hot reloading is currently enabled for the following services:
+
+    ${naturalList(hotReloadServiceNames)}
+  `
 }
 
 export function prettyPrintWorkflow(workflow: WorkflowConfig): string {

--- a/core/test/unit/src/commands/deploy.ts
+++ b/core/test/unit/src/commands/deploy.ts
@@ -126,6 +126,7 @@ describe("DeployCommand", () => {
         "force-build": true,
         "skip": undefined,
         "skip-dependencies": false,
+        "skip-watch": false,
         "forward": false,
       }),
     })
@@ -476,6 +477,7 @@ describe("DeployCommand", () => {
         "force-build": true,
         "skip": undefined,
         "skip-dependencies": false,
+        "skip-watch": false,
         "forward": false,
       }),
     })
@@ -525,6 +527,7 @@ describe("DeployCommand", () => {
           "force-build": true,
           "skip": undefined,
           "skip-dependencies": true, // <-----
+          "skip-watch": false,
           "forward": false,
         }),
       })
@@ -584,6 +587,7 @@ describe("DeployCommand", () => {
         "force-build": true,
         "skip": undefined,
         "skip-dependencies": false,
+        "skip-watch": false,
         "forward": false,
       }),
     })
@@ -637,6 +641,7 @@ describe("DeployCommand", () => {
         "force-build": true,
         "skip": undefined,
         "skip-dependencies": false,
+        "skip-watch": false,
         "forward": false,
       }),
     })
@@ -683,6 +688,7 @@ describe("DeployCommand", () => {
         "force-build": true,
         "skip": ["service-b"],
         "skip-dependencies": false,
+        "skip-watch": false,
         "forward": false,
       }),
     })
@@ -714,6 +720,7 @@ describe("DeployCommand", () => {
           "force-build": true,
           "skip": ["service-b"],
           "skip-dependencies": false,
+          "skip-watch": false,
           "forward": false,
         }),
       })
@@ -739,6 +746,7 @@ describe("DeployCommand", () => {
           "force-build": true,
           "skip": ["service-b"],
           "skip-dependencies": false,
+          "skip-watch": false,
           "forward": false,
         }),
       })
@@ -764,6 +772,7 @@ describe("DeployCommand", () => {
           "force-build": true,
           "skip": ["service-b"],
           "skip-dependencies": false,
+          "skip-watch": false,
           "forward": false,
         }),
       })
@@ -789,6 +798,7 @@ describe("DeployCommand", () => {
           "force-build": true,
           "skip": ["service-b"],
           "skip-dependencies": false,
+          "skip-watch": false,
           "forward": false,
         }),
       })
@@ -814,6 +824,7 @@ describe("DeployCommand", () => {
           "force-build": true,
           "skip": ["service-b"],
           "skip-dependencies": false,
+          "skip-watch": false,
           "forward": true,
         }),
       })

--- a/core/test/unit/src/commands/dev.ts
+++ b/core/test/unit/src/commands/dev.ts
@@ -83,6 +83,7 @@ describe("DevCommand", () => {
       "hot-reload": undefined,
       "local-mode": undefined,
       "skip-tests": false,
+      "skip-watch": false,
       "test-names": undefined,
     })
 
@@ -167,6 +168,7 @@ describe("DevCommand", () => {
       "hot-reload": undefined,
       "local-mode": undefined,
       "skip-tests": false,
+      "skip-watch": false,
       "test-names": undefined,
     })
 
@@ -190,6 +192,7 @@ describe("DevCommand", () => {
       "hot-reload": undefined,
       "local-mode": undefined,
       "skip-tests": false,
+      "skip-watch": false,
       "test-names": undefined,
     })
 
@@ -213,6 +216,7 @@ describe("DevCommand", () => {
       "hot-reload": undefined,
       "local-mode": undefined,
       "skip-tests": false,
+      "skip-watch": false,
       "test-names": undefined,
     })
 
@@ -236,6 +240,7 @@ describe("DevCommand", () => {
       "hot-reload": undefined,
       "local-mode": undefined,
       "skip-tests": false,
+      "skip-watch": false,
       "test-names": undefined,
     })
 
@@ -259,6 +264,7 @@ describe("DevCommand", () => {
       "hot-reload": undefined,
       "local-mode": undefined,
       "skip-tests": false,
+      "skip-watch": false,
       "test-names": undefined,
     })
 
@@ -282,6 +288,7 @@ describe("DevCommand", () => {
       "hot-reload": undefined,
       "local-mode": undefined,
       "skip-tests": false,
+      "skip-watch": false,
       "test-names": undefined,
     })
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -701,6 +701,10 @@ This always takes the precedence over the dev mode if there are any conflicts, i
   | `--skip` |  | array:string | The name(s) of services you&#x27;d like to skip when deploying.
   | `--skip-dependencies` | `--nodeps` | boolean | Deploy the specified services, but don&#x27;t deploy any additional services that they depend on or run any tasks that they depend on. This option can only be used when a list of service names is passed as CLI arguments. This can be useful e.g. when your stack has already been deployed, and you want to deploy a subset of services in dev mode without redeploying any service dependencies that may have changed since you last deployed.
   | `--forward` |  | boolean | Create port forwards and leave process running without watching for changes. Ignored if --watch/-w flag is set or when in dev or hot-reload mode.
+  | `--skip-watch` |  | boolean | [EXPERIMENTAL] If set to &#x60;false&#x60; while in dev-mode (i.e. the --dev-mode/--dev flag is used) then file syncing will still work but Garden will ignore changes to config files and services that are not in dev mode.
+This can be a performance improvement for projects that have a large number of files and where only syncing is needed when in dev mode.
+Note that this flag cannot used if hot reloading is enabled.
+This behaviour will change in a future release in favour of a &quot;smarter&quot; watching mechanism.
 
 #### Outputs
 
@@ -931,6 +935,11 @@ Examples:
 This always takes the precedence over the dev mode if there are any conflicts, i.e. if the same services are passed to both &#x60;--dev&#x60; and &#x60;--local&#x60; options.
   | `--skip-tests` |  | boolean | Disable running the tests.
   | `--test-names` | `--tn` | array:string | Filter the tests to run by test name across all modules (leave unset to run all tests). Accepts glob patterns (e.g. integ* would run both &#x27;integ&#x27; and &#x27;integration&#x27;).
+  | `--skip-watch` |  | boolean | [EXPERIMENTAL] Watching is enabled by default but can be disabled by setting this flag to &#x60;false&#x60;.
+If set to &#x60;false&#x60; then file syncing will still work but Garden will ignore changes to config files and services that are not in dev mode.
+This can be a performance improvement for projects that have a large number of files and where only file syncing is needed when in dev mode.
+Note that this flag cannot be used if hot reloading is enabled.
+This flag will be removed in future release in favour of a &quot;smarter&quot; watching mechanism.
 
 
 ### garden exec


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

This is an experimental behaviour that allows users to disable watching while in dev mode.

Note that this refers to Garden's watching, Mutagen syncs still work.

This behaviour will change in a future release where we'll make the whole watch mechanism smarter and more consistent.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

