### PR TITLE
improvement: more granular version control in `self-update` command

### DIFF
--- a/core/test/unit/src/commands/self-update.ts
+++ b/core/test/unit/src/commands/self-update.ts
@@ -71,14 +71,29 @@ describe("SelfUpdateCommand", () => {
   }
 
   it(`detects the current installation directory if none is provided`, async () => {
-    const { result } = await action({ version: "" }, { "force": false, "install-dir": "", "platform": "" })
+    const { result } = await action(
+      { version: "" },
+      {
+        "force": false,
+        "install-dir": "",
+        "platform": "",
+        "major": false,
+        // "minor": false,
+      }
+    )
     expect(result?.installationDirectory).to.equal(dirname(process.execPath))
   })
 
   it(`uses the specified --install-dir if set`, async () => {
     const { result } = await action(
       { version: "edge" },
-      { "force": false, "install-dir": tempDir.path, "platform": "" }
+      {
+        "force": false,
+        "install-dir": tempDir.path,
+        "platform": "",
+        "major": false,
+        // "minor": false,
+      }
     )
 
     expect(result?.installationDirectory).to.equal(tempDir.path)
@@ -87,7 +102,13 @@ describe("SelfUpdateCommand", () => {
   it(`aborts if desired version is the same as the current version`, async () => {
     const { result } = await action(
       { version: getPackageVersion() },
-      { "force": false, "install-dir": "", "platform": "" }
+      {
+        "force": false,
+        "install-dir": "",
+        "platform": "",
+        "major": false,
+        // "minor": false,
+      }
     )
     expect(result?.installedVersion).to.be.undefined
     expect(result?.abortReason).to.equal("Version already installed")
@@ -96,7 +117,13 @@ describe("SelfUpdateCommand", () => {
   it(`proceeds if desired version is the same as the current version and --force is set`, async () => {
     const { result } = await action(
       { version: getPackageVersion() },
-      { "force": true, "install-dir": "", "platform": "" }
+      {
+        "force": true,
+        "install-dir": "",
+        "platform": "",
+        "major": false,
+        // "minor": false,
+      }
     )
     expect(result?.installedVersion).to.be.undefined
     // The command will abort because we're running a dev build
@@ -104,13 +131,31 @@ describe("SelfUpdateCommand", () => {
   })
 
   it(`aborts if trying to run from a dev build`, async () => {
-    const { result } = await action({ version: "" }, { "force": true, "install-dir": "", "platform": "" })
+    const { result } = await action(
+      { version: "" },
+      {
+        "force": true,
+        "install-dir": "",
+        "platform": "",
+        "major": false,
+        // "minor": false,
+      }
+    )
     expect(result?.installedVersion).to.be.undefined
     expect(result?.abortReason).to.equal("Not running from binary installation")
   })
 
   it(`aborts cleanly if desired version isn't found`, async () => {
-    const { result } = await action({ version: "foo" }, { "force": true, "install-dir": tempDir.path, "platform": "" })
+    const { result } = await action(
+      { version: "foo" },
+      {
+        "force": true,
+        "install-dir": tempDir.path,
+        "platform": "",
+        "major": false,
+        // "minor": false,
+      }
+    )
     expect(result?.installedVersion).to.be.undefined
     expect(result?.abortReason).to.equal("Version not found")
   })
@@ -118,7 +163,13 @@ describe("SelfUpdateCommand", () => {
   it(`installs successfully to an empty --install-dir`, async () => {
     const { result } = await action(
       { version: "edge" },
-      { "force": false, "install-dir": tempDir.path, "platform": "" }
+      {
+        "force": false,
+        "install-dir": tempDir.path,
+        "platform": "",
+        "major": false,
+        // "minor": false,
+      }
     )
     expect(result?.installedVersion).to.equal("edge")
     expect(result?.abortReason).to.be.undefined
@@ -129,10 +180,25 @@ describe("SelfUpdateCommand", () => {
   })
 
   it(`installs successfully to an --install-dir with a previous release and creates a backup`, async () => {
-    await action({ version: "edge" }, { "force": false, "install-dir": tempDir.path, "platform": "" })
+    await action(
+      { version: "edge" },
+      {
+        "force": false,
+        "install-dir": tempDir.path,
+        "platform": "",
+        "major": false,
+        // "minor": false,
+      }
+    )
     const { result } = await action(
       { version: "edge" },
-      { "force": false, "install-dir": tempDir.path, "platform": "" }
+      {
+        "force": false,
+        "install-dir": tempDir.path,
+        "platform": "",
+        "major": false,
+        // "minor": false,
+      }
     )
     expect(result?.installedVersion).to.equal("edge")
     expect(result?.abortReason).to.be.undefined
@@ -144,13 +210,37 @@ describe("SelfUpdateCommand", () => {
   })
 
   it(`installs successfully to an --install-dir with a previous release and overwrites a backup`, async () => {
-    await action({ version: "edge" }, { "force": false, "install-dir": tempDir.path, "platform": "" })
-    await action({ version: "edge" }, { "force": false, "install-dir": tempDir.path, "platform": "" })
+    await action(
+      { version: "edge" },
+      {
+        "force": false,
+        "install-dir": tempDir.path,
+        "platform": "",
+        "major": false,
+        // "minor": false,
+      }
+    )
+    await action(
+      { version: "edge" },
+      {
+        "force": false,
+        "install-dir": tempDir.path,
+        "platform": "",
+        "major": false,
+        // "minor": false,
+      }
+    )
     const { result } = await action(
       {
         version: "edge",
       },
-      { "force": false, "install-dir": tempDir.path, "platform": "" }
+      {
+        "force": false,
+        "install-dir": tempDir.path,
+        "platform": "",
+        "major": false,
+        // "minor": false,
+      }
     )
     expect(result?.installedVersion).to.equal("edge")
     expect(result?.abortReason).to.be.undefined
@@ -162,7 +252,16 @@ describe("SelfUpdateCommand", () => {
   })
 
   it(`handles --platform=windows and zip archives correctly`, async () => {
-    await action({ version: "edge" }, { "force": false, "install-dir": tempDir.path, "platform": "windows" })
+    await action(
+      { version: "edge" },
+      {
+        "force": false,
+        "install-dir": tempDir.path,
+        "platform": "windows",
+        "major": false,
+        // "minor": false,
+      }
+    )
 
     const extracted = await readdir(tempDir.path)
     expect(extracted).to.include("garden.exe")
@@ -170,7 +269,16 @@ describe("SelfUpdateCommand", () => {
   })
 
   it(`handles --platform=macos and tar.gz archives correctly`, async () => {
-    await action({ version: "edge" }, { "force": false, "install-dir": tempDir.path, "platform": "macos" })
+    await action(
+      { version: "edge" },
+      {
+        "force": false,
+        "install-dir": tempDir.path,
+        "platform": "macos",
+        "major": false,
+        // "minor": false,
+      }
+    )
 
     const extracted = await readdir(tempDir.path)
     expect(extracted).to.include("garden")

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -3432,6 +3432,7 @@ Examples:
    garden self-update          # update to the latest Garden CLI version
    garden self-update edge     # switch to the latest edge build (which is created anytime a PR is merged)
    garden self-update 0.12.24  # switch to the 0.12.24 version of the CLI
+   garden self-update --major  # install the latest major version (if it exists) greater than the current one
    garden self-update --force  # re-install even if the same version is detected
    garden self-update --install-dir ~/garden  # install to ~/garden instead of detecting the directory
 
@@ -3452,6 +3453,9 @@ Examples:
   | `--force` |  | boolean | Install the Garden CLI even if the specified or detected latest version is the same as the current version.
   | `--install-dir` |  | string | Specify an installation directory, instead of using the directory of the Garden CLI being used. Implies --force.
   | `--platform` |  | `macos` `linux` `windows`  | Override the platform, instead of detecting it automatically.
+  | `--major` |  | boolean | Install the latest major version greater than the current one. Falls back to the current version if the greater major version does not exist.
+
+Note! If you use a non-stable version (i.e. pre-release, or draft, or edge), then the latest possible major version will be installed.
 
 
 ### garden test


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR cherry-picks #3999 to the `main` branch. it also contains some trivial whitespacing changes to satisfy the old linter.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
