### PR TITLE
refactor: rename `run-workflow` to `workflow`

### DIFF
--- a/core/src/commands/commands.ts
+++ b/core/src/commands/commands.ts
@@ -27,7 +27,7 @@ import { OptionsCommand } from "./options"
 import { PluginsCommand } from "./plugins"
 import { PublishCommand } from "./publish"
 import { RunCommand } from "./run"
-import { RunWorkflowCommand } from "./run-workflow"
+import { WorkflowCommand } from "./workflow"
 import { SelfUpdateCommand } from "./self-update"
 import { ServeCommand } from "./serve"
 import { SetCommand } from "./set"
@@ -59,7 +59,7 @@ export const getCoreCommands = (): (Command | CommandGroup)[] => [
   new PluginsCommand(),
   new PublishCommand(),
   new RunCommand(),
-  new RunWorkflowCommand(),
+  new WorkflowCommand(),
   new SelfUpdateCommand(),
   new ServeCommand(),
   new SetCommand(),

--- a/core/src/commands/run.ts
+++ b/core/src/commands/run.ts
@@ -217,7 +217,7 @@ export class RunCommand extends Command<Args, Opts> {
           dedent`
             ${divider}
             The ${chalk.white("garden run workflow")} command has been renamed to
-            ${chalk.whiteBright("garden run-workflow")} (note the dash).
+            ${chalk.whiteBright("garden workflow")}.
             ${divider}
           `
         ),
@@ -256,17 +256,20 @@ function detectOldRunCommand(names: string[], args: any, opts: any) {
   if (["test", "task", "workflow"].includes(names[0])) {
     let renameDescription = ""
     if (names[0] === "test") {
-      renameDescription = `The ${chalk.yellow("run test")} command was removed in Garden 0.13. Please use the ${chalk.yellow("test")} command instead.`
+      renameDescription = `The ${chalk.yellow(
+        "run test"
+      )} command was removed in Garden 0.13. Please use the ${chalk.yellow("test")} command instead.`
     }
     if (names[0] === "task") {
-      renameDescription = `The ${chalk.yellow("run task")} command was removed in Garden 0.13. Please use the ${chalk.yellow("run")} command instead.`
+      renameDescription = `The ${chalk.yellow(
+        "run task"
+      )} command was removed in Garden 0.13. Please use the ${chalk.yellow("run")} command instead.`
     }
     if (names[0] === "workflow") {
-      renameDescription = `The ${chalk.yellow("run workflow")} command was removed in Garden 0.13. Please use the ${chalk.yellow("run-workflow")} command instead.`
+      renameDescription = `The ${chalk.yellow(
+        "run workflow"
+      )} command was removed in Garden 0.13. Please use the ${chalk.yellow("workflow")} command instead.`
     }
-    throw new ParameterError(
-      `Error: ${renameDescription}`,
-      { args, opts }
-    )
+    throw new ParameterError(`Error: ${renameDescription}`, { args, opts })
   }
 }

--- a/core/src/commands/run.ts
+++ b/core/src/commands/run.ts
@@ -9,7 +9,7 @@
 import chalk from "chalk"
 import { Command, CommandParams, handleProcessResults, PrepareParams, processCommandResultSchema } from "./base"
 import { RunTask } from "../tasks/run"
-import { printHeader, renderDivider } from "../logger/util"
+import { printHeader } from "../logger/util"
 import { ParameterError } from "../exceptions"
 import { dedent, deline } from "../util/string"
 import { BooleanParameter, StringsParameter } from "../cli/params"
@@ -106,20 +106,22 @@ export class RunCommand extends Command<Args, Opts> {
   async action(params: CommandParams<Args, Opts>) {
     const { garden, log, footerLog, args, opts } = params
 
+    // Detect possible old-style invocations as early as possible
+    // Needs to be done before graph init to support lazy init usecases, e.g. workflows
+    let names: string[] | undefined = undefined
+    if (args.names && args.names.length > 0) {
+      names = args.names
+      detectOldRunCommand(names, args, opts)
+    }
+
     if (opts.watch) {
       await watchRemovedWarning(garden, log)
     }
 
     const graph = await garden.getConfigGraph({ log, emit: true })
 
-    let names: string[] | undefined = undefined
     const force = opts.force
     const skipRuntimeDependencies = opts["skip-dependencies"]
-
-    if (args.names && args.names.length > 0) {
-      names = args.names
-      detectOldRunCommand(names, args, opts)
-    }
 
     if (!names && !opts.module) {
       throw new ParameterError(
@@ -165,65 +167,6 @@ export class RunCommand extends Command<Args, Opts> {
 
     actions = actions.filter((a) => !a.isDisabled() || opts.force)
 
-    // Warn users if they seem to be trying to use old `run <...>` commands.
-    const divider = renderDivider()
-    const firstArg = args.names?.[0]
-    const warningKey = `run-${firstArg}-removed`
-
-    if (firstArg === "test") {
-      await garden.emitWarning({
-        key: warningKey,
-        log,
-        message: chalk.yellowBright(
-          dedent`
-            ${divider}
-            The ${chalk.white("garden run test")} command has been removed.
-            Please use ${chalk.whiteBright("garden test")} instead.
-            ${divider}
-          `
-        ),
-      })
-    } else if (firstArg === "task") {
-      await garden.emitWarning({
-        key: warningKey,
-        log,
-        message: chalk.yellowBright(
-          dedent`
-            ${divider}
-            The ${chalk.white("garden run task")} command has been renamed to
-            ${chalk.whiteBright("garden run")}. Please make sure you're using the right syntax.
-            ${divider}
-          `
-        ),
-      })
-    } else if (firstArg === "module" || firstArg === "service") {
-      await garden.emitWarning({
-        key: warningKey,
-        log,
-        message: chalk.yellowBright(
-          dedent`
-            ${divider}
-            The ${chalk.white("garden run " + firstArg)} command has been removed.
-            Please define a Run action instead, or use the underlying tools (e.g. Docker or Kubernetes) directly.
-            ${divider}
-          `
-        ),
-      })
-    } else if (firstArg === "workflow") {
-      await garden.emitWarning({
-        key: warningKey,
-        log,
-        message: chalk.yellowBright(
-          dedent`
-            ${divider}
-            The ${chalk.white("garden run workflow")} command has been renamed to
-            ${chalk.whiteBright("garden workflow")}.
-            ${divider}
-          `
-        ),
-      })
-    }
-
     const tasks = actions.map(
       (action) =>
         new RunTask({
@@ -253,19 +196,24 @@ export class RunCommand extends Command<Args, Opts> {
 }
 
 function detectOldRunCommand(names: string[], args: any, opts: any) {
-  if (["test", "task", "workflow"].includes(names[0])) {
+  if (["module", "service", "task", "test", "workflow"].includes(names[0])) {
     let renameDescription = ""
-    if (names[0] === "test") {
-      renameDescription = `The ${chalk.yellow(
-        "run test"
-      )} command was removed in Garden 0.13. Please use the ${chalk.yellow("test")} command instead.`
+    const firstArg = names[0]
+    if (firstArg === "module" || firstArg === "service") {
+      renameDescription = `The ${chalk.white("garden run " + firstArg)} command has been removed.
+      Please define a Run action instead, or use the underlying tools (e.g. Docker or Kubernetes) directly.`
     }
-    if (names[0] === "task") {
+    if (firstArg === "task") {
       renameDescription = `The ${chalk.yellow(
         "run task"
       )} command was removed in Garden 0.13. Please use the ${chalk.yellow("run")} command instead.`
     }
-    if (names[0] === "workflow") {
+    if (firstArg === "test") {
+      renameDescription = `The ${chalk.yellow(
+        "run test"
+      )} command was removed in Garden 0.13. Please use the ${chalk.yellow("test")} command instead.`
+    }
+    if (firstArg === "workflow") {
       renameDescription = `The ${chalk.yellow(
         "run workflow"
       )} command was removed in Garden 0.13. Please use the ${chalk.yellow("workflow")} command instead.`

--- a/core/src/commands/validate.ts
+++ b/core/src/commands/validate.ts
@@ -32,7 +32,7 @@ export class ValidateCommand extends Command {
     await garden.getResolvedConfigGraph({ log, emit: false })
 
     /*
-     * Normally, workflow configs are only resolved when they're run via the `run-workflow` command (and only the
+     * Normally, workflow configs are only resolved when they're run via the `workflow` command (and only the
      * workflow being run).
      *
      * Here, we want to validate all workflow configs (so we try resolving them all).

--- a/core/src/commands/workflow.ts
+++ b/core/src/commands/workflow.ts
@@ -52,8 +52,8 @@ interface WorkflowRunOutput {
   steps: { [stepName: string]: WorkflowStepResult }
 }
 
-export class RunWorkflowCommand extends Command<Args, {}> {
-  name = "run-workflow"
+export class WorkflowCommand extends Command<Args, {}> {
+  name = "workflow"
   help = "Run a Workflow."
 
   streamEvents = true
@@ -64,7 +64,7 @@ export class RunWorkflowCommand extends Command<Args, {}> {
 
     Examples:
 
-        garden run-workflow my-workflow
+        garden workflow my-workflow
   `
 
   arguments = runWorkflowArgs

--- a/core/src/config/template-contexts/project.ts
+++ b/core/src/config/template-contexts/project.ts
@@ -205,7 +205,7 @@ class CommandContext extends ConfigContext {
         dedent`
         The currently running Garden CLI command, without positional arguments or option flags. This can be handy to e.g. change some variables based on whether you're running \`garden test\` or some other specific command.
 
-        Note that this will currently always resolve to \`"run-workflow"\` when running Workflows, as opposed to individual workflow step commands. This may be revisited at a later time, but currently all configuration is resolved once for all workflow steps.
+        Note that this will currently always resolve to \`"workflow"\` when running Workflows, as opposed to individual workflow step commands. This may be revisited at a later time, but currently all configuration is resolved once for all workflow steps.
         `
       )
       .example("deploy")

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -801,7 +801,7 @@ export class Garden {
   }
 
   /**
-   * When running workflows via the `run-workflow` command, we only resolve the workflow being executed.
+   * When running workflows via the `workflow` command, we only resolve the workflow being executed.
    */
   async getWorkflowConfig(name: string): Promise<WorkflowConfig> {
     return resolveWorkflowConfig(this, await this.getRawWorkflowConfig(name))

--- a/core/test/unit/src/cli/helpers.ts
+++ b/core/test/unit/src/cli/helpers.ts
@@ -74,8 +74,8 @@ describe("pickCommand", () => {
   })
 
   it("picks a subcommand and returns the rest of arguments", () => {
-    const { command, rest } = pickCommand(commands, ["run-workflow", "foo", "--force"])
-    expect(command?.getPath()).to.eql(["run-workflow"])
+    const { command, rest } = pickCommand(commands, ["workflow", "foo", "--force"])
+    expect(command?.getPath()).to.eql(["workflow"])
     expect(rest).to.eql(["foo", "--force"])
   })
 

--- a/core/test/unit/src/commands/workflow.ts
+++ b/core/test/unit/src/commands/workflow.ts
@@ -21,7 +21,7 @@ import {
   getDataDir,
 } from "../../../helpers"
 import { DEFAULT_API_VERSION } from "../../../../src/constants"
-import { RunWorkflowCommand, shouldBeDropped } from "../../../../src/commands/run-workflow"
+import { WorkflowCommand, shouldBeDropped } from "../../../../src/commands/workflow"
 import { createGardenPlugin } from "../../../../src/plugin/plugin"
 import { joi } from "../../../../src/config/common"
 import { ProjectConfig } from "../../../../src/config/project"
@@ -32,7 +32,7 @@ import { LogEntry } from "../../../../src/logger/log-entry"
 import { defaultWorkflowResources, WorkflowStepSpec } from "../../../../src/config/workflow"
 
 describe("RunWorkflowCommand", () => {
-  const cmd = new RunWorkflowCommand()
+  const cmd = new WorkflowCommand()
   let garden: TestGarden
   let defaultParams: any
 
@@ -1019,7 +1019,7 @@ describe("RunWorkflowCommand", () => {
 })
 
 describe("Lazy provider initialization in RunWorkflowCommand", () => {
-  const cmd = new RunWorkflowCommand()
+  const cmd = new WorkflowCommand()
   let garden: TestGarden
   let defaultParams: any
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -3347,7 +3347,7 @@ success:
 graphResults:
 ```
 
-### garden run-workflow
+### garden workflow
 
 **Run a Workflow.**
 
@@ -3355,11 +3355,11 @@ Runs the commands and/or scripts defined in the workflow's steps, in sequence.
 
 Examples:
 
-    garden run-workflow my-workflow
+    garden workflow my-workflow
 
 #### Usage
 
-    garden run-workflow <workflow> 
+    garden workflow <workflow> 
 
 #### Arguments
 

--- a/docs/reference/template-strings/action-all-fields.md
+++ b/docs/reference/template-strings/action-all-fields.md
@@ -131,7 +131,7 @@ Information about the currently running command and its arguments.
 
 The currently running Garden CLI command, without positional arguments or option flags. This can be handy to e.g. change some variables based on whether you're running `garden test` or some other specific command.
 
-Note that this will currently always resolve to `"run-workflow"` when running Workflows, as opposed to individual workflow step commands. This may be revisited at a later time, but currently all configuration is resolved once for all workflow steps.
+Note that this will currently always resolve to `"workflow"` when running Workflows, as opposed to individual workflow step commands. This may be revisited at a later time, but currently all configuration is resolved once for all workflow steps.
 
 | Type     |
 | -------- |

--- a/docs/reference/template-strings/action-specs.md
+++ b/docs/reference/template-strings/action-specs.md
@@ -133,7 +133,7 @@ Information about the currently running command and its arguments.
 
 The currently running Garden CLI command, without positional arguments or option flags. This can be handy to e.g. change some variables based on whether you're running `garden test` or some other specific command.
 
-Note that this will currently always resolve to `"run-workflow"` when running Workflows, as opposed to individual workflow step commands. This may be revisited at a later time, but currently all configuration is resolved once for all workflow steps.
+Note that this will currently always resolve to `"workflow"` when running Workflows, as opposed to individual workflow step commands. This may be revisited at a later time, but currently all configuration is resolved once for all workflow steps.
 
 | Type     |
 | -------- |

--- a/docs/reference/template-strings/custom-commands.md
+++ b/docs/reference/template-strings/custom-commands.md
@@ -127,7 +127,7 @@ Information about the currently running command and its arguments.
 
 The currently running Garden CLI command, without positional arguments or option flags. This can be handy to e.g. change some variables based on whether you're running `garden test` or some other specific command.
 
-Note that this will currently always resolve to `"run-workflow"` when running Workflows, as opposed to individual workflow step commands. This may be revisited at a later time, but currently all configuration is resolved once for all workflow steps.
+Note that this will currently always resolve to `"workflow"` when running Workflows, as opposed to individual workflow step commands. This may be revisited at a later time, but currently all configuration is resolved once for all workflow steps.
 
 | Type     |
 | -------- |

--- a/docs/reference/template-strings/environments.md
+++ b/docs/reference/template-strings/environments.md
@@ -127,7 +127,7 @@ Information about the currently running command and its arguments.
 
 The currently running Garden CLI command, without positional arguments or option flags. This can be handy to e.g. change some variables based on whether you're running `garden test` or some other specific command.
 
-Note that this will currently always resolve to `"run-workflow"` when running Workflows, as opposed to individual workflow step commands. This may be revisited at a later time, but currently all configuration is resolved once for all workflow steps.
+Note that this will currently always resolve to `"workflow"` when running Workflows, as opposed to individual workflow step commands. This may be revisited at a later time, but currently all configuration is resolved once for all workflow steps.
 
 | Type     |
 | -------- |

--- a/docs/reference/template-strings/modules.md
+++ b/docs/reference/template-strings/modules.md
@@ -133,7 +133,7 @@ Information about the currently running command and its arguments.
 
 The currently running Garden CLI command, without positional arguments or option flags. This can be handy to e.g. change some variables based on whether you're running `garden test` or some other specific command.
 
-Note that this will currently always resolve to `"run-workflow"` when running Workflows, as opposed to individual workflow step commands. This may be revisited at a later time, but currently all configuration is resolved once for all workflow steps.
+Note that this will currently always resolve to `"workflow"` when running Workflows, as opposed to individual workflow step commands. This may be revisited at a later time, but currently all configuration is resolved once for all workflow steps.
 
 | Type     |
 | -------- |

--- a/docs/reference/template-strings/project-outputs.md
+++ b/docs/reference/template-strings/project-outputs.md
@@ -133,7 +133,7 @@ Information about the currently running command and its arguments.
 
 The currently running Garden CLI command, without positional arguments or option flags. This can be handy to e.g. change some variables based on whether you're running `garden test` or some other specific command.
 
-Note that this will currently always resolve to `"run-workflow"` when running Workflows, as opposed to individual workflow step commands. This may be revisited at a later time, but currently all configuration is resolved once for all workflow steps.
+Note that this will currently always resolve to `"workflow"` when running Workflows, as opposed to individual workflow step commands. This may be revisited at a later time, but currently all configuration is resolved once for all workflow steps.
 
 | Type     |
 | -------- |

--- a/docs/reference/template-strings/projects.md
+++ b/docs/reference/template-strings/projects.md
@@ -127,7 +127,7 @@ Information about the currently running command and its arguments.
 
 The currently running Garden CLI command, without positional arguments or option flags. This can be handy to e.g. change some variables based on whether you're running `garden test` or some other specific command.
 
-Note that this will currently always resolve to `"run-workflow"` when running Workflows, as opposed to individual workflow step commands. This may be revisited at a later time, but currently all configuration is resolved once for all workflow steps.
+Note that this will currently always resolve to `"workflow"` when running Workflows, as opposed to individual workflow step commands. This may be revisited at a later time, but currently all configuration is resolved once for all workflow steps.
 
 | Type     |
 | -------- |

--- a/docs/reference/template-strings/providers.md
+++ b/docs/reference/template-strings/providers.md
@@ -129,7 +129,7 @@ Information about the currently running command and its arguments.
 
 The currently running Garden CLI command, without positional arguments or option flags. This can be handy to e.g. change some variables based on whether you're running `garden test` or some other specific command.
 
-Note that this will currently always resolve to `"run-workflow"` when running Workflows, as opposed to individual workflow step commands. This may be revisited at a later time, but currently all configuration is resolved once for all workflow steps.
+Note that this will currently always resolve to `"workflow"` when running Workflows, as opposed to individual workflow step commands. This may be revisited at a later time, but currently all configuration is resolved once for all workflow steps.
 
 | Type     |
 | -------- |

--- a/docs/reference/template-strings/remote-sources.md
+++ b/docs/reference/template-strings/remote-sources.md
@@ -127,7 +127,7 @@ Information about the currently running command and its arguments.
 
 The currently running Garden CLI command, without positional arguments or option flags. This can be handy to e.g. change some variables based on whether you're running `garden test` or some other specific command.
 
-Note that this will currently always resolve to `"run-workflow"` when running Workflows, as opposed to individual workflow step commands. This may be revisited at a later time, but currently all configuration is resolved once for all workflow steps.
+Note that this will currently always resolve to `"workflow"` when running Workflows, as opposed to individual workflow step commands. This may be revisited at a later time, but currently all configuration is resolved once for all workflow steps.
 
 | Type     |
 | -------- |

--- a/docs/reference/template-strings/workflows.md
+++ b/docs/reference/template-strings/workflows.md
@@ -129,7 +129,7 @@ Information about the currently running command and its arguments.
 
 The currently running Garden CLI command, without positional arguments or option flags. This can be handy to e.g. change some variables based on whether you're running `garden test` or some other specific command.
 
-Note that this will currently always resolve to `"run-workflow"` when running Workflows, as opposed to individual workflow step commands. This may be revisited at a later time, but currently all configuration is resolved once for all workflow steps.
+Note that this will currently always resolve to `"workflow"` when running Workflows, as opposed to individual workflow step commands. This may be revisited at a later time, but currently all configuration is resolved once for all workflow steps.
 
 | Type     |
 | -------- |

--- a/docs/using-garden/using-the-cli.md
+++ b/docs/using-garden/using-the-cli.md
@@ -108,7 +108,6 @@ garden cleanup deploy my-deploy
 
 ## `Test` actions
 
-
 ### Running all tests in a project
 
 ```sh
@@ -158,7 +157,7 @@ garden build my-build
 Runs `my-workflow` in `my-namespace` in the `dev` environment.
 
 ```sh
-garden run-workflow my-workflow --env=my-namespace.dev
+garden workflow my-workflow --env=my-namespace.dev
 ```
 
 ## Logs
@@ -242,7 +241,7 @@ garden create module
 
 ### Creating an action
 
-[//]: # (TODO)
+[//]: # "TODO"
 
 ## Remote sources
 

--- a/docs/using-garden/workflows.md
+++ b/docs/using-garden/workflows.md
@@ -12,7 +12,7 @@ Custom shell scripts can be used for preparation ahead of running Garden command
 A sequence of commands executed in a workflow is also generally more efficent than scripting successive runs of Garden CLI commands, since state is cached between the commands, and there is no startup delay between the commands.
 
 {% hint style="warning" %}
-As of Garden 0.13, the CLI command to run a Workflow is `garden run-workflow` (note the dash), instead of `garden run workflow`.
+As of Garden 0.13, the CLI command to run a Workflow is `garden workflow` instead of `garden run workflow`.
 {% endhint %}
 
 ## How it Works
@@ -31,7 +31,7 @@ We suggest making a `workflows.garden.yml` next to your project configuration in
 
 Each step in your workflow can either trigger Garden commands, or run custom scripts. The steps are executed in succession. If a step fails, the remainder of the workflow is aborted.
 
-You can run a workflow by running `garden run-workflow <name>`, or have it [trigger automatically](#triggers) via Garden Enterprise.
+You can run a workflow by running `garden workflow <name>`, or have it [trigger automatically](#triggers) via Garden Enterprise.
 
 ### Command steps
 
@@ -41,7 +41,7 @@ A simple command step looks like this:
 kind: Workflow
 name: my-workflow
 steps:
-  - command: [deploy]  # runs garden deploy
+  - command: [deploy] # runs garden deploy
 ```
 
 You can also provide arguments to commands, and even template them:
@@ -92,8 +92,8 @@ envVars:
   MY_ENV_VAR: some-value
   MY_PROJECT_VAR: ${var.my-var} # Use template strings
   SECRET_ACCESS_TOKEN: ${secrets.SECRET_ACCESS_TOKEN} # Use a Garden Enterprise secret
-...
 ```
+
 Workflow-level environment variables like this can be useful e.g. for providing templated values (such as secrets or project variables) to several script steps, or to initialize providers in the context of a CI system.
 
 Note that workflow-level environment variables apply to all steps of a workflow (both command and script steps).
@@ -107,10 +107,11 @@ The `skip` field is a boolean. If its value is `true`, the step will be skipped,
 Note that skipped steps don't produce any outputs (see the [step outputs](#step-outputs) section below for more). However, skipped steps are shown in the command log.
 
 The `when` field can be used with the following values:
-* `onSuccess` (default): This step will be run if all preceding steps succeeded or were skipped.
-* `onError`: This step will be run if a preceding step failed, or if its preceding step has `when: onError`. If the next step has `when: onError`, it will also be run. Otherwise, all subsequent steps are ignored. See below for more.
-* `always`: The step will always be run, regardless of whether any previous steps have failed.
-* `never`: The step will always be ignored, even if all previous steps succeeded. Note: Ignored steps don't show up in the command logs.
+
+- `onSuccess` (default): This step will be run if all preceding steps succeeded or were skipped.
+- `onError`: This step will be run if a preceding step failed, or if its preceding step has `when: onError`. If the next step has `when: onError`, it will also be run. Otherwise, all subsequent steps are ignored. See below for more.
+- `always`: The step will always be run, regardless of whether any previous steps have failed.
+- `never`: The step will always be ignored, even if all previous steps succeeded. Note: Ignored steps don't show up in the command logs.
 
 The simplest usage pattern for `onError` steps is to place them at the end of your workflow (which ensures that they're run if any step in your workflow fails):
 
@@ -124,14 +125,14 @@ steps:
   - script: |
       echo "Run if any of the previous steps failed"
     when: onError
-  - script:
-      echo "This task is always run, regardless of whether any previous steps failed."
+  - script: echo "This task is always run, regardless of whether any previous steps failed."
     when: always
 ```
 
 A more advanced use case is to use `onError` steps to set up "error handling checkpoints" in your workflow.
 
 For example, if the first step (`run my-task`) fails in this workflow:
+
 ```yaml
 kind: Workflow
 name: my-workflow
@@ -152,9 +153,11 @@ steps:
       echo "This task is always run, regardless of whether any previous steps failed."
     when: always
 ```
+
 then the first two `onError` steps will be run, and all other steps will be skipped (except for the last one, since it has `when: always`). This can be useful for rollback operations that are relevant only at certain points in the workflow.
 
- You can also template the values of `skip` and `when` for even more flexibility. For example:
+You can also template the values of `skip` and `when` for even more flexibility. For example:
+
 ```yaml
 kind: Workflow
 name: my-workflow

--- a/e2e/projects/vote-modules/README.md
+++ b/e2e/projects/vote-modules/README.md
@@ -46,7 +46,7 @@ This example includes a usage example for Garden workflows. The `workflows.garde
 To run the workflow:
 
 ```sh
-garden run-workflow full-test
+garden workflow full-test
 ```
 
 For more complex use-cases and additional configuration options please refer to the [docs](https://docs.garden.io/using-garden/workflows).

--- a/e2e/test/pre-release.ts
+++ b/e2e/test/pre-release.ts
@@ -108,9 +108,9 @@ describe("PreReleaseTests", () => {
   if (project === "vote") {
     describe("vote", () => {
       describe("top-level sanity checks", () => {
-        it("runs the run-workflow command", async () => {
+        it("runs the workflow command", async () => {
           const workflowName = "full-test"
-          const logEntries = await runWithEnv(["run-workflow", workflowName])
+          const logEntries = await runWithEnv(["workflow", workflowName])
           expect(
             searchLog(logEntries, new RegExp(`Workflow ${workflowName} completed successfully.`, "g")),
             `expected to find "Workflow ${workflowName} completed successfully." in log output.`

--- a/examples/vote/README.md
+++ b/examples/vote/README.md
@@ -46,7 +46,7 @@ This example includes a usage example for Garden workflows. The `workflows.garde
 To run the workflow:
 
 ```sh
-garden run-workflow full-test
+garden workflow full-test
 ```
 
 For more complex use-cases and additional configuration options please refer to the [docs](https://docs.garden.io/using-garden/workflows).


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

This PR does two things:

- Renames `garden run-workflow` command to a simplified `garden workflow`
- Moves the old-style run command invocation detection earlier (before graph init), to support lazy-init usecases (e.g. workflows)

**Which issue(s) this PR fixes**:

Fixes https://github.com/garden-io/garden/issues/4166

**Special notes for your reviewer**:

Not flagging this commit specifically as a breaking change, as the breaking change in behavior has already been flagged earlier when moving from `run workflow` to `run-workflow`. This commit also makes sure all the docs are up to date, so we should be good in terms of communication.

Ship small, ship often. This PR continues the old behavior of throwing a config error in case of the use of old-style commands. If we decide to try to support old-style invocations by only warning and trying to continue execution, let's do that in another PR. We could try to add the invocation logic to `detectOldRunCommand` where we already branch for the different errors and suggestions.