### PR TITLE
test: use shorter form of `expectError` to examine error messages

### DIFF
--- a/core/test/unit/src/commands/create/create-module.ts
+++ b/core/test/unit/src/commands/create/create-module.ts
@@ -180,7 +180,9 @@ describe("CreateModuleCommand", () => {
             filename: defaultConfigFilename,
           }),
         }),
-      (err) => expect(stripAnsi(err.message)).to.equal("A Garden module named test already exists in " + configPath)
+      {
+        contains: `A Garden module named test already exists in ${configPath}`,
+      }
     )
   })
 
@@ -223,7 +225,7 @@ describe("CreateModuleCommand", () => {
             filename: defaultConfigFilename,
           }),
         }),
-      (err) => expect(stripAnsi(err.message)).to.equal("Could not find module type foo")
+      { contains: "Could not find module type foo" }
     )
   })
 

--- a/core/test/unit/src/config/base.ts
+++ b/core/test/unit/src/config/base.ts
@@ -18,7 +18,6 @@ import {
 import { resolve, join } from "path"
 import { expectError, getDataDir, getDefaultProjectConfig } from "../../../helpers"
 import { DEFAULT_API_VERSION } from "../../../../src/constants"
-import stripAnsi = require("strip-ansi")
 import { defaultDotIgnoreFile } from "../../../../src/util/fs"
 import { safeDumpYaml } from "../../../../src/util/util"
 
@@ -139,10 +138,8 @@ describe("loadConfigResources", () => {
     const projectPath = getDataDir("test-project-invalid-config")
     await expectError(
       async () => await loadConfigResources(projectPath, resolve(projectPath, "missing-type", "garden.yml")),
-      (err) => {
-        expect(stripAnsi(err.message)).to.contain(
-          "Error validating module (missing-type/garden.yml): key .type is required"
-        )
+      {
+        contains: "Error validating module (missing-type/garden.yml): key .type is required",
       }
     )
   })
@@ -151,10 +148,8 @@ describe("loadConfigResources", () => {
     const projectPath = getDataDir("test-project-invalid-config")
     await expectError(
       async () => await loadConfigResources(projectPath, resolve(projectPath, "missing-name", "garden.yml")),
-      (err) => {
-        expect(stripAnsi(err.message)).to.contain(
-          "Error validating module (missing-name/garden.yml): key .name is required"
-        )
+      {
+        contains: "Error validating module (missing-name/garden.yml): key .name is required",
       }
     )
   })

--- a/core/test/unit/src/config/common.ts
+++ b/core/test/unit/src/config/common.ts
@@ -7,6 +7,7 @@
  */
 
 import { expect } from "chai"
+
 const stripAnsi = require("strip-ansi")
 import {
   identifierRegex,
@@ -467,13 +468,10 @@ describe("joi.customObject", () => {
 
   it("should give validation error if object doesn't match specified JSON Schema", async () => {
     const joiSchema = joi.object().jsonSchema(jsonSchema)
-    await expectError(
-      () => validateSchema({ numberProperty: "oops", blarg: "blorg" }, joiSchema),
-      (err) =>
-        expect(stripAnsi(err.message)).to.equal(
-          "Validation error: value at . must have required property 'stringProperty', value at . must NOT have additional properties, value at ./numberProperty must be integer"
-        )
-    )
+    await expectError(() => validateSchema({ numberProperty: "oops", blarg: "blorg" }, joiSchema), {
+      contains:
+        "Validation error: value at . must have required property 'stringProperty', value at . must NOT have additional properties, value at ./numberProperty must be integer",
+    })
   })
 
   it("should throw if schema with wrong type is passed to .jsonSchema()", async () => {
@@ -495,28 +493,25 @@ describe("validateSchema", () => {
   it("should format a basic object validation error", async () => {
     const schema = joi.object().keys({ foo: joi.string() })
     const value = { foo: 123 }
-    await expectError(
-      () => validateSchema(value, schema),
-      (err) => expect(stripAnsi(err.message)).to.contain("Validation error: key .foo must be a string")
-    )
+    await expectError(() => validateSchema(value, schema), {
+      contains: "Validation error: key .foo must be a string",
+    })
   })
 
   it("should format a nested object validation error", async () => {
     const schema = joi.object().keys({ foo: joi.object().keys({ bar: joi.string() }) })
     const value = { foo: { bar: 123 } }
-    await expectError(
-      () => validateSchema(value, schema),
-      (err) => expect(stripAnsi(err.message)).to.contain("Validation error: key .foo.bar must be a string")
-    )
+    await expectError(() => validateSchema(value, schema), {
+      contains: "Validation error: key .foo.bar must be a string",
+    })
   })
 
   it("should format a nested pattern object validation error", async () => {
     const schema = joi.object().keys({ foo: joi.object().pattern(/.+/, joi.string()) })
     const value = { foo: { bar: 123 } }
-    await expectError(
-      () => validateSchema(value, schema),
-      (err) => expect(stripAnsi(err.message)).to.contain("Validation error: key .foo[bar] must be a string")
-    )
+    await expectError(() => validateSchema(value, schema), {
+      contains: "Validation error: key .foo[bar] must be a string",
+    })
   })
 })
 

--- a/core/test/unit/src/config/module-template.ts
+++ b/core/test/unit/src/config/module-template.ts
@@ -9,7 +9,6 @@
 import { expect } from "chai"
 import { DEFAULT_API_VERSION } from "../../../../src/constants"
 import { expectError, TestGarden, getDataDir, makeTestGarden } from "../../../helpers"
-import stripAnsi from "strip-ansi"
 import {
   ModuleTemplateResource,
   resolveModuleTemplate,
@@ -70,13 +69,9 @@ describe("module templates", () => {
         ...defaults,
         foo: "bar",
       }
-      await expectError(
-        () => resolveModuleTemplate(garden, config),
-        (err) =>
-          expect(stripAnsi(err.message)).to.contain(
-            'Error validating ModuleTemplate (templates.garden.yml): key "foo" is not allowed at path [foo]'
-          )
-      )
+      await expectError(() => resolveModuleTemplate(garden, config), {
+        contains: 'Error validating ModuleTemplate (templates.garden.yml): key "foo" is not allowed at path [foo]',
+      })
     })
 
     it("defaults to an empty object schema for inputs", async () => {
@@ -105,13 +100,9 @@ describe("module templates", () => {
         inputsSchemaPath: "foo.json",
       }
       const path = resolve(config.path, config.inputsSchemaPath!)
-      await expectError(
-        () => resolveModuleTemplate(garden, config),
-        (err) =>
-          expect(stripAnsi(err.message)).to.contain(
-            `Unable to read inputs schema for ModuleTemplate test: Error: ENOENT: no such file or directory, open '${path}'`
-          )
-      )
+      await expectError(() => resolveModuleTemplate(garden, config), {
+        contains: `Unable to read inputs schema for ModuleTemplate test: Error: ENOENT: no such file or directory, open '${path}'`,
+      })
     })
 
     it("throws if an invalid JSON schema is provided", async () => {
@@ -119,13 +110,9 @@ describe("module templates", () => {
         ...defaults,
         inputsSchemaPath: "invalid.json",
       }
-      await expectError(
-        () => resolveModuleTemplate(garden, config),
-        (err) =>
-          expect(stripAnsi(err.message)).to.contain(
-            `Inputs schema for ModuleTemplate test has type string, but should be "object".`
-          )
-      )
+      await expectError(() => resolveModuleTemplate(garden, config), {
+        contains: `Inputs schema for ModuleTemplate test has type string, but should be "object".`,
+      })
     })
   })
 
@@ -225,13 +212,9 @@ describe("module templates", () => {
           foo: "bar",
         },
       }
-      await expectError(
-        () => resolveTemplatedModule(garden, config, templates),
-        (err) =>
-          expect(stripAnsi(err.message)).to.contain(
-            'Error validating templated module test (modules.garden.yml): key "foo" is not allowed at path [foo]'
-          )
-      )
+      await expectError(() => resolveTemplatedModule(garden, config, templates), {
+        contains: 'Error validating templated module test (modules.garden.yml): key "foo" is not allowed at path [foo]',
+      })
     })
 
     it("throws if template cannot be found", async () => {
@@ -239,13 +222,9 @@ describe("module templates", () => {
         ...defaults,
         spec: { ...defaults.spec, template: "foo" },
       }
-      await expectError(
-        () => resolveTemplatedModule(garden, config, templates),
-        (err) =>
-          expect(stripAnsi(err.message)).to.contain(
-            "Templated module test references template foo, which cannot be found. Available templates: test"
-          )
-      )
+      await expectError(() => resolveTemplatedModule(garden, config, templates), {
+        contains: "Templated module test references template foo, which cannot be found. Available templates: test",
+      })
     })
 
     it("fully resolves the source path on module files", async () => {
@@ -403,13 +382,10 @@ describe("module templates", () => {
       const config: TemplatedModuleConfig = {
         ...defaults,
       }
-      await expectError(
-        () => resolveTemplatedModule(garden, config, _templates),
-        (err) =>
-          expect(stripAnsi(err.message)).to.contain(
-            "ModuleTemplate test returned an invalid module (named foo) for templated module test: Error validating module (modules.garden.yml): key .type must be a string"
-          )
-      )
+      await expectError(() => resolveTemplatedModule(garden, config, _templates), {
+        contains:
+          "ModuleTemplate test returned an invalid module (named foo) for templated module test: Error validating module (modules.garden.yml): key .type must be a string",
+      })
     })
 
     it("throws if a module spec has an invalid name", async () => {
@@ -427,13 +403,10 @@ describe("module templates", () => {
       const config: TemplatedModuleConfig = {
         ...defaults,
       }
-      await expectError(
-        () => resolveTemplatedModule(garden, config, _templates),
-        (err) =>
-          expect(stripAnsi(err.message)).to.contain(
-            "ModuleTemplate test returned an invalid module (named 123) for templated module test: Error validating module (modules.garden.yml): key .name must be a string"
-          )
-      )
+      await expectError(() => resolveTemplatedModule(garden, config, _templates), {
+        contains:
+          "ModuleTemplate test returned an invalid module (named 123) for templated module test: Error validating module (modules.garden.yml): key .name must be a string",
+      })
     })
 
     it("resolves project variable references in input fields", async () => {
@@ -497,18 +470,12 @@ describe("module templates", () => {
       const config: TemplatedModuleConfig = cloneDeep(defaults)
       config.spec.inputs = { name: "module-${modules.foo.version}" }
 
-      await expectError(
-        () => resolveTemplatedModule(garden, config, _templates),
-        (err) => {
-          const msg = stripAnsi(err.message)
-          expect(msg).to.contain(
-            'ModuleTemplate test returned an invalid module (named module-${modules.foo.version}-test) for templated module test: Error validating module (modules.garden.yml): key .name with value "module-${modules.foo.version}-test" fails to match the required pattern: /^(?!garden)(?=.{1,63}$)[a-z][a-z0-9]*(-[a-z0-9]+)*$/.'
-          )
-          expect(msg).to.contain(
-            "Note that if a template string is used in the name of a module in a template, then the template string must be fully resolvable at the time of module scanning. This means that e.g. references to other modules or runtime outputs cannot be used."
-          )
-        }
-      )
+      await expectError(() => resolveTemplatedModule(garden, config, _templates), {
+        contains: [
+          'ModuleTemplate test returned an invalid module (named module-${modules.foo.version}-test) for templated module test: Error validating module (modules.garden.yml): key .name with value "module-${modules.foo.version}-test" fails to match the required pattern: /^(?!garden)(?=.{1,63}$)[a-z][a-z0-9]*(-[a-z0-9]+)*$/.',
+          "Note that if a template string is used in the name of a module in a template, then the template string must be fully resolvable at the time of module scanning. This means that e.g. references to other modules or runtime outputs cannot be used.",
+        ],
+      })
     })
   })
 })

--- a/core/test/unit/src/config/project.ts
+++ b/core/test/unit/src/config/project.ts
@@ -24,7 +24,6 @@ import { createProjectConfig, expectError } from "../../../helpers"
 import { realpath, writeFile } from "fs-extra"
 import { dedent } from "../../../../src/util/string"
 import { resolve, join } from "path"
-import stripAnsi from "strip-ansi"
 
 const enterpriseDomain = "https://garden.mydomain.com"
 const commandInfo = { name: "test", args: {}, opts: {} }
@@ -1067,10 +1066,7 @@ describe("pickEnvironment", () => {
           secrets: {},
           commandInfo,
         }),
-      (err) =>
-        expect(stripAnsi(err.message)).to.contain(
-          "Error validating environment default: key .defaultNamespace must be a string"
-        )
+      { contains: "Error validating environment default: key .defaultNamespace must be a string" }
     )
   })
 
@@ -1263,10 +1259,10 @@ describe("pickEnvironment", () => {
           secrets: {},
           commandInfo,
         }),
-      (err) =>
-        expect(stripAnsi(err.message)).to.equal(
-          "Environment default has defaultNamespace set to null, and no explicit namespace was specified. Please either set a defaultNamespace or explicitly set a namespace at runtime (e.g. --env=some-namespace.default)."
-        )
+      {
+        contains:
+          "Environment default has defaultNamespace set to null, and no explicit namespace was specified. Please either set a defaultNamespace or explicitly set a namespace at runtime (e.g. --env=some-namespace.default).",
+      }
     )
   })
 })

--- a/core/test/unit/src/config/template-contexts/base.ts
+++ b/core/test/unit/src/config/template-contexts/base.ts
@@ -21,6 +21,7 @@ import { resolveTemplateStrings } from "../../../../../src/template-string/templ
 
 type TestValue = string | ConfigContext | TestValues | TestValueFunction
 type TestValueFunction = () => TestValue | Promise<TestValue>
+
 interface TestValues {
   [key: string]: TestValue
 }
@@ -58,20 +59,18 @@ describe("ConfigContext", () => {
     context("allowPartial=true", () => {
       it("should throw on missing key when allowPartial=true", async () => {
         const c = new TestContext({})
-        expectError(
-          () => resolveKey(c, ["basic"], { allowPartial: true }),
-          (err) => expect(stripAnsi(err.message)).to.equal("Could not find key basic.")
-        )
+        expectError(() => resolveKey(c, ["basic"], { allowPartial: true }), {
+          contains: "Could not find key basic.",
+        })
       })
 
       it("should throw on missing key on nested context", async () => {
         const c = new TestContext({
           nested: new TestContext({ key: "value" }),
         })
-        expectError(
-          () => resolveKey(c, ["nested", "bla"], { allowPartial: true }),
-          (err) => expect(stripAnsi(err.message)).to.equal("Could not find key bla under nested. Available keys: key.")
-        )
+        expectError(() => resolveKey(c, ["nested", "bla"], { allowPartial: true }), {
+          contains: "Could not find key bla under nested. Available keys: key.",
+        })
       })
     })
 
@@ -142,6 +141,7 @@ describe("ConfigContext", () => {
           return c.resolve({ key: circularKey, nodePath: [], opts })
         }
       }
+
       const c = new TestContext({
         nested: new NestedContext(),
       })
@@ -157,6 +157,7 @@ describe("ConfigContext", () => {
           this.nested = new Map()
         }
       }
+
       const c = new Context()
       const { message } = resolveKey(c, ["nested", "bla"])
       expect(stripAnsi(message!)).to.equal("Could not find key bla under nested.")
@@ -171,6 +172,7 @@ describe("ConfigContext", () => {
           this.nested = {}
         }
       }
+
       const c = new Context()
       const { message } = resolveKey(c, ["nested", "bla"])
       expect(stripAnsi(message!)).to.equal("Could not find key bla under nested.")
@@ -185,6 +187,7 @@ describe("ConfigContext", () => {
           this.nested = { deeper: {} }
         }
       }
+
       const c = new Context()
       const { message } = resolveKey(c, ["nested", "deeper", "bla"])
       expect(stripAnsi(message!)).to.equal("Could not find key bla under nested.deeper.")
@@ -192,6 +195,7 @@ describe("ConfigContext", () => {
 
     it("should show helpful error when unable to resolve in nested context", async () => {
       class Nested extends ConfigContext {}
+
       class Context extends ConfigContext {
         nested: ConfigContext
 
@@ -200,6 +204,7 @@ describe("ConfigContext", () => {
           this.nested = new Nested(this)
         }
       }
+
       const c = new Context()
       const { message } = resolveKey(c, ["nested", "bla"])
       expect(stripAnsi(message!)).to.equal("Could not find key bla under nested.")

--- a/core/test/unit/src/config/template-contexts/module.ts
+++ b/core/test/unit/src/config/template-contexts/module.ts
@@ -8,7 +8,6 @@
 
 import { expect } from "chai"
 import { join } from "path"
-import stripAnsi = require("strip-ansi")
 import { keyBy } from "lodash"
 import { ConfigContext } from "../../../../../src/config/template-contexts/base"
 import { expectError, makeTestGardenA, TestGarden } from "../../../../helpers"
@@ -21,6 +20,7 @@ import { DeployAction } from "../../../../../src/actions/deploy"
 
 type TestValue = string | ConfigContext | TestValues | TestValueFunction
 type TestValueFunction = () => TestValue | Promise<TestValue>
+
 interface TestValues {
   [key: string]: TestValue
 }
@@ -293,13 +293,10 @@ describe("WorkflowStepConfigContext", () => {
       resolvedSteps: {},
       stepName: "step-1",
     })
-    expectError(
-      () => c.resolve({ key: ["steps", "step-2", "log"], nodePath: [], opts: {} }),
-      (err) =>
-        expect(stripAnsi(err.message)).to.equal(
-          "Step step-2 is referenced in a template for step step-1, but step step-2 is later in the execution order. Only previous steps in the workflow can be referenced."
-        )
-    )
+    expectError(() => c.resolve({ key: ["steps", "step-2", "log"], nodePath: [], opts: {} }), {
+      contains:
+        "Step step-2 is referenced in a template for step step-1, but step step-2 is later in the execution order. Only previous steps in the workflow can be referenced.",
+    })
   })
 
   it("should throw error when attempting to reference current step", () => {
@@ -309,12 +306,8 @@ describe("WorkflowStepConfigContext", () => {
       resolvedSteps: {},
       stepName: "step-1",
     })
-    expectError(
-      () => c.resolve({ key: ["steps", "step-1", "log"], nodePath: [], opts: {} }),
-      (err) =>
-        expect(stripAnsi(err.message)).to.equal(
-          "Step step-1 references itself in a template. Only previous steps in the workflow can be referenced."
-        )
-    )
+    expectError(() => c.resolve({ key: ["steps", "step-1", "log"], nodePath: [], opts: {} }), {
+      contains: "Step step-1 references itself in a template. Only previous steps in the workflow can be referenced.",
+    })
   })
 })

--- a/core/test/unit/src/config/template-contexts/workflow.ts
+++ b/core/test/unit/src/config/template-contexts/workflow.ts
@@ -7,13 +7,13 @@
  */
 
 import { expect } from "chai"
-import stripAnsi = require("strip-ansi")
 import { ConfigContext } from "../../../../../src/config/template-contexts/base"
 import { expectError, makeTestGardenA, TestGarden } from "../../../../helpers"
 import { WorkflowConfigContext, WorkflowStepConfigContext } from "../../../../../src/config/template-contexts/workflow"
 
 type TestValue = string | ConfigContext | TestValues | TestValueFunction
 type TestValueFunction = () => TestValue | Promise<TestValue>
+
 interface TestValues {
   [key: string]: TestValue
 }
@@ -119,13 +119,10 @@ describe("WorkflowStepConfigContext", () => {
       resolvedSteps: {},
       stepName: "step-1",
     })
-    expectError(
-      () => c.resolve({ key: ["steps", "step-2", "log"], nodePath: [], opts: {} }),
-      (err) =>
-        expect(stripAnsi(err.message)).to.equal(
-          "Step step-2 is referenced in a template for step step-1, but step step-2 is later in the execution order. Only previous steps in the workflow can be referenced."
-        )
-    )
+    expectError(() => c.resolve({ key: ["steps", "step-2", "log"], nodePath: [], opts: {} }), {
+      contains:
+        "Step step-2 is referenced in a template for step step-1, but step step-2 is later in the execution order. Only previous steps in the workflow can be referenced.",
+    })
   })
 
   it("should throw error when attempting to reference current step", () => {
@@ -135,12 +132,8 @@ describe("WorkflowStepConfigContext", () => {
       resolvedSteps: {},
       stepName: "step-1",
     })
-    expectError(
-      () => c.resolve({ key: ["steps", "step-1", "log"], nodePath: [], opts: {} }),
-      (err) =>
-        expect(stripAnsi(err.message)).to.equal(
-          "Step step-1 references itself in a template. Only previous steps in the workflow can be referenced."
-        )
-    )
+    expectError(() => c.resolve({ key: ["steps", "step-1", "log"], nodePath: [], opts: {} }), {
+      contains: "Step step-1 references itself in a template. Only previous steps in the workflow can be referenced.",
+    })
   })
 })

