### PR TITLE
refactor: remove unnecessary schema field definition

### DIFF
--- a/core/src/commands/run.ts
+++ b/core/src/commands/run.ts
@@ -103,10 +103,7 @@ export class RunCommand extends Command<Args, Opts> {
 
   private garden?: Garden
 
-  outputsSchema = () =>
-    processCommandResultSchema().keys({
-      graphResults: graphResultsSchema(),
-    })
+  outputsSchema = () => processCommandResultSchema()
 
   printHeader({ headerLog }: PrepareParams<Args, Opts>) {
     const msg = `Run`


### PR DESCRIPTION
Field `graphResults: graphResultsSchema()` is already defined in `processCommandResultSchema`.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
