### PR TITLE
fix(helm): fix status checks around code syncing

### DIFF
--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -417,7 +417,7 @@ ${renderCommands(commands)}
             const userId = (await cloudApi.getProfile()).id
             const commandResultUrl = cloudApi.getCommandResultUrl({ sessionId, userId }).href
 
-            const msg = dedent`🌸 Connected to ${distroName}. View logs and command results at: \n\n${chalk.cyan(
+            const msg = dedent`🌸  Connected to ${distroName}. View logs and command results at: \n\n${chalk.cyan(
               commandResultUrl
             )}\n`
             log.info({ section: getCloudLogSectionName(distroName), msg })

--- a/core/src/cli/helpers.ts
+++ b/core/src/cli/helpers.ts
@@ -158,9 +158,12 @@ export function prepareMinimistOpts({
     if (!_skipDefault) {
       defaultValues[name] = spec.getDefaultValue(cli)
     }
+    if (!aliases[name]) {
+      aliases[name] = []
+    }
 
     for (const alias of spec.aliases || []) {
-      aliases[name] = alias
+      aliases[name].push(alias)
       if (!_skipDefault) {
         defaultValues[alias] = defaultValues[name]
       }

--- a/core/src/commands/sync/sync-start.ts
+++ b/core/src/commands/sync/sync-start.ts
@@ -57,25 +57,25 @@ export class SyncStartCommand extends Command<Args, Opts> {
 
     Examples:
         # start syncing to the 'api' Deploy, fail if it's not already deployed in sync mode
-        garden start sync api
+        garden sync start api
 
         # deploy 'api' in sync mode and dependencies if needed, then start syncing
-        garden start sync api --deploy
+        garden sync start api --deploy
 
         # start syncing to every Deploy already deployed in sync mode
-        garden start sync '*'
+        garden sync start '*'
 
         # start syncing to every Deploy that supports it, deploying if needed
-        garden start sync '*' --deploy
+        garden sync start '*' --deploy
 
         # start syncing to every Deploy that supports it, deploying if needed including runtime dependencies
-        garden start sync '*' --deploy --include-dependencies
+        garden sync start '*' --deploy --include-dependencies
 
         # start syncing to the 'api' and 'worker' Deploys
-        garden start sync api worker
+        garden sync start api worker
 
         # start syncing to the 'api' Deploy and keep the process running, following sync status messages
-        garden start sync api -f
+        garden sync start api -f
   `
 
   outputsSchema = () => joi.object()

