### PR TITLE
fix(kubernetes): make preStop command work with busybox

### DIFF
--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -501,7 +501,7 @@ export function getUtilContainer(authSecretName: string, provider: KubernetesPro
           command: [
             "/bin/sh",
             "-c",
-            "until test $(pgrep -fc '^[^ ]+rsync') = 1; do echo waiting for rsync to finish...; sleep 1; done",
+            "until pgrep -f '^[^ ]+rsync' > /dev/null; do echo waiting for rsync to finish...; sleep 1; done",
           ],
         },
       },

--- a/core/src/plugins/kubernetes/hot-reload/helpers.ts
+++ b/core/src/plugins/kubernetes/hot-reload/helpers.ts
@@ -172,7 +172,7 @@ export function configureHotReload({
           command: [
             "/bin/sh",
             "-c",
-            "until test $(pgrep -fc '^[^ ]+rsync') = 1; do echo waiting for rsync to finish...; sleep 1; done",
+            "until pgrep -f '^[^ ]+rsync' > /dev/null; do echo waiting for rsync to finish...; sleep 1; done",
           ],
         },
       },

--- a/core/test/unit/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/build/buildkit.ts
@@ -123,7 +123,7 @@ describe("buildkit build", () => {
               command: [
                 "/bin/sh",
                 "-c",
-                "until test $(pgrep -fc '^[^ ]+rsync') = 1; do echo waiting for rsync to finish...; sleep 1; done",
+                "until pgrep -f '^[^ ]+rsync' > /dev/null; do echo waiting for rsync to finish...; sleep 1; done",
               ],
             },
           },

--- a/core/test/unit/src/plugins/kubernetes/container/build/common.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/build/common.ts
@@ -93,7 +93,7 @@ describe("common build", () => {
                           command: [
                             "/bin/sh",
                             "-c",
-                            "until test $(pgrep -fc '^[^ ]+rsync') = 1; do echo waiting for rsync to finish...; sleep 1; done",
+                            "until pgrep -f '^[^ ]+rsync' > /dev/null; do echo waiting for rsync to finish...; sleep 1; done",
                           ],
                         },
                       },

--- a/core/test/unit/src/plugins/kubernetes/hot-reload.ts
+++ b/core/test/unit/src/plugins/kubernetes/hot-reload.ts
@@ -108,7 +108,7 @@ describe("configureHotReload", () => {
                       command: [
                         "/bin/sh",
                         "-c",
-                        "until test $(pgrep -fc '^[^ ]+rsync') = 1; do echo waiting for rsync to finish...; sleep 1; done",
+                        "until pgrep -f '^[^ ]+rsync' > /dev/null; do echo waiting for rsync to finish...; sleep 1; done",
                       ],
                     },
                   },
@@ -240,7 +240,7 @@ describe("configureHotReload", () => {
                   command: [
                     "/bin/sh",
                     "-c",
-                    "until test $(pgrep -fc '^[^ ]+rsync') = 1; do echo waiting for rsync to finish...; sleep 1; done",
+                    "until pgrep -f '^[^ ]+rsync' > /dev/null; do echo waiting for rsync to finish...; sleep 1; done",
                   ],
                 },
               },

--- a/static/kubernetes/system/build-sync/templates/deployment.yaml
+++ b/static/kubernetes/system/build-sync/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
                 # actually killing the pod. If the transfer takes more than 30 seconds, which is unlikely, the pod
                 # will be killed anyway. The command works by counting the number of rsync processes. This works
                 # because rsync forks for every connection.
-                command: ["/bin/sh", "-c", "until test $(pgrep -fc '^[^ ]+rsync') = 1; do echo waiting for rsync to finish...; sleep 1; done"]
+                command: ["/bin/sh", "-c", "until pgrep -f '^[^ ]+rsync' > /dev/null; do echo waiting for rsync to finish...; sleep 1; done"]
           volumeMounts:
             - mountPath: /data
               name: garden-build-sync


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

The pgrep -c option does not exist in busybox. Make the preStop command more portable.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
