### PR TITLE
fix: add backwards compatibility for old-style run commands

### DIFF
--- a/core/src/commands/run.ts
+++ b/core/src/commands/run.ts
@@ -229,7 +229,7 @@ function maybeOldRunCommand(names: string[], args: any, opts: any, log: Log, par
     }
     if (firstArg === "task") {
       log.warn(
-        `The ${chalk.yellow("run task")} command was removed in Garden 0.13. Please use the ${chalk.yellow(
+        `The ${chalk.yellow("run task")} command will be removed in Garden 0.14. Please use the ${chalk.yellow(
           "run"
         )} command instead.`
       )
@@ -239,7 +239,7 @@ function maybeOldRunCommand(names: string[], args: any, opts: any, log: Log, par
     }
     if (firstArg === "test") {
       log.warn(
-        `The ${chalk.yellow("run test")} command was removed in Garden 0.13. Please use the ${chalk.yellow(
+        `The ${chalk.yellow("run test")} command will be removed in Garden 0.14. Please use the ${chalk.yellow(
           "test"
         )} command instead.`
       )
@@ -250,7 +250,7 @@ function maybeOldRunCommand(names: string[], args: any, opts: any, log: Log, par
     }
     if (firstArg === "workflow") {
       log.warn(
-        `The ${chalk.yellow("run workflow")} command was removed in Garden 0.13. Please use the ${chalk.yellow(
+        `The ${chalk.yellow("run workflow")} command will be removed in Garden 0.14. Please use the ${chalk.yellow(
           "workflow"
         )} command instead.`
       )

--- a/core/src/commands/workflow.ts
+++ b/core/src/commands/workflow.ts
@@ -48,7 +48,7 @@ const runWorkflowArgs = {
 
 type Args = typeof runWorkflowArgs
 
-interface WorkflowRunOutput {
+export interface WorkflowRunOutput {
   steps: { [stepName: string]: WorkflowStepResult }
 }
 

--- a/core/test/data/test-projects/old-style-run-invocations/garden.yml
+++ b/core/test/data/test-projects/old-style-run-invocations/garden.yml
@@ -1,5 +1,5 @@
 # TODO: remove this entire test project directory in 0.14
-apiVersion: garden.io/v1
+apiVersion: garden.io/v0
 kind: Project
 name: test-project-a
 environments:

--- a/core/test/data/test-projects/old-style-run-invocations/garden.yml
+++ b/core/test/data/test-projects/old-style-run-invocations/garden.yml
@@ -1,0 +1,13 @@
+# TODO: remove this entire test project directory in 0.14
+apiVersion: garden.io/v1
+kind: Project
+name: test-project-a
+environments:
+  - name: local
+providers:
+  - name: test-plugin
+variables:
+  some: variable
+outputs:
+  - name: taskName
+    value: task-a

--- a/core/test/data/test-projects/old-style-run-invocations/module-a/garden.yml
+++ b/core/test/data/test-projects/old-style-run-invocations/module-a/garden.yml
@@ -1,0 +1,27 @@
+kind: Module
+name: module-a
+type: test
+variables:
+  msg: OK
+services:
+  - name: service-a
+build:
+  command: [echo, A]
+tests:
+  - name: unit
+    command: [echo, "${var.msg}"]
+  - name: integration
+    command: [echo, "${var.msg}"]
+    dependencies:
+      - service-a
+tasks:
+  - name: task-a
+    command: [echo, "${var.msg}"]
+  - name: task-a2
+    command: [echo, "${environment.name}-${var.msg}"]
+
+---
+kind: Workflow
+name: workflow-a
+steps:
+  - script: echo


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Adds backwards compatibility for old-style `run` command invocations.

```console
cd examples/vote/;
garden run task db-init;
garden run workflow full-test;
```

**Which issue(s) this PR fixes**:

Fixes https://github.com/garden-io/garden/issues/4166

**Special notes for your reviewer**:

I would appreciate if the reviewers could try this out on some known-working workflows and tasks to verify the backwards compatibility works, by using the old-style `garden run workflow foo`, `garden run task foo`, `garden run test foo` invocations. These should be run against both `0.12` style and `0.13` style config files.

Pardon the slightly hacky implementation. If you have suggestions on how to make this cleaner, I'm all ears <3

