### PR TITLE
fix(cloud): continue when token refresh fails

### DIFF
--- a/core/src/cloud/api.ts
+++ b/core/src/cloud/api.ts
@@ -9,7 +9,7 @@
 import { IncomingHttpHeaders } from "http"
 
 import { got, GotHeaders, GotHttpError, GotJsonOptions, GotResponse } from "../util/http"
-import { EnterpriseApiError } from "../exceptions"
+import { CloudApiError } from "../exceptions"
 import { LogEntry } from "../logger/log-entry"
 import { DEFAULT_GARDEN_CLOUD_DOMAIN, gardenEnv } from "../constants"
 import type { ClientAuthToken as ClientAuthTokenType } from "../db/entities/client-auth-token"
@@ -30,8 +30,8 @@ import { ProjectResource } from "../config/project"
 const gardenClientName = "garden-core"
 const gardenClientVersion = getPackageVersion()
 
-export class EnterpriseApiDuplicateProjectsError extends EnterpriseApiError {}
-export class EnterpriseApiTokenRefreshError extends EnterpriseApiError {}
+export class CloudApiDuplicateProjectsError extends CloudApiError {}
+export class CloudApiTokenRefreshError extends CloudApiError {}
 
 // If a GARDEN_AUTH_TOKEN is present and Garden is NOT running from a workflow runner pod,
 // switch to ci-token authentication method.
