### PR TITLE
0.13 `DevCommand` fixes

### DIFF
--- a/core/test/unit/src/commands/dev.ts
+++ b/core/test/unit/src/commands/dev.ts
@@ -72,7 +72,6 @@ describe("DevCommand", () => {
     const opts = withDefaultGlobalOpts({
       "force-build": false,
       "force": false,
-
       "local-mode": undefined,
       "skip-tests": false,
       "test-names": undefined,
@@ -96,7 +95,6 @@ describe("DevCommand", () => {
       "resolve-provider.templated",
       "resolve-provider.test-plugin",
       "resolve-provider.test-plugin-b",
-
       "task.task-c",
       "test.module-a.integration",
       "test.module-a.unit",
@@ -118,7 +116,6 @@ describe("DevCommand", () => {
     const opts = withDefaultGlobalOpts({
       "force-build": false,
       "force": false,
-
       "local-mode": undefined,
       "skip-tests": false,
       "test-names": undefined,
@@ -141,7 +138,6 @@ describe("DevCommand", () => {
     const opts = withDefaultGlobalOpts({
       "force-build": false,
       "force": false,
-
       "local-mode": undefined,
       "skip-tests": false,
       "test-names": undefined,
@@ -164,7 +160,6 @@ describe("DevCommand", () => {
     const opts = withDefaultGlobalOpts({
       "force-build": false,
       "force": false,
-
       "local-mode": undefined,
       "skip-tests": false,
       "test-names": undefined,
@@ -187,7 +182,6 @@ describe("DevCommand", () => {
     const opts = withDefaultGlobalOpts({
       "force-build": false,
       "force": false,
-
       "local-mode": undefined,
       "skip-tests": false,
       "test-names": undefined,
@@ -210,7 +204,6 @@ describe("DevCommand", () => {
     const opts = withDefaultGlobalOpts({
       "force-build": false,
       "force": false,
-
       "local-mode": undefined,
       "skip-tests": false,
       "test-names": undefined,
@@ -233,7 +226,6 @@ describe("DevCommand", () => {
     const opts = withDefaultGlobalOpts({
       "force-build": false,
       "force": false,
-
       "local-mode": undefined,
       "skip-tests": false,
       "test-names": undefined,
@@ -281,7 +273,6 @@ describe("getDevCommandWatchTasks", () => {
       "get-service-status.service-b",
       "get-service-status.service-c",
       "get-task-result.task-c",
-
       "task.task-c",
       "test.module-b.unit",
       "test.module-c.integ",

--- a/core/test/unit/src/commands/dev.ts
+++ b/core/test/unit/src/commands/dev.ts
@@ -247,7 +247,7 @@ describe("getDevCommandWatchTasks", () => {
     const graph = await garden.getConfigGraph({ log, emit: false })
 
     // TODO-G2: fix the semantics of the test
-    const deployAction = graph.getDeploy("deploy.module-b.service-b")
+    const deployAction = graph.getDeploy("service-b")
     const watchTasks = await getDevCommandWatchTasks({
       garden,
       log,


### PR DESCRIPTION
**What this PR does / why we need it**:
It looks like there is a bug in the [`getDevCommandWatchTasks`](https://github.com/garden-io/garden/blob/0.13/core/src/commands/dev.ts#L282-L283). Both `deploysWatched` and `devModeDeployNames` receive the same value in the [`getActionWatchTasks` function call](https://github.com/garden-io/garden/blob/0.13/core/src/commands/dev.ts#L277). But that function has the condition [`deploysWatched.includes(a.name) && !devModeDeployNames.includes(a.name)`](https://github.com/garden-io/garden/blob/0.13/core/src/tasks/helpers.ts#L105) that will never hold if `deploysWatched` and `devModeDeployNames` get the same value.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
