### PR TITLE
feat(dev): support persistent commands (logs, deploy --sync/local etc) in dev

### DIFF
--- a/cli/src/add-version-files.ts
+++ b/cli/src/add-version-files.ts
@@ -8,7 +8,7 @@
 
 import { GitHandler } from "@garden-io/core/build/src/vcs/git"
 import { Garden } from "@garden-io/core/build/src/garden"
-import { Logger, LogLevel } from "@garden-io/core/build/src/logger/logger"
+import { LogLevel, RootLogger } from "@garden-io/core/build/src/logger/logger"
 import { resolve, relative } from "path"
 import Bluebird from "bluebird"
 import { STATIC_DIR, GARDEN_VERSIONFILE_NAME } from "@garden-io/core/build/src/constants"
@@ -18,7 +18,7 @@ import { TreeCache } from "@garden-io/core/build/src/cache"
 require("source-map-support").install()
 
 // make sure logger is initialized
-Logger.initialize({ level: LogLevel.info, terminalWriterType: "quiet", storeEntries: false })
+RootLogger.initialize({ level: LogLevel.info, displayWriterType: "quiet", storeEntries: false })
 
 /**
  * Write .garden-version files for modules in garden-system/static.

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -25,7 +25,8 @@ export async function runCli({
   args,
   cli,
   exitOnError = true,
-}: { args?: string[]; cli?: GardenCli; exitOnError?: boolean } = {}) {
+  initLogger = true,
+}: { args?: string[]; cli?: GardenCli; exitOnError?: boolean; initLogger?: boolean } = {}) {
   let code = 0
   let result: RunOutput | undefined = undefined
 
@@ -35,7 +36,7 @@ export async function runCli({
 
   try {
     if (!cli) {
-      cli = new GardenCli({ plugins: getBundledPlugins(), initLogger: true })
+      cli = new GardenCli({ plugins: getBundledPlugins(), initLogger })
     }
     // Note: We slice off the binary/script name from argv.
     result = await cli.run({ args, exitOnError })

--- a/cli/src/generate-docs.ts
+++ b/cli/src/generate-docs.ts
@@ -8,7 +8,7 @@
 
 import { generateDocs } from "@garden-io/core/build/src/docs/generate"
 import { resolve } from "path"
-import { Logger, LogLevel } from "@garden-io/core/build/src/logger/logger"
+import { LogLevel, RootLogger } from "@garden-io/core/build/src/logger/logger"
 import { GARDEN_CLI_ROOT } from "@garden-io/core/build/src/constants"
 import { getBundledPlugins } from "./cli"
 import { getSupportedPlugins } from "@garden-io/core/build/src/plugins/plugins"
@@ -17,9 +17,9 @@ require("source-map-support").install()
 
 // make sure logger is initialized
 try {
-  Logger.initialize({
+  RootLogger.initialize({
     level: LogLevel.info,
-    terminalWriterType: "quiet",
+    displayWriterType: "quiet",
     storeEntries: false,
     // level: LogLevel.debug,
     // writers: [new TerminalWriter()],

--- a/cli/test/unit/src/cli.ts
+++ b/cli/test/unit/src/cli.ts
@@ -29,7 +29,11 @@ describe("runCli", () => {
 
   it("should add bundled plugins", async () => {
     const projectRoot = resolve(testRoot, "test-projects", "bundled-projects")
-    const { cli, result } = await runCli({ args: ["tools", "--root", projectRoot], exitOnError: false })
+    const { cli, result } = await runCli({
+      args: ["tools", "--root", projectRoot],
+      exitOnError: false,
+      initLogger: false,
+    })
 
     expect(cli!["plugins"].map((p) => p.name)).to.eql(getBundledPlugins().map((p) => p.name))
 
@@ -59,7 +63,12 @@ describe("runCli", () => {
     const cmd = new TestCommand()
     cli.addCommand(cmd)
 
-    const { result } = await runCli({ args: [cmd.name, "--root", projectRootA], cli, exitOnError: false })
+    const { result } = await runCli({
+      args: [cmd.name, "--root", projectRootA],
+      cli,
+      exitOnError: false,
+      initLogger: false,
+    })
 
     expect(result?.errors.length).to.equal(0)
   })
@@ -79,7 +88,7 @@ describe("runCli", () => {
     const cmd = new TestCommand()
     cli.addCommand(cmd)
 
-    await runCli({ args: [cmd.name, "--root", projectRootA], cli, exitOnError: false })
+    await runCli({ args: [cmd.name, "--root", projectRootA], cli, exitOnError: false, initLogger: false })
 
     const allProcesses = Object.values(await globalConfigStore.get("activeProcesses"))
     const record = find(allProcesses, (p) => p.command)

--- a/core/.mocharc.integ.yml
+++ b/core/.mocharc.integ.yml
@@ -6,7 +6,7 @@ ignore:
   - build/test/e2e/**/*
   - test/,src/,.garden
 reporter: spec
-timeout: 300000
+timeout: 50000
 exit: true
 spec:
   - build/test/integ/**/*.js

