### PR TITLE
test: use `expectError` helper in tests

### DIFF
--- a/core/src/util/testing.ts
+++ b/core/src/util/testing.ts
@@ -391,7 +391,9 @@ export function expectFuzzyMatch(str: string, sample: string | string[]) {
 type ExpectErrorAssertion =
   | string
   | ((err: any) => void)
-  | { type?: string; contains?: string | string[]; message?: string }
+  | { type?: string; contains?: string | string[]; errorMessageGetter?: (err: any) => string }
+
+const defaultErrorMessageGetter = (err: any) => err.message
 
 export function expectError(fn: Function, assertion: ExpectErrorAssertion = {}) {
   const handleError = (err: GardenError) => {
@@ -406,7 +408,8 @@ export function expectError(fn: Function, assertion: ExpectErrorAssertion = {}) 
 
     const type = typeof assertion === "string" ? assertion : assertion.type
     const contains = typeof assertion === "object" && assertion.contains
-    const message = typeof assertion === "object" && assertion.message
+    const errorMessageGetter = typeof assertion === "object" && assertion.errorMessageGetter
+    const message = errorMessageGetter && errorMessageGetter(err)
 
     if (type) {
       if (!err.type) {
@@ -422,7 +425,8 @@ export function expectError(fn: Function, assertion: ExpectErrorAssertion = {}) 
     }
 
     if (contains) {
-      expectFuzzyMatch(err.message, contains)
+      const errorMessage = (errorMessageGetter || defaultErrorMessageGetter)(err)
+      expectFuzzyMatch(errorMessage, contains)
     }
 
     if (message) {

--- a/core/test/unit/src/build-staging/helpers.ts
+++ b/core/test/unit/src/build-staging/helpers.ts
@@ -144,10 +144,9 @@ describe("build staging helpers", () => {
       const b = join(tmpPath, "b")
       await ensureDir(a)
 
-      await expectError(
-        () => cloneFileAsync({ from: a, to: b, statsHelper, allowDelete: false }),
-        (err) => expect(err.message).to.equal(`Attempted to copy non-file ${a}`)
-      )
+      await expectError(() => cloneFileAsync({ from: a, to: b, statsHelper, allowDelete: false }), {
+        contains: `Attempted to copy non-file ${a}`,
+      })
     })
   })
 

--- a/core/test/unit/src/cli/cli.ts
+++ b/core/test/unit/src/cli/cli.ts
@@ -84,10 +84,12 @@ describe("cli", () => {
         noProject = true
 
         printHeader() {}
+
         async action({ args }) {
           return { result: { args } }
         }
       }
+
       const cmd = new TestCommand()
       cli.addCommand(cmd)
 
@@ -193,7 +195,7 @@ describe("cli", () => {
               exitOnError: false,
               cwd: getDataDir("test-projects", "custom-commands-invalid"),
             }),
-          (err) => expect(err.message).to.include("Error validating custom Command 'invalid'")
+          { contains: "Error validating custom Command 'invalid'" }
         )
       })
 
@@ -233,10 +235,12 @@ describe("cli", () => {
           noProject = true
 
           printHeader() {}
+
           async action({}) {
             return { result: { something: "important" } }
           }
         }
+
         const cmd = new TestCommand()
         cli.addCommand(cmd)
 
@@ -253,10 +257,12 @@ describe("cli", () => {
           noProject = true
 
           printHeader() {}
+
           async action({}) {
             return { result: { something: "important" } }
           }
         }
+
         const cmd = new TestCommand()
         cli.addCommand(cmd)
 
@@ -276,10 +282,12 @@ describe("cli", () => {
           noProject = true
 
           printHeader() {}
+
           async action({}) {
             return { result: { something: "important" } }
           }
         }
+
         const cmd = new TestCommand()
         cli.addCommand(cmd)
 
@@ -337,10 +345,12 @@ describe("cli", () => {
         noProject = true
 
         printHeader() {}
+
         async action({}) {
           return { result: { something: "important" } }
         }
       }
+
       const cmd = new TestCommand()
       cli.addCommand(cmd)
 
@@ -357,10 +367,12 @@ describe("cli", () => {
         noProject = true
 
         printHeader() {}
+
         async action({}) {
           return { result: { something: "important" } }
         }
       }
+
       const cmd = new TestCommand()
       cli.addCommand(cmd)
 
@@ -379,6 +391,7 @@ describe("cli", () => {
         help = "halp!"
 
         printHeader() {}
+
         async action({ garden }: CommandParams) {
           expect(record.command).to.equal(this.name)
           expect(record.sessionId).to.equal(garden.sessionId)
@@ -393,6 +406,7 @@ describe("cli", () => {
           return { result: {} }
         }
       }
+
       const cmd = new TestCommand()
       cli.addCommand(cmd)
 
@@ -416,6 +430,7 @@ describe("cli", () => {
         }
 
         printHeader() {}
+
         async action({ garden }: CommandParams) {
           expect(record.command).to.equal(this.name)
           expect(record.sessionId).to.equal(garden.sessionId)
@@ -430,6 +445,7 @@ describe("cli", () => {
           return { result: {} }
         }
       }
+
       const cmd = new TestCommand()
       cli.addCommand(cmd)
 
@@ -470,11 +486,13 @@ describe("cli", () => {
         streamLogEntries = true
 
         printHeader() {}
+
         async action({ garden }: CommandParams) {
           garden.events.emit("_test", "funky functional test")
           return { result: {} }
         }
       }
+
       const cmd = new TestCommand()
       cli.addCommand(cmd)
 
@@ -503,11 +521,13 @@ describe("cli", () => {
         }
 
         printHeader() {}
+
         async action({ garden }: CommandParams) {
           garden.events.emit("_test", "nope")
           return { result: {} }
         }
       }
+
       const cmd = new TestCommand()
       cli.addCommand(cmd)
 
@@ -529,16 +549,19 @@ describe("cli", () => {
         noProject = true
 
         printHeader() {}
+
         async action({}) {
           return { result: { something: "important" } }
         }
       }
+
       class TestGroup extends CommandGroup {
         name = "test-group"
         help = ""
 
         subCommands = [TestCommand]
       }
+
       const group = new TestGroup()
 
       for (const cmd of group.getSubCommands()) {
@@ -559,10 +582,12 @@ describe("cli", () => {
         noProject = true
 
         printHeader() {}
+
         async action({ args, opts }) {
           return { result: { args, opts } }
         }
       }
+
       const cmd = new TestCommand()
       cli.addCommand(cmd)
 
@@ -621,10 +646,12 @@ describe("cli", () => {
         noProject = true
 
         printHeader() {}
+
         async action({ args, opts }) {
           return { result: { args, opts } }
         }
       }
+
       const cmd = new TestCommand()
       cli.addCommand(cmd)
 
@@ -653,10 +680,12 @@ describe("cli", () => {
         noProject = true
 
         printHeader() {}
+
         async action({ args, opts }) {
           return { result: { args, opts } }
         }
       }
+
       const cmd = new TestCommand()
       cli.addCommand(cmd)
 
@@ -701,10 +730,12 @@ describe("cli", () => {
         }
 
         printHeader() {}
+
         async action({ args, opts }) {
           return { result: { args, opts } }
         }
       }
+
       const cmd = new TestCommand()
       cli.addCommand(cmd)
 
@@ -760,6 +791,7 @@ describe("cli", () => {
         }
 
         printHeader() {}
+
         async action({ args, opts }) {
           return { result: { args, opts } }
         }
@@ -771,6 +803,7 @@ describe("cli", () => {
 
         subCommands = [TestCommand]
       }
+
       const group = new TestGroup()
 
       for (const cmd of group.getSubCommands()) {
@@ -835,10 +868,12 @@ describe("cli", () => {
         }
 
         printHeader() {}
+
         async action({ args, opts }) {
           return { result: { args, opts } }
         }
       }
+
       const cmd = new TestCommand()
       cli.addCommand(cmd)
 
@@ -858,6 +893,7 @@ describe("cli", () => {
         noProject = true
 
         printHeader() {}
+
         async action({ args }) {
           return { result: { args } }
         }
@@ -877,6 +913,7 @@ describe("cli", () => {
         noProject = true
 
         printHeader() {}
+
         async action({ args }) {
           return { result: { args } }
         }
@@ -896,6 +933,7 @@ describe("cli", () => {
         noProject = true
 
         printHeader() {}
+
         async action({ garden }) {
           return { result: { variables: garden.variables } }
         }
@@ -918,6 +956,7 @@ describe("cli", () => {
         noProject = true
 
         printHeader() {}
+
         async action() {
           return { result: { some: "output" } }
         }
@@ -937,6 +976,7 @@ describe("cli", () => {
         noProject = true
 
         printHeader() {}
+
         async action() {
           return { result: { some: "output" } }
         }
@@ -976,6 +1016,7 @@ describe("cli", () => {
         noProject = true
 
         printHeader() {}
+
         async action({ garden }) {
           return { result: { environmentName: garden.environmentName } }
         }
@@ -996,6 +1037,7 @@ describe("cli", () => {
         noProject = true
 
         printHeader() {}
+
         async action({ garden }) {
           return { result: { environmentName: garden.environmentName } }
         }
@@ -1040,6 +1082,7 @@ describe("cli", () => {
           noProject = true
 
           printHeader() {}
+
           async action({ args }) {
             return { result: { args } }
           }
@@ -1162,10 +1205,9 @@ describe("cli", () => {
           throw new Error("broken")
         }
 
-        await expectError(
-          () => validateRuntimeRequirementsCached(log, config, requirementCheckFunction),
-          (err) => expect(err.message).to.include("broken")
-        )
+        await expectError(() => validateRuntimeRequirementsCached(log, config, requirementCheckFunction), {
+          contains: "broken",
+        })
       })
     })
   })

--- a/core/test/unit/src/cli/helpers.ts
+++ b/core/test/unit/src/cli/helpers.ts
@@ -354,12 +354,9 @@ describe("processCliArgs", () => {
 
   it("throws with all found errors if applicable", () => {
     const cmd = new RunCommand()
-    expectError(
-      () => parseAndProcess(["--foo=bar", "--interactive=9", "--force"], cmd),
-      (err) => {
-        expectFuzzyMatch(err.message, ["Unrecognized option flag --foo", "Unrecognized option flag --interactive"])
-      }
-    )
+    expectError(() => parseAndProcess(["--foo=bar", "--interactive=9", "--force"], cmd), {
+      contains: ["Unrecognized option flag --foo", "Unrecognized option flag --interactive"],
+    })
   })
 
   it("parses args and opts for a DeployCommand", async () => {

--- a/core/test/unit/src/commands/create/create-module.ts
+++ b/core/test/unit/src/commands/create/create-module.ts
@@ -204,7 +204,7 @@ describe("CreateModuleCommand", () => {
             filename: defaultConfigFilename,
           }),
         }),
-      (err) => expect(err.message).to.equal(`Path ${dir} does not exist`)
+      { contains: `Path ${dir} does not exist` }
     )
   })
 

--- a/core/test/unit/src/commands/create/create-project.ts
+++ b/core/test/unit/src/commands/create/create-project.ts
@@ -219,7 +219,7 @@ describe("CreateProjectCommand", () => {
             filename: defaultProjectConfigFilename,
           }),
         }),
-      (err) => expect(err.message).to.equal("A Garden project already exists in " + configPath)
+      { contains: `A Garden project already exists in ${configPath}` }
     )
   })
 
@@ -240,7 +240,7 @@ describe("CreateProjectCommand", () => {
             filename: defaultProjectConfigFilename,
           }),
         }),
-      (err) => expect(err.message).to.equal(`Path ${dir} does not exist`)
+      { contains: `Path ${dir} does not exist` }
     )
   })
 })

--- a/core/test/unit/src/commands/custom.ts
+++ b/core/test/unit/src/commands/custom.ts
@@ -389,7 +389,7 @@ describe("CustomCommandWrapper", () => {
             command: ["sleep", "1"],
           },
         }),
-      (err) => expect(err.message).to.equal("Unexpected parameter type 'blorg'")
+      { contains: "Unexpected parameter type 'blorg'" }
     )
   })
 
@@ -411,7 +411,7 @@ describe("CustomCommandWrapper", () => {
             command: ["sleep", "1"],
           },
         }),
-      (err) => expect(err.message).to.equal("Unexpected parameter type 'blorg'")
+      { contains: "Unexpected parameter type 'blorg'" }
     )
   })
 })

--- a/core/test/unit/src/commands/login.ts
+++ b/core/test/unit/src/commands/login.ts
@@ -169,10 +169,9 @@ describe("LoginCommand", () => {
     })
     const command = new LoginCommand()
 
-    await expectError(
-      () => command.action(makeCommandParams({ cli, garden, args: {}, opts: {} })),
-      (err) => expect(stripAnsi(err.message)).to.match(/Project config is missing a cloud domain./)
-    )
+    await expectError(() => command.action(makeCommandParams({ cli, garden, args: {}, opts: {} })), {
+      contains: "Project config is missing a cloud domain.",
+    })
   })
 
   it("should throw if the user has an invalid auth token", async () => {
@@ -202,10 +201,9 @@ describe("LoginCommand", () => {
     expect(savedToken!.token).to.eql(testToken.token)
     expect(savedToken!.refreshToken).to.eql(testToken.refreshToken)
 
-    await expectError(
-      () => command.action(makeCommandParams({ cli, garden, args: {}, opts: {} })),
-      (err) => expect(stripAnsi(err.message)).to.match(/bummer/)
-    )
+    await expectError(() => command.action(makeCommandParams({ cli, garden, args: {}, opts: {} })), {
+      contains: "bummer",
+    })
   })
 
   it("should throw and print a helpful message on 401 errors", async () => {
@@ -235,10 +233,9 @@ describe("LoginCommand", () => {
     expect(savedToken!.token).to.eql(testToken.token)
     expect(savedToken!.refreshToken).to.eql(testToken.refreshToken)
 
-    await expectError(
-      () => command.action(makeCommandParams({ cli, garden, args: {}, opts: {} })),
-      (err) => expect(stripAnsi(err.message)).to.match(/bummer/)
-    )
+    await expectError(() => command.action(makeCommandParams({ cli, garden, args: {}, opts: {} })), {
+      contains: "bummer",
+    })
 
     const logOutput = getLogMessages(garden.log, (entry) => entry.level <= LogLevel.info).join("\n")
 
@@ -283,13 +280,10 @@ describe("LoginCommand", () => {
 
       td.replace(CloudApi.prototype, "checkClientAuthToken", async () => false)
 
-      await expectError(
-        () => command.action(makeCommandParams({ cli, garden, args: {}, opts: {} })),
-        (err) =>
-          expect(stripAnsi(err.message)).to.match(
-            /The provided access token is expired or has been revoked, please create a new one from the Garden Enterprise UI./
-          )
-      )
+      await expectError(() => command.action(makeCommandParams({ cli, garden, args: {}, opts: {} })), {
+        contains:
+          "The provided access token is expired or has been revoked, please create a new one from the Garden Enterprise UI.",
+      })
     })
 
     after(() => {

--- a/core/test/unit/src/commands/logs.ts
+++ b/core/test/unit/src/commands/logs.ts
@@ -18,7 +18,7 @@ import {
   customizedTestPlugin,
   expectError,
   makeTempDir,
-  withDefaultGlobalOpts
+  withDefaultGlobalOpts,
 } from "../../../helpers"
 import { DEFAULT_API_VERSION } from "../../../../src/constants"
 import { formatForTerminal } from "../../../../src/logger/renderers"
@@ -468,10 +468,9 @@ describe("LogsCommand", () => {
       garden.setActionConfigs([], actionConfigsForTags())
 
       const command = new LogsCommand()
-      await expectError(
-        () => command.action(makeCommandParams({ garden, opts: { tag: ["*-main"] } })),
-        (err) => expect(err.message).to.eql("Unable to parse the given --tag flags. Format should be key=value.")
-      )
+      await expectError(() => command.action(makeCommandParams({ garden, opts: { tag: ["*-main"] } })), {
+        contains: "Unable to parse the given --tag flags. Format should be key=value.",
+      })
     })
 
     it("should AND together tag filters in a given --tag option instance", async () => {

--- a/core/test/unit/src/commands/run-workflow.ts
+++ b/core/test/unit/src/commands/run-workflow.ts
@@ -452,11 +452,9 @@ describe("RunWorkflowCommand", () => {
       },
     ])
 
-    await expectError(
-      () => cmd.action({ ...defaultParams, args: { workflow: "workflow-a" } }),
-      (err) =>
-        expect(err.message).to.equal("File '.garden/test.txt' requires secret 'missing' which could not be found.")
-    )
+    await expectError(() => cmd.action({ ...defaultParams, args: { workflow: "workflow-a" } }), {
+      contains: "File '.garden/test.txt' requires secret 'missing' which could not be found.",
+    })
   })
 
   it("should throw if attempting to write a file with a directory path that contains an existing file", async () => {
@@ -473,12 +471,9 @@ describe("RunWorkflowCommand", () => {
       },
     ])
 
-    await expectError(
-      () => cmd.action({ ...defaultParams, args: { workflow: "workflow-a" } }),
-      (err) =>
-        expect(err.message.startsWith("Unable to write file 'garden.yml/foo.txt': EEXIST: file already exists, mkdir"))
-          .to.be.true
-    )
+    await expectError(() => cmd.action({ ...defaultParams, args: { workflow: "workflow-a" } }), {
+      contains: "Unable to write file 'garden.yml/foo.txt': EEXIST: file already exists, mkdir",
+    })
   })
 
   it("should throw if attempting to write a file to an existing directory path", async () => {
@@ -495,13 +490,9 @@ describe("RunWorkflowCommand", () => {
       },
     ])
 
-    await expectError(
-      () => cmd.action({ ...defaultParams, args: { workflow: "workflow-a" } }),
-      (err) =>
-        expect(err.message).to.equal(
-          `Unable to write file '.garden': EISDIR: illegal operation on a directory, open '${garden.gardenDirPath}'`
-        )
-    )
+    await expectError(() => cmd.action({ ...defaultParams, args: { workflow: "workflow-a" } }), {
+      contains: `Unable to write file '.garden': EISDIR: illegal operation on a directory, open '${garden.gardenDirPath}'`,
+    })
   })
 
   it("should run a script step in the project root", async () => {

--- a/core/test/unit/src/commands/run.ts
+++ b/core/test/unit/src/commands/run.ts
@@ -82,10 +82,10 @@ describe("RunCommand", () => {
             "module": undefined,
           },
         }),
-      (err) =>
-        expect(err.message).to.equal(
-          "A name argument or --module must be specified. If you really want to perform every Run in the project, please specify '*' as an argument."
-        )
+      {
+        contains:
+          "A name argument or --module must be specified. If you really want to perform every Run in the project, please specify '*' as an argument.",
+      }
     )
   })
 
@@ -242,7 +242,7 @@ describe("RunCommand", () => {
             "module": ["foo"],
           },
         }),
-      (err) => expect(err.message).to.equal("Could not find module(s): foo")
+      { contains: "Could not find module(s): foo" }
     )
   })
 

--- a/core/test/unit/src/commands/test.ts
+++ b/core/test/unit/src/commands/test.ts
@@ -188,8 +188,7 @@ describe("TestCommand", () => {
             "module": undefined,
           }),
         }),
-      (err) =>
-        expect(err.message).to.equal("The --interactive/-i option can only be used if a single test is selected.")
+      { contains: "The --interactive/-i option can only be used if a single test is selected." }
     )
   })
 
