### PR TITLE
improvement: add additional info to error message when sh is not found

### DIFF
--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -550,7 +550,10 @@ async function runWithArtifacts({
             deline`
               ${description} specifies artifacts to export, but the image doesn't
               contain the sh binary. In order to copy artifacts out of Kubernetes containers, both sh and tar need to
-              be installed in the image.`,
+              be installed in the image.
+
+              Original error message:
+              ${message}`,
             errorMetadata
           )
         } else {
@@ -1176,7 +1179,7 @@ export class PodRunner extends PodRunnerParams {
   }) {
     // Some types and predicates to identify known errors
     const knownErrorTypes = ["out-of-memory", "not-found", "timeout", "pod-runner", "kubernetes"] as const
-    type KnownErrorType = typeof knownErrorTypes[number]
+    type KnownErrorType = (typeof knownErrorTypes)[number]
     // A known error is always an instance of a subclass of GardenBaseError
     type KnownError = Error & {
       message: string

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -1179,7 +1179,7 @@ export class PodRunner extends PodRunnerParams {
   }) {
     // Some types and predicates to identify known errors
     const knownErrorTypes = ["out-of-memory", "not-found", "timeout", "pod-runner", "kubernetes"] as const
-    type KnownErrorType = (typeof knownErrorTypes)[number]
+    type KnownErrorType = typeof knownErrorTypes[number]
     // A known error is always an instance of a subclass of GardenBaseError
     type KnownError = Error & {
       message: string

--- a/core/test/integ/src/plugins/kubernetes/container/container.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/container.ts
@@ -339,7 +339,7 @@ describe("kubernetes container module handlers", () => {
         const key = "test.missing-sh.missing-sh-test"
         expect(result).to.have.property(key)
         expect(result[key]!.error).to.exist
-        expect(result[key]!.error!.message).to.equal(deline`
+        expect(result[key]!.error!.message).to.include(deline`
           Test 'missing-sh-test' in container module 'missing-sh' specifies artifacts to export, but the image doesn't
           contain the sh binary. In order to copy artifacts out of Kubernetes containers, both sh and tar need
           to be installed in the image.
@@ -366,7 +366,7 @@ describe("kubernetes container module handlers", () => {
         const key = "test.missing-tar.missing-tar-test"
         expect(result).to.have.property(key)
         expect(result[key]!.error).to.exist
-        expect(result[key]!.error!.message).to.equal(deline`
+        expect(result[key]!.error!.message).to.include(deline`
           Test 'missing-tar-test' in container module 'missing-tar' specifies artifacts to export, but the
           image doesn't contain the tar binary. In order to copy artifacts out of Kubernetes containers, both
           sh and tar need to be installed in the image.

--- a/core/test/integ/src/plugins/kubernetes/container/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/run.ts
@@ -237,7 +237,7 @@ describe("runContainerTask", () => {
 
       expect(result).to.have.property(key)
       expect(result[key]!.error).to.exist
-      expect(result[key]!.error!.message).to.equal(deline`
+      expect(result[key]!.error!.message).to.include(deline`
         Task 'missing-sh-task' in container module 'missing-sh' specifies artifacts to export, but the image doesn't
         contain the sh binary. In order to copy artifacts out of Kubernetes containers, both sh and tar need
         to be installed in the image.
@@ -265,7 +265,7 @@ describe("runContainerTask", () => {
 
       expect(result).to.have.property(key)
       expect(result[key]!.error).to.exist
-      expect(result[key]!.error!.message).to.equal(deline`
+      expect(result[key]!.error!.message).to.include(deline`
         Task 'missing-tar-task' in container module 'missing-tar' specifies artifacts to export, but the image doesn't
         contain the tar binary. In order to copy artifacts out of Kubernetes containers, both sh and tar need
         to be installed in the image.

--- a/core/test/integ/src/plugins/kubernetes/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/run.ts
@@ -1260,7 +1260,7 @@ describe("kubernetes Pod runner functions", () => {
               version: module.version.versionString,
             }),
           (err) =>
-            expect(err.message).to.equal(deline`
+            expect(err.message).to.include(deline`
               Foo specifies artifacts to export, but the image doesn't
               contain the sh binary. In order to copy artifacts out of Kubernetes containers, both sh and tar need
               to be installed in the image.
@@ -1300,7 +1300,7 @@ describe("kubernetes Pod runner functions", () => {
               version: module.version.versionString,
             }),
           (err) =>
-            expect(err.message).to.equal(deline`
+            expect(err.message).to.include(deline`
               Foo specifies artifacts to export, but the image doesn't
               contain the tar binary. In order to copy artifacts out of Kubernetes containers, both sh and tar need
               to be installed in the image.
@@ -1329,7 +1329,7 @@ describe("kubernetes Pod runner functions", () => {
               version: module.version.versionString,
             }),
           (err) =>
-            expect(err.message).to.equal(deline`
+            expect(err.message).to.include(deline`
               Foo specifies artifacts to export, but doesn't explicitly set a \`command\`.
               The kubernetes provider currently requires an explicit command to be set for tests and tasks that
               export artifacts, because the image's entrypoint cannot be inferred in that execution mode.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
A user is having intermittent errors when running a test with artifacts where Garden responds with the error message:
```
<test-name> specifies artifacts to export, but the image doesn't contain the sh binary. In order to copy artifacts out of Kubernetes containers, both sh and tar need to be installed in the image.
```

They are sure that both `sh` and `tar` are present in the container.

Given the way we determine if `sh` or `tar` are not present and the difficulty in reproducing the error, I propose to print the full error message we receive from the execution, in the hope we can identify the root cause.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
