### PR TITLE
fix(framework): omit detail property of errors for GraphResultEventPayload

### DIFF
--- a/core/src/events.ts
+++ b/core/src/events.ts
@@ -88,8 +88,12 @@ export interface CommandInfoPayload extends CommandInfo {
 
 export function toGraphResultEventPayload(result: GraphResult): GraphResultEventPayload {
   const payload = sanitizeObject(omit(result, "dependencyResults"))
+
+  // TODO: Use a combined blacklist of fields from all task types instead of hardcoding here.
+  if (result.error) {
+    payload.error = omit(result.error, "detail")
+  }
   if (result.output) {
-    // TODO: Use a combined blacklist of fields from all task types instead of hardcoding here.
     payload.output = omit(result.output, "dependencyResults", "log", "buildLog", "detail")
     if (result.output.version) {
       payload.output.version = result.output.version.versionString || null


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
Core sometimes dropped events on error, because the detail property was too large.

This PR omits the details event on stack graph results before sending the event payload to Garden Cloud.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
