### PR TITLE
ci: add edge-bonsai tag to image release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -522,6 +522,11 @@ jobs:
             if [[ "$TAG" == "$CIRCLE_TAG" ]] && [[ $VERSION != *"-"* ]]; then
               ./scripts/push-containers.sh latest
             fi
+            # Push again with bonsai-edge tag for 0.13 branch
+            if [ "$CIRCLE_BRANCH" == "0.13" ]; then
+              ./scripts/push-containers.sh bonsai-edge
+            fi
+
   release-service-dist:
     <<: *release-config
     steps:
@@ -1074,13 +1079,20 @@ workflows:
       - build-dist-edge:
           <<: *only-main
           requires: [build]
-      - release-service-docker:
-          <<: *only-main
-          context: docker
-          requires: [build-dist-edge]
       - release-service-dist-edge:
           <<: *only-main
           requires: [build-dist-edge]
+
+      ### MAIN AND 0.13 ###
+      - release-service-docker:
+          context: docker
+          requires: [build-dist-edge]
+          filters:
+            branches:
+              only:
+                - main
+                - "0.13"
+              ignore: /.*/
 
   tags:
     jobs:


### PR DESCRIPTION
**What this PR does / why we need it**:

For testing edge-bonsai it would be good to build and release container images for use where CI depends on a container image e.g. GitLab CI. Users sourcing the Garden binary as part of a multi-stage Dockerfile strategy should also be pleased with the option to have an edge release available.

**Special notes for your reviewer**:

Literally my first commit to Garden: be gentle 🌷 
