### PR TITLE
fix(k8s): more stable & performant log streaming

### DIFF
--- a/core/src/commands/logs.ts
+++ b/core/src/commands/logs.ts
@@ -42,7 +42,9 @@ const logsOpts = {
     `,
   }),
   "follow": new BooleanParameter({
-    help: "Continuously stream new logs from the service(s).",
+    help: deline`
+    Continuously stream new logs from the service(s).
+    When the \`--follow\` option is set, we default to \`--since 1m\`.`,
     alias: "f",
   }),
   "tail": new IntegerParameter({
@@ -104,8 +106,8 @@ export class LogsCommand extends Command<Args, Opts> {
   help = "Retrieves the most recent logs for the specified service(s)."
 
   description = dedent`
-    Outputs logs for all or specified services, and optionally waits for news logs to come in. Defaults
-    to getting logs from the last minute when in \`--follow\` mode. You can change this with the \`--since\` option.
+    Outputs logs for all or specified services, and optionally waits for news logs to come in. Defaults to getting logs
+    from the last minute when in \`--follow\` mode. You can change this with the \`--since\` or \`--tail\` options.
 
     Examples:
 

--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -778,3 +778,7 @@ export function renderPodEvents(events: CoreV1Event[]): string {
 
   return text
 }
+
+export function summarize(resources: KubernetesResource[]) {
+  return resources.map((r) => `${r.kind} ${r.metadata.name}`).join(", ")
+}

--- a/core/test/integ/src/plugins/kubernetes/container/logs.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/logs.ts
@@ -138,7 +138,7 @@ describe("kubernetes", () => {
         setTimeout(() => {
           logsFollower.close()
         }, 5000)
-        await logsFollower.followLogs({ limitBytes: null })
+        await logsFollower.followLogs({})
 
         expect(ctx.log.toString()).to.match(/Connected to container 'simple-service'/)
 
@@ -215,7 +215,7 @@ describe("kubernetes", () => {
         // Start following logs even when no services is deployed
         // (we don't wait for the Promise since it won't resolve unless we close the connection)
         // tslint:disable-next-line: no-floating-promises
-        logsFollower.followLogs({ limitBytes: null })
+        logsFollower.followLogs({})
         await sleep(1500)
 
         // Deploy the service
@@ -225,19 +225,19 @@ describe("kubernetes", () => {
         logsFollower.close()
 
         const missingContainerRegex = new RegExp(
-          `<No running containers found for service. Will retry in ${retryIntervalMs / 1000}s...>`
+          `<No running containers found for Deployment simple-service. Will retry in ${retryIntervalMs / 1000}s...>`
         )
         const connectedRegex = new RegExp("<Connected to container 'simple-service' in Pod")
         const serverRunningRegex = new RegExp("Server running...")
-        expect(ctx.log.toString()).to.match(missingContainerRegex)
-        expect(ctx.log.toString()).to.match(connectedRegex)
-        expect(ctx.log.toString()).to.match(serverRunningRegex)
 
         // First we expect to see a "missing container" entry because the service hasn't been deployed
+        expect(ctx.log.toString()).to.match(missingContainerRegex)
 
         // Then we expect to see a "container connected" entry when the service has been deployed
+        expect(ctx.log.toString()).to.match(connectedRegex)
 
-        // Finally we expect to see the service log
+        // Finally, we expect to see the service log
+        expect(ctx.log.toString()).to.match(serverRunningRegex)
       })
     })
   })

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -2759,8 +2759,8 @@ sources:
 
 **Retrieves the most recent logs for the specified service(s).**
 
-Outputs logs for all or specified services, and optionally waits for news logs to come in. Defaults
-to getting logs from the last minute when in `--follow` mode. You can change this with the `--since` option.
+Outputs logs for all or specified services, and optionally waits for news logs to come in. Defaults to getting logs
+from the last minute when in `--follow` mode. You can change this with the `--since` or `--tail` options.
 
 Examples:
 
@@ -2786,7 +2786,7 @@ Examples:
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
   | `--tag` |  | array:tag | Only show log lines that match the given tag, e.g. &#x60;--tag &#x27;container&#x3D;foo&#x27;&#x60;. If you specify multiple filters in a single tag option (e.g. &#x60;--tag &#x27;container&#x3D;foo,someOtherTag&#x3D;bar&#x27;&#x60;), they must all be matched. If you provide multiple &#x60;--tag&#x60; options (e.g. &#x60;--tag &#x27;container&#x3D;api&#x27; --tag &#x27;container&#x3D;frontend&#x27;&#x60;), they will be OR-ed together (i.e. if any of them match, the log line will be included). You can specify glob-style wildcards, e.g. &#x60;--tag &#x27;container&#x3D;prefix-*&#x27;&#x60;.
-  | `--follow` | `-f` | boolean | Continuously stream new logs from the service(s).
+  | `--follow` | `-f` | boolean | Continuously stream new logs from the service(s). When the &#x60;--follow&#x60; option is set, we default to &#x60;--since 1m&#x60;.
   | `--tail` | `-t` | number | Number of lines to show for each service. Defaults to showing all log lines (up to a certain limit). Takes precedence over the &#x60;--since&#x60; flag if both are set. Note that we don&#x27;t recommend using a large value here when in follow mode.
   | `--show-container` |  | boolean | Show the name of the container with log output. May not apply to all providers
   | `--show-tags` |  | boolean | Show any tags attached to each log line. May not apply to all providers


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes an issue with very high upload bandwidth use when running Kubernetes based tests/tasks that produce a lot of log output.

co-written by @stefreak and @thsig

* Improved connection management and pod lifecycle logic, including more robust connection timeout enforcement.

* Removed keepalive logic, since it doesn't work on all operating systems.

* Improved deduplication logic to generate fewer false positives (and eliminate false-negatives).

* Use `sinceTime` when fetching logs on retry to make sure we don't fetch any unnecessary logs.

* When a runner pod terminates, we make sure to wait until the final logs have been fetched.

* Default to using the `tail` option in conjunction with a "max log lines in memory" setting instead of `limitBytes` to avoid clipping / incomplete log lines while also avoiding the loading of too much log data into memory.

* Only start one connection attempt at a time, to prevent multiple connections to the same container at once.

* Make sure that we only call `createConnections` once it has finished, so that there is only one concurrent instance of the method running per `LogFollower` at a time.

**Which issue(s) this PR fixes**:

Fixes #3586.

**Notes to reviewer**:

I will use "squash and merge" when merging this PR.

One convenient way to test the reconnect logic in this PR on a macOS machine is by using the Network Link Conditioner: https://nshipster.com/network-link-conditioner/

**Deduplication fix example**:

With a container module + a little demo go program like this:

```go
	for i := 0; i < 10; i++ {
		for x := 0; x < i; x++ {
			fmt.Printf("You should see this line %d times\n", i)
		}
		time.Sleep(1 * time.Second)
	}
```

Difference for `garden test deduplication -l3 -f` before and after the change:
```diff
--- before.log  2023-02-24 15:28:00
+++ after.log   2023-02-24 15:28:18
@@ -1,4 +1,4 @@
-$ garden test deduplication -l3 -f
+$ gdev test deduplication -l3 -f
 Running tests 🌡️ 
 
 
@@ -16,17 +16,52 @@
 ℹ deduplication             → Getting build status for v-a5a55d7920...
 ✔ deduplication             → Getting build status for v-a5a55d7920... → Already built
 ℹ deduplication             → Running test tests
-ℹ deduplication [verbose]   → Starting Pod test-deduplication-test-29ab47 with command 'sh -c ./main 10'
+ℹ deduplication [verbose]   → Starting Pod test-deduplication-test-054b2c with command 'sh -c ./main 10'
 ℹ deduplication [verbose]   → [sh]: You should see this line 1 times
 ℹ deduplication [verbose]   → [sh]: You should see this line 2 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 2 times
 ℹ deduplication [verbose]   → [sh]: You should see this line 3 times
 ℹ deduplication [verbose]   → [sh]: You should see this line 3 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 3 times
 ℹ deduplication [verbose]   → [sh]: You should see this line 4 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 4 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 4 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 4 times
 ℹ deduplication [verbose]   → [sh]: You should see this line 5 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 5 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 5 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 5 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 5 times
 ℹ deduplication [verbose]   → [sh]: You should see this line 6 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 6 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 6 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 6 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 6 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 6 times
 ℹ deduplication [verbose]   → [sh]: You should see this line 7 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 7 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 7 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 7 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 7 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 7 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 7 times
 ℹ deduplication [verbose]   → [sh]: You should see this line 8 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 8 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 8 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 8 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 8 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 8 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 8 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 8 times
 ℹ deduplication [verbose]   → [sh]: You should see this line 9 times
-✔ deduplication             → Running test tests → Success (took 13.3 sec)
+ℹ deduplication [verbose]   → [sh]: You should see this line 9 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 9 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 9 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 9 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 9 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 9 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 9 times
+ℹ deduplication [verbose]   → [sh]: You should see this line 9 times
+✔ deduplication             → Running test tests → Success (took 14.8 sec)
 
 Done! ✔️ 
```