### PR TITLE
improvement: track the command run result and duration

### DIFF
--- a/core/src/analytics/analytics-types.ts
+++ b/core/src/analytics/analytics-types.ts
@@ -8,8 +8,14 @@
 
 export enum AnalyticsType {
   COMMAND = "Run Command",
+  COMMAND_RESULT = "Run Command Result",
   CALL_API = "Call API",
   MODULE_CONFIG_ERROR = "Module Configuration Error",
   PROJECT_CONFIG_ERROR = "Project Configuration Error",
   VALIDATION_ERROR = "Validation Error",
+}
+
+export enum AnalyticsCommandResult {
+  FAILURE = "failure",
+  SUCCESS = "success",
 }

--- a/core/src/analytics/analytics-types.ts
+++ b/core/src/analytics/analytics-types.ts
@@ -6,16 +6,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-export enum AnalyticsType {
-  COMMAND = "Run Command",
-  COMMAND_RESULT = "Run Command Result",
-  CALL_API = "Call API",
-  MODULE_CONFIG_ERROR = "Module Configuration Error",
-  PROJECT_CONFIG_ERROR = "Project Configuration Error",
-  VALIDATION_ERROR = "Validation Error",
-}
+export type AnalyticsEventType =
+  | "Run Command"
+  | "Command Result"
+  | "Call API"
+  | "Module Configuration Error"
+  | "Project Configuration Error"
+  | "Validation Error"
 
-export enum AnalyticsCommandResult {
-  FAILURE = "failure",
-  SUCCESS = "success",
-}
+export type AnalyticsCommandResult = "failure" | "success"

--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -690,6 +690,8 @@ ${renderCommands(commands)}
 
     this.processRecord = processRecord!
 
+    const commandStartTime = new Date()
+
     try {
       const runResults = await this.runCommand({ command, parsedArgs, parsedOpts, processRecord, workingDir })
       commandResult = runResults.result
@@ -700,12 +702,14 @@ ${renderCommands(commands)}
 
     errors.push(...(commandResult.errors || []))
 
+    const gardenErrors: GardenBaseError[] = errors.map(toGardenError)
+
+    analytics?.trackCommandResult(command.getFullName(), gardenErrors, commandStartTime)
+
     // Flushes the Analytics events queue in case there are some remaining events.
     if (analytics) {
       await analytics.flush()
     }
-
-    const gardenErrors: GardenBaseError[] = errors.map(toGardenError)
 
     // --output option set
     if (argv.output) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

When the anonymous analytics is enabled, we currently track that a command is run, but not the actual outcome of the command. With this PR, we add an analytics event after a command has finished including the result as success/failure, error type and command duration. 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
