### PR TITLE
refactor: remove old `garden dev` command implementation

### DIFF
--- a/core/src/commands/dev.ts
+++ b/core/src/commands/dev.ts
@@ -6,298 +6,72 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import deline = require("deline")
-import dedent = require("dedent")
+import { CommandResult, CommandParams } from "./base"
+import { dedent } from "../util/string"
+import { ServeCommand, ServeCommandArgs, ServeCommandOpts } from "./serve"
 import chalk from "chalk"
-import { readFile } from "fs-extra"
-import moment = require("moment")
-import { join } from "path"
-
-import { getActionWatchTasks } from "../tasks/helpers"
-import { Command, CommandResult, CommandParams, handleProcessResults, PrepareParams } from "./base"
-import { STATIC_DIR } from "../constants"
-import { processActions } from "../process"
-import { TestTask } from "../tasks/test"
-import { ConfigGraph } from "../graph/config-graph"
-import { getMatchingServiceNames } from "./helpers"
-import { startServer } from "../server/server"
-import { DeployTask } from "../tasks/deploy"
-import { Garden } from "../garden"
-import { LogEntry } from "../logger/log-entry"
-import { BooleanParameter, StringsParameter } from "../cli/params"
 import { printHeader } from "../logger/util"
-import { DeployAction } from "../actions/deploy"
-import { Action } from "../actions/types"
-import { getNames } from "../util/util"
 
 // NOTE: This is all due to change in 0.13, just getting it to compile for now - JE
 
-const ansiBannerPath = join(STATIC_DIR, "garden-banner-2.txt")
-
-const devArgs = {
-  deploys: new StringsParameter({
-    help: `Specify which deploys to develop (defaults to all configured in project).`,
-  }),
-}
-
-const devOpts = {
-  "force": new BooleanParameter({ help: "Force re-deploy of deploy(s)/service(s)." }),
-  "local-mode": new StringsParameter({
-    help: deline`
-    [EXPERIMENTAL] The name(s) of deploy action(s) to be started locally with local mode enabled.
-
-    Use comma as a separator to specify multiple actions. Use * to deploy all compatible actions with local mode enabled. When this option is used, the command is run in persistent mode.
-
-    This always takes the precedence over the dev mode if there are any conflicts, i.e. if the same services are passed to both \`--dev\` and \`--local\` options.
-    `,
-    alias: "local",
-  }),
-  "skip-tests": new BooleanParameter({
-    help: "Disable running the tests.",
-  }),
-  "test-names": new StringsParameter({
-    help:
-      "Filter the tests to run by test name across all modules (leave unset to run all tests). " +
-      "Accepts glob patterns (e.g. integ* would run both 'integ' and 'integration').",
-    alias: "tn",
-  }),
-}
-
-export type DevCommandArgs = typeof devArgs
-export type DevCommandOpts = typeof devOpts
+// const ansiBannerPath = join(STATIC_DIR, "garden-banner-2.txt")
 
 // TODO: allow limiting to certain modules and/or services
-export class DevCommand extends Command<DevCommandArgs, DevCommandOpts> {
+export class DevCommand extends ServeCommand {
   name = "dev"
-  help = "Starts the garden development console."
+  help = "Starts the Garden interactive development environment."
   protected = true
-
-  // Currently it doesn't make sense to do file watching except in the CLI
-  cliOnly = true
-
-  streamEvents = true
+  hidden = true
 
   description = dedent`
-    The Garden dev console is a combination of the \`build\`, \`deploy\` and \`test\` commands.
-    It builds, deploys and tests everything in your project, and re-builds, re-deploys and re-tests
-    as you modify the code.
+    [UNDER CONSTRUCTION]
 
-    Examples:
-
-        garden dev
-        garden dev --local=service-1,service-2    # enable local mode for service-1 and service-2
-        garden dev --local=*                      # enable local mode for all compatible deploys
-        garden dev --skip-tests                   # skip running any tests
-        garden dev --force                        # force redeploy of services when the command starts
-        garden dev --name integ                   # run all tests with the name 'integ' in the project
-        garden test --name integ*                 # run all tests with the name starting with 'integ' in the project
+    This command is due to be replaced. Please use \`garden deploy --dev\` instead for now.
   `
-
-  arguments = devArgs
-  options = devOpts
-
-  private garden?: Garden
 
   printHeader({ headerLog }) {
     printHeader(headerLog, "Dev", "keyboard")
   }
 
-  isPersistent() {
-    return true
-  }
+  // async prepare({ headerLog, footerLog }: PrepareParams<DevCommandArgs, DevCommandOpts>) {
+  //   // print ANSI banner image
+  //   if (chalk.supportsColor && chalk.supportsColor.level > 2) {
+  //     const data = await readFile(ansiBannerPath)
+  //     headerLog.info(data.toString())
+  //   }
 
-  async prepare({ headerLog, footerLog }: PrepareParams<DevCommandArgs, DevCommandOpts>) {
-    // print ANSI banner image
-    if (chalk.supportsColor && chalk.supportsColor.level > 2) {
-      const data = await readFile(ansiBannerPath)
-      headerLog.info(data.toString())
-    }
+  //   headerLog.info(chalk.gray.italic(`Good ${getGreetingTime()}! Let's get your environment wired up...`))
+  //   headerLog.info("")
 
-    headerLog.info(chalk.gray.italic(`Good ${getGreetingTime()}! Let's get your environment wired up...`))
-    headerLog.info("")
+  //   this.server = await startServer({ log: footerLog })
+  // }
 
-    this.server = await startServer({ log: footerLog })
-  }
+  async action(params: CommandParams<ServeCommandArgs, ServeCommandOpts>): Promise<CommandResult> {
+    params.log.warn({
+      msg:
+        chalk.bold(dedent`
+          🚧  This command is ${chalk.yellow.bold("under construction")}  🚧
 
-  terminate() {
-    this.garden?.events.emit("_exit", {})
-  }
+          As part of broader changes in Garden 0.13, the garden dev command is being replaced with a new interactive command. For now, this command only works in conjunction with the new Garden dashboard.
 
-  async action({
-    garden,
-    log,
-    footerLog,
-    args,
-    opts,
-  }: CommandParams<DevCommandArgs, DevCommandOpts>): Promise<CommandResult> {
-    this.garden = garden
-    this.server?.setGarden(garden)
-
-    const graph = await garden.getConfigGraph({ log, emit: true })
-    const actions = graph.getActions()
-
-    const skipTests = opts["skip-tests"]
-    const testNames = opts["test-names"]
-
-    if (actions.length === 0) {
-      footerLog && footerLog.setState({ msg: "" })
-      log.info({ msg: "No enabled actions found in project." })
-      log.info({ msg: "Aborting..." })
-      return {}
-    }
-
-    const deploys = graph.getDeploys({ names: args.deploys })
-
-    const localModeDeployNames = getMatchingServiceNames(opts["local-mode"], graph)
-
-    const devModeDeployNames = deploys
-      .map((s) => s.name)
-      // Since dev mode is implicit when using this command, we consider explicitly enabling local mode to
-      // take precedence over dev mode.
-      .filter((name) => !localModeDeployNames.includes(name))
-
-    const initialTasks = await getDevCommandInitialTasks({
-      garden,
-      log,
-      graph,
-      deploys,
-      devModeDeployNames,
-      localModeDeployNames,
-      skipTests,
-      testNames,
-      forceDeploy: opts.force,
+          Meanwhile, you likely want to use ${chalk.underline("garden deploy --dev")} to deploy services in dev mode.
+        `) + "\n",
     })
 
-    const results = await processActions({
-      garden,
-      graph,
-      log,
-      footerLog,
-      actions,
-      watch: true,
-      initialTasks,
-      skipWatch: [], // TODO-G2: need to work out what to ignore, but here we don't know what's actually in dev mode
-      changeHandler: async (updatedGraph: ConfigGraph, action: Action) => {
-        return getDevCommandWatchTasks({
-          garden,
-          log,
-          updatedGraph,
-          updatedAction: action,
-          devModeDeployNames,
-          localModeDeployNames,
-          testNames,
-          skipTests,
-        })
-      },
-    })
-
-    return handleProcessResults(footerLog, "dev", results)
+    return super.action(params)
   }
 }
 
-export async function getDevCommandInitialTasks({
-  garden,
-  log,
-  graph,
-  deploys,
-  devModeDeployNames,
-  localModeDeployNames,
-  skipTests,
-  testNames,
-  forceDeploy,
-}: {
-  garden: Garden
-  log: LogEntry
-  graph: ConfigGraph
-  deploys: DeployAction[]
-  devModeDeployNames: string[]
-  localModeDeployNames: string[]
-  skipTests: boolean
-  testNames?: string[]
-  forceDeploy: boolean
-}) {
-  const testTasks = skipTests
-    ? []
-    : graph.getTests({ names: testNames }).map(
-        (action) =>
-          new TestTask({
-            garden,
-            log,
-            graph,
-            action,
-            force: false,
-            forceActions: [],
-            fromWatch: false,
-            devModeDeployNames,
-            localModeDeployNames,
-          })
-      )
+// function getGreetingTime() {
+//   const m = moment()
 
-  const deployTasks = deploys
-    .filter((s) => !s.isDisabled())
-    .map(
-      (action) =>
-        new DeployTask({
-          garden,
-          log,
-          graph,
-          action,
-          force: forceDeploy,
-          forceActions: [],
-          fromWatch: false,
-          devModeDeployNames,
-          localModeDeployNames,
-        })
-    )
+//   const currentHour = parseFloat(m.format("HH"))
 
-  return [...testTasks, ...deployTasks]
-}
-
-export async function getDevCommandWatchTasks({
-  garden,
-  log,
-  updatedGraph,
-  updatedAction,
-  devModeDeployNames,
-  localModeDeployNames,
-  testNames,
-  skipTests,
-}: {
-  garden: Garden
-  log: LogEntry
-  updatedGraph: ConfigGraph
-  updatedAction: Action
-  devModeDeployNames: string[]
-  localModeDeployNames: string[]
-  testNames: string[] | undefined
-  skipTests: boolean
-}) {
-  const testsWatched = skipTests ? [] : testNames || getNames(updatedGraph.getTests())
-
-  const tasks = await getActionWatchTasks({
-    garden,
-    log,
-    graph: updatedGraph,
-    updatedAction,
-    deploysWatched: devModeDeployNames,
-    devModeDeployNames,
-    localModeDeployNames,
-    testsWatched,
-  })
-
-  return tasks
-}
-
-function getGreetingTime() {
-  const m = moment()
-
-  const currentHour = parseFloat(m.format("HH"))
-
-  if (currentHour >= 17) {
-    return "evening"
-  } else if (currentHour >= 12) {
-    return "afternoon"
-  } else {
-    return "morning"
-  }
-}
+//   if (currentHour >= 17) {
+//     return "evening"
+//   } else if (currentHour >= 12) {
+//     return "afternoon"
+//   } else {
+//     return "morning"
+//   }
+// }

--- a/core/src/commands/serve.ts
+++ b/core/src/commands/serve.ts
@@ -27,10 +27,10 @@ const serveOpts = {
   }),
 }
 
-type Args = typeof serveArgs
-type Opts = typeof serveOpts
+export type ServeCommandArgs = typeof serveArgs
+export type ServeCommandOpts = typeof serveOpts
 
-export class ServeCommand extends Command<Args, Opts> {
+export class ServeCommand extends Command<ServeCommandArgs, ServeCommandOpts> {
   name = "serve"
   aliases = ["dashboard"]
   help = "Starts the Garden Core API server for the current project and environment."
@@ -61,7 +61,7 @@ export class ServeCommand extends Command<Args, Opts> {
     return true
   }
 
-  async prepare({ log, footerLog, opts }: PrepareParams<Args, Opts>) {
+  async prepare({ log, footerLog, opts }: PrepareParams<ServeCommandArgs, ServeCommandOpts>) {
     this.server = await startServer({ log: footerLog, port: opts.port })
 
     // Print nicer error message when address is not available
@@ -80,7 +80,11 @@ export class ServeCommand extends Command<Args, Opts> {
     })
   }
 
-  async action({ garden, log, footerLog }: CommandParams<Args, Opts>): Promise<CommandResult<{}>> {
+  async action({
+    garden,
+    log,
+    footerLog,
+  }: CommandParams<ServeCommandArgs, ServeCommandOpts>): Promise<CommandResult<{}>> {
     log.info(
       chalk.gray(
         `Connected to environment ${chalk.white.bold(garden.namespace)}.${chalk.white.bold(garden.environmentName)}`

--- a/core/src/config/project.ts
+++ b/core/src/config/project.ts
@@ -351,20 +351,20 @@ export const projectSchema = () =>
       "Configuration for a Garden project. This should be specified in the garden.yml file in your project root."
     )
 
-export function getDefaultEnvironmentName(defaultEnvironment: string, config: ProjectConfig): string {
+export function getDefaultEnvironmentName(defaultName: string, config: ProjectConfig): string {
   const environments = config.environments
 
   // the default environment is the first specified environment in the config, unless specified
-  if (!defaultEnvironment) {
+  if (!defaultName) {
     return environments[0].name
   } else {
-    if (!findByName(environments, defaultEnvironment)) {
-      throw new ConfigurationError(`The specified default environment ${defaultEnvironment} is not defined`, {
-        defaultEnvironment,
+    if (!findByName(environments, defaultName)) {
+      throw new ConfigurationError(`The specified default environment ${defaultName} is not defined`, {
+        defaultEnvironment: defaultName,
         availableEnvironments: getNames(environments),
       })
     }
-    return defaultEnvironment
+    return defaultName
   }
 }
 
@@ -376,7 +376,7 @@ export function getDefaultEnvironmentName(defaultEnvironment: string, config: Pr
  * @param config raw project configuration
  */
 export function resolveProjectConfig({
-  defaultEnvironment,
+  defaultName,
   config,
   artifactsPath,
   vcsInfo,
@@ -386,7 +386,7 @@ export function resolveProjectConfig({
   secrets,
   commandInfo,
 }: {
-  defaultEnvironment: string
+  defaultName: string
   config: ProjectConfig
   artifactsPath: string
   vcsInfo: VcsInfo
@@ -426,7 +426,7 @@ export function resolveProjectConfig({
       ...config,
       ...globalConfig,
       name,
-      defaultEnvironment,
+      defaultEnvironment: defaultName,
       // environments are validated later
       environments: [{ defaultNamespace: null, name: "fake-env-only-here-for-inital-load", variables: {} }],
       sources: [],
@@ -449,7 +449,7 @@ export function resolveProjectConfig({
     sources,
   }
 
-  config.defaultEnvironment = getDefaultEnvironmentName(defaultEnvironment, config)
+  config.defaultEnvironment = getDefaultEnvironmentName(defaultName, config)
 
   return config
 }

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -1561,7 +1561,7 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
   const loggedIn = !!cloudApi
 
   config = resolveProjectConfig({
-    defaultEnvironment: defaultEnvironmentName,
+    defaultName: defaultEnvironmentName,
     config,
     artifactsPath,
     vcsInfo,

--- a/core/test/unit/src/commands/dev.ts
+++ b/core/test/unit/src/commands/dev.ts
@@ -6,286 +6,61 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import pEvent from "p-event"
 import { expect } from "chai"
-import { DevCommand, DevCommandArgs, DevCommandOpts, getDevCommandWatchTasks } from "../../../../src/commands/dev"
-import { makeTestGardenA, withDefaultGlobalOpts, TestGarden } from "../../../helpers"
-import { GlobalOptions, ParameterValues } from "../../../../src/cli/params"
+import { DevCommand } from "../../../../src/commands/dev"
 
 // TODO-G2: rename test cases to match the new graph model semantics
 describe("DevCommand", () => {
   const command = new DevCommand()
 
-  async function waitForEvent(garden: TestGarden, name: string) {
-    return pEvent(<any>garden.events, name, { timeout: 10000 })
-  }
+  // async function waitForEvent(garden: TestGarden, name: string) {
+  //   return pEvent(<any>garden.events, name, { timeout: 10000 })
+  // }
 
-  async function completeFirstTasks(
-    garden: TestGarden,
-    args: ParameterValues<DevCommandArgs>,
-    opts: ParameterValues<GlobalOptions & DevCommandOpts>
-  ) {
-    const log = garden.log
+  // async function completeFirstTasks(
+  //   garden: TestGarden,
+  //   args: ParameterValues<DevCommandArgs>,
+  //   opts: ParameterValues<GlobalOptions & DevCommandOpts>
+  // ) {
+  //   const log = garden.log
 
-    await command.prepare({ log, footerLog: log, headerLog: log, args, opts })
+  //   await command.prepare({ log, footerLog: log, headerLog: log, args, opts })
 
-    const promise = command
-      .action({
-        garden,
-        log,
-        headerLog: log,
-        footerLog: log,
-        args,
-        opts,
-      })
-      .then(({ errors }) => {
-        if (errors) {
-          throw errors[0]
-        }
-      })
-      .catch((err) => {
-        // tslint:disable-next-line: no-console
-        console.error(err)
-      })
+  //   const promise = command
+  //     .action({
+  //       garden,
+  //       log,
+  //       headerLog: log,
+  //       footerLog: log,
+  //       args,
+  //       opts,
+  //     })
+  //     .then(({ errors }) => {
+  //       if (errors) {
+  //         throw errors[0]
+  //       }
+  //     })
+  //     .catch((err) => {
+  //       // tslint:disable-next-line: no-console
+  //       console.error(err)
+  //     })
 
-    await waitForEvent(garden, "watchingForChanges")
+  //   await waitForEvent(garden, "watchingForChanges")
 
-    garden.events.emit("_exit", {})
+  //   garden.events.emit("_exit", {})
 
-    const completedTasks = garden.events.eventLog
-      .filter((e) => e.name === "taskComplete")
-      .map((e) => e.payload["key"])
-      .filter((key) => !key.startsWith("resolve-module."))
-      .sort()
+  //   const completedTasks = garden.events.eventLog
+  //     .filter((e) => e.name === "taskComplete")
+  //     .map((e) => e.payload["key"])
+  //     .filter((key) => !key.startsWith("resolve-module."))
+  //     .sort()
 
-    return { promise, completedTasks }
-  }
+  //   return { promise, completedTasks }
+  // }
 
   it("should be protected", async () => {
     expect(command.protected).to.be.true
   })
 
-  it("should deploy, run and test everything in a project", async () => {
-    const garden = await makeTestGardenA()
-
-    const args = { deploys: undefined }
-    const opts = withDefaultGlobalOpts({
-      "force-build": false,
-      "force": false,
-
-      "local-mode": undefined,
-      "skip-tests": false,
-      "test-names": undefined,
-    })
-
-    const { promise, completedTasks } = await completeFirstTasks(garden, args, opts)
-
-    expect(completedTasks).to.eql([
-      "build.module-a",
-      "build.module-b",
-      "build.module-c",
-      "deploy.service-a",
-      "deploy.service-b",
-      "deploy.service-c",
-      "get-service-status.service-a",
-      "get-service-status.service-b",
-      "get-service-status.service-c",
-      "get-task-result.task-c",
-      "resolve-provider.container",
-      "resolve-provider.exec",
-      "resolve-provider.templated",
-      "resolve-provider.test-plugin",
-      "resolve-provider.test-plugin-b",
-
-      "task.task-c",
-      "test.module-a.integration",
-      "test.module-a.unit",
-      "test.module-b.unit",
-      "test.module-c.integ",
-      "test.module-c.unit",
-    ])
-
-    return promise
-  })
-
-  it("should skip disabled services", async () => {
-    const garden = await makeTestGardenA()
-
-    await garden.scanAndAddConfigs()
-    garden["moduleConfigs"]["module-c"].spec.services[0].disabled = true
-
-    const args = { deploys: undefined }
-    const opts = withDefaultGlobalOpts({
-      "force-build": false,
-      "force": false,
-
-      "local-mode": undefined,
-      "skip-tests": false,
-      "test-names": undefined,
-    })
-
-    const { promise, completedTasks } = await completeFirstTasks(garden, args, opts)
-
-    expect(completedTasks).to.not.include("deploy.service-c")
-
-    return promise
-  })
-
-  it("should skip disabled tasks", async () => {
-    const garden = await makeTestGardenA()
-
-    await garden.scanAndAddConfigs()
-    garden["moduleConfigs"]["module-c"].spec.tasks[0].disabled = true
-
-    const args = { deploys: undefined }
-    const opts = withDefaultGlobalOpts({
-      "force-build": false,
-      "force": false,
-
-      "local-mode": undefined,
-      "skip-tests": false,
-      "test-names": undefined,
-    })
-
-    const { promise, completedTasks } = await completeFirstTasks(garden, args, opts)
-
-    expect(completedTasks).to.not.include("task.task-c")
-
-    return promise
-  })
-
-  it("should skip disabled tests", async () => {
-    const garden = await makeTestGardenA()
-
-    await garden.scanAndAddConfigs()
-    garden["moduleConfigs"]["module-b"].spec.tests[0].disabled = true
-
-    const args = { deploys: undefined }
-    const opts = withDefaultGlobalOpts({
-      "force-build": false,
-      "force": false,
-
-      "local-mode": undefined,
-      "skip-tests": false,
-      "test-names": undefined,
-    })
-
-    const { promise, completedTasks } = await completeFirstTasks(garden, args, opts)
-
-    expect(completedTasks).to.not.include("test.module-b.unit")
-
-    return promise
-  })
-
-  it("should skip services from disabled modules", async () => {
-    const garden = await makeTestGardenA()
-
-    await garden.scanAndAddConfigs()
-    garden["moduleConfigs"]["module-c"].disabled = true
-
-    const args = { deploys: undefined }
-    const opts = withDefaultGlobalOpts({
-      "force-build": false,
-      "force": false,
-
-      "local-mode": undefined,
-      "skip-tests": false,
-      "test-names": undefined,
-    })
-
-    const { promise, completedTasks } = await completeFirstTasks(garden, args, opts)
-
-    expect(completedTasks).to.not.include("deploy.service-c")
-
-    return promise
-  })
-
-  it("should skip tasks from disabled modules", async () => {
-    const garden = await makeTestGardenA()
-
-    await garden.scanAndAddConfigs()
-    garden["moduleConfigs"]["module-c"].disabled = true
-
-    const args = { deploys: undefined }
-    const opts = withDefaultGlobalOpts({
-      "force-build": false,
-      "force": false,
-
-      "local-mode": undefined,
-      "skip-tests": false,
-      "test-names": undefined,
-    })
-
-    const { promise, completedTasks } = await completeFirstTasks(garden, args, opts)
-
-    expect(completedTasks).to.not.include("task.task-c")
-
-    return promise
-  })
-
-  it("should skip tests from disabled modules", async () => {
-    const garden = await makeTestGardenA()
-
-    await garden.scanAndAddConfigs()
-    garden["moduleConfigs"]["module-c"].disabled = true
-
-    const args = { deploys: undefined }
-    const opts = withDefaultGlobalOpts({
-      "force-build": false,
-      "force": false,
-
-      "local-mode": undefined,
-      "skip-tests": false,
-      "test-names": undefined,
-    })
-
-    const { promise, completedTasks } = await completeFirstTasks(garden, args, opts)
-
-    expect(completedTasks).to.not.include("test.module-c.unit")
-    expect(completedTasks).to.not.include("test.module-c.integ")
-
-    return promise
-  })
-})
-
-describe("getDevCommandWatchTasks", () => {
-  it("should deploy, run and test appropriately on watch change", async () => {
-    const garden = await makeTestGardenA()
-    const log = garden.log
-    const graph = await garden.getConfigGraph({ log, emit: false })
-
-    // TODO-G2: fix the semantics of the test
-    const deployAction = graph.getDeploy("deploy.module-b.service-b")
-    const watchTasks = await getDevCommandWatchTasks({
-      garden,
-      log,
-      updatedGraph: graph,
-      updatedAction: deployAction,
-      // module: graph.getModule("module-b"),
-      //servicesWatched: graph.getDeploys().map((s) => s.name),
-      devModeDeployNames: [],
-      localModeDeployNames: [],
-      testNames: undefined,
-      skipTests: false,
-    })
-
-    const results = await garden.processTasks({ log, tasks: watchTasks })
-    expect(Object.keys(results).sort()).to.eql([
-      "build.module-a",
-      "build.module-b",
-      "build.module-c",
-      "deploy.service-a",
-      "deploy.service-b",
-      "deploy.service-c",
-      "get-service-status.service-a",
-      "get-service-status.service-b",
-      "get-service-status.service-c",
-      "get-task-result.task-c",
-
-      "task.task-c",
-      "test.module-b.unit",
-      "test.module-c.integ",
-      "test.module-c.unit",
-    ])
-  })
+  // TODO-G2
 })

--- a/core/test/unit/src/config/project.ts
+++ b/core/test/unit/src/config/project.ts
@@ -46,7 +46,7 @@ describe("resolveProjectConfig", () => {
 
     expect(
       resolveProjectConfig({
-        defaultEnvironment: "default",
+        defaultName: "default",
         config,
         artifactsPath: "/tmp",
         vcsInfo,
@@ -106,7 +106,7 @@ describe("resolveProjectConfig", () => {
 
     expect(
       resolveProjectConfig({
-        defaultEnvironment,
+        defaultName: defaultEnvironment,
         config,
         artifactsPath: "/tmp",
         vcsInfo,
@@ -179,7 +179,7 @@ describe("resolveProjectConfig", () => {
 
     expect(
       resolveProjectConfig({
-        defaultEnvironment,
+        defaultName: defaultEnvironment,
         config,
         artifactsPath: "/tmp",
         vcsInfo,
@@ -239,7 +239,7 @@ describe("resolveProjectConfig", () => {
     })
 
     const result = resolveProjectConfig({
-      defaultEnvironment,
+      defaultName: defaultEnvironment,
       config,
       artifactsPath: "/tmp",
       vcsInfo,
@@ -271,7 +271,7 @@ describe("resolveProjectConfig", () => {
 
     expect(
       resolveProjectConfig({
-        defaultEnvironment,
+        defaultName: defaultEnvironment,
         config,
         artifactsPath: "/tmp",
         vcsInfo,
@@ -306,11 +306,11 @@ describe("resolveProjectConfig", () => {
   })
 
   it("should set defaultEnvironment to first environment if not configured", async () => {
-    const defaultEnvironment = ""
+    const defaultName = ""
     const config: ProjectConfig = createProjectConfig({
       name: "my-project",
       path: "/tmp/foo",
-      defaultEnvironment,
+      defaultEnvironment: defaultName,
       environments: [{ defaultNamespace: null, name: "first-env", variables: {} }],
       outputs: [],
       providers: [{ name: "some-provider", dependencies: [] }],
@@ -319,7 +319,7 @@ describe("resolveProjectConfig", () => {
 
     expect(
       resolveProjectConfig({
-        defaultEnvironment,
+        defaultName,
         config,
         artifactsPath: "/tmp",
         vcsInfo,
@@ -340,11 +340,11 @@ describe("resolveProjectConfig", () => {
   })
 
   it("should populate default values in the schema", async () => {
-    const defaultEnvironment = ""
+    const defaultName = ""
     const config: ProjectConfig = createProjectConfig({
       name: "my-project",
       path: "/tmp/foo",
-      defaultEnvironment,
+      defaultEnvironment: defaultName,
       environments: [{ defaultNamespace: null, name: "default", variables: {} }],
       outputs: [],
       providers: [{ name: "some-provider", dependencies: [] }],
@@ -353,7 +353,7 @@ describe("resolveProjectConfig", () => {
 
     expect(
       resolveProjectConfig({
-        defaultEnvironment,
+        defaultName,
         config,
         artifactsPath: "/tmp",
         vcsInfo,
@@ -404,7 +404,7 @@ describe("resolveProjectConfig", () => {
 
     expect(
       resolveProjectConfig({
-        defaultEnvironment,
+        defaultName: defaultEnvironment,
         config,
         artifactsPath: "/tmp",
         vcsInfo,

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -507,46 +507,6 @@ success:
 graphResults:
 ```
 
-### garden dev
-
-**Starts the garden development console.**
-
-The Garden dev console is a combination of the `build`, `deploy` and `test` commands.
-It builds, deploys and tests everything in your project, and re-builds, re-deploys and re-tests
-as you modify the code.
-
-Examples:
-
-    garden dev
-    garden dev --local=service-1,service-2    # enable local mode for service-1 and service-2
-    garden dev --local=*                      # enable local mode for all compatible deploys
-    garden dev --skip-tests                   # skip running any tests
-    garden dev --force                        # force redeploy of services when the command starts
-    garden dev --name integ                   # run all tests with the name 'integ' in the project
-    garden test --name integ*                 # run all tests with the name starting with 'integ' in the project
-
-#### Usage
-
-    garden dev [deploys] [options]
-
-#### Arguments
-
-| Argument | Required | Description |
-| -------- | -------- | ----------- |
-  | `deploys` | No | Specify which deploys to develop (defaults to all configured in project).
-
-#### Options
-
-| Argument | Alias | Type | Description |
-| -------- | ----- | ---- | ----------- |
-  | `--force` |  | boolean | Force re-deploy of deploy(s)/service(s).
-  | `--local-mode` | `--local` | array:string | [EXPERIMENTAL] The name(s) of deploy action(s) to be started locally with local mode enabled.
-Use comma as a separator to specify multiple actions. Use * to deploy all compatible actions with local mode enabled. When this option is used, the command is run in persistent mode.
-This always takes the precedence over the dev mode if there are any conflicts, i.e. if the same services are passed to both &#x60;--dev&#x60; and &#x60;--local&#x60; options.
-  | `--skip-tests` |  | boolean | Disable running the tests.
-  | `--test-names` | `--tn` | array:string | Filter the tests to run by test name across all modules (leave unset to run all tests). Accepts glob patterns (e.g. integ* would run both &#x27;integ&#x27; and &#x27;integration&#x27;).
-
-
 ### garden exec
 
 **Executes a command (such as an interactive shell) in a running service.**


### PR DESCRIPTION
For now, the `dev` command implementation is basically that of the `serve` command, with an added "under construction" message to steer users to the `deploy --dev` command.

Later we will add interactivity on top, hopefully before the 0.13 GA.

BREAKING CHANGE:

The behavior of the `garden dev` command is being fully replaced. It will no longer automatically perform all tests and deployments, but instead connect to the new dashboard, and later feature a command input in the terminal.
