### PR TITLE
chore: remove dead link, fix check-docs ci step

### DIFF
--- a/core/src/plugins/kubernetes/helm/action.ts
+++ b/core/src/plugins/kubernetes/helm/action.ts
@@ -21,8 +21,6 @@ import { posix } from "path"
 
 export const helmDeployDocs = dedent`
   Specify a Helm chart (either in your repository or remote from a registry) to deploy.
-
-  Refer to the [Helm guide](${DOCS_BASE_URL}/guides/using-helm-charts) for usage instructions.
 `
 
 export const helmDeployDefinition = (): DeployActionDefinition<HelmDeployAction> => ({

--- a/docs/reference/action-types/Deploy/helm.md
+++ b/docs/reference/action-types/Deploy/helm.md
@@ -9,8 +9,6 @@ tocTitle: "`helm` Deploy"
 
 Specify a Helm chart (either in your repository or remote from a registry) to deploy.
 
-Refer to the [Helm guide](https://docs.garden.io/guides/using-helm-charts) for usage instructions.
-
 Below is the full schema reference for the action. For an introduction to configuring Garden, please look at our [Configuration
 guide](../../../using-garden/configuration-overview.md).
 

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -9,8 +9,6 @@ tocTitle: "`helm`"
 
 Specify a Helm chart (either in your repository or remote from a registry) to deploy.
 
-Refer to the [Helm guide](https://docs.garden.io/guides/using-helm-charts) for usage instructions.
-
 Below is the full schema reference. For an introduction to configuring Garden modules, please look at our [Configuration
 guide](../../using-garden/configuration-overview.md).
 

--- a/e2e/projects/vote-helm-modules/README.md
+++ b/e2e/projects/vote-helm-modules/README.md
@@ -12,8 +12,5 @@ ahead of deploying the charts.
 Furthermore, to showcase the chart re-use feature, the `api` and `result` modules use the `base-chart` module
 as a base.
 
-For more details on how to use Helm charts, please refer to our
-[Helm user guide](https://docs.garden.io/guides/using-helm-charts).
-
 The usage and workflow is the same as in the [vote project](../vote/README.md), please refer to that for usage
 instructions. Only difference being the base hostname (defined in project's [garden.yml file](garden.yml)).

--- a/examples/vote-helm/README.md
+++ b/examples/vote-helm/README.md
@@ -12,8 +12,5 @@ ahead of deploying the charts.
 Furthermore, to showcase the chart re-use feature, the `api` and `result` modules use the `base-chart` module
 as a base.
 
-For more details on how to use Helm charts, please refer to our
-[Helm user guide](https://docs.garden.io/guides/using-helm-charts).
-
 The usage and workflow is the same as in the [vote project](../vote/README.md), please refer to that for usage
 instructions. Only difference being the base hostname (defined in project's [garden.yml file](garden.yml)).


### PR DESCRIPTION
`https://docs.garden.io/guides/using-helm-charts` fails our `check-docs` step due to 404.
removing the link to make our CI happier. if we want, we can also change the link to something else - but on a quick glance, i didn't find a helm guide other than the reference specs on our docs site. let me know if you prefer to change the link to something else instead of removal.