### PR TITLE
fix(cli): don't throw in dev command if offline

### DIFF
--- a/core/src/commands/serve.ts
+++ b/core/src/commands/serve.ts
@@ -106,12 +106,13 @@ export class ServeCommand<
     this.garden = garden
     const loggedIn = this.garden?.isLoggedIn()
     if (!loggedIn) {
-      log.warn(
-        chalk.yellow(
+      garden.emitWarning({
+        key: "local-dashboard-removed",
+        log,
+        message: chalk.yellow(
           "The local dashboard has been removed. To use the new Garden Cloud Dashboard, please log in first."
-        )
-      )
-      throw new RuntimeError("You are not logged in. Please run `garden login` before running `garden serve`.", {})
+        ),
+      })
     }
 
     this.autocompleter = new Autocompleter({ log, commands: [], configDump: undefined })


### PR DESCRIPTION
**What this PR does / why we need it**:

 The dev command needs to work offline and when the user isn't logged in.