### PR TITLE
feat(core): --logs option for deploy command

### DIFF
--- a/core/src/monitors/logs.ts
+++ b/core/src/monitors/logs.ts
@@ -41,6 +41,7 @@ interface LogMonitorParams extends MonitorBaseParams {
   showTimestamps: boolean
   logLevel: LogLevel
   tagFilters?: LogsTagOrFilter
+  msgPrefix?: string
 }
 
 export type LogsTagFilter = [string, string]
@@ -64,6 +65,8 @@ export class LogMonitor extends Monitor {
   private showTimestamps: boolean
   private logLevel: LogLevel
   private tagFilters?: LogsTagOrFilter
+  // This could be replaced with e.g. a custom render function if more flexibility becomes needed.
+  private msgPrefix?: string
 
   constructor(params: LogMonitorParams) {
     super(params)
@@ -81,6 +84,7 @@ export class LogMonitor extends Monitor {
     this.showTimestamps = params.showTimestamps
     this.logLevel = params.logLevel
     this.tagFilters = params.tagFilters
+    this.msgPrefix = params.msgPrefix
   }
 
   static getColorForName(name: string) {
@@ -205,6 +209,9 @@ export class LogMonitor extends Monitor {
     }
 
     let out = ""
+    if (this.msgPrefix) {
+      out += this.msgPrefix
+    }
     if (!this.hideService) {
       out += `${sectionStyle(padSection(entry.name, maxDeployName))} → `
     }

--- a/core/test/unit/src/commands/deploy.ts
+++ b/core/test/unit/src/commands/deploy.ts
@@ -135,6 +135,8 @@ describe("DeployCommand", () => {
         "skip-dependencies": false,
         "skip-watch": false,
         "forward": false,
+        "logs": false,
+        "timestamps": false,
       }),
     })
 
@@ -202,6 +204,8 @@ describe("DeployCommand", () => {
         "skip-dependencies": false,
         "skip-watch": false,
         "forward": false,
+        "logs": false,
+        "timestamps": false,
       }),
     })
 
@@ -251,6 +255,8 @@ describe("DeployCommand", () => {
           "skip-dependencies": true, // <-----
           "skip-watch": false,
           "forward": false,
+          "logs": false,
+          "timestamps": false,
         }),
       })
 
@@ -301,6 +307,8 @@ describe("DeployCommand", () => {
         "skip-dependencies": false,
         "skip-watch": false,
         "forward": false,
+        "logs": false,
+        "timestamps": false,
       }),
     })
 
@@ -340,6 +348,8 @@ describe("DeployCommand", () => {
         "skip-dependencies": false,
         "skip-watch": false,
         "forward": false,
+        "logs": false,
+        "timestamps": false,
       }),
     })
 
@@ -374,6 +384,8 @@ describe("DeployCommand", () => {
         "skip-dependencies": false,
         "skip-watch": false,
         "forward": false,
+        "logs": false,
+        "timestamps": false,
       }),
     })
 
@@ -405,6 +417,8 @@ describe("DeployCommand", () => {
           "skip-dependencies": false,
           "skip-watch": false,
           "forward": false,
+          "logs": false,
+          "timestamps": false,
         }),
       })
       expect(persistent).to.be.true
@@ -430,6 +444,8 @@ describe("DeployCommand", () => {
           "skip-dependencies": false,
           "skip-watch": false,
           "forward": false,
+          "logs": false,
+          "timestamps": false,
         }),
       })
       expect(persistent).to.be.true
@@ -456,6 +472,8 @@ describe("DeployCommand", () => {
           "skip-dependencies": false,
           "skip-watch": false,
           "forward": true,
+          "logs": false,
+          "timestamps": false,
         }),
       })
       expect(persistent).to.be.true

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -703,7 +703,9 @@ the command stays running until explicitly aborted.
 This always takes the precedence over sync mode if there are any conflicts, i.e. if the same Deploys are matched with both &#x60;--sync&#x60; and &#x60;--local&#x60; options.
   | `--skip` |  | array:string | The name(s) of Deploys you&#x27;d like to skip.
   | `--skip-dependencies` |  | boolean | Deploy the specified actions, but don&#x27;t build, deploy or run any dependencies. This option can only be used when a list of Deploy names is passed as CLI arguments. This can be useful e.g. when your stack has already been deployed, and you want to run specific Deploys in sync mode without building, deploying or running dependencies that may have changed since you last deployed.
-  | `--forward` |  | boolean | Create port forwards and leave process running after deploying. This is implied if any of --sync or --local/--local-mode are set.
+  | `--forward` |  | boolean | Create port forwards and leave process running after deploying. This is implied if any of --sync / --local or --logs are set.
+  | `--logs` |  | boolean | Stream logs from the requested Deploy(s) (or services if using modules) during deployment, and leave the log streaming process running after deploying. Note: This option implies the --forward option.
+  | `--timestamps` |  | boolean | Show timestamps with log output. Should be used with the &#x60;--logs&#x60; option (has no effect if that option is not used).
 
 #### Outputs
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When used, the `--logs` option streams service logs during deployment, and then keeps the command running until the user exits it.

This is useful for combining deployment with log streaming.

**Special notes for your reviewer**:

We should only be streaming logs from the current time onwards, but the logs monitor currently doesn't support the `since` option. I didn't add it back in since IIRC @eysi09 is working on a branch that addresses that.