### PR TITLE
fix(kubernetes): detect that pod has been killed

### DIFF
--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -8,8 +8,8 @@
 
 import tar from "tar"
 import tmp from "tmp-promise"
-import { cloneDeep, omit, pick } from "lodash"
-import { V1Container, V1ContainerStatus, V1Pod, V1PodSpec, V1PodStatus } from "@kubernetes/client-node"
+import { cloneDeep, omit, pick, some } from "lodash"
+import { CoreV1Event, V1Container, V1ContainerStatus, V1Pod, V1PodSpec, V1PodStatus } from "@kubernetes/client-node"
 import { RunResult } from "../../types/plugin/base"
 import { GardenModule } from "../../types/module"
 import { LogEntry } from "../../logger/log-entry"
@@ -20,17 +20,18 @@ import {
   RuntimeError,
   ConfigurationError,
   OutOfMemoryError,
+  NotFoundError,
 } from "../../exceptions"
 import { KubernetesProvider } from "./config"
 import { Writable, Readable, PassThrough } from "stream"
 import { uniqByName, sleep } from "../../util/util"
-import { ExecInPodResult, KubeApi } from "./api"
+import { ExecInPodResult, KubeApi, KubernetesError } from "./api"
 import { getPodLogs, checkPodStatus } from "./status/pod"
 import { KubernetesResource, KubernetesPod, KubernetesServerResource } from "./types"
 import { RunModuleParams } from "../../types/plugin/module/runModule"
 import { ContainerEnvVars, ContainerResourcesSpec, ContainerVolumeSpec } from "../container/config"
-import { prepareEnvVars, makePodName } from "./util"
-import { deline, randomString } from "../../util/string"
+import { prepareEnvVars, makePodName, renderPodEvents } from "./util"
+import { dedent, deline, randomString } from "../../util/string"
 import { ArtifactSpec } from "../../config/validation"
 import { prepareSecrets } from "./secrets"
 import { configureVolumes } from "./container/deployment"
@@ -43,6 +44,7 @@ import { copy } from "fs-extra"
 import { K8sLogFollower, PodLogEntryConverter, PodLogEntryConverterParams } from "./logs"
 import { Stream } from "ts-stream"
 import { LogLevel } from "../../logger/logger"
+import { getResourceEvents } from "./status/events"
 
 // Default timeout for individual run/exec operations
 const defaultTimeout = 600
