### PR TITLE
fix(events): update log event timestamp type be string or number

### DIFF
--- a/core/src/events.ts
+++ b/core/src/events.ts
@@ -182,7 +182,22 @@ export interface Events extends LoggerEvents {
   }
   watchingForChanges: {}
   log: {
-    timestamp: number
+    /**
+     * Number of milliseconds since the epoch OR a date string.
+     *
+     * We need to allow both numberic and string types for backwards compatibility
+     * with Garden Cloud.
+     *
+     * Garden Cloud supports numeric date strings for log streaming as of v1.360.
+     * We can change this to just 'number' once all Cloud instances are up to date.
+     *
+     * Note that even though this has always been typed as a 'number' we've been
+     * attaching string timestamps to this payload because of missing types further
+     * up the pipe.
+     *
+     * TODO: Change to type 'number'.
+     */
+    timestamp: number | string
     actionUid: string
     entity: {
       moduleName: string

--- a/core/src/plugin-context.ts
+++ b/core/src/plugin-context.ts
@@ -106,8 +106,18 @@ export type PluginEventLogContext = {
 }
 
 export type PluginEventLogMessage = PluginEventLogContext & {
-  /** number of milliseconds since the epoch */
-  timestamp: number
+  /**
+   * Number of milliseconds since the epoch OR a date string.
+   *
+   * We need to allow both numberic and string types for backwards compatibility
+   * with Garden Cloud.
+   *
+   * Garden Cloud supports numeric date strings for log streaming as of v1.360.
+   * We can change this to just 'number' once all Cloud instances are up to date.
+   *
+   * TODO: Change to type 'number'.
+   */
+  timestamp: number | string
 
   /** log message */
   data: Buffer

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -799,7 +799,16 @@ export class PodRunner extends PodRunnerParams {
     void stream.forEach((entry) => {
       const { msg, timestamp } = entry
       events.emit("log", {
-        timestamp: timestamp?.getTime() || new Date().getTime(),
+        // This should be a numeric value (i.e. timestamp.getTime()) as opposed to a
+        // date string to be consistent with other event timestamps.
+        //
+        // However, due to missing types this has been a string value without us really noticing and
+        // and that's the shape Cloud expects. This was (rightly) changed to a numeric value with
+        // https://github.com/garden-io/garden/pull/3576 (b52e9b298f7c59b8210a77edc4c451301daa76e3)
+        // but we need to revert for Cloud backwards compatibility.
+        //
+        // TODO: Change to type number when all Cloud instance versions are >= v.1360.
+        timestamp: timestamp?.toISOString() || new Date().toISOString(),
         data: Buffer.from(msg),
         ...logEventContext,
       })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

This essentially reverts a change that was made in https://github.com/garden-io/garden/pull/3576
(commit: b52e9b298f7c59b8210a77edc4c451301daa76e3).

The type has always been 'number' but we were in fact sending strings to Garden Cloud which is the payload it expects.

Garden Cloud (version >= 1.360) now supports numbers but we need to continue sending strings for backwards compatibility.

We can tighten the type to just 'number' once all Cloud instances are up to date.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