@@ -214,8 +213,7 @@ describe("TestCommand", () => {
             "module": undefined,
           }),
         }),
-      (err) =>
-        expect(err.message).to.equal("The --interactive/-i option can only be used if a single test is selected.")
+      { contains: "The --interactive/-i option can only be used if a single test is selected." }
     )
   })
 
@@ -354,7 +352,7 @@ describe("TestCommand", () => {
             "module": ["foo"],
           }),
         }),
-      (err) => expect(err.message).to.equal("Could not find module(s): foo")
+      { contains: "Could not find module(s): foo" }
     )
   })
 

--- a/core/test/unit/src/commands/tools.ts
+++ b/core/test/unit/src/commands/tools.ts
@@ -186,10 +186,10 @@ describe("ToolsCommand", () => {
           args: { "tool": "51616ok3xnnz....361.2362&123", "--": ["0"] },
           opts: withDefaultGlobalOpts({ "get-path": false, "output": "json" }),
         }),
-      (err) =>
-        expect(err.message).to.equal(
-          "Invalid tool name argument. Please specify either a tool name (no periods) or <plugin name>.<tool name>."
-        )
+      {
+        contains:
+          "Invalid tool name argument. Please specify either a tool name (no periods) or <plugin name>.<tool name>.",
+      }
     )
   })
 
@@ -204,7 +204,7 @@ describe("ToolsCommand", () => {
           args: { "tool": "bla.tool", "--": ["0"] },
           opts: withDefaultGlobalOpts({ "get-path": false, "output": "json" }),
         }),
-      (err) => expect(err.message).to.equal("Could not find plugin bla.")
+      { contains: "Could not find plugin bla." }
     )
   })
 
@@ -219,7 +219,7 @@ describe("ToolsCommand", () => {
           args: { "tool": "bla", "--": ["0"] },
           opts: withDefaultGlobalOpts({ "get-path": false, "output": "json" }),
         }),
-      (err) => expect(err.message).to.equal("Could not find tool bla.")
+      { contains: "Could not find tool bla." }
     )
   })
 

--- a/core/test/unit/src/config/base.ts
+++ b/core/test/unit/src/config/base.ts
@@ -107,10 +107,7 @@ describe("loadConfigResources", () => {
     const projectPath = getDataDir("test-project-invalid-config")
     await expectError(
       async () => await loadConfigResources(projectPath, resolve(projectPath, "invalid-syntax-module", "garden.yml")),
-      (err) => {
-        expect(err.message).to.match(/Could not parse/)
-        expect(err.message).to.match(/duplicated mapping key/) // include syntax erorrs in the output
-      }
+      { contains: ["Could not parse", "duplicated mapping key"] }
     )
   })
 
