### PR TITLE
fix(core): use module test name as test action name

### DIFF
--- a/core/src/commands/get/get-test-result.ts
+++ b/core/src/commands/get/get-test-result.ts
@@ -15,7 +15,7 @@ import { GetTestResult, getTestResultSchema } from "../../plugin/handlers/Test/g
 import { ParameterValues, StringOption, StringParameter } from "../../cli/params"
 import { ParameterError } from "../../exceptions"
 import { ConfigGraph } from "../../graph/config-graph"
-import { GardenModule, moduleTestNameToActionName } from "../../types/module"
+import { GardenModule } from "../../types/module"
 import { findByName, getNames } from "../../util/util"
 import { createActionLog } from "../../logger/log-entry"
 
@@ -130,7 +130,7 @@ export function getTestActionFromArgs(graph: ConfigGraph, args: ParameterValues<
       })
     }
 
-    return graph.getTest(moduleTestNameToActionName(moduleName, testName))
+    return graph.getTest(testName)
   } else {
     return graph.getTest(args.name, { includeDisabled: true })
   }

--- a/core/src/plugin/handlers/Module/convert.ts
+++ b/core/src/plugin/handlers/Module/convert.ts
@@ -42,7 +42,6 @@ export interface ConvertModuleParams<T extends GardenModule = GardenModule> exte
       }
     }
   }
-  convertTestName: (d: string) => string
   convertBuildDependency: (d: string | BuildDependencyConfig) => string
   convertRuntimeDependencies: (d: string[]) => string[]
   prepareRuntimeDependencies: (deps: string[], build: BuildActionConfig<string, any> | undefined) => string[]
