### PR TITLE
chore(docs): change reference to demo-project in tutorial guide

### DIFF
--- a/docs/tutorials/your-first-project/1-initialize-a-project.md
+++ b/docs/tutorials/your-first-project/1-initialize-a-project.md
@@ -11,7 +11,7 @@ Start by cloning our repo and finding the example project:
 
 ```sh
 git clone https://github.com/garden-io/garden.git
-cd garden/examples/demo-project-start
+cd garden/examples/demo-project
 ```
 
 This directory contains two directories, with one container service each, `backend` and `frontend`. We'll first define a boilerplate Garden project, and then a Garden module for each of the services.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
Tutorial docs refer to `demo-project-start` however it already has the `project.garden.yml` which makes further steps in tutorial invalid. Hence changing reference to bare bones `demo-project` example.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
