### PR TITLE
fix: fix getDockerVersion helper

### DIFF
--- a/core/src/plugins/container/helpers.ts
+++ b/core/src/plugins/container/helpers.ts
@@ -249,12 +249,12 @@ const helpers = {
   /**
    * Retrieves the docker client and server version.
    */
-  async getDockerVersion(cliPath = "docker"): Promise<DockerVersion> {
+  async getDockerVersion(): Promise<DockerVersion> {
     const results = await Bluebird.map(["client", "server"], async (key) => {
       let res: SpawnOutput
 
       try {
-        res = await spawn(cliPath, ["version", "-f", `{{ .${titleize(key)}.Version }}`], { cwd: cliPath })
+        res = await spawn("docker", ["version", "-f", `{{ .${titleize(key)}.Version }}`])
       } catch (err) {
         return [key, undefined]
       }


### PR DESCRIPTION
Previously the cli was attemped to be spawned at path "docker", which doesn't exist, at least on my machine. The bug was introduced [here](https://github.com/garden-io/garden/commit/4c816700db7c1166316f63452f89de918863b4c1#diff-b0ee402f0d037eec73174cc4a8ce543692ed4ae12193f28c8bcfe91b0280868dL257-R257), probably due to the slightly confusing argument which I removed as it's never used. This also fixes all container integ tests. closes #3675