### PR TITLE
0.13: Mandatory `apiVersion`-field when using action kinds

### DIFF
--- a/core/src/config/base.ts
+++ b/core/src/config/base.ts
@@ -192,19 +192,6 @@ export function prepareResource({
 
   let kind = spec.kind
 
-  // Allow the default api version for all kinds except for Project where we expect it to be defined
-  // explicitly from 0.13 and forward.
-  /*if (!spec.apiVersion && spec.kind === "Project") {
-    throw new ConfigurationError(
-      `"apiVersion" is missing in the Project config. The "apiVersion"-field is required from 0.13 (Bonsai). Use "${PREVIOUS_API_VERSION}" for backwards compatibility with 0.12 or "${DEFAULT_API_VERSION}" for 0.13. A detailed migration guide is available at https://docs.garden.io/v/bonsai-release/tutorials/migrating-to-bonsai.`,
-      { spec, path: configFilePath }
-    )
-  }
-
-  if (!spec.apiVersion) {
-    spec.apiVersion = DEFAULT_API_VERSION
-  }*/
-
   const basePath = dirname(configFilePath)
 
   if (!allowInvalid) {
@@ -322,11 +309,9 @@ function handleMissingApiVersion(log: Log, projectSpec: ProjectResource): Projec
   // Field 'modules' was intentionally removed from the internal interface `ProjectResource`,
   // but it still can be presented in the runtime if the old config format is used.
   if (!projectSpec["apiVersion"]) {
-    throw new ConfigurationError(
-      `"apiVersion" is missing in the Project config. The "apiVersion"-field is required from 0.13 (Bonsai). Use "${PREVIOUS_API_VERSION}" for backwards compatibility with 0.12 or "${DEFAULT_API_VERSION}" for 0.13. A detailed migration guide is available at https://docs.garden.io/v/bonsai-release/tutorials/migrating-to-bonsai.`,
-      {
-        projectSpec,
-      }
+    emitNonRepeatableWarning(
+      log,
+      `"apiVersion" is missing in the Project config. The "apiVersion"-field is mandatory when using the new action Kind-configs. Use "${PREVIOUS_API_VERSION}" for backwards compatibility with 0.12 or "${DEFAULT_API_VERSION}" for 0.13. A detailed migration guide is available at https://docs.garden.io/v/bonsai-release/tutorials/migrating-to-bonsai.`
     )
   } else {
     if (projectSpec["apiVersion"] === PREVIOUS_API_VERSION) {

--- a/core/src/config/base.ts
+++ b/core/src/config/base.ts
@@ -306,13 +306,14 @@ function handleProjectModules(log: Log, projectSpec: ProjectResource): ProjectRe
 }
 
 function handleMissingApiVersion(log: Log, projectSpec: ProjectResource): ProjectResource {
-  // Field 'modules' was intentionally removed from the internal interface `ProjectResource`,
-  // but it still can be presented in the runtime if the old config format is used.
+  // We conservatively set the apiVersion to be compatible with 0.12.
   if (!projectSpec["apiVersion"]) {
     emitNonRepeatableWarning(
       log,
-      `"apiVersion" is missing in the Project config. The "apiVersion"-field is mandatory when using the new action Kind-configs. Use "${PREVIOUS_API_VERSION}" for backwards compatibility with 0.12 or "${DEFAULT_API_VERSION}" for 0.13. A detailed migration guide is available at https://docs.garden.io/v/bonsai-release/tutorials/migrating-to-bonsai.`
+      `"apiVersion" is missing in the Project config. Assuming "${PREVIOUS_API_VERSION}" for backwards compatibility with 0.12. The "apiVersion"-field is mandatory when using the new action Kind-configs. A detailed migration guide is available at https://docs.garden.io/v/bonsai-release/tutorials/migrating-to-bonsai.`
     )
+
+    return { ...projectSpec, apiVersion: PREVIOUS_API_VERSION }
   } else {
     if (projectSpec["apiVersion"] === PREVIOUS_API_VERSION) {
       emitNonRepeatableWarning(
@@ -373,7 +374,7 @@ export function prepareModuleResource(spec: any, configPath: string, projectRoot
   // Built-in keys are validated here and the rest are put into the `spec` field
   const path = dirname(configPath)
   const config: ModuleConfig = {
-    apiVersion: spec.apiVersion || DEFAULT_API_VERSION,
+    apiVersion: spec.apiVersion || PREVIOUS_API_VERSION,
     kind: "Module",
     allowPublish: spec.allowPublish,
     build: {

--- a/core/src/config/base.ts
+++ b/core/src/config/base.ts
@@ -310,7 +310,7 @@ function handleMissingApiVersion(log: Log, projectSpec: ProjectResource): Projec
   if (projectSpec["apiVersion"] === undefined) {
     emitNonRepeatableWarning(
       log,
-      `"apiVersion" is missing in the Project config. Assuming "${PREVIOUS_API_VERSION}" for backwards compatibility with 0.12. The "apiVersion"-field is mandatory when using the new action Kind-configs. A detailed migration guide is available at https://docs.garden.io/v/bonsai-release/tutorials/migrating-to-bonsai.`
+      `"apiVersion" is missing in the Project config. Assuming "${PREVIOUS_API_VERSION}" for backwards compatibility with 0.12. The "apiVersion"-field is mandatory when using the new action Kind-configs. A detailed migration guide is available at https://docs.garden.io/tutorials/migrating-to-bonsai`
     )
 
     return { ...projectSpec, apiVersion: PREVIOUS_API_VERSION }

--- a/core/src/config/base.ts
+++ b/core/src/config/base.ts
@@ -307,7 +307,7 @@ function handleProjectModules(log: Log, projectSpec: ProjectResource): ProjectRe
 
 function handleMissingApiVersion(log: Log, projectSpec: ProjectResource): ProjectResource {
   // We conservatively set the apiVersion to be compatible with 0.12.
-  if (!projectSpec["apiVersion"]) {
+  if (projectSpec["apiVersion"] === undefined) {
     emitNonRepeatableWarning(
       log,
       `"apiVersion" is missing in the Project config. Assuming "${PREVIOUS_API_VERSION}" for backwards compatibility with 0.12. The "apiVersion"-field is mandatory when using the new action Kind-configs. A detailed migration guide is available at https://docs.garden.io/v/bonsai-release/tutorials/migrating-to-bonsai.`

--- a/core/src/config/base.ts
+++ b/core/src/config/base.ts
@@ -192,8 +192,15 @@ export function prepareResource({
 
   let kind = spec.kind
 
-  if (!spec.apiVersion) {
+  // Allow the default api version for all kinds except for Project where we expect it to be defined
+  // explicitly from 0.13 and forward.
+  if (!spec.apiVersion && spec.kind !== "Project") {
     spec.apiVersion = DEFAULT_API_VERSION
+  } else {
+    throw new ConfigurationError(
+      `"apiVersion: garden.io/v0.13" is missing in the Project config. The "apiVersion"-field is required from 0.13 (Bonsai). A detailed migration guide is available at https://docs.garden.io/v/bonsai-release/tutorials/migrating-to-bonsai.`,
+      { spec, path: configFilePath }
+    )
   }
 
   const basePath = dirname(configFilePath)

--- a/core/src/config/common.ts
+++ b/core/src/config/common.ts
@@ -856,12 +856,10 @@ export const moduleVersionSchema = createSchema({
   }),
 })
 
-export const apiVersionSchema = () =>
-  joi
-    .string()
-    .default(DEFAULT_API_VERSION)
-    .valid(DEFAULT_API_VERSION)
-    .description("The schema version of this config (currently not used).")
+export const apiVersionSchema = () => apiVersionSchemaWithoutDefault().default(DEFAULT_API_VERSION)
+
+export const apiVersionSchemaWithoutDefault = () =>
+  joi.string().valid(DEFAULT_API_VERSION).description("The schema version of this config.")
 
 /**
  * A little hack to allow unknown fields on the schema and recursively on all object schemas nested in it.

--- a/core/src/config/common.ts
+++ b/core/src/config/common.ts
@@ -12,7 +12,7 @@ import addFormats from "ajv-formats"
 import { splitLast, deline, dedent, naturalList, titleize } from "../util/string"
 import { cloneDeep, isArray, isPlainObject, isString, mapValues, memoize } from "lodash"
 import { joiPathPlaceholder } from "./validation"
-import { DEFAULT_API_VERSION } from "../constants"
+import { DEFAULT_API_VERSION, PREVIOUS_API_VERSION } from "../constants"
 import { ActionKind, actionKinds, actionKindsLower } from "../actions/types"
 import { ConfigurationError, InternalError } from "../exceptions"
 import type { ConfigContextType } from "./template-contexts/base"
@@ -859,7 +859,7 @@ export const moduleVersionSchema = createSchema({
 export const apiVersionSchema = () => apiVersionSchemaWithoutDefault().default(DEFAULT_API_VERSION)
 
 export const apiVersionSchemaWithoutDefault = () =>
-  joi.string().valid(DEFAULT_API_VERSION).description("The schema version of this config.")
+  joi.string().valid(PREVIOUS_API_VERSION, DEFAULT_API_VERSION).description("The schema version of this config.")
 
 /**
  * A little hack to allow unknown fields on the schema and recursively on all object schemas nested in it.

--- a/core/src/config/project.ts
+++ b/core/src/config/project.ts
@@ -9,7 +9,7 @@
 import { apply, merge } from "json-merge-patch"
 import { dedent, deline, naturalList } from "../util/string"
 import {
-  apiVersionSchema,
+  apiVersionSchemaWithoutDefault,
   createSchema,
   DeepPrimitiveMap,
   includeGuideLink,
@@ -283,7 +283,7 @@ export const projectSchema = createSchema({
     "Configuration for a Garden project. This should be specified in the garden.yml file in your project root.",
   required: true,
   keys: () => ({
-    apiVersion: apiVersionSchema(),
+    apiVersion: apiVersionSchemaWithoutDefault().required(),
     kind: joi.string().default("Project").valid("Project").description("Indicate what kind of config this is."),
     path: projectRootSchema().meta({ internal: true }),
     configPath: joi.string().meta({ internal: true }).description("The path to the project config file."),

--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -23,7 +23,8 @@ export const ERROR_LOG_FILENAME = "error.log"
 export const GARDEN_VERSIONFILE_NAME = ".garden-version"
 export const DEFAULT_PORT_PROTOCOL = "TCP"
 
-export const DEFAULT_API_VERSION = "garden.io/v0"
+export const PREVIOUS_API_VERSION = "garden.io/v0"
+export const DEFAULT_API_VERSION = "garden.io/v1"
 
 export const DEFAULT_TEST_TIMEOUT = 60 * 1000
 export const DEFAULT_RUN_TIMEOUT = 60 * 1000

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -1274,7 +1274,7 @@ export class Garden {
         // This is only available with apiVersion `garden.io/v1` or newer.
         if (this.projectApiVersion !== DEFAULT_API_VERSION) {
           throw new ConfigurationError(
-            `Action kinds are only supported in project configurations with "apiVersion: ${DEFAULT_API_VERSION}". A detailed migration guide is available at https://docs.garden.io/v/bonsai-release/tutorials/migrating-to-bonsai.`,
+            `Action kinds are only supported in project configurations with "apiVersion: ${DEFAULT_API_VERSION}". A detailed migration guide is available at https://docs.garden.io/tutorials/migrating-to-bonsai`,
             {}
           )
         }

--- a/core/src/warnings.ts
+++ b/core/src/warnings.ts
@@ -16,6 +16,10 @@ const loggerContext: LoggerContext = {
   history: new Set<string>(),
 }
 
+export function resetNonRepeatableWarningHistory() {
+  loggerContext.history.clear()
+}
+
 export function emitNonRepeatableWarning(log: Log, message: string) {
   if (loggerContext.history.has(message)) {
     return

--- a/core/test/data/exec-provider-cache/project.garden.yml
+++ b/core/test/data/exec-provider-cache/project.garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: incident-repro
 environments:

--- a/core/test/data/test-build-dependants/project.garden.yaml
+++ b/core/test/data/test-build-dependants/project.garden.yaml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: test
 environments:

--- a/core/test/data/test-project-a/garden.yml
+++ b/core/test/data/test-project-a/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: test-project-a
 environments:

--- a/core/test/data/test-project-b/garden.yml
+++ b/core/test/data/test-project-b/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: test-project-b
 environments:

--- a/core/test/data/test-project-container/garden.yml
+++ b/core/test/data/test-project-container/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: container-module-test-project
 environments:

--- a/core/test/data/test-project-dependants/garden.yml
+++ b/core/test/data/test-project-dependants/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: test-project-dependants
 environments:

--- a/core/test/data/test-project-duplicate-project-config/garden.yml
+++ b/core/test/data/test-project-duplicate-project-config/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: test-project
 environments:
@@ -13,6 +14,7 @@ variables:
 
 ---
 
+apiVersion: garden.io/v1
 kind: Project
 name: test-project-duplicate
 environments:

--- a/core/test/data/test-project-empty/garden.yml
+++ b/core/test/data/test-project-empty/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: test-project-empty
 environments:

--- a/core/test/data/test-project-exec/garden.yml
+++ b/core/test/data/test-project-exec/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: test-project-a
 environments:

--- a/core/test/data/test-project-malformed-environments/garden.yml
+++ b/core/test/data/test-project-malformed-environments/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: test-project-malformed-environments
 environments:

--- a/core/test/data/test-project-templated/garden.yml
+++ b/core/test/data/test-project-templated/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: test-project-templated
 defaultEnvironment: "${local.env.TEST_VARIABLE == 'banana' ? 'local' : 'local'}"

--- a/core/test/data/test-project-test-deps/garden.yml
+++ b/core/test/data/test-project-test-deps/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: test-project-test-deps
 environments:

--- a/core/test/data/test-project-variable-versioning/garden.yml
+++ b/core/test/data/test-project-variable-versioning/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: test-project-variable-versioning
 environments:

--- a/core/test/data/test-project-yaml-file-extensions/garden.yaml
+++ b/core/test/data/test-project-yaml-file-extensions/garden.yaml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: test-project-a
 environments:

--- a/core/test/data/test-projects/1067-module-ref-within-file/garden.yml
+++ b/core/test/data/test-projects/1067-module-ref-within-file/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: issue-1067
 environments:

--- a/core/test/data/test-projects/build-dir/garden.yml
+++ b/core/test/data/test-projects/build-dir/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: build-products
 environments:

--- a/core/test/data/test-projects/config-action-kind-v0/project.garden.yml
+++ b/core/test/data/test-projects/config-action-kind-v0/project.garden.yml
@@ -1,0 +1,13 @@
+apiVersion: garden.io/v0
+kind: Project
+name: config-action-kind-v0
+environments:
+  - name: local
+
+---
+kind: Build
+type: test
+name: config-action-kind-v0-echo
+include: []
+spec:
+  command: ["echo"]

--- a/core/test/data/test-projects/config-templates/project.garden.yml
+++ b/core/test/data/test-projects/config-templates/project.garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: config-templates
 environments:

--- a/core/test/data/test-projects/container/garden.yml
+++ b/core/test/data/test-projects/container/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: container
 environments:

--- a/core/test/data/test-projects/custom-commands-invalid/project.garden.yml
+++ b/core/test/data/test-projects/custom-commands-invalid/project.garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: custom-commands-invalid
 environments:

--- a/core/test/data/test-projects/custom-commands/project.garden.yml
+++ b/core/test/data/test-projects/custom-commands/project.garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: custom-commands
 environments:

--- a/core/test/data/test-projects/custom-config-names/project.garden.yml
+++ b/core/test/data/test-projects/custom-config-names/project.garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: test-project-a
 id: test-project-id

--- a/core/test/data/test-projects/dotignore-custom-legacy/with-supported-legacy-config/garden.yml
+++ b/core/test/data/test-projects/dotignore-custom-legacy/with-supported-legacy-config/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 # todo: remove this in project in 0.14
 kind: Project
 name: include-exclude

--- a/core/test/data/test-projects/dotignore-custom-legacy/with-unsupported-legacy-config/garden.yml
+++ b/core/test/data/test-projects/dotignore-custom-legacy/with-unsupported-legacy-config/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 # todo: remove this in project in 0.14
 kind: Project
 name: include-exclude

--- a/core/test/data/test-projects/dotignore-custom/garden.yml
+++ b/core/test/data/test-projects/dotignore-custom/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: include-exclude
 # 0.13: the new dotIgnoreFile field always takes precedence over the old `dotIgnoreFiles`

--- a/core/test/data/test-projects/dotignore/garden.yml
+++ b/core/test/data/test-projects/dotignore/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: include-exclude
 environments:

--- a/core/test/data/test-projects/duplicate-config-templates/project.garden.yml
+++ b/core/test/data/test-projects/duplicate-config-templates/project.garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: duplicate-module-templates
 environments:

--- a/core/test/data/test-projects/duplicate-module/garden.yml
+++ b/core/test/data/test-projects/duplicate-module/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: duplicate-module
 environments:

--- a/core/test/data/test-projects/duplicate-service-and-task/garden.yml
+++ b/core/test/data/test-projects/duplicate-service-and-task/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: duplicate-module
 environments:

--- a/core/test/data/test-projects/duplicate-service/garden.yml
+++ b/core/test/data/test-projects/duplicate-service/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: duplicate-module
 environments:

--- a/core/test/data/test-projects/duplicate-task/garden.yml
+++ b/core/test/data/test-projects/duplicate-task/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: duplicate-module
 environments:

--- a/core/test/data/test-projects/dynamic-build-dependencies/garden.yml
+++ b/core/test/data/test-projects/dynamic-build-dependencies/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: dynamic-build-dependencies
 environments:

--- a/core/test/data/test-projects/empty-doc/garden.yml
+++ b/core/test/data/test-projects/empty-doc/garden.yml
@@ -1,4 +1,5 @@
 ---
+apiVersion: garden.io/v1
 kind: Project
 name: foo
 environments:

--- a/core/test/data/test-projects/exec-artifacts/garden.yml
+++ b/core/test/data/test-projects/exec-artifacts/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: exec-artifacts
 environments:

--- a/core/test/data/test-projects/exec-task-outputs/garden.yml
+++ b/core/test/data/test-projects/exec-task-outputs/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: exec-task-outputs
 environments:

--- a/core/test/data/test-projects/ext-action-sources/garden.yml
+++ b/core/test/data/test-projects/ext-action-sources/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: ext-project-sources
 environments:

--- a/core/test/data/test-projects/ext-module-sources/garden.yml
+++ b/core/test/data/test-projects/ext-module-sources/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: ext-project-sources
 environments:

--- a/core/test/data/test-projects/ext-project-sources/garden.yml
+++ b/core/test/data/test-projects/ext-project-sources/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: ext-project-sources
 sources:

--- a/core/test/data/test-projects/fixed-version-hashes-1/garden.yml
+++ b/core/test/data/test-projects/fixed-version-hashes-1/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: test-project-fixed-version-hashes-1
 environments:

--- a/core/test/data/test-projects/fixed-version-hashes-2/garden.yml
+++ b/core/test/data/test-projects/fixed-version-hashes-2/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: test-project-fixed-version-hashes-2
 environments:

--- a/core/test/data/test-projects/helm-local-mode/garden.yml
+++ b/core/test/data/test-projects/helm-local-mode/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: local-mode-helm
 # defaultEnvironment: "remote" # Uncomment if you'd like the remote environment to be the default for this project.

--- a/core/test/data/test-projects/helm/garden.yml
+++ b/core/test/data/test-projects/helm/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: helm-test
 environments:

--- a/core/test/data/test-projects/include-exclude/garden.yml
+++ b/core/test/data/test-projects/include-exclude/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: include-exclude
 environments:

--- a/core/test/data/test-projects/kubernetes-module/garden.yml
+++ b/core/test/data/test-projects/kubernetes-module/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: kubernetes-module-test
 environments:

--- a/core/test/data/test-projects/login/has-domain-and-id/garden.yml
+++ b/core/test/data/test-projects/login/has-domain-and-id/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: has-domain-and-id
 domain: http://example.invalid

--- a/core/test/data/test-projects/login/has-domain/garden.yml
+++ b/core/test/data/test-projects/login/has-domain/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: login
 domain: http://example.invalid

--- a/core/test/data/test-projects/login/missing-domain/garden.yml
+++ b/core/test/data/test-projects/login/missing-domain/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: login
 environments:

--- a/core/test/data/test-projects/login/secret-in-project-variables/garden.yml
+++ b/core/test/data/test-projects/login/secret-in-project-variables/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: login
 domain: http://example.invalid

--- a/core/test/data/test-projects/module-self-ref/garden.yml
+++ b/core/test/data/test-projects/module-self-ref/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: duplicate-module
 environments:

--- a/core/test/data/test-projects/module-templates/project.garden.yml
+++ b/core/test/data/test-projects/module-templates/project.garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: module-templates
 environments:

--- a/core/test/data/test-projects/module-varfiles/garden.yml
+++ b/core/test/data/test-projects/module-varfiles/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: module-varfiles
 varfile: garden.project.env

--- a/core/test/data/test-projects/multiple-module-config-bad/garden.yml
+++ b/core/test/data/test-projects/multiple-module-config-bad/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: test-project-multiple-modules-config-bad
 environments:

--- a/core/test/data/test-projects/multiple-module-config/garden.yml
+++ b/core/test/data/test-projects/multiple-module-config/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: test-project-multiple-modules
 variables:

--- a/core/test/data/test-projects/new-provider-spec/garden.yml
+++ b/core/test/data/test-projects/new-provider-spec/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: test-project-a
 environments:

--- a/core/test/data/test-projects/non-string-template-values/garden.yml
+++ b/core/test/data/test-projects/non-string-template-values/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: non-string-template-values
 environments:

--- a/core/test/data/test-projects/project-include-exclude-old-syntax/garden.yml
+++ b/core/test/data/test-projects/project-include-exclude-old-syntax/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: include-exclude-old-syntax
 environments:

--- a/core/test/data/test-projects/project-include-exclude/garden.yml
+++ b/core/test/data/test-projects/project-include-exclude/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: include-exclude
 environments:

--- a/core/test/data/test-projects/source-module/garden.yml
+++ b/core/test/data/test-projects/source-module/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: duplicate-module
 environments:

--- a/core/test/data/test-projects/varfiles-custom/garden.yml
+++ b/core/test/data/test-projects/varfiles-custom/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: varfiles-custom
 environments:

--- a/core/test/data/test-projects/varfiles/garden.yml
+++ b/core/test/data/test-projects/varfiles/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: varfiles
 environments:

--- a/core/test/data/validate/bad-module/garden.yml
+++ b/core/test/data/validate/bad-module/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: build-test-project
 environments:

--- a/core/test/data/validate/bad-workflow/garden.yml
+++ b/core/test/data/validate/bad-workflow/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: bad-workflow-project
 environments:

--- a/core/test/unit/src/commands/create/create-project.ts
+++ b/core/test/unit/src/commands/create/create-project.ts
@@ -15,6 +15,7 @@ import { basename, join } from "path"
 import { pathExists, readFile, writeFile } from "fs-extra"
 import { safeLoadAll } from "js-yaml"
 import { safeDumpYaml } from "../../../../../src/util/serialization"
+import { DEFAULT_API_VERSION } from "../../../../../src/constants"
 
 describe("CreateProjectCommand", () => {
   const command = new CreateProjectCommand()
@@ -198,6 +199,7 @@ describe("CreateProjectCommand", () => {
 
   it("should throw if a project is already in the directory", async () => {
     const existing = {
+      apiVersion: DEFAULT_API_VERSION,
       kind: "Project",
       name: "foo",
     }

--- a/core/test/unit/src/commands/plugins.ts
+++ b/core/test/unit/src/commands/plugins.ts
@@ -58,6 +58,7 @@ describe("PluginsCommand", () => {
     await writeFile(
       join(tmpDir.path, "garden.yml"),
       dedent`
+      apiVersion: garden.io/v1
       kind: Project
       name: test
       environments:

--- a/core/test/unit/src/config/base.ts
+++ b/core/test/unit/src/config/base.ts
@@ -116,14 +116,20 @@ describe("prepareProjectResource", () => {
     expect(processConfigAction).to.throw(ConfigurationError, /"apiVersion: unknown" is unknown/)
   })
 
-  it("should log a warning if the apiVersion is not defined", async () => {
+  it("should fall back to the previous apiVersion when not defined", async () => {
     const projectResource = {
       ...projectResourceTemplate,
       apiVersion: undefined,
     }
 
     const returnedProjectResource = prepareProjectResource(log, projectResource)
-    expect(returnedProjectResource).to.eql(projectResource)
+
+    // The apiVersion is set to the previous version for backwards compatibility.
+    const expectedProjectResource = {
+      ...projectResource,
+      apiVersion: PREVIOUS_API_VERSION,
+    }
+    expect(returnedProjectResource).to.eql(expectedProjectResource)
 
     const logEntries = logger.getLogEntries()
     expect(logEntries).to.have.length(1)

--- a/core/test/unit/src/config/base.ts
+++ b/core/test/unit/src/config/base.ts
@@ -23,6 +23,7 @@ import { defaultDotIgnoreFile } from "../../../../src/util/fs"
 import { safeDumpYaml } from "../../../../src/util/serialization"
 import { getRootLogger } from "../../../../src/logger/logger"
 import { ConfigurationError } from "../../../../src/exceptions"
+import { resetNonRepeatableWarningHistory } from "../../../../src/warnings"
 
 const projectPathA = getDataDir("test-project-a")
 const modulePathA = resolve(projectPathA, "module-a")
@@ -46,6 +47,12 @@ describe("prepareProjectResource", () => {
     providers: [{ name: "foo" }],
     variables: {},
   }
+
+  beforeEach(() => {
+    // we reset the non repeatable warning before each test to make sure that a
+    // previously displayed warning is logged in all tests
+    resetNonRepeatableWarningHistory()
+  })
 
   it("no changes if new `dotIgnoreFile` field is provided explicitly", () => {
     const projectResource = {

--- a/core/test/unit/src/config/base.ts
+++ b/core/test/unit/src/config/base.ts
@@ -131,9 +131,8 @@ describe("prepareProjectResource", () => {
     }
     expect(returnedProjectResource).to.eql(expectedProjectResource)
 
-    const logEntries = logger.getLogEntries()
-    expect(logEntries).to.have.length(1)
-    expect(logEntries[0].msg).to.include(`"apiVersion" is missing in the Project config`)
+    const logEntry = log.getLatestEntry()
+    expect(logEntry.msg).to.include(`"apiVersion" is missing in the Project config`)
   })
 
   it("should log a warning if the apiVersion is against the previous version", async () => {
@@ -145,9 +144,8 @@ describe("prepareProjectResource", () => {
     const returnedProjectResource = prepareProjectResource(log, projectResource)
     expect(returnedProjectResource).to.eql(projectResource)
 
-    const logEntries = logger.getLogEntries()
-    expect(logEntries).to.have.length(1)
-    expect(logEntries[0].msg).to.include(`Project "apiVersion" running with backwards compatibility`)
+    const logEntry = log.getLatestEntry()
+    expect(logEntry.msg).to.include(`Project "apiVersion" running with backwards compatibility`)
   })
 })
 

--- a/core/test/unit/src/config/base.ts
+++ b/core/test/unit/src/config/base.ts
@@ -249,7 +249,7 @@ describe("loadConfigResources", () => {
 
     expect(parsed).to.eql([
       {
-        apiVersion: DEFAULT_API_VERSION,
+        apiVersion: PREVIOUS_API_VERSION,
         kind: "Module",
         name: "module-a",
         type: "test",
@@ -393,7 +393,7 @@ describe("loadConfigResources", () => {
         variables: { some: "variable" },
       },
       {
-        apiVersion: DEFAULT_API_VERSION,
+        apiVersion: PREVIOUS_API_VERSION,
         kind: "Module",
         name: "module-from-project-config",
         type: "test",
@@ -428,7 +428,7 @@ describe("loadConfigResources", () => {
 
     expect(parsed).to.eql([
       {
-        apiVersion: DEFAULT_API_VERSION,
+        apiVersion: PREVIOUS_API_VERSION,
         kind: "Module",
         name: "module-a1",
         type: "test",
@@ -460,7 +460,7 @@ describe("loadConfigResources", () => {
         varfile: undefined,
       },
       {
-        apiVersion: DEFAULT_API_VERSION,
+        apiVersion: PREVIOUS_API_VERSION,
         kind: "Module",
         name: "module-a2",
         type: "test",

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -4564,9 +4564,9 @@ describe("Garden", () => {
     })
 
     context("test against fixed version hashes", async () => {
-      const moduleAVersionString = "v-294c5e9ae2"
-      const moduleBVersionString = "v-e84ffd879b"
-      const moduleCVersionString = "v-8e7923d3a5"
+      const moduleAVersionString = "v-0a4dda85e8"
+      const moduleBVersionString = "v-0ab7a050db"
+      const moduleCVersionString = "v-958ee38dd2"
 
       it("should return the same module versions between runtimes", async () => {
         const projectRoot = getDataDir("test-projects", "fixed-version-hashes-1")

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -38,7 +38,7 @@ import { createGardenPlugin, ProviderActionName } from "../../../src/plugin/plug
 import { ConfigureProviderParams } from "../../../src/plugin/handlers/Provider/configureProvider"
 import { ProjectConfig, defaultNamespace } from "../../../src/config/project"
 import { ModuleConfig, baseModuleSpecSchema } from "../../../src/config/module"
-import { DEFAULT_API_VERSION, gardenEnv } from "../../../src/constants"
+import { DEFAULT_API_VERSION, PREVIOUS_API_VERSION, gardenEnv } from "../../../src/constants"
 import { providerConfigBaseSchema } from "../../../src/config/provider"
 import { keyBy, set, mapValues, omit } from "lodash"
 import { joi } from "../../../src/config/common"
@@ -2389,8 +2389,9 @@ describe("Garden", () => {
       const configA = (await garden.getRawModuleConfigs(["foo-test-a"]))[0]
       const configB = (await garden.getRawModuleConfigs(["foo-test-b"]))[0]
 
+      // note that module config versions should default to v0 (previous version)
       expect(omitUndefined(configA)).to.eql({
-        apiVersion: DEFAULT_API_VERSION,
+        apiVersion: PREVIOUS_API_VERSION,
         kind: "Module",
         build: {
           dependencies: [],
@@ -2424,7 +2425,7 @@ describe("Garden", () => {
         },
       })
       expect(omitUndefined(configB)).to.eql({
-        apiVersion: DEFAULT_API_VERSION,
+        apiVersion: PREVIOUS_API_VERSION,
         kind: "Module",
         build: {
           dependencies: [{ name: "foo-test-a", copy: [] }],
@@ -2628,6 +2629,14 @@ describe("Garden", () => {
     it.skip("should throw an error if references to missing secrets are present in a module config", async () => {
       const garden = await makeTestGarden(getDataDir("missing-secrets", "module"))
       await expectError(() => garden.scanAndAddConfigs(), { contains: "Module module-a: missing" })
+    })
+
+    it("should throw when apiVersion v0 is set in a project with action configs", async () => {
+      const garden = await makeTestGarden(getDataDir("test-projects", "config-action-kind-v0"))
+
+      await expectError(() => garden.scanAndAddConfigs(), {
+        contains: `Action kinds are only supported in project configurations with "apiVersion: ${DEFAULT_API_VERSION}"`,
+      })
     })
   })
 

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -380,6 +380,7 @@ describe("Garden", () => {
         await writeFile(
           join(tmpPath, "garden.yml"),
           dedent`
+          apiVersion: garden.io/v1
           kind: Project
           name: foo
           environments:
@@ -4554,9 +4555,9 @@ describe("Garden", () => {
     })
 
     context("test against fixed version hashes", async () => {
-      const moduleAVersionString = "v-0a4dda85e8"
-      const moduleBVersionString = "v-0ab7a050db"
-      const moduleCVersionString = "v-958ee38dd2"
+      const moduleAVersionString = "v-294c5e9ae2"
+      const moduleBVersionString = "v-e84ffd879b"
+      const moduleCVersionString = "v-8e7923d3a5"
 
       it("should return the same module versions between runtimes", async () => {
         const projectRoot = getDataDir("test-projects", "fixed-version-hashes-1")

--- a/core/test/unit/src/vcs/vcs.ts
+++ b/core/test/unit/src/vcs/vcs.ts
@@ -329,7 +329,7 @@ describe("getModuleVersionString", () => {
     const garden = await makeTestGarden(projectRoot, { noCache: true })
     const module = await garden.resolveModule("module-a")
 
-    const fixedVersionString = "v-294c5e9ae2"
+    const fixedVersionString = "v-0a4dda85e8"
     expect(module.version.versionString).to.eql(fixedVersionString)
 
     delete process.env.TEST_ENV_VAR

--- a/core/test/unit/src/vcs/vcs.ts
+++ b/core/test/unit/src/vcs/vcs.ts
@@ -329,7 +329,7 @@ describe("getModuleVersionString", () => {
     const garden = await makeTestGarden(projectRoot, { noCache: true })
     const module = await garden.resolveModule("module-a")
 
-    const fixedVersionString = "v-0a4dda85e8"
+    const fixedVersionString = "v-294c5e9ae2"
     expect(module.version.versionString).to.eql(fixedVersionString)
 
     delete process.env.TEST_ENV_VAR

--- a/docs/reference/action-types/Build/container.md
+++ b/docs/reference/action-types/Build/container.md
@@ -21,8 +21,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 # The type of action, e.g. `exec`, `container` or `kubernetes`. Some are built into Garden but mostly these will be
 # defined by your configured providers.
@@ -213,11 +213,11 @@ spec:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `type`
 

--- a/docs/reference/action-types/Build/exec.md
+++ b/docs/reference/action-types/Build/exec.md
@@ -21,8 +21,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 # The type of action, e.g. `exec`, `container` or `kubernetes`. Some are built into Garden but mostly these will be
 # defined by your configured providers.
@@ -216,11 +216,11 @@ spec:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `type`
 

--- a/docs/reference/action-types/Build/jib-container.md
+++ b/docs/reference/action-types/Build/jib-container.md
@@ -33,8 +33,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 # The type of action, e.g. `exec`, `container` or `kubernetes`. Some are built into Garden but mostly these will be
 # defined by your configured providers.
@@ -272,11 +272,11 @@ spec:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `type`
 

--- a/docs/reference/action-types/Deploy/configmap.md
+++ b/docs/reference/action-types/Deploy/configmap.md
@@ -23,8 +23,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 # The type of action, e.g. `exec`, `container` or `kubernetes`. Some are built into Garden but mostly these will be
 # defined by your configured providers.
@@ -175,11 +175,11 @@ spec:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `type`
 

--- a/docs/reference/action-types/Deploy/container.md
+++ b/docs/reference/action-types/Deploy/container.md
@@ -23,8 +23,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 # The type of action, e.g. `exec`, `container` or `kubernetes`. Some are built into Garden but mostly these will be
 # defined by your configured providers.
@@ -427,11 +427,11 @@ spec:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `type`
 

--- a/docs/reference/action-types/Deploy/exec.md
+++ b/docs/reference/action-types/Deploy/exec.md
@@ -21,8 +21,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 # The type of action, e.g. `exec`, `container` or `kubernetes`. Some are built into Garden but mostly these will be
 # defined by your configured providers.
@@ -216,11 +216,11 @@ spec:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `type`
 

--- a/docs/reference/action-types/Deploy/helm.md
+++ b/docs/reference/action-types/Deploy/helm.md
@@ -23,8 +23,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 # The type of action, e.g. `exec`, `container` or `kubernetes`. Some are built into Garden but mostly these will be
 # defined by your configured providers.
@@ -457,11 +457,11 @@ spec:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `type`
 

--- a/docs/reference/action-types/Deploy/kubernetes.md
+++ b/docs/reference/action-types/Deploy/kubernetes.md
@@ -27,8 +27,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 # The type of action, e.g. `exec`, `container` or `kubernetes`. Some are built into Garden but mostly these will be
 # defined by your configured providers.
@@ -439,11 +439,11 @@ spec:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `type`
 

--- a/docs/reference/action-types/Deploy/persistentvolumeclaim.md
+++ b/docs/reference/action-types/Deploy/persistentvolumeclaim.md
@@ -23,8 +23,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 # The type of action, e.g. `exec`, `container` or `kubernetes`. Some are built into Garden but mostly these will be
 # defined by your configured providers.
@@ -227,11 +227,11 @@ spec:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `type`
 

--- a/docs/reference/action-types/Deploy/pulumi.md
+++ b/docs/reference/action-types/Deploy/pulumi.md
@@ -25,8 +25,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 # The type of action, e.g. `exec`, `container` or `kubernetes`. Some are built into Garden but mostly these will be
 # defined by your configured providers.
@@ -264,11 +264,11 @@ spec:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `type`
 

--- a/docs/reference/action-types/Deploy/terraform.md
+++ b/docs/reference/action-types/Deploy/terraform.md
@@ -29,8 +29,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 # The type of action, e.g. `exec`, `container` or `kubernetes`. Some are built into Garden but mostly these will be
 # defined by your configured providers.
@@ -218,11 +218,11 @@ spec:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `type`
 

--- a/docs/reference/action-types/Run/container.md
+++ b/docs/reference/action-types/Run/container.md
@@ -23,8 +23,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 # The type of action, e.g. `exec`, `container` or `kubernetes`. Some are built into Garden but mostly these will be
 # defined by your configured providers.
@@ -252,11 +252,11 @@ spec:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `type`
 

--- a/docs/reference/action-types/Run/exec.md
+++ b/docs/reference/action-types/Run/exec.md
@@ -21,8 +21,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 # The type of action, e.g. `exec`, `container` or `kubernetes`. Some are built into Garden but mostly these will be
 # defined by your configured providers.
@@ -191,11 +191,11 @@ spec:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `type`
 

--- a/docs/reference/action-types/Run/helm-pod.md
+++ b/docs/reference/action-types/Run/helm-pod.md
@@ -23,8 +23,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 # The type of action, e.g. `exec`, `container` or `kubernetes`. Some are built into Garden but mostly these will be
 # defined by your configured providers.
@@ -289,11 +289,11 @@ spec:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `type`
 

--- a/docs/reference/action-types/Run/kubernetes-exec.md
+++ b/docs/reference/action-types/Run/kubernetes-exec.md
@@ -23,8 +23,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 # The type of action, e.g. `exec`, `container` or `kubernetes`. Some are built into Garden but mostly these will be
 # defined by your configured providers.
@@ -217,11 +217,11 @@ spec:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `type`
 

--- a/docs/reference/action-types/Run/kubernetes-pod.md
+++ b/docs/reference/action-types/Run/kubernetes-pod.md
@@ -23,8 +23,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 # The type of action, e.g. `exec`, `container` or `kubernetes`. Some are built into Garden but mostly these will be
 # defined by your configured providers.
@@ -578,11 +578,11 @@ spec:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `type`
 

--- a/docs/reference/action-types/Test/conftest-helm.md
+++ b/docs/reference/action-types/Test/conftest-helm.md
@@ -27,8 +27,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 # The type of action, e.g. `exec`, `container` or `kubernetes`. Some are built into Garden but mostly these will be
 # defined by your configured providers.
@@ -186,11 +186,11 @@ spec:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `type`
 

--- a/docs/reference/action-types/Test/conftest.md
+++ b/docs/reference/action-types/Test/conftest.md
@@ -25,8 +25,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 # The type of action, e.g. `exec`, `container` or `kubernetes`. Some are built into Garden but mostly these will be
 # defined by your configured providers.
@@ -181,11 +181,11 @@ spec:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `type`
 

--- a/docs/reference/action-types/Test/container.md
+++ b/docs/reference/action-types/Test/container.md
@@ -23,8 +23,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 # The type of action, e.g. `exec`, `container` or `kubernetes`. Some are built into Garden but mostly these will be
 # defined by your configured providers.
@@ -247,11 +247,11 @@ spec:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `type`
 

--- a/docs/reference/action-types/Test/exec.md
+++ b/docs/reference/action-types/Test/exec.md
@@ -21,8 +21,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 # The type of action, e.g. `exec`, `container` or `kubernetes`. Some are built into Garden but mostly these will be
 # defined by your configured providers.
@@ -191,11 +191,11 @@ spec:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `type`
 

--- a/docs/reference/action-types/Test/hadolint.md
+++ b/docs/reference/action-types/Test/hadolint.md
@@ -27,8 +27,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 # The type of action, e.g. `exec`, `container` or `kubernetes`. Some are built into Garden but mostly these will be
 # defined by your configured providers.
@@ -168,11 +168,11 @@ spec:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `type`
 

--- a/docs/reference/action-types/Test/helm-pod.md
+++ b/docs/reference/action-types/Test/helm-pod.md
@@ -23,8 +23,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 # The type of action, e.g. `exec`, `container` or `kubernetes`. Some are built into Garden but mostly these will be
 # defined by your configured providers.
@@ -289,11 +289,11 @@ spec:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `type`
 

--- a/docs/reference/action-types/Test/kubernetes-exec.md
+++ b/docs/reference/action-types/Test/kubernetes-exec.md
@@ -23,8 +23,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 # The type of action, e.g. `exec`, `container` or `kubernetes`. Some are built into Garden but mostly these will be
 # defined by your configured providers.
@@ -217,11 +217,11 @@ spec:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `type`
 

--- a/docs/reference/action-types/Test/kubernetes-pod.md
+++ b/docs/reference/action-types/Test/kubernetes-pod.md
@@ -23,8 +23,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 # The type of action, e.g. `exec`, `container` or `kubernetes`. Some are built into Garden but mostly these will be
 # defined by your configured providers.
@@ -578,11 +578,11 @@ spec:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `type`
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -827,7 +827,7 @@ providers:
       environments:
 
     moduleConfigs:
-      - # The schema version of this config (currently not used).
+      - # The schema version of this config.
         apiVersion:
 
         kind:
@@ -1130,7 +1130,7 @@ actionConfigs:
   # Build action configs in the project.
   Build:
     <name>:
-      # The schema version of this config (currently not used).
+      # The schema version of this config.
       apiVersion:
 
       # The type of action, e.g. `exec`, `container` or `kubernetes`. Some are built into Garden but mostly these will
@@ -1303,7 +1303,7 @@ actionConfigs:
   # Deploy action configs in the project.
   Deploy:
     <name>:
-      # The schema version of this config (currently not used).
+      # The schema version of this config.
       apiVersion:
 
       # The type of action, e.g. `exec`, `container` or `kubernetes`. Some are built into Garden but mostly these will
@@ -1443,7 +1443,7 @@ actionConfigs:
   # Run action configs in the project.
   Run:
     <name>:
-      # The schema version of this config (currently not used).
+      # The schema version of this config.
       apiVersion:
 
       # The type of action, e.g. `exec`, `container` or `kubernetes`. Some are built into Garden but mostly these will
@@ -1586,7 +1586,7 @@ actionConfigs:
   # Test action configs in the project.
   Test:
     <name>:
-      # The schema version of this config (currently not used).
+      # The schema version of this config.
       apiVersion:
 
       # The type of action, e.g. `exec`, `container` or `kubernetes`. Some are built into Garden but mostly these will
@@ -1728,7 +1728,7 @@ actionConfigs:
 
 # All module configs in the project.
 moduleConfigs:
-  - # The schema version of this config (currently not used).
+  - # The schema version of this config.
     apiVersion:
 
     kind:
@@ -2233,7 +2233,7 @@ Examples:
 modules:
   # The configuration for a module.
   <name>:
-    # The schema version of this config (currently not used).
+    # The schema version of this config.
     apiVersion:
 
     kind:

--- a/docs/reference/config-template-config.md
+++ b/docs/reference/config-template-config.md
@@ -18,8 +18,8 @@ Also check out the [`RenderTemplate` reference](./render-template-config.md).
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 kind: ConfigTemplate
 
@@ -45,8 +45,8 @@ inputsSchemaPath:
 # ${inputs.*}, ${parent.name} and ${template.name} keys. Other identifiers can also reference those, plus any other
 # keys available for module templates (see [the module context reference](./template-strings/modules.md)).**
 modules:
-  - # The schema version of this config (currently not used).
-    apiVersion: garden.io/v0
+  - # The schema version of this config.
+    apiVersion: garden.io/v1
 
     kind: Module
 
@@ -202,8 +202,8 @@ modules:
 #
 # Also note that template strings are not allowed in the following fields: `apiVersion` and `kind`
 configs:
-  - # The schema version of this config (currently not used).
-    apiVersion: garden.io/v0
+  - # The schema version of this config.
+    apiVersion: garden.io/v1
 
     # The kind of resource to create.
     kind:
@@ -219,11 +219,11 @@ configs:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `kind`
 
@@ -263,11 +263,11 @@ In addition to any template strings you can normally use for modules (see [the r
 
 [modules](#modules) > apiVersion
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `modules[].kind`
 
@@ -617,11 +617,11 @@ Also note that template strings are not allowed in the following fields: `apiVer
 
 [configs](#configs) > apiVersion
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `configs[].kind`
 

--- a/docs/reference/module-types/configmap.md
+++ b/docs/reference/module-types/configmap.md
@@ -23,8 +23,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 kind: Module
 
@@ -178,11 +178,11 @@ data:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `kind`
 

--- a/docs/reference/module-types/conftest.md
+++ b/docs/reference/module-types/conftest.md
@@ -26,8 +26,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 kind: Module
 
@@ -176,11 +176,11 @@ combine: false
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `kind`
 

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -27,8 +27,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 kind: Module
 
@@ -716,11 +716,11 @@ tasks:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `kind`
 

--- a/docs/reference/module-types/exec.md
+++ b/docs/reference/module-types/exec.md
@@ -29,8 +29,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 kind: Module
 
@@ -341,11 +341,11 @@ tests:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `kind`
 

--- a/docs/reference/module-types/hadolint.md
+++ b/docs/reference/module-types/hadolint.md
@@ -29,8 +29,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 kind: Module
 
@@ -167,11 +167,11 @@ dockerfilePath:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `kind`
 

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -23,8 +23,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 kind: Module
 
@@ -615,11 +615,11 @@ version:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `kind`
 

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -33,8 +33,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 kind: Module
 
@@ -769,11 +769,11 @@ tasks:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `kind`
 

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -27,8 +27,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 kind: Module
 
@@ -566,11 +566,11 @@ tests:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `kind`
 

--- a/docs/reference/module-types/persistentvolumeclaim.md
+++ b/docs/reference/module-types/persistentvolumeclaim.md
@@ -23,8 +23,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 kind: Module
 
@@ -230,11 +230,11 @@ spec:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `kind`
 

--- a/docs/reference/module-types/pulumi.md
+++ b/docs/reference/module-types/pulumi.md
@@ -25,8 +25,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 kind: Module
 
@@ -245,11 +245,11 @@ stack:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `kind`
 

--- a/docs/reference/module-types/templated.md
+++ b/docs/reference/module-types/templated.md
@@ -28,8 +28,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 kind: Module
 
@@ -164,11 +164,11 @@ inputs:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `kind`
 

--- a/docs/reference/module-types/terraform.md
+++ b/docs/reference/module-types/terraform.md
@@ -29,8 +29,8 @@ The [first section](#complete-yaml-schema) contains the complete YAML schema, an
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 kind: Module
 
@@ -193,11 +193,11 @@ workspace:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `kind`
 

--- a/docs/reference/render-template-config.md
+++ b/docs/reference/render-template-config.md
@@ -18,8 +18,8 @@ Also check out the [`ConfigTemplate` reference](./config-template-config.md).
 The values in the schema below are the default values.
 
 ```yaml
-# The schema version of this config (currently not used).
-apiVersion: garden.io/v0
+# The schema version of this config.
+apiVersion: garden.io/v1
 
 kind: RenderTemplate
 
@@ -47,11 +47,11 @@ inputs:
 
 ### `apiVersion`
 
-The schema version of this config (currently not used).
+The schema version of this config.
 
-| Type     | Allowed Values | Default          | Required |
-| -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| Type     | Allowed Values                 | Default          | Required |
+| -------- | ------------------------------ | ---------------- | -------- |
+| `string` | "garden.io/v0", "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `kind`
 

--- a/docs/reference/workflow-config.md
+++ b/docs/reference/workflow-config.md
@@ -17,7 +17,7 @@ The values in the schema below are the default values.
 
 ```yaml
 # The schema version of this workflow's config (currently not used).
-apiVersion: garden.io/v0
+apiVersion: garden.io/v1
 
 kind: Workflow
 
@@ -183,7 +183,7 @@ The schema version of this workflow's config (currently not used).
 
 | Type     | Allowed Values | Default          | Required |
 | -------- | -------------- | ---------------- | -------- |
-| `string` | "garden.io/v0" | `"garden.io/v0"` | Yes      |
+| `string` | "garden.io/v1" | `"garden.io/v1"` | Yes      |
 
 ### `kind`
 

--- a/e2e/projects/code-synchronization-modules/garden.yml
+++ b/e2e/projects/code-synchronization-modules/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: code-synchronization
 environments:

--- a/e2e/projects/demo-project-modules/garden.yml
+++ b/e2e/projects/demo-project-modules/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: demo-project-modules
 # defaultEnvironment: "remote" # Uncomment if you'd like the remote environment to be the default for this project.

--- a/e2e/projects/hadolint-modules/garden.yml
+++ b/e2e/projects/hadolint-modules/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: hadolint-modules
 environments:

--- a/e2e/projects/jib-container-modules/project.garden.yml
+++ b/e2e/projects/jib-container-modules/project.garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: jib-container-modules
 environments:

--- a/e2e/projects/kustomize-modules/project.garden.yml
+++ b/e2e/projects/kustomize-modules/project.garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: kustomize-modules
 environments:

--- a/e2e/projects/remote-sources-modules/garden.yml
+++ b/e2e/projects/remote-sources-modules/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: remote-sources-modules
 sources:

--- a/e2e/projects/tasks-modules/garden.yml
+++ b/e2e/projects/tasks-modules/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: tasks-modules
 environments:

--- a/e2e/projects/templated-k8s-container-modules/project.garden.yml
+++ b/e2e/projects/templated-k8s-container-modules/project.garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: templated-k8s-container-modules
 environments:

--- a/e2e/projects/vote-helm-modules/garden.yml
+++ b/e2e/projects/vote-helm-modules/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: vote-helm-modules
 environments:

--- a/e2e/projects/vote-modules/garden.yml
+++ b/e2e/projects/vote-modules/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: vote-modules
 environments:

--- a/examples/argocd/project.garden.yml
+++ b/examples/argocd/project.garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: vote-helm-argocd
 defaultEnvironment: "${local.env.GITHUB_ACTIONS ? 'ci' : 'gke-gitops-dev'}"

--- a/examples/base-image/garden.yml
+++ b/examples/base-image/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: base-image
 environments:

--- a/examples/build-dependencies/garden.yml
+++ b/examples/build-dependencies/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: build-dependencies
 environments:

--- a/examples/code-synchronization/garden.yml
+++ b/examples/code-synchronization/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: code-synchronization
 environments:

--- a/examples/conftest/garden.yml
+++ b/examples/conftest/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: conftest
 environments:

--- a/examples/demo-project/garden.yml
+++ b/examples/demo-project/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: demo-project
 # defaultEnvironment: "remote" # Uncomment if you'd like the remote environment to be the default for this project.

--- a/examples/disabled-configs/garden.yml
+++ b/examples/disabled-configs/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: disabled-configs
 # defaultEnvironment: "remote" # Uncomment if you'd like the remote environment to be the default for this project.

--- a/examples/gatsby-code-sync/garden.yml
+++ b/examples/gatsby-code-sync/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: gatsby-sync
 environments:

--- a/examples/gke/garden.yml
+++ b/examples/gke/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: gke
 environments:

--- a/examples/hadolint/garden.yml
+++ b/examples/hadolint/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: hadolint
 environments:

--- a/examples/istio/project.garden.yaml
+++ b/examples/istio/project.garden.yaml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: istio-example
 environments:

--- a/examples/jib-container/project.garden.yml
+++ b/examples/jib-container/project.garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: jib-container
 environments:

--- a/examples/kaniko/garden.yml
+++ b/examples/kaniko/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: kaniko
 # defaultEnvironment: "remote" # Uncomment if you'd like the remote environment to be the default for this project.

--- a/examples/kubernetes-deploy/garden.yml
+++ b/examples/kubernetes-deploy/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: kubernetes-deploy
 environments:

--- a/examples/kubernetes-secrets/garden.yml
+++ b/examples/kubernetes-secrets/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: kubernetes-secrets
 environments:

--- a/examples/kustomize/project.garden.yml
+++ b/examples/kustomize/project.garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: kustomize
 environments:

--- a/examples/local-exec/project.garden.yml
+++ b/examples/local-exec/project.garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: local-exec
 environments:

--- a/examples/local-mode-helm/garden.yml
+++ b/examples/local-mode-helm/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: local-mode-helm
 environments:

--- a/examples/local-mode-k8s/garden.yml
+++ b/examples/local-mode-k8s/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: local-mode-k8s
 environments:

--- a/examples/local-mode/garden.yml
+++ b/examples/local-mode/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: local-mode
 environments:

--- a/examples/local-service/garden.yml
+++ b/examples/local-service/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: local-service
 environments:

--- a/examples/local-tls/garden.yml
+++ b/examples/local-tls/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: local-tls
 environments:

--- a/examples/modules-to-actions/garden.yml
+++ b/examples/modules-to-actions/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: modules-to-actions
 environments:

--- a/examples/pulumi/project.garden.yml
+++ b/examples/pulumi/project.garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: pulumi
 variables:

--- a/examples/remote-k8s/garden.yml
+++ b/examples/remote-k8s/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: remote-k8s
 defaultEnvironment: local

--- a/examples/remote-sources/garden.yml
+++ b/examples/remote-sources/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: remote-sources
 sources:

--- a/examples/run-actions/garden.yml
+++ b/examples/run-actions/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: run-actions
 environments:

--- a/examples/rust/garden.yml
+++ b/examples/rust/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: rust-example
 variables:

--- a/examples/templated-k8s-container/project.garden.yml
+++ b/examples/templated-k8s-container/project.garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: templated-k8s-container
 environments:

--- a/examples/terraform-gke/garden.yml
+++ b/examples/terraform-gke/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: terraform-gke
 

--- a/examples/variables/garden.yml
+++ b/examples/variables/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: variables
 variables:

--- a/examples/vote-helm/garden.yml
+++ b/examples/vote-helm/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: vote-helm
 environments:

--- a/examples/vote/garden.yml
+++ b/examples/vote/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: vote
 environments:

--- a/project.garden.yml
+++ b/project.garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v0
 kind: Project
 name: garden-core
 defaultEnvironment: testing

--- a/project.garden.yml
+++ b/project.garden.yml
@@ -1,4 +1,4 @@
-apiVersion: garden.io/v0
+apiVersion: garden.io/v1
 kind: Project
 name: garden-core
 defaultEnvironment: testing

--- a/static/garden.yml
+++ b/static/garden.yml
@@ -1,3 +1,4 @@
+apiVersion: garden.io/v1
 kind: Project
 name: garden-framework
 environments:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

This PR makes the `apiVersion` mandatory for 0.13 clients when using action kinds. Longer discussion in #4089.

**Which issue(s) this PR fixes**:

Fixes #4089

**Special notes for your reviewer**:
