### PR TITLE
0.13 template string fixing

### DIFF
--- a/core/src/actions/helpers.ts
+++ b/core/src/actions/helpers.ts
@@ -6,7 +6,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { InternalError } from "../exceptions"
 import { ExecutedBuildAction, isBuildAction, ResolvedBuildAction } from "./build"
 import { ExecutedDeployAction, isDeployAction, ResolvedDeployAction } from "./deploy"
 import { ExecutedRunAction, isRunAction, ResolvedRunAction } from "./run"
@@ -23,8 +22,8 @@ export function resolveAction<T extends Action>(action: T, params: ResolveAction
   } else if (isTestAction(action)) {
     return new ResolvedTestAction({ ...action["params"], ...params })
   } else {
-    // This should never happen
-    throw new InternalError(`Unexpected action kind`, {})
+    const _exhaustiveCheck: never = action
+    return _exhaustiveCheck
   }
 }
 
@@ -41,7 +40,7 @@ export function executeAction<T extends ResolvedAction>(
   } else if (isTestAction(action)) {
     return new ExecutedTestAction({ ...action["params"], ...params }) as Executed<T>
   } else {
-    // This should never happen
-    throw new InternalError(`Unexpected action kind`, {})
+    const _exhaustiveCheck: never = action
+    return _exhaustiveCheck
   }
 }

--- a/core/src/config/template-contexts/actions.ts
+++ b/core/src/config/template-contexts/actions.ts
@@ -118,7 +118,7 @@ class ActionReferencesContext extends ConfigContext {
     this.tasks = this.run
 
     for (const action of actions) {
-      this[action.kind].set(
+      this[action.kind.toLowerCase()].set(
         action.name,
         new ActionResultContext({
           root: this,

--- a/core/src/router/base.ts
+++ b/core/src/router/base.ts
@@ -295,6 +295,7 @@ export abstract class BaseActionRouter<K extends ActionKind> extends BaseRouter 
           partialRuntimeResolution: false,
           modules: graph.getModules(),
           executedDependencies: action.getExecutedDependencies(),
+          resolvedDependencies: action.getResolvedDependencies(),
           variables: action.getVariables(),
         })
       : new ActionConfigContext(this.garden)

--- a/core/src/tasks/publish.ts
+++ b/core/src/tasks/publish.ts
@@ -79,6 +79,7 @@ export class PublishTask extends BaseActionTask<BuildAction, PublishActionResult
         modules: this.graph.getModules(),
         partialRuntimeResolution: false,
         executedDependencies: action.getExecutedDependencies(),
+        resolvedDependencies: action.getResolvedDependencies(),
         variables: action.getVariables(),
       })
 

--- a/core/src/tasks/resolve-action.ts
+++ b/core/src/tasks/resolve-action.ts
@@ -111,6 +111,7 @@ export class ResolveActionTask<T extends Action> extends BaseActionTask<T, Resol
           modules: this.graph.getModules(),
           partialRuntimeResolution: false,
           executedDependencies,
+          resolvedDependencies,
           variables: {},
         })
       )
@@ -131,6 +132,7 @@ export class ResolveActionTask<T extends Action> extends BaseActionTask<T, Resol
         modules: this.graph.getModules(),
         partialRuntimeResolution: false,
         executedDependencies,
+        resolvedDependencies,
         variables: groupVariables,
       })
     )
@@ -150,6 +152,7 @@ export class ResolveActionTask<T extends Action> extends BaseActionTask<T, Resol
         modules: this.graph.getModules(),
         partialRuntimeResolution: false,
         executedDependencies,
+        resolvedDependencies,
         variables,
       })
     )


### PR DESCRIPTION
Class `ActionReferencesContext` uses lower-cased action kind names.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
