### PR TITLE
test: fix test context init for warning tests

### DIFF
--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -4511,10 +4511,11 @@ describe("Garden", () => {
 
   describe("warnings", () => {
     let garden: TestGarden
-    const key = randomString()
+    let key: string
 
     beforeEach(async () => {
       garden = await makeTestGardenA()
+      key = randomString()
     })
 
     describe("hideWarning", () => {


### PR DESCRIPTION
Using the same constant key caused some dirty state leaking across the tests.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
