### PR TITLE
chore(examples): update remote-k8s example to use actions

### DIFF
--- a/examples/remote-k8s/README.md
+++ b/examples/remote-k8s/README.md
@@ -21,7 +21,7 @@ You need to update the `remote` environment configuration in your project `garde
 Replace `my-context` with your configured `kubectl` context for the remote cluster, and `mycluster.example.com`
 with a hostname that points to the ingress controller on your cluster.
 
-If you don't have an ingress controller configured, you can add `setupIngressController: nginx` to the provider
+If you don't have an ingress controller configured, you can add `ingressClass: nginx` to the provider
 configuration, but you will then still need to work out your DNS to route requests to the cluster (how best to do
 that varies quite a bit by how you're hosting the cluster).
 
@@ -54,10 +54,4 @@ Once you've completed the above, you can run deploy the project to the `remote` 
 
 ```sh
 garden --env=remote deploy
-```
-
-And then try sending a simple request using:
-
-```sh
-garden --env=remote call node-service/hello
 ```

--- a/examples/remote-k8s/README.md
+++ b/examples/remote-k8s/README.md
@@ -1,8 +1,7 @@
 # Remote Kubernetes example project
 
 This project shows how you can configure Garden to work against a remote Kubernetes cluster, in addition to a local
-cluster. We also go through how to configure TLS for your `container` services, and set up
-[in-cluster building](https://docs.garden.io/kubernetes-plugins/advanced/in-cluster-building).
+cluster. We also set up [in-cluster building](https://docs.garden.io/kubernetes-plugins/advanced/in-cluster-building).
 
 The example follows the [Remote Kubernetes guide](https://docs.garden.io/guides/remote-kubernetes). Please look
 at the guide for more details on how to configure your own project.
@@ -25,21 +24,7 @@ If you don't have an ingress controller configured, you can add `ingressClass: n
 configuration, but you will then still need to work out your DNS to route requests to the cluster (how best to do
 that varies quite a bit by how you're hosting the cluster).
 
-### Step 2 - Get a certificate for your cluster hostname
-
-How you do this will depend on how you generally manage DNS. Basically, you need a valid TLS certificate and key for
-the hostname you configured above. If you don't have a prior preference on how to create certificates, we suggest using
-Let's Encrypt's [certbot](https://certbot.eff.org) and using the `certonly` option to generate certs.
-
-### Step 3 - Configure the certificate in your Kubernetes installation
-
-Create a Kubernetes Secret with your generated certificate and key (replace the filenames appropriately).
-
-```sh
-kubectl create secret tls garden-example --key my.key --cert my.crt
-```
-
-### Step 4 - Initialize cluster-wide services
+### Step 2 - Initialize cluster-wide services
 
 To start the services Garden needs to build images in your cluster, run the following command:
 
@@ -47,7 +32,7 @@ To start the services Garden needs to build images in your cluster, run the foll
 garden --env=remote plugins kubernetes cluster-init
 ```
 
-## Usage
+## Step 3 - Usage
 
 Once you've completed the above, you can run deploy the project to the `remote` environment, by setting the
 `--env` flag when running `garden` (or you can change the `defaultEnvironment` entry in your `garden.yml`):

--- a/examples/remote-k8s/garden.yml
+++ b/examples/remote-k8s/garden.yml
@@ -15,12 +15,6 @@ providers:
     environments: [remote]
     context: my-remote-context
     defaultHostname: my-cluster.example.com # change this to the hostname that points to your cluster
-    forceSsl: true
-    tlsCertificates:
-      - name: garden-example-tls
-        secretRef:
-          name: garden-example-tls
-          namespace: default
     buildMode: kaniko
     # Replace the below values as appropriate
     deploymentRegistry:

--- a/examples/remote-k8s/garden.yml
+++ b/examples/remote-k8s/garden.yml
@@ -1,18 +1,20 @@
 kind: Project
-name: local-tls
+name: remote-k8s
 defaultEnvironment: local
+
 environments:
   - name: local
-    # you can run garden against this environment by adding "--env remote" to your commands,
-    # e.g. garden --env remote deploy
+  # you can run garden against this environment by adding "--env remote" to your commands,
+  # e.g. garden --env remote deploy
   - name: remote
+
 providers:
   - name: local-kubernetes
     environments: [local]
   - name: kubernetes
     environments: [remote]
     context: my-remote-context
-    defaultHostname: my-cluster.example.com   # change this to the hostname that points to your cluster
+    defaultHostname: my-cluster.example.com # change this to the hostname that points to your cluster
     forceSsl: true
     tlsCertificates:
       - name: garden-example-tls
@@ -22,8 +24,8 @@ providers:
     buildMode: kaniko
     # Replace the below values as appropriate
     deploymentRegistry:
-      hostname: eu.gcr.io    # <- set this according to the region your cluster runs in
-      namespace: garden-ci   # <- set this to the project ID of the target cluster
+      hostname: eu.gcr.io # <- set this according to the region your cluster runs in
+      namespace: garden-ci # <- set this to the project ID of the target cluster
     imagePullSecrets:
       # Make sure this matches the name and namespace of the imagePullSecret you've created
       # to authenticate with your registry (if needed)

--- a/examples/remote-k8s/services/go-service/garden.yml
+++ b/examples/remote-k8s/services/go-service/garden.yml
@@ -1,12 +1,18 @@
-kind: Module
+kind: Build
 name: go-service
-description: Go service container
 type: container
-services:
-  - name: go-service
-    ports:
-      - name: http
-        containerPort: 80
-    ingresses:
-      - path: /
-        port: http
+description: Go service container
+
+---
+kind: Deploy
+name: go-service
+type: container
+description: Go service container
+build: go-service
+spec:
+  ports:
+    - name: http
+      containerPort: 80
+  ingresses:
+    - path: /
+      port: http

--- a/examples/remote-k8s/services/node-service/app.js
+++ b/examples/remote-k8s/services/node-service/app.js
@@ -1,28 +1,29 @@
-const express = require('express');
-const request = require('request-promise')
-const app = express();
+const express = require("express")
+const request = require("request-promise")
+const app = express()
 
 // Unless configured otherwise, the hostname is simply the service name
-const goServiceEndpoint = `http://go-service/`;
+const goServiceEndpoint = `http://go-service/`
 
-app.get('/hello', (req, res) => res.send('Hello from Node service!'));
+app.get("/hello", (req, res) => res.send("Hello from Node service!"))
 
-app.get('/call-go-service', (req, res) => {
+app.get("/call-go-service", (req, res) => {
   // Query the go-service and return the response
-  request.get(goServiceEndpoint)
-    .then(message => {
+  request
+    .get(goServiceEndpoint)
+    .then((message) => {
       message = `Go says: '${message}'`
       res.json({
         message,
       })
     })
-    .catch(err => {
+    .catch((err) => {
       res.statusCode = 500
       res.json({
         error: err,
         message: "Unable to reach service at " + goServiceEndpoint,
       })
-    });
-});
+    })
+})
 
 module.exports = { app }

--- a/examples/remote-k8s/services/node-service/garden.yml
+++ b/examples/remote-k8s/services/node-service/garden.yml
@@ -1,24 +1,41 @@
-kind: Module
+kind: Build
 name: node-service
-description: Node service container
 type: container
-services:
-  - name: node-service
-    args: [npm, start]
-    ports:
-      - name: http
-        containerPort: 8080
-    ingresses:
-      - path: /hello
-        port: http
-      - path: /call-go-service
-        port: http
-    dependencies:
-      - go-service
-tests:
-  - name: unit
-    args: [npm, test]
-  - name: integ
-    args: [npm, run, integ]
-    dependencies:
-      - go-service
+description: Node service container
+
+---
+kind: Deploy
+name: node-service
+type: container
+description: Node service
+build: node-service
+dependencies:
+  - deploy.go-service
+spec:
+  args: [npm, start]
+  ports:
+    - name: http
+      containerPort: 8080
+  ingresses:
+    - path: /hello
+      port: http
+    - path: /call-go-service
+      port: http
+
+---
+kind: Test
+name: node-service-unit
+type: container
+build: node-service
+spec:
+  args: [npm, test]
+
+---
+kind: Test
+name: node-service-integ
+type: container
+build: node-service
+dependencies:
+  - deploy.node-service
+spec:
+  args: [npm, run, integ]


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes https://github.com/garden-io/garden/issues/3846

**Special notes for your reviewer**:

I have now tested this enough with a GKE cluster to be personally comfortable with merging this.
Deploying and remote builds work, and the services are accessible via a custom hostname - with some not-committed, local changes required to the configuration, as per instructions.

I have also removed the mention of TLS configuration in the example, to keep this focused on the remote builds and deployments. We have other examples for `cert-manager` use, and using a load balancer for TLS termination is another viable choice for production workloads - either of which should be better than manually setting kube secrets.

Squashing before merging.