### PR TITLE
0.13 fix: use default target in sync overrides

### DIFF
--- a/core/src/plugins/kubernetes/commands/sync.ts
+++ b/core/src/plugins/kubernetes/commands/sync.ts
@@ -30,9 +30,6 @@ export const syncStatus: PluginCommand = {
     if (!(await pathExists(dataDir))) {
       log.info(dedent`
         No active sync session found.
-
-        Garden needs to be running in dev mode in this project for sync statuses to
-        be available.
       `)
 
       logSuccess(log)

--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -328,7 +328,8 @@ export async function configureSyncMode({
     const target = override.target || defaultTarget
     if (!target) {
       throw new ConfigurationError(
-        `Sync override configuration on ${action.longDescription()} doesn't specify a target, and none is set as a default.`,
+        dedent`Sync override configuration on ${action.longDescription()} doesn't specify a target, and none is set as a default.
+        Either specify a target via the \`spec.sync.overrides[].target\` or \`spec.defaultTarget\``,
         {
           override,
         }

--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -196,7 +196,7 @@ export const kubernetesDeploySyncSchema = () =>
       overrides: joi
         .array()
         .items(syncModeOverrideSpec())
-        .description("Overrides for the container command and/or arguments for when in sync mode"),
+        .description("Overrides for the container command and/or arguments for when in sync mode."),
     })
     .rename("syncs", "paths")
     .description(

--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -34,7 +34,6 @@ import {
   KubernetesResource,
   SupportedRuntimeAction,
   SyncableKind,
-  syncableKinds,
   SyncableResource,
   SyncableRuntimeAction,
 } from "./types"
@@ -46,7 +45,6 @@ import {
   KubernetesProvider,
   KubernetesTargetResourceSpec,
   ServiceResourceSpec,
-  targetContainerNameSchema,
   targetResourceSpecSchema,
 } from "./config"
 import { isConfiguredForSyncMode } from "./status/status"
@@ -64,6 +62,7 @@ import { HelmModule, HelmService } from "./helm/module-config"
 import { convertServiceResource } from "./kubernetes-type/common"
 import { prepareConnectionOpts } from "./kubectl"
 import { GetSyncStatusResult, SyncState } from "../../plugin/handlers/Deploy/get-sync-status"
+import { ConfigurationError } from "../../exceptions"
 
 export const builtInExcludes = ["/**/*.git", "**/*.garden"]
 
@@ -163,11 +162,7 @@ export const kubernetesDeploySyncPathSchema = () =>
     )
 
 export interface KubernetesDeployOverrideSpec {
-  target: {
-    kind: SyncableKind
-    name: string
-    containerName?: string
-  }
+  target?: KubernetesTargetResourceSpec
   command?: string[]
   args?: string[]
 }
@@ -180,15 +175,9 @@ export interface KubernetesDeploySyncSpec {
 
 const syncModeOverrideSpec = () =>
   joi.object().keys({
-    target: joi.object().keys({
-      kind: joi
-        .string()
-        .valid(...syncableKinds)
-        .required()
-        .description("The kind of the Kubernetes resource to modify."),
-      name: joi.string().required().description("The name of the resource."),
-      containerName: targetContainerNameSchema(),
-    }),
+    target: targetResourceSpecSchema().description(
+      "The Kubernetes resources to override. If specified, this is used instead of `spec.defaultTarget`."
+    ),
     command: joi.array().items(joi.string()).description("Override the command/entrypoint in the matched container."),
     args: joi.array().items(joi.string()).description("Override the args in the matched container."),
   })
@@ -204,7 +193,10 @@ export const kubernetesDeploySyncSchema = () =>
         .array()
         .items(kubernetesDeploySyncPathSchema())
         .description("A list of syncs to start once the Deploy is successfully started."),
-      overrides: joi.array().items(syncModeOverrideSpec()),
+      overrides: joi
+        .array()
+        .items(syncModeOverrideSpec())
+        .description("Overrides for the container command and/or arguments for when in sync mode"),
     })
     .rename("syncs", "paths")
     .description(
@@ -240,6 +232,7 @@ export function convertKubernetesModuleDevModeSpec(
             kind: target.kind,
             name: target.name,
             containerName: target.containerName,
+            podSelector: target.podSelector,
           },
           command: syncSpec.command,
           args: syncSpec.args,
@@ -332,7 +325,15 @@ export async function configureSyncMode({
   }
 
   for (const override of spec.overrides || []) {
-    const { target } = override
+    const target = override.target || defaultTarget
+    if (!target) {
+      throw new ConfigurationError(
+        `Sync override configuration on ${action.longDescription()} doesn't specify a target, and none is set as a default.`,
+        {
+          override,
+        }
+      )
+    }
     if (target.kind && target.name) {
       const key = targetKey(target)
       overridesByTarget[key] = override
@@ -344,12 +345,10 @@ export async function configureSyncMode({
     const target = sync.target || defaultTarget
 
     if (!target) {
-      log.warn(
-        chalk.yellow(
-          `Dev mode sync on ${action.longDescription()} doesn't specify a target, and none is set as a default.`
-        )
+      throw new ConfigurationError(
+        `Sync configuration on ${action.longDescription()} doesn't specify a target, and none is set as a default.`,
+        { sync }
       )
-      continue
     }
 
     if (target.podSelector) {
@@ -377,7 +376,11 @@ export async function configureSyncMode({
   })
 
   for (const override of spec.overrides || []) {
-    const { target } = override
+    const target = override.target || defaultTarget
+    if (!target) {
+      continue
+    }
+
     const key = targetKey(target)
     const resolved = resolvedTargets[key]
 

--- a/docs/reference/action-types/Deploy/helm.md
+++ b/docs/reference/action-types/Deploy/helm.md
@@ -372,13 +372,20 @@ spec:
         # more information.
         defaultGroup:
 
+    # Overrides for the container command and/or arguments for when in sync mode
     overrides:
-      - target:
-          # The kind of the Kubernetes resource to modify.
+      - # The Kubernetes resources to override. If specified, this is used instead of `spec.defaultTarget`.
+        target:
+          # The kind of Kubernetes resource to find.
           kind:
 
-          # The name of the resource.
+          # The name of the resource, of the specified `kind`. If specified, you must also specify `kind`.
           name:
+
+          # A map of string key/value labels to match on any Pods in the namespace. When specified, a random ready Pod
+          # with matching labels will be picked as a target, so make sure the labels will always match a specific Pod
+          # type.
+          podSelector:
 
           # The name of a container in the target. Specify this if the target contains more than one container and the
           # main container is not the first container in the spec.
@@ -1225,6 +1232,8 @@ Set the default group on files and directories at the target. Specify either an 
 
 [spec](#spec) > [sync](#specsync) > overrides
 
+Overrides for the container command and/or arguments for when in sync mode
+
 | Type            | Required |
 | --------------- | -------- |
 | `array[object]` | No       |
@@ -1232,6 +1241,8 @@ Set the default group on files and directories at the target. Specify either an 
 ### `spec.sync.overrides[].target`
 
 [spec](#spec) > [sync](#specsync) > [overrides](#specsyncoverrides) > target
+
+The Kubernetes resources to override. If specified, this is used instead of `spec.defaultTarget`.
 
 | Type     | Required |
 | -------- | -------- |
@@ -1241,7 +1252,7 @@ Set the default group on files and directories at the target. Specify either an 
 
 [spec](#spec) > [sync](#specsync) > [overrides](#specsyncoverrides) > [target](#specsyncoverridestarget) > kind
 
-The kind of the Kubernetes resource to modify.
+The kind of Kubernetes resource to find.
 
 | Type     | Allowed Values                           | Required |
 | -------- | ---------------------------------------- | -------- |
@@ -1251,11 +1262,21 @@ The kind of the Kubernetes resource to modify.
 
 [spec](#spec) > [sync](#specsync) > [overrides](#specsyncoverrides) > [target](#specsyncoverridestarget) > name
 
-The name of the resource.
+The name of the resource, of the specified `kind`. If specified, you must also specify `kind`.
 
 | Type     | Required |
 | -------- | -------- |
-| `string` | Yes      |
+| `string` | No       |
+
+### `spec.sync.overrides[].target.podSelector`
+
+[spec](#spec) > [sync](#specsync) > [overrides](#specsyncoverrides) > [target](#specsyncoverridestarget) > podSelector
+
+A map of string key/value labels to match on any Pods in the namespace. When specified, a random ready Pod with matching labels will be picked as a target, so make sure the labels will always match a specific Pod type.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
 
 ### `spec.sync.overrides[].target.containerName`
 

--- a/docs/reference/action-types/Deploy/helm.md
+++ b/docs/reference/action-types/Deploy/helm.md
@@ -372,7 +372,7 @@ spec:
         # more information.
         defaultGroup:
 
-    # Overrides for the container command and/or arguments for when in sync mode
+    # Overrides for the container command and/or arguments for when in sync mode.
     overrides:
       - # The Kubernetes resources to override. If specified, this is used instead of `spec.defaultTarget`.
         target:
@@ -1232,7 +1232,7 @@ Set the default group on files and directories at the target. Specify either an 
 
 [spec](#spec) > [sync](#specsync) > overrides
 
-Overrides for the container command and/or arguments for when in sync mode
+Overrides for the container command and/or arguments for when in sync mode.
 
 | Type            | Required |
 | --------------- | -------- |

--- a/docs/reference/action-types/Deploy/kubernetes.md
+++ b/docs/reference/action-types/Deploy/kubernetes.md
@@ -354,13 +354,20 @@ spec:
         # more information.
         defaultGroup:
 
+    # Overrides for the container command and/or arguments for when in sync mode
     overrides:
-      - target:
-          # The kind of the Kubernetes resource to modify.
+      - # The Kubernetes resources to override. If specified, this is used instead of `spec.defaultTarget`.
+        target:
+          # The kind of Kubernetes resource to find.
           kind:
 
-          # The name of the resource.
+          # The name of the resource, of the specified `kind`. If specified, you must also specify `kind`.
           name:
+
+          # A map of string key/value labels to match on any Pods in the namespace. When specified, a random ready Pod
+          # with matching labels will be picked as a target, so make sure the labels will always match a specific Pod
+          # type.
+          podSelector:
 
           # The name of a container in the target. Specify this if the target contains more than one container and the
           # main container is not the first container in the spec.
@@ -1169,6 +1176,8 @@ Set the default group on files and directories at the target. Specify either an 
 
 [spec](#spec) > [sync](#specsync) > overrides
 
+Overrides for the container command and/or arguments for when in sync mode
+
 | Type            | Required |
 | --------------- | -------- |
 | `array[object]` | No       |
@@ -1176,6 +1185,8 @@ Set the default group on files and directories at the target. Specify either an 
 ### `spec.sync.overrides[].target`
 
 [spec](#spec) > [sync](#specsync) > [overrides](#specsyncoverrides) > target
+
+The Kubernetes resources to override. If specified, this is used instead of `spec.defaultTarget`.
 
 | Type     | Required |
 | -------- | -------- |
@@ -1185,7 +1196,7 @@ Set the default group on files and directories at the target. Specify either an 
 
 [spec](#spec) > [sync](#specsync) > [overrides](#specsyncoverrides) > [target](#specsyncoverridestarget) > kind
 
-The kind of the Kubernetes resource to modify.
+The kind of Kubernetes resource to find.
 
 | Type     | Allowed Values                           | Required |
 | -------- | ---------------------------------------- | -------- |
@@ -1195,11 +1206,21 @@ The kind of the Kubernetes resource to modify.
 
 [spec](#spec) > [sync](#specsync) > [overrides](#specsyncoverrides) > [target](#specsyncoverridestarget) > name
 
-The name of the resource.
+The name of the resource, of the specified `kind`. If specified, you must also specify `kind`.
 
 | Type     | Required |
 | -------- | -------- |
-| `string` | Yes      |
+| `string` | No       |
+
+### `spec.sync.overrides[].target.podSelector`
+
+[spec](#spec) > [sync](#specsync) > [overrides](#specsyncoverrides) > [target](#specsyncoverridestarget) > podSelector
+
+A map of string key/value labels to match on any Pods in the namespace. When specified, a random ready Pod with matching labels will be picked as a target, so make sure the labels will always match a specific Pod type.
+
+| Type     | Required |
+| -------- | -------- |
+| `object` | No       |
 
 ### `spec.sync.overrides[].target.containerName`
 

--- a/docs/reference/action-types/Deploy/kubernetes.md
+++ b/docs/reference/action-types/Deploy/kubernetes.md
@@ -354,7 +354,7 @@ spec:
         # more information.
         defaultGroup:
 
-    # Overrides for the container command and/or arguments for when in sync mode
+    # Overrides for the container command and/or arguments for when in sync mode.
     overrides:
       - # The Kubernetes resources to override. If specified, this is used instead of `spec.defaultTarget`.
         target:
@@ -1176,7 +1176,7 @@ Set the default group on files and directories at the target. Specify either an 
 
 [spec](#spec) > [sync](#specsync) > overrides
 
-Overrides for the container command and/or arguments for when in sync mode
+Overrides for the container command and/or arguments for when in sync mode.
 
 | Type            | Required |
 | --------------- | -------- |


### PR DESCRIPTION
If a target is not specified for a sync override the default target is used.

Also unified the schema and types between targets for sync and sync overrides.

Changed the behavior to throw if target is not set instead of a warning. I don't think it makes sense to just warn here.