### PR TITLE
0.13 some refactoring and minor fixes for local mode

### DIFF
--- a/core/src/plugins/kubernetes/container/deployment.ts
+++ b/core/src/plugins/kubernetes/container/deployment.ts
@@ -9,7 +9,11 @@
 import chalk from "chalk"
 import { V1Affinity, V1Container, V1DaemonSet, V1Deployment, V1PodSpec, V1VolumeMount } from "@kubernetes/client-node"
 import { extend, keyBy, omit, set } from "lodash"
-import { ContainerDeployAction, ContainerDeploySpec, ContainerVolumeSpec } from "../../container/moduleConfig"
+import {
+  ContainerDeployAction,
+  ContainerDeploySpec,
+  ContainerVolumeSpec,
+} from "../../container/moduleConfig"
 import { createIngressResources } from "./ingress"
 import { createServiceResources } from "./service"
 import { waitForResources } from "../status/status"
@@ -26,7 +30,7 @@ import { killPortForwards } from "../port-forward"
 import { prepareSecrets } from "../secrets"
 import { configureSyncMode, convertContainerSyncSpec, startSyncs } from "../sync"
 import { getDeployedImageId, getResourceRequirements, getSecurityContext } from "./util"
-import { configureLocalMode, startServiceInLocalMode } from "../local-mode"
+import { configureLocalMode, convertContainerLocalModeSpec, startServiceInLocalMode } from "../local-mode"
 import { DeployActionHandler, DeployActionParams } from "../../../plugin/action-types"
 import { ActionMode, Resolved } from "../../../actions/types"
 import { ConfigurationError, DeploymentError } from "../../../exceptions"