--- a/core/test/unit/src/config/workflow.ts
+++ b/core/test/unit/src/config/workflow.ts
@@ -19,7 +19,6 @@ import {
   defaultWorkflowLimits,
 } from "../../../../src/config/workflow"
 import { EnvironmentConfig, defaultNamespace } from "../../../../src/config/project"
-import stripAnsi from "strip-ansi"
 
 describe("resolveWorkflowConfig", () => {
   let garden: TestGarden
@@ -168,13 +167,9 @@ describe("resolveWorkflowConfig", () => {
       ],
     }
 
-    expectError(
-      () => resolveWorkflowConfig(garden, configWithTemplateStringInName),
-      (err) =>
-        expect(stripAnsi(err.message)).to.include(
-          'key .name with value "workflow-${secrets.foo}" fails to match the required pattern'
-        )
-    )
+    expectError(() => resolveWorkflowConfig(garden, configWithTemplateStringInName), {
+      contains: 'key .name with value "workflow-${secrets.foo}" fails to match the required pattern',
+    })
 
     const configWithTemplateStringInTrigger: WorkflowConfig = {
       ...defaults,
@@ -288,13 +283,9 @@ describe("resolveWorkflowConfig", () => {
         },
       ]
 
-      expectError(
-        () => populateNamespaceForTriggers({ ...config, triggers: [trigger] }, environmentConfigs),
-        (err) =>
-          expect(stripAnsi(err.message)).to.equal(
-            `Invalid namespace in trigger for workflow workflow-a: Environment test has defaultNamespace set to null, and no explicit namespace was specified. Please either set a defaultNamespace or explicitly set a namespace at runtime (e.g. --env=some-namespace.test).`
-          )
-      )
+      expectError(() => populateNamespaceForTriggers({ ...config, triggers: [trigger] }, environmentConfigs), {
+        contains: `Invalid namespace in trigger for workflow workflow-a: Environment test has defaultNamespace set to null, and no explicit namespace was specified. Please either set a defaultNamespace or explicitly set a namespace at runtime (e.g. --env=some-namespace.test).`,
+      })
     })
 
     it("should populate the trigger with a default namespace if one is defined", () => {

--- a/core/test/unit/src/router/deploy.ts
+++ b/core/test/unit/src/router/deploy.ts
@@ -7,7 +7,6 @@
  */
 
 import { expect } from "chai"
-import stripAnsi from "strip-ansi"
 import Stream from "ts-stream"
 import { ResolvedDeployAction } from "../../../../src/actions/deploy"
 import { ConfigGraph } from "../../../../src/graph/config-graph"
@@ -90,10 +89,7 @@ describe("deploy actions", () => {
             devMode: false,
             localMode: false,
           }),
-        (err) =>
-          expect(stripAnsi(err.message)).to.include(
-            "Error validating runtime action outputs from Deploy 'service-a': key .foo must be a string."
-          )
+        { contains: "Error validating runtime action outputs from Deploy 'service-a': key .foo must be a string." }
       )
     })
   })
