### PR TITLE
ci: updated list of allowed endpoints in the scorecard GH action

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -35,6 +35,8 @@ jobs:
             codeload.github.com:443
             github.com:443
             pipelines.actions.githubusercontent.com:443
+            index.docker.io:443
+            fulcio.sigstore.dev:443
 
       - name: "Checkout code"
         uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3.0.0


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR should fix errors like [this](https://github.com/garden-io/garden/actions/runs/4073917619).

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
