### PR TITLE
fix: login/logout using the configured domain

### DIFF
--- a/core/src/cli/command-line.ts
+++ b/core/src/cli/command-line.ts
@@ -50,7 +50,6 @@ const directInputKeys = [
 ]
 
 const hideCommands = ["config analytics-enabled", "tools"]
-const overrideHiddenCommands = ["login", "logout"]
 
 interface CommandLineEvents {
   message: string
@@ -427,14 +426,7 @@ ${renderDivider({ width, char, color })}
   showHelp() {
     // TODO: group commands by category?
     const renderedCommands = renderCommands(
-      this.commands.filter(
-        (c) =>
-          !(
-            (c.hidden && !overrideHiddenCommands.includes(c.getFullName())) ||
-            c instanceof CommandGroup ||
-            hideCommands.includes(c.getFullName())
-          )
-      )
+      this.commands.filter((c) => !(c.hidden || c instanceof CommandGroup || hideCommands.includes(c.getFullName())))
     )
 
     const helpText = `

--- a/core/src/cli/command-line.ts
+++ b/core/src/cli/command-line.ts
@@ -50,6 +50,7 @@ const directInputKeys = [
 ]
 
 const hideCommands = ["config analytics-enabled", "tools"]
+const overrideHiddenCommands = ["login", "logout"]
 
 interface CommandLineEvents {
   message: string
@@ -426,7 +427,14 @@ ${renderDivider({ width, char, color })}
   showHelp() {
     // TODO: group commands by category?
     const renderedCommands = renderCommands(
-      this.commands.filter((c) => !(c.hidden || c instanceof CommandGroup || hideCommands.includes(c.getFullName())))
+      this.commands.filter(
+        (c) =>
+          !(
+            (c.hidden && !overrideHiddenCommands.includes(c.getFullName())) ||
+            c instanceof CommandGroup ||
+            hideCommands.includes(c.getFullName())
+          )
+      )
     )
 
     const helpText = `

--- a/core/src/commands/login.ts
+++ b/core/src/commands/login.ts
@@ -16,6 +16,7 @@ import { AuthRedirectServer } from "../cloud/auth"
 import { EventBus } from "../events"
 import { getCloudDistributionName } from "../util/util"
 import { ProjectResource } from "../config/project"
+import { findProjectConfig } from "../config/base"
 
 const loginTimeoutSec = 60
 
@@ -38,12 +39,12 @@ export class LoginCommand extends Command {
     printHeader(headerLog, "Login", "☁️")
   }
 
-  async action({ cli, garden, log }: CommandParams): Promise<CommandResult> {
+  async action({ garden, log }: CommandParams): Promise<CommandResult> {
     // NOTE: The Cloud API is missing from the Garden class for commands with noProject
     // so we initialize it here. noProject also make sure that the project config is not
     // initialized in the garden class, so we need to read it in here to get the cloud
     // domain.
-    const projectConfig: ProjectResource | undefined = await cli!.getProjectConfig(log, garden.projectRoot)
+    const projectConfig: ProjectResource | undefined = await findProjectConfig(log, garden.projectRoot)
 
     // Fail if this is not run within a garden project
     if (!projectConfig) {

--- a/core/src/commands/login.ts
+++ b/core/src/commands/login.ts
@@ -23,7 +23,6 @@ const loginTimeoutSec = 60
 export class LoginCommand extends Command {
   name = "login"
   help = "Log in to Garden Cloud."
-  hidden = true
 
   /**
    * Since we're logging in, we don't want to resolve e.g. the project config (since it may use secrets, which are

--- a/core/src/commands/logout.ts
+++ b/core/src/commands/logout.ts
@@ -18,7 +18,6 @@ import { findProjectConfig } from "../config/base"
 export class LogOutCommand extends Command {
   name = "logout"
   help = "Log out of Garden Cloud."
-  hidden = true
   noProject = true
 
   description = dedent`

--- a/core/src/commands/logout.ts
+++ b/core/src/commands/logout.ts
@@ -13,6 +13,7 @@ import { dedent } from "../util/string"
 import { getCloudDistributionName } from "../util/util"
 import { ConfigurationError } from "../exceptions"
 import { ProjectResource } from "../config/project"
+import { findProjectConfig } from "../config/base"
 
 export class LogOutCommand extends Command {
   name = "logout"
@@ -28,10 +29,10 @@ export class LogOutCommand extends Command {
     printHeader(headerLog, "Log out", "☁️")
   }
 
-  async action({ cli, garden, log }: CommandParams): Promise<CommandResult> {
+  async action({ garden, log }: CommandParams): Promise<CommandResult> {
     // The Enterprise API is missing from the Garden class for commands with noProject
     // so we initialize it here.
-    const projectConfig: ProjectResource | undefined = await cli!.getProjectConfig(log, garden.projectRoot)
+    const projectConfig: ProjectResource | undefined = await findProjectConfig(log, garden.projectRoot)
 
     // Fail if this is not run within a garden project
     if (!projectConfig) {

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -3010,6 +3010,30 @@ sources:
     path:
 ```
 
+### garden login
+
+**Log in to Garden Cloud.**
+
+Logs you in to Garden Cloud. Subsequent commands will have access to cloud features.
+
+#### Usage
+
+    garden login 
+
+
+
+### garden logout
+
+**Log out of Garden Cloud.**
+
+Logs you out of Garden Cloud.
+
+#### Usage
+
+    garden logout 
+
+
+
 ### garden logs
 
 **Retrieves the most recent logs for the specified Deploy(s).**


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Ensures that the login/logout commands uses the cloud domain in the project config. Both have the `noProject` flag set which leads to the garden instance not being initialized with a project config. Ensures that this is compatible with `garden dev` and also includes login/logout in the help listing.

**Which issue(s) this PR fixes**:

Fixes #4049 

**Special notes for your reviewer**:

@edvald There was an earlier commit which reverted this behavior because of the dev command, https://github.com/garden-io/garden/commit/7f93b90830e1968526fa7f748e6f195c9a6e4421. Could you give some more context on how this relates?