### PR TITLE
fix: cloud secrets and users delete

### DIFF
--- a/core/src/commands/cloud/helpers.ts
+++ b/core/src/commands/cloud/helpers.ts
@@ -19,7 +19,7 @@ import { CommandResult } from "../base"
 import { userPrompt } from "../../util/util"
 
 export interface DeleteResult {
-  id: number
+  id: string | number
   status: string
 }
 

--- a/core/src/commands/cloud/secrets/secrets-delete.ts
+++ b/core/src/commands/cloud/secrets/secrets-delete.ts
@@ -40,7 +40,7 @@ export class SecretsDeleteCommand extends Command<Args> {
   }
 
   async action({ garden, args, log, opts }: CommandParams<Args>): Promise<CommandResult<DeleteResult[]>> {
-    const secretsToDelete = (args.ids || []).map((id) => parseInt(id, 10))
+    const secretsToDelete = args.ids || []
     if (secretsToDelete.length === 0) {
       throw new CommandError(`No secret IDs provided.`, {
         args,

--- a/core/src/commands/cloud/users/users-delete.ts
+++ b/core/src/commands/cloud/users/users-delete.ts
@@ -40,7 +40,7 @@ export class UsersDeleteCommand extends Command<Args> {
   }
 
   async action({ garden, args, log, opts }: CommandParams<Args>): Promise<CommandResult<DeleteResult[]>> {
-    const usersToDelete = (args.ids || []).map((id) => parseInt(id, 10))
+    const usersToDelete = args.ids || []
     if (usersToDelete.length === 0) {
       throw new CommandError(`No user IDs provided.`, {
         args,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Allow for cloud users and secrets to be strings.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