@@ -218,7 +218,7 @@ export class CloudApi {
     if (gardenEnv.GARDEN_AUTH_TOKEN) {
       // Throw if using an invalid "CI" access token
       if (!tokenIsValid) {
-        throw new EnterpriseApiError(
+        throw new CloudApiError(
           deline`
             The provided access token is expired or has been revoked, please create a new
             one from the ${distroName} UI.`,
@@ -251,7 +251,7 @@ export class CloudApi {
         yet been created in Garden Cloud, or that there's a problem with your account's VCS username / login
         credentials.
       `
-      throw new EnterpriseApiError(errMsg, { tokenResponse })
+      throw new CloudApiError(errMsg, { tokenResponse })
     }
     try {
       // Note: lazy-loading for startup performance
@@ -272,7 +272,7 @@ export class CloudApi {
       })
       log.debug("Saved client auth token to local config db")
     } catch (error) {
-      throw new EnterpriseApiError(
+      throw new CloudApiError(
         `An error occurred while saving client auth token to local config db:\n${error.message}`,
         { tokenResponse }
       )
@@ -370,7 +370,7 @@ export class CloudApi {
     }
 
     if (!project) {
-      throw new EnterpriseApiError(`Garden Cloud has no project with ${projectId}`, {})
+      throw new CloudApiError(`Garden Cloud has no project with ${projectId}`, {})
     }
 
     return project
@@ -392,7 +392,7 @@ export class CloudApi {
 
     // Expect a single project, otherwise we fail with an error
     if (projects.length > 1) {
-      throw new EnterpriseApiDuplicateProjectsError(
+      throw new CloudApiDuplicateProjectsError(
         deline`Found an unexpected state with multiple projects using the same name, ${projectName}.
         Please make sure there is only one project with the given name.
         Projects can be deleted through the Garden Cloud UI at ${this.domain}`,
@@ -489,7 +489,7 @@ export class CloudApi {
     } catch (err) {
       this.log.debug({ msg: `Failed to refresh the token.` })
       const detail = is401Error(err) ? { statusCode: err.response.statusCode } : {}
-      throw new EnterpriseApiTokenRefreshError(
+      throw new CloudApiTokenRefreshError(
         `An error occurred while verifying client auth token with ${getCloudDistributionName(this.domain)}: ${
           err.message
         }`,
@@ -575,7 +575,7 @@ export class CloudApi {
     const res = await got<T>(url.href, requestOptions)
 
     if (!isObject(res.body)) {
-      throw new EnterpriseApiError(`Unexpected API response`, {
+      throw new CloudApiError(`Unexpected API response`, {
         path,
         body: res?.body,
       })
@@ -713,7 +713,7 @@ export class CloudApi {
       valid = true
     } catch (err) {
       if (!is401Error(err)) {
-        throw new EnterpriseApiError(
+        throw new CloudApiError(
           `An error occurred while verifying client auth token with ${getCloudDistributionName(this.domain)}: ${
             err.message
           }`,

--- a/core/src/cloud/workflow-lifecycle.ts
+++ b/core/src/cloud/workflow-lifecycle.ts
@@ -8,7 +8,7 @@
 
 import { WorkflowConfig, makeRunConfig } from "../config/workflow"
 import { LogEntry } from "../logger/log-entry"
-import { EnterpriseApiError } from "../exceptions"
+import { CloudApiError } from "../exceptions"
 import { gardenEnv } from "../constants"
 import { Garden } from "../garden"
 import { ApiFetchResponse, isGotError } from "./api"
@@ -59,7 +59,7 @@ export async function registerWorkflowRun({
           CLI version is compatible with your version of Garden Cloud. See error.log for details
           on the failed registration request payload.
         `
-        throw new EnterpriseApiError(errMsg, {
+        throw new CloudApiError(errMsg, {
           requestData,
         })
       } else {
@@ -71,11 +71,11 @@ export async function registerWorkflowRun({
     if (res?.workflowRunUid && res?.status === "success") {
       return res.workflowRunUid
     } else {
-      throw new EnterpriseApiError(`Error while registering workflow run: Request failed with status ${res?.status}`, {
+      throw new CloudApiError(`Error while registering workflow run: Request failed with status ${res?.status}`, {
         status: res?.status,
         workflowRunUid: res?.workflowRunUid,
       })
     }
   }
-  throw new EnterpriseApiError("Error while registering workflow run: Couldn't initialize API.", {})
+  throw new CloudApiError("Error while registering workflow run: Couldn't initialize API.", {})
 }

--- a/core/src/commands/cloud/secrets/secrets-create.ts
+++ b/core/src/commands/cloud/secrets/secrets-create.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { CommandError, ConfigurationError, EnterpriseApiError } from "../../../exceptions"
+import { CommandError, ConfigurationError, CloudApiError } from "../../../exceptions"
 import { CreateSecretResponse } from "@garden-io/platform-api-types"
 import { readFile } from "fs-extra"
 
@@ -129,7 +129,7 @@ export class SecretsCreateCommand extends Command<Args, Opts> {
     const project = await api.getProject()
 
     if (!project) {
-      throw new EnterpriseApiError(
+      throw new CloudApiError(
         `Project ${garden.projectName} is not a ${getCloudDistributionName(api.domain)} project`,
         {}
       )
@@ -140,7 +140,7 @@ export class SecretsCreateCommand extends Command<Args, Opts> {
     if (envName) {
       const environment = project.environments.find((e) => e.name === envName)
       if (!environment) {
-        throw new EnterpriseApiError(`Environment with name ${envName} not found in project`, {
+        throw new CloudApiError(`Environment with name ${envName} not found in project`, {
           environmentName: envName,
           availableEnvironmentNames: project.environments.map((e) => e.name),
         })
@@ -152,7 +152,7 @@ export class SecretsCreateCommand extends Command<Args, Opts> {
     if (userId) {
       const user = await api.get(`/users/${userId}`)
       if (!user) {
-        throw new EnterpriseApiError(`User with ID ${userId} not found.`, {
+        throw new CloudApiError(`User with ID ${userId} not found.`, {
           userId,
         })
       }

--- a/core/src/commands/cloud/secrets/secrets-list.ts
+++ b/core/src/commands/cloud/secrets/secrets-list.ts
@@ -7,7 +7,7 @@
  */
 
 import { stringify } from "query-string"
-import { ConfigurationError, EnterpriseApiError } from "../../../exceptions"
+import { ConfigurationError, CloudApiError } from "../../../exceptions"
 import { ListSecretsResponse } from "@garden-io/platform-api-types"
 
 import { printHeader } from "../../../logger/util"
@@ -67,7 +67,7 @@ export class SecretsListCommand extends Command<{}, Opts> {
     const project = await api.getProject()
 
     if (!project) {
-      throw new EnterpriseApiError(
+      throw new CloudApiError(
         `Project ${garden.projectName} is not a ${getCloudDistributionName(api.domain)} project`,
         {}
       )

--- a/core/src/commands/cloud/users/users-list.ts
+++ b/core/src/commands/cloud/users/users-list.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ConfigurationError, EnterpriseApiError } from "../../../exceptions"
+import { ConfigurationError, CloudApiError } from "../../../exceptions"
 import { ListUsersResponse } from "@garden-io/platform-api-types"
 
 import { printHeader } from "../../../logger/util"
@@ -59,7 +59,7 @@ export class UsersListCommand extends Command<{}, Opts> {
     const project = await api.getProject()
 
     if (!project) {
-      throw new EnterpriseApiError(
+      throw new CloudApiError(
         `Project ${garden.projectName} is not a ${getCloudDistributionName(api.domain)} project`,
         {}
       )

--- a/core/src/exceptions.ts
+++ b/core/src/exceptions.ts
@@ -115,8 +115,8 @@ export class WorkflowScriptError extends GardenBaseError {
   type = "workflow-script"
 }
 
-export class EnterpriseApiError extends GardenBaseError {
-  type = "enterprise-api"
+export class CloudApiError extends GardenBaseError {
+  type = "cloud-api"
 }
 
 export class TemplateStringError extends GardenBaseError {

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -110,7 +110,7 @@ import {
 } from "./config/module-template"
 import { TemplatedModuleConfig } from "./plugins/templated"
 import { BuildDirRsync } from "./build-staging/rsync"
-import { CloudApi, CloudProject, EnterpriseApiDuplicateProjectsError, getGardenCloudDomain } from "./cloud/api"
+import { CloudApi, CloudProject, CloudApiDuplicateProjectsError, getGardenCloudDomain } from "./cloud/api"
 import { DefaultEnvironmentContext, RemoteSourceConfigContext } from "./config/template-contexts/project"
 import { OutputConfigContext } from "./config/template-contexts/module"
 import { ProviderConfigContext } from "./config/template-contexts/provider"
@@ -1321,7 +1321,7 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
       try {
         project = await cloudApi.getOrCreateProject(projectName)
       } catch (err) {
-        if (err instanceof EnterpriseApiDuplicateProjectsError) {
+        if (err instanceof CloudApiDuplicateProjectsError) {
           cloudLog.warn(chalk.yellow(wordWrap(err.message, 120)))
         } else {
           cloudLog.debug(`Creating a new cloud project failed with error: ${err.message}`)

--- a/core/test/unit/src/commands/login.ts
+++ b/core/test/unit/src/commands/login.ts
@@ -19,7 +19,7 @@ import { dedent, randomString } from "../../../../src/util/string"
 import { CloudApi } from "../../../../src/cloud/api"
 import { LogLevel } from "../../../../src/logger/logger"
 import { gardenEnv } from "../../../../src/constants"
-import { EnterpriseApiError } from "../../../../src/exceptions"
+import { CloudApiError } from "../../../../src/exceptions"
 import { ensureConnected } from "../../../../src/db/connection"
 import { getLogMessages } from "../../../../src/util/testing"
 
@@ -228,7 +228,7 @@ describe("LoginCommand", () => {
     await CloudApi.saveAuthToken(garden.log, testToken)
     td.replace(CloudApi.prototype, "checkClientAuthToken", async () => false)
     td.replace(CloudApi.prototype, "refreshToken", async () => {
-      throw new EnterpriseApiError("bummer", { statusCode: 401 })
+      throw new CloudApiError("bummer", { statusCode: 401 })
     })
 
     const savedToken = await ClientAuthToken.findOne()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Improve handling of the case when switching between projects with that uses different cloud API endpoints.

- Continues the command even if the token refresh fails. 
- Clearer error message indicating that a logout is needed before the cloud API can be used for the current project.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
