### PR TITLE
Add "sync status" command

### DIFF
--- a/core/src/commands/logs.ts
+++ b/core/src/commands/logs.ts
@@ -183,7 +183,7 @@ export class LogsCommand extends Command<Args, Opts> {
 
     const resolvedActions = await garden.resolveActions({ actions, graph, log })
 
-    const monitors = await Bluebird.map(Object.values(resolvedActions), async (action) => {
+    const monitors = Object.values(resolvedActions).map((action) => {
       return new LogMonitor({
         garden,
         log,

--- a/core/src/commands/sync/sync-status.ts
+++ b/core/src/commands/sync/sync-status.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2018-2023 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import Bluebird from "bluebird"
+import chalk from "chalk"
+
+import { StringsParameter } from "../../cli/params"
+import { joi } from "../../config/common"
+import { printHeader } from "../../logger/util"
+import { dedent, deline, naturalList } from "../../util/string"
+import { Command, CommandParams } from "../base"
+import { createActionLog } from "../../logger/log-entry"
+import { PluginEventBroker } from "../../plugin-context"
+import { resolvedActionToExecuted } from "../../actions/helpers"
+import { GetSyncStatusResult } from "../../plugin/handlers/Deploy/get-sync-status"
+import { isEmpty } from "lodash"
+
+const syncStatusArgs = {
+  names: new StringsParameter({
+    help: deline`
+      The name(s) of the Deploy(s) to get the sync status for (skip to get status from
+      all Deploys in the project). You may specify multiple names, separated by space.
+    `,
+    required: false,
+    spread: true,
+    getSuggestions: ({ configDump }) => {
+      return Object.keys(configDump.actionConfigs.Deploy)
+    },
+  }),
+}
+type Args = typeof syncStatusArgs
+
+interface SyncStatusCommandResult {
+  result: {
+    actions: {
+      [actionName: string]: GetSyncStatusResult
+    }
+  }
+}
+
+export class SyncStatusCommand extends Command<Args> {
+  name = "status"
+  help = "Get sync statuses."
+
+  protected = true
+
+  arguments = syncStatusArgs
+
+  description = dedent`
+    Get the current status of the configured syncs for this project.
+
+    Examples:
+        # get all sync statuses
+        garden sync status 
+
+        # get sync statuses for the 'api' Deploy
+        garden sync status api
+
+        # output detailed sync statuses in JSON format
+        garden sync status -o json
+
+        # output detailed sync statuses in YAML format
+        garden sync status -o yaml
+  `
+
+  outputsSchema = () => joi.object()
+
+  printHeader({ headerLog }) {
+    printHeader(headerLog, "Getting sync statuses", "📟")
+  }
+
+  async action({ garden, log, args }: CommandParams<Args>): Promise<SyncStatusCommandResult> {
+    const router = await garden.getActionRouter()
+    const graph = await garden.getResolvedConfigGraph({ log, emit: true })
+
+    const deployActions = graph
+      .getDeploys({ includeDisabled: false, names: args.names })
+      .sort((a, b) => (a.name > b.name ? 1 : -1))
+    // This is fairly arbitrary
+    const concurrency = 5
+
+    const syncStatuses: { [actionName: string]: GetSyncStatusResult } = {}
+
+    log.info("")
+    log.info(
+      chalk.white(deline`
+      Getting sync statuses. For more detailed debug information, run this command with
+      the \`--json\` or \`--yaml\` flags.
+    `)
+    )
+    log.info("")
+
+    await Bluebird.map(
+      deployActions,
+      async (action) => {
+        const events = new PluginEventBroker(garden)
+        const actionLog = createActionLog({ log, actionName: action.name, actionKind: action.kind })
+        const { result: status } = await router.deploy.getStatus({
+          graph,
+          action,
+          log: actionLog,
+        })
+        const executedAction = resolvedActionToExecuted(action, { status })
+        const syncStatus = (
+          await router.deploy.getSyncStatus({
+            log: actionLog,
+            action: executedAction,
+            monitor: false,
+            graph,
+            events,
+          })
+        ).result
+
+        const syncs = syncStatus.syncs
+        if (!syncs || syncs.length === 0) {
+          return
+        }
+
+        // Return the syncs sorted
+        const sorted = syncs.sort((a, b) => {
+          const keyA = a.source + a.targetDescription + a.mode
+          const keyB = b.source + b.targetDescription + b.mode
+          return keyA > keyB ? 1 : -1
+        })
+        syncStatus["syncs"] = sorted
+
+        const styleFn = {
+          "active": chalk.green,
+          "failed": chalk.red,
+          "not-active": chalk.yellow
+        }[syncStatus.state] || chalk.bold.dim
+
+        log.info(
+          `The ${chalk.cyan(action.name)} Deploy has ${chalk.cyan(syncStatus.syncs.length)} syncs(s) configured:`
+        )
+        const leftPad = "  →"
+        syncs.forEach((sync, idx) => {
+          log.info(
+            `${leftPad} Sync from ${chalk.cyan(sync.source)} to ${chalk.cyan(sync.targetDescription)} is ${styleFn(
+              syncStatus.state
+            )}`
+          )
+          sync.mode && log.info(chalk.bold(`${leftPad} Mode: ${sync.mode}`))
+          sync.syncCount && log.info(chalk.bold(`${leftPad} Sync count: ${sync.syncCount}`))
+          idx !== syncs.length - 1 && log.info("")
+        })
+        log.info("")
+
+        syncStatuses[action.name] = syncStatus
+      },
+      { concurrency }
+    )
+
+    if (isEmpty(syncStatuses) && args.names && args.names.length > 0) {
+      log.warn(`No syncs have been configured for the requested Deploys (${naturalList(args.names!)}).`)
+    } else if (isEmpty(syncStatuses)) {
+      log.warn(deline`
+        No syncs have been configured in this project.
+
+        Follow the link below to learn how to enable live code syncing with Garden:
+      `)
+      log.info("")
+      log.info(chalk.cyan.underline("https://docs.garden.io/guides/code-synchronization-dev-mode"))
+    }
+
+    return { result: { actions: syncStatuses } }
+  }
+}

--- a/core/src/commands/sync/sync.ts
+++ b/core/src/commands/sync/sync.ts
@@ -8,11 +8,12 @@
 
 import { CommandGroup } from "../base"
 import { SyncStartCommand } from "./sync-start"
+import { SyncStatusCommand } from "./sync-status"
 import { SyncStopCommand } from "./sync-stop"
 
 export class SyncCommand extends CommandGroup {
   name = "sync"
   help = "Manage synchronization to running actions."
 
-  subCommands = [SyncStartCommand, SyncStopCommand]
+  subCommands = [SyncStartCommand, SyncStopCommand, SyncStatusCommand]
 }

--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -724,7 +724,7 @@ interface SyncEndpoint {
   stagingProgress?: SyncReceiverStatus
 }
 
-interface SyncSession {
+export interface SyncSession {
   identifier: string
   version: number
   creationTime: string

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -3506,6 +3506,37 @@ Examples:
 
 
 
+### garden sync status
+
+**Get sync statuses.**
+
+Get the current status of the configured syncs for this project.
+
+Examples:
+    # get all sync statuses
+    garden sync status 
+
+    # get sync statuses for the 'api' Deploy
+    garden sync status api
+
+    # output detailed sync statuses in JSON format
+    garden sync status -o json
+
+    # output detailed sync statuses in YAML format
+    garden sync status -o yaml
+
+#### Usage
+
+    garden sync status [names] 
+
+#### Arguments
+
+| Argument | Required | Description |
+| -------- | -------- | ----------- |
+  | `names` | No | The name(s) of the Deploy(s) to get the sync status for (skip to get status from all Deploys in the project). You may specify multiple names, separated by space.
+
+
+
 ### garden test
 
 **Run all or specified Test actions in the project.**


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

This PR adds a command for getting the current status of all
configured syncs.

In this first iteration the command is not persistent but we may decide
to add a "--follow" or "--monitor" flag later.

The main reason I'm not doing it here is because even if we're
monitoring the sync statuses, we don't get the "sync stop" events from
Mutagen which is one of the main events we'd want to follow in the first
place.

So since sync monitoring would be incomplete and you'd need to re-run
the command to get the latest status I decided leave it out for now.

**Which issue(s) this PR fixes**:

Fixes #


**Special notes for your reviewer**:

Here's a screenshot of the output. I was feeling a little uninspired tbh, so happy to receive suggestions.

<img width="930" alt="Screenshot 2023-05-14 at 15 10 30" src="https://github.com/garden-io/garden/assets/5373776/8b73f81a-9ba7-4683-ba98-47a15c4968ba">
