### PR TITLE
fix(server): ensure server logs aren't emitted twice

### DIFF
--- a/core/src/commands/base.ts
+++ b/core/src/commands/base.ts
@@ -16,7 +16,7 @@ import { createSchema, joi } from "../config/common"
 import { InternalError, RuntimeError, GardenBaseError } from "../exceptions"
 import { Garden } from "../garden"
 import { Log } from "../logger/log-entry"
-import { LoggerType } from "../logger/logger"
+import { LoggerType, LoggerBase, LoggerConfigBase } from "../logger/logger"
 import { printFooter, renderMessageWithDivider } from "../logger/util"
 import { GraphResultMapWithoutTask } from "../graph/results"
 import { capitalize } from "lodash"
@@ -261,6 +261,14 @@ export abstract class Command<A extends Parameters = {}, O extends Parameters = 
   }
 
   printHeader(_: PrintHeaderParams<A, O>) {}
+
+  /**
+   * Allow commands to specify what logger to use when executed by the server.
+   *
+   * Used e.g. by the logs command to disable logging for server requests since
+   * the log entries are emitted as events.
+   */
+  getServerLogger(_?: LoggerConfigBase): LoggerBase | void {}
 
   /**
    * Helper function for creating a new instance of the command.

--- a/core/src/commands/logs.ts
+++ b/core/src/commands/logs.ts
@@ -12,7 +12,7 @@ import chalk from "chalk"
 import { omit, sortBy } from "lodash"
 import Bluebird from "bluebird"
 import { DeployLogEntry } from "../types/service"
-import { parseLogLevel } from "../logger/logger"
+import { LogLevel, parseLogLevel, VoidLogger } from "../logger/logger"
 import { StringsParameter, BooleanParameter, IntegerParameter, DurationParameter, TagsOption } from "../cli/params"
 import { printHeader, renderDivider } from "../logger/util"
 import { dedent, deline, naturalList } from "../util/string"
@@ -100,6 +100,12 @@ export class LogsCommand extends Command<Args, Opts> {
 
   printHeader({ headerLog }) {
     printHeader(headerLog, "Logs", "📜")
+  }
+
+  getServerLogger() {
+    // We don't want to log anything when called via the server.
+    // Note that the level doesn't really matter here since the void logger doesn't log anything
+    return new VoidLogger({ level: LogLevel.info })
   }
 
   maybePersistent({ opts }: PrepareParams<Args, Opts>) {

--- a/core/src/logger/logger.ts
+++ b/core/src/logger/logger.ts
@@ -109,7 +109,7 @@ export function getTerminalWriterInstance(loggerType: LoggerType, level: LogLeve
   }
 }
 
-interface LoggerConfigBase {
+export interface LoggerConfigBase {
   /**
    * The Garden log level. This get propagated to the actual writers which have their own
    * levels which may in some cases overwrite this.
@@ -468,6 +468,13 @@ export class ServerLogger extends LoggerBase {
     if (entry.level <= eventLogLevel && !entry.skipEmit) {
       this.rootLogger.events.emit("logEntry", formatLogEntryForEventStream(entry))
     }
+  }
+}
+
+export class VoidLogger extends LoggerBase {
+
+  log() {
+    // No op
   }
 }
 

--- a/core/src/server/commands.ts
+++ b/core/src/server/commands.ts
@@ -74,8 +74,7 @@ export function parseRequest(ctx: Koa.ParameterizedContext, log: Log, commands: 
   // command instance and thereby that subscribers are properly isolated at the request level.
   const command = commandSpec.command.clone()
 
-  // The server logger only logs to stdout at the silly level but still emits log events
-  const serverLogger = new ServerLogger({ rootLogger: log.root, level: log.root.level })
+  const serverLogger = command.getServerLogger() || new ServerLogger({ rootLogger: log.root, level: log.root.level })
   const cmdLog = serverLogger.createLog({})
 
   // Prepare arguments for command action.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Before this, server logs would be emitted twice over ws. Once via the 'commandOutput' event which a request would subscribe to and once as a 'logEntry' event.

By setting the logger instance to the VoidLogger for the logs when executed by the server, we eliminate the latter and only emit the log once.

Note that this is a bit hacky and means that other log entries that the logs command creates are also ignored.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
