### PR TITLE
fix(core): improve event listener cleanup

### DIFF
--- a/core/src/cli/command-line.ts
+++ b/core/src/cli/command-line.ts
@@ -719,6 +719,7 @@ ${chalk.white.underline("Keys:")}
         this.flashError(getCmdFailMsg(name))
       })
       .finally(() => {
+        this.garden.events.clearKey(this.garden.sessionId)
         delete this.runningCommands[id]
         this.renderStatus()
       })

--- a/core/src/server/server.ts
+++ b/core/src/server/server.ts
@@ -270,6 +270,7 @@ export class GardenServer extends EventEmitter {
         args,
         opts,
       })
+      this.garden.events.clearKey(this.garden.sessionId)
 
       if (result.errors?.length) {
         throw result.errors[0]

--- a/core/test/unit/src/events.ts
+++ b/core/test/unit/src/events.ts
@@ -6,6 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import { range } from "lodash"
 import { EventBus } from "../../../src/events"
 import { expect } from "chai"
 
@@ -43,6 +44,63 @@ describe("EventBus", () => {
       })
       events.emit("_test", "foo")
       events.emit("_test", "bar")
+    })
+  })
+
+  describe("onKey", () => {
+    it("should add a listener under the specified key", (done) => {
+      const key = "gandalf"
+      events.onKey("_test", (payload) => {
+        expect(payload).to.equal("foo")
+        expect(events["keyIndex"][key]["_test"].length).to.eql(1)
+        done()
+      }, key)
+      events.emit("_test", "foo")
+    })
+  })
+
+  describe("offKey", () => {
+    it("should remove all listeners with the specified key and name", () => {
+      const key = "gandalf"
+      const otherKey = "blob"
+      for (const _i of range(3)) {
+        events.onKey("_test", () => {}, key)
+        events.onKey("_restart", () => {}, key)
+
+        events.onKey("_test", () => {}, otherKey)
+        events.onKey("_restart", () => {}, otherKey)
+      }
+      expect(events.listenerCount()).to.eql(12)
+      events.offKey("_test", key)
+      expect(events.listenerCount()).to.eql(9)
+      expect(events["keyIndex"][key]["_test"]).to.be.undefined
+
+      // We expect the index for other key + name combinations to be the same.
+      expect(events["keyIndex"][key]["_restart"].length).to.eql(3)
+      expect(events["keyIndex"][otherKey]["_test"].length).to.eql(3)
+      expect(events["keyIndex"][otherKey]["_restart"].length).to.eql(3)
+    })
+  })
+
+  describe("clearKey", () => {
+    it("should remove all listeners with the specified key", () => {
+      const key = "gandalf"
+      const otherKey = "blob"
+      for (const _i of range(3)) {
+        events.onKey("_test", () => {}, key)
+        events.onKey("_restart", () => {}, key)
+
+        events.onKey("_test", () => {}, otherKey)
+        events.onKey("_restart", () => {}, otherKey)
+      }
+      expect(events.listenerCount()).to.eql(12)
+      events.clearKey(key)
+      expect(events.listenerCount()).to.eql(6)
+      expect(events["keyIndex"][key]).to.be.undefined
+
+      // We expect the index for the other key to be the same.
+      expect(events["keyIndex"][otherKey]["_test"].length).to.eql(3)
+      expect(events["keyIndex"][otherKey]["_restart"].length).to.eql(3)
     })
   })
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Closes https://github.com/garden-io/garden/issues/4186.

Before this fix, we weren't removing event listeners registered by the plugin event brokers (mostly for the `_exit` and `_restart` control events).

This is now done in a simple way via the new `onKey`  and `clearKey` methods on the event bus, which facilitates removing all listeners matching a given key.

We use `garden.sessionId` as the key now, which is not quite ideal when running concurrent commands in `garden dev`, but we'll be assigning a command-unique `sessionId` in an upcoming PR (which gives us precisely the semantics we want here).


**Which issue(s) this PR fixes**:

Fixes #4186 and #2422.