### PR TITLE
test: fix cloud/api.ts

### DIFF
--- a/core/test/unit/src/cloud/api.ts
+++ b/core/test/unit/src/cloud/api.ts
@@ -14,9 +14,6 @@ import { uuidv4 } from "../../../../src/util/util"
 import { randomString } from "../../../../src/util/string"
 import { GlobalConfigStore } from "../../../../src/config-store/global"
 
-/**
- * Note: Running these tests locally will delete your saved auth token, if any.
- */
 describe("CloudApi", () => {
   const log = getLogger().placeholder()
   const domain = "https://garden." + randomString()

--- a/core/test/unit/src/cloud/api.ts
+++ b/core/test/unit/src/cloud/api.ts
@@ -22,20 +22,6 @@ describe("CloudApi", () => {
   const domain = "https://garden." + randomString()
   const globalConfigStore = new GlobalConfigStore()
 
-  describe("saveAuthToken", () => {
-    it("should persist an auth token to the local config db", async () => {
-      const testAuthToken = {
-        token: uuidv4(),
-        refreshToken: uuidv4(),
-        tokenValidity: 9999,
-      }
-      await CloudApi.saveAuthToken(log, globalConfigStore, testAuthToken, domain)
-      const savedToken = await CloudApi.getAuthToken(log, globalConfigStore, domain)
-      expect(savedToken).to.exist
-      expect(savedToken).to.equal(testAuthToken.token)
-    })
-  })
-
   describe("getAuthToken", () => {
     it("should return null when no auth token is present", async () => {
       const savedToken = await CloudApi.getAuthToken(log, globalConfigStore, domain)


### PR DESCRIPTION
Fixes https://github.com/garden-io/garden/issues/3727

The removed test saved an auth token, which breaks the test right below it as it expects a token to not exist yet.
This test was a duplicate anyway: saving and retrieving a token gets tested one test below as well.