### PR TITLE
ci: use audit egress-policy in the scorecard GH action

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -27,16 +27,19 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@18bf8ad2ca49c14cbb28b91346d626ccfb00c518
         with:
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            api.osv.dev:443
-            bestpractices.coreinfrastructure.org:443
-            codeload.github.com:443
-            github.com:443
-            pipelines.actions.githubusercontent.com:443
-            index.docker.io:443
-            fulcio.sigstore.dev:443
+          egress-policy: audit # block
+          # allowed-endpoints: >
+          #   api.github.com:443
+          #   api.osv.dev:443
+          #   bestpractices.coreinfrastructure.org:443
+          #   codeload.github.com:443
+          #   github.com:443
+          #   pipelines.actions.githubusercontent.com:443
+          #   auth.docker.io:443
+          #   index.docker.io:443
+          #   fulcio.sigstore.dev:443
+          #   sigstore-tuf-root.storage.googleapis.com:443
+          #   umsav3btlwg2zfcc35tn.blob.core.windows.net:443
 
       - name: "Checkout code"
         uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3.0.0


### PR DESCRIPTION
**What this PR does / why we need it**:
This is the continuation of #3664. The [issue](https://github.com/garden-io/garden/actions/runs/4076470288) still happens, but with different addresses.

This PR changes the `egress-policy` to `audit` to avoid maintenance of the `allowed-endpoints`.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
