### PR TITLE
fix(dev): trim trailing whitespace from cmd args

### DIFF
--- a/core/src/cli/command-line.ts
+++ b/core/src/cli/command-line.ts
@@ -549,7 +549,7 @@ ${chalk.white.underline("Keys:")}
       return
     }
 
-    const rawArgs = this.currentCommand.split(" ")
+    const rawArgs = this.currentCommand.trim().split(" ")
     const { command, rest, matchedPath } = pickCommand(this.commands, rawArgs)
 
     if (!command) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Before this fix, adding a space at the end of a command invocation in the `dev` command would result in unexpected CLI argument parsing behavior (e.g. no Deploys being requested when running `deploy --logs` with a trailing space).