### PR TITLE
cherry-pick for 0.13: ISO timestamp changes to event payloads

### DIFF
--- a/core/src/events.ts
+++ b/core/src/events.ts
@@ -72,8 +72,14 @@ export type GraphResultEventPayload = Omit<GraphResult, "task" | "dependencyResu
 }
 
 export interface ServiceStatusPayload extends Omit<ServiceStatus, "detail"> {
-  deployStartedAt?: Date
-  deployCompletedAt?: Date
+  /**
+   * ISO format date string
+   */
+  deployStartedAt?: string
+  /**
+   * ISO format date string
+   */
+  deployCompletedAt?: string
 }
 
 export interface CommandInfoPayload extends CommandInfo {
@@ -164,13 +170,19 @@ export interface Events extends LoggerEvents {
 
   // TaskGraph events
   taskPending: {
-    addedAt: Date
+    /**
+     * ISO format date string
+     */
+    addedAt: string
     key: string
     type: string
     name: string
   }
   taskProcessing: {
-    startedAt: Date
+    /**
+     * ISO format date string
+     */
+    startedAt: string
     key: string
     type: string
     name: string
@@ -179,35 +191,32 @@ export interface Events extends LoggerEvents {
   taskComplete: GraphResultEventPayload
   taskError: GraphResultEventPayload
   taskCancelled: {
-    cancelledAt: Date
+    /**
+     * ISO format date string
+     */
+    cancelledAt: string
     type: string
     key: string
     name: string
   }
   taskGraphProcessing: {
-    startedAt: Date
+    /**
+     * ISO format date string
+     */
+    startedAt: string
   }
   taskGraphComplete: {
-    completedAt: Date
+    /**
+     * ISO format date string
+     */
+    completedAt: string
   }
   watchingForChanges: {}
   log: {
     /**
-     * Number of milliseconds since the epoch OR a date string.
-     *
-     * We need to allow both numberic and string types for backwards compatibility
-     * with Garden Cloud.
-     *
-     * Garden Cloud supports numeric date strings for log streaming as of v1.360.
-     * We can change this to just 'number' once all Cloud instances are up to date.
-     *
-     * Note that even though this has always been typed as a 'number' we've been
-     * attaching string timestamps to this payload because of missing types further
-     * up the pipe.
-     *
-     * TODO: Change to type 'number'.
+     * ISO format date string
      */
-    timestamp: number | string
+    timestamp: string
     actionUid: string
     entity: {
       moduleName: string | null
@@ -248,8 +257,14 @@ export interface Events extends LoggerEvents {
     actionUid?: string
     status: {
       state: BuildState
-      startedAt?: Date
-      completedAt?: Date
+      /**
+       * ISO format date string
+       */
+      startedAt?: string
+      /**
+       * ISO format date string
+       */
+      completedAt?: string
     }
   }
   taskStatus: {

--- a/core/src/graph/solver.ts
+++ b/core/src/graph/solver.ts
@@ -363,7 +363,7 @@ export class GraphSolver extends TypedEventEmitter<SolverEvents> {
         name,
         type,
         key,
-        startedAt: new Date(),
+        startedAt: new Date().toISOString(),
         inputVersion: node.getInputVersion(),
       })
 

--- a/core/src/plugin-context.ts
+++ b/core/src/plugin-context.ts
@@ -107,17 +107,9 @@ export type PluginEventLogContext = {
 
 export type PluginEventLogMessage = PluginEventLogContext & {
   /**
-   * Number of milliseconds since the epoch OR a date string.
-   *
-   * We need to allow both numberic and string types for backwards compatibility
-   * with Garden Cloud.
-   *
-   * Garden Cloud supports numeric date strings for log streaming as of v1.360.
-   * We can change this to just 'number' once all Cloud instances are up to date.
-   *
-   * TODO: Change to type 'number'.
+   * ISO format date string
    */
-  timestamp: number | string
+  timestamp: string
 
   /** log message */
   data: Buffer

--- a/core/src/plugins/container/build.ts
+++ b/core/src/plugins/container/build.ts
@@ -72,7 +72,7 @@ export const buildContainer: BuildActionHandler<"build", ContainerBuildAction> =
   const outputStream = split2()
   outputStream.on("error", () => {})
   outputStream.on("data", (line: Buffer) => {
-    ctx.events.emit("log", { timestamp: new Date().getTime(), data: line, ...logEventContext })
+    ctx.events.emit("log", { timestamp: new Date().toISOString(), data: line, ...logEventContext })
   })
   const timeout = action.getConfig("timeout")
   const res = await containerHelpers.dockerCli({

--- a/core/src/plugins/exec/exec.ts
+++ b/core/src/plugins/exec/exec.ts
@@ -172,7 +172,7 @@ async function run({
   const outputStream = split2()
   outputStream.on("error", () => {})
   outputStream.on("data", (line: Buffer) => {
-    ctx.events.emit("log", { timestamp: new Date().getTime(), data: line, ...logEventContext })
+    ctx.events.emit("log", { timestamp: new Date().toISOString(), data: line, ...logEventContext })
   })
 
   const envVars = {

--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -111,7 +111,7 @@ export const buildkitBuildHandler: BuildHandler = async (params) => {
   const outputStream = split2()
   outputStream.on("error", () => {})
   outputStream.on("data", (line: Buffer) => {
-    ctx.events.emit("log", { timestamp: new Date().getTime(), data: line, ...logEventContext })
+    ctx.events.emit("log", { timestamp: new Date().toISOString(), data: line, ...logEventContext })
   })
 
   const command = [

--- a/core/src/plugins/kubernetes/helm/helm-cli.ts
+++ b/core/src/plugins/kubernetes/helm/helm-cli.ts
@@ -114,7 +114,7 @@ export async function helm({
   outputStream.on("error", () => {})
   outputStream.on("data", (line: Buffer) => {
     if (emitLogEvents) {
-      ctx.events.emit("log", { timestamp: new Date().getTime(), data: line, ...logEventContext })
+      ctx.events.emit("log", { timestamp: new Date().toISOString(), data: line, ...logEventContext })
     }
   })
 

--- a/core/src/plugins/kubernetes/logs.ts
+++ b/core/src/plugins/kubernetes/logs.ts
@@ -20,7 +20,7 @@ import Bluebird from "bluebird"
 import { KubernetesProvider } from "./config"
 import { PluginContext } from "../../plugin-context"
 import { getPodLogs } from "./status/pod"
-import { splitFirst } from "../../util/util"
+import { splitFirst, isValidDateInstance } from "../../util/util"
 import { Writable } from "stream"
 import request from "request"
 import { LogLevel } from "../../logger/logger"
@@ -327,7 +327,10 @@ export class K8sLogFollower<T> {
           let msg = line
           try {
             const parts = splitFirst(line, " ")
-            timestamp = new Date(parts[0])
+            const dateInstance = new Date(parts[0])
+            if (isValidDateInstance(dateInstance)) {
+              timestamp = dateInstance
+            }
             msg = parts[1]
           } catch {}
           if (_self.deduplicate({ msg, podName, containerName, timestamp })) {

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -215,7 +215,7 @@ export async function runAndCopy({
     const outputStream = new PassThrough()
     outputStream.on("error", () => {})
     outputStream.on("data", (data: Buffer) => {
-      ctx.events.emit("log", { timestamp: new Date().getTime(), data, ...logEventContext })
+      ctx.events.emit("log", { timestamp: new Date().toISOString(), data, ...logEventContext })
     })
 
     return runWithArtifacts({

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -799,17 +799,18 @@ export class PodRunner extends PodRunnerParams {
     const stream = new Stream<RunLogEntry>()
     void stream.forEach((entry) => {
       const { msg, timestamp } = entry
+      let isoTimestamp: string
+      try {
+        if (timestamp) {
+          isoTimestamp = timestamp.toISOString()
+        } else {
+          isoTimestamp = new Date().toISOString()
+        }
+      } catch {
+        isoTimestamp = new Date().toISOString()
+      }
       events.emit("log", {
-        // This should be a numeric value (i.e. timestamp.getTime()) as opposed to a
-        // date string to be consistent with other event timestamps.
-        //
-        // However, due to missing types this has been a string value without us really noticing and
-        // and that's the shape Cloud expects. This was (rightly) changed to a numeric value with
-        // https://github.com/garden-io/garden/pull/3576 (b52e9b298f7c59b8210a77edc4c451301daa76e3)
-        // but we need to revert for Cloud backwards compatibility.
-        //
-        // TODO: Change to type number when all Cloud instance versions are >= v.1360.
-        timestamp: timestamp?.toISOString() || new Date().toISOString(),
+        timestamp: isoTimestamp,
         data: Buffer.from(msg),
         ...logEventContext,
       })

--- a/core/src/plugins/kubernetes/status/status.ts
+++ b/core/src/plugins/kubernetes/status/status.ts
@@ -189,7 +189,7 @@ export async function waitForResources({
   }
 
   const emitLog = (msg: string) =>
-    ctx.events.emit("log", { timestamp: new Date().getTime(), data: Buffer.from(msg, "utf-8"), ...logEventContext })
+    ctx.events.emit("log", { timestamp: new Date().toISOString(), data: Buffer.from(msg, "utf-8"), ...logEventContext })
 
   const waitingMsg = `Waiting for resources to be ready...`
   const statusLine = log

--- a/core/src/router/build.ts
+++ b/core/src/router/build.ts
@@ -50,7 +50,7 @@ export const buildRouter = (baseParams: BaseRouterParams) =>
       const actionUid = uuidv4()
       params.events = params.events || new PluginEventBroker()
 
-      const startedAt = new Date()
+      const startedAt = new Date().toISOString()
 
       const actionName = action.name
       const actionVersion = action.versionString()
@@ -92,7 +92,7 @@ export const buildRouter = (baseParams: BaseRouterParams) =>
           status: {
             state,
             startedAt,
-            completedAt: new Date(),
+            completedAt: new Date().toISOString(),
           },
         })
       }

--- a/core/src/router/deploy.ts
+++ b/core/src/router/deploy.ts
@@ -46,7 +46,7 @@ export const deployRouter = (baseParams: BaseRouterParams) =>
         })
       })
 
-      const deployStartedAt = new Date()
+      const deployStartedAt = new Date().toISOString()
 
       garden.events.emit("serviceStatus", {
         actionName,
@@ -75,7 +75,7 @@ export const deployRouter = (baseParams: BaseRouterParams) =>
         status: {
           ...omit(result.detail, "detail"),
           deployStartedAt,
-          deployCompletedAt: new Date(),
+          deployCompletedAt: new Date().toISOString(),
         },
       })
 

--- a/core/src/util/ext-tools.ts
+++ b/core/src/util/ext-tools.ts
@@ -157,7 +157,7 @@ export class CliWrapper {
     }
 
     logStream.on("data", (line: Buffer) => {
-      ctx.events.emit("log", { timestamp: new Date().getTime(), data: line, ...logEventContext })
+      ctx.events.emit("log", { timestamp: new Date().toISOString(), data: line, ...logEventContext })
     })
 
     await new Promise<void>((resolve, reject) => {

--- a/core/src/util/util.ts
+++ b/core/src/util/util.ts
@@ -912,3 +912,10 @@ export function getGitHubIssueLink(title: string, type: "bug" | "feature-request
     return `https://github.com/garden-io/garden/issues/new?assignees=&labels=&template=BUG_REPORT.md&title=${title}`
   }
 }
+
+/**
+ * Check if a given date instance is valid.
+ */
+export function isValidDateInstance(d: any) {
+  return !isNaN(d) && d instanceof Date
+}

--- a/core/test/unit/src/util/util.ts
+++ b/core/test/unit/src/util/util.ts
@@ -22,6 +22,7 @@ import {
   spawn,
   relationshipClasses,
   safeDumpYaml,
+  isValidDateInstance,
 } from "../../../../src/util/util"
 import { expectError } from "../../../helpers"
 import { splitFirst } from "../../../../src/util/util"
@@ -382,6 +383,28 @@ describe("util", () => {
             c: c
         d: d\n
       `)
+    })
+  })
+  describe("isValidDateInstance", () => {
+    it("should validate a date instance and return the instance or undefined", () => {
+      const validA = new Date()
+      const validB = new Date("2023-02-01T19:46:42.266Z")
+      const validC = new Date(1675280826163)
+
+      // Tricking the compiler. We need to test for this because
+      // date strings can be created from runtime values that we don't validate.
+      const undef = undefined as any
+      const invalidA = new Date(undef)
+      const invalidB = new Date("foo")
+      const invalidC = new Date("")
+
+      expect(isValidDateInstance(validA)).to.be.true
+      expect(isValidDateInstance(validB)).to.be.true
+      expect(isValidDateInstance(validC)).to.be.true
+
+      expect(isValidDateInstance(invalidA)).to.be.false
+      expect(isValidDateInstance(invalidB)).to.be.false
+      expect(isValidDateInstance(invalidC)).to.be.false
     })
   })
 })

--- a/plugins/jib/index.ts
+++ b/plugins/jib/index.ts
@@ -199,7 +199,7 @@ export const gardenPlugin = () =>
               const outputStream = split2()
               outputStream.on("error", () => {})
               outputStream.on("data", (data: Buffer) => {
-                ctx.events.emit("log", { timestamp: new Date().getTime(), data, ...logEventContext })
+                ctx.events.emit("log", { timestamp: new Date().toISOString(), data, ...logEventContext })
                 buildLog += data.toString()
               })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Applies the changes from https://github.com/garden-io/garden/pull/3618 and https://github.com/garden-io/garden/pull/3653 on top of 0.13.

This was done by cherry-picking the commits and resolving the resulting conflicts.