### PR TITLE
chore(cloud): update action status & log events

### DIFF
--- a/core/src/actions/base.ts
+++ b/core/src/actions/base.ts
@@ -59,7 +59,7 @@ import { PickTypeByKind } from "../graph/config-graph"
 import { DeployAction } from "./deploy"
 import { TestAction } from "./test"
 import { RunAction } from "./run"
-import { uuidv4 } from "../util/util"
+import { uuidv4 } from "../util/random"
 
 // TODO-G2: split this file
 

--- a/core/src/actions/base.ts
+++ b/core/src/actions/base.ts
@@ -59,6 +59,7 @@ import { PickTypeByKind } from "../graph/config-graph"
 import { DeployAction } from "./deploy"
 import { TestAction } from "./test"
 import { RunAction } from "./run"
+import { uuidv4 } from "../util/util"
 
 // TODO-G2: split this file
 
@@ -497,6 +498,14 @@ export abstract class BaseAction<C extends BaseActionConfig = BaseActionConfig, 
   @Memoize()
   configVersion() {
     return versionStringPrefix + hashStrings([this.stringifyConfig()])
+  }
+
+  /**
+   * We use memoization to lazy-generate the uid to avoid unnecessary overhead when initializing every action.
+   */
+  @Memoize()
+  getUid() {
+    return uuidv4()
   }
 
   /**

--- a/core/src/actions/types.ts
+++ b/core/src/actions/types.ts
@@ -116,7 +116,7 @@ export const actionStateTypes = ["getting-status", "ready", "not-ready", "proces
  * ```
  *
  * The states have the following semantics:
- * 
+ *
  * - `"unknown"`: A null state used e.g. by default/no-op action handlers.
  *
  * - `"getting-status"`: The status of the action is being checked/fetched.

--- a/core/src/actions/types.ts
+++ b/core/src/actions/types.ts
@@ -99,7 +99,47 @@ export interface ActionConfigTypes {
 }
 
 // See https://melvingeorge.me/blog/convert-array-into-string-literal-union-type-typescript
-export const actionStateTypes = ["ready", "not-ready", "failed", "outdated", "unknown"] as const
+export const actionStateTypes = ["getting-status", "ready", "not-ready", "processing", "failed", "unknown"] as const
+/**
+ * This type represents the lifecycle of an individual action execution.
+ *
+ * The state transitions that take place when an action goes through the standard "check status and execute the
+ * action if no up-to date result exists" flow (as is done in the primary task classes) is as follows:
+ *
+ * ```
+ * initial state: "getting-status"
+ * final state: "ready" or "failed"
+ *
+ * "getting-status" -> "ready" | "not-ready"
+ * "not-ready" -> "processing"
+ * "processing" -> "ready" | "failed"
+ * ```
+ *
+ * The states have the following semantics:
+ * 
+ * - `"unknown"`: A null state used e.g. by default/no-op action handlers.
+ *
+ * - `"getting-status"`: The status of the action is being checked/fetched.
+ *   - For example, for a container build status check, this might involve querying a container registry to see if a
+ *     build exists for the requested action's version.
+ *   - Or for a Kubernetes deployment, this might involve checking if the requested resources are already live and up
+ *     to date.
+ *
+ * - `"ready"`: An up-to-date result exists for the action.
+ *   - This state can be reached by a status check that returned a successful cache hit (e.g. an up-to-date build
+ *     artifact / deployed resource / test result / run result already exists), or by successfully processing the
+ *     action after getting a `"not-ready"` state from the status check.
+ *
+ * - `"not-ready"`: No result (or no healthy result) for the action exists with the requested version.
+ *   - This state is reached by a status check that doesn't find an up-to-date result (e.g. no up-to-date container
+ *     image, or a deployed resource that's missing, unhealthy, stopped or out of date with the requested action's
+ *     version).
+ *
+ * - `"processing"`: The action is being executed.
+ *
+ * - `"failed"`: The action was executed, but a failure or error occurred, so no up-to-date result was created for
+ *   the action.
+ */
 export type ActionState = typeof actionStateTypes[number]
 
 export interface ActionStatus<

--- a/core/src/events.ts
+++ b/core/src/events.ts
@@ -10,16 +10,17 @@ import { omit } from "lodash"
 import { EventEmitter2 } from "eventemitter2"
 import type { LogEntryEventPayload } from "./cloud/buffered-event-stream"
 import type { ServiceStatus } from "./types/service"
-import type { RunStatus } from "./plugin/base"
+import type { RunStatusForEventPayload } from "./plugin/base"
 import type { Omit } from "./util/util"
 import type { AuthTokenResponse } from "./cloud/api"
 import type { RenderedActionGraph } from "./graph/config-graph"
 import type { CommandInfo } from "./plugin-context"
-import type { BuildState } from "./plugin/handlers/Build/get-status"
 import type { ActionReference } from "./config/common"
 import type { GraphResult } from "./graph/results"
 import { NamespaceStatus } from "./types/namespace"
 import { sanitizeValue } from "./util/logging"
+import { ActionState } from "./actions/types"
+import { BuildState } from "./plugin/handlers/Build/get-status"
 
 export type GardenEventListener<T extends EventName> = (payload: Events[T]) => void
 
