### PR TITLE
feat(pulumi): allow CLI options for plugin cmds

### DIFF
--- a/docs/pulumi-plugin/about.md
+++ b/docs/pulumi-plugin/about.md
@@ -79,6 +79,10 @@ For example:
 ```
 garden plugins pulumi preview -- my-pulumi-module my-other-pulumi-module
 ```
+Any CLI options passed after the `--` will be passed on to the Pulumi CLI, unless it's reserved by the plugin command (e.g. the `--plan-path` or `--config-file` options, which the Pulumi plugin needs to set internally to function correctly).
+
+For example, in `garden plugins pulumi preview -- some-service --same --suppress-outputs`, `--same` and `--suppres-outputs` would be passed as CLI options to `pulumi preview`.
+
 
 ## Next steps
 

--- a/plugins/pulumi/commands.ts
+++ b/plugins/pulumi/commands.ts
@@ -343,7 +343,7 @@ function makePulumiCommand({ name, commandDescription, beforeFn, runFn, afterFn 
         optionSpec: pulumiCommandOpts,
         cli: true,
       })
-      const { args: parsedArgs, opts } = parsed
+      const { args: parsedArgs, opts, otherOpts } = parsed
       const skipRuntimeDependencies = opts["skip-dependencies"]
       const serviceNames = parsedArgs.length === 0 ? undefined : parsedArgs
 
@@ -359,6 +359,7 @@ function makePulumiCommand({ name, commandDescription, beforeFn, runFn, afterFn 
           log,
           module: <PulumiModule>service.module,
           service,
+          extraCliOpts: otherOpts,
         }
         // TODO: Generate a non-empty runtime context to provide runtime values for template resolution in varfiles.
         // This will require processing deploy & task dependencies (also for non-pulumi modules).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Any CLI options that aren't used by the Pulumi plugin commands themselves are now passed along to the Pulumi CLI when running plugin commands.

For example, `--skip-dependencies` won't be passed to the Pulumi CLI (since it's a Garden-specific option that doesn't apply to the Pulumi CLI), but the `--same` option would be passed along unchanged to `pulumi preview`.

For example, in `garden plugins pulumi preview -- some-service --same --suppress-outputs`, `--same` and `--suppres-outputs` would be passed as CLI options to `pulumi preview`.