### PR TITLE
fix(terraform): update condition that triggers `terraform init`

### DIFF
--- a/plugins/terraform/common.ts
+++ b/plugins/terraform/common.ts
@@ -64,7 +64,8 @@ export async function tfValidate(params: TerraformParams) {
     if (
       reasons.includes("Could not satisfy plugin requirements") ||
       reasons.includes("Module not installed") ||
-      reasons.includes("Could not load plugin")
+      reasons.includes("Could not load plugin") ||
+      reasons.includes("Missing required provider")
     ) {
       // We need to run `terraform init` and retry validation
       log.debug("Initializing Terraform")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
A user was encountering an error when running Garden against a project using the Garden Terraform provider.
More specifically, Garden is supposed to run `terraform init` when a required Terraform provider is missing and we do this by checking the error message returned by the Terraform cli.
It's possible, that in-between releases this error message has changed and we were not running `terraform init` when a provider needed a fresh installation.

**Which issue(s) this PR fixes**:

Fixes #3325

**Special notes for your reviewer**:
This is a quick fix for unblocking a user, but theoretically, we'd want to rewrite this logic to be more robust (e.g. does the Terraform cli return machine-readable output and error codes we can parse?).