### PR TITLE
0.13 example local mode

### DIFF
--- a/examples/local-mode/README.md
+++ b/examples/local-mode/README.md
@@ -1,7 +1,7 @@
-# Local mode for `container` modules
+# Local mode for `container` build type
 
 A very basic demo project for Garden [local mode](../../docs/guides/running-service-in-local-mode.md) for `container`
-module type.
+build type.
 
 This project is based on the [demo-project](../demo-project). The only difference is that this one has 2 backend
 services. Each backend service (or both) can be started in the _local mode_.
@@ -33,19 +33,6 @@ garden deploy --local=backend-2
 garden deploy --local=backend-1,backend-2
 garden deploy --local
 garden deploy --local=*
-```
-
-Alternatively, you can also run the local mode using the `garden dev` command:
-
-```shell
-# To start a specific service in local mode
-garden dev --local=backend-1
-garden dev --local=backend-2
-
-# To start both services in local mode
-garden dev --local=backend-1,backend-2
-garden dev --local
-garden dev --local=*
 ```
 
 To verify the result, call the corresponding ingress URLs of the `frontend` and `backend` applications. The local

--- a/examples/local-mode/backend-1/garden.yml
+++ b/examples/local-mode/backend-1/garden.yml
@@ -1,35 +1,39 @@
-kind: Module
+kind: Build
 name: backend-1
-description: Backend service container
+description: Backend 1 service container image
 type: container
+
+---
+
+kind: Deploy
+name: backend-1
+description: Backend 1 service container
+type: container
+
+build: backend-1
 
 # You can specify variables here at the module level
 variables:
   ingressPath: /hello-backend-1
 
-services:
-  - name: backend-1
-    localMode:
-      ports:
-        - remote: 8080
-          local: 8090
-        - remote: 8000
-          local: 8001
-      # starts the local application
-      command: ["../backend-local-1/main"]
-    healthCheck:
-      httpGet:
-        path: ${var.ingressPath}
-        port: http
+spec:
+  localMode:
     ports:
-      - name: http
-        containerPort: 8080
-        # Maps service:80 -> container:8080
-        servicePort: 80
-    ingresses:
-      - path: ${var.ingressPath}
-        port: http # http2 can be used as an alternative port here
-
-tasks:
-  - name: test-1
-    command: ["sh", "-c", "echo task output"]
+      - remote: 8080
+        local: 8090
+      - remote: 8000
+        local: 8001
+    # starts the local application
+    command: [ "../backend-local-1/main" ]
+  healthCheck:
+    httpGet:
+      path: ${var.ingressPath}
+      port: http
+  ports:
+    - name: http
+      containerPort: 8080
+      # Maps service:80 -> container:8080
+      servicePort: 80
+  ingresses:
+    - path: ${var.ingressPath}
+      port: http # http2 can be used as an alternative port here

--- a/examples/local-mode/backend-2/garden.yml
+++ b/examples/local-mode/backend-2/garden.yml
@@ -1,33 +1,37 @@
-kind: Module
+kind: Build
 name: backend-2
-description: Backend service container
+description: Backend 2 service container image
 type: container
+
+---
+
+kind: Deploy
+name: backend-2
+description: Backend 2 service container
+type: container
+
+build: backend-2
 
 # You can specify variables here at the module level
 variables:
   ingressPath: /hello-backend-2
 
-services:
-  - name: backend-2
-    localMode:
-      ports:
-        - remote: 8081
-          local: 8091
-      # starts the local application
-      command: ["../backend-local-2/main"]
-    healthCheck:
-      httpGet:
-        path: ${var.ingressPath}
-        port: http
+spec:
+  localMode:
     ports:
-      - name: http
-        containerPort: 8081
-        # Maps service:80 -> container:8081
-        servicePort: 80
-    ingresses:
-      - path: ${var.ingressPath}
-        port: http
-
-tasks:
-  - name: test-2
-    command: ["sh", "-c", "echo task output"]
+      - remote: 8081
+        local: 8091
+    # starts the local application
+    command: [ "../backend-local-2/main" ]
+  healthCheck:
+    httpGet:
+      path: ${var.ingressPath}
+      port: http
+  ports:
+    - name: http
+      containerPort: 8081
+      # Maps service:80 -> container:8081
+      servicePort: 80
+  ingresses:
+    - path: ${var.ingressPath}
+      port: http

--- a/examples/local-mode/frontend/garden.yml
+++ b/examples/local-mode/frontend/garden.yml
@@ -1,30 +1,43 @@
-kind: Module
+kind: Build
+name: frontend
+description: Frontend service container image
+type: container
+
+---
+
+kind: Deploy
 name: frontend
 description: Frontend service container
 type: container
-services:
-  - name: frontend
-    ports:
-      - name: http
-        containerPort: 8080
-    healthCheck:
-      httpGet:
-        path: /hello-frontend
-        port: http
-    ingresses:
-      - path: /hello-frontend
-        port: http
-      - path: /call-backend-1
-        port: http
-      - path: /call-backend-2
-        port: http
-    dependencies:
-      - backend-1
-      - backend-2
-tests:
-  - name: unit
-    args: [npm, test]
-  - name: integ
-    args: [npm, run, integ]
-    dependencies:
-      - frontend
+
+build: frontend
+dependencies:
+  - deploy.backend-1
+  - deploy.backend-2
+
+spec:
+  ports:
+    - name: http
+      containerPort: 8080
+  healthCheck:
+    httpGet:
+      path: /hello-frontend
+      port: http
+  ingresses:
+    - path: /hello-frontend
+      port: http
+    - path: /call-backend-1
+      port: http
+    - path: /call-backend-2
+      port: http
+
+---
+
+kind: Test
+name: frontend-integ
+type: container
+build: frontend
+dependencies:
+  - deploy.frontend # <- we want the frontend service to be running and up-to-date for this test
+spec:
+  args: [ npm, run, integ ]


### PR DESCRIPTION
**What this PR does / why we need it**:

* Some bug fixes in local mode configuration (ssh keys naming)
* Action-based config for `local-mode` example

See individual commits for the details.

Note, the example works well and the apps in local mode are reachable. But, the Garden console gets stuck at build actions for both services. This will be fixed in the next PR(s).

**Which issue(s) this PR fixes**:

Closes #3750

**Special notes for your reviewer**:
