### PR TITLE
test: fix assertions for `run` command

### DIFF
--- a/core/src/util/testing.ts
+++ b/core/src/util/testing.ts
@@ -397,6 +397,10 @@ export function expectFuzzyMatch(str: string, sample: string | string[]) {
   samples.forEach((s) => expect(errorMessageNonAnsi.toLowerCase()).to.contain(s.toLowerCase()))
 }
 
+export function expectLogsContain(logs: string[], sample: string) {
+  expect(logs.some((line) => line.includes(sample))).to.be.true
+}
+
 type ExpectErrorAssertion =
   | string
   | ((err: any) => void)

--- a/core/test/unit/src/commands/run.ts
+++ b/core/test/unit/src/commands/run.ts
@@ -16,7 +16,7 @@ import {
   getDataDir,
   makeTestGardenA,
 } from "../../../helpers"
-import { getLogMessages } from "../../../../src/util/testing"
+import { expectLogsContain, getLogMessages } from "../../../../src/util/testing"
 import { LogLevel } from "../../../../src/logger/logger"
 
 // TODO-G2: fill in test implementations. use TestCommand tests for reference.
@@ -318,7 +318,7 @@ describe("RunCommand legacy invocations", () => {
         },
       })
       const logMessages = getLogMessages(log, (l) => l.level === LogLevel.warn)
-      expect(logMessages[0]).to.include("The run test command will be removed in Garden 0.14")
+      expectLogsContain(logMessages, "The run test command will be removed in Garden 0.14")
     })
 
     it("warns if called with 'task' as the first argument", async () => {
@@ -336,7 +336,7 @@ describe("RunCommand legacy invocations", () => {
         },
       })
       const logMessages = getLogMessages(log, (l) => l.level === LogLevel.warn)
-      expect(logMessages[0]).to.include("The run task command will be removed in Garden 0.14")
+      expectLogsContain(logMessages, "The run task command will be removed in Garden 0.14")
     })
 
     it("warns if called with 'workflow' as the first argument", async () => {
@@ -359,7 +359,7 @@ describe("RunCommand legacy invocations", () => {
         // ignoring it for test purposes - we're only interested in the warning
       }
       const logMessages = getLogMessages(log, (l) => l.level === LogLevel.warn)
-      expect(logMessages[0]).to.include("The run workflow command will be removed in Garden 0.14")
+      expectLogsContain(logMessages, "The run workflow command will be removed in Garden 0.14")
     })
   })
 })


### PR DESCRIPTION
Garden emits non-repeatable warning "Project is configured with `apiVersion: garden.io/v0`, running with backwards compatibility." Thus, the variable `logMessages` may contain 2 lines. This commit introduces helper function `expectLogsContain` to check if there is at least one entry of a given sample among all log lines.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
Patch for #4195

**Which issue(s) this PR fixes**:
It makes the log-checking unit test assertions more stable by taking into account non-repeatable warnings.

**Special notes for your reviewer**:
