### PR TITLE
chore(ci): fix gcloud gke auth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -768,6 +768,7 @@ jobs:
             choco upgrade --limit-output --no-progress -y git rsync gcloudsdk kubernetes-cli
             $Env:CLOUDSDK_PYTHON = gcloud components copy-bundled-python
             gcloud components install gke-gcloud-auth-plugin --quiet
+            $Env:USE_GKE_GCLOUD_AUTH_PLUGIN = True
             refreshenv
       - run:
           name: Write gcloud credentials to file

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,6 +208,8 @@ commands:
       - run:
           name: Configure kubectl context via gcloud and authenticate to Google Container Registry
           command: |
+            export USE_GKE_GCLOUD_AUTH_PLUGIN=True
+            echo "export USE_GKE_GCLOUD_AUTH_PLUGIN=True" >> $BASH_ENV
             export GOOGLE_APPLICATION_CREDENTIALS=$HOME/gcloud-key.json
             echo "export GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS" >> $BASH_ENV
             echo $GCLOUD_SERVICE_KEY > $GOOGLE_APPLICATION_CREDENTIALS


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes CI runs for `helm` cli invocations against a GKE cluster.

We have already installed the newer `gke` auth plugin, and it works by default for `kubectl`. However, the `helm` cli does not use it unless you specify the env var.

https://github.com/helm/helm/issues/11069

**Special notes for your reviewer**:

https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke

