### PR TITLE
test: implement missing unit tests for `getAction(s)ByKind`

### DIFF
--- a/core/test/unit/src/config-graph.ts
+++ b/core/test/unit/src/config-graph.ts
@@ -195,6 +195,12 @@ describe("ConfigGraph (action-based configs)", () => {
         expect(spec2.buildCommand).to.eql(["echo", "build-2", "ok"])
       })
 
+      it("should optionally return specified Build actions in the context", async () => {
+        const buildActions = configGraph.getBuilds({ names: ["build-1", "build-2"] })
+
+        expect(getNames(buildActions).sort()).to.eql(["build-1", "build-2"])
+      })
+
       it("should throw if named Build action is missing", async () => {
         try {
           configGraph.getBuilds({ names: ["missing-build"] })
@@ -241,6 +247,12 @@ describe("ConfigGraph (action-based configs)", () => {
 
         const spec2 = deployActions[1].getConfig("spec")
         expect(spec2.deployCommand).to.eql(["echo", "deploy-2", "ok"])
+      })
+
+      it("should optionally return specified Deploy actions in the context", async () => {
+        const deployActions = configGraph.getDeploys({ names: ["deploy-1", "deploy-2"] })
+
+        expect(getNames(deployActions).sort()).to.eql(["deploy-1", "deploy-2"])
       })
 
       it("should throw if named Deploy action is missing", async () => {
@@ -291,6 +303,12 @@ describe("ConfigGraph (action-based configs)", () => {
         expect(spec2.runCommand).to.eql(["echo", "run-2", "ok"])
       })
 
+      it("should optionally return specified Run actions in the context", async () => {
+        const runActions = configGraph.getRuns({ names: ["run-1", "run-2"] })
+
+        expect(getNames(runActions).sort()).to.eql(["run-1", "run-2"])
+      })
+
       it("should throw if named Run action is missing", async () => {
         try {
           configGraph.getRuns({ names: ["missing-run"] })
@@ -337,6 +355,12 @@ describe("ConfigGraph (action-based configs)", () => {
 
         const spec2 = testActions[1].getConfig("spec")
         expect(spec2.testCommand).to.eql(["echo", "test-2", "ok"])
+      })
+
+      it("should optionally return specified Test actions in the context", async () => {
+        const testActions = configGraph.getTests({ names: ["test-1", "test-2"] })
+
+        expect(getNames(testActions).sort()).to.eql(["test-1", "test-2"])
       })
 
       it("should throw if named Test action is missing", async () => {

--- a/core/test/unit/src/config-graph.ts
+++ b/core/test/unit/src/config-graph.ts
@@ -240,6 +240,17 @@ describe("ConfigGraph", () => {
           const spec2 = buildActions[1].getConfig("spec")
           expect(spec2.buildCommand).to.eql(["echo", "build-2", "ok"])
         })
+
+        it("should throw if named Build action is missing", async () => {
+          try {
+            configGraph.getBuilds({ names: ["missing-build"] })
+          } catch (err) {
+            expect(err.type).to.equal("graph")
+            return
+          }
+
+          throw new Error("Expected error")
+        })
       })
 
       describe("getDeploys", () => {
@@ -253,6 +264,17 @@ describe("ConfigGraph", () => {
 
           const spec2 = deployActions[1].getConfig("spec")
           expect(spec2.deployCommand).to.eql(["echo", "deploy-2", "ok"])
+        })
+
+        it("should throw if named Deploy action is missing", async () => {
+          try {
+            configGraph.getDeploys({ names: ["missing-deploy"] })
+          } catch (err) {
+            expect(err.type).to.equal("graph")
+            return
+          }
+
+          throw new Error("Expected error")
         })
       })
 
@@ -268,6 +290,17 @@ describe("ConfigGraph", () => {
           const spec2 = runActions[1].getConfig("spec")
           expect(spec2.runCommand).to.eql(["echo", "run-2", "ok"])
         })
+
+        it("should throw if named Run action is missing", async () => {
+          try {
+            configGraph.getRuns({ names: ["missing-run"] })
+          } catch (err) {
+            expect(err.type).to.equal("graph")
+            return
+          }
+
+          throw new Error("Expected error")
+        })
       })
 
       describe("getTests", () => {
@@ -282,6 +315,17 @@ describe("ConfigGraph", () => {
           const spec2 = testActions[1].getConfig("spec")
           expect(spec2.testCommand).to.eql(["echo", "test-2", "ok"])
         })
+
+        it("should throw if named Test action is missing", async () => {
+          try {
+            configGraph.getTests({ names: ["missing-test"] })
+          } catch (err) {
+            expect(err.type).to.equal("graph")
+            return
+          }
+
+          throw new Error("Expected error")
+        })
       })
     })
 
@@ -295,6 +339,17 @@ describe("ConfigGraph", () => {
           const spec = buildAction.getConfig("spec")
           expect(spec.buildCommand).to.eql(["echo", "build-1", "ok"])
         })
+
+        it("should throw if Build action is missing", async () => {
+          try {
+            configGraph.getBuild("missing-build")
+          } catch (err) {
+            expect(err.type).to.equal("graph")
+            return
+          }
+
+          throw new Error("Expected error")
+        })
       })
 
       describe("getDeploy", () => {
@@ -305,6 +360,17 @@ describe("ConfigGraph", () => {
 
           const spec = deployAction.getConfig("spec")
           expect(spec.deployCommand).to.eql(["echo", "deploy-1", "ok"])
+        })
+
+        it("should throw if Deploy action is missing", async () => {
+          try {
+            configGraph.getDeploy("missing-deploy")
+          } catch (err) {
+            expect(err.type).to.equal("graph")
+            return
+          }
+
+          throw new Error("Expected error")
         })
       })
 
@@ -317,6 +383,17 @@ describe("ConfigGraph", () => {
           const spec = runAction.getConfig("spec")
           expect(spec.runCommand).to.eql(["echo", "run-1", "ok"])
         })
+
+        it("should throw if Run action is missing", async () => {
+          try {
+            configGraph.getRun("missing-run")
+          } catch (err) {
+            expect(err.type).to.equal("graph")
+            return
+          }
+
+          throw new Error("Expected error")
+        })
       })
 
       describe("getTest", () => {
@@ -327,6 +404,17 @@ describe("ConfigGraph", () => {
 
           const spec = testAction.getConfig("spec")
           expect(spec.testCommand).to.eql(["echo", "test-1", "ok"])
+        })
+
+        it("should throw if Test action is missing", async () => {
+          try {
+            configGraph.getTest("missing-test")
+          } catch (err) {
+            expect(err.type).to.equal("graph")
+            return
+          }
+
+          throw new Error("Expected error")
         })
       })
     })

