### PR TITLE
chore: fix typo in pulumi cli's architecture

### DIFF
--- a/plugins/pulumi/cli.ts
+++ b/plugins/pulumi/cli.ts
@@ -67,7 +67,7 @@ export const pulumiCliSPecs: { [version: string]: PluginToolSpec } = {
     builds: [
       {
         platform: "darwin",
-        architecture: "and64",
+        architecture: "amd64",
         url: "https://github.com/pulumi/pulumi/releases/download/v3.64.0/pulumi-v3.64.0-darwin-x64.tar.gz",
         sha256: "ee62df4a40ab7cb016491f529e0256761a8ced6962dea28f88409d692cafcc82",
         extract: {
@@ -111,7 +111,7 @@ export const pulumiCliSPecs: { [version: string]: PluginToolSpec } = {
     name: "pulumi-3-48-0",
     description: "The pulumi CLI, v3.48.0",
     type: "binary",
-    _includeInGardenImage: true,
+    _includeInGardenImage: false,
     builds: [
       {
         platform: "darwin",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
Fixes typo in Platform architecture for Pulumi CLI. Also, updates the `_includeInGardenImage` flag for the previous default version. This is a follow-up fix for #4107.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
