### PR TITLE
fix: edge-bonsai-docker-release-0.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1162,7 +1162,6 @@ workflows:
               only:
                 - main
                 - "0.13"
-              ignore: /.*/
 
   tags:
     jobs:


### PR DESCRIPTION
Fixes #3868 by increasing filter to include `build-dist-edge-bonsai`. From [CircleCI's reference](https://circleci.com/docs/configuration-reference/#requires):

> A list of jobs that must succeed for the job to start. Note: When jobs in the current workflow that are listed as dependencies are not executed (due to a filter function for example), their requirement as a dependency for other jobs will be ignored by the requires option. However, if all dependencies of a job are filtered, then that job will not be executed either.