### PR TITLE
fix: unhandled errors when config store update fails

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -43,12 +43,18 @@ export async function runCli({
     code = result.code
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.log(err.message)
+    console.log(`Unhandled error when running garden\n${err.message}`)
     code = 1
   } finally {
     if (cli?.processRecord) {
       const globalConfigStore = new GlobalConfigStore()
-      await globalConfigStore.delete("activeProcesses", String(cli.processRecord.pid))
+
+      try {
+        await globalConfigStore.delete("activeProcesses", String(cli.processRecord.pid))
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.log(`Global config store cleanup failed, ${err.message}`)
+      }
     }
     await shutdown(code)
   }

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -43,18 +43,12 @@ export async function runCli({
     code = result.code
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.log(`Unhandled error when running garden\n${err.message}`)
+    console.log(`Warning: Exiting with unhandled error\n${err.message}`)
     code = 1
   } finally {
     if (cli?.processRecord) {
       const globalConfigStore = new GlobalConfigStore()
-
-      try {
-        await globalConfigStore.delete("activeProcesses", String(cli.processRecord.pid))
-      } catch (err) {
-        // eslint-disable-next-line no-console
-        console.log(`Global config store cleanup failed, ${err.message}`)
-      }
+      await globalConfigStore.delete("activeProcesses", String(cli.processRecord.pid))
     }
     await shutdown(code)
   }

--- a/core/src/config-store/base.ts
+++ b/core/src/config-store/base.ts
@@ -190,9 +190,9 @@ export abstract class ConfigStore<T extends z.ZodObject<any>> {
 
   private logLockReleaseError() {
     // eslint-disable-next-line
-    console.log("Warning: Unable to release the lock on the global config store; lock was already released")
-    // eslint-disable-next-line
-    console.log("Warning: If you run into this error repeatedly, please report on our GitHub or Discord")
+    console.log(
+      "Warning: Unable to release the lock on the global config store; lock was already released. If you run into this error repeatedly, please report on our GitHub or Discord"
+    )
   }
 
   private async readConfig(): Promise<I<T>> {

--- a/core/src/config-store/base.ts
+++ b/core/src/config-store/base.ts
@@ -177,7 +177,7 @@ export abstract class ConfigStore<T extends z.ZodObject<any>> {
     // NOTE: this allows the execution to continue, and the writeFile function potentially overwrites the config written by another call
     const onCompromised = (err, reject) => {
       // eslint-disable-next-line
-      console.log("Warning: The lock on the global config store was compromised. Overwriting the config")
+      console.log("Warning: The lock on the global config store was compromised. Updating the config anyway.")
       reject(err)
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

The lock library we use in the config store throws an uncaught exception when a lock is compromised. We catch the error and log out a warning to avoid the entire garden process to crash. This is a workaround for now until we can reproduce and fix the root cause. 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
