### PR TITLE
0.13: remote sources fix + example update

### DIFF
--- a/examples/remote-sources/README.md
+++ b/examples/remote-sources/README.md
@@ -1,14 +1,15 @@
 # Remote sources example project
 
-This example demonstrates how you can import remote sources and remote modules into a Garden project. Take a look at the [Using Remote Sources](https://docs.garden.io/advanced/using-remote-sources) section of our docs for more details.
+This example demonstrates how you can import remote sources into a Garden project.
+Take a look at the [Using Remote Sources](../../docs/advanced/using-remote-sources.md) section of our docs for more details.
 
 ## About
 
-This project is the same as the [vote example](https://github.com/garden-io/garden/tree/v0.9.0-docfix.2/examples/vote)—except that in this case the services live in their own repositories. The repositories are:
+This project is the same as the [vote example](../vote/README.md) — except that in this case the services live in their own repositories. The repositories are:
 
 * [Database services](https://github.com/garden-io/garden-example-remote-sources-db-services) (contains the Postgres and Redis services)
 * [Web services](https://github.com/garden-io/garden-example-remote-sources-web-services) (contains the Python Vote web service, Node.js Result web service and the api)
-* [Java worker module](https://github.com/garden-io/garden-example-remote-module-jworker)
+* [Java worker action](https://github.com/garden-io/garden-example-remote-module-jworker)
 
 _This split is pretty arbitrary and doesn't necessarily reflect how you would normally separate services into different repositories._
 
@@ -18,19 +19,19 @@ This project doesn't require any setup and can be deployed right away. If this i
 ```sh
 garden deploy
 ```
-Garden will continue to use the version originally downloaded. Use the `update-remote sources|modules|all` command to fetch the latest version of your remote sources and modules:
+Garden will continue to use the version originally downloaded. Use the `update-remote` command to fetch the latest version of your remote sources:
 ```sh
-garden update-remote modules worker
+garden update-remote all
 ```
-If you however change the repository URL of your remote source or module (e.g. switch to a different tag or branch), Garden will automatically fetch the correct version.
+If you change the repository URL of your remote source (e.g. switch to a different tag or branch), Garden will automatically fetch the correct version.
 
-It's also possible to link remote sources and modules to a local directory with the `link source|module` command. This is useful for when you want to try out changes to the remote source without having to push them to the remote repository. In this case, you clone the remote source to a local directory and link to its path:
+It's also possible to link remote sources to a local directory with the `link` command. This is useful for when you want to try out changes to the remote source without having to push them to the remote repository. In this case, you clone the remote source to a local directory and link to its path:
 ```sh
 garden link source web-services path/to/web-services
 ```
-Now Garden will read the module from its local path, and changes you make will be visible immediately.
+Now Garden will read the sources from their local path, and changes you make will be visible immediately.
 
-Use the `unlink source|module` command to unlink it again, and revert to the module version the repository URL points to:
+Use the `unlink` command to unlink it again, and revert to the version the repository URL points to:
 ```sh
 garden unlink source web-services
 ```

--- a/examples/remote-sources/garden.yml
+++ b/examples/remote-sources/garden.yml
@@ -4,9 +4,9 @@ name: remote-sources
 sources:
   - name: web-services
     # use #your-branch to specify a branch, #v0.3.0 for a tag or a full length commit SHA1
-    repositoryUrl: https://github.com/garden-io/garden-example-remote-sources-web-services.git#v0.4.0
+    repositoryUrl: https://github.com/garden-io/garden-example-remote-sources-web-services.git#0.13
   - name: db-services
-    repositoryUrl: https://github.com/garden-io/garden-example-remote-sources-db-services.git#main
+    repositoryUrl: https://github.com/garden-io/garden-example-remote-sources-db-services.git#0.13
 environments:
   - name: local
     variables:

--- a/examples/remote-sources/worker/garden.yml
+++ b/examples/remote-sources/worker/garden.yml
@@ -1,14 +1,21 @@
-kind: Module
+kind: Build
+type: container
+name: worker
+source:
+  repository:
+    url: https://github.com/garden-io/garden-example-remote-module-jworker.git#0.13
+
+---
+kind: Deploy
 description: The worker that collects votes and stores results in a postgres table
 type: container
 name: worker
-repositoryUrl: https://github.com/garden-io/garden-example-remote-module-jworker.git#v0.3.0
-services:
-  - name: worker
-    dependencies:
-      - redis
-      - db-init
-    env:
-      PGDATABASE: ${var.postgres-database}
-      PGUSER: ${var.postgres-username}
-      PGPASSWORD: ${var.postgres-password}
+build: worker
+dependencies:
+  - deploy.redis
+  - run.db-init
+spec:
+  env:
+    PGDATABASE: ${var.postgres-database}
+    PGUSER: ${var.postgres-username}
+    PGPASSWORD: ${var.postgres-password}


### PR DESCRIPTION
The git diff looks very odd, but basically I set the action base bath to the `remoteSourcePath` which fixes the treeVersion issue. Also updated the example.