### PR TITLE
0.13 set default target in module converter

### DIFF
--- a/core/src/plugins/kubernetes/helm/exec.ts
+++ b/core/src/plugins/kubernetes/helm/exec.ts
@@ -19,7 +19,6 @@ import chalk from "chalk"
 
 export const execInHelmDeploy: DeployActionHandler<"exec", HelmDeployAction> = async (params) => {
   const { ctx, log, action, command, interactive } = params
-
   const k8sCtx = <KubernetesPluginContext>ctx
   const provider = k8sCtx.provider
 
@@ -47,11 +46,10 @@ export const execInHelmDeploy: DeployActionHandler<"exec", HelmDeployAction> = a
   const manifests = await getChartResources({
     ctx: k8sCtx,
     action,
-
     log,
   })
 
-  const serviceResource = await getTargetResource({
+  const target = await getTargetResource({
     ctx,
     log,
     provider,
@@ -61,12 +59,12 @@ export const execInHelmDeploy: DeployActionHandler<"exec", HelmDeployAction> = a
   })
 
   // TODO: this check should probably live outside of the plugin
-  if (!serviceResource || !includes(["ready", "outdated"], status.state)) {
+  if (!target || !includes(["ready", "outdated"], status.state)) {
     throw new DeploymentError(`${action.longDescription()} is not running`, {
       name: action.name,
       state: status.detail?.state || status.state,
     })
   }
 
-  return execInWorkload({ ctx, provider, log, namespace, workload: serviceResource, command, interactive })
+  return execInWorkload({ ctx, provider, log, namespace, workload: target, command, interactive })
 }

--- a/core/src/plugins/kubernetes/helm/exec.ts
+++ b/core/src/plugins/kubernetes/helm/exec.ts
@@ -15,6 +15,7 @@ import { getHelmDeployStatus } from "./status"
 import { getChartResources } from "./common"
 import { DeployActionHandler } from "../../../plugin/action-types"
 import { HelmDeployAction } from "./config"
+import chalk from "chalk"
 
 export const execInHelmDeploy: DeployActionHandler<"exec", HelmDeployAction> = async (params) => {
   const { ctx, log, action, command, interactive } = params
@@ -27,7 +28,9 @@ export const execInHelmDeploy: DeployActionHandler<"exec", HelmDeployAction> = a
 
   if (!defaultTarget) {
     throw new ConfigurationError(
-      `${action.longDescription()} does not specify a defaultTarget. This is currently necessary for the exec command to work with helm Deploy actions.`,
+      `${action.longDescription()} does not specify a defaultTarget. Please configure this in order to be able to use this command with. This is currently necessary for the ${chalk.white(
+        "exec"
+      )} command to work with helm Deploy actions.`,
       {
         name: action.name,
       }

--- a/core/src/plugins/kubernetes/helm/handlers.ts
+++ b/core/src/plugins/kubernetes/helm/handlers.ts
@@ -233,9 +233,12 @@ function prepareDeployAction({
     deployAction.spec.chart!.path = baseModule.spec.chartPath
   }
 
-  if (serviceResource?.containerModule) {
-    const build = convertBuildDependency(serviceResource.containerModule)
-    deployAction.dependencies?.push(build)
+  if (serviceResource) {
+    if (serviceResource.containerModule) {
+      const build = convertBuildDependency(serviceResource.containerModule)
+      deployAction.dependencies?.push(build)
+    }
+    deployAction.spec.defaultTarget = convertServiceResource(module, serviceResource) || undefined
   }
 
   return deployAction

--- a/core/src/plugins/kubernetes/kubernetes-type/exec.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/exec.ts
@@ -14,6 +14,7 @@ import { execInWorkload, getTargetResource } from "../util"
 import { DeployActionHandler } from "../../../plugin/action-types"
 import { KubernetesDeployAction } from "./config"
 import { getKubernetesDeployStatus } from "./handlers"
+import chalk from "chalk"
 
 export const execInKubernetesDeploy: DeployActionHandler<"exec", KubernetesDeployAction> = async (params) => {
   const { ctx, log, action, command, interactive } = params
@@ -25,7 +26,9 @@ export const execInKubernetesDeploy: DeployActionHandler<"exec", KubernetesDeplo
 
   if (!defaultTarget) {
     throw new ConfigurationError(
-      `${action.longDescription()} does not specify a defaultTarget. Please configure this in order to be able to use this command with.`,
+      `${action.longDescription()} does not specify a defaultTarget. Please configure this in order to be able to use this command with. This is currently necessary for the ${chalk.white(
+        "exec"
+      )} command to work with kubernetes Deploy actions.`,
       {
         name: action.name,
       }

--- a/core/src/plugins/kubernetes/kubernetes-type/exec.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/exec.ts
@@ -37,17 +37,19 @@ export const execInKubernetesDeploy: DeployActionHandler<"exec", KubernetesDeplo
 
   const status = await getKubernetesDeployStatus({
     ctx,
-    log,
     action,
+    log,
   })
   const namespace = await getAppNamespace(k8sCtx, log, k8sCtx.provider)
+
+  const manifests = status.detail?.detail.remoteResources || []
 
   const target = await getTargetResource({
     ctx,
     log,
     provider,
     action,
-    manifests: status.detail?.detail.remoteResources || [],
+    manifests,
     query: defaultTarget,
   })
 

--- a/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
@@ -68,9 +68,12 @@ export const kubernetesHandlers: Partial<ModuleActionHandlers<KubernetesModule>>
       },
     }
 
-    if (serviceResource?.containerModule) {
-      const build = convertBuildDependency(serviceResource.containerModule)
-      deployAction.dependencies?.push(build)
+    if (serviceResource) {
+      if (serviceResource.containerModule) {
+        const build = convertBuildDependency(serviceResource.containerModule)
+        deployAction.dependencies?.push(build)
+      }
+      deployAction.spec.defaultTarget = convertServiceResource(module, serviceResource) || undefined
     }
 
     actions.push(deployAction)
@@ -179,11 +182,13 @@ export const getKubernetesDeployStatus: DeployActionHandler<"getStatus", Kuberne
   })
   const preparedManifests = prepareResult.manifests
 
-  let {
-    state,
-    remoteResources,
-    mode: deployedMode,
-  } = await compareDeployedResources(k8sCtx, api, namespace, preparedManifests, log)
+  let { state, remoteResources, mode: deployedMode } = await compareDeployedResources(
+    k8sCtx,
+    api,
+    namespace,
+    preparedManifests,
+    log
+  )
 
   // Local mode has its own port-forwarding configuration
   const forwardablePorts = deployedMode === "local" ? [] : getForwardablePorts(remoteResources, action)

--- a/examples/kubernetes-deploy/postgres/garden.yml
+++ b/examples/kubernetes-deploy/postgres/garden.yml
@@ -4,6 +4,10 @@ name: postgres
 description: Postgres deployment with kubernetes manifests inlined (extracted from the stable/postgresql Helm chart)
 
 spec:
+  # This is necessary for `garden exec <deploy> <command>` in 0.13
+  defaultTarget:
+    kind: StatefulSet
+    name: postgres
   manifests:
     # Source: postgresql/templates/secrets.yaml
     - apiVersion: v1

--- a/examples/kubernetes-deploy/redis/garden.yml
+++ b/examples/kubernetes-deploy/redis/garden.yml
@@ -4,4 +4,8 @@ name: redis
 description: Redis deployment with kubernetes manifests in a file (extracted from the stable/redis Helm chart)
 
 spec:
+  # This is necessary for `garden exec <deploy> <command>` in 0.13
+  defaultTarget:
+    kind: Deployment
+    name: redis-slave
   files: [ redis.yml ]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
This PR automatically converts the old-fashioned config entry `serviceResource` to the new `defaultTarget`, and ensures compatibility with the module-based configs.

There is also some code refactoring and k8s example config updates.

See individual commits for details.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