@@ -118,9 +115,7 @@ describe("loadConfigResources", () => {
     const projectPath = getDataDir("test-project-invalid-config")
     await expectError(
       async () => await loadConfigResources(projectPath, resolve(projectPath, "missing-kind", "garden.yml")),
-      (err) => {
-        expect(err.message).to.contain("Missing `kind` field in config at missing-kind/garden.yml")
-      }
+      { contains: "Missing `kind` field in config at missing-kind/garden.yml" }
     )
   })
 
@@ -128,9 +123,7 @@ describe("loadConfigResources", () => {
     const projectPath = getDataDir("test-project-invalid-config")
     await expectError(
       async () => await loadConfigResources(projectPath, resolve(projectPath, "invalid-config-kind", "garden.yml")),
-      (err) => {
-        expect(err.message).to.contain("Unknown config kind banana in invalid-config-kind/garden.yml")
-      }
+      { contains: "Unknown config kind banana in invalid-config-kind/garden.yml" }
     )
   })
 
@@ -464,12 +457,9 @@ describe("loadConfigResources", () => {
   })
 
   it("should throw if config file is not found", async () => {
-    await expectError(
-      async () => await loadConfigResources("/thisdoesnotexist", "/thisdoesnotexist"),
-      (err) => {
-        expect(err.message).to.equal("Could not find configuration file at /thisdoesnotexist")
-      }
-    )
+    await expectError(async () => await loadConfigResources("/thisdoesnotexist", "/thisdoesnotexist"), {
+      contains: "Could not find configuration file at /thisdoesnotexist",
+    })
   })
 
   it("should ignore empty documents in multi-doc YAML", async () => {
@@ -529,11 +519,8 @@ describe("findProjectConfig", async () => {
   })
 
   it("should throw an error if multiple projects are found", async () => {
-    await expectError(
-      async () => await findProjectConfig(projectPathDuplicateProjects),
-      (err) => {
-        expect(err.message).to.match(/Multiple project declarations found/)
-      }
-    )
+    await expectError(async () => await findProjectConfig(projectPathDuplicateProjects), {
+      contains: "Multiple project declarations found",
+    })
   })
 })

