### PR TITLE
fix: do not throw if no action kinds & garden.io/v0

### DIFF
--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -1270,16 +1270,18 @@ export class Garden {
       let actionsCount = 0
 
       for (const kind of actionKinds) {
+        const actionConfigs = groupedResources[kind] || []
+
         // Verify that the project apiVersion is defined as compatible with action kinds
         // This is only available with apiVersion `garden.io/v1` or newer.
-        if (this.projectApiVersion !== DEFAULT_API_VERSION) {
+        if (actionConfigs.length && this.projectApiVersion !== DEFAULT_API_VERSION) {
           throw new ConfigurationError(
             `Action kinds are only supported in project configurations with "apiVersion: ${DEFAULT_API_VERSION}". A detailed migration guide is available at https://docs.garden.io/tutorials/migrating-to-bonsai`,
             {}
           )
         }
 
-        for (const config of groupedResources[kind] || []) {
+        for (const config of actionConfigs) {
           this.addActionConfig(config as unknown as BaseActionConfig)
           actionsCount++
         }

--- a/core/test/data/test-projects/config-valid-v0/project.garden.yml
+++ b/core/test/data/test-projects/config-valid-v0/project.garden.yml
@@ -1,0 +1,11 @@
+apiVersion: garden.io/v0
+kind: Project
+name: config-valid-v0
+environments:
+  - name: local
+
+---
+kind: Module
+type: exec
+name: config-valid-v0
+include: []

--- a/core/test/integ/src/plugins/kubernetes/helm/config.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/config.ts
@@ -18,7 +18,7 @@ import { apply } from "json-merge-patch"
 import { getHelmTestGarden } from "./common"
 import { defaultHelmTimeout } from "../../../../../../src/plugins/kubernetes/helm/module-config"
 import stripAnsi = require("strip-ansi")
-import { DEFAULT_API_VERSION } from "../../../../../../src/constants"
+import { PREVIOUS_API_VERSION } from "../../../../../../src/constants"
 
 describe("configureHelmModule", () => {
   let garden: TestGarden
@@ -88,7 +88,7 @@ describe("configureHelmModule", () => {
     }
 
     expect(module._config).to.eql({
-      apiVersion: DEFAULT_API_VERSION,
+      apiVersion: PREVIOUS_API_VERSION,
       kind: "Module",
       allowPublish: true,
       build: {

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -2638,6 +2638,14 @@ describe("Garden", () => {
         contains: `Action kinds are only supported in project configurations with "apiVersion: ${DEFAULT_API_VERSION}"`,
       })
     })
+
+    it("should not throw when apiVersion v0 is set in a project without action configs", async () => {
+      const garden = await makeTestGarden(getDataDir("test-projects", "config-valid-v0"))
+
+      // don't throw
+      await garden.scanAndAddConfigs()
+    })
+
   })
 
   describe("resolveModules", () => {

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -2642,8 +2642,9 @@ describe("Garden", () => {
     it("should not throw when apiVersion v0 is set in a project without action configs", async () => {
       const garden = await makeTestGarden(getDataDir("test-projects", "config-valid-v0"))
 
-      // don't throw
-      await garden.scanAndAddConfigs()
+      await expect(async () => {
+        await garden.scanAndAddConfigs()
+      }).to.not.throw()
     })
 
   })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
Fixes this error in all projects that are missing `apiVersion: v1`:

✖ Action kinds are only supported in project configurations with "apiVersion: garden.io/v1". A detailed migration guide is available at https://docs.garden.io/tutorials/migrating-to-bonsai

The error is supposed to be thrown only if action kinds are declared.
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
