### PR TITLE
test(workflows): add test case for lazy initialization

### DIFF
--- a/core/test/data/test-execprovider-fail/garden.yml
+++ b/core/test/data/test-execprovider-fail/garden.yml
@@ -1,0 +1,8 @@
+kind: Project
+name: test-execprovider-fail
+environments:
+ - name: default
+providers:
+ # Exec provider initialization always fails
+ - name: exec
+   initScript: exit 1


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
To make it possible to prepare kubeconfigs and other prerequisites to
provider initialization in a workflow, we want to manifest this
behaviour using tests.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
