### PR TITLE
chore(ci): rebuild circleci-runner node16 image to have gh cli

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ orbs:
       docker_layer_caching: true
 
   runner-image: &runner-image
-    image: gardendev/circleci-runner:16.18.0
+    image: gardendev/circleci-runner:16.18.0-1
 
   # Configuration for our node jobs
   node-config: &node-config

--- a/images/circleci-runner/garden.yml
+++ b/images/circleci-runner/garden.yml
@@ -2,5 +2,5 @@ kind: Module
 type: container
 name: circleci-runner
 description: Used for the core pipeline in CircleCI
-image: gardendev/circleci-runner:16.18.0
+image: gardendev/circleci-runner:16.18.0-1
 extraFlags: ["--platform", "linux/amd64"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

I rebuilt and published the circleci-runner image, to include the `gh` cli tool that was added to the Dockerfile since the previous build. I forgot to rebuild and push after merging a newer main where the `gh` changes were added.

Quick fix to the release steps of our CI pipeline.
https://app.circleci.com/pipelines/github/garden-io/garden/14560/workflows/35b906c2-6a29-461f-ba45-7965d5e8cd24/jobs/246450

**Special notes for your reviewer**:
