### PR TITLE
fix(framework): increase consistency in verbose plugin logs

### DIFF
--- a/core/src/commands/logs.ts
+++ b/core/src/commands/logs.ts
@@ -135,7 +135,7 @@ export class LogsCommand extends Command<Args, Opts> {
   }
 
   terminate() {
-    this.events?.emit("abort", {})
+    this.events?.emit("abort")
   }
 
   async action({ garden, log, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<ServiceLogEntry[]>> {

--- a/core/src/plugin-context.ts
+++ b/core/src/plugin-context.ts
@@ -92,9 +92,32 @@ export const pluginContextSchema = () =>
       cloudApi: joi.any().optional(),
     })
 
-interface PluginEvents {
-  abort: { reason?: string }
-  log: { data: Buffer }
+export type PluginEventLogContext = {
+  /** entity that created the log message, e.g. tool that generated it */
+  origin: string
+
+  /**
+   * LogEntry placeholder to be used to stream the logs to the CLI
+   * It's recommended to pass a verbose placeholder created like this: `log.placeholder({ level: LogLevel.verbose })`
+   *
+   * @todo 0.13 consider removing this once we have the append-only logger (#3254)
+   */
+  log: LogEntry
+}
+
+export type PluginEventLogMessage = PluginEventLogContext & {
+  /** number of milliseconds since the epoch */
+  timestamp: number
+
+  /** log message */
+  data: Buffer
+}
+
+// Define your emitter's types like that:
+// Key: Event name; Value: Listener function signature
+type PluginEvents = {
+  abort: (reason?: string) => void
+  log: (msg: PluginEventLogMessage) => void
 }
 
 type PluginEventType = keyof PluginEvents

--- a/core/src/plugins/exec/exec.ts
+++ b/core/src/plugins/exec/exec.ts
@@ -26,7 +26,7 @@ import { BuildModuleParams, BuildResult } from "../../types/plugin/module/build"
 import { TestModuleParams } from "../../types/plugin/module/testModule"
 import { TestResult } from "../../types/plugin/module/getTestResult"
 import { RunTaskParams, RunTaskResult } from "../../types/plugin/task/runTask"
-import { exec, ExecOpts, renderOutputStream, runScript, sleep } from "../../util/util"
+import { exec, ExecOpts, runScript, sleep } from "../../util/util"
 import { ConfigurationError, RuntimeError, TimeoutError } from "../../exceptions"
 import { LogEntry } from "../../logger/log-entry"
 import { providerConfigBaseSchema } from "../../config/provider"
@@ -436,13 +436,15 @@ async function run({
   env?: PrimitiveMap
   opts?: ExecOpts
 }) {
-  const outputStream = split2()
+  const logEventContext = {
+    origin: command[0],
+    log,
+  }
 
+  const outputStream = split2()
   outputStream.on("error", () => {})
   outputStream.on("data", (line: Buffer) => {
-    const cmdName = command[0]
-    log.setState(renderOutputStream(line.toString(), cmdName))
-    ctx.events.emit("log", { timestamp: new Date().getTime(), data: line })
+    ctx.events.emit("log", { timestamp: new Date().getTime(), data: line, ...logEventContext })
   })
 
   const res = await exec(command.join(" "), [], {

--- a/core/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/src/plugins/kubernetes/container/build/kaniko.ts
@@ -36,9 +36,7 @@ import {
 } from "./common"
 import { differenceBy, isEmpty } from "lodash"
 import chalk from "chalk"
-import split2 from "split2"
 import { LogLevel } from "../../../../logger/logger"
-import { renderOutputStream } from "../../../../util/util"
 import { getDockerBuildFlags } from "../../../container/build"
 import { stringifyResources } from "../util"
 
@@ -106,17 +104,6 @@ export const kanikoBuild: BuildHandler = async (params) => {
 
   log.setState(`Building image ${localId}...`)
 
-  let buildLog = ""
-
-  // Stream verbose logs to a status line
-  const outputStream = split2()
-  const statusLine = log.placeholder({ level: LogLevel.verbose })
-
-  outputStream.on("error", () => {})
-  outputStream.on("data", (line: Buffer) => {
-    statusLine.setState(renderOutputStream(line.toString(), "kaniko"))
-  })
-
   // Use the project namespace if set to null in config
   // TODO: change in 0.13 to default to project namespace
   let kanikoNamespace =
@@ -169,7 +156,7 @@ export const kanikoBuild: BuildHandler = async (params) => {
     args,
   })
 
-  buildLog = buildRes.log
+  const buildLog = buildRes.log
 
   if (kanikoBuildFailed(buildRes)) {
     throw new BuildError(`Failed building module ${chalk.bold(module.name)}:\n\n${buildLog}`, { buildLog })
@@ -434,8 +421,14 @@ async function runKaniko({
     pod.spec.nodeSelector = provider.config.kaniko?.nodeSelector
   }
 
+  const logEventContext = {
+    origin: "kaniko",
+    log: log.placeholder({ level: LogLevel.verbose }),
+  }
+
   const runner = new PodRunner({
     ctx,
+    logEventContext,
     api,
     pod,
     provider,

--- a/core/src/plugins/kubernetes/helm/run.ts
+++ b/core/src/plugins/kubernetes/helm/run.ts
@@ -28,6 +28,7 @@ import { KubeApi } from "../api"
 import { getModuleNamespaceStatus } from "../namespace"
 import { DEFAULT_TASK_TIMEOUT } from "../../../constants"
 import { KubernetesPod } from "../types"
+import { LogLevel } from "../../../logger/logger"
 
 export async function runHelmModule({
   ctx,
@@ -103,8 +104,14 @@ export async function runHelmModule({
     },
   }
 
+  const logEventContext = {
+    origin: "helm",
+    log: log.placeholder({ level: LogLevel.verbose }),
+  }
+
   const runner = new PodRunner({
     ctx,
+    logEventContext,
     api,
     pod,
     provider,

--- a/core/src/plugins/kubernetes/status/status.ts
+++ b/core/src/plugins/kubernetes/status/status.ts
@@ -33,6 +33,7 @@ import { checkWorkloadStatus } from "./workload"
 import { checkWorkloadPodStatus } from "./pod"
 import { deline, gardenAnnotationKey, stableStringify } from "../../../util/string"
 import { SyncableResource } from "../hot-reload/hot-reload"
+import { LogLevel } from "../../../logger/logger"
 
 export interface ResourceStatus<T = BaseResource> {
   state: ServiceState
@@ -186,8 +187,14 @@ export async function waitForResources({
   let loops = 0
   let lastMessage: string | undefined
   const startTime = new Date().getTime()
+
+  const logEventContext = {
+    origin: "kubernetes-plugin",
+    log: log.placeholder({ level: LogLevel.verbose }),
+  }
+
   const emitLog = (msg: string) =>
-    ctx.events.emit("log", { timestamp: new Date().getTime(), data: Buffer.from(msg, "utf-8") })
+    ctx.events.emit("log", { timestamp: new Date().getTime(), data: Buffer.from(msg, "utf-8"), ...logEventContext })
 
   const waitingMsg = `Waiting for resources to be ready...`
   const statusLine = log.info({

--- a/core/src/util/ext-tools.ts
+++ b/core/src/util/ext-tools.ts
@@ -23,6 +23,7 @@ import { PluginToolSpec, ToolBuildSpec } from "../types/plugin/tools"
 import { parse } from "url"
 import AsyncLock from "async-lock"
 import { PluginContext } from "../plugin-context"
+import { LogLevel } from "../logger/logger"
 
 const toolsPath = join(GARDEN_GLOBAL_PATH, "tools")
 const lock = new AsyncLock()
@@ -150,10 +151,13 @@ export class CliWrapper {
       })
     }
 
+    const logEventContext = {
+      origin: this.name,
+      log: log.placeholder({ level: LogLevel.verbose }),
+    }
+
     logStream.on("data", (line: Buffer) => {
-      ctx.events.emit("log", { timestamp: new Date().getTime(), data: line })
-      const lineStr = line.toString()
-      log.verbose(lineStr)
+      ctx.events.emit("log", { timestamp: new Date().getTime(), data: line, ...logEventContext })
     })
 
     await new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
This commit makes it harder to forget sending verbose logs (mostly tool
output) to both Garden Cloud and to the CLI logs.

To accomplish that, this commit

1. Fixed the type assertions in the PluginEventBroker. Now typescript
   will actually verify the types for the events in `emit` and in `on`
   etc.
2. Added two additional parameters to the `log` event, origin and log.
   Log is supposed to be a LogEntry placeholder with verbose log level.
3. Make sure that we use the `ctx.events.emit` in the plugin
   implementations to stream logs to Garden Cloud and CLI

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #3331

**Special notes for your reviewer**:

Difference for `garden test --force -l3` before and after the change:

```diff
--- before.log	2023-01-24 19:01:51
+++ after.log	2023-01-24 19:01:59
@@ -1,4 +1,4 @@
-$ garden test --force -l3
+$ gdev test --force -l3
 Running tests 🌡️


@@ -20,26 +20,34 @@
 [verbose] Comparing expected and deployed resources...
 [verbose] All resources match.
 [verbose] Comparing expected and deployed resources...
-[verbose] Resource frontend is not a superset of deployed resource
-✔ frontend                  → Getting build status for v-2575c75f7b... → Already built
-ℹ frontend                  → Running unit tests
+[verbose] All resources match.
 ✔ backend                   → Getting build status for v-afcf6506f9... → Already built
 ℹ backend                   → Deploying version v-ea67a2a113...
 ✔ backend                   → Deploying version v-ea67a2a113... → Already deployed
 ℹ backend                   → Ingress: http://demo-project.local.app.garden/hello-backend
+✔ frontend                  → Getting build status for v-2575c75f7b... → Already built
+ℹ frontend                  → Running unit tests
 ℹ frontend                  → Deploying version v-cb2a872fe1...
-ℹ frontend [verbose]        → Starting Pod test-frontend-unit-c8d323 with command 'npm test'
-ℹ frontend                  → Waiting for resources to be ready...
-ℹ frontend                  → Deployment/frontend: Started container frontend
-✔ frontend                  → Running unit tests → Success (took 3.7 sec)
-ℹ frontend                  → Resources ready
-ℹ frontend [verbose]        → Comparing expected and deployed resources...
-ℹ frontend [verbose]        → All resources match.
-✔ frontend                  → Deploying version v-cb2a872fe1... → Done (took 8.8 sec)
+✔ frontend                  → Deploying version v-cb2a872fe1... → Already deployed
 ℹ frontend                  → Ingress: http://demo-project.local.app.garden/hello-frontend
 ℹ frontend                  → Ingress: http://demo-project.local.app.garden/call-backend
 ℹ frontend                  → Running integ tests
-ℹ frontend [verbose]        → Starting Pod test-frontend-integ-fab4e5 with command 'npm run integ'
-✔ frontend                  → Running integ tests → Success (took 2.6 sec)
+ℹ frontend [verbose]        → Starting Pod test-frontend-integ-60efd4 with command 'npm run integ'
+ℹ frontend [verbose]        → Starting Pod test-frontend-unit-0f5301 with command 'npm test'
+ℹ frontend [verbose]        → [npm]:
+ℹ frontend [verbose]        → [npm]: > frontend@1.0.0 test /app
+ℹ frontend [verbose]        → [npm]: > echo OK
+ℹ frontend [verbose]        → [npm]:
+ℹ frontend [verbose]        → [npm]: > frontend@1.0.0 integ /app
+ℹ frontend [verbose]        → [npm]: > node_modules/mocha/bin/mocha test/integ.js
+ℹ frontend [verbose]        → [npm]: OK
+ℹ frontend [verbose]        → [npm]:
+ℹ frontend [verbose]        → [npm]:
+ℹ frontend [verbose]        → [npm]:   GET /call-backend
+ℹ frontend [verbose]        → [npm]:     ✓ should respond with a message from the backend service (55ms)
+ℹ frontend [verbose]        → [npm]:
+ℹ frontend [verbose]        → [npm]:   1 passing (88ms)
+✔ frontend                  → Running integ tests → Success (took 3.6 sec)
+✔ frontend                  → Running unit tests → Success (took 3.6 sec)

 Done! ✔️
```

 Difference for `garden run task test -l3` before and after the change:

```diff
--- before.log	2023-01-24 19:03:43
+++ after.log	2023-01-24 19:03:50
@@ -1,4 +1,4 @@
-$ garden run task test -l3
+$ gdev run task test -l3
 Running task test 🏃‍♂️


@@ -18,8 +18,9 @@
 ✔ test                      → Checking result... → Done
 ✔ backend                   → Getting build status for v-afcf6506f9... → Already built
 ℹ test                      → Running...
-ℹ test [verbose]            → Starting Pod task-backend-test-532b15 with command 'sh -c echo task output'
-✔ test                      → Running... → Done (took 2.6 sec)
+ℹ test [verbose]            → Starting Pod task-backend-test-0d1dc6 with command 'sh -c echo task output'
+ℹ test [verbose]            → [sh]: task output
+✔ test                      → Running... → Done (took 2.7 sec)

 Task output:
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
 Difference for `garden deploy --force -l3` before and after the change:
```diff
--- before.log	2023-01-24 19:05:48
+++ after.log	2023-01-24 19:05:58
@@ -1,4 +1,4 @@
-$ garden deploy --force -l3
+$ gdev deploy --force -l3
 Deploy 🚀


@@ -21,10 +21,15 @@
 [verbose] All resources match.
 [verbose] Comparing expected and deployed resources...
 [verbose] All resources match.
+✔ frontend                  → Getting build status for v-2575c75f7b... → Already built
 ✔ backend                   → Getting build status for v-afcf6506f9... → Already built
 ℹ backend                   → Deploying version v-ea67a2a113...
-✔ frontend                  → Getting build status for v-2575c75f7b... → Already built
 ℹ backend                   → Waiting for resources to be ready...
+ℹ backend [verbose]         → [kubernetes-plugin]: Waiting for resources to be ready...
+ℹ backend [verbose]         → [kubernetes-plugin]: Status of Deployment backend is "ready"
+ℹ backend [verbose]         → [kubernetes-plugin]: Status of Service backend is "ready"
+ℹ backend [verbose]         → [kubernetes-plugin]: Status of Ingress backend-0 is "ready"
+ℹ backend [verbose]         → [kubernetes-plugin]: Resources ready
 ℹ backend                   → Resources ready
 ℹ backend [verbose]         → Comparing expected and deployed resources...
 ℹ backend [verbose]         → All resources match.
@@ -32,10 +37,16 @@
 ℹ backend                   → Ingress: http://demo-project.local.app.garden/hello-backend
 ℹ frontend                  → Deploying version v-cb2a872fe1...
 ℹ frontend                  → Waiting for resources to be ready...
+ℹ frontend [verbose]        → [kubernetes-plugin]: Waiting for resources to be ready...
+ℹ frontend [verbose]        → [kubernetes-plugin]: Status of Deployment frontend is "ready"
+ℹ frontend [verbose]        → [kubernetes-plugin]: Status of Service frontend is "ready"
+ℹ frontend [verbose]        → [kubernetes-plugin]: Status of Ingress frontend-0 is "ready"
+ℹ frontend [verbose]        → [kubernetes-plugin]: Status of Ingress frontend-1 is "ready"
+ℹ frontend [verbose]        → [kubernetes-plugin]: Resources ready
 ℹ frontend                  → Resources ready
 ℹ frontend [verbose]        → Comparing expected and deployed resources...
 ℹ frontend [verbose]        → All resources match.
-✔ frontend                  → Deploying version v-cb2a872fe1... → Done (took 2.7 sec)
+✔ frontend                  → Deploying version v-cb2a872fe1... → Done (took 2.6 sec)
 ℹ frontend                  → Ingress: http://demo-project.local.app.garden/hello-frontend
 ℹ frontend                  → Ingress: http://demo-project.local.app.garden/call-backend
```

Difference for `garden build frontend -f -l3` before and after the change:
```diff
--- before.log	2023-01-24 19:07:41
+++ after.log	2023-01-24 19:07:47
@@ -1,4 +1,4 @@
-$ garden build frontend -f -l3
+$ gdev build frontend -f -l3
 Build 🔨


@@ -16,42 +16,42 @@
 ℹ frontend                  → Building version v-2575c75f7b...
 ℹ frontend                  → Building frontend:v-2575c75f7b...
 ℹ frontend [verbose]        → [local-docker]: #1 [internal] load build definition from Dockerfile
-ℹ frontend [verbose]        → [local-docker]: #1 sha256:69f73cd0c521b3d89533a656b40bec4d15486a66ac53b6d9bc29af878b592b47
+ℹ frontend [verbose]        → [local-docker]: #1 sha256:c293296763c2172451efeb500599cd607fd6c96944b1dbc98c04c2303cbe4d5d
 ℹ frontend [verbose]        → [local-docker]: #1 transferring dockerfile: 37B done
 ℹ frontend [verbose]        → [local-docker]: #1 DONE 0.0s
 ℹ frontend [verbose]        → [local-docker]:
 ℹ frontend [verbose]        → [local-docker]: #2 [internal] load .dockerignore
-ℹ frontend [verbose]        → [local-docker]: #2 sha256:092363f9e7a6661d435fe9d40a962caccbf0a937f59608637e7ef2cb30416955
+ℹ frontend [verbose]        → [local-docker]: #2 sha256:0404ce02a29d685f0ead59f436f5750f3ad924d8013b3eeef8ee3ce425e804a1
 ℹ frontend [verbose]        → [local-docker]: #2 transferring context: 34B done
 ℹ frontend [verbose]        → [local-docker]: #2 DONE 0.0s
 ℹ frontend [verbose]        → [local-docker]:
 ℹ frontend [verbose]        → [local-docker]: #3 [internal] load metadata for docker.io/library/node:12.22.6-alpine
 ℹ frontend [verbose]        → [local-docker]: #3 sha256:8c845c5bb5f61356c6ea87ab8baac2509e836f78e594d726bdb38be8dd74682c
-ℹ frontend [verbose]        → [local-docker]: #3 DONE 1.2s
+ℹ frontend [verbose]        → [local-docker]: #3 DONE 0.7s
 ℹ frontend [verbose]        → [local-docker]:
 ℹ frontend [verbose]        → [local-docker]: #4 [1/5] FROM docker.io/library/node:12.22.6-alpine@sha256:1ea5900145028957ec0e7b7e590ac677797fa8962ccec4e73188092f7bc14da5
 ℹ frontend [verbose]        → [local-docker]: #4 sha256:f9b7064d0549fa042414ee7fc46254a89d6e31b544b99c741872d80e09646738
 ℹ frontend [verbose]        → [local-docker]: #4 DONE 0.0s
 ℹ frontend [verbose]        → [local-docker]:
 ℹ frontend [verbose]        → [local-docker]: #6 [internal] load build context
-ℹ frontend [verbose]        → [local-docker]: #6 sha256:800a162fee1f5a10942219d3a269361743864007ff3ce6d4b779e3899e367bcf
+ℹ frontend [verbose]        → [local-docker]: #6 sha256:06d8e52559f092be0b4e6cd965dd45379afe1b677b5cafc1dcbf176ce899d3a7
 ℹ frontend [verbose]        → [local-docker]: #6 transferring context: 207B done
 ℹ frontend [verbose]        → [local-docker]: #6 DONE 0.0s
 ℹ frontend [verbose]        → [local-docker]:
-ℹ frontend [verbose]        → [local-docker]: #8 [4/5] RUN npm install
-ℹ frontend [verbose]        → [local-docker]: #8 sha256:02f2fe35eaf09fe209c248ed189eb1bc1801235cb7cea3b995ae6e60a0c76636
-ℹ frontend [verbose]        → [local-docker]: #8 CACHED
-ℹ frontend [verbose]        → [local-docker]:
 ℹ frontend [verbose]        → [local-docker]: #7 [3/5] COPY package.json /app
-ℹ frontend [verbose]        → [local-docker]: #7 sha256:347b59bb54047c50b53774b3e9e16929bf5e5d742e5f7c8431843b1af1f7a542
+ℹ frontend [verbose]        → [local-docker]: #7 sha256:3ee7dec862448d84d277a0c65a8033aebad9d80b7270aa1473d596e4a33538bb
 ℹ frontend [verbose]        → [local-docker]: #7 CACHED
 ℹ frontend [verbose]        → [local-docker]:
+ℹ frontend [verbose]        → [local-docker]: #8 [4/5] RUN npm install
+ℹ frontend [verbose]        → [local-docker]: #8 sha256:d5e3f192ee870918cebb7f943d31617fe1864218bf8e45e46eb92aefb276db03
+ℹ frontend [verbose]        → [local-docker]: #8 CACHED
+ℹ frontend [verbose]        → [local-docker]:
 ℹ frontend [verbose]        → [local-docker]: #5 [2/5] WORKDIR /app
 ℹ frontend [verbose]        → [local-docker]: #5 sha256:3cf05f46b4f53e950e2261cb8efa8d6ff9e06fa397d7e47d48a836ec39981f98
 ℹ frontend [verbose]        → [local-docker]: #5 CACHED
 ℹ frontend [verbose]        → [local-docker]:
 ℹ frontend [verbose]        → [local-docker]: #9 [5/5] COPY . /app
-ℹ frontend [verbose]        → [local-docker]: #9 sha256:6eb40a2dc40629599329431487763a08f786dc5ba98468f897d930e426a201e9
+ℹ frontend [verbose]        → [local-docker]: #9 sha256:d644d68e0b6000981eb42bc78772ffbfb31cdb41bfd20bf0d6a18c1a55e8b198
 ℹ frontend [verbose]        → [local-docker]: #9 CACHED
 ℹ frontend [verbose]        → [local-docker]:
 ℹ frontend [verbose]        → [local-docker]: #10 exporting to image
@@ -60,6 +60,6 @@
 ℹ frontend [verbose]        → [local-docker]: #10 writing image sha256:b9c2a7117cbc51ace2a5bf32cfbde9ee7d24330cbc31a6ee58e9961b7400db58 done
 ℹ frontend [verbose]        → [local-docker]: #10 naming to docker.io/library/frontend:v-2575c75f7b done
 ℹ frontend [verbose]        → [local-docker]: #10 DONE 0.0s
-✔ frontend                  → Building frontend:v-2575c75f7b... → Done (took 2.7 sec)
+✔ frontend                  → Building frontend:v-2575c75f7b... → Done (took 1.9 sec)

 Done! ✔️
```

Difference in the `jib-container` example for `garden build -f -l3` before and after the change:
```diff
--- before.log	2023-01-24 19:40:11
+++ after.log	2023-01-24 19:40:30
@@ -1,4 +1,4 @@
-$ garden build -f -l3
+$ gdev build -f -l3
 Build 🔨


@@ -16,119 +16,119 @@
 ✔ helloworld [verbose]      → Syncing module sources (12 files)... → Done (took 0 sec)
 ℹ helloworld                → Building version v-28365e8c03...
 ℹ helloworld [verbose]      → The JDK path hasn't been specified explicitly. JDK 11 will be used by default.
+ℹ helloworld [verbose]      → Using JAVA_HOME=/Users/steffen/.garden/tools/openjdk-11/7fdb977bf902429e/jdk-11.0.9.1+1/Contents/Home
 ✔ spring-boot [verbose]     → Syncing module sources (15 files)... → Done (took 0 sec)
 ℹ spring-boot               → Building version v-1a655b5756...
-ℹ helloworld [verbose]      → Using JAVA_HOME=/Users/steffen/.garden/tools/openjdk-11/7fdb977bf902429e/jdk-11.0.9.1+1/Contents/Home
 ℹ spring-boot [verbose]     → The JDK path hasn't been specified explicitly. JDK 11 will be used by default.
 ℹ helloworld [verbose]      → The Gradle binary hasn't been specified explicitly, but a local one has been found at /Users/steffen/work/github/garden/examples/jib-container/helloworld/gradlew. It will be used by default.
 ℹ spring-boot [verbose]     → Using JAVA_HOME=/Users/steffen/.garden/tools/openjdk-11/7fdb977bf902429e/jdk-11.0.9.1+1/Contents/Home
 ℹ spring-boot [verbose]     → The Maven binary hasn't been specified explicitly. Maven 3.8.5 will be used by default.
-ℹ helloworld [verbose]      → > Task :compileJava UP-TO-DATE
-ℹ helloworld [verbose]      → > Task :processResources UP-TO-DATE
-ℹ helloworld [verbose]      → > Task :classes UP-TO-DATE
-ℹ helloworld [verbose]
-ℹ helloworld [verbose]      → Containerizing application to Docker daemon as helloworld:v-28365e8c03...
-ℹ helloworld [verbose]      → Base image 'adoptopenjdk:8-jre' does not use a specific image digest - build may not be reproducible
-ℹ helloworld [verbose]      → Getting manifest for base image adoptopenjdk:8-jre...
-ℹ helloworld [verbose]      → Building dependencies layer...
-ℹ helloworld [verbose]      → Building classes layer...
-ℹ helloworld [verbose]      → Building jvm arg files layer...
-ℹ helloworld [verbose]      → Building resources layer...
-ℹ helloworld [verbose]      → The base image requires auth. Trying again for adoptopenjdk:8-jre...
-ℹ spring-boot [verbose]     → [INFO] Scanning for projects...
-ℹ helloworld [verbose]      → The credential helper (docker-credential-desktop) has nothing for server URL: registry-1.docker.io
-ℹ helloworld [verbose]
-ℹ helloworld [verbose]      → Got output:
-ℹ helloworld [verbose]
-ℹ helloworld [verbose]      → credentials not found in native keychain
-ℹ helloworld [verbose]
-ℹ spring-boot [verbose]     → [INFO]
-ℹ spring-boot [verbose]     → [INFO] ------------------< example:spring-boot-k8s-example >-------------------
-ℹ spring-boot [verbose]     → [INFO] Building spring-boot-k8s-example 0.1.0
-ℹ spring-boot [verbose]     → [INFO] --------------------------------[ jar ]---------------------------------
-ℹ helloworld [verbose]      → The credential helper (docker-credential-desktop) has nothing for server URL: registry.hub.docker.com
-ℹ helloworld [verbose]
-ℹ helloworld [verbose]      → Got output:
-ℹ helloworld [verbose]
-ℹ helloworld [verbose]      → credentials not found in native keychain
-ℹ helloworld [verbose]
-ℹ helloworld [verbose]      → Using credentials from Docker config (/Users/steffen/.docker/config.json) for adoptopenjdk:8-jre
-ℹ spring-boot [verbose]     → [INFO]
-ℹ spring-boot [verbose]     → [INFO] --- maven-clean-plugin:3.1.0:clean (default-clean) @ spring-boot-k8s-example ---
-ℹ helloworld [verbose]      → Using base image with digest: sha256:bf736024c65942ab045c497e408706f9e599651bf8c01a75ecb3d6971d66700d
-ℹ spring-boot [verbose]     → [INFO] Deleting /Users/steffen/work/github/garden/examples/jib-container/spring-boot/target
-ℹ spring-boot [verbose]     → [INFO]
-ℹ spring-boot [verbose]     → [INFO] --- maven-resources-plugin:3.1.0:resources (default-resources) @ spring-boot-k8s-example ---
-ℹ spring-boot [verbose]     → [INFO] Using 'UTF-8' encoding to copy filtered resources.
-ℹ spring-boot [verbose]     → [INFO] skip non existing resourceDirectory /Users/steffen/work/github/garden/examples/jib-container/spring-boot/src/main/resources
-ℹ spring-boot [verbose]     → [INFO] skip non existing resourceDirectory /Users/steffen/work/github/garden/examples/jib-container/spring-boot/src/main/resources
-ℹ spring-boot [verbose]     → [INFO]
-ℹ spring-boot [verbose]     → [INFO] --- maven-compiler-plugin:3.8.1:compile (default-compile) @ spring-boot-k8s-example ---
-ℹ spring-boot [verbose]     → [INFO] Changes detected - recompiling the module!
-ℹ spring-boot [verbose]     → [INFO] Compiling 2 source files to /Users/steffen/work/github/garden/examples/jib-container/spring-boot/target/classes
-ℹ helloworld [verbose]
-ℹ helloworld [verbose]      → Container entrypoint set to [java, -cp, /app/resources:/app/classes:/app/libs/*, example.HelloWorld]
-ℹ helloworld [verbose]      → Container program arguments set to [GARDEN_MODULE_VERSION=v-28365e8c03]
-ℹ helloworld [verbose]      → Loading to Docker daemon...
-ℹ spring-boot [verbose]     → [INFO]
-ℹ spring-boot [verbose]     → [INFO] --- maven-resources-plugin:3.1.0:testResources (default-testResources) @ spring-boot-k8s-example ---
-ℹ spring-boot [verbose]     → [INFO] Using 'UTF-8' encoding to copy filtered resources.
-ℹ spring-boot [verbose]     → [INFO] skip non existing resourceDirectory /Users/steffen/work/github/garden/examples/jib-container/spring-boot/src/test/resources
-ℹ spring-boot [verbose]     → [INFO]
-ℹ spring-boot [verbose]     → [INFO] --- maven-compiler-plugin:3.8.1:testCompile (default-testCompile) @ spring-boot-k8s-example ---
-ℹ spring-boot [verbose]     → [INFO] No sources to compile
-ℹ spring-boot [verbose]     → [INFO]
-ℹ spring-boot [verbose]     → [INFO] --- maven-surefire-plugin:2.22.2:test (default-test) @ spring-boot-k8s-example ---
-ℹ spring-boot [verbose]     → [INFO] No tests to run.
-ℹ spring-boot [verbose]     → [INFO]
-ℹ spring-boot [verbose]     → [INFO] --- maven-jar-plugin:3.1.2:jar (default-jar) @ spring-boot-k8s-example ---
-ℹ helloworld [verbose]
-ℹ helloworld [verbose]      → Built image to Docker daemon as helloworld:v-28365e8c03
-ℹ helloworld [verbose]      → > Task :jibDockerBuild
-ℹ helloworld [verbose]
-ℹ helloworld [verbose]      → BUILD SUCCESSFUL in 7s
-ℹ helloworld [verbose]      → 3 actionable tasks: 1 executed, 2 up-to-date
-✔ helloworld                → Building version v-28365e8c03... → Done (took 8.3 sec)
-ℹ spring-boot [verbose]     → [INFO] Building jar: /Users/steffen/work/github/garden/examples/jib-container/spring-boot/target/spring-boot-k8s-example-0.1.0.jar
-ℹ spring-boot [verbose]     → [INFO]
-ℹ spring-boot [verbose]     → [INFO] --- jib-maven-plugin:3.1.4:dockerBuild (default-cli) @ spring-boot-k8s-example ---
-ℹ spring-boot [verbose]     → [WARNING] 'mainClass' configured in 'maven-jar-plugin' is not a valid Java class: ${start-class}
-ℹ spring-boot [verbose]     → [INFO]
-ℹ spring-boot [verbose]     → [INFO] Containerizing application to Docker daemon as spring-boot:v-1a655b5756...
-ℹ spring-boot [verbose]     → [WARNING] Base image 'adoptopenjdk:8-jre' does not use a specific image digest - build may not be reproducible
-ℹ spring-boot [verbose]     → [INFO] Getting manifest for base image adoptopenjdk:8-jre...
-ℹ spring-boot [verbose]     → [INFO] Building resources layer...
-ℹ spring-boot [verbose]     → [INFO] Building dependencies layer...
-ℹ spring-boot [verbose]     → [INFO] Building classes layer...
-ℹ spring-boot [verbose]     → [INFO] Building jvm arg files layer...
-ℹ spring-boot [verbose]     → [INFO] The base image requires auth. Trying again for adoptopenjdk:8-jre...
-ℹ spring-boot [verbose]     → [WARNING] The credential helper (docker-credential-desktop) has nothing for server URL: registry-1.docker.io
-ℹ spring-boot [verbose]
-ℹ spring-boot [verbose]     → Got output:
-ℹ spring-boot [verbose]
-ℹ spring-boot [verbose]     → credentials not found in native keychain
-ℹ spring-boot [verbose]
-ℹ spring-boot [verbose]     → [WARNING] The credential helper (docker-credential-desktop) has nothing for server URL: registry.hub.docker.com
-ℹ spring-boot [verbose]
-ℹ spring-boot [verbose]     → Got output:
-ℹ spring-boot [verbose]
-ℹ spring-boot [verbose]     → credentials not found in native keychain
-ℹ spring-boot [verbose]
-ℹ spring-boot [verbose]     → [INFO] Using credentials from Docker config (/Users/steffen/.docker/config.json) for adoptopenjdk:8-jre
-ℹ spring-boot [verbose]     → [INFO] Using base image with digest: sha256:bf736024c65942ab045c497e408706f9e599651bf8c01a75ecb3d6971d66700d
-ℹ spring-boot [verbose]     → [INFO]
-ℹ spring-boot [verbose]     → [INFO] Container entrypoint set to [java, -cp, /app/resources:/app/classes:/app/libs/*, hello.Application]
-ℹ spring-boot [verbose]     → [INFO] Container program arguments set to [GARDEN_MODULE_VERSION=v-1a655b5756]
-ℹ spring-boot [verbose]     → [INFO] Loading to Docker daemon...
-ℹ spring-boot [verbose]     → [INFO]
-ℹ spring-boot [verbose]     → [INFO] Built image to Docker daemon as spring-boot:v-1a655b5756
-ℹ spring-boot [verbose]     → [INFO]
-ℹ spring-boot [verbose]     → [INFO] ------------------------------------------------------------------------
-ℹ spring-boot [verbose]     → [INFO] BUILD SUCCESS
-ℹ spring-boot [verbose]     → [INFO] ------------------------------------------------------------------------
-ℹ spring-boot [verbose]     → [INFO] Total time:  13.607 s
-ℹ spring-boot [verbose]     → [INFO] Finished at: 2023-01-24T19:40:10+01:00
-ℹ spring-boot [verbose]     → [INFO] ------------------------------------------------------------------------
-✔ spring-boot               → Building version v-1a655b5756... → Done (took 16.3 sec)
+ℹ helloworld [verbose]      → [gradle]: > Task :compileJava UP-TO-DATE
+ℹ helloworld [verbose]      → [gradle]: > Task :processResources UP-TO-DATE
+ℹ helloworld [verbose]      → [gradle]: > Task :classes UP-TO-DATE
+ℹ helloworld [verbose]      → [gradle]:
+ℹ helloworld [verbose]      → [gradle]: Containerizing application to Docker daemon as helloworld:v-28365e8c03...
+ℹ helloworld [verbose]      → [gradle]: Base image 'adoptopenjdk:8-jre' does not use a specific image digest - build may not be reproducible
+ℹ helloworld [verbose]      → [gradle]: Getting manifest for base image adoptopenjdk:8-jre...
+ℹ helloworld [verbose]      → [gradle]: Building dependencies layer...
+ℹ helloworld [verbose]      → [gradle]: Building classes layer...
+ℹ helloworld [verbose]      → [gradle]: Building jvm arg files layer...
+ℹ helloworld [verbose]      → [gradle]: Building resources layer...
+ℹ helloworld [verbose]      → [gradle]: The base image requires auth. Trying again for adoptopenjdk:8-jre...
+ℹ spring-boot [verbose]     → [maven]: [INFO] Scanning for projects...
+ℹ helloworld [verbose]      → [gradle]: The credential helper (docker-credential-desktop) has nothing for server URL: registry-1.docker.io
+ℹ helloworld [verbose]      → [gradle]:
+ℹ helloworld [verbose]      → [gradle]: Got output:
+ℹ helloworld [verbose]      → [gradle]:
+ℹ helloworld [verbose]      → [gradle]: credentials not found in native keychain
+ℹ helloworld [verbose]      → [gradle]:
+ℹ helloworld [verbose]      → [gradle]: The credential helper (docker-credential-desktop) has nothing for server URL: registry.hub.docker.com
+ℹ helloworld [verbose]      → [gradle]:
+ℹ helloworld [verbose]      → [gradle]: Got output:
+ℹ helloworld [verbose]      → [gradle]:
+ℹ helloworld [verbose]      → [gradle]: credentials not found in native keychain
+ℹ helloworld [verbose]      → [gradle]:
+ℹ spring-boot [verbose]     → [maven]: [INFO]
+ℹ spring-boot [verbose]     → [maven]: [INFO] ------------------< example:spring-boot-k8s-example >-------------------
+ℹ spring-boot [verbose]     → [maven]: [INFO] Building spring-boot-k8s-example 0.1.0
+ℹ spring-boot [verbose]     → [maven]: [INFO] --------------------------------[ jar ]---------------------------------
+ℹ helloworld [verbose]      → [gradle]: Using credentials from Docker config (/Users/steffen/.docker/config.json) for adoptopenjdk:8-jre
+ℹ spring-boot [verbose]     → [maven]: [INFO]
+ℹ spring-boot [verbose]     → [maven]: [INFO] --- maven-clean-plugin:3.1.0:clean (default-clean) @ spring-boot-k8s-example ---
+ℹ spring-boot [verbose]     → [maven]: [INFO] Deleting /Users/steffen/work/github/garden/examples/jib-container/spring-boot/target
+ℹ helloworld [verbose]      → [gradle]: Using base image with digest: sha256:bf736024c65942ab045c497e408706f9e599651bf8c01a75ecb3d6971d66700d
+ℹ spring-boot [verbose]     → [maven]: [INFO]
+ℹ spring-boot [verbose]     → [maven]: [INFO] --- maven-resources-plugin:3.1.0:resources (default-resources) @ spring-boot-k8s-example ---
+ℹ spring-boot [verbose]     → [maven]: [INFO] Using 'UTF-8' encoding to copy filtered resources.
+ℹ spring-boot [verbose]     → [maven]: [INFO] skip non existing resourceDirectory /Users/steffen/work/github/garden/examples/jib-container/spring-boot/src/main/resources
+ℹ spring-boot [verbose]     → [maven]: [INFO] skip non existing resourceDirectory /Users/steffen/work/github/garden/examples/jib-container/spring-boot/src/main/resources
+ℹ spring-boot [verbose]     → [maven]: [INFO]
+ℹ spring-boot [verbose]     → [maven]: [INFO] --- maven-compiler-plugin:3.8.1:compile (default-compile) @ spring-boot-k8s-example ---
+ℹ spring-boot [verbose]     → [maven]: [INFO] Changes detected - recompiling the module!
+ℹ spring-boot [verbose]     → [maven]: [INFO] Compiling 2 source files to /Users/steffen/work/github/garden/examples/jib-container/spring-boot/target/classes
+ℹ helloworld [verbose]      → [gradle]:
+ℹ helloworld [verbose]      → [gradle]: Container entrypoint set to [java, -cp, /app/resources:/app/classes:/app/libs/*, example.HelloWorld]
+ℹ helloworld [verbose]      → [gradle]: Container program arguments set to [GARDEN_MODULE_VERSION=v-28365e8c03]
+ℹ helloworld [verbose]      → [gradle]: Loading to Docker daemon...
+ℹ spring-boot [verbose]     → [maven]: [INFO]
+ℹ spring-boot [verbose]     → [maven]: [INFO] --- maven-resources-plugin:3.1.0:testResources (default-testResources) @ spring-boot-k8s-example ---
+ℹ spring-boot [verbose]     → [maven]: [INFO] Using 'UTF-8' encoding to copy filtered resources.
+ℹ spring-boot [verbose]     → [maven]: [INFO] skip non existing resourceDirectory /Users/steffen/work/github/garden/examples/jib-container/spring-boot/src/test/resources
+ℹ spring-boot [verbose]     → [maven]: [INFO]
+ℹ spring-boot [verbose]     → [maven]: [INFO] --- maven-compiler-plugin:3.8.1:testCompile (default-testCompile) @ spring-boot-k8s-example ---
+ℹ spring-boot [verbose]     → [maven]: [INFO] No sources to compile
+ℹ spring-boot [verbose]     → [maven]: [INFO]
+ℹ spring-boot [verbose]     → [maven]: [INFO] --- maven-surefire-plugin:2.22.2:test (default-test) @ spring-boot-k8s-example ---
+ℹ spring-boot [verbose]     → [maven]: [INFO] No tests to run.
+ℹ spring-boot [verbose]     → [maven]: [INFO]
+ℹ spring-boot [verbose]     → [maven]: [INFO] --- maven-jar-plugin:3.1.2:jar (default-jar) @ spring-boot-k8s-example ---
+ℹ spring-boot [verbose]     → [maven]: [INFO] Building jar: /Users/steffen/work/github/garden/examples/jib-container/spring-boot/target/spring-boot-k8s-example-0.1.0.jar
+ℹ spring-boot [verbose]     → [maven]: [INFO]
+ℹ spring-boot [verbose]     → [maven]: [INFO] --- jib-maven-plugin:3.1.4:dockerBuild (default-cli) @ spring-boot-k8s-example ---
+ℹ helloworld [verbose]      → [gradle]:
+ℹ helloworld [verbose]      → [gradle]: Built image to Docker daemon as helloworld:v-28365e8c03
+ℹ helloworld [verbose]      → [gradle]: > Task :jibDockerBuild
+ℹ helloworld [verbose]      → [gradle]:
+ℹ helloworld [verbose]      → [gradle]: BUILD SUCCESSFUL in 7s
+ℹ helloworld [verbose]      → [gradle]: 3 actionable tasks: 1 executed, 2 up-to-date
+✔ helloworld                → Building version v-28365e8c03... → Done (took 8.7 sec)
+ℹ spring-boot [verbose]     → [maven]: [WARNING] 'mainClass' configured in 'maven-jar-plugin' is not a valid Java class: ${start-class}
+ℹ spring-boot [verbose]     → [maven]: [INFO]
+ℹ spring-boot [verbose]     → [maven]: [INFO] Containerizing application to Docker daemon as spring-boot:v-1a655b5756...
+ℹ spring-boot [verbose]     → [maven]: [WARNING] Base image 'adoptopenjdk:8-jre' does not use a specific image digest - build may not be reproducible
+ℹ spring-boot [verbose]     → [maven]: [INFO] Getting manifest for base image adoptopenjdk:8-jre...
+ℹ spring-boot [verbose]     → [maven]: [INFO] Building resources layer...
+ℹ spring-boot [verbose]     → [maven]: [INFO] Building dependencies layer...
+ℹ spring-boot [verbose]     → [maven]: [INFO] Building classes layer...
+ℹ spring-boot [verbose]     → [maven]: [INFO] Building jvm arg files layer...
+ℹ spring-boot [verbose]     → [maven]: [INFO] The base image requires auth. Trying again for adoptopenjdk:8-jre...
+ℹ spring-boot [verbose]     → [maven]: [WARNING] The credential helper (docker-credential-desktop) has nothing for server URL: registry-1.docker.io
+ℹ spring-boot [verbose]     → [maven]:
+ℹ spring-boot [verbose]     → [maven]: Got output:
+ℹ spring-boot [verbose]     → [maven]:
+ℹ spring-boot [verbose]     → [maven]: credentials not found in native keychain
+ℹ spring-boot [verbose]     → [maven]:
+ℹ spring-boot [verbose]     → [maven]: [WARNING] The credential helper (docker-credential-desktop) has nothing for server URL: registry.hub.docker.com
+ℹ spring-boot [verbose]     → [maven]:
+ℹ spring-boot [verbose]     → [maven]: Got output:
+ℹ spring-boot [verbose]     → [maven]:
+ℹ spring-boot [verbose]     → [maven]: credentials not found in native keychain
+ℹ spring-boot [verbose]     → [maven]:
+ℹ spring-boot [verbose]     → [maven]: [INFO] Using credentials from Docker config (/Users/steffen/.docker/config.json) for adoptopenjdk:8-jre
+ℹ spring-boot [verbose]     → [maven]: [INFO] Using base image with digest: sha256:bf736024c65942ab045c497e408706f9e599651bf8c01a75ecb3d6971d66700d
+ℹ spring-boot [verbose]     → [maven]: [INFO]
+ℹ spring-boot [verbose]     → [maven]: [INFO] Container entrypoint set to [java, -cp, /app/resources:/app/classes:/app/libs/*, hello.Application]
+ℹ spring-boot [verbose]     → [maven]: [INFO] Container program arguments set to [GARDEN_MODULE_VERSION=v-1a655b5756]
+ℹ spring-boot [verbose]     → [maven]: [INFO] Loading to Docker daemon...
+ℹ spring-boot [verbose]     → [maven]: [INFO]
+ℹ spring-boot [verbose]     → [maven]: [INFO] Built image to Docker daemon as spring-boot:v-1a655b5756
+ℹ spring-boot [verbose]     → [maven]: [INFO]
+ℹ spring-boot [verbose]     → [maven]: [INFO] ------------------------------------------------------------------------
+ℹ spring-boot [verbose]     → [maven]: [INFO] BUILD SUCCESS
+ℹ spring-boot [verbose]     → [maven]: [INFO] ------------------------------------------------------------------------
+ℹ spring-boot [verbose]     → [maven]: [INFO] Total time:  13.167 s
+ℹ spring-boot [verbose]     → [maven]: [INFO] Finished at: 2023-01-24T19:40:30+01:00
+ℹ spring-boot [verbose]     → [maven]: [INFO] ------------------------------------------------------------------------
+✔ spring-boot               → Building version v-1a655b5756... → Done (took 15.7 sec)

 Done! ✔️
```
```