### PR TITLE
0.13 cherry-pick: osx dependencies & rosetta in docs

### DIFF
--- a/docs/basics/quickstart.md
+++ b/docs/basics/quickstart.md
@@ -34,6 +34,11 @@ Then install the Garden CLI for your platform:
 ```sh
 brew tap garden-io/garden && brew install garden-cli
 ```
+
+{% hint style="info" %}
+For a Mac computer with Apple silicon, Garden needs [Rosetta](https://support.apple.com/en-us/HT211861).
+{% endhint %}
+
 {% endtab %}
 
 {% tab title="Linux" %}

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -32,6 +32,10 @@ And if you'd like to build and run services locally, you need [a local installat
 For Mac, we recommend the following steps to install Garden. You can also follow the manual installation
 steps below if you prefer.
 
+{% hint style="info" %}
+For a Mac computer with Apple silicon, Garden needs [Rosetta](https://support.apple.com/en-us/HT211861).
+{% endhint %}
+
 ### Step 1: Install Homebrew
 
 If you haven't already set up Homebrew, please follow [their installation instructions](https://brew.sh/).

--- a/scripts/install-osx-dependencies.sh
+++ b/scripts/install-osx-dependencies.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # install/update homebrew dependencies
-BREW_DEPS="jq cmake git kubectl kubernetes-helm rsync icu4c pkg-config dep git-chglog parallel"
+BREW_DEPS="jq cmake git kubectl helm rsync icu4c pkg-config dep git-chglog parallel"
 
 brew update
 brew tap git-chglog/git-chglog


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry-picks https://github.com/garden-io/garden/pull/4157 to 0.13.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