--- a/core/test/unit/src/config/common.ts
+++ b/core/test/unit/src/config/common.ts
@@ -464,17 +464,15 @@ describe("joi.customObject", () => {
   })
 
   it("should throw if schema with wrong type is passed to .jsonSchema()", async () => {
-    await expectError(
-      () => joi.object().jsonSchema({ type: "number" }),
-      (err) => expect(err.message).to.equal("jsonSchema must be a valid JSON Schema with type=object or reference")
-    )
+    await expectError(() => joi.object().jsonSchema({ type: "number" }), {
+      contains: "jsonSchema must be a valid JSON Schema with type=object or reference",
+    })
   })
 
   it("should throw if invalid schema is passed to .jsonSchema()", async () => {
-    await expectError(
-      () => joi.object().jsonSchema({ type: "banana", blorg: "blarg" }),
-      (err) => expect(err.message).to.equal("jsonSchema must be a valid JSON Schema with type=object or reference")
-    )
+    await expectError(() => joi.object().jsonSchema({ type: "banana", blorg: "blarg" }), {
+      contains: "jsonSchema must be a valid JSON Schema with type=object or reference",
+    })
   })
 })
 

--- a/core/test/unit/src/config/common.ts
+++ b/core/test/unit/src/config/common.ts
@@ -8,7 +8,6 @@
 
 import { expect } from "chai"
 
