### PR TITLE
refactor(k8s): don't set --atomic flag by default in helm Deploy actions

### DIFF
--- a/core/src/plugins/kubernetes/helm/config.ts
+++ b/core/src/plugins/kubernetes/helm/config.ts
@@ -47,7 +47,7 @@ interface HelmChartSpec {
 }
 
 interface HelmDeployActionSpec {
-  atomicInstall: boolean
+  atomic: boolean
   chart?: HelmChartSpec
   defaultTarget?: KubernetesTargetResourceSpec
   sync?: KubernetesDeploySyncSpec
@@ -98,12 +98,6 @@ const helmValueFilesSchema = () =>
   `)
 
 export const helmCommonSchemaKeys = () => ({
-  atomicInstall: joi
-    .boolean()
-    .default(true)
-    .description(
-      "Whether to set the --atomic flag during installs and upgrades. Set to false if e.g. you want to see more information about failures and then manually roll back, instead of having Helm do it automatically on failure."
-    ),
   namespace: namespaceNameSchema(),
   portForwards: portForwardsSchema(),
   releaseName: helmReleaseNameSchema(),
@@ -183,6 +177,12 @@ export const helmDeploySchema = () =>
     .object()
     .keys({
       ...helmCommonSchemaKeys(),
+      atomic: joi
+        .boolean()
+        .default(false)
+        .description(
+          "Whether to set the --atomic flag during installs and upgrades. Set to true if you'd like the changes applied to be reverted on failure."
+        ),
       chart: helmChartSpecSchema(),
       defaultTarget: defaultTargetSchema(),
       sync: kubernetesDeploySyncSchema(),

--- a/core/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/src/plugins/kubernetes/helm/deployment.ts
@@ -56,7 +56,7 @@ export const helmDeploy: DeployActionHandler<"deploy", HelmDeployAction> = async
     ...(await getValueArgs({ action, valuesPath: preparedTemplates.valuesPath })),
   ]
 
-  if (spec.atomicInstall) {
+  if (spec.atomic) {
     // Make sure chart gets purged if it fails to install
     commonArgs.push("--atomic")
   }

--- a/core/src/plugins/kubernetes/helm/handlers.ts
+++ b/core/src/plugins/kubernetes/helm/handlers.ts
@@ -209,7 +209,7 @@ function prepareDeployAction({
     dependencies: prepareRuntimeDependencies(module.spec.dependencies, dummyBuild),
 
     spec: {
-      atomicInstall: module.spec.atomicInstall,
+      atomic: module.spec.atomicInstall,
       portForwards: module.spec.portForwards,
       namespace: module.spec.namespace,
       releaseName: module.spec.releaseName,

--- a/core/src/plugins/kubernetes/helm/module-config.ts
+++ b/core/src/plugins/kubernetes/helm/module-config.ts
@@ -129,6 +129,12 @@ export const helmModuleSpecSchema = () =>
     .object()
     .keys({
       ...helmCommonSchemaKeys(),
+      atomicInstall: joi
+        .boolean()
+        .default(true)
+        .description(
+          "Whether to set the --atomic flag during installs and upgrades. Set to false if e.g. you want to see more information about failures and then manually roll back, instead of having Helm do it automatically on failure."
+        ),
       base: joiUserIdentifier()
         .description(
           deline`The name of another \`helm\` module to use as a base for this one. Use this to re-use a Helm chart across

--- a/docs/reference/action-types/Deploy/helm.md
+++ b/docs/reference/action-types/Deploy/helm.md
@@ -153,10 +153,6 @@ build:
 kind:
 
 spec:
-  # Whether to set the --atomic flag during installs and upgrades. Set to false if e.g. you want to see more
-  # information about failures and then manually roll back, instead of having Helm do it automatically on failure.
-  atomicInstall: true
-
   # A valid Kubernetes namespace name. Must be a valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters,
   # numbers and dashes, must start with a letter, and cannot end with a dash) and must not be longer than 63
   # characters.
@@ -201,6 +197,10 @@ spec:
   # Note that the paths here should be relative to the _config_ root, and the files should be contained in
   # this action config's directory.
   valueFiles: []
+
+  # Whether to set the --atomic flag during installs and upgrades. Set to true if you'd like the changes applied to be
+  # reverted on failure.
+  atomic: false
 
   # Specify the Helm chart to use.
   #
@@ -671,16 +671,6 @@ This would mean that instead of looking for manifest files relative to this acti
 | -------- | -------- |
 | `object` | No       |
 
-### `spec.atomicInstall`
-
-[spec](#spec) > atomicInstall
-
-Whether to set the --atomic flag during installs and upgrades. Set to false if e.g. you want to see more information about failures and then manually roll back, instead of having Helm do it automatically on failure.
-
-| Type      | Default | Required |
-| --------- | ------- | -------- |
-| `boolean` | `true`  | No       |
-
 ### `spec.namespace`
 
 [spec](#spec) > namespace
@@ -788,6 +778,16 @@ this action config's directory.
 | Type               | Default | Required |
 | ------------------ | ------- | -------- |
 | `array[posixPath]` | `[]`    | No       |
+
+### `spec.atomic`
+
+[spec](#spec) > atomic
+
+Whether to set the --atomic flag during installs and upgrades. Set to true if you'd like the changes applied to be reverted on failure.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `spec.chart`
 

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -159,10 +159,6 @@ variables:
 # varfiles exist).
 varfile:
 
-# Whether to set the --atomic flag during installs and upgrades. Set to false if e.g. you want to see more information
-# about failures and then manually roll back, instead of having Helm do it automatically on failure.
-atomicInstall: true
-
 # A valid Kubernetes namespace name. Must be a valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters,
 # numbers and dashes, must start with a letter, and cannot end with a dash) and must not be longer than 63 characters.
 namespace:
@@ -206,6 +202,10 @@ values: {}
 # Note that the paths here should be relative to the _config_ root, and the files should be contained in
 # this action config's directory.
 valueFiles: []
+
+# Whether to set the --atomic flag during installs and upgrades. Set to false if e.g. you want to see more information
+# about failures and then manually roll back, instead of having Helm do it automatically on failure.
+atomicInstall: true
 
 # The name of another `helm` module to use as a base for this one. Use this to re-use a Helm chart across multiple
 # services. For example, you might have an organization-wide base chart for certain types of services.
@@ -909,14 +909,6 @@ Example:
 varfile: "my-module.env"
 ```
 
-### `atomicInstall`
-
-Whether to set the --atomic flag during installs and upgrades. Set to false if e.g. you want to see more information about failures and then manually roll back, instead of having Helm do it automatically on failure.
-
-| Type      | Default | Required |
-| --------- | ------- | -------- |
-| `boolean` | `true`  | No       |
-
 ### `namespace`
 
 A valid Kubernetes namespace name. Must be a valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and dashes, must start with a letter, and cannot end with a dash) and must not be longer than 63 characters.
@@ -1012,6 +1004,14 @@ this action config's directory.
 | Type               | Default | Required |
 | ------------------ | ------- | -------- |
 | `array[posixPath]` | `[]`    | No       |
+
+### `atomicInstall`
+
+Whether to set the --atomic flag during installs and upgrades. Set to false if e.g. you want to see more information about failures and then manually roll back, instead of having Helm do it automatically on failure.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `true`  | No       |
 
 ### `base`
 

--- a/static/kubernetes/system/ingress-controller/garden.yml
+++ b/static/kubernetes/system/ingress-controller/garden.yml
@@ -5,6 +5,7 @@ type: helm
 repo: https://kubernetes.github.io/ingress-nginx
 chart: ingress-nginx
 releaseName: garden-nginx
+atomicInstall: false
 dependencies:
   - default-backend
 version: 4.0.13


### PR DESCRIPTION
BREAKING CHANGE:

`helm` Deploy actions don't default to atomic installs.

This isn't strictly speaking breaking, because helm Modules still retain the old behavior, but it's worth mentioning in release notes anyway.
