### PR TITLE
0.13: fix validate command not validating

### DIFF
--- a/core/src/commands/validate.ts
+++ b/core/src/commands/validate.ts
@@ -29,7 +29,7 @@ export class ValidateCommand extends Command {
 
   async action({ garden, log }: CommandParams): Promise<CommandResult> {
     // This implicitly validates modules and actions.
-    await garden.getConfigGraph({ log, emit: false })
+    await garden.getResolvedConfigGraph({ log, emit: false })
 
     /*
      * Normally, workflow configs are only resolved when they're run via the `run-workflow` command (and only the


### PR DESCRIPTION
continuation of https://github.com/garden-io/garden/pull/3997

closes #3802

attempt full graph resolution, thus running all the handler and schema validation and catching errors in the template strings.

