### PR TITLE
fix(core): improve graph result filtering

### DIFF
--- a/core/src/commands/base.ts
+++ b/core/src/commands/base.ts
@@ -19,7 +19,7 @@ import { Log } from "../logger/log-entry"
 import { LoggerType } from "../logger/logger"
 import { printFooter, renderMessageWithDivider } from "../logger/util"
 import { ProcessResults } from "../process"
-import { GraphResultExport } from "../graph/results"
+import { GraphResultMapWithoutTask } from "../graph/results"
 import { capitalize } from "lodash"
 import { userPrompt } from "../util/util"
 import { renderOptions, renderCommands, renderArguments, getCliStyles } from "../cli/helpers"
@@ -390,7 +390,7 @@ export interface ProcessCommandResult {
   // durationMsec?: number | null
   success: boolean
   error?: string
-  graphResults: GraphResultExport
+  graphResults: GraphResultMapWithoutTask
 }
 
 export const processCommandResultKeys = () => ({

--- a/core/src/graph/nodes.ts
+++ b/core/src/graph/nodes.ts
@@ -130,7 +130,7 @@ export abstract class TaskNode<T extends Task = Task> {
       key: task.getKey(),
       name: task.getName(),
       result,
-      dependencyResults: dependencyResults.export(),
+      dependencyResults: dependencyResults.filterForGraphResult(),
       aborted,
       startedAt,
       completedAt: new Date(),

--- a/core/src/graph/results.ts
+++ b/core/src/graph/results.ts
@@ -8,7 +8,7 @@
 
 import { BaseTask, Task, ValidResultType } from "../tasks/base"
 import { InternalError } from "../exceptions"
-import { fromPairs, omit } from "lodash"
+import { fromPairs, omit, pick } from "lodash"
 import { toGraphResultEventPayload } from "../events"
 import CircularJSON from "circular-json"
 
@@ -22,7 +22,7 @@ export interface TaskEventBase {
 
 export interface GraphResult<R extends ValidResultType = ValidResultType> extends TaskEventBase {
   result: R | null
-  dependencyResults: GraphResultExport | null
+  dependencyResults: GraphResultMapWithoutTask | null
   startedAt: Date | null
   completedAt: Date | null
   error: Error | null
@@ -33,14 +33,16 @@ export interface GraphResult<R extends ValidResultType = ValidResultType> extend
   success: boolean
 }
 
+export type GraphResultWithoutTask<T extends Task = Task> = Omit<GraphResultFromTask<T>, "task">
+
 export type GraphResultFromTask<T extends Task> = GraphResult<T["_resultType"]>
 
 export interface GraphResultMap<T extends Task = Task> {
   [key: string]: GraphResultFromTask<T> | null
 }
 
-export interface GraphResultExport<T extends Task = Task> {
-  [key: string]: Omit<GraphResultFromTask<T>, "task"> | null
+export interface GraphResultMapWithoutTask<T extends Task = Task> {
+  [key: string]: GraphResultWithoutTask<T> | null
 }
 
 export class GraphResults<B extends Task = Task> {
@@ -89,11 +91,15 @@ export class GraphResults<B extends Task = Task> {
     return fromPairs(Array.from(this.results.entries()))
   }
 
+  filterForGraphResult<T extends Task = Task>(): GraphResultMapWithoutTask<T> {
+    return mapResults(this.results, (v) => v ? { ...omit(v, "task") } : null)
+  }
+
   /**
    * Export the result object in a format that's suitable for JSON, command outputs etc.
    */
-  export(): GraphResultExport {
-    return fromPairs(Array.from(this.results.entries()).map(([k, v]) => [k, resultToExport(v)]))
+  export(): GraphResultMapWithoutTask {
+    return mapResults(this.results, (v) => prepareForExport(v))
   }
 
   private checkKey(key: string) {
@@ -111,6 +117,20 @@ export class GraphResults<B extends Task = Task> {
 }
 
 /**
+ * Convenience helper for mapping the values of a Map or plain object of graph results (note: Returns a plain object,not a Map).
+ */
+function mapResults<T extends Task = Task, R extends object = {}>(
+  results: Map<string, GraphResultWithoutTask<T> | null> | GraphResultMapWithoutTask<T> | null,
+  fn: (val: GraphResultWithoutTask<T> | null) => R | null
+): { [key: string]: R | null} {
+  if (!results) {
+    return {}
+  }
+  const entries = results instanceof Map ? results.entries() : Object.entries(results)
+  return fromPairs(Array.from(entries).map(([k, v]) => [k, fn(v)]))
+}
+
+/**
  * Render a result to string. Used for debugging and errors.
  */
 export function resultToString(result: GraphResult) {
@@ -121,12 +141,106 @@ export function resultToString(result: GraphResult) {
 /**
  * Prepares an individual GraphResult for export.
  */
-export function resultToExport(result: GraphResult | null) {
-  if (!result) {
-    return result
+function prepareForExport(graphResult: GraphResultWithoutTask | null) {
+  if (!graphResult) {
+    return null
   }
+  const { result, error, dependencyResults } = graphResult
+  const filteredDependencyResults = mapResults(dependencyResults || {}, prepareForExport)
+  // We have to omit instead of picking here, since we may have action-keyed output values in here.
   return {
-    ...omit(result, "task"),
-    result: omit(result.result, ["resolvedAction", "executedAction"]),
+    ...pick(
+      graphResult,
+      "type",
+      "description",
+      "key",
+      "name",
+      "aborted",
+      "startedAt",
+      "completedAt",
+      "version",
+      "processed",
+      "success",
+      "version",
+    ),
+    result: filterResultForExport(result),
+    error: filterErrorForExport(error),
+    outputs: filterOutputsForExport(graphResult.outputs),
+    dependencyResults: filteredDependencyResults,
+  }
+}
+
+function filterResultForExport(result: any) {
+  // Here, we pick a list of safe (bounded-size) keys across the result types for `BuildTask`, `DeployTask`, `TestTask`
+  // and `RunTask`.
+  const filteredDetail = pick(
+    result.detail || {},
+    // Leaving these in because many of our command unit tests rely on them
+    "fresh",
+    "buildLog",
+    "log",
+    "message",
+  )
+  return {
+    ...pick(
+      result,
+
+      // from DeployStatus
+      "createdAt",
+      "syncMode",
+      "localMode",
+      "namespaceStatuses",
+      "externalId",
+      "externalVersion",
+      "forwardablePorts",
+      "ingresses",
+      "lastMessage",
+      "lastError",
+      "outputs",
+      "runningReplicas",
+      "state",
+      "updatedAt",
+      "version",
+
+      // from BuildStatus
+      "fetched",
+      "fresh",
+
+      // from RunResult and TestResult
+      "success",
+      "exitCode",
+      "startedAt",
+      "completedAt",
+      "namespaceStatus",
+    ),
+    detail: filteredDetail,
+  }
+}
+
+function filterOutputsForExport(outputs: any) {
+  return omit(outputs, "resolvedAction", "executedAction")
+}
+
+function filterErrorForExport(error: any) {
+  if (!error) {
+    return null
+  }
+  const detail = error.detail || {}
+  const filteredDetail = pick(
+    detail || {},
+    "aborted",
+    "completedAt",
+    "description",
+    "message",
+    "stack",
+    "key",
+    "name",
+    "processed",
+    "success",
+    "type",
+  )
+  return {
+    ...pick(error, "message", "type", "stack"),
+    detail: filteredDetail
   }
 }

--- a/core/test/helpers.ts
+++ b/core/test/helpers.ts
@@ -55,7 +55,7 @@ import { GetRunResult } from "../src/plugin/handlers/Run/get-result"
 import { defaultEnvironment, defaultNamespace, ProjectConfig } from "../src/config/project"
 import { ConvertModuleParams } from "../src/plugin/handlers/Module/convert"
 import { baseServiceSpecSchema } from "../src/config/service"
-import { GraphResultExport, GraphResultMap } from "../src/graph/results"
+import { GraphResultMapWithoutTask, GraphResultMap } from "../src/graph/results"
 import { localConfigFilename } from "../src/config-store/local"
 import _ from "lodash"
 
@@ -532,7 +532,7 @@ export async function stubProviderAction<T extends keyof ProviderHandlers>(
 /**
  * Returns an alphabetically sorted list of all processed actions including dependencies from a GraphResultMap.
  */
-export function getAllProcessedTaskNames(results: GraphResultExport) {
+export function getAllProcessedTaskNames(results: GraphResultMapWithoutTask) {
   const all = Object.keys(results)
 
   for (const r of Object.values(results)) {
@@ -547,7 +547,7 @@ export function getAllProcessedTaskNames(results: GraphResultExport) {
 /**
  * Returns a map of all task results including dependencies from a GraphResultMap.
  */
-export function getAllTaskResults(results: GraphResultExport) {
+export function getAllTaskResults(results: GraphResultMapWithoutTask) {
   const all = { ...results }
 
   for (const r of Object.values(results)) {

--- a/core/test/unit/src/commands/deploy.ts
+++ b/core/test/unit/src/commands/deploy.ts
@@ -212,10 +212,6 @@ describe("DeployCommand", () => {
 
       expect(res.state).to.equal("ready")
       expect(res.outputs).to.eql({})
-
-      expect(res.detail.state).to.equal("ready")
-      expect(res.detail.forwardablePorts).to.eql([])
-      expect(res.detail.outputs).to.eql({})
     }
 
     expect(sortedEvents[0]).to.eql({

--- a/core/test/unit/src/commands/publish.ts
+++ b/core/test/unit/src/commands/publish.ts
@@ -17,6 +17,7 @@ import { execBuildActionSchema } from "../../../../src/plugins/exec/config"
 import { PublishActionResult, PublishBuildAction } from "../../../../src/plugin/handlers/Build/publish"
 import { createGardenPlugin, GardenPlugin } from "../../../../src/plugin/plugin"
 import { ConvertModuleParams } from "../../../../src/plugin/handlers/Module/convert"
+import { PublishTask } from "../../../../src/tasks/publish"
 
 const projectRootB = getDataDir("test-project-b")
 
@@ -122,89 +123,24 @@ describe("PublishCommand", () => {
 
     expect(taskResultOutputs(result!)).to.eql({
       "publish.module-a": {
-        detail: {
-          identifier: versionA,
-          published: true,
-        },
         outputs: {},
+        detail: {},
         state: "ready",
         version: versionA,
       },
       "publish.module-b": {
-        detail: {
-          identifier: versionB,
-          published: true,
-        },
         outputs: {},
+        detail: {},
         state: "ready",
         version: versionB,
       },
       "publish.module-c": {
-        detail: {
-          published: false,
-        },
         outputs: {},
+        detail: {},
         state: "ready",
         version: versionC,
       },
     })
-  })
-
-  it("should apply the specified tag to the published builds", async () => {
-    const garden = await getTestGarden()
-    const log = garden.log
-    const tag = "foo"
-
-    const { result } = await command.action({
-      garden,
-      log,
-      headerLog: log,
-      footerLog: log,
-      args: {
-        names: undefined,
-      },
-      opts: withDefaultGlobalOpts({
-        "force-build": false,
-        tag,
-      }),
-    })
-
-    const publishActionResult = taskResultOutputs(result!)
-
-    expect(publishActionResult["publish.module-a"].detail.published).to.be.true
-    expect(publishActionResult["publish.module-a"].detail.identifier).to.equal(tag)
-    expect(publishActionResult["publish.module-b"].detail.published).to.be.true
-    expect(publishActionResult["publish.module-b"].detail.identifier).to.equal(tag)
-  })
-
-  it("should resolve a templated tag and apply to the builds", async () => {
-    const garden = await getTestGarden()
-    const log = garden.log
-    const tag = "v1.0-${module.name}-${module.version}"
-
-    const { result } = await command.action({
-      garden,
-      log,
-      headerLog: log,
-      footerLog: log,
-      args: {
-        names: undefined,
-      },
-      opts: withDefaultGlobalOpts({
-        "force-build": false,
-        tag,
-      }),
-    })
-
-    const publishActionResult = taskResultOutputs(result!)
-    const graph = await garden.getResolvedConfigGraph({ log, emit: false })
-    const verA = graph.getBuild("module-a").versionString()
-    const verB = graph.getBuild("module-b").versionString()
-
-    expect(publishActionResult["publish.module-a"].detail.published).to.be.true
-    expect(publishActionResult["publish.module-a"].detail.identifier).to.equal(`v1.0-module-a-${verA}`)
-    expect(publishActionResult["publish.module-b"].detail.published).to.be.true
-    expect(publishActionResult["publish.module-b"].detail.identifier).to.equal(`v1.0-module-b-${verB}`)
   })
 
   it("should optionally force new build", async () => {
@@ -297,7 +233,72 @@ describe("PublishCommand", () => {
 
     expect(res).to.exist
     expect(res.state).to.equal("unknown")
-    expect(res.detail.published).to.be.false
     expect(res.detail.message).to.be.equal(chalk.yellow("No publish handler available for type test"))
+  })
+})
+
+describe("PublishTask", () => {
+  it("should apply the specified tag to the published build", async () => {
+    const garden = await getTestGarden()
+    const log = garden.log
+    const tag = "foo"
+    const graph = await garden.getConfigGraph({ log, emit: true })
+    const builds = graph.getBuilds()
+
+    const tasks = builds.map((action) => {
+      return new PublishTask({
+        garden,
+        graph,
+        log,
+        action,
+        forceBuild: false,
+        tagTemplate: tag,
+        syncModeDeployNames: [],
+        localModeDeployNames: [],
+
+        force: false,
+      })
+    })
+
+    const processed = await garden.processTasks({ tasks, log, throwOnError: true })
+    const graphResultsMap = processed.results.getMap()
+    expect(graphResultsMap["publish.module-a"]!.result.detail.published).to.be.true
+    expect(graphResultsMap["publish.module-a"]!.result.detail.identifier).to.equal(tag)
+    expect(graphResultsMap["publish.module-b"]!.result.detail.published).to.be.true
+    expect(graphResultsMap["publish.module-b"]!.result.detail.identifier).to.equal(tag)
+  })
+
+  it("should resolve a templated tag and apply to the builds", async () => {
+    const garden = await getTestGarden()
+    const log = garden.log
+    const tag = "v1.0-${module.name}-${module.version}"
+
+    const graph = await garden.getConfigGraph({ log, emit: true })
+    const builds = graph.getBuilds()
+
+    const tasks = builds.map((action) => {
+      return new PublishTask({
+        garden,
+        graph,
+        log,
+        action,
+        forceBuild: false,
+        tagTemplate: tag,
+        syncModeDeployNames: [],
+        localModeDeployNames: [],
+
+        force: false,
+      })
+    })
+
+    const processed = await garden.processTasks({ tasks, log, throwOnError: true })
+    const graphResultsMap = processed.results.getMap()
+    const verA = graph.getBuild("module-a").versionString()
+    const verB = graph.getBuild("module-b").versionString()
+
+    expect(graphResultsMap["publish.module-a"]!.result.detail.published).to.be.true
+    expect(graphResultsMap["publish.module-a"]!.result.detail.identifier).to.equal(`v1.0-module-a-${verA}`)
+    expect(graphResultsMap["publish.module-b"]!.result.detail.published).to.be.true
+    expect(graphResultsMap["publish.module-b"]!.result.detail.identifier).to.equal(`v1.0-module-b-${verB}`)
   })
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Fixes an OOM error that would occur when several actions failed during a command run.

We now mostly select a picked list of fields for including in our command result, instead of skipping fields (which has historically led to new fields with unbounded size slipping in, which calls for repeated fixes around this).