### PR TITLE
refactor: remove the color red from non-error related logging

### DIFF
--- a/core/src/monitors/logs.ts
+++ b/core/src/monitors/logs.ts
@@ -21,7 +21,7 @@ import { waitForOutputFlush } from "../process"
 import { DeployLogEntry } from "../types/service"
 import { MonitorBaseParams, Monitor } from "./base"
 
-export const logMonitorColors = ["green", "cyan", "magenta", "yellow", "blueBright", "red"]
+export const logMonitorColors = ["green", "cyan", "magenta", "yellow", "blueBright", "blue"]
 
 // Track these globally, across many monitors
 let colorMap: { [name: string]: string } = {}

--- a/scripts/run-script.ts
+++ b/scripts/run-script.ts
@@ -14,7 +14,7 @@ import { join, resolve } from "path"
 import { createWriteStream, WriteStream } from "fs"
 import { getPackages, yarnPath } from "./script-utils"
 
-const colors = [chalk.red, chalk.green, chalk.yellow, chalk.magenta, chalk.cyan]
+const colors = [chalk.blueBright, chalk.green, chalk.yellow, chalk.magenta, chalk.cyan]
 
 const lineChar = "┄"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Every time I ran `yarn build` I thought `cli` had errored out:
<img width="930" alt="Screenshot 2023-05-02 at 18 52 44" src="https://user-images.githubusercontent.com/658727/235734307-48472573-ae89-4bb9-afde-52b9436214ec.png">

So this PR removes the color red from the non-error based logs that I could find, making `cli` not look like something went wrong:
<img width="930" alt="Screenshot 2023-05-02 at 18 53 39" src="https://user-images.githubusercontent.com/658727/235734576-9b6ba398-ea96-4586-a8ea-8e09438e7e34.png">

Feel free to point me in the direction of other logging methods or helper functions that might be using the color red.