### PR TITLE
improvement(logger): various fixes to make basic logger render nicer

### DIFF
--- a/core/src/cli/helpers.ts
+++ b/core/src/cli/helpers.ts
@@ -25,12 +25,13 @@ import { printWarningMessage } from "../logger/util"
 import { GlobalConfigStore, globalConfigKeys } from "../config-store"
 import { got } from "../util/http"
 import minimist = require("minimist")
-import { renderTable, tablePresets, naturalList } from "../util/string"
+import { renderTable, tablePresets, naturalList, dedent } from "../util/string"
 import { globalOptions, GlobalOptions } from "./params"
 import { BuiltinArgs, Command, CommandGroup } from "../commands/base"
 import { DeepPrimitiveMap } from "../config/common"
 import { validateGitInstall } from "../vcs/vcs"
 import { validateRsyncInstall } from "../build-staging/rsync"
+import { emoji as nodeEmoji } from "node-emoji"
 
 let _cliStyles: any
 
@@ -422,4 +423,16 @@ function renderParameters(params: Parameters, formatName: (name: string, param: 
     ...tablePresets["no-borders"],
     colWidths: [nameColWidth, textColWidth],
   })
+}
+
+export function renderCloudLinkForBasicLogger({
+  commandResultUrl,
+  distroName,
+}: {
+  commandResultUrl: string
+  distroName: string
+}) {
+  return dedent`${
+    nodeEmoji.cherry_blossom
+  } Connected to ${distroName}  View logs and command results at: \n\n${chalk.cyan(commandResultUrl)}\n`
 }

--- a/core/src/cloud/api.ts
+++ b/core/src/cloud/api.ts
@@ -669,7 +669,7 @@ export class CloudApi {
 
   async getProject(): Promise<CloudProject | undefined> {
     if (!this.projectId) {
-      this.log.debug(`Could not retrieve a project which has not yet been configured`)
+      this.log.debug(`No project ID set. Will not fetch project.`)
       return
     }
 
@@ -721,5 +721,14 @@ export class CloudApi {
     }
     this.log.debug(`Checked client auth token with ${getCloudDistributionName(this.domain)} - valid: ${valid}`)
     return valid
+  }
+
+  getProjectUrl() {
+    return new URL(`/projects/${this.projectId}`, this.domain)
+  }
+
+  getCommandResultUrl({ sessionId, userId }: { sessionId: string; userId: string }) {
+    const path = `/projects/${this.projectId}?sessionId=${sessionId}&userId=${userId}`
+    return new URL(path, this.domain)
   }
 }

