### PR TITLE
Action logs

### DIFF
--- a/cli/src/add-version-files.ts
+++ b/cli/src/add-version-files.ts
@@ -18,7 +18,7 @@ import { TreeCache } from "@garden-io/core/build/src/cache"
 require("source-map-support").install()
 
 // make sure logger is initialized
-Logger.initialize({ level: LogLevel.info, type: "quiet", storeEntries: false })
+Logger.initialize({ level: LogLevel.info, terminalWriterType: "quiet", storeEntries: false })
 
 /**
  * Write .garden-version files for modules in garden-system/static.

--- a/cli/src/generate-docs.ts
+++ b/cli/src/generate-docs.ts
@@ -19,7 +19,7 @@ require("source-map-support").install()
 try {
   Logger.initialize({
     level: LogLevel.info,
-    type: "quiet",
+    terminalWriterType: "quiet",
     storeEntries: false,
     // level: LogLevel.debug,
     // writers: [new TerminalWriter()],

--- a/core/src/actions/base.ts
+++ b/core/src/actions/base.ts
@@ -723,7 +723,8 @@ export abstract class ExecutedRuntimeAction<
     O extends {} = any
   >
   extends ResolvedRuntimeAction<C, O>
-  implements ExecutedActionExtension<C, O> {
+  implements ExecutedActionExtension<C, O>
+{
   private readonly status: ActionStatus<this, any, O>
 
   constructor(params: ExecutedActionWrapperParams<C, O>) {

--- a/core/src/actions/build.ts
+++ b/core/src/actions/build.ts
@@ -183,7 +183,8 @@ export class ResolvedBuildAction<
     Outputs extends {} = any
   >
   extends BuildAction<C, Outputs>
-  implements ResolvedActionExtension<C, Outputs> {
+  implements ResolvedActionExtension<C, Outputs>
+{
   protected graph: ResolvedConfigGraph
   protected readonly params: ResolvedActionWrapperParams<C>
   protected readonly resolved: true
@@ -239,7 +240,8 @@ export class ExecutedBuildAction<
     O extends {} = any
   >
   extends ResolvedBuildAction<C, O>
-  implements ExecutedActionExtension<C, O> {
+  implements ExecutedActionExtension<C, O>
+{
   protected readonly executed: true
   private readonly status: ActionStatus<this, any, O>
 

--- a/core/src/cli/command-line.ts
+++ b/core/src/cli/command-line.ts
@@ -12,6 +12,7 @@ import { keyBy, max } from "lodash"
 import sliceAnsi from "slice-ansi"
 import stringWidth from "string-width"
 import { BuiltinArgs, Command, CommandGroup, CommandParams, CommandResult } from "../commands/base"
+import { toGardenError } from "../exceptions"
 import { ConfigDump, Garden } from "../garden"
 import { Log } from "../logger/log-entry"
 import { renderDivider } from "../logger/util"
@@ -632,7 +633,7 @@ ${chalk.white.underline("Keys:")}
       })
       .catch((error: Error) => {
         // TODO-G2: improve error rendering
-        this.log.error({ error })
+        this.log.error({ error: toGardenError(error) })
         this.log.error({ msg: renderDivider({ width, color: chalk.red, char: "┈" }) })
         this.flashError(failMessage)
       })

--- a/core/src/cli/helpers.ts
+++ b/core/src/cli/helpers.ts
@@ -31,7 +31,6 @@ import { globalOptions, GlobalOptions } from "./params"
 import { BuiltinArgs, Command, CommandGroup } from "../commands/base"
 import { DeepPrimitiveMap } from "../config/common"
 import { validateGitInstall } from "../vcs/vcs"
-import { FileWriter } from "../logger/writers/file-writer"
 
 export const cliStyles = {
   heading: (str: string) => chalk.white.bold(str),
@@ -487,7 +486,7 @@ function renderParameters(params: Parameters, formatName: (name: string, param: 
 export function renderCommandErrors(logger: Logger, errors: Error[], log?: Log) {
   const gardenErrors: GardenBaseError[] = errors.map(toGardenError)
 
-  const errorLog = log || logger.makeNewLogContext()
+  const errorLog = log || logger.createLog()
 
   for (const error of gardenErrors) {
     errorLog.error({
@@ -498,7 +497,7 @@ export function renderCommandErrors(logger: Logger, errors: Error[], log?: Log) 
     errorLog.silly(error.formatWithDetail())
   }
 
-  if (logger.getWriters().find((w) => w instanceof FileWriter)) {
+  if (logger.getWriters().file.length > 0) {
     errorLog.info(`\nSee .garden/${ERROR_LOG_FILENAME} for detailed error message`)
   }
 }

--- a/core/src/cli/params.ts
+++ b/core/src/cli/params.ts
@@ -379,8 +379,7 @@ export function describeParameters(args?: Parameters) {
 
 export const globalOptions = {
   "root": new PathParameter({
-    help:
-      "Override project root directory (defaults to working directory). Can be absolute or relative to current directory.",
+    help: "Override project root directory (defaults to working directory). Can be absolute or relative to current directory.",
   }),
   "silent": new BooleanParameter({
     help: "Suppress log output. Same as setting --logger-type=quiet.",
@@ -436,8 +435,7 @@ export const globalOptions = {
     defaultValue: false,
   }),
   "var": new StringsParameter({
-    help:
-      'Set a specific variable value, using the format <key>=<value>, e.g. `--var some-key=custom-value`. This will override any value set in your project configuration. You can specify multiple variables by separating with a comma, e.g. `--var key-a=foo,key-b="value with quotes"`.',
+    help: 'Set a specific variable value, using the format <key>=<value>, e.g. `--var some-key=custom-value`. This will override any value set in your project configuration. You can specify multiple variables by separating with a comma, e.g. `--var key-a=foo,key-b="value with quotes"`.',
   }),
   "version": new BooleanParameter({
     aliases: ["V"],
@@ -448,8 +446,7 @@ export const globalOptions = {
     help: "Show help",
   }),
   "disable-port-forwards": new BooleanParameter({
-    help:
-      "Disable automatic port forwarding when in watch mode. Note that you can also set GARDEN_DISABLE_PORT_FORWARDS=true in your environment.",
+    help: "Disable automatic port forwarding when in watch mode. Note that you can also set GARDEN_DISABLE_PORT_FORWARDS=true in your environment.",
   }),
 }
 

--- a/core/src/cloud/api.ts
+++ b/core/src/cloud/api.ts
@@ -515,7 +515,7 @@ export class CloudApi {
               // Intentionally skipping search params in case they contain tokens or sensitive data.
               const href = options.url.origin + options.url.pathname
               const description = retryDescription || `Request`
-              retryLog = retryLog || this.log.makeNewLogContext({ level: LogLevel.debug })
+              retryLog = retryLog || this.log.makeNewLogContext({ fixLevel: LogLevel.debug })
               const statusCodeDescription = error.code ? ` (status code ${error.code})` : ``
               retryLog.info(deline`
                 ${description} failed with error ${error.message}${statusCodeDescription},

--- a/core/src/cloud/auth.ts
+++ b/core/src/cloud/auth.ts
@@ -28,7 +28,7 @@ export class AuthRedirectServer {
   constructor(enterpriseDomain: string, events: EventEmitter2, log: Log, public port?: number) {
     this.enterpriseDomain = enterpriseDomain
     this.events = events
-    this.log = log.makeNewLogContext({})
+    this.log = log.createLog({})
   }
 
   async start() {

--- a/core/src/cloud/buffered-event-stream.ts
+++ b/core/src/cloud/buffered-event-stream.ts
@@ -9,7 +9,7 @@
 import Bluebird from "bluebird"
 
 import { Events, EventName, EventBus, pipedEventNames } from "../events"
-import { LogEntryMetadata, Log, LogEntry } from "../logger/log-entry"
+import { LogMetadata, Log, LogEntry } from "../logger/log-entry"
 import { got } from "../util/http"
 
 import { LogLevel } from "../logger/logger"
@@ -30,7 +30,7 @@ export interface LogEntryEventPayload {
   timestamp: string
   level: LogLevel
   message: LogEntryMessage
-  metadata?: LogEntryMetadata
+  metadata?: LogMetadata
 }
 
 export function formatLogEntryForEventStream(entry: LogEntry): LogEntryEventPayload {

--- a/core/src/commands/base.ts
+++ b/core/src/commands/base.ts
@@ -184,7 +184,7 @@ export abstract class Command<A extends Parameters = {}, O extends Parameters = 
     }
   }
 
-  getLoggerType(_: CommandParamsBase<A, O>): LoggerType {
+  getTerminalWriterType(_: CommandParamsBase<A, O>): LoggerType {
     return "default"
   }
 

--- a/core/src/commands/cloud/helpers.ts
+++ b/core/src/commands/cloud/helpers.ts
@@ -140,7 +140,7 @@ export function handleBulkOperationResult<T>({
       ${errorMsgs}\n
     `)
   } else {
-    cmdLog.setSuccess()
+    cmdLog.success("Done")
   }
 
   if (successCount > 0) {

--- a/core/src/commands/cloud/secrets/secrets-create.ts
+++ b/core/src/commands/cloud/secrets/secrets-create.ts
@@ -160,7 +160,7 @@ export class SecretsCreateCommand extends Command<Args, Opts> {
     }
 
     const secretsToCreate = Object.entries(secrets)
-    const cmdLog = log.makeNewLogContext({ section: "secrets-command" })
+    const cmdLog = log.createLog({ section: "secrets-command" })
     cmdLog.info("Creating secrets...")
 
     let count = 1

--- a/core/src/commands/cloud/secrets/secrets-delete.ts
+++ b/core/src/commands/cloud/secrets/secrets-delete.ts
@@ -57,7 +57,7 @@ export class SecretsDeleteCommand extends Command<Args> {
       throw new ConfigurationError(noApiMsg("delete", "secrets"), {})
     }
 
-    const cmdLog = log.makeNewLogContext({ section: "secrets-command" })
+    const cmdLog = log.createLog({ section: "secrets-command" })
     cmdLog.info("Deleting secrets...")
 
     let count = 1

--- a/core/src/commands/cloud/users/users-create.ts
+++ b/core/src/commands/cloud/users/users-create.ts
@@ -120,7 +120,7 @@ export class UsersCreateCommand extends Command<Args, Opts> {
       throw new ConfigurationError(noApiMsg("create", "users"), {})
     }
 
-    const cmdLog = log.makeNewLogContext({ section: "users-command" })
+    const cmdLog = log.createLog({ section: "users-command" })
     cmdLog.info("Creating users...")
 
     const usersToCreate = Object.entries(users).map(([vcsUsername, name]) => ({

--- a/core/src/commands/cloud/users/users-delete.ts
+++ b/core/src/commands/cloud/users/users-delete.ts
@@ -57,7 +57,7 @@ export class UsersDeleteCommand extends Command<Args> {
       throw new ConfigurationError(noApiMsg("delete", "user"), {})
     }
 
-    const cmdLog = log.makeNewLogContext({ section: "users-command" })
+    const cmdLog = log.createLog({ section: "users-command" })
     cmdLog.info("Deleting users...")
 
     let count = 1

--- a/core/src/commands/config/config-analytics-enabled.ts
+++ b/core/src/commands/config/config-analytics-enabled.ts
@@ -51,9 +51,9 @@ export class ConfigAnalyticsEnabled extends Command {
     await analyticsClient.setAnalyticsOptOut(!args.enable)
 
     if (args.enable) {
-      log.setSuccess(`Thanks for helping us make Garden better! Anonymized analytics collection is now active.`)
+      log.success(`Thanks for helping us make Garden better! Anonymized analytics collection is now active.`)
     } else {
-      log.setSuccess(`The collection of anonymous CLI usage data is now disabled.`)
+      log.success(`The collection of anonymous CLI usage data is now disabled.`)
     }
 
     return {}

--- a/core/src/commands/dev.tsx
+++ b/core/src/commands/dev.tsx
@@ -56,19 +56,24 @@ Let's get your development environment wired up.
     )
   }
 
-  getLoggerType(): LoggerType {
+  getTerminalWriterType(): LoggerType {
     return "ink"
   }
 
   async action(params: ActionParams): Promise<CommandResult> {
-    const logger = params.log.root
-    const writers = logger.getWriters()
-    const inkWriter = writers.find((w) => w.type === "ink") as InkTerminalWriter
+    const logger = getLogger()
+    const terminalWriter = logger.getWriters().terminal
 
+    let inkWriter: InkTerminalWriter
     // TODO: maybe enforce this elsewhere
-    if (!inkWriter) {
+    if (terminalWriter.type === "ink") {
+      inkWriter = terminalWriter as InkTerminalWriter
+    } else {
       throw new ParameterError(`This command can only be used with the ink logger type`, {
-        writerTypes: writers.map((w) => w.type),
+        writerTypes: {
+          terminalWriter: terminalWriter.type,
+          fileWriters: logger.getWriters().file.map((w) => w.type),
+        },
       })
     }
 

--- a/core/src/commands/dev.tsx
+++ b/core/src/commands/dev.tsx
@@ -61,8 +61,8 @@ Let's get your development environment wired up.
   }
 
   async action(params: ActionParams): Promise<CommandResult> {
-    const logger = getLogger()
-    const terminalWriter = logger.getWriters().terminal
+    const logger = params.log.root
+  const terminalWriter = logger.getWriters().terminal
 
     let inkWriter: InkTerminalWriter
     // TODO: maybe enforce this elsewhere

--- a/core/src/commands/get/get-config.ts
+++ b/core/src/commands/get/get-config.ts
@@ -25,8 +25,7 @@ export const getConfigOptions = {
     help: "Exclude disabled action and module configs from output.",
   }),
   "resolve": new ChoicesParameter({
-    help:
-      "Choose level of resolution of config templates. Defaults to full. Specify --resolve=partial to avoid resolving providers.",
+    help: "Choose level of resolution of config templates. Defaults to full. Specify --resolve=partial to avoid resolving providers.",
     // TODO: add "raw" option, to just scan for configs and return completely unresolved
     choices: ["full", "partial"],
     defaultValue: "full",

--- a/core/src/commands/get/get-run-result.ts
+++ b/core/src/commands/get/get-run-result.ts
@@ -45,8 +45,9 @@ export class GetRunResultCommand extends Command<Args, {}, GetRunResultCommandRe
   outputsSchema = () =>
     getRunResultSchema()
       .keys({
-        artifacts: joiArray(joi.string())
-          .description("Local file paths to any exported artifacts from the Run's execution."),
+        artifacts: joiArray(joi.string()).description(
+          "Local file paths to any exported artifacts from the Run's execution."
+        ),
       })
       .description("The output from the Run. May also return null if no Run result is found.")
 

--- a/core/src/commands/get/get-test-result.ts
+++ b/core/src/commands/get/get-test-result.ts
@@ -20,8 +20,7 @@ import { findByName, getNames } from "../../util/util"
 
 const getTestResultArgs = {
   name: new StringParameter({
-    help:
-      "The name of the test. If this test belongs to a module, specify the module name here instead, and specify the test name from the module in the second argument.",
+    help: "The name of the test. If this test belongs to a module, specify the module name here instead, and specify the test name from the module in the second argument.",
     required: true,
     getSuggestions: ({ configDump }) => {
       return Object.keys(configDump.actionConfigs.Test)
@@ -63,11 +62,7 @@ export class GetTestResultCommand extends Command<Args, {}, GetTestResultCommand
     const testName = args.name
     const moduleName = args.module
 
-    printHeader(
-      headerLog,
-      `Test result for test ${chalk.cyan(testName)} in module ${chalk.cyan(moduleName)}`,
-      "✔️"
-    )
+    printHeader(headerLog, `Test result for test ${chalk.cyan(testName)} in module ${chalk.cyan(moduleName)}`, "✔️")
   }
 
   async action({ garden, log, args }: CommandParams<Args>) {

--- a/core/src/commands/run-workflow.ts
+++ b/core/src/commands/run-workflow.ts
@@ -74,7 +74,7 @@ export class RunWorkflowCommand extends Command<Args, {}> {
   }
 
   async action({ cli, garden, log, args, opts }: CommandParams<Args, {}>): Promise<CommandResult<WorkflowRunOutput>> {
-    const outerLog = log.makeNewLogContext({})
+    const outerLog = log.createLog({})
     // Prepare any configured files before continuing
     const workflow = await garden.getWorkflowConfig(args.workflow)
 
@@ -112,9 +112,9 @@ export class RunWorkflowCommand extends Command<Args, {}> {
       const metadata = {
         workflowStep: { index },
       }
-      const stepHeaderLog = outerLog.makeNewLogContext({ metadata })
-      const stepBodyLog = outerLog.makeNewLogContext({ metadata })
-      const stepFooterLog = outerLog.makeNewLogContext({ metadata })
+      const stepHeaderLog = outerLog.createLog({ metadata })
+      const stepBodyLog = outerLog.createLog({ metadata })
+      const stepFooterLog = outerLog.createLog({ metadata })
       garden.log.info({ metadata })
 
       if (step.skip) {

--- a/core/src/commands/serve.ts
+++ b/core/src/commands/serve.ts
@@ -239,9 +239,10 @@ class LogLevelCommand extends InteractiveCommand<LogLevelArguments> {
 
     const logger = log.root
 
-    for (const writer of logger.getWriters()) {
+    const writers = logger.getWriters()
+    for (const writer of [writers.terminal, ...writers.file]) {
       if (displayWriterTypes.includes(writer.type)) {
-        writer.level = (level as unknown) as LogLevel
+        writer.level = level as unknown as LogLevel
       }
     }
 

--- a/core/src/commands/test.ts
+++ b/core/src/commands/test.ts
@@ -57,8 +57,7 @@ export const testOpts = {
   }),
   "force-build": new BooleanParameter({ help: "Force rebuild of any Build dependencies encountered." }),
   "interactive": new BooleanParameter({
-    help:
-      "Run the specified test in interactive mode (i.e. to allow attaching to a shell). A single test must be selected, otherwise an error is thrown.",
+    help: "Run the specified test in interactive mode (i.e. to allow attaching to a shell). A single test must be selected, otherwise an error is thrown.",
     aliases: ["i"],
     cliOnly: true,
   }),

--- a/core/src/commands/tools.ts
+++ b/core/src/commands/tools.ts
@@ -76,11 +76,11 @@ export class ToolsCommand extends Command<Args, Opts> {
 
   printHeader() {}
 
-  async prepare({ log }) {
+  async prepare({ log }: { log: Log }) {
     // Override the logger output, to output to stderr instead of stdout, to avoid contaminating command output
-    const basicWriter = log.root.writers.find((w) => w.type === "basic")
-    if (basicWriter) {
-      basicWriter.output = process.stderr
+    const terminalWriter = log.root.getWriters().terminal
+    if (terminalWriter.type === "default" || terminalWriter.type === "basic") {
+      terminalWriter.output = process.stderr
     }
   }
 

--- a/core/src/commands/update-remote/helpers.ts
+++ b/core/src/commands/update-remote/helpers.ts
@@ -17,8 +17,7 @@ import { BooleanParameter } from "../../cli/params"
 
 export const updateRemoteSharedOptions = {
   parallel: new BooleanParameter({
-    help:
-      "Allow git updates to happen in parallel. This will automatically reject any Git prompt, such as username / password.",
+    help: "Allow git updates to happen in parallel. This will automatically reject any Git prompt, such as username / password.",
     defaultValue: false,
   }),
 }

--- a/core/src/docs/joi-schema.ts
+++ b/core/src/docs/joi-schema.ts
@@ -101,7 +101,7 @@ export class JoiKeyDescription extends BaseKeyDescription {
         const metas: any = extend({}, ...(objSchema.metas || []))
         childDescriptions.push(
           new JoiKeyDescription({
-            joiDescription: (objSchema.patterns[0].rule as JoiDescription) as JoiDescription,
+            joiDescription: objSchema.patterns[0].rule as JoiDescription as JoiDescription,
             name: metas.keyPlaceholder || "<name>",
             level: nextLevel,
             parent,

--- a/core/src/events.ts
+++ b/core/src/events.ts
@@ -165,7 +165,6 @@ export interface Events {
   // Stack Graph events
   stackGraph: RenderedActionGraph
 
-
   // TODO: Remove these once the Cloud UI no longer uses them.
 
   // TaskGraph events

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -665,7 +665,7 @@ export class Garden {
 
       log.silly(`Resolving providers`)
 
-      const providerLog = log.makeNewLogContext({ section: "providers" })
+      const providerLog = log.createLog({ name: "providers", showDuration: true })
       providerLog.info("Getting status...")
 
       const plugins = keyBy(await this.getAllPlugins(), "name")
@@ -750,13 +750,10 @@ export class Garden {
       }
 
       if (gotCachedResult) {
-        providerLog.setSuccess(chalk.green("Cached"))
-        providerLog.info({
-          symbol: "info",
-          msg: chalk.gray("Run with --force-refresh to force a refresh of provider statuses."),
-        })
+        providerLog.success("Cached")
+        providerLog.info(chalk.gray("Run with --force-refresh to force a refresh of provider statuses."))
       } else {
-        providerLog.setSuccess(chalk.green("Done"))
+        providerLog.success("Done")
       }
 
       providerLog.silly(`Resolved providers: ${providers.map((p) => p.name).join(", ")}`)
@@ -876,7 +873,7 @@ export class Garden {
     const resolvedProviders = await this.resolveProviders(log)
     const rawModuleConfigs = await this.getRawModuleConfigs()
 
-    const graphLog = log.makeNewLogContext({ section: "graph" }).info(`Resolving actions and modules...`)
+    const graphLog = log.createLog({ name: "graph", showDuration: true }).info(`Resolving actions and modules...`)
 
     // Resolve the project module configs
     const resolver = new ModuleResolver({
@@ -1047,7 +1044,7 @@ export class Garden {
       this.events.emit("stackGraph", graph.render())
     }
 
-    graphLog.setSuccess(chalk.green("Done"))
+    graphLog.success(chalk.green("Done"))
 
     return graph.toConfigGraph()
   }
@@ -1509,7 +1506,7 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
   opts: GardenOpts
 ): Promise<GardenParams> {
   let { environmentName: environmentStr, config, gardenDirPath, plugins = [], disablePortForwards } = opts
-  const log = opts.log || getLogger().makeNewLogContext()
+  const log = opts.log || getLogger().createLog()
 
   if (!config) {
     config = await findProjectConfig(log, currentDirectory)
@@ -1590,8 +1587,8 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
   if (!opts.noEnterprise && cloudApi) {
     const distroName = getCloudDistributionName(cloudDomain || "")
     const section = getCloudLogSectionName(distroName)
-    const cloudLog = log.makeNewLogContext({ section })
-    cloudLog.info("Initializing...")
+    const cloudLog = log.createLog({ section, showDuration: true })
+    cloudLog.info(`Initializing ${distroName}...`)
 
     let project: CloudProject | undefined
 
@@ -1629,7 +1626,7 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
         // Only fetch secrets if the projectId exists in the cloud API instance
         try {
           secrets = await getSecrets({ log: cloudLog, projectId: cloudApi.projectId, environmentName, cloudApi })
-          cloudLog.setSuccess(chalk.green("Ready"))
+          cloudLog.success(chalk.green("Ready"))
           cloudLog.silly(`Fetched ${Object.keys(secrets).length} secrets from ${cloudDomain}`)
         } catch (err) {
           cloudLog.debug(`Fetching secrets failed with error: ${err.message}`)

--- a/core/src/graph/common.ts
+++ b/core/src/graph/common.ts
@@ -18,7 +18,7 @@ import Bluebird from "bluebird"
 import { loadVarfile } from "../config/base"
 import { DeepPrimitiveMap } from "../config/common"
 import { Task } from "../tasks/base"
-import { LogEntryMetadata, TaskLogStatus } from "../logger/log-entry"
+import { LogMetadata, TaskLogStatus } from "../logger/log-entry"
 
 // Shared type used by ConfigGraph and TaskGraph to facilitate circular dependency detection
 export type DependencyGraphNode = {
@@ -215,7 +215,7 @@ export function nodeKey(type: ActionKind | ModuleDependencyGraphNodeKind, name: 
   return `${type}.${name}`
 }
 
-export function metadataForLog(task: Task, status: TaskLogStatus, outputVersion?: string): LogEntryMetadata {
+export function metadataForLog(task: Task, status: TaskLogStatus, outputVersion?: string): LogMetadata {
   return {
     task: {
       type: task.type,

--- a/core/src/graph/results.ts
+++ b/core/src/graph/results.ts
@@ -96,7 +96,7 @@ export class GraphResults<B extends Task = Task> {
   }
 
   filterForGraphResult<T extends Task = Task>(): GraphResultMapWithoutTask<T> {
-    return mapResults(this.results, (v) => v ? { ...omit(v, "task") } : null)
+    return mapResults(this.results, (v) => (v ? { ...omit(v, "task") } : null))
   }
 
   /**
@@ -126,7 +126,7 @@ export class GraphResults<B extends Task = Task> {
 function mapResults<T extends Task = Task, R extends object = {}>(
   results: Map<string, GraphResultWithoutTask<T> | null> | GraphResultMapWithoutTask<T> | null,
   fn: (val: GraphResultWithoutTask<T> | null) => R | null
-): { [key: string]: R | null} {
+): { [key: string]: R | null } {
   if (!results) {
     return {}
   }
@@ -165,7 +165,7 @@ function prepareForExport(graphResult: GraphResultWithoutTask | null) {
       "version",
       "processed",
       "success",
-      "version",
+      "version"
     ),
     result: filterResultForExport(result),
     error: filterErrorForExport(error),
@@ -186,7 +186,7 @@ function filterResultForExport(result: any) {
     "fresh",
     "buildLog",
     "log",
-    "message",
+    "message"
   )
   return {
     ...pick(
@@ -218,7 +218,7 @@ function filterResultForExport(result: any) {
       "exitCode",
       "startedAt",
       "completedAt",
-      "namespaceStatus",
+      "namespaceStatus"
     ),
     detail: filteredDetail,
   }
@@ -244,10 +244,10 @@ function filterErrorForExport(error: any) {
     "name",
     "processed",
     "success",
-    "type",
+    "type"
   )
   return {
     ...pick(error, "message", "type", "stack"),
-    detail: filteredDetail
+    detail: filteredDetail,
   }
 }

--- a/core/src/logger/logger.ts
+++ b/core/src/logger/logger.ts
@@ -233,16 +233,13 @@ export class Logger {
    * Creates a new log context from the root Logger.
    */
   makeNewLogContext({
-    level = LogLevel.info,
     metadata,
     fixLevel,
   }: {
-    level?: LogLevel
     metadata?: LogEntryMetadata
-    fixLevel?: boolean
+    fixLevel?: LogLevel
   } = {}) {
     return new Log({
-      level,
       fixLevel,
       metadata,
       root: this,

--- a/core/src/logger/logger.ts
+++ b/core/src/logger/logger.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { Log, LogEntryMetadata, LogEntry } from "./log-entry"
+import { LogMetadata, LogEntry, CoreLog } from "./log-entry"
 import { Writer } from "./writers/base"
 import { CommandError, InternalError, ParameterError } from "../exceptions"
 import { TerminalWriter } from "./writers/terminal-writer"
@@ -17,6 +17,7 @@ import { gardenEnv } from "../constants"
 import { getEnumKeys } from "../util/util"
 import { range } from "lodash"
 import { InkTerminalWriter } from "./writers/ink-terminal-writer"
+import { QuietWriter } from "./writers/quiet-writer"
 
 export type LoggerType = "quiet" | "default" | "basic" | "json" | "ink"
 export const LOGGER_TYPES = new Set<LoggerType>(["quiet", "default", "basic", "json", "ink"])
@@ -34,14 +35,15 @@ const getLogLevelNames = () => getEnumKeys(LogLevel)
 const getNumericLogLevels = () => range(getLogLevelNames().length)
 // Allow string or numeric log levels as CLI choices
 export const getLogLevelChoices = () => [...getLogLevelNames(), ...getNumericLogLevels().map(String)]
+
 export function parseLogLevel(level: string): LogLevel {
   let lvl: LogLevel
   const parsed = parseInt(level, 10)
-  // Level is numeric
   if (parsed || parsed === 0) {
+    // Level is numeric
     lvl = parsed
-    // Level is a string
   } else {
+    // Level is a string
     lvl = LogLevel[level]
   }
   if (!getNumericLogLevels().includes(lvl)) {
@@ -64,7 +66,28 @@ export const logLevelMap = {
 
 const eventLogLevel = LogLevel.debug
 
-export function getWriterInstance(loggerType: LoggerType, level: LogLevel) {
+/**
+ * Return the logger type, depending on what command line args have been set
+ * and whether the commnad specifies a logger type.
+ */
+export function getTerminalWriterType({
+  silent,
+  output,
+  loggerTypeOpt,
+  commandLoggerType,
+}: {
+  silent: boolean
+  output: boolean
+  loggerTypeOpt: LoggerType | null
+  commandLoggerType: LoggerType | null
+}) {
+  if (silent || output) {
+    return "quiet"
+  }
+  return loggerTypeOpt || commandLoggerType || "default"
+}
+
+export function getTerminalWriterInstance(loggerType: LoggerType, level: LogLevel): Writer {
   switch (loggerType) {
     case "default":
     case "basic":
@@ -74,26 +97,39 @@ export function getWriterInstance(loggerType: LoggerType, level: LogLevel) {
     case "ink":
       return new InkTerminalWriter({ level })
     case "quiet":
-      return undefined
+      return new QuietWriter({ level })
   }
 }
 
 interface LoggerConfigBase {
+  /**
+   * The Garden log level. This get propagated to the actual writers which have their own
+   * levels which may in some cases overwrite this.
+   */
   level: LogLevel
+  /**
+   * Whether or not the log entries are stored in-memory on the logger instance. Useful for testing.
+   */
   storeEntries?: boolean
   showTimestamps?: boolean
   useEmoji?: boolean
-  type: LoggerType
 }
 
-interface LoggerConfig extends LoggerConfigBase {
-  type: LoggerType
-  storeEntries: boolean
+interface LoggerInitParams extends LoggerConfigBase {
+  /**
+   * The type of terminal writer to use. This is configurable by the user
+   * and exposed as a "logger type" which is a bit more user friendly.
+   *
+   * The logger also has a set of file writers that are set internally.
+   */
+  terminalWriterType: LoggerType
 }
 
 interface LoggerConstructor extends LoggerConfigBase {
-  writers: Writer[]
-  storeEntries: boolean
+  writers: {
+    terminal: Writer
+    file: Writer[]
+  }
 }
 
 /**
@@ -103,22 +139,31 @@ interface LoggerConstructor extends LoggerConfigBase {
  * Is initialized as a singleton class.
  *
  * Note that this class does not have methods for logging at different levels. Rather
- * thats handled by the 'Log' class which in turns calls the root Logger.
+ * that's handled by the 'Log' class which in turns calls the root Logger.
  */
-export class Logger {
+export class Logger implements Required<LoggerConfigBase> {
   public events: EventBus
   public useEmoji: boolean
   public showTimestamps: boolean
   public level: LogLevel
   public entries: LogEntry[]
-  /**
-   * Whether or not the log entries are stored in-memory on the logger instance. Useful for testing.
-   */
   public storeEntries: boolean
-  public type: LoggerType
 
-  private writers: Writer[]
+  private writers: {
+    terminal: Writer
+    file: Writer[]
+  }
   private static instance?: Logger
+
+  private constructor(config: LoggerConstructor) {
+    this.level = config.level
+    this.entries = []
+    this.writers = config.writers
+    this.useEmoji = config.useEmoji === false ? false : true
+    this.showTimestamps = !!config.showTimestamps
+    this.events = new EventBus()
+    this.storeEntries = config.storeEntries || false
+  }
 
   /**
    * Returns the already initialized Logger singleton instance.
@@ -138,8 +183,8 @@ export class Logger {
    * Initializes the logger as a singleton from config. Also ensures that the logger settings make sense
    * in the context of environment variables and writer types.
    */
-  static initialize(config: LoggerConfig, force = false): Logger {
-    if (Logger.instance && !force) {
+  static initialize(config: LoggerInitParams): Logger {
+    if (Logger.instance) {
       return Logger.instance
     }
 
@@ -165,14 +210,18 @@ export class Logger {
         })
       }
 
-      config.type = loggerTypeFromEnv
+      config.terminalWriterType = loggerTypeFromEnv
     }
 
-    const writer = getWriterInstance(config.type, config.level)
+    const terminalWriter = getTerminalWriterInstance(config.terminalWriterType, config.level)
+    const writers = {
+      terminal: terminalWriter,
+      file: [],
+    }
 
-    instance = new Logger({ ...config, storeEntries: config.storeEntries, writers: writer ? [writer] : [] })
+    instance = new Logger({ ...config, storeEntries: config.storeEntries, writers })
 
-    const initLog = instance.makeNewLogContext()
+    const initLog = instance.createLog()
 
     if (gardenEnv.GARDEN_LOG_LEVEL) {
       initLog.debug(`Setting log level to ${gardenEnv.GARDEN_LOG_LEVEL} (from GARDEN_LOG_LEVEL)`)
@@ -192,27 +241,26 @@ export class Logger {
     Logger.instance = undefined
   }
 
-  constructor(config: LoggerConstructor) {
-    this.level = config.level
-    this.entries = []
-    this.writers = config.writers || []
-    this.useEmoji = config.useEmoji === false ? false : true
-    this.showTimestamps = !!config.showTimestamps
-    this.events = new EventBus()
-    this.storeEntries = config.storeEntries
-    this.type = config.type
-  }
-
   toSanitizedValue() {
     return "<Logger>"
   }
 
-  addWriter(writer: Writer) {
-    this.writers.push(writer)
+  addFileWriter(writer: Writer) {
+    this.writers.file.push(writer)
   }
 
   getWriters() {
     return this.writers
+  }
+
+  /**
+   * Reset the default terminal writer that the logger was initialized with.
+   *
+   * This is required because when we initialize the logger we don't know what writer
+   * the command may require and we need to re-set it when we've resolved the command.
+   */
+  setTerminalWriter(type: LoggerType) {
+    this.writers.terminal = getTerminalWriterInstance(type, this.level)
   }
 
   log(entry: LogEntry) {
@@ -222,7 +270,8 @@ export class Logger {
     if (entry.level <= eventLogLevel) {
       this.events.emit("logEntry", formatLogEntryForEventStream(entry))
     }
-    for (const writer of this.writers) {
+    const writers = [this.writers.terminal, ...this.writers.file]
+    for (const writer of writers) {
       if (entry.level <= writer.level) {
         writer.write(entry, this)
       }
@@ -230,18 +279,28 @@ export class Logger {
   }
 
   /**
-   * Creates a new log context from the root Logger.
+   * Creates a new CoreLog context from the root Logger.
    */
-  makeNewLogContext({
+  createLog({
     metadata,
     fixLevel,
+    name,
   }: {
-    metadata?: LogEntryMetadata
+    metadata?: LogMetadata
     fixLevel?: LogLevel
+    /**
+     * The name of the log context. Will be printed as the "section" part of the log lines
+     * belonging to this context.
+     */
+    name?: string
   } = {}) {
-    return new Log({
+    return new CoreLog({
+      parentConfigs: [],
       fixLevel,
       metadata,
+      context: {
+        name,
+      },
       root: this,
     })
   }
@@ -257,14 +316,14 @@ export class Logger {
     }
     return this.entries
   }
-}
 
-/**
- * Dummy Logger instance, just swallows log entries and prints nothing.
- */
-export class VoidLogger extends Logger {
-  constructor() {
-    super({ writers: [], level: LogLevel.error, storeEntries: false, type: "default" })
+  /**
+   * WARNING: Only use for tests.
+   *
+   * The logger is a singleton which makes it hard to test. This is an escape hatch.
+   */
+  static _createInstanceForTests(params: LoggerConstructor) {
+    return new Logger(params)
   }
 }
 

--- a/core/src/logger/util.ts
+++ b/core/src/logger/util.ts
@@ -7,7 +7,6 @@
  */
 
 import chalk, { Chalk } from "chalk"
-import type { Log } from "./log-entry"
 import hasAnsi from "has-ansi"
 import dedent from "dedent"
 import stringWidth from "string-width"
@@ -24,10 +23,6 @@ export interface LogLike {
 }
 
 export type ProcessLog<T extends LogLike = LogLike> = (node: T) => boolean
-
-export function findParentLogContext(log: Log, predicate: ProcessLog<Log>): Log | null {
-  return predicate(log) ? log : log.parent ? findParentLogContext(log.parent, predicate) : null
-}
 
 /**
  * Returns the entry's section or first parent section it finds.

--- a/core/src/logger/writers/ink-terminal-writer.ts
+++ b/core/src/logger/writers/ink-terminal-writer.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { render } from "../renderers"
+import { formatForTerminal } from "../renderers"
 import { LogEntry } from "../log-entry"
 import { Logger } from "../logger"
 import { BaseWriterParams, Writer } from "./base"
@@ -30,7 +30,7 @@ export class InkTerminalWriter extends Writer {
   }
 
   write(entry: LogEntry, logger: Logger) {
-    const out = render(entry, logger)
+    const out = formatForTerminal(entry, logger)
     if (out) {
       this.writeCallback(out)
     }

--- a/core/src/logger/writers/json-terminal-writer.ts
+++ b/core/src/logger/writers/json-terminal-writer.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { LogEntryMetadata, LogEntry } from "../log-entry"
+import { LogMetadata, LogEntry } from "../log-entry"
 import { Logger } from "../logger"
 import { Writer } from "./base"
 import { formatForJson } from "../renderers"
@@ -17,7 +17,7 @@ export interface JsonLogEntry {
   data?: any
   errorDetail?: string
   section?: string
-  metadata?: LogEntryMetadata
+  metadata?: LogMetadata
   level: string
 }
 

--- a/core/src/logger/writers/quiet-writer.ts
+++ b/core/src/logger/writers/quiet-writer.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2018-2022 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Writer } from "./base"
+
+/**
+ * The QuietWriter doesn't write any log lines as the name suggests.
+ * We still implement it as actual class since that's simpler then special
+ * casing it elsewhere in the code.
+ */
+export class QuietWriter extends Writer {
+  type = "quiet"
+
+  // no-op
+  write() {
+    this.level
+  }
+}

--- a/core/src/logger/writers/terminal-writer.ts
+++ b/core/src/logger/writers/terminal-writer.ts
@@ -6,22 +6,19 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { render } from "../renderers"
 import { LogEntry } from "../log-entry"
 import { Logger } from "../logger"
+import { formatForTerminal } from "../renderers"
 import { Writer } from "./base"
 
 export class TerminalWriter extends Writer {
-  type = "basic"
-
-  render(entry: LogEntry, logger: Logger): string | null {
-    return render(entry, logger)
-  }
+  type = "default"
 
   write(entry: LogEntry, logger: Logger) {
-    const out = this.render(entry, logger)
+    const out = formatForTerminal(entry, logger)
     if (out) {
       this.output.write(out)
     }
+    return out
   }
 }

--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -374,7 +374,7 @@ export class Mutagen {
       }
 
       if (!this.syncStatusLines[key]) {
-        this.syncStatusLines[key] = log.makeNewLogContext({})
+        this.syncStatusLines[key] = log.createLog({})
       }
       let statusMsg: string | undefined
 

--- a/core/src/plugin/action-types.ts
+++ b/core/src/plugin/action-types.ts
@@ -278,11 +278,9 @@ export interface ResolvedActionTypeHandlerDescription<N = string> extends Resolv
 }
 
 export type ResolvedActionTypeHandlerDescriptions = {
-  [K in ActionKind]: Required<
-    {
-      [H in keyof ActionTypeClasses<K>]: ResolvedActionTypeHandlerDescription<H>
-    }
-  >
+  [K in ActionKind]: Required<{
+    [H in keyof ActionTypeClasses<K>]: ResolvedActionTypeHandlerDescription<H>
+  }>
 }
 
 // It takes a short while to resolve all these schemas, so we cache the result

--- a/core/src/plugin/handlers/Deploy/stop-sync.ts
+++ b/core/src/plugin/handlers/Deploy/stop-sync.ts
@@ -14,7 +14,11 @@ import { ActionTypeHandlerSpec } from "../base/base"
 
 type StopSyncParams<T extends DeployAction> = PluginDeployActionParamsBase<T>
 
-export class StopSync<T extends DeployAction = DeployAction> extends ActionTypeHandlerSpec<"Deploy", StopSyncParams<T>, {}> {
+export class StopSync<T extends DeployAction = DeployAction> extends ActionTypeHandlerSpec<
+  "Deploy",
+  StopSyncParams<T>,
+  {}
+> {
   description = dedent`
     Stop syncing to the given Deploy.
   `

--- a/core/src/plugins/container/build.ts
+++ b/core/src/plugins/container/build.ts
@@ -69,7 +69,7 @@ export const buildContainer: BuildActionHandler<"build", ContainerBuildAction> =
 
   const logEventContext = {
     origin: "docker build",
-    log: log.makeNewLogContext({ fixLevel: LogLevel.verbose }),
+    log: log.createLog({ fixLevel: LogLevel.verbose }),
   }
 
   const outputStream = split2()

--- a/core/src/plugins/container/build.ts
+++ b/core/src/plugins/container/build.ts
@@ -69,7 +69,7 @@ export const buildContainer: BuildActionHandler<"build", ContainerBuildAction> =
 
   const logEventContext = {
     origin: "docker build",
-    log: log.makeNewLogContext({ level: LogLevel.verbose }),
+    log: log.makeNewLogContext({ fixLevel: LogLevel.verbose }),
   }
 
   const outputStream = split2()

--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -118,7 +118,7 @@ interface Annotations {
 }
 
 const deploymentStrategies = ["RollingUpdate", "Recreate"] as const
-export type DeploymentStrategy = typeof deploymentStrategies[number]
+export type DeploymentStrategy = (typeof deploymentStrategies)[number]
 export const defaultDeploymentStrategy: DeploymentStrategy = "RollingUpdate"
 
 export const commandExample = ["/bin/sh", "-c"]

--- a/core/src/plugins/container/container.ts
+++ b/core/src/plugins/container/container.ts
@@ -359,7 +359,7 @@ export const gardenPlugin = () =>
             async getOutputs({ action }) {
               // TODO-G2B: figure out why this cast is needed here
               return {
-                outputs: (getContainerBuildActionOutputs(action) as unknown) as DeepPrimitiveMap,
+                outputs: getContainerBuildActionOutputs(action) as unknown as DeepPrimitiveMap,
               }
             },
 
@@ -552,8 +552,7 @@ export const gardenPlugin = () =>
           {
             platform: "windows",
             architecture: "amd64",
-            url:
-              "https://github.com/rgl/docker-ce-windows-binaries-vagrant/releases/download/v20.10.9/docker-20.10.9.zip",
+            url: "https://github.com/rgl/docker-ce-windows-binaries-vagrant/releases/download/v20.10.9/docker-20.10.9.zip",
             sha256: "360ca42101d453022eea17747ae0328709c7512e71553b497b88b7242b9b0ee4",
             extract: {
               format: "zip",

--- a/core/src/plugins/container/helpers.ts
+++ b/core/src/plugins/container/helpers.ts
@@ -250,31 +250,29 @@ const helpers = {
   /**
    * Retrieves the docker client and server version.
    */
-  getDockerVersion: pMemoize(
-    async (cliPath = "docker"): Promise<DockerVersion> => {
-      const results = await Bluebird.map(["client", "server"], async (key) => {
-        let res: SpawnOutput
+  getDockerVersion: pMemoize(async (cliPath = "docker"): Promise<DockerVersion> => {
+    const results = await Bluebird.map(["client", "server"], async (key) => {
+      let res: SpawnOutput
 
-        try {
-          res = await spawn(cliPath, ["version", "-f", `{{ .${titleize(key)}.Version }}`])
-        } catch (err) {
-          return [key, undefined]
-        }
+      try {
+        res = await spawn(cliPath, ["version", "-f", `{{ .${titleize(key)}.Version }}`])
+      } catch (err) {
+        return [key, undefined]
+      }
 
-        const output = res.stdout.trim()
+      const output = res.stdout.trim()
 
-        if (!output) {
-          throw new RuntimeError(`Unexpected docker version output: ${res.all.trim()}`, {
-            output,
-          })
-        }
+      if (!output) {
+        throw new RuntimeError(`Unexpected docker version output: ${res.all.trim()}`, {
+          output,
+        })
+      }
 
-        return [key, output]
-      })
+      return [key, output]
+    })
 
-      return fromPairs(results)
-    }
-  ),
+    return fromPairs(results)
+  }),
 
   /**
    * Asserts that the specified docker client version meets the minimum requirements.

--- a/core/src/plugins/kubernetes/api.ts
+++ b/core/src/plugins/kubernetes/api.ts
@@ -1022,7 +1022,7 @@ async function requestWithRetry<R>(
       return await req()
     } catch (err) {
       if (shouldRetry(err)) {
-        retryLog = retryLog || log.makeNewLogContext({ fixLevel: LogLevel.debug })
+        retryLog = retryLog || log.createLog({ fixLevel: LogLevel.debug })
         if (usedRetries <= maxRetries) {
           const sleepMsec = minTimeoutMs + usedRetries * minTimeoutMs
           retryLog.info(deline`

--- a/core/src/plugins/kubernetes/api.ts
+++ b/core/src/plugins/kubernetes/api.ts
@@ -1022,7 +1022,7 @@ async function requestWithRetry<R>(
       return await req()
     } catch (err) {
       if (shouldRetry(err)) {
-        retryLog = retryLog || log.makeNewLogContext({ level: LogLevel.debug })
+        retryLog = retryLog || log.makeNewLogContext({ fixLevel: LogLevel.debug })
         if (usedRetries <= maxRetries) {
           const sleepMsec = minTimeoutMs + usedRetries * minTimeoutMs
           retryLog.info(deline`

--- a/core/src/plugins/kubernetes/commands/pull-image.ts
+++ b/core/src/plugins/kubernetes/commands/pull-image.ts
@@ -62,7 +62,7 @@ export const pullImage: PluginCommand = {
 
     await pullBuilds(k8sCtx, Object.values(resolvedBuilds), log)
 
-    log.setSuccess(chalk.green("\nDone!"))
+    log.success("\nDone!")
 
     return { result }
   },

--- a/core/src/plugins/kubernetes/config.ts
+++ b/core/src/plugins/kubernetes/config.ts
@@ -981,7 +981,7 @@ export const kubernetesCommonRunSchemaKeys = () => ({
 
 export const runPodResourceSchema = (kind: string) =>
   targetResourceSpecSchema().description(
-      dedent`
+    dedent`
         Specify a Kubernetes resource to derive the Pod spec from for the ${kind}.
 
         This resource will be selected from the manifests provided in this ${kind}'s \`files\` or \`manifests\` config field.
@@ -989,7 +989,7 @@ export const runPodResourceSchema = (kind: string) =>
         The following fields from the Pod will be used (if present) when executing the ${kind}:
         ${runPodSpecWhitelistDescription()}
         `
-    )
+  )
 
 // Need to use a sync read to avoid having to refactor createGardenPlugin()
 // The `podspec-v1.json` file is copied from the handy
@@ -997,17 +997,18 @@ export const runPodResourceSchema = (kind: string) =>
 const jsonSchema = () => JSON.parse(readFileSync(join(STATIC_DIR, "kubernetes", "podspec-v1.json")).toString())
 
 // TODO: allow reading the pod spec from a file
-export const runPodSpecSchema = (kind: string) => joi
-  .object()
-  .jsonSchema({ ...jsonSchema(), type: "object" })
-  .description(
-    dedent`
+export const runPodSpecSchema = (kind: string) =>
+  joi
+    .object()
+    .jsonSchema({ ...jsonSchema(), type: "object" })
+    .description(
+      dedent`
     Supply a custom Pod specification. This should be a normal Kubernetes Pod manifest. Note that the spec will be modified for the ${kind}, including overriding with other fields you may set here (such as \`args\` and \`env\`), and removing certain fields that are not supported.
 
     The following Pod spec fields from the selected \`resource\` will be used (if present) when executing the ${kind}:
     ${runPodSpecWhitelistDescription()}
   `
-  )
+    )
 
 export const kubernetesTaskSchema = () =>
   baseTaskSpecSchema()

--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -105,7 +105,7 @@ export const buildkitBuildHandler: BuildHandler = async (params) => {
 
   const logEventContext = {
     origin: "buildkit",
-    log: log.makeNewLogContext({ level: LogLevel.verbose }),
+    log: log.makeNewLogContext({ fixLevel: LogLevel.verbose }),
   }
 
   const outputStream = split2()

--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -101,11 +101,12 @@ export const buildkitBuildHandler: BuildHandler = async (params) => {
     deploymentName: buildkitDeploymentName,
   })
 
-  log.info(`Building image ${localId}...`)
+  log.info(`Buildkit Building image ${localId}...`)
 
   const logEventContext = {
     origin: "buildkit",
-    log: log.makeNewLogContext({ fixLevel: LogLevel.verbose }),
+    // log: log.createLog({ fixLevel: LogLevel.verbose }),
+    log: log.createLog({ fixLevel: LogLevel.verbose, section: "foobar" }),
   }
 
   const outputStream = split2()
@@ -185,7 +186,7 @@ export async function ensureBuildkit({
   namespace: string
 }) {
   return deployLock.acquire(namespace, async () => {
-    const deployLog = log.makeNewLogContext({})
+    const deployLog = log.createLog({})
 
     // Make sure auth secret is in place
     const { authSecret, updated: secretUpdated } = await ensureBuilderSecret({

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -293,7 +293,7 @@ export async function ensureUtilDeployment({
   namespace: string
 }) {
   return deployLock.acquire(namespace, async () => {
-    const deployLog = log.makeNewLogContext({})
+    const deployLog = log.createLog({})
 
     const { authSecret, updated: secretUpdated } = await ensureBuilderSecret({
       provider,

--- a/core/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/src/plugins/kubernetes/container/build/kaniko.ts
@@ -117,7 +117,7 @@ export const kanikoBuild: BuildHandler = async (params) => {
     // Make sure the Kaniko Pod namespace has the auth secret ready
     const secretRes = await ensureBuilderSecret({
       provider,
-      log: log.makeNewLogContext({}),
+      log: log.createLog({}),
       api,
       namespace: kanikoNamespace,
     })
@@ -374,7 +374,7 @@ async function runKaniko({
 
   const logEventContext = {
     origin: "kaniko",
-    log: log.makeNewLogContext({ fixLevel: LogLevel.verbose }),
+    log: log.createLog({ fixLevel: LogLevel.verbose }),
   }
 
   const runner = new PodRunner({

--- a/core/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/src/plugins/kubernetes/container/build/kaniko.ts
@@ -374,7 +374,7 @@ async function runKaniko({
 
   const logEventContext = {
     origin: "kaniko",
-    log: log.makeNewLogContext({ level: LogLevel.verbose }),
+    log: log.makeNewLogContext({ fixLevel: LogLevel.verbose }),
   }
 
   const runner = new PodRunner({

--- a/core/src/plugins/kubernetes/container/extensions.ts
+++ b/core/src/plugins/kubernetes/container/extensions.ts
@@ -44,7 +44,7 @@ export const k8sContainerBuildExtension = (): BuildActionExtension<ContainerBuil
       const provider = ctx.provider as KubernetesProvider
       // TODO-G2B: figure out why this cast is needed here
       return {
-        outputs: (k8sGetContainerBuildActionOutputs({ action, provider }) as unknown) as DeepPrimitiveMap,
+        outputs: k8sGetContainerBuildActionOutputs({ action, provider }) as unknown as DeepPrimitiveMap,
       }
     },
 

--- a/core/src/plugins/kubernetes/container/status.ts
+++ b/core/src/plugins/kubernetes/container/status.ts
@@ -52,13 +52,12 @@ export const k8sGetContainerDeployStatus: DeployActionHandler<"getStatus", Conta
     action,
     imageId,
   })
-  let { state, remoteResources, mode: deployedMode, selectorChangedResourceKeys } = await compareDeployedResources(
-    k8sCtx,
-    api,
-    namespace,
-    manifests,
-    log
-  )
+  let {
+    state,
+    remoteResources,
+    mode: deployedMode,
+    selectorChangedResourceKeys,
+  } = await compareDeployedResources(k8sCtx, api, namespace, manifests, log)
   const ingresses = await getIngresses(action, api, provider)
 
   // Local mode has its own port-forwarding configuration

--- a/core/src/plugins/kubernetes/container/test.ts
+++ b/core/src/plugins/kubernetes/container/test.ts
@@ -19,18 +19,8 @@ import { runResultToActionState } from "../../../actions/base"
 
 export const k8sContainerTest: TestActionHandler<"run", ContainerTestAction> = async (params) => {
   const { ctx, action, log } = params
-  const {
-    command,
-    args,
-    artifacts,
-    env,
-    cpu,
-    memory,
-    volumes,
-    privileged,
-    addCapabilities,
-    dropCapabilities,
-  } = action.getSpec()
+  const { command, args, artifacts, env, cpu, memory, volumes, privileged, addCapabilities, dropCapabilities } =
+    action.getSpec()
   const timeout = action.getConfig("timeout") || DEFAULT_TEST_TIMEOUT
   const k8sCtx = ctx as KubernetesPluginContext
 

--- a/core/src/plugins/kubernetes/helm/common.ts
+++ b/core/src/plugins/kubernetes/helm/common.ts
@@ -273,13 +273,16 @@ export async function getChartPath(action: Resolved<HelmRuntimeAction>) {
  */
 export async function getValueArgs({
   action,
-  valuesPath
-}: { action: Resolved<HelmRuntimeAction>; valuesPath: string }) {
+  valuesPath,
+}: {
+  action: Resolved<HelmRuntimeAction>
+  valuesPath: string
+}) {
   // The garden-values.yml file (which is created from the `values` field in the module config) takes precedence,
   // so it's added to the end of the list.
   const valueFiles = action
-    .getSpec().valueFiles
-    .map((f) => resolve(action.getBuildPath(), f))
+    .getSpec()
+    .valueFiles.map((f) => resolve(action.getBuildPath(), f))
     .concat([valuesPath])
 
   const args = flatten(valueFiles.map((f) => ["--values", f]))

--- a/core/src/plugins/kubernetes/helm/config.ts
+++ b/core/src/plugins/kubernetes/helm/config.ts
@@ -6,7 +6,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { createSchema, DeepPrimitiveMap, joi, joiIdentifier, joiPrimitive, joiSparseArray } from "../../../config/common"
+import {
+  createSchema,
+  DeepPrimitiveMap,
+  joi,
+  joiIdentifier,
+  joiPrimitive,
+  joiSparseArray,
+} from "../../../config/common"
 import {
   kubernetesCommonRunSchemaKeys,
   KubernetesCommonRunSpec,
@@ -62,20 +69,23 @@ const parameterValueSchema = () =>
     )
     .id("parameterValue")
 
-const helmReleaseNameSchema = () => joiIdentifier().description(
+const helmReleaseNameSchema = () =>
+  joiIdentifier().description(
     "Optionally override the release name used when installing (defaults to the Deploy name)."
   )
 
-const helmValuesSchema = () => joi
-  .object()
-  .pattern(/.+/, parameterValueSchema())
-  .default(() => ({})).description(deline`
+const helmValuesSchema = () =>
+  joi
+    .object()
+    .pattern(/.+/, parameterValueSchema())
+    .default(() => ({})).description(deline`
     Map of values to pass to Helm when rendering the templates. May include arrays and nested objects.
     When specified, these take precedence over the values in the \`values.yaml\` file (or the files specified
     in \`valueFiles\`).
   `)
 
-const helmValueFilesSchema = () => joiSparseArray(joi.posixPath()).description(dedent`
+const helmValueFilesSchema = () =>
+  joiSparseArray(joi.posixPath()).description(dedent`
     Specify value files to use when rendering the Helm chart. These will take precedence over the \`values.yaml\` file
     bundled in the Helm chart, and should be specified in ascending order of precedence. Meaning, the last file in
     this list will have the highest precedence.
@@ -135,26 +145,27 @@ export const defaultTargetSchema = () =>
     `
   )
 
-const helmChartSpecSchema = () => joi
-  .object()
-  .keys({
-    name: helmChartNameSchema(),
-    path: joi
-      .posixPath()
-      .subPathOnly()
-      .description(
-        "The path, relative to the action path, to the chart sources (i.e. where the Chart.yaml file is, if any)."
-      ),
-    repo: helmChartRepoSchema(),
-    url: joi.string().uri().description("An absolute URL to a packaged URL."),
-    version: helmChartVersionSchema(),
-  })
-  .with("name", ["version"])
-  .without("path", ["name", "repo", "version", "url"])
-  .without("url", ["name", "repo", "version", "path"])
-  .xor("name", "path", "url")
-  .description(
-    dedent`
+const helmChartSpecSchema = () =>
+  joi
+    .object()
+    .keys({
+      name: helmChartNameSchema(),
+      path: joi
+        .posixPath()
+        .subPathOnly()
+        .description(
+          "The path, relative to the action path, to the chart sources (i.e. where the Chart.yaml file is, if any)."
+        ),
+      repo: helmChartRepoSchema(),
+      url: joi.string().uri().description("An absolute URL to a packaged URL."),
+      version: helmChartVersionSchema(),
+    })
+    .with("name", ["version"])
+    .without("path", ["name", "repo", "version", "url"])
+    .without("url", ["name", "repo", "version", "path"])
+    .xor("name", "path", "url")
+    .description(
+      dedent`
   Specify the Helm chart to use.
 
   If the chart is defined in the same directory as the action, you can skip this, and the chart sources will be detected. If the chart is in the source tree but in a sub-directory, you should set \`chart.path\` to the directory path, relative to the action directory.
@@ -165,7 +176,7 @@ const helmChartSpecSchema = () => joi
 
   One of \`chart.name\`, \`chart.path\` or \`chart.url\` must be specified.
   `
-  )
+    )
 
 export const helmDeploySchema = () =>
   joi
@@ -206,8 +217,9 @@ export const helmPodRunSchema = (kind: string) => {
     name: `${kind}:helm-pod`,
     keys: () => ({
       ...kubernetesCommonRunSchemaKeys(),
-      releaseName: helmReleaseNameSchema()
-        .description(`Optionally override the release name used when rendering the templates (defaults to the ${kind} name).`),
+      releaseName: helmReleaseNameSchema().description(
+        `Optionally override the release name used when rendering the templates (defaults to the ${kind} name).`
+      ),
       chart: helmChartSpecSchema(),
       values: helmValuesSchema(),
       valueFiles: helmValueFilesSchema(),
@@ -217,7 +229,7 @@ export const helmPodRunSchema = (kind: string) => {
         .integer()
         .default(defaultHelmTimeout)
         .description("Time in seconds to wait for Helm to render templates."),
-      }),
+    }),
     xor: ["resource", "podSpec"],
   })()
   runSchemas[name] = schema

--- a/core/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/src/plugins/kubernetes/helm/deployment.ts
@@ -202,7 +202,7 @@ export const deleteHelmDeploy: DeployActionHandler<"delete", HelmDeployAction> =
   // Wait for resources to terminate
   await deleteResources({ log, ctx, provider, resources, namespace })
 
-  log.setSuccess("Service deleted")
+  log.success("Service deleted")
 
   return { state: "not-ready", outputs: {}, detail: { state: "missing", detail: { remoteResources: [] } } }
 }

--- a/core/src/plugins/kubernetes/helm/handlers.ts
+++ b/core/src/plugins/kubernetes/helm/handlers.ts
@@ -49,7 +49,7 @@ export const helmModuleHandlers: Partial<ModuleActionHandlers<HelmModule>> = {
     }
 
     // There's one service on helm modules expect when skipDeploy = true
-    const service: typeof services[0] | undefined = services[0]
+    const service: (typeof services)[0] | undefined = services[0]
 
     // The helm Deploy type does not support the `base` field. We handle the field here during conversion,
     // for compatibility.
@@ -73,13 +73,7 @@ export const helmModuleHandlers: Partial<ModuleActionHandlers<HelmModule>> = {
       actions.push(deployAction)
     }
 
-    const {
-      namespace,
-      releaseName,
-      timeout,
-      values,
-      valueFiles,
-    } = module.spec
+    const { namespace, releaseName, timeout, values, valueFiles } = module.spec
     const chart = {
       name: module.spec.chart,
       path: module.spec.chart ? undefined : module.spec.chartPath,

--- a/core/src/plugins/kubernetes/helm/helm-cli.ts
+++ b/core/src/plugins/kubernetes/helm/helm-cli.ts
@@ -107,7 +107,7 @@ export async function helm({
 
   const logEventContext = {
     origin: "helm",
-    log: log.makeNewLogContext({ fixLevel: LogLevel.verbose }),
+    log: log.createLog({ fixLevel: LogLevel.verbose }),
   }
 
   const outputStream = split2()

--- a/core/src/plugins/kubernetes/helm/helm-cli.ts
+++ b/core/src/plugins/kubernetes/helm/helm-cli.ts
@@ -107,7 +107,7 @@ export async function helm({
 
   const logEventContext = {
     origin: "helm",
-    log: log.makeNewLogContext({ level: LogLevel.verbose }),
+    log: log.makeNewLogContext({ fixLevel: LogLevel.verbose }),
   }
 
   const outputStream = split2()

--- a/core/src/plugins/kubernetes/helm/helm-pod.ts
+++ b/core/src/plugins/kubernetes/helm/helm-pod.ts
@@ -44,7 +44,7 @@ export const helmPodRunDefinition = (): RunActionDefinition<HelmPodRunAction> =>
         ctx: k8sCtx,
         log,
         action,
-        provider: k8sCtx.provider
+        provider: k8sCtx.provider,
       })
       const namespace = namespaceStatus.namespaceName
 
@@ -92,7 +92,7 @@ export const helmPodTestDefinition = (): TestActionDefinition<HelmPodTestAction>
         ctx: k8sCtx,
         log,
         action,
-        provider: k8sCtx.provider
+        provider: k8sCtx.provider,
       })
       const namespace = namespaceStatus.namespaceName
 
@@ -183,4 +183,3 @@ export async function runOrTestWithChart(
     version,
   })
 }
-

--- a/core/src/plugins/kubernetes/helm/status.ts
+++ b/core/src/plugins/kubernetes/helm/status.ts
@@ -6,12 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import {
-  ForwardablePort,
-  ServiceIngress,
-  DeployState,
-  ServiceStatus,
-} from "../../../types/service"
+import { ForwardablePort, ServiceIngress, DeployState, ServiceStatus } from "../../../types/service"
 import { Log } from "../../../logger/log-entry"
 import { helm } from "./helm-cli"
 import { getReleaseName, loadTemplate } from "./common"

--- a/core/src/plugins/kubernetes/init.ts
+++ b/core/src/plugins/kubernetes/init.ts
@@ -180,7 +180,7 @@ export async function getEnvironmentStatus({
   detail.deployStatuses = mapValues(systemServiceStatus.serviceStatuses, (s) => omit(s, "executedAction"))
   detail.systemServiceState = systemServiceStatus.state
 
-  sysGarden.log.setSuccess()
+  sysGarden.log.success("Done")
 
   return result
 }
@@ -329,7 +329,7 @@ export async function prepareSystem({
     names: systemServiceNames,
   })
 
-  sysGarden.log.setSuccess()
+  sysGarden.log.success("Done")
 
   return {}
 }
@@ -368,7 +368,7 @@ export async function cleanupEnvironment({ ctx, log }: CleanupEnvironmentParams)
   }
 
   const entry = log
-    .makeNewLogContext({
+    .createLog({
       section: "kubernetes",
     })
     .info(`Deleting ${nsDescription} (this may take a while)`)

--- a/core/src/plugins/kubernetes/integrations/cert-manager.ts
+++ b/core/src/plugins/kubernetes/integrations/cert-manager.ts
@@ -24,7 +24,6 @@ import { V1Pod } from "@kubernetes/client-node"
 import { DeployState } from "../../../types/service"
 import { EnvironmentStatus } from "../../../plugin/handlers/Provider/getEnvironmentStatus"
 import { PrimitiveMap } from "../../../config/common"
-import chalk from "chalk"
 import { defaultIngressClass } from "../constants"
 
 /**
@@ -95,7 +94,7 @@ export async function waitForResourcesWith({
   const startTime = new Date().getTime()
 
   const statusLine = log
-    .makeNewLogContext({
+    .createLog({
       section: resourcesType,
     })
     .info(`Waiting for resources to be ready...`)
@@ -216,7 +215,7 @@ export async function setupCertManager({ ctx, provider, log, status }: SetupCert
   const { systemCertManagerReady, systemManagedCertificatesReady } = status.detail
 
   if (!systemCertManagerReady || !systemManagedCertificatesReady) {
-    const certsLog = log.makeNewLogContext({ section: "cert-manager" })
+    const certsLog = log.createLog({ name: "cert-manager", showDuration: true })
     certsLog.info(`Verifying installation...`)
     // const certsLog = log.info({
     //   section: "cert-manager",
@@ -298,7 +297,7 @@ export async function setupCertManager({ ctx, provider, log, status }: SetupCert
         certsLog.info("No certificates found...")
       }
     }
-    certsLog.setSuccess(chalk.green(`Done (took ${certsLog.getDuration(1)} sec)`))
+    certsLog.success(`Done`)
   }
 }
 

--- a/core/src/plugins/kubernetes/kubernetes-type/config.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/config.ts
@@ -19,10 +19,20 @@ import { KubernetesKustomizeSpec, kustomizeSpecSchema } from "./kustomize"
 import type { KubernetesResource } from "../types"
 import type { DeployAction, DeployActionConfig } from "../../../actions/deploy"
 import { defaultTargetSchema } from "../helm/config"
-import type { KubernetesPodRunAction, KubernetesPodRunActionConfig, KubernetesPodTestAction, KubernetesPodTestActionConfig } from "./kubernetes-pod"
+import type {
+  KubernetesPodRunAction,
+  KubernetesPodRunActionConfig,
+  KubernetesPodTestAction,
+  KubernetesPodTestActionConfig,
+} from "./kubernetes-pod"
 import { kubernetesLocalModeSchema, KubernetesLocalModeSpec } from "../local-mode"
 import { containerRunOutputSchema } from "../../container/config"
-import { KubernetesExecRunAction, KubernetesExecRunActionConfig, KubernetesExecTestAction, KubernetesExecTestActionConfig } from "./kubernetes-exec"
+import {
+  KubernetesExecRunAction,
+  KubernetesExecRunActionConfig,
+  KubernetesExecTestAction,
+  KubernetesExecTestActionConfig,
+} from "./kubernetes-exec"
 
 export interface KubernetesTypeCommonDeploySpec {
   files: string[]
@@ -60,13 +70,13 @@ const kubernetesResourceSchema = () =>
 
 export const kubernetesFilesSchema = () =>
   joiSparseArray(joi.posixPath().subPathOnly()).description(
-      "POSIX-style paths to YAML files to load manifests from. Each can contain multiple manifests, and can include any Garden template strings, which will be resolved before applying the manifests."
-    )
+    "POSIX-style paths to YAML files to load manifests from. Each can contain multiple manifests, and can include any Garden template strings, which will be resolved before applying the manifests."
+  )
 
 export const kubernetesManifestsSchema = () =>
   joiSparseArray(kubernetesResourceSchema()).description(
-      "List of Kubernetes resource manifests to deploy. If `files` is also specified, this is combined with the manifests read from the files."
-    )
+    "List of Kubernetes resource manifests to deploy. If `files` is also specified, this is combined with the manifests read from the files."
+  )
 
 export const kubernetesCommonDeploySpecKeys = () => ({
   files: kubernetesFilesSchema(),
@@ -94,7 +104,7 @@ export interface KubernetesRunOutputs {
 export const kubernetesRunOutputsSchema = () => containerRunOutputSchema()
 
 export type KubernetesRunActionConfig = KubernetesPodRunActionConfig | KubernetesExecRunActionConfig
-export type KubernetesRunAction = KubernetesPodRunAction  | KubernetesExecRunAction
+export type KubernetesRunAction = KubernetesPodRunAction | KubernetesExecRunAction
 
 export interface KubernetesTestOutputs extends KubernetesRunOutputs {}
 export const kubernetesTestOutputsSchema = () => kubernetesRunOutputsSchema()

--- a/core/src/plugins/kubernetes/kubernetes-type/kubernetes-exec.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/kubernetes-exec.ts
@@ -20,7 +20,13 @@ import { RunActionDefinition, TestActionDefinition } from "../../../plugin/actio
 import { RunResult } from "../../../plugin/base"
 import { dedent, deline } from "../../../util/string"
 import { KubeApi } from "../api"
-import { kubernetesCommonRunSchemaKeys, KubernetesCommonRunSpec, KubernetesPluginContext, KubernetesTargetResourceSpec, runPodResourceSchema } from "../config"
+import {
+  kubernetesCommonRunSchemaKeys,
+  KubernetesCommonRunSpec,
+  KubernetesPluginContext,
+  KubernetesTargetResourceSpec,
+  runPodResourceSchema,
+} from "../config"
 import { getActionNamespaceStatus } from "../namespace"
 import { k8sGetRunResult } from "../run-results"
 import { SyncableResource } from "../types"
@@ -66,7 +72,7 @@ export const kubernetesExecRunDefinition = (): RunActionDefinition<KubernetesExe
   handlers: {
     run: async (params) => {
       const { ctx, log, action } = params
-      const result = await readAndExec({ ctx, log, action})
+      const result = await readAndExec({ ctx, log, action })
       // Note: We don't store a result for this action type, since there's no clear underlying version to use.
       return { state: runResultToActionState(result), detail: result, outputs: { log: result.log } }
     },
@@ -93,7 +99,7 @@ export const kubernetesExecTestDefinition = (): TestActionDefinition<KubernetesE
   handlers: {
     run: async (params) => {
       const { ctx, log, action } = params
-      const result = await readAndExec({ ctx, log, action})
+      const result = await readAndExec({ ctx, log, action })
       // Note: We don't store a result for this action type, since there's no clear underlying version to use.
       return { state: runResultToActionState(result), detail: result, outputs: { log: result.log } }
     },
@@ -102,13 +108,12 @@ export const kubernetesExecTestDefinition = (): TestActionDefinition<KubernetesE
   },
 })
 
-
 // helpers //
 
 async function readAndExec({
   ctx,
   log,
-  action
+  action,
 }: {
   ctx: PluginContext
   log: Log
@@ -133,7 +138,7 @@ async function readAndExec({
     target = await readTargetResource({
       api,
       namespace,
-      query: resource
+      query: resource,
     })
   } catch (err) {
     if (err.statusCode === 404) {
@@ -157,13 +162,13 @@ async function readAndExec({
     provider,
     log,
     namespace,
-     workload: target,
-     command: args,
-     interactive: false,
-     streamLogs: true
+    workload: target,
+    command: args,
+    interactive: false,
+    streamLogs: true,
   })
   const completedAt = new Date()
-  const execLog = res.output ||""
+  const execLog = res.output || ""
 
   return {
     success: res.code === 0,

--- a/core/src/plugins/kubernetes/kubernetes-type/kubernetes-pod.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/kubernetes-pod.ts
@@ -29,7 +29,7 @@ import {
   KubernetesRunOutputs,
   kubernetesRunOutputsSchema,
   KubernetesTestOutputs,
-  kubernetesTestOutputsSchema
+  kubernetesTestOutputsSchema,
 } from "./config"
 import { KubernetesResource } from "../types"
 import { KubernetesKustomizeSpec } from "./kustomize"
@@ -61,14 +61,12 @@ export const kubernetesRunPodSchema = (kind: string) => {
     name,
     keys: () => ({
       ...kubernetesCommonRunSchemaKeys(),
-      manifests: kubernetesManifestsSchema()
-        .description(
+      manifests: kubernetesManifestsSchema().description(
         `List of Kubernetes resource manifests to be searched (using \`resource\`e for the pod spec for the ${kind}. If \`files\` is also specified, this is combined with the manifests read from the files.`
       ),
-      files: kubernetesFilesSchema()
-        .description(
+      files: kubernetesFilesSchema().description(
         `POSIX-style paths to YAML files to load manifests from. Each can contain multiple manifests, and can include any Garden template strings, which will be resolved before searching the manifests for the resource that contains the Pod spec for the ${kind}.`
-  ),
+      ),
       resource: runPodResourceSchema(kind),
       podSpec: runPodSpecSchema(kind),
     }),

--- a/core/src/plugins/kubernetes/kubernetes-type/kustomize.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/kustomize.ts
@@ -42,8 +42,7 @@ export const kustomizeSpec: PluginToolSpec = {
     {
       platform: "darwin",
       architecture: "amd64",
-      url:
-        "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.5.2/kustomize_v4.5.2_darwin_amd64.tar.gz",
+      url: "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.5.2/kustomize_v4.5.2_darwin_amd64.tar.gz",
       sha256: "4b7dac92c8f2dd383651276c78d9e6d28031f50f3711cd987347a08edf0c8335",
       extract: {
         format: "tar",
@@ -53,8 +52,7 @@ export const kustomizeSpec: PluginToolSpec = {
     {
       platform: "darwin",
       architecture: "arm64",
-      url:
-        "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.5.2/kustomize_v4.5.2_darwin_arm64.tar.gz",
+      url: "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.5.2/kustomize_v4.5.2_darwin_arm64.tar.gz",
       sha256: "4ee7ef099b8f59d65cb393d9c1b8fa49a392529dbefcd469359cc51094dad517",
       extract: {
         format: "tar",
@@ -64,8 +62,7 @@ export const kustomizeSpec: PluginToolSpec = {
     {
       platform: "linux",
       architecture: "amd64",
-      url:
-        "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.5.2/kustomize_v4.5.2_linux_amd64.tar.gz",
+      url: "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.5.2/kustomize_v4.5.2_linux_amd64.tar.gz",
       sha256: "c4215332da8da16ddeb88e218d8dceb76c85b366a5c58d012bc5ece904bf2fd0",
       extract: {
         format: "tar",
@@ -75,8 +72,7 @@ export const kustomizeSpec: PluginToolSpec = {
     {
       platform: "windows",
       architecture: "amd64",
-      url:
-        "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.5.2/kustomize_v4.5.2_windows_amd64.tar.gz",
+      url: "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.5.2/kustomize_v4.5.2_windows_amd64.tar.gz",
       sha256: "3c6310caa6a23d17711a312f1a33690365ba6be9a806752aac215613fdf7c605",
       extract: {
         format: "tar",

--- a/core/src/plugins/kubernetes/kubernetes.ts
+++ b/core/src/plugins/kubernetes/kubernetes.ts
@@ -29,7 +29,6 @@ import { resolve } from "path"
 import { dedent } from "../../util/string"
 import { kubernetesModuleSpecSchema } from "./kubernetes-type/module-config"
 import { helmModuleSpecSchema, helmModuleOutputsSchema } from "./helm/module-config"
-import chalk from "chalk"
 import pluralize from "pluralize"
 import { getSystemMetadataNamespaceName } from "./system"
 import { DOCS_BASE_URL } from "../../constants"
@@ -106,7 +105,9 @@ export async function configureProvider({
 export async function debugInfo({ ctx, log, includeProject }: GetDebugInfoParams): Promise<DebugInfo> {
   const k8sCtx = <KubernetesPluginContext>ctx
   const provider = k8sCtx.provider
-  const providerLog = log.makeNewLogContext({ section: ctx.provider.name }).info("collecting provider configuration")
+  const providerLog = log
+    .createLog({ name: ctx.provider.name, showDuration: true })
+    .info("collecting provider configuration")
 
   const systemNamespace = await getSystemNamespace(ctx, provider, log)
   const systemMetadataNamespace = getSystemMetadataNamespaceName(provider.config)
@@ -117,18 +118,18 @@ export async function debugInfo({ ctx, log, includeProject }: GetDebugInfoParams
     namespacesList.push(appNamespace)
   }
   const namespaces = await Bluebird.map(namespacesList, async (ns) => {
-    const nsLog = providerLog.makeNewLogContext({ section: ns }).info("collecting namespace configuration")
+    const nsLog = providerLog.createLog({ name: ns, showDuration: true }).info("collecting namespace configuration")
     const out = await kubectl(ctx, provider).stdout({
       log,
       args: ["get", "all", "--namespace", ns, "--output", "json"],
     })
-    nsLog.setSuccess(chalk.green(`Done (took ${log.getDuration(1)} sec)`))
+    nsLog.success(`Done`)
     return {
       namespace: ns,
       output: JSON.parse(out),
     }
   })
-  providerLog.setSuccess(chalk.green(`Done (took ${log.getDuration(1)} sec)`))
+  providerLog.success(`Done`)
 
   const version = await kubectl(ctx, provider).stdout({ log, args: ["version", "--output", "json"] })
 

--- a/core/src/plugins/kubernetes/local-mode.ts
+++ b/core/src/plugins/kubernetes/local-mode.ts
@@ -820,7 +820,7 @@ async function getReversePortForwardProcesses(
             })
           },
           onMessage: (msg: ProcessMessage) => {
-            log.setSuccess({
+            log.success({
               section,
               msg: chalk.white(composeMessage(msg, `${msg.processDescription} is up and running`)),
             })
@@ -831,7 +831,7 @@ async function getReversePortForwardProcesses(
           hasErrors: (_chunk: any) => false,
           onError: (_msg: ProcessMessage) => {},
           onMessage: (msg: ProcessMessage) => {
-            log.setSuccess({
+            log.success({
               section,
               msg: chalk.white(composeMessage(msg, `${msg.processDescription} is up and running`)),
             })

--- a/core/src/plugins/kubernetes/namespace.ts
+++ b/core/src/plugins/kubernetes/namespace.ts
@@ -273,7 +273,7 @@ export async function deleteNamespaces(namespaces: string[], api: KubeApi, log?:
     const nsNames = await getAllNamespaces(api)
     if (intersection(nsNames, namespaces).length === 0) {
       if (log) {
-        log.setSuccess()
+        log.success("Done")
       }
       break
     }

--- a/core/src/plugins/kubernetes/port-forward.ts
+++ b/core/src/plugins/kubernetes/port-forward.ts
@@ -262,7 +262,7 @@ export function getForwardablePorts(
       }
 
       for (const servicePort of service.spec?.ports || []) {
-        const serviceTargetPort = (servicePort.targetPort as any) as number
+        const serviceTargetPort = servicePort.targetPort as any as number
 
         if (serviceTargetPort && serviceTargetPort === portSpec.containerPort) {
           return true

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -212,7 +212,7 @@ export async function runAndCopy({
     const logEventContext = {
       // XXX command cannot be possibly undefined, can it?
       origin: command ? command[0] : "unknown command",
-      log: log.makeNewLogContext({ level: LogLevel.verbose }),
+      log: log.makeNewLogContext({ fixLevel: LogLevel.verbose }),
     }
 
     const outputStream = new PassThrough()
@@ -800,7 +800,7 @@ export class PodRunner extends PodRunnerParams {
       ? this.logEventContext
       : {
           origin: this.getFullCommand()[0]!,
-          log: log.makeNewLogContext({ level: LogLevel.verbose }),
+          log: log.makeNewLogContext({ fixLevel: LogLevel.verbose }),
         }
 
     const stream = new Stream<RunLogEntry>()

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -212,7 +212,7 @@ export async function runAndCopy({
     const logEventContext = {
       // XXX command cannot be possibly undefined, can it?
       origin: command ? command[0] : "unknown command",
-      log: log.makeNewLogContext({ fixLevel: LogLevel.verbose }),
+      log: log.createLog({ fixLevel: LogLevel.verbose }),
     }
 
     const outputStream = new PassThrough()
@@ -800,7 +800,7 @@ export class PodRunner extends PodRunnerParams {
       ? this.logEventContext
       : {
           origin: this.getFullCommand()[0]!,
-          log: log.makeNewLogContext({ fixLevel: LogLevel.verbose }),
+          log: log.createLog({ fixLevel: LogLevel.verbose }),
         }
 
     const stream = new Stream<RunLogEntry>()
@@ -1184,7 +1184,7 @@ export class PodRunner extends PodRunnerParams {
   }) {
     // Some types and predicates to identify known errors
     const knownErrorTypes = ["out-of-memory", "not-found", "timeout", "pod-runner", "kubernetes"] as const
-    type KnownErrorType = typeof knownErrorTypes[number]
+    type KnownErrorType = (typeof knownErrorTypes)[number]
     // A known error is always an instance of a subclass of GardenBaseError
     type KnownError = Error & {
       message: string

--- a/core/src/plugins/kubernetes/status/status.ts
+++ b/core/src/plugins/kubernetes/status/status.ts
@@ -200,7 +200,7 @@ export async function waitForResources({
 
   const logEventContext = {
     origin: "kubernetes-plugin",
-    log: log.makeNewLogContext({ fixLevel: LogLevel.verbose }),
+    log: log.createLog({ fixLevel: LogLevel.verbose }),
   }
 
   const emitLog = (msg: string) =>
@@ -208,7 +208,7 @@ export async function waitForResources({
 
   const waitingMsg = `Waiting for resources to be ready...`
   const statusLine = log
-    .makeNewLogContext({
+    .createLog({
       section: actionName,
     })
     .info(waitingMsg)

--- a/core/src/plugins/kubernetes/status/status.ts
+++ b/core/src/plugins/kubernetes/status/status.ts
@@ -200,7 +200,7 @@ export async function waitForResources({
 
   const logEventContext = {
     origin: "kubernetes-plugin",
-    log: log.makeNewLogContext({ level: LogLevel.verbose }),
+    log: log.makeNewLogContext({ fixLevel: LogLevel.verbose }),
   }
 
   const emitLog = (msg: string) =>

--- a/core/src/plugins/kubernetes/system.ts
+++ b/core/src/plugins/kubernetes/system.ts
@@ -77,8 +77,7 @@ export async function getSystemGarden(
     log: log
       .makeNewLogContext({
         section: "garden system",
-        level: LogLevel.debug,
-        fixLevel: true,
+        fixLevel: LogLevel.debug,
       })
       .info("Initializing..."),
   })
@@ -97,7 +96,7 @@ export async function getSystemServiceStatus({ sysGarden, log, names }: GetSyste
   const graph = await sysGarden.getConfigGraph({ log, emit: false })
 
   const serviceStatuses = await actions.getDeployStatuses({
-    log: log.makeNewLogContext({ level: LogLevel.verbose, fixLevel: true }),
+    log: log.makeNewLogContext({ fixLevel: LogLevel.verbose }),
     graph,
     names,
   })

--- a/core/src/plugins/kubernetes/system.ts
+++ b/core/src/plugins/kubernetes/system.ts
@@ -75,7 +75,7 @@ export async function getSystemGarden(
     },
     commandInfo: ctx.command,
     log: log
-      .makeNewLogContext({
+      .createLog({
         section: "garden system",
         fixLevel: LogLevel.debug,
       })
@@ -96,7 +96,7 @@ export async function getSystemServiceStatus({ sysGarden, log, names }: GetSyste
   const graph = await sysGarden.getConfigGraph({ log, emit: false })
 
   const serviceStatuses = await actions.getDeployStatuses({
-    log: log.makeNewLogContext({ fixLevel: LogLevel.verbose }),
+    log: log.createLog({ fixLevel: LogLevel.verbose }),
     graph,
     names,
   })

--- a/core/src/plugins/kubernetes/types.ts
+++ b/core/src/plugins/kubernetes/types.ts
@@ -47,15 +47,14 @@ export type KubernetesResource<T extends BaseResource | KubernetesObject = BaseR
     metadata: Partial<V1ObjectMeta> & {
       name: string
     }
-  } & Omit<T, "apiVersion" | "kind" | "metadata"> &
-    {
+  } & Omit<T, "apiVersion" | "kind" | "metadata"> & {
       // Make sure these are required if they're on the provided type
       [P in Extract<keyof T, "spec">]: Exclude<T[P], undefined>
     }
 
 // Server-side resources always have some fields set if they're in the schema, e.g. status
-export type KubernetesServerResource<T extends BaseResource | KubernetesObject = BaseResource> = KubernetesResource<T> &
-  {
+export type KubernetesServerResource<T extends BaseResource | KubernetesObject = BaseResource> =
+  KubernetesResource<T> & {
     // Make sure these are required if they're on the provided type
     [P in Extract<keyof T, "status">]: Exclude<T[P], undefined>
   }

--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -286,7 +286,7 @@ export async function execInWorkload({
     const logEventContext = {
       // To avoid an awkwardly long prefix for the log lines when rendered, we set a max length here.
       origin: truncate(command.join(" "), 25),
-      log: log.makeNewLogContext({ fixLevel: LogLevel.verbose }),
+      log: log.createLog({ fixLevel: LogLevel.verbose }),
     }
 
     const outputStream = new PassThrough()
@@ -683,7 +683,7 @@ export async function getTargetResource({
 export async function readTargetResource({
   api,
   namespace,
-  query
+  query,
 }: {
   api: KubeApi
   namespace: string

--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -286,7 +286,7 @@ export async function execInWorkload({
     const logEventContext = {
       // To avoid an awkwardly long prefix for the log lines when rendered, we set a max length here.
       origin: truncate(command.join(" "), 25),
-      log: log.makeNewLogContext({ level: LogLevel.verbose }),
+      log: log.makeNewLogContext({ fixLevel: LogLevel.verbose }),
     }
 
     const outputStream = new PassThrough()

--- a/core/src/plugins/kubernetes/volumes/configmap.ts
+++ b/core/src/plugins/kubernetes/volumes/configmap.ts
@@ -175,6 +175,6 @@ function getKubernetesAction(action: Resolved<ConfigmapAction>) {
   return new ResolvedDeployAction<KubernetesDeployActionConfig, {}>({
     ...action["params"],
     config,
-    spec: config.spec
+    spec: config.spec,
   })
 }

--- a/core/src/router/deploy.ts
+++ b/core/src/router/deploy.ts
@@ -74,11 +74,12 @@ export const deployRouter = (baseParams: BaseRouterParams) =>
       return output
     },
 
+    // TODO @eysi: The type here should explictly be ActionLog
     delete: async (params) => {
       const { action, router, handlers } = params
 
       const log = params.log
-        .makeNewLogContext({
+        .createLog({
           section: action.key(),
         })
         .info("Deleting...")
@@ -87,7 +88,7 @@ export const deployRouter = (baseParams: BaseRouterParams) =>
       const status = statusOutput.result
 
       if (status.detail?.state === "missing") {
-        log.setSuccess({
+        log.success({
           section: action.key(),
           msg: "Not found",
         })
@@ -110,7 +111,8 @@ export const deployRouter = (baseParams: BaseRouterParams) =>
 
       router.emitNamespaceEvents(output.result.detail?.namespaceStatuses)
 
-      log.setSuccess(chalk.green(`Done (took ${log.getDuration(1)} sec)`))
+      // TODO @eysi: Validate that timestamp gets printed
+      log.success(`Done`)
 
       return output
     },

--- a/core/src/router/provider.ts
+++ b/core/src/router/provider.ts
@@ -184,7 +184,7 @@ export class ProviderRouter extends BaseRouter {
       environmentStatuses[provider.name] = { ready: false, outputs: {} }
     })
 
-    log.setSuccess()
+    log.success("Done")
 
     return environmentStatuses
   }

--- a/core/src/router/router.ts
+++ b/core/src/router/router.ts
@@ -161,7 +161,7 @@ export class ActionRouter extends BaseRouter {
     dependantsFirst?: boolean
     names?: string[]
   }): Promise<DeployStatusMap> {
-    const servicesLog = log.makeNewLogContext({}).info(chalk.white("Deleting deployments..."))
+    const servicesLog = log.createLog({}).info(chalk.white("Deleting deployments..."))
     const deploys = graph.getDeploys({ names })
 
     const tasks = deploys.map((action) => {
@@ -181,7 +181,7 @@ export class ActionRouter extends BaseRouter {
 
     const serviceStatuses = deletedDeployStatuses(results)
 
-    servicesLog.setSuccess()
+    servicesLog.success("Done")
 
     return serviceStatuses
   }

--- a/core/src/router/run.ts
+++ b/core/src/router/run.ts
@@ -34,7 +34,7 @@ export const runRouter = (baseParams: BaseRouterParams) =>
         actionVersion,
         moduleName,
         actionUid,
-        startedAt: new Date().toISOString()
+        startedAt: new Date().toISOString(),
       }
 
       garden.events.emit("runStatus", {
@@ -108,13 +108,13 @@ export const runRouter = (baseParams: BaseRouterParams) =>
         actionVersion,
         moduleName,
         actionUid: action.getUid(),
-        startedAt: new Date().toISOString()
+        startedAt: new Date().toISOString(),
       }
 
       garden.events.emit("runStatus", {
         ...payloadAttrs,
         state: "getting-status",
-        status: { state: "unknown" }
+        status: { state: "unknown" },
       })
 
       const output = await router.callHandler({

--- a/core/src/server/commands.ts
+++ b/core/src/server/commands.ts
@@ -63,7 +63,7 @@ export function parseRequest(ctx: Koa.ParameterizedContext, log: Log, commands: 
   const command = commandSpec.command
 
   // We generally don't want actions to log anything in the server.
-  const cmdLog = log.makeNewLogContext({ level: LogLevel.silly, fixLevel: true })
+  const cmdLog = log.makeNewLogContext({ fixLevel: LogLevel.silly })
 
   const cmdArgs = mapParams(ctx, request.parameters, command.arguments)
   const optParams = extend({ ...globalOptions, ...command.options })

--- a/core/src/server/commands.ts
+++ b/core/src/server/commands.ts
@@ -63,7 +63,7 @@ export function parseRequest(ctx: Koa.ParameterizedContext, log: Log, commands: 
   const command = commandSpec.command
 
   // We generally don't want actions to log anything in the server.
-  const cmdLog = log.makeNewLogContext({ fixLevel: LogLevel.silly })
+  const cmdLog = log.createLog({ fixLevel: LogLevel.silly })
 
   const cmdArgs = mapParams(ctx, request.parameters, command.arguments)
   const optParams = extend({ ...globalOptions, ...command.options })

--- a/core/src/server/server.ts
+++ b/core/src/server/server.ts
@@ -116,7 +116,7 @@ export class GardenServer extends EventEmitter {
   constructor({ log, command, port }: GardenServerParams) {
     super()
     this.log = log
-    this.debugLog = this.log.makeNewLogContext({ level: LogLevel.debug, fixLevel: true })
+    this.debugLog = this.log.makeNewLogContext({ fixLevel: LogLevel.debug })
     this.commands = prepareCommands(getBuiltinCommands()) // This gets updated when .setGarden() is called
     this.serveCommand = command
     this.clientRouter = undefined

--- a/core/src/server/server.ts
+++ b/core/src/server/server.ts
@@ -116,7 +116,7 @@ export class GardenServer extends EventEmitter {
   constructor({ log, command, port }: GardenServerParams) {
     super()
     this.log = log
-    this.debugLog = this.log.makeNewLogContext({ fixLevel: LogLevel.debug })
+    this.debugLog = this.log.createLog({ fixLevel: LogLevel.debug })
     this.commands = prepareCommands(getBuiltinCommands()) // This gets updated when .setGarden() is called
     this.serveCommand = command
     this.clientRouter = undefined
@@ -165,7 +165,7 @@ export class GardenServer extends EventEmitter {
     })
 
     this.log.info("")
-    this.statusLog = this.log.makeNewLogContext({})
+    this.statusLog = this.log.createLog({})
   }
 
   getBaseUrl() {

--- a/core/src/tasks/base.ts
+++ b/core/src/tasks/base.ts
@@ -9,7 +9,7 @@
 import { GraphResults } from "../graph/results"
 import { v1 as uuidv1 } from "uuid"
 import { Garden } from "../garden"
-import { Log as Log } from "../logger/log-entry"
+import { ActionLog, createActionLog, Log as Log } from "../logger/log-entry"
 import { Profile } from "../util/profiling"
 import type { Action, ActionState, Executed, Resolved } from "../actions/types"
 import { ConfigGraph, GraphError } from "../graph/config-graph"
@@ -90,7 +90,7 @@ export abstract class BaseTask<O extends ValidResultType = ValidResultType> {
   concurrencyLimit = 10
 
   public readonly garden: Garden
-  public readonly log: Log
+  public readonly log: Log | ActionLog
   public readonly uid: string
   public readonly force: boolean
   public readonly skipDependencies: boolean
@@ -197,10 +197,12 @@ export abstract class BaseActionTask<T extends Action, O extends ValidResultType
   forceActions: ActionReference[]
   skipRuntimeDependencies: boolean
   startSyncs: boolean
+  log: ActionLog
 
   constructor(params: BaseActionTaskParams<T>) {
     const { action } = params
-    super({ ...params, log: params.log.makeNewLogContext({ section: action.key() }) })
+    super({ ...params })
+    this.log = createActionLog({ log: params.log, actionName: action.name, actionKind: action.kind })
     this.action = action
     this.graph = params.graph
     this.forceActions = params.forceActions || []

--- a/core/src/tasks/build.ts
+++ b/core/src/tasks/build.ts
@@ -45,9 +45,7 @@ export class BuildTask extends ExecuteActionTask<BuildAction, BuildStatus> {
       )
     }
 
-    let log = this.log
-      .makeNewLogContext({ section: this.getName() })
-      .info(`Building version ${action.versionString()}...`)
+    const log = this.log.info(`Building version ${action.versionString()}...`)
 
     const files = action.getFullVersion().files
 
@@ -70,7 +68,8 @@ export class BuildTask extends ExecuteActionTask<BuildAction, BuildStatus> {
         action,
         log,
       })
-      log.setSuccess(chalk.green(`Done (took ${log.getDuration(1)} sec)`))
+      // TODO @eysi: Verify duration
+      log.success(`Done`)
 
       return {
         ...result,

--- a/core/src/tasks/deploy.ts
+++ b/core/src/tasks/deploy.ts
@@ -27,7 +27,7 @@ export class DeployTask extends ExecuteActionTask<DeployAction, DeployStatus> {
   }
 
   async getStatus({ statusOnly, dependencyResults }: ActionTaskStatusParams<DeployAction>) {
-    const log = this.log
+    const log = this.log.createLog({})
     const action = this.getResolvedAction(this.action, dependencyResults)
 
     const router = await this.garden.getActionRouter()
@@ -60,7 +60,7 @@ export class DeployTask extends ExecuteActionTask<DeployAction, DeployStatus> {
 
     const router = await this.garden.getActionRouter()
 
-    const log = this.log
+    const log = this.log.createLog().info(`Deploying version ${version}...`)
     log.info(`Deploying version ${version}...`)
 
     try {
@@ -76,7 +76,7 @@ export class DeployTask extends ExecuteActionTask<DeployAction, DeployStatus> {
       throw err
     }
 
-    log.setSuccess(chalk.green(`Done (took ${log.getDuration(1)} sec)`))
+    log.success(`Done`)
 
     const executedAction = resolvedActionToExecuted(action, { status })
 

--- a/core/src/tasks/publish.ts
+++ b/core/src/tasks/publish.ts
@@ -6,7 +6,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import chalk from "chalk"
 import { BuildTask } from "./build"
 import { ActionTaskProcessParams, BaseActionTask, BaseActionTaskParams } from "../tasks/base"
 import { resolveTemplateString } from "../template-string/template-string"
@@ -99,11 +98,7 @@ export class PublishTask extends BaseActionTask<BuildAction, PublishActionResult
       // TODO: validate the tag?
     }
 
-    const log = this.log
-      .makeNewLogContext({
-        section: action.key(),
-      })
-      .info("Publishing with tag " + tag)
+    const log = this.log.createLog().info("Publishing with tag " + tag)
 
     const router = await this.garden.getActionRouter()
 
@@ -117,7 +112,7 @@ export class PublishTask extends BaseActionTask<BuildAction, PublishActionResult
     }
 
     if (result.detail?.published) {
-      log.setSuccess(chalk.green(result.detail.message || `Ready`))
+      log.success(result.detail.message || `Ready`)
     } else if (result.detail?.message) {
       log.warn(result.detail.message)
     }

--- a/core/src/tasks/resolve-provider.ts
+++ b/core/src/tasks/resolve-provider.ts
@@ -6,7 +6,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import chalk from "chalk"
 import { BaseTask, CommonTaskParams, ResolveProcessDependenciesParams, TaskProcessParams } from "./base"
 import {
   GenericProviderConfig,
@@ -366,7 +365,7 @@ export class ResolveProviderTask extends BaseTask<Provider> {
       this.log.info(`Preparing environment...`)
 
       const envLogEntry = this.log
-        .makeNewLogContext({
+        .createLog({
           section: pluginName,
         })
         .info("Configuring...")
@@ -381,7 +380,7 @@ export class ResolveProviderTask extends BaseTask<Provider> {
 
       status = result.status
 
-      envLogEntry.setSuccess({ msg: chalk.green("Ready") })
+      envLogEntry.success("Ready")
     }
 
     if (!status.ready) {

--- a/core/src/tasks/run.ts
+++ b/core/src/tasks/run.ts
@@ -6,7 +6,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import chalk from "chalk"
 import { BaseActionTaskParams, ActionTaskProcessParams, ActionTaskStatusParams, ExecuteActionTask } from "./base"
 import { Profile } from "../util/profiling"
 import { RunAction } from "../actions/run"
@@ -30,11 +29,7 @@ export class RunTask extends ExecuteActionTask<RunAction, GetRunResult> {
   }
 
   async getStatus({ dependencyResults }: ActionTaskStatusParams<RunAction>) {
-    const taskLog = this.log
-      .makeNewLogContext({
-        section: this.action.name,
-      })
-      .info("Checking result...")
+    const taskLog = this.log.createLog().info("Checking result...")
     const router = await this.garden.getActionRouter()
     const action = this.getResolvedAction(this.action, dependencyResults)
 
@@ -45,7 +40,7 @@ export class RunTask extends ExecuteActionTask<RunAction, GetRunResult> {
         action,
         log: taskLog,
       })
-      taskLog.setSuccess(chalk.green(`Done`))
+      taskLog.success(`Done`)
 
       // Should return a null value here if there is no result
       if (status.detail === null) {
@@ -66,11 +61,7 @@ export class RunTask extends ExecuteActionTask<RunAction, GetRunResult> {
   async process({ dependencyResults }: ActionTaskProcessParams<RunAction, GetRunResult>) {
     const action = this.getResolvedAction(this.action, dependencyResults)
 
-    const taskLog = this.log
-      .makeNewLogContext({
-        section: action.key(),
-      })
-      .info("Running...")
+    const taskLog = this.log.createLog().info("Running...")
 
     const actions = await this.garden.getActionRouter()
 
@@ -89,7 +80,7 @@ export class RunTask extends ExecuteActionTask<RunAction, GetRunResult> {
       throw err
     }
     if (status.state === "ready") {
-      taskLog.setSuccess(chalk.green(`Done (took ${taskLog.getDuration(1)} sec)`))
+      taskLog.success(`Done`)
     } else {
       taskLog.error(`Failed!`)
       throw new RunTaskError(status.detail?.log)

--- a/core/src/tasks/test.ts
+++ b/core/src/tasks/test.ts
@@ -6,7 +6,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import chalk from "chalk"
 import { find } from "lodash"
 import minimatch from "minimatch"
 
@@ -62,8 +61,7 @@ export class TestTask extends ExecuteActionTask<TestAction, GetTestResult> {
     const testResult = status?.detail
 
     if (testResult && testResult.success) {
-      const passedEntry = this.log.makeNewLogContext({ section: action.key() }).info(chalk.green("Already passed"))
-      passedEntry.setSuccess(chalk.green("Already passed"))
+      this.log.createLog().success("Already passed")
       return {
         ...status,
         version: action.versionString(),
@@ -77,11 +75,7 @@ export class TestTask extends ExecuteActionTask<TestAction, GetTestResult> {
   async process({ dependencyResults }: ActionTaskProcessParams<TestAction, GetTestResult>) {
     const action = this.getResolvedAction(this.action, dependencyResults)
 
-    const taskLog = this.log
-      .makeNewLogContext({
-        section: action.key(),
-      })
-      .info(`Running...`)
+    const taskLog = this.log.createLog().info(`Running...`)
 
     const router = await this.garden.getActionRouter()
 
@@ -100,7 +94,7 @@ export class TestTask extends ExecuteActionTask<TestAction, GetTestResult> {
       throw err
     }
     if (status.detail?.success) {
-      taskLog.setSuccess(chalk.green(`Success (took ${taskLog.getDuration(1)} sec)`))
+      taskLog.success(`Success`)
     } else {
       const exitCode = status.detail?.exitCode
       const failedMsg = !!exitCode ? `Failed with code ${exitCode}!` : `Failed!`

--- a/core/src/types/service.ts
+++ b/core/src/types/service.ts
@@ -73,7 +73,7 @@ export function serviceFromConfig<M extends GardenModule = GardenModule>(
 }
 
 export const serviceStates = ["ready", "deploying", "stopped", "unhealthy", "unknown", "outdated", "missing"] as const
-export type DeployState = typeof serviceStates[number]
+export type DeployState = (typeof serviceStates)[number]
 
 /**
  * Given a list of states, return a single state representing the list.

--- a/core/src/util/ext-tools.ts
+++ b/core/src/util/ext-tools.ts
@@ -154,7 +154,7 @@ export class CliWrapper {
 
     const logEventContext = {
       origin: this.name,
-      log: log.makeNewLogContext({ fixLevel: LogLevel.verbose }),
+      log: log.createLog({ fixLevel: LogLevel.verbose }),
     }
 
     logStream.on("data", (line: Buffer) => {
@@ -297,9 +297,9 @@ export class PluginTool extends CliWrapper {
       const tmpPath = join(this.toolPath, this.versionDirname + "." + uuidv4().substr(0, 8))
       const targetAbsPath = join(tmpPath, ...this.targetSubpath.split(posix.sep))
 
-      const downloadLog = log.makeNewLogContext({}).info(`Fetching ${this.name}...`)
+      const downloadLog = log.createLog({}).info(`Fetching ${this.name}...`)
       const debug = downloadLog
-        .makeNewLogContext({
+        .createLog({
           fixLevel: LogLevel.debug,
         })
         .info(`Downloading ${this.buildSpec.url}...`)
@@ -324,8 +324,8 @@ export class PluginTool extends CliWrapper {
         }
       }
 
-      debug && debug.setSuccess("Done")
-      downloadLog.setSuccess(`Fetched ${this.name}`)
+      debug && debug.success("Done")
+      downloadLog.success(`Fetched ${this.name}`)
     })
   }
 

--- a/core/src/util/ext-tools.ts
+++ b/core/src/util/ext-tools.ts
@@ -154,7 +154,7 @@ export class CliWrapper {
 
     const logEventContext = {
       origin: this.name,
-      log: log.makeNewLogContext({ level: LogLevel.verbose }),
+      log: log.makeNewLogContext({ fixLevel: LogLevel.verbose }),
     }
 
     logStream.on("data", (line: Buffer) => {
@@ -300,7 +300,7 @@ export class PluginTool extends CliWrapper {
       const downloadLog = log.makeNewLogContext({}).info(`Fetching ${this.name}...`)
       const debug = downloadLog
         .makeNewLogContext({
-          level: LogLevel.debug,
+          fixLevel: LogLevel.debug,
         })
         .info(`Downloading ${this.buildSpec.url}...`)
 

--- a/core/src/util/profiling.ts
+++ b/core/src/util/profiling.ts
@@ -13,6 +13,8 @@ import { renderTable, tablePresets } from "./string"
 import chalk from "chalk"
 import { isPromise } from "./util"
 
+const skipProfiling = process.env.GARDEN_SKIP_TEST_PROFILING
+
 const maxReportRows = 60
 
 // Just storing the invocation duration for now
@@ -42,6 +44,10 @@ export class Profiler {
   }
 
   report() {
+    if (skipProfiling) {
+      return
+    }
+
     function formatKey(key: string) {
       const split = key.split("#")
 

--- a/core/src/util/testing.ts
+++ b/core/src/util/testing.ts
@@ -168,7 +168,7 @@ export class TestGarden extends Garden {
     if (cacheKey && paramCache[cacheKey]) {
       params = cloneDeep(paramCache[cacheKey])
       // Need to do these separately to avoid issues around cloning
-      params.log = opts?.log || getLogger().makeNewLogContext()
+      params.log = opts?.log || getLogger().createLog()
       params.plugins = opts?.plugins || []
     } else {
       params = await resolveGardenParams(currentDirectory, { commandInfo: defaultCommandinfo, ...opts })

--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -252,7 +252,7 @@ export class GitHandler extends VcsHandler {
     }
 
     const gitLog = log
-      .makeNewLogContext({})
+      .createLog({})
       .debug(
         `Scanning ${pathDescription} at ${path}\n→ Includes: ${include || "(none)"}\n→ Excludes: ${exclude || "(none)"}`
       )
@@ -579,7 +579,7 @@ export class GitHandler extends VcsHandler {
     const isCloned = await pathExists(absPath)
 
     if (!isCloned) {
-      const gitLog = log.makeNewLogContext({ section: name }).info(`Fetching from ${url}`)
+      const gitLog = log.createLog({ name, showDuration: true }).info(`Fetching from ${url}`)
       const { repositoryUrl, hash } = parseGitUrl(url)
 
       try {
@@ -592,7 +592,7 @@ export class GitHandler extends VcsHandler {
         })
       }
 
-      gitLog.setSuccess()
+      gitLog.success("Done")
     }
 
     return absPath
@@ -605,7 +605,7 @@ export class GitHandler extends VcsHandler {
 
     await this.ensureRemoteSource({ url, name, sourceType, log, failOnPrompt })
 
-    const gitLog = log.makeNewLogContext({ section: name }).info("Getting remote state")
+    const gitLog = log.createLog({ name, showDuration: true }).info("Getting remote state")
     await git("remote", "update")
 
     const localCommitId = (await git("rev-parse", "HEAD"))[0]
@@ -629,9 +629,9 @@ export class GitHandler extends VcsHandler {
         })
       }
 
-      gitLog.setSuccess("Source updated")
+      gitLog.success("Source updated")
     } else {
-      gitLog.setSuccess("Source already up to date")
+      gitLog.success("Source already up to date")
     }
   }
 

--- a/core/test/helpers.ts
+++ b/core/test/helpers.ts
@@ -799,7 +799,7 @@ export function initTestLogger() {
     Logger.initialize({
       level: LogLevel.info,
       storeEntries: true,
-      type: "quiet",
+      terminalWriterType: "quiet",
     })
   } catch (_) {}
 }

--- a/core/test/integ/src/plugins/kubernetes/container/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/deployment.ts
@@ -62,7 +62,7 @@ describe("kubernetes container deployment handlers", () => {
 
   async function resolveDeployAction(name: string, mode: ActionMode = "default") {
     if (mode !== "default") {
-      graph = await garden.getConfigGraph({ log: garden.log, emit: false, actionModes: { [mode]: ["deploy." + name]} })
+      graph = await garden.getConfigGraph({ log: garden.log, emit: false, actionModes: { [mode]: ["deploy." + name] } })
     }
     return garden.resolveAction<ContainerDeployAction>({ action: graph.getDeploy(name), log: garden.log, graph })
   }

--- a/core/test/integ/src/plugins/kubernetes/container/logs.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/logs.ts
@@ -240,6 +240,10 @@ describe("kubernetes", () => {
 
         // Then we expect to see a "container connected" entry when the Deploy has been completed
         expect(logString).to.match(/<Connected to container 'simple-service' in Pod/)
+
+        const deployLog = entries.find((e) => e.msg.includes("Server running..."))
+        expect(deployLog).to.exist
+
       })
     })
   })

--- a/core/test/integ/src/plugins/kubernetes/container/logs.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/logs.ts
@@ -243,7 +243,6 @@ describe("kubernetes", () => {
 
         const deployLog = entries.find((e) => e.msg.includes("Server running..."))
         expect(deployLog).to.exist
-
       })
     })
   })

--- a/core/test/integ/src/plugins/kubernetes/helm/common.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/common.ts
@@ -674,7 +674,9 @@ ${expectedIngressOutput}
           log,
           graph,
         })
-        log.entries = []
+
+        const l = log as any
+        l.entries = []
 
         await prepareTemplates({ ctx, log, action })
 

--- a/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
@@ -278,11 +278,7 @@ describe("helmDeploy", () => {
   })
 
   it("should mark a chart that has been paused by Garden Cloud AEC as outdated", async () => {
-    const fakeCloudApi = new CloudApi(
-      getLogger().makeNewLogContext(),
-      "https://test.cloud.garden.io",
-      new GlobalConfigStore()
-    )
+    const fakeCloudApi = new CloudApi(getLogger().createLog(), "https://test.cloud.garden.io", new GlobalConfigStore())
     const projectRoot = getDataDir("test-projects", "helm")
     const gardenWithCloudApi = await makeTestGarden(projectRoot, { cloudApi: fakeCloudApi, noCache: true })
 

--- a/core/test/unit/src/analytics/analytics.ts
+++ b/core/test/unit/src/analytics/analytics.ts
@@ -19,6 +19,7 @@ import { Log } from "../../../../src/logger/log-entry"
 import { Logger, LogLevel } from "../../../../src/logger/logger"
 import { AnalyticsGlobalConfig, GlobalConfigStore } from "../../../../src/config-store/global"
 import { ProjectResource } from "../../../../src/config/project"
+import { QuietWriter } from "../../../../src/logger/writers/quiet-writer"
 
 class FakeCloudApi extends CloudApi {
   static async factory(params: { log: Log; projectConfig?: ProjectResource; skipLogging?: boolean }) {
@@ -261,13 +262,12 @@ describe("AnalyticsHandler", () => {
 
   describe("factory (user is logged in)", async () => {
     beforeEach(async () => {
-      const logger = new Logger({
+      const logger = Logger._createInstanceForTests({
         level: LogLevel.info,
-        writers: [],
+        writers: { terminal: new QuietWriter({ level: LogLevel.info }), file: [] },
         storeEntries: false,
-        type: "default",
       })
-      const cloudApi = await FakeCloudApi.factory({ log: logger.makeNewLogContext() })
+      const cloudApi = await FakeCloudApi.factory({ log: logger.createLog() })
       garden = await makeTestGardenA(undefined, { cloudApi })
       garden.vcsInfo.originUrl = remoteOriginUrl
       await enableAnalytics(garden)

--- a/core/test/unit/src/cache.ts
+++ b/core/test/unit/src/cache.ts
@@ -13,7 +13,7 @@ import { getLogger } from "../../../src/logger/logger"
 
 describe("TreeCache", () => {
   let cache: TreeCache
-  const log = getLogger().makeNewLogContext()
+  const log = getLogger().createLog()
 
   beforeEach(() => {
     cache = new TreeCache()

--- a/core/test/unit/src/cli/cli.ts
+++ b/core/test/unit/src/cli/cli.ts
@@ -43,7 +43,7 @@ import { ServeCommand } from "../../../../src/commands/serve"
 describe("cli", () => {
   let cli: GardenCli
   const globalConfigStore = new GlobalConfigStore()
-  const log = getLogger().makeNewLogContext()
+  const log = getLogger().createLog()
 
   beforeEach(() => {
     cli = new GardenCli()
@@ -255,7 +255,7 @@ describe("cli", () => {
 
         const logger = getLogger()
         const writers = logger.getWriters()
-        expect(writers.map((w) => w.type)).to.include("basic")
+        expect(writers.terminal.type).to.equal("default")
       })
     })
 
@@ -1064,7 +1064,7 @@ describe("cli", () => {
     describe("validateRuntimeRequirementsCached", () => {
       let config: GlobalConfigStore
       let tmpDir
-      const log = getLogger().makeNewLogContext()
+      const log = getLogger().createLog()
 
       before(async () => {
         tmpDir = await tmp.dir({ unsafeCleanup: true })

--- a/core/test/unit/src/cloud/api.ts
+++ b/core/test/unit/src/cloud/api.ts
@@ -15,7 +15,7 @@ import { randomString } from "../../../../src/util/string"
 import { GlobalConfigStore } from "../../../../src/config-store/global"
 
 describe("CloudApi", () => {
-  const log = getLogger().makeNewLogContext()
+  const log = getLogger().createLog()
   const domain = "https://garden." + randomString()
   const globalConfigStore = new GlobalConfigStore()
 

--- a/core/test/unit/src/cloud/buffered-event-stream.ts
+++ b/core/test/unit/src/cloud/buffered-event-stream.ts
@@ -35,7 +35,7 @@ describe("BufferedEventStream", () => {
     const flushedEvents: StreamEvent[] = []
     const flushedLogEntries: LogEntryEventPayload[] = []
 
-    const log = getLogger().makeNewLogContext()
+    const log = getLogger().createLog()
 
     const bufferedEventStream = new BufferedEventStream({ log, sessionId: "dummy-session-id" })
 
@@ -64,7 +64,7 @@ describe("BufferedEventStream", () => {
     const flushedEvents: StreamEvent[] = []
     const flushedLogEntries: LogEntryEventPayload[] = []
 
-    const log = getLogger().makeNewLogContext()
+    const log = getLogger().createLog()
 
     const bufferedEventStream = new BufferedEventStream({ log, sessionId: "dummy-session-id" })
 
@@ -101,7 +101,7 @@ describe("BufferedEventStream", () => {
     const maxBatchBytes = 3 * 1024 // Set this to a low value (3 Kb) to keep the memory use of the test suite low.
     it("should pick records until the batch size reaches MAX_BATCH_BYTES", async () => {
       const recordSizeKb = 0.5
-      const log = getLogger().makeNewLogContext()
+      const log = getLogger().createLog()
       const bufferedEventStream = new BufferedEventStream({ log, sessionId: "dummy-session-id" })
       bufferedEventStream["maxBatchBytes"] = maxBatchBytes
       // Total size is ~3MB, which exceeds MAX_BATCH_BYTES
@@ -115,7 +115,7 @@ describe("BufferedEventStream", () => {
 
     it("should drop individual records whose payload size exceeds MAX_BATCH_BYTES", async () => {
       const recordSizeKb = 0.5
-      const log = getLogger().makeNewLogContext()
+      const log = getLogger().createLog()
       const bufferedEventStream = new BufferedEventStream({ log, sessionId: "dummy-session-id" })
       bufferedEventStream["maxBatchBytes"] = maxBatchBytes
       // This record's size, exceeds MAX_BATCH_BYTES, so it should be dropped by `makeBatch`.

--- a/core/test/unit/src/commands/deploy.ts
+++ b/core/test/unit/src/commands/deploy.ts
@@ -386,7 +386,7 @@ describe("DeployCommand", () => {
   describe("isPersistent", () => {
     it("should return persistent=true if --sync is set", async () => {
       const cmd = new DeployCommand()
-      const log = getLogger().makeNewLogContext()
+      const log = getLogger().createLog()
       const persistent = cmd.isPersistent({
         log,
         headerLog: log,
@@ -411,7 +411,7 @@ describe("DeployCommand", () => {
 
     it("should return persistent=true if --local-mode is set", async () => {
       const cmd = new DeployCommand()
-      const log = getLogger().makeNewLogContext()
+      const log = getLogger().createLog()
       const persistent = cmd.isPersistent({
         log,
         headerLog: log,
@@ -436,7 +436,7 @@ describe("DeployCommand", () => {
 
     it("should return persistent=true if --follow is set", async () => {
       const cmd = new DeployCommand()
-      const log = getLogger().makeNewLogContext()
+      const log = getLogger().createLog()
       const persistent = cmd.isPersistent({
         log,
         headerLog: log,

--- a/core/test/unit/src/commands/logs.ts
+++ b/core/test/unit/src/commands/logs.ts
@@ -85,7 +85,7 @@ function getLogOutput(garden: TestGarden, msg: string, extraFilter: (e: LogEntry
     .getChildLogEntries()
     .filter(extraFilter)
     .filter((e) => e.msg?.includes(msg))!
-  return entries.map((e) => formatForTerminal(e).trim())
+  return entries.map((e) => formatForTerminal(e, garden.log.root).trim())
 }
 
 describe("LogsCommand", () => {

--- a/core/test/unit/src/commands/util/hide-warning.ts
+++ b/core/test/unit/src/commands/util/hide-warning.ts
@@ -15,7 +15,7 @@ import { getLogMessages } from "../../../../../src/util/testing"
 describe("HideWarningCommand", () => {
   it("should hide a warning message", async () => {
     const garden = await makeTestGarden(projectRootA)
-    const log = garden.log.makeNewLogContext({})
+    const log = garden.log.createLog({})
     const cmd = new HideWarningCommand()
     const key = randomString(10)
 

--- a/core/test/unit/src/config/base.ts
+++ b/core/test/unit/src/config/base.ts
@@ -30,7 +30,7 @@ const projectPathMultipleModules = getDataDir("test-projects", "multiple-module-
 const modulePathAMultiple = resolve(projectPathMultipleModules, "module-a")
 
 const projectPathDuplicateProjects = getDataDir("test-project-duplicate-project-config")
-const log = getLogger().makeNewLogContext()
+const log = getLogger().createLog()
 
 // TODO: remove this describe block in 0.14
 describe("prepareProjectResource", () => {

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -258,7 +258,7 @@ describe("Garden", () => {
         providers: [{ name: "foo" }],
       })
       config.environments = [] // this is omitted later to simulate a config where envs are not set
-      config = (omit(config, "environments") as any) as ProjectConfig
+      config = omit(config, "environments") as any as ProjectConfig
       await expectError(async () => await TestGarden.factory(pathFoo, { config }), {
         contains: "Error validating project environments: value is required",
       })
@@ -4654,7 +4654,7 @@ describe("Garden", () => {
 
     describe("emitWarning", () => {
       it("should log a warning if the key has not been hidden", async () => {
-        const log = garden.log.makeNewLogContext({})
+        const log = garden.log.createLog({})
         const message = "Oh noes!"
         await garden.emitWarning({ key, log, message })
         const logs = getLogMessages(log)
@@ -4663,7 +4663,7 @@ describe("Garden", () => {
       })
 
       it("should not log a warning if the key has been hidden", async () => {
-        const log = garden.log.makeNewLogContext({})
+        const log = garden.log.createLog({})
         const message = "Oh noes!"
         await garden.hideWarning(key)
         await garden.emitWarning({ key, log, message })

--- a/core/test/unit/src/logger/log-entry.ts
+++ b/core/test/unit/src/logger/log-entry.ts
@@ -80,9 +80,9 @@ describe("Log", () => {
       expect(childLog.metadata).to.eql(undefined)
     })
   })
-  context("fixLevel=true", () => {
+  context("fixLevel=verbose", () => {
     it("should create a log whose child logs and entries inherit the level", () => {
-      const logVerbose = logger.makeNewLogContext({ fixLevel: true, level: LogLevel.verbose })
+      const logVerbose = logger.makeNewLogContext({ fixLevel: LogLevel.verbose })
       const verboseEntryInfo = logVerbose.info("").getLatestEntry()
       const verboseEntryError = logVerbose.error("").getLatestEntry()
       const verboseEntrySilly = logVerbose.silly("").getLatestEntry()
@@ -91,12 +91,12 @@ describe("Log", () => {
       const childEntryError = childLog.error("").getLatestEntry()
       const childEntrySilly = childLog.silly("").getLatestEntry()
 
-      expect(logVerbose.level).to.eql(LogLevel.verbose)
+      expect(logVerbose.fixLevel).to.eql(LogLevel.verbose)
       expect(verboseEntryInfo.level).to.eql(LogLevel.verbose)
       expect(verboseEntryError.level).to.eql(LogLevel.verbose)
       expect(verboseEntrySilly.level).to.eql(LogLevel.silly)
 
-      expect(childLog.level).to.eql(LogLevel.verbose)
+      expect(childLog.fixLevel).to.eql(LogLevel.verbose)
       expect(childEntryInfo.level).to.eql(LogLevel.verbose)
       expect(childEntryError.level).to.eql(LogLevel.verbose)
       expect(childEntrySilly.level).to.eql(LogLevel.silly)

--- a/core/test/unit/src/logger/log-entry.ts
+++ b/core/test/unit/src/logger/log-entry.ts
@@ -10,8 +10,9 @@ import { expect } from "chai"
 
 import { getLogger, LogLevel, Logger } from "../../../../src/logger/logger"
 import { freezeTime } from "../../../helpers"
-import { LogEntryMetadata } from "../../../../src/logger/log-entry"
-import { omit } from "lodash"
+import { createActionLog, Log, LogMetadata } from "../../../../src/logger/log-entry"
+import { omit, pick } from "lodash"
+import chalk from "chalk"
 
 const logger: Logger = getLogger()
 
@@ -20,86 +21,319 @@ beforeEach(() => {
 })
 
 describe("Log", () => {
-  const log = logger.makeNewLogContext()
-  it("should create log entries with the appropriate fields set", () => {
-    const timestamp = freezeTime().toISOString()
-    const entry = log
-      .info({
-        id: "my-id",
-        msg: "hello",
-        section: "80",
-        symbol: "info",
-        data: { foo: "bar" },
-        dataFormat: "json",
+  let log: Log
+  beforeEach(() => {
+    log = logger.createLog()
+  })
+
+  describe("silly", () => {
+    it("should log an entry with the silly level", () => {
+      const entry = log.silly("silly").getLatestEntry()
+      expect(entry.level).to.eql(LogLevel.silly)
+    })
+  })
+  describe("debug", () => {
+    it("should log an entry with the debug level", () => {
+      const entry = log.debug("debug").getLatestEntry()
+      expect(entry.level).to.eql(LogLevel.debug)
+    })
+  })
+  describe("verbose", () => {
+    it("should log an entry with the verbose level", () => {
+      const entry = log.verbose("verbose").getLatestEntry()
+      expect(entry.level).to.eql(LogLevel.verbose)
+    })
+  })
+  describe("warn", () => {
+    it("should log an entry with the warn level", () => {
+      const entry = log.warn("warn").getLatestEntry()
+      expect(entry.level).to.eql(LogLevel.warn)
+    })
+  })
+  describe("error", () => {
+    it("should log an entry with the error level", () => {
+      const entry = log.error("error").getLatestEntry()
+      expect(entry.level).to.eql(LogLevel.error)
+    })
+    it("should color the message red", () => {
+      const entry = log.error("error").getLatestEntry()
+      expect(entry.msg).to.eql(chalk.red("error"))
+    })
+    it("should print the duration if showDuration=true", () => {
+      const errorLog = log.createLog({ name: "test-log", showDuration: true })
+      const entry = errorLog.error("error").getLatestEntry()
+      expect(entry.msg).to.include("(in ")
+    })
+  })
+  describe("success", () => {
+    it("should log success message", () => {
+      const entry = log.success("success").getLatestEntry()
+      expect(entry.level).to.eql(LogLevel.info)
+      expect(entry.msg).to.eql(chalk.green("success"))
+    })
+    it("should print the duration if showDuration=true", () => {
+      const successLog = log.createLog({ name: "success-log", showDuration: true })
+      const entry = successLog.success("success").getLatestEntry()
+      expect(entry.msg).to.include("(in ")
+    })
+  })
+  describe("general logging", () => {
+    context("metadata", () => {
+      const metadata: LogMetadata = { workflowStep: { index: 1 } }
+      it("should pass on any metadata to child logs", () => {
+        const log1 = logger.createLog({ metadata })
+        const log2 = log1.createLog({})
+        const log3 = log2.createLog({})
+        const log4 = log3.createLog({ metadata })
+        expect(log1.metadata).to.eql(metadata)
+        expect(log2.metadata).to.eql(metadata)
+        expect(log3.metadata).to.eql(metadata)
+        expect(log4.metadata).to.eql(metadata)
+      })
+      it("should not set empty metadata objects on child entries", () => {
+        const log = logger.createLog()
+        const childLog = log.createLog({})
+        expect(log.metadata).to.eql(undefined)
+        expect(childLog.metadata).to.eql(undefined)
+      })
+    })
+    context("fixLevel=verbose", () => {
+      it("should create a log whose child logs and entries inherit the level", () => {
+        const logVerbose = logger.createLog({ fixLevel: LogLevel.verbose })
+        const verboseEntryInfo = logVerbose.info("").getLatestEntry()
+        const verboseEntryError = logVerbose.error("").getLatestEntry()
+        const verboseEntrySilly = logVerbose.silly("").getLatestEntry()
+        const childLog = logVerbose.createLog({})
+        const childEntryInfo = childLog.info("").getLatestEntry()
+        const childEntryError = childLog.error("").getLatestEntry()
+        const childEntrySilly = childLog.silly("").getLatestEntry()
+
+        expect(logVerbose.fixLevel).to.eql(LogLevel.verbose)
+        expect(verboseEntryInfo.level).to.eql(LogLevel.verbose)
+        expect(verboseEntryError.level).to.eql(LogLevel.verbose)
+        expect(verboseEntrySilly.level).to.eql(LogLevel.silly)
+
+        expect(childLog.fixLevel).to.eql(LogLevel.verbose)
+        expect(childEntryInfo.level).to.eql(LogLevel.verbose)
+        expect(childEntryError.level).to.eql(LogLevel.verbose)
+        expect(childEntrySilly.level).to.eql(LogLevel.silly)
+      })
+    })
+  })
+})
+
+describe("CoreLog", () => {
+  let log: Log
+  beforeEach(() => {
+    log = logger.createLog()
+  })
+
+  describe("createLog", () => {
+    it("should create a new CoreLog context, optionally overwriting some fields", () => {
+      const timestamp = freezeTime().toISOString()
+      const testLog = log.createLog({ name: "test-log" })
+      const partialTestLog = omit(testLog, "root")
+
+      expect(testLog.root).to.exist
+      expect(partialTestLog).to.eql({
+        type: "coreLog",
+        entries: [],
+        key: testLog.key,
+        metadata: undefined,
+        fixLevel: undefined,
+        section: undefined,
+        showDuration: false,
+        timestamp,
+        context: {
+          name: "test-log",
+        },
+        parentConfigs: [
+          {
+            context: log.context,
+            metadata: log.metadata,
+            timestamp: log.timestamp,
+            key: log.key,
+            section: log.section,
+            fixLevel: log.fixLevel,
+            type: "coreLog",
+          },
+        ],
+      })
+
+      const testLogChild = testLog.createLog()
+      const partialTestLogChild = omit(testLogChild, "root")
+      expect(partialTestLogChild).to.eql({
+        type: "coreLog",
+        entries: [],
+        key: testLogChild.key,
+        metadata: undefined,
+        fixLevel: undefined,
+        section: undefined,
+        showDuration: false,
+        timestamp,
+        context: {
+          name: "test-log", // <--- Inherits context
+        },
+        parentConfigs: [log.getConfig(), testLog.getConfig()],
+      })
+
+      const testLogChildWithOverwrites = testLog.createLog({
+        name: "test-log-overwrites",
+        fixLevel: LogLevel.warn,
+        metadata: { workflowStep: { index: 2 } },
+      })
+      const partialTestLogChildWithOverwrites = omit(testLogChildWithOverwrites, "root")
+      expect(partialTestLogChildWithOverwrites).to.eql({
+        type: "coreLog",
+        entries: [],
+        key: testLogChildWithOverwrites.key,
+        metadata: { workflowStep: { index: 2 } },
+        fixLevel: LogLevel.warn,
+        section: undefined,
+        showDuration: false,
+        timestamp,
+        context: {
+          name: "test-log-overwrites", // <--- Overwrites context
+        },
+        parentConfigs: [log.getConfig(), testLog.getConfig()],
+      })
+    })
+    it("should create a new log context and have it inherit the metadata", () => {
+      const testLog = log.createLog({ name: "test-log", metadata: { workflowStep: { index: 2 } } })
+      const childLog = testLog.createLog()
+
+      expect(testLog.metadata).to.eql({ workflowStep: { index: 2 } })
+      expect(childLog.metadata).to.eql({ workflowStep: { index: 2 } })
+    })
+  })
+  describe("createLogEntry", () => {
+    it("should pass its config on to the log entry", () => {
+      const timestamp = freezeTime().toISOString()
+      const testLog = log.createLog({ name: "test-log", metadata: { workflowStep: { index: 2 } } })
+      const entry = testLog.info("hello").getLatestEntry()
+
+      expect(entry.key).to.be.a.string
+      expect(entry).to.eql({
+        key: entry.key,
+        level: LogLevel.info,
         metadata: {
           workflowStep: {
             index: 2,
           },
         },
+        msg: "hello",
+        parentLogKey: testLog.key,
+        section: undefined,
+        timestamp,
+        type: "coreLogEntry",
+        context: {
+          name: "test-log",
+        },
       })
-      .getLatestEntry()
-
-    expect(entry.metadata).to.eql({
-      workflowStep: {
-        index: 2,
-      },
-    })
-    expect(entry.root).to.exist
-    const partialEntry = omit(entry, "root", "metadata")
-
-    expect(partialEntry).to.eql({
-      type: "logEntry",
-      msg: "hello",
-      section: "80",
-      symbol: "info",
-      data: { foo: "bar" },
-      dataFormat: "json",
-      timestamp,
-      key: entry.key,
-      id: "my-id",
-      level: LogLevel.info,
-      error: undefined,
     })
   })
-  context("metadata", () => {
-    const metadata: LogEntryMetadata = { workflowStep: { index: 1 } }
-    it("should pass on any metadata to child logs", () => {
-      const log1 = logger.makeNewLogContext({ metadata })
-      const log2 = log1.makeNewLogContext({})
-      const log3 = log2.makeNewLogContext({})
-      const log4 = log3.makeNewLogContext({ metadata })
-      expect(log1.metadata).to.eql(metadata)
-      expect(log2.metadata).to.eql(metadata)
-      expect(log3.metadata).to.eql(metadata)
-      expect(log4.metadata).to.eql(metadata)
+})
+
+describe("ActionLog", () => {
+  let log: Log
+  beforeEach(() => {
+    log = logger.createLog()
+  })
+
+  describe("createActionLog helper", () => {
+    it("should create a new ActionLog context, optionally overwriting some fields", () => {
+      const timestamp = freezeTime().toISOString()
+      const testLog = createActionLog({ log, actionName: "api", actionKind: "build" })
+      const partialTestLog = omit(testLog, "root")
+
+      expect(testLog.root).to.exist
+      expect(partialTestLog).to.eql({
+        type: "actionLog",
+        entries: [],
+        key: testLog.key,
+        metadata: undefined,
+        fixLevel: undefined,
+        section: undefined,
+        showDuration: true, // <--- Always true for ActionLog
+        timestamp,
+        context: {
+          actionName: "api",
+          actionKind: "build",
+        },
+        parentConfigs: [
+          {
+            context: log.context,
+            metadata: log.metadata,
+            timestamp: log.timestamp,
+            key: log.key,
+            section: log.section,
+            fixLevel: log.fixLevel,
+            type: "coreLog",
+          },
+        ],
+      })
+
+      const testLogChild = testLog.createLog()
+      const partialTestLogChild = omit(testLogChild, "root")
+      expect(partialTestLogChild).to.eql({
+        type: "actionLog",
+        entries: [],
+        key: testLogChild.key,
+        metadata: undefined,
+        fixLevel: undefined,
+        section: undefined,
+        showDuration: true,
+        timestamp,
+        context: {
+          // <--- Inherits context
+          actionName: "api",
+          actionKind: "build",
+        },
+        parentConfigs: [log.getConfig(), testLog.getConfig()],
+      })
     })
-    it("should not set empty metadata objects on child entries", () => {
-      const log = logger.makeNewLogContext()
-      const childLog = log.makeNewLogContext({})
-      expect(log.metadata).to.eql(undefined)
-      expect(childLog.metadata).to.eql(undefined)
+    it("should always show duration", () => {
+      const testLog = createActionLog({ log, actionName: "api", actionKind: "build" })
+      expect(testLog.showDuration).to.be.true
+    })
+    it("should create a new log context and have it inherit the metadata", () => {
+      const testLog = log.createLog({ name: "test-log", metadata: { workflowStep: { index: 2 } } })
+      const childLog = testLog.createLog()
+
+      expect(testLog.metadata).to.eql({ workflowStep: { index: 2 } })
+      expect(childLog.metadata).to.eql({ workflowStep: { index: 2 } })
     })
   })
-  context("fixLevel=verbose", () => {
-    it("should create a log whose child logs and entries inherit the level", () => {
-      const logVerbose = logger.makeNewLogContext({ fixLevel: LogLevel.verbose })
-      const verboseEntryInfo = logVerbose.info("").getLatestEntry()
-      const verboseEntryError = logVerbose.error("").getLatestEntry()
-      const verboseEntrySilly = logVerbose.silly("").getLatestEntry()
-      const childLog = logVerbose.makeNewLogContext({})
-      const childEntryInfo = childLog.info("").getLatestEntry()
-      const childEntryError = childLog.error("").getLatestEntry()
-      const childEntrySilly = childLog.silly("").getLatestEntry()
+  describe("createLogEntry", () => {
+    it("should pass its config on to the log entry", () => {
+      const timestamp = freezeTime().toISOString()
+      const testLog = createActionLog({
+        log,
+        actionKind: "build",
+        actionName: "api",
+        metadata: { workflowStep: { index: 2 } },
+      })
+      const entry = testLog.info("hello").getLatestEntry()
 
-      expect(logVerbose.fixLevel).to.eql(LogLevel.verbose)
-      expect(verboseEntryInfo.level).to.eql(LogLevel.verbose)
-      expect(verboseEntryError.level).to.eql(LogLevel.verbose)
-      expect(verboseEntrySilly.level).to.eql(LogLevel.silly)
-
-      expect(childLog.fixLevel).to.eql(LogLevel.verbose)
-      expect(childEntryInfo.level).to.eql(LogLevel.verbose)
-      expect(childEntryError.level).to.eql(LogLevel.verbose)
-      expect(childEntrySilly.level).to.eql(LogLevel.silly)
+      expect(entry.key).to.be.a.string
+      expect(entry).to.eql({
+        key: entry.key,
+        level: LogLevel.info,
+        metadata: {
+          workflowStep: {
+            index: 2,
+          },
+        },
+        msg: "hello",
+        parentLogKey: testLog.key,
+        section: undefined,
+        timestamp,
+        type: "actionLogEntry",
+        context: {
+          actionKind: "build",
+          actionName: "api",
+        },
+      })
     })
   })
 })

--- a/core/test/unit/src/logger/renderers.ts
+++ b/core/test/unit/src/logger/renderers.ts
@@ -39,11 +39,11 @@ beforeEach(() => {
 describe("renderers", () => {
   describe("renderMsg", () => {
     it("should render the message with the message style", () => {
-      const log = logger.makeNewLogContext().info("hello message")
+      const log = logger.createLog().info("hello message")
       expect(renderMsg(log.entries[0])).to.equal(msgStyle("hello message"))
     })
     it("should render the message with the error style if the entry has error level", () => {
-      const log = logger.makeNewLogContext().error({ msg: "hello error" })
+      const log = logger.createLog().error({ msg: "hello error" })
       expect(renderMsg(log.entries[0])).to.equal(errorStyle("hello error"))
     })
   })
@@ -58,70 +58,76 @@ describe("renderers", () => {
           _internal: "no show",
         },
       }
-      const log = logger.makeNewLogContext().info({ msg: "foo", error })
-      const rendered = renderError(log.entries[0])
-      expect(rendered).to.include("Error: hello error")
-      expect(rendered).to.include("Error Details:")
+      const log = logger.createLog().info({ msg: "foo", error })
+      expect(renderError(log.entries[0])).to.equal(dedent`
+          hello error
+
+          Error Details:
+
+          foo: bar\n
+        `)
     })
   })
   describe("renderSection", () => {
     it("should render the log entry section with padding", () => {
-      const log = logger.makeNewLogContext().info({ msg: "foo", section: "hello" })
+      const log = logger.createLog().info({ msg: "foo", section: "hello" })
       const withWhitespace = "hello".padEnd(SECTION_PADDING, " ")
       const rendered = stripAnsi(renderSection(log.entries[0]))
       expect(rendered).to.equal(`${withWhitespace} → `)
     })
     it("should not render arrow if message is empty", () => {
-      const log = logger.makeNewLogContext().info({ section: "hello" })
+      const log = logger.createLog().info({ section: "hello" })
       const withWhitespace = "hello".padEnd(SECTION_PADDING, " ")
       const rendered = stripAnsi(renderSection(log.entries[0]))
       expect(rendered).to.equal(`${withWhitespace}`)
     })
     it("should not not truncate the section", () => {
-      const log = logger.makeNewLogContext().info({ msg: "foo", section: "very-very-very-very-very-long" })
+      const log = logger.createLog().info({ msg: "foo", section: "very-very-very-very-very-long" })
       const rendered = stripAnsi(renderSection(log.entries[0]))
       expect(rendered).to.equal(`very-very-very-very-very-long → `)
     })
   })
   describe("formatForTerminal", () => {
     it("should return the entry as a formatted string with a new line character", () => {
-      const log = logger.makeNewLogContext().info("")
-      expect(formatForTerminal(log.entries[0])).to.equal("\n")
+      const log = logger.createLog().info("")
+      expect(formatForTerminal(log.entries[0], logger)).to.equal("\n")
     })
     it("should return an empty string without a new line if the parameter LogEntryParams is empty", () => {
-      const log = logger.makeNewLogContext().info({})
-      expect(formatForTerminal(log.entries[0])).to.equal("")
+      const log = logger.createLog().info({})
+      expect(formatForTerminal(log.entries[0], logger)).to.equal("")
     })
     it("should return a string with a new line if any of the members of entry.message is not empty", () => {
-      const logMsg = logger.makeNewLogContext().info({ msg: "msg" })
-      expect(formatForTerminal(logMsg.entries[0])).contains("\n")
+      const logMsg = logger.createLog().info({ msg: "msg" })
+      expect(formatForTerminal(logMsg.entries[0], logger)).contains("\n")
 
-      const logSection = logger.makeNewLogContext().info({ section: "section" })
-      expect(formatForTerminal(logSection.entries[0])).contains("\n")
+      const logSection = logger.createLog().info({ section: "section" })
+      expect(formatForTerminal(logSection.entries[0], logger)).contains("\n")
 
-      const logSymbol = logger.makeNewLogContext().info({ symbol: "success" })
-      expect(formatForTerminal(logSymbol.entries[0])).contains("\n")
+      const logSymbol = logger.createLog().info({ symbol: "success" })
+      expect(formatForTerminal(logSymbol.entries[0], logger)).contains("\n")
 
-      const logData = logger.makeNewLogContext().info({ data: { some: "data" } })
-      expect(formatForTerminal(logData.entries[0])).contains("\n")
+      const logData = logger.createLog().info({ data: { some: "data" } })
+      expect(formatForTerminal(logData.entries[0], logger)).contains("\n")
     })
     it("should always render a symbol with sections", () => {
-      const entry = logger.makeNewLogContext().info({ msg: "hello world", section: "foo" }).getLatestEntry()
+      const entry = logger.createLog().info({ msg: "hello world", section: "foo" }).getLatestEntry()
 
-      expect(formatForTerminal(entry)).to.equal(
+      expect(formatForTerminal(entry, logger)).to.equal(
         `${logSymbols["info"]} ${renderSection(entry)}${msgStyle("hello world")}\n`
       )
     })
     it("should print the log level if it's higher then 'info'", () => {
-      const entry = logger.makeNewLogContext().debug({ msg: "hello world" }).getLatestEntry()
+      const entry = logger.createLog().debug({ msg: "hello world" }).getLatestEntry()
 
-      expect(formatForTerminal(entry)).to.equal(`${chalk.gray("[debug]")} ${msgStyle("hello world")}\n`)
+      expect(formatForTerminal(entry, logger)).to.equal(
+        `${logSymbols["info"]} ${chalk.gray("[debug]")} ${msgStyle("hello world")}\n`
+      )
     })
     it("should print the log level if it's higher then 'info' after the section if there is one", () => {
-      const entry = logger.makeNewLogContext().debug({ msg: "hello world", section: "foo" }).getLatestEntry()
+      const entry = logger.createLog().debug({ msg: "hello world", section: "foo" }).getLatestEntry()
 
       const section = `foo ${chalk.gray("[debug]")}`
-      expect(formatForTerminal(entry)).to.equal(
+      expect(formatForTerminal(entry, logger)).to.equal(
         `${logSymbols["info"]} ${chalk.cyan.italic(padSection(section))} → ${msgStyle("hello world")}\n`
       )
     })
@@ -131,9 +137,9 @@ describe("renderers", () => {
       })
       it("should include timestamp with formatted string", () => {
         const now = freezeTime()
-        const entry = logger.makeNewLogContext().info("hello world").getLatestEntry()
+        const entry = logger.createLog().info("hello world").getLatestEntry()
 
-        expect(formatForTerminal(entry)).to.equal(`[${now.toISOString()}] ${msgStyle("hello world")}\n`)
+        expect(formatForTerminal(entry, logger)).to.equal(`[${now.toISOString()}] ${msgStyle("hello world")}\n`)
       })
       after(() => {
         logger.showTimestamps = false
@@ -150,7 +156,7 @@ describe("renderers", () => {
           inputVersion: "123",
         }
         const entry = logger
-          .makeNewLogContext()
+          .createLog()
           .info({
             msg: "hello",
             symbol: "info",
@@ -170,7 +176,7 @@ describe("renderers", () => {
       })
       it("should handle undefined messages", () => {
         const now = freezeTime()
-        const entry = logger.makeNewLogContext().info({}).getLatestEntry()
+        const entry = logger.createLog().info({}).getLatestEntry()
         expect(formatForJson(entry)).to.eql({
           msg: "",
           level: "info",
@@ -194,21 +200,21 @@ describe("renderers", () => {
         },
       }
       it("should render an empty string when no data is passed", () => {
-        const entry = logger.makeNewLogContext().info({}).getLatestEntry()
+        const entry = logger.createLog().info({}).getLatestEntry()
         expect(renderData(entry)).to.eql("")
       })
       it("should render yaml by default if data is passed", () => {
-        const entry = logger.makeNewLogContext().info({ data: sampleData }).getLatestEntry()
+        const entry = logger.createLog().info({ data: sampleData }).getLatestEntry()
         const dataAsYaml = safeDumpYaml(sampleData, { noRefs: true })
         expect(renderData(entry)).to.eql(highlightYaml(dataAsYaml))
       })
       it('should render yaml if dataFormat is "yaml"', () => {
-        const entry = logger.makeNewLogContext().info({ data: sampleData, dataFormat: "yaml" }).getLatestEntry()
+        const entry = logger.createLog().info({ data: sampleData, dataFormat: "yaml" }).getLatestEntry()
         const dataAsYaml = safeDumpYaml(sampleData, { noRefs: true })
         expect(renderData(entry)).to.eql(highlightYaml(dataAsYaml))
       })
       it('should render json if dataFormat is "json"', () => {
-        const entry = logger.makeNewLogContext().info({ data: sampleData, dataFormat: "json" }).getLatestEntry()
+        const entry = logger.createLog().info({ data: sampleData, dataFormat: "json" }).getLatestEntry()
         expect(renderData(entry)).to.eql(JSON.stringify(sampleData, null, 2))
       })
     })

--- a/core/test/unit/src/logger/renderers.ts
+++ b/core/test/unit/src/logger/renderers.ts
@@ -59,13 +59,9 @@ describe("renderers", () => {
         },
       }
       const log = logger.createLog().info({ msg: "foo", error })
-      expect(renderError(log.entries[0])).to.equal(dedent`
-          hello error
-
-          Error Details:
-
-          foo: bar\n
-        `)
+      const rendered = renderError(log.entries[0])
+      expect(rendered).to.include("Error: hello error")
+      expect(rendered).to.include("Error Details:")
     })
   })
   describe("renderSection", () => {

--- a/core/test/unit/src/logger/writers/file-writer.ts
+++ b/core/test/unit/src/logger/writers/file-writer.ts
@@ -23,16 +23,16 @@ beforeEach(() => {
 describe("FileWriter", () => {
   describe("render", () => {
     it("should render message without ansi characters", () => {
-      const entry = logger.makeNewLogContext().info(chalk.red("hello")).getLatestEntry()
+      const entry = logger.createLog().info(chalk.red("hello")).getLatestEntry()
       expect(render(LogLevel.info, entry)).to.equal("hello")
     })
     it("should render error message if entry level is error", () => {
-      const entry = logger.makeNewLogContext().error("error").getLatestEntry()
+      const entry = logger.createLog().error("error").getLatestEntry()
       const expectedOutput = stripAnsi(renderError(entry))
       expect(render(LogLevel.info, entry)).to.equal(expectedOutput)
     })
     it("should return null if entry level is geq to writer level", () => {
-      const entry = logger.makeNewLogContext().silly("silly").getLatestEntry()
+      const entry = logger.createLog().silly("silly").getLatestEntry()
       expect(render(LogLevel.info, entry)).to.equal(null)
     })
   })

--- a/core/test/unit/src/logger/writers/json-terminal-writer.ts
+++ b/core/test/unit/src/logger/writers/json-terminal-writer.ts
@@ -23,21 +23,21 @@ describe("JsonTerminalWriter", () => {
     it("should return a JSON-formatted message if level is geq than entry level", () => {
       const now = freezeTime()
       const writer = new JsonTerminalWriter()
-      const entry = logger.makeNewLogContext().info("hello logger").getLatestEntry()
+      const entry = logger.createLog().info("hello logger").getLatestEntry()
       const out = writer.render(entry, logger)
       expect(out).to.eql(`{"msg":"hello logger","section":"","timestamp":"${now.toISOString()}","level":"info"}`)
     })
 
     it("should return null if message is an empty string", () => {
       const writer = new JsonTerminalWriter()
-      const entry = logger.makeNewLogContext().info("").getLatestEntry()
+      const entry = logger.createLog().info("").getLatestEntry()
       const out = writer.render(entry, logger)
       expect(out).to.eql(null)
     })
 
     it("should return null if entry level is geq to writer level", () => {
       const writer = new JsonTerminalWriter()
-      const entry = logger.makeNewLogContext().verbose("abc").getLatestEntry()
+      const entry = logger.createLog().verbose("abc").getLatestEntry()
       const out = writer.render(entry, logger)
       expect(out).to.eql(null)
     })
@@ -46,7 +46,7 @@ describe("JsonTerminalWriter", () => {
       const now = freezeTime()
       const writer = new JsonTerminalWriter()
       const entry = logger
-        .makeNewLogContext()
+        .createLog()
         .info(JSON.stringify({ message: "foo" }))
         .getLatestEntry()
       const out = writer.render(entry, logger)

--- a/core/test/unit/src/logger/writers/terminal-writer.ts
+++ b/core/test/unit/src/logger/writers/terminal-writer.ts
@@ -22,21 +22,15 @@ describe("TerminalWriter", () => {
   describe("render", () => {
     it("should return a formatted message if level is geq than entry level", () => {
       const writer = new TerminalWriter()
-      const entry = logger.makeNewLogContext().info("hello logger").getLatestEntry()
-      const out = writer.render(entry, logger)
-      expect(out).to.eql(formatForTerminal(entry))
+      const entry = logger.createLog().info("hello logger").getLatestEntry()
+      const out = writer.write(entry, logger)
+      expect(out).to.eql(formatForTerminal(entry, logger))
     })
     it("should return a new line if message is an empty string", () => {
       const writer = new TerminalWriter()
-      const entry = logger.makeNewLogContext().info("").getLatestEntry()
-      const out = writer.render(entry, logger)
+      const entry = logger.createLog().info("").getLatestEntry()
+      const out = writer.write(entry, logger)
       expect(out).to.eql("\n")
-    })
-    it("should return null if entry level is geq to writer level", () => {
-      const writer = new TerminalWriter()
-      const entry = logger.makeNewLogContext().verbose("abc").getLatestEntry()
-      const out = writer.render(entry, logger)
-      expect(out).to.eql(null)
     })
   })
 })

--- a/core/test/unit/src/plugins.ts
+++ b/core/test/unit/src/plugins.ts
@@ -16,7 +16,7 @@ import { findByName } from "../../../src/util/util"
 import { expectError } from "../../helpers"
 
 describe("resolvePlugins", () => {
-  const log = getLogger().makeNewLogContext()
+  const log = getLogger().createLog()
 
   const testHandler = (params: PluginBuildActionParamsBase<any>) => {
     return {

--- a/core/test/unit/src/plugins/kubernetes/util.ts
+++ b/core/test/unit/src/plugins/kubernetes/util.ts
@@ -24,7 +24,7 @@ import { sleep } from "../../../../../src/util/util"
 
 describe("deduplicatePodsByLabel", () => {
   it("should return a list of pods, unique by label so that the latest pod is kept", () => {
-    const podA = ({
+    const podA = {
       apiVersion: "v1",
       kind: "Pod",
       metadata: {
@@ -35,8 +35,8 @@ describe("deduplicatePodsByLabel", () => {
         },
       },
       spec: {},
-    } as unknown) as KubernetesServerResource<V1Pod>
-    const podADupe = ({
+    } as unknown as KubernetesServerResource<V1Pod>
+    const podADupe = {
       apiVersion: "v1",
       kind: "Pod",
       metadata: {
@@ -46,39 +46,39 @@ describe("deduplicatePodsByLabel", () => {
           service: "a",
         },
       },
-    } as unknown) as KubernetesServerResource<V1Pod>
-    const podUndefinedLabelA = ({
+    } as unknown as KubernetesServerResource<V1Pod>
+    const podUndefinedLabelA = {
       apiVersion: "v1",
       kind: "Pod",
       metadata: {
         creationTimestamp: new Date("2019-11-13T14:44:26Z"),
         labels: undefined,
       },
-    } as unknown) as KubernetesServerResource<V1Pod>
-    const podUndefinedLabelB = ({
+    } as unknown as KubernetesServerResource<V1Pod>
+    const podUndefinedLabelB = {
       apiVersion: "v1",
       kind: "Pod",
       metadata: {
         creationTimestamp: new Date("2019-11-14T14:44:26Z"),
         labels: undefined,
       },
-    } as unknown) as KubernetesServerResource<V1Pod>
-    const podEmptyLabelA = ({
+    } as unknown as KubernetesServerResource<V1Pod>
+    const podEmptyLabelA = {
       apiVersion: "v1",
       kind: "Pod",
       metadata: {
         creationTimestamp: new Date("2019-11-15T14:44:26Z"),
         labels: {},
       },
-    } as unknown) as KubernetesServerResource<V1Pod>
-    const podEmptyLabelB = ({
+    } as unknown as KubernetesServerResource<V1Pod>
+    const podEmptyLabelB = {
       apiVersion: "v1",
       kind: "Pod",
       metadata: {
         creationTimestamp: new Date("2019-11-16T14:44:26Z"),
         labels: {},
       },
-    } as unknown) as KubernetesServerResource<V1Pod>
+    } as unknown as KubernetesServerResource<V1Pod>
     const uniq = deduplicatePodsByLabel([
       podA,
       podADupe,
@@ -275,7 +275,7 @@ describe("flattenResources", () => {
 
 describe("getStaticLabelsFromPod", () => {
   it("should should only select labels without characters", () => {
-    const pod = ({
+    const pod = {
       apiVersion: "v1",
       kind: "Pod",
       metadata: {
@@ -288,7 +288,7 @@ describe("getStaticLabelsFromPod", () => {
         },
       },
       spec: {},
-    } as unknown) as KubernetesPod
+    } as unknown as KubernetesPod
 
     const labels = getStaticLabelsFromPod(pod)
 

--- a/core/test/unit/src/router/_helpers.ts
+++ b/core/test/unit/src/router/_helpers.ts
@@ -20,13 +20,8 @@ import { getProviderActionDescriptions, ProviderHandlers } from "../../../../src
 import { createProjectConfig, makeTestGarden, projectRootA } from "../../../helpers"
 
 export async function getRouterTestData() {
-  const {
-    basePlugin,
-    dateUsedForCompleted,
-    returnWrongOutputsCfgKey,
-    testPluginA,
-    testPluginB,
-  } = getRouterUnitTestPlugins()
+  const { basePlugin, dateUsedForCompleted, returnWrongOutputsCfgKey, testPluginA, testPluginB } =
+    getRouterUnitTestPlugins()
   const garden = await makeTestGarden(projectRootA, {
     plugins: [basePlugin, testPluginA, testPluginB],
     config: createProjectConfig({
@@ -267,15 +262,8 @@ function getRouterUnitTestPlugins() {
           convert: async (params) => {
             validateParams(params, moduleActionDescriptions.convert.paramsSchema)
 
-            const {
-              module,
-              services,
-              tasks,
-              tests,
-              dummyBuild,
-              convertBuildDependency,
-              convertRuntimeDependencies,
-            } = params
+            const { module, services, tasks, tests, dummyBuild, convertBuildDependency, convertRuntimeDependencies } =
+              params
 
             const actions: (BuildActionConfig | BaseRuntimeActionConfig)[] = []
 

--- a/core/test/unit/src/util/artifacts.ts
+++ b/core/test/unit/src/util/artifacts.ts
@@ -25,7 +25,7 @@ describe("artifacts", () => {
   describe("getArtifactFileList", () => {
     let tmpDir: tmp.DirectoryResult
     let artifactsPath: string
-    const log = getLogger().makeNewLogContext()
+    const log = getLogger().createLog()
 
     beforeEach(async () => {
       tmpDir = await tmp.dir({ unsafeCleanup: true })

--- a/core/test/unit/src/util/logging.ts
+++ b/core/test/unit/src/util/logging.ts
@@ -135,7 +135,7 @@ describe("sanitizeValue", () => {
   })
 
   it("replaces LogEntry instances", async () => {
-    const log = logger.makeNewLogContext().info("foo")
+    const log = logger.createLog().info("foo")
     const obj = {
       a: log,
     }
@@ -165,7 +165,7 @@ describe("sanitizeValue", () => {
       log: Log
 
       constructor() {
-        const log = logger.makeNewLogContext().info("foo")
+        const log = logger.createLog().info("foo")
         this.log = log
       }
     }

--- a/core/test/unit/src/util/recoverable-process.ts
+++ b/core/test/unit/src/util/recoverable-process.ts
@@ -75,7 +75,7 @@ describe("validateRetryConfig", () => {
 
 describe("RecoverableProcess", async () => {
   initTestLogger()
-  const log = getLogger().makeNewLogContext()
+  const log = getLogger().createLog()
 
   const doNothingForeverOsCommand = { command: "tail -f /dev/null" }
   const badOsCommand = { command: "bad_os_command_which_does_not_exists_and_must_fail_the_process" }

--- a/core/test/unit/src/util/util.ts
+++ b/core/test/unit/src/util/util.ts
@@ -122,7 +122,7 @@ describe("util", () => {
 
     it("should optionally pipe stdout to an output stream", async () => {
       const logger = getLogger()
-      const log = logger.makeNewLogContext()
+      const log = logger.createLog()
 
       await exec("echo", ["hello"], { stdout: createOutputStream(log) })
 
@@ -131,7 +131,7 @@ describe("util", () => {
 
     it("should optionally pipe stderr to an output stream", async () => {
       const logger = getLogger()
-      const log = logger.makeNewLogContext()
+      const log = logger.createLog()
 
       await exec("sh", ["-c", "echo hello 1>&2"], { stderr: createOutputStream(log) })
 
@@ -140,7 +140,7 @@ describe("util", () => {
 
     it("should buffer outputs when piping to stream", async () => {
       const logger = getLogger()
-      const log = logger.makeNewLogContext()
+      const log = logger.createLog()
 
       const res = await exec("echo", ["hello"], { stdout: createOutputStream(log) })
 

--- a/plugins/jib/index.ts
+++ b/plugins/jib/index.ts
@@ -180,7 +180,7 @@ export const gardenPlugin = () =>
                 openJdkPath = await openJdk.getPath(log)
               }
 
-              const statusLine = log.makeNewLogContext({ level: LogLevel.verbose, fixLevel: true })
+              const statusLine = log.makeNewLogContext({ fixLevel: LogLevel.verbose })
 
               let projectType = spec.projectType
 
@@ -193,7 +193,7 @@ export const gardenPlugin = () =>
 
               const logEventContext: PluginEventLogContext = {
                 origin: ["maven", "mavend", "gradle"].includes(projectType) ? projectType : "gradle",
-                log: log.makeNewLogContext({ level: LogLevel.verbose }),
+                log: log.makeNewLogContext({ fixLevel: LogLevel.verbose }),
               }
 
               const outputStream = split2()

--- a/plugins/jib/index.ts
+++ b/plugins/jib/index.ts
@@ -180,7 +180,7 @@ export const gardenPlugin = () =>
                 openJdkPath = await openJdk.getPath(log)
               }
 
-              const statusLine = log.makeNewLogContext({ fixLevel: LogLevel.verbose })
+              const statusLine = log.createLog({ fixLevel: LogLevel.verbose })
 
               let projectType = spec.projectType
 
@@ -193,7 +193,7 @@ export const gardenPlugin = () =>
 
               const logEventContext: PluginEventLogContext = {
                 origin: ["maven", "mavend", "gradle"].includes(projectType) ? projectType : "gradle",
-                log: log.makeNewLogContext({ fixLevel: LogLevel.verbose }),
+                log: log.createLog({ fixLevel: LogLevel.verbose }),
               }
 
               const outputStream = split2()

--- a/plugins/pulumi/commands.ts
+++ b/plugins/pulumi/commands.ts
@@ -266,11 +266,7 @@ class PulumiPluginCommandTask extends PluginActionTask<PulumiDeploy, PulumiComma
   }
 
   async process({ dependencyResults }: ActionTaskProcessParams<PulumiDeploy, PulumiCommandResult>) {
-    const log = this.log
-      .makeNewLogContext({
-        section: this.action.key(),
-      })
-      .info(chalk.gray(`Running ${chalk.white(this.commandDescription)}`))
+    const log = this.log.createLog().info(chalk.gray(`Running ${chalk.white(this.commandDescription)}`))
 
     const params = { ...this.pulumiParams, action: this.getResolvedAction(this.action, dependencyResults) }
 
@@ -283,7 +279,7 @@ class PulumiPluginCommandTask extends PluginActionTask<PulumiDeploy, PulumiComma
         graph: this.graph,
       })
       const result = await this.runFn({ ...params, ctx: ctxForService })
-      log.setSuccess({
+      log.success({
         msg: chalk.green(`Success (took ${log.getDuration(1)} sec)`),
       })
       return result

--- a/plugins/terraform/common.ts
+++ b/plugins/terraform/common.ts
@@ -146,7 +146,7 @@ export async function getStackStatus(params: TerraformParamsWithVariables): Prom
   await setWorkspace(params)
   await tfValidate(params)
 
-  const statusLog = log.makeNewLogContext({ section: "terraform" }).info("Running plan...")
+  const statusLog = log.createLog({ section: "terraform" }).info("Running plan...")
 
   const plan = await terraform(ctx, provider).exec({
     log,
@@ -166,7 +166,7 @@ export async function getStackStatus(params: TerraformParamsWithVariables): Prom
 
   if (plan.exitCode === 0) {
     // Stack is up-to-date
-    statusLog.setSuccess(chalk.green("Stack up-to-date"))
+    statusLog.success(chalk.green("Stack up-to-date"))
     return "up-to-date"
   } else if (plan.exitCode === 1) {
     // Error from terraform. This can, for example, happen if variables are missing or there are errors in the tf files.
@@ -195,7 +195,7 @@ export async function applyStack(params: TerraformParamsWithVariables) {
   const args = ["apply", "-auto-approve", "-input=false", ...(await prepareVariables(root, variables))]
   const proc = await terraform(ctx, provider).spawn({ log, args, cwd: root })
 
-  const statusLine = log.makeNewLogContext({}).info("→ Applying Terraform stack...")
+  const statusLine = log.createLog({}).info("→ Applying Terraform stack...")
   const logStream = split2()
 
   let stdout: string = ""

--- a/sdk/testing.ts
+++ b/sdk/testing.ts
@@ -19,7 +19,7 @@ export const makeTestGarden = async (projectRoot: string, opts: TestGardenOpts =
   try {
     Logger.initialize({
       level: LogLevel.info,
-      type: "quiet",
+      terminalWriterType: "quiet",
       storeEntries: true,
     })
   } catch (_) {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

This PR adds the `ActionLog` class which extends the `CoreLog` and has action related metadata. That goal is to ensure that log entries that are generated by actions and further downstream have the data (namely `actionKind` and `actionName`) attached to them to render the full context. This data is also useful for Cloud. 

The idea is for this context to replace the current log entry sections which are just strings with little consistency and no semantic meaning. 

So instead of an API like this:

```
const log = logger.getLog()
log.info({ section: "api", msg: "hello world" }) // Rendered as api → hello world
```

we have:

```
const actionLog = createLog({ log, actionName: "api", actionKind: "build" })
actionLog.info("hello world") // Rendered as build.api → hello world
```

This allows us to create the action log context once and not have to worry about the setting the section everywhere. 

The idea is to have a corresponding `PluginLog` and maybe even `PluginActionLog`. 

Beyond that, there are some other minor changes:

- Fix bug introduced in #3969.
- Clean up how writers are initialised and discern between terminal writer and file writers.
- Have error and success messages print duration instead of specifying at call site for more consistency.

**Which issue(s) this PR fixes**:

Partially addresses #3254 

**Special notes for your reviewer**:

This is not 100% quite yet. First off, the set-up is still a little awkward and I don't love how much testing is needed around adding new Log types, e.g. PluginLog. Beyond that:

- More tests are needed
- Need to add more Log types, like aforementioned PluginLog
- It's a little inconsistent how CoreLog.createLog can overwrite the `context` whereas ActionLog.createLog cannot. It shouldn't be allowed in either case and CoreLogs with a different context should probably be created differently. 

All that being said, this should be enough for the 0.13 pre-release and I'll continue iterating from here.   
