### PR TITLE
fix(events): use ISO format date strings in event payload

### DIFF
--- a/core/src/actions.ts
+++ b/core/src/actions.ts
@@ -376,7 +376,7 @@ export class ActionRouter implements TypeGuard {
     const actionUid = uuidv4()
     params.events = params.events || new PluginEventBroker()
     let result: BuildResult
-    const startedAt = new Date()
+    const startedAt = new Date().toISOString()
     const moduleName = params.module.name
     const moduleVersion = params.module.version.versionString
     params.events.on("log", ({ timestamp, data, origin, log }) => {
@@ -410,7 +410,7 @@ export class ActionRouter implements TypeGuard {
         status: {
           state,
           startedAt,
-          completedAt: new Date(),
+          completedAt: new Date().toISOString(),
         },
       })
     }
@@ -573,7 +573,7 @@ export class ActionRouter implements TypeGuard {
       })
     })
     const serviceVersion = params.service.version
-    const deployStartedAt = new Date()
+    const deployStartedAt = new Date().toISOString()
     this.garden.events.emit("serviceStatus", {
       serviceName,
       moduleName,
@@ -592,7 +592,7 @@ export class ActionRouter implements TypeGuard {
       status: {
         ...omit(result, "detail"),
         deployStartedAt,
-        deployCompletedAt: new Date(),
+        deployCompletedAt: new Date().toISOString(),
       },
     })
     this.emitNamespaceEvents(result.namespaceStatuses)

--- a/core/src/events.ts
+++ b/core/src/events.ts
@@ -205,21 +205,9 @@ export interface Events extends LoggerEvents {
   watchingForChanges: {}
   log: {
     /**
-     * Number of milliseconds since the epoch OR a date string.
-     *
-     * We need to allow both numberic and string types for backwards compatibility
-     * with Garden Cloud.
-     *
-     * Garden Cloud supports numeric date strings for log streaming as of v1.360.
-     * We can change this to just 'number' once all Cloud instances are up to date.
-     *
-     * Note that even though this has always been typed as a 'number' we've been
-     * attaching string timestamps to this payload because of missing types further
-     * up the pipe.
-     *
-     * TODO: Change to type 'number'.
+     * ISO format date string
      */
-    timestamp: number | string
+    timestamp: string
     actionUid: string
     entity: {
       moduleName: string

--- a/core/src/events.ts
+++ b/core/src/events.ts
@@ -68,8 +68,14 @@ export type LoggerEventName = keyof LoggerEvents
 export type GraphResultEventPayload = Omit<GraphResult, "dependencyResults">
 
 export interface ServiceStatusPayload extends Omit<ServiceStatus, "detail"> {
-  deployStartedAt?: Date
-  deployCompletedAt?: Date
+  /**
+   * ISO format date string
+   */
+  deployStartedAt?: string
+  /**
+   * ISO format date string
+   */
+  deployCompletedAt?: string
 }
 
 export interface CommandInfoPayload extends CommandInfo {
@@ -152,14 +158,20 @@ export interface Events extends LoggerEvents {
 
   // TaskGraph events
   taskPending: {
-    addedAt: Date
+    /**
+     * ISO format date string
+     */
+    addedAt: string
     batchId: string
     key: string
     type: string
     name: string
   }
   taskProcessing: {
-    startedAt: Date
+    /**
+     * ISO format date string
+     */
+    startedAt: string
     batchId: string
     key: string
     type: string
@@ -169,17 +181,26 @@ export interface Events extends LoggerEvents {
   taskComplete: GraphResultEventPayload
   taskError: GraphResultEventPayload
   taskCancelled: {
-    cancelledAt: Date
+    /**
+     * ISO format date string
+     */
+    cancelledAt: string
     batchId: string
     type: string
     key: string
     name: string
   }
   taskGraphProcessing: {
-    startedAt: Date
+    /**
+     * ISO format date string
+     */
+    startedAt: string
   }
   taskGraphComplete: {
-    completedAt: Date
+    /**
+     * ISO format date string
+     */
+    completedAt: string
   }
   watchingForChanges: {}
   log: {
@@ -235,8 +256,14 @@ export interface Events extends LoggerEvents {
     actionUid?: string
     status: {
       state: BuildState
-      startedAt?: Date
-      completedAt?: Date
+      /**
+       * ISO format date string
+       */
+      startedAt?: string
+      /**
+       * ISO format date string
+       */
+      completedAt?: string
     }
   }
   taskStatus: {

--- a/core/src/plugin-context.ts
+++ b/core/src/plugin-context.ts
@@ -107,17 +107,9 @@ export type PluginEventLogContext = {
 
 export type PluginEventLogMessage = PluginEventLogContext & {
   /**
-   * Number of milliseconds since the epoch OR a date string.
-   *
-   * We need to allow both numberic and string types for backwards compatibility
-   * with Garden Cloud.
-   *
-   * Garden Cloud supports numeric date strings for log streaming as of v1.360.
-   * We can change this to just 'number' once all Cloud instances are up to date.
-   *
-   * TODO: Change to type 'number'.
+   * ISO format date string
    */
-  timestamp: number | string
+  timestamp: string
 
   /** log message */
   data: Buffer

--- a/core/src/plugins/container/build.ts
+++ b/core/src/plugins/container/build.ts
@@ -72,7 +72,7 @@ export async function buildContainerModule({ ctx, module, log }: BuildModulePara
   const outputStream = split2()
   outputStream.on("error", () => {})
   outputStream.on("data", (line: Buffer) => {
-    ctx.events.emit("log", { timestamp: new Date().getTime(), data: line, ...logEventContext })
+    ctx.events.emit("log", { timestamp: new Date().toISOString(), data: line, ...logEventContext })
   })
   const timeout = module.spec.build.timeout
   const res = await containerHelpers.dockerCli({

--- a/core/src/plugins/exec/exec.ts
+++ b/core/src/plugins/exec/exec.ts
@@ -444,7 +444,7 @@ async function run({
   const outputStream = split2()
   outputStream.on("error", () => {})
   outputStream.on("data", (line: Buffer) => {
-    ctx.events.emit("log", { timestamp: new Date().getTime(), data: line, ...logEventContext })
+    ctx.events.emit("log", { timestamp: new Date().toISOString(), data: line, ...logEventContext })
   })
 
   const res = await exec(command.join(" "), [], {

--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -109,7 +109,7 @@ export const buildkitBuildHandler: BuildHandler = async (params) => {
   const outputStream = split2()
   outputStream.on("error", () => {})
   outputStream.on("data", (line: Buffer) => {
-    ctx.events.emit("log", { timestamp: new Date().getTime(), data: line, ...logEventContext })
+    ctx.events.emit("log", { timestamp: new Date().toISOString(), data: line, ...logEventContext })
   })
 
   const command = [

--- a/core/src/plugins/kubernetes/container/build/cluster-docker.ts
+++ b/core/src/plugins/kubernetes/container/build/cluster-docker.ts
@@ -97,7 +97,7 @@ export const clusterDockerBuild: BuildHandler = async (params) => {
   const stdout = split2()
   stdout.on("error", () => {})
   stdout.on("data", (line: Buffer) => {
-    ctx.events.emit("log", { timestamp: new Date().getTime(), data: line, ...logEventContext })
+    ctx.events.emit("log", { timestamp: new Date().toISOString(), data: line, ...logEventContext })
   })
 
   // Prepare the build command

--- a/core/src/plugins/kubernetes/helm/helm-cli.ts
+++ b/core/src/plugins/kubernetes/helm/helm-cli.ts
@@ -114,7 +114,7 @@ export async function helm({
   outputStream.on("error", () => {})
   outputStream.on("data", (line: Buffer) => {
     if (emitLogEvents) {
-      ctx.events.emit("log", { timestamp: new Date().getTime(), data: line, ...logEventContext })
+      ctx.events.emit("log", { timestamp: new Date().toISOString(), data: line, ...logEventContext })
     }
   })
 

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -214,7 +214,7 @@ export async function runAndCopy({
     const outputStream = new PassThrough()
     outputStream.on("error", () => {})
     outputStream.on("data", (data: Buffer) => {
-      ctx.events.emit("log", { timestamp: new Date().getTime(), data, ...logEventContext })
+      ctx.events.emit("log", { timestamp: new Date().toISOString(), data, ...logEventContext })
     })
 
     return runWithArtifacts({

--- a/core/src/plugins/kubernetes/status/status.ts
+++ b/core/src/plugins/kubernetes/status/status.ts
@@ -194,7 +194,7 @@ export async function waitForResources({
   }
 
   const emitLog = (msg: string) =>
-    ctx.events.emit("log", { timestamp: new Date().getTime(), data: Buffer.from(msg, "utf-8"), ...logEventContext })
+    ctx.events.emit("log", { timestamp: new Date().toISOString(), data: Buffer.from(msg, "utf-8"), ...logEventContext })
 
   const waitingMsg = `Waiting for resources to be ready...`
   const statusLine = log.info({

--- a/core/src/task-graph.ts
+++ b/core/src/task-graph.ts
@@ -257,7 +257,7 @@ export class TaskGraph extends EventEmitter2 {
     if (this.index.contains(node)) {
       const task = node.task
       this.garden.events.emit("taskPending", {
-        addedAt: new Date(),
+        addedAt: new Date().toISOString(),
         batchId: node.batchId,
         key: node.key,
         name: task.getName(),
@@ -346,7 +346,7 @@ export class TaskGraph extends EventEmitter2 {
       this.log.silly(safeDumpYaml(this.index.inspect(), { noRefs: true }))
 
       this.garden.events.emit("taskGraphProcessing", {
-        startedAt: new Date(),
+        startedAt: new Date().toISOString(),
       })
     }
 
@@ -357,7 +357,7 @@ export class TaskGraph extends EventEmitter2 {
     if (this.index.length === 0 && this.pendingBatches.length === 0 && this.inProgressBatches.length === 0) {
       // done!
       this.logEntryMap.counter && this.logEntryMap.counter.setDone({ symbol: "info" })
-      this.garden.events.emit("taskGraphComplete", { completedAt: new Date() })
+      this.garden.events.emit("taskGraphComplete", { completedAt: new Date().toISOString() })
       return
     }
 
@@ -430,7 +430,7 @@ export class TaskGraph extends EventEmitter2 {
           type,
           key,
           batchId,
-          startedAt: new Date(),
+          startedAt: new Date().toISOString(),
           versionString: task.version,
         })
         result = await node.process(dependencyResults)
@@ -472,7 +472,7 @@ export class TaskGraph extends EventEmitter2 {
    * Recursively remove node's dependants, without removing node.
    */
   private cancelDependants(node: TaskNode) {
-    const cancelledAt = new Date()
+    const cancelledAt = new Date().toISOString()
     for (const dependant of this.getDependants(node)) {
       this.logTaskComplete(dependant, false)
       this.garden.events.emit("taskCancelled", {

--- a/core/src/util/ext-tools.ts
+++ b/core/src/util/ext-tools.ts
@@ -157,7 +157,7 @@ export class CliWrapper {
     }
 
     logStream.on("data", (line: Buffer) => {
-      ctx.events.emit("log", { timestamp: new Date().getTime(), data: line, ...logEventContext })
+      ctx.events.emit("log", { timestamp: new Date().toISOString(), data: line, ...logEventContext })
     })
 
     await new Promise<void>((resolve, reject) => {

--- a/core/test/unit/src/task-graph.ts
+++ b/core/test/unit/src/task-graph.ts
@@ -130,7 +130,7 @@ describe("task-graph", () => {
     })
 
     it("should emit a taskPending event when adding a task", async () => {
-      const now = freezeTime()
+      const now = freezeTime().toISOString()
 
       const garden = await getGarden()
       const graph = new TaskGraph(garden, garden.log)
@@ -183,7 +183,7 @@ describe("task-graph", () => {
     })
 
     it("should emit events when processing and completing a task", async () => {
-      const now = freezeTime()
+      const now = freezeTime().toISOString()
 
       const garden = await getGarden()
       const graph = new TaskGraph(garden, garden.log)
@@ -207,7 +207,7 @@ describe("task-graph", () => {
     })
 
     it("should emit a taskError event when failing a task", async () => {
-      const now = freezeTime()
+      const now = freezeTime().toISOString()
 
       const garden = await getGarden()
       const graph = new TaskGraph(garden, garden.log)

--- a/plugins/jib/index.ts
+++ b/plugins/jib/index.ts
@@ -244,7 +244,7 @@ export const gardenPlugin = () =>
             const outputStream = split2()
             outputStream.on("error", () => {})
             outputStream.on("data", (data: Buffer) => {
-              ctx.events.emit("log", { timestamp: new Date().getTime(), data, ...logEventContext })
+              ctx.events.emit("log", { timestamp: new Date().toISOString(), data, ...logEventContext })
               buildLog += data.toString()
             })
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Previously the event payload type for dates was a JS Date instance. When these events are emitted to other consumers such as Cloud the dates are marshalled to ISO strings.

This commit updates the payload types to strings so that the types reflect what the consumers actually receive and so that the types can be re-used across consumers.


**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