-const stripAnsi = require("strip-ansi")
 import {
   identifierRegex,
   envVarRegex,
@@ -157,12 +156,10 @@ describe("validate", () => {
         .required(),
     })
 
-    await expectError(
-      () => validateSchema(obj, schema),
-      (err) => {
-        expect(stripAnsi(err.detail.errorDescription)).to.contain("key .A is required, key .B.b is required")
-      }
-    )
+    await expectError(() => validateSchema(obj, schema), {
+      contains: "key .A is required, key .B.b is required",
+      errorMessageGetter: (err) => err.detail.errorDescription,
+    })
   })
 
   it("should throw a nice error when keys are wrong in a pattern object", async () => {
@@ -184,12 +181,10 @@ describe("validate", () => {
         .required(),
     })
 
-    await expectError(
-      () => validateSchema(obj, schema),
-      (err) => {
-        expect(stripAnsi(err.detail.errorDescription)).to.contain("key .A.B[c].C is required")
-      }
-    )
+    await expectError(() => validateSchema(obj, schema), {
+      contains: "key .A.B[c].C is required",
+      errorMessageGetter: (err) => err.detail.errorDescription,
+    })
   })
 
   it("should throw a nice error when key is invalid", async () => {
@@ -199,24 +194,20 @@ describe("validate", () => {
       .pattern(/[a-z]+/, joi.string())
       .unknown(false)
 
-    await expectError(
-      () => validateSchema(obj, schema),
-      (err) => {
-        expect(stripAnsi(err.detail.errorDescription)).to.contain('key "123" is not allowed at path .')
-      }
-    )
+    await expectError(() => validateSchema(obj, schema), {
+      contains: 'key "123" is not allowed at path .',
+      errorMessageGetter: (err) => err.detail.errorDescription,
+    })
   })
 
   it("should throw a nice error when nested key is invalid", async () => {
     const obj = { a: { 123: "abc" } }
     const schema = joi.object().keys({ a: joi.object().pattern(/[a-z]+/, joi.string()) })
 
-    await expectError(
-      () => validateSchema(obj, schema),
-      (err) => {
-        expect(stripAnsi(err.detail.errorDescription)).to.contain('key "123" is not allowed at path .a')
-      }
-    )
+    await expectError(() => validateSchema(obj, schema), {
+      contains: 'key "123" is not allowed at path .a',
+      errorMessageGetter: (err) => err.detail.errorDescription,
+    })
   })
 
   it("should throw a nice error when xor rule fails", async () => {
@@ -229,12 +220,10 @@ describe("validate", () => {
       })
       .xor("a", "b")
 
-    await expectError(
-      () => validateSchema(obj, schema),
-      (err) => {
-        expect(stripAnsi(err.detail.errorDescription)).to.contain("object at . can only contain one of [a, b]")
-      }
-    )
+    await expectError(() => validateSchema(obj, schema), {
+      contains: "object at . can only contain one of [a, b]",
+      errorMessageGetter: (err) => err.detail.errorDescription,
+    })
   })
 })
 

--- a/core/test/unit/src/config/project.ts
+++ b/core/test/unit/src/config/project.ts
@@ -1097,7 +1097,7 @@ describe("pickEnvironment", () => {
           secrets: {},
           commandInfo,
         }),
-      (err) => expect(err.message).to.equal("Could not find varfile at path 'foo.env'")
+      { contains: "Could not find varfile at path 'foo.env'" }
     )
   })
 
@@ -1128,7 +1128,7 @@ describe("pickEnvironment", () => {
           secrets: {},
           commandInfo,
         }),
-      (err) => expect(err.message).to.equal("Could not find varfile at path 'foo.env'")
+      { contains: "Could not find varfile at path 'foo.env'" }
     )
   })
 
@@ -1232,10 +1232,7 @@ describe("pickEnvironment", () => {
           secrets: {},
           commandInfo,
         }),
