### PR TITLE
feat(cli): support spread positional arguments

### DIFF
--- a/core/src/cli/autocomplete.ts
+++ b/core/src/cli/autocomplete.ts
@@ -176,18 +176,26 @@ export class Autocompleter {
     const parsed = parseCliArgs({ stringArgs, command, cli: true })
     const argIndex = parsed._.length
     const argSpecs = <Parameter<any>[]>Object.values(command.arguments || {})
-    const argSpec = argSpecs[argIndex]
+
+    let argSpec = argSpecs[argIndex]
 
     if (!argSpec) {
       // No more positional args
-      return []
+      const lastSpec = argSpecs[argSpecs.length - 1]
+
+      if (lastSpec?.spread) {
+        // There is a spread argument
+        argSpec = lastSpec
+      } else {
+        return []
+      }
     }
 
     const prefix = rest.length === 0 ? "" : rest[rest.length - 1]
     const argSuggestions = argSpec.getSuggestions({ configDump })
 
     return argSuggestions
-      .filter((s) => s.startsWith(prefix))
+      .filter((s) => s.startsWith(prefix) && !rest.includes(s))
       .map((s) => {
         const split = [...matchedPath, ...rest]
 

--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -27,9 +27,9 @@ import {
   pickCommand,
   parseCliArgs,
   optionsWithAliasValues,
-  getCliStyles,
   checkRequirements,
   renderCommandErrors,
+  cliStyles,
 } from "./helpers"
 import { Parameters, globalOptions, OUTPUT_RENDERERS, GlobalOptions, ParameterValues } from "./params"
 import {
@@ -129,8 +129,6 @@ export class GardenCli {
   }
 
   async renderHelp(workingDir: string) {
-    const cliStyles = getCliStyles()
-
     const commands = Object.values(this.commands)
       .sort()
       .filter((cmd) => cmd.getPath().length === 1)

--- a/core/src/cli/helpers.ts
+++ b/core/src/cli/helpers.ts
@@ -33,23 +33,19 @@ import { DeepPrimitiveMap } from "../config/common"
 import { validateGitInstall } from "../vcs/vcs"
 import { FileWriter } from "../logger/writers/file-writer"
 
-let _cliStyles: any
+export const cliStyles = {
+  heading: (str: string) => chalk.white.bold(str),
+  commandPlaceholder: () => chalk.blueBright("<command>"),
+  optionsPlaceholder: () => chalk.yellowBright("[options]"),
+  hints: (str: string) => chalk.gray(str),
+  usagePositional: (key: string, required: boolean, spread: boolean) => {
+    if (spread) {
+      key += " ..."
+    }
 
-export function getCliStyles() {
-  if (_cliStyles) {
-    return _cliStyles
-  }
-
-  _cliStyles = {
-    heading: (str: string) => chalk.white.bold(str),
-    commandPlaceholder: () => chalk.blueBright("<command>"),
-    optionsPlaceholder: () => chalk.yellowBright("[options]"),
-    hints: (str: string) => chalk.gray(str),
-    usagePositional: (key: string, required: boolean) => chalk.cyan(required ? `<${key}>` : `[${key}]`),
-    usageOption: (str: string) => chalk.cyan(`<${str}>`),
-  }
-
-  return _cliStyles
+    return chalk.cyan(required ? `<${key}>` : `[${key}]`)
+  },
+  usageOption: (str: string) => chalk.cyan(`<${str}>`),
 }
 
 /**
@@ -261,18 +257,28 @@ export function processCliArgs<A extends Parameters, O extends Parameters>({
     }
   }
 
-  // TODO: support variadic arguments
+  let lastKey: string | undefined
+  let lastSpec: Parameter<any> | undefined
+
   for (const idx of range(parsedArgs._.length)) {
-    const argKey = argKeys[idx]
     const argVal = parsedArgs._[idx]
-    const spec = argSpec[argKey]
 
-    if (!spec) {
-      if (command.allowUndefinedArguments) {
-        continue
-      }
+    let spread = false
+    let argKey = argKeys[idx]
+    let spec = argSpec[argKey]
 
+    if (argKey) {
+      lastKey = argKey
+      lastSpec = spec
+    } else if (lastKey && lastSpec?.spread) {
+      spread = true
+      argKey = lastKey
+      spec = lastSpec
+    } else if (command.allowUndefinedArguments) {
+      continue
+    } else {
       const expected = argKeys.length > 0 ? "only " + naturalList(argKeys.map((key) => chalk.white.bold(key))) : "none"
+
       throw new ParameterError(`Unexpected positional argument "${argVal}" (expected ${expected})`, {
         expectedKeys: argKeys,
         extraValue: argVal,
@@ -280,7 +286,16 @@ export function processCliArgs<A extends Parameters, O extends Parameters>({
     }
 
     try {
-      processedArgs[argKey] = spec.validate(spec.coerce(argVal))
+      const validated = spec.validate(spec.coerce(argVal))
+
+      if (spread && validated) {
+        if (!processedArgs[argKey]) {
+          processedArgs[argKey] = []
+        }
+        processedArgs[argKey].push(...validated)
+      } else {
+        processedArgs[argKey] = validated
+      }
     } catch (error) {
       throw new ParameterError(`Invalid value for argument ${chalk.white.bold(argKey)}: ${error.message}`, {
         error,
@@ -420,8 +435,7 @@ export function renderCommands(commands: Command[]) {
 
 export function renderArguments(params: Parameters) {
   return renderParameters(params, (name, param) => {
-    const cliStyles = getCliStyles()
-    return " " + cliStyles.usagePositional(name, param.required)
+    return " " + cliStyles.usagePositional(name, param.required, param.spread)
   })
 }
 

--- a/core/src/cli/params.ts
+++ b/core/src/cli/params.ts
@@ -48,7 +48,7 @@ interface GetSuggestionsParams {
 
 type GetSuggestionsCallback = (params: GetSuggestionsParams) => string[]
 
-export interface ParameterConstructor<T> {
+export interface ParameterConstructorParams<T> {
   help: string
   required?: boolean
   aliases?: string[]
@@ -100,7 +100,7 @@ export abstract class Parameter<T> {
     spread,
     suggestionPriority,
     getSuggestions,
-  }: ParameterConstructor<T>) {
+  }: ParameterConstructorParams<T>) {
     this.help = help
     this.required = required || false
     this.aliases = aliases
@@ -124,7 +124,7 @@ export abstract class Parameter<T> {
   }
 
   coerce(input?: string): T {
-    return (input as unknown) as T
+    return input as unknown as T
   }
 
   getDefaultValue(cli: boolean) {
@@ -152,9 +152,9 @@ export class StringOption extends Parameter<string | undefined> {
   schema = joi.string()
 }
 
-export interface StringsConstructor extends ParameterConstructor<string[]> {
+export interface StringsConstructorParams extends ParameterConstructorParams<string[]> {
   delimiter?: string
-  variadic?: boolean
+  spread?: boolean
 }
 
 export class StringsParameter extends Parameter<string[] | undefined> {
@@ -162,14 +162,12 @@ export class StringsParameter extends Parameter<string[] | undefined> {
   schema = joi.array().items(joi.string())
 
   delimiter: string | RegExp
-  variadic: boolean
 
-  constructor(args: StringsConstructor) {
+  constructor(args: StringsConstructorParams) {
     super(args)
 
     // The default delimiter splits on commas, ignoring commas between double quotes
     this.delimiter = args.delimiter || /,(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)/
-    this.variadic = !!args.variadic
   }
 
   coerce(input?: string | string[]): string[] {
@@ -259,7 +257,7 @@ export class IntegerParameter extends Parameter<number> {
   }
 }
 
-export interface ChoicesConstructor extends ParameterConstructor<string> {
+export interface ChoicesConstructor extends ParameterConstructorParams<string> {
   choices: string[]
 }
 
@@ -300,7 +298,7 @@ export class BooleanParameter extends Parameter<boolean> {
   type = "boolean"
   schema = joi.boolean()
 
-  constructor(args: ParameterConstructor<boolean>) {
+  constructor(args: ParameterConstructorParams<boolean>) {
     super(args)
     this.defaultValue = args.defaultValue || false
   }

--- a/core/src/commands/base.ts
+++ b/core/src/commands/base.ts
@@ -22,7 +22,7 @@ import { ProcessResults } from "../process"
 import { GraphResultMapWithoutTask } from "../graph/results"
 import { capitalize } from "lodash"
 import { userPrompt } from "../util/util"
-import { renderOptions, renderCommands, renderArguments, getCliStyles } from "../cli/helpers"
+import { renderOptions, renderCommands, renderArguments, cliStyles } from "../cli/helpers"
 import { GlobalOptions, ParameterValues, Parameters } from "../cli/params"
 import { GardenCli } from "../cli/cli"
 import { CommandLine } from "../cli/command-line"
@@ -287,8 +287,6 @@ export abstract class Command<A extends Parameters = {}, O extends Parameters = 
   }
 
   renderHelp() {
-    const cliStyles = getCliStyles()
-
     let out = this.description ? `${cliStyles.heading("DESCRIPTION")}\n\n${chalk.dim(this.description.trim())}\n\n` : ""
 
     out += `${cliStyles.heading("USAGE")}\n  garden ${this.getFullName()} `
@@ -296,7 +294,7 @@ export abstract class Command<A extends Parameters = {}, O extends Parameters = 
     if (this.arguments) {
       out +=
         Object.entries(this.arguments)
-          .map(([name, param]) => cliStyles.usagePositional(name, param.required))
+          .map(([name, param]) => cliStyles.usagePositional(name, param.required, param.spread))
           .join(" ") + " "
     }
 
@@ -355,7 +353,6 @@ export abstract class CommandGroup extends Command {
   }
 
   renderHelp() {
-    const cliStyles = getCliStyles()
     const commands = this.subCommands.map((c) => new c(this))
 
     return `

--- a/core/src/commands/build.ts
+++ b/core/src/commands/build.ts
@@ -28,7 +28,8 @@ import { watchParameter, watchRemovedWarning } from "./helpers"
 
 const buildArgs = {
   names: new StringsParameter({
-    help: "Specify builds to run. Use comma as a separator to specify multiple names.",
+    help: "Specify builds to run. You may specify multiple names, separated by spaces.",
+    spread: true,
     getSuggestions: ({ configDump }) => {
       return Object.keys(configDump.actionConfigs.Build)
     },
@@ -63,8 +64,9 @@ export class BuildCommand extends Command<Args, Opts> {
 
     Examples:
 
-        garden build            # build everything in the project
-        garden build my-image   # only build my-image
+        garden build                   # build everything in the project
+        garden build my-image          # only build my-image
+        garden build image-a image-b   # build image-a and image-b
         garden build --force    # force re-builds, even if builds had already been performed at current version
   `
 

--- a/core/src/commands/cloud/groups/groups.ts
+++ b/core/src/commands/cloud/groups/groups.ts
@@ -33,7 +33,8 @@ export class GroupsCommand extends CommandGroup {
 
 export const groupsListOpts = {
   "filter-names": new StringsParameter({
-    help: deline`Filter on group name. Use comma as a separator to filter on multiple names. Accepts glob patterns.`,
+    help: deline`Filter on group name. You may filter on multiple names by setting this flag multiple times. Accepts glob patterns.`,
+    spread: true,
   }),
 }
 

--- a/core/src/commands/cloud/secrets/secrets-create.ts
+++ b/core/src/commands/cloud/secrets/secrets-create.ts
@@ -22,8 +22,9 @@ import { getCloudDistributionName } from "../../../util/util"
 export const secretsCreateArgs = {
   secrets: new StringsParameter({
     help: deline`The names and values of the secrets to create, separated by '='.
-      Use comma as a separator to specify multiple secret name/value pairs. Note
+      You may specify multiple secret name/value pairs, separated by spaces. Note
       that you can also leave this empty and have Garden read the secrets from file.`,
+    spread: true,
   }),
 }
 
@@ -59,7 +60,7 @@ export class SecretsCreateCommand extends Command<Args, Opts> {
     You can optionally read the secrets from a file.
 
     Examples:
-        garden cloud secrets create DB_PASSWORD=my-pwd,ACCESS_KEY=my-key   # create two secrets
+        garden cloud secrets create DB_PASSWORD=my-pwd ACCESS_KEY=my-key   # create two secrets
         garden cloud secrets create ACCESS_KEY=my-key --scope-to-env ci    # create a secret and scope it to the ci environment
         garden cloud secrets create ACCESS_KEY=my-key --scope-to-env ci --scope-to-user 9  # create a secret and scope it to the ci environment and user with ID 9
         garden cloud secrets create --from-file /path/to/secrets.txt  # create secrets from the key value pairs in the secrets.txt file

--- a/core/src/commands/cloud/secrets/secrets-delete.ts
+++ b/core/src/commands/cloud/secrets/secrets-delete.ts
@@ -16,7 +16,8 @@ import { ApiCommandError, confirmDelete, DeleteResult, handleBulkOperationResult
 
 export const secretsDeleteArgs = {
   ids: new StringsParameter({
-    help: deline`The IDs of the secrets to delete.`,
+    help: deline`The ID(s) of the secrets to delete.`,
+    spread: true,
   }),
 }
 
@@ -30,7 +31,7 @@ export class SecretsDeleteCommand extends Command<Args> {
     which you which you can get from the \`garden cloud secrets list\` command.
 
     Examples:
-        garden cloud secrets delete 1,2,3   # delete secrets with IDs 1,2, and 3.
+        garden cloud secrets delete 1 2 3   # delete secrets with IDs 1, 2, and 3.
   `
 
   arguments = secretsDeleteArgs

--- a/core/src/commands/cloud/secrets/secrets-list.ts
+++ b/core/src/commands/cloud/secrets/secrets-list.ts
@@ -23,14 +23,14 @@ const pageLimit = 100
 
 export const secretsListOpts = {
   "filter-envs": new StringsParameter({
-    help: deline`Filter on environment. Use comma as a separator to filter on multiple environments.
+    help: deline`Filter on environment. You may filter on multiple environments by setting this flag multiple times.
     Accepts glob patterns."`,
   }),
   "filter-user-ids": new StringsParameter({
-    help: deline`Filter on user ID. Use comma as a separator to filter on multiple user IDs. Accepts glob patterns.`,
+    help: deline`Filter on user ID. You may filter on multiple user IDs by setting this flag multiple times. Accepts glob patterns.`,
   }),
   "filter-names": new StringsParameter({
-    help: deline`Filter on secret name. Use comma as a separator to filter on multiple secret names. Accepts glob patterns.`,
+    help: deline`Filter on secret name. You may filter on multiple secret names by setting this flag multiple times. Accepts glob patterns.`,
   }),
 }
 

--- a/core/src/commands/cloud/users/users-create.ts
+++ b/core/src/commands/cloud/users/users-create.ts
@@ -30,14 +30,15 @@ const MAX_USERS_PER_REQUEST = 100
 export const secretsCreateArgs = {
   users: new StringsParameter({
     help: deline`The VCS usernames and the names of the users to create, separated by '='.
-      Use comma as a separator to specify multiple VCS username/name pairs. Note
+      You may specify multiple VCS username/name pairs, separated by spaces. Note
       that you can also leave this empty and have Garden read the users from file.`,
+    spread: true,
   }),
 }
 
 export const secretsCreateOpts = {
   "add-to-groups": new StringsParameter({
-    help: deline`Add the user to the group with the given ID. Use comma as a separator to add the user to multiple groups.`,
+    help: deline`Add the user to the group with the given ID. You may add the user to multiple groups by setting this flag multiple times.`,
   }),
   "from-file": new PathParameter({
     help: deline`Read the users from the file at the given path. The file should have standard "dotenv"
@@ -66,7 +67,7 @@ export class UsersCreateCommand extends Command<Args, Opts> {
     gordon99="Gordon G"
 
     Examples:
-        garden cloud users create fatema_m="Fatema M",gordon99="Gordon G"      # create two users
+        garden cloud users create fatema_m="Fatema M" gordon99="Gordon G"  # create two users
         garden cloud users create fatema_m="Fatema M" --add-to-groups 1,2  # create a user and add two groups with IDs 1,2
         garden cloud users create --from-file /path/to/users.txt           # create users from the key value pairs in the users.txt file
   `

--- a/core/src/commands/cloud/users/users-delete.ts
+++ b/core/src/commands/cloud/users/users-delete.ts
@@ -17,6 +17,7 @@ import { ApiCommandError, confirmDelete, DeleteResult, handleBulkOperationResult
 export const usersDeleteArgs = {
   ids: new StringsParameter({
     help: deline`The IDs of the users to delete.`,
+    spread: true,
   }),
 }
 
@@ -30,7 +31,7 @@ export class UsersDeleteCommand extends Command<Args> {
     which you which you can get from the \`garden cloud users list\` command.
 
     Examples:
-        garden cloud users delete 1,2,3   # delete users with IDs 1,2, and 3.
+        garden cloud users delete 1 2 3   # delete users with IDs 1, 2, and 3.
   `
 
   arguments = usersDeleteArgs

--- a/core/src/commands/cloud/users/users-list.ts
+++ b/core/src/commands/cloud/users/users-list.ts
@@ -20,10 +20,10 @@ import { getCloudDistributionName } from "../../../util/util"
 
 export const usersListOpts = {
   "filter-names": new StringsParameter({
-    help: deline`Filter on user name. Use comma as a separator to filter on multiple names. Accepts glob patterns.`,
+    help: deline`Filter on user name. You may filter on multiple names by setting this flag multiple times. Accepts glob patterns.`,
   }),
   "filter-groups": new StringsParameter({
-    help: deline`Filter on the groups the user belongs to. Use comma as a separator to filter on multiple groups. Accepts glob patterns.`,
+    help: deline`Filter on the groups the user belongs to. You may filter on multiple groups by setting this flag multiple times. Accepts glob patterns.`,
   }),
 }
 

--- a/core/src/commands/delete.ts
+++ b/core/src/commands/delete.ts
@@ -109,8 +109,8 @@ export class DeleteEnvironmentCommand extends Command<{}, DeleteEnvironmentOpts>
 
 const deleteDeployArgs = {
   names: new StringsParameter({
-    help:
-      "The name(s) of the deploy(s) (or services if using modules) to delete. Use comma as a separator to specify multiple names.",
+    help: "The name(s) of the deploy(s) (or services if using modules) to delete. You may specify multiple names, separated by spaces.",
+    spread: true,
     getSuggestions: ({ configDump }) => {
       return Object.keys(configDump.actionConfigs.Deploy)
     },

--- a/core/src/commands/deploy.ts
+++ b/core/src/commands/deploy.ts
@@ -32,7 +32,8 @@ import { ActionModeMap } from "../actions/types"
 export const deployArgs = {
   names: new StringsParameter({
     help: deline`The name(s) of the deploy(s) (or deploys if using modules) to deploy (skip to deploy everything).
-      Use comma as a separator to specify multiple names.`,
+      You may specify multiple names, separated by spaces.`,
+    spread: true,
     getSuggestions: ({ configDump }) => {
       return Object.keys(configDump.actionConfigs.Deploy)
     },
@@ -45,7 +46,7 @@ export const deployOpts = {
   "watch": watchParameter,
   "sync": new StringsParameter({
     help: deline`The name(s) of the deploys to deploy with sync enabled.
-      Use comma as a separator to specify multiple names. Use * to deploy all
+      You may specify multiple names by setting this flag multiple times. Use * to deploy all
       supported deployments with sync enabled.
     `,
     aliases: ["dev", "dev-mode"],
@@ -55,7 +56,7 @@ export const deployOpts = {
   }),
   "local-mode": new StringsParameter({
     help: deline`[EXPERIMENTAL] The name(s) of the deploy(s) to be started locally with local mode enabled.
-    Use comma as a separator to specify multiple deploys. Use * to deploy all
+    You may specify multiple deploys by setting this flag multiple times. Use * to deploy all
     deploys with local mode enabled. When this option is used,
     the command is run in persistent mode.
 

--- a/core/src/commands/exec.ts
+++ b/core/src/commands/exec.ts
@@ -10,7 +10,7 @@ import chalk from "chalk"
 import { printHeader } from "../logger/util"
 import { Command, CommandResult, CommandParams } from "./base"
 import dedent = require("dedent")
-import { StringParameter, BooleanParameter, ParameterValues } from "../cli/params"
+import { StringParameter, BooleanParameter, ParameterValues, StringsParameter } from "../cli/params"
 import { ExecInDeployResult, execInDeployResultSchema } from "../plugin/handlers/Deploy/exec"
 import { executeAction } from "../graph/actions"
 
@@ -22,10 +22,10 @@ const execArgs = {
       return Object.keys(configDump.actionConfigs.Deploy)
     },
   }),
-  // TODO: make this variadic
-  command: new StringParameter({
+  command: new StringsParameter({
     help: "The command to run.",
     required: true,
+    spread: true,
   }),
 }
 
@@ -95,6 +95,6 @@ export class ExecCommand extends Command<Args, Opts> {
   }
 
   private getCommand(args: ParameterValues<Args>) {
-    return args.command.split(" ") || []
+    return args.command || []
   }
 }

--- a/core/src/commands/get/get-modules.ts
+++ b/core/src/commands/get/get-modules.ts
@@ -23,8 +23,8 @@ import { deepMap } from "../../util/objects"
 
 const getModulesArgs = {
   modules: new StringsParameter({
-    help:
-      "Specify module(s) to list. Use comma as a separator to specify multiple modules. Skip to return all modules.",
+    help: "Specify module(s) to list. You may specify multiple modules, separated by spaces. Skip to return all modules.",
+    spread: true,
     getSuggestions: ({ configDump }) => {
       return Object.keys(configDump.moduleConfigs)
     },

--- a/core/src/commands/get/get-runs.ts
+++ b/core/src/commands/get/get-runs.ts
@@ -15,7 +15,8 @@ import { keyBy } from "lodash"
 
 const getRunsArgs = {
   names: new StringsParameter({
-    help: "Specify run(s)/task(s) to list. Use comma as a separator to specify multiple names.",
+    help: "Specify run(s)/task(s) to list. You may specify multiple names, separated by spaces.",
+    spread: true,
     getSuggestions: ({ configDump }) => {
       return Object.keys(configDump.actionConfigs.Run)
     },

--- a/core/src/commands/get/get-tests.ts
+++ b/core/src/commands/get/get-tests.ts
@@ -15,7 +15,8 @@ import { ActionDescriptionMap } from "../../actions/base"
 
 const getTestsArgs = {
   names: new StringsParameter({
-    help: "Specify tests(s) to list. Use comma as a separator to specify multiple tests.",
+    help: "Specify tests(s) to list. You may specify multiple test names, separated by spaces.",
+    spread: true,
     getSuggestions: ({ configDump }) => {
       return Object.keys(configDump.actionConfigs.Test)
     },

--- a/core/src/commands/get/get-workflows.ts
+++ b/core/src/commands/get/get-workflows.ts
@@ -13,7 +13,8 @@ import { prettyPrintWorkflow } from "../helpers"
 
 const getWorkflowsArgs = {
   workflows: new StringsParameter({
-    help: "Specify workflow(s) to list. Use comma as a separator to specify multiple workflows.",
+    help: "Specify workflow(s) to list. You may specify multiple workflows, separated by spaces.",
+    spread: true,
     getSuggestions: ({ configDump }) => {
       return Object.keys(configDump.workflowConfigs)
     },

--- a/core/src/commands/logs.ts
+++ b/core/src/commands/logs.ts
@@ -26,7 +26,8 @@ const logsArgs = {
   names: new StringsParameter({
     help:
       "The name(s) of the deploy(s) to log (skip to get logs from all deploys in the project). " +
-      "Use comma as a separator to specify multiple names.",
+      "You may specify multiple names, separated by spaces.",
+    spread: true,
     getSuggestions: ({ configDump }) => {
       return Object.keys(configDump.actionConfigs.Deploy)
     },

--- a/core/src/commands/migrate.ts
+++ b/core/src/commands/migrate.ts
@@ -27,8 +27,8 @@ const migrateOpts = {
 }
 
 const migrateArgs = {
-  configPaths: new StringsParameter({
-    help: "Specify the path to a `garden.yml` file to convert. Use comma as a separator to specify multiple files.",
+  "config-paths": new StringsParameter({
+    help: "Specify the path to a `garden.yml` file to convert. You may specify multiple files by setting this flag multiple times.",
   }),
 }
 
@@ -84,8 +84,8 @@ export class MigrateCommand extends Command<Args, Opts> {
     const updatedConfigs: { path: string; specs: any[] }[] = []
 
     let configPaths: string[] = []
-    if (args.configPaths && args.configPaths.length > 0) {
-      configPaths = args.configPaths.map((path) => resolve(root, path))
+    if (args["config-paths"] && args["config-paths"].length > 0) {
+      configPaths = args["config-paths"].map((path) => resolve(root, path))
     } else {
       const vcs = new GitHandler({
         garden,

--- a/core/src/commands/options.ts
+++ b/core/src/commands/options.ts
@@ -7,7 +7,7 @@
  */
 
 import { Command, CommandParams, CommandResult } from "./base"
-import { renderOptions, getCliStyles } from "../cli/helpers"
+import { renderOptions, cliStyles } from "../cli/helpers"
 import { globalOptions } from "../cli/params"
 
 export class OptionsCommand extends Command {
@@ -20,8 +20,6 @@ export class OptionsCommand extends Command {
   printHeader() {}
 
   async action({ log }: CommandParams): Promise<CommandResult> {
-    const cliStyles = getCliStyles()
-
     log.info("")
     log.info(cliStyles.heading("GLOBAL OPTIONS"))
     log.info(renderOptions(globalOptions))

--- a/core/src/commands/publish.ts
+++ b/core/src/commands/publish.ts
@@ -26,7 +26,8 @@ export const publishArgs = {
   names: new StringsParameter({
     help:
       "The name(s) of the builds (or modules) to publish (skip to publish every build). " +
-      "Use comma as a separator to specify multiple names.",
+      "You may specify multiple names, separated by spaces.",
+    spread: true,
     getSuggestions: ({ configDump }) => {
       return Object.keys(configDump.actionConfigs.Build)
     },

--- a/core/src/commands/run.ts
+++ b/core/src/commands/run.ts
@@ -22,9 +22,10 @@ const runArgs = {
   names: new StringsParameter({
     help: deline`
       The name(s) of the Run action(s) to perform.
-      Use comma as a separator to specify multiple names.
+      You may specify multiple names, separated by spaces.
       Accepts glob patterns (e.g. init* would run both 'init' and 'initialize').
     `,
+    spread: true,
     getSuggestions: ({ configDump }) => {
       return Object.keys(configDump.actionConfigs.Run)
     },

--- a/core/src/commands/test.ts
+++ b/core/src/commands/test.ts
@@ -27,9 +27,10 @@ export const testArgs = {
   names: new StringsParameter({
     help: deline`
       The name(s) of the Test action(s) to test (skip to run all tests in the project).
-      Use comma as a separator to specify multiple tests.
+      You may specify multiple test names, separated by spaces.
       Accepts glob patterns (e.g. integ* would run both 'integ' and 'integration').
     `,
+    spread: true,
     getSuggestions: ({ configDump }) => {
       return Object.keys(configDump.actionConfigs.Test)
     },

--- a/core/src/commands/unlink/module.ts
+++ b/core/src/commands/unlink/module.ts
@@ -16,7 +16,8 @@ import { StringsParameter, BooleanParameter } from "../../cli/params"
 
 const unlinkModuleArguments = {
   modules: new StringsParameter({
-    help: "The name(s) of the module(s) to unlink. Use comma as a separator to specify multiple modules.",
+    help: "The name(s) of the module(s) to unlink. You may specify multiple modules, separated by spaces.",
+    spread: true,
     getSuggestions: ({ configDump }) => {
       return Object.keys(configDump.moduleConfigs)
     },

--- a/core/src/commands/unlink/source.ts
+++ b/core/src/commands/unlink/source.ts
@@ -16,7 +16,8 @@ import { StringsParameter, BooleanParameter } from "../../cli/params"
 
 const unlinkSourceArguments = {
   sources: new StringsParameter({
-    help: "The name(s) of the source(s) to unlink. Use comma as a separator to specify multiple sources.",
+    help: "The name(s) of the source(s) to unlink. You may specify multiple sources, separated by spaces.",
+    spread: true,
     getSuggestions: ({ configDump }) => {
       return configDump.sources.map((s) => s.name)
     },

--- a/core/src/commands/update-remote/modules.ts
+++ b/core/src/commands/update-remote/modules.ts
@@ -23,7 +23,8 @@ import { StringsParameter, ParameterValues } from "../../cli/params"
 
 const updateRemoteModulesArguments = {
   modules: new StringsParameter({
-    help: "The name(s) of the remote module(s) to update. Use comma as a separator to specify multiple modules.",
+    help: "The name(s) of the remote module(s) to update. You may specify multiple modules, separated by spaces.",
+    spread: true,
     getSuggestions: ({ configDump }) => {
       return Object.keys(configDump.moduleConfigs)
     },

--- a/core/src/commands/update-remote/sources.ts
+++ b/core/src/commands/update-remote/sources.ts
@@ -22,7 +22,8 @@ import { StringsParameter, ParameterValues } from "../../cli/params"
 
 const updateRemoteSourcesArguments = {
   sources: new StringsParameter({
-    help: "The name(s) of the remote source(s) to update. Use comma as a separator to specify multiple sources.",
+    help: "The name(s) of the remote source(s) to update. You may specify multiple sources, separated by spaces.",
+    spread: true,
     getSuggestions: ({ configDump }) => {
       return configDump.sources.map((s) => s.name)
     },

--- a/core/test/unit/src/cli/autocomplete.ts
+++ b/core/test/unit/src/cli/autocomplete.ts
@@ -131,6 +131,35 @@ describe("Autocompleter", () => {
       }
     })
 
+    it("returns more (unique) suggestions for variadic args after first arg", () => {
+      const input = "build module-a "
+      const result = ac.getSuggestions(input)
+
+      const lines = result.map((s) => s.line)
+
+      for (const s of ["module-b", "module-c", ...flags]) {
+        expect(lines).to.include(input + s)
+      }
+
+      // Should not suggest already entered suggestions
+      expect(lines).to.not.include(input + "module-a")
+    })
+
+    it("returns more (unique) suggestions for variadic args after second arg", () => {
+      const input = "build module-a module-b "
+      const result = ac.getSuggestions(input)
+
+      const lines = result.map((s) => s.line)
+
+      for (const s of ["module-c", ...flags]) {
+        expect(lines).to.include(input + s)
+      }
+
+      // Should not suggest already entered suggestions
+      expect(lines).to.not.include(input + "module-a")
+      expect(lines).to.not.include(input + "module-b")
+    })
+
     it("returns nothing if typing a positional argument that matches no suggested value", () => {
       const result = ac.getSuggestions("build z")
       expect(result).to.eql([])

--- a/core/test/unit/src/cli/helpers.ts
+++ b/core/test/unit/src/cli/helpers.ts
@@ -8,8 +8,8 @@
 
 import { expect } from "chai"
 import { optionsWithAliasValues, pickCommand, processCliArgs } from "../../../../src/cli/helpers"
-import { Parameters } from "../../../../src/cli/params"
-import { expectError, expectFuzzyMatch } from "../../../helpers"
+import { Parameters, StringParameter, StringsParameter } from "../../../../src/cli/params"
+import { expectError } from "../../../helpers"
 import { getPackageVersion } from "../../../../src/util/util"
 import { GARDEN_CORE_ROOT } from "../../../../src/constants"
 import { join } from "path"
@@ -29,6 +29,7 @@ import { getBuiltinCommands } from "../../../../src/commands/commands"
 import { DeepPrimitiveMap } from "../../../../src/config/common"
 import { getLogLevelChoices, LogLevel, parseLogLevel } from "../../../../src/logger/logger"
 import { ExecCommand } from "../../../../src/commands/exec"
+import { GetRunResultCommand } from "../../../../src/commands/get/get-run-result"
 
 const validLogLevels = getLogLevelChoices()
 
@@ -260,62 +261,33 @@ describe("processCliArgs", () => {
     expect(opts["log-level"]).to.equal("debug")
   })
 
-  // TODO: do this after the refactor is done and tested
-  // it("should handle a variadic argument spec", async () => {
-  //   const argSpec = {
-  //     first: new StringParameter({
-  //       help: "Some help text.",
-  //     }),
-  //     rest: new StringsParameter({
-  //       help: "Some help text.",
-  //       variadic: true,
-  //     }),
-  //   }
-
-  //   class VarCommand extends Command<typeof argSpec> {
-  //     name = "var-command"
-  //     help = "halp!"
-  //     noProject = true
-
-  //     arguments = argSpec
-
-  //     async action(params) {
-  //       return { result: params }
-  //     }
-  //   }
-
-  //   const cmd = new VarCommand()
-  //   const { args } = parseAndProcess(["test-command", "something", "a", "b", "c"], cmd)
-
-  //   expect(args.first).to.equal("something")
-  //   expect(args.rest).to.eql(["a", "b", "c"])
-  // })
-
   it("throws an error when a required positional argument is missing", () => {
     const cmd = new ExecCommand()
-    expectError(() => parseAndProcess([], cmd), { contains: "Missing required argument" })
+    void expectError(() => parseAndProcess([], cmd), { contains: "Missing required argument" })
   })
 
   it("throws an error when an unexpected positional argument is given", () => {
-    const cmd = new DeleteDeployCommand()
-    expectError(() => parseAndProcess(["my-service", "bla"], cmd), { contains: 'Unexpected positional argument "bla"' })
+    const cmd = new GetRunResultCommand()
+    void expectError(() => parseAndProcess(["my-run", "bla"], cmd), {
+      contains: 'Unexpected positional argument "bla"',
+    })
   })
 
   it("throws an error when an unrecognized option is set", () => {
     const cmd = new BuildCommand()
-    expectError(() => parseAndProcess(["--foo=bar"], cmd), { contains: "Unrecognized option flag --foo" })
+    void expectError(() => parseAndProcess(["--foo=bar"], cmd), { contains: "Unrecognized option flag --foo" })
   })
 
   it("throws an error when an invalid argument is given to a choice option", () => {
     const cmd = new BuildCommand()
-    expectError(() => parseAndProcess(["--logger-type=foo"], cmd), {
+    void expectError(() => parseAndProcess(["--logger-type=foo"], cmd), {
       contains: 'Invalid value for option --logger-type: "foo" is not a valid argument (should be any of ',
     })
   })
 
   it("throws an error when an invalid argument is given to an integer option", () => {
     const cmd = new LogsCommand()
-    expectError(() => parseAndProcess(["--tail=foo"], cmd), {
+    void expectError(() => parseAndProcess(["--tail=foo"], cmd), {
       contains: 'Invalid value for option --tail: Could not parse "foo" as integer',
     })
   })
@@ -353,7 +325,7 @@ describe("processCliArgs", () => {
 
   it("throws with all found errors if applicable", () => {
     const cmd = new RunCommand()
-    expectError(() => parseAndProcess(["--foo=bar", "--interactive=9", "--force"], cmd), {
+    void expectError(() => parseAndProcess(["--foo=bar", "--interactive=9", "--force"], cmd), {
       contains: ["Unrecognized option flag --foo", "Unrecognized option flag --interactive"],
     })
   })
@@ -435,6 +407,46 @@ describe("processCliArgs", () => {
       ...defaultActionParams,
       args,
       opts: withDefaultGlobalOpts(opts),
+    })
+  })
+
+  context("spread args", () => {
+    const argSpec = {
+      first: new StringParameter({
+        help: "Some help text.",
+      }),
+      spread: new StringsParameter({
+        help: "Some help text.",
+        spread: true,
+      }),
+    }
+
+    class SpreadCommand extends Command<typeof argSpec> {
+      name = "spread-command"
+      help = "halp!"
+      noProject = true
+
+      arguments = argSpec
+
+      async action(params: any) {
+        return { result: params }
+      }
+    }
+
+    it("should handle a spread argument spec", async () => {
+      const cmd = new SpreadCommand()
+      const { args } = parseAndProcess(["something", "a", "b", "c"], cmd)
+
+      expect(args.first).to.equal("something")
+      expect(args.spread).to.eql(["a", "b", "c"])
+    })
+
+    it("should handle a spread argument spec with comma-based values entered", async () => {
+      const cmd = new SpreadCommand()
+      const { args } = parseAndProcess(["something", "a,b,c"], cmd)
+
+      expect(args.first).to.equal("something")
+      expect(args.spread).to.eql(["a", "b", "c"])
     })
   })
 })

--- a/core/test/unit/src/commands/exec.ts
+++ b/core/test/unit/src/commands/exec.ts
@@ -17,7 +17,7 @@ describe("ExecCommand", () => {
     const garden = await makeTestGardenA()
     const log = garden.log
 
-    const args = { deploy: "service-a", command: "echo ok" }
+    const args = { deploy: "service-a", command: ["echo", "ok"] }
 
     command.printHeader({ headerLog: log, args })
 

--- a/core/test/unit/src/commands/migrate.ts
+++ b/core/test/unit/src/commands/migrate.ts
@@ -48,7 +48,7 @@ describe("commands", () => {
           log,
           headerLog: log,
           footerLog: log,
-          args: { configPaths: [] },
+          args: { "config-paths": [] },
           opts: withDefaultGlobalOpts({
             root: projectPath,
             write: false,
@@ -216,7 +216,7 @@ describe("commands", () => {
             log,
             headerLog: log,
             footerLog: log,
-            args: { configPaths: ["./project-varfile/garden.yml"] },
+            args: { "config-paths": ["./project-varfile/garden.yml"] },
             opts: withDefaultGlobalOpts({
               root: projectPathErrors,
               write: false,
@@ -252,7 +252,7 @@ describe("commands", () => {
             log,
             headerLog: log,
             footerLog: log,
-            args: { configPaths: [] },
+            args: { "config-paths": [] },
             opts: withDefaultGlobalOpts({
               write: true,
               root: tmpDir.path,
@@ -275,7 +275,7 @@ describe("commands", () => {
           log,
           headerLog: log,
           footerLog: log,
-          args: { configPaths: ["./garden.yml"] },
+          args: { "config-paths": ["./garden.yml"] },
           opts: withDefaultGlobalOpts({
             root: projectPath,
             write: false,

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -44,8 +44,9 @@ Optionally stays running and automatically builds when sources (or dependencies'
 
 Examples:
 
-    garden build            # build everything in the project
-    garden build my-image   # only build my-image
+    garden build                   # build everything in the project
+    garden build my-image          # only build my-image
+    garden build image-a image-b   # build image-a and image-b
     garden build --force    # force re-builds, even if builds had already been performed at current version
 
 #### Usage
@@ -56,7 +57,7 @@ Examples:
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
-  | `names` | No | Specify builds to run. Use comma as a separator to specify multiple names.
+  | `names` | No | Specify builds to run. You may specify multiple names, separated by spaces.
 
 #### Options
 
@@ -331,7 +332,7 @@ Examples:
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
-  | `names` | No | The name(s) of the deploy(s) (or services if using modules) to delete. Use comma as a separator to specify multiple names.
+  | `names` | No | The name(s) of the deploy(s) (or services if using modules) to delete. You may specify multiple names, separated by spaces.
 
 #### Options
 
@@ -471,7 +472,7 @@ Examples:
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
-  | `names` | No | The name(s) of the deploy(s) (or deploys if using modules) to deploy (skip to deploy everything). Use comma as a separator to specify multiple names.
+  | `names` | No | The name(s) of the deploy(s) (or deploys if using modules) to deploy (skip to deploy everything). You may specify multiple names, separated by spaces.
 
 #### Options
 
@@ -479,8 +480,8 @@ Examples:
 | -------- | ----- | ---- | ----------- |
   | `--force` |  | boolean | Force re-deploy.
   | `--force-build` |  | boolean | Force re-build of build dependencies.
-  | `--sync` |  | array:string | The name(s) of the deploys to deploy with sync enabled. Use comma as a separator to specify multiple names. Use * to deploy all supported deployments with sync enabled.
-  | `--local-mode` |  | array:string | [EXPERIMENTAL] The name(s) of the deploy(s) to be started locally with local mode enabled. Use comma as a separator to specify multiple deploys. Use * to deploy all deploys with local mode enabled. When this option is used, the command is run in persistent mode.
+  | `--sync` |  | array:string | The name(s) of the deploys to deploy with sync enabled. You may specify multiple names by setting this flag multiple times. Use * to deploy all supported deployments with sync enabled.
+  | `--local-mode` |  | array:string | [EXPERIMENTAL] The name(s) of the deploy(s) to be started locally with local mode enabled. You may specify multiple deploys by setting this flag multiple times. Use * to deploy all deploys with local mode enabled. When this option is used, the command is run in persistent mode.
 This always takes the precedence over sync mode if there are any conflicts, i.e. if the same deploys are passed to both &#x60;--sync&#x60; and &#x60;--local&#x60; options.
   | `--skip` |  | array:string | The name(s) of deploys you&#x27;d like to skip.
   | `--skip-dependencies` |  | boolean | Deploy the specified actions, but don&#x27;t build, deploy or run any dependencies. This option can only be used when a list of Deploy names is passed as CLI arguments. This can be useful e.g. when your stack has already been deployed, and you want to run specific deploys in sync mode without building, deploying or running dependencies that may have changed since you last deployed.
@@ -564,9 +565,9 @@ Examples:
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
-  | `--filter-envs` |  | array:string | Filter on environment. Use comma as a separator to filter on multiple environments. Accepts glob patterns.&quot;
-  | `--filter-user-ids` |  | array:string | Filter on user ID. Use comma as a separator to filter on multiple user IDs. Accepts glob patterns.
-  | `--filter-names` |  | array:string | Filter on secret name. Use comma as a separator to filter on multiple secret names. Accepts glob patterns.
+  | `--filter-envs` |  | array:string | Filter on environment. You may filter on multiple environments by setting this flag multiple times. Accepts glob patterns.&quot;
+  | `--filter-user-ids` |  | array:string | Filter on user ID. You may filter on multiple user IDs by setting this flag multiple times. Accepts glob patterns.
+  | `--filter-names` |  | array:string | Filter on secret name. You may filter on multiple secret names by setting this flag multiple times. Accepts glob patterns.
 
 
 ### garden cloud secrets create
@@ -582,7 +583,7 @@ To scope secrets to a user, you will need the user's ID which you can get from t
 You can optionally read the secrets from a file.
 
 Examples:
-    garden cloud secrets create DB_PASSWORD=my-pwd,ACCESS_KEY=my-key   # create two secrets
+    garden cloud secrets create DB_PASSWORD=my-pwd ACCESS_KEY=my-key   # create two secrets
     garden cloud secrets create ACCESS_KEY=my-key --scope-to-env ci    # create a secret and scope it to the ci environment
     garden cloud secrets create ACCESS_KEY=my-key --scope-to-env ci --scope-to-user 9  # create a secret and scope it to the ci environment and user with ID 9
     garden cloud secrets create --from-file /path/to/secrets.txt  # create secrets from the key value pairs in the secrets.txt file
@@ -595,7 +596,7 @@ Examples:
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
-  | `secrets` | No | The names and values of the secrets to create, separated by &#x27;&#x3D;&#x27;. Use comma as a separator to specify multiple secret name/value pairs. Note that you can also leave this empty and have Garden read the secrets from file.
+  | `secrets` | No | The names and values of the secrets to create, separated by &#x27;&#x3D;&#x27;. You may specify multiple secret name/value pairs, separated by spaces. Note that you can also leave this empty and have Garden read the secrets from file.
 
 #### Options
 
@@ -614,7 +615,7 @@ Delete secrets in Garden Cloud. You will nee the IDs of the secrets you want to 
 which you which you can get from the `garden cloud secrets list` command.
 
 Examples:
-    garden cloud secrets delete 1,2,3   # delete secrets with IDs 1,2, and 3.
+    garden cloud secrets delete 1 2 3   # delete secrets with IDs 1, 2, and 3.
 
 #### Usage
 
@@ -624,7 +625,7 @@ Examples:
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
-  | `ids` | No | The IDs of the secrets to delete.
+  | `ids` | No | The ID(s) of the secrets to delete.
 
 
 
@@ -647,8 +648,8 @@ Examples:
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
-  | `--filter-names` |  | array:string | Filter on user name. Use comma as a separator to filter on multiple names. Accepts glob patterns.
-  | `--filter-groups` |  | array:string | Filter on the groups the user belongs to. Use comma as a separator to filter on multiple groups. Accepts glob patterns.
+  | `--filter-names` |  | array:string | Filter on user name. You may filter on multiple names by setting this flag multiple times. Accepts glob patterns.
+  | `--filter-groups` |  | array:string | Filter on the groups the user belongs to. You may filter on multiple groups by setting this flag multiple times. Accepts glob patterns.
 
 
 ### garden cloud users create
@@ -668,7 +669,7 @@ fatema_m="Fatema M"
 gordon99="Gordon G"
 
 Examples:
-    garden cloud users create fatema_m="Fatema M",gordon99="Gordon G"      # create two users
+    garden cloud users create fatema_m="Fatema M" gordon99="Gordon G"  # create two users
     garden cloud users create fatema_m="Fatema M" --add-to-groups 1,2  # create a user and add two groups with IDs 1,2
     garden cloud users create --from-file /path/to/users.txt           # create users from the key value pairs in the users.txt file
 
@@ -680,13 +681,13 @@ Examples:
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
-  | `users` | No | The VCS usernames and the names of the users to create, separated by &#x27;&#x3D;&#x27;. Use comma as a separator to specify multiple VCS username/name pairs. Note that you can also leave this empty and have Garden read the users from file.
+  | `users` | No | The VCS usernames and the names of the users to create, separated by &#x27;&#x3D;&#x27;. You may specify multiple VCS username/name pairs, separated by spaces. Note that you can also leave this empty and have Garden read the users from file.
 
 #### Options
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
-  | `--add-to-groups` |  | array:string | Add the user to the group with the given ID. Use comma as a separator to add the user to multiple groups.
+  | `--add-to-groups` |  | array:string | Add the user to the group with the given ID. You may add the user to multiple groups by setting this flag multiple times.
   | `--from-file` |  | path | Read the users from the file at the given path. The file should have standard &quot;dotenv&quot; format (as defined by [dotenv](https://github.com/motdotla/dotenv#rules)) where the VCS username is the key and the name is the value.
 
 
@@ -698,7 +699,7 @@ Delete users in Garden Cloud. You will nee the IDs of the users you want to dele
 which you which you can get from the `garden cloud users list` command.
 
 Examples:
-    garden cloud users delete 1,2,3   # delete users with IDs 1,2, and 3.
+    garden cloud users delete 1 2 3   # delete users with IDs 1, 2, and 3.
 
 #### Usage
 
@@ -731,7 +732,7 @@ Examples:
 
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
-  | `--filter-names` |  | array:string | Filter on group name. Use comma as a separator to filter on multiple names. Accepts glob patterns.
+  | `--filter-names` |  | array:string | Filter on group name. You may filter on multiple names by setting this flag multiple times. Accepts glob patterns.
 
 
 ### garden get graph
@@ -2187,7 +2188,7 @@ Examples:
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
-  | `modules` | No | Specify module(s) to list. Use comma as a separator to specify multiple modules. Skip to return all modules.
+  | `modules` | No | Specify module(s) to list. You may specify multiple modules, separated by spaces. Skip to return all modules.
 
 #### Options
 
@@ -2723,7 +2724,7 @@ actions:
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
-  | `names` | No | Specify run(s)/task(s) to list. Use comma as a separator to specify multiple names.
+  | `names` | No | Specify run(s)/task(s) to list. You may specify multiple names, separated by spaces.
 
 
 
@@ -2740,7 +2741,7 @@ actions:
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
-  | `names` | No | Specify tests(s) to list. Use comma as a separator to specify multiple tests.
+  | `names` | No | Specify tests(s) to list. You may specify multiple test names, separated by spaces.
 
 
 
@@ -2893,7 +2894,7 @@ Note that this may include sensitive data, depending on the provider and your co
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
-  | `workflows` | No | Specify workflow(s) to list. Use comma as a separator to specify multiple workflows.
+  | `workflows` | No | Specify workflow(s) to list. You may specify multiple workflows, separated by spaces.
 
 
 
@@ -2993,7 +2994,7 @@ Examples:
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
-  | `names` | No | The name(s) of the deploy(s) to log (skip to get logs from all deploys in the project). Use comma as a separator to specify multiple names.
+  | `names` | No | The name(s) of the deploy(s) to log (skip to get logs from all deploys in the project). You may specify multiple names, separated by spaces.
 
 #### Options
 
@@ -3027,13 +3028,13 @@ Examples:
 
 #### Usage
 
-    garden migrate [configPaths] [options]
+    garden migrate [config-paths] [options]
 
 #### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
-  | `configPaths` | No | Specify the path to a &#x60;garden.yml&#x60; file to convert. Use comma as a separator to specify multiple files.
+  | `config-paths` | No | Specify the path to a &#x60;garden.yml&#x60; file to convert. You may specify multiple files by setting this flag multiple times.
 
 #### Options
 
@@ -3119,7 +3120,7 @@ Examples:
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
-  | `names` | No | The name(s) of the builds (or modules) to publish (skip to publish every build). Use comma as a separator to specify multiple names.
+  | `names` | No | The name(s) of the builds (or modules) to publish (skip to publish every build). You may specify multiple names, separated by spaces.
 
 #### Options
 
@@ -3189,7 +3190,7 @@ Examples:
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
-  | `names` | No | The name(s) of the Run action(s) to perform. Use comma as a separator to specify multiple names. Accepts glob patterns (e.g. init* would run both &#x27;init&#x27; and &#x27;initialize&#x27;).
+  | `names` | No | The name(s) of the Run action(s) to perform. You may specify multiple names, separated by spaces. Accepts glob patterns (e.g. init* would run both &#x27;init&#x27; and &#x27;initialize&#x27;).
 
 #### Options
 
@@ -3300,7 +3301,7 @@ Examples:
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
-  | `names` | No | The name(s) of the Test action(s) to test (skip to run all tests in the project). Use comma as a separator to specify multiple tests. Accepts glob patterns (e.g. integ* would run both &#x27;integ&#x27; and &#x27;integration&#x27;).
+  | `names` | No | The name(s) of the Test action(s) to test (skip to run all tests in the project). You may specify multiple test names, separated by spaces. Accepts glob patterns (e.g. integ* would run both &#x27;integ&#x27; and &#x27;integration&#x27;).
 
 #### Options
 
@@ -3391,7 +3392,7 @@ Examples:
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
-  | `sources` | No | The name(s) of the source(s) to unlink. Use comma as a separator to specify multiple sources.
+  | `sources` | No | The name(s) of the source(s) to unlink. You may specify multiple sources, separated by spaces.
 
 #### Options
 
@@ -3420,7 +3421,7 @@ Examples:
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
-  | `modules` | No | The name(s) of the module(s) to unlink. Use comma as a separator to specify multiple modules.
+  | `modules` | No | The name(s) of the module(s) to unlink. You may specify multiple modules, separated by spaces.
 
 #### Options
 
@@ -3449,7 +3450,7 @@ Examples:
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
-  | `sources` | No | The name(s) of the remote source(s) to update. Use comma as a separator to specify multiple sources.
+  | `sources` | No | The name(s) of the remote source(s) to update. You may specify multiple sources, separated by spaces.
 
 #### Options
 
@@ -3491,7 +3492,7 @@ Examples:
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
-  | `modules` | No | The name(s) of the remote module(s) to update. Use comma as a separator to specify multiple modules.
+  | `modules` | No | The name(s) of the remote module(s) to update. You may specify multiple modules, separated by spaces.
 
 #### Options
 


### PR DESCRIPTION
This has been grinding me for a while actually, glad to finally get this sorted.

Instead of `garden deploy service-a,service-b` we can now run `garden deploy service-a service-b ...`.

The older syntax also works btw, so it's not a breaking change.
