### PR TITLE
chore(release): bump version to 0.12.49

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,34 +4,33 @@
 
 ### Bug Fixes
 
-* re-initialize providers changing environments ([#3481](https://github.com/garden-io/garden/issues/3481)) ([02903809f](https://github.com/garden-io/garden/commit/02903809f))
-* **cli:** failure in self-update command due to GitHub API change ([99fcd90c7](https://github.com/garden-io/garden/commit/99fcd90c7))
-* **events:** update log event timestamp type be string or number ([4241e4523](https://github.com/garden-io/garden/commit/4241e4523))
-* **events:** use ISO format date strings in event payload ([#3618](https://github.com/garden-io/garden/issues/3618)) ([42a76f339](https://github.com/garden-io/garden/commit/42a76f339))
+* **terraform:** update condition to trigger terraform init ([#3632](https://github.com/garden-io/garden/issues/3632)) ([ac5fbf4a9](https://github.com/garden-io/garden/commit/ac5fbf4a9))
+* **terraform:** fix checksums for terraform 1.2.9 darwin builds ([#3630](https://github.com/garden-io/garden/issues/3630)) ([21ea30f42](https://github.com/garden-io/garden/commit/21ea30f42))
 * **exec:** more informative error msg on timeout ([#3584](https://github.com/garden-io/garden/issues/3584)) ([0808531db](https://github.com/garden-io/garden/commit/0808531db))
-* **framework:** omit detail property of errors ([24f32fad3](https://github.com/garden-io/garden/commit/24f32fad3))
+* **kubernetes:** detect that pod has been killed ([#3571](https://github.com/garden-io/garden/issues/3571)) ([9193a857d](https://github.com/garden-io/garden/commit/9193a857d))
 * **framework:** increase consistency in verbose plugin logs ([236987d52](https://github.com/garden-io/garden/commit/236987d52))
 * **helm:** stream logs to CLI and Garden Cloud ([#3582](https://github.com/garden-io/garden/issues/3582)) ([22d46a497](https://github.com/garden-io/garden/commit/22d46a497))
-* **kubernetes:** detect that pod has been killed ([#3571](https://github.com/garden-io/garden/issues/3571)) ([9193a857d](https://github.com/garden-io/garden/commit/9193a857d))
+* **framework** re-initialize providers changing environments ([#3481](https://github.com/garden-io/garden/issues/3481)) ([02903809f](https://github.com/garden-io/garden/commit/02903809f))
+* **cli:** failure in self-update command due to GitHub API change ([99fcd90c7](https://github.com/garden-io/garden/commit/99fcd90c7))
+* **events:** use ISO format date strings in event payload ([#3618](https://github.com/garden-io/garden/issues/3618)) ([42a76f339](https://github.com/garden-io/garden/commit/42a76f339))
+* **events:** update log event timestamp type be string or number ([4241e4523](https://github.com/garden-io/garden/commit/4241e4523))
+* **framework:** omit detail property of errors ([24f32fad3](https://github.com/garden-io/garden/commit/24f32fad3))
 * **kubernetes:** make preStop command work with busybox ([#3568](https://github.com/garden-io/garden/issues/3568)) ([b062281a0](https://github.com/garden-io/garden/commit/b062281a0))
 * **scripts:** release.ts unintentionally also ran scripts ([#3626](https://github.com/garden-io/garden/issues/3626)) ([e7024fe63](https://github.com/garden-io/garden/commit/e7024fe63))
-* **terraform:** fix checksums for terraform 1.2.9 darwin builds ([#3630](https://github.com/garden-io/garden/issues/3630)) ([21ea30f42](https://github.com/garden-io/garden/commit/21ea30f42))
-* **terraform:** update condition to trigger tf init ([#3632](https://github.com/garden-io/garden/issues/3632)) ([ac5fbf4a9](https://github.com/garden-io/garden/commit/ac5fbf4a9))
 
 ### Features
 
-* allow to specify commit for remote sources ([78ddb509e](https://github.com/garden-io/garden/commit/78ddb509e))
+* **remote sources:** allow to specify commit for remote sources ([78ddb509e](https://github.com/garden-io/garden/commit/78ddb509e))
 * **commands:** add experimental watch disable flag for dev mode ([2d8bf03e5](https://github.com/garden-io/garden/commit/2d8bf03e5))
 * **kubernetes:** add sync helper commands ([e2a084af0](https://github.com/garden-io/garden/commit/e2a084af0))
 
 ### Improvements
 
 * **cli:** trim binary size by approx 1/3 ([ee3554eb0](https://github.com/garden-io/garden/commit/ee3554eb0))
-* **cloud:** automate remote project creation ([#3462](https://github.com/garden-io/garden/issues/3462)) ([f8f2cf706](https://github.com/garden-io/garden/commit/f8f2cf706))
-* **dev-mode:** address PR comments ([53f824002](https://github.com/garden-io/garden/commit/53f824002))
 * **examples:** add a rust example ([#3503](https://github.com/garden-io/garden/issues/3503)) ([e04324ad6](https://github.com/garden-io/garden/commit/e04324ad6))
 * **helm:** relax path validation requirements for valueFiles ([#3445](https://github.com/garden-io/garden/issues/3445)) ([24589b62c](https://github.com/garden-io/garden/commit/24589b62c))
 * **server:** ensure serverReady event has correct type ([81350c768](https://github.com/garden-io/garden/commit/81350c768))
+* **cloud:** automate remote project creation ([#3462](https://github.com/garden-io/garden/issues/3462)) ([f8f2cf706](https://github.com/garden-io/garden/commit/f8f2cf706))
 
 <a name="0.12.48"></a>
 ## [0.12.48](https://github.com/garden-io/garden/compare/0.12.47...0.12.48) (2022-12-16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,38 @@
 
+<a name="0.12.49"></a>
+## [0.12.49](https://github.com/garden-io/garden/compare/0.12.48...0.12.49) (2023-01-31)
+
+### Bug Fixes
+
+* re-initialize providers changing environments ([#3481](https://github.com/garden-io/garden/issues/3481)) ([02903809f](https://github.com/garden-io/garden/commit/02903809f))
+* **cli:** failure in self-update command due to GitHub API change ([99fcd90c7](https://github.com/garden-io/garden/commit/99fcd90c7))
+* **events:** update log event timestamp type be string or number ([4241e4523](https://github.com/garden-io/garden/commit/4241e4523))
+* **events:** use ISO format date strings in event payload ([#3618](https://github.com/garden-io/garden/issues/3618)) ([42a76f339](https://github.com/garden-io/garden/commit/42a76f339))
+* **exec:** more informative error msg on timeout ([#3584](https://github.com/garden-io/garden/issues/3584)) ([0808531db](https://github.com/garden-io/garden/commit/0808531db))
+* **framework:** omit detail property of errors ([24f32fad3](https://github.com/garden-io/garden/commit/24f32fad3))
+* **framework:** increase consistency in verbose plugin logs ([236987d52](https://github.com/garden-io/garden/commit/236987d52))
+* **helm:** stream logs to CLI and Garden Cloud ([#3582](https://github.com/garden-io/garden/issues/3582)) ([22d46a497](https://github.com/garden-io/garden/commit/22d46a497))
+* **kubernetes:** detect that pod has been killed ([#3571](https://github.com/garden-io/garden/issues/3571)) ([9193a857d](https://github.com/garden-io/garden/commit/9193a857d))
+* **kubernetes:** make preStop command work with busybox ([#3568](https://github.com/garden-io/garden/issues/3568)) ([b062281a0](https://github.com/garden-io/garden/commit/b062281a0))
+* **scripts:** release.ts unintentionally also ran scripts ([#3626](https://github.com/garden-io/garden/issues/3626)) ([e7024fe63](https://github.com/garden-io/garden/commit/e7024fe63))
+* **terraform:** fix checksums for terraform 1.2.9 darwin builds ([#3630](https://github.com/garden-io/garden/issues/3630)) ([21ea30f42](https://github.com/garden-io/garden/commit/21ea30f42))
+* **terraform:** update condition to trigger tf init ([#3632](https://github.com/garden-io/garden/issues/3632)) ([ac5fbf4a9](https://github.com/garden-io/garden/commit/ac5fbf4a9))
+
+### Features
+
+* allow to specify commit for remote sources ([78ddb509e](https://github.com/garden-io/garden/commit/78ddb509e))
+* **commands:** add experimental watch disable flag for dev mode ([2d8bf03e5](https://github.com/garden-io/garden/commit/2d8bf03e5))
+* **kubernetes:** add sync helper commands ([e2a084af0](https://github.com/garden-io/garden/commit/e2a084af0))
+
+### Improvements
+
+* **cli:** trim binary size by approx 1/3 ([ee3554eb0](https://github.com/garden-io/garden/commit/ee3554eb0))
+* **cloud:** automate remote project creation ([#3462](https://github.com/garden-io/garden/issues/3462)) ([f8f2cf706](https://github.com/garden-io/garden/commit/f8f2cf706))
+* **dev-mode:** address PR comments ([53f824002](https://github.com/garden-io/garden/commit/53f824002))
+* **examples:** add a rust example ([#3503](https://github.com/garden-io/garden/issues/3503)) ([e04324ad6](https://github.com/garden-io/garden/commit/e04324ad6))
+* **helm:** relax path validation requirements for valueFiles ([#3445](https://github.com/garden-io/garden/issues/3445)) ([24589b62c](https://github.com/garden-io/garden/commit/24589b62c))
+* **server:** ensure serverReady event has correct type ([81350c768](https://github.com/garden-io/garden/commit/81350c768))
+
 <a name="0.12.48"></a>
 ## [0.12.48](https://github.com/garden-io/garden/compare/0.12.47...0.12.48) (2022-12-16)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://docs.garden.io/?utm_source=github">Docs</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://github.com/garden-io/garden/tree/0.12.48/examples">Examples</a>
+  <a href="https://github.com/garden-io/garden/tree/0.12.49/examples">Examples</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://garden.io/blog/?utm_source=github">Blog</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garden-io/cli",
-  "version": "0.12.48",
+  "version": "0.12.49",
   "description": "Cloud native testing platform for testing and developing container applications on Kubernetes",
   "repository": {
     "type": "git",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garden-io/core",
-  "version": "0.12.48",
+  "version": "0.12.49",
   "description": "A full-featured development framework for containers and serverless",
   "repository": {
     "type": "git",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garden-io/dashboard",
-  "version": "0.12.48",
+  "version": "0.12.49",
   "private": true,
   "devDependencies": {
     "@garden-io/cli": "*",

--- a/docs/advanced/using-remote-sources.md
+++ b/docs/advanced/using-remote-sources.md
@@ -11,7 +11,7 @@ You can import **two** types of remote repositories with Garden:
 
 > **Remote _module_**: The source code for a single Garden module. In this case, the `garden.yml` config file is stored in the main project repository while the module code itself is in the remote repository.
 
-The code examples below are from our [remote sources example](https://github.com/garden-io/garden/tree/0.12.48/examples/remote-sources).
+The code examples below are from our [remote sources example](https://github.com/garden-io/garden/tree/0.12.49/examples/remote-sources).
 
 ## Importing Remote Repositories
 

--- a/docs/basics/quickstart.md
+++ b/docs/basics/quickstart.md
@@ -201,7 +201,7 @@ If you'd like to better understand how a Garden project is configured when using
 through our [first project tutorial](../tutorials/your-first-project/README.md) which walks you through configuring a Garden project step-by-step.
 
 If you like to dive right in and configure your own project for Garden, we recommend using our [example
-projects on GitHub](https://github.com/garden-io/garden/tree/0.12.48/examples) for reference and reading through the different pages
+projects on GitHub](https://github.com/garden-io/garden/tree/0.12.49/examples) for reference and reading through the different pages
 of the [Using Garden section](../using-garden/configuration-overview.md) of our docs.
 
 And if you have any questions or feedback—or just want to say hi 🙂—we encourage you to join our [Discord community](https://discord.gg/gxeuDgp6Xt)!

--- a/docs/guides/using-garden-in-ci.md
+++ b/docs/guides/using-garden-in-ci.md
@@ -23,7 +23,7 @@ The guide uses the [Remote Kubernetes plugin](../k8s-plugins/remote-k8s/README.m
 
 ## Project overview
 
-The project is based on our basic [demo-project](https://github.com/garden-io/garden/tree/0.12.48/examples/demo-project) example, but configured for multiple environments. Additionally it contains a CircleCI config file. You'll find the entire source code [here](https://github.com/garden-io/ci-demo-project).
+The project is based on our basic [demo-project](https://github.com/garden-io/garden/tree/0.12.49/examples/demo-project) example, but configured for multiple environments. Additionally it contains a CircleCI config file. You'll find the entire source code [here](https://github.com/garden-io/ci-demo-project).
 
 The CI pipeline is configured so that Garden tests the project and deploys it to a **preview** environment on every pull request. Additionally, it tests the project and deploys it to a separate **staging** environment on every merge to the `main` branch.
 

--- a/docs/k8s-plugins/module-types/container.md
+++ b/docs/k8s-plugins/module-types/container.md
@@ -11,7 +11,7 @@ The Kubernetes plugins can deploy `container` modules that define one or more `s
 
 Garden will take the simplified `container` service specification and convert it to the corresponding Kubernetes manifests, i.e. Deployment, Service and (if applicable) Ingress resources.
 
-Here, for example, is the spec for the `frontend` service in our example [demo project](https://github.com/garden-io/garden/tree/0.12.48/examples/demo-project):
+Here, for example, is the spec for the `frontend` service in our example [demo project](https://github.com/garden-io/garden/tree/0.12.49/examples/demo-project):
 
 ```yaml
 kind: Module
@@ -95,5 +95,5 @@ kubectl --namespace <my-app-namespace> create secret generic --from-literal=some
 
 Where `<my-app-namespace>` is your project namespace (which is either set with `namespace` in your provider config, or defaults to your project name). There are notably other, more secure ways to create secrets via `kubectl`. Please refer to the official [Kubernetes Secrets docs](https://kubernetes.io/docs/concepts/configuration/secret/#creating-a-secret-using-kubectl-create-secret) for details.
 
-Also check out the [Kubernetes Secrets example project](https://github.com/garden-io/garden/tree/0.12.48/examples/kubernetes-secrets) for a working example.
+Also check out the [Kubernetes Secrets example project](https://github.com/garden-io/garden/tree/0.12.49/examples/kubernetes-secrets) for a working example.
 

--- a/docs/k8s-plugins/module-types/helm.md
+++ b/docs/k8s-plugins/module-types/helm.md
@@ -7,13 +7,13 @@ order: 3
 
 The [Helm](https://helm.sh/) package manager is one of the most commonly used tools for managing Kubernetes manifests. Garden supports using your own Helm charts, alongside your container modules, via the `kubernetes` and `local-kubernetes` providers. This guide shows you how to configure and use 3rd-party (or otherwise external) Helm charts, as well as your own charts in your Garden project. We also go through how to set up tests, tasks and hot-reloading for your charts.
 
-In this guide we'll be using the [vote-helm](https://github.com/garden-io/garden/tree/0.12.48/examples/vote-helm) project. If you prefer to just check out a complete example, the project itself is also a good resource.
+In this guide we'll be using the [vote-helm](https://github.com/garden-io/garden/tree/0.12.49/examples/vote-helm) project. If you prefer to just check out a complete example, the project itself is also a good resource.
 
 You may also want to check out the full [helm module reference](../../reference/module-types/helm.md).
 
 _Note: If you only need a way to deploy some Kubernetes manifests and don't need all the features of Helm, you can_
 _use the simpler `kubernetes` module type instead. Check out the_
-_[kubernetes-module](https://github.com/garden-io/garden/tree/0.12.48/examples/kubernetes-module) example for more info._
+_[kubernetes-module](https://github.com/garden-io/garden/tree/0.12.49/examples/kubernetes-module) example for more info._
 
 ## Basics
 
@@ -315,7 +315,7 @@ You can define a remote environment as a `production` environment by setting the
 
 ## Next steps
 
-Check out the full [helm module reference](../../reference/module-types/helm.md) for more details, and the [vote-helm](https://github.com/garden-io/garden/tree/0.12.48/examples/vote-helm) example project for a full project that showcases Garden's Helm support.
+Check out the full [helm module reference](../../reference/module-types/helm.md) for more details, and the [vote-helm](https://github.com/garden-io/garden/tree/0.12.49/examples/vote-helm) example project for a full project that showcases Garden's Helm support.
 
 Also check out the [Kubernetes module](./kubernetes.md)
 example for a simpler alternative, if you don't need all the features of Helm.

--- a/docs/k8s-plugins/remote-k8s/ingress-and-dns.md
+++ b/docs/k8s-plugins/remote-k8s/ingress-and-dns.md
@@ -5,7 +5,7 @@ order: 3
 
 # 3. Set Up Ingress, TLS and DNS
 
-By default, Garden will not install an ingress controller for remote environments. This can be toggled by setting the [`setupIngressController` flag](../../reference/providers/kubernetes.md#providerssetupingresscontroller) to `nginx`. Alternatively, you can set up your own ingress controller, e.g. using [Traefik](https://traefik.io/), [Ambassador](https://www.getambassador.io/) or [Istio](https://istio.io/). You can find an example for [using Garden with Istio](https://github.com/garden-io/garden/tree/0.12.46/examples/istio) in our [examples directory](https://github.com/garden-io/garden/tree/0.12.46/examples).
+By default, Garden will not install an ingress controller for remote environments. This can be toggled by setting the [`setupIngressController` flag](../../reference/providers/kubernetes.md#providerssetupingresscontroller) to `nginx`. Alternatively, you can set up your own ingress controller, e.g. using [Traefik](https://traefik.io/), [Ambassador](https://www.getambassador.io/) or [Istio](https://istio.io/). You can find an example for [using Garden with Istio](https://github.com/garden-io/garden/tree/0.12.49/examples/istio) in our [examples directory](https://github.com/garden-io/garden/tree/0.12.49/examples).
 
 You'll also need to point one or more DNS entries to your cluster, and configure a TLS certificate for the hostnames
 you will expose for ingress.

--- a/docs/misc/faq.md
+++ b/docs/misc/faq.md
@@ -45,7 +45,7 @@ You can also deploy `kubernetes` and `helm` modules to their own namespaces.
 
 ### How do I share code between modules?
 
-You can use the [copy directive](https://docs.garden.io/reference/module-types/container#build-dependencies-copy) of the `build.dependencies[]` field for that. See e.g. [this example project](https://github.com/garden-io/garden/tree/0.12.48/examples/build-dependencies).
+You can use the [copy directive](https://docs.garden.io/reference/module-types/container#build-dependencies-copy) of the `build.dependencies[]` field for that. See e.g. [this example project](https://github.com/garden-io/garden/tree/0.12.49/examples/build-dependencies).
 
 Alternatively you can hoist your `garden.yml` file so that it is at the same level or parent to all relevant build context and use the `include` field.
 
@@ -65,7 +65,7 @@ Use the [`targetImage` field](https://docs.garden.io/reference/module-types/cont
 
 ### How do I use base images?
 
-See [this example project](https://github.com/garden-io/garden/tree/0.12.48/examples/base-image).
+See [this example project](https://github.com/garden-io/garden/tree/0.12.49/examples/base-image).
 
 ### Can I use runtime variables in container builds (e.g. from tasks)?
 
@@ -111,11 +111,11 @@ include: [frontend/**/*]
 
 Note that you can put multiple Garden configuration files in the same directory, e.g. `project.garden.yml`, `api.garden.yml` and `frontend.garden.yml`.
 
-If you need the Dockerfile outside of the module root because you want to share it with other modules, you should consider having a single base image instead and then let each module have its own Dockerfile that's built on the base image. See the [base image example project](https://github.com/garden-io/garden/tree/0.12.48/examples/base-image) for an example of this.
+If you need the Dockerfile outside of the module root because you want to share it with other modules, you should consider having a single base image instead and then let each module have its own Dockerfile that's built on the base image. See the [base image example project](https://github.com/garden-io/garden/tree/0.12.49/examples/base-image) for an example of this.
 
 ### How do I include files/dirs (e.g. shared libraries) from outside the module root with the build context?
 
-See [this example project](https://github.com/garden-io/garden/tree/0.12.48/examples/build-dependencies).
+See [this example project](https://github.com/garden-io/garden/tree/0.12.49/examples/build-dependencies).
 
 ### How do I add Docker specific flags to the build command?
 
@@ -129,7 +129,7 @@ You can use the `dockerfile` field. For example:
 dockerfile: "${environment.name == 'prod' ? Dockerfile.prod : Dockerfile.dev}"
 ```
 
-See also the [base image example project](https://github.com/garden-io/garden/tree/0.12.48/examples/base-image) for an example of this.
+See also the [base image example project](https://github.com/garden-io/garden/tree/0.12.49/examples/base-image) for an example of this.
 
 ## Remote Building
 

--- a/docs/other-plugins/exec.md
+++ b/docs/other-plugins/exec.md
@@ -99,7 +99,7 @@ services:
     env: ${modules.frontend.env} # <--- Reference the env variable defined above
 ```
 
-See also this [example project](https://github.com/garden-io/garden/tree/main/examples/local-service).
+See also this [example project](https://github.com/garden-io/garden/tree/0.12.49/examples/local-service).
 
 ## Next Steps
 

--- a/docs/pulumi-plugin/about.md
+++ b/docs/pulumi-plugin/about.md
@@ -82,7 +82,7 @@ garden plugins pulumi preview -- my-pulumi-module my-other-pulumi-module
 
 ## Next steps
 
-Check out the [`pulumi` example](https://github.com/garden-io/garden/tree/0.12.48/examples/pulumi) project.
+Check out the [`pulumi` example](https://github.com/garden-io/garden/tree/0.12.49/examples/pulumi) project.
 
 Also take a look at the [pulumi provider reference]() and the [pulumi module type reference] for details on all the configuration parameters.
 

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -7,7 +7,7 @@ tocTitle: "`jib-container`"
 
 ## Description
 
-Extends the [container module type](./container.md) to build the image with [Jib](https://github.com/GoogleContainerTools/jib). Use this to efficiently build container images for Java services. Check out the [jib example](https://github.com/garden-io/garden/tree/0.12.48/examples/jib-container) to see it in action.
+Extends the [container module type](./container.md) to build the image with [Jib](https://github.com/GoogleContainerTools/jib). Use this to efficiently build container images for Java services. Check out the [jib example](https://github.com/garden-io/garden/tree/0.12.49/examples/jib-container) to see it in action.
 
 The image is always built locally, directly from the module source directory (see the note on that below), before shipping the container image to the right place. You can set `build.tarOnly: true` to only build the image as a tarball.
 

--- a/docs/reference/providers/conftest-kubernetes.md
+++ b/docs/reference/providers/conftest-kubernetes.md
@@ -14,7 +14,7 @@ Simply add this provider to your project configuration, and configure your polic
 reference for how to configure default policies, default namespaces, and test failure thresholds for the generated
 modules.
 
-See the [conftest example project](https://github.com/garden-io/garden/tree/0.12.48/examples/conftest) for a simple
+See the [conftest example project](https://github.com/garden-io/garden/tree/0.12.49/examples/conftest) for a simple
 usage example.
 
 Below is the full schema reference for the provider configuration. For an introduction to configuring a Garden project with providers, please look at our [configuration guide](../../using-garden/configuration-overview.md).

--- a/docs/reference/providers/conftest.md
+++ b/docs/reference/providers/conftest.md
@@ -9,7 +9,7 @@ tocTitle: "`conftest`"
 
 This provider allows you to validate your configuration files against policies that you specify, using the [conftest tool](https://github.com/instrumenta/conftest) and Open Policy Agent rego query files. The provider creates a module type of the same name, which allows you to specify files to validate. Each module then creates a Garden test that becomes part of your Stack Graph.
 
-Note that, in many cases, you'll actually want to use more specific providers that can automatically configure your `conftest` modules, e.g. the [`conftest-container`](../module-types/conftest.md) and/or [`conftest-kubernetes`](../module-types/conftest.md) providers. See the [conftest example project](https://github.com/garden-io/garden/tree/0.12.48/examples/conftest) for a simple usage example of the latter.
+Note that, in many cases, you'll actually want to use more specific providers that can automatically configure your `conftest` modules, e.g. the [`conftest-container`](../module-types/conftest.md) and/or [`conftest-kubernetes`](../module-types/conftest.md) providers. See the [conftest example project](https://github.com/garden-io/garden/tree/0.12.49/examples/conftest) for a simple usage example of the latter.
 
 If those don't match your needs, you can use this provider directly and manually configure your `conftest` modules. Simply add this provider to your project configuration, and see the [conftest module documentation](../module-types/conftest.md) for a detailed reference. Also, check out the below reference for how to configure default policies, default namespaces, and test failure thresholds for all `conftest` modules.
 

--- a/docs/reference/providers/hadolint.md
+++ b/docs/reference/providers/hadolint.md
@@ -11,7 +11,7 @@ This provider creates a [`hadolint`](../module-types/hadolint.md) module type, a
 
 To configure `hadolint`, you can use `.hadolint.yaml` config files. For each test, we first look for one in the relevant module root. If none is found there, we check the project root, and if none is there we fall back to default configuration. Note that for reasons of portability, we do not fall back to global/user configuration files.
 
-See the [hadolint docs](https://github.com/hadolint/hadolint#configure) for details on how to configure it, and the [hadolint example project](https://github.com/garden-io/garden/tree/0.12.48/examples/hadolint) for a usage example.
+See the [hadolint docs](https://github.com/hadolint/hadolint#configure) for details on how to configure it, and the [hadolint example project](https://github.com/garden-io/garden/tree/0.12.49/examples/hadolint) for a usage example.
 
 Below is the full schema reference for the provider configuration. For an introduction to configuring a Garden project with providers, please look at our [configuration guide](../../using-garden/configuration-overview.md).
 

--- a/docs/reference/providers/jib.md
+++ b/docs/reference/providers/jib.md
@@ -11,7 +11,7 @@ tocTitle: "`jib`"
 
 Provides support for [Jib](https://github.com/GoogleContainerTools/jib) via the [jib module type](../module-types/jib-container.md).
 
-Use this to efficiently build container images for Java services. Check out the [jib example](https://github.com/garden-io/garden/tree/0.12.48/examples/jib-container) to see it in action.
+Use this to efficiently build container images for Java services. Check out the [jib example](https://github.com/garden-io/garden/tree/0.12.49/examples/jib-container) to see it in action.
 
 Below is the full schema reference for the provider configuration. For an introduction to configuring a Garden project with providers, please look at our [configuration guide](../../using-garden/configuration-overview.md).
 

--- a/docs/reference/providers/openfaas.md
+++ b/docs/reference/providers/openfaas.md
@@ -11,7 +11,7 @@ This provider adds support for [OpenFaaS](https://www.openfaas.com/). It adds th
 
 See the reference below for configuration options for `faas-netes`, and the [module type docs](../module-types/openfaas.md) for how to configure the individual functions.
 
-Also see the [openfaas example project](https://github.com/garden-io/garden/tree/0.12.48/examples/openfaas) for a simple usage example.
+Also see the [openfaas example project](https://github.com/garden-io/garden/tree/0.12.49/examples/openfaas) for a simple usage example.
 
 Below is the full schema reference for the provider configuration. For an introduction to configuring a Garden project with providers, please look at our [configuration guide](../../using-garden/configuration-overview.md).
 

--- a/docs/terraform-plugin/about.md
+++ b/docs/terraform-plugin/about.md
@@ -15,7 +15,7 @@ Under the hood, Garden simply wraps Terraform, so there's no magic involved. Gar
 
 The `terraform` provider can both provision a Terraform stack when initializing Garden, or through `terraform` modules that are deployed like other services in your stack.
 
-The former, having a single Terraform stack for your whole project, is most helpful if other provider configurations need to reference the outputs from your Terraform stack, or if most/all of your services depend on the infrastructure provisioned in your Terraform stack. A good example of this is the [terraform-gke example](https://github.com/garden-io/garden/tree/0.12.48/examples/terraform-gke) project, which provisions a GKE cluster that the `kubernetes` provider then runs on, along with the services in the project. The drawback is that Garden doesn't currently watch for changes in those Terraform files, and you need to restart to apply new changes, or apply them manually.
+The former, having a single Terraform stack for your whole project, is most helpful if other provider configurations need to reference the outputs from your Terraform stack, or if most/all of your services depend on the infrastructure provisioned in your Terraform stack. A good example of this is the [terraform-gke example](https://github.com/garden-io/garden/tree/0.12.49/examples/terraform-gke) project, which provisions a GKE cluster that the `kubernetes` provider then runs on, along with the services in the project. The drawback is that Garden doesn't currently watch for changes in those Terraform files, and you need to restart to apply new changes, or apply them manually.
 
 The latter method, using one or more `terraform` _modules_, can be better if your other providers don't need to reference the stack outputs but your _services, tasks and tests_ do. In this style, you can basically create small Terraform stacks that are part of your Stack Graph much like other services. A good example would be deploying a database instance, that other services in your project can then connect to.
 
@@ -88,6 +88,6 @@ Now when you deploy a new Terraformed environment, the new backend statefile wil
 
 ## Next steps
 
-Check out the [terraform-gke example](https://github.com/garden-io/garden/tree/0.12.48/examples/terraform-gke) project. Also take a look at the [Terraform provider reference](../reference/providers/terraform.md) and the [Terraform module type reference](../reference/module-types/terraform.md) for details on all the configuration parameters.
+Check out the [terraform-gke example](https://github.com/garden-io/garden/tree/0.12.49/examples/terraform-gke) project. Also take a look at the [Terraform provider reference](../reference/providers/terraform.md) and the [Terraform module type reference](../reference/module-types/terraform.md) for details on all the configuration parameters.
 
 If you're having issues with Terraform itself, please refer to the [official docs](https://www.terraform.io/docs/index.html).

--- a/docs/terraform-plugin/configure-provider.md
+++ b/docs/terraform-plugin/configure-provider.md
@@ -16,7 +16,7 @@ providers:
   ...
 ```
 
-If you'd like to apply the stack when starting Garden, and then reference the stack outputs in other providers (or modules), you need to add a couple of more flags. Here's the project config from the aforementioned [terraform-gke example](https://github.com/garden-io/garden/tree/0.12.46/examples/terraform-gke):
+If you'd like to apply the stack when starting Garden, and then reference the stack outputs in other providers (or modules), you need to add a couple of more flags. Here's the project config from the aforementioned [terraform-gke example](https://github.com/garden-io/garden/tree/0.12.49/examples/terraform-gke):
 
 ```yaml
 kind: Project

--- a/docs/tutorials/your-first-project/4-configure-your-project.md
+++ b/docs/tutorials/your-first-project/4-configure-your-project.md
@@ -11,7 +11,7 @@ Garden is a powerful and flexible tool, and there are several things to learn al
 
 1. Place the project configuration you created for the example, which will be all set to connect to your cluster, in your own project root.
 2. Go through the [Using Garden](../../using-garden/README.md) documentation section. This will cover all the key concepts, and introduce all the moving parts, including the different module types that Garden supports.
-3. Have a look at the [examples](https://github.com/garden-io/garden/tree/0.12.48/examples) folder in the Garden repository, which offers several usage examples that you can refer to while building out your project.
+3. Have a look at the [examples](https://github.com/garden-io/garden/tree/0.12.49/examples) folder in the Garden repository, which offers several usage examples that you can refer to while building out your project.
 4. Set up your modules, getting them building and deploying, **one at a time**.
 5. Make sure your whole project builds and deploys successfully.
 6. Start thinking about tests. Garden excels at managing all the different test suites in your stack, especially integration and end-to-end tests that need to run inside your deployment environment.

--- a/docs/using-garden/module-templates.md
+++ b/docs/using-garden/module-templates.md
@@ -17,7 +17,7 @@ This feature was introduced in Garden 0.12.7. Please make sure you have an up-to
 
 ## How it works
 
-We'll use the [`templated-k8s-container example`](https://github.com/garden-io/garden/tree/0.12.48/examples/templated-k8s-container) to illustrate how module templates work. This example has a `k8s-container` template, that generates one `container` module for building an image, and one `kubernetes` module for deploying that image. A template like this is useful to customize the Kubernetes manifests for your services, but of course it's just one simple example of what you could do.
+We'll use the [`templated-k8s-container example`](https://github.com/garden-io/garden/tree/0.12.49/examples/templated-k8s-container) to illustrate how module templates work. This example has a `k8s-container` template, that generates one `container` module for building an image, and one `kubernetes` module for deploying that image. A template like this is useful to customize the Kubernetes manifests for your services, but of course it's just one simple example of what you could do.
 
 The template is defined like this:
 
@@ -158,7 +158,7 @@ Garden will then scan that repo when starting up, and you can reference the temp
 
 - [ModuleTemplate reference docs](../reference/module-template-config.md).
 - [`templated` module type reference docs](../reference/module-types/templated.md).
-- [`templated-k8s-container example`](https://github.com/garden-io/garden/tree/0.12.48/examples/templated-k8s-container).
+- [`templated-k8s-container example`](https://github.com/garden-io/garden/tree/0.12.49/examples/templated-k8s-container).
 
 ## Next steps
 

--- a/docs/using-garden/modules.md
+++ b/docs/using-garden/modules.md
@@ -9,7 +9,7 @@ Modules are the basic **unit of building** in Garden. They are usually the first
 
 A module can correspond to a Dockerfile and its associated code, a remote Docker image, a Helm chart, an OpenFaaS function, and more, all depending on the module type.
 
-Below is a simple example of a module's `garden.yml` (from the [`demo-project`](https://github.com/garden-io/garden/tree/0.12.48/examples/demo-project) example project):
+Below is a simple example of a module's `garden.yml` (from the [`demo-project`](https://github.com/garden-io/garden/tree/0.12.49/examples/demo-project) example project):
 
 ```yaml
 kind: Module

--- a/docs/using-garden/tasks.md
+++ b/docs/using-garden/tasks.md
@@ -86,7 +86,7 @@ tasks:
       - postgres
 ```
 
-The full example is [available here](https://github.com/garden-io/garden/tree/0.12.48/examples/vote-helm/postgres/garden.yml). There's [also a version](https://github.com/garden-io/garden/tree/0.12.48/examples/vote) that uses the `container` module type instead of Helm charts.
+The full example is [available here](https://github.com/garden-io/garden/tree/0.12.49/examples/vote-helm/postgres/garden.yml). There's [also a version](https://github.com/garden-io/garden/tree/0.12.49/examples/vote) that uses the `container` module type instead of Helm charts.
 
 ## Advanced
 

--- a/docs/using-garden/tests.md
+++ b/docs/using-garden/tests.md
@@ -49,7 +49,7 @@ For full test configuration by module type, please take a look at our [reference
 
 ### Integration Testing
 
-Below is an example of a `frontend` module that has a `unit` test and an `integ` test that depends on a `backend` module. The `integ` test checks whether the frontend gets the correct response from the backend. The example is based on our [vote example project](https://github.com/garden-io/garden/tree/0.12.48/examples/vote).
+Below is an example of a `frontend` module that has a `unit` test and an `integ` test that depends on a `backend` module. The `integ` test checks whether the frontend gets the correct response from the backend. The example is based on our [vote example project](https://github.com/garden-io/garden/tree/0.12.49/examples/vote).
 
 Here's the configuration for `frontend` module:
 

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garden-io/e2e",
-  "version": "0.12.48",
+  "version": "0.12.49",
   "description": "End-to-end tests for the Garden CLI",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "git+https://github.com/garden-io/garden.git"
   },
-  "version": "0.12.48",
+  "version": "0.12.49",
   "author": "Garden Technologies, Inc. <info@garden.io>",
   "license": "MPL-2.0",
   "homepage": "https://github.com/garden-io/garden",

--- a/plugins/conftest-container/package.json
+++ b/plugins/conftest-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garden-io/garden-conftest-container",
-  "version": "0.12.48",
+  "version": "0.12.49",
   "description": "Auto-generator for the conftest plugin and Garden container modules",
   "main": "index.js",
   "dependencies": {

--- a/plugins/conftest-kubernetes/package.json
+++ b/plugins/conftest-kubernetes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garden-io/garden-conftest-kubernetes",
-  "version": "0.12.48",
+  "version": "0.12.49",
   "description": "Auto-generator for the conftest plugin and Garden kubernetes/helm modules",
   "main": "index.js",
   "private": true,

--- a/plugins/conftest/package.json
+++ b/plugins/conftest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garden-io/garden-conftest",
-  "version": "0.12.48",
+  "version": "0.12.49",
   "description": "conftest plugin for Garden",
   "main": "index.js",
   "private": true,

--- a/plugins/jib/package.json
+++ b/plugins/jib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garden-io/garden-jib",
-  "version": "0.12.48",
+  "version": "0.12.49",
   "description": "Jib container plugin for Garden",
   "main": "index.js",
   "dependencies": {

--- a/plugins/maven-container/package.json
+++ b/plugins/maven-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garden-io/garden-maven-container",
-  "version": "0.12.48",
+  "version": "0.12.49",
   "description": "maven-container plugin for Garden (DEPRECATED)",
   "main": "index.js",
   "dependencies": {

--- a/plugins/pulumi/package.json
+++ b/plugins/pulumi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garden-io/garden-pulumi",
-  "version": "0.12.48",
+  "version": "0.12.49",
   "description": "Pulumi plugin for Garden",
   "main": "index.js",
   "dependencies": {

--- a/plugins/terraform/package.json
+++ b/plugins/terraform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garden-io/garden-terraform",
-  "version": "0.12.48",
+  "version": "0.12.49",
   "description": "Terraform plugin for Garden",
   "main": "index.js",
   "dependencies": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garden-io/sdk",
-  "version": "0.12.48",
+  "version": "0.12.49",
   "description": "TypeScript plugin SDK for Garden",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Garden 0.12.49 is out! :tada:

This is a maintenance release. It includes a few bug fixes, minor features, and improvements.

Many thanks to @ITHedgeHog for the contributions to this release!

## Assets

Download the Garden binary for your platform from below or simply run `garden self-update` if you already have it installed.

* [Garden v0.12.49 for Alpine AMD64 (tar.gz)](https://download.garden.io/core/0.12.49/garden-0.12.49-alpine-amd64.tar.gz)
* [Garden v0.12.49 for Linux AMD64 (tar.gz)](https://download.garden.io/core/0.12.49/garden-0.12.49-linux-amd64.tar.gz)
* [Garden v0.12.49 for MacOS AMD64 (tar.gz)](https://download.garden.io/core/0.12.49/garden-0.12.49-macos-amd64.tar.gz)
* [Garden v0.12.49 for Windows AMD64 (.zip)](https://download.garden.io/core/0.12.49/garden-0.12.49-windows-amd64.zip)

## Changelog

### Features

* **remote sources:** allow to specify commit for remote sources ([78ddb509e](https://github.com/garden-io/garden/commit/78ddb509e))
* **commands:** add experimental watch disable flag for dev mode ([2d8bf03e5](https://github.com/garden-io/garden/commit/2d8bf03e5))
* **kubernetes:** add sync helper commands ([e2a084af0](https://github.com/garden-io/garden/commit/e2a084af0))

### Bug Fixes

* **terraform:** update condition to trigger terraform init ([#3632](https://github.com/garden-io/garden/issues/3632)) ([ac5fbf4a9](https://github.com/garden-io/garden/commit/ac5fbf4a9))
* **terraform:** fix checksums for terraform 1.2.9 darwin builds ([#3630](https://github.com/garden-io/garden/issues/3630)) ([21ea30f42](https://github.com/garden-io/garden/commit/21ea30f42))
* **exec:** more informative error msg on timeout ([#3584](https://github.com/garden-io/garden/issues/3584)) ([0808531db](https://github.com/garden-io/garden/commit/0808531db))
* **kubernetes:** detect that pod has been killed ([#3571](https://github.com/garden-io/garden/issues/3571)) ([9193a857d](https://github.com/garden-io/garden/commit/9193a857d))
* **framework:** increase consistency in verbose plugin logs ([236987d52](https://github.com/garden-io/garden/commit/236987d52))
* **helm:** stream logs to CLI and Garden Cloud ([#3582](https://github.com/garden-io/garden/issues/3582)) ([22d46a497](https://github.com/garden-io/garden/commit/22d46a497))
* **framework** re-initialize providers changing environments ([#3481](https://github.com/garden-io/garden/issues/3481)) ([02903809f](https://github.com/garden-io/garden/commit/02903809f))
* **cli:** failure in self-update command due to GitHub API change ([99fcd90c7](https://github.com/garden-io/garden/commit/99fcd90c7))
* **events:** use ISO format date strings in event payload ([#3618](https://github.com/garden-io/garden/issues/3618)) ([42a76f339](https://github.com/garden-io/garden/commit/42a76f339))
* **events:** update log event timestamp type be string or number ([4241e4523](https://github.com/garden-io/garden/commit/4241e4523))
* **framework:** omit detail property of errors ([24f32fad3](https://github.com/garden-io/garden/commit/24f32fad3))
* **kubernetes:** make preStop command work with busybox ([#3568](https://github.com/garden-io/garden/issues/3568)) ([b062281a0](https://github.com/garden-io/garden/commit/b062281a0))
* **scripts:** release.ts unintentionally also ran scripts ([#3626](https://github.com/garden-io/garden/issues/3626)) ([e7024fe63](https://github.com/garden-io/garden/commit/e7024fe63))

### Improvements

* **cli:** trim binary size by approx 1/3 ([ee3554eb0](https://github.com/garden-io/garden/commit/ee3554eb0))
* **examples:** add a rust example ([#3503](https://github.com/garden-io/garden/issues/3503)) ([e04324ad6](https://github.com/garden-io/garden/commit/e04324ad6))
* **helm:** relax path validation requirements for valueFiles ([#3445](https://github.com/garden-io/garden/issues/3445)) ([24589b62c](https://github.com/garden-io/garden/commit/24589b62c))
* **server:** ensure serverReady event has correct type ([81350c768](https://github.com/garden-io/garden/commit/81350c768))
* **cloud:** automate remote project creation ([#3462](https://github.com/garden-io/garden/issues/3462)) ([f8f2cf706](https://github.com/garden-io/garden/commit/f8f2cf706))
