### PR TITLE
chore: fix discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://garden.io/blog/?utm_source=github">Blog</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://discord.gg/gxeuDgp6Xt">Discord</a>
+  <a href="https://discord.gg/FrmhuUjFs6">Discord</a>
 </div>
 
 ### **What is Garden?**


### PR DESCRIPTION
The old Discord invite link had expired.
This new link should point new members directly to the rules channel, and never expire.
We should edit our website to have this new link as well: https://discord.gg/FrmhuUjFs6