### PR TITLE
chore: switch the cleanup command emoji

### DIFF
--- a/core/src/commands/delete.ts
+++ b/core/src/commands/delete.ts
@@ -78,7 +78,7 @@ export class DeleteEnvironmentCommand extends Command<{}, DeleteEnvironmentOpts>
     })
 
   printHeader({ headerLog }) {
-    printHeader(headerLog, `Cleanup namespace`, "skull_and_crossbones")
+    printHeader(headerLog, `Cleanup namespace`, "recycle")
   }
 
   async action({
@@ -154,7 +154,7 @@ export class DeleteDeployCommand extends Command<DeleteDeployArgs, DeleteDeployO
     joiIdentifierMap(getDeployStatusSchema()).description("A map of statuses for all the deleted deploys.")
 
   printHeader({ headerLog }) {
-    printHeader(headerLog, "Cleaning up deployment(s)", "skull_and_crossbones")
+    printHeader(headerLog, "Cleaning up deployment(s)", "recycle")
   }
 
   async action({ garden, log, args, opts }: CommandParams<DeleteDeployArgs, DeleteDeployOpts>): Promise<CommandResult> {


### PR DESCRIPTION
Just a random small thought - maybe some other emoji could be more aligned with our tone and visual style in the cleanup command.

Originally I wanted to use the broom emoji 🧹  but the emoji library we use does not have it available, so I chose the recycling icon instead. Let me know if you have better suggestions or if we should close without merging.