--- a/core/test/unit/src/config-graph.ts
+++ b/core/test/unit/src/config-graph.ts
@@ -64,7 +64,11 @@ async function makeGarden(tmpDir: tmp.DirectoryResult, plugin: GardenPlugin) {
   return garden
 }
 
-// TODO-G2: implement the test cases similar to the existing module-based getBuild(s)/getDeploys/getRun(s)/getTest(s)
+/**
+ * TODO-G2B:
+ *  - implement the remained test cases similar to the existing module-based (getDependants* and getDependencies)
+ *  - consider using template helper functions or parameteric tests for the similar Build/Deploy/Run/Test spec
+ */
 describe("ConfigGraph (action-based configs)", () => {
   let tmpDir: tmp.DirectoryResult
   let garden: TestGarden

--- a/core/test/unit/src/config-graph.ts
+++ b/core/test/unit/src/config-graph.ts
@@ -113,7 +113,7 @@ describe("ConfigGraph (action-based configs)", () => {
   // Helpers to create minimalistic action configs.
   // Each action type has its own simple spec with a single field named `${lowercase(kind)}Command`.
 
-  const makeBuild = (name: string) =>
+  const _makeBuild = (name: string, disabled: boolean) =>
     makeAction({
       basePath: tmpDir.path,
       name,
@@ -121,10 +121,12 @@ describe("ConfigGraph (action-based configs)", () => {
       spec: {
         buildCommand: ["echo", name, "ok"],
       },
-      disabled: false,
+      disabled,
     })
+  const makeBuild = (name: string) => _makeBuild(name, false)
+  const makeDisabledBuild = (name: string) => _makeBuild(name, true)
 
-  const makeDeploy = (name: string) =>
+  const _makeDeploy = (name: string, disabled: boolean) =>
     makeAction({
       basePath: tmpDir.path,
       name,
@@ -132,10 +134,12 @@ describe("ConfigGraph (action-based configs)", () => {
       spec: {
         deployCommand: ["echo", name, "ok"],
       },
-      disabled: false,
+      disabled,
     })
+  const makeDeploy = (name: string) => _makeDeploy(name, false)
+  const makeDisabledDeploy = (name: string) => _makeDeploy(name, true)
 
-  const makeRun = (name: string) =>
+  const _makeRun = (name: string, disabled: boolean) =>
     makeAction({
       basePath: tmpDir.path,
       name,
@@ -143,10 +147,12 @@ describe("ConfigGraph (action-based configs)", () => {
       spec: {
         runCommand: ["echo", name, "ok"],
       },
-      disabled: false,
+      disabled,
     })
+  const makeRun = (name: string) => _makeRun(name, false)
+  const makeDisabledRun = (name: string) => _makeRun(name, true)
 
-  const makeTest = (name: string) =>
+  const _makeTest = (name: string, disabled: boolean) =>
     makeAction({
       basePath: tmpDir.path,
       name,
@@ -154,8 +160,10 @@ describe("ConfigGraph (action-based configs)", () => {
       spec: {
         testCommand: ["echo", name, "ok"],
       },
-      disabled: false,
+      disabled,
     })
+  const makeTest = (name: string) => _makeTest(name, false)
+  const makeDisabledTest = (name: string) => _makeTest(name, true)
 
   before(async () => {
     tmpDir = await tmp.dir({ unsafeCleanup: true })
@@ -211,18 +219,7 @@ describe("ConfigGraph (action-based configs)", () => {
       it("should omit disabled Build actions", async () => {
         const tmpGarden = await makeGarden(tmpDir, testPlugin)
 
-        tmpGarden.setActionConfigs(
-          [],
-          [
-            makeAction({
-              basePath: tmpDir.path,
-              name: "disabled-build",
-              kind: "Build",
-              spec: {},
-              disabled: true,
-            }),
-          ]
-        )
+        tmpGarden.setActionConfigs([], [makeDisabledBuild("disabled-build")])
 
         const graph = await tmpGarden.getConfigGraph({ log: tmpGarden.log, emit: false })
         const buildActions = graph.getBuilds()
@@ -233,18 +230,7 @@ describe("ConfigGraph (action-based configs)", () => {
       it("should optionally include disabled Build actions", async () => {
         const tmpGarden = await makeGarden(tmpDir, testPlugin)
 
-        tmpGarden.setActionConfigs(
-          [],
-          [
-            makeAction({
-              basePath: tmpDir.path,
-              name: "disabled-build",
-              kind: "Build",
-              spec: {},
-              disabled: true,
-            }),
-          ]
-        )
+        tmpGarden.setActionConfigs([], [makeDisabledBuild("disabled-build")])
 
         const graph = await tmpGarden.getConfigGraph({ log: tmpGarden.log, emit: false })
         const disabledBuildActions = graph.getBuilds({ includeDisabled: true })
@@ -266,18 +252,7 @@ describe("ConfigGraph (action-based configs)", () => {
       it("should throw if specifically requesting a disabled Build action", async () => {
         const tmpGarden = await makeGarden(tmpDir, testPlugin)
 
-        tmpGarden.setActionConfigs(
-          [],
-          [
-            makeAction({
-              basePath: tmpDir.path,
-              name: "disabled-build",
-              kind: "Build",
-              spec: {},
-              disabled: true,
-            }),
-          ]
-        )
+        tmpGarden.setActionConfigs([], [makeDisabledBuild("disabled-build")])
 
         const graph = await tmpGarden.getConfigGraph({ log: tmpGarden.log, emit: false })
 
@@ -312,18 +287,7 @@ describe("ConfigGraph (action-based configs)", () => {
       it("should omit disabled Deploy actions", async () => {
         const tmpGarden = await makeGarden(tmpDir, testPlugin)
 
-        tmpGarden.setActionConfigs(
-          [],
-          [
-            makeAction({
-              basePath: tmpDir.path,
-              name: "disabled-deploy",
-              kind: "Deploy",
-              spec: {},
-              disabled: true,
-            }),
-          ]
-        )
+        tmpGarden.setActionConfigs([], [makeDisabledDeploy("disabled-deploy")])
 
         const graph = await tmpGarden.getConfigGraph({ log: tmpGarden.log, emit: false })
         const deployActions = graph.getDeploys()
@@ -334,18 +298,7 @@ describe("ConfigGraph (action-based configs)", () => {
       it("should optionally include disabled Deploy actions", async () => {
         const tmpGarden = await makeGarden(tmpDir, testPlugin)
 
-        tmpGarden.setActionConfigs(
-          [],
-          [
-            makeAction({
-              basePath: tmpDir.path,
-              name: "disabled-deploy",
-              kind: "Deploy",
-              spec: {},
-              disabled: true,
-            }),
-          ]
-        )
+        tmpGarden.setActionConfigs([], [makeDisabledDeploy("disabled-deploy")])
 
         const graph = await tmpGarden.getConfigGraph({ log: tmpGarden.log, emit: false })
         const disabledDeployActions = graph.getDeploys({ includeDisabled: true })
@@ -367,18 +320,7 @@ describe("ConfigGraph (action-based configs)", () => {
       it("should throw if specifically requesting a disabled Deploy action", async () => {
         const tmpGarden = await makeGarden(tmpDir, testPlugin)
 
-        tmpGarden.setActionConfigs(
-          [],
-          [
-            makeAction({
-              basePath: tmpDir.path,
-              name: "disabled-deploy",
-              kind: "Deploy",
-              spec: {},
-              disabled: true,
-            }),
-          ]
-        )
+        tmpGarden.setActionConfigs([], [makeDisabledDeploy("disabled-deploy")])
 
         const graph = await tmpGarden.getConfigGraph({ log: tmpGarden.log, emit: false })
 
@@ -413,18 +355,7 @@ describe("ConfigGraph (action-based configs)", () => {
       it("should omit disabled Run actions", async () => {
         const tmpGarden = await makeGarden(tmpDir, testPlugin)
 
-        tmpGarden.setActionConfigs(
-          [],
-          [
-            makeAction({
-              basePath: tmpDir.path,
-              name: "disabled-run",
-              kind: "Run",
-              spec: {},
-              disabled: true,
-            }),
-          ]
-        )
+        tmpGarden.setActionConfigs([], [makeDisabledRun("disabled-run")])
 
         const graph = await tmpGarden.getConfigGraph({ log: tmpGarden.log, emit: false })
         const runActions = graph.getRuns()
@@ -435,18 +366,7 @@ describe("ConfigGraph (action-based configs)", () => {
       it("should optionally include disabled Run actions", async () => {
         const tmpGarden = await makeGarden(tmpDir, testPlugin)
 
-        tmpGarden.setActionConfigs(
-          [],
-          [
-            makeAction({
-              basePath: tmpDir.path,
-              name: "disabled-run",
-              kind: "Run",
-              spec: {},
-              disabled: true,
-            }),
-          ]
-        )
+        tmpGarden.setActionConfigs([], [makeDisabledRun("disabled-run")])
 
         const graph = await tmpGarden.getConfigGraph({ log: tmpGarden.log, emit: false })
         const disabledRunActions = graph.getRuns({ includeDisabled: true })
@@ -468,18 +388,7 @@ describe("ConfigGraph (action-based configs)", () => {
       it("should throw if specifically requesting a disabled Run action", async () => {
         const tmpGarden = await makeGarden(tmpDir, testPlugin)
 
-        tmpGarden.setActionConfigs(
-          [],
-          [
-            makeAction({
-              basePath: tmpDir.path,
-              name: "disabled-run",
-              kind: "Run",
-              spec: {},
-              disabled: true,
-            }),
-          ]
-        )
+        tmpGarden.setActionConfigs([], [makeDisabledRun("disabled-run")])
 
         const graph = await tmpGarden.getConfigGraph({ log: tmpGarden.log, emit: false })
 
@@ -514,18 +423,7 @@ describe("ConfigGraph (action-based configs)", () => {
       it("should omit disabled Test actions", async () => {
         const tmpGarden = await makeGarden(tmpDir, testPlugin)
 
-        tmpGarden.setActionConfigs(
-          [],
-          [
-            makeAction({
-              basePath: tmpDir.path,
-              name: "disabled-test",
-              kind: "Test",
-              spec: {},
-              disabled: true,
-            }),
-          ]
-        )
+        tmpGarden.setActionConfigs([], [makeDisabledTest("disabled-test")])
 
         const graph = await tmpGarden.getConfigGraph({ log: tmpGarden.log, emit: false })
         const testActions = graph.getTests()
@@ -536,18 +434,7 @@ describe("ConfigGraph (action-based configs)", () => {
       it("should optionally include disabled Test actions", async () => {
         const tmpGarden = await makeGarden(tmpDir, testPlugin)
 
-        tmpGarden.setActionConfigs(
-          [],
-          [
-            makeAction({
-              basePath: tmpDir.path,
-              name: "disabled-test",
-              kind: "Test",
-              spec: {},
-              disabled: true,
-            }),
-          ]
-        )
+        tmpGarden.setActionConfigs([], [makeDisabledTest("disabled-test")])
 
         const graph = await tmpGarden.getConfigGraph({ log: tmpGarden.log, emit: false })
         const disabledTestActions = graph.getTests({ includeDisabled: true })
@@ -569,18 +456,7 @@ describe("ConfigGraph (action-based configs)", () => {
       it("should throw if specifically requesting a disabled Test action", async () => {
         const tmpGarden = await makeGarden(tmpDir, testPlugin)
 
-        tmpGarden.setActionConfigs(
-          [],
-          [
-            makeAction({
-              basePath: tmpDir.path,
-              name: "disabled-test",
-              kind: "Test",
-              spec: {},
-              disabled: true,
-            }),
-          ]
-        )
+        tmpGarden.setActionConfigs([], [makeDisabledTest("disabled-test")])
 
         const graph = await tmpGarden.getConfigGraph({ log: tmpGarden.log, emit: false })
 

--- a/core/test/unit/src/config-graph.ts
+++ b/core/test/unit/src/config-graph.ts
@@ -208,6 +208,28 @@ describe("ConfigGraph (action-based configs)", () => {
         expect(getNames(buildActions).sort()).to.eql(["build-1", "build-2"])
       })
 
+      it("should omit disabled Build actions", async () => {
+        const tmpGarden = await makeGarden(tmpDir, testPlugin)
+
+        tmpGarden.setActionConfigs(
+          [],
+          [
+            makeAction({
+              basePath: tmpDir.path,
+              name: "disabled-build",
+              kind: "Build",
+              spec: {},
+              disabled: true,
+            }),
+          ]
+        )
+
+        const graph = await tmpGarden.getConfigGraph({ log: tmpGarden.log, emit: false })
+        const buildActions = graph.getBuilds()
+
+        expect(buildActions).to.eql([])
+      })
+
       it("should optionally include disabled Build actions", async () => {
         const tmpGarden = await makeGarden(tmpDir, testPlugin)
 
@@ -285,6 +307,28 @@ describe("ConfigGraph (action-based configs)", () => {
         const deployActions = configGraph.getDeploys({ names: ["deploy-1", "deploy-2"] })
 
         expect(getNames(deployActions).sort()).to.eql(["deploy-1", "deploy-2"])
+      })
+
+      it("should omit disabled Deploy actions", async () => {
+        const tmpGarden = await makeGarden(tmpDir, testPlugin)
+
+        tmpGarden.setActionConfigs(
+          [],
+          [
+            makeAction({
+              basePath: tmpDir.path,
+              name: "disabled-deploy",
+              kind: "Deploy",
+              spec: {},
+              disabled: true,
+            }),
+          ]
+        )
+
+        const graph = await tmpGarden.getConfigGraph({ log: tmpGarden.log, emit: false })
+        const deployActions = graph.getDeploys()
+
+        expect(deployActions).to.eql([])
       })
 
       it("should optionally include disabled Deploy actions", async () => {
@@ -366,6 +410,28 @@ describe("ConfigGraph (action-based configs)", () => {
         expect(getNames(runActions).sort()).to.eql(["run-1", "run-2"])
       })
 
+      it("should omit disabled Run actions", async () => {
+        const tmpGarden = await makeGarden(tmpDir, testPlugin)
+
+        tmpGarden.setActionConfigs(
+          [],
+          [
+            makeAction({
+              basePath: tmpDir.path,
+              name: "disabled-run",
+              kind: "Run",
+              spec: {},
+              disabled: true,
+            }),
+          ]
+        )
+
+        const graph = await tmpGarden.getConfigGraph({ log: tmpGarden.log, emit: false })
+        const runActions = graph.getRuns()
+
+        expect(runActions).to.eql([])
+      })
+
       it("should optionally include disabled Run actions", async () => {
         const tmpGarden = await makeGarden(tmpDir, testPlugin)
 
@@ -443,6 +509,28 @@ describe("ConfigGraph (action-based configs)", () => {
         const testActions = configGraph.getTests({ names: ["test-1", "test-2"] })
 
         expect(getNames(testActions).sort()).to.eql(["test-1", "test-2"])
+      })
+
+      it("should omit disabled Test actions", async () => {
+        const tmpGarden = await makeGarden(tmpDir, testPlugin)
+
+        tmpGarden.setActionConfigs(
+          [],
+          [
+            makeAction({
+              basePath: tmpDir.path,
+              name: "disabled-test",
+              kind: "Test",
+              spec: {},
+              disabled: true,
+            }),
+          ]
+        )
+
+        const graph = await tmpGarden.getConfigGraph({ log: tmpGarden.log, emit: false })
+        const testActions = graph.getTests()
+
+        expect(testActions).to.eql([])
       })
 
       it("should optionally include disabled Test actions", async () => {

--- a/core/test/unit/src/config-graph.ts
+++ b/core/test/unit/src/config-graph.ts
@@ -166,12 +166,16 @@ describe("ConfigGraph (action-based configs)", () => {
     const validActionConfigs: BaseActionConfig[] = [
       makeBuild("build-1"),
       makeBuild("build-2"),
+      makeBuild("build-3"),
       makeDeploy("deploy-1"),
       makeDeploy("deploy-2"),
+      makeDeploy("deploy-3"),
       makeRun("run-1"),
       makeRun("run-2"),
+      makeRun("run-3"),
       makeTest("test-1"),
       makeTest("test-2"),
+      makeTest("test-3"),
     ]
     garden.setActionConfigs([], [...validActionConfigs])
     configGraph = await garden.getConfigGraph({ log: garden.log, emit: false })
@@ -186,13 +190,16 @@ describe("ConfigGraph (action-based configs)", () => {
       it("should return all registered Build actions", async () => {
         const buildActions = configGraph.getBuilds()
 
-        expect(getNames(buildActions).sort()).to.eql(["build-1", "build-2"])
+        expect(getNames(buildActions).sort()).to.eql(["build-1", "build-2", "build-3"])
 
         const spec1 = buildActions[0].getConfig("spec")
         expect(spec1.buildCommand).to.eql(["echo", "build-1", "ok"])
 
         const spec2 = buildActions[1].getConfig("spec")
         expect(spec2.buildCommand).to.eql(["echo", "build-2", "ok"])
+
+        const spec3 = buildActions[2].getConfig("spec")
+        expect(spec3.buildCommand).to.eql(["echo", "build-3", "ok"])
       })
 
       it("should optionally return specified Build actions in the context", async () => {
@@ -240,13 +247,16 @@ describe("ConfigGraph (action-based configs)", () => {
       it("should return all registered Deploy actions", async () => {
         const deployActions = configGraph.getDeploys()
 
-        expect(getNames(deployActions).sort()).to.eql(["deploy-1", "deploy-2"])
+        expect(getNames(deployActions).sort()).to.eql(["deploy-1", "deploy-2", "deploy-3"])
 
         const spec1 = deployActions[0].getConfig("spec")
         expect(spec1.deployCommand).to.eql(["echo", "deploy-1", "ok"])
 
         const spec2 = deployActions[1].getConfig("spec")
         expect(spec2.deployCommand).to.eql(["echo", "deploy-2", "ok"])
+
+        const spec3 = deployActions[2].getConfig("spec")
+        expect(spec3.deployCommand).to.eql(["echo", "deploy-3", "ok"])
       })
 
       it("should optionally return specified Deploy actions in the context", async () => {
@@ -294,13 +304,16 @@ describe("ConfigGraph (action-based configs)", () => {
       it("should return all registered Run actions", async () => {
         const runActions = configGraph.getRuns()
 
-        expect(getNames(runActions).sort()).to.eql(["run-1", "run-2"])
+        expect(getNames(runActions).sort()).to.eql(["run-1", "run-2", "run-3"])
 
         const spec1 = runActions[0].getConfig("spec")
         expect(spec1.runCommand).to.eql(["echo", "run-1", "ok"])
 
         const spec2 = runActions[1].getConfig("spec")
         expect(spec2.runCommand).to.eql(["echo", "run-2", "ok"])
+
+        const spec3 = runActions[2].getConfig("spec")
+        expect(spec3.runCommand).to.eql(["echo", "run-3", "ok"])
       })
 
       it("should optionally return specified Run actions in the context", async () => {
@@ -348,13 +361,16 @@ describe("ConfigGraph (action-based configs)", () => {
       it("should return all registered Test actions", async () => {
         const testActions = configGraph.getTests()
 
-        expect(getNames(testActions).sort()).to.eql(["test-1", "test-2"])
+        expect(getNames(testActions).sort()).to.eql(["test-1", "test-2", "test-3"])
 
         const spec1 = testActions[0].getConfig("spec")
         expect(spec1.testCommand).to.eql(["echo", "test-1", "ok"])
 
         const spec2 = testActions[1].getConfig("spec")
         expect(spec2.testCommand).to.eql(["echo", "test-2", "ok"])
+
+        const spec3 = testActions[2].getConfig("spec")
+        expect(spec3.testCommand).to.eql(["echo", "test-3", "ok"])
       })
 
       it("should optionally return specified Test actions in the context", async () => {

--- a/core/test/unit/src/config-graph.ts
+++ b/core/test/unit/src/config-graph.ts
@@ -205,6 +205,29 @@ describe("ConfigGraph (action-based configs)", () => {
 
         throw new Error("Expected error")
       })
+
+      it("should throw if specifically requesting a disabled Build action", async () => {
+        const tmpGarden = await makeGarden(tmpDir, testPlugin)
+
+        tmpGarden.setActionConfigs(
+          [],
+          [
+            makeAction({
+              basePath: tmpDir.path,
+              name: "disabled-build",
+              kind: "Build",
+              spec: {},
+              disabled: true,
+            }),
+          ]
+        )
+
+        const graph = await tmpGarden.getConfigGraph({ log: tmpGarden.log, emit: false })
+
+        await expectError(() => graph.getBuilds({ names: ["disabled-build"] }), {
+          contains: "Could not find one or more Build actions: disabled-build",
+        })
+      })
     })
 
     describe("getDeploys", () => {
@@ -229,6 +252,29 @@ describe("ConfigGraph (action-based configs)", () => {
         }
 
         throw new Error("Expected error")
+      })
+
+      it("should throw if specifically requesting a disabled Deploy action", async () => {
+        const tmpGarden = await makeGarden(tmpDir, testPlugin)
+
+        tmpGarden.setActionConfigs(
+          [],
+          [
+            makeAction({
+              basePath: tmpDir.path,
+              name: "disabled-deploy",
+              kind: "Deploy",
+              spec: {},
+              disabled: true,
+            }),
+          ]
+        )
+
+        const graph = await tmpGarden.getConfigGraph({ log: tmpGarden.log, emit: false })
+
+        await expectError(() => graph.getDeploys({ names: ["disabled-deploy"] }), {
+          contains: "Could not find one or more Deploy actions: disabled-deploy",
+        })
       })
     })
 
@@ -255,6 +301,29 @@ describe("ConfigGraph (action-based configs)", () => {
 
         throw new Error("Expected error")
       })
+
+      it("should throw if specifically requesting a disabled Run action", async () => {
+        const tmpGarden = await makeGarden(tmpDir, testPlugin)
+
+        tmpGarden.setActionConfigs(
+          [],
+          [
+            makeAction({
+              basePath: tmpDir.path,
+              name: "disabled-run",
+              kind: "Run",
+              spec: {},
+              disabled: true,
+            }),
+          ]
+        )
+
+        const graph = await tmpGarden.getConfigGraph({ log: tmpGarden.log, emit: false })
+
+        await expectError(() => graph.getRuns({ names: ["disabled-run"] }), {
+          contains: "Could not find one or more Run actions: disabled-run",
+        })
+      })
     })
 
     describe("getTests", () => {
@@ -279,6 +348,29 @@ describe("ConfigGraph (action-based configs)", () => {
         }
 
         throw new Error("Expected error")
+      })
+
+      it("should throw if specifically requesting a disabled Test action", async () => {
+        const tmpGarden = await makeGarden(tmpDir, testPlugin)
+
+        tmpGarden.setActionConfigs(
+          [],
+          [
+            makeAction({
+              basePath: tmpDir.path,
+              name: "disabled-test",
+              kind: "Test",
+              spec: {},
+              disabled: true,
+            }),
+          ]
+        )
+
+        const graph = await tmpGarden.getConfigGraph({ log: tmpGarden.log, emit: false })
+
+        await expectError(() => graph.getTests({ names: ["disabled-test"] }), {
+          contains: "Could not find one or more Test actions: disabled-test",
+        })
       })
     })
   })

--- a/core/test/unit/src/config-graph.ts
+++ b/core/test/unit/src/config-graph.ts
@@ -208,6 +208,28 @@ describe("ConfigGraph (action-based configs)", () => {
         expect(getNames(buildActions).sort()).to.eql(["build-1", "build-2"])
       })
 
+      it("should optionally include disabled Build actions", async () => {
+        const tmpGarden = await makeGarden(tmpDir, testPlugin)
+
+        tmpGarden.setActionConfigs(
+          [],
+          [
+            makeAction({
+              basePath: tmpDir.path,
+              name: "disabled-build",
+              kind: "Build",
+              spec: {},
+              disabled: true,
+            }),
+          ]
+        )
+
+        const graph = await tmpGarden.getConfigGraph({ log: tmpGarden.log, emit: false })
+        const disabledBuildActions = graph.getBuilds({ includeDisabled: true })
+
+        expect(getNames(disabledBuildActions).sort()).to.eql(["disabled-build"])
+      })
+
       it("should throw if named Build action is missing", async () => {
         try {
           configGraph.getBuilds({ names: ["missing-build"] })
@@ -263,6 +285,28 @@ describe("ConfigGraph (action-based configs)", () => {
         const deployActions = configGraph.getDeploys({ names: ["deploy-1", "deploy-2"] })
 
         expect(getNames(deployActions).sort()).to.eql(["deploy-1", "deploy-2"])
+      })
+
+      it("should optionally include disabled Deploy actions", async () => {
+        const tmpGarden = await makeGarden(tmpDir, testPlugin)
+
+        tmpGarden.setActionConfigs(
+          [],
+          [
+            makeAction({
+              basePath: tmpDir.path,
+              name: "disabled-deploy",
+              kind: "Deploy",
+              spec: {},
+              disabled: true,
+            }),
+          ]
+        )
+
+        const graph = await tmpGarden.getConfigGraph({ log: tmpGarden.log, emit: false })
+        const disabledDeployActions = graph.getDeploys({ includeDisabled: true })
+
+        expect(getNames(disabledDeployActions).sort()).to.eql(["disabled-deploy"])
       })
 
       it("should throw if named Deploy action is missing", async () => {
@@ -322,6 +366,28 @@ describe("ConfigGraph (action-based configs)", () => {
         expect(getNames(runActions).sort()).to.eql(["run-1", "run-2"])
       })
 
+      it("should optionally include disabled Run actions", async () => {
+        const tmpGarden = await makeGarden(tmpDir, testPlugin)
+
+        tmpGarden.setActionConfigs(
+          [],
+          [
+            makeAction({
+              basePath: tmpDir.path,
+              name: "disabled-run",
+              kind: "Run",
+              spec: {},
+              disabled: true,
+            }),
+          ]
+        )
+
+        const graph = await tmpGarden.getConfigGraph({ log: tmpGarden.log, emit: false })
+        const disabledRunActions = graph.getRuns({ includeDisabled: true })
+
+        expect(getNames(disabledRunActions).sort()).to.eql(["disabled-run"])
+      })
+
       it("should throw if named Run action is missing", async () => {
         try {
           configGraph.getRuns({ names: ["missing-run"] })
@@ -377,6 +443,28 @@ describe("ConfigGraph (action-based configs)", () => {
         const testActions = configGraph.getTests({ names: ["test-1", "test-2"] })
 
         expect(getNames(testActions).sort()).to.eql(["test-1", "test-2"])
+      })
+
+      it("should optionally include disabled Test actions", async () => {
+        const tmpGarden = await makeGarden(tmpDir, testPlugin)
+
+        tmpGarden.setActionConfigs(
+          [],
+          [
+            makeAction({
+              basePath: tmpDir.path,
+              name: "disabled-test",
+              kind: "Test",
+              spec: {},
+              disabled: true,
+            }),
+          ]
+        )
+
+        const graph = await tmpGarden.getConfigGraph({ log: tmpGarden.log, emit: false })
+        const disabledTestActions = graph.getTests({ includeDisabled: true })
+
+        expect(getNames(disabledTestActions).sort()).to.eql(["disabled-test"])
       })
 
       it("should throw if named Test action is missing", async () => {

--- a/core/test/unit/src/config-graph.ts
+++ b/core/test/unit/src/config-graph.ts
@@ -624,7 +624,7 @@ describe("ConfigGraph (module-based configs)", () => {
       const graph = await garden.getConfigGraph({ log: garden.log, emit: false })
       const modules = graph.getModules()
 
-      expect(modules.map((m) => m.name).sort()).to.eql(["module-a", "module-b"])
+      expect(getNames(modules).sort()).to.eql(["module-a", "module-b"])
     })
 
     it("should optionally include disabled modules", async () => {
@@ -636,7 +636,7 @@ describe("ConfigGraph (module-based configs)", () => {
       const graph = await garden.getConfigGraph({ log: garden.log, emit: false })
       const modules = graph.getModules({ includeDisabled: true })
 
-      expect(modules.map((m) => m.name).sort()).to.eql(["module-a", "module-b", "module-c"])
+      expect(getNames(modules).sort()).to.eql(["module-a", "module-b", "module-c"])
     })
 
     it("should throw if specifically requesting a disabled module", async () => {
@@ -786,9 +786,9 @@ describe("ConfigGraph (module-based configs)", () => {
       ])
 
       const graph = await garden.getConfigGraph({ log: garden.log, emit: false })
-      const deps = graph.getDeploys({ includeDisabled: true })
+      const deploys = graph.getDeploys({ includeDisabled: true })
 
-      expect(deps.map((s) => s.name)).to.eql(["disabled-service"])
+      expect(getNames(deploys)).to.eql(["disabled-service"])
     })
 
     it("should throw if specifically requesting a disabled deploy", async () => {
@@ -932,9 +932,9 @@ describe("ConfigGraph (module-based configs)", () => {
       ])
 
       const graph = await garden.getConfigGraph({ log: garden.log, emit: false })
-      const deps = graph.getRuns({ includeDisabled: true })
+      const runs = graph.getRuns({ includeDisabled: true })
 
-      expect(deps.map((t) => t.name)).to.eql(["disabled-task"])
+      expect(getNames(runs)).to.eql(["disabled-task"])
     })
 
     it("should throw if specifically requesting a disabled run", async () => {
@@ -1052,7 +1052,7 @@ describe("ConfigGraph (module-based configs)", () => {
       })
 
       const buildDeps = deps.filter((d) => d.kind === "Build")
-      expect(buildDeps.map((m) => m.name)).to.eql(["module-a"])
+      expect(getNames(buildDeps)).to.eql(["module-a"])
     })
 
     it("should ignore dependencies by deploys on disabled deploys", async () => {
@@ -1341,7 +1341,7 @@ describe("ConfigGraph (module-based configs)", () => {
       const graph = await garden.getConfigGraph({ log: garden.log, emit: false })
       const deps = graph.moduleGraph.resolveDependencyModules([{ name: "module-a", copy: [] }], [])
 
-      expect(deps.map((m) => m.name)).to.eql(["module-a"])
+      expect(getNames(deps)).to.eql(["module-a"])
     })
   })
 
@@ -1459,8 +1459,8 @@ describe("ConfigGraph (module-based configs)", () => {
       const moduleA = graph.getModule("module-a")
       const deps = graph.moduleGraph.getDependantsForModule(moduleA, true)
 
-      expect(deps.deploy.map((m) => m.name)).to.eql(["service-b"])
-      expect(deps.run.map((m) => m.name)).to.eql(["task-b"])
+      expect(getNames(deps.deploy)).to.eql(["service-b"])
+      expect(getNames(deps.run)).to.eql(["task-b"])
     })
   })
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements the missing tests in `config-graph.ts`. The broken tests were fixed in #3596.

The tests are based on the *action-based* configs instead of the module-based ones. The new tests also do not use any predefined Garden test projects from the `test/data` directory.

**Which issue(s) this PR fixes**:

Fixes #3595

**Special notes for your reviewer**:
