### PR TITLE
docs: update remote-sources guide

### DIFF
--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -229,6 +229,7 @@ export async function actionFromConfig({
       linked = linkedSources[key]
     }
   }
+
   const dependencies = dependenciesFromActionConfig(log, config, configsByKey, definition, templateContext)
   const treeVersion = await garden.vcs.getTreeVersion(log, garden.projectName, config)
 


### PR DESCRIPTION
also add back a sweeet line break that was missing from https://github.com/garden-io/garden/pull/4193