### PR TITLE
refactor: moved some type definitions to other the packages

### DIFF
--- a/core/src/events.ts
+++ b/core/src/events.ts
@@ -9,7 +9,7 @@
 import { omit } from "lodash"
 import { EventEmitter2 } from "eventemitter2"
 import type { LogEntryEventPayload } from "./cloud/buffered-event-stream"
-import type { DeployState, ServiceStatus } from "./types/service"
+import type { DeployState, DeployStatusForEventPayload } from "./types/service"
 import type { RunState, RunStatusForEventPayload } from "./plugin/base"
 import type { Omit } from "./util/util"
 import type { AuthTokenResponse } from "./cloud/api"
@@ -18,7 +18,7 @@ import type { CommandInfo } from "./plugin-context"
 import type { ActionReference } from "./config/common"
 import type { GraphResult } from "./graph/results"
 import { NamespaceStatus } from "./types/namespace"
-import { BuildState } from "./plugin/handlers/Build/get-status"
+import { BuildState, BuildStatusForEventPayload } from "./plugin/handlers/Build/get-status"
 import { ActionStateForEvent } from "./actions/types"
 import { sanitizeValue } from "./util/logging"
 
@@ -65,8 +65,6 @@ export class EventBus extends EventEmitter2 {
 export type GraphResultEventPayload = Omit<GraphResult, "task" | "dependencyResults" | "error"> & {
   error: string | null
 }
-
-export type DeployStatusForEventPayload = Omit<ServiceStatus, "detail">
 
 export interface CommandInfoPayload extends CommandInfo {
   // Contains additional context for the command info available during init
@@ -244,7 +242,7 @@ export interface Events {
    * are no associated logs or timestamps to track).
    */
 
-  buildStatus: ActionStatusPayload<{ state: BuildState }>
+  buildStatus: ActionStatusPayload<BuildStatusForEventPayload>
   runStatus: ActionStatusPayload<RunStatusForEventPayload>
   testStatus: ActionStatusPayload<RunStatusForEventPayload>
   deployStatus: ActionStatusPayload<DeployStatusForEventPayload>

--- a/core/src/plugin/handlers/Build/get-status.ts
+++ b/core/src/plugin/handlers/Build/get-status.ts
@@ -23,6 +23,10 @@ import { joi } from "../../../config/common"
  */
 export type BuildState = "fetching" | "fetched" | "outdated" | "building" | "built" | "failed"
 
+export interface BuildStatusForEventPayload {
+  state: BuildState
+}
+
 interface GetBuildStatusParams<T extends BuildAction = BuildAction> extends PluginBuildActionParamsBase<T> {}
 
 export interface BuildResult {

--- a/core/src/types/service.ts
+++ b/core/src/types/service.ts
@@ -28,6 +28,7 @@ import { NamespaceStatus, namespaceStatusesSchema } from "./namespace"
 import type { LogLevel } from "../logger/logger"
 import type { ActionMode } from "../actions/types"
 import type { ModuleGraph } from "../graph/modules"
+import { Omit } from "../util/util"
 
 export interface GardenService<M extends GardenModule = GardenModule, S extends GardenModule = GardenModule> {
   name: string
@@ -74,6 +75,8 @@ export function serviceFromConfig<M extends GardenModule = GardenModule>(
 
 export const deployStates = ["ready", "deploying", "stopped", "unhealthy", "unknown", "outdated", "missing"] as const
 export type DeployState = typeof deployStates[number]
+
+export type DeployStatusForEventPayload = Omit<ServiceStatus, "detail">
 
 /**
  * Given a list of states, return a single state representing the list.


### PR DESCRIPTION
Define `{ActionKind}StatusForEventPayload` interfaces and types in the same places where `{ActionKind}State` interfaces are defined. That has already been done for `RunState` and `RunStatusForEventPayload`. This makes the code navigation a bit easier.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
