### PR TITLE
improvement(container): redeploy when spec changes

### DIFF
--- a/core/src/graph/solver.ts
+++ b/core/src/graph/solver.ts
@@ -477,7 +477,7 @@ export class GraphSolver extends TypedEventEmitter<SolverEvents> {
   }
 
   private logTaskError(node: TaskNode, err: Error) {
-    const prefix = `Failed to ${node.describe()}. Here is the output:`
+    const prefix = `Failed ${node.describe()}. Here is the output:`
     this.logError(node.task.log, err, prefix)
   }
 

--- a/core/src/plugins/kubernetes/kubectl.ts
+++ b/core/src/plugins/kubernetes/kubectl.ts
@@ -131,14 +131,7 @@ export async function apply({
   }
 }
 
-export async function deleteResources({
-  log,
-  ctx,
-  provider,
-  namespace,
-  resources,
-  includeUninitialized = false,
-}: {
+export async function deleteResources(params: {
   log: Log
   ctx: PluginContext
   provider: KubernetesProvider
@@ -146,7 +139,26 @@ export async function deleteResources({
   resources: KubernetesResource[]
   includeUninitialized?: boolean
 }) {
-  const args = ["delete", "--wait=true", "--ignore-not-found=true", ...resources.map(getResourceKey)]
+  const keys = params.resources.map(getResourceKey)
+  return deleteResourceKeys({ ...params, keys })
+}
+
+export async function deleteResourceKeys({
+  log,
+  ctx,
+  provider,
+  namespace,
+  keys,
+  includeUninitialized = false,
+}: {
+  log: Log
+  ctx: PluginContext
+  provider: KubernetesProvider
+  namespace: string
+  keys: string[]
+  includeUninitialized?: boolean
+}) {
+  const args = ["delete", "--wait=true", "--ignore-not-found=true", ...keys]
 
   includeUninitialized && args.push("--include-uninitialized")
 

--- a/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
@@ -178,7 +178,7 @@ export const getKubernetesDeployStatus: DeployActionHandler<"getStatus", Kuberne
   let {
     state,
     remoteResources,
-    deployedWithSyncMode: deployedWithDevMode,
+    deployedWithSyncMode,
     deployedWithLocalMode,
   } = await compareDeployedResources(k8sCtx, api, namespace, preparedManifests, log)
 
@@ -227,7 +227,7 @@ export const getKubernetesDeployStatus: DeployActionHandler<"getStatus", Kuberne
       state,
       version: state === "ready" ? action.versionString() : undefined,
       detail: { remoteResources },
-      syncMode: deployedWithDevMode,
+      syncMode: deployedWithSyncMode,
       localMode: deployedWithLocalMode,
       namespaceStatuses: [namespaceStatus],
       ingresses: getK8sIngresses(remoteResources),
@@ -293,6 +293,8 @@ export const kubernetesDeploy: DeployActionHandler<"deploy", KubernetesDeployAct
       modifiedResources = configured.updated
     }
 
+    // TODO: Similarly to `container` deployments, check if immutable fields have changed (and delete before
+    // redeploying, unless in a production environment).
     await apply({ log, ctx, api, provider: k8sCtx.provider, manifests: preparedManifests, pruneLabels })
     await waitForResources({
       namespace,

--- a/core/src/plugins/kubernetes/status/status.ts
+++ b/core/src/plugins/kubernetes/status/status.ts
@@ -14,8 +14,8 @@ import { sleep, deepMap } from "../../../util/util"
 import { KubeApi } from "../api"
 import { getAppNamespace } from "../namespace"
 import Bluebird from "bluebird"
-import { KubernetesResource, KubernetesServerResource, BaseResource } from "../types"
-import { zip, isArray, isPlainObject, pickBy, mapValues, flatten, cloneDeep, omit } from "lodash"
+import { KubernetesResource, KubernetesServerResource, BaseResource, KubernetesWorkload } from "../types"
+import { zip, isArray, isPlainObject, pickBy, mapValues, flatten, cloneDeep, omit, isEqual, keyBy } from "lodash"
 import { KubernetesProvider, KubernetesPluginContext } from "../config"
 import { isSubset } from "../../../util/is-subset"
 import { Log } from "../../../logger/log-entry"
@@ -26,6 +26,7 @@ import {
   V1PersistentVolumeClaim,
   V1Service,
   V1Container,
+  KubernetesObject,
 } from "@kubernetes/client-node"
 import dedent = require("dedent")
 import { getPods, getResourceKey, hashManifest } from "../util"
@@ -279,6 +280,11 @@ interface ComparisonResult {
   remoteResources: KubernetesResource[]
   deployedWithSyncMode: boolean
   deployedWithLocalMode: boolean
+  /**
+   * These resources have changes in `spec.selector`, and would need to be deleted before redeploying (since Kubernetes
+   * doesn't allow updates to immutable fields).
+   */
+  selectorChangedResourceKeys: string[]
 }
 
 /**
@@ -299,19 +305,23 @@ export async function compareDeployedResources(
     getDeployedResource(ctx, ctx.provider, resource, log)
   )
   const deployedResources = <KubernetesResource[]>maybeDeployedObjects.filter((o) => o !== null)
+  const manifestsMap = keyBy(manifests, (m) => getResourceKey(m))
+  const manifestKeys = Object.keys(manifestsMap)
+  const deployedMap = keyBy(deployedResources, (m) => getResourceKey(m))
 
   const result: ComparisonResult = {
     state: "unknown",
     remoteResources: <KubernetesResource[]>deployedResources.filter((o) => o !== null),
     deployedWithSyncMode: false,
     deployedWithLocalMode: false,
+    selectorChangedResourceKeys: detectChangedSpecSelector(manifestsMap, deployedMap),
   }
 
   const logDescription = (resource: KubernetesResource) => getResourceKey(resource)
 
-  const missingObjectNames = zip(manifests, maybeDeployedObjects)
-    .filter(([_, deployed]) => !deployed)
-    .map(([resource, _]) => logDescription(resource!))
+  const missingObjectNames = manifestKeys
+    .filter((k) => !deployedMap[k])
+    .map((k) => logDescription(manifestsMap[k]))
 
   if (missingObjectNames.length === manifests.length) {
     // All resources missing.
@@ -352,8 +362,9 @@ export async function compareDeployedResources(
 
   log.verbose(`Comparing expected and deployed resources...`)
 
-  for (let [newManifest, deployedResource] of zip(manifests, deployedResources) as KubernetesResource[][]) {
-    let manifest = cloneDeep(newManifest)
+  for (const key of Object.keys(manifestsMap)) {
+    let manifest = cloneDeep(manifestsMap[key])
+    let deployedResource = deployedMap[key]
 
     if (!manifest.metadata.annotations) {
       manifest.metadata.annotations = {}
@@ -364,11 +375,11 @@ export async function compareDeployedResources(
       delete manifest.metadata.annotations[gardenAnnotationKey("manifest-hash")]
     }
 
-    if (manifest.kind === "DaemonSet" || manifest.kind === "Deployment" || manifest.kind === "StatefulSet") {
-      if (isConfiguredForSyncMode(<SyncableResource>manifest)) {
+    if (isWorkloadResource(manifest)) {
+      if (isConfiguredForSyncMode(manifest)) {
         result.deployedWithSyncMode = true
       }
-      if (isConfiguredForLocalMode(<SyncableResource>manifest)) {
+      if (isConfiguredForLocalMode(manifest)) {
         result.deployedWithLocalMode = true
       }
     }
@@ -463,18 +474,42 @@ export function isConfiguredForLocalMode(resource: SyncableResource): boolean {
   return resource.metadata.annotations?.[gardenAnnotationKey("local-mode")] === "true"
 }
 
-export async function getDeployedResource(
+function isWorkloadResource(resource: KubernetesResource): resource is KubernetesWorkload {
+  return resource.kind === "Deployment" || resource.kind === "DaemonSet" || resource.kind === "StatefulSet" || resource.kind === "ReplicaSet"
+}
+
+type KubernetesResourceMap = { [key: string]: KubernetesResource }
+
+function detectChangedSpecSelector(manifestsMap: KubernetesResourceMap, deployedMap: KubernetesResourceMap): string[] {
+  const manifestKeys = Object.keys(manifestsMap)
+  const changedKeys: string[] = []
+  for (const k of manifestKeys) {
+    const manifest = manifestsMap[k]
+    const deployedResource = deployedMap[k]
+    if (
+      deployedResource // If no corresponding resource to the local manifest has been deployed, this will be undefined.
+      && isWorkloadResource(manifest)
+      && isWorkloadResource(deployedResource)
+      && !isEqual(manifest.spec.selector, deployedResource.spec.selector)
+    ) {
+      changedKeys.push(getResourceKey(manifest))
+    }
+  }
+  return changedKeys
+}
+
+export async function getDeployedResource<ResourceKind extends KubernetesObject>(
   ctx: PluginContext,
   provider: KubernetesProvider,
-  resource: KubernetesResource,
+  resource: KubernetesResource<ResourceKind>,
   log: Log
-): Promise<KubernetesResource | null> {
+): Promise<KubernetesResource<ResourceKind> | null> {
   const api = await KubeApi.factory(log, ctx, provider)
   const namespace = resource.metadata?.namespace || (await getAppNamespace(ctx, log, provider))
 
   try {
     const res = await api.readBySpec({ namespace, manifest: resource, log })
-    return <KubernetesResource>res
+    return <KubernetesResource<ResourceKind>>res
   } catch (err) {
     if (err.statusCode === 404) {
       return null

--- a/core/src/plugins/kubernetes/volumes/persistentvolumeclaim.ts
+++ b/core/src/plugins/kubernetes/volumes/persistentvolumeclaim.ts
@@ -19,7 +19,7 @@ import { ConfigureModuleParams } from "../../../plugin/handlers/Module/configure
 import { GardenModule } from "../../../types/module"
 import { KubernetesResource } from "../types"
 import { ConvertModuleParams } from "../../../plugin/handlers/Module/convert"
-import { DeployAction, DeployActionConfig } from "../../../actions/deploy"
+import { DeployAction, DeployActionConfig, ResolvedDeployAction } from "../../../actions/deploy"
 import { KubernetesDeployActionConfig } from "../kubernetes-type/config"
 import { DeployActionDefinition } from "../../../plugin/action-types"
 import { getKubernetesDeployStatus, kubernetesDeploy } from "../kubernetes-type/handlers"
@@ -201,8 +201,9 @@ function getKubernetesAction(action: Resolved<PersistentVolumeClaimAction>) {
     },
   }
 
-  return new DeployAction<KubernetesDeployActionConfig, {}>({
+  return new ResolvedDeployAction<KubernetesDeployActionConfig, {}>({
     ...action["params"],
     config,
+    spec: config.spec,
   })
 }

--- a/core/src/router/router.ts
+++ b/core/src/router/router.ts
@@ -11,7 +11,7 @@ import chalk from "chalk"
 import type { Garden } from "../garden"
 import type { Log } from "../logger/log-entry"
 import { GardenPlugin, ModuleTypeDefinition, PluginActionContextParams } from "../plugin/plugin"
-import { getServiceStatuses } from "../tasks/helpers"
+import { getDeployStatuses } from "../tasks/helpers"
 import { DeleteDeployTask, deletedDeployStatuses } from "../tasks/delete-deploy"
 import { DeployTask } from "../tasks/deploy"
 import { Profile } from "../util/profiling"
@@ -125,7 +125,7 @@ export class ActionRouter extends BaseRouter {
     )
     const { results } = await this.garden.processTasks({ tasks, log, throwOnError: true, statusOnly: true })
 
-    return getServiceStatuses(results)
+    return getDeployStatuses(results)
   }
 
   async deployMany({ graph, deployNames, force = false, forceBuild = false, log }: DeployManyParams) {

--- a/core/src/tasks/helpers.ts
+++ b/core/src/tasks/helpers.ts
@@ -54,7 +54,7 @@ export function getExecuteTaskForAction<T extends Action>(
   }
 }
 
-export function getServiceStatuses(dependencyResults: GraphResults): { [name: string]: DeployStatus } {
+export function getDeployStatuses(dependencyResults: GraphResults): { [name: string]: DeployStatus } {
   const deployResults = pickBy(dependencyResults.getMap(), (r) => r && r.type === "deploy")
   const statuses = mapValues(deployResults, (r) => omit(r!.result, "version") as DeployStatus)
   return mapKeys(statuses, (_, key) => splitLast(key, ".")[1])

--- a/core/test/integ/src/plugins/kubernetes/container/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/deployment.ts
@@ -13,6 +13,8 @@ import { KubeApi } from "../../../../../../src/plugins/kubernetes/api"
 import {
   createContainerManifests,
   createWorkloadManifest,
+  getDeploymentLabels,
+  handleChangedSelector,
 } from "../../../../../../src/plugins/kubernetes/container/deployment"
 import { KubernetesPluginContext, KubernetesProvider } from "../../../../../../src/plugins/kubernetes/config"
 import { V1ConfigMap, V1Secret } from "@kubernetes/client-node"
@@ -20,12 +22,11 @@ import { KubernetesResource, KubernetesWorkload } from "../../../../../../src/pl
 import { cloneDeep, keyBy } from "lodash"
 import { getContainerTestGarden } from "./container"
 import { DeployTask } from "../../../../../../src/tasks/deploy"
-import { getServiceStatuses } from "../../../../../../src/tasks/helpers"
 import { expectError, grouped } from "../../../../../helpers"
 import { kilobytesToString, millicpuToString } from "../../../../../../src/plugins/kubernetes/util"
 import { getDeployedImageId, getResourceRequirements } from "../../../../../../src/plugins/kubernetes/container/util"
 import { isConfiguredForSyncMode } from "../../../../../../src/plugins/kubernetes/status/status"
-import { ContainerDeployAction } from "../../../../../../src/plugins/container/moduleConfig"
+import { ContainerDeployAction, ContainerDeployActionConfig, ContainerDeployOutputs } from "../../../../../../src/plugins/container/moduleConfig"
 import { apply } from "../../../../../../src/plugins/kubernetes/kubectl"
 import { getAppNamespace } from "../../../../../../src/plugins/kubernetes/namespace"
 import { gardenAnnotationKey } from "../../../../../../src/util/string"
@@ -42,9 +43,13 @@ import {
   ProxySshKeystore,
 } from "../../../../../../src/plugins/kubernetes/local-mode"
 import stripAnsi = require("strip-ansi")
+import { getDeployStatuses } from "../../../../../../src/tasks/helpers"
+import { ResolvedDeployAction } from "../../../../../../src/actions/deploy"
+import { ActionRouter } from "../../../../../../src/router/router"
 
 describe("kubernetes container deployment handlers", () => {
   let garden: Garden
+  let router: ActionRouter
   let graph: ConfigGraph
   let ctx: KubernetesPluginContext
   let provider: KubernetesProvider
@@ -66,6 +71,7 @@ describe("kubernetes container deployment handlers", () => {
 
   const init = async (environmentName: string) => {
     garden = await getContainerTestGarden(environmentName)
+    router = await garden.getActionRouter()
     provider = <KubernetesProvider>await garden.resolveProvider(garden.log, "local-kubernetes")
     ctx = <KubernetesPluginContext>(
       await garden.getPluginContext({ provider, templateContext: undefined, events: undefined })
@@ -287,14 +293,14 @@ describe("kubernetes container deployment handlers", () => {
           name: "simple-service",
           annotations: { "garden.io/configured.replicas": "1" },
           namespace,
-          labels: { "garden.io/module": "simple-service", "garden.io/action": "deploy.simple-service" },
+          labels: getDeploymentLabels(action),
         },
         spec: {
-          selector: { matchLabels: { "garden.io/action": "deploy.simple-service" } },
+          selector: { matchLabels: { [gardenAnnotationKey("action")]: action.key() } },
           template: {
             metadata: {
               annotations: {},
-              labels: { "garden.io/module": "simple-service", "garden.io/action": "deploy.simple-service" },
+              labels: getDeploymentLabels(action),
             },
             spec: {
               containers: [
@@ -331,7 +337,7 @@ describe("kubernetes container deployment handlers", () => {
       })
     })
 
-    it("should attach service annotations to Pod template", async () => {
+    it("should attach Deploy annotations to Pod template", async () => {
       const action = await resolveDeployAction("simple-service")
       const namespace = provider.config.namespace!.name!
 
@@ -649,13 +655,13 @@ describe("kubernetes container deployment handlers", () => {
     })
   })
 
-  describe("deployContainerService", () => {
+  describe("k8sContainerDeploy", () => {
     context("local mode", () => {
       before(async () => {
         await init("local")
       })
 
-      it("should deploy a simple service", async () => {
+      it("should deploy a simple Deploy", async () => {
         const action = await resolveDeployAction("simple-service")
 
         const deployTask = new DeployTask({
@@ -672,7 +678,7 @@ describe("kubernetes container deployment handlers", () => {
         })
 
         const results = await garden.processTasks({ tasks: [deployTask], log: garden.log, throwOnError: true })
-        const statuses = getServiceStatuses(results.results)
+        const statuses = getDeployStatuses(results.results)
         const status = statuses[action.name]
         const resources = keyBy(status.detail?.detail["remoteResources"], "kind")
         expect(resources.Deployment.metadata.annotations["garden.io/version"]).to.equal(`${action.versionString()}`)
@@ -779,7 +785,7 @@ describe("kubernetes container deployment handlers", () => {
         })
 
         const results = await garden.processTasks({ tasks: [deployTask], log: garden.log, throwOnError: true })
-        const statuses = getServiceStatuses(results.results)
+        const statuses = getDeployStatuses(results.results)
         const status = statuses[action.name]
         expect(status.state).to.eql("ready")
       })
@@ -802,7 +808,7 @@ describe("kubernetes container deployment handlers", () => {
         })
 
         const results = await garden.processTasks({ tasks: [deployTask], log: garden.log, throwOnError: true })
-        const statuses = getServiceStatuses(results.results)
+        const statuses = getDeployStatuses(results.results)
         const status = statuses[action.name]
         const resources = keyBy(status.detail?.detail["remoteResources"], "kind")
 
@@ -837,7 +843,7 @@ describe("kubernetes container deployment handlers", () => {
         })
 
         const results = await garden.processTasks({ tasks: [deployTask], log: garden.log, throwOnError: true })
-        const statuses = getServiceStatuses(results.results)
+        const statuses = getDeployStatuses(results.results)
         const status = statuses[action.name]
         const resources = keyBy(status.detail?.detail["remoteResources"], "kind")
         expect(resources.Deployment.spec.template.spec.containers[0].image).to.equal(
@@ -846,4 +852,157 @@ describe("kubernetes container deployment handlers", () => {
       })
     })
   })
+
+  describe("handleChangedSelector", () => {
+    before(async () => {
+      await init("local")
+    })
+
+    const deploySpecChangedSimpleService = async (action: ResolvedDeployAction<ContainerDeployActionConfig, ContainerDeployOutputs>) => {
+      const namespace = provider.config.namespace!.name
+      const deploymentManifest = await createWorkloadManifest({
+        ctx,
+        api,
+        provider,
+        action,
+        imageId: getDeployedImageId(action, provider),
+        namespace,
+        enableSyncMode: false,
+        enableLocalMode: false,
+        log: garden.log,
+        production: false,
+      })
+
+      // Override to test spec change detection logic.
+      deploymentManifest.spec.selector.matchLabels = {
+        service: action.name,
+      }
+      deploymentManifest.metadata.labels = {
+        service: action.name,
+        module: action.name,
+      }
+      deploymentManifest.spec.template!.metadata!.labels = {
+        service: action.name,
+        module: action.name,
+      }
+
+      const pruneLabels = {
+        "service": action.name, // The pre-0.13 selector
+        [gardenAnnotationKey("action")]: action.key(), // The 0.13+ selector
+      }
+
+      await apply({ log: garden.log, ctx, api, provider, manifests: [deploymentManifest], namespace, pruneLabels })
+    }
+
+    const cleanupSpecChangedSimpleService = async (action: ResolvedDeployAction<ContainerDeployActionConfig, ContainerDeployOutputs>) => {
+      await api.apps.deleteNamespacedDeployment(action.name, provider.config.namespace!.name)
+    }
+
+    const simpleServiceIsRunning = async (action: ResolvedDeployAction<ContainerDeployActionConfig, ContainerDeployOutputs>) => {
+      try {
+        await api.apps.readNamespacedDeployment(action.name, provider.config.namespace!.name)
+        return true
+      } catch (err) {
+        if (err.statusCode === 404) {
+          return false
+        } else {
+          throw err
+        }
+      }
+    }
+
+    it("should redeploy if production = false", async () => {
+      const action = await resolveDeployAction("simple-service")
+      await deploySpecChangedSimpleService(action)
+      expect(await simpleServiceIsRunning(action)).to.eql(true)
+
+      const status = await router.deploy.getStatus({
+        graph,
+        action,
+        log: garden.log,
+        syncMode: false,
+        localMode: false
+      })
+
+      const specChangedResourceKeys: string[] = (status.detail?.detail.selectorChangedResourceKeys) || []
+      expect(specChangedResourceKeys).to.eql(["Deployment/simple-service"])
+
+      await handleChangedSelector({
+        action,
+        ctx,
+        namespace: provider.config.namespace!.name,
+        log: garden.log,
+        specChangedResourceKeys,
+        production: false, // <----
+        force: false,
+      })
+
+      expect(await simpleServiceIsRunning(action)).to.eql(false)
+    })
+
+    it("should redeploy if production = true anad force = true", async () => {
+      const action = await resolveDeployAction("simple-service")
+      await deploySpecChangedSimpleService(action)
+      expect(await simpleServiceIsRunning(action)).to.eql(true)
+
+      const status = await router.deploy.getStatus({
+        graph,
+        action,
+        log: garden.log,
+        syncMode: false,
+        localMode: false
+      })
+
+      const specChangedResourceKeys: string[] = (status.detail?.detail.selectorChangedResourceKeys) || []
+      expect(specChangedResourceKeys).to.eql(["Deployment/simple-service"])
+
+      await handleChangedSelector({
+        action,
+        ctx,
+        namespace: provider.config.namespace!.name,
+        log: garden.log,
+        specChangedResourceKeys,
+        production: true, // <----
+        force: true, // <---
+      })
+
+      expect(await simpleServiceIsRunning(action)).to.eql(false)
+    })
+
+    it("should not redeploy and throw an error if production = true anad force = false", async () => {
+      const action = await resolveDeployAction("simple-service")
+      await deploySpecChangedSimpleService(action)
+      expect(await simpleServiceIsRunning(action)).to.eql(true)
+
+      const status = await router.deploy.getStatus({
+        graph,
+        action,
+        log: garden.log,
+        syncMode: false,
+        localMode: false
+      })
+
+      const specChangedResourceKeys: string[] = (status.detail?.detail.selectorChangedResourceKeys) || []
+      expect(specChangedResourceKeys).to.eql(["Deployment/simple-service"])
+
+      await expectError(
+        () =>
+          handleChangedSelector({
+            action,
+            ctx,
+            namespace: provider.config.namespace!.name,
+            log: garden.log,
+            specChangedResourceKeys,
+            production: true, // <----
+            force: false, // <---
+          }),
+        (err) =>
+          expect(stripAnsi(err.message)).to.equal("Deploy simple-service was deployed with a different spec.selector and needs to be deleted before redeploying. Since this environment has production = true, Garden won't automatically delete this resource. To do so, use the --force flag when deploying e.g. with the garden deploy command. You can also delete the resource from your cluster manually and try again.")
+      )
+
+      expect(await simpleServiceIsRunning(action)).to.eql(true)
+      await cleanupSpecChangedSimpleService(action)
+    })
+  })
+
 })

--- a/core/test/integ/src/plugins/kubernetes/kubernetes-module/handlers.ts
+++ b/core/test/integ/src/plugins/kubernetes/kubernetes-module/handlers.ts
@@ -30,7 +30,7 @@ import {
 import Bluebird from "bluebird"
 import { buildHelmModules } from "../helm/common"
 import { gardenAnnotationKey } from "../../../../../../src/util/string"
-import { getServiceStatuses } from "../../../../../../src/tasks/helpers"
+import { getDeployStatuses } from "../../../../../../src/tasks/helpers"
 import { LocalModeProcessRegistry, ProxySshKeystore } from "../../../../../../src/plugins/kubernetes/local-mode"
 import { KubernetesDeployAction } from "../../../../../../src/plugins/kubernetes/kubernetes-type/config"
 import { DEFAULT_API_VERSION } from "../../../../../../src/constants"
@@ -343,7 +343,7 @@ describe("kubernetes-module handlers", () => {
         localModeDeployNames: [],
       })
       const results = await garden.processTasks({ tasks: [deployTask], throwOnError: true })
-      const status = getServiceStatuses(results.results)["namespace-resource"]
+      const status = getDeployStatuses(results.results)["namespace-resource"]
       ns1Resource = await getDeployedResource(ctx, ctx.provider, ns1Manifest!, log)
 
       expect(ns1Manifest, "ns1Manifest").to.exist


### PR DESCRIPTION
**What this PR does / why we need it**:

In 0.12, we had wanted to update the `selector.matchLabels` used for `container` deploys, but doing so would require redeploying those resources (since `spec.selector.matchLabels` is an immutable field).

In 0.13, we decided to simply automatically redeploy any `container` deploys if needed (unless the environment in question is a production environment), since we wanted to use different labels (e.g. `action` instead of `service`).

Deleting the resources before redeploying them is necessary in this case, since the `spec.selector` field is immutable and attempting to update it for running resources will simply result in an error).

We don't automatically do this for production environments, except when force-deploying (which is a framework-native way for users to redeploy services with full awareness what they're doing).

Also fixed a bug in the `persistentvolumeclaim` implementation where an unresolved action was returned instead of the resolved one (which led to errors at runtime during deployment).