### PR TITLE
improvement(k8s): catch internal etcdserver throttling error from API

### DIFF
--- a/core/src/plugins/kubernetes/api.ts
+++ b/core/src/plugins/kubernetes/api.ts
@@ -1033,7 +1033,7 @@ async function requestWithRetry<R>(
         if (usedRetries <= maxRetries) {
           const sleepMsec = minTimeoutMs + usedRetries * minTimeoutMs
           retryLog.setState(deline`
-            ${description} failed with error ${err.message}, retrying in ${sleepMsec}ms
+            ${description} failed with error '${err.message}', retrying in ${sleepMsec}ms
             (${usedRetries}/${maxRetries})
           `)
           await sleep(sleepMsec)
@@ -1084,4 +1084,11 @@ const statusCodesForRetry: number[] = [
   524, // A Timeout Occurred
 ]
 
-const errorMessageRegexesForRetry = [/ETIMEDOUT/, /ENOTFOUND/, /EAI_AGAIN/]
+const errorMessageRegexesForRetry = [
+  /ETIMEDOUT/,
+  /ENOTFOUND/,
+  /EAI_AGAIN/,
+  // This can happen if etcd is overloaded
+  // (rpc error: code = ResourceExhausted desc = etcdserver: throttle: too many requests)
+  /too many requests/,
+]


### PR DESCRIPTION
A user came across this nice little Kubernetes API peculiarity. Should help make the API wrapper more resilient to etcd throttling issues.