### PR TITLE
fix(helm): stream logs to CLI and Garden Cloud

### DIFF
--- a/core/src/plugins/kubernetes/commands/cluster-init.ts
+++ b/core/src/plugins/kubernetes/commands/cluster-init.ts
@@ -49,6 +49,7 @@ export const clusterInit: PluginCommand = {
         log,
         namespace: systemNamespace,
         args: ["uninstall", "garden-nfs-provisioner"],
+        emitLogEvents: true,
       })
     } catch (_) {}
 

--- a/core/src/plugins/kubernetes/commands/uninstall-garden-services.ts
+++ b/core/src/plugins/kubernetes/commands/uninstall-garden-services.ts
@@ -45,6 +45,7 @@ export const uninstallGardenServices: PluginCommand = {
         log,
         namespace: systemNamespace,
         args: ["uninstall", "garden-nfs-provisioner"],
+        emitLogEvents: true,
       })
     } catch (_) {}
     try {
@@ -53,6 +54,7 @@ export const uninstallGardenServices: PluginCommand = {
         log,
         namespace: systemNamespace,
         args: ["uninstall", "garden-nfs-provisioner-v2"],
+        emitLogEvents: true,
       })
     } catch (_) {}
 

--- a/core/src/plugins/kubernetes/helm/build.ts
+++ b/core/src/plugins/kubernetes/helm/build.ts
@@ -41,8 +41,9 @@ export async function buildHelmModule({ ctx, module, log }: BuildModuleParams<He
         ctx: k8sCtx,
         log,
         args: ["repo", "add", "stable", "https://charts.helm.sh/stable", "--force-update"],
+        emitLogEvents: true,
       })
-      await helm({ ctx: k8sCtx, log, args: ["repo", "update"] })
+      await helm({ ctx: k8sCtx, log, args: ["repo", "update"], emitLogEvents: true })
       log.debug("Fetching chart (after updating)...")
       await pullChart(k8sCtx, log, module)
     }
@@ -67,7 +68,7 @@ async function pullChart(ctx: KubernetesPluginContext, log: LogEntry, module: He
       args.push("--repo", module.spec.repo)
     }
 
-    await helm({ ctx, log, args: [...args], cwd: tmpDir.path })
+    await helm({ ctx, log, args: [...args], cwd: tmpDir.path, emitLogEvents: true })
 
     await move(join(tmpDir.path, chartDir), chartPath, { overwrite: true })
   } finally {

--- a/core/src/plugins/kubernetes/helm/common.ts
+++ b/core/src/plugins/kubernetes/helm/common.ts
@@ -46,6 +46,7 @@ async function dependencyUpdate(ctx: KubernetesPluginContext, log: LogEntry, nam
     log,
     namespace,
     args: ["dependency", "update", chartPath],
+    emitLogEvents: true,
   })
 }
 
@@ -181,6 +182,8 @@ export async function prepareManifests(params: PrepareManifestsParams): Promise<
       module.spec.timeout.toString(10) + "s",
       ...(await getValueArgs(module, devMode, hotReload, localMode)),
     ],
+    // do not send JSON output to Garden Cloud or CLI verbose log
+    emitLogEvents: false,
   })
 
   const manifest = JSON.parse(res).manifest as string
@@ -341,6 +344,7 @@ export async function renderHelmTemplateString(
           relPath,
           chartPath,
         ],
+        emitLogEvents: true,
       })
     )
 