@@ -60,27 +61,12 @@ export class EventBus extends EventEmitter2 {
 /**
  * Supported logger events and their interfaces.
  */
-export interface LoggerEvents {
-  _test: any
-  logEntry: LogEntryEventPayload
-}
-
-export type LoggerEventName = keyof LoggerEvents
 
 export type GraphResultEventPayload = Omit<GraphResult, "task" | "dependencyResults" | "error"> & {
   error: string | null
 }
 
-export interface ServiceStatusPayload extends Omit<ServiceStatus, "detail"> {
-  /**
-   * ISO format date string
-   */
-  deployStartedAt?: string
-  /**
-   * ISO format date string
-   */
-  deployCompletedAt?: string
-}
+export type DeployStatusForEventPayload = Omit<ServiceStatus, "detail">
 
 export interface CommandInfoPayload extends CommandInfo {
   // Contains additional context for the command info available during init
@@ -116,10 +102,23 @@ export function toGraphResultEventPayload(result: GraphResult): GraphResultEvent
   return payload
 }
 
+interface ActionStatusPayload<S> {
+  actionName: string
+  actionVersion: string
+  // TODO: Generate for each task class instance instead of generating in actions, and provide to the action router
+  // calls. This way, we can tie together the `actionUid` of the status check action with that of the processing action.
+  actionUid: string | undefined
+  moduleName: string | null // DEPRECATED: Remove in 0.14
+  startedAt: string
+  completedAt?: string
+  state: ActionState
+  status: S
+}
+
 /**
  * Supported Garden events and their interfaces.
  */
-export interface Events extends LoggerEvents {
+export interface Events {
   // Internal test/control events
   _exit: {}
   _restart: {}
@@ -168,16 +167,10 @@ export interface Events extends LoggerEvents {
   // Stack Graph events
   stackGraph: RenderedActionGraph
 
+
+  // TODO: Remove these once the Cloud UI no longer uses them.
+
   // TaskGraph events
-  taskPending: {
-    /**
-     * ISO format date string
-     */
-    addedAt: string
-    key: string
-    type: string
-    name: string
-  }
   taskProcessing: {
     /**
      * ISO format date string
@@ -212,110 +205,47 @@ export interface Events extends LoggerEvents {
     completedAt: string
   }
   watchingForChanges: {}
+  /**
+   * Line-by-line action log events. These are emitted by the `PluginEventBroker` instance passed to action handlers.
+   *
+   * This is in contrast with the `logEntry` event below, which represents framework-level logs emitted by the logger.
+   *
+   * TODO: Instead of having two event types (`log` and `logEntry`), we may want to unify the two.
+   */
   log: {
     /**
      * ISO format date string
      */
     timestamp: string
     actionUid: string
-    entity: {
-      moduleName: string | null
-      type: string
-      key: string
-    }
+    actionName: string
+    moduleName: string | null
     data: string
   }
+  logEntry: LogEntryEventPayload
 
-  // Status events
+  // Action status events
 
   /**
-   * In the `buildStatus`, `taskStatus`, `testStatus` and `serviceStatus` events, the optional `actionUid` field
-   * identifies a single build/deploy/run.
+   * In the `buildStatus`, `runStatus`, `testStatus` and `deployStatus` events, the optional `actionUid` field
+   * identifies a single build/run/test/deploy.
    *
-   * The `build`/`testModule`/`runTask`/`deployService` actions emit two events: One before the plugin handler is
-   * called (a "building"/"running"/"deploying" event), and another one after the handler finishes successfully or
-   * throws an error.
+   * The `ActionRouter.build.build`/`ActionRouter.test.test`/`ActionRouter.run.run`/`ActionRouter.deploy.deploy`
+   * actions emit two events: One before the plugin handler is called (a "building"/"running"/"deploying" event), and
+   * another one after the handler finishes successfully or throws an error.
    *
    * When logged in, the `actionUid` is used by the Garden Cloud backend to group these two events for each of these
    * action invocations.
    *
-   * No `actionUid` is set for the corresponding "get status" actions (e.g. `getBuildStatus` or `getServiceStatus`),
-   * since those actions don't result in a build/deploy/run (so there are no associated logs or timestamps to track).
+   * No `actionUid` is set for the corresponding "get status/result" actions (e.g. `ActionRouter.build.getStatus` or
+   * `ActionRouter.test.getResult`), since those actions don't result in a build/deploy/run being executed (so there
+   * are no associated logs or timestamps to track).
    */
 
-  buildStatus: {
-    actionName: string
-    actionVersion: string
-
-    // DEPRECATED: remove in 0.14
-    moduleName: string | null
-    moduleVersion: string
-    /**
-     * `actionUid` should only be defined if `state = "building" | "built" | "failed"` (and not if `state = "fetched",
-     * since in that case, no build took place and there are no logs/timestamps to view).
-     */
-    actionUid?: string
-    status: {
-      state: BuildState
-      /**
-       * ISO format date string
-       */
-      startedAt?: string
-      /**
-       * ISO format date string
-       */
-      completedAt?: string
-    }
-  }
-  taskStatus: {
-    actionName: string
-    actionVersion: string
-
-    // DEPRECATED: remove in 0.14
-    taskName: string
-    moduleName: string | null
-    moduleVersion: string
-    taskVersion: string
-    /**
-     * `actionUid` should only be defined if the task was run , i.e. if `state = "running" | "succeeded" | "failed"`
-     * (and not if `state = "outdated" | "not-implemented, since in that case, no run took place and there are no
-     * logs/timestamps to view).
-     */
-    actionUid?: string
-    status: RunStatus
-  }
-  testStatus: {
-    actionName: string
-    actionVersion: string
-
-    // DEPRECATED: remove in 0.14
-    testName: string
-    moduleName: string | null
-    moduleVersion: string
-    testVersion: string
-    /**
-     * `actionUid` should only be defined if the test was run, i.e. if `state = "running" | "succeeded" | "failed"`
-     * (and not if `state = "outdated" | "not-implemented, since in that case, no run took place and there are no
-     * logs/timestamps to view).
-     */
-    actionUid?: string
-    status: RunStatus
-  }
-  serviceStatus: {
-    actionName: string
-    actionVersion: string
-
-    // DEPRECATED: remove in 0.14
-    serviceName: string
-    moduleName: string | null
-    moduleVersion: string
-    serviceVersion: string
-    /**
-     * `actionUid` should only be defined if a deploy took place (i.e. when emitted from the `deployService` action).
-     */
-    actionUid?: string
-    status: ServiceStatusPayload
-  }
+  buildStatus: ActionStatusPayload<{ state: BuildState }>
+  runStatus: ActionStatusPayload<RunStatusForEventPayload>
+  testStatus: ActionStatusPayload<RunStatusForEventPayload>
+  deployStatus: ActionStatusPayload<DeployStatusForEventPayload>
   namespaceStatus: NamespaceStatus
 
   // Workflow events
@@ -363,17 +293,16 @@ export const pipedEventNames: EventName[] = [
   "actionSourcesChanged",
   "namespaceStatus",
   "projectConfigChanged",
-  "serviceStatus",
+  "deployStatus",
   "stackGraph",
   "taskCancelled",
   "taskComplete",
   "taskError",
   "taskGraphComplete",
   "taskGraphProcessing",
-  "taskPending",
   "taskProcessing",
   "buildStatus",
-  "taskStatus",
+  "runStatus",
   "testStatus",
   "watchingForChanges",
   "workflowComplete",

--- a/core/src/events.ts
+++ b/core/src/events.ts
@@ -102,12 +102,10 @@ export function toGraphResultEventPayload(result: GraphResult): GraphResultEvent
   return payload
 }
 
-interface ActionStatusPayload<S> {
+export interface ActionStatusPayload<S = {}> {
   actionName: string
   actionVersion: string
-  // TODO: Generate for each task class instance instead of generating in actions, and provide to the action router
-  // calls. This way, we can tie together the `actionUid` of the status check action with that of the processing action.
-  actionUid: string | undefined
+  actionUid: string
   moduleName: string | null // DEPRECATED: Remove in 0.14
   startedAt: string
   completedAt?: string
@@ -220,6 +218,7 @@ export interface Events {
     actionUid: string
     actionName: string
     moduleName: string | null
+    origin: string
     data: string
   }
   logEntry: LogEntryEventPayload

--- a/core/src/events.ts
+++ b/core/src/events.ts
@@ -18,9 +18,9 @@ import type { CommandInfo } from "./plugin-context"
 import type { ActionReference } from "./config/common"
 import type { GraphResult } from "./graph/results"
 import { NamespaceStatus } from "./types/namespace"
-import { sanitizeValue } from "./util/logging"
-import { ActionState } from "./actions/types"
 import { BuildState } from "./plugin/handlers/Build/get-status"
+import { ActionStateForEvent } from "./actions/types"
+import { sanitizeValue } from "./util/logging"
 
 export type GardenEventListener<T extends EventName> = (payload: Events[T]) => void
 
@@ -109,7 +109,7 @@ export interface ActionStatusPayload<S = {}> {
   moduleName: string | null // DEPRECATED: Remove in 0.14
   startedAt: string
   completedAt?: string
-  state: ActionState
+  state: ActionStateForEvent
   status: S
 }
 

--- a/core/src/plugin/base.ts
+++ b/core/src/plugin/base.ts
@@ -140,20 +140,15 @@ export const runResultSchema = createSchema({
 export const artifactsPathSchema = () =>
   joi.string().required().description("A directory path where the handler should write any exported artifacts to.")
 
-export type RunState = "outdated" | "running" | "succeeded" | "failed" | "not-implemented"
+export type RunState = "outdated" | "unknown" | "running" | "succeeded" | "failed" | "not-implemented"
 
-export interface RunStatus {
+export interface RunStatusForEventPayload {
   state: RunState
-  startedAt?: Date
-  completedAt?: Date
 }
 
-export function runStatus<R extends RunResult>(result: R | null | undefined): RunStatus {
+export function runStatusForEventPayload<R extends RunResult>(result: R | null | undefined): RunStatusForEventPayload {
   if (result) {
-    const { startedAt, completedAt } = result
     return {
-      startedAt,
-      completedAt,
       state: result.success ? "succeeded" : "failed",
     }
   } else {

--- a/core/src/plugin/handlers/Build/get-status.ts
+++ b/core/src/plugin/handlers/Build/get-status.ts
@@ -14,15 +14,16 @@ import { actionStatusSchema } from "../../../actions/base"
 import { ActionStatus, ActionStatusMap, Resolved } from "../../../actions/types"
 import { joi } from "../../../config/common"
 
-interface GetBuildStatusParams<T extends BuildAction = BuildAction> extends PluginBuildActionParamsBase<T> {}
-
 /**
- * - `fetched`: The build was fetched from a remote repository instead of building.
+ * - `fetched`: The build was fetched from a repository instead of building.
+ * - `outdated`: No up-to-date build was found the remote repository.
  * - `building`: The build is in progress.
  * - `built`: The build was completed successfully.
  * - `failed`: An error occurred while fetching or building.
  */
-export type BuildState = "fetched" | "building" | "built" | "failed"
+export type BuildState = "fetching" | "fetched" | "outdated" | "building" | "built" | "failed"
+
+interface GetBuildStatusParams<T extends BuildAction = BuildAction> extends PluginBuildActionParamsBase<T> {}
 
 export interface BuildResult {
   buildLog?: string

--- a/core/src/plugin/handlers/Deploy/get-status.ts
+++ b/core/src/plugin/handlers/Deploy/get-status.ts
@@ -8,12 +8,12 @@
 
 import { actionParamsSchema, PluginDeployActionParamsBase } from "../../base"
 import { dedent } from "../../../util/string"
-import { ServiceStatus, serviceStatusSchema } from "../../../types/service"
-import { createSchema } from "../../../config/common"
 import type { DeployAction } from "../../../actions/deploy"
 import { ActionTypeHandlerSpec } from "../base/base"
-import type { ActionStatus, ActionStatusMap, GetActionOutputType, Resolved } from "../../../actions/types"
+import type { ActionState, ActionStatus, ActionStatusMap, GetActionOutputType, Resolved } from "../../../actions/types"
 import { actionStatusSchema } from "../../../actions/base"
+import { createSchema } from "../../../config/common"
+import { ServiceStatus, DeployState, serviceStatusSchema } from "../../../types/service"
 
 interface GetDeployStatusParams<T extends DeployAction> extends PluginDeployActionParamsBase<T> {}
 
@@ -24,6 +24,20 @@ export type DeployStatus<T extends DeployAction = DeployAction> = ActionStatus<
 
 export interface DeployStatusMap extends ActionStatusMap<DeployAction> {
   [key: string]: DeployStatus
+}
+
+const deployStateMap: { [key in DeployState]: ActionState } = {
+  ready: "ready",
+  deploying: "processing",
+  stopped: "not-ready",
+  unhealthy: "failed",
+  unknown: "unknown",
+  outdated: "not-ready",
+  missing: "not-ready",
+}
+
+export function deployStateToActionState(state: DeployState): ActionState {
+  return deployStateMap[state]
 }
 
 export const getDeployStatusSchema = createSchema({

--- a/core/src/plugins/exec/deploy.ts
+++ b/core/src/plugins/exec/deploy.ts
@@ -25,7 +25,7 @@ import { ExecLogsFollower } from "./logs"
 import { PluginContext } from "../../plugin-context"
 import { ExecDeploy } from "./config"
 import { DeployActionHandler } from "../../plugin/action-types"
-import { DeployStatus } from "../../plugin/handlers/Deploy/get-status"
+import { deployStateToActionState, DeployStatus } from "../../plugin/handlers/Deploy/get-status"
 import { Resolved } from "../../actions/types"
 import { convertCommandSpec, execRun, getDefaultEnvVars } from "./common"
 import { kill } from "process"
@@ -50,7 +50,7 @@ export const getExecDeployStatus: DeployActionHandler<"getStatus", ExecDeploy> =
     const state = result.exitCode === 0 ? "ready" : "outdated"
 
     return {
-      state,
+      state: deployStateToActionState(state),
       detail: {
         state,
         version: action.versionString(),
@@ -64,7 +64,7 @@ export const getExecDeployStatus: DeployActionHandler<"getStatus", ExecDeploy> =
     const state = "unknown"
 
     return {
-      state,
+      state: deployStateToActionState(state),
       detail: { state, version: action.versionString(), detail: {} },
       outputs: {
         log: "",

--- a/core/src/plugins/kubernetes/container/status.ts
+++ b/core/src/plugins/kubernetes/container/status.ts
@@ -8,7 +8,7 @@
 
 import { PluginContext } from "../../../plugin-context"
 import { Log } from "../../../logger/log-entry"
-import { ServiceStatus, ForwardablePort, serviceStateToActionState } from "../../../types/service"
+import { ServiceStatus, ForwardablePort } from "../../../types/service"
 import { createContainerManifests, startContainerDevSync } from "./deployment"
 import { KUBECTL_DEFAULT_TIMEOUT } from "../kubectl"
 import { DeploymentError } from "../../../exceptions"
@@ -23,6 +23,7 @@ import { KubernetesServerResource, KubernetesWorkload } from "../types"
 import { DeployActionHandler } from "../../../plugin/action-types"
 import { getDeployedImageId } from "./util"
 import { Resolved } from "../../../actions/types"
+import { deployStateToActionState } from "../../../plugin/handlers/Deploy/get-status"
 
 interface ContainerStatusDetail {
   remoteResources: KubernetesServerResource[]
@@ -101,7 +102,7 @@ export const k8sGetContainerDeployStatus: DeployActionHandler<"getStatus", Conta
   }
 
   return {
-    state: serviceStateToActionState(state),
+    state: deployStateToActionState(state),
     detail,
     outputs,
   }
@@ -126,7 +127,9 @@ export async function waitForContainerService(
       action,
     })
 
-    if (status.state === "ready" || status.state === "outdated") {
+    const deployState = status.detail?.state
+
+    if (deployState === "ready" || deployState === "outdated") {
       return
     }
 

--- a/core/src/plugins/kubernetes/helm/status.ts
+++ b/core/src/plugins/kubernetes/helm/status.ts
@@ -9,8 +9,7 @@
 import {
   ForwardablePort,
   ServiceIngress,
-  ServiceState,
-  serviceStateToActionState,
+  DeployState,
   ServiceStatus,
 } from "../../../types/service"
 import { Log } from "../../../logger/log-entry"
@@ -29,10 +28,11 @@ import { getK8sIngresses } from "../status/ingress"
 import { DeployActionHandler } from "../../../plugin/action-types"
 import { HelmDeployAction } from "./config"
 import { ActionMode, Resolved } from "../../../actions/types"
+import { deployStateToActionState } from "../../../plugin/handlers/Deploy/get-status"
 
 export const gardenCloudAECPauseAnnotation = "garden.io/aec-status"
 
-const helmStatusMap: { [status: string]: ServiceState } = {
+const helmStatusMap: { [status: string]: DeployState } = {
   unknown: "unknown",
   deployed: "ready",
   deleted: "missing",
@@ -55,7 +55,7 @@ export const getHelmDeployStatus: DeployActionHandler<"getStatus", HelmDeployAct
   const releaseName = getReleaseName(action)
 
   const detail: HelmStatusDetail = {}
-  let state: ServiceState
+  let state: DeployState
   let helmStatus: ServiceStatus
 
   const namespaceStatus = await getActionNamespaceStatus({
@@ -136,7 +136,7 @@ export const getHelmDeployStatus: DeployActionHandler<"getStatus", HelmDeployAct
   }
 
   return {
-    state: serviceStateToActionState(state),
+    state: deployStateToActionState(state),
     detail: {
       forwardablePorts,
       state,

--- a/core/src/plugins/kubernetes/init.ts
+++ b/core/src/plugins/kubernetes/init.ts
@@ -22,7 +22,7 @@ import { CleanupEnvironmentParams, CleanupEnvironmentResult } from "../../plugin
 import { millicpuToString, megabytesToString } from "./util"
 import chalk from "chalk"
 import { deline, dedent, gardenAnnotationKey } from "../../util/string"
-import { combineStates, ServiceState } from "../../types/service"
+import { combineStates, DeployState } from "../../types/service"
 import {
   setupCertManager,
   checkCertManagerStatus,
@@ -56,7 +56,7 @@ interface KubernetesProviderOutputs extends PrimitiveMap {
 interface KubernetesEnvironmentDetail {
   deployStatuses: DeployStatusMap
   systemReady: boolean
-  systemServiceState: ServiceState
+  systemServiceState: DeployState
   systemCertManagerReady: boolean
   systemManagedCertificatesReady: boolean
 }
@@ -83,7 +83,7 @@ export async function getEnvironmentStatus({
   const detail: KubernetesEnvironmentDetail = {
     deployStatuses: {},
     systemReady: true,
-    systemServiceState: <ServiceState>"unknown",
+    systemServiceState: <DeployState>"unknown",
     systemCertManagerReady: true,
     systemManagedCertificatesReady: true,
   }

--- a/core/src/plugins/kubernetes/integrations/cert-manager.ts
+++ b/core/src/plugins/kubernetes/integrations/cert-manager.ts
@@ -21,7 +21,7 @@ import yaml from "js-yaml"
 import { checkResourceStatuses } from "../status/status"
 import { KubernetesServerResource } from "../types"
 import { V1Pod } from "@kubernetes/client-node"
-import { ServiceState } from "../../../types/service"
+import { DeployState } from "../../../types/service"
 import { EnvironmentStatus } from "../../../plugin/handlers/Provider/getEnvironmentStatus"
 import { PrimitiveMap } from "../../../config/common"
 import chalk from "chalk"
@@ -163,7 +163,7 @@ export async function getAllCertificates(
  *
  * @export
  * @param {*} { provider, log, namespace = "cert-manager" }
- * @returns {Promise<ServiceState>}
+ * @returns {Promise<DeployState>}
  */
 export async function checkCertManagerStatus({
   ctx,
@@ -175,7 +175,7 @@ export async function checkCertManagerStatus({
   ctx: PluginContext
   provider: KubernetesProvider
   namespace?: string
-}): Promise<ServiceState> {
+}): Promise<DeployState> {
   const api = await KubeApi.factory(log, ctx, provider)
   const systemPods = await api.core.listNamespacedPod(namespace)
   const certManagerPods: KubernetesServerResource<V1Pod>[] = []

--- a/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
@@ -10,7 +10,7 @@ import Bluebird from "bluebird"
 import { cloneDeep, isEmpty, omit, partition, uniq } from "lodash"
 import type { NamespaceStatus } from "../../../types/namespace"
 import type { ModuleActionHandlers } from "../../../plugin/plugin"
-import { serviceStateToActionState, ServiceStatus } from "../../../types/service"
+import { ServiceStatus } from "../../../types/service"
 import { gardenAnnotationKey } from "../../../util/string"
 import { KubeApi } from "../api"
 import type { KubernetesPluginContext } from "../config"
@@ -31,6 +31,7 @@ import type { DeployActionHandler } from "../../../plugin/action-types"
 import { getTargetResource } from "../util"
 import type { Log } from "../../../logger/log-entry"
 import type { Resolved } from "../../../actions/types"
+import { deployStateToActionState } from "../../../plugin/handlers/Deploy/get-status"
 
 export const kubernetesHandlers: Partial<ModuleActionHandlers<KubernetesModule>> = {
   configure: configureKubernetesModule,
@@ -208,7 +209,7 @@ export const getKubernetesDeployStatus: DeployActionHandler<"getStatus", Kuberne
   }
 
   return {
-    state: serviceStateToActionState(state),
+    state: deployStateToActionState(state),
     detail: {
       forwardablePorts,
       state,

--- a/core/src/plugins/kubernetes/status/pod.ts
+++ b/core/src/plugins/kubernetes/status/pod.ts
@@ -12,11 +12,11 @@ import { KubernetesServerResource, KubernetesPod } from "../types"
 import { V1Pod, V1Status } from "@kubernetes/client-node"
 import { ResourceStatus } from "./status"
 import chalk from "chalk"
-import { ServiceState, combineStates } from "../../../types/service"
+import { DeployState, combineStates } from "../../../types/service"
 
 export const POD_LOG_LINES = 30
 
-export function checkPodStatus(pod: KubernetesServerResource<V1Pod>): ServiceState {
+export function checkPodStatus(pod: KubernetesServerResource<V1Pod>): DeployState {
   const phase = pod.status!.phase
 
   // phase can be "Running" even if some containers have failed, so we need to check container statuses

--- a/core/src/router/build.ts
+++ b/core/src/router/build.ts
@@ -10,7 +10,6 @@ import chalk from "chalk"
 
 import { renderOutputStream } from "../util/util"
 import { PluginEventBroker } from "../plugin-context"
-import { BuildState } from "../plugin/handlers/Build/get-status"
 import { BaseRouterParams, createActionRouter } from "./base"
 import { ActionState } from "../actions/types"
 import { PublishActionResult } from "../plugin/handlers/Build/publish"
@@ -21,6 +20,23 @@ export const buildRouter = (baseParams: BaseRouterParams) =>
     getStatus: async (params) => {
       const { router, action, garden } = params
 
+      const startedAt = new Date().toISOString()
+
+      // Then an actual build won't take place, so we emit a build status event to that effect.
+      const actionVersion = action.versionString()
+      const payloadAttrs = {
+        moduleName: action.moduleName(),
+        actionName: action.name,
+        actionUid: undefined,
+        actionVersion,
+        startedAt,
+      }
+
+      garden.events.emit("buildStatus", {
+        ...payloadAttrs,
+        state: "getting-status",
+        status: { state: "fetching" },
+      })
       const status = await router.callHandler({
         params,
         handlerType: "getStatus",
@@ -29,19 +45,12 @@ export const buildRouter = (baseParams: BaseRouterParams) =>
 
       // TODO-G2: only validate if state is ready?
       await router.validateActionOutputs(action, "runtime", status.outputs)
-
-      if (status.state === "ready") {
-        // Then an actual build won't take place, so we emit a build status event to that effect.
-        const actionVersion = action.versionString()
-
-        garden.events.emit("buildStatus", {
-          moduleName: action.moduleName(),
-          moduleVersion: action.moduleVersion().versionString,
-          actionName: action.name,
-          actionVersion,
-          status: { state: "fetched" },
-        })
-      }
+      garden.events.emit("buildStatus", {
+        ...payloadAttrs,
+        completedAt: new Date().toISOString(),
+        state: status.state,
+        status: { state: status.state === "ready" ? "fetched" : "outdated" },
+      })
       return status
     },
 
@@ -55,7 +64,6 @@ export const buildRouter = (baseParams: BaseRouterParams) =>
 
       const actionName = action.name
       const actionVersion = action.versionString()
-      const moduleVersion = action.moduleVersion().versionString
       const moduleName = action.moduleName()
 
       params.events.on("log", ({ timestamp, data, origin, log }) => {
@@ -66,34 +74,32 @@ export const buildRouter = (baseParams: BaseRouterParams) =>
         garden.events.emit("log", {
           timestamp,
           actionUid,
-          entity: {
-            type: "build",
-            key: `${moduleName}`,
-            moduleName,
-          },
+          actionName,
+          moduleName,
           data: data.toString(),
         })
       })
-      garden.events.emit("buildStatus", {
+      const payloadAttrs = {
         actionName,
         actionVersion,
         moduleName,
-        moduleVersion,
         actionUid,
-        status: { state: "building", startedAt },
+        startedAt,
+      }
+
+      garden.events.emit("buildStatus", {
+        ...payloadAttrs,
+        state: "processing",
+        status: { state: "building" },
       })
 
-      const emitBuildStatusEvent = (state: BuildState) => {
+      const emitBuildStatusEvent = (state: "ready" | "failed") => {
         garden.events.emit("buildStatus", {
-          actionName,
-          actionVersion,
-          moduleName,
-          moduleVersion,
-          actionUid,
+          ...payloadAttrs,
+          state,
+          completedAt: new Date().toISOString(),
           status: {
-            state,
-            startedAt,
-            completedAt: new Date().toISOString(),
+            state: state === "ready" ? "built" : "failed",
           },
         })
       }
@@ -108,7 +114,7 @@ export const buildRouter = (baseParams: BaseRouterParams) =>
         // TODO-G2: only validate if state is ready?
         await router.validateActionOutputs(action, "runtime", result.outputs)
 
-        emitBuildStatusEvent("built")
+        emitBuildStatusEvent("ready")
         return result
       } catch (err) {
         emitBuildStatusEvent("failed")

--- a/core/src/router/build.ts
+++ b/core/src/router/build.ts
@@ -27,7 +27,7 @@ export const buildRouter = (baseParams: BaseRouterParams) =>
       const payloadAttrs = {
         moduleName: action.moduleName(),
         actionName: action.name,
-        actionUid: undefined,
+        actionUid: action.getUid(),
         actionVersion,
         startedAt,
       }
@@ -57,7 +57,7 @@ export const buildRouter = (baseParams: BaseRouterParams) =>
     build: async (params) => {
       const { action, garden, router } = params
 
-      const actionUid = uuidv4()
+      const actionUid = action.getUid()
       params.events = params.events || new PluginEventBroker()
 
       const startedAt = new Date().toISOString()
@@ -70,12 +70,12 @@ export const buildRouter = (baseParams: BaseRouterParams) =>
         // stream logs to CLI
         log.info(renderOutputStream(data.toString(), origin))
         // stream logs to Garden Cloud
-        // TODO: consider sending origin as well
         garden.events.emit("log", {
           timestamp,
           actionUid,
           actionName,
           moduleName,
+          origin,
           data: data.toString(),
         })
       })

--- a/core/src/router/deploy.ts
+++ b/core/src/router/deploy.ts
@@ -8,7 +8,7 @@
 
 import chalk from "chalk"
 import { omit } from "lodash"
-import { ActionState } from "../actions/types"
+import { ActionState, stateForCacheStatusEvent } from "../actions/types"
 import { PluginEventBroker } from "../plugin-context"
 import { DeployState } from "../types/service"
 import { renderOutputStream } from "../util/util"
@@ -159,7 +159,7 @@ export const deployRouter = (baseParams: BaseRouterParams) =>
       garden.events.emit("deployStatus", {
         ...payloadAttrs,
         completedAt: new Date().toISOString(),
-        state: result.state,
+        state: stateForCacheStatusEvent(result.state),
         status: omit(result.detail, "detail")
       })
 

--- a/core/src/router/deploy.ts
+++ b/core/src/router/deploy.ts
@@ -11,7 +11,6 @@ import { omit } from "lodash"
 import { ActionState } from "../actions/types"
 import { PluginEventBroker } from "../plugin-context"
 import { DeployState } from "../types/service"
-import { uuidv4 } from "../util/random"
 import { renderOutputStream } from "../util/util"
 import { BaseRouterParams, createActionRouter } from "./base"
 
@@ -20,7 +19,7 @@ export const deployRouter = (baseParams: BaseRouterParams) =>
     deploy: async (params) => {
       const { router, action, garden } = params
 
-      const actionUid = uuidv4()
+      const actionUid = action.getUid()
       params.events = params.events || new PluginEventBroker()
 
       const actionName = action.name
@@ -31,12 +30,12 @@ export const deployRouter = (baseParams: BaseRouterParams) =>
         // stream logs to CLI
         log.info(renderOutputStream(data.toString(), origin))
         // stream logs to Garden Cloud
-        // TODO: consider sending origin as well
         garden.events.emit("log", {
           timestamp,
           actionUid,
           actionName,
           moduleName,
+          origin,
           data: data.toString(),
         })
       })
@@ -144,7 +143,7 @@ export const deployRouter = (baseParams: BaseRouterParams) =>
       const payloadAttrs = {
         actionName,
         actionVersion,
-        actionUid: undefined,
+        actionUid: action.getUid(),
         moduleName: action.moduleName(),
         startedAt: new Date().toISOString(),
       }

--- a/core/src/router/run.ts
+++ b/core/src/router/run.ts
@@ -11,7 +11,7 @@ import normalizePath from "normalize-path"
 import tmp from "tmp-promise"
 import { ActionState } from "../actions/types"
 import { PluginEventBroker } from "../plugin-context"
-import { runStatus } from "../plugin/base"
+import { runStatusForEventPayload } from "../plugin/base"
 import { copyArtifacts, getArtifactKey } from "../util/artifacts"
 import { uuidv4 } from "../util/random"
 import { renderOutputStream } from "../util/util"
@@ -28,20 +28,20 @@ export const runRouter = (baseParams: BaseRouterParams) =>
 
       const actionName = action.name
       const actionVersion = action.versionString()
-      const taskName = actionName
-      const taskVersion = actionVersion
       const moduleName = action.moduleName()
-      const moduleVersion = action.moduleVersion().versionString
 
-      garden.events.emit("taskStatus", {
+      const payloadAttrs = {
         actionName,
         actionVersion,
-        taskName,
         moduleName,
-        moduleVersion,
-        taskVersion,
         actionUid,
-        status: { state: "running", startedAt: new Date() },
+        startedAt: new Date().toISOString()
+      }
+
+      garden.events.emit("runStatus", {
+        ...payloadAttrs,
+        state: "processing",
+        status: { state: "running" },
       })
 
       params.events = params.events || new PluginEventBroker()
@@ -59,11 +59,8 @@ export const runRouter = (baseParams: BaseRouterParams) =>
           garden.events.emit("log", {
             timestamp,
             actionUid,
-            entity: {
-              type: "task",
-              key: taskName,
-              moduleName,
-            },
+            actionName,
+            moduleName,
             data: data.toString(),
           })
         })
@@ -73,15 +70,11 @@ export const runRouter = (baseParams: BaseRouterParams) =>
         await router.validateActionOutputs(action, "runtime", result.outputs)
 
         // Emit status
-        garden.events.emit("taskStatus", {
-          actionName,
-          actionVersion,
-          taskName,
-          moduleName,
-          moduleVersion,
-          taskVersion,
-          actionUid,
-          status: runStatus(result.detail),
+        garden.events.emit("runStatus", {
+          ...payloadAttrs,
+          state: result.state,
+          completedAt: new Date().toISOString(),
+          status: runStatusForEventPayload(result.detail),
         })
         // result && this.validateTaskOutputs(params.task, result)
         // TODO-G2: get this out of the core framework and shift it to the provider
@@ -106,27 +99,35 @@ export const runRouter = (baseParams: BaseRouterParams) =>
     getResult: async (params) => {
       const { garden, router, action } = params
 
+      const actionName = action.name
+      const actionVersion = action.versionString()
+      const moduleName = action.moduleName()
+
+      const payloadAttrs = {
+        actionName,
+        actionVersion,
+        moduleName,
+        actionUid: undefined,
+        startedAt: new Date().toISOString()
+      }
+
+      garden.events.emit("runStatus", {
+        ...payloadAttrs,
+        state: "getting-status",
+        status: { state: "unknown" }
+      })
+
       const result = await router.callHandler({
         params,
         handlerType: "getResult",
         defaultHandler: async () => ({ state: <ActionState>"unknown", detail: null, outputs: {} }),
       })
 
-      const actionName = action.name
-      const actionVersion = action.versionString()
-      const taskName = actionName
-      const taskVersion = actionVersion
-      const moduleName = action.moduleName()
-      const moduleVersion = action.moduleVersion().versionString
-
-      garden.events.emit("taskStatus", {
-        actionName,
-        actionVersion,
-        taskName,
-        moduleName,
-        moduleVersion,
-        taskVersion,
-        status: runStatus(result.detail),
+      garden.events.emit("runStatus", {
+        ...payloadAttrs,
+        state: result.state,
+        completedAt: new Date().toISOString(),
+        status: runStatusForEventPayload(result.detail),
       })
 
       if (result) {

--- a/core/src/router/run.ts
+++ b/core/src/router/run.ts
@@ -13,7 +13,6 @@ import { ActionState } from "../actions/types"
 import { PluginEventBroker } from "../plugin-context"
 import { runStatusForEventPayload } from "../plugin/base"
 import { copyArtifacts, getArtifactKey } from "../util/artifacts"
-import { uuidv4 } from "../util/random"
 import { renderOutputStream } from "../util/util"
 import { BaseRouterParams, createActionRouter } from "./base"
 
@@ -22,7 +21,7 @@ export const runRouter = (baseParams: BaseRouterParams) =>
     run: async (params) => {
       const { garden, router, action } = params
 
-      const actionUid = uuidv4()
+      const actionUid = action.getUid()
       const tmpDir = await tmp.dir({ unsafeCleanup: true })
       const artifactsPath = normalizePath(await realpath(tmpDir.path))
 
@@ -55,12 +54,12 @@ export const runRouter = (baseParams: BaseRouterParams) =>
             log.info(renderOutputStream(data.toString(), origin))
           }
           // stream logs to Garden Cloud
-          // TODO: consider sending origin as well
           garden.events.emit("log", {
             timestamp,
             actionUid,
             actionName,
             moduleName,
+            origin,
             data: data.toString(),
           })
         })
@@ -107,7 +106,7 @@ export const runRouter = (baseParams: BaseRouterParams) =>
         actionName,
         actionVersion,
         moduleName,
-        actionUid: undefined,
+        actionUid: action.getUid(),
         startedAt: new Date().toISOString()
       }
 

--- a/core/src/router/run.ts
+++ b/core/src/router/run.ts
@@ -9,7 +9,7 @@
 import { realpath } from "fs-extra"
 import normalizePath from "normalize-path"
 import tmp from "tmp-promise"
-import { ActionState } from "../actions/types"
+import { ActionState, stateForCacheStatusEvent } from "../actions/types"
 import { PluginEventBroker } from "../plugin-context"
 import { runStatusForEventPayload } from "../plugin/base"
 import { copyArtifacts, getArtifactKey } from "../util/artifacts"
@@ -124,7 +124,7 @@ export const runRouter = (baseParams: BaseRouterParams) =>
 
       garden.events.emit("runStatus", {
         ...payloadAttrs,
-        state: result.state,
+        state: stateForCacheStatusEvent(result.state),
         completedAt: new Date().toISOString(),
         status: runStatusForEventPayload(result.detail),
       })

--- a/core/src/router/test.ts
+++ b/core/src/router/test.ts
@@ -10,7 +10,7 @@ import { realpath } from "fs-extra"
 import normalizePath from "normalize-path"
 import { ActionState } from "../actions/types"
 import { PluginEventBroker } from "../plugin-context"
-import { runStatus } from "../plugin/base"
+import { runStatusForEventPayload } from "../plugin/base"
 import { copyArtifacts, getArtifactKey } from "../util/artifacts"
 import { makeTempDir } from "../util/fs"
 import { uuidv4 } from "../util/random"
@@ -28,20 +28,20 @@ export const testRouter = (baseParams: BaseRouterParams) =>
 
       const actionName = action.name
       const actionVersion = action.versionString()
-      const testName = actionName
-      const testVersion = actionVersion
       const moduleName = action.moduleName()
-      const moduleVersion = action.moduleVersion().versionString
 
-      garden.events.emit("testStatus", {
+      const payloadAttrs = {
         actionName,
         actionVersion,
-        testName,
         moduleName,
-        moduleVersion,
-        testVersion,
         actionUid,
-        status: { state: "running", startedAt: new Date() },
+        startedAt: new Date().toISOString(),
+      }
+
+      garden.events.emit("testStatus", {
+        ...payloadAttrs,
+        state: "processing",
+        status: { state: "running" },
       })
 
       params.events = params.events || new PluginEventBroker()
@@ -59,11 +59,8 @@ export const testRouter = (baseParams: BaseRouterParams) =>
           garden.events.emit("log", {
             timestamp,
             actionUid,
-            entity: {
-              type: "test",
-              key: `${moduleName}.${testName}`,
-              moduleName,
-            },
+            actionName,
+            moduleName,
             data: data.toString(),
           })
         })
@@ -74,14 +71,10 @@ export const testRouter = (baseParams: BaseRouterParams) =>
 
         // Emit status
         garden.events.emit("testStatus", {
-          actionName,
-          actionVersion,
-          testName,
-          moduleName,
-          moduleVersion,
-          testVersion,
-          actionUid,
-          status: runStatus(result.detail),
+          ...payloadAttrs,
+          completedAt: new Date().toISOString(),
+          state: result.state,
+          status: runStatusForEventPayload(result.detail),
         })
         // TODO-G2: get this out of the core framework and shift it to the provider
         router.emitNamespaceEvent(result.detail?.namespaceStatus)
@@ -105,23 +98,34 @@ export const testRouter = (baseParams: BaseRouterParams) =>
     getResult: async (params) => {
       const { garden, router, action } = params
 
+      const actionName = action.name
+      const actionVersion = action.versionString()
+
+      const payloadAttrs = {
+        actionName,
+        actionVersion,
+        moduleName: action.moduleName(),
+        actionUid: undefined,
+        startedAt: new Date().toISOString(),
+      }
+
+      garden.events.emit("testStatus", {
+        ...payloadAttrs,
+        state: "getting-status",
+        status: { state: "unknown" },
+      })
+
       const result = await router.callHandler({
         params,
         handlerType: "getResult",
         defaultHandler: async () => ({ state: <ActionState>"unknown", detail: null, outputs: {} }),
       })
 
-      const actionName = action.name
-      const actionVersion = action.versionString()
-
       garden.events.emit("testStatus", {
-        actionName,
-        actionVersion,
-        testName: actionName,
-        moduleName: action.moduleName(),
-        moduleVersion: action.moduleVersion().versionString,
-        testVersion: actionVersion,
-        status: runStatus(result.detail),
+        ...payloadAttrs,
+        state: result.state,
+        completedAt: new Date().toISOString(),
+        status: runStatusForEventPayload(result.detail),
       })
 
       if (result) {

--- a/core/src/router/test.ts
+++ b/core/src/router/test.ts
@@ -13,7 +13,6 @@ import { PluginEventBroker } from "../plugin-context"
 import { runStatusForEventPayload } from "../plugin/base"
 import { copyArtifacts, getArtifactKey } from "../util/artifacts"
 import { makeTempDir } from "../util/fs"
-import { uuidv4 } from "../util/random"
 import { renderOutputStream } from "../util/util"
 import { BaseRouterParams, createActionRouter } from "./base"
 
@@ -24,7 +23,7 @@ export const testRouter = (baseParams: BaseRouterParams) =>
 
       const tmpDir = await makeTempDir()
       const artifactsPath = normalizePath(await realpath(tmpDir.path))
-      const actionUid = uuidv4()
+      const actionUid = action.getUid()
 
       const actionName = action.name
       const actionVersion = action.versionString()
@@ -55,12 +54,12 @@ export const testRouter = (baseParams: BaseRouterParams) =>
             log.info(renderOutputStream(data.toString(), origin))
           }
           // stream logs to Garden Cloud
-          // TODO: consider sending origin as well
           garden.events.emit("log", {
             timestamp,
             actionUid,
             actionName,
             moduleName,
+            origin,
             data: data.toString(),
           })
         })
@@ -105,7 +104,7 @@ export const testRouter = (baseParams: BaseRouterParams) =>
         actionName,
         actionVersion,
         moduleName: action.moduleName(),
-        actionUid: undefined,
+        actionUid: action.getUid(),
         startedAt: new Date().toISOString(),
       }
 

--- a/core/src/router/test.ts
+++ b/core/src/router/test.ts
@@ -8,7 +8,7 @@
 
 import { realpath } from "fs-extra"
 import normalizePath from "normalize-path"
-import { ActionState } from "../actions/types"
+import { ActionState, stateForCacheStatusEvent } from "../actions/types"
 import { PluginEventBroker } from "../plugin-context"
 import { runStatusForEventPayload } from "../plugin/base"
 import { copyArtifacts, getArtifactKey } from "../util/artifacts"
@@ -122,7 +122,7 @@ export const testRouter = (baseParams: BaseRouterParams) =>
 
       garden.events.emit("testStatus", {
         ...payloadAttrs,
-        state: result.state,
+        state: stateForCacheStatusEvent(result.state),
         completedAt: new Date().toISOString(),
         status: runStatusForEventPayload(result.detail),
       })

--- a/core/src/types/service.ts
+++ b/core/src/types/service.ts
@@ -26,7 +26,7 @@ import { uniq } from "lodash"
 import { getEntityVersion } from "../vcs/vcs"
 import { NamespaceStatus, namespaceStatusesSchema } from "./namespace"
 import type { LogLevel } from "../logger/logger"
-import type { ActionMode, ActionState } from "../actions/types"
+import type { ActionMode } from "../actions/types"
 import type { ModuleGraph } from "../graph/modules"
 
 export interface GardenService<M extends GardenModule = GardenModule, S extends GardenModule = GardenModule> {
@@ -73,26 +73,12 @@ export function serviceFromConfig<M extends GardenModule = GardenModule>(
 }
 
 export const serviceStates = ["ready", "deploying", "stopped", "unhealthy", "unknown", "outdated", "missing"] as const
-export type ServiceState = typeof serviceStates[number]
-
-const serviceStateMap: { [key in ServiceState]: ActionState } = {
-  ready: "ready",
-  deploying: "not-ready",
-  stopped: "not-ready",
-  unhealthy: "failed",
-  unknown: "unknown",
-  outdated: "outdated",
-  missing: "not-ready",
-}
-
-export function serviceStateToActionState(state: ServiceState): ActionState {
-  return serviceStateMap[state]
-}
+export type DeployState = typeof serviceStates[number]
 
 /**
  * Given a list of states, return a single state representing the list.
  */
-export function combineStates(states: ServiceState[]): ServiceState {
+export function combineStates(states: DeployState[]): DeployState {
   const unique = uniq(states)
 
   if (unique.length === 1) {
@@ -208,7 +194,7 @@ export interface ServiceStatus<D = any, O = PrimitiveMap> {
   lastError?: string
   outputs?: O
   runningReplicas?: number
-  state: ServiceState
+  state: DeployState
   updatedAt?: string
   version?: string
 }

--- a/core/test/helpers.ts
+++ b/core/test/helpers.ts
@@ -774,12 +774,13 @@ export async function enableAnalytics(garden: TestGarden) {
   return resetConfig
 }
 
-export function getRuntimeStatusEvents(eventLog: EventLogEntry[]) {
+export function getRuntimeStatusEventsWithoutTimestamps(eventLog: EventLogEntry[]) {
   const runtimeEventNames = ["runStatus", "testStatus", "deployStatus"]
   return eventLog
     .filter((e) => runtimeEventNames.includes(e.name))
     .map((e) => {
       const cloned = { ...e }
+      cloned.payload = omit(cloned.payload, "startedAt", "completedAt")
       cloned.payload.status = pick(cloned.payload.status, ["state"])
       return cloned
     })

--- a/core/test/helpers.ts
+++ b/core/test/helpers.ts
@@ -775,7 +775,7 @@ export async function enableAnalytics(garden: TestGarden) {
 }
 
 export function getRuntimeStatusEvents(eventLog: EventLogEntry[]) {
-  const runtimeEventNames = ["taskStatus", "testStatus", "serviceStatus"]
+  const runtimeEventNames = ["runStatus", "testStatus", "deployStatus"]
   return eventLog
     .filter((e) => runtimeEventNames.includes(e.name))
     .map((e) => {

--- a/core/test/integ/src/plugins/kubernetes/container/container.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/container.ts
@@ -138,7 +138,7 @@ describe("kubernetes container module handlers", () => {
       garden.events.eventLog = []
 
       const result = await garden.processTasks({ tasks: [testTask], throwOnError: true })
-      const logEvent = garden.events.eventLog.find((l) => l.name === "log" && l.payload["entity"]["type"] === "test")
+      const logEvent = garden.events.eventLog.find((l) => l.name === "log")
 
       expect(result.error).to.be.null
       const task = result.results.getResult(testTask)!

--- a/core/test/integ/src/plugins/kubernetes/container/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/run.ts
@@ -55,7 +55,7 @@ describe("runContainerTask", () => {
 
     const results = await garden.processTasks({ tasks: [testTask], throwOnError: true })
     const result = results.results.getResult(testTask)
-    const logEvent = garden.events.eventLog.find((l) => l.name === "log" && l.payload["entity"]["type"] === "task")
+    const logEvent = garden.events.eventLog.find((l) => l.name === "log")
 
     expect(result).to.exist
     expect(result!.result).to.exist

--- a/core/test/unit/src/commands/deploy.ts
+++ b/core/test/unit/src/commands/deploy.ts
@@ -181,16 +181,16 @@ describe("DeployCommand", () => {
 
     // Note: Runs A and C should not run or be queried for status because service-a is ready beforehand
     const runTaskBUid = getActionUid("task-b")
-    const taskVersionB = getRunVersion("task-b")
+    const runVersionB = getRunVersion("task-b")
 
     const moduleVersionA = getModuleVersion("module-a")
     const moduleVersionB = getModuleVersion("module-b")
     const moduleVersionC = getModuleVersion("module-c")
 
-    const serviceVersionA = getDeployVersion("service-a")
-    const serviceVersionB = getDeployVersion("service-b")
-    const serviceVersionC = getDeployVersion("service-c")
-    const serviceVersionD = getDeployVersion("service-d") // `service-d` is defined in `module-c`
+    const deployVersionA = getDeployVersion("service-a")
+    const deployVersionB = getDeployVersion("service-b")
+    const deployVersionC = getDeployVersion("service-c")
+    const deployVersionD = getDeployVersion("service-d") // `service-d` is defined in `module-c`
 
     for (const graphResult of Object.values(deployResults)) {
       expect(graphResult).to.exist
@@ -215,165 +215,102 @@ describe("DeployCommand", () => {
     }
 
     expect(sortedEvents[0]).to.eql({
-      name: "serviceStatus",
+      name: "deployStatus",
       payload: {
         actionName: "service-a",
-        serviceName: "service-a",
-        moduleName: "module-a",
-        moduleVersion: moduleVersionA,
-        actionVersion: serviceVersionA,
         actionUid: deployServiceAUid,
-        serviceVersion: serviceVersionA,
         status: { state: "deploying" },
       },
     })
     expect(sortedEvents[1]).to.eql({
-      name: "serviceStatus",
+      name: "deployStatus",
       payload: {
         actionName: "service-a",
-        serviceName: "service-a",
-        moduleName: "module-a",
-        moduleVersion: moduleVersionA,
-        actionVersion: serviceVersionA,
-        serviceVersion: serviceVersionA,
+        actionVersion: deployVersionA,
         status: { state: "ready" },
       },
     })
     expect(sortedEvents[2]).to.eql({
-      name: "serviceStatus",
+      name: "deployStatus",
       payload: {
         actionName: "service-a",
-        serviceName: "service-a",
-        moduleName: "module-a",
-        moduleVersion: moduleVersionA,
-        actionVersion: serviceVersionA,
-        serviceVersion: serviceVersionA,
+        actionVersion: deployVersionA,
         actionUid: deployServiceAUid,
         status: { state: "ready" },
       },
     })
     expect(sortedEvents[3]).to.eql({
-      name: "serviceStatus",
+      name: "deployStatus",
       payload: {
         actionName: "service-b",
-        serviceName: "service-b",
-        moduleName: "module-b",
-        actionUid: deployServiceBUid,
-        moduleVersion: moduleVersionB,
-        actionVersion: serviceVersionB,
-        serviceVersion: serviceVersionB,
+        actionVersion: deployVersionB,
         status: { state: "deploying" },
       },
     })
     expect(sortedEvents[4]).to.eql({
-      name: "serviceStatus",
+      name: "deployStatus",
       payload: {
         actionName: "service-b",
-        serviceName: "service-b",
-        moduleName: "module-b",
-        actionUid: deployServiceBUid,
-        moduleVersion: moduleVersionB,
-        actionVersion: serviceVersionB,
-        serviceVersion: serviceVersionB,
+        actionVersion: deployVersionB,
         status: { state: "ready" },
       },
     })
     expect(sortedEvents[5]).to.eql({
-      name: "serviceStatus",
+      name: "deployStatus",
       payload: {
         actionName: "service-b",
-        serviceName: "service-b",
-        moduleName: "module-b",
-        moduleVersion: moduleVersionB,
-        actionVersion: serviceVersionB,
-        serviceVersion: serviceVersionB,
         status: { state: "unknown" },
       },
     })
     expect(sortedEvents[6]).to.eql({
-      name: "serviceStatus",
+      name: "deployStatus",
       payload: {
         actionName: "service-c",
-        serviceName: "service-c",
-        moduleName: "module-c",
-        moduleVersion: moduleVersionC,
-        actionVersion: serviceVersionC,
-        serviceVersion: serviceVersionC,
         status: { state: "ready" },
       },
     })
     expect(sortedEvents[7]).to.eql({
-      name: "serviceStatus",
+      name: "deployStatus",
       payload: {
         actionName: "service-d",
-        serviceName: "service-d",
-        moduleName: "module-c",
-        actionUid: deployServiceDUid,
-        moduleVersion: moduleVersionC,
-        actionVersion: serviceVersionD,
-        serviceVersion: serviceVersionD,
+        actionVersion: deployVersionD,
         status: { state: "deploying" },
       },
     })
     expect(sortedEvents[8]).to.eql({
-      name: "serviceStatus",
+      name: "deployStatus",
       payload: {
         actionName: "service-d",
-        serviceName: "service-d",
-        moduleName: "module-c",
-        actionUid: deployServiceDUid,
-        moduleVersion: moduleVersionC,
-        actionVersion: serviceVersionD,
-        serviceVersion: serviceVersionD,
+        actionVersion: deployVersionD,
         status: { state: "ready" },
       },
     })
     expect(sortedEvents[9]).to.eql({
-      name: "serviceStatus",
+      name: "deployStatus",
       payload: {
         actionName: "service-d",
-        serviceName: "service-d",
-        moduleName: "module-c",
-        moduleVersion: moduleVersionC,
-        actionVersion: serviceVersionD,
-        serviceVersion: serviceVersionD,
         status: { state: "unknown" },
       },
     })
     expect(sortedEvents[10]).to.eql({
-      name: "taskStatus",
+      name: "runStatus",
       payload: {
         actionName: "task-b",
-        taskName: "task-b",
-        moduleName: "module-b",
-        moduleVersion: moduleVersionB,
-        actionVersion: taskVersionB,
-        taskVersion: taskVersionB,
         status: { state: "outdated" },
       },
     })
     expect(sortedEvents[11]).to.eql({
-      name: "taskStatus",
+      name: "runStatus",
       payload: {
         actionName: "task-b",
-        taskName: "task-b",
-        moduleName: "module-b",
-        moduleVersion: moduleVersionB,
-        actionVersion: taskVersionB,
-        taskVersion: taskVersionB,
         actionUid: runTaskBUid,
         status: { state: "running" },
       },
     })
     expect(sortedEvents[12]).to.eql({
-      name: "taskStatus",
+      name: "runStatus",
       payload: {
         actionName: "task-b",
-        taskName: "task-b",
-        moduleName: "module-b",
-        moduleVersion: moduleVersionB,
-        actionVersion: taskVersionB,
-        taskVersion: taskVersionB,
         actionUid: runTaskBUid,
         status: { state: "succeeded" },
       },

--- a/core/test/unit/src/plugins/exec/exec.ts
+++ b/core/test/unit/src/plugins/exec/exec.ts
@@ -841,7 +841,7 @@ describe("exec plugin", () => {
           expect(detail.detail.statusCommandOutput).to.equal("already deployed")
         })
 
-        it("returns 'outdated' if statusCommand returns non-zero exit code", async () => {
+        it("returns 'not-ready' if statusCommand returns non-zero exit code", async () => {
           const actionName = "touch"
           const rawAction = graph.getDeploy(actionName)
           const router = await garden.getActionRouter()
@@ -853,8 +853,9 @@ describe("exec plugin", () => {
           })
 
           const actionRes = res[actionName]
-          expect(actionRes.state).to.equal("outdated")
+          expect(actionRes.state).to.equal("not-ready")
           const detail = actionRes.detail!
+          // The deploy state is different (has more states) than the action state
           expect(detail.state).to.equal("outdated")
           expect(detail.version).to.equal(action.versionString())
           expect(detail.detail.statusCommandOutput).to.be.empty

--- a/core/test/unit/src/router/build.ts
+++ b/core/test/unit/src/router/build.ts
@@ -56,14 +56,14 @@ describe("build actions", () => {
       expect(event1).to.exist
       expect(event1.name).to.eql("buildStatus")
       expect(event1.payload.moduleName).to.eql("module-a")
-      expect(event1.payload.actionUid).to.be.undefined
+      expect(event1.payload.actionUid).to.be.ok
       expect(event1.payload.state).to.eql("getting-status")
       expect(event1.payload.status.state).to.eql("fetching")
 
       expect(event2).to.exist
       expect(event2.name).to.eql("buildStatus")
       expect(event2.payload.moduleName).to.eql("module-a")
-      expect(event2.payload.actionUid).to.be.undefined
+      expect(event2.payload.actionUid).to.eql(event1.payload.actionUid)
       expect(event2.payload.state).to.eql("ready")
       expect(event2.payload.status.state).to.eql("fetched")
     })
@@ -91,16 +91,16 @@ describe("build actions", () => {
       expect(event1).to.exist
       expect(event1.name).to.eql("buildStatus")
       expect(event1.payload.moduleName).to.eql("module-a")
+      expect(event1.payload.actionUid).to.be.ok
       expect(event1.payload.state).to.eql("processing")
       expect(event1.payload.status.state).to.eql("building")
-      expect(event1.payload.actionUid).to.be.ok
 
       expect(event2).to.exist
       expect(event2.name).to.eql("buildStatus")
       expect(event2.payload.moduleName).to.eql("module-a")
+      expect(event2.payload.actionUid).to.eql(event1.payload.actionUid)
       expect(event2.payload.state).to.eql("ready")
       expect(event2.payload.status.state).to.eql("built")
-      expect(event2.payload.actionUid).to.eql(event1.payload.actionUid)
     })
   })
 })

--- a/core/test/unit/src/router/build.ts
+++ b/core/test/unit/src/router/build.ts
@@ -46,16 +46,26 @@ describe("build actions", () => {
       expect(result.outputs.foo).to.eql("bar")
     })
 
-    it("should emit a buildStatus event", async () => {
+    it("should emit buildStatus events", async () => {
       garden.events.eventLog = []
       await actionRouter.build.getStatus({ log, action: resolvedBuildAction, graph })
-      const event = garden.events.eventLog[0]
-      expect(event).to.exist
-      expect(event.name).to.eql("buildStatus")
-      expect(event.payload.moduleName).to.eql("module-a")
-      expect(event.payload.moduleVersion).to.eql(module.version.versionString)
-      expect(event.payload.actionUid).to.be.undefined
-      expect(event.payload.status.state).to.eql("fetched")
+
+      const event1 = garden.events.eventLog[0]
+      const event2 = garden.events.eventLog[1]
+
+      expect(event1).to.exist
+      expect(event1.name).to.eql("buildStatus")
+      expect(event1.payload.moduleName).to.eql("module-a")
+      expect(event1.payload.actionUid).to.be.undefined
+      expect(event1.payload.state).to.eql("getting-status")
+      expect(event1.payload.status.state).to.eql("fetching")
+
+      expect(event2).to.exist
+      expect(event2.name).to.eql("buildStatus")
+      expect(event2.payload.moduleName).to.eql("module-a")
+      expect(event2.payload.actionUid).to.be.undefined
+      expect(event2.payload.state).to.eql("ready")
+      expect(event2.payload.status.state).to.eql("fetched")
     })
   })
 
@@ -77,17 +87,18 @@ describe("build actions", () => {
       await actionRouter.build.build({ log, action: resolvedBuildAction, graph })
       const event1 = garden.events.eventLog[0]
       const event2 = garden.events.eventLog[1]
-      const moduleVersion = module.version.versionString
+
       expect(event1).to.exist
       expect(event1.name).to.eql("buildStatus")
       expect(event1.payload.moduleName).to.eql("module-a")
-      expect(event1.payload.moduleVersion).to.eql(moduleVersion)
+      expect(event1.payload.state).to.eql("processing")
       expect(event1.payload.status.state).to.eql("building")
       expect(event1.payload.actionUid).to.be.ok
+
       expect(event2).to.exist
       expect(event2.name).to.eql("buildStatus")
       expect(event2.payload.moduleName).to.eql("module-a")
-      expect(event2.payload.moduleVersion).to.eql(moduleVersion)
+      expect(event2.payload.state).to.eql("ready")
       expect(event2.payload.status.state).to.eql("built")
       expect(event2.payload.actionUid).to.eql(event1.payload.actionUid)
     })

--- a/core/test/unit/src/router/build.ts
+++ b/core/test/unit/src/router/build.ts
@@ -64,7 +64,7 @@ describe("build actions", () => {
       expect(event2.name).to.eql("buildStatus")
       expect(event2.payload.moduleName).to.eql("module-a")
       expect(event2.payload.actionUid).to.eql(event1.payload.actionUid)
-      expect(event2.payload.state).to.eql("ready")
+      expect(event2.payload.state).to.eql("cached")
       expect(event2.payload.status.state).to.eql("fetched")
     })
   })

--- a/core/test/unit/src/router/deploy.ts
+++ b/core/test/unit/src/router/deploy.ts
@@ -72,14 +72,14 @@ describe("deploy actions", () => {
       expect(event1.name).to.eql("deployStatus")
       expect(event1.payload.actionVersion).to.eql(resolvedDeployAction.versionString())
       expect(event1.payload.moduleName).to.eql("module-a")
-      expect(event1.payload.actionUid).to.be.undefined
+      expect(event1.payload.actionUid).to.be.ok
       expect(event1.payload.state).to.eql("getting-status")
       expect(event1.payload.status.state).to.eql("unknown")
 
       expect(event2.name).to.eql("deployStatus")
       expect(event2.payload.actionVersion).to.eql(resolvedDeployAction.versionString())
       expect(event2.payload.moduleName).to.eql("module-a")
-      expect(event2.payload.actionUid).to.be.undefined
+      expect(event2.payload.actionUid).to.eql(event1.payload.actionUid)
       expect(event2.payload.state).to.eql("ready")
       expect(event2.payload.status.state).to.eql("ready")
     })

--- a/core/test/unit/src/router/deploy.ts
+++ b/core/test/unit/src/router/deploy.ts
@@ -56,21 +56,32 @@ describe("deploy actions", () => {
       })
     })
 
-    it("should emit a serviceStatus event", async () => {
+    it("should emit serviceStatus events", async () => {
       garden.events.eventLog = []
       await actionRouter.deploy.getStatus({
         log,
         action: resolvedDeployAction,
         graph,
       })
-      const event = garden.events.eventLog[0]
-      expect(event).to.exist
-      expect(event.name).to.eql("serviceStatus")
-      expect(event.payload.serviceName).to.eql("service-a")
-      expect(event.payload.actionVersion).to.eql(resolvedDeployAction.versionString())
-      expect(event.payload.serviceVersion).to.eql(resolvedDeployAction.versionString())
-      expect(event.payload.actionUid).to.be.undefined
-      expect(event.payload.status.state).to.eql("ready")
+      const event1 = garden.events.eventLog[0]
+      const event2 = garden.events.eventLog[1]
+
+      expect(event1).to.exist
+      expect(event2).to.exist
+
+      expect(event1.name).to.eql("deployStatus")
+      expect(event1.payload.actionVersion).to.eql(resolvedDeployAction.versionString())
+      expect(event1.payload.moduleName).to.eql("module-a")
+      expect(event1.payload.actionUid).to.be.undefined
+      expect(event1.payload.state).to.eql("getting-status")
+      expect(event1.payload.status.state).to.eql("unknown")
+
+      expect(event2.name).to.eql("deployStatus")
+      expect(event2.payload.actionVersion).to.eql(resolvedDeployAction.versionString())
+      expect(event2.payload.moduleName).to.eql("module-a")
+      expect(event2.payload.actionUid).to.be.undefined
+      expect(event2.payload.state).to.eql("ready")
+      expect(event2.payload.status.state).to.eql("ready")
     })
 
     it("should throw if the outputs don't match the service outputs schema of the plugin", async () => {
@@ -114,20 +125,16 @@ describe("deploy actions", () => {
       const event1 = garden.events.eventLog[0]
       const event2 = garden.events.eventLog[1]
       expect(event1).to.exist
-      expect(event1.name).to.eql("serviceStatus")
-      expect(event1.payload.serviceName).to.eql("service-a")
+      expect(event1.name).to.eql("deployStatus")
       expect(event1.payload.moduleName).to.eql("module-a")
-      expect(event1.payload.moduleVersion).to.eql(moduleVersion)
-      expect(event1.payload.serviceVersion).to.eql(resolvedDeployAction.versionString())
       expect(event1.payload.actionUid).to.be.ok
+      expect(event1.payload.state).to.eql("processing")
       expect(event1.payload.status.state).to.eql("deploying")
       expect(event2).to.exist
-      expect(event2.name).to.eql("serviceStatus")
-      expect(event2.payload.serviceName).to.eql("service-a")
+      expect(event2.name).to.eql("deployStatus")
       expect(event2.payload.moduleName).to.eql("module-a")
-      expect(event2.payload.moduleVersion).to.eql(moduleVersion)
-      expect(event2.payload.serviceVersion).to.eql(resolvedDeployAction.versionString())
       expect(event2.payload.actionUid).to.eql(event2.payload.actionUid)
+      expect(event2.payload.state).to.eql("ready")
       expect(event2.payload.status.state).to.eql("ready")
     })
 

--- a/core/test/unit/src/router/deploy.ts
+++ b/core/test/unit/src/router/deploy.ts
@@ -80,7 +80,7 @@ describe("deploy actions", () => {
       expect(event2.payload.actionVersion).to.eql(resolvedDeployAction.versionString())
       expect(event2.payload.moduleName).to.eql("module-a")
       expect(event2.payload.actionUid).to.eql(event1.payload.actionUid)
-      expect(event2.payload.state).to.eql("ready")
+      expect(event2.payload.state).to.eql("cached")
       expect(event2.payload.status.state).to.eql("ready")
     })
 

--- a/core/test/unit/src/router/run.ts
+++ b/core/test/unit/src/router/run.ts
@@ -72,22 +72,29 @@ describe("run actions", () => {
       expect(result).to.eql(taskResult)
     })
 
-    it("should emit a taskStatus event", async () => {
+    it("should emit a runStatus event", async () => {
       garden.events.eventLog = []
       await actionRouter.run.getResult({
         log,
         action: resolvedRunAction,
         graph,
       })
-      const event = garden.events.eventLog[0]
-      expect(event).to.exist
-      expect(event.name).to.eql("taskStatus")
-      expect(event.payload.taskName).to.eql("task-a")
-      expect(event.payload.moduleName).to.eql("module-a")
-      expect(event.payload.moduleVersion).to.eql(resolvedRunAction.moduleVersion().versionString)
-      expect(event.payload.taskVersion).to.eql(resolvedRunAction.versionString())
-      expect(event.payload.actionUid).to.be.undefined
-      expect(event.payload.status.state).to.eql("succeeded")
+      const event1 = garden.events.eventLog[0]
+      const event2 = garden.events.eventLog[1]
+
+      expect(event1).to.exist
+      expect(event1.name).to.eql("runStatus")
+      expect(event1.payload.moduleName).to.eql("module-a")
+      expect(event1.payload.actionUid).to.be.undefined
+      expect(event1.payload.state).to.eql("getting-status")
+      expect(event1.payload.status.state).to.eql("unknown")
+
+      expect(event2).to.exist
+      expect(event2.name).to.eql("runStatus")
+      expect(event2.payload.moduleName).to.eql("module-a")
+      expect(event2.payload.actionUid).to.be.undefined
+      expect(event2.payload.state).to.eql("ready")
+      expect(event2.payload.status.state).to.eql("succeeded")
     })
 
     it("should throw if the outputs don't match the task outputs schema of the plugin", async () => {
@@ -109,7 +116,7 @@ describe("run actions", () => {
       expect(result).to.eql(taskResult)
     })
 
-    it("should emit taskStatus events", async () => {
+    it("should emit runStatus events", async () => {
       garden.events.eventLog = []
       await actionRouter.run.run({
         log,
@@ -117,24 +124,21 @@ describe("run actions", () => {
         interactive: true,
         graph,
       })
-      const moduleVersion = resolvedRunAction.moduleVersion().versionString
       const event1 = garden.events.eventLog[0]
       const event2 = garden.events.eventLog[1]
+
       expect(event1).to.exist
-      expect(event1.name).to.eql("taskStatus")
-      expect(event1.payload.taskName).to.eql("task-a")
+      expect(event1.name).to.eql("runStatus")
       expect(event1.payload.moduleName).to.eql("module-a")
-      expect(event1.payload.moduleVersion).to.eql(moduleVersion)
-      expect(event1.payload.taskVersion).to.eql(resolvedRunAction.versionString())
       expect(event1.payload.actionUid).to.be.ok
+      expect(event1.payload.state).to.eql("processing")
       expect(event1.payload.status.state).to.eql("running")
+
       expect(event2).to.exist
-      expect(event2.name).to.eql("taskStatus")
-      expect(event2.payload.taskName).to.eql("task-a")
+      expect(event2.name).to.eql("runStatus")
       expect(event2.payload.moduleName).to.eql("module-a")
-      expect(event2.payload.moduleVersion).to.eql(moduleVersion)
-      expect(event2.payload.taskVersion).to.eql(resolvedRunAction.versionString())
       expect(event2.payload.actionUid).to.eql(event1.payload.actionUid)
+      expect(event2.payload.state).to.eql("ready")
       expect(event2.payload.status.state).to.eql("succeeded")
     })
 

--- a/core/test/unit/src/router/run.ts
+++ b/core/test/unit/src/router/run.ts
@@ -85,14 +85,14 @@ describe("run actions", () => {
       expect(event1).to.exist
       expect(event1.name).to.eql("runStatus")
       expect(event1.payload.moduleName).to.eql("module-a")
-      expect(event1.payload.actionUid).to.be.undefined
+      expect(event1.payload.actionUid).to.be.ok
       expect(event1.payload.state).to.eql("getting-status")
       expect(event1.payload.status.state).to.eql("unknown")
 
       expect(event2).to.exist
       expect(event2.name).to.eql("runStatus")
       expect(event2.payload.moduleName).to.eql("module-a")
-      expect(event2.payload.actionUid).to.be.undefined
+      expect(event2.payload.actionUid).to.eql(event1.payload.actionUid)
       expect(event2.payload.state).to.eql("ready")
       expect(event2.payload.status.state).to.eql("succeeded")
     })

--- a/core/test/unit/src/router/run.ts
+++ b/core/test/unit/src/router/run.ts
@@ -93,7 +93,7 @@ describe("run actions", () => {
       expect(event2.name).to.eql("runStatus")
       expect(event2.payload.moduleName).to.eql("module-a")
       expect(event2.payload.actionUid).to.eql(event1.payload.actionUid)
-      expect(event2.payload.state).to.eql("ready")
+      expect(event2.payload.state).to.eql("cached")
       expect(event2.payload.status.state).to.eql("succeeded")
     })
 

--- a/core/test/unit/src/router/test.ts
+++ b/core/test/unit/src/router/test.ts
@@ -194,13 +194,13 @@ describe("test actions", () => {
 
     expect(event1.name).to.eql("testStatus")
     expect(event1.payload.moduleName).to.eql("module-a")
-    expect(event1.payload.actionUid).to.be.undefined
+    expect(event1.payload.actionUid).to.be.ok
     expect(event1.payload.state).to.eql("getting-status")
     expect(event1.payload.status.state).to.eql("unknown")
 
     expect(event2.name).to.eql("testStatus")
     expect(event1.payload.moduleName).to.eql("module-a")
-    expect(event2.payload.actionUid).to.be.undefined
+    expect(event2.payload.actionUid).to.eql(event1.payload.actionUid)
     expect(event2.payload.state).to.eql("ready")
     expect(event2.payload.status.state).to.eql("succeeded")
   })

--- a/core/test/unit/src/router/test.ts
+++ b/core/test/unit/src/router/test.ts
@@ -94,19 +94,20 @@ describe("test actions", () => {
       const testVersion = action.versionString()
       const event1 = garden.events.eventLog[0]
       const event2 = garden.events.eventLog[1]
+
       expect(event1).to.exist
-      expect(event1.name).to.eql("testStatus")
-      expect(event1.payload.testName).to.eql("test")
-      expect(event1.payload.actionName).to.eql("test")
-      expect(event1.payload.testVersion).to.eql(testVersion)
-      expect(event1.payload.actionUid).to.be.ok
-      expect(event1.payload.status.state).to.eql("running")
       expect(event2).to.exist
+
+      expect(event1.name).to.eql("testStatus")
+      expect(event1.payload.actionName).to.eql("test")
+      expect(event1.payload.actionUid).to.be.ok
+      expect(event1.payload.state).to.eql("processing")
+      expect(event1.payload.status.state).to.eql("running")
+
       expect(event2.name).to.eql("testStatus")
-      expect(event2.payload.testName).to.eql("test")
       expect(event2.payload.actionName).to.eql("test")
-      expect(event2.payload.testVersion).to.eql(testVersion)
       expect(event2.payload.actionUid).to.eql(event1.payload.actionUid)
+      expect(event2.payload.state).to.eql("ready")
       expect(event2.payload.status.state).to.eql("succeeded")
     })
 
@@ -176,7 +177,7 @@ describe("test actions", () => {
     })
   })
 
-  it("should emit a testStatus event", async () => {
+  it("should emit testStatus events", async () => {
     const action = await garden.resolveAction({ action: graph.getTest("module-a-unit"), log, graph })
     garden.events.eventLog = []
 
@@ -185,14 +186,22 @@ describe("test actions", () => {
       action,
       graph,
     })
-    const event = garden.events.eventLog[0]
+    const event1 = garden.events.eventLog[0]
+    const event2 = garden.events.eventLog[1]
 
-    expect(event).to.exist
-    expect(event.name).to.eql("testStatus")
-    expect(event.payload.testName).to.eql("module-a-unit")
-    expect(event.payload.moduleVersion).to.eql(module.version.versionString)
-    expect(event.payload.testVersion).to.eql(action.versionString())
-    expect(event.payload.actionUid).to.be.undefined
-    expect(event.payload.status.state).to.eql("succeeded")
+    expect(event1).to.exist
+    expect(event2).to.exist
+
+    expect(event1.name).to.eql("testStatus")
+    expect(event1.payload.moduleName).to.eql("module-a")
+    expect(event1.payload.actionUid).to.be.undefined
+    expect(event1.payload.state).to.eql("getting-status")
+    expect(event1.payload.status.state).to.eql("unknown")
+
+    expect(event2.name).to.eql("testStatus")
+    expect(event1.payload.moduleName).to.eql("module-a")
+    expect(event2.payload.actionUid).to.be.undefined
+    expect(event2.payload.state).to.eql("ready")
+    expect(event2.payload.status.state).to.eql("succeeded")
   })
 })

--- a/core/test/unit/src/router/test.ts
+++ b/core/test/unit/src/router/test.ts
@@ -201,7 +201,7 @@ describe("test actions", () => {
     expect(event2.name).to.eql("testStatus")
     expect(event1.payload.moduleName).to.eql("module-a")
     expect(event2.payload.actionUid).to.eql(event1.payload.actionUid)
-    expect(event2.payload.state).to.eql("ready")
+    expect(event2.payload.state).to.eql("cached")
     expect(event2.payload.status.state).to.eql("succeeded")
   })
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Here, we udpate and simplify the action status event payload types used to communicate with Cloud.

The event payload types have been streamlined and standardized. We now use `actionState` as the primary state indicator field, which should reduce the special-casing needed on the backend (since we can interpret a common sum type for status events from all the main action kinds).

The action states have also been documented thoroughly, which should help newcomers understand the larger flow more easily.

We now also generate action UIDs for individual task instances, enabling us to use the same UID for the status handler call and the processing handler call.

This way, the API can correlate a status check with its subsequent processing call (if any).

We'll be able to utilize this in the Cloud UI e.g.  for flame charts that capture the full lifecycle of the framework's primary action kinds.