### PR TITLE
fix(monitors): ensure status isn't overwritten due to a race condition

### DIFF
--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -495,7 +495,7 @@ ${renderCommands(commands)}
         if (garden.monitors.anyMonitorsActive()) {
           // Wait for monitors to exit
           log.debug(chalk.gray("One or more monitors active, waiting until all exit."))
-          await garden.monitors.waitUntilAllStopped()
+          await garden.monitors.waitUntilStopped()
         }
 
         await garden.close()

--- a/core/src/cloud/buffered-event-stream.ts
+++ b/core/src/cloud/buffered-event-stream.ts
@@ -38,7 +38,7 @@ export interface LogEntryEventPayload {
 // TODO @eysi: Add log context to payload
 export function formatLogEntryForEventStream(entry: LogEntry): LogEntryEventPayload {
   // TODO @eysi: We're sending the section for backwards compatibility but it shouldn't really be needed.
-  const section = getSection(entry) ||  ""
+  const section = getSection(entry) || ""
   return {
     key: entry.key,
     metadata: entry.metadata,

--- a/core/src/commands/serve.ts
+++ b/core/src/commands/serve.ts
@@ -114,6 +114,9 @@ export class ServeCommand<
       })
     }
 
+    // Ensure we emit stack graph for Cloud
+    await garden.getConfigGraph({ log, emit: true })
+
     this.autocompleter = new Autocompleter({ log, commands: [], configDump: undefined })
 
     return new Promise((resolve, reject) => {

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -2646,7 +2646,6 @@ describe("Garden", () => {
         await garden.scanAndAddConfigs()
       }).to.not.throw()
     })
-
   })
 
   describe("resolveModules", () => {

--- a/core/test/unit/src/logger/renderers.ts
+++ b/core/test/unit/src/logger/renderers.ts
@@ -127,9 +127,7 @@ describe("renderers", () => {
     it("should print the log level if it's higher then 'info'", () => {
       const entry = logger.createLog().debug({ msg: "hello world" }).getLatestEntry()
 
-      expect(formatForTerminal(entry, logger)).to.equal(
-        `${chalk.gray("[debug]")} ${msgStyle("hello world")}\n`
-      )
+      expect(formatForTerminal(entry, logger)).to.equal(`${chalk.gray("[debug]")} ${msgStyle("hello world")}\n`)
     })
     it("should print the log level if it's higher then 'info' after the section if there is one", () => {
       const entry = logger.createLog({ name: "foo" }).debug("hello world").getLatestEntry()

--- a/e2e/test/pre-release.ts
+++ b/e2e/test/pre-release.ts
@@ -99,7 +99,9 @@ describe("PreReleaseTests", () => {
     })
     it("runs the test command", async () => {
       const logEntries = await runWithEnv(["test"])
-      expect(searchLog(logEntries, /(Done!|No Test actions found)/), "expected to find 'Done!' in log output").to.eql("passed")
+      expect(searchLog(logEntries, /(Done!|No Test actions found)/), "expected to find 'Done!' in log output").to.eql(
+        "passed"
+      )
     })
   })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Previously, the monitor statuses known to the monitor manager could be wrong due to a race condition when toggling monitors.

Consider the following:

- T1: Log monitor A is requested via websocket
- T2: Log monitor A is aborted via websocket
- T3: The stop function from T2 returns and sets the status to stopped
- T4: The start function from T1 returns and set the status to started

In this case the final status is incorrectly 'started' as opposed to 'stopped'.  

It's not clear if this actually causes issues but in any case it's confusing and makes it hard to debug other issues around monitors if we can't trust the statuses displayed by the manager.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
