### PR TITLE
chore: switch the cleanup command emoji

### DIFF
--- a/core/src/commands/delete.ts
+++ b/core/src/commands/delete.ts
@@ -78,7 +78,7 @@ export class DeleteEnvironmentCommand extends Command<{}, DeleteEnvironmentOpts>
     })
 
   printHeader({ headerLog }) {
-    printHeader(headerLog, `Cleanup namespace`, "☠️")
+    printHeader(headerLog, `Cleanup namespace`, "♻️")
   }
 
   async action({
@@ -161,7 +161,7 @@ export class DeleteDeployCommand extends Command<DeleteDeployArgs, DeleteDeployO
     ).description("A map of statuses for all the deleted deploys.")
 
   printHeader({ headerLog }) {
-    printHeader(headerLog, "Cleaning up deployment(s)", "☠️")
+    printHeader(headerLog, "Cleaning up deployment(s)", "♻️")
   }
 
   async action({ garden, log, args, opts }: CommandParams<DeleteDeployArgs, DeleteDeployOpts>): Promise<CommandResult> {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

Just a tiny detail I noticed - this got initially done in https://github.com/garden-io/garden/pull/3768/ and ended up reverted in 61ef901523e1140df6fd4b464c06e7a40d8a25c7. Do we want to switch again to the recycling symbol, or do we want to keep the revert to skull? This PR can be closed without merging if we prefer to keep the skull in our messaging and style.