### PR TITLE
fix: 0.13 export the status state-field consistently across action types

### DIFF
--- a/core/src/commands/exec.ts
+++ b/core/src/commands/exec.ts
@@ -84,7 +84,7 @@ export class ExecCommand extends Command<Args, Opts> {
     const executed = await executeAction({ garden, graph, action, log, statusOnly: true })
     const status: DeployStatus = executed.getStatus()
 
-    const deployState = status.detail?.deployState
+    const deployState = status.detail?.state
     switch (deployState) {
       // Warn if the deployment is not ready yet or unhealthy, but still proceed.
       case undefined:

--- a/core/src/commands/sync/sync-start.ts
+++ b/core/src/commands/sync/sync-start.ts
@@ -189,7 +189,7 @@ export class SyncStartCommand extends Command<Args, Opts> {
         const result = statusResult.results.getResult(task)
 
         const mode = result?.result?.detail?.mode
-        const state = result?.result?.detail?.deployState
+        const state = result?.result?.detail?.state
         const executedAction = result?.result?.executedAction
 
         if (executedAction && (state === "outdated" || state === "ready")) {

--- a/core/src/events.ts
+++ b/core/src/events.ts
@@ -9,8 +9,8 @@
 import { omit } from "lodash"
 import { EventEmitter2 } from "eventemitter2"
 import type { LogEntryEventPayload } from "./cloud/buffered-event-stream"
-import type { ServiceStatus } from "./types/service"
-import type { RunStatusForEventPayload } from "./plugin/base"
+import type { DeployState, ServiceStatus } from "./types/service"
+import type { RunState, RunStatusForEventPayload } from "./plugin/base"
 import type { Omit } from "./util/util"
 import type { AuthTokenResponse } from "./cloud/api"
 import type { RenderedActionGraph } from "./graph/config-graph"
@@ -102,7 +102,9 @@ export function toGraphResultEventPayload(result: GraphResult): GraphResultEvent
   return payload
 }
 
-export interface ActionStatusPayload<S = {}> {
+export type ActionStatusDetailedState = DeployState | BuildState | RunState
+
+export interface ActionStatusPayload<S = { state: ActionStatusDetailedState }> {
   actionName: string
   actionVersion: string
   actionUid: string

--- a/core/src/plugins/exec/deploy.ts
+++ b/core/src/plugins/exec/deploy.ts
@@ -52,7 +52,7 @@ export const getExecDeployStatus: DeployActionHandler<"getStatus", ExecDeploy> =
     return {
       state: deployStateToActionState(state),
       detail: {
-        deployState: state,
+        state,
         version: action.versionString(),
         detail: { statusCommandOutput: result.all },
       },
@@ -65,7 +65,7 @@ export const getExecDeployStatus: DeployActionHandler<"getStatus", ExecDeploy> =
 
     return {
       state: deployStateToActionState(state),
-      detail: { deployState: state, version: action.versionString(), detail: {} },
+      detail: { state, version: action.versionString(), detail: {} },
       outputs: {
         log: "",
       },
@@ -101,7 +101,7 @@ export const execDeployAction: DeployActionHandler<"deploy", ExecDeploy> = async
 
   if (spec.deployCommand.length === 0) {
     log.info({ msg: "No deploy command found. Skipping.", symbol: "info" })
-    return { state: "ready", detail: { deployState: "ready", detail: { skipped: true } }, outputs: {} }
+    return { state: "ready", detail: { state: "ready", detail: { skipped: true } }, outputs: {} }
   } else if (spec.persistent) {
     return deployPersistentExecService({ action, log, ctx, env, deployName: action.name })
   } else {
@@ -122,7 +122,7 @@ export const execDeployAction: DeployActionHandler<"deploy", ExecDeploy> = async
 
     return {
       state: "ready",
-      detail: { deployState: "ready", detail: { deployCommandOutput: result.all } },
+      detail: { state: "ready", detail: { deployCommandOutput: result.all } },
       outputs: {},
     }
   }
@@ -231,7 +231,7 @@ export async function deployPersistentExecService({
 
   return {
     state: "ready",
-    detail: { deployState: "ready", detail: { persistent: true, pid: proc.pid } },
+    detail: { state: "ready", detail: { persistent: true, pid: proc.pid } },
     outputs: {},
   }
 }
@@ -255,7 +255,7 @@ export const deleteExecDeploy: DeployActionHandler<"delete", ExecDeploy> = async
 
     return {
       state: "not-ready",
-      detail: { deployState: "missing", detail: { cleanupCommandOutput: result.all } },
+      detail: { state: "missing", detail: { cleanupCommandOutput: result.all } },
       outputs: {},
     }
   } else {
@@ -264,7 +264,7 @@ export const deleteExecDeploy: DeployActionHandler<"delete", ExecDeploy> = async
       symbol: "warning",
       msg: chalk.gray(`Missing cleanupCommand, unable to clean up service`),
     })
-    return { state: "unknown", detail: { deployState: "unknown", detail: {} }, outputs: {} }
+    return { state: "unknown", detail: { state: "unknown", detail: {} }, outputs: {} }
   }
 }
 

--- a/core/src/plugins/kubernetes/container/deployment.ts
+++ b/core/src/plugins/kubernetes/container/deployment.ts
@@ -678,7 +678,7 @@ export const deleteContainerDeploy: DeployActionHandler<"delete", ContainerDeplo
     includeUninitialized: false,
   })
 
-  return { state: "ready", detail: { deployState: "missing", detail: {} }, outputs: {} }
+  return { state: "ready", detail: { state: "missing", detail: {} }, outputs: {} }
 }
 
 /**

--- a/core/src/plugins/kubernetes/container/exec.ts
+++ b/core/src/plugins/kubernetes/container/exec.ts
@@ -27,7 +27,7 @@ export const execInContainer: DeployActionHandler<"exec", ContainerDeployAction>
   const namespace = await getAppNamespace(k8sCtx, log, k8sCtx.provider)
 
   // TODO: this check should probably live outside of the plugin
-  if (!status.detail?.detail.workload || !includes(["ready", "outdated"], status.detail?.deployState)) {
+  if (!status.detail?.detail.workload || !includes(["ready", "outdated"], status.detail?.state)) {
     throw new DeploymentError(`${action.longDescription()} is not running`, {
       name: action.name,
       state: status.state,

--- a/core/src/plugins/kubernetes/container/status.ts
+++ b/core/src/plugins/kubernetes/container/status.ts
@@ -117,7 +117,7 @@ export function prepareContainerDeployStatus({
   const detail: ContainerServiceStatus = {
     forwardablePorts,
     ingresses,
-    deployState: state,
+    state,
     namespaceStatuses: [namespaceStatus],
     detail: { remoteResources, workload, selectorChangedResourceKeys },
     mode: deployedMode,
@@ -150,7 +150,7 @@ export async function waitForContainerService(
       action,
     })
 
-    const deployState = status.detail?.deployState
+    const deployState = status.detail?.state
 
     if (deployState === "ready" || deployState === "outdated") {
       return

--- a/core/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/src/plugins/kubernetes/helm/deployment.ts
@@ -61,7 +61,7 @@ export const helmDeploy: DeployActionHandler<"deploy", HelmDeployAction> = async
     commonArgs.push("--atomic")
   }
 
-  if (releaseStatus.deployState === "missing") {
+  if (releaseStatus.state === "missing") {
     log.silly(`Installing Helm release ${releaseName}`)
     const installArgs = ["install", releaseName, ...reference, ...commonArgs]
     if (force && !ctx.production) {
@@ -170,7 +170,7 @@ export const helmDeploy: DeployActionHandler<"deploy", HelmDeployAction> = async
     state: "ready",
     detail: {
       forwardablePorts,
-      deployState: "ready",
+      state: "ready",
       version: action.versionString(),
       detail: { remoteResources: statuses.map((s) => s.resource) },
       namespaceStatuses: [namespaceStatus],
@@ -204,5 +204,5 @@ export const deleteHelmDeploy: DeployActionHandler<"delete", HelmDeployAction> =
 
   log.success("Service deleted")
 
-  return { state: "not-ready", outputs: {}, detail: { deployState: "missing", detail: { remoteResources: [] } } }
+  return { state: "not-ready", outputs: {}, detail: { state: "missing", detail: { remoteResources: [] } } }
 }

--- a/core/src/plugins/kubernetes/helm/exec.ts
+++ b/core/src/plugins/kubernetes/helm/exec.ts
@@ -59,10 +59,10 @@ export const execInHelmDeploy: DeployActionHandler<"exec", HelmDeployAction> = a
   })
 
   // TODO: this check should probably live outside of the plugin
-  if (!target || !includes(["ready", "outdated"], status.detail?.deployState)) {
+  if (!target || !includes(["ready", "outdated"], status.detail?.state)) {
     throw new DeploymentError(`${action.longDescription()} is not running`, {
       name: action.name,
-      state: status.detail?.deployState || status.state,
+      state: status.detail?.state || status.state,
     })
   }
 

--- a/core/src/plugins/kubernetes/helm/status.ts
+++ b/core/src/plugins/kubernetes/helm/status.ts
@@ -65,7 +65,7 @@ export const getHelmDeployStatus: DeployActionHandler<"getStatus", HelmDeployAct
 
   try {
     helmStatus = await getReleaseStatus({ ctx: k8sCtx, action, releaseName, log })
-    state = helmStatus.deployState
+    state = helmStatus.state
     deployedMode = helmStatus.detail.mode || "default"
   } catch (err) {
     state = "missing"
@@ -113,7 +113,7 @@ export const getHelmDeployStatus: DeployActionHandler<"getStatus", HelmDeployAct
     state: deployStateToActionState(state),
     detail: {
       forwardablePorts,
-      deployState: state,
+      state,
       version: state === "ready" ? action.versionString() : undefined,
       detail,
       mode: deployedMode,
@@ -241,12 +241,12 @@ export async function getReleaseStatus({
     }
 
     return {
-      deployState: state,
+      state,
       detail: { ...res, values, mode: deployedMode },
     }
   } catch (err) {
     if (err.message.includes("release: not found")) {
-      return { deployState: "missing", detail: {} }
+      return { state: "missing", detail: {} }
     } else {
       throw err
     }

--- a/core/src/plugins/kubernetes/init.ts
+++ b/core/src/plugins/kubernetes/init.ts
@@ -210,7 +210,7 @@ export async function prepareSystem({
   }
 
   const deployStatuses: DeployStatusMap = (status.detail && status.detail.deployStatuses) || {}
-  const serviceStates = Object.values(deployStatuses).map((s) => s.detail?.deployState || "unknown")
+  const serviceStates = Object.values(deployStatuses).map((s) => s.detail?.state || "unknown")
   const combinedState = combineStates(serviceStates)
 
   const remoteCluster = provider.name !== "local-kubernetes"

--- a/core/src/plugins/kubernetes/kubernetes-type/exec.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/exec.ts
@@ -54,7 +54,7 @@ export const execInKubernetesDeploy: DeployActionHandler<"exec", KubernetesDeplo
   })
 
   // TODO: this check should probably live outside of the plugin
-  if (!target || !includes(["ready", "outdated"], status.detail?.deployState)) {
+  if (!target || !includes(["ready", "outdated"], status.detail?.state)) {
     throw new DeploymentError(`${action.longDescription()} is not running`, {
       name: action.name,
       state: status.state,

--- a/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
@@ -182,13 +182,11 @@ export const getKubernetesDeployStatus: DeployActionHandler<"getStatus", Kuberne
   })
   const preparedManifests = prepareResult.manifests
 
-  let { state, remoteResources, mode: deployedMode } = await compareDeployedResources(
-    k8sCtx,
-    api,
-    namespace,
-    preparedManifests,
-    log
-  )
+  let {
+    state,
+    remoteResources,
+    mode: deployedMode,
+  } = await compareDeployedResources(k8sCtx, api, namespace, preparedManifests, log)
 
   // Local mode has its own port-forwarding configuration
   const forwardablePorts = deployedMode === "local" ? [] : getForwardablePorts(remoteResources, action)
@@ -206,7 +204,7 @@ export const getKubernetesDeployStatus: DeployActionHandler<"getStatus", Kuberne
     state: deployStateToActionState(state),
     detail: {
       forwardablePorts,
-      deployState: state,
+      state,
       version: state === "ready" ? action.versionString() : undefined,
       detail: { remoteResources },
       mode: deployedMode,
@@ -384,7 +382,7 @@ export const deleteKubernetesDeploy: DeployActionHandler<"delete", KubernetesDep
     })
   }
 
-  const status: KubernetesServiceStatus = { deployState: "missing", detail: { remoteResources: [] } }
+  const status: KubernetesServiceStatus = { state: "missing", detail: { remoteResources: [] } }
 
   if (namespaceManifests.length > 0) {
     status.namespaceStatuses = namespaceManifests.map((m) => ({

--- a/core/src/plugins/kubernetes/system.ts
+++ b/core/src/plugins/kubernetes/system.ts
@@ -100,7 +100,7 @@ export async function getSystemServiceStatus({ sysGarden, log, names }: GetSyste
     graph,
     names,
   })
-  const state = combineStates(Object.values(serviceStatuses).map((s) => s.detail?.deployState || "unknown"))
+  const state = combineStates(Object.values(serviceStatuses).map((s) => s.detail?.state || "unknown"))
 
   return {
     state,

--- a/core/src/router/deploy.ts
+++ b/core/src/router/deploy.ts
@@ -57,7 +57,7 @@ export const deployRouter = (baseParams: BaseRouterParams) =>
       garden.events.emit("deployStatus", {
         ...payloadAttrs,
         state: "processing",
-        status: { deployState: "deploying" },
+        status: { state: "deploying" },
       })
 
       const output = await router.callHandler({ params, handlerType: "deploy" })
@@ -90,7 +90,7 @@ export const deployRouter = (baseParams: BaseRouterParams) =>
       const statusOutput = await handlers.getStatus({ ...params })
       const status = statusOutput.result
 
-      if (status.detail?.deployState === "missing") {
+      if (status.detail?.state === "missing") {
         log.success({
           section: action.key(),
           msg: "Not found",
@@ -106,7 +106,7 @@ export const deployRouter = (baseParams: BaseRouterParams) =>
           p.log.error(msg)
           return {
             state: "not-ready" as ActionState,
-            detail: { deployState: "missing" as DeployState, detail: {} },
+            detail: { state: "missing" as DeployState, detail: {} },
             outputs: {},
           }
         },
@@ -160,7 +160,7 @@ export const deployRouter = (baseParams: BaseRouterParams) =>
       garden.events.emit("deployStatus", {
         ...payloadAttrs,
         state: "getting-status",
-        status: { deployState: "unknown" },
+        status: { state: "unknown" },
       })
 
       const output = await router.callHandler({ params, handlerType: "getStatus" })

--- a/core/src/tasks/deploy.ts
+++ b/core/src/tasks/deploy.ts
@@ -72,7 +72,7 @@ export class DeployTask extends ExecuteActionTask<DeployAction, DeployStatus> {
         log.info(chalk.green(`${action.longDescription()} is already deployed.`))
         printIngresses(status, log)
       } else {
-        const state = status.detail?.deployState || displayState(status.state)
+        const state = status.detail?.state || displayState(status.state)
         log.info(chalk.green(`${action.longDescription()} is ${state}.`))
       }
     }

--- a/core/src/types/service.ts
+++ b/core/src/types/service.ts
@@ -73,7 +73,7 @@ export function serviceFromConfig<M extends GardenModule = GardenModule>(
 }
 
 export const deployStates = ["ready", "deploying", "stopped", "unhealthy", "unknown", "outdated", "missing"] as const
-export type DeployState = typeof deployStates[number]
+export type DeployState = (typeof deployStates)[number]
 
 /**
  * Given a list of states, return a single state representing the list.
@@ -194,7 +194,7 @@ export interface ServiceStatus<D = any, O = PrimitiveMap> {
   lastError?: string
   outputs?: O
   runningReplicas?: number
-  deployState: DeployState
+  state: DeployState
   updatedAt?: string
 }
 

--- a/core/src/types/service.ts
+++ b/core/src/types/service.ts
@@ -73,7 +73,7 @@ export function serviceFromConfig<M extends GardenModule = GardenModule>(
 }
 
 export const deployStates = ["ready", "deploying", "stopped", "unhealthy", "unknown", "outdated", "missing"] as const
-export type DeployState = (typeof deployStates)[number]
+export type DeployState = typeof deployStates[number]
 
 /**
  * Given a list of states, return a single state representing the list.
@@ -227,7 +227,7 @@ export const serviceStatusSchema = () =>
       lastError: joi.string().description("Latest error status message of the service (if any)."),
       outputs: joiVariables().description("A map of values output from the deployment."),
       runningReplicas: joi.number().description("How many replicas of the service are currently running."),
-      deployState: joi
+      state: joi
         .string()
         .valid(...deployStates)
         .default("unknown")

--- a/core/test/helpers.ts
+++ b/core/test/helpers.ts
@@ -276,11 +276,11 @@ export const testPlugin = () =>
               return { config, supportedModes: { sync: !!config.spec.syncMode, local: true } }
             },
             deploy: async ({}) => {
-              return { state: "ready", detail: { deployState: "ready", detail: {} }, outputs: {} }
+              return { state: "ready", detail: { state: "ready", detail: {} }, outputs: {} }
             },
             getStatus: async ({ ctx, action }) => {
               const result = get(ctx.provider, ["_actionStatuses", action.kind, action.name])
-              return result || { state: "ready", detail: { deployState: "ready", detail: {} }, outputs: {} }
+              return result || { state: "ready", detail: { state: "ready", detail: {} }, outputs: {} }
             },
             exec: async ({ command }) => {
               return { code: 0, output: "Ran command: " + command.join(" ") }

--- a/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
@@ -87,7 +87,7 @@ describe("helmDeploy in local-mode", () => {
       log: garden.log,
     })
 
-    expect(status.deployState).to.equal("ready")
+    expect(status.state).to.equal("ready")
     expect(status.mode).to.equal("local")
     expect(status.detail["values"][".garden"]).to.eql({
       moduleName: "backend",
@@ -149,7 +149,7 @@ describe("helmDeploy", () => {
       log: garden.log,
     })
 
-    expect(releaseStatus.deployState).to.equal("ready")
+    expect(releaseStatus.state).to.equal("ready")
     expect(releaseStatus.detail["values"][".garden"]).to.eql({
       moduleName: "api",
       projectName: garden.projectName,
@@ -188,7 +188,7 @@ describe("helmDeploy", () => {
       log: garden.log,
     })
 
-    expect(releaseStatus.deployState).to.equal("ready")
+    expect(releaseStatus.state).to.equal("ready")
     expect(releaseStatus.detail["values"][".garden"]).to.eql({
       moduleName: "api-helm-module",
       projectName: garden.projectName,
@@ -231,7 +231,7 @@ describe("helmDeploy", () => {
       log: garden.log,
     })
 
-    expect(status.deployState).to.equal("ready")
+    expect(status.state).to.equal("ready")
     expect(status.detail["values"][".garden"]).to.eql({
       moduleName: "api",
       projectName: garden.projectName,
@@ -266,7 +266,7 @@ describe("helmDeploy", () => {
       log: garden.log,
     })
 
-    expect(status.deployState).to.equal("ready")
+    expect(status.state).to.equal("ready")
 
     const api = await KubeApi.factory(garden.log, ctx, provider)
 
@@ -315,7 +315,7 @@ describe("helmDeploy", () => {
       log: gardenWithCloudApi.log,
     })
 
-    expect(releaseStatus.deployState).to.equal("ready")
+    expect(releaseStatus.state).to.equal("ready")
     expect(releaseStatus.detail["values"][".garden"]).to.eql({
       moduleName: "api",
       projectName: gardenWithCloudApi.projectName,
@@ -361,6 +361,6 @@ describe("helmDeploy", () => {
       releaseName,
       log: gardenWithCloudApi.log,
     })
-    expect(releaseStatusAfterScaleDown.deployState).to.equal("outdated")
+    expect(releaseStatusAfterScaleDown.state).to.equal("outdated")
   })
 })

--- a/core/test/unit/src/commands/delete.ts
+++ b/core/test/unit/src/commands/delete.ts
@@ -68,7 +68,7 @@ const moduleConfigs: ModuleConfig[] = [
 
 const missingDeployStatus: ActionStatus = {
   state: "not-ready",
-  detail: { deployState: "missing", forwardablePorts: [], outputs: {}, detail: {}, mode: "default" },
+  detail: { state: "missing", forwardablePorts: [], outputs: {}, detail: {}, mode: "default" },
   outputs: {},
 }
 

--- a/core/test/unit/src/commands/delete.ts
+++ b/core/test/unit/src/commands/delete.ts
@@ -98,15 +98,15 @@ describe("DeleteEnvironmentCommand", () => {
           schema: execDeployActionSchema(),
           handlers: {
             deploy: async (_params) => {
-              return { state: "ready", detail: { deployState: "ready", detail: {} }, outputs: {} }
+              return { state: "ready", detail: { state: "ready", detail: {} }, outputs: {} }
             },
             getStatus: async (_params) => {
-              return { state: "ready", detail: { deployState: "ready", detail: {} }, outputs: {} }
+              return { state: "ready", detail: { state: "ready", detail: {} }, outputs: {} }
             },
             delete: async (params) => {
               deletedServices.push(params.action.name)
               deleteOrder.push(params.action.name)
-              return { state: "not-ready", detail: { deployState: "missing", detail: {} }, outputs: {} }
+              return { state: "not-ready", detail: { state: "missing", detail: {} }, outputs: {} }
             },
           },
         },
@@ -202,10 +202,10 @@ describe("DeleteDeployCommand", () => {
           schema: execDeployActionSchema(),
           handlers: {
             deploy: async (_params) => {
-              return { state: "ready", detail: { deployState: "ready", detail: {} }, outputs: {} }
+              return { state: "ready", detail: { state: "ready", detail: {} }, outputs: {} }
             },
             getStatus: async (_params) => {
-              return { state: "ready", detail: { deployState: "ready", detail: {} }, outputs: {} }
+              return { state: "ready", detail: { state: "ready", detail: {} }, outputs: {} }
             },
             delete: async (params) => {
               deleteOrder.push(params.action.name)

--- a/core/test/unit/src/commands/deploy.ts
+++ b/core/test/unit/src/commands/deploy.ts
@@ -30,7 +30,7 @@ const testProvider = () => {
     "service-a": {
       state: "ready",
       detail: {
-        deployState: "ready",
+        state: "ready",
         detail: {},
         ingresses: [
           {
@@ -45,7 +45,7 @@ const testProvider = () => {
     },
     "service-c": {
       state: "ready",
-      detail: { deployState: "ready", detail: {} },
+      detail: { state: "ready", detail: {} },
       outputs: {},
     },
   }
@@ -60,11 +60,7 @@ const testProvider = () => {
           schema: testDeploySchema(),
           handlers: {
             deploy: async (params) => {
-              const newStatus: DeployStatus = {
-                state: "ready",
-                detail: { state: "ready", detail: {} },
-                outputs: {},
-              }
+              const newStatus: DeployStatus = { state: "ready", detail: { state: "ready", detail: {} }, outputs: {} }
               testStatuses[params.action.name] = newStatus
               return newStatus
             },

--- a/core/test/unit/src/commands/deploy.ts
+++ b/core/test/unit/src/commands/deploy.ts
@@ -62,7 +62,7 @@ const testProvider = () => {
             deploy: async (params) => {
               const newStatus: DeployStatus = {
                 state: "ready",
-                detail: { deployState: "ready", detail: {} },
+                detail: { state: "ready", detail: {} },
                 outputs: {},
               }
               testStatuses[params.action.name] = newStatus
@@ -72,7 +72,7 @@ const testProvider = () => {
               return (
                 testStatuses[params.action.name] || {
                   state: "unknown",
-                  detail: { deployState: "unknown", detail: {} },
+                  detail: { state: "unknown", detail: {} },
                   outputs: {},
                 }
               )

--- a/core/test/unit/src/commands/get/get-status.ts
+++ b/core/test/unit/src/commands/get/get-status.ts
@@ -75,7 +75,7 @@ describe("GetStatusCommand", () => {
             "service-b": {
               state: "ready",
               detail: {
-                deployState: "ready",
+                state: "ready",
                 detail: {},
                 forwardablePorts: [],
                 outputs: {},
@@ -86,7 +86,7 @@ describe("GetStatusCommand", () => {
             "service-c": {
               state: "ready",
               detail: {
-                deployState: "ready",
+                state: "ready",
                 detail: {},
                 forwardablePorts: [],
                 outputs: {},
@@ -97,7 +97,7 @@ describe("GetStatusCommand", () => {
             "service-a": {
               state: "ready",
               detail: {
-                deployState: "ready",
+                state: "ready",
                 detail: {},
                 forwardablePorts: [],
                 outputs: {},
@@ -169,7 +169,7 @@ describe("GetStatusCommand", () => {
         name: "service-a",
         status: {
           state: "unknown",
-          detail: { deployState: "unknown", detail: {} },
+          detail: { state: "unknown", detail: {} },
           outputs: {},
         },
       })

--- a/core/test/unit/src/outputs.ts
+++ b/core/test/unit/src/outputs.ts
@@ -141,7 +141,7 @@ describe("resolveProjectOutputs", () => {
             handlers: {
               getOutputs: async (params) => ({ outputs: params.action.getSpec().outputs }),
               getStatus: async (params) => ({
-                detail: { outputs: params.action.getSpec().outputs, deployState: "ready", detail: {} },
+                detail: { outputs: params.action.getSpec().outputs, state: "ready", detail: {} },
                 outputs: params.action.getSpec().outputs,
                 state: "ready",
               }),

--- a/core/test/unit/src/plugins/exec/exec.ts
+++ b/core/test/unit/src/plugins/exec/exec.ts
@@ -565,7 +565,7 @@ describe("exec plugin", () => {
             graph,
           })
           expect(res.state).to.eql("ready")
-          expect(res.detail?.deployState).to.eql("ready")
+          expect(res.detail?.state).to.eql("ready")
           expect(res.detail?.detail.deployCommandOutput).to.eql("deployed echo service")
         })
 
@@ -811,7 +811,7 @@ describe("exec plugin", () => {
           const actionRes = res[actionName]
           expect(actionRes.state).to.equal("unknown")
           const detail = actionRes.detail!
-          expect(detail.deployState).to.equal("unknown")
+          expect(detail.state).to.equal("unknown")
           expect(detail.detail).to.be.empty
         })
 
@@ -835,7 +835,7 @@ describe("exec plugin", () => {
           const actionRes = res[actionName]
           expect(actionRes.state).to.equal("ready")
           const detail = actionRes.detail!
-          expect(detail.deployState).to.equal("ready")
+          expect(detail.state).to.equal("ready")
           expect(detail.detail.statusCommandOutput).to.equal("already deployed")
         })
 
@@ -854,7 +854,7 @@ describe("exec plugin", () => {
           expect(actionRes.state).to.equal("not-ready")
           const detail = actionRes.detail!
           // The deploy state is different (has more states) than the action state
-          expect(detail.deployState).to.equal("outdated")
+          expect(detail.state).to.equal("outdated")
           expect(detail.detail.statusCommandOutput).to.be.empty
         })
       })
@@ -878,7 +878,7 @@ describe("exec plugin", () => {
 
           expect(res.state).to.equal("not-ready")
           const detail = res.detail!
-          expect(detail.deployState).to.equal("missing")
+          expect(detail.state).to.equal("missing")
           expect(detail.detail.cleanupCommandOutput).to.equal("cleaned up")
         })
 
@@ -893,7 +893,7 @@ describe("exec plugin", () => {
           })
 
           expect(res.state).to.equal("unknown")
-          expect(res.detail?.deployState).to.equal("unknown")
+          expect(res.detail?.state).to.equal("unknown")
         })
 
         it("throws if cleanupCommand returns with non-zero code", async () => {

--- a/core/test/unit/src/router/_helpers.ts
+++ b/core/test/unit/src/router/_helpers.ts
@@ -411,7 +411,7 @@ function getRouterUnitTestPlugins() {
             getStatus: async (params) => {
               return {
                 state: "ready",
-                detail: { deployState: "ready", detail: {} },
+                detail: { state: "ready", detail: {} },
                 outputs: getTestPluginOutputs(params),
               }
             },
@@ -420,13 +420,13 @@ function getRouterUnitTestPlugins() {
               // validateParams(params, moduleActionDescriptions.deployService.paramsSchema)
               return {
                 state: "ready",
-                detail: { deployState: "ready", detail: {} },
+                detail: { state: "ready", detail: {} },
                 outputs: getTestPluginOutputs(params),
               }
             },
 
             delete: async (_params) => {
-              return { state: "ready", detail: { deployState: "ready", detail: {} }, outputs: {} }
+              return { state: "ready", detail: { state: "ready", detail: {} }, outputs: {} }
             },
 
             exec: async (_params) => {

--- a/core/test/unit/src/router/deploy.ts
+++ b/core/test/unit/src/router/deploy.ts
@@ -50,7 +50,7 @@ describe("deploy actions", () => {
         graph,
       })
       expect(result).to.eql({
-        detail: { forwardablePorts: [], deployState: "ready", outputs: {}, detail: {}, mode: "default" },
+        detail: { forwardablePorts: [], state: "ready", outputs: {}, detail: {}, mode: "default" },
         outputs: { base: "ok", foo: "ok" },
         state: "ready",
       })
@@ -74,14 +74,14 @@ describe("deploy actions", () => {
       expect(event1.payload.moduleName).to.eql("module-a")
       expect(event1.payload.actionUid).to.be.ok
       expect(event1.payload.state).to.eql("getting-status")
-      expect(event1.payload.status.deployState).to.eql("unknown")
+      expect(event1.payload.status.state).to.eql("unknown")
 
       expect(event2.name).to.eql("deployStatus")
       expect(event2.payload.actionVersion).to.eql(resolvedDeployAction.versionString())
       expect(event2.payload.moduleName).to.eql("module-a")
       expect(event2.payload.actionUid).to.eql(event1.payload.actionUid)
       expect(event2.payload.state).to.eql("cached")
-      expect(event2.payload.status.deployState).to.eql("ready")
+      expect(event2.payload.status.state).to.eql("ready")
     })
 
     it("should throw if the outputs don't match the service outputs schema of the plugin", async () => {
@@ -107,7 +107,7 @@ describe("deploy actions", () => {
         force: true,
       })
       expect(result).to.eql({
-        detail: { forwardablePorts: [], deployState: "ready", outputs: {}, detail: {}, mode: "default" },
+        detail: { forwardablePorts: [], state: "ready", outputs: {}, detail: {}, mode: "default" },
         outputs: { base: "ok", foo: "ok" },
         state: "ready",
       })
@@ -128,13 +128,13 @@ describe("deploy actions", () => {
       expect(event1.payload.moduleName).to.eql("module-a")
       expect(event1.payload.actionUid).to.be.ok
       expect(event1.payload.state).to.eql("processing")
-      expect(event1.payload.status.deployState).to.eql("deploying")
+      expect(event1.payload.status.state).to.eql("deploying")
       expect(event2).to.exist
       expect(event2.name).to.eql("deployStatus")
       expect(event2.payload.moduleName).to.eql("module-a")
       expect(event2.payload.actionUid).to.eql(event2.payload.actionUid)
       expect(event2.payload.state).to.eql("ready")
-      expect(event2.payload.status.deployState).to.eql("ready")
+      expect(event2.payload.status.state).to.eql("ready")
     })
 
     it("should throw if the outputs don't match the service outputs schema of the plugin", async () => {
@@ -161,7 +161,7 @@ describe("deploy actions", () => {
           forwardablePorts: [],
           outputs: {},
           detail: {},
-          deployState: "ready",
+          state: "ready",
           mode: "default",
         },
         outputs: {},

--- a/core/test/unit/src/tasks/deploy.ts
+++ b/core/test/unit/src/tasks/deploy.ts
@@ -55,12 +55,12 @@ describe("DeployTask", () => {
             handlers: {
               deploy: async (params) => ({
                 state: "ready",
-                detail: { detail: {}, deployState: "ready" },
+                detail: { detail: {}, state: "ready" },
                 outputs: { log: params.action.getSpec().log },
               }),
               getStatus: async (params) => ({
                 state: "ready",
-                detail: { detail: {}, deployState: "ready" },
+                detail: { detail: {}, state: "ready" },
                 outputs: { log: params.action.getSpec().log },
               }),
             },

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -306,7 +306,7 @@ deployStatuses:
       runningReplicas:
 
       # The current deployment status of the service.
-      deployState:
+      state:
 
       # When the service was last updated by the provider.
       updatedAt:
@@ -437,7 +437,7 @@ When this flag is not used, all services in the project are cleaned up simultane
     runningReplicas:
 
     # The current deployment status of the service.
-    deployState:
+    state:
 
     # When the service was last updated by the provider.
     updatedAt:
@@ -2654,7 +2654,7 @@ actions:
         runningReplicas:
 
         # The current deployment status of the service.
-        deployState:
+        state:
 
         # When the service was last updated by the provider.
         updatedAt:

--- a/plugins/pulumi/handlers.ts
+++ b/plugins/pulumi/handlers.ts
@@ -72,7 +72,7 @@ export const getPulumiDeployStatus: DeployActionHandlers<PulumiDeploy>["getStatu
       state: deployStateToActionState("outdated"),
       outputs: {},
       detail: {
-        deployState: "outdated",
+        state: "outdated",
         detail: {},
       },
     }
@@ -87,7 +87,7 @@ export const getPulumiDeployStatus: DeployActionHandlers<PulumiDeploy>["getStatu
     state: deployStateToActionState(deployState),
     outputs: await getStackOutputs(pulumiParams),
     detail: {
-      deployState,
+      state: deployState,
       detail: {},
     },
   }
@@ -106,7 +106,7 @@ export const deployPulumi: DeployActionHandlers<PulumiDeploy>["deploy"] = async 
       state: "ready",
       outputs: await getStackOutputs(pulumiParams),
       detail: {
-        deployState: "ready",
+        state: "ready",
         detail: {},
       },
     }
@@ -141,7 +141,7 @@ export const deployPulumi: DeployActionHandlers<PulumiDeploy>["deploy"] = async 
     state: "ready",
     outputs: await getStackOutputs(pulumiParams),
     detail: {
-      deployState: "ready",
+      state: "ready",
       detail: {},
     },
   }
@@ -154,7 +154,7 @@ export const deletePulumiDeploy: DeployActionHandlers<PulumiDeploy>["delete"] = 
       state: deployStateToActionState("outdated"),
       outputs: {},
       detail: {
-        deployState: "outdated",
+        state: "outdated",
         detail: {},
       },
     }
@@ -182,7 +182,7 @@ export const deletePulumiDeploy: DeployActionHandlers<PulumiDeploy>["delete"] = 
     state: deployStateToActionState("missing"),
     outputs: {},
     detail: {
-      deployState: "missing",
+      state: "missing",
       detail: {},
     },
   }

--- a/plugins/terraform/action.ts
+++ b/plugins/terraform/action.ts
@@ -94,7 +94,7 @@ export const getTerraformStatus: DeployActionHandler<"getStatus", TerraformDeplo
     state: deployStateToActionState(deployState),
     outputs: await getTfOutputs({ log, ctx, provider, root }),
     detail: {
-      deployState,
+      state: deployState,
       detail: {},
     },
   }
@@ -126,7 +126,7 @@ export const deployTerraform: DeployActionHandler<"deploy", TerraformDeploy> = a
     state: "ready",
     outputs: await getTfOutputs({ log, ctx, provider, root }),
     detail: {
-      deployState: "ready",
+      state: "ready",
       detail: {},
     },
   }
@@ -142,7 +142,7 @@ export const deleteTerraformModule: DeployActionHandler<"delete", TerraformDeplo
     return {
       state: deployStateToActionState(deployState),
       detail: {
-        deployState,
+        state: deployState,
         detail: {},
       },
       outputs: {},
@@ -162,7 +162,7 @@ export const deleteTerraformModule: DeployActionHandler<"delete", TerraformDeplo
     state: "not-ready",
     outputs: {},
     detail: {
-      deployState: "missing",
+      state: "missing",
       detail: {},
     },
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

This ensures that the detailed status state-field is named consistently across action kinds. It reverts a previous commit which changed `state` -> `deployState` for the `deploy` action.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Details in this thread: https://discord.com/channels/817392104711651328/1095652284379168869