### PR TITLE
ci: add garden as node user

### DIFF
--- a/support/alpine.Dockerfile
+++ b/support/alpine.Dockerfile
@@ -15,10 +15,11 @@ RUN apk add --no-cache \
   libstdc++
 
 # Note: This is run with the dist/alpine-amd64 directory as the context root
-ADD . /garden
+ADD --chown=node:node . /garden
 
 WORKDIR /project
 
+USER node
 RUN chmod +x /garden/garden \
   && ln -s /garden/garden /bin/garden \
   && chmod +x /bin/garden \

--- a/support/buster.Dockerfile
+++ b/support/buster.Dockerfile
@@ -22,10 +22,11 @@ RUN set -ex; \
   rm -rf /var/lib/apt/lists/*;
 
 # Note: This Dockerfile is run with dist/linux-amd64 as the context root
-ADD . /garden
+ADD --chown=node:node . /garden
 
 WORKDIR /project
 
+USER node
 RUN ln -s /garden/garden /bin/garden \
   && chmod +x /bin/garden \
   && cd /garden/static \


### PR DESCRIPTION
**What this PR does / why we need it**:

Our Dockerfiles [extend the Node Docker image](https://github.com/nodejs/docker-node/blob/3bd9718274b8dd92ed4e6719ecedcfa4b476252a/docs/BestPractices.md#non-root-user). Users who wish to use our container image in CI or as a Dev Container base image must run 
```sh
    - git config --global --add safe.directory $CI_PROJECT_DIR
```
as in https://gitlab.hansen.agency/worldofgeese/little_bits_of_buddha/-/blob/main/.gitlab-ci.yml before running any Garden commands in CI that interact with `/garden/static`.

The Node base image does ship with a user named `node`. So we should be able to get away with running the container as the node user. See the [Node Dockerfile team's own advice on this](https://github.com/nodejs/docker-node/blob/3bd9718274b8dd92ed4e6719ecedcfa4b476252a/docs/BestPractices.md#non-root-user).

When runners run with non-root UIDs such as GitLab's Runner Operator which runs as 1001, images must also run as a non-root user to succeed

```sh
$ garden run workflow my-workflow --env=ci
[debug] Setting log level to debug (from GARDEN_LOG_LEVEL)
[debug] Setting logger type to basic (from GARDEN_LOGGER_TYPE)
Running workflow my-workflow 
[debug] Cloud/Enterprise domain not configured. Aborting.
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🌍  Running in namespace lbob-195 in environment ci
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
[debug] Scanning project root at /builds/worldofgeese/little_bits_of_buddha
→ Includes: **/*garden.y*ml
→ Excludes: .garden/**/*,.git,.gitmodules,.garden/**/*,debug-info*/**
[debug] Found 3 files in project root /builds/worldofgeese/little_bits_of_buddha
Running step 1/4 — Test dubious ownership
════════════════════════════════════════════════════════════════════════════════
total 236K   
drwxrwxrwx    9 1001     root        4.0K Mar  2 08:40 .
drwxrwxrwx    4 1001     root          68 Mar  2 08:40 ..
-rw-rw-rw-    1 1001     root         613 Mar  2 08:40 .envrc
drwxr-xr-x    4 root     root          80 Mar  2 08:40 .garden
drwxrwxrwx    6 1001     root         128 Mar  2 08:40 .git
-rw-rw-rw-    1 1001     root         176 Mar  2 08:40 .gitignore
-rw-rw-rw-    1 1001     root         168 Mar  2 08:40 .gitlab-ci.yml
-rw-rw-rw-    1 1001     root           5 Mar  2 08:40 .python-version
-rw-rw-rw-    1 1001     root       33.7K Mar  2 08:40 LICENSE
-rw-rw-rw-    1 1001     root        2.1K Mar  2 08:40 README.org
drwxrwxrwx    2 1001     root          32 Mar  2 08:40 conf
-rw-rw-rw-    1 1001     root         299 Mar  2 08:40 devbox.json
drwxrwxrwx    2 1001     root          79 Mar  2 08:40 docs
drwxrwxrwx    2 1001     root          90 Mar  2 08:40 little_bits_of_buddha_worldofgeese
-rw-rw-rw-    1 1001     root        1.3K Mar  2 08:40 modules.garden.yml
-rw-rw-rw-    1 1001     root      149.6K Mar  2 08:40 pdm.lock
-rw-rw-rw-    1 1001     root        1.4K Mar  2 08:40 project.garden.yml
-rw-rw-rw-    1 1001     root         969 Mar  2 08:40 pyproject.toml
-rw-rw-rw-    1 1001     root          36 Mar  2 08:40 pyrightconfig.json
drwxrwxrwx    2 1001     root          53 Mar  2 08:40 terraform
drwxrwxrwx    2 1001     root          53 Mar  2 08:40 tests
-rw-rw-rw-    1 1001     root         428 Mar  2 08:40 workflows.garden.yml

[debug] Error reading safe directories from the .gitconfig: Error: Command "git config --get-all safe.directory" failed with code 1:
Unexpected Git error occurred while running 'git status' from path "/builds/worldofgeese/little_bits_of_buddha". Exit code: 128. Error message: fatal: detected dubious ownership in repository at '/builds/worldofgeese/little_bits_of_buddha'
To add an exception for this directory, call:
	git config --global --add safe.directory /builds/worldofgeese/little_bits_of_buddha
[debug] Done flushing all events and log entries.
Command "git status" failed with code 128:
   fatal: detected dubious ownership in repository at '/builds/worldofgeese/little_bits_of_buddha'
To add an exception for this directory, call:
	git config --global --add safe.directory /builds/worldofgeese/little_bits_of_buddha
```

Relevant part of the [GitLab Runner Operator docs](https://docs.gitlab.com/runner/configuration/configuring_runner_operator.html#root-vs-non-root):

>  The GitLab Runner Operator and the GitLab Runner pod run as non-root users. As a result, the build image used in the job would need to run as a non-root user to be able to complete successfully. This is to ensure that jobs can run successfully with the least permission. However, for this to work, the build image used for the CI jobs also needs to be built to run as non-root and should not write to a restricted filesystem. Keep in mind that most container filesystems on an OpenShift cluster will be read-only, except for mounted volumes, /var/tmp, /tmp and other volumes mounted on the root filesystem as tmpfs.

And here's the GitLab Runner Operator [Dockerfile](https://gitlab.com/gitlab-org/gl-openshift/gitlab-runner-operator/-/blob/master/Dockerfile#L41)

I've tested this successfully in a Dev Container [Dockerfile](https://gitlab.hansen.agency/worldofgeese/little_bits_of_buddha/-/blob/18-extract-nikayas-to-tokenized-csv/prebuild-devcontainer/Dockerfile#L11) that suffered from the same issue

**Special notes for your reviewer**:

Because these Dockerfiles rely on CI-generated artifacts to run, I'd appreciate any advice on getting out test images from CI to validate my work.

There is also a [Slack thread](https://garden-io.slack.com/archives/C010P7ZCE9H/p1677679832412999) if you wish to follow the conversation. 
