### PR TITLE
refactor(k8s): change default kaniko namespace to the project namespace

### DIFF
--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -540,12 +540,9 @@ export const kubernetesConfigBase = () =>
         namespace: joi
           .string()
           .allow(null)
-          .default(defaultSystemNamespace)
           .description(
             dedent`
-              Choose the namespace where the Kaniko pods will be run. Set to \`null\` to use the project namespace.
-
-              **IMPORTANT: The default namespace will change to the project namespace instead of the garden-system namespace in an upcoming release!**
+              Choose the namespace where the Kaniko pods will be run. Defaults to the project namespace.
             `
           ),
         nodeSelector: joiStringMap(joi.string()).description(

--- a/core/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/src/plugins/kubernetes/container/build/kaniko.ts
@@ -106,10 +106,8 @@ export const kanikoBuild: BuildHandler = async (params) => {
 
   log.setState(`Building image ${localId}...`)
 
-  // Use the project namespace if set to null in config
-  // TODO: change in 0.13 to default to project namespace
-  let kanikoNamespace =
-    provider.config.kaniko?.namespace === null ? projectNamespace : provider.config.kaniko?.namespace
+  // Use the project namespace by default
+  let kanikoNamespace = provider.config.kaniko?.namespace || projectNamespace
 
   if (!kanikoNamespace) {
     kanikoNamespace = await getSystemNamespace(ctx, provider, log)

--- a/core/test/data/test-projects/container/garden.yml
+++ b/core/test/data/test-projects/container/garden.yml
@@ -35,8 +35,6 @@ providers:
   - <<: *base
     environments: [kaniko-project-namespace]
     buildMode: kaniko
-    kaniko:
-      namespace: null
   - <<: *base
     environments: [kaniko-image-override]
     buildMode: kaniko

--- a/docs/k8s-plugins/advanced/in-cluster-building.md
+++ b/docs/k8s-plugins/advanced/in-cluster-building.md
@@ -29,8 +29,6 @@ providers:
   - name: kubernetes
     # Use the kaniko build mode
     buildMode: kaniko
-    kaniko:
-      namespace: null  # <--- use the project namespace for builds
     # Recommended: Configure a remote registry
     deploymentRegistry:
       hostname: my-private-registry.com      # <--- the hostname of your registry
@@ -106,9 +104,11 @@ In this mode, builds are executed as follows:
 As of Garden v0.12.22, the `kaniko` build mode no longer requires shared system services or an NFS provisioner, nor running `cluster-init` ahead of usage.
 {% endhint %}
 
-Enable this by setting `buildMode: kaniko` in your `kubernetes` provider configuration.
+{% hint style="info" %}
+As of Garden v0.13, the default namespace for the build Pods is the project namespace. Set `kaniko.namespace` in the provider configuration to override to a specific, separate namespace.
+{% endhint %}
 
-_As of Garden v0.12.22, we also recommend setting `kaniko.namespace: null` in the `kubernetes` provider configuration, so that builder pods are started in the project namespace instead of the `garden-system` namespace, which is the current default. This will become the default in Garden v0.13._
+Enable this by setting `buildMode: kaniko` in your `kubernetes` provider configuration.
 
 Note the difference in how resources for the builder are allocated between Kaniko and the other modes. For this mode, the resource configuration applies to _each Kaniko pod_. See the [builder resources](../../reference/providers/kubernetes.md#providersresourcesbuilder) reference for details.
 

--- a/docs/reference/providers/kubernetes.md
+++ b/docs/reference/providers/kubernetes.md
@@ -219,11 +219,8 @@ providers:
       # Change the kaniko image (repository/image:tag) to use when building in kaniko mode.
       image: 'gcr.io/kaniko-project/executor:v1.8.1-debug'
 
-      # Choose the namespace where the Kaniko pods will be run. Set to `null` to use the project namespace.
-      #
-      # **IMPORTANT: The default namespace will change to the project namespace instead of the garden-system namespace
-      # in an upcoming release!**
-      namespace: garden-system
+      # Choose the namespace where the Kaniko pods will be run. Defaults to the project namespace.
+      namespace:
 
       # Exposes the `nodeSelector` field on the PodSpec of the Kaniko pods. This allows you to constrain the Kaniko
       # pods to only run on particular nodes. The same nodeSelector will be used for each util pod unless they are
@@ -975,13 +972,11 @@ Change the kaniko image (repository/image:tag) to use when building in kaniko mo
 
 [providers](#providers) > [kaniko](#providerskaniko) > namespace
 
-Choose the namespace where the Kaniko pods will be run. Set to `null` to use the project namespace.
+Choose the namespace where the Kaniko pods will be run. Defaults to the project namespace.
 
-**IMPORTANT: The default namespace will change to the project namespace instead of the garden-system namespace in an upcoming release!**
-
-| Type     | Default           | Required |
-| -------- | ----------------- | -------- |
-| `string` | `"garden-system"` | No       |
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
 
 ### `providers[].kaniko.nodeSelector`
 

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -215,11 +215,8 @@ providers:
       # Change the kaniko image (repository/image:tag) to use when building in kaniko mode.
       image: 'gcr.io/kaniko-project/executor:v1.8.1-debug'
 
-      # Choose the namespace where the Kaniko pods will be run. Set to `null` to use the project namespace.
-      #
-      # **IMPORTANT: The default namespace will change to the project namespace instead of the garden-system namespace
-      # in an upcoming release!**
-      namespace: garden-system
+      # Choose the namespace where the Kaniko pods will be run. Defaults to the project namespace.
+      namespace:
 
       # Exposes the `nodeSelector` field on the PodSpec of the Kaniko pods. This allows you to constrain the Kaniko
       # pods to only run on particular nodes. The same nodeSelector will be used for each util pod unless they are
@@ -924,13 +921,11 @@ Change the kaniko image (repository/image:tag) to use when building in kaniko mo
 
 [providers](#providers) > [kaniko](#providerskaniko) > namespace
 
-Choose the namespace where the Kaniko pods will be run. Set to `null` to use the project namespace.
+Choose the namespace where the Kaniko pods will be run. Defaults to the project namespace.
 
-**IMPORTANT: The default namespace will change to the project namespace instead of the garden-system namespace in an upcoming release!**
-
-| Type     | Default           | Required |
-| -------- | ----------------- | -------- |
-| `string` | `"garden-system"` | No       |
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
 
 ### `providers[].kaniko.nodeSelector`
 

--- a/examples/kaniko/README.md
+++ b/examples/kaniko/README.md
@@ -16,7 +16,5 @@ providers:
   - name: local-kubernetes
     environments: [local]
     buildMode: kaniko
-    kaniko:
-      namespace: null # This will make the kaniko builder pod appear in the same namespace as the project
 ...
 ```

--- a/examples/kaniko/garden.yml
+++ b/examples/kaniko/garden.yml
@@ -8,8 +8,6 @@ providers:
   - name: local-kubernetes
     environments: [local]
     buildMode: kaniko
-    kaniko:
-      namespace: null # This will make the kaniko builder pod appear in the same namespace as the project
   - name: kubernetes
     environments: [remote]
     # Replace the below values as appropriate
@@ -17,8 +15,6 @@ providers:
     namespace: ${project.name}-testing-${var.userId}
     defaultHostname: ${project.name}-testing-${var.userId}.dev-1.sys.garden
     buildMode: kaniko
-    kaniko:
-      namespace: null # This will make the kaniko builder pod appear in the same namespace as the project
     deploymentRegistry:
       hostname: eu.gcr.io    # <- set this according to the region your cluster runs in
       namespace: garden-ci   # <- set this to the project ID of the target cluster


### PR DESCRIPTION
Closes #3508

BREAKING CHANGE:

The default namespace for kaniko build Pods is now the project namespace. Set `kaniko.namespace` in the provider configuration to override to a specific, separate namespace.
