### PR TITLE
0.13 cherry-pick: feat(plugins): set the manifest to unknown if repository is not found

### DIFF
--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -243,7 +243,7 @@ export function skopeoManifestUnknown(errMsg: string | null | undefined): boolea
   if (!errMsg) {
     return false
   }
-  return errMsg.includes("manifest unknown") || /artifact [^ ]+ not found/.test(errMsg)
+  return errMsg.includes("manifest unknown") || /(artifact|repository) [^ ]+ not found/.test(errMsg)
 }
 
 /**

--- a/core/test/unit/src/plugins/kubernetes/container/build/common.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/build/common.ts
@@ -30,6 +30,13 @@ describe("common build", () => {
       expect(skopeoManifestUnknown(errorMessage)).to.be.true
     })
 
+    it("should result in manifest unknown for Harbor registry repository not found", () => {
+      const errorMessage =
+        'Unable to query registry for image status: time="2021-10-13T17:50:25Z" level=fatal msg="Error parsing image name "docker://registry.domain/namespace/image-name:v-1f160eadbb": Error reading manifest v-1f160eadbb in registry.domain/namespace/image-name: unknown: repository namespace/image-name not found"'
+
+      expect(skopeoManifestUnknown(errorMessage)).to.be.true
+    })
+
     it("should result in manifest not unknown for other errors", () => {
       const errorMessage =
         "unauthorized: unauthorized to access repository: namespace/image-name, action: push: unauthorized to access repository: namespace/image-name, action: push"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
Cherry-picks #4229 to `0.13`.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
