### PR TITLE
refactor(logger): cleanup the original implementation

### DIFF
--- a/core/src/analytics/analytics.ts
+++ b/core/src/analytics/analytics.ts
@@ -396,7 +396,7 @@ export class AnalyticsHandler {
       const msg = dedent`
         Thanks for installing Garden! We work hard to provide you with the best experience we can. We collect some anonymized usage data while you use Garden. If you'd like to know more about what we collect or if you'd like to opt out of telemetry, please read more at ${gitHubUrl}
       `
-      log.info({ symbol: "info", msg })
+      log.info(msg)
     }
 
     const anonymousUserId = getAnonymousUserId({ analyticsConfig: currentAnalyticsConfig, isCi: ciInfo.isCi })

--- a/core/src/cli/autocomplete.ts
+++ b/core/src/cli/autocomplete.ts
@@ -47,7 +47,7 @@ export class Autocompleter {
   private enableDebug: boolean
 
   constructor({ log, commands, configDump, debug }: AutocompleterParams) {
-    this.log = log
+    this.log = log.createLog({ name: "autocompleter" })
     this.configDump = configDump
     this.commands = commands
     this.enableDebug = !!debug
@@ -110,8 +110,7 @@ export class Autocompleter {
   }
 
   private debug(msg: any) {
-    this.enableDebug &&
-      this.log.silly({ section: "autocompleter", msg: typeof msg === "string" ? msg : JSON.stringify(msg) })
+    this.enableDebug && this.log.silly(typeof msg === "string" ? msg : JSON.stringify(msg))
   }
 
   private matchCommandNames(commands: Command[], input: string) {

--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -158,6 +158,7 @@ ${renderCommands(commands)}
     if (this.fileWritersInitialized) {
       return
     }
+
     const { debugLogfileName, jsonLogfileName } = await prepareDebugLogfiles(
       log,
       join(gardenDirPath, LOGS_DIR_NAME),
@@ -355,7 +356,7 @@ ${renderCommands(commands)}
     contextOpts.persistent = persistent
     const { streamEvents, streamLogEntries } = command
     // TODO: Link to Cloud namespace page here.
-    const nsLog = log.createLog({})
+    const nsLog = log.createLog({ name: "garden" })
 
     do {
       try {
@@ -364,18 +365,12 @@ ${renderCommands(commands)}
         } else {
           garden = await this.getGarden(workingDir, contextOpts)
 
-          nsLog.info({
-            section: "garden",
-            msg: `Running in Garden environment ${chalk.cyan(`${garden.environmentName}.${garden.namespace}`)}`,
-          })
+          nsLog.info(`Running in Garden environment ${chalk.cyan(`${garden.environmentName}.${garden.namespace}`)}`)
 
           if (!cloudApi && garden.projectId) {
-            log.warn({
-              symbol: "warning",
-              msg: `You are not logged in into Garden Cloud. Please log in via the ${chalk.green(
-                "garden login"
-              )} command.`,
-            })
+            log.warn(
+              `You are not logged in into Garden Cloud. Please log in via the ${chalk.green("garden login")} command.`
+            )
             log.info("")
           }
 
@@ -416,11 +411,12 @@ ${renderCommands(commands)}
             const distroName = getCloudDistributionName(cloudApi.domain)
             const userId = (await cloudApi.getProfile()).id
             const commandResultUrl = cloudApi.getCommandResultUrl({ sessionId, userId }).href
+            const cloudLog = log.createLog({ name: getCloudLogSectionName(distroName) })
 
             const msg = dedent`🌸  Connected to ${distroName}. View logs and command results at: \n\n${chalk.cyan(
               commandResultUrl
             )}\n`
-            log.info({ section: getCloudLogSectionName(distroName), msg })
+            cloudLog.info(msg)
           }
         }
 

--- a/core/src/cli/helpers.ts
+++ b/core/src/cli/helpers.ts
@@ -387,10 +387,7 @@ export function processCliArgs<A extends Parameters, O extends Parameters>({
         .map(([name, _]) => `--${name}`)
 
       if (usedGlobalOptions.length > 0) {
-        log.warn({
-          symbol: "warning",
-          msg: chalk.yellow(`Command includes global options that will be ignored: ${usedGlobalOptions.join(", ")}`),
-        })
+        log.warn(`Command includes global options that will be ignored: ${usedGlobalOptions.join(", ")}`)
       }
     }
   }

--- a/core/src/cloud/buffered-event-stream.ts
+++ b/core/src/cloud/buffered-event-stream.ts
@@ -15,6 +15,7 @@ import { got } from "../util/http"
 import { LogLevel } from "../logger/logger"
 import { Garden } from "../garden"
 import { CloudApi, makeAuthHeader } from "./api"
+import { renderSection } from "../logger/renderers"
 
 export type StreamEvent = {
   name: EventName
@@ -22,9 +23,10 @@ export type StreamEvent = {
   timestamp: Date
 }
 
-type LogEntryMessage = Pick<LogEntry, "msg" | "section" | "symbol" | "data" | "dataFormat">
+type LogEntryMessage = Pick<LogEntry, "msg" | "symbol" | "data" | "dataFormat"> & {
+  section: string
+}
 
-// TODO: Remove data, section, timestamp and msg once we've updated GE (it's included in the message)
 export interface LogEntryEventPayload {
   key: string
   timestamp: string
@@ -33,17 +35,20 @@ export interface LogEntryEventPayload {
   metadata?: LogMetadata
 }
 
+// TODO @eysi: Add log context to payload
 export function formatLogEntryForEventStream(entry: LogEntry): LogEntryEventPayload {
+  // TODO @eysi: We're sending the section for backwards compatibility but it shouldn't really be needed.
+  const section = renderSection(entry)
   return {
     key: entry.key,
     metadata: entry.metadata,
     timestamp: entry.timestamp,
     level: entry.level,
     message: {
+      section,
       msg: entry.msg,
       symbol: entry.symbol,
       data: entry.data,
-      section: entry.section,
       dataFormat: entry.dataFormat,
     },
   }

--- a/core/src/commands/cloud/secrets/secrets-create.ts
+++ b/core/src/commands/cloud/secrets/secrets-create.ts
@@ -160,7 +160,7 @@ export class SecretsCreateCommand extends Command<Args, Opts> {
     }
 
     const secretsToCreate = Object.entries(secrets)
-    const cmdLog = log.createLog({ section: "secrets-command" })
+    const cmdLog = log.createLog({ name: "secrets-command" })
     cmdLog.info("Creating secrets...")
 
     let count = 1

--- a/core/src/commands/cloud/secrets/secrets-delete.ts
+++ b/core/src/commands/cloud/secrets/secrets-delete.ts
@@ -57,7 +57,7 @@ export class SecretsDeleteCommand extends Command<Args> {
       throw new ConfigurationError(noApiMsg("delete", "secrets"), {})
     }
 
-    const cmdLog = log.createLog({ section: "secrets-command" })
+    const cmdLog = log.createLog({ name: "secrets-command" })
     cmdLog.info("Deleting secrets...")
 
     let count = 1

--- a/core/src/commands/cloud/users/users-create.ts
+++ b/core/src/commands/cloud/users/users-create.ts
@@ -120,7 +120,7 @@ export class UsersCreateCommand extends Command<Args, Opts> {
       throw new ConfigurationError(noApiMsg("create", "users"), {})
     }
 
-    const cmdLog = log.createLog({ section: "users-command" })
+    const cmdLog = log.createLog({ name: "users-command" })
     cmdLog.info("Creating users...")
 
     const usersToCreate = Object.entries(users).map(([vcsUsername, name]) => ({

--- a/core/src/commands/cloud/users/users-delete.ts
+++ b/core/src/commands/cloud/users/users-delete.ts
@@ -58,7 +58,7 @@ export class UsersDeleteCommand extends Command<Args> {
       throw new ConfigurationError(noApiMsg("delete", "user"), {})
     }
 
-    const cmdLog = log.createLog({ section: "users-command" })
+    const cmdLog = log.createLog({ name: "users-command" })
     cmdLog.info("Deleting users...")
 
     let count = 1

--- a/core/src/commands/create/create-module.ts
+++ b/core/src/commands/create/create-module.ts
@@ -251,15 +251,14 @@ export class CreateModuleCommand extends Command<CreateModuleArgs, CreateModuleO
     const formattedType = chalk.bold(type)
     const formattedPluginName = chalk.bold(pluginName)
 
-    log.info({
-      symbol: "info",
-      msg: wordWrap(
+    log.info(
+      wordWrap(
         dedent`
         For more information about ${formattedType} modules, please check out ${moduleTypeUrlFormatted}, and the ${formattedPluginName} provider docs at ${providerUrl}. For general information about Garden configuration files, take a look at ${configFilesUrl}.
         `,
         120
-      ),
-    })
+      )
+    )
 
     log.info("")
 

--- a/core/src/commands/create/create-project.ts
+++ b/core/src/commands/create/create-project.ts
@@ -195,15 +195,14 @@ export class CreateProjectCommand extends Command<CreateProjectArgs, CreateProje
     const configFilesUrl = chalk.cyan.underline("https://docs.garden.io/using-garden/configuration-overview")
     const referenceUrl = chalk.cyan.underline(projectReferenceURL)
 
-    log.info({
-      symbol: "info",
-      msg: wordWrap(
+    log.info(
+      wordWrap(
         dedent`
         For more information about Garden configuration files, please check out ${configFilesUrl}, and for a detailed reference, take a look at ${referenceUrl}.
         `,
         120
-      ),
-    })
+      )
+    )
 
     log.info("")
 

--- a/core/src/commands/deploy.ts
+++ b/core/src/commands/deploy.ts
@@ -174,7 +174,7 @@ export class DeployCommand extends Command<Args, Opts> {
       const bold = disabled.map((d) => chalk.bold(d))
       const msg =
         disabled.length === 1 ? `Deploy action ${bold} is disabled` : `Deploy actions ${naturalList(bold)} are disabled`
-      log.info({ symbol: "info", msg: chalk.white(msg) })
+      log.info(chalk.white(msg))
     }
 
     const skipped = opts.skip || []

--- a/core/src/commands/exec.ts
+++ b/core/src/commands/exec.ts
@@ -15,6 +15,7 @@ import { ExecInDeployResult, execInDeployResultSchema } from "../plugin/handlers
 import { executeAction } from "../graph/actions"
 import { NotFoundError } from "../exceptions"
 import { DeployStatus } from "../plugin/handlers/Deploy/get-status"
+import { createActionLog } from "../logger/log-entry"
 
 const execArgs = {
   deploy: new StringParameter({
@@ -113,9 +114,10 @@ export class ExecCommand extends Command<Args, Opts> {
     }
 
     const router = await garden.getActionRouter()
+    const actionLog = createActionLog({ log, actionName: action.name, actionKind: action.kind })
 
     const { result } = await router.deploy.exec({
-      log,
+      log: actionLog,
       graph,
       action: executed,
       command,

--- a/core/src/commands/get/get-run-result.ts
+++ b/core/src/commands/get/get-run-result.ts
@@ -14,6 +14,7 @@ import { getArtifactFileList, getArtifactKey } from "../../util/artifacts"
 import { joiArray, joi } from "../../config/common"
 import { StringParameter } from "../../cli/params"
 import { GetRunResult, getRunResultSchema } from "../../plugin/handlers/Run/get-result"
+import { createActionLog } from "../../logger/log-entry"
 
 const getRunResultArgs = {
   name: new StringParameter({
@@ -63,9 +64,10 @@ export class GetRunResultCommand extends Command<Args, {}, GetRunResultCommandRe
     const router = await garden.getActionRouter()
 
     const resolved = await garden.resolveAction({ action, graph, log })
+    const actionLog = createActionLog({ log, actionName: action.name, actionKind: action.kind })
 
     const { result: res } = await router.run.getResult({
-      log,
+      log: actionLog,
       action: resolved,
       graph,
     })

--- a/core/src/commands/get/get-status.ts
+++ b/core/src/commands/get/get-status.ts
@@ -11,7 +11,7 @@ import { fromPairs } from "lodash"
 import { deepFilter } from "../../util/objects"
 import { Command, CommandResult, CommandParams } from "../base"
 import { ResolvedConfigGraph } from "../../graph/config-graph"
-import { Log } from "../../logger/log-entry"
+import { createActionLog, Log } from "../../logger/log-entry"
 import chalk from "chalk"
 import { deline } from "../../util/string"
 import { EnvironmentStatusMap } from "../../plugin/handlers/Provider/getEnvironmentStatus"
@@ -106,7 +106,8 @@ async function getBuildStatuses(router: ActionRouter, graph: ResolvedConfigGraph
 
   return fromPairs(
     await Bluebird.map(actions, async (action) => {
-      const { result } = await router.build.getStatus({ action, log, graph })
+      const actionLog = createActionLog({ log, actionName: action.name, actionKind: action.kind })
+      const { result } = await router.build.getStatus({ action, log: actionLog, graph })
       return [action.name, result]
     })
   )
@@ -117,7 +118,8 @@ async function getTestStatuses(router: ActionRouter, graph: ResolvedConfigGraph,
 
   return fromPairs(
     await Bluebird.map(actions, async (action) => {
-      const { result } = await router.test.getResult({ action, log, graph })
+      const actionLog = createActionLog({ log, actionName: action.name, actionKind: action.kind })
+      const { result } = await router.test.getResult({ action, log: actionLog, graph })
       return [action.name, result]
     })
   )
@@ -128,7 +130,8 @@ async function getRunStatuses(router: ActionRouter, graph: ResolvedConfigGraph, 
 
   return fromPairs(
     await Bluebird.map(actions, async (action) => {
-      const { result } = await router.run.getResult({ action, log, graph })
+      const actionLog = createActionLog({ log, actionName: action.name, actionKind: action.kind })
+      const { result } = await router.run.getResult({ action, log: actionLog, graph })
       return [action.name, result]
     })
   )

--- a/core/src/commands/get/get-test-result.ts
+++ b/core/src/commands/get/get-test-result.ts
@@ -17,6 +17,7 @@ import { ParameterError } from "../../exceptions"
 import { ConfigGraph } from "../../graph/config-graph"
 import { GardenModule, moduleTestNameToActionName } from "../../types/module"
 import { findByName, getNames } from "../../util/util"
+import { createActionLog } from "../../logger/log-entry"
 
 const getTestResultArgs = {
   name: new StringParameter({
@@ -72,9 +73,10 @@ export class GetTestResultCommand extends Command<Args, {}, GetTestResultCommand
     const router = await garden.getActionRouter()
 
     const resolved = await garden.resolveAction({ action, graph, log })
+    const actionLog = createActionLog({ log, actionName: action.name, actionKind: action.kind })
 
     const { result: res } = await router.test.getResult({
-      log,
+      log: actionLog,
       graph,
       action: resolved,
     })

--- a/core/src/commands/login.ts
+++ b/core/src/commands/login.ts
@@ -85,7 +85,7 @@ export class LoginCommand extends Command {
           Looks like your session token is invalid. If you were previously logged into a different instance
           of ${distroName}, log out first before logging in.
         `
-        log.warn({ msg, symbol: "warning" })
+        log.warn(msg)
         log.info("")
       }
       throw err

--- a/core/src/commands/logout.ts
+++ b/core/src/commands/logout.ts
@@ -75,10 +75,7 @@ export class LogOutCommand extends Command {
       const msg = dedent`
       The following issue occurred while logging out from ${distroName} (your session will be cleared regardless): ${err.message}\n
       `
-      log.warn({
-        symbol: "warning",
-        msg,
-      })
+      log.warn(msg)
     } finally {
       await CloudApi.clearAuthToken(log, garden.globalConfigStore, cloudDomain)
       log.info({ msg: `Succesfully logged out from ${cloudDomain}.` })

--- a/core/src/commands/self-update.ts
+++ b/core/src/commands/self-update.ts
@@ -65,7 +65,7 @@ export type SelfUpdateArgs = typeof selfUpdateArgs
 export type SelfUpdateOpts = typeof selfUpdateOpts
 
 const versionScopes = ["major", "minor", "patch"] as const
-export type VersionScope = typeof versionScopes[number]
+export type VersionScope = (typeof versionScopes)[number]
 
 function getVersionScope(opts: ParameterValues<GlobalOptions & SelfUpdateOpts>): VersionScope {
   if (opts["major"]) {

--- a/core/src/commands/serve.ts
+++ b/core/src/commands/serve.ts
@@ -105,7 +105,7 @@ export class ServeCommand<
     this.garden = garden
     const loggedIn = this.garden?.isLoggedIn()
     if (!loggedIn) {
-      garden.emitWarning({
+      await garden.emitWarning({
         key: "local-dashboard-removed",
         log,
         message: chalk.yellow(

--- a/core/src/commands/sync/sync-stop.ts
+++ b/core/src/commands/sync/sync-stop.ts
@@ -13,6 +13,7 @@ import { dedent, naturalList } from "../../util/string"
 import { Command, CommandParams, CommandResult } from "../base"
 import Bluebird from "bluebird"
 import chalk from "chalk"
+import { createActionLog } from "../../logger/log-entry"
 
 const syncStopArgs = {
   names: new StringsParameter({
@@ -104,14 +105,15 @@ export class SyncStopCommand extends Command<Args, Opts> {
     const router = await garden.getActionRouter()
 
     await Bluebird.map(actions, async (action) => {
-      log.info({ section: action.key(), msg: "Stopping active syncs (if any)..." })
+      const actionLog = createActionLog({ log, actionName: action.name, actionKind: action.kind })
+      actionLog.info("Stopping active syncs (if any)...")
 
-      await router.deploy.stopSync({ log, action, graph })
+      await router.deploy.stopSync({ log: actionLog, action, graph })
 
       // Halt any active monitors for the sync
       garden.monitors.find({ type: "sync", key: action.name }).map((m) => m.stop())
 
-      log.info({ section: action.key(), msg: "Syncing successfully stopped." })
+      actionLog.info("Syncing successfully stopped.")
     })
 
     log.info(chalk.green("\nDone!"))

--- a/core/src/config/base.ts
+++ b/core/src/config/base.ts
@@ -26,6 +26,7 @@ import { emitNonRepeatableWarning } from "../warnings"
 import { ActionKind, actionKinds } from "../actions/types"
 import { mayContainTemplateString } from "../template-string/template-string"
 import { Log } from "../logger/log-entry"
+import { deline } from "../util/string"
 
 export const configTemplateKind = "ConfigTemplate"
 export const renderTemplateKind = "RenderTemplate"
@@ -280,7 +281,7 @@ function handleDotIgnoreFiles(log: Log, projectSpec: ProjectResource) {
   if (dotIgnoreFiles.length === 1) {
     emitNonRepeatableWarning(
       log,
-      "Multi-valued project configuration field `dotIgnoreFiles` is deprecated in 0.13 and will be removed in 0.14. Please use single-valued `dotIgnoreFile` instead."
+      deline`Multi-valued project configuration field \`dotIgnoreFiles\` is deprecated in 0.13 and will be removed in 0.14. Please use single-valued \`dotIgnoreFile\` instead.`
     )
     return { ...projectSpec, dotIgnoreFile: dotIgnoreFiles[0] }
   }

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -463,10 +463,7 @@ export class Garden {
 
       if (!existing || !existing.hidden) {
         this.emittedWarnings.add(key)
-        log.warn({
-          symbol: "warning",
-          msg: message + `\n→ Run ${chalk.underline(`garden util hide-warning ${key}`)} to disable this warning.`,
-        })
+        log.warn(message + `\n→ Run ${chalk.underline(`garden util hide-warning ${key}`)} to disable this warning.`)
       }
     })
   }
@@ -1612,8 +1609,7 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
 
   if (!opts.noEnterprise && cloudApi) {
     const distroName = getCloudDistributionName(cloudDomain || "")
-    const section = getCloudLogSectionName(distroName)
-    const cloudLog = log.createLog({ section, showDuration: true })
+    const cloudLog = log.createLog({ name: getCloudLogSectionName(distroName), showDuration: true })
     cloudLog.info(`Initializing ${distroName}...`)
 
     let project: CloudProject | undefined

--- a/core/src/graph/solver.ts
+++ b/core/src/graph/solver.ts
@@ -481,8 +481,9 @@ export class GraphSolver extends TypedEventEmitter<SolverEvents> {
   // Logging
   //
   private logTask(node: TaskNode) {
-    node.task.log.silly({
-      section: "graph-solver",
+    // The task.log instance is of type ActionLog but we want to use a "CoreLog" here.
+    const taskLog = node.task.log.root.createLog({ name: "graph-solver" })
+    taskLog.silly({
       msg: `Processing node ${taskStyle(node.getKey())}`,
       metadata: metadataForLog(node.task, "active"),
     })

--- a/core/src/logger/writers/event-writer.ts
+++ b/core/src/logger/writers/event-writer.ts
@@ -33,7 +33,7 @@ export class EventLogWriter extends Writer {
     const out = formatForTerminal(entry, logger)
     if (out) {
       this.events.emit("log", {
-        origin: entry.origin || this.defaultOrigin,
+        origin: entry.context.origin || this.defaultOrigin,
         level: logLevelToString(entry.level),
         msg: out,
         timestamp: entry.timestamp,

--- a/core/src/monitors/logs.ts
+++ b/core/src/monitors/logs.ts
@@ -13,7 +13,7 @@ import Stream from "ts-stream"
 import type { DeployAction } from "../actions/deploy"
 import { Resolved } from "../actions/types"
 import { ConfigGraph } from "../graph/config-graph"
-import { Log } from "../logger/log-entry"
+import { createActionLog, Log } from "../logger/log-entry"
 import { LogLevel, logLevelMap } from "../logger/logger"
 import { padSection } from "../logger/renderers"
 import { PluginEventBroker } from "../plugin-context"
@@ -141,8 +141,13 @@ export class LogMonitor extends Monitor {
     })
 
     const router = await this.garden.getActionRouter()
-    await router.deploy.getLogs({
+    const actionLog = createActionLog({
       log: this.garden.log,
+      actionName: this.action.name,
+      actionKind: this.action.kind,
+    })
+    await router.deploy.getLogs({
+      log: actionLog,
       action: this.action,
       follow: !this.collect,
       graph: this.graph,

--- a/core/src/monitors/manager.ts
+++ b/core/src/monitors/manager.ts
@@ -32,7 +32,7 @@ export class MonitorManager extends TypedEventEmitter<MonitorEvents> {
     this.monitors = new KeyedSet<Monitor>((monitor) => monitor.id())
     this.monitorStatuses = new Map()
 
-    this.log = garden.log.createLog({ section: "[monitors]" })
+    this.log = garden.log.createLog({ name: "[monitors]" })
 
     garden.events.on("_exit", () => this.stopAll())
     // TODO: see if we want this

--- a/core/src/monitors/port-forward.ts
+++ b/core/src/monitors/port-forward.ts
@@ -39,7 +39,7 @@ export class PortForwardMonitor extends Monitor {
     this.action = params.action
     this.graph = params.graph
     this.proxies = []
-    this.log = params.log.createLog({ section: params.action.key(), origin: "proxy" })
+    this.log = params.log.createLog({ name: params.action.key(), origin: "proxy" })
     this.events = new PluginEventBroker(params.garden)
   }
 

--- a/core/src/monitors/sync.ts
+++ b/core/src/monitors/sync.ts
@@ -9,7 +9,7 @@
 import type { DeployAction } from "../actions/deploy"
 import { Executed } from "../actions/types"
 import { ConfigGraph } from "../graph/config-graph"
-import { Log } from "../logger/log-entry"
+import { createActionLog, Log } from "../logger/log-entry"
 import { PluginEventBroker } from "../plugin-context"
 import { MonitorBaseParams, Monitor } from "./base"
 
@@ -34,7 +34,7 @@ export class SyncMonitor extends Monitor {
     super(params)
     this.action = params.action
     this.graph = params.graph
-    this.log = params.log.createLog({ section: params.action.key() })
+    this.log = params.log.createLog({ name: params.action.key() })
     this.events = new PluginEventBroker(params.garden)
   }
 
@@ -48,8 +48,9 @@ export class SyncMonitor extends Monitor {
 
   async start() {
     const router = await this.garden.getActionRouter()
+    const actionLog = createActionLog({ log: this.log, actionName: this.action.name, actionKind: this.action.kind })
     await router.deploy.getSyncStatus({
-      log: this.log,
+      log: actionLog,
       action: this.action,
       monitor: true,
       graph: this.graph,

--- a/core/src/plugin/base.ts
+++ b/core/src/plugin/base.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import type { Log } from "../logger/log-entry"
+import type { ActionLog, Log } from "../logger/log-entry"
 import { PluginContext, pluginContextSchema } from "../plugin-context"
 import { GardenModule, moduleSchema } from "../types/module"
 import { createSchema, joi } from "../config/common"
@@ -78,18 +78,22 @@ export const actionParamsSchema = () =>
   })
 
 export interface PluginBuildActionParamsBase<T extends BuildAction<any, any>> extends PluginActionParamsBase {
+  log: ActionLog
   action: T
 }
 
 export interface PluginDeployActionParamsBase<T extends DeployAction<any, any>> extends PluginActionParamsBase {
+  log: ActionLog
   action: T
 }
 
 export interface PluginRunActionParamsBase<T extends RunAction<any, any>> extends PluginActionParamsBase {
+  log: ActionLog
   action: T
 }
 
 export interface PluginTestActionParamsBase<T extends TestAction<any, any>> extends PluginActionParamsBase {
+  log: ActionLog
   action: T
 }
 

--- a/core/src/plugins/container/build.ts
+++ b/core/src/plugins/container/build.ts
@@ -25,11 +25,7 @@ export const getContainerBuildStatus: BuildActionHandler<"getStatus", ContainerB
   const identifier = await containerHelpers.imageExistsLocally(outputs.localImageId, log, ctx)
 
   if (identifier) {
-    log.debug({
-      section: action.key(),
-      msg: `Image ${identifier} already exists`,
-      symbol: "info",
-    })
+    log.debug(`Image ${identifier} already exists`)
   }
 
   const state = !!identifier ? "ready" : "not-ready"

--- a/core/src/plugins/container/container.ts
+++ b/core/src/plugins/container/container.ts
@@ -487,7 +487,7 @@ export const gardenPlugin = () =>
               validateRuntimeCommon(action)
               return {}
             },
-          }
+          },
         },
       ],
     },

--- a/core/src/plugins/exec/deploy.ts
+++ b/core/src/plugins/exec/deploy.ts
@@ -100,7 +100,7 @@ export const execDeployAction: DeployActionHandler<"deploy", ExecDeploy> = async
   const env = spec.env
 
   if (spec.deployCommand.length === 0) {
-    log.info({ msg: "No deploy command found. Skipping.", symbol: "info" })
+    log.info("No deploy command found. Skipping.")
     return { state: "ready", detail: { state: "ready", detail: { skipped: true } }, outputs: {} }
   } else if (spec.persistent) {
     return deployPersistentExecService({ action, log, ctx, env, deployName: action.name })
@@ -259,11 +259,7 @@ export const deleteExecDeploy: DeployActionHandler<"delete", ExecDeploy> = async
       outputs: {},
     }
   } else {
-    log.warn({
-      section: action.key(),
-      symbol: "warning",
-      msg: chalk.gray(`Missing cleanupCommand, unable to clean up service`),
-    })
+    log.warn(`Missing cleanupCommand, unable to clean up service`)
     return { state: "unknown", detail: { state: "unknown", detail: {} }, outputs: {} }
   }
 }

--- a/core/src/plugins/exec/exec.ts
+++ b/core/src/plugins/exec/exec.ts
@@ -248,10 +248,11 @@ export const execPlugin = () =>
         return { ready: !ctx.provider.config.initScript, outputs: {} }
       },
       async prepareEnvironment({ ctx, log }) {
+        const execLog = log.createLog({ name: "exec" })
         if (ctx.provider.config.initScript) {
           try {
-            log.info({ section: "exec", msg: "Running init script" })
-            await runScript({ log, cwd: ctx.projectRoot, script: ctx.provider.config.initScript })
+            execLog.info("Running init script")
+            await runScript({ log: execLog, cwd: ctx.projectRoot, script: ctx.provider.config.initScript })
           } catch (_err) {
             const error = _err as ExecaError
 

--- a/core/src/plugins/kubernetes/commands/cleanup-cluster-registry.ts
+++ b/core/src/plugins/kubernetes/commands/cleanup-cluster-registry.ts
@@ -6,7 +6,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import chalk from "chalk"
 import { PluginCommand } from "../../../plugin/command"
 
 export const cleanupClusterRegistry: PluginCommand = {
@@ -18,12 +17,9 @@ export const cleanupClusterRegistry: PluginCommand = {
   handler: async ({ log }) => {
     const result = {}
 
-    log.warn({
-      symbol: "warning",
-      msg: chalk.yellow(
-        "This command no longer has any effect as of version 0.13! You probably want to remove this from any pipelines running it :)"
-      ),
-    })
+    log.warn(
+      "This command no longer has any effect as of version 0.13! You probably want to remove this from any pipelines running it :)"
+    )
 
     return { result }
   },

--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -184,7 +184,7 @@ export async function ensureBuildkit({
   namespace: string
 }) {
   return deployLock.acquire(namespace, async () => {
-    const deployLog = log.createLog({})
+    const deployLog = log.createLog()
 
     // Make sure auth secret is in place
     const { authSecret, updated: secretUpdated } = await ensureBuilderSecret({

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -145,7 +145,7 @@ export async function syncToBuildSync(params: SyncToSharedBuildSyncParams) {
     })
 
     // -> Flush the sync once
-    await mutagen.flushSync(log, key)
+    await mutagen.flushSync(key)
     log.debug(`Sync from ${sourcePath} to ${resourceName} completed`)
   } finally {
     // -> Terminate the sync
@@ -293,7 +293,7 @@ export async function ensureUtilDeployment({
   namespace: string
 }) {
   return deployLock.acquire(namespace, async () => {
-    const deployLog = log.createLog({})
+    const deployLog = log.createLog()
 
     const { authSecret, updated: secretUpdated } = await ensureBuilderSecret({
       provider,

--- a/core/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/src/plugins/kubernetes/container/build/kaniko.ts
@@ -116,7 +116,7 @@ export const kanikoBuild: BuildHandler = async (params) => {
     // Make sure the Kaniko Pod namespace has the auth secret ready
     const secretRes = await ensureBuilderSecret({
       provider,
-      log: log.createLog({}),
+      log: log.createLog(),
       api,
       namespace: kanikoNamespace,
     })

--- a/core/src/plugins/kubernetes/container/deployment.ts
+++ b/core/src/plugins/kubernetes/container/deployment.ts
@@ -18,7 +18,7 @@ import { getAppNamespace, getAppNamespaceStatus } from "../namespace"
 import { PluginContext } from "../../../plugin-context"
 import { KubeApi } from "../api"
 import { KubernetesPluginContext, KubernetesProvider } from "../config"
-import { Log } from "../../../logger/log-entry"
+import { ActionLog, Log } from "../../../logger/log-entry"
 import { prepareEnvVars } from "../util"
 import { deline, gardenAnnotationKey } from "../../../util/string"
 import { resolve } from "path"
@@ -106,7 +106,7 @@ export async function startLocalMode({
 }: {
   ctx: KubernetesPluginContext
   status: ContainerServiceStatus
-  log: Log
+  log: ActionLog
   action: Resolved<ContainerDeployAction>
 }) {
   const localModeSpec = action.getSpec("localMode")
@@ -171,7 +171,7 @@ export async function createContainerManifests({
 }: {
   ctx: PluginContext
   api: KubeApi
-  log: Log
+  log: ActionLog
   action: Resolved<ContainerDeployAction>
   imageId: string
 }) {
@@ -210,7 +210,7 @@ interface CreateDeploymentParams {
   action: Resolved<ContainerDeployAction>
   namespace: string
   imageId: string
-  log: Log
+  log: ActionLog
   production: boolean
 }
 
@@ -240,10 +240,7 @@ export async function createWorkloadManifest({
   }
 
   if (mode === "sync" && configuredReplicas > 1) {
-    log.warn({
-      msg: chalk.gray(`Ignoring replicas config on container service ${action.name} while in sync mode`),
-      symbol: "warning",
-    })
+    log.warn(`Ignoring replicas config on container service ${action.name} while in sync mode`)
     configuredReplicas = 1
   }
 
@@ -446,7 +443,7 @@ export async function createWorkloadManifest({
 
     workload = <KubernetesResource<V1Deployment | V1DaemonSet>>configured.updated[0]
   } else if (mode === "sync" && syncSpec) {
-    log.debug({ section: action.key(), msg: chalk.gray(`-> Configuring in sync mode`) })
+    log.debug(chalk.gray(`-> Configuring in sync mode`))
     const configured = await configureSyncMode({
       ctx,
       log,

--- a/core/src/plugins/kubernetes/container/status.ts
+++ b/core/src/plugins/kubernetes/container/status.ts
@@ -7,7 +7,7 @@
  */
 
 import { PluginContext } from "../../../plugin-context"
-import { Log } from "../../../logger/log-entry"
+import { createActionLog, Log } from "../../../logger/log-entry"
 import { ServiceStatus, ForwardablePort, DeployState, ServiceIngress } from "../../../types/service"
 import { createContainerManifests } from "./deployment"
 import { KUBECTL_DEFAULT_TIMEOUT } from "../kubectl"
@@ -142,11 +142,12 @@ export async function waitForContainerService(
   timeout = KUBECTL_DEFAULT_TIMEOUT
 ) {
   const startTime = new Date().getTime()
+  const actionLog = createActionLog({ log, actionName: action.name, actionKind: action.kind })
 
   while (true) {
     const status = await k8sGetContainerDeployStatus({
       ctx,
-      log,
+      log: actionLog,
       action,
     })
 

--- a/core/src/plugins/kubernetes/helm/status.ts
+++ b/core/src/plugins/kubernetes/helm/status.ts
@@ -141,9 +141,9 @@ export async function getDeployedChartResources({
   action: Resolved<HelmDeployAction>
 }): Promise<KubernetesResource[]> {
   const manifests = await getRenderedResources({ ctx, action, releaseName, log })
-  const deployedResources = (await Bluebird.map(manifests, (resource) =>
-    getDeployedResource(ctx, ctx.provider, resource, log)
-  )).filter(isTruthy)
+  const deployedResources = (
+    await Bluebird.map(manifests, (resource) => getDeployedResource(ctx, ctx.provider, resource, log))
+  ).filter(isTruthy)
   return deployedResources
 }
 

--- a/core/src/plugins/kubernetes/init.ts
+++ b/core/src/plugins/kubernetes/init.ts
@@ -89,7 +89,7 @@ export async function getEnvironmentStatus({
     log,
     api
   )
-  ingressWarnings.forEach((w) => log.warn({ symbol: "warning", msg: chalk.yellow(w) }))
+  ingressWarnings.forEach((w) => log.warn(w))
 
   const namespaceNames = mapValues(namespaces, (s) => s.namespaceName)
   const result: KubernetesEnvironmentStatus = {
@@ -149,7 +149,7 @@ export async function getIngressMisconfigurationWarnings(
   ingressApiVersion: string | undefined,
   log: Log,
   api: KubeApi
-): Promise<String[]> {
+): Promise<string[]> {
   if (!customIngressClassName) {
     return []
   }
@@ -251,13 +251,10 @@ export async function prepareSystem({
       // If system services are outdated but none are *missing*, we warn instead of flagging as not ready here.
       // This avoids blocking users where there's variance in configuration between users of the same cluster,
       // that often doesn't affect usage.
-      log.warn({
-        symbol: "warning",
-        msg: chalk.gray(deline`
-          One or more cluster-wide system services are outdated or their configuration does not match your current
-          configuration. You may want to run ${initCommand} to update them, or contact a cluster admin to do so.
-        `),
-      })
+      log.warn(deline`
+        One or more cluster-wide system services are outdated or their configuration does not match your current
+        configuration. You may want to run ${initCommand} to update them, or contact a cluster admin to do so.
+      `)
 
       return {}
     }
@@ -327,7 +324,7 @@ export async function cleanupEnvironment({ ctx, log }: CleanupEnvironmentParams)
 
   const entry = log
     .createLog({
-      section: "kubernetes",
+      name: "kubernetes",
     })
     .info(`Deleting ${nsDescription} (this may take a while)`)
 

--- a/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
@@ -28,7 +28,7 @@ import { configureLocalMode, startServiceInLocalMode } from "../local-mode"
 import type { ExecBuildConfig } from "../../exec/config"
 import type { KubernetesActionConfig, KubernetesDeployAction, KubernetesDeployActionConfig } from "./config"
 import type { DeployActionHandler } from "../../../plugin/action-types"
-import type { Log } from "../../../logger/log-entry"
+import type { ActionLog } from "../../../logger/log-entry"
 import type { Resolved } from "../../../actions/types"
 import { deployStateToActionState } from "../../../plugin/handlers/Deploy/get-status"
 
@@ -437,7 +437,7 @@ async function configureSpecialModesForManifests({
   manifests,
 }: {
   ctx: KubernetesPluginContext
-  log: Log
+  log: ActionLog
   action: Resolved<KubernetesDeployAction>
   manifests: KubernetesResource<BaseResource>[]
 }) {

--- a/core/src/plugins/kubernetes/local/config.ts
+++ b/core/src/plugins/kubernetes/local/config.ts
@@ -59,12 +59,13 @@ export async function configureProvider(params: ConfigureProviderParams<LocalKub
   const { base, log, projectName, ctx } = params
 
   let { config } = await base!(params)
+  const providerLog = log.createLog({ name: config.name })
 
   const provider = ctx.provider as KubernetesProvider
   provider.config = config
   const _systemServices = config._systemServices
 
-  const kubeConfig: any = await getKubeConfig(log, ctx, provider)
+  const kubeConfig: any = await getKubeConfig(providerLog, ctx, provider)
 
   const currentContext = kubeConfig["current-context"]!
 
@@ -73,14 +74,14 @@ export async function configureProvider(params: ConfigureProviderParams<LocalKub
     if (currentContext && isSupportedContext(currentContext)) {
       // prefer current context if set and supported
       config.context = currentContext
-      log.debug({ section: config.name, msg: `Using current context: ${config.context}` })
+      providerLog.debug(`Using current context: ${config.context}`)
     } else {
       const availableContexts = kubeConfig.contexts?.map((c: any) => c.name) || []
 
       for (const context of availableContexts) {
         if (isSupportedContext(context)) {
           config.context = context
-          log.debug({ section: config.name, msg: `Using detected context: ${config.context}` })
+          providerLog.debug(`Using detected context: ${config.context}`)
           break
         }
       }
@@ -88,30 +89,27 @@ export async function configureProvider(params: ConfigureProviderParams<LocalKub
 
     if (!config.context && kubeConfig.contexts?.length > 0) {
       config.context = kubeConfig.contexts[0]!.name
-      log.debug({
-        section: config.name,
-        msg: `No kubectl context auto-detected, using first available: ${config.context}`,
-      })
+      providerLog.debug(`No kubectl context auto-detected, using first available: ${config.context}`)
     }
   }
 
   // TODO: change this in 0.12 to use the current context
   if (!config.context) {
     config.context = supportedContexts[0]
-    log.debug({ section: config.name, msg: `No kubectl context configured, using default: ${config.context}` })
+    providerLog.debug(`No kubectl context configured, using default: ${config.context}`)
   }
 
-  if (await isKindCluster(ctx, provider, log)) {
+  if (await isKindCluster(ctx, provider, providerLog)) {
     config.clusterType = "kind"
 
     if (config.setupIngressController === "nginx") {
-      log.debug("Using nginx-kind service for ingress")
+      providerLog.debug("Using nginx-kind service for ingress")
       remove(_systemServices, (s) => nginxServices.includes(s))
       let versions: K8sClientServerVersions | undefined
       try {
         versions = await getK8sClientServerVersions(config.context)
       } catch (err) {
-        log.debug("failed to get k8s version with error: " + err)
+        providerLog.debug("failed to get k8s version with error: " + err)
       }
       // TODO: remove this once we no longer support k8s v1.20
       if (versions && versions.serverVersion.minor >= 21) {
@@ -132,11 +130,11 @@ export async function configureProvider(params: ConfigureProviderParams<LocalKub
     }
 
     if (config.setupIngressController === "nginx") {
-      log.debug("Using minikube's ingress addon")
+      providerLog.debug("Using minikube's ingress addon")
       try {
         await exec("minikube", ["addons", "enable", "ingress"])
       } catch (err) {
-        log.warn(chalk.yellow(`Unable to enable minikube ingress addon: ${err.all}`))
+        providerLog.warn(chalk.yellow(`Unable to enable minikube ingress addon: ${err.all}`))
       }
       remove(_systemServices, (s) => nginxServices.includes(s))
     }
@@ -148,13 +146,13 @@ export async function configureProvider(params: ConfigureProviderParams<LocalKub
     config.clusterType = "microk8s"
 
     if (config.setupIngressController === "nginx") {
-      log.debug("Using microk8s's ingress addon")
+      providerLog.debug("Using microk8s's ingress addon")
       addons.push("ingress")
       remove(_systemServices, (s) => nginxServices.includes(s))
       _systemServices.push("nginx-ingress-class")
     }
 
-    await configureMicrok8sAddons(log, addons)
+    await configureMicrok8sAddons(providerLog, addons)
   }
 
   if (!config.defaultHostname) {

--- a/core/src/plugins/kubernetes/local/microk8s.ts
+++ b/core/src/plugins/kubernetes/local/microk8s.ts
@@ -18,16 +18,18 @@ import { ExecaReturnValue } from "execa"
 import { PluginContext } from "../../../plugin-context"
 import { parse as parsePath } from "path"
 
+// TODO: Pass the correct log context instead of creating it here.
 export async function configureMicrok8sAddons(log: Log, addons: string[]) {
   let statusCommandResult: ExecaReturnValue | undefined = undefined
   let status = ""
+  const microK8sLog = log.createLog({ name: "microk8s" })
 
   try {
     statusCommandResult = await exec("microk8s", ["status"])
     status = statusCommandResult.stdout
   } catch (err) {
     if (err.all?.includes("permission denied") || err.all?.includes("Insufficient permissions")) {
-      log.warn(
+      microK8sLog.warn(
         chalk.yellow(
           deline`Unable to get microk8s status and manage addons. You may need to add the current user to the microk8s
           group. Alternatively, you can manually ensure that the ${naturalList(addons)} are enabled.`
@@ -49,7 +51,7 @@ export async function configureMicrok8sAddons(log: Log, addons: string[]) {
   const missingAddons = addons.filter((addon) => !status.includes(`${addon}: enabled`))
 
   if (missingAddons.length > 0) {
-    log.info({ section: "microk8s", msg: `enabling required addons (${missingAddons.join(", ")})` })
+    microK8sLog.info(`enabling required addons (${missingAddons.join(", ")})`)
     await exec("microk8s", ["enable"].concat(missingAddons))
   }
 }

--- a/core/src/plugins/kubernetes/status/service.ts
+++ b/core/src/plugins/kubernetes/status/service.ts
@@ -64,7 +64,7 @@ export async function waitForServiceEndpoints(
         })
       }
 
-      log.info({ symbol: "warning", msg: `Waiting for Service '${serviceName}' Endpoints to resolve...` })
+      log.info(`Waiting for Service '${serviceName}' Endpoints to resolve...`)
       await sleep(1000)
     }
   })

--- a/core/src/plugins/kubernetes/status/status.ts
+++ b/core/src/plugins/kubernetes/status/status.ts
@@ -208,7 +208,8 @@ export async function waitForResources({
   const waitingMsg = `Waiting for resources to be ready...`
   const statusLine = log
     .createLog({
-      section: actionName,
+      // TODO: Avoid setting fallback, the action name should be known
+      name: actionName || "<kubernetes>",
     })
     .info(waitingMsg)
   emitLog(waitingMsg)
@@ -216,7 +217,7 @@ export async function waitForResources({
   if (resources.length === 0) {
     const noResourcesMsg = `No resources to wait`
     emitLog(noResourcesMsg)
-    statusLine.info({ symbol: "info", section: actionName, msg: noResourcesMsg })
+    statusLine.info(noResourcesMsg)
     return []
   }
 
@@ -291,7 +292,7 @@ export async function waitForResources({
 
   const readyMsg = `Resources ready`
   emitLog(readyMsg)
-  statusLine.info({ symbol: "info", section: actionName, msg: readyMsg })
+  statusLine.info(readyMsg)
 
   return statuses
 }

--- a/core/src/plugins/kubernetes/system.ts
+++ b/core/src/plugins/kubernetes/system.ts
@@ -76,7 +76,7 @@ export async function getSystemGarden(
     commandInfo: ctx.command,
     log: log
       .createLog({
-        section: "garden system",
+        name: "garden system",
         fixLevel: LogLevel.debug,
       })
       .info("Initializing..."),

--- a/core/src/process.ts
+++ b/core/src/process.ts
@@ -18,13 +18,13 @@ export async function waitForExitEvent(garden: Garden, log: Log) {
 
   await new Promise((resolve) => {
     garden.events.on("_restart", () => {
-      log.debug({ symbol: "info", msg: `Manual restart triggered` })
+      log.debug(`Manual restart triggered`)
       restartRequired = true
       resolve({})
     })
 
     garden.events.on("_exit", () => {
-      log.debug({ symbol: "info", msg: `Manual exit triggered` })
+      log.debug(`Manual exit triggered`)
       resolve({})
     })
   })

--- a/core/src/proxy.ts
+++ b/core/src/proxy.ts
@@ -15,7 +15,7 @@ import getPort = require("get-port")
 import { ServiceStatus, ForwardablePort } from "./types/service"
 import { Garden } from "./garden"
 import { registerCleanupFunction, sleep } from "./util/util"
-import { Log } from "./logger/log-entry"
+import { createActionLog, Log } from "./logger/log-entry"
 import { ConfigGraph } from "./graph/config-graph"
 import { DeployAction } from "./actions/deploy"
 import { GetPortForwardResult } from "./plugin/handlers/Deploy/get-port-forward"
@@ -116,7 +116,8 @@ async function createProxy({ garden, graph, log, action, spec, events }: StartPo
       log.debug(`Starting port forward to ${key}`)
 
       try {
-        const output = await router.deploy.getPortForward({ action, log, graph, events, ...spec })
+        const actionLog = createActionLog({ log, actionName: action.name, actionKind: action.kind })
+        const output = await router.deploy.getPortForward({ action, log: actionLog, graph, events, ...spec })
         fwd = output.result
       } catch (err) {
         const msg = err.message.trim()
@@ -308,8 +309,9 @@ export async function stopPortProxy({ garden, graph, log, action, proxy, events 
   closeProxyServer(proxy)
 
   const router = await garden.getActionRouter()
+  const actionLog = createActionLog({ log, actionName: action.name, actionKind: action.kind })
 
-  await router.deploy.stopPortForward({ log, graph, action, events, ...proxy.spec })
+  await router.deploy.stopPortForward({ log: actionLog, graph, action, events, ...proxy.spec })
 }
 
 function getHostname(action: DeployAction, spec: ForwardablePort) {

--- a/core/src/router/deploy.ts
+++ b/core/src/router/deploy.ts
@@ -77,24 +77,16 @@ export const deployRouter = (baseParams: BaseRouterParams) =>
       return output
     },
 
-    // TODO @eysi: The type here should explictly be ActionLog
     delete: async (params) => {
       const { action, router, handlers } = params
 
-      const log = params.log
-        .createLog({
-          section: action.key(),
-        })
-        .info("Cleaning up...")
+      const log = params.log.createLog().info("Cleaning up...")
 
       const statusOutput = await handlers.getStatus({ ...params })
       const status = statusOutput.result
 
       if (status.detail?.state === "missing") {
-        log.success({
-          section: action.key(),
-          msg: "Not found",
-        })
+        log.success("Not found")
         return statusOutput
       }
 
@@ -114,7 +106,6 @@ export const deployRouter = (baseParams: BaseRouterParams) =>
 
       router.emitNamespaceEvents(output.result.detail?.namespaceStatuses)
 
-      // TODO @eysi: Validate that timestamp gets printed
       log.success(`Done`)
 
       return output
@@ -132,10 +123,7 @@ export const deployRouter = (baseParams: BaseRouterParams) =>
         params,
         handlerType: "getLogs",
         defaultHandler: async () => {
-          log.warn({
-            section: action.key(),
-            msg: chalk.yellow(`No handler for log retrieval available for action type ${action.type}`),
-          })
+          log.warn(chalk.yellow(`No handler for log retrieval available for action type ${action.type}`))
           return {}
         },
       })
@@ -195,10 +183,7 @@ export const deployRouter = (baseParams: BaseRouterParams) =>
         params,
         handlerType: "getSyncStatus",
         defaultHandler: async () => {
-          log.debug({
-            section: action.key(),
-            msg: `No getSyncStatus handler available for action type ${action.type}`,
-          })
+          log.debug(`No getSyncStatus handler available for action type ${action.type}`)
           return {
             state: "unknown" as const,
           }
@@ -213,10 +198,7 @@ export const deployRouter = (baseParams: BaseRouterParams) =>
         params,
         handlerType: "startSync",
         defaultHandler: async () => {
-          log.warn({
-            section: action.key(),
-            msg: chalk.yellow(`No startSync handler available for action type ${action.type}`),
-          })
+          log.warn(chalk.yellow(`No startSync handler available for action type ${action.type}`))
           return {}
         },
       })
@@ -229,10 +211,7 @@ export const deployRouter = (baseParams: BaseRouterParams) =>
         params,
         handlerType: "stopSync",
         defaultHandler: async () => {
-          log.warn({
-            section: action.key(),
-            msg: chalk.yellow(`No stopSync handler available for action type ${action.type}`),
-          })
+          log.warn(chalk.yellow(`No stopSync handler available for action type ${action.type}`))
           return {}
         },
       })

--- a/core/src/server/server.ts
+++ b/core/src/server/server.ts
@@ -165,7 +165,7 @@ export class GardenServer extends EventEmitter {
     })
 
     this.log.info("")
-    this.statusLog = this.log.createLog({})
+    this.statusLog = this.log.createLog()
   }
 
   getBaseUrl() {

--- a/core/src/tasks/base.ts
+++ b/core/src/tasks/base.ts
@@ -9,7 +9,7 @@
 import { GraphResults } from "../graph/results"
 import { v1 as uuidv1 } from "uuid"
 import { Garden } from "../garden"
-import { ActionLog, createActionLog, Log as Log } from "../logger/log-entry"
+import { ActionLog, createActionLog, Log } from "../logger/log-entry"
 import { Profile } from "../util/profiling"
 import type { Action, ActionState, Executed, Resolved } from "../actions/types"
 import { ConfigGraph, GraphError } from "../graph/config-graph"
@@ -102,7 +102,7 @@ export abstract class BaseTask<O extends ValidResultType = ValidResultType> exte
   concurrencyLimit = 10
 
   public readonly garden: Garden
-  public readonly log: Log | ActionLog
+  public readonly log: Log
   public readonly uid: string
   public readonly force: boolean
   public readonly skipDependencies: boolean
@@ -213,6 +213,10 @@ export abstract class BaseActionTask<T extends Action, O extends ValidResultType
 
   constructor(params: BaseActionTaskParams<T>) {
     const { action } = params
+
+    const coreLog = params.log.root.createLog({ name: "foo" })
+    const newCoreLog = coreLog.createLog()
+
     super({ ...params })
     this.log = createActionLog({ log: params.log, actionName: action.name, actionKind: action.kind })
     this.action = action

--- a/core/src/tasks/build.ts
+++ b/core/src/tasks/build.ts
@@ -51,6 +51,16 @@ export class BuildTask extends ExecuteActionTask<BuildAction, BuildStatus> {
     }
 
     const log = this.log.info(`Building version ${action.versionString()}...`)
+    // const newActionLog = log.createLog()
+
+    // const newCoreLog = log.createLog({ name: "foo" })
+    // const anotherCoreLog = newCoreLog.createLog()
+    // const anotherActionLog = anotherCoreLog.createLog({ actionKind: "build", actionName: "api" })
+
+    // const newActionLog = log.new({})
+    // const newCoreLog = log.new({ name: "foo" })
+    // const anotherCoreLog = newCoreLog.new({})
+    // const anotherActionLog = anotherCoreLog.new({ actionKind: "build", actionName: "api" })
 
     const files = action.getFullVersion().files
 
@@ -73,7 +83,6 @@ export class BuildTask extends ExecuteActionTask<BuildAction, BuildStatus> {
         action,
         log,
       })
-      // TODO @eysi: Verify duration
       log.success(`Done`)
 
       return {

--- a/core/src/tasks/deploy.ts
+++ b/core/src/tasks/deploy.ts
@@ -52,7 +52,7 @@ export class DeployTask extends ExecuteActionTask<DeployAction, DeployStatus> {
   }
 
   async getStatus({ statusOnly, dependencyResults }: ActionTaskStatusParams<DeployAction>) {
-    const log = this.log.createLog({})
+    const log = this.log.createLog()
     const action = this.getResolvedAction(this.action, dependencyResults)
 
     const router = await this.garden.getActionRouter()

--- a/core/src/tasks/publish.ts
+++ b/core/src/tasks/publish.ts
@@ -60,10 +60,7 @@ export class PublishTask extends BaseActionTask<BuildAction, PublishActionResult
 
   async process({ dependencyResults }: ActionTaskProcessParams<BuildAction, PublishActionResult>) {
     if (this.action.getConfig("allowPublish") === false) {
-      this.log.info({
-        section: this.action.key(),
-        msg: "Publishing disabled (allowPublish=false set on build)",
-      })
+      this.log.info("Publishing disabled (allowPublish=false set on build)")
       return {
         state: <ActionState>"ready",
         detail: { published: false },
@@ -98,23 +95,23 @@ export class PublishTask extends BaseActionTask<BuildAction, PublishActionResult
       // TODO: validate the tag?
     }
 
-    const log = this.log.createLog().info("Publishing with tag " + tag)
+    this.log.info("Publishing with tag " + tag)
 
     const router = await this.garden.getActionRouter()
 
     let result: PublishActionResult
     try {
-      const output = await router.build.publish({ action, log, graph: this.graph, tag })
+      const output = await router.build.publish({ action, log: this.log, graph: this.graph, tag })
       result = output.result
     } catch (err) {
-      log.error(`Failed publishing build ${action.name}`)
+      this.log.error(`Failed publishing build ${action.name}`)
       throw err
     }
 
     if (result.detail?.published) {
-      log.success(result.detail.message || `Ready`)
+      this.log.success(result.detail.message || `Ready`)
     } else if (result.detail?.message) {
-      log.warn(result.detail.message)
+      this.log.warn(result.detail.message)
     }
 
     return { ...result, version }

--- a/core/src/tasks/resolve-provider.ts
+++ b/core/src/tasks/resolve-provider.ts
@@ -366,7 +366,7 @@ export class ResolveProviderTask extends BaseTask<Provider> {
 
       const envLogEntry = this.log
         .createLog({
-          section: pluginName,
+          name: pluginName,
         })
         .info("Configuring...")
 

--- a/core/src/tasks/run.ts
+++ b/core/src/tasks/run.ts
@@ -49,7 +49,7 @@ export class RunTask extends ExecuteActionTask<RunAction, GetRunResult> {
       }
 
       if (status.state === "ready" && !statusOnly) {
-        this.log.info(chalk.green(`${action.longDescription()} already complete.`))
+        taskLog.info(chalk.green(`${action.longDescription()} already complete.`))
       }
 
       return {

--- a/core/src/tasks/test.ts
+++ b/core/src/tasks/test.ts
@@ -61,7 +61,7 @@ export class TestTask extends ExecuteActionTask<TestAction, GetTestResult> {
     const testResult = status?.detail
 
     if (testResult && testResult.success) {
-      this.log.createLog().success("Already passed")
+      this.log.success("Already passed")
       return {
         ...status,
         version: action.versionString(),
@@ -75,14 +75,14 @@ export class TestTask extends ExecuteActionTask<TestAction, GetTestResult> {
   async process({ dependencyResults }: ActionTaskProcessParams<TestAction, GetTestResult>) {
     const action = this.getResolvedAction(this.action, dependencyResults)
 
-    const taskLog = this.log.createLog().info(`Running...`)
+    this.log.info(`Running...`)
 
     const router = await this.garden.getActionRouter()
 
     let status: GetTestResult<TestAction>
     try {
       const output = await router.test.run({
-        log: taskLog,
+        log: this.log,
         action,
         graph: this.graph,
         silent: this.silent,
@@ -90,15 +90,15 @@ export class TestTask extends ExecuteActionTask<TestAction, GetTestResult> {
       })
       status = output.result
     } catch (err) {
-      taskLog.error(`Failed running test`)
+      this.log.error(`Failed running test`)
       throw err
     }
     if (status.detail?.success) {
-      taskLog.success(`Success`)
+      this.log.success(`Success`)
     } else {
       const exitCode = status.detail?.exitCode
       const failedMsg = !!exitCode ? `Failed with code ${exitCode}!` : `Failed!`
-      taskLog.error(`${failedMsg} (took ${taskLog.getDuration(1)} sec)`)
+      this.log.error(failedMsg)
       throw new TestError(status.detail?.log)
     }
 

--- a/core/src/types/service.ts
+++ b/core/src/types/service.ts
@@ -74,7 +74,7 @@ export function serviceFromConfig<M extends GardenModule = GardenModule>(
 }
 
 export const deployStates = ["ready", "deploying", "stopped", "unhealthy", "unknown", "outdated", "missing"] as const
-export type DeployState = typeof deployStates[number]
+export type DeployState = (typeof deployStates)[number]
 
 export type DeployStatusForEventPayload = Omit<ServiceStatus, "detail">
 

--- a/core/src/util/ext-tools.ts
+++ b/core/src/util/ext-tools.ts
@@ -297,7 +297,7 @@ export class PluginTool extends CliWrapper {
       const tmpPath = join(this.toolPath, this.versionDirname + "." + uuidv4().substr(0, 8))
       const targetAbsPath = join(tmpPath, ...this.targetSubpath.split(posix.sep))
 
-      const downloadLog = log.createLog({}).info(`Fetching ${this.name}...`)
+      const downloadLog = log.createLog().info(`Fetching ${this.name}...`)
       const debug = downloadLog
         .createLog({
           fixLevel: LogLevel.debug,

--- a/core/src/util/util.ts
+++ b/core/src/util/util.ts
@@ -152,17 +152,15 @@ export function defer<T>() {
 }
 
 /**
- * Creates an output stream that updates a log entry on data events (in an opinionated way).
- *
- * Note that new entries are not created but rather the passed log entry gets updated.
- * It's therefore recommended to pass a placeholder entry, for example: `log.placeholder(LogLevel.debug)`
+ * Creates an output stream that logs the message.
  */
 export function createOutputStream(log: Log, origin?: string) {
   const outputStream = split2()
+  const streamLog = log.createLog({ origin })
 
   outputStream.on("error", () => {})
   outputStream.on("data", (line: Buffer) => {
-    log.info({ msg: line.toString(), origin })
+    streamLog.info({ msg: line.toString() })
   })
 
   return outputStream

--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -261,19 +261,13 @@ export class GitHandler extends VcsHandler {
       const pathStats = await stat(path)
 
       if (!pathStats.isDirectory()) {
-        gitLog.warn({
-          symbol: "warning",
-          msg: chalk.gray(`Expected directory at ${path}, but found ${getStatsType(pathStats)}.`),
-        })
+        gitLog.warn(`Expected directory at ${path}, but found ${getStatsType(pathStats)}.`)
         return []
       }
     } catch (err) {
       // 128 = File no longer exists
       if (err.exitCode === 128 || err.code === "ENOENT") {
-        gitLog.warn({
-          symbol: "warning",
-          msg: chalk.gray(`Attempted to scan directory at ${path}, but it does not exist.`),
-        })
+        gitLog.warn(`Attempted to scan directory at ${path}, but it does not exist.`)
         return []
       } else {
         throw err
@@ -407,23 +401,15 @@ export class GitHandler extends VcsHandler {
 
             if (!pathStats.isDirectory()) {
               const pathType = getStatsType(pathStats)
-              gitLog.warn({
-                symbol: "warning",
-                msg: chalk.gray(
-                  `Expected submodule directory at ${path}, but found ${pathType}. ${submoduleErrorSuggestion}`
-                ),
-              })
+              gitLog.warn(`Expected submodule directory at ${path}, but found ${pathType}. ${submoduleErrorSuggestion}`)
               return
             }
           } catch (err) {
             // 128 = File no longer exists
             if (err.exitCode === 128 || err.code === "ENOENT") {
-              gitLog.warn({
-                symbol: "warning",
-                msg: chalk.yellow(
-                  `Found reference to submodule at ${submoduleRelPath}, but the path could not be found. ${submoduleErrorSuggestion}`
-                ),
-              })
+              gitLog.warn(
+                `Found reference to submodule at ${submoduleRelPath}, but the path could not be found. ${submoduleErrorSuggestion}`
+              )
               return
             } else {
               throw err

--- a/core/src/warnings.ts
+++ b/core/src/warnings.ts
@@ -6,7 +6,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import chalk from "chalk"
 import { Log } from "./logger/log-entry"
 
 interface LoggerContext {
@@ -22,9 +21,6 @@ export function emitNonRepeatableWarning(log: Log, message: string) {
     return
   }
 
-  log.warn({
-    symbol: "warning",
-    msg: chalk.yellow(message),
-  })
+  log.warn(message)
   loggerContext.history.add(message)
 }

--- a/core/test/integ/src/plugins/container/container.ts
+++ b/core/test/integ/src/plugins/container/container.ts
@@ -11,7 +11,7 @@ import td from "testdouble"
 import { PluginContext } from "../../../../../src/plugin-context"
 import { gardenPlugin, ContainerProvider } from "../../../../../src/plugins/container/container"
 import { expectError, getDataDir, getPropertyName, makeTestGarden, TestGarden } from "../../../../helpers"
-import { Log } from "../../../../../src/logger/log-entry"
+import { ActionLog, createActionLog } from "../../../../../src/logger/log-entry"
 import { expect } from "chai"
 import { ContainerBuildAction, ContainerBuildActionSpec } from "../../../../../src/plugins/container/moduleConfig"
 import { cloneDeep } from "lodash"
@@ -39,12 +39,12 @@ describe("plugins.container", () => {
 
   let garden: TestGarden
   let ctx: PluginContext
-  let log: Log
+  let log: ActionLog
   let containerProvider: ContainerProvider
 
   beforeEach(async () => {
     garden = await makeTestGarden(projectRoot, { plugins: [gardenPlugin()] })
-    log = garden.log
+    log = createActionLog({ log: garden.log, actionName: "", actionKind: "" })
     containerProvider = await garden.resolveProvider(garden.log, "container")
     ctx = await garden.getPluginContext({ provider: containerProvider, templateContext: undefined, events: undefined })
     td.replace(garden.buildStaging, "syncDependencyProducts", () => null)

--- a/core/test/integ/src/plugins/kubernetes/commands/pull-image.ts
+++ b/core/test/integ/src/plugins/kubernetes/commands/pull-image.ts
@@ -17,6 +17,7 @@ import { containerHelpers } from "../../../../../../src/plugins/container/helper
 import { expect } from "chai"
 import { grouped } from "../../../../../helpers"
 import { BuildAction } from "../../../../../../src/actions/build"
+import { createActionLog } from "../../../../../../src/logger/log-entry"
 
 describe("pull-image plugin command", () => {
   let garden: Garden
@@ -74,10 +75,15 @@ describe("pull-image plugin command", () => {
 
       // build the image
       await garden.buildStaging.syncFromSrc({ action, log: garden.log })
+      const actionLog = createActionLog({
+        log: garden.log,
+        actionName: resolvedAction.name,
+        actionKind: resolvedAction.kind,
+      })
 
       await k8sBuildContainer({
         ctx,
-        log: garden.log,
+        log: actionLog,
         action: resolvedAction,
       })
     })
@@ -106,10 +112,11 @@ describe("pull-image plugin command", () => {
 
       // build the image
       await garden.buildStaging.syncFromSrc({ action, log: garden.log })
+      const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
 
       await k8sBuildContainer({
         ctx,
-        log: garden.log,
+        log: actionLog,
         action: resolvedAction,
       })
     })

--- a/core/test/integ/src/plugins/kubernetes/container/build/build.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/build/build.ts
@@ -19,14 +19,14 @@ import { expect } from "chai"
 import { getContainerTestGarden } from "../container"
 import { containerHelpers } from "../../../../../../../src/plugins/container/helpers"
 import { k8sPublishContainerBuild } from "../../../../../../../src/plugins/kubernetes/container/publish"
-import { Log } from "../../../../../../../src/logger/log-entry"
+import { ActionLog, createActionLog } from "../../../../../../../src/logger/log-entry"
 import { cloneDeep } from "lodash"
 import { ContainerBuildAction } from "../../../../../../../src/plugins/container/config"
 import { BuildTask } from "../../../../../../../src/tasks/build"
 
 describe("kubernetes build flow", () => {
   let garden: Garden
-  let log: Log
+  let log: ActionLog
   let graph: ConfigGraph
   let provider: KubernetesProvider
   let ctx: PluginContext
@@ -43,7 +43,7 @@ describe("kubernetes build flow", () => {
   const init = async (environmentName: string) => {
     currentEnv = environmentName
     garden = await getContainerTestGarden(environmentName)
-    log = garden.log
+    log = createActionLog({ log: garden.log, actionName: "", actionKind: "" })
     graph = await garden.getConfigGraph({ log: garden.log, emit: false })
     provider = <KubernetesProvider>await garden.resolveProvider(garden.log, "local-kubernetes")
     ctx = await garden.getPluginContext({ provider, templateContext: undefined, events: undefined })

--- a/core/test/integ/src/plugins/kubernetes/container/container.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/container.ts
@@ -22,6 +22,7 @@ import { KubernetesResource } from "../../../../../../src/plugins/kubernetes/typ
 import { V1Secret } from "@kubernetes/client-node"
 import { clusterInit } from "../../../../../../src/plugins/kubernetes/commands/cluster-init"
 import { ContainerTestAction } from "../../../../../../src/plugins/container/config"
+import { createActionLog } from "../../../../../../src/logger/log-entry"
 
 const root = getDataDir("test-projects", "container")
 const defaultEnvironment = process.env.GARDEN_INTEG_TEST_MODE === "remote" ? "kaniko" : "local"
@@ -174,10 +175,15 @@ describe("kubernetes container module handlers", () => {
         graph,
       })
       const actions = await garden.getActionRouter()
+      const actionLog = createActionLog({
+        log: garden.log,
+        actionName: resolvedRuntimeAction.name,
+        actionKind: resolvedRuntimeAction.kind,
+      })
 
       // We also verify that, despite the test failing, its result was still saved.
       const result = await actions.test.getResult({
-        log: garden.log,
+        log: actionLog,
         graph,
         action: resolvedRuntimeAction,
       })

--- a/core/test/integ/src/plugins/kubernetes/container/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/deployment.ts
@@ -51,6 +51,7 @@ import { getDeployStatuses } from "../../../../../../src/tasks/helpers"
 import { ResolvedDeployAction } from "../../../../../../src/actions/deploy"
 import { ActionRouter } from "../../../../../../src/router/router"
 import { ActionMode } from "../../../../../../src/actions/types"
+import { createActionLog } from "../../../../../../src/logger/log-entry"
 
 describe("kubernetes container deployment handlers", () => {
   let garden: Garden
@@ -142,7 +143,7 @@ describe("kubernetes container deployment handlers", () => {
           ctx,
           api,
           action,
-          log: garden.log,
+          log: createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind }),
           imageId: getDeployedImageId(action, provider),
         })
 
@@ -156,7 +157,7 @@ describe("kubernetes container deployment handlers", () => {
           ctx,
           api,
           action,
-          log: garden.log,
+          log: createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind }),
           imageId: getDeployedImageId(action, provider),
         })
 
@@ -170,7 +171,7 @@ describe("kubernetes container deployment handlers", () => {
           ctx,
           api,
           action,
-          log: garden.log,
+          log: createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind }),
           imageId: getDeployedImageId(action, provider),
         })
 
@@ -184,7 +185,7 @@ describe("kubernetes container deployment handlers", () => {
           ctx,
           api,
           action,
-          log: garden.log,
+          log: createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind }),
           imageId: getDeployedImageId(action, provider),
         })
 
@@ -200,7 +201,7 @@ describe("kubernetes container deployment handlers", () => {
           ctx,
           api,
           action,
-          log: garden.log,
+          log: createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind }),
           imageId: getDeployedImageId(action, provider),
         })
 
@@ -214,7 +215,7 @@ describe("kubernetes container deployment handlers", () => {
           ctx,
           api,
           action,
-          log: garden.log,
+          log: createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind }),
           imageId: getDeployedImageId(action, provider),
         })
 
@@ -229,7 +230,7 @@ describe("kubernetes container deployment handlers", () => {
           ctx,
           api,
           action,
-          log: garden.log,
+          log: createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind }),
           imageId: getDeployedImageId(action, provider),
         })
 
@@ -243,7 +244,7 @@ describe("kubernetes container deployment handlers", () => {
           ctx,
           api,
           action,
-          log: garden.log,
+          log: createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind }),
           imageId: getDeployedImageId(action, provider),
         })
 
@@ -270,8 +271,7 @@ describe("kubernetes container deployment handlers", () => {
         action,
         imageId,
         namespace,
-
-        log: garden.log,
+        log: createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind }),
         production: false,
       })
 
@@ -341,8 +341,7 @@ describe("kubernetes container deployment handlers", () => {
         action,
         imageId: getDeployedImageId(action, provider),
         namespace,
-
-        log: garden.log,
+        log: createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind }),
         production: false,
       })
 
@@ -367,8 +366,7 @@ describe("kubernetes container deployment handlers", () => {
         action,
         imageId: getDeployedImageId(action, provider),
         namespace,
-
-        log: garden.log,
+        log: createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind }),
         production: false,
       })
 
@@ -392,8 +390,7 @@ describe("kubernetes container deployment handlers", () => {
         action,
         imageId: getDeployedImageId(action, provider),
         namespace,
-
-        log: garden.log,
+        log: createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind }),
         production: false,
       })
 
@@ -418,7 +415,7 @@ describe("kubernetes container deployment handlers", () => {
         action,
         imageId: getDeployedImageId(action, provider),
         namespace,
-        log: garden.log,
+        log: createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind }),
         production: false,
       })
 
@@ -461,7 +458,7 @@ describe("kubernetes container deployment handlers", () => {
         action,
         imageId: getDeployedImageId(action, provider),
         namespace,
-        log: garden.log,
+        log: createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind }),
         production: false,
       })
 
@@ -507,8 +504,7 @@ describe("kubernetes container deployment handlers", () => {
         action,
         imageId: getDeployedImageId(action, provider),
         namespace,
-
-        log: garden.log,
+        log: createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind }),
         production: false,
       })
 
@@ -546,8 +542,7 @@ describe("kubernetes container deployment handlers", () => {
         action,
         imageId: getDeployedImageId(action, provider),
         namespace,
-
-        log: garden.log,
+        log: createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind }),
         production: false,
       })
 
@@ -567,8 +562,7 @@ describe("kubernetes container deployment handlers", () => {
         action,
         imageId: getDeployedImageId(action, provider),
         namespace,
-
-        log: garden.log,
+        log: createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind }),
         production: false,
       })
 
@@ -589,8 +583,7 @@ describe("kubernetes container deployment handlers", () => {
         action,
         imageId: getDeployedImageId(action, provider),
         namespace,
-
-        log: garden.log,
+        log: createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind }),
         production: false,
       })
 
@@ -622,7 +615,7 @@ describe("kubernetes container deployment handlers", () => {
             action,
             imageId: getDeployedImageId(action, provider),
             namespace,
-            log: garden.log,
+            log: createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind }),
             production: false,
           }),
         (err) =>
@@ -831,7 +824,7 @@ describe("kubernetes container deployment handlers", () => {
         action,
         imageId: getDeployedImageId(action, provider),
         namespace,
-        log: garden.log,
+        log: createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind }),
         production: false,
       })
 
@@ -881,6 +874,8 @@ describe("kubernetes container deployment handlers", () => {
 
     it("should delete resources if production = false", async () => {
       const action = await resolveDeployAction("simple-service")
+      const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
+
       await cleanupSpecChangedSimpleService(action) // Clean up in case we're re-running the test case
       await deploySpecChangedSimpleService(action)
       expect(await simpleServiceIsRunning(action)).to.eql(true)
@@ -888,7 +883,7 @@ describe("kubernetes container deployment handlers", () => {
       const { result: status } = await router.deploy.getStatus({
         graph,
         action,
-        log: garden.log,
+        log: actionLog,
       })
 
       const specChangedResourceKeys: string[] = status.detail?.detail.selectorChangedResourceKeys || []
@@ -909,6 +904,8 @@ describe("kubernetes container deployment handlers", () => {
 
     it("should delete resources if production = true anad force = true", async () => {
       const action = await resolveDeployAction("simple-service")
+      const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
+
       await cleanupSpecChangedSimpleService(action) // Clean up in case we're re-running the test case
       await deploySpecChangedSimpleService(action)
       expect(await simpleServiceIsRunning(action)).to.eql(true)
@@ -916,7 +913,7 @@ describe("kubernetes container deployment handlers", () => {
       const { result: status } = await router.deploy.getStatus({
         graph,
         action,
-        log: garden.log,
+        log: actionLog,
       })
 
       const specChangedResourceKeys: string[] = status.detail?.detail.selectorChangedResourceKeys || []
@@ -926,7 +923,7 @@ describe("kubernetes container deployment handlers", () => {
         action,
         ctx,
         namespace: provider.config.namespace!.name,
-        log: garden.log,
+        log: actionLog,
         specChangedResourceKeys,
         production: true, // <----
         force: true, // <---
@@ -940,11 +937,12 @@ describe("kubernetes container deployment handlers", () => {
       await cleanupSpecChangedSimpleService(action) // Clean up in case we're re-running the test case
       await deploySpecChangedSimpleService(action)
       expect(await simpleServiceIsRunning(action)).to.eql(true)
+      const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
 
       const { result: status } = await router.deploy.getStatus({
         graph,
         action,
-        log: garden.log,
+        log: actionLog,
       })
 
       const specChangedResourceKeys: string[] = status.detail?.detail.selectorChangedResourceKeys || []

--- a/core/test/integ/src/plugins/kubernetes/container/logs.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/logs.ts
@@ -21,6 +21,7 @@ import { sleep } from "../../../../../../src/util/util"
 import { DeleteDeployTask } from "../../../../../../src/tasks/delete-deploy"
 import { getDeployedImageId } from "../../../../../../src/plugins/kubernetes/container/util"
 import { ContainerDeployAction } from "../../../../../../src/plugins/container/config"
+import { createActionLog } from "../../../../../../src/logger/log-entry"
 
 describe("kubernetes", () => {
   let garden: TestGarden
@@ -47,6 +48,7 @@ describe("kubernetes", () => {
   describe("k8sGetContainerDeployLogs", () => {
     it("should write Deploy logs to stream", async () => {
       const action = graph.getDeploy("simple-service")
+      const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
 
       const entries: DeployLogEntry[] = []
 
@@ -72,7 +74,7 @@ describe("kubernetes", () => {
       await k8sGetContainerDeployLogs({
         ctx,
         action: resolvedDeployAction,
-        log: garden.log,
+        log: actionLog,
         stream,
         follow: false,
       })
@@ -117,6 +119,7 @@ describe("kubernetes", () => {
           graph,
         })
 
+        const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
         const resources = [
           await createWorkloadManifest({
             ctx,
@@ -127,7 +130,7 @@ describe("kubernetes", () => {
             imageId: getDeployedImageId(resolvedDeployAction, provider),
 
             production: ctx.production,
-            log,
+            log: actionLog,
           }),
         ]
         logsFollower = new K8sLogFollower({
@@ -156,9 +159,8 @@ describe("kubernetes", () => {
 
       it("should automatically connect if a Deploy that was missing is deployed", async () => {
         const action = graph.getDeploy("simple-service")
-        const log = garden.log
         const namespace = provider.config.namespace!.name!
-        const api = await KubeApi.factory(log, ctx, provider)
+        const api = await KubeApi.factory(garden.log, ctx, provider)
 
         const entries: DeployLogEntry[] = []
 
@@ -192,6 +194,7 @@ describe("kubernetes", () => {
           graph,
         })
 
+        const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
         const resources = [
           await createWorkloadManifest({
             ctx,
@@ -201,14 +204,14 @@ describe("kubernetes", () => {
             namespace,
             imageId: getDeployedImageId(resolvedDeployAction, provider),
             production: ctx.production,
-            log,
+            log: actionLog,
           }),
         ]
         const retryIntervalMs = 1000
         logsFollower = new K8sLogFollower({
           defaultNamespace: provider.config.namespace!.name!,
           stream,
-          log,
+          log: actionLog,
           entryConverter: makeDeployLogEntry(action.name),
           resources,
           k8sApi: api,
@@ -229,7 +232,7 @@ describe("kubernetes", () => {
 
         logsFollower.close()
 
-        const logString = log.toString()
+        const logString = actionLog.toString()
 
         // First we expect to see a "missing container" entry because the Deploy hasn't been completed
         expect(logString).to.match(

--- a/core/test/integ/src/plugins/kubernetes/container/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/run.ts
@@ -17,6 +17,7 @@ import { getContainerTestGarden } from "./container"
 import { clearRunResult } from "../../../../../../src/plugins/kubernetes/run-results"
 import { KubernetesProvider } from "../../../../../../src/plugins/kubernetes/config"
 import { ContainerRunAction } from "../../../../../../src/plugins/container/config"
+import { createActionLog } from "../../../../../../src/logger/log-entry"
 
 describe("runContainerTask", () => {
   let garden: TestGarden
@@ -67,9 +68,16 @@ describe("runContainerTask", () => {
 
     // Verify that the result was saved
     const actions = await garden.getActionRouter()
-    const storedResult = await actions.run.getResult({
+    const resolvedAction = await garden.resolveAction<ContainerRunAction>({ action, log: garden.log, graph })
+    const actionLog = createActionLog({
       log: garden.log,
-      action: await garden.resolveAction<ContainerRunAction>({ action, log: garden.log, graph }),
+      actionName: resolvedAction.name,
+      actionKind: resolvedAction.kind,
+    })
+
+    const storedResult = await actions.run.getResult({
+      log: actionLog,
+      action: resolvedAction,
       graph,
     })
 
@@ -96,9 +104,16 @@ describe("runContainerTask", () => {
 
     // Verify that the result was not saved
     const router = await garden.getActionRouter()
-    const { result } = await router.run.getResult({
+    const resolvedAction = await garden.resolveAction<ContainerRunAction>({ action, log: garden.log, graph })
+    const actionLog = createActionLog({
       log: garden.log,
-      action: await garden.resolveAction<ContainerRunAction>({ action, log: garden.log, graph }),
+      actionName: resolvedAction.name,
+      actionKind: resolvedAction.kind,
+    })
+
+    const { result } = await router.run.getResult({
+      log: actionLog,
+      action: resolvedAction,
       graph,
     })
 
@@ -128,9 +143,16 @@ describe("runContainerTask", () => {
 
     // We also verify that, despite the task failing, its result was still saved.
     const actions = await garden.getActionRouter()
-    const { result } = await actions.run.getResult({
+    const resolvedAction = await garden.resolveAction<ContainerRunAction>({ action, log: garden.log, graph })
+    const actionLog = createActionLog({
       log: garden.log,
-      action: await garden.resolveAction<ContainerRunAction>({ action, log: garden.log, graph }),
+      actionName: resolvedAction.name,
+      actionKind: resolvedAction.kind,
+    })
+
+    const { result } = await actions.run.getResult({
+      log: actionLog,
+      action: resolvedAction,
       graph,
     })
 

--- a/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
@@ -27,6 +27,7 @@ import { getRootLogger } from "../../../../../../src/logger/logger"
 import { LocalModeProcessRegistry, ProxySshKeystore } from "../../../../../../src/plugins/kubernetes/local-mode"
 import { HelmDeployAction } from "../../../../../../src/plugins/kubernetes/helm/config"
 import { GlobalConfigStore } from "../../../../../../src/config-store/global"
+import { createActionLog } from "../../../../../../src/logger/log-entry"
 
 describe("helmDeploy in local-mode", () => {
   let garden: TestGarden
@@ -71,11 +72,12 @@ describe("helmDeploy in local-mode", () => {
       log: garden.log,
       graph,
     })
+    const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
 
     const releaseName = getReleaseName(action)
     await helmDeploy({
       ctx,
-      log: garden.log,
+      log: actionLog,
       action,
       force: false,
     })
@@ -133,10 +135,11 @@ describe("helmDeploy", () => {
       log: garden.log,
       graph,
     })
+    const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
 
     const status = await helmDeploy({
       ctx,
-      log: garden.log,
+      log: actionLog,
       action,
       force: false,
     })
@@ -172,10 +175,11 @@ describe("helmDeploy", () => {
       log: garden.log,
       graph,
     })
+    const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
 
     const status = await helmDeploy({
       ctx,
-      log: garden.log,
+      log: actionLog,
       action,
       force: false,
     })
@@ -215,11 +219,12 @@ describe("helmDeploy", () => {
       log: garden.log,
       graph,
     })
+    const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
 
     const releaseName = getReleaseName(action)
     await helmDeploy({
       ctx,
-      log: garden.log,
+      log: actionLog,
       action,
       force: false,
     })
@@ -247,13 +252,14 @@ describe("helmDeploy", () => {
       log: garden.log,
       graph,
     })
+    const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
 
     const namespace = action.getSpec().namespace!
     expect(namespace).to.equal(provider.config.namespace!.name + "-extra")
 
     await helmDeploy({
       ctx,
-      log: garden.log,
+      log: actionLog,
       action,
       force: false,
     })
@@ -299,10 +305,11 @@ describe("helmDeploy", () => {
       log: garden.log,
       graph,
     })
+    const actionLog = createActionLog({ log: gardenWithCloudApi.log, actionName: action.name, actionKind: action.kind })
 
     const status = await helmDeploy({
       ctx: ctxWithCloudApi,
-      log: gardenWithCloudApi.log,
+      log: actionLog,
       action,
       force: false,
     })

--- a/core/test/integ/src/plugins/kubernetes/helm/run.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/run.ts
@@ -15,6 +15,7 @@ import { RunTask } from "../../../../../../src/tasks/run"
 import { emptyDir, pathExists } from "fs-extra"
 import { join } from "path"
 import { clearRunResult } from "../../../../../../src/plugins/kubernetes/run-results"
+import { createActionLog } from "../../../../../../src/logger/log-entry"
 
 describe("Helm Pod Run", () => {
   let garden: TestGarden
@@ -56,8 +57,10 @@ describe("Helm Pod Run", () => {
 
     // We also verify that result was saved.
     const actions = await garden.getActionRouter()
+    const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
+
     const storedResult = await actions.run.getResult({
-      log: garden.log,
+      log: actionLog,
       action: await garden.resolveAction({ action, log: garden.log, graph }),
       graph,
     })
@@ -87,8 +90,10 @@ describe("Helm Pod Run", () => {
 
     // Verify that the result was not saved
     const router = await garden.getActionRouter()
+    const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
+
     const { result } = await router.run.getResult({
-      log: garden.log,
+      log: actionLog,
       action: await garden.resolveAction({ action, log: garden.log, graph }),
       graph,
     })
@@ -138,10 +143,11 @@ describe("Helm Pod Run", () => {
     )
 
     const actions = await garden.getActionRouter()
+    const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
 
     // We also verify that, despite the task failing, its result was still saved.
     const result = await actions.run.getResult({
-      log: garden.log,
+      log: actionLog,
       action: await garden.resolveAction({ action, log: garden.log, graph }),
       graph,
     })

--- a/core/test/integ/src/plugins/kubernetes/helm/test.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/test.ts
@@ -14,6 +14,7 @@ import { getHelmTestGarden } from "./common"
 import { TestTask } from "../../../../../../src/tasks/test"
 import { emptyDir, pathExists } from "fs-extra"
 import { join } from "path"
+import { createActionLog } from "../../../../../../src/logger/log-entry"
 
 describe("Helm Pod Test", () => {
   let garden: TestGarden
@@ -90,10 +91,11 @@ describe("Helm Pod Test", () => {
     )
 
     const actions = await garden.getActionRouter()
+    const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
 
     // We also verify that, despite the test failing, its result was still saved.
     const result = await actions.test.getResult({
-      log: garden.log,
+      log: actionLog,
       action: await garden.resolveAction({ action, log: garden.log, graph }),
       graph,
     })

--- a/core/test/integ/src/plugins/kubernetes/kubernetes-module/handlers.ts
+++ b/core/test/integ/src/plugins/kubernetes/kubernetes-module/handlers.ts
@@ -16,7 +16,7 @@ import { getKubernetesTestGarden } from "./common"
 import { DeployTask } from "../../../../../../src/tasks/deploy"
 import { getManifests } from "../../../../../../src/plugins/kubernetes/kubernetes-type/common"
 import { KubeApi } from "../../../../../../src/plugins/kubernetes/api"
-import { Log } from "../../../../../../src/logger/log-entry"
+import { ActionLog, createActionLog, Log } from "../../../../../../src/logger/log-entry"
 import { KubernetesPluginContext, KubernetesProvider } from "../../../../../../src/plugins/kubernetes/config"
 import { getActionNamespace } from "../../../../../../src/plugins/kubernetes/namespace"
 import { getDeployedResource } from "../../../../../../src/plugins/kubernetes/status/status"
@@ -40,6 +40,7 @@ describe("kubernetes-module handlers", () => {
   let tmpDir: tmp.DirectoryResult
   let garden: TestGarden
   let log: Log
+  let actionLog: ActionLog
   let ctx: KubernetesPluginContext
   let api: KubeApi
   /**
@@ -74,6 +75,7 @@ describe("kubernetes-module handlers", () => {
     garden = await getKubernetesTestGarden()
     moduleConfigBackup = await garden.getRawModuleConfigs()
     log = garden.log
+    actionLog = createActionLog({ log: log, actionName: "", actionKind: "" })
     const provider = <KubernetesProvider>await garden.resolveProvider(log, "local-kubernetes")
     ctx = <KubernetesPluginContext>(
       await garden.getPluginContext({ provider, templateContext: undefined, events: undefined })
@@ -135,7 +137,7 @@ describe("kubernetes-module handlers", () => {
       })
       const deployParams = {
         ctx,
-        log: garden.log,
+        log: actionLog,
         action,
         force: false,
       }
@@ -164,7 +166,7 @@ describe("kubernetes-module handlers", () => {
       const resolvedAction = await garden.resolveAction<KubernetesDeployAction>({ action, log: garden.log, graph })
       const deployParams = {
         ctx,
-        log: garden.log,
+        log: actionLog,
         action: resolvedAction,
         force: false,
       }
@@ -190,7 +192,7 @@ describe("kubernetes-module handlers", () => {
       const action = graph.getDeploy("module-simple")
       const deployParams = {
         ctx,
-        log: garden.log,
+        log: actionLog,
         action: await garden.resolveAction<KubernetesDeployAction>({ action, log: garden.log, graph }),
         force: false,
       }

--- a/core/test/integ/src/plugins/kubernetes/kubernetes-module/kubernetes-pod-run.ts
+++ b/core/test/integ/src/plugins/kubernetes/kubernetes-module/kubernetes-pod-run.ts
@@ -16,6 +16,7 @@ import { emptyDir, pathExists } from "fs-extra"
 import { join } from "path"
 import { clearRunResult } from "../../../../../../src/plugins/kubernetes/run-results"
 import { KubernetesPodRunAction } from "../../../../../../src/plugins/kubernetes/kubernetes-type/kubernetes-pod"
+import { createActionLog } from "../../../../../../src/logger/log-entry"
 
 describe("kubernetes-type pod Run", () => {
   let garden: TestGarden
@@ -57,8 +58,9 @@ describe("kubernetes-type pod Run", () => {
 
     // Verify that the result was saved
     const actions = await garden.getActionRouter()
+    const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
     const storedResult = await actions.run.getResult({
-      log: garden.log,
+      log: actionLog,
       action: await garden.resolveAction<KubernetesPodRunAction>({ action, log: garden.log, graph }),
       graph,
     })
@@ -88,8 +90,9 @@ describe("kubernetes-type pod Run", () => {
 
     // Verify that the result was saved
     const router = await garden.getActionRouter()
+    const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
     const { result } = await router.run.getResult({
-      log: garden.log,
+      log: actionLog,
       action: await garden.resolveAction<KubernetesPodRunAction>({ action, log: garden.log, graph }),
       graph,
     })
@@ -138,8 +141,9 @@ describe("kubernetes-type pod Run", () => {
     const actions = await garden.getActionRouter()
 
     // We also verify that, despite the task failing, its result was still saved.
+    const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
     const result = await actions.run.getResult({
-      log: garden.log,
+      log: actionLog,
       action: await garden.resolveAction<KubernetesPodRunAction>({ action, log: garden.log, graph }),
       graph,
     })

--- a/core/test/integ/src/plugins/kubernetes/kubernetes-module/kubernetes-pod-test.ts
+++ b/core/test/integ/src/plugins/kubernetes/kubernetes-module/kubernetes-pod-test.ts
@@ -15,6 +15,7 @@ import { TestTask } from "../../../../../../src/tasks/test"
 import { emptyDir, pathExists } from "fs-extra"
 import { join } from "path"
 import { KubernetesPodTestAction } from "../../../../../../src/plugins/kubernetes/kubernetes-type/kubernetes-pod"
+import { createActionLog } from "../../../../../../src/logger/log-entry"
 
 describe("kubernetes-type pod Test", () => {
   let garden: TestGarden
@@ -91,8 +92,9 @@ describe("kubernetes-type pod Test", () => {
     const actions = await garden.getActionRouter()
 
     // We also verify that, despite the test failing, its result was still saved.
+    const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
     const result = await actions.test.getResult({
-      log: garden.log,
+      log: actionLog,
       action: await garden.resolveAction<KubernetesPodTestAction>({ action, log: garden.log, graph }),
       graph,
     })

--- a/core/test/integ/src/plugins/kubernetes/local-mode.ts
+++ b/core/test/integ/src/plugins/kubernetes/local-mode.ts
@@ -21,6 +21,7 @@ import { LocalModeProcessRegistry, ProxySshKeystore } from "../../../../../src/p
 import pRetry = require("p-retry")
 import { sleep } from "../../../../../src/util/util"
 import { DeployTask } from "../../../../../src/tasks/deploy"
+import { createActionLog } from "../../../../../src/logger/log-entry"
 
 describe("local mode deployments and ssh tunneling behavior", () => {
   let garden: TestGarden
@@ -74,6 +75,7 @@ describe("local mode deployments and ssh tunneling behavior", () => {
       skipRuntimeDependencies: true,
     })
     await garden.processTask(task, log, {})
+    const actionLog = createActionLog({ log: log, actionName: action.name, actionKind: action.kind })
 
     const status = await pRetry(
       async () => {
@@ -81,7 +83,7 @@ describe("local mode deployments and ssh tunneling behavior", () => {
         const _status = await k8sGetContainerDeployStatus({
           ctx,
           action: resolvedAction,
-          log,
+          log: actionLog,
         })
         if (_status.state === "not-ready") {
           throw "not-yet ready, wait a bit and try again"

--- a/core/test/integ/src/plugins/kubernetes/task-results.ts
+++ b/core/test/integ/src/plugins/kubernetes/task-results.ts
@@ -14,6 +14,7 @@ import { randomString } from "../../../../../src/util/string"
 import { expect } from "chai"
 import { k8sGetRunResult, storeRunResult } from "../../../../../src/plugins/kubernetes/run-results"
 import { MAX_RUN_RESULT_LOG_LENGTH } from "../../../../../src/plugins/kubernetes/constants"
+import { createActionLog } from "../../../../../src/logger/log-entry"
 
 describe("kubernetes Run results", () => {
   let garden: Garden
@@ -56,10 +57,11 @@ describe("kubernetes Run results", () => {
       })
 
       expect(trimmed.log.length).to.be.lte(MAX_RUN_RESULT_LOG_LENGTH)
+      const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
 
       const stored = await k8sGetRunResult({
         ctx,
-        log: garden.log,
+        log: actionLog,
         action,
       })
 

--- a/core/test/integ/src/plugins/kubernetes/util.ts
+++ b/core/test/integ/src/plugins/kubernetes/util.ts
@@ -30,7 +30,7 @@ import {
 import { createWorkloadManifest } from "../../../../../src/plugins/kubernetes/container/deployment"
 import { getHelmTestGarden } from "./helm/common"
 import { getChartResources } from "../../../../../src/plugins/kubernetes/helm/common"
-import { Log } from "../../../../../src/logger/log-entry"
+import { createActionLog, Log } from "../../../../../src/logger/log-entry"
 import { BuildTask } from "../../../../../src/tasks/build"
 import { getContainerTestGarden } from "./container/container"
 import {
@@ -140,8 +140,7 @@ describe("util", () => {
           ctx,
           imageId: action.getSpec().image,
           namespace: provider.config.namespace!.name!,
-
-          log: garden.log,
+          log: createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind }),
           production: false,
         })
         await garden.processTasks({ tasks: [deployTask], throwOnError: true })

--- a/core/test/integ/src/plugins/kubernetes/volume/configmap.ts
+++ b/core/test/integ/src/plugins/kubernetes/volume/configmap.ts
@@ -14,6 +14,7 @@ import { expect } from "chai"
 import { TestGarden, makeTempDir, createProjectConfig } from "../../../../../helpers"
 import { DeployTask } from "../../../../../../src/tasks/deploy"
 import { isSubset } from "../../../../../../src/util/is-subset"
+import { createActionLog } from "../../../../../../src/logger/log-entry"
 
 describe("configmap module", () => {
   let tmpDir: tmp.DirectoryResult
@@ -95,6 +96,7 @@ describe("configmap module", () => {
       })
     ).to.be.true
 
-    await actions.deploy.delete({ log: garden.log, action, graph })
+    const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
+    await actions.deploy.delete({ log: actionLog, action, graph })
   })
 })

--- a/core/test/integ/src/plugins/kubernetes/volume/persistentvolumeclaim.ts
+++ b/core/test/integ/src/plugins/kubernetes/volume/persistentvolumeclaim.ts
@@ -14,6 +14,7 @@ import { expect } from "chai"
 import { TestGarden, makeTempDir, createProjectConfig } from "../../../../../helpers"
 import { DeployTask } from "../../../../../../src/tasks/deploy"
 import { isSubset } from "../../../../../../src/util/is-subset"
+import { createActionLog } from "../../../../../../src/logger/log-entry"
 
 describe("persistentvolumeclaim", () => {
   let tmpDir: tmp.DirectoryResult
@@ -100,6 +101,7 @@ describe("persistentvolumeclaim", () => {
       })
     ).to.be.true
 
-    await actions.deploy.delete({ log: garden.log, action, graph })
+    const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
+    await actions.deploy.delete({ log: actionLog, action, graph })
   })
 })

--- a/core/test/unit/src/commands/util/hide-warning.ts
+++ b/core/test/unit/src/commands/util/hide-warning.ts
@@ -15,7 +15,7 @@ import { getLogMessages } from "../../../../../src/util/testing"
 describe("HideWarningCommand", () => {
   it("should hide a warning message", async () => {
     const garden = await makeTestGarden(projectRootA)
-    const log = garden.log.createLog({})
+    const log = garden.log.createLog()
     const cmd = new HideWarningCommand()
     const key = randomString(10)
 

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -53,9 +53,6 @@ import { convertExecModule } from "../../../src/plugins/exec/convert"
 import { getLogMessages } from "../../../src/util/testing"
 import { TreeCache } from "../../../src/cache"
 import { omitUndefined } from "../../../src/util/objects"
-import { prepareProjectResource } from "../../../src/config/base"
-import { CoreLog } from "../../../src/logger/log-entry"
-import { Logger, LogLevel } from "../../../src/logger/logger"
 
 // TODO-G2: change all module config based tests to be action-based.
 
@@ -4723,7 +4720,7 @@ describe("Garden", () => {
 
     describe("emitWarning", () => {
       it("should log a warning if the key has not been hidden", async () => {
-        const log = garden.log.createLog({})
+        const log = garden.log.createLog()
         const message = "Oh noes!"
         await garden.emitWarning({ key, log, message })
         const logs = getLogMessages(log)
@@ -4732,7 +4729,7 @@ describe("Garden", () => {
       })
 
       it("should not log a warning if the key has been hidden", async () => {
-        const log = garden.log.createLog({})
+        const log = garden.log.createLog()
         const message = "Oh noes!"
         await garden.hideWarning(key)
         await garden.emitWarning({ key, log, message })

--- a/core/test/unit/src/logger/logger.ts
+++ b/core/test/unit/src/logger/logger.ts
@@ -37,8 +37,7 @@ describe("Logger", () => {
         const log = logger.createLog()
         log.info({
           msg: "hello",
-          section: "80",
-          symbol: "info",
+          symbol: "success",
           data: { foo: "bar" },
           dataFormat: "json",
           metadata: {
@@ -55,8 +54,7 @@ describe("Logger", () => {
           level: 2,
           message: {
             msg: "hello",
-            section: "80",
-            symbol: "info",
+            symbol: "success",
             dataFormat: "json",
             data: { foo: "bar" },
           },

--- a/core/test/unit/src/plugins/container/build.ts
+++ b/core/test/unit/src/plugins/container/build.ts
@@ -10,7 +10,7 @@ import { expect } from "chai"
 import td from "testdouble"
 import { ResolvedBuildAction, BuildActionConfig } from "../../../../../src/actions/build"
 import { ConfigGraph } from "../../../../../src/graph/config-graph"
-import { Log } from "../../../../../src/logger/log-entry"
+import { ActionLog, createActionLog, Log } from "../../../../../src/logger/log-entry"
 import { PluginContext } from "../../../../../src/plugin-context"
 import { buildContainer, getContainerBuildStatus } from "../../../../../src/plugins/container/build"
 import { ContainerProvider, gardenPlugin } from "../../../../../src/plugins/container/container"
@@ -23,12 +23,14 @@ context("build.ts", () => {
   let garden: TestGarden
   let ctx: PluginContext
   let log: Log
+  let actionLog: ActionLog
   let containerProvider: ContainerProvider
   let graph: ConfigGraph
 
   beforeEach(async () => {
     garden = await makeTestGarden(projectRoot, { plugins: [gardenPlugin()] })
     log = garden.log
+    actionLog = createActionLog({ log: log, actionName: "", actionKind: "" })
     containerProvider = await garden.resolveProvider(garden.log, "container")
     ctx = await garden.getPluginContext({ provider: containerProvider, templateContext: undefined, events: undefined })
     graph = await garden.getConfigGraph({ log, emit: false })
@@ -45,7 +47,7 @@ context("build.ts", () => {
         async () => "fake image identifier string"
       )
 
-      const result = await getContainerBuildStatus({ ctx, log, action })
+      const result = await getContainerBuildStatus({ ctx, log: actionLog, action })
       expect(result.state).to.eql("ready")
     })
 
@@ -57,7 +59,7 @@ context("build.ts", () => {
         async () => null
       )
 
-      const result = await getContainerBuildStatus({ ctx, log, action })
+      const result = await getContainerBuildStatus({ ctx, log: actionLog, action })
       expect(result.state).to.eql("not-ready")
     })
   })
@@ -96,7 +98,7 @@ context("build.ts", () => {
         expect(_ctx).to.exist
         return { all: "log" }
       })
-      const result = await buildContainer({ ctx, log, action })
+      const result = await buildContainer({ ctx, log: actionLog, action })
       expect(result.state).to.eql("ready")
       expect(result.detail?.buildLog).to.eql("log")
       expect(result.detail?.fresh).to.eql(true)
@@ -118,7 +120,7 @@ context("build.ts", () => {
         expect(_ctx).to.exist
         return { all: "log" }
       })
-      const result = await buildContainer({ ctx, log, action })
+      const result = await buildContainer({ ctx, log: actionLog, action })
       expect(result.state).to.eql("ready")
       expect(result.detail?.buildLog).to.eql("log")
       expect(result.detail?.fresh).to.eql(true)

--- a/core/test/unit/src/plugins/exec/exec.ts
+++ b/core/test/unit/src/plugins/exec/exec.ts
@@ -13,7 +13,7 @@ import psTree from "ps-tree"
 
 import { Garden } from "../../../../../src/garden"
 import { ExecProvider, gardenPlugin } from "../../../../../src/plugins/exec/exec"
-import { Log } from "../../../../../src/logger/log-entry"
+import { ActionLog, createActionLog } from "../../../../../src/logger/log-entry"
 import { keyBy, omit } from "lodash"
 import {
   getDataDir,
@@ -59,14 +59,14 @@ describe("exec plugin", () => {
     let ctx: PluginContext
     let execProvider: ExecProvider
     let graph: ConfigGraph
-    let log: Log
+    let log: ActionLog
 
     beforeEach(async () => {
       garden = await makeTestGarden(testProjectRoot, { plugins: [plugin] })
       graph = await garden.getConfigGraph({ log: garden.log, emit: false })
       execProvider = await garden.resolveProvider(garden.log, "exec")
       ctx = await garden.getPluginContext({ provider: execProvider, templateContext: undefined, events: undefined })
-      log = garden.log
+      log = createActionLog({ log: garden.log, actionName: "", actionKind: "" })
       await garden.clearBuilds()
     })
 

--- a/core/test/unit/src/router/_helpers.ts
+++ b/core/test/unit/src/router/_helpers.ts
@@ -14,6 +14,7 @@ import { BaseRuntimeActionConfig } from "../../../../src/actions/base"
 import { BuildActionConfig } from "../../../../src/actions/build"
 import { joi, CustomObjectSchema } from "../../../../src/config/common"
 import { validateSchema } from "../../../../src/config/validation"
+import { createActionLog } from "../../../../src/logger/log-entry"
 import { getModuleHandlerDescriptions } from "../../../../src/plugin/module-types"
 import { createGardenPlugin, GardenPluginSpec } from "../../../../src/plugin/plugin"
 import { getProviderActionDescriptions, ProviderHandlers } from "../../../../src/plugin/providers"
@@ -30,7 +31,7 @@ export async function getRouterTestData() {
     }),
     onlySpecifiedPlugins: true,
   })
-  const log = garden.log
+  const log = createActionLog({ log: garden.log, actionName: "", actionKind: "" })
   const actionRouter = await garden.getActionRouter()
   const graph = await garden.getConfigGraph({ log: garden.log, emit: false })
   const module = graph.getModule("module-a")

--- a/core/test/unit/src/router/build.ts
+++ b/core/test/unit/src/router/build.ts
@@ -9,7 +9,7 @@
 import { expect } from "chai"
 import { ResolvedBuildAction } from "../../../../src/actions/build"
 import { ConfigGraph } from "../../../../src/graph/config-graph"
-import { Log } from "../../../../src/logger/log-entry"
+import { ActionLog } from "../../../../src/logger/log-entry"
 import { ActionRouter } from "../../../../src/router/router"
 import { GardenModule } from "../../../../src/types/module"
 import { TestGarden } from "../../../helpers"
@@ -18,7 +18,7 @@ import { getRouterTestData } from "./_helpers"
 describe("build actions", () => {
   let garden: TestGarden
   let graph: ConfigGraph
-  let log: Log
+  let log: ActionLog
   let actionRouter: ActionRouter
   // eslint-disable-next-line no-unused
   let returnWrongOutputsCfgKey: string

--- a/core/test/unit/src/router/deploy.ts
+++ b/core/test/unit/src/router/deploy.ts
@@ -10,7 +10,7 @@ import { expect } from "chai"
 import Stream from "ts-stream"
 import { ResolvedDeployAction } from "../../../../src/actions/deploy"
 import { ConfigGraph } from "../../../../src/graph/config-graph"
-import { Log } from "../../../../src/logger/log-entry"
+import { ActionLog, Log } from "../../../../src/logger/log-entry"
 import { ActionRouter } from "../../../../src/router/router"
 import { DeployLogEntry } from "../../../../src/types/service"
 import { TestGarden, expectError } from "../../../helpers"
@@ -19,7 +19,7 @@ import { getRouterTestData } from "./_helpers"
 describe("deploy actions", () => {
   let garden: TestGarden
   let graph: ConfigGraph
-  let log: Log
+  let log: ActionLog
   let actionRouter: ActionRouter
   let resolvedDeployAction: ResolvedDeployAction
   let returnWrongOutputsCfgKey: string

--- a/core/test/unit/src/router/run.ts
+++ b/core/test/unit/src/router/run.ts
@@ -11,7 +11,7 @@ import { emptyDir, pathExists, readFile } from "fs-extra"
 import { join } from "path"
 import { ResolvedRunAction } from "../../../../src/actions/run"
 import { ConfigGraph } from "../../../../src/graph/config-graph"
-import { Log } from "../../../../src/logger/log-entry"
+import { ActionLog, Log } from "../../../../src/logger/log-entry"
 import { ActionRouter } from "../../../../src/router/router"
 import { TestGarden, expectError } from "../../../helpers"
 import { getRouterTestData } from "./_helpers"
@@ -19,7 +19,7 @@ import { getRouterTestData } from "./_helpers"
 describe("run actions", () => {
   let garden: TestGarden
   let graph: ConfigGraph
-  let log: Log
+  let log: ActionLog
   let actionRouter: ActionRouter
   let returnWrongOutputsCfgKey: string
   let resolvedRunAction: ResolvedRunAction

--- a/core/test/unit/src/router/test.ts
+++ b/core/test/unit/src/router/test.ts
@@ -12,7 +12,7 @@ import { join } from "path"
 import { TestActionConfig, TestAction } from "../../../../src/actions/test"
 import { actionFromConfig } from "../../../../src/graph/actions"
 import { ConfigGraph } from "../../../../src/graph/config-graph"
-import { Log } from "../../../../src/logger/log-entry"
+import { ActionLog } from "../../../../src/logger/log-entry"
 import { ActionRouter } from "../../../../src/router/router"
 import { GardenModule } from "../../../../src/types/module"
 import { TestGarden } from "../../../helpers"
@@ -21,7 +21,7 @@ import { getRouterTestData } from "./_helpers"
 describe("test actions", () => {
   let garden: TestGarden
   let graph: ConfigGraph
-  let log: Log
+  let log: ActionLog
   let actionRouter: ActionRouter
   let module: GardenModule
 

--- a/plugins/jib/index.ts
+++ b/plugins/jib/index.ts
@@ -206,7 +206,7 @@ export const gardenPlugin = () =>
                 buildLog += data.toString()
               })
 
-              statusLine.info({ section: action.key(), msg: `Using JAVA_HOME=${openJdkPath}` })
+              statusLine.info(`Using JAVA_HOME=${openJdkPath}`)
 
               const { args, tarPath } = getBuildFlags(action, projectType)
 

--- a/plugins/jib/test/index.ts
+++ b/plugins/jib/test/index.ts
@@ -17,6 +17,7 @@ import { defaultDotIgnoreFile } from "@garden-io/core/build/src/util/fs"
 import { JibBuildAction } from "../util"
 import { Resolved } from "@garden-io/core/build/src/actions/types"
 import { ResolvedConfigGraph } from "@garden-io/core/build/src/graph/config-graph"
+import { createActionLog } from "@garden-io/core/build/src/logger/log-entry"
 
 describe("jib-container", function () {
   // eslint-disable-next-line no-invalid-this
@@ -84,10 +85,11 @@ describe("jib-container", function () {
         action["spec"].tarOnly = true
 
         const router = await garden.getActionRouter()
+        const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
 
         const { result: res } = await router.build.build({
           action,
-          log: garden.log,
+          log: actionLog,
           graph,
         })
 
@@ -101,10 +103,11 @@ describe("jib-container", function () {
         action["spec"].tarOnly = true
 
         const router = await garden.getActionRouter()
+        const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
 
         const { result: res } = await router.build.build({
           action,
-          log: garden.log,
+          log: actionLog,
           graph,
         })
 
@@ -122,10 +125,11 @@ describe("jib-container", function () {
         action["spec"].tarOnly = false
 
         const router = await garden.getActionRouter()
+        const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
 
         await router.build.build({
           action,
-          log: garden.log,
+          log: actionLog,
           graph,
         })
       })
@@ -135,10 +139,11 @@ describe("jib-container", function () {
         action["spec"].tarOnly = false
 
         const router = await garden.getActionRouter()
+        const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
 
         await router.build.build({
           action,
-          log: garden.log,
+          log: actionLog,
           graph,
         })
       })
@@ -151,10 +156,11 @@ describe("jib-container", function () {
         action["spec"].dockerBuild = true
 
         const router = await garden.getActionRouter()
+        const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
 
         await router.build.build({
           action,
-          log: garden.log,
+          log: actionLog,
           graph,
         })
       })
@@ -165,10 +171,11 @@ describe("jib-container", function () {
         action["spec"].dockerBuild = true
 
         const router = await garden.getActionRouter()
+        const actionLog = createActionLog({ log: garden.log, actionName: action.name, actionKind: action.kind })
 
         await router.build.build({
           action,
-          log: garden.log,
+          log: actionLog,
           graph,
         })
       })

--- a/plugins/pulumi/helpers.ts
+++ b/plugins/pulumi/helpers.ts
@@ -24,10 +24,11 @@ import { defaultPulumiEnv, pulumi } from "./cli"
 import { PulumiDeploy, PulumiProvider } from "./config"
 import { deline } from "@garden-io/sdk/util/string"
 import { Resolved } from "@garden-io/core/build/src/actions/types"
+import { ActionLog } from "@garden-io/core/build/src/logger/log-entry"
 
 export interface PulumiParams {
   ctx: PluginContext
-  log: Log
+  log: ActionLog
   provider: PulumiProvider
   action: Resolved<PulumiDeploy>
 }

--- a/plugins/pulumi/index.ts
+++ b/plugins/pulumi/index.ts
@@ -13,12 +13,7 @@ import { getPulumiCommands } from "./commands"
 
 import { joiVariables } from "@garden-io/core/build/src/config/common"
 import { pulumiCliSPecs } from "./cli"
-import {
-  PulumiDeployConfig,
-  pulumiDeploySpecSchema,
-  PulumiModule,
-  pulumiProviderConfigSchema,
-} from "./config"
+import { PulumiDeployConfig, pulumiDeploySpecSchema, PulumiModule, pulumiProviderConfigSchema } from "./config"
 import { ExecBuildConfig } from "@garden-io/core/build/src/plugins/exec/config"
 import { join } from "path"
 import { pathExists } from "fs-extra"

--- a/plugins/terraform/action.ts
+++ b/plugins/terraform/action.ts
@@ -138,7 +138,7 @@ export const deleteTerraformModule: DeployActionHandler<"delete", TerraformDeplo
   const deployState: DeployState = "outdated"
 
   if (!spec.allowDestroy) {
-    log.warn({ section: action.key(), msg: "allowDestroy is set to false. Not calling terraform destroy." })
+    log.warn("allowDestroy is set to false. Not calling terraform destroy.")
     return {
       state: deployStateToActionState(deployState),
       detail: {

--- a/plugins/terraform/common.ts
+++ b/plugins/terraform/common.ts
@@ -146,7 +146,7 @@ export async function getStackStatus(params: TerraformParamsWithVariables): Prom
   await setWorkspace(params)
   await tfValidate(params)
 
-  const statusLog = log.createLog({ section: "terraform" }).info("Running plan...")
+  const statusLog = log.createLog({ name: "terraform" }).info("Running plan...")
 
   const plan = await terraform(ctx, provider).exec({
     log,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

The first iteration on the new append-only logger was a bit rushed.

This commit cleans up some to dos, adds code comments, tests, and
more.

We also remove some fields that were previously configurable to ensure
logs are more consistent. In particular we remove the 'section' and
'symbol' fields for some levels and instead have the log/renderers handle
the styling.

E.g., now you can just do `log.warn("oh noes)` as opposed to
`log.warn({ msg: chalk.yellow("oh noes"), symbol: "warning})`.

If we realise we need more control we can always re-introduce it,
but it feels right to start conservatively.

There's a chance this may break the rendering of some log lines but that
should be easy to fix in follow up commits.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

cc @Orzelius, since you've been asking about the logger. There's a [massive code comment](https://github.com/garden-io/garden/pull/4138/files#diff-2fee54686b6485a8cf439dffd7d848c0d6a60f0ce4f0eff9b9dc67b161762769R160) there that attempts to explain how things work. Lmk if you think it makes sense or requires further clarification. 