--- a/core/src/commands/sync/sync-stop.ts
+++ b/core/src/commands/sync/sync-stop.ts
@@ -45,10 +45,10 @@ export class SyncStopCommand extends Command<Args, Opts> {
 
     Examples:
         # stop syncing to the 'api' Deploy
-        garden stop sync api
+        garden sync stop api
 
         # stop all active syncs
-        garden stop sync '*'
+        garden sync stop '*'
   `
 
   outputsSchema = () => joi.object()

--- a/core/src/logger/renderers.ts
+++ b/core/src/logger/renderers.ts
@@ -88,7 +88,7 @@ export function renderMsg(entry: LogEntry): string {
 
   const styleFn = level === LogLevel.error ? errorStyle : msgStyle
 
-  return styleFn(origin ? `[${hasAnsi(origin) ? origin : chalk.gray(origin)}] ${msg}` : msg)
+  return styleFn(origin ? chalk.gray(`[${origin}] ${msg}`) : msg)
 }
 
 export function renderData(entry: LogEntry): string {

--- a/core/src/plugins/kubernetes/helm/common.ts
+++ b/core/src/plugins/kubernetes/helm/common.ts
@@ -379,7 +379,7 @@ export async function renderHelmTemplateString({
  * We therefore need to use the `loadAll` function. See the following link for a conversation on using
  * `loadAll` in this context: https://github.com/kubeapps/kubeapps/issues/636.
  */
-export function loadTemplate(template: string) {
+export function loadTemplate(template: string): KubernetesResource[] {
   return loadAll(template || "", undefined, { json: true })
     .filter((obj) => obj !== null)
     .map((obj) => {

--- a/core/src/plugins/kubernetes/helm/logs.ts
+++ b/core/src/plugins/kubernetes/helm/logs.ts
@@ -10,7 +10,7 @@ import { streamK8sLogs } from "../logs"
 import { KubernetesPluginContext } from "../config"
 import { getReleaseName } from "./common"
 import { getActionNamespace } from "../namespace"
-import { getRenderedResources } from "./status"
+import { getDeployedChartResources } from "./status"
 import { sleep } from "../../../util/util"
 import { DeployActionHandler } from "../../../plugin/action-types"
 import { HelmDeployAction } from "./config"
@@ -38,7 +38,7 @@ export const getHelmDeployLogs: DeployActionHandler<"getLogs", HelmDeployAction>
     //    terminated when the command exits.
     while (true) {
       try {
-        resources = await getRenderedResources({ ctx: k8sCtx, action, releaseName, log })
+        resources = await getDeployedChartResources({ ctx: k8sCtx, action, releaseName, log })
         break
       } catch (err) {
         log.debug(`Failed getting deployed resources. Retrying...`)
@@ -47,7 +47,7 @@ export const getHelmDeployLogs: DeployActionHandler<"getLogs", HelmDeployAction>
       await sleep(2000)
     }
   } else {
-    resources = await getRenderedResources({ ctx: k8sCtx, action, releaseName, log })
+    resources = await getDeployedChartResources({ ctx: k8sCtx, action, releaseName, log })
   }
   return streamK8sLogs({
     ...params,

--- a/core/src/plugins/kubernetes/helm/sync.ts
+++ b/core/src/plugins/kubernetes/helm/sync.ts
@@ -12,7 +12,7 @@ import { getActionNamespace } from "../namespace"
 import { getSyncStatus, startSyncs } from "../sync"
 import { getReleaseName } from "./common"
 import { HelmDeployAction } from "./config"
-import { getRenderedResources } from "./status"
+import { getDeployedChartResources } from "./status"
 
 export const helmStartSync: DeployActionHandler<"startSync", HelmDeployAction> = async (params) => {
   const { ctx, log, action } = params
@@ -33,7 +33,7 @@ export const helmStartSync: DeployActionHandler<"startSync", HelmDeployAction> =
     provider: k8sCtx.provider,
   })
 
-  const resources = await getRenderedResources({ ctx: k8sCtx, action, releaseName, log })
+  const deployedResources = await getDeployedChartResources({ ctx: k8sCtx, action, releaseName, log })
 
   await startSyncs({
     ctx: k8sCtx,
@@ -43,7 +43,7 @@ export const helmStartSync: DeployActionHandler<"startSync", HelmDeployAction> =
     defaultTarget: spec.defaultTarget,
     basePath: action.basePath(),
     defaultNamespace: namespace,
-    manifests: resources,
+    manifests: deployedResources,
     syncs: spec.sync.paths,
   })
 
@@ -71,7 +71,7 @@ export const helmGetSyncStatus: DeployActionHandler<"getSyncStatus", HelmDeployA
     provider: k8sCtx.provider,
   })
 
-  const resources = await getRenderedResources({ ctx: k8sCtx, action, releaseName, log })
+  const resources = await getDeployedChartResources({ ctx: k8sCtx, action, releaseName, log })
 
   return getSyncStatus({
     ctx: k8sCtx,

--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -578,7 +578,7 @@ export async function startSyncs(params: StartSyncsParams) {
     expectedKeys.push(key)
   })
 
-  const allSyncs = await mutagen.getActiveSyncSessions(log)
+  const allSyncs = expectedKeys.length === 0 ? [] : await mutagen.getActiveSyncSessions(log)
   const keyPrefix = getSyncKeyPrefix(ctx, action)
 
   for (const sync of allSyncs.filter((s) => s.name.startsWith(keyPrefix) && !expectedKeys.includes(s.name))) {

--- a/core/test/unit/src/cli/helpers.ts
+++ b/core/test/unit/src/cli/helpers.ts
@@ -225,9 +225,12 @@ describe("processCliArgs", () => {
 
   it("correctly handles option aliases", () => {
     const cmd = new DeployCommand()
-    const { opts } = parseAndProcess(["--sync", "--force-build=false"], cmd)
-    expect(opts["sync"]).to.eql([])
-    expect(opts["force-build"]).to.be.false
+    // The --sync option has two aliases: dev and dev-mode, so we test both of them.
+    const { opts: firstOpts } = parseAndProcess(["--dev", "some-deploy", "--force-build=false"], cmd)
+    const { opts: secondOpts } = parseAndProcess(["--dev-mode", "some-deploy"], cmd)
+    expect(firstOpts["sync"]).to.eql(["some-deploy"])
+    expect(firstOpts["force-build"]).to.be.false
+    expect(secondOpts["sync"]).to.eql(["some-deploy"])
   })
 
   it("correctly handles multiple instances of a string array parameter", () => {

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -3382,25 +3382,25 @@ Start a sync between your local project directory and one or more Deploys.
 
 Examples:
     # start syncing to the 'api' Deploy, fail if it's not already deployed in sync mode
-    garden start sync api
+    garden sync start api
 
     # deploy 'api' in sync mode and dependencies if needed, then start syncing
-    garden start sync api --deploy
+    garden sync start api --deploy
 
     # start syncing to every Deploy already deployed in sync mode
-    garden start sync '*'
+    garden sync start '*'
 
     # start syncing to every Deploy that supports it, deploying if needed
-    garden start sync '*' --deploy
+    garden sync start '*' --deploy
 
     # start syncing to every Deploy that supports it, deploying if needed including runtime dependencies
-    garden start sync '*' --deploy --include-dependencies
+    garden sync start '*' --deploy --include-dependencies
 
     # start syncing to the 'api' and 'worker' Deploys
-    garden start sync api worker
+    garden sync start api worker
 
     # start syncing to the 'api' Deploy and keep the process running, following sync status messages
-    garden start sync api -f
+    garden sync start api -f
 
 #### Usage
 
@@ -3429,10 +3429,10 @@ Stops one or more active syncs.
 
 Examples:
     # stop syncing to the 'api' Deploy
-    garden stop sync api
+    garden sync stop api
 
     # stop all active syncs
-    garden stop sync '*'
+    garden sync stop '*'
 
 #### Usage
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Before this fix, we were using locally rendered manifests instead of remotely deployed resources for status checks for helm Deploys.  This caused problems when starting/stopping syncs.

We were also using locally rendered manifests to find target resources
for log streaming for Helm Deploys. While this probably didn't cause problems in most cases, it also didn't make proper use of the retry loop in our Helm logging control flow.

A couple of other fixes were also made along the way:

**fix(sync-mode): ensure project mutagen dir exists**

Before this fix, we'd get Mutagen-related errors when listing syncs if the target resource wasn't deployed with sync mode.

**fix(cli):  correctly handle multiple opt aliases**

This fixes an issue with CLI options with more than one alias. Previously, only the last / highest-indexed alias would actually be applied.

This was fixed by passing an array of alias strings to minimist (instead of a single string).