@@ -750,6 +752,7 @@ export interface PodErrorDetails {
   containerStatus?: V1ContainerStatus
   podStatus?: V1PodStatus
   result?: ExecInPodResult
+  podEvents?: CoreV1Event[]
 }
 
 export class PodRunner extends PodRunnerParams {
@@ -831,6 +834,7 @@ export class PodRunner extends PodRunnerParams {
    * If tty=true, we attach to the process stdio during execution.
    *
    * @throws {OutOfMemoryError}
+   * @throws {NotFoundError}
    * @throws {TimeoutError}
    * @throws {PodRunnerError}
    * @throws {KubernetesError}
@@ -851,6 +855,10 @@ export class PodRunner extends PodRunnerParams {
 
       // Wait until main container terminates
       const exitCode = await this.awaitRunningPod(params, startedAt)
+
+      // the Pod might have been killed – if the process exits with code zero when
+      // receiving SIGINT, we might not notice if we don't double check this.
+      await this.throwIfPodKilled()
 
       // Retrieve logs after run
       const mainContainerLogs = await this.getMainContainerLogs()
@@ -873,6 +881,7 @@ export class PodRunner extends PodRunnerParams {
 
   /**
    * @throws {OutOfMemoryError}
+   * @throws {NotFoundError}
    * @throws {TimeoutError}
    * @throws {PodRunnerError}
    */
@@ -881,8 +890,37 @@ export class PodRunner extends PodRunnerParams {
     const { namespace, podName } = this
     const mainContainerName = this.getMainContainerName()
 
+    const notFoundErrorDetails = async (): Promise<PodErrorDetails> => {
+      let podEvents: CoreV1Event[] | undefined
+      try {
+        podEvents = await getResourceEvents(this.api, this.pod)
+      } catch (e) {
+        podEvents = undefined
+      }
+      return {
+        podEvents,
+      }
+    }
+
     while (true) {
-      const serverPod = await this.api.core.readNamespacedPodStatus(podName, namespace)
+      let serverPod: KubernetesServerResource<V1Pod>
+      try {
+        serverPod = await this.api.core.readNamespacedPodStatus(podName, namespace)
+      } catch (e) {
+        if (e instanceof KubernetesError) {
+          // if the pod has been deleted during execution we might run into a 404 error.
+          // Convert it to Garden NotFoundError and fetch the logs for more details.
+          if (e.statusCode === 404) {
+            throw new NotFoundError(
+              "Could not find Pod while waiting for it to complete. The Pod might have been evicted or deleted.",
+              await notFoundErrorDetails()
+            )
+          }
+        }
+
+        throw e
+      }
+
       const state = checkPodStatus(serverPod)
 
       const mainContainerStatus = (serverPod.status.containerStatuses || []).find((s) => s.name === mainContainerName)
@@ -890,7 +928,7 @@ export class PodRunner extends PodRunnerParams {
       const exitReason = terminated?.reason
       const exitCode = terminated?.exitCode
 
-      const errorDetails = async (): Promise<PodErrorDetails> => ({
+      const podErrorDetails = async (): Promise<PodErrorDetails> => ({
         logs: await this.getMainContainerLogs(),
         exitCode,
         containerStatus: mainContainerStatus,
@@ -901,7 +939,7 @@ export class PodRunner extends PodRunnerParams {
       // Garden computes is "stopped". However, in those instances the exitReason is still "OOMKilled"
       // and we handle that case specifically here.
       if (exitCode === 137 || exitReason === "OOMKilled") {
-        throw new OutOfMemoryError("Pod container was OOMKilled.", await errorDetails())
+        throw new OutOfMemoryError("Pod container was OOMKilled.", await podErrorDetails())
       }
 
       if (state === "unhealthy") {
@@ -914,12 +952,12 @@ export class PodRunner extends PodRunnerParams {
           // Successfully ran the command in the main container, but returned non-zero exit code.
           if (throwOnExitCode === true) {
             // Consider it as a task execution error inside the Pod.
-            throw newExitCodePodRunnerError(await errorDetails())
+            throw newExitCodePodRunnerError(await podErrorDetails())
           } else {
             return exitCode
           }
         } else {
-          throw new PodRunnerError(`Failed to start Pod ${podName}.`, await errorDetails())
+          throw new PodRunnerError(`Failed to start Pod ${podName}.`, await podErrorDetails())
         }
       }
 
@@ -927,7 +965,7 @@ export class PodRunner extends PodRunnerParams {
       if (state === "stopped" || exitReason === "Completed") {
         if (exitCode !== undefined && exitCode !== 0) {
           if (throwOnExitCode === true) {
-            throw newExitCodePodRunnerError(await errorDetails())
+            throw newExitCodePodRunnerError(await podErrorDetails())
           } else {
             return exitCode
           }
@@ -938,7 +976,7 @@ export class PodRunner extends PodRunnerParams {
       const elapsed = (new Date().getTime() - startedAt.getTime()) / 1000
 
       if (timeoutSec && elapsed > timeoutSec) {
-        throw new TimeoutError(`Command timed out after ${timeoutSec} seconds.`, await errorDetails())
+        throw new TimeoutError(`Command timed out after ${timeoutSec} seconds.`, await podErrorDetails())
       }
 
       await sleep(800)
@@ -965,6 +1003,7 @@ export class PodRunner extends PodRunnerParams {
    * Executes a command in the running Pod. Must be called after {@link start()}.
    *
    * @throws {OutOfMemoryError}
+   * @throws {NotFoundError}
    * @throws {TimeoutError}
    * @throws {PodRunnerError}
    */
@@ -1021,6 +1060,10 @@ export class PodRunner extends PodRunnerParams {
       throw new OutOfMemoryError("Pod container was OOMKilled.", errorDetails)
     }
 
+    // the Pod might have been killed – if the process exits with code zero when
+    // receiving SIGINT, we might not notice if we don't double check this.
+    await this.throwIfPodKilled()
+
     if (result.exitCode !== 0) {
       const errorDetails: PodErrorDetails = {
         logs: await collectLogs(),
@@ -1037,6 +1080,19 @@ export class PodRunner extends PodRunnerParams {
       log: (result.stdout + result.stderr).trim(),
       exitCode: result.exitCode,
       success: result.exitCode === 0,
+    }
+  }
+
+  /**
+   * Helper to detect pod disruption, and throw NotFoundError in case the Pod has been evicted
+   *
+   * @throws NotFoundError
+   */
+  private async throwIfPodKilled(): Promise<void> {
+    const events = await getResourceEvents(this.api, this.pod)
+    if (some(events, (event) => event.reason === "Killing")) {
+      const details: PodErrorDetails = { podEvents: events }
+      throw new NotFoundError("Pod has been killed or evicted.", details)
     }
   }
 
@@ -1107,17 +1163,17 @@ export class PodRunner extends PodRunnerParams {
     version,
     moduleName,
   }: {
-    err: any
+    err: Error
     command: string[]
     startedAt: Date
     version: string
     moduleName
   }) {
     // Some types and predicates to identify known errors
-    const knownErrorTypes = ["out-of-memory", "timeout", "pod-runner", "kubernetes"] as const
+    const knownErrorTypes = ["out-of-memory", "not-found", "timeout", "pod-runner", "kubernetes"] as const
     type KnownErrorType = typeof knownErrorTypes[number]
     // A known error is always an instance of a subclass of GardenBaseError
-    type KnownError = {
+    type KnownError = Error & {
       message: string
       type: KnownErrorType
       detail: PodErrorDetails
@@ -1179,6 +1235,20 @@ export class PodRunner extends PodRunnerParams {
           }
 
           return errorDesc
+        case "not-found":
+          let notFoundError = dedent`
+            ${error.message}
+            There are several different possible causes for Pod disruptions.
+
+            You can read more about the topic in the Kubernetes documentation:
+            https://kubernetes.io/docs/concepts/workloads/pods/disruptions/`
+
+          const events = error.detail.podEvents
+          if (!!events) {
+            notFoundError += `\n\n${renderPodEvents(events)}`
+          }
+
+          return notFoundError
         case "kubernetes":
           return `Unable to start command execution. Failed to initiate a runner pod with error:\n${error.message}\n\nPlease check the cluster health and network connectivity.`
         default:

--- a/core/src/plugins/kubernetes/status/events.ts
+++ b/core/src/plugins/kubernetes/status/events.ts
@@ -6,6 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import { sortBy } from "lodash"
 import { KubeApi } from "../api"
 import { KubernetesResource } from "../types"
 
@@ -30,5 +31,5 @@ export async function getResourceEvents(api: KubeApi, resource: KubernetesResour
         parseInt(e.involvedObject!.resourceVersion, 10) > minVersion
     )
 
-  return events
+  return sortBy(events, (e) => e.metadata.creationTimestamp)
 }

--- a/core/src/plugins/kubernetes/status/pod.ts
+++ b/core/src/plugins/kubernetes/status/pod.ts
@@ -136,7 +136,9 @@ export async function getPodLogs({
             timestamps
           )
         } catch (err) {
-          log = ""
+          log = `[Could not retrieve previous logs for deleted pod ${pod.metadata!.name!}: ${
+            err.message || "Unknown error occurred"
+          }]`
         }
       } else if (err instanceof KubernetesError && err.message.includes("waiting to start")) {
         log = ""

--- a/core/src/plugins/kubernetes/status/workload.ts
+++ b/core/src/plugins/kubernetes/status/workload.ts
@@ -21,7 +21,7 @@ import {
   V1DeploymentSpec,
 } from "@kubernetes/client-node"
 import dedent = require("dedent")
-import { getCurrentWorkloadPods } from "../util"
+import { getCurrentWorkloadPods, renderPodEvents } from "../util"
 import { getFormattedPodLogs, POD_LOG_LINES } from "./pod"
 import { ResourceStatus, StatusHandlerParams } from "./status"
 import { getResourceEvents } from "./events"
@@ -71,15 +71,7 @@ export async function checkWorkloadStatus({ api, namespace, resource }: StatusHa
     // List events
     const events = await getEvents()
     if (events.length > 0) {
-      logs += chalk.white("━━━ Events ━━━")
-      for (const event of events) {
-        const obj = event.involvedObject
-        const name = chalk.blueBright(`${obj.kind} ${obj.name}:`)
-        const msg = `${event.reason} - ${event.message}`
-        const colored =
-          event.type === "Error" ? chalk.red(msg) : event.type === "Warning" ? chalk.yellow(msg) : chalk.white(msg)
-        logs += `\n${name} ${colored}`
-      }
+      logs += renderPodEvents(events)
     }
 
     // Attach pod logs for debug output

--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -8,7 +8,7 @@
 
 import Bluebird from "bluebird"
 import { get, flatten, sortBy, omit, chain, sample, isEmpty, find, cloneDeep } from "lodash"
-import { V1Pod, V1EnvVar, V1Container, V1PodSpec } from "@kubernetes/client-node"
+import { V1Pod, V1EnvVar, V1Container, V1PodSpec, CoreV1Event } from "@kubernetes/client-node"
 import { apply as jsonMerge } from "json-merge-patch"
 import chalk from "chalk"
 import hasha from "hasha"
@@ -757,4 +757,24 @@ export function getK8sProvider(providers: ProviderMap): KubernetesProvider {
  */
 export function usingInClusterRegistry(provider: KubernetesProvider) {
   return provider.config.deploymentRegistry?.hostname === inClusterRegistryHostname
+}
+
+export function renderPodEvents(events: CoreV1Event[]): string {
+  let text = ""
+
+  text += `${chalk.white("━━━ Events ━━━")}\n`
+  for (const event of events) {
+    const obj = event.involvedObject
+    const name = chalk.blueBright(`${obj.kind} ${obj.name}:`)
+    const msg = `${event.reason} - ${event.message}`
+    const colored =
+      event.type === "Error" ? chalk.red(msg) : event.type === "Warning" ? chalk.yellow(msg) : chalk.white(msg)
+    text += `${name} ${colored}\n`
+  }
+
+  if (events.length === 0) {
+    text += `${chalk.red("No matching events found")}\n`
+  }
+
+  return text
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
Detect that the pod has been killed, in order to
- improve the error message (relates to #3331)
- fix a bug where a test might have been reported as successful while it
  actually was killed (Fixes #3535)

This has been extracted from the PR #3537 (to keep it separate and merge
it more quickly)

**Which issue(s) this PR fixes**:

Fixes #3535

**Special notes for your reviewer**:
<img width="1447" alt="Screenshot 2023-01-24 at 15 53 40" src="https://user-images.githubusercontent.com/139624/214327256-5b93ea93-b2f0-4e76-9bf4-8b50811ac1d4.png">
