### PR TITLE
fix(server): ensure fresh command instance per request

### DIFF
--- a/core/src/commands/base.ts
+++ b/core/src/commands/base.ts
@@ -256,7 +256,8 @@ export abstract class Command<A extends Parameters = {}, O extends Parameters = 
    * so that subscribers are managed properly.
    */
   clone(): Command {
-    return Object.getPrototypeOf(this).constructor(this.parent)
+    // See: https://stackoverflow.com/a/64638986
+    return new (this.constructor as new (parent?: CommandGroup) => this)(this.parent)
   }
 
   // Note: Due to a current TS limitation (apparently covered by https://github.com/Microsoft/TypeScript/issues/7011),

--- a/core/src/commands/base.ts
+++ b/core/src/commands/base.ts
@@ -372,7 +372,7 @@ export abstract class CommandGroup extends Command {
 
   describe() {
     const description = super.describe()
-    const subCommands = this.subCommands.map((S) => new S(this).describe())
+    const subCommands = this.getSubCommands().map((c) => c.describe())
 
     return {
       ...description,
@@ -381,7 +381,7 @@ export abstract class CommandGroup extends Command {
   }
 
   renderHelp() {
-    const commands = this.subCommands.map((c) => new c(this))
+    const commands = this.getSubCommands()
 
     return `
 ${cliStyles.heading("USAGE")}

--- a/core/src/commands/base.ts
+++ b/core/src/commands/base.ts
@@ -250,6 +250,15 @@ export abstract class Command<A extends Parameters = {}, O extends Parameters = 
 
   printHeader(_: PrintHeaderParams<A, O>) {}
 
+  /**
+   * Helper function for creating a new instance of the command.
+   * Used e.g. by the server to ensure that each request gets a unique command instance
+   * so that subscribers are managed properly.
+   */
+  clone(): Command {
+    return Object.getPrototypeOf(this).constructor(this.parent)
+  }
+
   // Note: Due to a current TS limitation (apparently covered by https://github.com/Microsoft/TypeScript/issues/7011),
   // subclass implementations need to explicitly set the types in the implemented function signature. So for now we
   // can't enforce the types of `args` and `opts` automatically at the abstract class level and have to specify

--- a/core/src/commands/custom.ts
+++ b/core/src/commands/custom.ts
@@ -79,7 +79,7 @@ export class CustomCommandWrapper extends Command {
   allowUndefinedArguments = true
 
   constructor(public spec: CommandResource) {
-    super()
+    super(spec)
     this.name = spec.name
     this.help = spec.description?.short
     this.description = spec.description?.long

--- a/core/src/commands/dev.tsx
+++ b/core/src/commands/dev.tsx
@@ -178,7 +178,7 @@ class QuitCommand extends ConsoleCommand {
   aliases = ["exit"]
 
   constructor(private quit: () => void) {
-    super()
+    super(quit)
   }
 
   async action() {

--- a/core/src/commands/logs.ts
+++ b/core/src/commands/logs.ts
@@ -189,14 +189,13 @@ export class LogsCommand extends Command<Args, Opts> {
         showTimestamps: opts.timestamps,
         logLevel,
         tagFilters,
-        command: this,
         tail,
         since,
       })
     })
 
     if (follow) {
-      monitors.forEach((m) => garden.monitors.add(m))
+      monitors.forEach((m) => garden.monitors.addAndSubscribe(m, this))
       return { result: [] }
     } else {
       const entries = await Bluebird.map(monitors, async (m) => {

--- a/core/src/commands/serve.ts
+++ b/core/src/commands/serve.ts
@@ -211,7 +211,7 @@ class AutocompleteCommand extends ConsoleCommand<AutocompleteArguments> {
   arguments = autocompleteArguments
 
   constructor(private serverCommand: ServeCommand) {
-    super()
+    super(serverCommand)
   }
 
   async action({ args }: CommandParams<AutocompleteArguments>): Promise<CommandResult<AutocompleteResult>> {
@@ -231,7 +231,7 @@ class ReloadCommand extends ConsoleCommand {
   help = "Reload the project and action/module configuration."
 
   constructor(private serverCommand: ServeCommand) {
-    super()
+    super(serverCommand)
   }
 
   async action({ garden, log }: CommandParams) {

--- a/core/src/commands/sync/sync-start.ts
+++ b/core/src/commands/sync/sync-start.ts
@@ -153,8 +153,8 @@ export class SyncStartCommand extends Command<Args, Opts> {
         if (opts.monitor) {
           task.on("ready", ({ result }) => {
             const executedAction = result?.executedAction
-            const monitor = new SyncMonitor({ garden, log, command: this, action: executedAction, graph })
-            garden.monitors.add(monitor)
+            const monitor = new SyncMonitor({ garden, log, action: executedAction, graph })
+            garden.monitors.addAndSubscribe(monitor, this)
           })
         }
         return task
@@ -206,8 +206,8 @@ export class SyncStartCommand extends Command<Args, Opts> {
             someSyncStarted = true
 
             if (opts.monitor) {
-              const monitor = new SyncMonitor({ garden, log, command: this, action: executedAction, graph })
-              garden.monitors.add(monitor)
+              const monitor = new SyncMonitor({ garden, log, action: executedAction, graph })
+              garden.monitors.addAndSubscribe(monitor, this)
             }
           } catch (error) {
             actionLog.warn(

--- a/core/src/monitors/base.ts
+++ b/core/src/monitors/base.ts
@@ -38,7 +38,7 @@ export abstract class Monitor {
   }
 
   unsubscribe(subscriber: Command) {
-    this.subscribers.filter((sub) => sub === subscriber)
+    this.subscribers = this.subscribers.filter((sub) => sub !== subscriber)
   }
 
   unsubscribeAll() {

--- a/core/src/monitors/base.ts
+++ b/core/src/monitors/base.ts
@@ -12,17 +12,16 @@ import type { Garden } from "../garden"
 
 export interface MonitorBaseParams {
   garden: Garden
-  command: Command
 }
 
 export type MonitorKey = PrimitiveMap
 
 export abstract class Monitor {
-  public command: Command
+  public subscribers: Command[]
   protected garden: Garden
 
   constructor(params: MonitorBaseParams) {
-    this.command = params.command
+    this.subscribers = []
     this.garden = params.garden
   }
 
@@ -33,6 +32,18 @@ export abstract class Monitor {
 
   abstract start(): Promise<{}>
   abstract stop(): Promise<{}>
+
+  subscribe(subscriber: Command) {
+    this.subscribers.push(subscriber)
+  }
+
+  unsubscribe(subscriber: Command) {
+    this.subscribers.filter((sub) => sub === subscriber)
+  }
+
+  unsubscribeAll() {
+    this.subscribers = []
+  }
 
   id() {
     return `"type=${this.type}--key=${this.key()}`

--- a/core/src/monitors/logs.ts
+++ b/core/src/monitors/logs.ts
@@ -186,7 +186,9 @@ export class LogMonitor extends Monitor {
   logEntry(entry: DeployLogEntry) {
     const levelStr = logLevelMap[entry.level || LogLevel.info] || "info"
     const msg = this.formatLogMonitorEntry(entry)
-    this.command.emit(this.log, JSON.stringify({ msg, timestamp: entry.timestamp?.getTime(), level: levelStr }))
+    for (const cmd of this.subscribers) {
+      cmd.emit(this.log, JSON.stringify({ msg, timestamp: entry.timestamp?.getTime(), level: levelStr }))
+    }
     this.log[levelStr]({ msg })
   }
 

--- a/core/src/monitors/manager.ts
+++ b/core/src/monitors/manager.ts
@@ -98,6 +98,17 @@ export class MonitorManager extends TypedEventEmitter<MonitorEvents> {
     }
   }
 
+  unsubscribe(command: Command) {
+    const monitors = this.getBySubscriber(command) || []
+    monitors.forEach((m) => {
+      m.unsubscribe(command)
+      // Stop monitor if it doesn't have any subscribers
+      if (m.subscribers.length === 0) {
+        this.stop(m)
+      }
+    })
+  }
+
   start(monitor: Monitor) {
     let status = this.getStatus(monitor)
 

--- a/core/src/server/commands.ts
+++ b/core/src/server/commands.ts
@@ -70,12 +70,14 @@ export function parseRequest(ctx: Koa.ParameterizedContext, log: Log, commands: 
     ctx.throw(400, `Invalid request format for command ${request.command}`)
   }
 
-  // Prepare arguments for command action.
-  const command = commandSpec.command
+  // Note that we clone the command here to ensure that each request gets its own
+  // command instance and thereby that subscribers are properly isolated at the request level.
+  const command = commandSpec.command.clone()
 
   // We generally don't want actions to log anything in the server.
   const cmdLog = log.createLog({ fixLevel: LogLevel.silly })
 
+  // Prepare arguments for command action.
   let cmdArgs: ParameterValues<any> = {}
   let cmdOpts: ParameterValues<any> = {}
 

--- a/core/src/server/server.ts
+++ b/core/src/server/server.ts
@@ -535,7 +535,7 @@ export class GardenServer extends EventEmitter {
 
             // Request was aborted in-flight so we cleanup its monitors
             if (!req) {
-              this.unsubscribeFromMonitors(command)
+              this.garden?.monitors.unsubscribe(command)
             }
 
             const monitors = garden?.monitors.getBySubscriber(command) || []
@@ -587,7 +587,7 @@ export class GardenServer extends EventEmitter {
 
       if (req) {
         req.command.terminate()
-        this.unsubscribeFromMonitors(req.command)
+        this.garden?.monitors.unsubscribe(req.command)
       }
 
       delete this.activePersistentRequests[requestId]
@@ -600,13 +600,6 @@ export class GardenServer extends EventEmitter {
         message: `Unsupported request type: ${requestType}`,
       })
     }
-  }
-
-  private unsubscribeFromMonitors(command: Command) {
-    const monitors = this.garden?.monitors.getBySubscriber(command) || []
-    monitors.forEach((m) => {
-      m.unsubscribe(command)
-    })
   }
 }
 

--- a/core/test/unit/src/commands/base.ts
+++ b/core/test/unit/src/commands/base.ts
@@ -117,6 +117,8 @@ describe("Command", () => {
       }
 
       const cmd = new TestCommand(new TestGroup())
+      // FIXME: This is needs to be set "manually" for now to work around issues with cloning commands.
+      cmd["parent"] = new TestGroup()
       expect(cmd.getPaths()).to.eql([["test-group", "test-command"]])
     })
 
@@ -141,6 +143,8 @@ describe("Command", () => {
       }
 
       const cmd = new TestCommand(new TestGroup())
+      // FIXME: This is needs to be set "manually" for now to work around issues with cloning commands.
+      cmd["parent"] = new TestGroup()
       expect(cmd.getPaths()).to.eql([
         ["test-group", "test-command"],
         ["group-alias", "test-command"],
@@ -168,6 +172,8 @@ describe("Command", () => {
       }
 
       const cmd = new TestCommand(new TestGroup())
+      // FIXME: This is needs to be set "manually" for now to work around issues with cloning commands.
+      cmd["parent"] = new TestGroup()
       expect(cmd.getPaths()).to.eql([
         ["test-group", "test-command"],
         ["test-group", "command-alias"],
@@ -196,6 +202,8 @@ describe("Command", () => {
       }
 
       const cmd = new TestCommand(new TestGroup())
+      // FIXME: This is needs to be set "manually" for now to work around issues with cloning commands.
+      cmd["parent"] = new TestGroup()
       expect(cmd.getPaths()).to.eql([
         ["test-group", "test-command"],
         ["test-group", "command-alias"],
@@ -283,6 +291,7 @@ describe("CommandGroup", () => {
       }
 
       const cmd = new TestGroup()
+      // FIXME: This is needs to be set "manually" for now to work around issues with cloning commands.
 
       expect(trimLineEnds(stripAnsi(cmd.renderHelp())).trim()).to.equal(dedent`
       USAGE

--- a/core/test/unit/src/commands/logs.ts
+++ b/core/test/unit/src/commands/logs.ts
@@ -295,7 +295,7 @@ describe("LogsCommand", () => {
       const command = new LogsCommand()
       await command.action(makeCommandParams({ garden, opts: { tail: 5, follow: true } }))
 
-      const monitors = garden.monitors.getByCommand(command)
+      const monitors = garden.monitors.getBySubscriber(command)
       const tailOpts = monitors.map((m) => m["tail"])
       expect(tailOpts.every((o) => o === 5)).to.be.true
     })
@@ -304,7 +304,7 @@ describe("LogsCommand", () => {
       const command = new LogsCommand()
       await command.action(makeCommandParams({ garden, opts: { since: "10s", follow: true } }))
 
-      const monitors = garden.monitors.getByCommand(command)
+      const monitors = garden.monitors.getBySubscriber(command)
       const sinceOpts = monitors.map((m) => m["since"])
       expect(sinceOpts.every((o) => o === "10s")).to.be.true
     })
@@ -313,7 +313,7 @@ describe("LogsCommand", () => {
       const command = new LogsCommand()
       await command.action(makeCommandParams({ garden, opts: { since: "10s", tail: 5, follow: true } }))
 
-      const monitors = garden.monitors.getByCommand(command)
+      const monitors = garden.monitors.getBySubscriber(command)
       const tailOpts = monitors.map((m) => m["tail"])
       const sinceOpts = monitors.map((m) => m["since"])
       expect(tailOpts.every((o) => o === 5)).to.be.true
@@ -324,7 +324,7 @@ describe("LogsCommand", () => {
       const command = new LogsCommand()
       await command.action(makeCommandParams({ garden, opts: { since: "10s", tail: 0, follow: true } }))
 
-      const monitors = garden.monitors.getByCommand(command)
+      const monitors = garden.monitors.getBySubscriber(command)
       const tailOpts = monitors.map((m) => m["tail"])
       const sinceOpts = monitors.map((m) => m["since"])
       expect(tailOpts.every((o) => o === 0)).to.be.true


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Previously we were re-using the same command instance for every server request (created at start time via `getCoreCommands()`).

This meant that multiple requests would all subscribe to the same instance.

Concretely, if request A, asks for logs for service X and request B, asks for logs for service Y, they would both subscribe to the same logs command.

Now, when service X writes logs, the callbacks for both request A and request B would be called and to the end user it looks like both services X and service Y are writing the logs.

**UPDATE:**

This first one didn't quite do the trick. There's a follow up commit with following commit message:

This is a follow up to: https://github.com/garden-io/garden/commit/ac54b93ef8680f12e86b24b52dcf5221af5e8be7

The previous commit ensured that different ws requests would not
subscribe to the same command instance.

The introduced an issue around monitors: Now we have multiple command
instances but they weren't being set on properly on a given monitor.

The commit fixes that by treating commands as subscribers to monitors
and allowing for multiple command to subscribe to the same monitor at
the same time. 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
