### PR TITLE
fix: use the correct secret in pullFromExternalRegistry in kaniko builds

### DIFF
--- a/core/src/plugins/kubernetes/commands/pull-image.ts
+++ b/core/src/plugins/kubernetes/commands/pull-image.ts
@@ -149,7 +149,7 @@ async function pullFromExternalRegistry(
   let namespace: string
   let authSecretName: string
 
-  if (buildMode === "cluster-buildkit") {
+  if (buildMode === "cluster-buildkit" || buildMode === "kaniko") {
     namespace = await getAppNamespace(ctx, log, ctx.provider)
 
     const { authSecret } = await ensureBuilderSecret({


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes `garden publish` on our example projects, where we use GCR as the registry and `kaniko` build mode. Without this change, `skopeo` invocation during the image pull was using the wrong secret, with no permissions attached.

**Special notes for your reviewer**:
