### PR TITLE
ci: clean-up docker tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -417,10 +417,14 @@ jobs:
             if [ "$CIRCLE_BRANCH" == "0.13" ]; then
               ./scripts/push-containers.sh bonsai-edge
             fi
+            # Get remote image digest of pushed container
+            DIGEST=$(docker inspect --format='{{.RepoDigests}}' gardendev/garden:bonsai-edge-buster | tr -d '[]')
+            echo "export DIGEST=$DIGEST" >> $BASH_ENV
 
   test-docker-gcloud:
     docker:
-      - image: gardendev/garden-gcloud:latest
+    # Use remote image digest from previous job
+      - image: $DIGEST
         environment:
           <<: *shared-env-config
           GARDEN_TASK_CONCURRENCY_LIMIT: "10"
@@ -835,7 +839,7 @@ workflows:
       # - test-docker-gcloud:
       #     <<: *only-internal-prs
       #     context: docker
-      #     requires: [build-docker-gcloud]
+      #     requires: [release-service-docker]
       - test-framework:
           requires: [build]
       - test-dist:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -397,114 +397,30 @@ jobs:
       - cleanup_remote_cluster:
           filter: <<parameters.project>>-testing-ci-$CIRCLE_BUILD_NUM-e2e
 
-  build-docker-alpine:
+  release-service-docker:
     <<: *node-config
     steps:
       - *remote-docker
       - checkout
+      # This is to copy the pre-built code from a previous step
       - *attach-workspace
       - docker_login
-      - run:
-          name: Build image and push to registry
+      # TODO: use garden publish here
+      - deploy:
+          name: Release docker images
           command: |
-            TAG=gardendev/garden:${CIRCLE_SHA1}
-            docker build -t ${TAG} -f support/alpine.Dockerfile dist/alpine-amd64
-            docker push ${TAG}
-  build-docker-aws:
-    <<: *node-config
-    steps:
-      - *remote-docker
-      - checkout
-      - *attach-workspace
-      - docker_login
-      - run:
-          name: Build image and push to registry
-          command: |
-            TAG=gardendev/garden:${CIRCLE_SHA1}-aws
-            docker build -t ${TAG} --build-arg TAG=${CIRCLE_SHA1} -f support/aws.Dockerfile dist/alpine-amd64
-            docker push ${TAG}
-  build-docker-azure:
-    <<: *node-config
-    steps:
-      - *remote-docker
-      - checkout
-      - *attach-workspace
-      - docker_login
-      - run:
-          name: Build image and push to registry
-          command: |
-            TAG=gardendev/garden:${CIRCLE_SHA1}-azure
-            docker build -t ${TAG} --build-arg TAG=${CIRCLE_SHA1} -f support/azure.Dockerfile dist/alpine-amd64
-            docker push ${TAG}
-  build-docker-gcloud:
-    <<: *node-config
-    steps:
-      - *remote-docker
-      - checkout
-      - *attach-workspace
-      - docker_login
-      - run:
-          name: Build image and push to registry
-          command: |
-            TAG=gardendev/garden:${CIRCLE_SHA1}-gcloud
-            docker build -t ${TAG} --build-arg TAG=${CIRCLE_SHA1} -f support/gcloud.Dockerfile dist/alpine-amd64
-            docker push ${TAG}
-  build-docker-aws-gcloud:
-    <<: *node-config
-    steps:
-      - *remote-docker
-      - checkout
-      - *attach-workspace
-      - docker_login
-      - run:
-          name: Build image and push to registry
-          command: |
-            TAG=gardendev/garden:${CIRCLE_SHA1}-aws-gcloud
-            docker build -t ${TAG} --build-arg TAG=${CIRCLE_SHA1} -f support/aws-gcloud.Dockerfile dist/alpine-amd64
-            docker push ${TAG}
-  build-docker-aws-gcloud-azure:
-    <<: *node-config
-    steps:
-      - *remote-docker
-      - checkout
-      - *attach-workspace
-      - docker_login
-      - run:
-          name: Build image and push to registry
-          command: |
-            TAG=gardendev/garden:${CIRCLE_SHA1}-aws-gcloud-azure
-            docker build -t ${TAG} --build-arg TAG=${CIRCLE_SHA1} -f support/aws-gcloud-azure.Dockerfile dist/alpine-amd64
-            docker push ${TAG}
-  build-docker-full:
-    <<: *node-config
-    steps:
-      - *remote-docker
-      - checkout
-      - *attach-workspace
-      - docker_login
-      - run:
-          name: Build image and push to registry
-          command: |
-            TAG=gardendev/garden:${CIRCLE_SHA1}-full
-            docker build -t ${TAG} --build-arg TAG=${CIRCLE_SHA1} -f support/full.Dockerfile dist/alpine-amd64
-            docker push ${TAG}
-  build-docker-buster:
-    <<: *node-config
-    steps:
-      - *remote-docker
-      - checkout
-      - *attach-workspace
-      - docker_login
-      - run:
-          name: Build image and push to registry
-          command: |
-            TAG=gardendev/garden:${CIRCLE_SHA1}-buster
-            docker build -t ${TAG} -f support/buster.Dockerfile dist/linux-amd64
-            docker push ${TAG}
+            # Push with latest tag for non-pre-release tags
+            if [[ "$TAG" == "$CIRCLE_TAG" ]] && [[ $VERSION != *"-"* ]]; then
+              ./scripts/push-containers.sh latest
+            fi
+            # Push again with bonsai-edge tag for 0.13 branch
+            if [ "$CIRCLE_BRANCH" == "0.13" ]; then
+              ./scripts/push-containers.sh bonsai-edge
+            fi
 
   test-docker-gcloud:
     docker:
-      - image: gardendev/garden:${CIRCLE_SHA1}-gcloud
+      - image: gardendev/garden-gcloud:latest
         environment:
           <<: *shared-env-config
           GARDEN_TASK_CONCURRENCY_LIMIT: "10"
@@ -519,31 +435,6 @@ jobs:
           command: CIRCLE_BUILD_NUM=$CIRCLE_BUILD_NUM-docker /garden/garden build --root examples/demo-project --env remote --logger-type basic
       - cleanup_remote_cluster:
           filter: $CIRCLE_BUILD_NUM-docker
-
-  release-service-docker:
-    <<: *node-config
-    steps:
-      - *remote-docker
-      - checkout
-      # This is to copy the pre-built code from a previous step
-      - *attach-workspace
-      - docker_login
-      # TODO: use garden publish here
-      - deploy:
-          name: Release docker images
-          command: |
-            # Switches between git tag and main for releases
-            TAG=${CIRCLE_TAG:-main}
-            # Push the container
-            ./scripts/push-containers.sh $TAG
-            # Push again with latest tag for non-pre-release tags
-            if [[ "$TAG" == "$CIRCLE_TAG" ]] && [[ $VERSION != *"-"* ]]; then
-              ./scripts/push-containers.sh latest
-            fi
-            # Push again with bonsai-edge tag for 0.13 branch
-            if [ "$CIRCLE_BRANCH" == "0.13" ]; then
-              ./scripts/push-containers.sh bonsai-edge
-            fi
 
   release-service-dist:
     <<: *release-config


### PR DESCRIPTION
This stops git hashes from proliferating in our Docker Hub by removing any step that pushes a git hash. Building is already taken care of by our push-containers.sh scripts which itself calls build-containers.sh.

We want to move to images for clouds (AWS, GCP, etc.) as an image tag for 0.13.  This does not address that. This also tests using `latest` which is not in any way ideal when any number of image builds could be competing for the tag.