### PR TITLE
improvement(server): ensure serverReady event has correct type

### DIFF
--- a/core/src/events.ts
+++ b/core/src/events.ts
@@ -114,6 +114,7 @@ export interface Events extends LoggerEvents {
   serversUpdated: {
     servers: { host: string; command: string; serverAuthKey: string }[]
   }
+  serverReady: {}
   receivedToken: AuthTokenResponse
 
   // Session events - one of these is emitted when the command process ends

--- a/core/src/server/server.ts
+++ b/core/src/server/server.ts
@@ -363,7 +363,7 @@ export class GardenServer {
         return
       }
 
-      send("serverReady", { message: "Server ready" })
+      send("event", { name: "serverReady", payload: {} })
 
       // Set up heartbeat to detect dead connections
       let isAlive = true
@@ -546,9 +546,6 @@ interface ServerWebsocketMessages {
     requestId: string
     args: object
     opts: object
-  }
-  serverReady: {
-    message: string
   }
   error: {
     requestId?: string

--- a/core/test/unit/src/server/server.ts
+++ b/core/test/unit/src/server/server.ts
@@ -229,7 +229,7 @@ describe("GardenServer", () => {
         const parsed = JSON.parse(msg.toString())
         // This message is always sent at the beginning and we skip it here
         // to simplify testing.
-        if (parsed.type !== "serverReady") {
+        if (parsed.name !== "serverReady") {
           cb(parsed)
         }
       })
@@ -278,7 +278,7 @@ describe("GardenServer", () => {
 
         if (msgs.length === 2) {
           expect(msgs).to.eql([
-            { type: "serverReady", message: "Server ready" },
+            { type: "event", name: "serverReady", payload: {} },
             { type: "event", name: "_test", payload: "foo" },
           ])
           done()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

This event was introduced awhile ago but isn't used by any client at the moment.

It was made into its own event type by mistake, it should've just been a normal event with the name 'serverReady'. This fixes that.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
