### PR TITLE
chore(scripts): release.ts unintentionally also ran scripts

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -8,7 +8,7 @@ import parseArgs = require("minimist")
 import deline = require("deline")
 import { resolve, relative } from "path"
 import { readFile, createWriteStream, writeFile } from "fs-extra"
-import { getPackages } from "./run-script"
+import { getPackages } from "./script-utils"
 import Bluebird = require("bluebird")
 const replace = require("replace-in-file")
 

--- a/scripts/run-script.ts
+++ b/scripts/run-script.ts
@@ -2,7 +2,6 @@
 
 import execa from "execa"
 import minimist from "minimist"
-import minimatch from "minimatch"
 import Bluebird from "bluebird"
 import { max, padEnd, padStart, mapValues, pickBy } from "lodash"
 import { DepGraph } from "dependency-graph"
@@ -11,34 +10,11 @@ import chalk from "chalk"
 import wrapAnsi from "wrap-ansi"
 import stripAnsi from "strip-ansi"
 import { resolve } from "path"
+import { getPackages, yarnPath } from "./script-utils"
 
 const colors = [chalk.red, chalk.green, chalk.yellow, chalk.magenta, chalk.cyan]
 
 const lineChar = "┄"
-const yarnPath = resolve(__dirname, "..", ".yarn", "releases", "yarn-1.22.5.js")
-
-export async function getPackages({ scope, ignore }: { scope?: string; ignore?: string } = {}) {
-  let packages = JSON.parse((await execa("node", [yarnPath, "--silent", "workspaces", "info"])).stdout)
-
-  if (scope) {
-    packages = pickBy(packages, (_, k) => minimatch(k, scope))
-  }
-
-  if (ignore) {
-    packages = pickBy(packages, (_, k) => !minimatch(k, ignore))
-  }
-
-  return mapValues(packages, (p, k) => {
-    const location = resolve(__dirname, "..", p.location)
-    return {
-      ...p,
-      name: k,
-      location,
-      packageJson: require(resolve(location, "package.json")),
-      shortName: k.split("/")[1],
-    }
-  })
-}
 
 async function runInPackages(args: string[]) {
   const argv = minimist(args, { boolean: ["bail", "parallel"], default: { bail: true } })

--- a/scripts/script-utils.ts
+++ b/scripts/script-utils.ts
@@ -1,0 +1,31 @@
+// This file contains functions that are being used in multiple different scripts.
+
+import execa from "execa";
+import { mapValues, pickBy } from "lodash";
+import minimatch from "minimatch"
+import { resolve } from "path"
+
+export const yarnPath = resolve(__dirname, "..", ".yarn", "releases", "yarn-1.22.5.js")
+
+export async function getPackages({ scope, ignore }: { scope?: string; ignore?: string } = {}) {
+  let packages = JSON.parse((await execa("node", [yarnPath, "--silent", "workspaces", "info"])).stdout)
+
+  if (scope) {
+    packages = pickBy(packages, (_, k) => minimatch(k, scope))
+  }
+
+  if (ignore) {
+    packages = pickBy(packages, (_, k) => !minimatch(k, ignore))
+  }
+
+  return mapValues(packages, (p, k) => {
+    const location = resolve(__dirname, "..", p.location)
+    return {
+      ...p,
+      name: k,
+      location,
+      packageJson: require(resolve(location, "package.json")),
+      shortName: k.split("/")[1],
+    }
+  })
+}


### PR DESCRIPTION
The release script used to import the utility `getPackages` from another script
called `run-script.ts`.

This in turn led to the side effect of `runInPackages` which would run
a script in all packages, if the first argument of release.ts happens to
be a script in that package.

It also led to a confusing error message on release.ts with no params:

```
% ./scripts/release.ts
Error: Must specify script name
```

This error is thrown in `run-scripts.ts`.

This PR moves the utilities to a different package with no side effects
on import.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