-      (err) =>
-        expect(err.message).to.equal(
-          "Invalid environment specified ($.%): must be a valid environment name or <namespace>.<environment>"
-        )
+      { contains: "Invalid environment specified ($.%): must be a valid environment name or <namespace>.<environment>" }
     )
   })
 
@@ -1279,20 +1276,14 @@ describe("parseEnvironment", () => {
   })
 
   it("should throw if string contains more than two segments", () => {
-    expectError(
-      () => parseEnvironment("a.b.c"),
-      (err) =>
-        expect(err.message).to.equal("Invalid environment specified (a.b.c): may only contain a single delimiter")
-    )
+    expectError(() => parseEnvironment("a.b.c"), {
+      contains: "Invalid environment specified (a.b.c): may only contain a single delimiter",
+    })
   })
 
   it("should throw if string is not a valid hostname", () => {
-    expectError(
-      () => parseEnvironment("&.$"),
-      (err) =>
-        expect(err.message).to.equal(
-          "Invalid environment specified (&.$): must be a valid environment name or <namespace>.<environment>"
-        )
-    )
+    expectError(() => parseEnvironment("&.$"), {
+      contains: "Invalid environment specified (&.$): must be a valid environment name or <namespace>.<environment>",
+    })
   })
 })

--- a/core/test/unit/src/config/provider.ts
+++ b/core/test/unit/src/config/provider.ts
@@ -40,14 +40,9 @@ describe("getProviderDependencies", () => {
       someKey: "${providers}",
     }
 
-    await expectError(
-      () => getAllProviderDependencyNames(plugin, config),
-      (err) => {
-        expect(err.message).to.equal(
-          "Invalid template key 'providers' in configuration for provider 'my-provider'. " +
-            "You must specify a provider name as well (e.g. \\${providers.my-provider})."
-        )
-      }
-    )
+    await expectError(() => getAllProviderDependencyNames(plugin, config), {
+      contains:
+        "Invalid template key 'providers' in configuration for provider 'my-provider'. You must specify a provider name as well (e.g. \\${providers.my-provider}).",
+    })
   })
 })

--- a/core/test/unit/src/config/template-contexts/base.ts
+++ b/core/test/unit/src/config/template-contexts/base.ts
@@ -266,13 +266,10 @@ describe("ConfigContext", () => {
       })
       const nested: any = new TestContext({ key: "${'${nested.key}'}" }, c)
       c.addValues({ nested })
-      expectError(
-        () => resolveKey(c, ["nested", "key"]),
-        (err) =>
-          expect(err.message).to.equal(
-            "Invalid template string (${'${nested.key}'}): Invalid template string (${nested.key}): Circular reference detected when resolving key nested.key (nested -> nested.key)"
-          )
-      )
+      expectError(() => resolveKey(c, ["nested", "key"]), {
+        contains:
+          "Invalid template string (${'${nested.key}'}): Invalid template string (${nested.key}): Circular reference detected when resolving key nested.key (nested -> nested.key)",
+      })
     })
   })
 

--- a/core/test/unit/src/config/workflow.ts
+++ b/core/test/unit/src/config/workflow.ts
@@ -189,10 +189,9 @@ describe("resolveWorkflowConfig", () => {
       ],
     }
 
