### PR TITLE
chore: fix confusing log lines in BuildTask

### DIFF
--- a/core/src/tasks/build.ts
+++ b/core/src/tasks/build.ts
@@ -51,7 +51,7 @@ export class BuildTask extends ExecuteActionTask<BuildAction, BuildStatus> {
     const files = action.getFullVersion().files
 
     if (files.length > 0) {
-      log.verbose(`Syncing module sources (${pluralize("file", files.length, true)})...`)
+      log.verbose(`Syncing sources (${pluralize("file", files.length, true)})...`)
     }
 
     await this.garden.buildStaging.syncFromSrc({
@@ -59,7 +59,7 @@ export class BuildTask extends ExecuteActionTask<BuildAction, BuildStatus> {
       log: log || this.log,
     })
 
-    log.setSuccess(chalk.green(`Done (took ${log.getDuration(1)} sec)`))
+    log.verbose(chalk.green(`Done syncing sources (took ${log.getDuration(1)} sec)`))
 
     await this.garden.buildStaging.syncDependencyProducts(action, log)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Before this fix, the log line emitted in `BuildTask`'s `process` method was a rather confusing, since it seemed to indicate that the build was complete before it was executed.