### PR TITLE
revert: remove noProject flag from custom commands

### DIFF
--- a/core/src/commands/custom.ts
+++ b/core/src/commands/custom.ts
@@ -72,7 +72,6 @@ export class CustomCommandWrapper extends Command {
   help = ""
 
   allowUndefinedArguments = true
-  noProject = true
 
   constructor(public spec: CommandResource) {
     super()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Refs: 96f6721 and #3983

In PR #3983 we set noProject=true on the custom commands class.

This was to prevent the entire init logic from re-running for the inner command when set.

Re-running the init logic means the user is authenticated against Cloud twice, two buffered event streams are created, the command is tracked twice, etc etc.

However, setting noProject=true on the outer command means that variables aren't resolved which means you can't reference them in custom commands which of course also causes issues.

So despite its flaws, we're reverting to the previous version. But in general this behaviour hasn't been thought fully through, and the implementation we're reverting to doesn't play well with Cloud.

In my opinion, we should create a single session for a single custom command and have primitives that allow for the inner command to "belong" to the outer custom command and display things appropriately in Cloud.

That's a larger task though and needs to be addressed separately.


**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
