### PR TITLE
0.13 cloud alignment

### DIFF
--- a/core/src/events.ts
+++ b/core/src/events.ts
@@ -217,6 +217,7 @@ export interface Events {
     timestamp: string
     actionUid: string
     actionName: string
+    actionType: string
     moduleName: string | null
     origin: string
     data: string

--- a/core/src/router/build.ts
+++ b/core/src/router/build.ts
@@ -14,10 +14,13 @@ import { BaseRouterParams, createActionRouter } from "./base"
 import { ActionState, stateForCacheStatusEvent } from "../actions/types"
 import { PublishActionResult } from "../plugin/handlers/Build/publish"
 
+const API_ACTION_TYPE = "build"
+
 export const buildRouter = (baseParams: BaseRouterParams) =>
   createActionRouter("Build", baseParams, {
     getStatus: async (params) => {
       const { router, action, garden } = params
+      const actionType = API_ACTION_TYPE
 
       const startedAt = new Date().toISOString()
 
@@ -26,6 +29,7 @@ export const buildRouter = (baseParams: BaseRouterParams) =>
       const payloadAttrs = {
         moduleName: action.moduleName(),
         actionName: action.name,
+        actionType,
         actionUid: action.getUid(),
         actionVersion,
         startedAt,
@@ -63,7 +67,7 @@ export const buildRouter = (baseParams: BaseRouterParams) =>
       const startedAt = new Date().toISOString()
 
       const actionName = action.name
-      const actionType = "build"
+      const actionType = API_ACTION_TYPE
       const actionVersion = action.versionString()
       const moduleName = action.moduleName()
 
@@ -84,6 +88,7 @@ export const buildRouter = (baseParams: BaseRouterParams) =>
       const payloadAttrs = {
         actionName,
         actionVersion,
+        actionType,
         moduleName,
         actionUid,
         startedAt,

--- a/core/src/router/build.ts
+++ b/core/src/router/build.ts
@@ -63,6 +63,7 @@ export const buildRouter = (baseParams: BaseRouterParams) =>
       const startedAt = new Date().toISOString()
 
       const actionName = action.name
+      const actionType = "build"
       const actionVersion = action.versionString()
       const moduleName = action.moduleName()
 
@@ -74,6 +75,7 @@ export const buildRouter = (baseParams: BaseRouterParams) =>
           timestamp,
           actionUid,
           actionName,
+          actionType,
           moduleName,
           origin,
           data: data.toString(),

--- a/core/src/router/deploy.ts
+++ b/core/src/router/deploy.ts
@@ -14,6 +14,8 @@ import { DeployState } from "../types/service"
 import { renderOutputStream } from "../util/util"
 import { BaseRouterParams, createActionRouter } from "./base"
 
+const API_ACTION_TYPE = "deploy"
+
 export const deployRouter = (baseParams: BaseRouterParams) =>
   createActionRouter("Deploy", baseParams, {
     deploy: async (params) => {
@@ -23,7 +25,7 @@ export const deployRouter = (baseParams: BaseRouterParams) =>
       params.events = params.events || new PluginEventBroker()
 
       const actionName = action.name
-      const actionType = "deploy"
+      const actionType = API_ACTION_TYPE
       const actionVersion = action.versionString()
       const moduleName = action.moduleName()
 
@@ -47,6 +49,7 @@ export const deployRouter = (baseParams: BaseRouterParams) =>
       const payloadAttrs = {
         actionName,
         actionVersion,
+        actionType,
         moduleName,
         actionUid,
         startedAt,
@@ -141,10 +144,12 @@ export const deployRouter = (baseParams: BaseRouterParams) =>
       const { garden, router, action } = params
       const actionName = action.name
       const actionVersion = action.versionString()
+      const actionType = API_ACTION_TYPE
 
       const payloadAttrs = {
         actionName,
         actionVersion,
+        actionType,
         actionUid: action.getUid(),
         moduleName: action.moduleName(),
         startedAt: new Date().toISOString(),

--- a/core/src/router/deploy.ts
+++ b/core/src/router/deploy.ts
@@ -23,6 +23,7 @@ export const deployRouter = (baseParams: BaseRouterParams) =>
       params.events = params.events || new PluginEventBroker()
 
       const actionName = action.name
+      const actionType = "deploy"
       const actionVersion = action.versionString()
       const moduleName = action.moduleName()
 
@@ -34,6 +35,7 @@ export const deployRouter = (baseParams: BaseRouterParams) =>
           timestamp,
           actionUid,
           actionName,
+          actionType,
           moduleName,
           origin,
           data: data.toString(),

--- a/core/src/router/run.ts
+++ b/core/src/router/run.ts
@@ -16,6 +16,8 @@ import { copyArtifacts, getArtifactKey } from "../util/artifacts"
 import { renderOutputStream } from "../util/util"
 import { BaseRouterParams, createActionRouter } from "./base"
 
+const API_ACTION_TYPE = "run"
+
 export const runRouter = (baseParams: BaseRouterParams) =>
   createActionRouter("Run", baseParams, {
     run: async (params) => {
@@ -27,12 +29,13 @@ export const runRouter = (baseParams: BaseRouterParams) =>
 
       const actionName = action.name
       const actionVersion = action.versionString()
-      const actionType = "run"
+      const actionType = API_ACTION_TYPE
       const moduleName = action.moduleName()
 
       const payloadAttrs = {
         actionName,
         actionVersion,
+        actionType,
         moduleName,
         actionUid,
         startedAt: new Date().toISOString()
@@ -102,11 +105,14 @@ export const runRouter = (baseParams: BaseRouterParams) =>
 
       const actionName = action.name
       const actionVersion = action.versionString()
+      const actionType = API_ACTION_TYPE
+
       const moduleName = action.moduleName()
 
       const payloadAttrs = {
         actionName,
         actionVersion,
+        actionType,
         moduleName,
         actionUid: action.getUid(),
         startedAt: new Date().toISOString()

--- a/core/src/router/run.ts
+++ b/core/src/router/run.ts
@@ -27,6 +27,7 @@ export const runRouter = (baseParams: BaseRouterParams) =>
 
       const actionName = action.name
       const actionVersion = action.versionString()
+      const actionType = "run"
       const moduleName = action.moduleName()
 
       const payloadAttrs = {
@@ -58,6 +59,7 @@ export const runRouter = (baseParams: BaseRouterParams) =>
             timestamp,
             actionUid,
             actionName,
+            actionType,
             moduleName,
             origin,
             data: data.toString(),

--- a/core/src/router/test.ts
+++ b/core/src/router/test.ts
@@ -16,6 +16,8 @@ import { makeTempDir } from "../util/fs"
 import { renderOutputStream } from "../util/util"
 import { BaseRouterParams, createActionRouter } from "./base"
 
+const API_ACTION_TYPE = "test"
+
 export const testRouter = (baseParams: BaseRouterParams) =>
   createActionRouter("Test", baseParams, {
     run: async (params) => {
@@ -26,13 +28,14 @@ export const testRouter = (baseParams: BaseRouterParams) =>
       const actionUid = action.getUid()
 
       const actionName = action.name
-      const actionType = "test"
+      const actionType = API_ACTION_TYPE
       const actionVersion = action.versionString()
       const moduleName = action.moduleName()
 
       const payloadAttrs = {
         actionName,
         actionVersion,
+        actionType,
         moduleName,
         actionUid,
         startedAt: new Date().toISOString(),
@@ -101,10 +104,12 @@ export const testRouter = (baseParams: BaseRouterParams) =>
 
       const actionName = action.name
       const actionVersion = action.versionString()
+      const actionType = API_ACTION_TYPE
 
       const payloadAttrs = {
         actionName,
         actionVersion,
+        actionType,
         moduleName: action.moduleName(),
         actionUid: action.getUid(),
         startedAt: new Date().toISOString(),

--- a/core/src/router/test.ts
+++ b/core/src/router/test.ts
@@ -26,6 +26,7 @@ export const testRouter = (baseParams: BaseRouterParams) =>
       const actionUid = action.getUid()
 
       const actionName = action.name
+      const actionType = "test"
       const actionVersion = action.versionString()
       const moduleName = action.moduleName()
 
@@ -58,6 +59,7 @@ export const testRouter = (baseParams: BaseRouterParams) =>
             timestamp,
             actionUid,
             actionName,
+            actionType,
             moduleName,
             origin,
             data: data.toString(),


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to have Cloud process events from 0.13 correctly, we needed to add the `actionType` key to emitted events which is one of "build", "deploy", "run" or "test".

These are hardcoded here as the property `action.type` available internally contained a different kind of information.


**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
