### PR TITLE
fix(logs): ensure invalid dates are handled properly

### DIFF
--- a/core/src/plugins/kubernetes/logs.ts
+++ b/core/src/plugins/kubernetes/logs.ts
@@ -22,7 +22,7 @@ import { KubernetesProvider } from "./config"
 import { PluginToolSpec } from "../../types/plugin/tools"
 import { PluginContext } from "../../plugin-context"
 import { getPodLogs } from "./status/pod"
-import { splitFirst } from "../../util/util"
+import { splitFirst, isValidDateInstance } from "../../util/util"
 import { Writable } from "stream"
 import request from "request"
 import { LogLevel } from "../../logger/logger"
@@ -329,7 +329,10 @@ export class K8sLogFollower<T> {
           let msg = line
           try {
             const parts = splitFirst(line, " ")
-            timestamp = new Date(parts[0])
+            const dateInstance = new Date(parts[0])
+            if (isValidDateInstance(dateInstance)) {
+              timestamp = dateInstance
+            }
             msg = parts[1]
           } catch {}
           if (_self.deduplicate({ msg, podName, containerName, timestamp })) {

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -798,17 +798,18 @@ export class PodRunner extends PodRunnerParams {
     const stream = new Stream<RunLogEntry>()
     void stream.forEach((entry) => {
       const { msg, timestamp } = entry
+      let isoTimestamp: string
+      try {
+        if (timestamp) {
+          isoTimestamp = timestamp.toISOString()
+        } else {
+          isoTimestamp = new Date().toISOString()
+        }
+      } catch {
+        isoTimestamp = new Date().toISOString()
+      }
       events.emit("log", {
-        // This should be a numeric value (i.e. timestamp.getTime()) as opposed to a
-        // date string to be consistent with other event timestamps.
-        //
-        // However, due to missing types this has been a string value without us really noticing and
-        // and that's the shape Cloud expects. This was (rightly) changed to a numeric value with
-        // https://github.com/garden-io/garden/pull/3576 (b52e9b298f7c59b8210a77edc4c451301daa76e3)
-        // but we need to revert for Cloud backwards compatibility.
-        //
-        // TODO: Change to type number when all Cloud instance versions are >= v.1360.
-        timestamp: timestamp?.toISOString() || new Date().toISOString(),
+        timestamp: isoTimestamp,
         data: Buffer.from(msg),
         ...logEventContext,
       })

--- a/core/src/util/util.ts
+++ b/core/src/util/util.ts
@@ -909,3 +909,10 @@ export function getGitHubIssueLink(title: string, type: "bug" | "feature-request
     return `https://github.com/garden-io/garden/issues/new?assignees=&labels=&template=BUG_REPORT.md&title=${title}`
   }
 }
+
+/**
+ * Check if a given date instance is valid.
+ */
+export function isValidDateInstance(d: any) {
+  return !isNaN(d) && d instanceof Date
+}

--- a/core/test/unit/src/util/util.ts
+++ b/core/test/unit/src/util/util.ts
@@ -22,6 +22,7 @@ import {
   spawn,
   relationshipClasses,
   safeDumpYaml,
+  isValidDateInstance,
 } from "../../../../src/util/util"
 import { expectError } from "../../../helpers"
 import { splitFirst } from "../../../../src/util/util"
@@ -385,6 +386,28 @@ describe("util", () => {
             c: c
         d: d\n
       `)
+    })
+  })
+  describe("isValidDateInstance", () => {
+    it("should validate a date instance and return the instance or undefined", () => {
+      const validA = new Date()
+      const validB = new Date("2023-02-01T19:46:42.266Z")
+      const validC = new Date(1675280826163)
+
+      // Tricking the compiler. We need to test for this because
+      // date strings can be created from runtime values that we don't validate.
+      const undef = undefined as any
+      const invalidA = new Date(undef)
+      const invalidB = new Date("foo")
+      const invalidC = new Date("")
+
+      expect(isValidDateInstance(validA)).to.be.true
+      expect(isValidDateInstance(validB)).to.be.true
+      expect(isValidDateInstance(validC)).to.be.true
+
+      expect(isValidDateInstance(invalidA)).to.be.false
+      expect(isValidDateInstance(invalidB)).to.be.false
+      expect(isValidDateInstance(invalidC)).to.be.false
     })
   })
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

This bug was introduced when we changed `timestamp.getTime()` to `timestamp.toISOString()` in #3576.

Turns out that the former returns `NaN` if the date instance is invalid whereas the latter throws. So this had basically been failing silently until that change was made.

This commit ensures we check for the validity of the date instance.

**Which issue(s) this PR fixes**:

Fixes #3652 

**Special notes for your reviewer**:
