### PR TITLE
chore: eslint: add no-console at error level

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,7 @@
     "arrow-body-style": "off",
     "jsdoc/check-indentation": "off",
     "jsdoc/newline-after-description": "off",
+    "no-console": "error",
     "max-len": [
       "warn",
       {


### PR DESCRIPTION
Add an ESlint rule for disallowing `console.log` family of commands