-    expectError(
-      () => resolveWorkflowConfig(garden, configWithTemplateStringInTrigger),
-      (err) => expect(err.message).to.include("Invalid environment in trigger for workflow")
-    )
+    expectError(() => resolveWorkflowConfig(garden, configWithTemplateStringInTrigger), {
+      contains: "Invalid environment in trigger for workflow",
+    })
   })
 
   it("should populate default values in the schema", async () => {
@@ -237,10 +236,9 @@ describe("resolveWorkflowConfig", () => {
       ],
     }
 
-    await expectError(
-      () => resolveWorkflowConfig(garden, config),
-      (err) => expect(err.message).to.match(/Invalid environment in trigger for workflow workflow-a/)
-    )
+    await expectError(() => resolveWorkflowConfig(garden, config), {
+      contains: "Invalid environment in trigger for workflow workflow-a",
+    })
   })
 
   describe("populateNamespaceForTriggers", () => {

--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -171,10 +171,7 @@ describe("resolveTemplateString", async () => {
   it("should throw on nested format strings", async () => {
     return expectError(
       () => resolveTemplateString("${resol${part}ed}", new TestContext({})),
-      (err) =>
-        expect(err.message).to.equal(
-          "Invalid template string (${resol${part}ed}): Unable to parse as valid template string."
-        )
+      {contains:"Invalid template string (${resol${part}ed}): Unable to parse as valid template string."}
     )
   })
 
@@ -231,16 +228,14 @@ describe("resolveTemplateString", async () => {
   it("should throw on invalid single-quoted string", async () => {
     return expectError(
       () => resolveTemplateString("${'foo}", new TestContext({})),
-      (err) =>
-        expect(err.message).to.equal("Invalid template string (${'foo}): Unable to parse as valid template string.")
+      {contains:"Invalid template string (${'foo}): Unable to parse as valid template string."}
     )
   })
 
   it("should throw on invalid double-quoted string", async () => {
     return expectError(
       () => resolveTemplateString('${"foo}', new TestContext({})),
-      (err) =>
-        expect(err.message).to.equal('Invalid template string (${"foo}): Unable to parse as valid template string.')
+      {contains:'Invalid template string (${"foo}): Unable to parse as valid template string.'}
     )
   })
 
@@ -305,8 +300,7 @@ describe("resolveTemplateString", async () => {
   it("should throw on invalid logical OR string", async () => {
     return expectError(
       () => resolveTemplateString("${a || 'b}", new TestContext({})),
-      (err) =>
-        expect(err.message).to.equal("Invalid template string (${a || 'b}): Unable to parse as valid template string.")
+      {contains:"Invalid template string (${a || 'b}): Unable to parse as valid template string."}
     )
   })
 
@@ -594,30 +588,21 @@ describe("resolveTemplateString", async () => {
   it("should throw if bracket expression resolves to a non-primitive", async () => {
     return expectError(
       () => resolveTemplateString("${foo[bar]}", new TestContext({ foo: {}, bar: {} })),
-      (err) =>
-        expect(err.message).to.equal(
-          "Invalid template string (${foo[bar]}): Expression in bracket must resolve to a primitive (got object)."
-        )
+      {contains:"Invalid template string (${foo[bar]}): Expression in bracket must resolve to a primitive (got object)."}
     )
   })
 
   it("should throw if attempting to index a primitive with brackets", async () => {
     return expectError(
       () => resolveTemplateString("${foo[bar]}", new TestContext({ foo: 123, bar: "baz" })),
-      (err) =>
-        expect(err.message).to.equal(
-          'Invalid template string (${foo[bar]}): Attempted to look up key "baz" on a number.'
-        )
+      {contains:'Invalid template string (${foo[bar]}): Attempted to look up key "baz" on a number.'}
     )
   })
 
   it("should throw when using >= on non-numeric terms", async () => {
     return expectError(
       () => resolveTemplateString("${a >= b}", new TestContext({ a: 123, b: "foo" })),
-      (err) =>
-        expect(err.message).to.equal(
-          "Invalid template string (${a >= b}): Both terms need to be numbers for >= operator (got number and string)."
-        )
+      {contains:"Invalid template string (${a >= b}): Both terms need to be numbers for >= operator (got number and string)."}
     )
   })
 

--- a/core/test/unit/src/util/util.ts
+++ b/core/test/unit/src/util/util.ts
@@ -232,12 +232,9 @@ describe("util", () => {
 
     it("should use given description in error message", async () => {
       const obj = { a: 1, b: 2, c: 3 }
-      await expectError(
-        () => pickKeys(obj, <any>["a", "foo", "bar"], "banana"),
-        (err) => {
-          expect(err.message).to.equal("Could not find banana(s): foo, bar")
-        }
-      )
+      await expectError(() => pickKeys(obj, <any>["a", "foo", "bar"], "banana"), {
+        contains: "Could not find banana(s): foo, bar",
+      })
     })
   })
 

--- a/core/test/unit/src/util/validateInstall.ts
+++ b/core/test/unit/src/util/validateInstall.ts
@@ -30,7 +30,7 @@ describe("validateInstall", () => {
           versionCommand: { cmd: "git", args: ["--version"] },
           versionRegex: gitVersionRegex,
         }),
-      (err) => expect(err.message).to.include("version is too old")
+      { contains: "version is too old" }
     )
   })
   it("should throw if binary is not installed", async () => {
@@ -42,7 +42,7 @@ describe("validateInstall", () => {
           versionCommand: { cmd: "this-binary-does-not-exist", args: ["--version"] }, // <--
           versionRegex: gitVersionRegex,
         }),
-      (err) => expect(err.message).to.include("is installed and on your PATH")
+      { contains: "is installed and on your PATH" }
     )
   })
   it("should include name in error message", async () => {
@@ -54,7 +54,7 @@ describe("validateInstall", () => {
           versionCommand: { cmd: "this-binary-does-not-exist", args: ["--version"] }, // <--
           versionRegex: gitVersionRegex,
         }),
-      (err) => expect(err.message).to.include("Could not find name-of-the-thing binary.")
+      { contains: "Could not find name-of-the-thing binary." }
     )
   })
 })

--- a/plugins/jib/test/util.ts
+++ b/plugins/jib/test/util.ts
@@ -40,10 +40,9 @@ describe("util", () => {
           files: [],
         },
       }
-      void expectError(
-        () => detectProjectType(module),
-        (err) => expect(err.message).to.equal("Could not detect a gradle or maven project to build module foo")
-      )
+      void expectError(() => detectProjectType(module), {
+        contains: "Could not detect a gradle or maven project to build module foo",
+      })
     })
   })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
More janitorial work to use the benefits of the `expectError` helper function.

The helper function `expectError` was refactored in https://github.com/garden-io/garden/pull/3733/commits/42513956dfd026f29b3e2d598664a7c47b84d667.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
Checked all affected tests manually and verified the results.