### PR TITLE
chore: improve error for when ns in terminating

### DIFF
--- a/core/src/plugins/kubernetes/namespace.ts
+++ b/core/src/plugins/kubernetes/namespace.ts
@@ -77,6 +77,13 @@ export async function ensureNamespace(
         }
         if (n.metadata.name === namespace.name) {
           result.remoteResource = n
+          if (n.status.phase === "Terminating") {
+            throw new KubernetesError(
+              dedent`Namespace "${n.metadata.name}" is in "Terminating" state so Garden is unable to create it.
+            Please try again once the namespace has terminated.`,
+              {}
+            )
+          }
         }
       }
 


### PR DESCRIPTION
previously the error was

"Namespace garden-system doesn't exist and Garden was unable to create it. You may need to create it manually or ask an administrator to do so."

which is plain misleading.

I tried to implement logic that waits for the termination to complete, but the `ensureNamespace` function is called multiple times which makes it hard and I judged it not worth the effort.

This probably closes #3696