--- a/core/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/src/plugins/kubernetes/helm/deployment.ts
@@ -108,14 +108,14 @@ export async function deployHelmService({
     if (force && !ctx.production) {
       installArgs.push("--replace")
     }
-    await helm({ ctx: k8sCtx, namespace, log, args: [...installArgs] })
+    await helm({ ctx: k8sCtx, namespace, log, args: [...installArgs], emitLogEvents: true })
   } else {
     if (hotReload) {
       hotReloadSpec = getHotReloadSpec(service)
     }
     log.silly(`Upgrading Helm release ${releaseName}`)
     const upgradeArgs = ["upgrade", releaseName, chartPath, "--install", ...commonArgs]
-    await helm({ ctx: k8sCtx, namespace, log, args: [...upgradeArgs] })
+    await helm({ ctx: k8sCtx, namespace, log, args: [...upgradeArgs], emitLogEvents: true })
 
     // If ctx.cloudApi is defined, the user is logged in and they might be trying to deploy to an environment
     // that could have been paused by by Garden Cloud's AEC functionality. We therefore make sure to clean up any
@@ -264,7 +264,7 @@ export async function deleteService(params: DeleteServiceParams): Promise<HelmSe
 
   const resources = await getRenderedResources({ ctx: k8sCtx, module, releaseName, log })
 
-  await helm({ ctx: k8sCtx, log, namespace, args: ["uninstall", releaseName] })
+  await helm({ ctx: k8sCtx, log, namespace, args: ["uninstall", releaseName], emitLogEvents: true })
 
   // Wait for resources to terminate
   await deleteResources({ log, ctx, provider, resources, namespace })

--- a/core/src/plugins/kubernetes/helm/helm-cli.ts
+++ b/core/src/plugins/kubernetes/helm/helm-cli.ts
@@ -13,6 +13,8 @@ import { GARDEN_GLOBAL_PATH } from "../../../constants"
 import { mkdirp } from "fs-extra"
 import { StringMap } from "../../../config/common"
 import { PluginToolSpec } from "../../../types/plugin/tools"
+import split2 from "split2"
+import { LogLevel } from "../../../logger/logger"
 
 export const helm3Spec: PluginToolSpec = {
   name: "helm",
@@ -71,6 +73,7 @@ export async function helm({
   version = 3,
   env = {},
   cwd,
+  emitLogEvents,
 }: {
   ctx: KubernetesPluginContext
   namespace?: string
@@ -79,6 +82,7 @@ export async function helm({
   version?: 2 | 3
   env?: { [key: string]: string }
   cwd?: string
+  emitLogEvents: boolean
 }) {
   const opts = ["--kube-context", ctx.provider.config.context]
 
@@ -101,6 +105,19 @@ export async function helm({
     opts.push("--namespace", namespace)
   }
 
+  const logEventContext = {
+    origin: "helm",
+    log: log.placeholder({ level: LogLevel.verbose }),
+  }
+
+  const outputStream = split2()
+  outputStream.on("error", () => {})
+  outputStream.on("data", (line: Buffer) => {
+    if (emitLogEvents) {
+      ctx.events.emit("log", { timestamp: new Date().getTime(), data: line, ...logEventContext })
+    }
+  })
+
   return cmd.stdout({
     log,
     args: [...opts, ...args],
@@ -108,5 +125,7 @@ export async function helm({
     // Helm itself will time out pretty reliably, so we shouldn't time out early on our side.
     timeoutSec: 3600,
     cwd,
+    stderr: outputStream,
+    stdout: outputStream,
   })
 }

--- a/core/src/plugins/kubernetes/helm/run.ts
+++ b/core/src/plugins/kubernetes/helm/run.ts
@@ -28,7 +28,6 @@ import { KubeApi } from "../api"
 import { getModuleNamespaceStatus } from "../namespace"
 import { DEFAULT_TASK_TIMEOUT } from "../../../constants"
 import { KubernetesPod } from "../types"
-import { LogLevel } from "../../../logger/logger"
 
 export async function runHelmModule({
   ctx,
@@ -104,14 +103,8 @@ export async function runHelmModule({
     },
   }
 
-  const logEventContext = {
-    origin: "helm",
-    log: log.placeholder({ level: LogLevel.verbose }),
-  }
-
   const runner = new PodRunner({
     ctx,
-    logEventContext,
     api,
     pod,
     provider,

--- a/core/src/plugins/kubernetes/helm/status.ts
+++ b/core/src/plugins/kubernetes/helm/status.ts
@@ -188,6 +188,7 @@ export async function getRenderedResources({
       log,
       namespace,
       args: ["get", "manifest", releaseName],
+      emitLogEvents: true,
     })
   )
 }
@@ -220,7 +221,16 @@ export async function getReleaseStatus({
       provider: ctx.provider,
     })
 
-    const res = JSON.parse(await helm({ ctx, log, namespace, args: ["status", releaseName, "--output", "json"] }))
+    const res = JSON.parse(
+      await helm({
+        ctx,
+        log,
+        namespace,
+        args: ["status", releaseName, "--output", "json"],
+        // do not send JSON output to Garden Cloud or CLI verbose log
+        emitLogEvents: false,
+      })
+    )
 
     let state = helmStatusMap[res.info.status] || "unknown"
     let values = {}
@@ -237,6 +247,8 @@ export async function getReleaseStatus({
           log,
           namespace,
           args: ["get", "values", releaseName, "--output", "json"],
+          // do not send JSON output to Garden Cloud or CLI verbose log
+          emitLogEvents: false,
         })
       )
 

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -755,7 +755,7 @@ export interface PodErrorDetails {
 export class PodRunner extends PodRunnerParams {
   podName: string
   running: boolean
-  logEventContext: PluginEventLogContext
+  logEventContext: PluginEventLogContext | undefined
 
   constructor(params: PodRunnerParams) {
     super()
@@ -771,10 +771,7 @@ export class PodRunner extends PodRunnerParams {
     Object.assign(this, params)
 
     this.podName = this.pod.metadata.name
-
-    if (params.logEventContext !== undefined) {
-      this.logEventContext
-    }
+    this.logEventContext = params.logEventContext
   }
 
   getFullCommand() {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
Actually stream helm module outputs to CLI and Garden Cloud; the
log context was in the wrong place before.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
Difference for `garden deploy --force -l3 --env testing` in `vote-helm` example before and after the change:
```diff
--- before.log	2023-01-25 11:14:34
+++ after.log	2023-01-25 11:15:09
@@ -1,4 +1,4 @@
-$ garden deploy --force -l3 --env testing
+$ gdev deploy --force -l3 --env testing
 Deploy 🚀


@@ -14,8 +14,8 @@
 ℹ db-init                   → Checking result...
 ℹ base-chart [verbose]      → Syncing module sources (8 files)...
 ℹ result-image [verbose]    → Syncing module sources (10 files)...
-ℹ vote-image [verbose]      → Syncing module sources (26 files)...
 ℹ api-image [verbose]       → Syncing module sources (4 files)...
+ℹ vote-image [verbose]      → Syncing module sources (26 files)...
 ℹ worker-image [verbose]    → Syncing module sources (4 files)...
 ✔ api-image [verbose]       → Syncing module sources (4 files)... → Done (took 0.1 sec)
 ℹ api-image                 → Getting build status for v-5e1b35f98d...
@@ -29,59 +29,155 @@
 ℹ vote-image                → Getting build status for v-4511769535...
 ℹ postgres                  → Getting build status for v-5fb6d7be3a...
 ℹ postgres                  → Building version v-5fb6d7be3a...
-ℹ redis                     → Getting build status for v-ddd40fa14d...
-ℹ redis                     → Building version v-ddd40fa14d...
 ✔ worker-image [verbose]    → Syncing module sources (4 files)... → Done (took 0.2 sec)
 ℹ worker-image              → Getting build status for v-a3dd69d9c7...
+ℹ redis                     → Getting build status for v-ddd40fa14d...
+ℹ redis                     → Building version v-ddd40fa14d...
 ✔ db-init                   → Checking result... → Done
 [verbose] Comparing expected and deployed resources...
 [verbose] All resources match.
-✔ postgres                  → Building version v-5fb6d7be3a... → Done (took 2.7 sec)
+✔ postgres                  → Building version v-5fb6d7be3a... → Done (took 2.8 sec)
 ℹ postgres                  → Deploying version v-ffa064ad19...
-✔ redis                     → Building version v-ddd40fa14d... → Done (took 2.7 sec)
-ℹ redis                     → Deploying version v-27093a1e1d...
+ℹ postgres [verbose]        → [helm]: Getting updates for unmanaged Helm repositories...
+✔ api-image                 → Getting build status for v-5e1b35f98d... → Already built
 [verbose] Comparing expected and deployed resources...
 [verbose] All resources match.
-✔ result-image              → Getting build status for v-f5d453bdfb... → Already built
-ℹ result                    → Getting build status for v-770d14dbdc...
-ℹ result                    → Building version v-770d14dbdc...
-✔ result                    → Building version v-770d14dbdc... → Done (took 0 sec)
-[verbose] Comparing expected and deployed resources...
-[verbose] All resources match.
-✔ vote-image                → Getting build status for v-4511769535... → Already built
-ℹ vote [verbose]            → Syncing module sources (8 files)...
-✔ vote [verbose]            → Syncing module sources (8 files)... → Done (took 0 sec)
-ℹ vote                      → Getting build status for v-c4a45ecdd4...
-ℹ vote                      → Building version v-c4a45ecdd4...
-✔ vote                      → Building version v-c4a45ecdd4... → Done (took 0 sec)
-[verbose] Comparing expected and deployed resources...
-[verbose] All resources match.
-✔ api-image                 → Getting build status for v-5e1b35f98d... → Already built
 ℹ api                       → Getting build status for v-6adf624c64...
 ℹ api                       → Building version v-6adf624c64...
 ✔ api                       → Building version v-6adf624c64... → Done (took 0 sec)
+✔ redis                     → Building version v-ddd40fa14d... → Done (took 3.2 sec)
+ℹ redis                     → Deploying version v-27093a1e1d...
+ℹ redis [verbose]           → [helm]: Getting updates for unmanaged Helm repositories...
+ℹ postgres [verbose]        → [helm]: ...Successfully got an update from the "https://charts.bitnami.com/bitnami" chart repository
+ℹ postgres [verbose]        → [helm]: Hang tight while we grab the latest from your chart repositories...
+[verbose] Comparing expected and deployed resources...
+[verbose] All resources match.
 ✔ worker-image              → Getting build status for v-a3dd69d9c7... → Already built
 ℹ worker [verbose]          → Syncing module sources (5 files)...
 ✔ worker [verbose]          → Syncing module sources (5 files)... → Done (took 0 sec)
 ℹ worker                    → Getting build status for v-fc6386c8df...
 ℹ worker                    → Building version v-fc6386c8df...
+ℹ redis [verbose]           → [helm]: ...Successfully got an update from the "https://charts.bitnami.com/bitnami" chart repository
+ℹ redis [verbose]           → [helm]: Hang tight while we grab the latest from your chart repositories...
 ✔ worker                    → Building version v-fc6386c8df... → Done (took 0 sec)
 ℹ worker                    → Deploying version v-e0c3fbd7bb...
+✔ result-image              → Getting build status for v-f5d453bdfb... → Already built
+[verbose] Comparing expected and deployed resources...
+[verbose] All resources match.
+ℹ result                    → Getting build status for v-770d14dbdc...
+ℹ result                    → Building version v-770d14dbdc...
+✔ result                    → Building version v-770d14dbdc... → Done (took 0.1 sec)
+ℹ postgres [verbose]        → [helm]: ...Successfully got an update from the "stable" chart repository
+ℹ postgres [verbose]        → [helm]: Update Complete. ⎈Happy Helming!⎈
+ℹ redis [verbose]           → [helm]: ...Successfully got an update from the "stable" chart repository
+ℹ redis [verbose]           → [helm]: Update Complete. ⎈Happy Helming!⎈
+✔ vote-image                → Getting build status for v-4511769535... → Already built
+ℹ vote [verbose]            → Syncing module sources (8 files)...
+ℹ worker [verbose]          → [helm]: Release "worker" has been upgraded. Happy Helming!
+ℹ worker [verbose]          → [helm]: NAME: worker
+ℹ worker [verbose]          → [helm]: LAST DEPLOYED: Wed Jan 25 11:14:45 2023
+ℹ worker [verbose]          → [helm]: NAMESPACE: vote-helm-testing-steffen
+ℹ worker [verbose]          → [helm]: STATUS: deployed
+ℹ worker [verbose]          → [helm]: REVISION: 10
+ℹ worker [verbose]          → [helm]: TEST SUITE: None
+✔ vote [verbose]            → Syncing module sources (8 files)... → Done (took 0 sec)
+ℹ vote                      → Getting build status for v-c4a45ecdd4...
+ℹ vote                      → Building version v-c4a45ecdd4...
+✔ vote                      → Building version v-c4a45ecdd4... → Done (took 0 sec)
+ℹ postgres [verbose]        → [helm]: Saving 1 charts
 ℹ worker                    → Waiting for resources to be ready...
 ℹ worker [verbose]          → [kubernetes-plugin]: Waiting for resources to be ready...
+ℹ redis [verbose]           → [helm]: Saving 1 charts
+ℹ postgres [verbose]        → [helm]: Downloading common from repo https://charts.bitnami.com/bitnami
+ℹ redis [verbose]           → [helm]: Downloading common from repo https://charts.bitnami.com/bitnami
+ℹ postgres [verbose]        → [helm]: Deleting outdated charts
+ℹ redis [verbose]           → [helm]: Deleting outdated charts
 ℹ worker [verbose]          → [kubernetes-plugin]: Status of Deployment worker is "ready"
 ℹ worker [verbose]          → [kubernetes-plugin]: Resources ready
 ℹ worker                    → Resources ready
-✔ worker                    → Deploying version v-e0c3fbd7bb... → Done (took 5 sec)
+✔ worker                    → Deploying version v-e0c3fbd7bb... → Done (took 5.1 sec)
+ℹ postgres [verbose]        → [helm]: Release "postgres" has been upgraded. Happy Helming!
+ℹ postgres [verbose]        → [helm]: NAME: postgres
+ℹ postgres [verbose]        → [helm]: LAST DEPLOYED: Wed Jan 25 11:14:50 2023
+ℹ postgres [verbose]        → [helm]: NAMESPACE: vote-helm-testing-steffen
+ℹ postgres [verbose]        → [helm]: STATUS: deployed
+ℹ postgres [verbose]        → [helm]: REVISION: 10
+ℹ postgres [verbose]        → [helm]: TEST SUITE: None
+ℹ postgres [verbose]        → [helm]: NOTES:
+ℹ postgres [verbose]        → [helm]: CHART NAME: postgresql
+ℹ postgres [verbose]        → [helm]: CHART VERSION: 11.6.12
+ℹ postgres [verbose]        → [helm]: APP VERSION: 14.4.0
+ℹ postgres [verbose]        → [helm]:
+ℹ postgres [verbose]        → [helm]: ** Please be patient while the chart is being deployed **
+ℹ postgres [verbose]        → [helm]:
+ℹ postgres [verbose]        → [helm]: PostgreSQL can be accessed via port 5432 on the following DNS names from within your cluster:
+ℹ postgres [verbose]        → [helm]:
+ℹ postgres [verbose]        → [helm]:     postgres.vote-helm-testing-steffen.svc.cluster.local - Read/Write connection
+ℹ postgres [verbose]        → [helm]:
+ℹ postgres [verbose]        → [helm]: To get the password for "postgres" run:
+ℹ postgres [verbose]        → [helm]:
+ℹ postgres [verbose]        → [helm]:     export POSTGRES_PASSWORD=$(kubectl get secret --namespace vote-helm-testing-steffen postgres -o jsonpath="{.data.postgres-password}" | base64 -d)
+ℹ postgres [verbose]        → [helm]:
+ℹ postgres [verbose]        → [helm]: To connect to your database run the following command:
+ℹ postgres [verbose]        → [helm]:
+ℹ postgres [verbose]        → [helm]:     kubectl run postgres-client --rm --tty -i --restart='Never' --namespace vote-helm-testing-steffen --image docker.io/bitnami/postgresql:14.4.0-debian-11-r4 --env="PGPASSWORD=$POSTGRES_PASSWORD" \
+ℹ postgres [verbose]        → [helm]:       --command -- psql --host postgres -U postgres -d postgres -p 5432
+ℹ postgres [verbose]        → [helm]:
+ℹ postgres [verbose]        → [helm]:     > NOTE: If you access the container using bash, make sure that you execute "/opt/bitnami/scripts/postgresql/entrypoint.sh /bin/bash" in order to avoid the error "psql: local user with ID 1001} does not exist"
+ℹ postgres [verbose]        → [helm]:
+ℹ postgres [verbose]        → [helm]: To connect to your database from outside the cluster execute the following commands:
+ℹ postgres [verbose]        → [helm]:
+ℹ postgres [verbose]        → [helm]:     kubectl port-forward --namespace vote-helm-testing-steffen svc/postgres 5432:5432 &
+ℹ postgres [verbose]        → [helm]:     PGPASSWORD="$POSTGRES_PASSWORD" psql --host 127.0.0.1 -U postgres -d postgres -p 5432
 ℹ postgres                  → Waiting for resources to be ready...
 ℹ postgres [verbose]        → [kubernetes-plugin]: Waiting for resources to be ready...
+ℹ redis [verbose]           → [helm]: Release "redis" has been upgraded. Happy Helming!
+ℹ redis [verbose]           → [helm]: NAME: redis
+ℹ redis [verbose]           → [helm]: LAST DEPLOYED: Wed Jan 25 11:14:51 2023
+ℹ redis [verbose]           → [helm]: NAMESPACE: vote-helm-testing-steffen
+ℹ redis [verbose]           → [helm]: STATUS: deployed
+ℹ redis [verbose]           → [helm]: REVISION: 10
+ℹ redis [verbose]           → [helm]: TEST SUITE: None
+ℹ redis [verbose]           → [helm]: NOTES:
+ℹ redis [verbose]           → [helm]: CHART NAME: redis
+ℹ redis [verbose]           → [helm]: CHART VERSION: 16.13.1
+ℹ redis [verbose]           → [helm]: APP VERSION: 6.2.7
+ℹ redis [verbose]           → [helm]:
+ℹ redis [verbose]           → [helm]: ** Please be patient while the chart is being deployed **
+ℹ redis [verbose]           → [helm]:
+ℹ redis [verbose]           → [helm]: Redis&reg; can be accessed on the following DNS names from within your cluster:
+ℹ redis [verbose]           → [helm]:
+ℹ redis [verbose]           → [helm]:     redis-master.vote-helm-testing-steffen.svc.cluster.local for read/write operations (port 6379)
+ℹ redis [verbose]           → [helm]:     redis-replicas.vote-helm-testing-steffen.svc.cluster.local for read-only operations (port 6379)
+ℹ redis [verbose]           → [helm]:
+ℹ redis [verbose]           → [helm]:
+ℹ redis [verbose]           → [helm]:
+ℹ redis [verbose]           → [helm]: To connect to your Redis&reg; server:
+ℹ redis [verbose]           → [helm]:
+ℹ redis [verbose]           → [helm]: 1. Run a Redis&reg; pod that you can use as a client:
+ℹ redis [verbose]           → [helm]:
+ℹ redis [verbose]           → [helm]:    kubectl run --namespace vote-helm-testing-steffen redis-client --restart='Never'  --image docker.io/bitnami/redis:6.2.7-debian-11-r9 --command -- sleep infinity
+ℹ redis [verbose]           → [helm]:
+ℹ redis [verbose]           → [helm]:    Use the following command to attach to the pod:
+ℹ redis [verbose]           → [helm]:
+ℹ redis [verbose]           → [helm]:    kubectl exec --tty -i redis-client \
+ℹ redis [verbose]           → [helm]:    --namespace vote-helm-testing-steffen -- bash
+ℹ redis [verbose]           → [helm]:
+ℹ redis [verbose]           → [helm]: 2. Connect using the Redis&reg; CLI:
+ℹ redis [verbose]           → [helm]:    redis-cli -h redis-master
+ℹ redis [verbose]           → [helm]:    redis-cli -h redis-replicas
+ℹ redis [verbose]           → [helm]:
+ℹ redis [verbose]           → [helm]: To connect to your database from outside the cluster execute the following commands:
+ℹ redis [verbose]           → [helm]:
+ℹ redis [verbose]           → [helm]:     kubectl port-forward --namespace vote-helm-testing-steffen svc/redis-master 6379:6379 &
+ℹ redis [verbose]           → [helm]:     redis-cli -h 127.0.0.1 -p 6379
 ℹ postgres [verbose]        → [kubernetes-plugin]: Status of Secret postgres is "ready"
 ℹ postgres [verbose]        → [kubernetes-plugin]: Status of Service postgres-hl is "ready"
 ℹ postgres [verbose]        → [kubernetes-plugin]: Status of Service postgres is "ready"
 ℹ postgres [verbose]        → [kubernetes-plugin]: Status of StatefulSet postgres is "ready"
 ℹ postgres [verbose]        → [kubernetes-plugin]: Resources ready
 ℹ postgres                  → Resources ready
-✔ postgres                  → Deploying version v-ffa064ad19... → Done (took 12.3 sec)
+✔ postgres                  → Deploying version v-ffa064ad19... → Done (took 13.2 sec)
 ℹ db-init
 ✔ db-init                   → Already run
 ℹ result                    → Deploying version v-609aa2f908...
@@ -98,10 +194,30 @@
 ℹ redis [verbose]           → [kubernetes-plugin]: Status of StatefulSet redis-replicas is "ready"
 ℹ redis [verbose]           → [kubernetes-plugin]: Resources ready
 ℹ redis                     → Resources ready
-✔ redis                     → Deploying version v-27093a1e1d... → Done (took 15 sec)
+✔ redis                     → Deploying version v-27093a1e1d... → Done (took 15.1 sec)
 ℹ api                       → Deploying version v-f5ada78d44...
+ℹ result [verbose]          → [helm]: Release "result" has been upgraded. Happy Helming!
+ℹ result [verbose]          → [helm]: NAME: result
+ℹ result [verbose]          → [helm]: LAST DEPLOYED: Wed Jan 25 11:14:57 2023
+ℹ result [verbose]          → [helm]: NAMESPACE: vote-helm-testing-steffen
+ℹ result [verbose]          → [helm]: STATUS: deployed
+ℹ result [verbose]          → [helm]: REVISION: 10
+ℹ result [verbose]          → [helm]: TEST SUITE: None
+ℹ result [verbose]          → [helm]: NOTES:
+ℹ result [verbose]          → [helm]: 1. Get the application URL by running these commands:
+ℹ result [verbose]          → [helm]:   http://result.vote-helm-testing-steffen.dev-1.sys.garden/
 ℹ result                    → Waiting for resources to be ready...
 ℹ result [verbose]          → [kubernetes-plugin]: Waiting for resources to be ready...
+ℹ api [verbose]             → [helm]: Release "api" has been upgraded. Happy Helming!
+ℹ api [verbose]             → [helm]: NAME: api
+ℹ api [verbose]             → [helm]: LAST DEPLOYED: Wed Jan 25 11:14:59 2023
+ℹ api [verbose]             → [helm]: NAMESPACE: vote-helm-testing-steffen
+ℹ api [verbose]             → [helm]: STATUS: deployed
+ℹ api [verbose]             → [helm]: REVISION: 10
+ℹ api [verbose]             → [helm]: TEST SUITE: None
+ℹ api [verbose]             → [helm]: NOTES:
+ℹ api [verbose]             → [helm]: 1. Get the application URL by running these commands:
+ℹ api [verbose]             → [helm]:   http://api.vote-helm-testing-steffen.dev-1.sys.garden/
 ℹ result [verbose]          → [kubernetes-plugin]: Status of Service result is "ready"
 ℹ result [verbose]          → [kubernetes-plugin]: Status of Deployment result is "ready"
 ℹ result [verbose]          → [kubernetes-plugin]: Status of Ingress result is "ready"
@@ -115,8 +231,18 @@
 ℹ api [verbose]             → [kubernetes-plugin]: Status of Ingress api is "ready"
 ℹ api [verbose]             → [kubernetes-plugin]: Resources ready
 ℹ api                       → Resources ready
-✔ api                       → Deploying version v-f5ada78d44... → Done (took 5.6 sec)
+✔ api                       → Deploying version v-f5ada78d44... → Done (took 5.5 sec)
 ℹ vote                      → Deploying version v-6d092509a8...
+ℹ vote [verbose]            → [helm]: Release "vote" has been upgraded. Happy Helming!
+ℹ vote [verbose]            → [helm]: NAME: vote
+ℹ vote [verbose]            → [helm]: LAST DEPLOYED: Wed Jan 25 11:15:05 2023
+ℹ vote [verbose]            → [helm]: NAMESPACE: vote-helm-testing-steffen
+ℹ vote [verbose]            → [helm]: STATUS: deployed
+ℹ vote [verbose]            → [helm]: REVISION: 10
+ℹ vote [verbose]            → [helm]: TEST SUITE: None
+ℹ vote [verbose]            → [helm]: NOTES:
+ℹ vote [verbose]            → [helm]: 1. Get the application URL by running these commands:
+ℹ vote [verbose]            → [helm]:   http://vote.vote-helm-testing-steffen.dev-1.sys.garden/
 ℹ vote                      → Waiting for resources to be ready...
 ℹ vote [verbose]            → [kubernetes-plugin]: Waiting for resources to be ready...
 ℹ vote [verbose]            → [kubernetes-plugin]: Status of Service vote is "ready"
@@ -124,6 +250,6 @@
 ℹ vote [verbose]            → [kubernetes-plugin]: Status of Ingress vote is "ready"
 ℹ vote [verbose]            → [kubernetes-plugin]: Resources ready
 ℹ vote                      → Resources ready
-✔ vote                      → Deploying version v-6d092509a8... → Done (took 5.8 sec)
+✔ vote                      → Deploying version v-6d092509a8... → Done (took 5.7 sec)

 Done! ✔️
```