--- a/core/src/commands/custom.ts
+++ b/core/src/commands/custom.ts
@@ -72,6 +72,7 @@ export class CustomCommandWrapper extends Command {
   help = ""
 
   allowUndefinedArguments = true
+  noProject = true
 
   constructor(public spec: CommandResource) {
     super()

--- a/core/src/commands/dev.ts
+++ b/core/src/commands/dev.ts
@@ -141,13 +141,15 @@ export class DevCommand extends Command<DevCommandArgs, DevCommandOpts> {
 
   async prepare({ headerLog, footerLog }: PrepareParams<DevCommandArgs, DevCommandOpts>) {
     // print ANSI banner image
-    if (chalk.supportsColor && chalk.supportsColor.level > 2) {
-      const data = await readFile(ansiBannerPath)
-      headerLog.info(data.toString())
-    }
+    if (headerLog.root.type === "fancy") {
+      if (chalk.supportsColor && chalk.supportsColor.level > 2) {
+        const data = await readFile(ansiBannerPath)
+        headerLog.info(data.toString())
+      }
 
-    headerLog.info(chalk.gray.italic(`Good ${getGreetingTime()}! Let's get your environment wired up...`))
-    headerLog.info("")
+      headerLog.info(chalk.gray.italic(`Good ${getGreetingTime()}! Let's get your environment wired up...`))
+      headerLog.info("")
+    }
 
     this.server = await startServer({ log: footerLog })
   }

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -1330,9 +1330,6 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
     }
 
     if (project) {
-      const projectUrl = new URL(`/projects/${project.id}`, cloudDomain)
-      cloudLog.info({ symbol: "info", msg: `Visit project at ${projectUrl.href}` })
-
       if (cloudApi.projectId) {
         // ensure we use the fetched/created project ID
         cloudProjectId = cloudApi.projectId

--- a/core/src/logger/logger.ts
+++ b/core/src/logger/logger.ts
@@ -83,10 +83,10 @@ export interface LoggerConfigBase {
   storeEntries?: boolean
   showTimestamps?: boolean
   useEmoji?: boolean
+  type: LoggerType
 }
 
 export interface LoggerConfig extends LoggerConfigBase {
-  type: LoggerType
   storeEntries: boolean
 }
 
@@ -135,6 +135,7 @@ export class Logger implements LogNode {
    * is required. Otherwise useful for testing.
    */
   public storeEntries: boolean
+  public type: LoggerType
 
   private writers: Writer[]
   private static instance?: Logger
@@ -216,6 +217,7 @@ export class Logger implements LogNode {
     this.showTimestamps = !!config.showTimestamps
     this.events = new EventBus()
     this.storeEntries = config.storeEntries
+    this.type = config.type
   }
 
   private addNode(params: CreateNodeParams): LogEntry {
@@ -313,7 +315,7 @@ export class Logger implements LogNode {
  */
 export class VoidLogger extends Logger {
   constructor() {
-    super({ writers: [], level: LogLevel.error, storeEntries: false })
+    super({ writers: [], level: LogLevel.error, storeEntries: false, type: "basic" })
   }
 }
 

--- a/core/src/plugins/kubernetes/status/status.ts
+++ b/core/src/plugins/kubernetes/status/status.ts
@@ -357,7 +357,7 @@ export async function compareDeployedResources(
     return result
   }
 
-  log.verbose(`Comparing expected and deployed resources...`)
+  log.debug(`Comparing expected and deployed resources...`)
 
   for (let [newManifest, deployedResource] of zip(manifests, deployedResources) as KubernetesResource[][]) {
     let manifest = cloneDeep(newManifest)
@@ -447,7 +447,7 @@ export async function compareDeployedResources(
 
     if (!isSubset(deployedResource, manifest)) {
       if (manifest) {
-        log.verbose(`Resource ${manifest.metadata.name} is not a superset of deployed resource`)
+        log.debug(`Resource ${manifest.metadata.name} is not a superset of deployed resource`)
         log.silly(diffString(deployedResource, manifest))
       }
       // console.log(JSON.stringify(resource, null, 4))
@@ -459,7 +459,7 @@ export async function compareDeployedResources(
     }
   }
 
-  log.verbose(`All resources match.`)
+  log.debug(`All resources match.`)
 
   result.state = "ready"
   return result

--- a/core/src/server/server.ts
+++ b/core/src/server/server.ts
@@ -144,7 +144,6 @@ export class GardenServer {
       } while (!this.server)
     }
 
-    this.log.info("")
     this.statusLog = this.log.placeholder()
   }
 
@@ -157,10 +156,15 @@ export class GardenServer {
   }
 
   showUrl(url?: string) {
-    this.statusLog.setState({
-      emoji: "sunflower",
-      msg: chalk.cyan("Garden dashboard running at ") + chalk.blueBright(url || this.getUrl()),
-    })
+    const msg = chalk.white("Garden dashboard running at ") + chalk.blueBright(url || this.getUrl())
+    if (this.statusLog.root.type === "fancy") {
+      this.statusLog.setState({
+        emoji: "sunflower",
+        msg,
+      })
+    } else {
+      this.statusLog.info({ section: "garden", msg })
+    }
   }
 
   async close() {

--- a/core/test/unit/src/analytics/analytics.ts
+++ b/core/test/unit/src/analytics/analytics.ts
@@ -268,6 +268,7 @@ describe("AnalyticsHandler", () => {
         level: LogLevel.info,
         writers: [],
         storeEntries: false,
+        type: "basic",
       })
       const cloudApi = await FakeCloudApi.factory({ log: logger.placeholder() })
       garden = await makeTestGardenA(undefined, { cloudApi })

--- a/core/test/unit/src/cli/cli.ts
+++ b/core/test/unit/src/cli/cli.ts
@@ -37,11 +37,12 @@ import { startServer, GardenServer } from "../../../../src/server/server"
 import { FancyTerminalWriter } from "../../../../src/logger/writers/fancy-terminal-writer"
 import { BasicTerminalWriter } from "../../../../src/logger/writers/basic-terminal-writer"
 import { envSupportsEmoji } from "../../../../src/logger/util"
-import { expectError } from "../../../../src/util/testing"
+import { expectError, getLogMessages } from "../../../../src/util/testing"
 import { GlobalConfigStore, RequirementsCheck } from "../../../../src/config-store"
 import { ExecConfigStore } from "../config-store"
 import tmp from "tmp-promise"
 import { CloudCommand } from "../../../../src/commands/cloud/cloud"
+import { LogEntry } from "../../../../src/logger/log-entry"
 
 describe("cli", () => {
   let cli: GardenCli
@@ -545,8 +546,11 @@ describe("cli", () => {
 
       await cli.run({ args, exitOnError: false })
 
-      const serverStatus = cmd.server!["statusLog"].getLatestMessage().msg!
-      expect(stripAnsi(serverStatus)).to.equal(`Garden dashboard running at ${cmd.server!.getUrl()}`)
+      const serverStatus = getLogMessages(
+        cmd.server!["statusLog"],
+        (e: LogEntry) => e.getLatestMessage().msg?.includes("Garden dashboard running at") || false
+      )
+      expect(stripAnsi(serverStatus[0])).to.equal(`Garden dashboard running at ${cmd.server!.getUrl()}`)
     })
 
     it("shows the URL of an external dashboard if applicable, instead of the built-in server URL", async () => {
@@ -601,8 +605,11 @@ describe("cli", () => {
         await server.close()
       }
 
-      const serverStatus = cmd.server!["statusLog"].getLatestMessage().msg!
-      expect(stripAnsi(serverStatus)).to.equal(`Garden dashboard running at ${server.getUrl()}`)
+      const serverStatus = getLogMessages(
+        cmd.server!["statusLog"],
+        (e: LogEntry) => e.getLatestMessage().msg?.includes("Garden dashboard running at") || false
+      )
+      expect(stripAnsi(serverStatus[0])).to.equal(`Garden dashboard running at ${server.getUrl()}`)
     })
 
     it("picks and runs a subcommand in a group", async () => {

--- a/core/test/unit/src/logger/logger.ts
+++ b/core/test/unit/src/logger/logger.ts
@@ -166,6 +166,7 @@ describe("Logger", () => {
         level: LogLevel.info,
         writers: [],
         storeEntries: false,
+        type: "basic",
       })
 
       loggerB.error("error")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

In a handful of places the rendered output assumes the fancy logger is being used and it really doesn't play nice with the basic logger.

This commit adds a logger "type" field to the root Logger and in a handful of places tweaks a given log message depending on the that type.

This is a prerequisite to making the basic logger the default but we still need to add some sort of a status indicator at the bottom before doing that since otherwise it's hard to tell whether Garden is still executing or waiting for changes when in persistent mode.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
