### PR TITLE
improvement(container): redeploy when spec changes

### DIFF
--- a/core/src/plugins/kubernetes/container/status.ts
+++ b/core/src/plugins/kubernetes/container/status.ts
@@ -26,6 +26,7 @@ import { KubernetesServerResource, KubernetesWorkload } from "../types"
 interface ContainerStatusDetail {
   remoteResources: KubernetesServerResource[]
   workload: KubernetesWorkload | null
+  selectorChangedResourceKeys: string[]
 }
 
 export type ContainerServiceStatus = ServiceStatus<ContainerStatusDetail>
@@ -65,6 +66,7 @@ export async function getContainerServiceStatus({
     deployedWithDevMode,
     deployedWithHotReloading,
     deployedWithLocalMode,
+    selectorChangedResourceKeys,
   } = await compareDeployedResources(k8sCtx, api, namespace, manifests, log)
   const ingresses = await getIngresses(service, api, provider)
 
@@ -90,7 +92,7 @@ export async function getContainerServiceStatus({
     state,
     namespaceStatuses: [namespaceStatus],
     version: state === "ready" ? service.version : undefined,
-    detail: { remoteResources, workload },
+    detail: { remoteResources, workload, selectorChangedResourceKeys },
     devMode: deployedWithDevMode || deployedWithHotReloading,
     localMode: deployedWithLocalMode,
   }

--- a/core/src/plugins/kubernetes/status/status.ts
+++ b/core/src/plugins/kubernetes/status/status.ts
@@ -14,8 +14,8 @@ import { sleep, deepMap } from "../../../util/util"
 import { KubeApi } from "../api"
 import { getAppNamespace } from "../namespace"
 import Bluebird from "bluebird"
-import { KubernetesResource, KubernetesServerResource, BaseResource } from "../types"
-import { zip, isArray, isPlainObject, pickBy, mapValues, flatten, cloneDeep, omit } from "lodash"
+import { KubernetesResource, KubernetesServerResource, BaseResource, KubernetesWorkload } from "../types"
+import { zip, isArray, isPlainObject, pickBy, mapValues, flatten, cloneDeep, omit, isEqual, keyBy } from "lodash"
 import { KubernetesProvider, KubernetesPluginContext } from "../config"
 import { isSubset } from "../../../util/is-subset"
 import { LogEntry } from "../../../logger/log-entry"
@@ -26,9 +26,10 @@ import {
   V1PersistentVolumeClaim,
   V1Service,
   V1Container,
+  KubernetesObject,
 } from "@kubernetes/client-node"
 import dedent = require("dedent")
-import { getPods, hashManifest } from "../util"
+import { getPods, getResourceKey, hashManifest } from "../util"
 import { checkWorkloadStatus } from "./workload"
 import { checkWorkloadPodStatus } from "./pod"
 import { deline, gardenAnnotationKey, stableStringify } from "../../../util/string"
@@ -285,6 +286,11 @@ interface ComparisonResult {
   deployedWithDevMode: boolean
   deployedWithHotReloading: boolean
   deployedWithLocalMode: boolean
+  /**
+   * These resources have changes in `spec.selector`, and would need to be deleted before redeploying (since Kubernetes
+   * doesn't allow updates to immutable fields).
+   */
+  selectorChangedResourceKeys: string[]
 }
 
 /**
@@ -305,6 +311,9 @@ export async function compareDeployedResources(
     getDeployedResource(ctx, ctx.provider, resource, log)
   )
   const deployedResources = <KubernetesResource[]>maybeDeployedObjects.filter((o) => o !== null)
+  const manifestsMap = keyBy(manifests, (m) => getResourceKey(m))
+  const manifestKeys = Object.keys(manifestsMap)
+  const deployedMap = keyBy(deployedResources, (m) => getResourceKey(m))
 
   const result: ComparisonResult = {
     state: "unknown",
@@ -312,13 +321,12 @@ export async function compareDeployedResources(
     deployedWithDevMode: false,
     deployedWithHotReloading: false,
     deployedWithLocalMode: false,
+    selectorChangedResourceKeys: detectChangedSpecSelector(manifestsMap, deployedMap),
   }
 
-  const logDescription = (resource: KubernetesResource) => `${resource.kind}/${resource.metadata.name}`
+  const logDescription = (resource: KubernetesResource) => getResourceKey(resource)
 
-  const missingObjectNames = zip(manifests, maybeDeployedObjects)
-    .filter(([_, deployed]) => !deployed)
-    .map(([resource, _]) => logDescription(resource!))
+  const missingObjectNames = manifestKeys.filter((k) => !deployedMap[k]).map((k) => logDescription(manifestsMap[k]))
 
   if (missingObjectNames.length === manifests.length) {
     // All resources missing.
@@ -357,10 +365,11 @@ export async function compareDeployedResources(
     return result
   }
 
-  log.debug(`Comparing expected and deployed resources...`)
+  log.verbose(`Comparing expected and deployed resources...`)
 
-  for (let [newManifest, deployedResource] of zip(manifests, deployedResources) as KubernetesResource[][]) {
-    let manifest = cloneDeep(newManifest)
+  for (const key of Object.keys(manifestsMap)) {
+    let manifest = cloneDeep(manifestsMap[key])
+    let deployedResource = deployedMap[key]
 
     if (!manifest.metadata.annotations) {
       manifest.metadata.annotations = {}
@@ -371,14 +380,14 @@ export async function compareDeployedResources(
       delete manifest.metadata.annotations[gardenAnnotationKey("manifest-hash")]
     }
 
-    if (manifest.kind === "DaemonSet" || manifest.kind === "Deployment" || manifest.kind === "StatefulSet") {
-      if (isConfiguredForDevMode(<SyncableResource>manifest)) {
+    if (isWorkloadResource(manifest)) {
+      if (isConfiguredForDevMode(manifest)) {
         result.deployedWithDevMode = true
       }
-      if (isConfiguredForHotReloading(<SyncableResource>manifest)) {
+      if (isConfiguredForHotReloading(manifest)) {
         result.deployedWithHotReloading = true
       }
-      if (isConfiguredForLocalMode(<SyncableResource>manifest)) {
+      if (isConfiguredForLocalMode(manifest)) {
         result.deployedWithLocalMode = true
       }
     }
@@ -477,18 +486,48 @@ export function isConfiguredForLocalMode(resource: SyncableResource): boolean {
   return resource.metadata.annotations?.[gardenAnnotationKey("local-mode")] === "true"
 }
 
-export async function getDeployedResource(
+function isWorkloadResource(resource: KubernetesResource): resource is KubernetesWorkload {
+  return (
+    resource.kind === "Deployment" ||
+    resource.kind === "DaemonSet" ||
+    resource.kind === "StatefulSet" ||
+    resource.kind === "ReplicaSet"
+  )
+}
+
+type KubernetesResourceMap = { [key: string]: KubernetesResource }
+
+function detectChangedSpecSelector(manifestsMap: KubernetesResourceMap, deployedMap: KubernetesResourceMap): string[] {
+  const manifestKeys = Object.keys(manifestsMap)
+  const changedKeys: string[] = []
+  for (const k of manifestKeys) {
+    const manifest = manifestsMap[k]
+    const deployedResource = deployedMap[k]
+    if (
+      // If no corresponding resource to the local manifest has been deployed, this will be undefined.
+      deployedResource &&
+      isWorkloadResource(manifest) &&
+      isWorkloadResource(deployedResource) &&
+      !isEqual(manifest.spec.selector, deployedResource.spec.selector)
+    ) {
+      changedKeys.push(getResourceKey(manifest))
+    }
+  }
+  return changedKeys
+}
+
+export async function getDeployedResource<ResourceKind extends KubernetesObject>(
   ctx: PluginContext,
   provider: KubernetesProvider,
-  resource: KubernetesResource,
+  resource: KubernetesResource<ResourceKind>,
   log: LogEntry
-): Promise<KubernetesResource | null> {
+): Promise<KubernetesResource<ResourceKind> | null> {
   const api = await KubeApi.factory(log, ctx, provider)
   const namespace = resource.metadata?.namespace || (await getAppNamespace(ctx, log, provider))
 
   try {
     const res = await api.readBySpec({ namespace, manifest: resource, log })
-    return <KubernetesResource>res
+    return <KubernetesResource<ResourceKind>>res
   } catch (err) {
     if (err.statusCode === 404) {
       return null

--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -42,6 +42,10 @@ export function getAnnotation(obj: KubernetesResource, key: string): string | nu
   return get(obj, ["metadata", "annotations", key])
 }
 
+export function getResourceKey(resource: KubernetesResource) {
+  return `${resource.kind}/${resource.metadata.name}`
+}
+
 /**
  * Returns a hash of the manifest. We use this instead of the raw manifest when setting the
  * "manifest-hash" annotation. This prevents "Too long annotation" errors for long manifests.

--- a/core/src/util/string.ts
+++ b/core/src/util/string.ts
@@ -22,7 +22,7 @@ export const deline = _deline
 export const urlJoin = _urlJoin as (...args: string[]) => string
 export const stableStringify = _stableStringify
 
-const gardenAnnotationPrefix = "garden.io/"
+export const gardenAnnotationPrefix = "garden.io/"
 
 export type GardenAnnotationKey =
   | "dev-mode"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

This is a port of https://github.com/garden-io/garden/pull/3884 for 0.12, to facilitate users switching back and forth between 0.12 and 0.13.

In 0.12, we had wanted to update the `selector.matchLabels` used for container deploys, but doing so would require redeploying those resources (since `spec.selector.matchLabels` is an immutable field).

In 0.13, we decided to simply automatically redeploy any container deploys if needed (unless the environment in question is a production environment), since we wanted to use different labels (e.g. `action` instead of `service`).

Deleting the resources before redeploying them is necessary in this case, since the `spec.selector` field is immutable and attempting to update it for running resources will simply result in an error).

We don't automatically do this for production environments, except when force-deploying (which is a framework-native way for users to redeploy services with full awareness what they're doing).

**Which issue(s) this PR fixes**:

Closes #4126.