### PR TITLE
feat: support pre-release versions in `self-update` command

### DIFF
--- a/core/src/commands/self-update.ts
+++ b/core/src/commands/self-update.ts
@@ -247,15 +247,10 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
 
     try {
       // Fetch the desired version and extract it to a temp directory
+      const { build, filename, extension, url } = this.getReleaseArtifactDetails(platform, desiredVersion)
       if (!platform) {
         platform = getPlatform() === "darwin" ? "macos" : getPlatform()
       }
-      const architecture = "amd64" // getArchitecture()
-      const extension = platform === "windows" ? "zip" : "tar.gz"
-      const build = `${platform}-${architecture}`
-
-      const filename = `garden-${desiredVersion}-${build}.${extension}`
-      const url = `${this._baseReleasesUrl}${desiredVersion}/${filename}`
 
       log.info("")
       log.info(chalk.white(`Downloading version ${chalk.cyan(desiredVersion)} from ${chalk.underline(url)}...`))
@@ -361,6 +356,20 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
     } finally {
       await tempDir.cleanup()
     }
+  }
+
+  private getReleaseArtifactDetails(platform: string, desiredVersion: string) {
+    if (!platform) {
+      platform = getPlatform() === "darwin" ? "macos" : getPlatform()
+    }
+    const architecture = "amd64" // getArchitecture()
+    const extension = platform === "windows" ? "zip" : "tar.gz"
+    const build = `${platform}-${architecture}`
+
+    const filename = `garden-${desiredVersion}-${build}.${extension}`
+    const url = `${this._baseReleasesUrl}${desiredVersion}/${filename}`
+
+    return { build, filename, extension, url }
   }
 
   /**

--- a/core/src/commands/self-update.ts
+++ b/core/src/commands/self-update.ts
@@ -84,8 +84,8 @@ export function isEdgeVersion(version: string) {
   return version === "edge" || version.startsWith("edge-")
 }
 
-function isPreReleaseVersion(semVersion: semver.SemVer | null) {
-  return semVersion?.prerelease.length || 0
+export function isPreReleaseVersion(semVersion: semver.SemVer | null) {
+  return (semVersion?.prerelease.length || 0) > 0
 }
 
 interface SelfUpdateResult {

--- a/core/src/commands/self-update.ts
+++ b/core/src/commands/self-update.ts
@@ -83,7 +83,7 @@ function getVersionScope(opts: ParameterValues<GlobalOptions & SelfUpdateOpts>):
 interface SelfUpdateResult {
   currentVersion: string
   latestVersion: string
-  targetVersion: string
+  desiredVersion: string
   installationDirectory: string
   installedBuild?: string
   installedVersion?: string
@@ -147,18 +147,16 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
     installationDirectory = resolve(installationDirectory)
 
     log.info(chalk.white("Checking for target and latest versions..."))
-
-    const versionScope: VersionScope = getVersionScope(opts)
-    const targetVersion = await this.getTargetVersion(currentVersion, versionScope)
     const latestVersion = await this.getLatestVersion()
 
     if (!desiredVersion) {
-      desiredVersion = targetVersion
+      const versionScope = getVersionScope(opts)
+      desiredVersion = await this.getTargetVersion(currentVersion, versionScope)
     }
 
     log.info(chalk.white("Installation directory: ") + chalk.cyan(installationDirectory))
     log.info(chalk.white("Current Garden version: ") + chalk.cyan(currentVersion))
-    log.info(chalk.white("Target Garden version to be installed: ") + chalk.cyan(targetVersion))
+    log.info(chalk.white("Target Garden version to be installed: ") + chalk.cyan(desiredVersion))
     log.info(chalk.white("Latest release version: ") + chalk.cyan(latestVersion))
 
     if (!opts.force && !opts["install-dir"] && desiredVersion === currentVersion) {
@@ -173,7 +171,7 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
           currentVersion,
           installationDirectory,
           latestVersion,
-          targetVersion,
+          desiredVersion,
           abortReason: "Version already installed",
         },
       }
@@ -194,7 +192,7 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
           currentVersion,
           installationDirectory,
           latestVersion,
-          targetVersion,
+          desiredVersion,
           abortReason: "Not running from binary installation",
         },
       }
@@ -249,7 +247,7 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
             result: {
               currentVersion,
               latestVersion,
-              targetVersion,
+              desiredVersion,
               installationDirectory,
               abortReason: "Version not found",
             },
@@ -311,7 +309,7 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
           installedVersion: desiredVersion,
           installedBuild: build,
           latestVersion,
-          targetVersion,
+          desiredVersion,
           installationDirectory,
         },
       }

--- a/core/src/commands/self-update.ts
+++ b/core/src/commands/self-update.ts
@@ -25,7 +25,7 @@ import stream from "stream"
 
 const selfUpdateArgs = {
   version: new StringParameter({
-    help: `Specify which version to switch/update to.`,
+    help: `Specify which version to switch/update to. It can be either a stable release version, or a pre-release version, or an edge one.`,
   }),
 }
 

--- a/core/src/commands/self-update.ts
+++ b/core/src/commands/self-update.ts
@@ -80,11 +80,11 @@ function getVersionScope(opts: ParameterValues<GlobalOptions & SelfUpdateOpts>):
   return "patch"
 }
 
-export function isEdgeVersion(version: string) {
+export function isEdgeVersion(version: string): boolean {
   return version === "edge" || version.startsWith("edge-")
 }
 
-export function isPreReleaseVersion(semVersion: semver.SemVer | null) {
+export function isPreReleaseVersion(semVersion: semver.SemVer | null): boolean {
   return (semVersion?.prerelease.length || 0) > 0
 }
 

--- a/core/src/commands/self-update.ts
+++ b/core/src/commands/self-update.ts
@@ -80,7 +80,7 @@ function getVersionScope(opts: ParameterValues<GlobalOptions & SelfUpdateOpts>):
   return "patch"
 }
 
-function isEdgeVersion(version: string) {
+export function isEdgeVersion(version: string) {
   return version === "edge" || version.startsWith("edge-")
 }
 

--- a/core/src/commands/self-update.ts
+++ b/core/src/commands/self-update.ts
@@ -99,7 +99,7 @@ namespace GitHubApi {
    *
    * @param predicate the predicate to identify the wanted release
    */
