### PR TITLE
docs: improve sync mode docs

### DIFF
--- a/core/src/plugin/handlers/Deploy/deploy.ts
+++ b/core/src/plugin/handlers/Deploy/deploy.ts
@@ -27,7 +27,7 @@ export class DoDeployAction<T extends DeployAction = DeployAction> extends Actio
     Deploy the specified service. This should wait until the service is ready and accessible,
     and fail if the service doesn't reach a ready state.
 
-    Called by the \`garden deploy\` and \`garden dev\` commands.
+    Called by the \`garden deploy\`command.
   `
 
   paramsSchema = () =>

--- a/docs/basics/how-garden-works.md
+++ b/docs/basics/how-garden-works.md
@@ -83,7 +83,7 @@ garden test --name e2e
 Garden also has a special mode called "sync mode" which live reloads changes to your running services—ensuring **blazing fast feedback while developing**. To enable it, simply run:
 
 ```yaml
-garden dev
+garden deploy --sync
 ```
 
 There are also a handful of utility commands for getting logs, exec-ing into services, publishing images, and more.

--- a/docs/guides/code-synchronization.md
+++ b/docs/guides/code-synchronization.md
@@ -4,7 +4,9 @@ order: 3
 ---
 # Code Synchronization
 
-Garden allows you to rapidly synchronize your code (and other files) to and from running containers.
+Garden includes a *sync* mode that allows you to rapidly synchronize your code (and other files) to and from running containers.
+
+The sync mode uses [Mutagen](https://mutagen.io/) under the hood. Garden automatically takes care of fetching Mutagen, so you don't need to install any dependencies yourself to make use of dev mode.
 
 {% hint style="info" %}
 This feature used to be called _dev mode_ but as of version 0.13 we've opted for more straightforward terminology. The functionality is exactly the same as before.
@@ -16,7 +18,7 @@ This feature used to be called _dev mode_ but as of version 0.13 we've opted for
 Please make sure to specify any paths that should not be synced by setting the provider-level default excludes and/or the `exclude` field on each configured sync! Otherwise you may end up syncing large directories and even run into application errors.
 {% endhint %}
 
-To configure a service for sync, add `sync` to your Deploy configuration to specify your sync targets:
+To configure a service for sync mode, add `sync` to your Deploy configuration to specify your sync targets:
 
 ### Configuring sync for `container` modules
 

--- a/docs/guides/code-synchronization.md
+++ b/docs/guides/code-synchronization.md
@@ -6,7 +6,7 @@ order: 3
 
 Garden includes a *sync* mode that allows you to rapidly synchronize your code (and other files) to and from running containers.
 
-The sync mode uses [Mutagen](https://mutagen.io/) under the hood. Garden automatically takes care of fetching Mutagen, so you don't need to install any dependencies yourself to make use of dev mode.
+The sync mode uses [Mutagen](https://mutagen.io/) under the hood. Garden automatically takes care of fetching Mutagen, so you don't need to install any dependencies yourself to make use of sync mode.
 
 {% hint style="info" %}
 This feature used to be called _dev mode_ but as of version 0.13 we've opted for more straightforward terminology. The functionality is exactly the same as before.

--- a/docs/guides/migrating-from-docker-compose.md
+++ b/docs/guides/migrating-from-docker-compose.md
@@ -137,7 +137,7 @@ With the four config files added, we can test our service on Garden. We've moved
 Now run:
 
 ```bash
-garden dev
+garden deploy
 ```
 
 in the project folder. Garden will start up locally. You should see output in your terminal showing that this worked successfully.

--- a/docs/k8s-plugins/advanced/in-cluster-building.md
+++ b/docs/k8s-plugins/advanced/in-cluster-building.md
@@ -225,7 +225,7 @@ and to have Docker running locally. For development clusters, you
 may in fact get set up quicker if you use the in-cluster build
 modes.
 
-When you deploy to your environment (via `garden deploy` or `garden dev`) using the local Docker mode, images are first
+When you deploy to your environment (via `garden deploy`) using the local Docker mode, images are first
 built locally and then pushed to the configured _deployment registry_, where the K8s cluster will then pull the built
 images when deploying. This should generally be a _private_ container registry, or at least a private project in a
 public registry.

--- a/docs/misc/faq.md
+++ b/docs/misc/faq.md
@@ -167,7 +167,7 @@ It is, which is why we recommend that tasks are written to be idempotent. Tasks 
 
 This is intentional, we don't re-run tasks on file watch events. We debated this behavior quite a bit and ultimately opted not to run task dependencies on every watch event.
 
-### Why is my task not running on `garden deploy` or `garden dev`?
+### Why is my task not running on `garden deploy`?
 
 The task result is likely cached. Garden won't run tasks with cached results unless `cacheResult: false` is set on the task definition.
 

--- a/docs/other-plugins/container.md
+++ b/docs/other-plugins/container.md
@@ -118,7 +118,7 @@ tests:
 
 Here we first define a `unit` test suite, which has no dependencies, and simply runs `npm test` in the container. The `integ` suite is similar but adds a _runtime dependency_. This means that before the `integ` test is run, Garden makes sure that `some-service` is running and up-to-date.
 
-When you run `garden test` or `garden dev` we will run those tests. In both cases, the tests will be executed by running the container with the specified command _in your configured environment_ (as opposed to locally on the machine you're running the `garden` CLI from).
+When you run `garden test`, we will run those tests. The tests will be executed by running the container with the specified command _in your configured environment_ (as opposed to locally on the machine you're running the `garden` CLI from).
 
 The names and commands to run are of course completely up to you, but we suggest naming the test suites consistently across your different modules.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Improve docs around sync mode as `garden dev` now opens interactive shell env instead of dev mode as it was in 0.12.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

