### PR TITLE
refactor(cli): make -V instead of -v (lowercase) print Garden version

### DIFF
--- a/core/src/cli/params.ts
+++ b/core/src/cli/params.ts
@@ -417,7 +417,7 @@ export const globalOptions = {
       'Set a specific variable value, using the format <key>=<value>, e.g. `--var some-key=custom-value`. This will override any value set in your project configuration. You can specify multiple variables by separating with a comma, e.g. `--var key-a=foo,key-b="value with quotes"`.',
   }),
   "version": new BooleanParameter({
-    alias: "v",
+    alias: "V",
     help: "Show the current CLI version.",
   }),
   "help": new BooleanParameter({

--- a/core/test/unit/src/cli/cli.ts
+++ b/core/test/unit/src/cli/cli.ts
@@ -97,8 +97,8 @@ describe("cli", () => {
       expect(consoleOutput).to.equal(cmd.renderHelp())
     })
 
-    it("aborts with version text if -v is set", async () => {
-      const { code, consoleOutput } = await cli.run({ args: ["-v"], exitOnError: false })
+    it("aborts with version text if -V is set", async () => {
+      const { code, consoleOutput } = await cli.run({ args: ["-V"], exitOnError: false })
 
       expect(code).to.equal(0)
       expect(consoleOutput).to.equal(getPackageVersion())

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -31,7 +31,7 @@ The following option flags can be used with any of the CLI commands:
   | `--yes` | `-y` | boolean | Automatically approve any yes/no prompts during execution.
   | `--force-refresh` |  | boolean | Force refresh of any caches, e.g. cached provider statuses.
   | `--var` |  | array:string | Set a specific variable value, using the format &lt;key&gt;&#x3D;&lt;value&gt;, e.g. &#x60;--var some-key&#x3D;custom-value&#x60;. This will override any value set in your project configuration. You can specify multiple variables by separating with a comma, e.g. &#x60;--var key-a&#x3D;foo,key-b&#x3D;&quot;value with quotes&quot;&#x60;.
-  | `--version` | `-v` | boolean | Show the current CLI version.
+  | `--version` | `-V` | boolean | Show the current CLI version.
   | `--help` | `-h` | boolean | Show help
   | `--disable-port-forwards` |  | boolean | Disable automatic port forwarding when in watch mode. Note that you can also set GARDEN_DISABLE_PORT_FORWARDS&#x3D;true in your environment.
 


### PR DESCRIPTION
BREAKING CHANGE:

The -v CLI flag (alias for --version) has been replaced by -V (upper-case). This is to make way for #3499.
