### PR TITLE
feat(server): stream log entries over ws

### DIFF
--- a/core/src/cloud/buffered-event-stream.ts
+++ b/core/src/cloud/buffered-event-stream.ts
@@ -9,7 +9,7 @@
 import Bluebird from "bluebird"
 
 import { Events, EventName, EventBus, pipedEventNames } from "../events"
-import { LogMetadata, Log, LogEntry } from "../logger/log-entry"
+import { LogMetadata, Log, LogEntry, LogContext } from "../logger/log-entry"
 import { got } from "../util/http"
 
 import { LogLevel } from "../logger/logger"
@@ -32,6 +32,7 @@ export interface LogEntryEventPayload {
   timestamp: string
   level: LogLevel
   message: LogEntryMessage
+  context: LogContext
   metadata?: LogMetadata
 }
 
@@ -44,6 +45,7 @@ export function formatLogEntryForEventStream(entry: LogEntry): LogEntryEventPayl
     metadata: entry.metadata,
     timestamp: entry.timestamp,
     level: entry.level,
+    context: entry.context,
     message: {
       section,
       msg: entry.msg,

--- a/core/src/logger/log-entry.ts
+++ b/core/src/logger/log-entry.ts
@@ -68,7 +68,7 @@ export interface ActionLogContext extends BaseContext {
   actionKind: string
 }
 
-type LogContext = CoreLogContext | ActionLogContext
+export type LogContext = CoreLogContext | ActionLogContext
 
 /**
  * Common Log config that the class implements and other interfaces pick / omit from.
@@ -135,10 +135,11 @@ export interface LogEntry<C extends BaseContext = LogContext>
   data?: any
   dataFormat?: "json" | "yaml"
   error?: GardenError
+  skipEmit?: boolean
 }
 
 interface LogParams
-  extends Pick<LogEntry, "metadata" | "msg" | "symbol" | "data" | "dataFormat" | "error">,
+  extends Pick<LogEntry, "metadata" | "msg" | "symbol" | "data" | "dataFormat" | "error" | "skipEmit">,
     Pick<LogContext, "origin"> {}
 
 interface CreateLogEntryParams extends LogParams {

--- a/core/src/server/commands.ts
+++ b/core/src/server/commands.ts
@@ -12,7 +12,7 @@ import { Command } from "../commands/base"
 import { joi } from "../config/common"
 import { validateSchema } from "../config/validation"
 import { extend, mapValues, omitBy } from "lodash"
-import { LogLevel } from "../logger/logger"
+import { ServerLogger } from "../logger/logger"
 import { Log } from "../logger/log-entry"
 import { Parameters, ParameterValues, globalOptions } from "../cli/params"
 import { parseCliArgs, processCliArgs } from "../cli/helpers"
@@ -74,8 +74,9 @@ export function parseRequest(ctx: Koa.ParameterizedContext, log: Log, commands: 
   // command instance and thereby that subscribers are properly isolated at the request level.
   const command = commandSpec.command.clone()
 
-  // We generally don't want actions to log anything in the server.
-  const cmdLog = log.createLog({ fixLevel: LogLevel.silly })
+  // The server logger only logs to stdout at the silly level but still emits log events
+  const serverLogger = new ServerLogger({ rootLogger: log.root, level: log.root.level })
+  const cmdLog = serverLogger.createLog({})
 
   // Prepare arguments for command action.
   let cmdArgs: ParameterValues<any> = {}

--- a/core/test/unit/src/logger/log-entry.ts
+++ b/core/test/unit/src/logger/log-entry.ts
@@ -224,7 +224,11 @@ describe("CoreLog", () => {
   describe("createLogEntry", () => {
     it("should pass its config on to the log entry", () => {
       const timestamp = freezeTime().toISOString()
-      const testLog = log.createLog({ name: "test-log", origin: "foo", metadata: { workflowStep: { index: 2 } } })
+      const testLog = log.createLog({
+        name: "test-log",
+        origin: "foo",
+        metadata: { workflowStep: { index: 2 } },
+      })
       const entry = testLog.info("hello").getLatestEntry()
 
       expect(entry.key).to.be.a.string
@@ -325,7 +329,6 @@ describe("ActionLog", () => {
       })
     })
     it("should optionally overwrite origin", () => {
-      const timestamp = freezeTime().toISOString()
       const actionLog = createActionLog({
         log,
         origin: "origin",

--- a/core/test/unit/src/logger/logger.ts
+++ b/core/test/unit/src/logger/logger.ts
@@ -59,6 +59,11 @@ describe("Logger", () => {
             dataFormat: "json",
             data: { foo: "bar" },
           },
+          context: {
+            name: "log-context-name",
+            origin: undefined,
+            type: "coreLog",
+          },
           metadata: {
             workflowStep: {
               index: 2,


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Previously, we'd only stream Garden events to websocket subscribers but not actual log entries.

This meant clients could only respond to events and subscribe to service logs but not render actual Core log entries.

This fixes that by simply piping log events to websocket subscribers.


**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
