### PR TITLE
chore: misc fixes for cloud

### DIFF
--- a/core/src/cloud/api.ts
+++ b/core/src/cloud/api.ts
@@ -261,10 +261,11 @@ export class CloudApi {
       throw new EnterpriseApiError(errMsg, { tokenResponse })
     }
     try {
+      const validityMs = tokenResponse.tokenValidity || 604800000
       await globalConfigStore.set("clientAuthTokens", domain, {
         token: tokenResponse.token,
         refreshToken: tokenResponse.refreshToken,
-        validity: add(new Date(), { seconds: tokenResponse.tokenValidity / 1000 }),
+        validity: add(new Date(), { seconds: validityMs / 1000 }),
       })
       log.debug("Saved client auth token to config store")
     } catch (error) {

--- a/core/src/plugins/container/container.ts
+++ b/core/src/plugins/container/container.ts
@@ -213,6 +213,12 @@ function convertContainerModuleRuntimeActions(
   const { module, services, tasks, tests, prepareRuntimeDependencies } = convertParams
   const actions: ContainerActionConfig[] = []
 
+  let deploymentImageId = module.spec.image
+  if (deploymentImageId) {
+    // If `module.spec.image` is set, but the image id is missing a tag, we need to add the module version as the tag.
+    deploymentImageId = containerHelpers.getModuleDeploymentImageId(module, module.version, undefined)
+  }
+
   for (const service of services) {
     const action: ContainerActionConfig = {
       kind: "Deploy",
@@ -226,7 +232,7 @@ function convertContainerModuleRuntimeActions(
 
       spec: {
         ...omit(service.spec, ["name", "dependencies", "disabled"]),
-        image: module.spec.image,
+        image: deploymentImageId,
         volumes: [], // added later
       },
     }

--- a/core/src/plugins/container/moduleConfig.ts
+++ b/core/src/plugins/container/moduleConfig.ts
@@ -86,7 +86,7 @@ export const defaultTag = "latest"
 
 const containerBuildSpecSchema = () =>
   baseBuildSpecSchema().keys({
-    target: joi.string().description(deline`
+    targetImage: joi.string().description(deline`
       For multi-stage Dockerfiles, specify which image/stage to build (see
       https://docs.docker.com/engine/reference/commandline/build/#specifying-target-build-stage---target for
       details).

--- a/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
@@ -58,7 +58,7 @@ export const kubernetesHandlers: Partial<ModuleActionHandlers<KubernetesModule>>
       include: module.spec.files,
 
       spec: {
-        ...omit(module.spec, ["build", "name", "dependencies", "serviceResource", "tasks", "tests", "sync"]),
+        ...omit(module.spec, ["name", "build", "dependencies", "serviceResource", "tasks", "tests", "sync", "devMode"]),
         files: module.spec.files || [],
         manifests: module.spec.manifests || [],
         sync: convertKubernetesModuleDevModeSpec(module, service, serviceResource),

--- a/core/src/tasks/build.ts
+++ b/core/src/tasks/build.ts
@@ -77,7 +77,7 @@ export class BuildTask extends ExecuteActionTask<BuildAction, BuildStatus> {
         executedAction: resolvedActionToExecuted(action, { status: result }),
       }
     } catch (err) {
-      log.error(`Error syncing modules`)
+      log.error(`Build failed`)
       throw err
     }
   }

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -59,7 +59,7 @@ build:
 
   # For multi-stage Dockerfiles, specify which image/stage to build (see
   # https://docs.docker.com/engine/reference/commandline/build/#specifying-target-build-stage---target for details).
-  target:
+  targetImage:
 
 # A description of the module.
 description:
@@ -834,9 +834,9 @@ Maximum time in seconds to wait for build to finish.
 | -------- | ------- | -------- |
 | `number` | `1200`  | No       |
 
-### `build.target`
+### `build.targetImage`
 
-[build](#build) > target
+[build](#build) > targetImage
 
 For multi-stage Dockerfiles, specify which image/stage to build (see https://docs.docker.com/engine/reference/commandline/build/#specifying-target-build-stage---target for details).
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**fix(container): fix spec.image in container conversion**

When `module.spec.image` is provided, but the value has no tag, we weren't setting the Build/module version as the default tag/suffix to the image ID.

In 0.12, this was done by referencing the deployment image ID from the container build's outputs, which we can't do here. Therefore, we simply call the relevant helper to shim that behaviour here.

**fix: schema fixes around k8s/container conversion**

The `spec.targetImage` field was called `spec.image` on `containerBuildSchema` (i.e. the interface and the schema didn't agree).

Also fixed the spec conversion logic for `kubernetes` modules.

**chore: set default Cloud API auth token validity**
