### PR TITLE
improvement(framework): allow users to specify proxy hostname in project config

### DIFF
--- a/core/src/config/project.ts
+++ b/core/src/config/project.ts
@@ -171,6 +171,10 @@ export interface OutputSpec {
   value: Primitive
 }
 
+export interface ProxyConfig {
+  hostname: string
+}
+
 export interface ProjectConfig {
   apiVersion: string
   kind: "Project"
@@ -179,6 +183,7 @@ export interface ProjectConfig {
   id?: string
   domain?: string
   configPath?: string
+  proxy?: ProxyConfig
   defaultEnvironment: string
   dotIgnoreFiles: string[]
   environments: EnvironmentConfig[]
@@ -319,6 +324,19 @@ export const projectDocsSchema = () =>
       `
         )
         .example([".gardenignore", ".gitignore"]),
+      proxy: joi.object().keys({
+        hostname: joi
+          .string()
+          .default("localhost")
+          .description(
+            dedent`
+        The URL that Garden uses when creating port forwards. Defaults to "localhost".
+
+        Note that the \`GARDEN_PROXY_DEFAULT_ADDRESS\` environment variable takes precedence over this value.
+        `
+          )
+          .example(["127.0.0.1"]),
+      }),
       modules: projectModulesSchema().description("Control where to scan for modules in the project."),
       outputs: joiSparseArray(projectOutputSchema())
         .unique("name")

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -40,7 +40,7 @@ import {
   baseBuildSpecSchema,
   defaultBuildTimeout,
 } from "../../../src/config/module"
-import { DEFAULT_API_VERSION } from "../../../src/constants"
+import { DEFAULT_API_VERSION, gardenEnv } from "../../../src/constants"
 import { providerConfigBaseSchema } from "../../../src/config/provider"
 import { keyBy, set, mapValues } from "lodash"
 import stripAnsi from "strip-ansi"
@@ -376,6 +376,103 @@ describe("Garden", () => {
       })
 
       expect(garden.variables).to.eql({ foo: "override", bar: "something" })
+    })
+
+    it("should set the default proxy config if non is specified", async () => {
+      const config: ProjectConfig = {
+        apiVersion: DEFAULT_API_VERSION,
+        kind: "Project",
+        name: "test",
+        path: pathFoo,
+        defaultEnvironment: "default",
+        dotIgnoreFiles: [],
+        environments: [{ name: "default", defaultNamespace: "foo", variables: {} }],
+        providers: [{ name: "foo" }],
+        variables: { foo: "default", bar: "something" },
+      }
+
+      const garden = await TestGarden.factory(pathFoo, {
+        config,
+        environmentName: "default",
+        variables: { foo: "override" },
+      })
+
+      expect(garden.proxy).to.eql({ hostname: "localhost" })
+    })
+
+    it("should optionally read the proxy config from the project config", async () => {
+      const config: ProjectConfig = {
+        apiVersion: DEFAULT_API_VERSION,
+        kind: "Project",
+        name: "test",
+        path: pathFoo,
+        proxy: {
+          hostname: "127.0.0.1", // <--- Proxy config is set here
+        },
+        defaultEnvironment: "default",
+        dotIgnoreFiles: [],
+        environments: [{ name: "default", defaultNamespace: "foo", variables: {} }],
+        providers: [{ name: "foo" }],
+        variables: { foo: "default", bar: "something" },
+      }
+
+      const garden = await TestGarden.factory(pathFoo, {
+        config,
+        environmentName: "default",
+        variables: { foo: "override" },
+      })
+
+      expect(garden.proxy).to.eql({ hostname: "127.0.0.1" })
+    })
+
+    it("should use the GARDEN_PROXY_DEFAULT_ADDRESS env variable if set", async () => {
+      const saveEnv = gardenEnv.GARDEN_PROXY_DEFAULT_ADDRESS
+      try {
+        gardenEnv.GARDEN_PROXY_DEFAULT_ADDRESS = "example.com"
+        const configNoProxy: ProjectConfig = {
+          apiVersion: DEFAULT_API_VERSION,
+          kind: "Project",
+          name: "test",
+          path: pathFoo,
+          defaultEnvironment: "default",
+          dotIgnoreFiles: [],
+          environments: [{ name: "default", defaultNamespace: "foo", variables: {} }],
+          providers: [{ name: "foo" }],
+          variables: { foo: "default", bar: "something" },
+        }
+        const configWithProxy: ProjectConfig = {
+          apiVersion: DEFAULT_API_VERSION,
+          kind: "Project",
+          name: "test",
+          path: pathFoo,
+          proxy: {
+            hostname: "127.0.0.1", // <--- This should be overwritten
+          },
+          defaultEnvironment: "default",
+          dotIgnoreFiles: [],
+          environments: [{ name: "default", defaultNamespace: "foo", variables: {} }],
+          providers: [{ name: "foo" }],
+          variables: { foo: "default", bar: "something" },
+        }
+
+        const gardenWithProxyConfig = await TestGarden.factory(pathFoo, {
+          config: configWithProxy,
+          environmentName: "default",
+          variables: { foo: "override" },
+          noCache: true,
+        })
+        const gardenNoProxyConfig = await TestGarden.factory(pathFoo, {
+          config: configNoProxy,
+          environmentName: "default",
+          variables: { foo: "override" },
+          noCache: true,
+        })
+
+        expect(gardenWithProxyConfig.proxy).to.eql({ hostname: "example.com" })
+        expect(gardenNoProxyConfig.proxy).to.eql({ hostname: "example.com" })
+      } finally {
+        gardenEnv.GARDEN_PROXY_DEFAULT_ADDRESS = saveEnv
+      }
     })
   })
 

--- a/docs/reference/project-config.md
+++ b/docs/reference/project-config.md
@@ -110,6 +110,12 @@ defaultEnvironment: ''
 # details.
 dotIgnoreFiles:
 
+proxy:
+  # The URL that Garden uses when creating port forwards. Defaults to "localhost".
+  #
+  # Note that the `GARDEN_PROXY_DEFAULT_ADDRESS` environment variable takes precedence over this value.
+  hostname: localhost
+
 # Control where to scan for modules in the project.
 modules:
   # Specify a list of POSIX-style paths or globs that should be scanned for Garden modules.
@@ -489,6 +495,32 @@ Example:
 dotIgnoreFiles:
   - .gardenignore
   - .gitignore
+```
+
+### `proxy`
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
+
+### `proxy.hostname`
+
+[proxy](#proxy) > hostname
+
+The URL that Garden uses when creating port forwards. Defaults to "localhost".
+
+Note that the `GARDEN_PROXY_DEFAULT_ADDRESS` environment variable takes precedence over this value.
+
+| Type     | Default       | Required |
+| -------- | ------------- | -------- |
+| `string` | `"localhost"` | No       |
+
+Example:
+
+```yaml
+proxy:
+  ...
+  hostname: - 127.0.0.1
 ```
 
 ### `modules`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

After upgrading to Node 18, some users reported issues with port forwarding to "localhost" when using Node's `createProxyMiddleware` package.

This appears to be mostly the [expected behaviour in Node 17+](https://github.com/garden-io/garden/issues/3667#issuecomment-1415665510) and previously the only workaround was to set the proxy URL via the `GARDEN_DEFAULT_PROXY_ADDRESS` env var.

This PR adds a `proxy` field to the project config so that user can explicitly set the proxy address for the project without having to ask everyone to update their environment variables:

```yaml
kind: Project
name: <my-project>
proxy:
  hostname: 127.0.0.1
```

**Which issue(s) this PR fixes**:

Fixes #3667

**Special notes for your reviewer**:
