### PR TITLE
fix: set defaultEnv default value

### DIFF
--- a/core/src/config-store/local.ts
+++ b/core/src/config-store/local.ts
@@ -32,7 +32,7 @@ const localSchema = z.object({
   analytics: analyticsSchema,
 
   devCommandHistory: z.array(z.string()).default([]),
-  defaultEnv: z.string().describe("An environment override, set with the `set env` command."),
+  defaultEnv: z.string().default("").describe("An environment override, set with the `set env` command."),
 
   linkedModuleSources: z.record(linkedSourceSchema),
   linkedProjectSources: z.record(linkedSourceSchema),


### PR DESCRIPTION
Currently the `garden set default-env ''` command doesn't work due to garden thinking `""` is a non-existing parameter. I think we should implement a `garden clear` instead as that's a more clear api, no pun intended. I can do that if we agree that's the best way to go