### PR TITLE
0.13 fix `resolveProviders` spec in garden unit tests

### DIFF
--- a/core/src/docs/generate.ts
+++ b/core/src/docs/generate.ts
@@ -116,7 +116,9 @@ export async function writeConfigReferenceDocs(docsRoot: string, plugins: Garden
       const path = resolve(dir, `${type}.md`)
 
       console.log("->", path)
-      await writeFile(path, renderActionTypeReference(kind as ActionKind, type, definition))
+      if (!!definition) {
+        await writeFile(path, renderActionTypeReference(kind as ActionKind, type, definition))
+      }
 
       actionsReadme.push(`  * [\`${type}\`](./${kind}/${type}.md)`)
     }

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -581,12 +581,12 @@ export class Garden {
     const definitions = await this.getActionTypes()
 
     if (this.actionTypeBases[kind][type]) {
-      return this.actionTypeBases[kind][type]
+      return this.actionTypeBases[kind][type] || []
     }
 
     const bases = getActionTypeBases(definitions[kind][type], definitions[kind])
     this.actionTypeBases[kind][type] = bases.map((b) => ({ ...b, schema: allowUnknown(b.schema) }))
-    return this.actionTypeBases[kind][type]
+    return this.actionTypeBases[kind][type] || []
   }
 
   getRawProviderConfigs(names?: string[]) {

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -49,6 +49,7 @@ import { resolveVariables } from "./common"
 import { ConfigGraph, MutableConfigGraph } from "./config-graph"
 import type { ModuleGraph } from "./modules"
 import chalk from "chalk"
+import { MaybeUndefined } from "../util/util"
 
 export async function actionConfigsToGraph({
   garden,
@@ -408,7 +409,7 @@ async function preprocessActionConfig({
 function dependenciesFromActionConfig(
   config: ActionConfig,
   configsByKey: ActionConfigsByKey,
-  definition: ActionTypeDefinition<any>
+  definition: MaybeUndefined<ActionTypeDefinition<any>>
 ) {
   const description = describeActionConfig(config)
 
@@ -462,7 +463,7 @@ function dependenciesFromActionConfig(
 
   // Action template references in spec/variables
   // -> We avoid depending on action execution when referencing static output keys
-  const staticKeys = definition.staticOutputsSchema ? describeSchema(definition.staticOutputsSchema).keys : []
+  const staticKeys = definition?.staticOutputsSchema ? describeSchema(definition.staticOutputsSchema).keys : []
 
   for (const ref of getActionTemplateReferences(config)) {
     let needsExecuted = false

--- a/core/src/plugins.ts
+++ b/core/src/plugins.ts
@@ -19,7 +19,7 @@ import {
 import type { GenericProviderConfig } from "./config/provider"
 import { ConfigurationError, PluginError, RuntimeError } from "./exceptions"
 import { uniq, mapValues, fromPairs, flatten, keyBy, some, isString, sortBy, Dictionary } from "lodash"
-import { findByName, pushToKey, getNames, isNotNull } from "./util/util"
+import { findByName, pushToKey, getNames, isNotNull, MaybeUndefined } from "./util/util"
 import { deline } from "./util/string"
 import { validateSchema } from "./config/validation"
 import type { LogEntry } from "./logger/log-entry"
@@ -415,10 +415,10 @@ export function getPluginBaseNames(name: string, loadedPlugins: PluginMap) {
  * Recursively resolves all the bases for the given action type, ordered from closest base to last.
  */
 export function getActionTypeBases(
-  type: ActionTypeDefinition<any>,
-  actionTypes: { [name: string]: ActionTypeDefinition<any> }
+  type: MaybeUndefined<ActionTypeDefinition<any>>,
+  actionTypes: { [name: string]: MaybeUndefined<ActionTypeDefinition<any>> }
 ): ActionTypeDefinition<any>[] {
-  if (!type.base) {
+  if (!type || !type.base) {
     return []
   }
 
@@ -457,7 +457,7 @@ export function getPluginDependencies(plugin: GardenPlugin, loadedPlugins: Plugi
 
 export type ActionTypeMap<T> = {
   [K in ActionKind]: {
-    [type: string]: T
+    [type: string]: MaybeUndefined<T>
   }
 }
 
@@ -717,6 +717,7 @@ function cloneHandler(org: any): any {
   function handler() {
     return org.apply(org, arguments)
   }
+
   for (const key in org) {
     if (org.hasOwnProperty(key)) {
       handler[key] = org[key]

--- a/core/src/tasks/resolve-action.ts
+++ b/core/src/tasks/resolve-action.ts
@@ -212,7 +212,8 @@ export class ResolveActionTask<T extends Action> extends BaseActionTask<T, Resol
       configType: `spec for ${description}`,
     })
 
-    for (const base of await this.garden.getActionTypeBases(kind, type)) {
+    const actionTypeBases = await this.garden.getActionTypeBases(kind, type)
+    for (const base of actionTypeBases) {
       this.log.silly(`Validating ${description} spec against '${base.name}' schema`)
 
       spec = validateWithPath({

--- a/core/src/util/util.ts
+++ b/core/src/util/util.ts
@@ -61,6 +61,7 @@ export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
 export type Diff<T, U> = T extends U ? never : T
 export type Mutable<T> = { -readonly [K in keyof T]: T[K] }
 export type Nullable<T> = { [P in keyof T]: T[P] | null }
+export type MaybeUndefined<T> = T | undefined
 // From: https://stackoverflow.com/a/49936686/5629940
 export type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends Array<infer U>

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -27,6 +27,7 @@ import {
   testGitUrl,
   expectFuzzyMatch,
   createProjectConfig,
+  makeModuleConfig,
 } from "../../helpers"
 import { getNames, findByName, omitUndefined, exec } from "../../../src/util/util"
 import { LinkedSource } from "../../../src/config-store/local"
@@ -1567,19 +1568,10 @@ describe("Garden", () => {
     })
 
     it("should add plugin modules if returned by the provider", async () => {
-      const pluginModule: ModuleConfig = {
-        apiVersion: DEFAULT_API_VERSION,
-        allowPublish: false,
-        build: { dependencies: [] },
-        disabled: false,
+      const pluginModule: ModuleConfig = makeModuleConfig("/tmp", {
         name: "foo",
-        path: "/tmp",
-        serviceConfigs: [],
-        taskConfigs: [],
-        spec: {},
-        testConfigs: [],
         type: "exec",
-      }
+      })
 
       const test = createGardenPlugin({
         name: "test",

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -1568,7 +1568,7 @@ describe("Garden", () => {
     })
 
     it("should add plugin modules if returned by the provider", async () => {
-      const pluginModule: ModuleConfig = makeModuleConfig("/tmp", {
+      const pluginModule: ModuleConfig = makeModuleConfig(`${projectRootA}/tmp`, {
         name: "foo",
         type: "exec",
       })

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -1600,7 +1600,7 @@ describe("Garden", () => {
       const garden = await makeTestGarden(projectRootA, { config: projectConfig, plugins: [test] })
 
       const graph = await garden.getConfigGraph({ log: garden.log, emit: false })
-      expect(graph.getModule("test--foo")).to.exist
+      expect(graph.getModule("foo")).to.exist
     })
 
     it("should throw if plugins have declared circular dependencies", async () => {


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes only one failing test, but brings some changes to the existing type system to ensure that some custom [mapped types](https://www.typescriptlang.org/docs/handbook/2/mapped-types.html) can also return optional values, i.e. the ones that can be `undefined`.

For example, let's consider the type
```
export type ActionTypeMap<T> = {
  [K in ActionKind]: {
    [type: string]: T
  }
}
```

When an object of the type above is referenced as `typeMap[kind][type]` it still can return an `undefined` value. The first-level sub-map can to forced to never return `undefined` by explicit initialization of `typeMap` for each `kind` like this: `typeMap[kind] = {}`. But `type` is an arbitrary string here.

If there is a better way or TS best practice to handle `undefined` values in the mapped types, I'm all ears.

Maybe, it's better to do some fail-fast validation instead of allowing undefined action-type handlers.

See individual commits for details.

**Which issue(s) this PR fixes**:

Partially addresses #3530

**Special notes for your reviewer**:
