### PR TITLE
test: fix ingress integ tests

### DIFF
--- a/core/test/integ/src/plugins/kubernetes/container/ingress.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/ingress.ts
@@ -401,6 +401,7 @@ describe("createIngressResources", () => {
       annotations: {},
       path: "/",
       port: "http",
+      hostname: "my.domain.com",
     })
 
     const api = await getKubeApi(basicProvider)
@@ -481,6 +482,7 @@ describe("createIngressResources", () => {
         annotations: {},
         path: "/",
         port: "http",
+        hostname: "my.domain.com",
       },
       {
         annotations: {},
@@ -509,6 +511,7 @@ describe("createIngressResources", () => {
       annotations: {},
       path: "/",
       port: "http",
+      hostname: "my.domain.com"
     })
 
     const api = await getKubeApi(singleTlsProvider)


### PR DESCRIPTION
The failures were caused by https://github.com/garden-io/garden/pull/3997 as the container validation
handler actually modifies the deployment's ingress hostname
to the project default hostname if it's not specified on the deploy
itself.

I couldn't figure out how to fix this in a way where the proper default would be passed from the mocked provider config in the tests so I just manually assigned the hostnames.