@@ -488,7 +492,7 @@ export async function createWorkloadManifest({
   }
 
   const syncSpec = convertContainerSyncSpec(ctx, action)
-  const localModeSpec = spec.localMode
+  const localModeSpec = convertContainerLocalModeSpec(ctx, action)
 
   // Local mode always takes precedence over sync mode
   if (mode === "local" && localModeSpec) {

--- a/core/src/plugins/kubernetes/container/deployment.ts
+++ b/core/src/plugins/kubernetes/container/deployment.ts
@@ -184,7 +184,7 @@ export async function startLocalMode({
   await startServiceInLocalMode({
     ctx,
     spec: localModeSpec,
-    manifest: targetResource,
+    targetResource,
     manifests: status.detail.remoteResources,
     action,
     namespace,

--- a/core/src/plugins/kubernetes/container/deployment.ts
+++ b/core/src/plugins/kubernetes/container/deployment.ts
@@ -188,7 +188,7 @@ export async function startLocalMode({
   await startServiceInLocalMode({
     ctx,
     spec: localModeSpec,
-    targetResource,
+    manifest: targetResource,
     action,
     namespace,
     log,
@@ -499,7 +499,7 @@ export async function createWorkloadManifest({
     await configureLocalMode({
       ctx,
       spec: localModeSpec,
-      targetResource: workload,
+      manifest: workload,
       action,
       log,
     })

--- a/core/src/plugins/kubernetes/container/deployment.ts
+++ b/core/src/plugins/kubernetes/container/deployment.ts
@@ -496,9 +496,12 @@ export async function createWorkloadManifest({
 
   // Local mode always takes precedence over sync mode
   if (mode === "local" && localModeSpec) {
+    const target = { kind: <SyncableKind>workload.kind, name: workload.metadata.name }
+
     await configureLocalMode({
       ctx,
       spec: localModeSpec,
+      defaultTarget: target,
       manifest: workload,
       action,
       log,

--- a/core/src/plugins/kubernetes/container/deployment.ts
+++ b/core/src/plugins/kubernetes/container/deployment.ts
@@ -189,6 +189,7 @@ export async function startLocalMode({
     ctx,
     spec: localModeSpec,
     manifest: targetResource,
+    manifests: status.detail.remoteResources,
     action,
     namespace,
     log,
@@ -503,6 +504,7 @@ export async function createWorkloadManifest({
       spec: localModeSpec,
       defaultTarget: target,
       manifest: workload,
+      manifests: [workload],
       action,
       log,
     })

--- a/core/src/plugins/kubernetes/container/deployment.ts
+++ b/core/src/plugins/kubernetes/container/deployment.ts
@@ -502,7 +502,6 @@ export async function createWorkloadManifest({
       ctx,
       spec: localModeSpec,
       defaultTarget: getDefaultWorkloadTarget(workload),
-      manifest: workload,
       manifests: [workload],
       action,
       log,

--- a/core/src/plugins/kubernetes/container/deployment.ts
+++ b/core/src/plugins/kubernetes/container/deployment.ts
@@ -508,7 +508,7 @@ export async function createWorkloadManifest({
       log,
     })
 
-    workload = <KubernetesResource<V1Deployment | V1DaemonSet>>configured.updated
+    workload = <KubernetesResource<V1Deployment | V1DaemonSet>>configured.updated[0]
   } else if (mode === "sync" && syncSpec) {
     log.debug({ section: action.key(), msg: chalk.gray(`-> Configuring in sync mode`) })
     const configured = await configureSyncMode({

--- a/core/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/src/plugins/kubernetes/helm/deployment.ts
@@ -127,7 +127,7 @@ export const helmDeploy: DeployActionHandler<"deploy", HelmDeployAction> = async
   // installing/upgrading via Helm, we need to separately update the target here for sync-mode/local-mode.
   // Local mode always takes precedence over sync mode.
   if (mode === "local" && spec.localMode && !isEmpty(spec.localMode) && localModeTarget) {
-    await configureLocalMode({
+    const configured = await configureLocalMode({
       ctx,
       spec: spec.localMode,
       defaultTarget: spec.defaultTarget,
@@ -136,7 +136,7 @@ export const helmDeploy: DeployActionHandler<"deploy", HelmDeployAction> = async
       action,
       log,
     })
-    await apply({ log, ctx, api, provider, manifests: [localModeTarget], namespace })
+    await apply({ log, ctx, api, provider, manifests: [configured.updated], namespace })
   } else if (mode === "sync" && spec.sync && !isEmpty(spec.sync)) {
     const configured = await configureSyncMode({
       ctx,

--- a/core/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/src/plugins/kubernetes/helm/deployment.ts
@@ -157,7 +157,7 @@ export const helmDeploy: DeployActionHandler<"deploy", HelmDeployAction> = async
     await startServiceInLocalMode({
       ctx,
       spec: spec.localMode,
-      manifest: configuredLocalMode.updated[0],
+      targetResource: configuredLocalMode.updated[0],
       manifests,
       action,
       namespace,

--- a/core/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/src/plugins/kubernetes/helm/deployment.ts
@@ -130,7 +130,7 @@ export const helmDeploy: DeployActionHandler<"deploy", HelmDeployAction> = async
     await configureLocalMode({
       ctx,
       spec: spec.localMode,
-      targetResource: localModeTarget,
+      manifest: localModeTarget,
       action,
       log,
     })
@@ -171,7 +171,7 @@ export const helmDeploy: DeployActionHandler<"deploy", HelmDeployAction> = async
     await startServiceInLocalMode({
       ctx,
       spec: spec.localMode,
-      targetResource: localModeTarget,
+      manifest: localModeTarget,
       action,
       namespace,
       log,

--- a/core/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/src/plugins/kubernetes/helm/deployment.ts
@@ -116,7 +116,6 @@ export const helmDeploy: DeployActionHandler<"deploy", HelmDeployAction> = async
       ctx,
       spec: spec.localMode,
       defaultTarget: spec.defaultTarget,
-      manifest: undefined,
       manifests,
       action,
       log,

--- a/core/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/src/plugins/kubernetes/helm/deployment.ts
@@ -17,12 +17,10 @@ import { getForwardablePorts, killPortForwards } from "../port-forward"
 import { getActionNamespace, getActionNamespaceStatus } from "../namespace"
 import { configureSyncMode, startSyncs } from "../sync"
 import { KubeApi } from "../api"
-import { configureLocalMode, startServiceInLocalMode } from "../local-mode"
+import { ConfiguredLocalMode, configureLocalMode, startServiceInLocalMode } from "../local-mode"
 import { DeployActionHandler } from "../../../plugin/action-types"
 import { HelmDeployAction } from "./config"
 import { isEmpty } from "lodash"
-import { SyncableResource } from "../types"
-import { getTargetResource } from "../util"
 
 export const helmDeploy: DeployActionHandler<"deploy", HelmDeployAction> = async (params) => {
   const { ctx, action, log, force } = params
@@ -109,34 +107,21 @@ export const helmDeploy: DeployActionHandler<"deploy", HelmDeployAction> = async
 
   const mode = action.mode()
 
-  const localModeTargetSpec = spec.localMode?.target || spec.defaultTarget
-  let localModeTarget: SyncableResource | undefined = undefined
-
-  if (mode === "local" && localModeTargetSpec) {
-    localModeTarget = await getTargetResource({
-      ctx,
-      log,
-      provider,
-      action,
-      manifests,
-      query: localModeTargetSpec,
-    })
-  }
-
   // Because we need to modify the Deployment, and because there is currently no reliable way to do that before
   // installing/upgrading via Helm, we need to separately update the target here for sync-mode/local-mode.
   // Local mode always takes precedence over sync mode.
-  if (mode === "local" && spec.localMode && !isEmpty(spec.localMode) && localModeTarget) {
-    const configured = await configureLocalMode({
+  let configuredLocalMode: ConfiguredLocalMode | undefined = undefined
+  if (mode === "local" && spec.localMode && !isEmpty(spec.localMode)) {
+    configuredLocalMode = await configureLocalMode({
       ctx,
       spec: spec.localMode,
       defaultTarget: spec.defaultTarget,
-      manifest: localModeTarget,
+      manifest: undefined,
       manifests,
       action,
       log,
     })
-    await apply({ log, ctx, api, provider, manifests: configured.updated, namespace })
+    await apply({ log, ctx, api, provider, manifests: configuredLocalMode.updated, namespace })
   } else if (mode === "sync" && spec.sync && !isEmpty(spec.sync)) {
     const configured = await configureSyncMode({
       ctx,
@@ -169,11 +154,11 @@ export const helmDeploy: DeployActionHandler<"deploy", HelmDeployAction> = async
   killPortForwards(action, forwardablePorts || [], log)
 
   // Local mode always takes precedence over sync mode.
-  if (mode === "local" && spec.localMode && localModeTarget) {
+  if (mode === "local" && spec.localMode && configuredLocalMode && configuredLocalMode.updated?.length) {
     await startServiceInLocalMode({
       ctx,
       spec: spec.localMode,
-      manifest: localModeTarget,
+      manifest: configuredLocalMode.updated[0],
       manifests,
       action,
       namespace,

--- a/core/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/src/plugins/kubernetes/helm/deployment.ts
@@ -136,7 +136,7 @@ export const helmDeploy: DeployActionHandler<"deploy", HelmDeployAction> = async
       action,
       log,
     })
-    await apply({ log, ctx, api, provider, manifests: [configured.updated], namespace })
+    await apply({ log, ctx, api, provider, manifests: configured.updated, namespace })
   } else if (mode === "sync" && spec.sync && !isEmpty(spec.sync)) {
     const configured = await configureSyncMode({
       ctx,

--- a/core/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/src/plugins/kubernetes/helm/deployment.ts
@@ -133,7 +133,6 @@ export const helmDeploy: DeployActionHandler<"deploy", HelmDeployAction> = async
       targetResource: localModeTarget,
       action,
       log,
-      containerName: spec.localMode.target?.containerName,
     })
     await apply({ log, ctx, api, provider, manifests: [localModeTarget], namespace })
   } else if (mode === "sync" && spec.sync && !isEmpty(spec.sync)) {

--- a/core/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/src/plugins/kubernetes/helm/deployment.ts
@@ -132,6 +132,7 @@ export const helmDeploy: DeployActionHandler<"deploy", HelmDeployAction> = async
       spec: spec.localMode,
       defaultTarget: spec.defaultTarget,
       manifest: localModeTarget,
+      manifests,
       action,
       log,
     })
@@ -173,6 +174,7 @@ export const helmDeploy: DeployActionHandler<"deploy", HelmDeployAction> = async
       ctx,
       spec: spec.localMode,
       manifest: localModeTarget,
+      manifests,
       action,
       namespace,
       log,

--- a/core/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/src/plugins/kubernetes/helm/deployment.ts
@@ -130,6 +130,7 @@ export const helmDeploy: DeployActionHandler<"deploy", HelmDeployAction> = async
     await configureLocalMode({
       ctx,
       spec: spec.localMode,
+      defaultTarget: spec.defaultTarget,
       manifest: localModeTarget,
       action,
       log,

--- a/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
@@ -315,6 +315,7 @@ export const kubernetesDeploy: DeployActionHandler<"deploy", KubernetesDeployAct
         spec: spec.localMode,
         // TODO-G2: Support multiple processes+targets.
         manifest: modifiedResources[0],
+        manifests: preparedManifests,
         action,
         namespace,
         log,
@@ -502,6 +503,7 @@ async function configureSpecialModesForManifests({
       spec: spec.localMode,
       defaultTarget: spec.defaultTarget,
       manifest: target,
+      manifests,
       action,
       log,
     })

--- a/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
@@ -513,7 +513,7 @@ async function configureSpecialModesForManifests({
       .filter((m) => !(m.kind === target!.kind && target?.metadata.name === m.metadata.name))
       .concat(<KubernetesResource<BaseResource>>target)
 
-    return { updated: [configured.updated], manifests: preparedManifests }
+    return { updated: configured.updated, manifests: preparedManifests }
   } else if (mode === "sync" && spec.sync && !isEmpty(spec.sync)) {
     // The "sync-mode" annotation is set in `configureDevMode`.
     return configureSyncMode({

--- a/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
@@ -101,7 +101,7 @@ export const kubernetesHandlers: Partial<ModuleActionHandlers<KubernetesModule>>
           resource,
           files,
           manifests,
-          namespace: module.spec.namespace
+          namespace: module.spec.namespace,
         },
       })
     }
@@ -129,7 +129,7 @@ export const kubernetesHandlers: Partial<ModuleActionHandlers<KubernetesModule>>
           resource,
           files,
           manifests,
-          namespace: module.spec.namespace
+          namespace: module.spec.namespace,
         },
       })
     }
@@ -498,7 +498,7 @@ async function configureSpecialModesForManifests({
     )
 
     // The "local-mode" annotation is set in `configureLocalMode`.
-    await configureLocalMode({
+    const configured = await configureLocalMode({
       ctx,
       spec: spec.localMode,
       defaultTarget: spec.defaultTarget,
@@ -513,7 +513,7 @@ async function configureSpecialModesForManifests({
       .filter((m) => !(m.kind === target!.kind && target?.metadata.name === m.metadata.name))
       .concat(<KubernetesResource<BaseResource>>target)
 
-    return { updated: [target], manifests: preparedManifests }
+    return { updated: [configured.updated], manifests: preparedManifests }
   } else if (mode === "sync" && spec.sync && !isEmpty(spec.sync)) {
     // The "sync-mode" annotation is set in `configureDevMode`.
     return configureSyncMode({

--- a/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
@@ -314,7 +314,7 @@ export const kubernetesDeploy: DeployActionHandler<"deploy", KubernetesDeployAct
         ctx,
         spec: spec.localMode,
         // TODO-G2: Support multiple processes+targets.
-        targetResource: modifiedResources[0],
+        manifest: modifiedResources[0],
         action,
         namespace,
         log,
@@ -500,7 +500,7 @@ async function configureSpecialModesForManifests({
     await configureLocalMode({
       ctx,
       spec: spec.localMode,
-      targetResource: target,
+      manifest: target,
       action,
       log,
     })

--- a/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
@@ -479,7 +479,6 @@ async function configureSpecialModesForManifests({
       ctx,
       spec: spec.localMode,
       defaultTarget: spec.defaultTarget,
-      manifest: undefined,
       manifests,
       action,
       log,

--- a/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
@@ -313,7 +313,7 @@ export const kubernetesDeploy: DeployActionHandler<"deploy", KubernetesDeployAct
         ctx,
         spec: spec.localMode,
         // TODO-G2: Support multiple processes+targets.
-        manifest: modifiedResources[0],
+        targetResource: modifiedResources[0],
         manifests: preparedManifests,
         action,
         namespace,

--- a/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
@@ -503,7 +503,6 @@ async function configureSpecialModesForManifests({
       targetResource: target,
       action,
       log,
-      containerName: spec.localMode.target?.containerName,
     })
 
     // Replace the original resource with the modified spec

--- a/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
@@ -7,7 +7,7 @@
  */
 
 import Bluebird from "bluebird"
-import { cloneDeep, isEmpty, omit, partition, uniq } from "lodash"
+import { isEmpty, omit, partition, uniq } from "lodash"
 import type { NamespaceStatus } from "../../../types/namespace"
 import type { ModuleActionHandlers } from "../../../plugin/plugin"
 import { ServiceStatus } from "../../../types/service"
@@ -28,7 +28,6 @@ import { configureLocalMode, startServiceInLocalMode } from "../local-mode"
 import type { ExecBuildConfig } from "../../exec/config"
 import type { KubernetesActionConfig, KubernetesDeployAction, KubernetesDeployActionConfig } from "./config"
 import type { DeployActionHandler } from "../../../plugin/action-types"
-import { getTargetResource } from "../util"
 import type { Log } from "../../../logger/log-entry"
 import type { Resolved } from "../../../actions/types"
 import { deployStateToActionState } from "../../../plugin/handlers/Deploy/get-status"
@@ -475,45 +474,16 @@ async function configureSpecialModesForManifests({
   // Local mode always takes precedence over sync mode
   if (mode === "local" && spec.localMode && !isEmpty(spec.localMode)) {
     // TODO-G2: Support multiple local processes+targets
-    const query = spec.localMode.target || spec.defaultTarget
-
-    if (!query) {
-      log.warn({
-        section: action.key(),
-        symbol: "warning",
-        msg: "Neither `localMode.target` nor `defaultTarget` is configured. Cannot Deploy in local mode.",
-      })
-      return { updated: [], manifests }
-    }
-
-    const target = cloneDeep(
-      await getTargetResource({
-        ctx,
-        log,
-        provider: ctx.provider,
-        action,
-        manifests,
-        query,
-      })
-    )
-
     // The "local-mode" annotation is set in `configureLocalMode`.
-    const configured = await configureLocalMode({
+    return await configureLocalMode({
       ctx,
       spec: spec.localMode,
       defaultTarget: spec.defaultTarget,
-      manifest: target,
+      manifest: undefined,
       manifests,
       action,
       log,
     })
-
-    // Replace the original resource with the modified spec
-    const preparedManifests = manifests
-      .filter((m) => !(m.kind === target!.kind && target?.metadata.name === m.metadata.name))
-      .concat(<KubernetesResource<BaseResource>>target)
-
-    return { updated: configured.updated, manifests: preparedManifests }
   } else if (mode === "sync" && spec.sync && !isEmpty(spec.sync)) {
     // The "sync-mode" annotation is set in `configureDevMode`.
     return configureSyncMode({

--- a/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
@@ -500,6 +500,7 @@ async function configureSpecialModesForManifests({
     await configureLocalMode({
       ctx,
       spec: spec.localMode,
+      defaultTarget: spec.defaultTarget,
       manifest: target,
       action,
       log,

--- a/core/src/plugins/kubernetes/local-mode.ts
+++ b/core/src/plugins/kubernetes/local-mode.ts
@@ -85,7 +85,6 @@ export const kubernetesLocalModeSchema = () =>
 interface BaseLocalModeParams {
   ctx: PluginContext
   spec: KubernetesLocalModeSpec
-  manifest: SyncableResource | undefined
   manifests: KubernetesResource[]
   action: Resolved<SyncableRuntimeAction>
   log: Log
@@ -431,11 +430,10 @@ export async function configureLocalMode(configParams: ConfigureLocalModeParams)
   const k8sCtx = ctx as KubernetesPluginContext
   const provider = k8sCtx.provider
 
-  let { manifests, manifest } = configParams
+  let { manifests } = configParams
 
   // Make sure we don't modify inputs in-place
   manifests = cloneDeep(manifests)
-  manifest = cloneDeep(manifest)
 
   const query = spec.target || defaultTarget
   if (!query) {
@@ -444,19 +442,17 @@ export async function configureLocalMode(configParams: ConfigureLocalModeParams)
       symbol: "warning",
       msg: "Neither `localMode.target` nor `defaultTarget` is configured. Cannot Deploy in local mode.",
     })
-    return { updated: [] , manifests }
+    return { updated: [], manifests }
   }
 
-  const resolvedTarget =
-    manifest ||
-    (await getTargetResource({
-      ctx,
-      log,
-      provider,
-      action,
-      manifests,
-      query,
-    }))
+  const resolvedTarget = await getTargetResource({
+    ctx,
+    log,
+    provider,
+    action,
+    manifests,
+    query,
+  })
 
   const section = action.key()
 

--- a/core/src/plugins/kubernetes/local-mode.ts
+++ b/core/src/plugins/kubernetes/local-mode.ts
@@ -9,7 +9,7 @@
 import { ContainerDeployAction, containerLocalModeSchema, ContainerLocalModeSpec } from "../container/config"
 import { dedent, gardenAnnotationKey } from "../../util/string"
 import { remove, set } from "lodash"
-import { SyncableResource, SyncableRuntimeAction } from "./types"
+import { KubernetesResource, SyncableResource, SyncableRuntimeAction } from "./types"
 import { PrimitiveMap } from "../../config/common"
 import {
   k8sReverseProxyImageName,
@@ -86,6 +86,7 @@ interface BaseLocalModeParams {
   ctx: PluginContext
   spec: KubernetesLocalModeSpec
   manifest: SyncableResource
+  manifests: KubernetesResource[]
   action: Resolved<SyncableRuntimeAction>
   log: Log
 }

--- a/core/src/plugins/kubernetes/local-mode.ts
+++ b/core/src/plugins/kubernetes/local-mode.ts
@@ -96,7 +96,7 @@ interface ConfigureLocalModeParams extends BaseLocalModeParams {
 
 interface StartLocalModeParams extends BaseLocalModeParams {
   namespace: string
-  manifest: SyncableResource
+  targetResource: SyncableResource
 }
 
 export interface ConfiguredLocalMode {
@@ -860,12 +860,12 @@ function composeSshTunnelProcessTree(
  *   3. Starts reverse port forwarding from the proxy's containerPort to the local app port.
  */
 export async function startServiceInLocalMode(configParams: StartLocalModeParams): Promise<void> {
-  const { manifest, action, namespace, log } = configParams
-  const targetResourceId = getResourceKey(manifest)
+  const { targetResource, action, namespace, log } = configParams
+  const targetResourceId = getResourceKey(targetResource)
 
   // Validate the target
-  if (!isConfiguredForLocalMode(manifest)) {
-    throw new ConfigurationError(`Resource ${targetResourceId} is not deployed in local mode`, { manifest })
+  if (!isConfiguredForLocalMode(targetResource)) {
+    throw new ConfigurationError(`Resource ${targetResourceId} is not deployed in local mode`, { targetResource })
   }
 
   const section = action.key()
@@ -908,7 +908,7 @@ export async function startServiceInLocalMode(configParams: StartLocalModeParams
     }
   }
 
-  const targetNamespace = manifest.metadata.namespace || namespace
+  const targetNamespace = targetResource.metadata.namespace || namespace
   const kubectlPortForward = await getKubectlPortForwardProcess(
     configParams,
     localSshPort,

--- a/core/src/plugins/kubernetes/local-mode.ts
+++ b/core/src/plugins/kubernetes/local-mode.ts
@@ -6,10 +6,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ContainerDeployAction, containerLocalModeSchema, ContainerLocalModeSpec } from "../container/config"
+import { containerLocalModeSchema, ContainerLocalModeSpec } from "../container/config"
 import { dedent, gardenAnnotationKey } from "../../util/string"
 import { remove, set } from "lodash"
-import { SyncableResource } from "./types"
+import { SyncableResource, SyncableRuntimeAction } from "./types"
 import { PrimitiveMap } from "../../config/common"
 import {
   k8sReverseProxyImageName,
@@ -32,10 +32,9 @@ import { kubectl } from "./kubectl"
 import { OsCommand, ProcessMessage, RecoverableProcess, RetryInfo } from "../../util/recoverable-process"
 import { isConfiguredForLocalMode } from "./status/status"
 import { exec, registerCleanupFunction, shutdown } from "../../util/util"
-import { HelmDeployAction } from "./helm/config"
-import { KubernetesDeployAction } from "./kubernetes-type/config"
 import getPort = require("get-port")
 import touch = require("touch")
+import { Resolved } from "../../actions/types"
 
 export const localModeGuideLink = "https://docs.garden.io/guides/running-service-in-local-mode"
 
@@ -73,7 +72,7 @@ interface BaseLocalModeParams {
   ctx: PluginContext
   spec: ContainerLocalModeSpec
   targetResource: SyncableResource
-  action: ContainerDeployAction | KubernetesDeployAction | HelmDeployAction
+  action: Resolved<SyncableRuntimeAction>
   log: Log
 }
 

--- a/core/src/plugins/kubernetes/local-mode.ts
+++ b/core/src/plugins/kubernetes/local-mode.ts
@@ -100,7 +100,7 @@ interface StartLocalModeParams extends BaseLocalModeParams {
 }
 
 interface ConfiguredLocalMode {
-  updated: SyncableResource
+  updated: SyncableResource[]
   manifests: KubernetesResource<BaseResource, string>[]
 }
 
@@ -455,7 +455,7 @@ export async function configureLocalMode(configParams: ConfigureLocalModeParams)
 
   patchSyncableManifest(manifest, targetContainer.name, localModeEnvVars, localModePorts)
 
-  return { updated: manifest, manifests }
+  return { updated: [manifest], manifests }
 }
 
 const attemptsLeft = ({ maxRetries, minTimeoutMs, retriesLeft }: RetryInfo): string => {

--- a/core/src/plugins/kubernetes/local-mode.ts
+++ b/core/src/plugins/kubernetes/local-mode.ts
@@ -90,7 +90,9 @@ interface BaseLocalModeParams {
   log: Log
 }
 
-interface ConfigureLocalModeParams extends BaseLocalModeParams {}
+interface ConfigureLocalModeParams extends BaseLocalModeParams {
+  defaultTarget: KubernetesTargetResourceSpec | undefined
+}
 
 interface StartLocalModeParams extends BaseLocalModeParams {
   namespace: string

--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -30,7 +30,14 @@ import {
   getTargetResource,
   labelSelectorToString,
 } from "./util"
-import { KubernetesResource, SupportedRuntimeActions, SyncableKind, syncableKinds, SyncableResource } from "./types"
+import {
+  KubernetesResource,
+  SupportedRuntimeActions,
+  SyncableKind,
+  syncableKinds,
+  SyncableResource,
+  SyncableRuntimeAction,
+} from "./types"
 import { Log } from "../../logger/log-entry"
 import chalk from "chalk"
 import { joi, joiIdentifier } from "../../config/common"
@@ -304,7 +311,7 @@ export async function configureSyncMode({
   ctx: PluginContext
   log: Log
   provider: KubernetesProvider
-  action: Resolved<SupportedRuntimeActions>
+  action: Resolved<SyncableRuntimeAction>
   defaultTarget: KubernetesTargetResourceSpec | undefined
   manifests: KubernetesResource[]
   spec: KubernetesDeploySyncSpec

--- a/core/src/plugins/kubernetes/types.ts
+++ b/core/src/plugins/kubernetes/types.ts
@@ -96,6 +96,8 @@ export type SyncableResource = KubernetesWorkload | KubernetesPod
 export type SyncableKind = "Deployment" | "DaemonSet" | "StatefulSet"
 export const syncableKinds: string[] = ["Deployment", "DaemonSet", "StatefulSet"]
 
+export type SyncableRuntimeAction = ContainerDeployAction | KubernetesDeployAction | HelmDeployAction
+
 export type HelmRuntimeAction = HelmDeployAction | HelmPodRunAction | HelmPodTestAction
 
 export type SupportedRuntimeActions =

--- a/core/test/integ/src/plugins/kubernetes/local-mode.ts
+++ b/core/test/integ/src/plugins/kubernetes/local-mode.ts
@@ -96,7 +96,7 @@ describe("local mode deployments and ssh tunneling behavior", () => {
     expect(status.detail?.mode).to.eql("local")
 
     const actionSshKeysPath = ProxySshKeystore.getSshDirPath(ctx.gardenDirPath)
-    const actionSshKeyName = action.name
+    const actionSshKeyName = action.key()
     const privateSshKeyPath = join(actionSshKeysPath, actionSshKeyName)
     const publicSshKeyPath = join(actionSshKeysPath, `${actionSshKeyName}.pub`)
     expect(await pathExists(privateSshKeyPath)).to.be.true

--- a/core/test/integ/src/plugins/kubernetes/local-mode.ts
+++ b/core/test/integ/src/plugins/kubernetes/local-mode.ts
@@ -102,7 +102,7 @@ describe("local mode deployments and ssh tunneling behavior", () => {
     expect(await pathExists(privateSshKeyPath)).to.be.true
     expect(await pathExists(publicSshKeyPath)).to.be.true
 
-    const localModePortSpec = action.getConfig().config.spec.localMode.ports[0]
+    const localModePortSpec = action.getConfig("spec").localMode.ports[0]
     const containerPort = localModePortSpec.remote
     const localPort = localModePortSpec.local
 

--- a/core/test/integ/src/plugins/kubernetes/local-mode.ts
+++ b/core/test/integ/src/plugins/kubernetes/local-mode.ts
@@ -95,10 +95,10 @@ describe("local mode deployments and ssh tunneling behavior", () => {
     expect(status.state).to.eql("ready")
     expect(status.detail?.mode).to.eql("local")
 
-    const serviceSshKeysPath = ProxySshKeystore.getSshDirPath(ctx.gardenDirPath)
-    const serviceSshKeyName = action.name
-    const privateSshKeyPath = join(serviceSshKeysPath, serviceSshKeyName)
-    const publicSshKeyPath = join(serviceSshKeysPath, `${serviceSshKeyName}.pub`)
+    const actionSshKeysPath = ProxySshKeystore.getSshDirPath(ctx.gardenDirPath)
+    const actionSshKeyName = action.name
+    const privateSshKeyPath = join(actionSshKeysPath, actionSshKeyName)
+    const publicSshKeyPath = join(actionSshKeysPath, `${actionSshKeyName}.pub`)
     expect(await pathExists(privateSshKeyPath)).to.be.true
     expect(await pathExists(publicSshKeyPath)).to.be.true
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
This PR **does not** fully fix the local mode integration tests. It refactors the local mode implementation, making it aligned with sync mode code, more readable, and easier to maintain. It also fixes some minor issues, and unifies the way of local mode config and start for all supported providers.

See individual commits for details. The commits be squashed before the merge. 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
The local mode works well. Most likely, there is something wrong with the test implementation. That does not block the `0.13` release, and could be fixed in a separate PR.