@@ -81,11 +80,6 @@ export const convert = () => ({
       .unknown(true)
       .required()
       .description("Fields that should generally be applied to all returned actions, based on the input Module."),
-    convertTestName: joi
-      .function()
-      .description(
-        "A helper that accepts a test name from the module and returns the correct action name for the converted test."
-      ),
     convertBuildDependency: joi
       .function()
       .description(

--- a/core/src/plugins/container/container.ts
+++ b/core/src/plugins/container/container.ts
@@ -265,7 +265,7 @@ function convertContainerModuleRuntimeActions(
     actions.push({
       kind: "Test",
       type: "container",
-      name: module.name + "-" + test.name,
+      name: test.name,
       ...convertParams.baseFields,
 
       disabled: test.disabled,

--- a/core/src/plugins/exec/convert.ts
+++ b/core/src/plugins/exec/convert.ts
@@ -141,7 +141,7 @@ export async function convertExecModule(params: ConvertModuleParams<ExecModule>)
     actions.push({
       kind: "Test",
       type: "exec",
-      name: module.name + "-" + test.name,
+      name: test.name,
       ...params.baseFields,
 
       disabled: test.disabled,

--- a/core/src/plugins/kubernetes/helm/handlers.ts
+++ b/core/src/plugins/kubernetes/helm/handlers.ts
@@ -111,7 +111,7 @@ export const helmModuleHandlers: Partial<ModuleActionHandlers<HelmModule>> = {
     }
 
     for (const test of tests) {
-      const testName = module.name + "-" + test.name
+      const testName = test.name
       const resource = convertServiceResource(module, test.spec.resource, testName)
 
       if (!resource) {

--- a/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
@@ -116,7 +116,7 @@ export const kubernetesHandlers: Partial<ModuleActionHandlers<KubernetesModule>>
       actions.push({
         kind: "Test",
         type: "kubernetes-pod",
-        name: module.name + "-" + test.name,
+        name: test.name,
         ...params.baseFields,
         disabled: test.disabled,
 

--- a/core/src/resolve-module.ts
+++ b/core/src/resolve-module.ts
@@ -727,10 +727,6 @@ export const convertModules = profileAsync(async function convertModules(
       },
 
       convertBuildDependency,
-      convertTestName: (d: string) => {
-        return d
-      },
-
       convertRuntimeDependencies,
       prepareRuntimeDependencies(deps: string[], build?: BuildActionConfig<string, any>) {
         const resolved: string[] = convertRuntimeDependencies(deps)

--- a/core/src/resolve-module.ts
+++ b/core/src/resolve-module.ts
@@ -728,7 +728,7 @@ export const convertModules = profileAsync(async function convertModules(
 
       convertBuildDependency,
       convertTestName: (d: string) => {
-        return module.name + "-" + d
+        return d
       },
 
       convertRuntimeDependencies,

--- a/core/src/server/client-router.ts
+++ b/core/src/server/client-router.ts
@@ -15,7 +15,6 @@ import { filterTestConfigs, TestTask } from "../tasks/test"
 import { naturalList } from "../util/string"
 import { ConfigGraph } from "../graph/config-graph"
 import { RunTask } from "../tasks/run"
-import { moduleTestNameToActionName } from "../types/module"
 import { printEmoji } from "../logger/util"
 import { ActionMode } from "../actions/types"
 
@@ -212,7 +211,7 @@ export const clientRequestHandlers = {
     const { moduleName, testNames, force, forceBuild } = params.request
     const module = graph.getModule(moduleName)
     return filterTestConfigs(module, testNames).map((config) => {
-      const testName = moduleTestNameToActionName(params.request.moduleName, config.name)
+      const testName = config.name
       return new TestTask({
         garden,
         graph,

--- a/core/src/tasks/test.ts
+++ b/core/src/tasks/test.ts
@@ -16,7 +16,6 @@ import { resolvedActionToExecuted } from "../actions/helpers"
 import { TestAction } from "../actions/test"
 import { GetTestResult } from "../plugin/handlers/Test/get-result"
 import { TestConfig } from "../config/test"
-import { moduleTestNameToActionName } from "../types/module"
 
 class TestError extends Error {
   toString() {
@@ -123,8 +122,7 @@ export function filterTestConfigs(module: ModuleConfig, filterNames?: string[]):
     if (!filterNames || filterNames.length === 0) {
       return true
     }
-    const testName = moduleTestNameToActionName(module.name, test.name)
-    return find(filterNames, (n: string) => minimatch(testName, n))
+    return find(filterNames, (n: string) => minimatch(test.name, n))
   }
   return module.testConfigs.filter(acceptableTestConfig)
 }

--- a/core/src/types/module.ts
+++ b/core/src/types/module.ts
@@ -170,10 +170,6 @@ export function getModuleCacheContext<M extends ModuleConfig>(config: M) {
   return pathToCacheContext(config.path)
 }
 
-export function moduleTestNameToActionName(moduleName: string, testName: string) {
-  return `${moduleName}-${testName}`
-}
-
 /**
  * Recursively resolves all the bases for the given module type, ordered from closest base to last.
  */

--- a/core/test/unit/src/plugins/container/container.ts
+++ b/core/test/unit/src/plugins/container/container.ts
@@ -93,7 +93,6 @@ describe("plugins.container", () => {
       },
       convertBuildDependency: () => "buildDep",
       convertRuntimeDependencies: () => ["runtimeDep"],
-      convertTestName: () => "testName",
       ctx,
       dummyBuild: undefined,
       log,

--- a/core/test/unit/src/router/_helpers.ts
+++ b/core/test/unit/src/router/_helpers.ts
@@ -324,7 +324,7 @@ function getRouterUnitTestPlugins() {
               actions.push({
                 kind: "Test",
                 type: "test",
-                name: module.name + "-" + test.name,
+                name: test.name,
                 ...params.baseFields,
 
                 disabled: test.disabled,


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
Use module test name directly as action name. Tests had to be uniquely
named in 0.12, so prefixing the module name is not necessary.
That way the `-n` option of the `garden test`command, that has been kept for backwards
compatibility, continues to work just as before.

**Which issue(s) this PR fixes**:

Fixes #4178

**Special notes for your reviewer**:
