### PR TITLE
chore: garden serve: require login

### DIFF
--- a/core/src/analytics/analytics.ts
+++ b/core/src/analytics/analytics.ts
@@ -268,7 +268,7 @@ export class AnalyticsHandler {
     this.isEnabled = isEnabled
     this.garden = garden
     this.sessionId = garden.sessionId
-    this.isLoggedIn = !!garden.cloudApi
+    this.isLoggedIn = garden.isLoggedIn()
     // Events that are queued or flushed but the network response hasn't returned
     this.pendingEvents = new Map()
 

--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -364,7 +364,7 @@ ${renderCommands(commands)}
 
           nsLog.info({
             section: "garden",
-            msg: `Running in Running in environment ${chalk.cyan(`${garden.environmentName}.${garden.namespace}`)}`,
+            msg: `Running in environment ${chalk.cyan(`${garden.environmentName}.${garden.namespace}`)}`,
           })
 
           if (!cloudApi && garden.projectId) {

--- a/core/src/commands/serve.ts
+++ b/core/src/commands/serve.ts
@@ -20,6 +20,7 @@ import { Log } from "../logger/log-entry"
 import { CommandLine } from "../cli/command-line"
 import { Autocompleter, AutocompleteSuggestion } from "../cli/autocomplete"
 import chalk from "chalk"
+import { RuntimeError } from "../exceptions"
 
 export const defaultServerPort = 9700
 
@@ -97,6 +98,16 @@ export class ServeCommand<
 
   async action({ garden, log }: CommandParams<A, O>): Promise<CommandResult<R>> {
     this.garden = garden
+    const loggedIn = this.garden?.isLoggedIn()
+    if (!loggedIn) {
+      log.warn(
+        chalk.yellow(
+          "The local dashboard has been removed. To use the new Garden Cloud Dashboard, please log in first."
+        )
+      )
+      throw new RuntimeError("You are not logged in. Please run `garden login` before running `garden serve`.", {})
+    }
+
     this.autocompleter = new Autocompleter({ log, commands: [], configDump: undefined })
 
     return new Promise((resolve, reject) => {

--- a/core/src/config/config-template.ts
+++ b/core/src/config/config-template.ts
@@ -59,7 +59,7 @@ export async function resolveConfigTemplate(
     modules: [],
     configs: [],
   }
-  const loggedIn = !!garden.cloudApi
+  const loggedIn = garden.isLoggedIn()
   const enterpriseDomain = garden.cloudApi?.domain
   const context = new ProjectConfigContext({ ...garden, loggedIn, enterpriseDomain })
   const resolved = resolveTemplateStrings(partial, context)

--- a/core/src/config/render-template.ts
+++ b/core/src/config/render-template.ts
@@ -117,7 +117,7 @@ export async function renderConfigTemplate({
   // Resolve template strings for fields. Note that inputs are partially resolved, and will be fully resolved later
   // when resolving the resolving the resulting modules. Inputs that are used in module names must however be resolvable
   // immediately.
-  const loggedIn = !!garden.cloudApi
+  const loggedIn = garden.isLoggedIn()
   const enterpriseDomain = garden.cloudApi?.domain
   const templateContext = new EnvironmentConfigContext({ ...garden, loggedIn, enterpriseDomain })
   const resolvedWithoutInputs = resolveTemplateStrings({ ...omit(config, "inputs") }, templateContext)
@@ -161,7 +161,7 @@ export async function renderConfigTemplate({
   // Prepare modules and resolve templated names
   const context = new RenderTemplateConfigContext({
     ...garden,
-    loggedIn: !!garden.cloudApi,
+    loggedIn: garden.isLoggedIn(),
     enterpriseDomain,
     parentName: resolved.name,
     templateName: template.name,

--- a/core/src/config/template-contexts/project.ts
+++ b/core/src/config/template-contexts/project.ts
@@ -402,7 +402,7 @@ export class RemoteSourceConfigContext extends EnvironmentConfigContext {
       artifactsPath: garden.artifactsPath,
       vcsInfo: garden.vcsInfo,
       username: garden.username,
-      loggedIn: !!garden.cloudApi,
+      loggedIn: garden.isLoggedIn(),
       enterpriseDomain: garden.cloudApi?.domain,
       secrets: garden.secrets,
       commandInfo: garden.commandInfo,

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -432,7 +432,7 @@ export class Garden {
   }
 
   getProjectConfigContext() {
-    const loggedIn = !!this.cloudApi
+    const loggedIn = this.isLoggedIn()
     const enterpriseDomain = this.cloudApi?.domain
     return new ProjectConfigContext({ ...this, loggedIn, enterpriseDomain })
   }
@@ -1500,6 +1500,11 @@ export class Garden {
       sources: this.projectSources,
     }
   }
+
+  /** Returns whether the user is logged in to the Garden Cloud */
+  public isLoggedIn(): boolean {
+    return !!this.cloudApi
+  }
 }
 
 export const resolveGardenParams = profileAsync(async function _resolveGardenParams(
@@ -1560,17 +1565,19 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
     log.debug(`Using environment ${localConfigDefaultEnv}, set with the \`set default-env\` command`)
   }
 
-  const defaultEnvironmentName = localConfigDefaultEnv || resolveTemplateString(
-    config.defaultEnvironment,
-    new DefaultEnvironmentContext({
-      projectName,
-      projectRoot,
-      artifactsPath,
-      vcsInfo,
-      username: _username,
-      commandInfo,
-    })
-  ) as string
+  const defaultEnvironmentName =
+    localConfigDefaultEnv ||
+    (resolveTemplateString(
+      config.defaultEnvironment,
+      new DefaultEnvironmentContext({
+        projectName,
+        projectRoot,
+        artifactsPath,
+        vcsInfo,
+        username: _username,
+        commandInfo,
+      })
+    ) as string)
 
   const defaultEnvironment = getDefaultEnvironmentName(defaultEnvironmentName, config)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

The local dashboard has been removed in `0.13`. If users run `garden serve` but are not logged in to the Garden Cloud, throw an error with a helpful message.

I've also added a tiny helper method `isLoggedIn()` to the Garden class, to remove the `!!cloudApi` use and make things slightly more readable.
