### PR TITLE
fix(k8s): fix namespace caching logic

### DIFF
--- a/core/src/cache.ts
+++ b/core/src/cache.ts
@@ -301,3 +301,47 @@ export function pathToCacheContext(path: string): CacheContext {
   const parsed = parse(normalize(path))
   return ["path", ...parsed.dir.split(sep)]
 }
+
+/**
+ * A simple in-memory cache that prunes older entries once the maximum size (as measured by key count) has been
+ * reached.
+ *
+ * Useful for scenarios where new keys accumulate indefinitely, and there's a need to prevent unbounded memory use.
+ */
+export class BoundedCache<CachedValue> {
+  private cache: {
+    [key: string]: CachedValue
+  } = {}
+  private keys: string[] = []
+
+  constructor(private maxCacheCount = 1000) {}
+
+  get(key: string): CachedValue | null {
+    return this.cache[key] || null
+  }
+
+  set(key: string, val: CachedValue): void {
+    if (this.keys.length >= this.maxCacheCount) {
+      const pruneCount = Math.floor(this.maxCacheCount / 2)
+      // We remove the oldest `pruneCount` ids and their associated values.
+      const idsToPrune = this.keys.slice(0, pruneCount)
+      for (const pruneId of idsToPrune) {
+        delete this.cache[pruneId]
+      }
+      this.keys.splice(0, pruneCount)
+    }
+    if (!this.cache[key]) {
+      this.keys.push(key)
+    }
+    this.cache[key] = val
+  }
+
+  /**
+   * Returns true if a value existed and was deleted, returns false otherwise.
+   */
+  delete(key: string): boolean {
+    const existed = !!this.cache[key]
+    delete this.cache[key]
+    return existed
+  }
+}

--- a/core/src/config/provider.ts
+++ b/core/src/config/provider.ts
@@ -27,6 +27,7 @@ import { environmentStatusSchema } from "./status"
 import { DashboardPage, dashboardPagesSchema } from "../plugin/handlers/Provider/getDashboardPage"
 import type { ActionState } from "../actions/types"
 import { ValidResultType } from "../tasks/base"
