### PR TITLE
fix(docs): fix broken links

### DIFF
--- a/core/src/plugins/kubernetes/local/local.ts
+++ b/core/src/plugins/kubernetes/local/local.ts
@@ -20,7 +20,7 @@ export const gardenPlugin = () =>
     docs: dedent`
     The \`local-kubernetes\` provider is a specialized version of the [\`kubernetes\` provider](${providerUrl}) that automates and simplifies working with local Kubernetes clusters.
 
-    For general Kubernetes usage information, please refer to the [Kubernetes plugin section](${DOCS_BASE_URL}/kubernetes-plugins/about) in the docs. For local clusters a good place to start is the [Local Kubernetes guide](${DOCS_BASE_URL}/kubernetes-plugins/local-k8s) guide.
+    For general Kubernetes usage information, please refer to the [Kubernetes guides](${DOCS_BASE_URL}/kubernetes-plugins/about). For local clusters a good place to start is the [Local Kubernetes](${DOCS_BASE_URL}/kubernetes-plugins/local-k8s) guide. The [Quickstart Guide](${DOCS_BASE_URL}/basics/quickstart) guide is also helpful as an introduction.
 
     If you're working with a remote Kubernetes cluster, please refer to the [\`kubernetes\` provider](${providerUrl}) docs, and the [Remote Kubernetes guide](${DOCS_BASE_URL}/kubernetes-plugins/remote-k8s) guide.
   `,

