### PR TITLE
chore: switch from k8s.gcr.io to registry.k8s.io due to deprecation

### DIFF
--- a/static/kubernetes/system/nginx-kind/nginx-kind-new.garden.yml
+++ b/static/kubernetes/system/nginx-kind/nginx-kind-new.garden.yml
@@ -423,7 +423,7 @@ manifests:
                   fieldPath: metadata.namespace
             - name: LD_PRELOAD
               value: /usr/local/lib/libmimalloc.so
-            image: k8s.gcr.io/ingress-nginx/controller:v1.1.3@sha256:31f47c1e202b39fadecf822a9b76370bd4baed199a005b3e7d4d1455f4fd3fe2
+            image: registry.k8s.io/ingress-nginx/controller:v1.1.3@sha256:31f47c1e202b39fadecf822a9b76370bd4baed199a005b3e7d4d1455f4fd3fe2
             imagePullPolicy: IfNotPresent
             lifecycle:
               preStop:
@@ -526,7 +526,7 @@ manifests:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660
+            image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660
             imagePullPolicy: IfNotPresent
             name: create
             securityContext:
@@ -574,7 +574,7 @@ manifests:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660
+            image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660
             imagePullPolicy: IfNotPresent
             name: patch
             securityContext:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

https://cloud.google.com/blog/products/containers-kubernetes/how-the-kubernetes-k8sgcrio-redirect-impacts-gke-and-anthos

> In November 2022, the open source Kubernetes project [announced](https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/) that its new image registry, registry.k8s.gcr.io, was [officially GA](https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/). The new registry would replace the legacy k8s.gcr.io registry, with k8s.gcr.io getting [no further updates](https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/) after April 3, 2023. To assist in this transition and ensure that users of earlier Kubernetes releases and tooling can update to supported versions in time, the Kubernetes project, in partnership with Google, gradually started [redirecting image requests from k8s.gcr.io to registry.k8s.io](https://kubernetes.io/blog/2023/03/10/image-registry-redirect/) on March 20, 2023.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

This seems to be the only file where we use the k8s registry.