### PR TITLE
improvement(dev): handle config changes

### DIFF
--- a/core/src/commands/dev.tsx
+++ b/core/src/commands/dev.tsx
@@ -129,8 +129,6 @@ Let's get your development environment wired up.
 
     render(<Dev />, { exitOnCtrlC: false })
 
-    // TODO: detect config changes and notify user in status
-
     await super.action({ ...params, commandLine })
 
     return {}
@@ -148,6 +146,7 @@ Let's get your development environment wired up.
      */
     const cl = (this.commandLine = new CommandLine({
       garden,
+      serverCommand: this,
       log,
       commands: [...commands, new HelpCommand(), new QuitCommand(quit), new QuietCommand(), new QuiteCommand()],
       configDump: undefined, // This gets loaded later

--- a/core/src/events.ts
+++ b/core/src/events.ts
@@ -15,7 +15,6 @@ import type { Omit } from "./util/util"
 import type { AuthTokenResponse } from "./cloud/api"
 import type { RenderedActionGraph } from "./graph/config-graph"
 import type { CommandInfo } from "./plugin-context"
-import type { ActionReference } from "./config/common"
 import type { GraphResult } from "./graph/results"
 import { NamespaceStatus } from "./types/namespace"
 import { BuildState, BuildStatusForEventPayload } from "./plugin/handlers/Build/get-status"
@@ -138,26 +137,15 @@ export interface Events {
   sessionCancelled: {} // Command exited because of an interrupt signal (e.g. CTRL-C)
 
   // Watcher events
-  configAdded: {
-    path: string
-  }
-  configRemoved: {
-    path: string
-  }
   internalError: {
     timestamp: Date
     error: Error
   }
-  projectConfigChanged: {}
-  actionConfigChanged: {
-    names: string[]
+  // TODO: We may want to split this up into `projectConfigChanged` and `actionConfigChanged`, but we don't currently
+  // need that distinction for our purposes.
+  configChanged: {
     path: string
   }
-  actionSourcesChanged: {
-    refs: ActionReference[]
-    pathsChanged: string[]
-  }
-  actionRemoved: {}
 
   // Command/project metadata events
   commandInfo: CommandInfoPayload
@@ -270,10 +258,6 @@ export interface Events {
 
 export type EventName = keyof Events
 
-/**
- * These events indicate a request from Cloud to Core.
- */
-
 // Note: Does not include logger events.
 export const pipedEventNames: EventName[] = [
   "_exit",
@@ -283,16 +267,10 @@ export const pipedEventNames: EventName[] = [
   "sessionCompleted",
   "sessionFailed",
   "sessionCancelled",
-  "configAdded",
-  "configRemoved",
   "internalError",
   "log",
-  "actionConfigChanged",
-  "actionRemoved",
   "commandInfo",
-  "actionSourcesChanged",
   "namespaceStatus",
-  "projectConfigChanged",
   "deployStatus",
   "stackGraph",
   "taskCancelled",

--- a/core/src/watch.ts
+++ b/core/src/watch.ts
@@ -7,83 +7,48 @@
  */
 
 import { watch, FSWatcher } from "chokidar"
-import { parse, basename, resolve } from "path"
-import { pathToCacheContext } from "./cache"
-import { GardenModule } from "./types/module"
 import { Garden } from "./garden"
 import { Log } from "./logger/log-entry"
-import { sleep } from "./util/util"
-import { some } from "lodash"
-import { isConfigFilename, matchPath } from "./util/fs"
-import Bluebird from "bluebird"
 import { InternalError } from "./exceptions"
 import { EventEmitter } from "events"
-import { Action } from "./actions/types"
-
-// How long we wait between processing added files and directories
-const DEFAULT_BUFFER_INTERVAL = 1250
-
-export type ChangeHandler = (module: GardenModule | null, configChanged: boolean) => Promise<void>
-
-type ChangeType = "added" | "changed" | "removed"
-
-interface ChangedPath {
-  type: "dir" | "file"
-  path: string
-  change: ChangeType
-}
 
 let watcher: FSWatcher | undefined
 
 /**
- * Wrapper around the Chokidar file watcher. Emits events on `garden.events` when project files are changed.
+ * Wrapper around the Chokidar file watcher. Emits events on `garden.events` when Garden config files are changed.
+ *
  * This needs to be enabled by calling the `.start()` method, and stopped with the `.stop()` method.
+ *
+ * Note: Unlike the 0.12-era Watcher, this implementation only watches a specific list of paths (not entire
+ * directories). This is done both for performance and simplicity. If we want to introduce functionality that benefits
+ * from watching all of an action's included sources, we can revisit & adapt an older version of this class from the
+ * Git history.
  */
 export class Watcher extends EventEmitter {
   private garden: Garden
   private log: Log
-  private paths: string[]
-  private skipPaths: string[]
-  private actions: Action[]
-  private bufferInterval: number = DEFAULT_BUFFER_INTERVAL
+  private configPaths: string[]
   private watcher?: FSWatcher
-  private buffer: { [path: string]: ChangedPath }
-  private running: boolean
   public ready: boolean
-  public processing: boolean
 
   constructor({
     garden,
     log,
-    paths,
-    actions,
-    skipPaths,
-    bufferInterval,
+    configPaths
   }: {
     garden: Garden
     log: Log
-    paths: string[]
-    actions: Action[]
-    skipPaths?: string[]
-    bufferInterval?: number
+    configPaths: string[]
   }) {
     super()
     this.garden = garden
     this.log = log
-    this.paths = paths
-    this.actions = actions
-    this.skipPaths = skipPaths || []
-    this.bufferInterval = bufferInterval || DEFAULT_BUFFER_INTERVAL
-    this.buffer = {}
-    this.running = false
+    this.configPaths = configPaths
     this.ready = false
-    this.processing = false
     this.start()
   }
 
   async stop() {
-    this.running = false
-
     if (this.watcher) {
       this.log.debug(`Watcher: Clearing handlers`)
       this.watcher.removeAllListeners()
@@ -96,31 +61,16 @@ export class Watcher extends EventEmitter {
   }
 
   start() {
-    this.log.debug(`Watcher: Watching paths ${this.paths.join(", ")}`)
-
-    this.running = true
+    this.log.debug(`Watcher: Watching paths ${this.configPaths.join(", ")}`)
 
     if (!this.watcher) {
-      // Collect all the configured excludes and pass to the watcher.
-      // This allows chokidar to optimize polling based on the exclusions.
-      // See https://github.com/garden-io/garden/issues/1269.
-      // TODO: see if we can extract paths from dotignore files as well (we'd have to deal with negations etc. somehow).
-      const projectExcludes = this.garden.moduleExcludePatterns.map((p) => resolve(this.garden.projectRoot, p))
-      const ignored = [...projectExcludes, ...this.skipPaths]
-      // TODO: filter paths based on module excludes as well
-      //       (requires more complex logic to handle overlapping module sources).
-      // const moduleExcludes = flatten(this.actions.map((m) => (m.exclude || []).map((p) => resolve(m.path, p))))
-
       // We keep a single instance of FSWatcher to avoid segfault issues on Mac
       if (watcher) {
         this.log.debug(`Watcher: Using existing FSWatcher`)
         this.watcher = watcher
 
-        this.log.debug(`Watcher: Ignoring paths ${ignored.join(", ")}`)
-        watcher.unwatch(ignored)
-
-        this.log.debug(`Watcher: Watch ${this.paths}`)
-        watcher.add(this.paths)
+        this.log.debug(`Watcher: Watch ${this.configPaths}`)
+        watcher.add(this.configPaths)
 
         this.ready = true
 
@@ -142,7 +92,7 @@ export class Watcher extends EventEmitter {
         }
 
         this.log.debug(`Watcher: Starting FSWatcher`)
-        this.watcher = watch(this.paths, {
+        this.watcher = watch(this.configPaths, {
           ignoreInitial: true,
           ignorePermissionErrors: true,
           persistent: true,
@@ -150,7 +100,6 @@ export class Watcher extends EventEmitter {
             stabilityThreshold: 300,
             pollInterval: 100,
           },
-          ignored,
         })
 
         if (process.platform === "darwin") {
@@ -160,11 +109,7 @@ export class Watcher extends EventEmitter {
       }
 
       this.watcher
-        .on("add", this.makeFileAddedHandler())
         .on("change", this.makeFileChangedHandler())
-        .on("unlink", this.makeFileRemovedHandler())
-        .on("addDir", this.makeDirAddedHandler())
-        .on("unlinkDir", this.makeDirRemovedHandler())
         .on("ready", () => {
           this.emit("ready")
           this.ready = true
@@ -177,255 +122,12 @@ export class Watcher extends EventEmitter {
           this.log.silly(`FSWatcher event: ${name} ${path} ${JSON.stringify(payload)}`)
         })
     }
-
-    this.processBuffer().catch((err: Error) => {
-      // Log error and restart loop
-      this.processing = false
-      this.watcher?.emit("error", err)
-      this.start()
-    })
-  }
-
-  private async processBuffer() {
-    while (this.running) {
-      this.processing = false
-      await sleep(this.bufferInterval)
-      this.processing = true
-
-      const allChanged = Object.values(this.buffer)
-      this.buffer = {}
-
-      if (allChanged.length === 0) {
-        continue
-      }
-
-      const added = allChanged.filter((c) => c.change === "added")
-      const removed = allChanged.filter((c) => c.change === "removed")
-
-      this.log.silly(`Watcher: Processing ${added.length} added and ${removed.length} removed path(s)`)
-
-      // These three checks all emit the appropriate events and then return true if configuration is affected.
-      // If configuration is affected, there is no need to proceed because that will trigger a full reload of the
-      // Garden instance.
-
-      // Check if any added file is a config file
-      if (this.checkForAddedConfig(added)) {
-        continue
-      }
-
-      // Check if any config file or module dir was removed
-      if (this.checkForRemovedConfig(removed)) {
-        continue
-      }
-
-      // Check if any directories containing config files were added
-      if (await this.checkForAddedDirWithConfig(added)) {
-        continue
-      }
-
-      // First filter actions by path prefix, and include/exclude filters if applicable
-      const applicableactions = this.actions.filter((m) => {
-        return some(allChanged, (p) => {
-          const { include, exclude } = m.getConfig()
-          return (
-            p.path.startsWith(m.basePath()) &&
-            (isConfigFilename(basename(p.path)) || matchPath(p.path, include, exclude))
-          )
-        })
-      })
-
-      // No need to proceed if no actions are affected
-      if (applicableactions.length === 0) {
-        this.log.silly(`Watcher: No applicable actions for ${allChanged.length} changed path(s)`)
-        continue
-      }
-
-      this.log.silly(`Watcher: ${applicableactions.length} applicable actions for ${allChanged.length} changed path(s)`)
-
-      // Match removed files against current file lists
-      removed.length > 0 && this.sourcesChanged(removed)
-
-      // If some actions still apply, update their file lists and match added files against those
-      this.invalidateCached(this.actions)
-      await this.updateactions()
-
-      added.length > 0 && this.sourcesChanged(added)
-    }
-
-    this.processing = false
-  }
-
-  private checkForAddedConfig(added: ChangedPath[]) {
-    for (const p of added) {
-      if (isConfigFilename(basename(p.path))) {
-        this.invalidateCached(this.actions)
-        this.garden.events.emit("configAdded", { path: p.path })
-        return true
-      }
-    }
-
-    return false
-  }
-
-  private checkForRemovedConfig(removed: ChangedPath[]) {
-    for (const p of removed) {
-      // Check if project config was removed
-      const { dir, base } = parse(p.path)
-      if (dir === this.garden.projectRoot && isConfigFilename(base)) {
-        this.garden.events.emit("projectConfigChanged", {})
-        return true
-      }
-
-      // Check if any action directory was removed
-      for (const action of this.actions) {
-        if (p.type === "dir" && action.basePath().startsWith(p.path)) {
-          // at least one module's root dir was removed
-          this.invalidateCached(this.actions)
-          this.garden.events.emit("actionRemoved", {})
-          return true
-        }
-      }
-    }
-
-    return false
-  }
-
-  private async checkForAddedDirWithConfig(added: ChangedPath[]) {
-    let dirWithConfigAdded = false
-
-    const directoryPaths = added.filter((a) => a.type === "dir").map((a) => a.path)
-
-    if (directoryPaths.length > 0) {
-      // Check added directories for new config files
-      await Bluebird.map(directoryPaths, async (path) => {
-        const configPaths = await this.garden.scanForConfigs(path)
-
-        if (configPaths.length > 0) {
-          // The added dir contains one or more garden.yml files
-          this.invalidateCached(this.actions)
-          for (const configPath of configPaths) {
-            this.garden.events.emit("configAdded", { path: configPath })
-          }
-          dirWithConfigAdded = true
-        }
-      })
-    }
-
-    return dirWithConfigAdded
-  }
-
-  private async updateactions() {
-    this.log.silly(`Watcher: Updating list of actions`)
-    const graph = await this.garden.getConfigGraph({ log: this.log, emit: false })
-    this.actions = graph.getActions()
-  }
-
-  private matchActions(paths: ChangedPath[]) {
-    return this.actions.filter((a) =>
-      some(
-        paths,
-        (p) =>
-          a.configPath() === p.path ||
-          (p.type === "file" && a.getFullVersion().files.includes(p.path)) ||
-          (p.type === "dir" && p.path.startsWith(a.basePath()))
-      )
-    )
-  }
-
-  private makeFileAddedHandler() {
-    return (path: string) => {
-      this.buffer[path] = { type: "file", path, change: "added" }
-      this.log.silly(`Watcher: File ${path} added`)
-    }
-  }
-
-  private makeFileRemovedHandler() {
-    return (path: string) => {
-      this.buffer[path] = { type: "file", path, change: "removed" }
-      this.log.silly(`Watcher: File ${path} removed`)
-    }
   }
 
   private makeFileChangedHandler() {
     return (path: string) => {
       this.log.silly(`Watcher: File ${path} modified`)
-      this.sourcesChanged([{ type: "file", path, change: "changed" }])
-    }
-  }
-
-  private makeDirAddedHandler() {
-    return (path: string) => {
-      this.buffer[path] = { type: "dir", path, change: "added" }
-      this.log.silly(`Watcher: Directory ${path} added to buffer`)
-    }
-  }
-
-  private makeDirRemovedHandler() {
-    return (path: string) => {
-      this.buffer[path] = { type: "dir", path, change: "removed" }
-      this.log.silly(`Watcher: Directory ${path} removed`)
-    }
-  }
-
-  private sourcesChanged(paths: ChangedPath[]) {
-    const changedActions = this.matchActions(paths)
-
-    this.log.silly(`Matched ${changedActions.length} actions`)
-
-    for (const { path, change } of paths) {
-      const parsed = parse(path)
-      const filename = parsed.base
-
-      const isIgnoreFile = this.garden.dotIgnoreFile === filename
-
-      if (isIgnoreFile) {
-        // TODO: check to see if the project structure actually changed after the ignore file change
-        this.invalidateCached(this.actions)
-        this.garden.events.emit("projectConfigChanged", {})
-
-        // No need to emit other events if config changed
-        return
-      }
-
-      if (isConfigFilename(filename)) {
-        this.log.silly(`Config file ${path} ${change}`)
-        this.invalidateCached(this.actions)
-
-        if (change === "changed") {
-          const changedActionConfigs = changedActions.filter((a) => a.configPath() === path)
-
-          if (changedActionConfigs.length > 0) {
-            const names = changedActionConfigs.map((m) => m.name)
-            this.garden.events.emit("actionConfigChanged", { names, path })
-          } else if (parsed.dir === this.garden.projectRoot) {
-            this.garden.events.emit("projectConfigChanged", {})
-          }
-        } else if (change === "added") {
-          this.garden.events.emit("configAdded", { path })
-        } else if (change === "removed") {
-          this.garden.events.emit("configRemoved", { path })
-        }
-
-        // No need to emit other events if config changed
-        return
-      }
-    }
-
-    if (changedActions.length > 0) {
-      const refs = changedActions.map((m) => m.reference())
-      this.invalidateCached(changedActions)
-      this.garden.events.emit("actionSourcesChanged", {
-        refs,
-        pathsChanged: paths.map((p) => p.path),
-      })
-    }
-  }
-
-  private invalidateCached(actions: Action[]) {
-    // invalidate the cache for anything attached to the module path or upwards in the directory tree
-    for (const action of actions) {
-      const cacheContext = pathToCacheContext(action.basePath())
-      this.garden.cache.invalidateUp(this.log, cacheContext)
+      this.garden.events.emit("configChanged", { path })
     }
   }
 }

--- a/core/test/unit/src/watch.ts
+++ b/core/test/unit/src/watch.ts
@@ -8,29 +8,18 @@
 
 import { resolve, join } from "path"
 import { expect } from "chai"
-import pEvent from "p-event"
-
 import {
   TestGarden,
   makeTestGarden,
-  withDefaultGlobalOpts,
-  makeExtModuleSourcesGarden,
-  resetLocalConfig,
-  makeExtProjectSourcesGarden,
   getDataDir,
 } from "../../helpers"
 import { CacheContext, pathToCacheContext } from "../../../src/cache"
-import { remove, pathExists, writeFile } from "fs-extra"
-import { LinkModuleCommand } from "../../../src/commands/link/module"
-import { LinkSourceCommand } from "../../../src/commands/link/source"
-import { sleep } from "../../../src/util/util"
-import { Garden } from "../../../src/garden"
 
 function emitEvent(garden: TestGarden, name: string, payload: any) {
   garden["watcher"]["watcher"]!.emit(name, payload)
 }
 
-describe.skip("Watcher", () => {
+describe("Watcher", () => {
   let garden: TestGarden
   let modulePath: string
   let doubleModulePath: string
@@ -43,11 +32,7 @@ describe.skip("Watcher", () => {
     doubleModulePath = resolve(garden.projectRoot, "double-module")
     includeModulePath = resolve(garden.projectRoot, "with-include")
     moduleContext = pathToCacheContext(modulePath)
-    await garden.startWatcher({
-      graph: await garden.getConfigGraph({ log: garden.log, emit: false, noCache: true }),
-      bufferInterval: 10,
-    })
-    await waitUntilReady(garden)
+    await garden.startWatcher()
   })
 
   beforeEach(async () => {
@@ -55,31 +40,9 @@ describe.skip("Watcher", () => {
     garden["watcher"]["addBuffer"] = {}
   })
 
-  afterEach(async () => {
-    // Wait for processing to complete
-    await waitForProcessing()
-  })
-
   after(async () => {
     await garden.close()
   })
-
-  async function waitUntilReady(_garden: Garden) {
-    if (_garden["watcher"].ready) {
-      return
-    }
-    return pEvent(_garden["watcher"], "ready", { timeout: 5000 })
-  }
-
-  async function waitForEvent(name: string) {
-    return pEvent(<any>garden.events, name, { timeout: 5000 })
-  }
-
-  async function waitForProcessing() {
-    while (garden["watcher"].processing) {
-      await sleep(100)
-    }
-  }
 
   function getEventLog() {
     // Filter out task events, which come from module resolution
@@ -90,372 +53,9 @@ describe.skip("Watcher", () => {
     return join(path, "garden.yml")
   }
 
-  it("should emit a actionConfigChanged changed event when module config is changed", async () => {
+  it("should emit a configChanged changed event when a config is changed", async () => {
     const path = getConfigFilePath(modulePath)
     emitEvent(garden, "change", path)
-    expect(getEventLog()).to.eql([{ name: "actionConfigChanged", payload: { names: ["module-a"], path } }])
-  })
-
-  it("should emit a actionConfigChanged event when module config is changed and include field is set", async () => {
-    const path = getConfigFilePath(includeModulePath)
-    emitEvent(garden, "change", path)
-    expect(getEventLog()).to.eql([
-      {
-        name: "actionConfigChanged",
-        payload: { names: ["with-include"], path },
-      },
-    ])
-  })
-
-  it("should clear all module caches when a module config is changed", async () => {
-    const path = getConfigFilePath(modulePath)
-    emitEvent(garden, "change", path)
-    expect(garden.cache.getByContext(moduleContext)).to.eql(new Map())
-  })
-
-  it("should emit a projectConfigChanged changed event when project config is changed", async () => {
-    const path = getConfigFilePath(garden.projectRoot)
-    emitEvent(garden, "change", path)
-    expect(getEventLog()).to.eql([{ name: "projectConfigChanged", payload: {} }])
-  })
-
-  it("should emit a projectConfigChanged changed event when project config is removed", async () => {
-    const path = getConfigFilePath(garden.projectRoot)
-    emitEvent(garden, "unlink", path)
-    await waitForEvent("projectConfigChanged")
-    expect(getEventLog()).to.eql([{ name: "projectConfigChanged", payload: {} }])
-  })
-
-  it("should emit a projectConfigChanged changed event when ignore files are changed", async () => {
-    const path = join(getConfigFilePath(garden.projectRoot), ".gardenignore")
-    emitEvent(garden, "change", path)
-    expect(getEventLog()).to.eql([{ name: "projectConfigChanged", payload: {} }])
-  })
-
-  it("should clear all module caches when project config is changed", async () => {
-    const path = getConfigFilePath(garden.projectRoot)
-    emitEvent(garden, "change", path)
-    expect(garden.cache.getByContext(moduleContext)).to.eql(new Map())
-  })
-
-  it("should emit a configAdded event when adding a garden.yml file", async () => {
-    const path = getConfigFilePath(join(garden.projectRoot, "module-b"))
-    emitEvent(garden, "add", path)
-    expect(await waitForEvent("configAdded")).to.eql({ path })
-  })
-
-  it("should emit a configRemoved event when removing a garden.yml file", async () => {
-    const path = getConfigFilePath(join(garden.projectRoot, "module-a"))
-    emitEvent(garden, "unlink", path)
-    await waitForEvent("configRemoved")
-    expect(getEventLog()).to.eql([{ name: "configRemoved", payload: { path } }])
-  })
-
-  context("should emit a actionSourcesChanged event", () => {
-    it("containing the module's name when one of its files is changed", async () => {
-      const pathsChanged = [resolve(modulePath, "foo.txt")]
-      emitEvent(garden, "change", pathsChanged[0])
-      expect(getEventLog()).to.eql([
-        {
-          name: "actionSourcesChanged",
-          payload: { names: ["module-a"], pathsChanged },
-        },
-      ])
-    })
-
-    it("if a file is changed and it matches a module's include list", async () => {
-      const pathsChanged = [resolve(includeModulePath, "subdir", "foo2.txt")]
-      emitEvent(garden, "change", pathsChanged[0])
-      expect(getEventLog()).to.eql([
-        {
-          name: "actionSourcesChanged",
-          payload: { names: ["with-include"], pathsChanged },
-        },
-      ])
-    })
-
-    it("if a file is added to a module", async () => {
-      const path = resolve(modulePath, "new.txt")
-      try {
-        await writeFile(path, "foo")
-        expect(await waitForEvent("actionSourcesChanged")).to.eql({
-          names: ["module-a"],
-          pathsChanged: [path],
-        })
-      } finally {
-        const exists = await pathExists(path)
-        exists && (await remove(path))
-      }
-    })
-
-    it("containing both modules' names when a source file is changed for two co-located modules", async () => {
-      const pathsChanged = [resolve(doubleModulePath, "foo.txt")]
-      emitEvent(garden, "change", pathsChanged[0])
-      const event = getEventLog()[0]
-      event.payload.names = event.payload.names.sort()
-      expect(event).to.eql({
-        name: "actionSourcesChanged",
-        payload: { names: ["module-b", "module-c"], pathsChanged },
-      })
-    })
-  })
-
-  it("should not emit actionSourcesChanged if file is changed and matches the modules.exclude list", async () => {
-    const pathChanged = resolve(includeModulePath, "project-excluded.txt")
-    emitEvent(garden, "change", pathChanged)
-    expect(getEventLog()).to.eql([])
-  })
-
-  it("should not emit actionSourcesChanged if file is changed and doesn't match module's include list", async () => {
-    const pathChanged = resolve(includeModulePath, "foo.txt")
-    emitEvent(garden, "change", pathChanged)
-    expect(getEventLog()).to.eql([])
-  })
-
-  it("should not emit actionSourcesChanged if file is changed and it's in a gardenignore in the module", async () => {
-    const pathChanged = resolve(modulePath, "module-excluded.txt")
-    emitEvent(garden, "change", pathChanged)
-    expect(getEventLog()).to.eql([])
-  })
-
-  it("should not emit actionSourcesChanged if file is changed and it's in a gardenignore in the project", async () => {
-    const pathChanged = resolve(modulePath, "gardenignore-excluded.txt")
-    emitEvent(garden, "change", pathChanged)
-    expect(getEventLog()).to.eql([])
-  })
-
-  it("should clear a module's cache when a module file is changed", async () => {
-    const pathChanged = resolve(modulePath, "foo.txt")
-    emitEvent(garden, "change", pathChanged)
-    expect(garden.cache.getByContext(moduleContext)).to.eql(new Map())
-  })
-
-  it("should emit a configAdded event when a directory is added that contains a garden.yml file", async () => {
-    emitEvent(garden, "addDir", modulePath)
-    expect(await waitForEvent("configAdded")).to.eql({
-      path: getConfigFilePath(modulePath),
-    })
-  })
-
-  it("should emit a actionSourcesChanged event when a directory is added under a module directory", async () => {
-    const pathsChanged = [resolve(modulePath, "subdir")]
-    emitEvent(garden, "addDir", pathsChanged[0])
-    expect(await waitForEvent("actionSourcesChanged")).to.eql({
-      names: ["module-a"],
-      pathsChanged,
-    })
-  })
-
-  it("should clear a module's cache when a directory is added under a module directory", async () => {
-    const pathChanged = resolve(modulePath, "subdir")
-    emitEvent(garden, "addDir", pathChanged)
-    await waitForEvent("actionSourcesChanged")
-    expect(garden.cache.getByContext(moduleContext)).to.eql(new Map())
-  })
-
-  it("should emit a moduleRemoved event if a directory containing a module is removed", async () => {
-    emitEvent(garden, "unlinkDir", modulePath)
-    await waitForEvent("moduleRemoved")
-    expect(getEventLog()).to.eql([{ name: "moduleRemoved", payload: {} }])
-  })
-
-  it("should emit a actionSourcesChanged event if a directory within a module is removed", async () => {
-    const pathsChanged = [resolve(modulePath, "subdir")]
-    emitEvent(garden, "unlinkDir", pathsChanged[0])
-    await waitForEvent("actionSourcesChanged")
-    expect(getEventLog()).to.eql([
-      {
-        name: "actionSourcesChanged",
-        payload: { names: ["module-a"], pathsChanged },
-      },
-    ])
-  })
-
-  it("should emit a actionSourcesChanged event if a module's file is removed", async () => {
-    const pathsChanged = [resolve(modulePath, "foo.txt")]
-    emitEvent(garden, "unlink", pathsChanged[0])
-    await waitForEvent("actionSourcesChanged")
-    expect(getEventLog()).to.eql([
-      {
-        name: "actionSourcesChanged",
-        payload: { names: ["module-a"], pathsChanged },
-      },
-    ])
-  })
-
-  // Note: This is to ensure correct handling of version file lists and cache invalidation
-  it("should correctly handle removing a file and then re-adding it", async () => {
-    const pathsChanged = [resolve(modulePath, "foo.txt")]
-    emitEvent(garden, "unlink", pathsChanged[0])
-    await waitForEvent("actionSourcesChanged")
-    expect(getEventLog()).to.eql([
-      {
-        name: "actionSourcesChanged",
-        payload: { names: ["module-a"], pathsChanged },
-      },
-    ])
-
-    garden.events.eventLog = []
-
-    emitEvent(garden, "add", pathsChanged[0])
-    await waitForEvent("actionSourcesChanged")
-    expect(getEventLog()).to.eql([
-      {
-        name: "actionSourcesChanged",
-        payload: { names: ["module-a"], pathsChanged },
-      },
-    ])
-  })
-
-  context("linked module sources", () => {
-    let localModuleSourceDir: string
-    let localModulePathA: string
-    let localModulePathB: string
-
-    before(async () => {
-      await garden.close()
-
-      garden = await makeExtModuleSourcesGarden({ noCache: true })
-
-      localModuleSourceDir = garden.projectRoot
-      localModulePathA = join(localModuleSourceDir, "module-a")
-      localModulePathB = join(localModuleSourceDir, "module-b")
-
-      // Link some modules
-      const linkCmd = new LinkModuleCommand()
-      await linkCmd.action({
-        garden,
-        log: garden.log,
-        headerLog: garden.log,
-        footerLog: garden.log,
-        args: {
-          module: "module-a",
-          path: localModulePathA,
-        },
-        opts: withDefaultGlobalOpts({}),
-      })
-      await linkCmd.action({
-        garden,
-        log: garden.log,
-        headerLog: garden.log,
-        footerLog: garden.log,
-        args: {
-          module: "module-b",
-          path: localModulePathB,
-        },
-        opts: withDefaultGlobalOpts({}),
-      })
-
-      // We need to make a new instance of Garden after linking the sources
-      // This is not an issue in practice because there are specific commands just for linking
-      // so the user will always have a new instance of Garden when they run their next command.
-      garden = await makeExtModuleSourcesGarden({ noCache: true })
-      const graph = await garden.getConfigGraph({ log: garden.log, emit: false, noCache: true })
-
-      await garden.startWatcher({ graph })
-      await waitUntilReady(garden)
-    })
-
-    after(async () => {
-      await resetLocalConfig(garden.gardenDirPath)
-    })
-
-    it("should watch all linked repositories", () => {
-      const watcher = garden["watcher"]["watcher"]
-      const shouldWatch = [garden.projectRoot, localModulePathA, localModulePathB]
-      const watched = Object.keys(watcher!.getWatched())
-      expect(
-        shouldWatch.every((path) => watched.includes(path)),
-        "Watched: " + watched.join(", ")
-      ).to.be.true
-    })
-
-    it("should emit a actionSourcesChanged event when a linked module source is changed", async () => {
-      const pathsChanged = [resolve(localModulePathA, "foo.txt")]
-      emitEvent(garden, "change", pathsChanged[0])
-      await sleep(1000)
-      await waitForProcessing()
-      expect(getEventLog()).to.eql([
-        {
-          name: "actionSourcesChanged",
-          payload: { names: ["module-a"], pathsChanged },
-        },
-      ])
-    })
-  })
-
-  context("linked project sources", () => {
-    let localProjectSourceDir: string
-    let localSourcePathA: string
-    let localSourcePathB: string
-
-    before(async () => {
-      await garden.close()
-
-      garden = await makeExtProjectSourcesGarden({ noCache: true })
-
-      localProjectSourceDir = getDataDir("test-projects", "local-project-sources")
-      localSourcePathA = join(localProjectSourceDir, "source-a")
-      localSourcePathB = join(localProjectSourceDir, "source-b")
-
-      // Link some projects
-      const linkCmd = new LinkSourceCommand()
-      await linkCmd.action({
-        garden,
-        log: garden.log,
-        headerLog: garden.log,
-        footerLog: garden.log,
-        args: {
-          source: "source-a",
-          path: localSourcePathA,
-        },
-        opts: withDefaultGlobalOpts({}),
-      })
-      await linkCmd.action({
-        garden,
-        log: garden.log,
-        headerLog: garden.log,
-        footerLog: garden.log,
-        args: {
-          source: "source-b",
-          path: localSourcePathB,
-        },
-        opts: withDefaultGlobalOpts({}),
-      })
-
-      // We need to make a new instance of Garden after linking the sources
-      // This is not an issue in practice because there are specific commands just for linking
-      // so the user will always have a new instance of Garden when they run their next command.
-      garden = await makeExtProjectSourcesGarden({ noCache: true })
-      const graph = await garden.getConfigGraph({ log: garden.log, emit: false, noCache: true })
-
-      await garden.startWatcher({ graph })
-      await waitUntilReady(garden)
-    })
-
-    after(async () => {
-      await resetLocalConfig(garden.gardenDirPath)
-    })
-
-    it("should watch all linked repositories", () => {
-      const watcher = garden["watcher"]["watcher"]
-      const shouldWatch = [garden.projectRoot, localSourcePathA, localSourcePathB]
-      const watched = Object.keys(watcher!.getWatched())
-      expect(
-        shouldWatch.every((path) => watched.includes(path)),
-        "Watched: " + watched.join(", ")
-      ).to.be.true
-    })
-
-    it("should emit a actionSourcesChanged event when a linked project source is changed", async () => {
-      const pathsChanged = [resolve(localProjectSourceDir, "source-a", "module-a", "foo.txt")]
-      emitEvent(garden, "change", pathsChanged[0])
-      expect(getEventLog()).to.eql([
-        {
-          name: "actionSourcesChanged",
-          payload: { names: ["module-a"], pathsChanged },
-        },
-      ])
-    })
+    expect(getEventLog()).to.eql([{ name: "configChanged", payload: { path } }])
   })
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

If one or more Garden configs is changed during a `dev` command, we lazily reload the project when the next command is run.

This approach avoids multiple reloads when the user is modifying their Garden configs.

The old Watcher class was reduced down to its bare essentials for this purpose (up to this point, it had been unused in 0.13).

**Which issue(s) this PR fixes**:

Fixes #4213.