### PR TITLE
feat: allow `-i` alias for interactive mode in `exec` command

### DIFF
--- a/core/src/commands/exec.ts
+++ b/core/src/commands/exec.ts
@@ -34,6 +34,7 @@ const execArgs = {
 const execOpts = {
   interactive: new BooleanParameter({
     help: "Set to false to skip interactive mode and just output the command result",
+    aliases: ["i"],
     defaultValue: false,
     cliDefault: true,
     cliOnly: true,


### PR DESCRIPTION
To keep the same DX and in `test` command.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
