### PR TITLE
ci: add dependabot docker and npm ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,21 @@
 
 version: 2
 updates:
-  # Maintain dependencies for GitHub Actions
+  # Automatically update GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "weekly"
+  # Automatically update Dockerfile FROM images
+  - package-ecosystem: "docker"
+    directory: "/"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "daily"
+  # Automatically update NPM packages
+  - package-ecosystem: "npm"
+    directory: "/"
+    open-pull-requests-limit: 3 # for now, once 0.13 landed we can increase this
     schedule:
       interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,18 +8,19 @@ updates:
   # Automatically update GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     schedule:
       interval: "weekly"
   # Automatically update Dockerfile FROM images
   - package-ecosystem: "docker"
     directory: "/"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     schedule:
       interval: "daily"
+  # TODO: Consider enabling the NPM package ecosystem once we have fixed our build process to support pure ESM build dependencies, see also https://github.com/garden-io/garden/issues/3841
   # Automatically update NPM packages
-  - package-ecosystem: "npm"
-    directory: "/"
-    open-pull-requests-limit: 3 # for now, once 0.13 landed we can increase this
-    schedule:
-      interval: "daily"
+  # - package-ecosystem: "npm"
+  #   directory: "/"
+  #   open-pull-requests-limit: 5
+  #   schedule:
+  #     interval: "daily"


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
This means more dependabot PRs, and hopefully less manual work keeping Dockerfiles up to date.

In some cases careful testing will be required before merging Docker PRs but at least we have a to-do list in the form of dependabot PRs.

With the npm package ecosystem, dependabot will also start suggesting more NPM updates, and not just the security updates (that's why I limited the number of them until 0.13 has landed).

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