--- a/core/src/actions/base.ts
+++ b/core/src/actions/base.ts
@@ -119,7 +119,11 @@ export const baseActionConfigSchema = createSchema({
       .string()
       .required()
       .allow(...actionKinds)
-      .description(`The kind of action you want to define (one of ${naturalList(actionKinds.map(titleize), "or")}).`)
+      .description(
+        `The kind of action you want to define (one of ${naturalList(actionKinds.map(titleize), {
+          trailingWord: "or",
+        })}).`
+      )
       .meta({ templateContext: null }),
     type: joiIdentifier()
       .required()

--- a/core/src/actions/types.ts
+++ b/core/src/actions/types.ts
@@ -164,7 +164,6 @@ export interface ActionStatus<
   state: ActionState
   detail: D | null
   outputs: O
-  attached?: boolean
 }
 
 export interface ActionStatusMap<T extends BaseAction = BaseAction> {

--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -43,7 +43,7 @@ import {
   defaultNamespace,
   parseEnvironment,
   ProjectResource,
-  EnvironmentConfig,
+  defaultEnvironment,
 } from "../config/project"
 import {
   ERROR_LOG_FILENAME,
@@ -74,9 +74,13 @@ import { uuidv4 } from "../util/random"
 import { SemVer } from "semver"
 
 export async function makeDummyGarden(root: string, gardenOpts: GardenOpts) {
-  const environments: EnvironmentConfig[] = gardenOpts.environmentName
-    ? [{ name: parseEnvironment(gardenOpts.environmentName).environment, defaultNamespace, variables: {} }]
-    : [{ defaultNamespace: "default", name: "default", variables: {} }]
+  if (!gardenOpts.environmentName) {
+    gardenOpts.environmentName = `${defaultEnvironment}.${defaultNamespace}`
+  }
+
+  const parsed = parseEnvironment(gardenOpts.environmentName)
+  const environmentName = parsed.environment || defaultEnvironment
+  const _defaultNamespace = parsed.namespace || defaultNamespace
 
   const config: ProjectConfig = {
     path: root,
@@ -85,7 +89,7 @@ export async function makeDummyGarden(root: string, gardenOpts: GardenOpts) {
     name: "no-project",
     defaultEnvironment: "",
     dotIgnoreFile: defaultDotIgnoreFile,
-    environments,
+    environments: [{ name: environmentName, defaultNamespace: _defaultNamespace, variables: {} }],
     providers: [],
     variables: {},
   }

--- a/core/src/cli/params.ts
+++ b/core/src/cli/params.ts
@@ -271,7 +271,7 @@ export class ChoicesParameter extends Parameter<string> {
 
     this.choices = args.choices
 
-    if (args.defaultValue !== undefined) {
+    if (args.defaultValue !== undefined && !this.choices.includes(args.defaultValue)) {
       this.choices.push(args.defaultValue)
     }
 

--- a/core/src/cli/params.ts
+++ b/core/src/cli/params.ts
@@ -270,7 +270,12 @@ export class ChoicesParameter extends Parameter<string> {
     super(args)
 
     this.choices = args.choices
-    this.schema = joi.string().valid(...args.choices)
+
+    if (args.defaultValue !== undefined) {
+      this.choices.push(args.defaultValue)
+    }
+
+    this.schema = joi.string().valid(...this.choices)
   }
 
   coerce(input: string) {

--- a/core/src/cli/params.ts
+++ b/core/src/cli/params.ts
@@ -336,7 +336,7 @@ export class TagsOption extends Parameter<string[] | undefined> {
   }
 }
 
-export class EnvironmentParameter extends StringParameter {
+export class EnvironmentParameter extends StringOption {
   type = "string"
   schema = joi.environment()
 
@@ -355,6 +355,7 @@ export class EnvironmentParameter extends StringParameter {
     if (!input) {
       return
     }
+
     // Validate the environment
     parseEnvironment(input)
     return input

--- a/core/src/commands/build.ts
+++ b/core/src/commands/build.ts
@@ -16,7 +16,6 @@ import {
   processCommandResultSchema,
 } from "./base"
 import dedent from "dedent"
-import { processActions } from "../process"
 import { printHeader } from "../logger/util"
 import { flatten } from "lodash"
 import { BuildTask } from "../tasks/build"
@@ -103,7 +102,7 @@ export class BuildCommand extends Command<Args, Opts> {
       ])
     }
 
-    const initialTasks = flatten(
+    const tasks = flatten(
       await Bluebird.map(
         actions,
         (action) =>
@@ -118,15 +117,8 @@ export class BuildCommand extends Command<Args, Opts> {
       )
     )
 
-    const results = await processActions({
-      garden,
-      graph,
-      log,
-      actions,
-      persistent: this.isPersistent(params),
-      initialTasks,
-    })
+    const result = await garden.processTasks({ tasks, log })
 
-    return handleProcessResults(footerLog, "build", results)
+    return handleProcessResults(garden, footerLog, "build", result)
   }
 }

--- a/core/src/commands/commands.ts
+++ b/core/src/commands/commands.ts
@@ -70,6 +70,10 @@ export const getCoreCommands = (): (Command | CommandGroup)[] => [
   new ValidateCommand(),
 ]
 
+export function flattenCommands(commands: (Command | CommandGroup)[]) {
+  return commands.flatMap((cmd) => (cmd instanceof CommandGroup ? [cmd, ...cmd.getSubCommands()] : [cmd]))
+}
+
 export const getBuiltinCommands = memoize(() => {
-  return getCoreCommands().flatMap((cmd) => (cmd instanceof CommandGroup ? [cmd, ...cmd.getSubCommands()] : [cmd]))
+  return flattenCommands(getCoreCommands())
 })

--- a/core/src/commands/create/create-module.ts
+++ b/core/src/commands/create/create-module.ts
@@ -94,9 +94,8 @@ export class CreateModuleCommand extends Command<CreateModuleArgs, CreateModuleO
     printHeader(headerLog, "Create new module", "✏️")
   }
 
-  // Defining it like this because it'll stall on waiting for user input.
-  isPersistent() {
-    return true
+  allowInDevCommand() {
+    return false
   }
 
   async action({

--- a/core/src/commands/create/create-project.ts
+++ b/core/src/commands/create/create-project.ts
@@ -91,8 +91,12 @@ export class CreateProjectCommand extends Command<CreateProjectArgs, CreateProje
   }
 
   // Defining it like this because it'll stall on waiting for user input.
-  isPersistent() {
+  maybePersistent() {
     return true
+  }
+
+  allowInDevCommand() {
+    return false
   }
 
   async action({

--- a/core/src/commands/delete.ts
+++ b/core/src/commands/delete.ts
@@ -19,6 +19,7 @@ import { uniqByName } from "../util/util"
 import { isDeployAction } from "../actions/deploy"
 import { omit, mapValues } from "lodash"
 import { DeployStatus, DeployStatusMap, getDeployStatusSchema } from "../plugin/handlers/Deploy/get-status"
+import chalk from "chalk"
 
 // TODO-G2 rename this to CleanupCommand, and do the same for all related classes, constants, variables and functions
 export class DeleteCommand extends CommandGroup {
@@ -97,6 +98,8 @@ export class DeleteEnvironmentCommand extends Command<{}, DeleteEnvironmentOpts>
     log.info("")
 
     const providerStatuses = await actions.provider.cleanupAll(log)
+
+    log.info(chalk.green("\nDone!"))
 
     return {
       result: {
@@ -201,6 +204,8 @@ export class DeleteDeployCommand extends Command<DeleteDeployArgs, DeleteDeployO
 
     const processed = await garden.processTasks({ tasks, log })
     const result = deletedDeployStatuses(processed.results)
+
+    log.info(chalk.green("\nDone!"))
 
     return { result }
   }

--- a/core/src/commands/dev.tsx
+++ b/core/src/commands/dev.tsx
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { CommandResult, CommandParams, InteractiveCommand } from "./base"
+import { CommandResult, CommandParams, ConsoleCommand } from "./base"
 import { renderDivider } from "../logger/util"
 import React, { FC, useState } from "react"
 import { Box, render, Text, useInput, useStdout } from "ink"
@@ -46,6 +46,8 @@ export class DevCommand extends ServeCommand<DevCommandArgs, DevCommandOpts> {
   printHeader({ headerLog }) {
     const width = process.stdout?.columns ? process.stdout?.columns - 2 : 100
 
+    console.clear()
+
     headerLog.info(
       chalk.magenta(`
 ${renderDivider({ color: chalk.green, title: chalk.green.bold("🌳  garden dev 🌳 "), width })}
@@ -60,9 +62,13 @@ Let's get your development environment wired up.
     return "ink"
   }
 
+  allowInDevCommand() {
+    return false
+  }
+
   async action(params: ActionParams): Promise<CommandResult> {
     const logger = params.log.root
-  const terminalWriter = logger.getWriters().terminal
+    const terminalWriter = logger.getWriters().display
 
     let inkWriter: InkTerminalWriter
     // TODO: maybe enforce this elsewhere
@@ -155,7 +161,7 @@ Let's get your development environment wired up.
   }
 }
 
-class HelpCommand extends InteractiveCommand {
+class HelpCommand extends ConsoleCommand {
   name = "help"
   help = ""
   hidden = true
@@ -166,7 +172,7 @@ class HelpCommand extends InteractiveCommand {
   }
 }
 
-class QuitCommand extends InteractiveCommand {
+class QuitCommand extends ConsoleCommand {
   name = "quit"
   help = "Exit the dev console."
   aliases = ["exit"]
@@ -181,7 +187,7 @@ class QuitCommand extends InteractiveCommand {
   }
 }
 
-class QuietCommand extends InteractiveCommand {
+class QuietCommand extends ConsoleCommand {
   name = "quiet"
   help = ""
   hidden = true
@@ -192,7 +198,7 @@ class QuietCommand extends InteractiveCommand {
   }
 }
 
-class QuiteCommand extends InteractiveCommand {
+class QuiteCommand extends ConsoleCommand {
   name = "quite"
   help = ""
   hidden = true

--- a/core/src/commands/helpers.ts
+++ b/core/src/commands/helpers.ts
@@ -68,7 +68,8 @@ export async function watchRemovedWarning(garden: Garden, log: Log) {
   return garden.emitWarning({
     log,
     key: "watch-flag-removed",
-    message:
-      "The -w/--watch flag has been removed. Please use other options instead, such as the --sync option for Deploy actions. If you need this feature and would like it re-introduced, please don't hesitate to reach out: https://garden.io/community",
+    message: chalk.yellow(
+      "The -w/--watch flag has been removed. Please use other options instead, such as the --sync option for Deploy actions. If you need this feature and would like it re-introduced, please don't hesitate to reach out: https://garden.io/community"
+    ),
   })
 }

--- a/core/src/commands/logs.ts
+++ b/core/src/commands/logs.ts
@@ -9,18 +9,15 @@
 import dotenv = require("dotenv")
 import { Command, CommandResult, CommandParams, PrepareParams } from "./base"
 import chalk from "chalk"
-import { every, some, sortBy } from "lodash"
-import Bluebird = require("bluebird")
+import { omit, sortBy } from "lodash"
+import Bluebird from "bluebird"
 import { DeployLogEntry } from "../types/service"
-import Stream from "ts-stream"
-import { logLevelMap, LogLevel, parseLogLevel } from "../logger/logger"
+import { parseLogLevel } from "../logger/logger"
 import { StringsParameter, BooleanParameter, IntegerParameter, DurationParameter, TagsOption } from "../cli/params"
 import { printHeader, renderDivider } from "../logger/util"
-import hasAnsi = require("has-ansi")
 import { dedent, deline, naturalList } from "../util/string"
-import { padSection } from "../logger/renderers"
-import { PluginEventBroker } from "../plugin-context"
 import { CommandError, ParameterError } from "../exceptions"
+import { LogMonitor, LogsTagOrFilter } from "../monitors/logs"
 
 const logsArgs = {
   names: new StringsParameter({
@@ -80,20 +77,6 @@ const logsOpts = {
 type Args = typeof logsArgs
 type Opts = typeof logsOpts
 
-export const colors = ["green", "cyan", "magenta", "yellow", "blueBright", "red"]
-
-type LogsTagFilter = [string, string]
-type LogsTagAndFilter = LogsTagFilter[]
-type LogsTagOrFilter = LogsTagAndFilter[]
-
-/**
- * Skip empty entries.
- */
-function skipEntry(entry: DeployLogEntry) {
-  const validDate = entry.timestamp && entry.timestamp instanceof Date && !isNaN(entry.timestamp.getTime())
-  return !entry.msg && !validDate
-}
-
 export class LogsCommand extends Command<Args, Opts> {
   name = "logs"
   help = "Retrieves the most recent logs for the specified Deploy(s)."
@@ -115,30 +98,20 @@ export class LogsCommand extends Command<Args, Opts> {
   arguments = logsArgs
   options = logsOpts
 
-  private events?: PluginEventBroker
-
-  constructor() {
-    super()
-    this.events = new PluginEventBroker()
-  }
-
   printHeader({ headerLog }) {
     printHeader(headerLog, "Logs", "📜")
   }
 
-  isPersistent({ opts }: PrepareParams<Args, Opts>) {
+  maybePersistent({ opts }: PrepareParams<Args, Opts>) {
     return !!opts.follow
   }
 
-  terminate() {
-    super.terminate()
-    this.events?.emit("abort")
-  }
-
   async action({ garden, log, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<DeployLogEntry[]>> {
-    const { follow, timestamps, tag } = opts
+    const { follow, tag } = opts
+
     let tail = opts.tail as number | undefined
     let since = opts.since as string | undefined
+
     const showTags = opts["show-tags"]
     const hideService = opts["hide-name"]
     const logLevel = parseLogLevel(opts["log-level"])
@@ -190,11 +163,6 @@ export class LogsCommand extends Command<Args, Opts> {
       throw new CommandError(msg, { args, opts, availableDeploys: allDeployNames })
     }
 
-    // If the container name should be displayed, we align the output wrt to the longest container name
-    let maxDeployName = 1
-
-    const result: DeployLogEntry[] = []
-    const stream = new Stream<DeployLogEntry>()
     let details: string = ""
 
     if (tail) {
@@ -207,112 +175,47 @@ export class LogsCommand extends Command<Args, Opts> {
     log.info(chalk.white.bold("Service logs" + details + ":"))
     log.info(chalk.white.bold(renderDivider()))
 
-    // Map all deploys names in the project to a specific color. This ensures
-    // that in most cases they have the same color (unless any have been added/removed),
-    // regardless of what params you pass to the command.
-    const colorMap = allDeployNames.reduce((acc, name, idx) => {
-      const color = colors[idx % colors.length]
-      acc[name] = color
-      return acc
-    }, {})
-
-    // Note: lazy-loading for startup performance
-    const { isMatch } = require("micromatch")
-
-    const matchTagFilters = (entry: DeployLogEntry): boolean => {
-      if (!tagFilters) {
-        return true
-      }
-      // We OR together the filter results of each tag option instance.
-      return some(tagFilters, (andFilter: LogsTagAndFilter) => {
-        // We AND together the filter results within a given tag option instance.
-        return every(andFilter, ([key, value]: LogsTagFilter) => {
-          return isMatch(entry.tags?.[key] || "", value)
-        })
-      })
-    }
-
-    const formatEntry = (entry: DeployLogEntry) => {
-      const style = chalk[colorMap[entry.name]]
-      const sectionStyle = style.bold
-      const serviceLog = entry.msg
-      const entryLevel = entry.level || LogLevel.info
-
-      let timestamp: string | undefined
-      let tags: string | undefined
-
-      if (timestamps && entry.timestamp) {
-        timestamp = "                        "
-        try {
-          timestamp = entry.timestamp.toISOString()
-        } catch {}
-      }
-
-      if (showTags && entry.tags) {
-        tags = Object.entries(entry.tags)
-          .map(([k, v]) => `${k}=${v}`)
-          .join(" ")
-      }
-
-      if (entryLevel <= logLevel) {
-        maxDeployName = Math.max(maxDeployName, entry.name.length)
-      }
-
-      let out = ""
-      if (!hideService) {
-        out += `${sectionStyle(padSection(entry.name, maxDeployName))} → `
-      }
-      if (timestamp) {
-        out += `${chalk.gray(timestamp)} → `
-      }
-      if (tags) {
-        out += chalk.gray("[" + tags + "] ")
-      }
-      // If the line doesn't have ansi encoding, we color it white to prevent logger from applying styles.
-      out += hasAnsi(serviceLog) ? serviceLog : chalk.white(serviceLog)
-
-      return out
-    }
-
-    void stream.forEach((entry) => {
-      // Skip empty entries
-      if (skipEntry(entry)) {
-        return
-      }
-
-      // Match against all of the specified filters, if any
-      if (!matchTagFilters(entry)) {
-        return
-      }
-
-      if (follow) {
-        const levelStr = logLevelMap[entry.level || LogLevel.info] || "info"
-        const msg = formatEntry(entry)
-        this.emit(log, JSON.stringify({ msg, timestamp: entry.timestamp?.getTime(), level: levelStr }))
-        log[levelStr]({ msg })
-      } else {
-        result.push(entry)
-      }
-    })
-
-    const router = await garden.getActionRouter()
-
     const resolvedActions = await garden.resolveActions({ actions, graph, log })
 
-    await Bluebird.map(Object.values(resolvedActions), async (action) => {
-      await router.deploy.getLogs({ log, graph, action, stream, follow, tail, since, events: this.events })
+    const monitors = await Bluebird.map(Object.values(resolvedActions), async (action) => {
+      return new LogMonitor({
+        garden,
+        log,
+        action,
+        graph,
+        collect: !follow,
+        hideService,
+        showTags,
+        showTimestamps: opts.timestamps,
+        logLevel,
+        tagFilters,
+        command: this,
+      })
     })
 
-    const sorted = sortBy(result, "timestamp")
+    if (follow) {
+      monitors.forEach((m) => garden.monitors.add(m))
+      return { result: [] }
+    } else {
+      const entries = await Bluebird.map(monitors, async (m) => {
+        await m.start()
+        return m.getEntries().map((e) => ({ ...e, monitor: m }))
+      })
 
-    if (!follow) {
-      for (const entry of sorted) {
-        const levelStr = logLevelMap[entry.level || LogLevel.info] || "info"
-        const msg = formatEntry(entry)
-        log[levelStr]({ msg })
+      const sorted = sortBy(
+        entries.flatMap((e) => e),
+        "timestamp"
+      )
+
+      sorted.forEach((entry) => {
+        entry.monitor.logEntry(entry)
+      })
+
+      log.info(chalk.white.bold(renderDivider()))
+
+      return {
+        result: sorted.map((e) => omit(e, "monitor")),
       }
     }
-
-    return { result: sorted }
   }
 }

--- a/core/src/commands/publish.ts
+++ b/core/src/commands/publish.ts
@@ -119,6 +119,6 @@ export class PublishCommand extends Command<Args, Opts, ProcessCommandResult> {
     })
 
     const processed = await garden.processTasks({ tasks, log, throwOnError: true })
-    return handleProcessResults(footerLog, "publish", { graphResults: processed.results })
+    return handleProcessResults(garden, footerLog, "publish", processed)
   }
 }

--- a/core/src/commands/run-workflow.ts
+++ b/core/src/commands/run-workflow.ts
@@ -360,11 +360,11 @@ export async function runStepCommand(params: RunStepCommandParams): Promise<Comm
     opts,
   }
 
-  const persistent = command.isPersistent(commandParams)
+  const persistent = command.maybePersistent(commandParams)
 
   if (persistent) {
     throw new ConfigurationError(
-      `Workflow steps cannot run Garden commands that are persistent (e.g. the dev command, commands with watch flags set etc.)`,
+      `Workflow steps cannot run Garden commands that are persistent (e.g. the dev command, interactive commands, commands with monitor flags set etc.)`,
       {
         step,
       }

--- a/core/src/commands/run.ts
+++ b/core/src/commands/run.ts
@@ -13,7 +13,6 @@ import { printHeader, renderDivider } from "../logger/util"
 import { ParameterError } from "../exceptions"
 import { dedent, deline } from "../util/string"
 import { BooleanParameter, StringsParameter } from "../cli/params"
-import { processActions } from "../process"
 import { watchParameter, watchRemovedWarning } from "./helpers"
 
 // TODO-G2: support interactive execution for a single Run (needs implementation from RunTask through plugin handlers).
@@ -213,7 +212,7 @@ export class RunCommand extends Command<Args, Opts> {
       })
     }
 
-    const initialTasks = actions.map(
+    const tasks = actions.map(
       (action) =>
         new RunTask({
           garden,
@@ -235,15 +234,8 @@ export class RunCommand extends Command<Args, Opts> {
     //   })
     // }
 
-    const results = await processActions({
-      garden,
-      graph,
-      log,
-      actions,
-      initialTasks,
-      persistent: this.isPersistent(params),
-    })
+    const results = await garden.processTasks({ tasks, log })
 
-    return handleProcessResults(footerLog, "test", results)
+    return handleProcessResults(garden, footerLog, "test", results)
   }
 }

--- a/core/src/commands/serve.ts
+++ b/core/src/commands/serve.ts
@@ -6,21 +6,22 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { InteractiveCommand, PrepareParams } from "./base"
+import { ConsoleCommand, PrepareParams } from "./base"
 import { Command, CommandResult, CommandParams } from "./base"
 import { GardenServer, startServer } from "../server/server"
-import { Parameters, IntegerParameter, ChoicesParameter, StringParameter } from "../cli/params"
+import { Parameters, IntegerParameter, ChoicesParameter, StringParameter, StringsParameter } from "../cli/params"
 import { printHeader } from "../logger/util"
 import { Garden } from "../garden"
-import { dedent } from "../util/string"
+import { dedent, naturalList } from "../util/string"
 import { getLogLevelChoices, LogLevel } from "../logger/logger"
-import { getBuiltinCommands } from "./commands"
+import { flattenCommands, getBuiltinCommands } from "./commands"
 import { getCustomCommands } from "./custom"
 import { Log } from "../logger/log-entry"
 import { CommandLine } from "../cli/command-line"
 import { Autocompleter, AutocompleteSuggestion } from "../cli/autocomplete"
 import chalk from "chalk"
 import { RuntimeError } from "../exceptions"
+import { isMatch } from "micromatch"
 
 export const defaultServerPort = 9700
 
@@ -69,12 +70,17 @@ export class ServeCommand<
 
   terminate() {
     super.terminate()
+    // Note: This will stop monitors. The CLI wrapper will wait for those to halt.
     this.garden?.events.emit("_exit", {})
     this.server?.close().catch(() => {})
   }
 
-  isPersistent() {
+  maybePersistent() {
     return true
+  }
+
+  allowInDevCommand() {
+    return false
   }
 
   async prepare({ log, footerLog, opts }: PrepareParams<ServeCommandArgs, ServeCommandOpts>) {
@@ -136,6 +142,8 @@ export class ServeCommand<
       const configDump = await newGarden.dumpConfig({ log })
       const commands = await this.getCommands(newGarden)
 
+      // TODO: restart monitors
+
       this.garden = newGarden
       await this.commandLine?.update(newGarden, configDump, commands)
       await this.server?.setGarden(newGarden)
@@ -159,9 +167,12 @@ export class ServeCommand<
     return [
       ...builtinCommands,
       ...customCommands,
-      new AutocompleteCommand(this),
-      new ReloadCommand(this),
-      new LogLevelCommand(),
+      ...flattenCommands([
+        new AutocompleteCommand(this),
+        new ReloadCommand(this),
+        new LogLevelCommand(),
+        new HideCommand(),
+      ]),
     ]
   }
 
@@ -189,7 +200,7 @@ interface AutocompleteResult {
   suggestions: AutocompleteSuggestion[]
 }
 
-class AutocompleteCommand extends InteractiveCommand<AutocompleteArguments> {
+class AutocompleteCommand extends ConsoleCommand<AutocompleteArguments> {
   name = "autocomplete"
   help = "Given an input string, provide a list of suggestions for available Garden commands."
   hidden = true
@@ -212,7 +223,7 @@ class AutocompleteCommand extends InteractiveCommand<AutocompleteArguments> {
   }
 }
 
-class ReloadCommand extends InteractiveCommand {
+class ReloadCommand extends ConsoleCommand {
   name = "reload"
   help = "Reload the project and action/module configuration."
 
@@ -239,7 +250,7 @@ type LogLevelArguments = typeof logLevelArguments
 // These are the only writers for which we want to dynamically update the log level
 const displayWriterTypes = ["basic", "ink"]
 
-class LogLevelCommand extends InteractiveCommand<LogLevelArguments> {
+class LogLevelCommand extends ConsoleCommand<LogLevelArguments> {
   name = "log-level"
   help = "Change the max log level of (future) printed logs in the console."
 
@@ -251,13 +262,70 @@ class LogLevelCommand extends InteractiveCommand<LogLevelArguments> {
     const logger = log.root
 
     const writers = logger.getWriters()
-    for (const writer of [writers.terminal, ...writers.file]) {
+    for (const writer of [writers.display, ...writers.file]) {
       if (displayWriterTypes.includes(writer.type)) {
         writer.level = level as unknown as LogLevel
       }
     }
 
     commandLine?.flashMessage(`Log level set to ${level}`)
+
+    return {}
+  }
+}
+
+const hideArgs = {
+  type: new ChoicesParameter({
+    help: "The type of monitor to stop. Skip to stop all monitoring.",
+    choices: ["log", "logs", "sync", "syncs", "local", ""],
+    defaultValue: "",
+  }),
+  names: new StringsParameter({
+    help: "The name(s) of the deploy(s) to stop monitoring for (skip to stop monitoring all of them). You may specify multiple names, separated by spaces.",
+    spread: true,
+    getSuggestions: ({ configDump }) => {
+      return Object.keys(configDump.actionConfigs.Deploy)
+    },
+  }),
+}
+
+type HideArgs = typeof hideArgs
+
+class HideCommand extends ConsoleCommand<HideArgs> {
+  name = "hide"
+  help = "Stop monitoring for logs for all or specified Deploy actions"
+
+  arguments = hideArgs
+
+  async action({ garden, log, args }: CommandParams<HideArgs>) {
+    let type = args.type
+    const names = !args.names || args.names.length === 0 ? ["*"] : args.names
+
+    // Support plurals as aliases
+    if (type === "logs" || type === "syncs") {
+      type = type.slice(0, -1)
+    }
+
+    log.info("")
+
+    if (!type) {
+      log.info("Stopping all monitors...")
+    } else if (names.includes("*")) {
+      log.info(`Stopping all ${type} monitors...`)
+    } else {
+      log.info(`Stopping ${type} monitors for Deploy(s) matching ` + naturalList(names, { quote: true }))
+    }
+
+    const monitors = garden.monitors.getActive()
+
+    for (const monitor of monitors) {
+      if (monitor && (!type || monitor.type === type) && isMatch(monitor.key(), names)) {
+        log.info(`Stopping ${monitor.description()}...`)
+        garden.monitors.stop(monitor, log)
+      }
+    }
+
+    log.info("Done!\n")
 
     return {}
   }

--- a/core/src/commands/set.ts
+++ b/core/src/commands/set.ts
@@ -6,6 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import chalk from "chalk"
 import { EnvironmentParameter } from "../cli/params"
 import { dedent } from "../util/string"
 import { Command, CommandGroup, CommandParams } from "./base"
@@ -21,7 +22,7 @@ export class SetCommand extends CommandGroup {
 const setDefaultEnvArgs = {
   env: new EnvironmentParameter({
     help: "The default environment to set for the current project",
-    required: true,
+    required: false,
   }),
 }
 
@@ -39,18 +40,20 @@ export class SetDefaultEnvCommand extends Command<SetDefaultEnvArgs, {}> {
 
       garden set default-env remote       # Set the default env to remote (with the configured default namespace)
       garden set default-env dev.my-env   # Set the default env to dev.my-env
-      garden set default-env ''           # Clear any previously set override
+      garden set default-env              # Clear any previously set override
   `
 
   arguments = setDefaultEnvArgs
 
   async action({ garden, log, args }: CommandParams<SetDefaultEnvArgs, {}>) {
-    await garden.localConfigStore.set("defaultEnv", args.env)
+    await garden.localConfigStore.set("defaultEnv", args.env || "")
+
+    log.info("")
 
     if (args.env) {
-      log.info(`Set the default environment to ${args.env}`)
+      log.success(chalk.white(`Set the default environment to ${chalk.cyan(args.env)}`))
     } else {
-      log.info("Cleared the default environment")
+      log.success(chalk.white("Cleared the default environment"))
     }
 
     return {}

--- a/core/src/commands/tools.ts
+++ b/core/src/commands/tools.ts
@@ -78,7 +78,7 @@ export class ToolsCommand extends Command<Args, Opts> {
 
   async prepare({ log }: { log: Log }) {
     // Override the logger output, to output to stderr instead of stdout, to avoid contaminating command output
-    const terminalWriter = log.root.getWriters().terminal
+    const terminalWriter = log.root.getWriters().display
     if (terminalWriter.type === "default" || terminalWriter.type === "basic") {
       terminalWriter.output = process.stderr
     }

--- a/core/src/config/common.ts
+++ b/core/src/config/common.ts
@@ -463,10 +463,7 @@ export interface ActionReference<K extends ActionKind = ActionKind> {
 }
 
 const actionRefParseError = (reference: any) => {
-  const validActionKinds = naturalList(
-    actionKindsLower.map((k) => "'" + k + "'"),
-    "or"
-  )
+  const validActionKinds = naturalList(actionKindsLower, { trailingWord: "or", quote: true })
 
   const refStr = JSON.stringify(reference)
 

--- a/core/src/config/project.ts
+++ b/core/src/config/project.ts
@@ -293,8 +293,7 @@ export const projectSchema = createSchema({
         "Please refer to individual plugins/providers for details on how to configure them."
     ),
     defaultEnvironment: joi
-      .string()
-      .hostname()
+      .environment()
       .allow("")
       .default("")
       .description(
@@ -411,7 +410,7 @@ export function getDefaultEnvironmentName(defaultName: string, config: ProjectCo
  * @param config raw project configuration
  */
 export function resolveProjectConfig({
-  defaultName,
+  defaultEnvironmentName,
   config,
   artifactsPath,
   vcsInfo,
@@ -421,7 +420,7 @@ export function resolveProjectConfig({
   secrets,
   commandInfo,
 }: {
-  defaultName: string
+  defaultEnvironmentName: string
   config: ProjectConfig
   artifactsPath: string
   vcsInfo: VcsInfo
@@ -461,7 +460,7 @@ export function resolveProjectConfig({
       ...config,
       ...globalConfig,
       name,
-      defaultEnvironment: defaultName,
+      defaultEnvironment: defaultEnvironmentName,
       // environments are validated later
       environments: [{ defaultNamespace: null, name: "fake-env-only-here-for-inital-load", variables: {} }],
       sources: [],
@@ -484,7 +483,7 @@ export function resolveProjectConfig({
     sources,
   }
 
-  config.defaultEnvironment = getDefaultEnvironmentName(defaultName, config)
+  config.defaultEnvironment = getDefaultEnvironmentName(defaultEnvironmentName, config)
 
   return config
 }

--- a/core/src/events.ts
+++ b/core/src/events.ts
@@ -35,7 +35,7 @@ export class EventBus extends EventEmitter2 {
     super({
       wildcard: false,
       newListener: false,
-      maxListeners: 100, // we may need to adjust this
+      maxListeners: 1000, // we may need to adjust this
     })
   }
 
@@ -179,6 +179,7 @@ export interface Events {
     inputVersion: string
   }
   taskComplete: GraphResultEventPayload
+  taskReady: GraphResult
   taskError: GraphResultEventPayload
   taskCancelled: {
     /**

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -465,7 +465,7 @@ export class Garden {
         this.emittedWarnings.add(key)
         log.warn({
           symbol: "warning",
-          msg: message + `\n→ Run ${chalk.underline(`garden util hide-warning ${key}`)} to disable this warning`,
+          msg: message + `\n→ Run ${chalk.underline(`garden util hide-warning ${key}`)} to disable this warning.`,
         })
       }
     })

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -1577,7 +1577,7 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
   const localConfigDefaultEnv = await localConfigStore.get("defaultEnv")
 
   if (localConfigDefaultEnv) {
-    log.debug(`Using environment ${localConfigDefaultEnv}, set with the \`set default-env\` command`)
+    log.info(`Using environment ${localConfigDefaultEnv}, set with the \`set default-env\` command`)
   }
 
   const defaultEnvironmentName =

--- a/core/src/graph/results.ts
+++ b/core/src/graph/results.ts
@@ -17,7 +17,7 @@ export interface TaskEventBase {
   description: string
   key: string
   name: string
-  version: string
+  inputVersion: string
 }
 
 export interface GraphResult<R extends ValidResultType = ValidResultType> extends TaskEventBase {
@@ -165,7 +165,7 @@ function prepareForExport(graphResult: GraphResultWithoutTask | null) {
       "version",
       "processed",
       "success",
-      "version"
+      "inputVersion"
     ),
     result: filterResultForExport(result),
     error: filterErrorForExport(error),

--- a/core/src/logger/renderers.ts
+++ b/core/src/logger/renderers.ts
@@ -80,7 +80,7 @@ export function getTimestamp(entry: LogEntry): string {
 }
 
 export function renderMsg(entry: LogEntry): string {
-  const { level, msg } = entry
+  const { level, msg, origin } = entry
 
   if (!msg) {
     return ""
@@ -88,7 +88,7 @@ export function renderMsg(entry: LogEntry): string {
 
   const styleFn = level === LogLevel.error ? errorStyle : msgStyle
 
-  return styleFn(msg)
+  return styleFn(origin ? `[${hasAnsi(origin) ? origin : chalk.gray(origin)}] ${msg}` : msg)
 }
 
 export function renderData(entry: LogEntry): string {

--- a/core/src/logger/writers/event-writer.ts
+++ b/core/src/logger/writers/event-writer.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2018-2022 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import type { PluginEventBroker } from "../../plugin-context"
+import type { LogEntry } from "../log-entry"
+import { Logger, logLevelToString } from "../logger"
+import { formatForTerminal } from "../renderers"
+import { BaseWriterParams, Writer } from "./base"
+
+interface EventWriterParams extends BaseWriterParams {
+  defaultOrigin?: string
+  events: PluginEventBroker
+}
+
+export class EventLogWriter extends Writer {
+  type = "event"
+
+  private defaultOrigin?: string
+  private events: PluginEventBroker
+
+  constructor(params: EventWriterParams) {
+    super(params)
+    this.defaultOrigin = params.defaultOrigin
+    this.events = params.events
+  }
+
+  write(entry: LogEntry, logger: Logger) {
+    const out = formatForTerminal(entry, logger)
+    if (out) {
+      this.events.emit("log", {
+        origin: entry.origin || this.defaultOrigin,
+        level: logLevelToString(entry.level),
+        msg: out,
+        timestamp: entry.timestamp,
+      })
+    }
+    return out
+  }
+}

--- a/core/src/monitors/base.ts
+++ b/core/src/monitors/base.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2018-2022 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import type { Command } from "../commands/base"
+import type { PrimitiveMap } from "../config/common"
+import type { Garden } from "../garden"
+
+export interface MonitorBaseParams {
+  garden: Garden
+  command: Command
+}
+
+export type MonitorKey = PrimitiveMap
+
+export abstract class Monitor {
+  public command: Command
+  protected garden: Garden
+
+  constructor(params: MonitorBaseParams) {
+    this.command = params.command
+    this.garden = params.garden
+  }
+
+  abstract type: string
+
+  abstract key(): string
+  abstract description(): string
+
+  abstract start(): Promise<{}>
+  abstract stop(): Promise<{}>
+
+  id() {
+    return `"type=${this.type}--key=${this.key()}`
+  }
+}

--- a/core/src/monitors/handler.ts
+++ b/core/src/monitors/handler.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2018-2022 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import type { Action } from "../actions/types"
+import { Log } from "../logger/log-entry"
+import type { PluginEventBroker } from "../plugin-context"
+import { MonitorBaseParams, Monitor } from "./base"
+
+interface HandlerMonitorParams extends MonitorBaseParams {
+  type: string
+  events: PluginEventBroker
+  key: string
+  description: string
+  action?: Action
+  log: Log
+}
+
+/**
+ * Generic monitor that basically waits until plugin events indicate completion of a handler
+ */
+export class HandlerMonitor extends Monitor {
+  public type: string
+
+  private events: PluginEventBroker
+  public action?: Action
+  private _key: string
+  private _description: string
+  // private log: Log
+
+  isActive: boolean
+
+  constructor(params: HandlerMonitorParams) {
+    super(params)
+    this.events = params.events
+    this.action = params.action
+    this._key = params.key
+    this._description = params.description
+    this.isActive = true
+    // this.log = params.log.createLog({ section: params.action?.key() })
+
+    this.events.on("abort", () => this.done())
+    this.events.on("done", () => this.done())
+    // TODO: log error if any given (done in relevant plugin handlers for now)
+    this.events.on("failed", () => this.done())
+  }
+
+  key() {
+    return this._key
+  }
+
+  description() {
+    return this._description
+  }
+
+  async start() {
+    // This is done in the constructor, nothing to do here
+    return {}
+  }
+
+  private done() {
+    this.isActive = false
+    this.events.removeAllListeners()
+  }
+
+  async stop() {
+    this.events.emit("abort")
+
+    // TODO: wait until handler signals exit
+    return {}
+  }
+}

--- a/core/src/monitors/logs.ts
+++ b/core/src/monitors/logs.ts
@@ -1,0 +1,229 @@
+/*
+ * Copyright (C) 2018-2022 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import chalk from "chalk"
+import hasAnsi from "has-ansi"
+import { every, some } from "lodash"
+import Stream from "ts-stream"
+import type { DeployAction } from "../actions/deploy"
+import { Resolved } from "../actions/types"
+import { ConfigGraph } from "../graph/config-graph"
+import { Log } from "../logger/log-entry"
+import { LogLevel, logLevelMap } from "../logger/logger"
+import { padSection } from "../logger/renderers"
+import { PluginEventBroker } from "../plugin-context"
+import { waitForOutputFlush } from "../process"
+import { DeployLogEntry } from "../types/service"
+import { MonitorBaseParams, Monitor } from "./base"
+
+export const logMonitorColors = ["green", "cyan", "magenta", "yellow", "blueBright", "red"]
+
+// Track these globally, across many monitors
+let colorMap: { [name: string]: string } = {}
+let colorIndex = -1
+// If the container name should be displayed, we align the output wrt to the longest container name
+let maxDeployName = 1
+
+interface LogMonitorParams extends MonitorBaseParams {
+  action: Resolved<DeployAction>
+  graph: ConfigGraph
+  log: Log
+  events?: PluginEventBroker
+
+  collect: boolean
+  hideService: boolean
+  showTags: boolean
+  showTimestamps: boolean
+  logLevel: LogLevel
+  tagFilters?: LogsTagOrFilter
+}
+
+export type LogsTagFilter = [string, string]
+export type LogsTagAndFilter = LogsTagFilter[]
+export type LogsTagOrFilter = LogsTagAndFilter[]
+
+export class LogMonitor extends Monitor {
+  type = "log"
+
+  public action: Resolved<DeployAction>
+
+  private graph: ConfigGraph
+  private log: Log
+
+  private entries: DeployLogEntry[]
+  private events: PluginEventBroker
+
+  private collect: boolean
+  private hideService: boolean
+  private showTags: boolean
+  private showTimestamps: boolean
+  private logLevel: LogLevel
+  private tagFilters?: LogsTagOrFilter
+
+  constructor(params: LogMonitorParams) {
+    super(params)
+
+    this.action = params.action
+    this.graph = params.graph
+    this.log = params.log
+
+    this.entries = []
+    this.events = params.events || new PluginEventBroker(params.garden)
+
+    this.collect = params.collect
+    this.hideService = params.hideService
+    this.showTags = params.showTags
+    this.showTimestamps = params.showTimestamps
+    this.logLevel = params.logLevel
+    this.tagFilters = params.tagFilters
+  }
+
+  static getColorForName(name: string) {
+    if (!colorMap[name]) {
+      colorMap[name] = logMonitorColors[++colorIndex % logMonitorColors.length]
+    }
+    return colorMap[name]
+  }
+
+  static resetGlobalState() {
+    maxDeployName = 1
+    colorMap = {}
+    colorIndex = -1
+  }
+
+  key() {
+    return this.action.key()
+  }
+
+  description() {
+    return `log monitor for ${this.action.longDescription()}`
+  }
+
+  async start() {
+    const stream = new Stream<DeployLogEntry>()
+    // Note: lazy-loading for startup performance
+    const { isMatch } = require("micromatch")
+
+    const matchTagFilters = (entry: DeployLogEntry): boolean => {
+      if (!this.tagFilters) {
+        return true
+      }
+      // We OR together the filter results of each tag option instance.
+      return some(this.tagFilters, (andFilter: LogsTagAndFilter) => {
+        // We AND together the filter results within a given tag option instance.
+        return every(andFilter, ([key, value]: LogsTagFilter) => {
+          return isMatch(entry.tags?.[key] || "", value)
+        })
+      })
+    }
+
+    void stream.forEach((entry) => {
+      // Skip empty entries
+      if (skipEntry(entry)) {
+        return
+      }
+
+      // Match against all of the specified filters, if any
+      if (!matchTagFilters(entry)) {
+        return
+      }
+
+      if (this.collect) {
+        this.entries.push(entry)
+      } else {
+        this.logEntry(entry)
+      }
+    })
+
+    const router = await this.garden.getActionRouter()
+    await router.deploy.getLogs({
+      log: this.garden.log,
+      action: this.action,
+      follow: !this.collect,
+      graph: this.graph,
+      stream,
+      events: this.events,
+    })
+
+    if (this.collect) {
+      await waitForOutputFlush()
+    }
+
+    return {}
+  }
+
+  async stop() {
+    this.events.emit("abort")
+    return {}
+  }
+
+  getEntries() {
+    return [...this.entries]
+  }
+
+  logEntry(entry: DeployLogEntry) {
+    const levelStr = logLevelMap[entry.level || LogLevel.info] || "info"
+    const msg = this.formatLogMonitorEntry(entry)
+    this.command.emit(this.log, JSON.stringify({ msg, timestamp: entry.timestamp?.getTime(), level: levelStr }))
+    this.log[levelStr]({ msg })
+  }
+
+  private formatLogMonitorEntry(entry: DeployLogEntry) {
+    const style = chalk[LogMonitor.getColorForName(entry.name)]
+    const sectionStyle = style.bold
+    const serviceLog = entry.msg
+    const entryLevel = entry.level || LogLevel.info
+
+    let timestamp: string | undefined
+    let tags: string | undefined
+
+    if (this.showTimestamps && entry.timestamp) {
+      timestamp = "                        "
+      try {
+        timestamp = entry.timestamp.toISOString()
+      } catch {}
+    }
+
+    if (this.showTags && entry.tags) {
+      tags = Object.entries(entry.tags)
+        .map(([k, v]) => `${k}=${v}`)
+        .join(" ")
+    }
+
+    if (entryLevel <= this.logLevel) {
+      maxDeployName = Math.max(maxDeployName, entry.name.length)
+    }
+
+    let out = ""
+    if (!this.hideService) {
+      out += `${sectionStyle(padSection(entry.name, maxDeployName))} → `
+    }
+    if (timestamp) {
+      out += `${chalk.gray(timestamp)} → `
+    }
+    if (tags) {
+      out += chalk.gray("[" + tags + "] ")
+    }
+    // If the line doesn't have ansi encoding, we color it white to prevent logger from applying styles.
+    out += hasAnsi(serviceLog) ? serviceLog : chalk.white(serviceLog)
+
+    return out
+  }
+}
+
+export function isLogsMonitor(monitor: Monitor): monitor is LogMonitor {
+  return monitor.type === "log"
+}
+
+/**
+ * Skip empty entries.
+ */
+function skipEntry(entry: DeployLogEntry) {
+  const validDate = entry.timestamp && entry.timestamp instanceof Date && !isNaN(entry.timestamp.getTime())
+  return !entry.msg && !validDate
+}

--- a/core/src/monitors/manager.ts
+++ b/core/src/monitors/manager.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2018-2022 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import chalk from "chalk"
+import type { Command } from "../commands/base"
+import type { Garden } from "../garden"
+import type { Log } from "../logger/log-entry"
+import { LogLevel } from "../logger/logger"
+import { TypedEventEmitter } from "../util/events"
+import { KeyedSet } from "../util/keyed-set"
+import type { Monitor } from "./base"
+
+type MonitorStatus = "started" | "starting" | "stopped"
+
+interface MonitorEvents {
+  monitorStatus: { monitor: Monitor; status: MonitorStatus }
+}
+
+export class MonitorManager extends TypedEventEmitter<MonitorEvents> {
+  private monitors: KeyedSet<Monitor>
+  private monitorStatuses: Map<string, MonitorStatus>
+  private log: Log
+
+  constructor(garden: Garden) {
+    super()
+
+    this.monitors = new KeyedSet<Monitor>((monitor) => monitor.id())
+    this.monitorStatuses = new Map()
+
+    this.log = garden.log.createLog({ section: "[monitors]" })
+
+    garden.events.on("_exit", () => this.stopAll())
+    // TODO: see if we want this
+    garden.events.on("_restart", () => this.stopAll())
+  }
+
+  add(monitor: Monitor) {
+    if (this.monitors.has(monitor)) {
+      this.log.debug(`${monitor.description()} already registered.`)
+      return
+    }
+
+    this.log.debug(`Added ${monitor.description()}.`)
+    this.monitors.add(monitor)
+    this.start(monitor)
+  }
+
+  getAll() {
+    return this.monitors.entries()
+  }
+
+  getActive() {
+    return this.monitors.entries().filter((m) => this.getStatus(m) !== "stopped")
+  }
+
+  find({ type, key }: { type?: string; key?: string }) {
+    return this.getAll().filter((m) => (!type || type === m.type) && (!key || key === m.key()))
+  }
+
+  getByCommand(command: Command) {
+    return this.getAll().filter((m) => m.command === command)
+  }
+
+  getStatus(monitor: Monitor) {
+    return this.monitorStatuses.get(monitor.id()) || "stopped"
+  }
+
+  private setStatus(monitor: Monitor, status: MonitorStatus) {
+    const previous = this.getStatus(monitor)
+    if (status !== previous) {
+      this.monitorStatuses.set(monitor.id(), status)
+      this.emit("monitorStatus", { monitor, status })
+      this.log.debug(`${monitor.description()} is ${status}.`)
+    }
+  }
+
+  start(monitor: Monitor) {
+    let status = this.getStatus(monitor)
+
+    if (status !== "stopped") {
+      this.log.silly(`${monitor.description()} already ${status}.`)
+      return
+    }
+
+    this.setStatus(monitor, "starting")
+
+    this.log.verbose(`Starting ${monitor.description()}...`)
+
+    monitor
+      .start()
+      .then(() => {
+        this.setStatus(monitor, "starting")
+      })
+      .catch((error) => {
+        this.log.error({ msg: chalk.red(`${monitor.description()} failed: ${error}`), error })
+        this.setStatus(monitor, "stopped")
+        // TODO: should we retry up to some limit?
+      })
+  }
+
+  stop(monitor: Monitor, logOverride?: Log) {
+    const log = logOverride || this.log.createLog({ fixLevel: LogLevel.verbose })
+    log.verbose(`Stopping ${monitor.description()}...`)
+
+    monitor
+      .stop()
+      .then(() => {
+        log.verbose(`${monitor.description()} stopped.`)
+        this.setStatus(monitor, "stopped")
+        this.removeAllListeners()
+      })
+      .catch((error) => {
+        log.error(chalk.red(`Error when stopping ${monitor.description()}: ${error}`))
+        this.setStatus(monitor, "stopped")
+      })
+  }
+
+  stopAll() {
+    this.monitors.entries().forEach((monitor) => this.stop(monitor))
+  }
+
+  /**
+   * Returns true if one or more monitors are registered and running
+   */
+  anyMonitorsActive() {
+    for (const monitor of this.getAll()) {
+      const status = this.getStatus(monitor)
+      if (status !== "stopped") {
+        return true
+      }
+    }
+
+    return false
+  }
+
+  /**
+   * Wait for all monitors to exit
+   */
+  async waitUntilAllStopped() {
+    return new Promise<void>((resolve) => {
+      const handler = () => {
+        if (!this.anyMonitorsActive()) {
+          resolve()
+          this.off("monitorStatus", handler)
+        }
+      }
+
+      this.on("monitorStatus", handler)
+
+      handler()
+    })
+  }
+}

--- a/core/src/monitors/port-forward.ts
+++ b/core/src/monitors/port-forward.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2018-2022 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import type { DeployAction } from "../actions/deploy"
+import { Executed } from "../actions/types"
+import { ConfigGraph } from "../graph/config-graph"
+import { Log } from "../logger/log-entry"
+import { PluginEventBroker } from "../plugin-context"
+import { MonitorBaseParams, Monitor } from "./base"
+import { startPortProxies, PortProxy, stopPortProxy } from "../proxy"
+import chalk from "chalk"
+import Bluebird from "bluebird"
+
+interface PortForwardMonitorParams extends MonitorBaseParams {
+  action: Executed<DeployAction>
+  graph: ConfigGraph
+  log: Log
+}
+
+/**
+ * Monitor the sync status for the given Deploy
+ */
+export class PortForwardMonitor extends Monitor {
+  type = "port-forward"
+
+  public action: Executed<DeployAction>
+  private graph: ConfigGraph
+  private log: Log
+  protected events: PluginEventBroker
+  private proxies: PortProxy[]
+
+  constructor(params: PortForwardMonitorParams) {
+    super(params)
+    this.action = params.action
+    this.graph = params.graph
+    this.proxies = []
+    this.log = params.log.createLog({ section: params.action.key(), origin: "proxy" })
+    this.events = new PluginEventBroker(params.garden)
+  }
+
+  key() {
+    return this.action.key()
+  }
+
+  description() {
+    return `port proxy for ${this.action.longDescription()}`
+  }
+
+  async stopProxies() {
+    await Bluebird.map(this.proxies, (proxy) =>
+      stopPortProxy({
+        garden: this.garden,
+        graph: this.graph,
+        log: this.log,
+        action: this.action,
+        proxy,
+        spec: proxy.spec,
+      })
+    )
+  }
+
+  async start() {
+    await this.stopProxies()
+
+    const status = this.action.getStatus()
+
+    this.proxies = await startPortProxies({
+      garden: this.garden,
+      graph: this.graph,
+      log: this.log,
+      action: this.action,
+      status: status.detail!,
+    })
+
+    for (const proxy of this.proxies) {
+      const targetHost = proxy.spec.targetName || this.action.name
+
+      this.log.info(
+        chalk.gray(
+          `Port forward: ` +
+            chalk.underline(proxy.localUrl) +
+            ` → ${targetHost}:${proxy.spec.targetPort}` +
+            (proxy.spec.name ? ` (${proxy.spec.name})` : "")
+        )
+      )
+    }
+
+    return {}
+  }
+
+  async stop() {
+    await this.stopProxies()
+    return {}
+  }
+}

--- a/core/src/monitors/sync.ts
+++ b/core/src/monitors/sync.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2018-2022 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import type { DeployAction } from "../actions/deploy"
+import { Executed } from "../actions/types"
+import { ConfigGraph } from "../graph/config-graph"
+import { Log } from "../logger/log-entry"
+import { PluginEventBroker } from "../plugin-context"
+import { MonitorBaseParams, Monitor } from "./base"
+
+interface SyncMonitorParams extends MonitorBaseParams {
+  action: Executed<DeployAction>
+  graph: ConfigGraph
+  log: Log
+}
+
+/**
+ * Monitor the sync status for the given Deploy
+ */
+export class SyncMonitor extends Monitor {
+  type = "sync"
+
+  public action: Executed<DeployAction>
+  private graph: ConfigGraph
+  private log: Log
+  private events: PluginEventBroker
+
+  constructor(params: SyncMonitorParams) {
+    super(params)
+    this.action = params.action
+    this.graph = params.graph
+    this.log = params.log.createLog({ section: params.action.key() })
+    this.events = new PluginEventBroker(params.garden)
+  }
+
+  key() {
+    return this.action.key()
+  }
+
+  description() {
+    return `sync monitor for ${this.action.longDescription()}`
+  }
+
+  async start() {
+    const router = await this.garden.getActionRouter()
+    await router.deploy.getSyncStatus({
+      log: this.log,
+      action: this.action,
+      monitor: true,
+      graph: this.graph,
+      events: this.events,
+    })
+
+    return {}
+  }
+
+  async stop() {
+    this.events.emit("abort")
+    return {}
+  }
+}

--- a/core/src/plugin/handlers/Deploy/start-sync.ts
+++ b/core/src/plugin/handlers/Deploy/start-sync.ts
@@ -13,7 +13,7 @@ import { DeployAction } from "../../../actions/deploy"
 import { ActionTypeHandlerSpec } from "../base/base"
 import { Executed } from "../../../actions/types"
 
-type StartSyncParams<T extends DeployAction> = PluginDeployActionParamsBase<T>
+interface StartSyncParams<T extends DeployAction> extends PluginDeployActionParamsBase<T> {}
 
 export class StartSync<T extends DeployAction = DeployAction> extends ActionTypeHandlerSpec<
   "Deploy",

--- a/core/src/plugins/container/build.ts
+++ b/core/src/plugins/container/build.ts
@@ -8,7 +8,6 @@
 
 import { containerHelpers } from "./helpers"
 import { ConfigurationError } from "../../exceptions"
-import { LogLevel } from "../../logger/logger"
 import { PrimitiveMap } from "../../config/common"
 import split2 from "split2"
 import { BuildActionHandler } from "../../plugin/action-types"
@@ -69,13 +68,13 @@ export const buildContainer: BuildActionHandler<"build", ContainerBuildAction> =
 
   const logEventContext = {
     origin: "docker build",
-    log: log.createLog({ fixLevel: LogLevel.verbose }),
+    level: "verbose" as const,
   }
 
   const outputStream = split2()
   outputStream.on("error", () => {})
   outputStream.on("data", (line: Buffer) => {
-    ctx.events.emit("log", { timestamp: new Date().toISOString(), data: line, ...logEventContext })
+    ctx.events.emit("log", { timestamp: new Date().toISOString(), msg: line.toString(), ...logEventContext })
   })
   const timeout = action.getConfig("timeout")
   const res = await containerHelpers.dockerCli({

--- a/core/src/plugins/exec/common.ts
+++ b/core/src/plugins/exec/common.ts
@@ -52,13 +52,13 @@ export async function execRun({
 }) {
   const logEventContext = {
     origin: command[0],
-    log,
+    level: "info" as const,
   }
 
   const outputStream = split2()
   outputStream.on("error", () => {})
   outputStream.on("data", (line: Buffer) => {
-    ctx.events.emit("log", { timestamp: new Date().toISOString(), data: line, ...logEventContext })
+    ctx.events.emit("log", { timestamp: new Date().toISOString(), msg: line.toString(), ...logEventContext })
   })
 
   const envVars = {

--- a/core/src/plugins/exec/deploy.ts
+++ b/core/src/plugins/exec/deploy.ts
@@ -82,6 +82,7 @@ export const getExecDeployLogs: DeployActionHandler<"getLogs", ExecDeploy> = asy
   if (follow) {
     ctx.events.on("abort", () => {
       logsFollower.stop()
+      ctx.events.emit("done")
     })
 
     await logsFollower.streamLogs({ since: params.since, tail: params.tail, follow: true })

--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -27,7 +27,6 @@ import {
   builderToleration,
 } from "./common"
 import { getNamespaceStatus } from "../../namespace"
-import { LogLevel } from "../../../../logger/logger"
 import { sleep } from "../../../../util/util"
 import { ContainerBuildAction, ContainerModuleOutputs } from "../../../container/moduleConfig"
 import { getDockerBuildArgs } from "../../../container/build"
@@ -105,14 +104,13 @@ export const buildkitBuildHandler: BuildHandler = async (params) => {
 
   const logEventContext = {
     origin: "buildkit",
-    // log: log.createLog({ fixLevel: LogLevel.verbose }),
-    log: log.createLog({ fixLevel: LogLevel.verbose, section: "foobar" }),
+    level: "verbose" as const,
   }
 
   const outputStream = split2()
   outputStream.on("error", () => {})
   outputStream.on("data", (line: Buffer) => {
-    ctx.events.emit("log", { timestamp: new Date().toISOString(), data: line, ...logEventContext })
+    ctx.events.emit("log", { timestamp: new Date().toISOString(), msg: line.toString(), ...logEventContext })
   })
 
   const command = [

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -126,7 +126,7 @@ export async function syncToBuildSync(params: SyncToSharedBuildSyncParams) {
     await mutagen.ensureSync({
       log,
       key,
-      logSection: action.name,
+      logSection: action.key(),
       sourceDescription: `Module ${action.name} build path`,
       targetDescription: "Build sync Pod",
       config: {

--- a/core/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/src/plugins/kubernetes/container/build/kaniko.ts
@@ -33,7 +33,6 @@ import {
 } from "./common"
 import { differenceBy, isEmpty } from "lodash"
 import chalk from "chalk"
-import { LogLevel } from "../../../../logger/logger"
 import { getDockerBuildFlags } from "../../../container/build"
 import { k8sGetContainerBuildActionOutputs } from "../handlers"
 import { stringifyResources } from "../util"
@@ -372,14 +371,12 @@ async function runKaniko({
     pod.spec.nodeSelector = provider.config.kaniko?.nodeSelector
   }
 
-  const logEventContext = {
-    origin: "kaniko",
-    log: log.createLog({ fixLevel: LogLevel.verbose }),
-  }
-
   const runner = new PodRunner({
     ctx,
-    logEventContext,
+    logEventContext: {
+      origin: "kaniko",
+      level: "verbose",
+    },
     api,
     pod,
     provider,

--- a/core/src/plugins/kubernetes/container/extensions.ts
+++ b/core/src/plugins/kubernetes/container/extensions.ts
@@ -34,7 +34,7 @@ import { k8sGetContainerDeployLogs } from "./logs"
 import { k8sPublishContainerBuild } from "./publish"
 import { k8sContainerRun } from "./run"
 import { k8sGetContainerDeployStatus } from "./status"
-import { k8sContainerStartSync, k8sContainerStopSync } from "./sync"
+import { k8sContainerGetSyncStatus, k8sContainerStartSync, k8sContainerStopSync } from "./sync"
 import { k8sContainerTest } from "./test"
 
 export const k8sContainerBuildExtension = (): BuildActionExtension<ContainerBuildAction> => ({
@@ -80,8 +80,11 @@ export const k8sContainerDeployExtension = (): DeployActionExtension<ContainerDe
       return getPortForwardHandler({ ...params, namespace: undefined })
     },
     getStatus: k8sGetContainerDeployStatus,
+
     startSync: k8sContainerStartSync,
     stopSync: k8sContainerStopSync,
+    getSyncStatus: k8sContainerGetSyncStatus,
+
     validate: async ({ ctx, action }) => {
       validateDeploySpec(action.name, <KubernetesProvider>ctx.provider, action.getSpec())
       return {}

--- a/core/src/plugins/kubernetes/container/sync.ts
+++ b/core/src/plugins/kubernetes/container/sync.ts
@@ -6,46 +6,27 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import chalk from "chalk"
 import { ContainerDeployAction } from "../../container/moduleConfig"
 import { getAppNamespace } from "../namespace"
-import { KubernetesPluginContext } from "../config"
-import { startSyncs, stopSyncs } from "../sync"
+import { KubernetesPluginContext, KubernetesTargetResourceSpec } from "../config"
+import { getSyncStatus, KubernetesDeployDevModeSyncSpec, startSyncs, stopSyncs } from "../sync"
 import { DeployActionHandler } from "../../../plugin/action-types"
-import { SyncableKind } from "../types"
+import { KubernetesResource, SyncableKind } from "../types"
 import { KubernetesDeployAction } from "../kubernetes-type/config"
 import { HelmDeployAction } from "../helm/config"
+import { Executed } from "../../../actions/types"
 
 export const k8sContainerStartSync: DeployActionHandler<"startSync", ContainerDeployAction> = async (params) => {
   const { ctx, action, log } = params
   const k8sCtx = <KubernetesPluginContext>ctx
-  const status = action.getStatus()
 
-  const sync = action.getSpec("sync")
-  const workload = status.detail.detail.workload
+  const { target, syncs, manifests } = getSyncs(action)
 
-  if (!sync?.paths || !workload) {
+  if (syncs.length === 0) {
     return {}
   }
 
-  log.info({
-    section: action.name,
-    msg: chalk.grey(`Starting syncs`),
-  })
-
   const defaultNamespace = await getAppNamespace(k8sCtx, log, k8sCtx.provider)
-
-  const target = {
-    kind: <SyncableKind>workload.kind,
-    name: workload.metadata.name,
-  }
-
-  const syncs = sync.paths.map((s) => ({
-    ...s,
-    sourcePath: s.source,
-    containerPath: s.target,
-    target,
-  }))
 
   await startSyncs({
     ctx: k8sCtx,
@@ -55,7 +36,7 @@ export const k8sContainerStartSync: DeployActionHandler<"startSync", ContainerDe
     basePath: action.basePath(),
     defaultNamespace,
     defaultTarget: target,
-    manifests: status.detail.remoteResources,
+    manifests,
     syncs,
   })
 
@@ -77,4 +58,56 @@ export const k8sContainerStopSync: DeployActionHandler<
   })
 
   return {}
+}
+
+export const k8sContainerGetSyncStatus: DeployActionHandler<"getSyncStatus", ContainerDeployAction> = async (
+  params
+) => {
+  const { ctx, log, action, monitor } = params
+  const k8sCtx = <KubernetesPluginContext>ctx
+
+  const { target, syncs, manifests } = getSyncs(action)
+
+  const defaultNamespace = await getAppNamespace(k8sCtx, log, k8sCtx.provider)
+
+  return getSyncStatus({
+    ctx: k8sCtx,
+    log,
+    action,
+    actionDefaults: {},
+    basePath: action.basePath(),
+    defaultNamespace,
+    defaultTarget: target,
+    manifests,
+    syncs,
+    monitor,
+  })
+}
+
+function getSyncs(action: Executed<ContainerDeployAction>): {
+  syncs: KubernetesDeployDevModeSyncSpec[]
+  target?: KubernetesTargetResourceSpec | undefined
+  manifests: KubernetesResource[]
+} {
+  const status = action.getStatus()
+  const sync = action.getSpec("sync")
+  const workload = status.detail.detail.workload
+
+  if (!sync?.paths || !workload) {
+    return { syncs: [], manifests: [] }
+  }
+
+  const target = {
+    kind: <SyncableKind>workload.kind,
+    name: workload.metadata.name,
+  }
+
+  const syncs = sync.paths.map((s) => ({
+    ...s,
+    sourcePath: s.source,
+    containerPath: s.target,
+    target,
+  }))
+
+  return { syncs, target, manifests: status.detail.remoteResources }
 }

--- a/core/src/plugins/kubernetes/helm/action.ts
+++ b/core/src/plugins/kubernetes/helm/action.ts
@@ -19,7 +19,7 @@ import { getHelmDeployLogs } from "./logs"
 import { getHelmDeployStatus } from "./status"
 import { posix } from "path"
 import { k8sContainerStopSync } from "../container/sync"
-import { helmStartSync } from "./sync"
+import { helmGetSyncStatus, helmStartSync } from "./sync"
 
 export const helmDeployDocs = dedent`
   Specify a Helm chart (either in your repository or remote from a registry) to deploy.
@@ -41,6 +41,7 @@ export const helmDeployDefinition = (): DeployActionDefinition<HelmDeployAction>
 
     startSync: helmStartSync,
     stopSync: k8sContainerStopSync,
+    getSyncStatus: helmGetSyncStatus,
 
     getPortForward: async (params) => {
       const { ctx, log, action } = params

--- a/core/src/plugins/kubernetes/helm/helm-cli.ts
+++ b/core/src/plugins/kubernetes/helm/helm-cli.ts
@@ -14,7 +14,6 @@ import { mkdirp } from "fs-extra"
 import { StringMap } from "../../../config/common"
 import { PluginToolSpec } from "../../../plugin/tools"
 import split2 from "split2"
-import { LogLevel } from "../../../logger/logger"
 
 export const helm3Spec: PluginToolSpec = {
   name: "helm",
@@ -107,14 +106,14 @@ export async function helm({
 
   const logEventContext = {
     origin: "helm",
-    log: log.createLog({ fixLevel: LogLevel.verbose }),
+    level: "verbose" as const,
   }
 
   const outputStream = split2()
   outputStream.on("error", () => {})
   outputStream.on("data", (line: Buffer) => {
     if (emitLogEvents) {
-      ctx.events.emit("log", { timestamp: new Date().toISOString(), data: line, ...logEventContext })
+      ctx.events.emit("log", { timestamp: new Date().toISOString(), msg: line.toString(), ...logEventContext })
     }
   })
 

--- a/core/src/plugins/kubernetes/kubernetes-type/deploy.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/deploy.ts
@@ -22,7 +22,7 @@ import {
 import { ConfigurationError } from "../../../exceptions"
 import { uniq } from "lodash"
 import { DOCS_BASE_URL } from "../../../constants"
-import { kubernetesStartSync } from "./sync"
+import { kubernetesGetSyncStatus, kubernetesStartSync } from "./sync"
 import { k8sContainerStopSync } from "../container/sync"
 
 export const kubernetesDeployDocs = dedent`
@@ -73,6 +73,7 @@ export const kubernetesDeployDefinition = (): DeployActionDefinition<KubernetesD
 
     startSync: kubernetesStartSync,
     stopSync: k8sContainerStopSync,
+    getSyncStatus: kubernetesGetSyncStatus,
 
     getPortForward: async (params) => {
       const { ctx, log, action } = params

--- a/core/src/plugins/kubernetes/kubernetes-type/sync.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/sync.ts
@@ -10,7 +10,7 @@ import { DeployActionHandler } from "../../../plugin/action-types"
 import { KubeApi } from "../api"
 import { KubernetesPluginContext } from "../config"
 import { getActionNamespace } from "../namespace"
-import { startSyncs } from "../sync"
+import { getSyncStatus, startSyncs } from "../sync"
 import { getManifests } from "./common"
 import { KubernetesDeployAction } from "./config"
 
@@ -49,4 +49,42 @@ export const kubernetesStartSync: DeployActionHandler<"startSync", KubernetesDep
   })
 
   return {}
+}
+
+export const kubernetesGetSyncStatus: DeployActionHandler<"getSyncStatus", KubernetesDeployAction> = async (params) => {
+  const { ctx, log, action, monitor } = params
+
+  const k8sCtx = <KubernetesPluginContext>ctx
+  const provider = k8sCtx.provider
+  const spec = action.getSpec()
+
+  if (!spec.sync?.paths?.length) {
+    return {
+      state: "not-active",
+    }
+  }
+
+  const api = await KubeApi.factory(log, k8sCtx, provider)
+
+  const namespace = await getActionNamespace({
+    ctx: k8sCtx,
+    log,
+    action,
+    provider,
+  })
+
+  const manifests = await getManifests({ ctx, api, log, action, defaultNamespace: namespace })
+
+  return getSyncStatus({
+    ctx: k8sCtx,
+    log,
+    action,
+    actionDefaults: spec.sync.defaults || {},
+    defaultTarget: spec.defaultTarget,
+    basePath: action.basePath(),
+    defaultNamespace: namespace,
+    manifests,
+    syncs: spec.sync.paths,
+    monitor,
+  })
 }

--- a/core/src/plugins/kubernetes/local-mode.ts
+++ b/core/src/plugins/kubernetes/local-mode.ts
@@ -570,6 +570,7 @@ function getLocalAppProcess(configParams: StartLocalModeParams): RecoverableProc
   const section = action.key()
 
   return new RecoverableProcess({
+    events: ctx.events,
     osCommand: localAppCmd,
     retryConfig: {
       maxRetries: configParams.spec.restart.max,
@@ -660,6 +661,7 @@ async function getKubectlPortForwardProcess(
   const section = action.key()
 
   return new RecoverableProcess({
+    events: ctx.events,
     osCommand: kubectlPortForwardCmd,
     retryConfig: {
       maxRetries: Number.POSITIVE_INFINITY,
@@ -756,6 +758,7 @@ async function getReversePortForwardProcesses(
   return reversePortForwardingCmds.map(
     (cmd) =>
       new RecoverableProcess({
+        events: ctx.events,
         osCommand: cmd,
         retryConfig: {
           maxRetries: Number.POSITIVE_INFINITY,

--- a/core/src/plugins/kubernetes/logs.ts
+++ b/core/src/plugins/kubernetes/logs.ts
@@ -61,6 +61,7 @@ export async function streamK8sLogs(params: GetAllLogsParams) {
 
     params.ctx.events.on("abort", () => {
       logsFollower.close()
+      params.ctx.events.emit("done")
     })
 
     // We use sinceOnRetry 30s here, to cap the maximum age of log messages on retry attempts to max 30s

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -218,7 +218,12 @@ export async function runAndCopy({
     const outputStream = new PassThrough()
     outputStream.on("error", () => {})
     outputStream.on("data", (data: Buffer) => {
-      ctx.events.emit("log", { timestamp: new Date().toISOString(), data, ...logEventContext })
+      ctx.events.emit("log", {
+        level: "verbose",
+        timestamp: new Date().toISOString(),
+        msg: data.toString(),
+        ...logEventContext,
+      })
     })
 
     return runWithArtifacts({
@@ -817,8 +822,9 @@ export class PodRunner extends PodRunnerParams {
         isoTimestamp = new Date().toISOString()
       }
       events.emit("log", {
+        level: "verbose",
         timestamp: isoTimestamp,
-        data: Buffer.from(msg),
+        msg,
         ...logEventContext,
       })
       if (tty) {

--- a/core/src/plugins/kubernetes/status/status.ts
+++ b/core/src/plugins/kubernetes/status/status.ts
@@ -389,8 +389,12 @@ export async function compareDeployedResources(
     }
 
     // Discard any last applied config from the input manifest
-    if (manifest.metadata.annotations[gardenAnnotationKey("manifest-hash")]) {
-      delete manifest.metadata.annotations[gardenAnnotationKey("manifest-hash")]
+    const hashKey = gardenAnnotationKey("manifest-hash")
+    if (manifest.metadata?.annotations?.[hashKey]) {
+      delete manifest.metadata?.annotations?.[hashKey]
+    }
+    if (manifest.spec?.template?.metadata?.annotations?.[hashKey]) {
+      delete manifest.spec?.template?.metadata?.annotations?.[hashKey]
     }
 
     if (isWorkloadResource(manifest)) {

--- a/core/src/plugins/kubernetes/status/status.ts
+++ b/core/src/plugins/kubernetes/status/status.ts
@@ -44,7 +44,6 @@ import { checkWorkloadStatus } from "./workload"
 import { checkWorkloadPodStatus } from "./pod"
 import { deline, gardenAnnotationKey, stableStringify } from "../../../util/string"
 import { SyncableResource } from "../types"
-import { LogLevel } from "../../../logger/logger"
 import { ActionMode } from "../../../actions/types"
 import { deepMap } from "../../../util/objects"
 import { DeployState, combineStates } from "../../../types/service"
@@ -200,11 +199,11 @@ export async function waitForResources({
 
   const logEventContext = {
     origin: "kubernetes-plugin",
-    log: log.createLog({ fixLevel: LogLevel.verbose }),
+    level: "verbose" as const,
   }
 
   const emitLog = (msg: string) =>
-    ctx.events.emit("log", { timestamp: new Date().toISOString(), data: Buffer.from(msg, "utf-8"), ...logEventContext })
+    ctx.events.emit("log", { timestamp: new Date().toISOString(), msg, ...logEventContext })
 
   const waitingMsg = `Waiting for resources to be ready...`
   const statusLine = log

--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -42,7 +42,6 @@ import { getActionNamespace } from "./namespace"
 import { Resolved } from "../../actions/types"
 import { serializeValues } from "../../util/serialization"
 import { PassThrough } from "stream"
-import { LogLevel } from "../../logger/logger"
 
 const STATIC_LABEL_REGEX = /[0-9]/g
 export const workloadTypes = ["Deployment", "DaemonSet", "ReplicaSet", "StatefulSet"]
@@ -286,15 +285,15 @@ export async function execInWorkload({
     const logEventContext = {
       // To avoid an awkwardly long prefix for the log lines when rendered, we set a max length here.
       origin: truncate(command.join(" "), 25),
-      log: log.createLog({ fixLevel: LogLevel.verbose }),
+      level: "verbose" as const,
     }
 
     const outputStream = new PassThrough()
     outputStream.on("error", () => {})
     outputStream.on("data", (line: Buffer) => {
       // For some reason, we're getting extra newlines for each line here, so we trim them.
-      const data = Buffer.from(line.toString().trimEnd(), "utf-8")
-      ctx.events.emit("log", { timestamp: new Date().toISOString(), data, ...logEventContext })
+      const msg = line.toString().trimEnd()
+      ctx.events.emit("log", { timestamp: new Date().toISOString(), msg, ...logEventContext })
     })
     execParams.stdout = outputStream
     execParams.stderr = outputStream

--- a/core/src/proxy.ts
+++ b/core/src/proxy.ts
@@ -20,8 +20,9 @@ import { ConfigGraph } from "./graph/config-graph"
 import { DeployAction } from "./actions/deploy"
 import { GetPortForwardResult } from "./plugin/handlers/Deploy/get-port-forward"
 import { Executed } from "./actions/types"
+import { PluginEventBroker } from "./plugin-context"
 
-interface PortProxy {
+export interface PortProxy {
   key: string
   localPort: number
   localUrl: string
@@ -37,7 +38,7 @@ registerCleanupFunction("kill-service-port-proxies", () => {
     try {
       // Avoid EPIPE errors
       proxy.server.on("error", () => {})
-      stopPortProxy(proxy)
+      closeProxyServer(proxy)
     } catch {}
   }
 })
@@ -50,12 +51,14 @@ export async function startPortProxies({
   log,
   action,
   status,
+  events,
 }: {
   garden: Garden
   graph: ConfigGraph
   log: Log
   action: Executed<DeployAction>
   status: ServiceStatus
+  events?: PluginEventBroker
 }) {
   if (garden.disablePortForwards) {
     log.info({ msg: chalk.gray("Port forwards disabled") })
@@ -63,7 +66,7 @@ export async function startPortProxies({
   }
 
   return Bluebird.map(status.forwardablePorts || [], (spec) => {
-    return startPortProxy({ garden, graph, log, action, spec })
+    return startPortProxy({ garden, graph, log, action, spec, events })
   })
 }
 
@@ -73,25 +76,28 @@ interface StartPortProxyParams {
   log: Log
   action: Executed<DeployAction>
   spec: ForwardablePort
+  events?: PluginEventBroker
 }
 
-async function startPortProxy({ garden, graph, log, action, spec }: StartPortProxyParams) {
+async function startPortProxy({ garden, graph, log, action, spec, events }: StartPortProxyParams) {
   const key = getPortKey(action, spec)
   let proxy = activeProxies[key]
 
+  const createParams = { garden, graph, log, action, spec, events }
+
   if (!proxy) {
     // Start new proxy
-    proxy = activeProxies[key] = await createProxy({ garden, graph, log, action, spec })
+    proxy = activeProxies[key] = await createProxy(createParams)
   } else if (!isEqual(proxy.spec, spec)) {
     // Stop existing proxy and create new one
-    stopPortProxy(proxy, log)
-    proxy = activeProxies[key] = await createProxy({ garden, graph, log, action, spec })
+    await stopPortProxy({ ...createParams, proxy })
+    proxy = activeProxies[key] = await createProxy(createParams)
   }
 
   return proxy
 }
 
-async function createProxy({ garden, graph, log, action, spec }: StartPortProxyParams): Promise<PortProxy> {
+async function createProxy({ garden, graph, log, action, spec, events }: StartPortProxyParams): Promise<PortProxy> {
   const router = await garden.getActionRouter()
   const key = getPortKey(action, spec)
   let fwd: GetPortForwardResult | null = null
@@ -110,7 +116,7 @@ async function createProxy({ garden, graph, log, action, spec }: StartPortProxyP
       log.debug(`Starting port forward to ${key}`)
 
       try {
-        const output = await router.deploy.getPortForward({ action, log, graph, ...spec })
+        const output = await router.deploy.getPortForward({ action, log, graph, events, ...spec })
         fwd = output.result
       } catch (err) {
         const msg = err.message.trim()
@@ -283,14 +289,27 @@ async function createProxy({ garden, graph, log, action, spec }: StartPortProxyP
   }
 }
 
-function stopPortProxy(proxy: PortProxy, log?: Log) {
+function closeProxyServer(proxy: PortProxy) {
   // TODO: call stopPortForward handler
-  log && log.debug(`Stopping port forward to ${proxy.key}`)
   delete activeProxies[proxy.key]
 
   try {
     proxy.server.close(() => {})
   } catch {}
+}
+
+interface StopPortProxyParams extends StartPortProxyParams {
+  proxy: PortProxy
+}
+
+export async function stopPortProxy({ garden, graph, log, action, proxy, events }: StopPortProxyParams) {
+  log.verbose(`Stopping port forward to ${proxy.key}`)
+
+  closeProxyServer(proxy)
+
+  const router = await garden.getActionRouter()
+
+  await router.deploy.stopPortForward({ log, graph, action, events, ...proxy.spec })
 }
 
 function getHostname(action: DeployAction, spec: ForwardablePort) {

--- a/core/src/router/run.ts
+++ b/core/src/router/run.ts
@@ -13,7 +13,6 @@ import { ActionState, stateForCacheStatusEvent } from "../actions/types"
 import { PluginEventBroker } from "../plugin-context"
 import { runStatusForEventPayload } from "../plugin/base"
 import { copyArtifacts, getArtifactKey } from "../util/artifacts"
-import { renderOutputStream } from "../util/util"
 import { BaseRouterParams, createActionRouter } from "./base"
 
 const API_ACTION_TYPE = "run"
@@ -47,15 +46,15 @@ export const runRouter = (baseParams: BaseRouterParams) =>
         status: { state: "running" },
       })
 
-      params.events = params.events || new PluginEventBroker()
+      params.events = params.events || new PluginEventBroker(garden)
 
       try {
         // Annotate + emit log output
-        params.events.on("log", ({ timestamp, data, origin, log }) => {
+        params.events.on("log", ({ timestamp, msg, origin, level }) => {
           if (!params.interactive) {
             // stream logs to CLI; if interactive is true, the output will already be streamed to process.stdout
             // TODO: 0.13 make sure that logs of different tasks in the same module can be differentiated
-            log.info(renderOutputStream(data.toString(), origin))
+            params.log[level]({ msg, origin })
           }
           // stream logs to Garden Cloud
           garden.events.emit("log", {
@@ -64,8 +63,8 @@ export const runRouter = (baseParams: BaseRouterParams) =>
             actionName,
             actionType,
             moduleName,
-            origin,
-            data: data.toString(),
+            origin: origin || "",
+            data: msg,
           })
         })
 

--- a/core/src/tasks/build.ts
+++ b/core/src/tasks/build.ts
@@ -27,11 +27,16 @@ export class BuildTask extends ExecuteActionTask<BuildAction, BuildStatus> {
     return this.action.longDescription()
   }
 
-  async getStatus({ dependencyResults }: ActionTaskStatusParams<BuildAction>) {
+  async getStatus({ statusOnly, dependencyResults }: ActionTaskStatusParams<BuildAction>) {
     const router = await this.garden.getActionRouter()
     const action = this.getResolvedAction(this.action, dependencyResults)
     const output = await router.build.getStatus({ log: this.log, graph: this.graph, action })
     const status = output.result
+
+    if (status.state === "ready" && !statusOnly) {
+      this.log.info(`${action.longDescription()} already complete, nothing to do.`)
+    }
+
     return { ...status, version: action.versionString(), executedAction: resolvedActionToExecuted(action, { status }) }
   }
 

--- a/core/src/tasks/delete-deploy.ts
+++ b/core/src/tasks/delete-deploy.ts
@@ -83,6 +83,7 @@ export class DeleteDeployTask extends BaseActionTask<DeployAction, DeployStatus>
     try {
       const output = await router.deploy.delete({ log: this.log, action, graph: this.graph })
       status = output.result
+      this.log.info("Done!")
     } catch (err) {
       this.log.error(`Failed deleting ${action.name}`)
       throw err

--- a/core/src/tasks/run.ts
+++ b/core/src/tasks/run.ts
@@ -11,6 +11,7 @@ import { Profile } from "../util/profiling"
 import { RunAction } from "../actions/run"
 import { GetRunResult } from "../plugin/handlers/Run/get-result"
 import { resolvedActionToExecuted } from "../actions/helpers"
+import chalk from "chalk"
 
 export interface RunTaskParams extends BaseActionTaskParams<RunAction> {}
 
@@ -28,7 +29,7 @@ export class RunTask extends ExecuteActionTask<RunAction, GetRunResult> {
     return this.action.longDescription()
   }
 
-  async getStatus({ dependencyResults }: ActionTaskStatusParams<RunAction>) {
+  async getStatus({ statusOnly, dependencyResults }: ActionTaskStatusParams<RunAction>) {
     const taskLog = this.log.createLog().info("Checking result...")
     const router = await this.garden.getActionRouter()
     const action = this.getResolvedAction(this.action, dependencyResults)
@@ -45,6 +46,10 @@ export class RunTask extends ExecuteActionTask<RunAction, GetRunResult> {
       // Should return a null value here if there is no result
       if (status.detail === null) {
         return null
+      }
+
+      if (status.state === "ready" && !statusOnly) {
+        this.log.info(chalk.green(`${action.longDescription()} already complete.`))
       }
 
       return {

--- a/core/src/types/service.ts
+++ b/core/src/types/service.ts
@@ -196,7 +196,6 @@ export interface ServiceStatus<D = any, O = PrimitiveMap> {
   runningReplicas?: number
   state: DeployState
   updatedAt?: string
-  version?: string
 }
 
 export interface ServiceStatusMap {

--- a/core/src/util/events.ts
+++ b/core/src/util/events.ts
@@ -31,31 +31,31 @@ interface ListenerFn<V = any> {
 
 // Copied and adapted from the eventemitter2 type
 // @ts-expect-error
-declare class _TypedEventEmitter<T extends object> {
+declare class _TypedEventEmitter<T> {
   constructor(options?: ConstructorOptions)
-  emit<N extends keyof T>(event: N | eventNS, payload: T[N]): boolean
-  emitAsync<N extends keyof T>(event: N | eventNS, payload: T[N]): Promise<any[]>
-  addListener<N extends keyof T>(event: N | eventNS, listener: ListenerFn<T[N]>): this | Listener
-  on<N extends keyof T>(event: N | eventNS, listener: ListenerFn<T[N]>, options?: boolean | OnOptions): this | Listener
+  emit<N extends keyof T>(event: N, payload: T[N]): boolean
+  emitAsync<N extends keyof T>(event: N, payload: T[N]): Promise<any[]>
+  addListener<N extends keyof T>(event: N, listener: ListenerFn<T[N]>): this | Listener
+  on<N extends keyof T>(event: N, listener: ListenerFn<T[N]>, options?: boolean | OnOptions): this | Listener
   prependListener<N extends keyof T>(
-    event: N | eventNS,
+    event: N,
     listener: ListenerFn<T[N]>,
     options?: boolean | OnOptions
   ): this | Listener
-  once<N extends keyof T>(event: N | eventNS, listener: ListenerFn<T[N]>, options?: true | OnOptions): this | Listener
+  once<N extends keyof T>(event: N, listener: ListenerFn<T[N]>, options?: true | OnOptions): this | Listener
   prependOnceListener<N extends keyof T>(
-    event: N | eventNS,
+    event: N,
     listener: ListenerFn<T[N]>,
     options?: boolean | OnOptions
   ): this | Listener
   many<N extends keyof T>(
-    event: N | eventNS,
+    event: N,
     timesToListen: number,
     listener: ListenerFn<T[N]>,
     options?: boolean | OnOptions
   ): this | Listener
   prependMany<N extends keyof T>(
-    event: N | eventNS,
+    event: N,
     timesToListen: number,
     listener: ListenerFn<T[N]>,
     options?: boolean | OnOptions
@@ -63,8 +63,8 @@ declare class _TypedEventEmitter<T extends object> {
   onAny(listener: EventAndListener): this
   prependAny(listener: EventAndListener): this
   offAny(listener: ListenerFn): this
-  removeListener<N extends keyof T>(event: N | eventNS, listener: ListenerFn<T[N]>): this
-  off<N extends keyof T>(event: N | eventNS, listener: ListenerFn<T[N]>): this
+  removeListener<N extends keyof T>(event: N, listener: ListenerFn<T[N]>): this
+  off<N extends keyof T>(event: N, listener: ListenerFn<T[N]>): this
   removeAllListeners(event?: keyof T | eventNS): this
   setMaxListeners(n: number): void
   getMaxListeners(): number
@@ -91,7 +91,7 @@ declare class _TypedEventEmitter<T extends object> {
 // @ts-ignore
 class _TypedEventEmitter {}
 
-export class TypedEventEmitter<T extends object> extends _TypedEventEmitter<T> {
+export class TypedEventEmitter<T> extends _TypedEventEmitter<T> {
   constructor(options?: ConstructorOptions) {
     super()
     const cls = new EventEmitter2(options)

--- a/core/src/util/ext-tools.ts
+++ b/core/src/util/ext-tools.ts
@@ -154,11 +154,11 @@ export class CliWrapper {
 
     const logEventContext = {
       origin: this.name,
-      log: log.createLog({ fixLevel: LogLevel.verbose }),
+      level: "verbose" as const,
     }
 
     logStream.on("data", (line: Buffer) => {
-      ctx.events.emit("log", { timestamp: new Date().toISOString(), data: line, ...logEventContext })
+      ctx.events.emit("log", { timestamp: new Date().toISOString(), msg: line.toString(), ...logEventContext })
     })
 
     await new Promise<void>((resolve, reject) => {

--- a/core/src/util/keyed-set.ts
+++ b/core/src/util/keyed-set.ts
@@ -14,7 +14,7 @@
 export class KeyedSet<V> {
   private map: Map<string, V>
 
-  constructor(private keyFn: (V) => string) {
+  constructor(private keyFn: (v: V) => string) {
     this.map = new Map()
   }
 

--- a/core/src/util/string.ts
+++ b/core/src/util/string.ts
@@ -75,7 +75,10 @@ export function base64(str: string) {
  * Returns an array of strings, joined together as a string in a natural language manner.
  * Example: `naturalList(["a", "b", "c"])` -> `"a, b and c"`
  */
-export function naturalList(list: string[], trailingWord = "and") {
+export function naturalList(list: string[], { trailingWord = "and", quote = false } = {}) {
+  if (quote) {
+    list = list.map((s) => "'" + s + "'")
+  }
   if (list.length === 0) {
     return ""
   } else if (list.length === 1) {

--- a/core/src/util/testing.ts
+++ b/core/src/util/testing.ts
@@ -21,7 +21,7 @@ import { dedent } from "./string"
 import pathIsInside from "path-is-inside"
 import { join, resolve } from "path"
 import { DEFAULT_API_VERSION, GARDEN_CORE_ROOT } from "../constants"
-import { getLogger } from "../logger/logger"
+import { getRootLogger } from "../logger/logger"
 import stripAnsi from "strip-ansi"
 import { VcsHandler } from "../vcs/vcs"
 import { ConfigGraph } from "../graph/config-graph"
@@ -168,7 +168,7 @@ export class TestGarden extends Garden {
     if (cacheKey && paramCache[cacheKey]) {
       params = cloneDeep(paramCache[cacheKey])
       // Need to do these separately to avoid issues around cloning
-      params.log = opts?.log || getLogger().createLog()
+      params.log = opts?.log || getRootLogger().createLog()
       params.plugins = opts?.plugins || []
     } else {
       params = await resolveGardenParams(currentDirectory, { commandInfo: defaultCommandinfo, ...opts })

--- a/core/src/util/util.ts
+++ b/core/src/util/util.ts
@@ -28,7 +28,6 @@ import exitHook from "async-exit-hook"
 import _spawn from "cross-spawn"
 import { readFile } from "fs-extra"
 import { GardenError, ParameterError, RuntimeError, TimeoutError } from "../exceptions"
-import chalk from "chalk"
 import { safeLoad } from "js-yaml"
 import { createHash } from "crypto"
 import { dedent, tailString } from "./string"
@@ -153,24 +152,17 @@ export function defer<T>() {
 }
 
 /**
- * Extracting to a separate function so that we can test output streams
- */
-export function renderOutputStream(msg: string, command?: string) {
-  return command ? chalk.gray(`[${command}]: ${msg}`) : chalk.gray(msg)
-}
-
-/**
  * Creates an output stream that updates a log entry on data events (in an opinionated way).
  *
  * Note that new entries are not created but rather the passed log entry gets updated.
  * It's therefore recommended to pass a placeholder entry, for example: `log.placeholder(LogLevel.debug)`
  */
-export function createOutputStream(log: Log) {
+export function createOutputStream(log: Log, origin?: string) {
   const outputStream = split2()
 
   outputStream.on("error", () => {})
   outputStream.on("data", (line: Buffer) => {
-    log.info(renderOutputStream(line.toString()))
+    log.info({ msg: line.toString(), origin })
   })
 
   return outputStream

--- a/core/src/vcs/vcs.ts
+++ b/core/src/vcs/vcs.ts
@@ -30,6 +30,7 @@ import { validateInstall } from "../util/validateInstall"
 import { isActionConfig } from "../actions/base"
 import type { BaseActionConfig } from "../actions/types"
 import { Garden } from "../garden"
+import chalk = require("chalk")
 
 const AsyncLock = require("async-lock")
 const scanLock = new AsyncLock()
@@ -192,10 +193,10 @@ export abstract class VcsHandler {
           await this.garden?.emitWarning({
             key: `${projectName}-filecount-${config.name}`,
             log,
-            message: dedent`
+            message: chalk.yellow(dedent`
               Large number of files (${files.length}) found in ${description}. You may need to configure file exclusions.
               See https://docs.garden.io/using-garden/configuration-overview#including-excluding-files-and-directories for details.
-            `,
+            `),
           })
         }
 

--- a/core/test/helpers.ts
+++ b/core/test/helpers.ts
@@ -43,7 +43,7 @@ import { CommandParams, ProcessCommandResult } from "../src/commands/base"
 import { SuiteFunction, TestFunction } from "mocha"
 import { AnalyticsGlobalConfig } from "../src/config-store/global"
 import { EventLogEntry, TestGarden, TestGardenOpts } from "../src/util/testing"
-import { Logger, LogLevel } from "../src/logger/logger"
+import { LogLevel, RootLogger } from "../src/logger/logger"
 import { GardenCli } from "../src/cli/cli"
 import { profileAsync } from "../src/util/profiling"
 import { defaultDotIgnoreFile, makeTempDir } from "../src/util/fs"
@@ -561,14 +561,14 @@ export function getAllProcessedTaskNames(results: GraphResultMapWithoutTask) {
 }
 
 /**
- * Returns a map of all Run results including dependencies from a GraphResultMap.
+ * Returns a map of all task results including dependencies from a GraphResultMap.
  */
-export function getAllRunResults(results: GraphResultMapWithoutTask) {
+export function getAllTaskResults(results: GraphResultMapWithoutTask) {
   const all = { ...results }
 
   for (const r of Object.values(results)) {
     if (r?.dependencyResults) {
-      for (const [key, result] of Object.entries(getAllRunResults(r.dependencyResults))) {
+      for (const [key, result] of Object.entries(getAllTaskResults(r.dependencyResults))) {
         all[key] = result
       }
     }
@@ -796,10 +796,10 @@ export function getRuntimeStatusEventsWithoutTimestamps(eventLog: EventLogEntry[
 export function initTestLogger() {
   // make sure logger is initialized
   try {
-    Logger.initialize({
+    RootLogger.initialize({
       level: LogLevel.info,
       storeEntries: true,
-      terminalWriterType: "quiet",
+      displayWriterType: "quiet",
     })
   } catch (_) {}
 }

--- a/core/test/helpers.ts
+++ b/core/test/helpers.ts
@@ -800,6 +800,7 @@ export function initTestLogger() {
       level: LogLevel.info,
       storeEntries: true,
       displayWriterType: "quiet",
+      force: true,
     })
   } catch (_) {}
 }

--- a/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
@@ -23,7 +23,7 @@ import { ConfigGraph } from "../../../../../../src/graph/config-graph"
 import { isWorkload } from "../../../../../../src/plugins/kubernetes/util"
 import Bluebird from "bluebird"
 import { CloudApi } from "../../../../../../src/cloud/api"
-import { getLogger } from "../../../../../../src/logger/logger"
+import { getRootLogger } from "../../../../../../src/logger/logger"
 import { LocalModeProcessRegistry, ProxySshKeystore } from "../../../../../../src/plugins/kubernetes/local-mode"
 import { HelmDeployAction } from "../../../../../../src/plugins/kubernetes/helm/config"
 import { GlobalConfigStore } from "../../../../../../src/config-store/global"
@@ -278,7 +278,11 @@ describe("helmDeploy", () => {
   })
 
   it("should mark a chart that has been paused by Garden Cloud AEC as outdated", async () => {
-    const fakeCloudApi = new CloudApi(getLogger().createLog(), "https://test.cloud.garden.io", new GlobalConfigStore())
+    const fakeCloudApi = new CloudApi(
+      getRootLogger().createLog(),
+      "https://test.cloud.garden.io",
+      new GlobalConfigStore()
+    )
     const projectRoot = getDataDir("test-projects", "helm")
     const gardenWithCloudApi = await makeTestGarden(projectRoot, { cloudApi: fakeCloudApi, noCache: true })
 

--- a/core/test/unit/src/analytics/analytics.ts
+++ b/core/test/unit/src/analytics/analytics.ts
@@ -16,7 +16,7 @@ import { AnalyticsHandler, getAnonymousUserId } from "../../../../src/analytics/
 import { DEFAULT_API_VERSION, DEFAULT_GARDEN_CLOUD_DOMAIN, gardenEnv } from "../../../../src/constants"
 import { CloudApi } from "../../../../src/cloud/api"
 import { Log } from "../../../../src/logger/log-entry"
-import { Logger, LogLevel } from "../../../../src/logger/logger"
+import { LogLevel, RootLogger } from "../../../../src/logger/logger"
 import { AnalyticsGlobalConfig, GlobalConfigStore } from "../../../../src/config-store/global"
 import { ProjectResource } from "../../../../src/config/project"
 import { QuietWriter } from "../../../../src/logger/writers/quiet-writer"
@@ -262,9 +262,9 @@ describe("AnalyticsHandler", () => {
 
   describe("factory (user is logged in)", async () => {
     beforeEach(async () => {
-      const logger = Logger._createInstanceForTests({
+      const logger = RootLogger._createInstanceForTests({
         level: LogLevel.info,
-        writers: { terminal: new QuietWriter({ level: LogLevel.info }), file: [] },
+        writers: { display: new QuietWriter({ level: LogLevel.info }), file: [] },
         storeEntries: false,
       })
       const cloudApi = await FakeCloudApi.factory({ log: logger.createLog() })

--- a/core/test/unit/src/cache.ts
+++ b/core/test/unit/src/cache.ts
@@ -9,11 +9,11 @@
 import { TreeCache } from "../../../src/cache"
 import { expect } from "chai"
 import { expectError } from "../../helpers"
-import { getLogger } from "../../../src/logger/logger"
+import { getRootLogger } from "../../../src/logger/logger"
 
 describe("TreeCache", () => {
   let cache: TreeCache
-  const log = getLogger().createLog()
+  const log = getRootLogger().createLog()
 
   beforeEach(() => {
     cache = new TreeCache()

--- a/core/test/unit/src/cli/cli.ts
+++ b/core/test/unit/src/cli/cli.ts
@@ -29,7 +29,7 @@ import { UtilCommand } from "../../../../src/commands/util/util"
 import { StringParameter } from "../../../../src/cli/params"
 import stripAnsi from "strip-ansi"
 import { ToolsCommand } from "../../../../src/commands/tools"
-import { Logger, getLogger } from "../../../../src/logger/logger"
+import { getRootLogger, RootLogger } from "../../../../src/logger/logger"
 import { safeLoad } from "js-yaml"
 import { startServer, GardenServer } from "../../../../src/server/server"
 import { envSupportsEmoji } from "../../../../src/logger/util"
@@ -43,7 +43,7 @@ import { ServeCommand } from "../../../../src/commands/serve"
 describe("cli", () => {
   let cli: GardenCli
   const globalConfigStore = new GlobalConfigStore()
-  const log = getLogger().createLog()
+  const log = getRootLogger().createLog()
 
   beforeEach(() => {
     cli = new GardenCli()
@@ -223,7 +223,7 @@ describe("cli", () => {
         delete process.env.GARDEN_LOG_LEVEL
         gardenEnv.GARDEN_LOGGER_TYPE = ""
         gardenEnv.GARDEN_LOG_LEVEL = ""
-        Logger.clearInstance()
+        RootLogger.clearInstance()
       })
       // Re-initialise the test logger
       after(() => {
@@ -231,7 +231,7 @@ describe("cli", () => {
         process.env.GARDEN_LOG_LEVEL = envLogLevel
         gardenEnv.GARDEN_LOGGER_TYPE = envLoggerType || ""
         gardenEnv.GARDEN_LOG_LEVEL = envLogLevel || ""
-        Logger.clearInstance()
+        RootLogger.clearInstance()
         initTestLogger()
       })
 
@@ -253,9 +253,9 @@ describe("cli", () => {
 
         await cli.run({ args: ["test-command"], exitOnError: false })
 
-        const logger = getLogger()
+        const logger = log.root
         const writers = logger.getWriters()
-        expect(writers.terminal.type).to.equal("default")
+        expect(writers.display.type).to.equal("default")
       })
     })
 
@@ -1064,7 +1064,7 @@ describe("cli", () => {
     describe("validateRuntimeRequirementsCached", () => {
       let config: GlobalConfigStore
       let tmpDir
-      const log = getLogger().createLog()
+      const log = getRootLogger().createLog()
 
       before(async () => {
         tmpDir = await tmp.dir({ unsafeCleanup: true })

--- a/core/test/unit/src/cloud/api.ts
+++ b/core/test/unit/src/cloud/api.ts
@@ -7,7 +7,7 @@
  */
 
 import { expect } from "chai"
-import { getLogger } from "../../../../src/logger/logger"
+import { getRootLogger } from "../../../../src/logger/logger"
 import { gardenEnv } from "../../../../src/constants"
 import { CloudApi } from "../../../../src/cloud/api"
 import { uuidv4 } from "../../../../src/util/random"
@@ -15,7 +15,7 @@ import { randomString } from "../../../../src/util/string"
 import { GlobalConfigStore } from "../../../../src/config-store/global"
 
 describe("CloudApi", () => {
-  const log = getLogger().createLog()
+  const log = getRootLogger().createLog()
   const domain = "https://garden." + randomString()
   const globalConfigStore = new GlobalConfigStore()
 

--- a/core/test/unit/src/cloud/buffered-event-stream.ts
+++ b/core/test/unit/src/cloud/buffered-event-stream.ts
@@ -8,7 +8,7 @@
 
 import { expect } from "chai"
 import { StreamEvent, LogEntryEventPayload, BufferedEventStream } from "../../../../src/cloud/buffered-event-stream"
-import { getLogger } from "../../../../src/logger/logger"
+import { getRootLogger } from "../../../../src/logger/logger"
 import { Garden } from "../../../../src/garden"
 import { makeTestGardenA } from "../../../helpers"
 import { find, isMatch, range, repeat } from "lodash"
@@ -35,7 +35,7 @@ describe("BufferedEventStream", () => {
     const flushedEvents: StreamEvent[] = []
     const flushedLogEntries: LogEntryEventPayload[] = []
 
-    const log = getLogger().createLog()
+    const log = getRootLogger().createLog()
 
     const bufferedEventStream = new BufferedEventStream({ log, sessionId: "dummy-session-id" })
 
@@ -64,7 +64,7 @@ describe("BufferedEventStream", () => {
     const flushedEvents: StreamEvent[] = []
     const flushedLogEntries: LogEntryEventPayload[] = []
 
-    const log = getLogger().createLog()
+    const log = getRootLogger().createLog()
 
     const bufferedEventStream = new BufferedEventStream({ log, sessionId: "dummy-session-id" })
 
@@ -101,7 +101,7 @@ describe("BufferedEventStream", () => {
     const maxBatchBytes = 3 * 1024 // Set this to a low value (3 Kb) to keep the memory use of the test suite low.
     it("should pick records until the batch size reaches MAX_BATCH_BYTES", async () => {
       const recordSizeKb = 0.5
-      const log = getLogger().createLog()
+      const log = getRootLogger().createLog()
       const bufferedEventStream = new BufferedEventStream({ log, sessionId: "dummy-session-id" })
       bufferedEventStream["maxBatchBytes"] = maxBatchBytes
       // Total size is ~3MB, which exceeds MAX_BATCH_BYTES
@@ -115,7 +115,7 @@ describe("BufferedEventStream", () => {
 
     it("should drop individual records whose payload size exceeds MAX_BATCH_BYTES", async () => {
       const recordSizeKb = 0.5
-      const log = getLogger().createLog()
+      const log = getRootLogger().createLog()
       const bufferedEventStream = new BufferedEventStream({ log, sessionId: "dummy-session-id" })
       bufferedEventStream["maxBatchBytes"] = maxBatchBytes
       // This record's size, exceeds MAX_BATCH_BYTES, so it should be dropped by `makeBatch`.

--- a/core/test/unit/src/commands/custom.ts
+++ b/core/test/unit/src/commands/custom.ts
@@ -18,7 +18,7 @@ import { makeTestGardenA, withDefaultGlobalOpts } from "../../../helpers"
 describe("CustomCommandWrapper", () => {
   let garden: TestGarden
   let log: Log
-  const cli = new GardenCli({ initLogger: false })
+  const cli = new GardenCli()
 
   before(async () => {
     garden = await makeTestGardenA()

--- a/core/test/unit/src/commands/custom.ts
+++ b/core/test/unit/src/commands/custom.ts
@@ -18,7 +18,7 @@ import { makeTestGardenA, withDefaultGlobalOpts } from "../../../helpers"
 describe("CustomCommandWrapper", () => {
   let garden: TestGarden
   let log: Log
-  const cli = new GardenCli()
+  const cli = new GardenCli({ initLogger: false })
 
   before(async () => {
     garden = await makeTestGardenA()

--- a/core/test/unit/src/commands/deploy.ts
+++ b/core/test/unit/src/commands/deploy.ts
@@ -18,7 +18,7 @@ import {
   getAllProcessedTaskNames,
   getDataDir,
 } from "../../../helpers"
-import { getLogger } from "../../../../src/logger/logger"
+import { getRootLogger } from "../../../../src/logger/logger"
 import { ActionStatus } from "../../../../src/actions/types"
 
 // TODO-G2: rename test cases to match the new graph model semantics
@@ -165,7 +165,7 @@ describe("DeployCommand", () => {
       }
 
       expect(graphResult.name).to.exist
-      expect(graphResult.version).to.equal(getDeployVersion(graphResult.name))
+      expect(graphResult.inputVersion).to.equal(getDeployVersion(graphResult.name))
       expect(graphResult.aborted).to.be.false
       expect(graphResult.error).to.be.null
       expect(graphResult.result).to.exist
@@ -386,8 +386,8 @@ describe("DeployCommand", () => {
   describe("isPersistent", () => {
     it("should return persistent=true if --sync is set", async () => {
       const cmd = new DeployCommand()
-      const log = getLogger().createLog()
-      const persistent = cmd.isPersistent({
+      const log = getRootLogger().createLog()
+      const persistent = cmd.maybePersistent({
         log,
         headerLog: log,
         footerLog: log,
@@ -411,8 +411,8 @@ describe("DeployCommand", () => {
 
     it("should return persistent=true if --local-mode is set", async () => {
       const cmd = new DeployCommand()
-      const log = getLogger().createLog()
-      const persistent = cmd.isPersistent({
+      const log = getRootLogger().createLog()
+      const persistent = cmd.maybePersistent({
         log,
         headerLog: log,
         footerLog: log,
@@ -436,8 +436,8 @@ describe("DeployCommand", () => {
 
     it("should return persistent=true if --follow is set", async () => {
       const cmd = new DeployCommand()
-      const log = getLogger().createLog()
-      const persistent = cmd.isPersistent({
+      const log = getRootLogger().createLog()
+      const persistent = cmd.maybePersistent({
         log,
         headerLog: log,
         footerLog: log,

--- a/core/test/unit/src/commands/publish.ts
+++ b/core/test/unit/src/commands/publish.ts
@@ -10,7 +10,7 @@ import chalk from "chalk"
 import { it } from "mocha"
 import { expect } from "chai"
 import { PublishCommand } from "../../../../src/commands/publish"
-import { withDefaultGlobalOpts, makeTestGarden, getAllRunResults, getDataDir } from "../../../helpers"
+import { withDefaultGlobalOpts, makeTestGarden, getAllTaskResults, getDataDir } from "../../../helpers"
 import { taskResultOutputs } from "../../../helpers"
 import { cloneDeep } from "lodash"
 import { execBuildActionSchema } from "../../../../src/plugins/exec/config"
@@ -161,7 +161,7 @@ describe("PublishCommand", () => {
       }),
     })
 
-    const allResults = getAllRunResults(result?.graphResults!)
+    const allResults = getAllTaskResults(result?.graphResults!)
 
     expect(allResults["build.module-a"]?.processed).to.be.true
     expect(allResults["build.module-b"]?.processed).to.be.true

--- a/core/test/unit/src/commands/run-workflow.ts
+++ b/core/test/unit/src/commands/run-workflow.ts
@@ -83,7 +83,7 @@ describe("RunWorkflowCommand", () => {
   it("should add workflowStep metadata to log entries provided to steps", async () => {
     const _garden = await makeTestGardenA(undefined)
     // Ensure log entries are empty
-    _garden.log.root.entries = []
+    _garden.log.root["entries"] = []
     const _log = _garden.log
     const _defaultParams = {
       garden: _garden,
@@ -109,7 +109,7 @@ describe("RunWorkflowCommand", () => {
     await cmd.action({ ..._defaultParams, args: { workflow: "workflow-a" } })
     const entries = _garden.log.getAllLogEntries()
     const stepHeaderEntries = filterLogEntries(entries, /Running step/)
-    const stepBodyEntries = filterLogEntries(entries, /Starting processActions/)
+    const stepBodyEntries = filterLogEntries(entries, /Resolving actions/)
     const stepFooterEntries = filterLogEntries(entries, /Step.*completed/)
     const workflowCompletedEntry = filterLogEntries(entries, /Workflow.*completed/)[0]
 

--- a/core/test/unit/src/commands/set.ts
+++ b/core/test/unit/src/commands/set.ts
@@ -37,6 +37,23 @@ describe("SetDefaultEnvCommand", () => {
     expect(defaultEnv).to.equal("other")
   })
 
+  it("clears the specified environment if no args given", async () => {
+    await garden.localConfigStore.set("defaultEnv", "other")
+
+    await command.action({
+      garden,
+      log,
+      headerLog: log,
+      footerLog: log,
+      args: { env: undefined },
+      opts: withDefaultGlobalOpts({}),
+    })
+
+    const defaultEnv = await garden.localConfigStore.get("defaultEnv")
+
+    expect(defaultEnv).to.equal("")
+  })
+
   it("clears the specified environment if given an empty string", async () => {
     await garden.localConfigStore.set("defaultEnv", "other")
 

--- a/core/test/unit/src/commands/test.ts
+++ b/core/test/unit/src/commands/test.ts
@@ -147,6 +147,7 @@ describe("TestCommand", () => {
             completedAt: new Date(),
           },
           outputs: {},
+          version: "v-1234",
         },
       }
     })

--- a/core/test/unit/src/config/base.ts
+++ b/core/test/unit/src/config/base.ts
@@ -21,7 +21,7 @@ import { expectError, getDataDir, getDefaultProjectConfig } from "../../../helpe
 import { DEFAULT_API_VERSION } from "../../../../src/constants"
 import { defaultDotIgnoreFile } from "../../../../src/util/fs"
 import { safeDumpYaml } from "../../../../src/util/serialization"
-import { getLogger } from "../../../../src/logger/logger"
+import { getRootLogger } from "../../../../src/logger/logger"
 
 const projectPathA = getDataDir("test-project-a")
 const modulePathA = resolve(projectPathA, "module-a")
@@ -30,7 +30,7 @@ const projectPathMultipleModules = getDataDir("test-projects", "multiple-module-
 const modulePathAMultiple = resolve(projectPathMultipleModules, "module-a")
 
 const projectPathDuplicateProjects = getDataDir("test-project-duplicate-project-config")
-const log = getLogger().createLog()
+const log = getRootLogger().createLog()
 
 // TODO: remove this describe block in 0.14
 describe("prepareProjectResource", () => {

--- a/core/test/unit/src/config/project.ts
+++ b/core/test/unit/src/config/project.ts
@@ -45,7 +45,7 @@ describe("resolveProjectConfig", () => {
 
     expect(
       resolveProjectConfig({
-        defaultName: "default",
+        defaultEnvironmentName: "default",
         config,
         artifactsPath: "/tmp",
         vcsInfo,
@@ -105,7 +105,7 @@ describe("resolveProjectConfig", () => {
 
     expect(
       resolveProjectConfig({
-        defaultName: defaultEnvironment,
+        defaultEnvironmentName: defaultEnvironment,
         config,
         artifactsPath: "/tmp",
         vcsInfo,
@@ -178,7 +178,7 @@ describe("resolveProjectConfig", () => {
 
     expect(
       resolveProjectConfig({
-        defaultName: defaultEnvironment,
+        defaultEnvironmentName: defaultEnvironment,
         config,
         artifactsPath: "/tmp",
         vcsInfo,
@@ -238,7 +238,7 @@ describe("resolveProjectConfig", () => {
     })
 
     const result = resolveProjectConfig({
-      defaultName: defaultEnvironment,
+      defaultEnvironmentName: defaultEnvironment,
       config,
       artifactsPath: "/tmp",
       vcsInfo,
@@ -270,7 +270,7 @@ describe("resolveProjectConfig", () => {
 
     expect(
       resolveProjectConfig({
-        defaultName: defaultEnvironment,
+        defaultEnvironmentName: defaultEnvironment,
         config,
         artifactsPath: "/tmp",
         vcsInfo,
@@ -305,11 +305,11 @@ describe("resolveProjectConfig", () => {
   })
 
   it("should set defaultEnvironment to first environment if not configured", async () => {
-    const defaultName = ""
+    const defaultEnvironmentName = ""
     const config: ProjectConfig = createProjectConfig({
       name: "my-project",
       path: "/tmp/foo",
-      defaultEnvironment: defaultName,
+      defaultEnvironment: defaultEnvironmentName,
       environments: [{ defaultNamespace: null, name: "first-env", variables: {} }],
       outputs: [],
       providers: [{ name: "some-provider", dependencies: [] }],
@@ -318,7 +318,7 @@ describe("resolveProjectConfig", () => {
 
     expect(
       resolveProjectConfig({
-        defaultName,
+        defaultEnvironmentName,
         config,
         artifactsPath: "/tmp",
         vcsInfo,
@@ -339,11 +339,11 @@ describe("resolveProjectConfig", () => {
   })
 
   it("should populate default values in the schema", async () => {
-    const defaultName = ""
+    const defaultEnvironmentName = ""
     const config: ProjectConfig = createProjectConfig({
       name: "my-project",
       path: "/tmp/foo",
-      defaultEnvironment: defaultName,
+      defaultEnvironment: defaultEnvironmentName,
       environments: [{ defaultNamespace: null, name: "default", variables: {} }],
       outputs: [],
       providers: [{ name: "some-provider", dependencies: [] }],
@@ -352,7 +352,7 @@ describe("resolveProjectConfig", () => {
 
     expect(
       resolveProjectConfig({
-        defaultName,
+        defaultEnvironmentName,
         config,
         artifactsPath: "/tmp",
         vcsInfo,
@@ -403,7 +403,7 @@ describe("resolveProjectConfig", () => {
 
     expect(
       resolveProjectConfig({
-        defaultName: defaultEnvironment,
+        defaultEnvironmentName: defaultEnvironment,
         config,
         artifactsPath: "/tmp",
         vcsInfo,
@@ -1259,13 +1259,13 @@ describe("parseEnvironment", () => {
   })
 
   it("should throw if string contains more than two segments", () => {
-    expectError(() => parseEnvironment("a.b.c"), {
+    void expectError(() => parseEnvironment("a.b.c"), {
       contains: "Invalid environment specified (a.b.c): may only contain a single delimiter",
     })
   })
 
   it("should throw if string is not a valid hostname", () => {
-    expectError(() => parseEnvironment("&.$"), {
+    void expectError(() => parseEnvironment("&.$"), {
       contains: "Invalid environment specified (&.$): must be a valid environment name or <namespace>.<environment>",
     })
   })

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -4706,7 +4706,7 @@ describe("Garden", () => {
         await garden.emitWarning({ key, log, message })
         const logs = getLogMessages(log)
         expect(logs.length).to.equal(1)
-        expect(logs[0]).to.equal(message + `\nRun garden util hide-warning ${key} to disable this warning.`)
+        expect(logs[0]).to.equal(message + `\n→ Run garden util hide-warning ${key} to disable this warning.`)
       })
 
       it("should not log a warning if the key has been hidden", async () => {

--- a/core/test/unit/src/graph/solver.ts
+++ b/core/test/unit/src/graph/solver.ts
@@ -148,7 +148,7 @@ describe("GraphSolver", () => {
     expect(result!.name).to.equal("task-a")
     expect(result!.startedAt).to.eql(now)
     expect(result!.completedAt).to.eql(now)
-    expect(result!.version).to.equal(task.getInputVersion())
+    expect(result!.inputVersion).to.equal(task.getInputVersion())
     expect(result!.result?.state).to.equal("ready")
     expect(result!.outputs["processed"]).to.equal(true)
   })

--- a/core/test/unit/src/logger/log-entry.ts
+++ b/core/test/unit/src/logger/log-entry.ts
@@ -8,13 +8,13 @@
 
 import { expect } from "chai"
 
-import { getLogger, LogLevel, Logger } from "../../../../src/logger/logger"
+import { getRootLogger, LogLevel, Logger } from "../../../../src/logger/logger"
 import { freezeTime } from "../../../helpers"
 import { createActionLog, Log, LogMetadata } from "../../../../src/logger/log-entry"
-import { omit, pick } from "lodash"
+import { omit } from "lodash"
 import chalk from "chalk"
 
-const logger: Logger = getLogger()
+const logger: Logger = getRootLogger()
 
 beforeEach(() => {
   logger["entries"] = []
@@ -140,6 +140,7 @@ describe("CoreLog", () => {
         entries: [],
         key: testLog.key,
         metadata: undefined,
+        origin: undefined,
         fixLevel: undefined,
         section: undefined,
         showDuration: false,
@@ -167,6 +168,7 @@ describe("CoreLog", () => {
         entries: [],
         key: testLogChild.key,
         metadata: undefined,
+        origin: undefined,
         fixLevel: undefined,
         section: undefined,
         showDuration: false,
@@ -188,6 +190,7 @@ describe("CoreLog", () => {
         entries: [],
         key: testLogChildWithOverwrites.key,
         metadata: { workflowStep: { index: 2 } },
+        origin: undefined,
         fixLevel: LogLevel.warn,
         section: undefined,
         showDuration: false,
@@ -209,7 +212,7 @@ describe("CoreLog", () => {
   describe("createLogEntry", () => {
     it("should pass its config on to the log entry", () => {
       const timestamp = freezeTime().toISOString()
-      const testLog = log.createLog({ name: "test-log", metadata: { workflowStep: { index: 2 } } })
+      const testLog = log.createLog({ name: "test-log", origin: "foo", metadata: { workflowStep: { index: 2 } } })
       const entry = testLog.info("hello").getLatestEntry()
 
       expect(entry.key).to.be.a.string
@@ -222,6 +225,7 @@ describe("CoreLog", () => {
           },
         },
         msg: "hello",
+        origin: "foo",
         parentLogKey: testLog.key,
         section: undefined,
         timestamp,
@@ -252,6 +256,7 @@ describe("ActionLog", () => {
         entries: [],
         key: testLog.key,
         metadata: undefined,
+        origin: undefined,
         fixLevel: undefined,
         section: undefined,
         showDuration: true, // <--- Always true for ActionLog
@@ -280,6 +285,7 @@ describe("ActionLog", () => {
         entries: [],
         key: testLogChild.key,
         metadata: undefined,
+        origin: undefined,
         fixLevel: undefined,
         section: undefined,
         showDuration: true,
@@ -311,6 +317,7 @@ describe("ActionLog", () => {
         log,
         actionKind: "build",
         actionName: "api",
+        origin: "foo",
         metadata: { workflowStep: { index: 2 } },
       })
       const entry = testLog.info("hello").getLatestEntry()
@@ -325,6 +332,7 @@ describe("ActionLog", () => {
           },
         },
         msg: "hello",
+        origin: "foo",
         parentLogKey: testLog.key,
         section: undefined,
         timestamp,

--- a/core/test/unit/src/logger/logger.ts
+++ b/core/test/unit/src/logger/logger.ts
@@ -7,13 +7,13 @@
  */
 
 import { expect } from "chai"
-import { getLogger, Logger, LogLevel } from "../../../../src/logger/logger"
+import { getRootLogger, Logger, LogLevel, RootLogger } from "../../../../src/logger/logger"
 import { LogEntryEventPayload } from "../../../../src/cloud/buffered-event-stream"
 import { freezeTime } from "../../../helpers"
 import { QuietWriter } from "../../../../src/logger/writers/quiet-writer"
 import chalk from "chalk"
 
-const logger: Logger = getLogger()
+const logger: Logger = getRootLogger()
 
 describe("Logger", () => {
   beforeEach(() => {
@@ -79,15 +79,16 @@ describe("Logger", () => {
       log.debug("debug")
       log.silly("silly")
 
-      expect(logger.entries).to.have.lengthOf(6)
-      const messages = logger.entries.map((e) => e.msg)
+      const entries = logger.getLogEntries()
+      expect(entries).to.have.lengthOf(6)
+      const messages = entries.map((e) => e.msg)
       expect(messages).to.eql([chalk.red("error"), "warn", "info", "verbose", "debug", "silly"])
     })
     it("should not store entries if storeEntries=false", () => {
-      const logWriterB = Logger._createInstanceForTests({
+      const logWriterB = RootLogger._createInstanceForTests({
         level: LogLevel.info,
         writers: {
-          terminal: new QuietWriter({ level: LogLevel.info }),
+          display: new QuietWriter({ level: LogLevel.info }),
           file: [],
         },
         storeEntries: false,
@@ -100,7 +101,7 @@ describe("Logger", () => {
       log.debug("debug")
       log.silly("silly")
 
-      expect(logger.entries).to.eql([])
+      expect(logger.getLogEntries()).to.eql([])
     })
   })
   describe("getLogEntries", () => {

--- a/core/test/unit/src/logger/renderers.ts
+++ b/core/test/unit/src/logger/renderers.ts
@@ -8,7 +8,7 @@
 
 import { expect } from "chai"
 
-import { getLogger, Logger } from "../../../../src/logger/logger"
+import { getRootLogger, Logger } from "../../../../src/logger/logger"
 import {
   renderMsg,
   msgStyle,
@@ -30,7 +30,7 @@ import { highlightYaml, safeDumpYaml } from "../../../../src/util/serialization"
 import { freezeTime } from "../../../helpers"
 import chalk = require("chalk")
 
-const logger: Logger = getLogger()
+const logger: Logger = getRootLogger()
 
 beforeEach(() => {
   logger["entries"] = []

--- a/core/test/unit/src/logger/writers/file-writer.ts
+++ b/core/test/unit/src/logger/writers/file-writer.ts
@@ -10,11 +10,11 @@ import { expect } from "chai"
 import chalk from "chalk"
 import stripAnsi from "strip-ansi"
 
-import { getLogger, Logger, LogLevel } from "../../../../../src/logger/logger"
+import { getRootLogger, Logger, LogLevel } from "../../../../../src/logger/logger"
 import { renderError } from "../../../../../src/logger/renderers"
 import { render } from "../../../../../src/logger/writers/file-writer"
 
-const logger: Logger = getLogger()
+const logger: Logger = getRootLogger()
 
 beforeEach(() => {
   logger["entries"] = []

--- a/core/test/unit/src/logger/writers/json-terminal-writer.ts
+++ b/core/test/unit/src/logger/writers/json-terminal-writer.ts
@@ -9,10 +9,10 @@
 import { expect } from "chai"
 
 import { JsonTerminalWriter } from "../../../../../src/logger/writers/json-terminal-writer"
-import { getLogger, Logger } from "../../../../../src/logger/logger"
+import { getRootLogger, Logger } from "../../../../../src/logger/logger"
 import { freezeTime } from "../../../../helpers"
 
-const logger: Logger = getLogger()
+const logger: Logger = getRootLogger()
 
 beforeEach(() => {
   logger["entries"] = []

--- a/core/test/unit/src/logger/writers/terminal-writer.ts
+++ b/core/test/unit/src/logger/writers/terminal-writer.ts
@@ -9,10 +9,10 @@
 import { expect } from "chai"
 
 import { TerminalWriter } from "../../../../../src/logger/writers/terminal-writer"
-import { getLogger, Logger } from "../../../../../src/logger/logger"
+import { getRootLogger, Logger } from "../../../../../src/logger/logger"
 import { formatForTerminal } from "../../../../../src/logger/renderers"
 
-const logger: Logger = getLogger()
+const logger: Logger = getRootLogger()
 
 beforeEach(() => {
   logger["entries"] = []

--- a/core/test/unit/src/plugins.ts
+++ b/core/test/unit/src/plugins.ts
@@ -8,7 +8,7 @@
 
 import { expect } from "chai"
 import { joi } from "../../../src/config/common"
-import { getLogger } from "../../../src/logger/logger"
+import { getRootLogger } from "../../../src/logger/logger"
 import { BuildActionDefinition } from "../../../src/plugin/action-types"
 import { createGardenPlugin, PluginBuildActionParamsBase } from "../../../src/plugin/plugin"
 import { resolvePlugins } from "../../../src/plugins"
@@ -16,7 +16,7 @@ import { findByName } from "../../../src/util/util"
 import { expectError } from "../../helpers"
 
 describe("resolvePlugins", () => {
-  const log = getLogger().createLog()
+  const log = getRootLogger().createLog()
 
   const testHandler = (params: PluginBuildActionParamsBase<any>) => {
     return {

--- a/core/test/unit/src/plugins/exec/exec.ts
+++ b/core/test/unit/src/plugins/exec/exec.ts
@@ -812,7 +812,6 @@ describe("exec plugin", () => {
           expect(actionRes.state).to.equal("unknown")
           const detail = actionRes.detail!
           expect(detail.state).to.equal("unknown")
-          expect(detail.version).to.equal(action.versionString())
           expect(detail.detail).to.be.empty
         })
 
@@ -837,7 +836,6 @@ describe("exec plugin", () => {
           expect(actionRes.state).to.equal("ready")
           const detail = actionRes.detail!
           expect(detail.state).to.equal("ready")
-          expect(detail.version).to.equal(action.versionString())
           expect(detail.detail.statusCommandOutput).to.equal("already deployed")
         })
 
@@ -857,7 +855,6 @@ describe("exec plugin", () => {
           const detail = actionRes.detail!
           // The deploy state is different (has more states) than the action state
           expect(detail.state).to.equal("outdated")
-          expect(detail.version).to.equal(action.versionString())
           expect(detail.detail.statusCommandOutput).to.be.empty
         })
       })

--- a/core/test/unit/src/tasks/resolve-action.ts
+++ b/core/test/unit/src/tasks/resolve-action.ts
@@ -19,7 +19,7 @@ import {
   makeTestGarden,
   getDataDir,
   expectError,
-  getAllRunResults,
+  getAllTaskResults,
   getDefaultProjectConfig,
 } from "../../../helpers"
 
@@ -266,7 +266,7 @@ describe("ResolveActionTask", () => {
       const task = await getTask("Deploy", "foo")
       const result = await garden.processTask(task, log, { throwOnError: true })
 
-      const all = getAllRunResults(result?.dependencyResults!)
+      const all = getAllTaskResults(result?.dependencyResults!)
 
       const resolvedBuild = all["resolve-action.build.foo"]!.outputs.resolvedAction
       const buildVersion = resolvedBuild.versionString()

--- a/core/test/unit/src/util/artifacts.ts
+++ b/core/test/unit/src/util/artifacts.ts
@@ -12,7 +12,7 @@ import { realpath, writeFile } from "fs-extra"
 import normalizePath from "normalize-path"
 import { join } from "path"
 import { getArtifactFileList, getArtifactKey } from "../../../../src/util/artifacts"
-import { getLogger } from "../../../../src/logger/logger"
+import { getRootLogger } from "../../../../src/logger/logger"
 
 describe("artifacts", () => {
   describe("getArtifactKey", () => {
@@ -25,7 +25,7 @@ describe("artifacts", () => {
   describe("getArtifactFileList", () => {
     let tmpDir: tmp.DirectoryResult
     let artifactsPath: string
-    const log = getLogger().createLog()
+    const log = getRootLogger().createLog()
 
     beforeEach(async () => {
       tmpDir = await tmp.dir({ unsafeCleanup: true })

--- a/core/test/unit/src/util/logging.ts
+++ b/core/test/unit/src/util/logging.ts
@@ -10,12 +10,12 @@ import { expect } from "chai"
 import { makeDummyGarden } from "../../../../src/cli/cli"
 import { joi } from "../../../../src/config/common"
 import type { Log } from "../../../../src/logger/log-entry"
-import { getLogger, Logger } from "../../../../src/logger/logger"
+import { getRootLogger, Logger } from "../../../../src/logger/logger"
 import { sanitizeValue } from "../../../../src/util/logging"
 import { projectRootA } from "../../../helpers"
 
 describe("sanitizeValue", () => {
-  const logger: Logger = getLogger()
+  const logger: Logger = getRootLogger()
 
   it("replaces Buffer instances", () => {
     const obj = {

--- a/core/test/unit/src/util/recoverable-process.ts
+++ b/core/test/unit/src/util/recoverable-process.ts
@@ -13,9 +13,10 @@ import {
   RecoverableProcessState,
   validateRetryConfig,
 } from "../../../../src/util/recoverable-process"
-import { getLogger } from "../../../../src/logger/logger"
+import { getRootLogger } from "../../../../src/logger/logger"
 import { sleep } from "../../../../src/util/util"
-import { initTestLogger } from "../../../helpers"
+import { initTestLogger, makeTempGarden, TestGarden } from "../../../helpers"
+import { PluginEventBroker } from "../../../../src/plugin-context"
 
 describe("validateRetryConfig", () => {
   it("must fail on negative minTimeoutMs", () => {
@@ -75,13 +76,21 @@ describe("validateRetryConfig", () => {
 
 describe("RecoverableProcess", async () => {
   initTestLogger()
-  const log = getLogger().createLog()
+  const log = getRootLogger().createLog()
 
   const doNothingForeverOsCommand = { command: "tail -f /dev/null" }
   const badOsCommand = { command: "bad_os_command_which_does_not_exists_and_must_fail_the_process" }
 
   const longTimeMs = 10000000
   const longSleepOsCommand = { command: `sleep ${longTimeMs}` }
+
+  let garden: TestGarden
+  let events: PluginEventBroker
+
+  before(async () => {
+    garden = (await makeTempGarden()).garden
+    events = new PluginEventBroker(garden)
+  })
 
   /**
    * FIXME: some tests are skipped because child-processes are not getting killed in CircleCI pipeline for some reason.
@@ -100,6 +109,7 @@ describe("RecoverableProcess", async () => {
 
   function infiniteProcess(maxRetries: number, minTimeoutMs: number): RecoverableProcess {
     return new RecoverableProcess({
+      events,
       osCommand: doNothingForeverOsCommand,
       retryConfig: {
         maxRetries,
@@ -111,6 +121,7 @@ describe("RecoverableProcess", async () => {
 
   function failingProcess(maxRetries: number, minTimeoutMs: number): RecoverableProcess {
     return new RecoverableProcess({
+      events,
       osCommand: badOsCommand,
       retryConfig: {
         maxRetries,
@@ -122,6 +133,7 @@ describe("RecoverableProcess", async () => {
 
   function longSleepingProcess(maxRetries: number, minTimeoutMs: number): RecoverableProcess {
     return new RecoverableProcess({
+      events,
       osCommand: longSleepOsCommand,
       retryConfig: {
         maxRetries,
@@ -194,6 +206,7 @@ describe("RecoverableProcess", async () => {
 
   it("new instance has state 'runnable'", () => {
     const p = new RecoverableProcess({
+      events,
       osCommand: { command: "pwd" },
       retryConfig: { maxRetries: 1, minTimeoutMs: 1000 },
       log,

--- a/core/test/unit/src/util/util.ts
+++ b/core/test/unit/src/util/util.ts
@@ -15,14 +15,13 @@ import {
   exec,
   createOutputStream,
   makeErrorMsg,
-  renderOutputStream,
   spawn,
   relationshipClasses,
   isValidDateInstance,
 } from "../../../../src/util/util"
 import { expectError } from "../../../helpers"
 import { splitLast, splitFirst } from "../../../../src/util/string"
-import { getLogger } from "../../../../src/logger/logger"
+import { getRootLogger } from "../../../../src/logger/logger"
 import { dedent } from "../../../../src/util/string"
 import { safeDumpYaml } from "../../../../src/util/serialization"
 
@@ -121,25 +120,25 @@ describe("util", () => {
     })
 
     it("should optionally pipe stdout to an output stream", async () => {
-      const logger = getLogger()
+      const logger = getRootLogger()
       const log = logger.createLog()
 
       await exec("echo", ["hello"], { stdout: createOutputStream(log) })
 
-      expect(log.getLatestEntry().msg).to.equal(renderOutputStream("hello"))
+      expect(log.getLatestEntry().msg).to.equal("hello")
     })
 
     it("should optionally pipe stderr to an output stream", async () => {
-      const logger = getLogger()
+      const logger = getRootLogger()
       const log = logger.createLog()
 
       await exec("sh", ["-c", "echo hello 1>&2"], { stderr: createOutputStream(log) })
 
-      expect(log.getLatestEntry().msg).to.equal(renderOutputStream("hello"))
+      expect(log.getLatestEntry().msg).to.equal("hello")
     })
 
     it("should buffer outputs when piping to stream", async () => {
-      const logger = getLogger()
+      const logger = getRootLogger()
       const log = logger.createLog()
 
       const res = await exec("echo", ["hello"], { stdout: createOutputStream(log) })

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -488,12 +488,20 @@ Examples:
 | -------- | ----- | ---- | ----------- |
   | `--force` |  | boolean | Force re-deploy.
   | `--force-build` |  | boolean | Force re-build of build dependencies.
-  | `--sync` |  | array:string | The name(s) of the deploys to deploy with sync enabled. You may specify multiple names by setting this flag multiple times. Use * to deploy all supported deployments with sync enabled.
-  | `--local-mode` |  | array:string | [EXPERIMENTAL] The name(s) of the deploy(s) to be started locally with local mode enabled. You may specify multiple deploys by setting this flag multiple times. Use * to deploy all deploys with local mode enabled. When this option is used, the command is run in persistent mode.
-This always takes the precedence over sync mode if there are any conflicts, i.e. if the same deploys are passed to both &#x60;--sync&#x60; and &#x60;--local&#x60; options.
+  | `--sync` |  | array:string | The name(s) of the deploys to deploy with sync enabled.
+You may specify multiple names by setting this flag multiple times.
+Use * to deploy all supported deployments with sync enabled.
+
+Important: The syncs stay active after the command exits. To stop the syncs, use the &#x60;sync stop&#x60; command.
+  | `--local-mode` |  | array:string | [EXPERIMENTAL] The name(s) of deploy(s) to be started locally with local mode enabled.
+
+You may specify multiple deploys by setting this flag multiple times. Use * to deploy all deploys with local mode enabled. When this option is used,
+the command stays running until explicitly aborted.
+
+This always takes the precedence over sync mode if there are any conflicts, i.e. if the same deploys are matched with both &#x60;--sync&#x60; and &#x60;--local&#x60; options.
   | `--skip` |  | array:string | The name(s) of deploys you&#x27;d like to skip.
   | `--skip-dependencies` |  | boolean | Deploy the specified actions, but don&#x27;t build, deploy or run any dependencies. This option can only be used when a list of Deploy names is passed as CLI arguments. This can be useful e.g. when your stack has already been deployed, and you want to run specific deploys in sync mode without building, deploying or running dependencies that may have changed since you last deployed.
-  | `--forward` |  | boolean | Create port forwards and leave process running without watching for changes. This is unnecessary and ignored if any of --sync or --local/--local-mode are set.
+  | `--forward` |  | boolean | Create port forwards and leave process running after deploying. This is implied if any of --sync or --local/--local-mode are set.
 
 #### Outputs
 
@@ -3386,7 +3394,7 @@ Examples:
 | -------- | ----- | ---- | ----------- |
   | `--deploy` |  | boolean | Deploy the specified actions, if they&#x27;re out of date and/or not deployed in sync mode.
   | `--with-dependencies` |  | boolean | When deploying actions, also include any runtime dependencies. Ignored if --deploy is not set.
-  | `--follow` |  | boolean | Keep the process running and print sync status logs after starting them.
+  | `--monitor` |  | boolean | Keep the process running and print sync status logs after starting them.
 
 
 ### garden sync stop

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -3336,17 +3336,17 @@ Examples:
 
   garden set default-env remote       # Set the default env to remote (with the configured default namespace)
   garden set default-env dev.my-env   # Set the default env to dev.my-env
-  garden set default-env ''           # Clear any previously set override
+  garden set default-env              # Clear any previously set override
 
 #### Usage
 
-    garden set default-env <env> 
+    garden set default-env [env] 
 
 #### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
-  | `env` | Yes | The default environment to set for the current project
+  | `env` | No | The default environment to set for the current project
 
 
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -480,7 +480,7 @@ Examples:
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
-  | `names` | No | The name(s) of the deploy(s) (or deploys if using modules) to deploy (skip to deploy everything). You may specify multiple names, separated by spaces.
+  | `names` | No | The name(s) of the deploy(s) (or services if using modules) to deploy (skip to deploy everything). You may specify multiple names, separated by spaces.
 
 #### Options
 

--- a/docs/reference/project-config.md
+++ b/docs/reference/project-config.md
@@ -391,9 +391,9 @@ providers:
 
 The default environment to use when calling commands without the `--env` parameter. May include a namespace name, in the format `<namespace>.<environment>`. Defaults to the first configured environment, with no namespace set.
 
-| Type     | Default | Required |
-| -------- | ------- | -------- |
-| `string` | `""`    | No       |
+| Type          | Default | Required |
+| ------------- | ------- | -------- |
+| `environment` | `""`    | No       |
 
 Example:
 

--- a/examples/local-mode/backend-1/garden.yml
+++ b/examples/local-mode/backend-1/garden.yml
@@ -10,6 +10,7 @@ name: backend-1
 description: Backend 1 service container
 type: container
 
+#build: '${this.mode == "local" ? "backend-1-local" : "backend-1"}'
 build: backend-1
 
 # You can specify variables here at the module level

--- a/examples/local-mode/backend-local-1/garden.yml
+++ b/examples/local-mode/backend-local-1/garden.yml
@@ -1,0 +1,7 @@
+kind: Build
+name: backend-1-local
+description: Backend 1 local build
+type: exec
+buildAtSource: true
+spec:
+  command: [sh, -c "go build -o main && chmod +x main"]

--- a/plugins/jib/index.ts
+++ b/plugins/jib/index.ts
@@ -23,7 +23,6 @@ import {
   containerModuleSpecSchema,
 } from "@garden-io/core/build/src/plugins/container/moduleConfig"
 import { joi } from "@garden-io/core/build/src/config/common"
-import { renderOutputStream } from "@garden-io/core/build/src/util/util"
 import { baseBuildSpecSchema } from "@garden-io/core/build/src/config/module"
 import { ConfigureModuleParams } from "@garden-io/core/build/src/plugin/handlers/Module/configure"
 import { containerHelpers } from "@garden-io/core/build/src/plugins/container/helpers"
@@ -186,20 +185,24 @@ export const gardenPlugin = () =>
 
               if (!projectType) {
                 projectType = detectProjectType(action)
-                statusLine.info(renderOutputStream(`Detected project type ${projectType}`))
+                statusLine.info(`Detected project type ${projectType}`)
               }
 
               let buildLog = ""
 
               const logEventContext: PluginEventLogContext = {
+                level: "verbose",
                 origin: ["maven", "mavend", "gradle"].includes(projectType) ? projectType : "gradle",
-                log: log.createLog({ fixLevel: LogLevel.verbose }),
               }
 
               const outputStream = split2()
               outputStream.on("error", () => {})
               outputStream.on("data", (data: Buffer) => {
-                ctx.events.emit("log", { timestamp: new Date().toISOString(), data, ...logEventContext })
+                ctx.events.emit("log", {
+                  timestamp: new Date().toISOString(),
+                  msg: data.toString(),
+                  ...logEventContext,
+                })
                 buildLog += data.toString()
               })
 

--- a/sdk/testing.ts
+++ b/sdk/testing.ts
@@ -8,7 +8,7 @@
 
 import { TestGarden, TestGardenOpts } from "@garden-io/core/build/src/util/testing"
 import { uuidv4 } from "@garden-io/core/build/src/util/random"
-import { Logger, LogLevel } from "@garden-io/core/build/src/logger/logger"
+import { LogLevel, RootLogger } from "@garden-io/core/build/src/logger/logger"
 
 export { TestGarden, getLogMessages } from "@garden-io/core/build/src/util/testing"
 export { expectError } from "@garden-io/core/build/src/util/testing"
@@ -17,9 +17,9 @@ export { makeTempDir } from "@garden-io/core/build/src/util/fs"
 export const makeTestGarden = async (projectRoot: string, opts: TestGardenOpts = {}): Promise<TestGarden> => {
   // Make sure Logger is initialized
   try {
-    Logger.initialize({
+    RootLogger.initialize({
       level: LogLevel.info,
-      terminalWriterType: "quiet",
+      displayWriterType: "quiet",
       storeEntries: true,
     })
   } catch (_) {}


### PR DESCRIPTION
This needed a major refactor, but ultimately results in a nice structure that
we can build rapidly on and add various commands and monitoring features.

The way this is implemented is via a new concept called a `Monitor`. For
example, `SyncMonitor` and `LogsMonitor`. So when you run 
`garden logs --follow`, a `LogsMonitor` instance is created and attached for
each Deploy action.

Any number of these can be added to the Garden instance via the `MonitorManager` 
instance on `garden.monitors`. When those are found to be active at the end of a 
Command execution, the process will wait until the monitors exit.

In the dev command, a single Garden instance is shared across many command runs,
so the monitors are persisted. There's also a new `hide` command (only in the
dev command) to halt any started monitors.

cc @thsig 
