### PR TITLE
Create tar.gz archive container images, which need to be in the Kuber…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,6 +248,9 @@ commands:
       - run:
           name: Run dist script
           command: yarn run dist --version "<<parameters.version>>"
+      - run:
+          name: Run dist script air gapped images
+          command: ./scripts/package-airgap.sh amd64
       - persist_to_workspace:
           root: ./
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,7 +250,7 @@ commands:
           command: yarn run dist --version "<<parameters.version>>"
       - run:
           name: Run dist script air gapped images
-          command: ./scripts/package-airgap.sh amd64
+          command: ./scripts/package-airgap.sh amd64 "<<parameters.version>>"
       - persist_to_workspace:
           root: ./
           paths:

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ static/**/.garden-version
 
 #debug files
 debug-info-*
+
+# airgap
+airgap

--- a/scripts/package-airgap.sh
+++ b/scripts/package-airgap.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# based on https://github.com/k3s-io/k3s/blob/8915e4c7f7d56c6e5255b6c50b006e9c264133f1/scripts/package-airgap
+
+set -e -x
+
+ARCH="$1"
+
+cd $(dirname $0)/..
+
+mkdir -p scripts/airgap
+mkdir -p dist
+
+airgap_image_file='scripts/airgap/image-list.txt'
+echo "$(find images/*/garden.yml | xargs perl -lne 'print $1 if /image: (.*)/')" > "$airgap_image_file"
+
+images=$(cat "${airgap_image_file}")
+xargs -n1 docker pull <<< "${images}"
+docker save ${images} | gzip > dist/garden-airgap-images-${ARCH}.tar.gz
+if [ ${ARCH} = amd64 ]; then
+  cp "${airgap_image_file}" dist/garden-images.txt
+fi

--- a/scripts/package-airgap.sh
+++ b/scripts/package-airgap.sh
@@ -5,6 +5,7 @@
 set -e -x
 
 ARCH="$1"
+VERSION="$2"
 
 cd $(dirname $0)/..
 
@@ -12,11 +13,13 @@ mkdir -p scripts/airgap
 mkdir -p dist
 
 airgap_image_file='scripts/airgap/image-list.txt'
-echo "$(find images/*/garden.yml | xargs perl -lne 'print $1 if /image: (.*)/')" > "$airgap_image_file"
+rm -f "$airgap_image_file"
+echo "$(find images/*/garden.yml -not -path '*/circleci-runner/*' | xargs perl -lne 'print $1 if /image: (.*)/')" > "$airgap_image_file"
 
 images=$(cat "${airgap_image_file}")
 xargs -n1 docker pull <<< "${images}"
-docker save ${images} | gzip > dist/garden-airgap-images-${ARCH}.tar.gz
+docker save ${images} | gzip > "dist/garden-${VERSION}-airgap-images-${ARCH}.tar.gz"
+sha256sum "dist/garden-${VERSION}-airgap-images-${ARCH}.tar.gz" | cut -d " " -f 1 > "dist/garden-${VERSION}-airgap-images-${ARCH}.tar.gz.sha256"
 if [ ${ARCH} = amd64 ]; then
   cp "${airgap_image_file}" dist/garden-images.txt
 fi


### PR DESCRIPTION
…netes cluser, as Github artifacts

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
Add a `tar.gz` archive with all the container images which need to be in the Kubernetes cluster, so air gapped users can import these container images into their local registry.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
