### PR TITLE
0.13 fix exec to not deploy anything

### DIFF
--- a/core/src/commands/exec.ts
+++ b/core/src/commands/exec.ts
@@ -98,7 +98,7 @@ export class ExecCommand extends Command<Args, Opts> {
       case "missing":
       case "stopped":
         throw new NotFoundError(
-          `Cannot execute command in the '${action.name}' service. The target container is ${deployState}.`,
+          `${action.key()} status is ${deployState}. Cannot execute command.`,
           { deployState }
         )
       case "ready":

--- a/core/src/commands/exec.ts
+++ b/core/src/commands/exec.ts
@@ -63,21 +63,21 @@ export class ExecCommand extends Command<Args, Opts> {
   outputsSchema = () => execInDeployResultSchema()
 
   printHeader({ headerLog, args }) {
-    const serviceName = args.deploy
+    const deployName = args.deploy
     const command = this.getCommand(args)
     printHeader(
       headerLog,
-      `Running command ${chalk.cyan(command.join(" "))} in service ${chalk.cyan(serviceName)}`,
+      `Running command ${chalk.cyan(command.join(" "))} in service ${chalk.cyan(deployName)}`,
       "runner"
     )
   }
 
   async action({ garden, log, args, opts }: CommandParams<Args, Opts>): Promise<CommandResult<ExecInDeployResult>> {
-    const serviceName = args.deploy
+    const deployName = args.deploy
     const command = this.getCommand(args)
 
     const graph = await garden.getConfigGraph({ log, emit: false })
-    const action = graph.getDeploy(serviceName)
+    const action = graph.getDeploy(deployName)
 
     const resolved = await resolveAction({ garden, graph, action, log })
 

--- a/core/src/commands/exec.ts
+++ b/core/src/commands/exec.ts
@@ -92,15 +92,16 @@ export class ExecCommand extends Command<Args, Opts> {
       case "outdated":
       case "unhealthy":
       case "unknown":
-        log.warn(chalk.white(`Current state: ${chalk.whiteBright(deployState)}`))
+        log.warn(
+          `The current state of ${action.key()} is ${chalk.whiteBright(
+            deployState
+          )}. If this command fails, you may need to re-deploy it with the ${chalk.whiteBright("deploy")} command.`
+        )
         break
       // Only fail if the deployment is missing or stopped.
       case "missing":
       case "stopped":
-        throw new NotFoundError(
-          `${action.key()} status is ${deployState}. Cannot execute command.`,
-          { deployState }
-        )
+        throw new NotFoundError(`${action.key()} status is ${deployState}. Cannot execute command.`, { deployState })
       case "ready":
         // Nothing to report/throw, the deployment is ready
         break

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -335,11 +335,13 @@ export async function executeAction<T extends Action>({
   graph,
   action,
   log,
+  statusOnly,
 }: {
   garden: Garden
   graph: ConfigGraph
   action: T
   log: Log
+  statusOnly?: boolean
 }): Promise<Executed<T>> {
   const task = getExecuteTaskForAction(action, {
     garden,
@@ -348,7 +350,7 @@ export async function executeAction<T extends Action>({
     force: true,
   })
 
-  const results = await garden.processTasks({ tasks: [task], log, throwOnError: true })
+  const results = await garden.processTasks({ tasks: [task], log, throwOnError: true, statusOnly })
 
   return <Executed<T>>(<unknown>results.results.getResult(task)!.result!.executedAction)
 }

--- a/core/src/plugin/handlers/Deploy/exec.ts
+++ b/core/src/plugin/handlers/Deploy/exec.ts
@@ -11,7 +11,7 @@ import { dedent } from "../../../util/string"
 import { joiArray, joi } from "../../../config/common"
 import { DeployAction } from "../../../actions/deploy"
 import { ActionTypeHandlerSpec } from "../base/base"
-import { Executed } from "../../../actions/types"
+import { Resolved } from "../../../actions/types"
 
 interface ExecInDeployParams<T extends DeployAction> extends PluginDeployActionParamsBase<T> {
   command: string[]
@@ -35,7 +35,7 @@ export const execInDeployResultSchema = () =>
 
 export class ExecInDeploy<T extends DeployAction = DeployAction> extends ActionTypeHandlerSpec<
   "Deploy",
-  ExecInDeployParams<Executed<T>>,
+  ExecInDeployParams<Resolved<T>>,
   ExecInDeployResult
 > {
   description = dedent`

--- a/core/src/plugin/handlers/Deploy/exec.ts
+++ b/core/src/plugin/handlers/Deploy/exec.ts
@@ -11,7 +11,7 @@ import { dedent } from "../../../util/string"
 import { joiArray, joi } from "../../../config/common"
 import { DeployAction } from "../../../actions/deploy"
 import { ActionTypeHandlerSpec } from "../base/base"
-import { Resolved } from "../../../actions/types"
+import { Executed } from "../../../actions/types"
 
 interface ExecInDeployParams<T extends DeployAction> extends PluginDeployActionParamsBase<T> {
   command: string[]
@@ -35,7 +35,7 @@ export const execInDeployResultSchema = () =>
 
 export class ExecInDeploy<T extends DeployAction = DeployAction> extends ActionTypeHandlerSpec<
   "Deploy",
-  ExecInDeployParams<Resolved<T>>,
+  ExecInDeployParams<Executed<T>>,
   ExecInDeployResult
 > {
   description = dedent`

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -523,7 +523,7 @@ graphResults:
 Finds an active container for a deployed service and executes the given command within the container.
 Supports interactive shells.
 
-_NOTE: This command may not be supported for all module types._
+_NOTE: This command may not be supported for all action types._
 
 Examples:
 
@@ -537,7 +537,7 @@ Examples:
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
-  | `deploy` | Yes | The service to exec the command in.
+  | `deploy` | Yes | The running Deploy action to exec the command in.
   | `command` | Yes | The command to run.
 
 #### Options


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
This prevents the `garden exec` command from executing any deployments. If the target container is found, the command execution proceeds. Otherwise, an error is thrown.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
The commits will be squashed before the merge.