--- a/core/src/plugins/kubernetes/volumes/configmap.ts
+++ b/core/src/plugins/kubernetes/volumes/configmap.ts
@@ -49,7 +49,7 @@ type ConfigmapAction = DeployAction<ConfigmapActionConfig, {}>
 const docs = dedent`
   Creates a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) in your namespace, that can be referenced and mounted by other resources and [container modules](./container.md).
 
-  See the [Mounting Kubernetes ConfigMaps](${DOCS_BASE_URL}/other-plugins/container#mounting-kubernetes-configmaps) guide for more info and usage examples.
+  See the [Mounting Kubernetes ConfigMaps](${DOCS_BASE_URL}/k8s-plugins/module-types/container#mounting-kubernetes-configmaps) guide for more info and usage examples.
 `
 
 export const configmapDeployDefinition = (): DeployActionDefinition<ConfigmapAction> => ({
@@ -88,7 +88,6 @@ export const configmapDeployDefinition = (): DeployActionDefinition<ConfigmapAct
 export const configMapModuleDefinition = (): ModuleTypeDefinition => ({
   name: "configmap",
   docs,
-
   schema: joi.object().keys({
     build: baseBuildSpecSchema(),
     dependencies: joiSparseArray(joiIdentifier()).description(

--- a/core/src/util/validateInstall.ts
+++ b/core/src/util/validateInstall.ts
@@ -23,7 +23,7 @@ function versionCheckError(params: BinaryVersionCheckParams, msg: string, detail
     deline`
       ${msg}
       Please make sure ${params.name} (version ${params.minVersion} or later) is installed and on your PATH.
-      More about garden installation and requirements can be found in our documentation at https://docs.garden.io/guides/installation#requirements
+      More about garden installation and requirements can be found in our documentation at https://docs.garden.io/guides/installation
       `,
     detail
   )

--- a/docs/basics/how-garden-works.md
+++ b/docs/basics/how-garden-works.md
@@ -95,10 +95,10 @@ It’s the plugins that determine what happens when you run a given Garden comma
 
 You can for example use the Kubernetes plugin to install your Helm charts and apply your Kubernetes manifests, and the Terraform plugin to provision infrastructure.
 
-For more detail on how some common plugins work, see below:
+For more detail on how some common plugins work, see for example:
 
-- How the Kubernetes plugin works
-- How the Terraform plugin works
+- [How the Kubernetes plugin works](../k8s-plugins/about.md)
+- [How the Terraform plugin works](../terraform-plugin/about.md)
 
 We will be adding more plugins and releasing a Plugin SDK (exact timeline TBD) which will allow the community to maintain their own Garden plugins.
 

--- a/docs/k8s-plugins/module-types/container.md
+++ b/docs/k8s-plugins/module-types/container.md
@@ -41,7 +41,7 @@ This, first of all, tells Garden that it should deploy the built `frontend` cont
 
 If you need to use advanced (or otherwise very specific) features of the underlying platform, you may need to use more platform-specific module types (e.g. `kubernetes` or `helm`). The `container` module type is not intended to capture all those features.
 
-### Environment variables
+## Environment variables
 
 Container services can specify environment variables, using the `services[].env` field:
 
@@ -61,7 +61,7 @@ services:
 
 `env` is a simple mapping of "name: value". Above, we see a simple example with a string value, but you'll also commonly use [template strings](../../using-garden/variables-and-templating.md#template-string-basics) to interpolate variables to be consumed by the container service.
 
-#### Secrets
+### Secrets
 
 As of Garden v0.10.1 you can reference secrets in environment variables. For Kubernetes, this translates to `valueFrom.secretKeyRef` fields in the Pod specs, which direct Kubernetes to mount values from `Secret` resources that you have created in the application namespace, as environment variables in the Pod.
 

--- a/docs/k8s-plugins/remote-k8s/configure-provider.md
+++ b/docs/k8s-plugins/remote-k8s/configure-provider.md
@@ -77,8 +77,4 @@ And that's it! Your Kubernetes plugin is now configured
 and you can proceed to deploying your project to
 Kubernetes with Garden.
 
-If you're coming here from our [Your First Project guide](https://docs.garden.io/tutorials/your-first-project) you can now proceed with it.
-
-Otherwise we recommend heading to the [Kubernetes Module
-Types](../module-types/README.md) guide to learn how you can use
-different types with your Garden project.
+Next, we recommend learning more about configuring [Kubernetes modules](../module-types/README.md).

--- a/docs/k8s-plugins/remote-k8s/configure-registry/README.md
+++ b/docs/k8s-plugins/remote-k8s/configure-registry/README.md
@@ -10,7 +10,7 @@ You can skip this step and use Garden's built-in in-cluster registry.
 
 The in-cluster registry is a simple way to get started with Garden that requires no configuration but is not a particularly good approach for clusters with many users or lots of builds.
 
-You can learn more in our [advanced in-cluster building guide](https://docs.garden.io/kubernetes-plugins/advanced/in-cluster-building#configuring-a-deployment-registry).
+You can learn more in our [advanced in-cluster building guide](https://docs.garden.io/kubernetes-plugins/advanced/in-cluster-building).
 {% endhint %}
 
 You'll need a container registry to be able to push and pull your container images. We typically refer to this as a **deployment registry**.

--- a/docs/misc/faq.md
+++ b/docs/misc/faq.md
@@ -199,7 +199,7 @@ This will run the task even if the result is cached.
 
 ### How do I pass secrets to container modules?
 
-See [this section](https://docs.garden.io/other-plugins/container#secrets) of our docs.
+See [this section](https://docs.garden.io/k8s-plugins/module-types/container#secrets) of our docs.
 
 ### How do I mount secrets as volumes?
 
@@ -207,7 +207,7 @@ You'll need to use the [`kubernetes`](https://docs.garden.io/reference/module-ty
 
 ### Can I use Kubernetes secrets as `buildArgs`?
 
-No, Kubernetes secrets can only be used at runtime, by referencing them in the `environment` field of `tasks`, `services` and `tests`. See [the secrets section](https://docs.garden.io/other-plugins/container#secrets) of our docs for more.
+No, Kubernetes secrets can only be used at runtime, by referencing them in the `environment` field of `tasks`, `services` and `tests`. See [the secrets section](https://docs.garden.io/k8s-plugins/module-types/container#secrets) of our docs for more.
 
 Also note that secrets as `buildArgs` are considered a bad practice and a security risk.
 
@@ -219,13 +219,13 @@ No, secrets have to be in the same namespace as the project. This is how Kuberne
 
 ### How do I mount persistent volumes?
 
-See [this section](https://docs.garden.io/other-plugins/container#mounting-volumes) of our docs.
+See [this section](https://docs.garden.io/k8s-plugins/module-types/container#mounting-volumes) of our docs.
 
 ### How do I access files that are generated at runtime (e.g. migration files that are checked into version control)?
 
 You can generate the files via a task, store them as artifacts, and copy them from the local artifacts directory. [Here's an example](https://docs.garden.io/using-garden/tests#test-artifacts) of this.
 
-You can also use the [`persistentvolumeclaim`](https://docs.garden.io/reference/module-types/persistentvolumeclaim) module type to store data and share it across modules. See [this section](https://docs.garden.io/other-plugins/container#mounting-volumes) of our docs for more.
+You can also use the [`persistentvolumeclaim`](https://docs.garden.io/reference/module-types/persistentvolumeclaim) module type to store data and share it across modules. See [this section](https://docs.garden.io/k8s-plugins/module-types/container#mounting-volumes) of our docs for more.
 
 ## Kubernetes
 

--- a/docs/reference/action-types/Deploy/configmap.md
+++ b/docs/reference/action-types/Deploy/configmap.md
@@ -9,7 +9,7 @@ tocTitle: "`configmap` Deploy"
 
 Creates a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) in your namespace, that can be referenced and mounted by other resources and [container modules](./container.md).
 
-See the [Mounting Kubernetes ConfigMaps](https://docs.garden.io/other-plugins/container#mounting-kubernetes-configmaps) guide for more info and usage examples.
+See the [Mounting Kubernetes ConfigMaps](https://docs.garden.io/k8s-plugins/module-types/container#mounting-kubernetes-configmaps) guide for more info and usage examples.
 
 Below is the full schema reference for the action. For an introduction to configuring Garden, please look at our [Configuration
 guide](../../../using-garden/configuration-overview.md).

--- a/docs/reference/module-types/configmap.md
+++ b/docs/reference/module-types/configmap.md
@@ -9,7 +9,7 @@ tocTitle: "`configmap`"
 
 Creates a [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) in your namespace, that can be referenced and mounted by other resources and [container modules](./container.md).
 
-See the [Mounting Kubernetes ConfigMaps](https://docs.garden.io/other-plugins/container#mounting-kubernetes-configmaps) guide for more info and usage examples.
+See the [Mounting Kubernetes ConfigMaps](https://docs.garden.io/k8s-plugins/module-types/container#mounting-kubernetes-configmaps) guide for more info and usage examples.
 
 Below is the full schema reference. For an introduction to configuring Garden modules, please look at our [Configuration
 guide](../../using-garden/configuration-overview.md).

--- a/docs/reference/providers/local-kubernetes.md
+++ b/docs/reference/providers/local-kubernetes.md
@@ -9,7 +9,7 @@ tocTitle: "`local-kubernetes`"
 
 The `local-kubernetes` provider is a specialized version of the [`kubernetes` provider](./kubernetes.md) that automates and simplifies working with local Kubernetes clusters.
 
-For general Kubernetes usage information, please refer to the [Kubernetes plugin section](https://docs.garden.io/kubernetes-plugins/about) in the docs. For local clusters a good place to start is the [Local Kubernetes guide](https://docs.garden.io/kubernetes-plugins/local-k8s) guide.
+For general Kubernetes usage information, please refer to the [Kubernetes guides](https://docs.garden.io/kubernetes-plugins/about). For local clusters a good place to start is the [Local Kubernetes](https://docs.garden.io/kubernetes-plugins/local-k8s) guide. The [Quickstart Guide](https://docs.garden.io/basics/quickstart) guide is also helpful as an introduction.
 
 If you're working with a remote Kubernetes cluster, please refer to the [`kubernetes` provider](./kubernetes.md) docs, and the [Remote Kubernetes guide](https://docs.garden.io/kubernetes-plugins/remote-k8s) guide.
 

--- a/docs/using-garden/variables-and-templating.md
+++ b/docs/using-garden/variables-and-templating.md
@@ -508,7 +508,7 @@ On top of that, you can reference the resolved module variables in other modules
 
 You can also provide variables using "variable files" or _varfiles_. These work mostly like "dotenv" files or envfiles. However, they don't implicitly affect the environment of the Garden process and the configured services, but rather are added on top of the `variables` you define in your project configuration (or module variables defined in the `variables` of your individual module configurations).
 
-This can be very useful when you need to provide secrets and other contextual values to your stack. You could add your varfiles to your `.gitignore` file to keep them out of your repository, or use e.g. [git-crypt](https://github.com/AGWA/git-crypt), [BlackBox](https://github.com/StackExchange/blackbox) or [git-secret](https://git-secret.io/) to securely store the files in your Git repo.
+This can be very useful when you need to provide secrets and other contextual values to your stack. You could add your varfiles to your `.gitignore` file to keep them out of your repository, or use e.g. [git-crypt](https://github.com/AGWA/git-crypt), [BlackBox](https://github.com/StackExchange/blackbox) or [git-secret](https://github.com/sobolevn/git-secret) to securely store the files in your Git repo.
 
 By default, Garden will look for a `garden.env` file in your project root for project-wide variables, and a `garden.<env-name>.env` file for environment-specific variables. You can override the filename for each as well.
 

--- a/examples/demo-project/README.md
+++ b/examples/demo-project/README.md
@@ -2,6 +2,6 @@
 
 A very basic demo project for Garden.
 
-Take a look at the [Your First Project guide](https://docs.garden.io/tutorials/your-first-project) to see how this project is set up.
+Take a look at the [getting started](https://docs.garden.io/basics/quickstart) guide to see how this project is set up.
 
 For a more advanced project check out the [vote](../vote) example project.

--- a/examples/local-service/README.md
+++ b/examples/local-service/README.md
@@ -62,7 +62,7 @@ yarn install
 cd ..
 ```
 
-Assuming you've [set _your_ K8s context](https://docs.garden.io/tutorials/your-first-project/2-connect-to-a-cluster), you can start the project with:
+Assuming you've [set _your_ K8s context](https://docs.garden.io/kubernetes-plugins/remote-k8s), you can start the project with:
 
 ```console
 garden deploy --sync


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit was cherry-picked from `main` to `0.13`, and the resulting conflicts resolved.

This should fix the dead links in the `check-docs` step on 0.13.