### PR TITLE
chore: allow slightly longer commit messages

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,19 +1,12 @@
 module.exports = {
-  extends: ['@commitlint/config-conventional'],
+  extends: ["@commitlint/config-conventional"],
   rules: {
     // Extend to add improvement key
-    "type-enum": [2, "always", [
-      "chore",
-      "ci",
-      "docs",
-      "feat",
-      "fix",
-      "improvement",
-      "perf",
-      "refactor",
-      "revert",
-      "style",
-      "test",
-    ]]
-  }
-};
+    "type-enum": [
+      2,
+      "always",
+      ["chore", "ci", "docs", "feat", "fix", "improvement", "perf", "refactor", "revert", "style", "test"],
+    ],
+    "header-max-length": [2, "always", 120],
+  },
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

While concise commit messages are a good goal to strive for, 72 characters is incredibly limiting when function names, type names, file names and similar are involved. 120 characters could probably be a happy medium.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Re-formatting done by prettier and eslint.
