### PR TITLE
improvement(api): return arguments seperately in autocomplete suggestion

### DIFF
--- a/core/src/cli/autocomplete.ts
+++ b/core/src/cli/autocomplete.ts
@@ -21,6 +21,7 @@ export interface AutocompleteSuggestion {
     name: string[]
     cliOnly: boolean
   }
+  stringArguments?: string[]
   priority: number
 }
 
@@ -241,6 +242,9 @@ export class Autocompleter {
           split[split.length - 1] = s
         }
 
+        // Separate the string arguments from the command
+        const stringArguments = split.filter((arg) => arg !== command.getPath().join(" "))
+
         return <AutocompleteSuggestion>{
           type: "argument",
           line: split.join(" "),
@@ -248,6 +252,7 @@ export class Autocompleter {
             name: command.getPath(),
             cliOnly: command.cliOnly,
           },
+          stringArguments,
           priority: 1000, // Rank these above option flags
         }
       })

--- a/core/test/unit/src/cli/autocomplete.ts
+++ b/core/test/unit/src/cli/autocomplete.ts
@@ -167,6 +167,15 @@ describe("Autocompleter", () => {
       expect(lines).to.include("build module-a")
     })
 
+    it("returns arguments separate from command when matched with positional argument", () => {
+      const results = ac.getSuggestions("build module-a mod")
+
+      for (const result of results) {
+        const [_, ...argumentsFromLine] = result.line.split(" ")
+        expect(result.stringArguments).to.eql(argumentsFromLine)
+      }
+    })
+
     it("returns more (unique) suggestions for variadic args after first arg", () => {
       const input = "build module-a "
       const result = ac.getSuggestions(input)


### PR DESCRIPTION
**What this PR does / why we need it**:
Expands on #4035 to return string arguments from argument based autocomplete suggestions in api
