### PR TITLE
improvement(k8s): catch internal etcdserver throttling error from API

### DIFF
--- a/core/src/plugins/kubernetes/api.ts
+++ b/core/src/plugins/kubernetes/api.ts
@@ -1026,7 +1026,7 @@ async function requestWithRetry<R>(
         if (usedRetries <= maxRetries) {
           const sleepMsec = minTimeoutMs + usedRetries * minTimeoutMs
           retryLog.info(deline`
-            ${description} failed with error ${err.message}, retrying in ${sleepMsec}ms
+            ${description} failed with error '${err.message}', retrying in ${sleepMsec}ms
             (${usedRetries}/${maxRetries})
           `)
           await sleep(sleepMsec)
@@ -1077,4 +1077,11 @@ const statusCodesForRetry: number[] = [
   524, // A Timeout Occurred
 ]
 
-const errorMessageRegexesForRetry = [/ETIMEDOUT/, /ENOTFOUND/, /EAI_AGAIN/]
+const errorMessageRegexesForRetry = [
+  /ETIMEDOUT/,
+  /ENOTFOUND/,
+  /EAI_AGAIN/,
+  // This can happen if etcd is overloaded
+  // (rpc error: code = ResourceExhausted desc = etcdserver: throttle: too many requests)
+  /too many requests/,
+]


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR cherry-picks #4053 to the `0.13` branch.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