@@ -158,10 +154,7 @@ describe("deploy actions", () => {
             devMode: false,
             localMode: false,
           }),
-        (err) =>
-          expect(stripAnsi(err.message)).to.include(
-            "Error validating runtime action outputs from Deploy 'service-a': key .foo must be a string."
-          )
+        { contains: "Error validating runtime action outputs from Deploy 'service-a': key .foo must be a string." }
       )
     })
   })

--- a/core/test/unit/src/router/run.ts
+++ b/core/test/unit/src/router/run.ts
@@ -9,7 +9,6 @@
 import { expect } from "chai"
 import { emptyDir, pathExists, readFile } from "fs-extra"
 import { join } from "path"
-import stripAnsi from "strip-ansi"
 import { ResolvedRunAction } from "../../../../src/actions/run"
 import { ConfigGraph } from "../../../../src/graph/config-graph"
 import { LogEntry } from "../../../../src/logger/log-entry"
@@ -93,13 +92,9 @@ describe("run actions", () => {
 
     it("should throw if the outputs don't match the task outputs schema of the plugin", async () => {
       resolvedRunAction._config[returnWrongOutputsCfgKey] = true
-      await expectError(
-        () => actionRouter.run.getResult({ log, action: resolvedRunAction, graph }),
-        (err) =>
-          expect(stripAnsi(err.message)).to.include(
-            "Error validating runtime action outputs from Run 'task-a': key .foo must be a string"
-          )
-      )
+      await expectError(() => actionRouter.run.getResult({ log, action: resolvedRunAction, graph }), {
+        contains: "Error validating runtime action outputs from Run 'task-a': key .foo must be a string",
+      })
     })
   })
 
@@ -153,10 +148,7 @@ describe("run actions", () => {
             interactive: true,
             graph,
           }),
-        (err) =>
-          expect(stripAnsi(err.message)).to.include(
-            "Error validating runtime action outputs from Run 'task-a': key .foo must be a string"
-          )
+        { contains: "Error validating runtime action outputs from Run 'task-a': key .foo must be a string" }
       )
     })
 

--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -1505,10 +1505,9 @@ describe("resolveTemplateStrings", () => {
         },
       }
 
-      expectError(
-        () => resolveTemplateStrings(obj, new TestContext({})),
-        (err) => expect(stripAnsi(err.message)).to.equal("Missing $return field next to $forEach field.")
-      )
+      expectError(() => resolveTemplateStrings(obj, new TestContext({})), {
+        contains: "Missing $return field next to $forEach field.",
+      })
     })
 
     it("throws if there are superfluous keys on the object", () => {


### PR DESCRIPTION
**What this PR does / why we need it**:
Yet another round of trivial refactoring to use shorter and simpler form of `expectError` helper when examine error messages.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
There are many other places to be refactored. Those will be done in the separate PRs.