### PR TITLE
refactor(cli): remove some aliases for CLI options

### DIFF
--- a/core/src/cli/params.ts
+++ b/core/src/cli/params.ts
@@ -381,14 +381,10 @@ export function describeParameters(args?: Parameters) {
 
 export const globalOptions = {
   "root": new PathParameter({
-    // TODO: remove this alias in 0.13?
-    aliases: ["r"],
     help:
       "Override project root directory (defaults to working directory). Can be absolute or relative to current directory.",
   }),
   "silent": new BooleanParameter({
-    // TODO: remove this alias in 0.13?
-    aliases: ["s"],
     help: "Suppress log output. Same as setting --logger-type=quiet.",
     defaultValue: false,
     cliOnly: true,

--- a/core/src/commands/unlink/module.ts
+++ b/core/src/commands/unlink/module.ts
@@ -26,8 +26,6 @@ const unlinkModuleArguments = {
 const unlinkModuleOptions = {
   all: new BooleanParameter({
     help: "Unlink all modules.",
-    // TODO: remove this alias in 0.13
-    aliases: ["a"],
   }),
 }
 

--- a/core/src/commands/unlink/source.ts
+++ b/core/src/commands/unlink/source.ts
@@ -26,8 +26,6 @@ const unlinkSourceArguments = {
 const unlinkSourceOptions = {
   all: new BooleanParameter({
     help: "Unlink all sources.",
-    // TODO: remove this alias in 0.13
-    aliases: ["a"],
   }),
 }
 


### PR DESCRIPTION
BREAKING CHANGE:

Some aliases for CLI options have been permanently removed and are no longer supported:
* `-r` for `--root`
* `-s` for `--silent`
* `-a` for `--all` in `garden unlink module` and `garden unlink source` commands

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
