### PR TITLE
improvement(cli): detect calls to removed run cmds

### DIFF
--- a/core/src/commands/run.ts
+++ b/core/src/commands/run.ts
@@ -118,6 +118,7 @@ export class RunCommand extends Command<Args, Opts> {
 
     if (args.names && args.names.length > 0) {
       names = args.names
+      detectOldRunCommand(names, args, opts)
     }
 
     if (!names && !opts.module) {
@@ -248,5 +249,24 @@ export class RunCommand extends Command<Args, Opts> {
     const results = await garden.processTasks({ tasks, log })
 
     return handleProcessResults(garden, footerLog, "test", results)
+  }
+}
+
+function detectOldRunCommand(names: string[], args: any, opts: any) {
+  if (["test", "task", "workflow"].includes(names[0])) {
+    let renameDescription = ""
+    if (names[0] === "test") {
+      renameDescription = `The ${chalk.yellow("run test")} command was removed in Garden 0.13. Please use the ${chalk.yellow("test")} command instead.`
+    }
+    if (names[0] === "task") {
+      renameDescription = `The ${chalk.yellow("run task")} command was removed in Garden 0.13. Please use the ${chalk.yellow("run")} command instead.`
+    }
+    if (names[0] === "workflow") {
+      renameDescription = `The ${chalk.yellow("run workflow")} command was removed in Garden 0.13. Please use the ${chalk.yellow("run-workflow")} command instead.`
+    }
+    throw new ParameterError(
+      `Error: ${renameDescription}`,
+      { args, opts }
+    )
   }
 }

--- a/core/test/unit/src/commands/run.ts
+++ b/core/test/unit/src/commands/run.ts
@@ -89,6 +89,74 @@ describe("RunCommand", () => {
     )
   })
 
+  context("detecting invocations to removed 0.12-era run subcommands", () => {
+    it("throws if called with 'test' as the first argument", async () => {
+      await expectError(
+        () =>
+          garden.runCommand({
+            command,
+            args: { names: ["test", "foo"] },
+            opts: {
+              "force": true,
+              "force-build": true,
+              "watch": false,
+              "skip": [],
+              "skip-dependencies": false,
+              "module": undefined,
+            },
+          }),
+        {
+          contains:
+            "The run test command was removed in Garden 0.13",
+        }
+      )
+    })
+
+    it("throws if called with 'task' as the first argument", async () => {
+      await expectError(
+        () =>
+          garden.runCommand({
+            command,
+            args: { names: ["task", "foo"] },
+            opts: {
+              "force": true,
+              "force-build": true,
+              "watch": false,
+              "skip": [],
+              "skip-dependencies": false,
+              "module": undefined,
+            },
+          }),
+        {
+          contains:
+            "The run task command was removed in Garden 0.13",
+        }
+      )
+    })
+
+    it("throws if called with 'workflow' as the first argument", async () => {
+      await expectError(
+        () =>
+          garden.runCommand({
+            command,
+            args: { names: ["workflow", "foo"] },
+            opts: {
+              "force": true,
+              "force-build": true,
+              "watch": false,
+              "skip": [],
+              "skip-dependencies": false,
+              "module": undefined,
+            },
+          }),
+        {
+          contains:
+            "The run workflow command was removed in Garden 0.13",
+        }
+      )
+    })
+  })
+
   it("supports '*' as an argument to select all Runs", async () => {
     const { result } = await garden.runCommand({
       command,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

We now throw if the user calls `garden run test ...`, `garden run task ...` or `garden run workflow ...`, since that almost certainly implies they were trying to run commands that were removed in 0.13.