### PR TITLE
fix(server): ensure ws connection is closed on Garden "_exit" event

### DIFF
--- a/core/src/server/server.ts
+++ b/core/src/server/server.ts
@@ -441,6 +441,13 @@ export class GardenServer extends EventEmitter {
       websocket.on("message", (msg: string | Buffer) => {
         this.handleWsMessage({ msg, ctx, send, connectionId })
       })
+
+      // Make sure we close the connection when Garden exits. Otherwise the
+      // Garden process may appear to hang after the user attempts to quit.
+      this.garden.events.on("_exit", () => {
+        websocket.close(1000, "Garden exited")
+      })
+
     })
 
     app.ws.use(<Koa.Middleware<any>>wsRouter.routes())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Before this fix, the dev command would appear to hang indefinitely after typing "exit" or killing the process with ctrl+c because the websocket connection wasn't closed properly.

**Which issue(s) this PR fixes**:

Fixes #4209 

**Special notes for your reviewer**:
