### PR TITLE
0.13 enable timeout for hadolint plugin

### DIFF
--- a/core/src/actions/deploy.ts
+++ b/core/src/actions/deploy.ts
@@ -16,9 +16,7 @@ import {
 import { Action, BaseActionConfig } from "./types"
 
 export interface DeployActionConfig<N extends string = any, S extends object = any>
-  extends BaseRuntimeActionConfig<"Deploy", N, S> {
-  type: N
-}
+  extends BaseRuntimeActionConfig<"Deploy", N, S> {}
 
 export const deployActionConfigSchema = () => baseRuntimeActionConfigSchema()
 

--- a/core/src/actions/run.ts
+++ b/core/src/actions/run.ts
@@ -18,7 +18,6 @@ import { Action, BaseActionConfig } from "./types"
 
 export interface RunActionConfig<N extends string = any, S extends object = any>
   extends BaseRuntimeActionConfig<"Run", N, S> {
-  type: N
   timeout?: number
 }
 

--- a/core/src/actions/test.ts
+++ b/core/src/actions/test.ts
@@ -18,7 +18,6 @@ import { Action, BaseActionConfig } from "./types"
 
 export interface TestActionConfig<N extends string = any, S extends object = any>
   extends BaseRuntimeActionConfig<"Test", N, S> {
-  type: N
   timeout?: number
 }
 

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -355,7 +355,7 @@ async function preprocessActionConfig({
         spec: {},
       },
       schema: getActionSchema(config.kind),
-      configType: `${describeActionConfig(config)}`,
+      configType: describeActionConfig(config),
       name: config.name,
       path: config.internal.basePath,
       projectRoot: garden.projectRoot,

--- a/core/src/plugin/handlers/base/configure.ts
+++ b/core/src/plugin/handlers/base/configure.ts
@@ -65,6 +65,13 @@ export class ConfigureActionConfig<T extends BaseActionConfig = BaseActionConfig
   resultSchema = () =>
     joi.object().keys({
       // Using runtime action schema here because it's a superset of baseActionSchema
-      config: baseRuntimeActionConfigSchema(),
+      config: baseRuntimeActionConfigSchema().keys({
+        // allow timeout field that can exists in Run and Test actions
+        timeout: joi
+          .number()
+          .integer()
+          .optional()
+          .description("The optional timeout for some kinds of runtime action to complete, in seconds."),
+      }),
     })
 }

--- a/core/src/plugins/hadolint/hadolint.ts
+++ b/core/src/plugins/hadolint/hadolint.ts
@@ -342,8 +342,7 @@ export const gardenPlugin = () =>
 
               include: [module.spec.dockerfilePath],
 
-              // TODO-G2 schema validation fails if the timeout is defined
-              // timeout: 10,
+              timeout: 10,
 
               spec: {
                 dockerfilePath: module.spec.dockerfilePath,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
This enables `timeout` field in the `convert` handler of the `hadolint` plugin.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
The original error message was confusing:
```
Error: 
Error parsing config for Test action foo:
Error validating configure handler output from provider hadolint for Test type hadolint: key "timeout" is not allowed at path .config[timeout]. Available keys: config)
    at garden/core/src/graph/actions.ts:108:13
```

It should be fixed as well. Looks like there are some issues in the error description rendering in the [`validateSchema` function](https://github.com/garden-io/garden/blob/0.13/core/src/config/validation.ts#L84). It does not expand the existing `config` field and does not print the correct available keys.