-  export async function findRelease(predicate: (any) => boolean) {
+  export async function findRelease(predicate: (any: any) => boolean) {
     const releasesPerPage = 100
     let page = 1
     let fetchedReleases: any[]

--- a/core/src/commands/self-update.ts
+++ b/core/src/commands/self-update.ts
@@ -227,7 +227,6 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
     // -> Make sure it's an actual executable, not a script (e.g. from a local dev build)
     const expectedExecutableName = process.platform === "win32" ? "garden.exe" : "garden"
     if (!opts["install-dir"] && basename(process.execPath) !== expectedExecutableName) {
-      log.error("")
       log.error(
         chalk.redBright(
           `The executable path ${process.execPath} doesn't indicate this is a normal binary installation for your platform. Perhaps you're running a local development build?`

--- a/core/src/commands/self-update.ts
+++ b/core/src/commands/self-update.ts
@@ -93,7 +93,7 @@ interface SelfUpdateResult {
 /**
  * Utilities and wrappers on top of GitHub REST API.
  */
-namespace GitHubApi {
+namespace GitHubReleaseApi {
   /**
    * Traverse the Garden releases on GitHub and get the first one matching the given predicate.
    *
@@ -194,7 +194,7 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
     installationDirectory = resolve(installationDirectory)
 
     log.info(chalk.white("Checking for target and latest versions..."))
-    const latestVersion = await GitHubApi.getLatestVersion()
+    const latestVersion = await GitHubReleaseApi.getLatestVersion()
 
     if (!desiredVersion) {
       const versionScope = getVersionScope(opts)
@@ -398,12 +398,12 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
    */
   private async findTargetVersion(currentVersion: string, versionScope: VersionScope): Promise<string> {
     if (this.isEdgeVersion(currentVersion)) {
-      return GitHubApi.getLatestVersion()
+      return GitHubReleaseApi.getLatestVersion()
     }
 
     const currentSemVer = semver.parse(currentVersion)
     if (this.isPreReleaseVersion(currentSemVer)) {
-      return GitHubApi.getLatestVersion()
+      return GitHubReleaseApi.getLatestVersion()
     }
 
     // The current version is necessary, it's not possible to proceed without its value
@@ -415,7 +415,7 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
       )
     }
 
-    const targetRelease = await GitHubApi.findRelease((release) => {
+    const targetRelease = await GitHubReleaseApi.findRelease((release) => {
       const tagName = release.tag_name
       // skip pre-release, draft and edge tags
       if (this.isEdgeVersion(tagName) || release.prerelease || release.draft) {

--- a/core/src/commands/self-update.ts
+++ b/core/src/commands/self-update.ts
@@ -162,6 +162,7 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
   arguments = selfUpdateArgs
   options = selfUpdateOpts
 
+  _basePreReleasesUrl = "https://github.com/garden-io/garden/releases/download/"
   // Overridden during testing
   _baseReleasesUrl = "https://download.garden.io/core/"
 
@@ -366,8 +367,18 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
     const extension = platform === "windows" ? "zip" : "tar.gz"
     const build = `${platform}-${architecture}`
 
-    const filename = `garden-${desiredVersion}-${build}.${extension}`
-    const url = `${this._baseReleasesUrl}${desiredVersion}/${filename}`
+    const desiredSemVer = semver.parse(desiredVersion)
+
+    let filename: string
+    let url: string
+    if (desiredSemVer && this.isPreReleaseVersion(desiredSemVer)) {
+      const desiredVersionWithoutPreRelease = `${desiredSemVer.major}.${desiredSemVer.minor}.${desiredSemVer.patch}`
+      filename = `garden-${desiredVersionWithoutPreRelease}-${build}.${extension}`
+      url = `${this._basePreReleasesUrl}${desiredVersion}/${filename}`
+    } else {
+      filename = `garden-${desiredVersion}-${build}.${extension}`
+      url = `${this._baseReleasesUrl}${desiredVersion}/${filename}`
+    }
 
     return { build, filename, extension, url }
   }

--- a/core/src/commands/self-update.ts
+++ b/core/src/commands/self-update.ts
@@ -29,9 +29,6 @@ const selfUpdateArgs = {
   }),
 }
 
-const versionScopes = ["major", "minor", "patch"] as const
-type VersionScope = typeof versionScopes[number]
-
 const selfUpdateOpts = {
   "force": new BooleanParameter({
     help: `Install the Garden CLI even if the specified or detected latest version is the same as the current version.`,
@@ -68,6 +65,9 @@ const selfUpdateOpts = {
 
 export type SelfUpdateArgs = typeof selfUpdateArgs
 export type SelfUpdateOpts = typeof selfUpdateOpts
+
+const versionScopes = ["major", "minor", "patch"] as const
+type VersionScope = typeof versionScopes[number]
 
 function getVersionScope(opts: ParameterValues<GlobalOptions & SelfUpdateOpts>): VersionScope {
   if (opts["major"]) {

--- a/core/src/commands/self-update.ts
+++ b/core/src/commands/self-update.ts
@@ -133,6 +133,18 @@ namespace GitHubReleaseApi {
 
     return latestVersionRes.tag_name
   }
+
+  export async function getLatestVersions(numOfStableVersions: number) {
+    const res: any = await got("https://api.github.com/repos/garden-io/garden/releases?per_page=100").json()
+
+    return [
+      chalk.cyan("edge"),
+      ...res
+        .filter((r: any) => !r.prerelease && !r.draft)
+        .map((r: any) => chalk.cyan(r.name))
+        .slice(0, numOfStableVersions),
+    ]
+  }
 }
 
 export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
@@ -269,15 +281,7 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
 
           // Print the latest available stable versions
           try {
-            const res: any = await got("https://api.github.com/repos/garden-io/garden/releases?per_page=100").json()
-
-            const latestVersions = [
-              chalk.cyan("edge"),
-              ...res
-                .filter((r: any) => !r.prerelease && !r.draft)
-                .map((r: any) => chalk.cyan(r.name))
-                .slice(0, 10),
-            ]
+            const latestVersions = await GitHubReleaseApi.getLatestVersions(10)
 
             log.info(
               chalk.white.bold(`Here are the latest available versions: `) + latestVersions.join(chalk.white(", "))

--- a/core/src/commands/self-update.ts
+++ b/core/src/commands/self-update.ts
@@ -139,7 +139,7 @@ namespace GitHubReleaseApi {
       })
     }
 
-    return latestVersionRes.tag_name
+    return latestVersion
   }
 
   export async function getLatestVersions(numOfStableVersions: number) {

--- a/core/src/commands/self-update.ts
+++ b/core/src/commands/self-update.ts
@@ -153,7 +153,8 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
 
        garden self-update          # update to the latest Garden CLI version
        garden self-update edge     # switch to the latest edge build (which is created anytime a PR is merged)
-       garden self-update 0.12.24  # switch to the 0.12.24 version of the CLI
+       garden self-update 0.12.24  # switch to the 0.12.24 stable version of the CLI
+       garden self-update 0.13.0-0 # switch to the 0.13.0-0 pre-release version of the CLI
        garden self-update --major  # install the latest major version (if it exists) greater than the current one
        garden self-update --force  # re-install even if the same version is detected
        garden self-update --install-dir ~/garden  # install to ~/garden instead of detecting the directory

--- a/core/src/commands/self-update.ts
+++ b/core/src/commands/self-update.ts
@@ -391,8 +391,7 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
     }
 
     const currentSemVer = semver.parse(currentVersion)
-    const isCurrentPrerelease = currentSemVer?.prerelease.length || 0
-    if (isCurrentPrerelease) {
+    if (this.isPreReleaseVersion(currentSemVer)) {
       return GitHubApi.getLatestVersion()
     }
 
@@ -447,5 +446,9 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
 
   private isEdgeVersion(version: string) {
     return version === "edge" || version.startsWith("edge-")
+  }
+
+  private isPreReleaseVersion(semVersion: semver.SemVer | null) {
+    return semVersion?.prerelease.length || 0
   }
 }

--- a/core/src/commands/self-update.ts
+++ b/core/src/commands/self-update.ts
@@ -67,7 +67,7 @@ export type SelfUpdateArgs = typeof selfUpdateArgs
 export type SelfUpdateOpts = typeof selfUpdateOpts
 
 const versionScopes = ["major", "minor", "patch"] as const
-type VersionScope = typeof versionScopes[number]
+export type VersionScope = typeof versionScopes[number]
 
 function getVersionScope(opts: ParameterValues<GlobalOptions & SelfUpdateOpts>): VersionScope {
   if (opts["major"]) {
@@ -454,8 +454,13 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
       }
 
       switch (versionScope) {
-        case "major":
+        case "major": {
+          // TODO Core 1.0 major release: remove this check
+          if (tagSemVer.major === currentSemVer.major) {
+            return tagSemVer.minor >= currentSemVer.minor
+          }
           return tagSemVer.major >= currentSemVer.major
+        }
         case "minor":
           return tagSemVer.major === currentSemVer.major && tagSemVer.minor >= currentSemVer.minor
         case "patch":

--- a/core/src/commands/self-update.ts
+++ b/core/src/commands/self-update.ts
@@ -25,7 +25,7 @@ import stream from "stream"
 
 const selfUpdateArgs = {
   version: new StringParameter({
-    help: `Specify which version to switch/update to. It can be either a stable release version, or a pre-release version, or an edge one.`,
+    help: `Specify which version to switch/update to. It can be either a stable release, a pre-release, or an edge release version.`,
   }),
 }
 

--- a/core/test/unit/src/commands/self-update.ts
+++ b/core/test/unit/src/commands/self-update.ts
@@ -14,12 +14,32 @@ import getPort from "get-port"
 import { dirname } from "path"
 import { makeDummyGarden } from "../../../../src/cli/cli"
 import { ParameterValues } from "../../../../src/cli/params"
-import { SelfUpdateArgs, SelfUpdateCommand, SelfUpdateOpts } from "../../../../src/commands/self-update"
+import { isEdgeVersion, SelfUpdateArgs, SelfUpdateCommand, SelfUpdateOpts } from "../../../../src/commands/self-update"
 import { DummyGarden } from "../../../../src/garden"
 import { makeTempDir, TempDirectory } from "../../../../src/util/fs"
 import { getPackageVersion } from "../../../../src/util/util"
 import { getDataDir, withDefaultGlobalOpts } from "../../../helpers"
 import { createServer, Server } from "http"
+
+describe("version helpers", () => {
+  describe("isEdgeVersion", () => {
+    it("should be true for 'edge' version name", () => {
+      expect(isEdgeVersion("edge")).to.be.true
+    })
+
+    it("should be true for a version name starting with 'edge-'", () => {
+      expect(isEdgeVersion("edge-bonsai")).to.be.true
+    })
+
+    it("should be false for a pre-release version name", () => {
+      expect(isEdgeVersion("0.13.0-0")).to.be.false
+    })
+
+    it("should be false for a stable version name", () => {
+      expect(isEdgeVersion("0.13.0")).to.be.false
+    })
+  })
+})
 
 describe("SelfUpdateCommand", () => {
   const command = new SelfUpdateCommand()

--- a/core/test/unit/src/commands/self-update.ts
+++ b/core/test/unit/src/commands/self-update.ts
@@ -402,15 +402,15 @@ describe("SelfUpdateCommand", () => {
 
     context("skip any draft", () => {
       it("should skip an older pre-release version", () => {
-        expectSkipped({ tag_name: "test", draft: true, prerelease: false }, semver.parse("0.13.0")!, "patch")
+        expectSkipped({ tag_name: "0.12.53-0", draft: true, prerelease: false }, semver.parse("0.13.0")!, "patch")
       })
 
       it("should skip the same pre-release version", () => {
-        expectSkipped({ tag_name: "test", draft: true, prerelease: false }, semver.parse("0.13.0")!, "patch")
+        expectSkipped({ tag_name: "0.13", draft: true, prerelease: false }, semver.parse("0.13.0")!, "patch")
       })
 
       it("should skip a newer pre-release version", () => {
-        expectSkipped({ tag_name: "test", draft: true, prerelease: false }, semver.parse("0.13.0")!, "patch")
+        expectSkipped({ tag_name: "0.13.1-0", draft: true, prerelease: false }, semver.parse("0.13.0")!, "patch")
       })
     })
 

--- a/core/test/unit/src/commands/self-update.ts
+++ b/core/test/unit/src/commands/self-update.ts
@@ -14,12 +14,19 @@ import getPort from "get-port"
 import { dirname } from "path"
 import { makeDummyGarden } from "../../../../src/cli/cli"
 import { ParameterValues } from "../../../../src/cli/params"
-import { isEdgeVersion, SelfUpdateArgs, SelfUpdateCommand, SelfUpdateOpts } from "../../../../src/commands/self-update"
+import {
+  isEdgeVersion,
+  isPreReleaseVersion,
+  SelfUpdateArgs,
+  SelfUpdateCommand,
+  SelfUpdateOpts,
+} from "../../../../src/commands/self-update"
 import { DummyGarden } from "../../../../src/garden"
 import { makeTempDir, TempDirectory } from "../../../../src/util/fs"
 import { getPackageVersion } from "../../../../src/util/util"
 import { getDataDir, withDefaultGlobalOpts } from "../../../helpers"
 import { createServer, Server } from "http"
+import semver from "semver"
 
 describe("version helpers", () => {
   describe("isEdgeVersion", () => {
@@ -37,6 +44,28 @@ describe("version helpers", () => {
 
     it("should be false for a stable version name", () => {
       expect(isEdgeVersion("0.13.0")).to.be.false
+    })
+  })
+
+  describe("isPreReleaseVersion", () => {
+    it("should be false for 'edge' version name", () => {
+      const version = semver.parse("edge")
+      expect(isPreReleaseVersion(version)).to.be.false
+    })
+
+    it("should be false for a version name starting with 'edge-'", () => {
+      const version = semver.parse("edge-bonsai")
+      expect(isPreReleaseVersion(version)).to.be.false
+    })
+
+    it("should be true for a pre-release version name", () => {
+      const version = semver.parse("0.13.0-0")
+      expect(isPreReleaseVersion(version)).to.be.true
+    })
+
+    it("should be false for a stable version name", () => {
+      const version = semver.parse("0.13.0")
+      expect(isPreReleaseVersion(version)).to.be.false
     })
   })
 })

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -3444,7 +3444,7 @@ Examples:
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
-  | `version` | No | Specify which version to switch/update to.
+  | `version` | No | Specify which version to switch/update to. It can be either a stable release version, or a pre-release version, or an edge one.
 
 #### Options
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -3444,7 +3444,7 @@ Examples:
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
-  | `version` | No | Specify which version to switch/update to. It can be either a stable release version, or a pre-release version, or an edge one.
+  | `version` | No | Specify which version to switch/update to. It can be either a stable release, a pre-release, or an edge release version.
 
 #### Options
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -3431,7 +3431,8 @@ Examples:
 
    garden self-update          # update to the latest Garden CLI version
    garden self-update edge     # switch to the latest edge build (which is created anytime a PR is merged)
-   garden self-update 0.12.24  # switch to the 0.12.24 version of the CLI
+   garden self-update 0.12.24  # switch to the 0.12.24 stable version of the CLI
+   garden self-update 0.13.0-0 # switch to the 0.13.0-0 pre-release version of the CLI
    garden self-update --major  # install the latest major version (if it exists) greater than the current one
    garden self-update --force  # re-install even if the same version is detected
    garden self-update --install-dir ~/garden  # install to ~/garden instead of detecting the directory


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
To be able to update to the `0.13` pre-releases from `0.12.x` using `garden self-update` command.
This PR also contains some refactoring.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
The commits will be squashed before the merge. See individual commits for details.