### PR TITLE
fix(k8s): retry exec attempts in PodRunner

### DIFF
--- a/core/src/plugins/kubernetes/api.ts
+++ b/core/src/plugins/kubernetes/api.ts
@@ -789,19 +789,26 @@ export class KubeApi {
       const execWithRetry = () => {
         const execHandler = new Exec(this.config)
 
-        return requestWithRetry(log, "Kubernetes API: exec", () => execHandler.exec(
-          namespace,
-          podName,
-          containerName,
-          command,
-          _stdout,
-          _stderr,
-          stdin || null,
-          tty,
-          (status) => {
-            finish(false, getExecExitCode(status))
+        const apiDescription = "Pod exec"
+        return requestWithRetry(log, `Kubernetes API: ${apiDescription}`, () => {
+          try {
+            return execHandler.exec(
+              namespace,
+              podName,
+              containerName,
+              command,
+              _stdout,
+              _stderr,
+              stdin || null,
+              tty,
+              (status) => {
+                finish(false, getExecExitCode(status))
+              }
+            )
+          } catch (err) {
+            throw wrapError(apiDescription, err)
           }
-        ))
+        })
       }
 
       if (timeoutSec) {

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -1036,6 +1036,7 @@ export class PodRunner extends PodRunnerParams {
     log.debug(`Execing command in ${this.namespace}/Pod/${this.podName}/${containerName}: ${command.join(" ")}`)
 
     const result = await this.api.execInPod({
+      log,
       namespace: this.namespace,
       podName: this.podName,
       containerName,

--- a/core/src/plugins/kubernetes/types.ts
+++ b/core/src/plugins/kubernetes/types.ts
@@ -40,15 +40,15 @@ export type KubernetesResource<T extends BaseResource | KubernetesObject = BaseR
       name: string
     }
   } & Omit<T, "apiVersion" | "kind" | "metadata"> &
-    // Make sure these are required if they're on the provided type
     {
+      // Make sure these are required if they're on the provided type
       [P in Extract<keyof T, "spec">]: Exclude<T[P], undefined>
     }
 
 // Server-side resources always have some fields set if they're in the schema, e.g. status
 export type KubernetesServerResource<T extends BaseResource | KubernetesObject = BaseResource> = KubernetesResource<T> &
-  // Make sure these are required if they're on the provided type
   {
+    // Make sure these are required if they're on the provided type
     [P in Extract<keyof T, "status">]: Exclude<T[P], undefined>
   }
 

--- a/core/test/integ/src/plugins/kubernetes/api.ts
+++ b/core/test/integ/src/plugins/kubernetes/api.ts
@@ -110,6 +110,7 @@ describe("KubeApi", () => {
 
       try {
         const res = await api.execInPod({
+          log: garden.log,
           namespace,
           podName,
           containerName,
@@ -143,6 +144,7 @@ describe("KubeApi", () => {
 
       try {
         const res = await api.execInPod({
+          log: garden.log,
           namespace,
           podName,
           containerName,
@@ -176,6 +178,7 @@ describe("KubeApi", () => {
 
       try {
         const res = await api.execInPod({
+          log: garden.log,
           namespace,
           podName,
           containerName: "main",


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
Before this change, the Kubernetes API request sent as part of PodRunner
exec calls have not been retried.

This change makes sure that we use the existing Kubernetes API retry
implementation and at the same time it makes sure that HttpErrors are
wrapped properly, for improved error messages.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
