### PR TITLE
0.13 ensure dev command sends events

### DIFF
--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -111,10 +111,14 @@ export class GardenCli {
   private commands: { [key: string]: Command } = {}
   private fileWritersInitialized: boolean = false
   private plugins: GardenPluginReference[]
-  private bufferedEventStream: BufferedEventStream | undefined
   private sessionFinished = false
   private initLogger: boolean
   public processRecord: GardenProcess
+  // FIXME @instance-manager: This was changed from public to private so that we can
+  // access the bufferedEventStream instance via the cli instance for
+  // some commands. We can remove this all together when we introduce the
+  // instance manager.
+  public bufferedEventStream: BufferedEventStream | undefined
 
   constructor({ plugins, initLogger = false }: { plugins?: GardenPluginReference[]; initLogger?: boolean } = {}) {
     this.plugins = plugins || []

--- a/core/src/cloud/buffered-event-stream.ts
+++ b/core/src/cloud/buffered-event-stream.ts
@@ -154,6 +154,21 @@ export class BufferedEventStream {
     this.eventNames = pipedEventNames
   }
 
+  /**
+   * Helper for overwriting the Garden instance that's used by commands that need to create a new instance.
+   *
+   * FIXME @instance-manager: We can remove this when we introduce the instance manager.
+   */
+  setGarden(garden: Garden) {
+    this.log.debug("Setting new Garden instance on buffered event stream")
+    this.connect({
+      garden,
+      targets: this.targets,
+      streamEvents: this.streamEvents,
+      streamLogEntries: this.streamLogEntries,
+    })
+  }
+
   connect({ garden, targets, streamEvents, streamLogEntries }: ConnectBufferedEventStreamParams) {
     if (this.intervalId) {
       clearInterval(this.intervalId)

--- a/core/src/commands/base.ts
+++ b/core/src/commands/base.ts
@@ -27,6 +27,7 @@ import { GardenCli } from "../cli/cli"
 import { CommandLine } from "../cli/command-line"
 import { SolveResult } from "../graph/solver"
 import { waitForOutputFlush } from "../process"
+import { BufferedEventStream } from "../cloud/buffered-event-stream"
 
 export interface CommandConstructor {
   new (parent?: CommandGroup): Command
@@ -65,6 +66,7 @@ export interface PrepareParams<T extends Parameters = {}, U extends Parameters =
 
 export interface CommandParams<T extends Parameters = {}, U extends Parameters = {}> extends PrepareParams<T, U> {
   cli?: GardenCli
+  bufferedEventStream?: BufferedEventStream
   garden: Garden
 }
 

--- a/core/src/commands/dev.tsx
+++ b/core/src/commands/dev.tsx
@@ -39,6 +39,7 @@ export class DevCommand extends ServeCommand<DevCommandArgs, DevCommandOpts> {
 
   protected = true
   cliOnly = true
+  streamEvents = true
 
   arguments = devCommandArgs
   options = devCommandOpts

--- a/core/src/commands/test.ts
+++ b/core/src/commands/test.ts
@@ -149,7 +149,9 @@ export class TestCommand extends Command<Args, Opts> {
     }
 
     if (opts["name"]) {
-      log.warn("The --name option will be removed in 0.14. Please use a positional argument <module-name>-<test-name> instead.")
+      log.warn(
+        "The --name option will be removed in 0.14. Please use a positional argument <module-name>-<test-name> instead."
+      )
     }
 
     const graph = await garden.getConfigGraph({ log, emit: true })

--- a/core/src/server/server.ts
+++ b/core/src/server/server.ts
@@ -535,7 +535,7 @@ export class GardenServer extends EventEmitter {
             }
 
             if (printLogs) {
-              logCommandStart({ commandName: command.getFullName(), width: termWidth, log })
+              logCommandStart({ commandName: command.getFullName(), width: termWidth, log: this.log })
             }
 
             // TODO: validate result schema
@@ -588,9 +588,9 @@ export class GardenServer extends EventEmitter {
             )
             if (printLogs) {
               if (errors?.length) {
-                logCommandOutputErrors({ errors, log, width: termWidth })
+                logCommandOutputErrors({ errors, log: this.log, width: termWidth })
               } else {
-                logCommandSuccess({ commandName: command.getFullName(), width: termWidth, log })
+                logCommandSuccess({ commandName: command.getFullName(), width: termWidth, log: this.log })
               }
             }
             delete this.activePersistentRequests[requestId]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

When starting the CLI, a buffered event stream is created that subscribes
to events from a Garden instance.

However, when running a serve command, a new Garden instance is created
via the "reload" function which the buffered event stream wasn't
subscribing to.

This commit fixes that by setting the new instance explicitly on the
buffered event stream.

This is pretty hacky and just a workaround to unblock things which will
be removed when we introduce a proper instance manager.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