+import { uuidv4 } from "../util/random"
 
 export interface BaseProviderConfig {
   name: string
@@ -64,6 +65,7 @@ export const providerConfigBaseSchema = memoize(() =>
 
 export interface Provider<T extends BaseProviderConfig = BaseProviderConfig> extends ValidResultType {
   name: string
+  uid: string // This is generated at creatinon time, and is intended for use by plugins e.g. for caching purposes.
   dependencies: { [name: string]: Provider }
   environments?: string[]
   moduleConfigs: ModuleConfig[]
@@ -81,6 +83,7 @@ export const providerSchema = createSchema({
     dependencies: joiIdentifierMap(joi.link("..."))
       .description("Map of all the providers that this provider depends on.")
       .required(),
+    uid: joi.string().required().meta({ internal: true }),
     config: providerConfigBaseSchema().required(),
     moduleConfigs: joiArray(moduleConfigSchema().optional()),
     status: environmentStatusSchema(),
@@ -99,6 +102,7 @@ export const defaultProviders = [{ name: "container" }]
 // this is used for default handlers in the action handler
 export const defaultProvider: Provider = {
   name: "_default",
+  uid: uuidv4(),
   dependencies: {},
   moduleConfigs: [],
   state: "ready",
@@ -123,6 +127,7 @@ export function providerFromConfig({
 }): Provider {
   return {
     name: config.name,
+    uid: uuidv4(),
     dependencies,
     moduleConfigs,
     config,

--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -49,7 +49,7 @@ export const getBuildkitBuildStatus: BuildStatusHandler = async (params) => {
   const provider = k8sCtx.provider
 
   const api = await KubeApi.factory(log, ctx, provider)
-  const namespace = (await getNamespaceStatus({ log, ctx, provider })).namespaceName
+  const namespace = (await getNamespaceStatus({ log, ctx: k8sCtx, provider })).namespaceName
 
   const { authSecret } = await ensureBuildkit({
     ctx,
@@ -74,10 +74,11 @@ export const getBuildkitBuildStatus: BuildStatusHandler = async (params) => {
 export const buildkitBuildHandler: BuildHandler = async (params) => {
   const { ctx, action, log } = params
   const spec = action.getSpec()
+  const k8sCtx = ctx as KubernetesPluginContext
 
   const provider = <KubernetesProvider>ctx.provider
   const api = await KubeApi.factory(log, ctx, provider)
-  const namespace = (await getNamespaceStatus({ log, ctx, provider })).namespaceName
+  const namespace = (await getNamespaceStatus({ log, ctx: k8sCtx, provider })).namespaceName
 
   await ensureBuildkit({
     ctx,
@@ -94,7 +95,7 @@ export const buildkitBuildHandler: BuildHandler = async (params) => {
 
   const { contextPath } = await syncToBuildSync({
     ...params,
-    ctx: ctx as KubernetesPluginContext,
+    ctx: k8sCtx,
     api,
     namespace,
     deploymentName: buildkitDeploymentName,

--- a/core/src/plugins/kubernetes/jib-container.ts
+++ b/core/src/plugins/kubernetes/jib-container.ts
@@ -60,6 +60,7 @@ export const k8sJibContainerBuildExtension = (): BuildActionExtension<ContainerB
 
 async function buildAndPushViaRemote(params: BuildActionParams<"build", ContainerBuildAction>) {
   const { ctx, log, action, base } = params
+  const k8sCtx = ctx as KubernetesPluginContext
 
   const provider = <KubernetesProvider>ctx.provider
   let buildMode = provider.config.buildMode
@@ -79,7 +80,7 @@ async function buildAndPushViaRemote(params: BuildActionParams<"build", Containe
   // Push to util or buildkit deployment on remote, and push to registry from there to make sure auth/access is
   // consistent with normal image pushes.
   const api = await KubeApi.factory(log, ctx, provider)
-  const namespace = (await getNamespaceStatus({ log, ctx, provider })).namespaceName
+  const namespace = (await getNamespaceStatus({ log, ctx: k8sCtx, provider })).namespaceName
 
   const tempDir = await makeTempDir()
 
@@ -124,7 +125,7 @@ async function buildAndPushViaRemote(params: BuildActionParams<"build", Containe
     // Sync the archive to the remote
     const { dataPath } = await syncToBuildSync({
       ...params,
-      ctx: ctx as KubernetesPluginContext,
+      ctx: k8sCtx,
       api,
       namespace,
       deploymentName,

--- a/core/src/plugins/kubernetes/kubernetes.ts
+++ b/core/src/plugins/kubernetes/kubernetes.ts
@@ -97,7 +97,7 @@ export async function debugInfo({ ctx, log, includeProject }: GetDebugInfoParams
     .createLog({ name: ctx.provider.name, showDuration: true })
     .info("collecting provider configuration")
 
-  const systemNamespace = await getSystemNamespace(ctx, provider, log)
+  const systemNamespace = await getSystemNamespace(k8sCtx, provider, log)
   const systemMetadataNamespace = getSystemMetadataNamespaceName(provider.config)
 
   const namespacesList = [systemNamespace, systemMetadataNamespace]

--- a/core/src/plugins/kubernetes/namespace.ts
+++ b/core/src/plugins/kubernetes/namespace.ts
@@ -8,7 +8,6 @@
 
 import { intersection, cloneDeep } from "lodash"
 
-import type { PluginContext } from "../../plugin-context"
 import { KubeApi, KubernetesError } from "./api"
 import type { KubernetesProvider, KubernetesPluginContext, NamespaceConfig } from "./config"
 import { DeploymentError, TimeoutError } from "../../exceptions"
@@ -24,21 +23,31 @@ import chalk from "chalk"
 import type { NamespaceStatus } from "../../types/namespace"
 import type { KubernetesServerResource, SupportedRuntimeAction } from "./types"
 import type { Resolved } from "../../actions/types"
+import { BoundedCache } from "../../cache"
+import AsyncLock from "async-lock"
 
 const GARDEN_VERSION = getPackageVersion()
 
-const cache: {
-  [name: string]: {
-    status: "pending" | "created"
-    resource?: KubernetesServerResource<V1Namespace>
-  }
-} = {}
+interface NamespaceCacheForProvider {
+    [namespaceName: string]: {
+      status: "pending" | "created"
+      resource?: KubernetesServerResource<V1Namespace>
+    }
+}
+
+// TODO: Provide a cache via the `PluginContext` instead. Let's think about that once we have 1-2 more
+// motivating use-cases before we settle on the shape.
+const nsCache = new BoundedCache<NamespaceCacheForProvider>(50)
 
 interface EnsureNamespaceResult {
   remoteResource?: KubernetesServerResource<V1Namespace>
   patched: boolean
   created: boolean
 }
+
+// To prevent race conditions when two `ensureNamespace` calls attempt to create the namespace simultaneously
+// (which can happen e.g. during deploys after a `delete namespace` command in an interactive session).
+const nsCreationLock = new AsyncLock()
 
 /**
  * Makes sure the given namespace exists and has the configured annotations and labels.
@@ -47,67 +56,73 @@ interface EnsureNamespaceResult {
  */
 export async function ensureNamespace(
   api: KubeApi,
+  ctx: KubernetesPluginContext,
   namespace: NamespaceConfig,
   log: Log
 ): Promise<EnsureNamespaceResult> {
-  const result: EnsureNamespaceResult = { patched: false, created: false }
+  let result: EnsureNamespaceResult = { patched: false, created: false }
+  await nsCreationLock.acquire(namespace.name, async () => {
+    const providerUid = ctx.provider.uid
+    const cache = nsCache.get(providerUid) || {}
 
-  if (!cache[namespace.name] || namespaceNeedsUpdate(cache[namespace.name].resource!, namespace)) {
-    cache[namespace.name] = { status: "pending" }
+    if (!cache[namespace.name] || namespaceNeedsUpdate(cache[namespace.name].resource!, namespace)) {
+      cache[namespace.name] = { status: "pending" }
 
-    // Get the latest remote namespace list
-    const namespacesStatus = await api.core.listNamespace()
+      // Get the latest remote namespace list
+      const namespacesStatus = await api.core.listNamespace()
 
-    for (const n of namespacesStatus.items) {
-      if (n.status.phase === "Active") {
-        cache[n.metadata.name] = { status: "created", resource: n }
+      for (const n of namespacesStatus.items) {
+        if (n.status.phase === "Active") {
+          cache[n.metadata.name] = { status: "created", resource: n }
+        }
+        if (n.metadata.name === namespace.name) {
+          result.remoteResource = n
+        }
       }
-      if (n.metadata.name === namespace.name) {
-        result.remoteResource = n
-      }
-    }
 
-    if (cache[namespace.name].status !== "created") {
-      log.verbose("Creating namespace " + namespace.name)
-      try {
-        result.remoteResource = await api.core.createNamespace({
-          apiVersion: "v1",
-          kind: "Namespace",
-          metadata: {
-            name: namespace.name,
-            annotations: {
-              [gardenAnnotationKey("generated")]: "true",
-              [gardenAnnotationKey("version")]: GARDEN_VERSION,
-              ...(namespace.annotations || {}),
+      if (cache[namespace.name].status !== "created") {
+        log.verbose("Creating namespace " + namespace.name)
+        try {
+          result.remoteResource = await api.core.createNamespace({
+            apiVersion: "v1",
+            kind: "Namespace",
+            metadata: {
+              name: namespace.name,
+              annotations: {
+                [gardenAnnotationKey("generated")]: "true",
+                [gardenAnnotationKey("version")]: GARDEN_VERSION,
+                ...(namespace.annotations || {}),
+              },
+              labels: namespace.labels,
             },
-            labels: namespace.labels,
-          },
-        })
-        result.created = true
-      } catch (error) {
-        throw new KubernetesError(
-          `Namespace ${namespace.name} doesn't exist and Garden was unable to create it. You may need to create it manually or ask an administrator to do so.`,
-          { error }
-        )
+          })
+          result.created = true
+        } catch (error) {
+          throw new KubernetesError(
+            `Namespace ${namespace.name} doesn't exist and Garden was unable to create it. You may need to create it manually or ask an administrator to do so.`,
+            { error }
+          )
+        }
+      } else if (namespaceNeedsUpdate(result.remoteResource, namespace)) {
+        // Make sure annotations and labels are set correctly if the namespace already exists
+        log.verbose("Updating annotations and labels on namespace " + namespace.name)
+        try {
+          result.remoteResource = await api.core.patchNamespace(namespace.name, {
+            metadata: {
+              annotations: namespace.annotations,
+              labels: namespace.labels,
+            },
+          })
+          result.patched = true
+        } catch {
+          log.warn(chalk.yellow(`Unable to apply the configured annotations and labels on namespace ${namespace.name}`))
+        }
       }
-    } else if (namespaceNeedsUpdate(result.remoteResource, namespace)) {
-      // Make sure annotations and labels are set correctly if the namespace already exists
-      log.verbose("Updating annotations and labels on namespace " + namespace.name)
-      try {
-        result.remoteResource = await api.core.patchNamespace(namespace.name, {
-          metadata: {
-            annotations: namespace.annotations,
-            labels: namespace.labels,
-          },
-        })
-        result.patched = true
-      } catch {
-        log.warn(chalk.yellow(`Unable to apply the configured annotations and labels on namespace ${namespace.name}`))
-      }
-    }
 
-    cache[namespace.name] = { status: "created", resource: result.remoteResource }
-  }
+      cache[namespace.name] = { status: "created", resource: result.remoteResource }
+      nsCache.set(providerUid, cache)
+    }
+  })
 
   return result
 }
@@ -123,8 +138,9 @@ function namespaceNeedsUpdate(resource: KubernetesServerResource<V1Namespace> | 
 /**
  * Returns `true` if the namespace exists, `false` otherwise.
  */
-export async function namespaceExists(api: KubeApi, name: string): Promise<boolean> {
-  if (cache[name]) {
+export async function namespaceExists(api: KubeApi, ctx: KubernetesPluginContext, name: string): Promise<boolean> {
+  const cache = nsCache.get(ctx.provider.uid)
+  if (cache && cache[name]) {
     return true
   }
 
@@ -143,7 +159,7 @@ export async function namespaceExists(api: KubeApi, name: string): Promise<boole
 interface GetNamespaceParams {
   log: Log
   override?: NamespaceConfig
-  ctx: PluginContext
+  ctx: KubernetesPluginContext
   provider: KubernetesProvider
   skipCreate?: boolean
 }
@@ -165,7 +181,7 @@ export async function getNamespaceStatus({
 
   const api = await KubeApi.factory(log, ctx, provider)
   if (!skipCreate) {
-    await ensureNamespace(api, namespace, log)
+    await ensureNamespace(api, ctx, namespace, log)
     return {
       pluginName: provider.name,
       namespaceName: namespace.name,
@@ -175,13 +191,13 @@ export async function getNamespaceStatus({
     return {
       pluginName: provider.name,
       namespaceName: namespace.name,
-      state: (await namespaceExists(api, namespace.name)) ? "ready" : "missing",
+      state: (await namespaceExists(api, ctx, namespace.name)) ? "ready" : "missing",
     }
   }
 }
 
 export async function getSystemNamespace(
-  ctx: PluginContext,
+  ctx: KubernetesPluginContext,
   provider: KubernetesProvider,
   log: Log,
   api?: KubeApi
@@ -191,12 +207,12 @@ export async function getSystemNamespace(
   if (!api) {
     api = await KubeApi.factory(log, ctx, provider)
   }
-  await ensureNamespace(api, namespace, log)
+  await ensureNamespace(api, ctx, namespace, log)
 
   return namespace.name
 }
 
-export async function getAppNamespace(ctx: PluginContext, log: Log, provider: KubernetesProvider): Promise<string> {
+export async function getAppNamespace(ctx: KubernetesPluginContext, log: Log, provider: KubernetesProvider): Promise<string> {
   const status = await getNamespaceStatus({
     log,
     ctx,
@@ -206,7 +222,7 @@ export async function getAppNamespace(ctx: PluginContext, log: Log, provider: Ku
 }
 
 export async function getAppNamespaceStatus(
-  ctx: PluginContext,
+  ctx: KubernetesPluginContext,
   log: Log,
   provider: KubernetesProvider
 ): Promise<NamespaceStatus> {
@@ -220,6 +236,10 @@ export async function getAppNamespaceStatus(
 export async function getAllNamespaces(api: KubeApi): Promise<string[]> {
   const allNamespaces = await api.core.listNamespace()
   return allNamespaces.items.map((n) => n.metadata.name)
+}
+
+export function clearNamespaceCache(provider: KubernetesProvider) {
+  nsCache.delete(provider.uid)
 }
 
 /**

--- a/core/src/plugins/kubernetes/port-forward.ts
+++ b/core/src/plugins/kubernetes/port-forward.ts
@@ -198,7 +198,7 @@ export async function getPortForwardHandler(params: {
   let namespace = params.namespace
 
   if (!namespace) {
-    namespace = await getAppNamespace(ctx, log, provider)
+    namespace = await getAppNamespace(ctx as KubernetesPluginContext, log, provider)
   }
 
   const targetResource = getTargetResourceName(action, targetName)

--- a/core/src/plugins/kubernetes/run-results.ts
+++ b/core/src/plugins/kubernetes/run-results.ts
@@ -82,7 +82,7 @@ interface StoreTaskResultParams {
 export async function storeRunResult({ ctx, log, action, result }: StoreTaskResultParams): Promise<RunResult> {
   const provider = <KubernetesProvider>ctx.provider
   const api = await KubeApi.factory(log, ctx, provider)
-  const namespace = await getAppNamespace(ctx, log, provider)
+  const namespace = await getAppNamespace(ctx as KubernetesPluginContext, log, provider)
 
   // FIXME: We should store the logs separately, because of the 1MB size limit on ConfigMaps.
   const data = trimRunOutput(result)
@@ -120,7 +120,7 @@ export async function clearRunResult({
 }): Promise<void> {
   const provider = <KubernetesProvider>ctx.provider
   const api = await KubeApi.factory(log, ctx, provider)
-  const namespace = await getAppNamespace(ctx, log, provider)
+  const namespace = await getAppNamespace(ctx as KubernetesPluginContext, log, provider)
 
   const key = getRunResultKey(ctx, action)
 

--- a/core/src/plugins/kubernetes/status/status.ts
+++ b/core/src/plugins/kubernetes/status/status.ts
@@ -523,7 +523,8 @@ export async function getDeployedResource<ResourceKind extends KubernetesObject>
   log: Log
 ): Promise<KubernetesResource<ResourceKind> | null> {
   const api = await KubeApi.factory(log, ctx, provider)
-  const namespace = resource.metadata?.namespace || (await getAppNamespace(ctx, log, provider))
+  const k8sCtx = ctx as KubernetesPluginContext
+  const namespace = resource.metadata?.namespace || (await getAppNamespace(k8sCtx, log, provider))
 
   try {
     const res = await api.readBySpec({ namespace, manifest: resource, log })

--- a/core/test/integ/src/plugins/kubernetes/api.ts
+++ b/core/test/integ/src/plugins/kubernetes/api.ts
@@ -8,7 +8,7 @@
 
 import { Garden } from "../../../../../src/garden"
 import { Provider } from "../../../../../src/config/provider"
-import { KubernetesConfig } from "../../../../../src/plugins/kubernetes/config"
+import { KubernetesConfig, KubernetesPluginContext } from "../../../../../src/plugins/kubernetes/config"
 import { KubeApi } from "../../../../../src/plugins/kubernetes/api"
 import { getDataDir, makeTestGarden } from "../../../../helpers"
 import { getAppNamespace } from "../../../../../src/plugins/kubernetes/namespace"
@@ -35,7 +35,7 @@ describe("KubeApi", () => {
     provider = (await garden.resolveProvider(garden.log, "local-kubernetes")) as Provider<KubernetesConfig>
     ctx = await garden.getPluginContext({ provider, templateContext: undefined, events: undefined })
     api = await KubeApi.factory(garden.log, ctx, provider)
-    namespace = await getAppNamespace(ctx, garden.log, provider)
+    namespace = await getAppNamespace(ctx as KubernetesPluginContext, garden.log, provider)
   })
 
   after(async () => {

--- a/core/test/integ/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/build/buildkit.ts
@@ -7,7 +7,7 @@
  */
 
 import { getContainerTestGarden } from "../container"
-import { ClusterBuildkitCacheConfig, KubernetesProvider } from "../../../../../../../src/plugins/kubernetes/config"
+import { ClusterBuildkitCacheConfig, KubernetesPluginContext, KubernetesProvider } from "../../../../../../../src/plugins/kubernetes/config"
 import { Garden } from "../../../../../../../src"
 import { PluginContext } from "../../../../../../../src/plugin-context"
 import {
@@ -46,7 +46,7 @@ grouped("cluster-buildkit").describe("ensureBuildkit", () => {
     provider = <KubernetesProvider>await garden.resolveProvider(garden.log, "local-kubernetes")
     ctx = await garden.getPluginContext({ provider, templateContext: undefined, events: undefined })
     api = await KubeApi.factory(garden.log, ctx, provider)
-    namespace = (await getNamespaceStatus({ log: garden.log, ctx, provider })).namespaceName
+    namespace = (await getNamespaceStatus({ log: garden.log, ctx: ctx as KubernetesPluginContext, provider })).namespaceName
   })
 
   after(async () => {

--- a/core/test/integ/src/plugins/kubernetes/container/ingress.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/ingress.ts
@@ -25,6 +25,7 @@ import { PartialBy } from "../../../../../../src/util/util"
 import { Resolved } from "../../../../../../src/actions/types"
 import { actionFromConfig } from "../../../../../../src/graph/actions"
 import { DeployAction } from "../../../../../../src/actions/deploy"
+import { uuidv4 } from "../../../../../../src/util/random"
 
 const namespace = "my-namespace"
 const ports = [
@@ -316,6 +317,7 @@ describe("createIngressResources", () => {
 
     basicProvider = {
       name: "kubernetes",
+      uid: uuidv4(),
       config: { ...basicConfig, context },
       dependencies: {},
       moduleConfigs: [],
@@ -327,6 +329,7 @@ describe("createIngressResources", () => {
 
     multiTlsProvider = {
       name: "kubernetes",
+      uid: uuidv4(),
       config: { ...multiTlsConfig, context },
       dependencies: {},
       moduleConfigs: [],
@@ -338,6 +341,7 @@ describe("createIngressResources", () => {
 
     singleTlsProvider = {
       name: "kubernetes",
+      uid: uuidv4(),
       config: { ...singleTlsConfig, context },
       dependencies: {},
       moduleConfigs: [],
@@ -541,6 +545,7 @@ describe("createIngressResources", () => {
 
     const provider: KubernetesProvider = {
       name: "kubernetes",
+      uid: uuidv4(),
       config: {
         ...basicConfig,
         context,
@@ -579,6 +584,7 @@ describe("createIngressResources", () => {
 
     const provider: KubernetesProvider = {
       name: "kubernetes",
+      uid: uuidv4(),
       config: {
         ...basicConfig,
         context,
@@ -619,6 +625,7 @@ describe("createIngressResources", () => {
 
     const provider: KubernetesProvider = {
       name: "kubernetes",
+      uid: uuidv4(),
       config: {
         ...basicConfig,
         context,
@@ -684,6 +691,7 @@ describe("createIngressResources", () => {
 
     const provider: KubernetesProvider = {
       name: "kubernetes",
+      uid: uuidv4(),
       config: {
         ...basicConfig,
         context,

--- a/core/test/integ/src/plugins/kubernetes/namespace.ts
+++ b/core/test/integ/src/plugins/kubernetes/namespace.ts
@@ -10,7 +10,7 @@ import { randomString, gardenAnnotationKey } from "../../../../../src/util/strin
 import { KubeApi } from "../../../../../src/plugins/kubernetes/api"
 import { getDataDir, makeTestGarden } from "../../../../helpers"
 import { Provider } from "../../../../../src/config/provider"
-import { KubernetesConfig } from "../../../../../src/plugins/kubernetes/config"
+import { KubernetesConfig, KubernetesPluginContext } from "../../../../../src/plugins/kubernetes/config"
 import { ensureNamespace } from "../../../../../src/plugins/kubernetes/namespace"
 import { Log } from "../../../../../src/logger/log-entry"
 import { expect } from "chai"
@@ -18,6 +18,7 @@ import { getPackageVersion } from "../../../../../src/util/util"
 
 describe("ensureNamespace", () => {
   let api: KubeApi
+  let ctx: KubernetesPluginContext
   let log: Log
   let namespaceName: string
 
@@ -25,7 +26,7 @@ describe("ensureNamespace", () => {
     const root = getDataDir("test-projects", "container")
     const garden = await makeTestGarden(root)
     const provider = (await garden.resolveProvider(garden.log, "local-kubernetes")) as Provider<KubernetesConfig>
-    const ctx = await garden.getPluginContext({ provider, templateContext: undefined, events: undefined })
+    ctx = <KubernetesPluginContext>await garden.getPluginContext({ provider, templateContext: undefined, events: undefined })
     log = garden.log
     api = await KubeApi.factory(log, ctx, provider)
   })
@@ -47,7 +48,7 @@ describe("ensureNamespace", () => {
       labels: { floo: "blar" },
     }
 
-    const result = await ensureNamespace(api, namespace, log)
+    const result = await ensureNamespace(api, ctx, namespace, log)
 
     const ns = result.remoteResource
 
@@ -81,7 +82,7 @@ describe("ensureNamespace", () => {
       annotations: { foo: "bar" },
     }
 
-    const result = await ensureNamespace(api, namespace, log)
+    const result = await ensureNamespace(api, ctx, namespace, log)
 
     const ns = result.remoteResource
 
@@ -111,7 +112,7 @@ describe("ensureNamespace", () => {
       labels: { floo: "blar" },
     }
 
-    const result = await ensureNamespace(api, namespace, log)
+    const result = await ensureNamespace(api, ctx, namespace, log)
 
     const ns = result.remoteResource
 
@@ -144,7 +145,7 @@ describe("ensureNamespace", () => {
       labels: { floo: "blar" },
     }
 
-    const result = await ensureNamespace(api, namespace, log)
+    const result = await ensureNamespace(api, ctx, namespace, log)
 
     expect(result.created).to.be.false
     expect(result.patched).to.be.false

--- a/core/test/unit/src/cache.ts
+++ b/core/test/unit/src/cache.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { TreeCache } from "../../../src/cache"
+import { BoundedCache, TreeCache } from "../../../src/cache"
 import { expect } from "chai"
 import { expectError } from "../../helpers"
 import { getRootLogger } from "../../../src/logger/logger"
@@ -231,6 +231,33 @@ describe("TreeCache", () => {
 
     it("should return if the specified context cannot be found", () => {
       cache.invalidateDown(log, ["bla"])
+    })
+  })
+})
+
+describe("BoundedCache", () => {
+  it("should set and retrieve a value under a given key", () => {
+    const cache = new BoundedCache<string>(100)
+    cache.set("a", "foo")
+    expect(cache.get("a")).to.eql("foo")
+    expect(cache.get("b")).to.eql(null)
+  })
+
+  it("should prune older keys when the maximum number of keys is exceeded", () => {
+    const maxCount = 10
+    const cache = new BoundedCache<string>(maxCount)
+    for (let i = 0; i < maxCount + 1; i++) {
+      cache.set(`${i}`, `val#${i}`)
+    }
+    // We expect the first 5 keys to have been removed.
+    expect(cache["keys"]).to.eql(["5", "6", "7", "8", "9", "10"])
+    expect(cache["cache"]).to.eql({
+      "5": "val#5",
+      "6": "val#6",
+      "7": "val#7",
+      "8": "val#8",
+      "9": "val#9",
+      "10": "val#10",
     })
   })
 })

--- a/core/test/unit/src/plugins/kubernetes/init.ts
+++ b/core/test/unit/src/plugins/kubernetes/init.ts
@@ -23,6 +23,7 @@ import { V1IngressClass, V1Secret } from "@kubernetes/client-node"
 import { PluginContext } from "../../../../../src/plugin-context"
 import { kubectlSpec } from "../../../../../src/plugins/kubernetes/kubectl"
 import { PluginTool } from "../../../../../src/util/ext-tools"
+import { uuidv4 } from "../../../../../src/util/random"
 
 const basicConfig: KubernetesConfig = {
   name: "kubernetes",
@@ -65,6 +66,7 @@ const basicConfig: KubernetesConfig = {
 
 const basicProvider: KubernetesProvider = {
   name: "kubernetes",
+  uid: uuidv4(),
   config: basicConfig,
   dependencies: {},
   moduleConfigs: [],


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Because the `delete namespace` command can be called interactively (which deletes the default app namespace), and because of the `reload` command, we needed a different approach to caching namespace statuses in the Kubernetes plugin.

The new approach scopes the cache by provider UID, and clears the cache for a given provider UID if the `delete namespace` command is called.

We also introduced an async lock to the `ensureNamespace` helper, since the first `deploy` command after a `delete namespace` command can result in more than one concurrent `ensureNamespace` call for the same namespace.

**Which issue(s) this PR fixes**:

Fixes #4223.

**Special notes for your reviewer**:

As noted in one of the comments, we may want to provide a cache to all plugin handlers via the plugin context. We should probably come up with one or two more motivating examples before we dive into that, but it's something to keep in mind for the future.