### PR TITLE
chore: linter fixes for core

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -247,7 +247,7 @@
     "clean": "shx rm -rf build",
     "dev": "gulp pegjs-watch",
     "fix-format": "prettier --write \"{src,test}/**/*.ts\"",
-    "lint": "eslint -c ../.eslintrc --ignore-pattern 'src/lib/**' --ext .ts src/",
+    "lint": "eslint -c ../.eslintrc --ignore-pattern 'src/lib/**' --ext .ts src/ test/",
     "migration:generate": "typeorm migration:generate --config ormconfig.js -n",
     "_integ": "mocha --config .mocharc.integ.yml",
     "integ-kind": "GARDEN_INTEG_TEST_MODE=local GARDEN_SKIP_TESTS=\"cluster-buildkit cluster-buildkit-rootless kaniko remote-only\" yarn _integ",

--- a/core/test/integ/src/plugins/kubernetes/kubernetes-module/handlers.ts
+++ b/core/test/integ/src/plugins/kubernetes/kubernetes-module/handlers.ts
@@ -75,7 +75,7 @@ describe("kubernetes-module handlers", () => {
     garden = await getKubernetesTestGarden()
     moduleConfigBackup = await garden.getRawModuleConfigs()
     log = garden.log
-    actionLog = createActionLog({ log: log, actionName: "", actionKind: "" })
+    actionLog = createActionLog({ log, actionName: "", actionKind: "" })
     const provider = <KubernetesProvider>await garden.resolveProvider(log, "local-kubernetes")
     ctx = <KubernetesPluginContext>(
       await garden.getPluginContext({ provider, templateContext: undefined, events: undefined })

--- a/core/test/integ/src/plugins/kubernetes/local-mode.ts
+++ b/core/test/integ/src/plugins/kubernetes/local-mode.ts
@@ -75,7 +75,7 @@ describe("local mode deployments and ssh tunneling behavior", () => {
       skipRuntimeDependencies: true,
     })
     await garden.processTask(task, log, {})
-    const actionLog = createActionLog({ log: log, actionName: action.name, actionKind: action.kind })
+    const actionLog = createActionLog({ log, actionName: action.name, actionKind: action.kind })
 
     const status = await pRetry(
       async () => {

--- a/core/test/integ/src/plugins/kubernetes/sync-mode.ts
+++ b/core/test/integ/src/plugins/kubernetes/sync-mode.ts
@@ -101,7 +101,7 @@ describe("sync mode deployments and sync behavior", () => {
       log: garden.log,
       graph: await garden.getConfigGraph({ log: garden.log, emit: false, actionModes: { sync: ["deploy.sync-mode"] } }),
     })
-    const actionLog = createActionLog({ log: log, actionName: action.name, actionKind: action.kind })
+    const actionLog = createActionLog({ log, actionName: action.name, actionKind: action.kind })
 
     const status = await k8sGetContainerDeployStatus({
       ctx,
@@ -165,7 +165,7 @@ describe("sync mode deployments and sync behavior", () => {
       log: garden.log,
       graph: await garden.getConfigGraph({ log: garden.log, emit: false, actionModes: { sync: ["deploy.sync-mode"] } }),
     })
-    const actionLog = createActionLog({ log: log, actionName: action.name, actionKind: action.kind })
+    const actionLog = createActionLog({ log, actionName: action.name, actionKind: action.kind })
     const status = await k8sGetContainerDeployStatus({
       ctx,
       action: resolvedAction,

--- a/core/test/unit/src/cache.ts
+++ b/core/test/unit/src/cache.ts
@@ -252,12 +252,12 @@ describe("BoundedCache", () => {
     // We expect the first 5 keys to have been removed.
     expect(cache["keys"]).to.eql(["5", "6", "7", "8", "9", "10"])
     expect(cache["cache"]).to.eql({
-      "5": "val#5",
-      "6": "val#6",
-      "7": "val#7",
-      "8": "val#8",
-      "9": "val#9",
-      "10": "val#10",
+      5: "val#5",
+      6: "val#6",
+      7: "val#7",
+      8: "val#8",
+      9: "val#9",
+      10: "val#10",
     })
   })
 })

--- a/core/test/unit/src/commands/deploy.ts
+++ b/core/test/unit/src/commands/deploy.ts
@@ -123,7 +123,7 @@ describe("DeployCommand", () => {
     "logs": false,
     "timestamps": false,
     "port": defaultServerPort,
-    "cmd": undefined
+    "cmd": undefined,
   })
 
   // TODO: Verify that services don't get redeployed when same version is already deployed.
@@ -199,7 +199,7 @@ describe("DeployCommand", () => {
       args: {
         names: ["service-b"],
       },
-      opts: defaultDeployOpts
+      opts: defaultDeployOpts,
     })
 
     if (errors) {
@@ -241,7 +241,7 @@ describe("DeployCommand", () => {
         opts: {
           ...defaultDeployOpts,
           "skip-dependencies": true,
-        }
+        },
       })
 
       if (errors) {
@@ -336,7 +336,7 @@ describe("DeployCommand", () => {
       },
       opts: {
         ...defaultDeployOpts,
-        "skip": ["service-b"],
+        skip: ["service-b"],
       },
     })
 
@@ -379,7 +379,7 @@ describe("DeployCommand", () => {
         opts: {
           ...defaultDeployOpts,
           "local-mode": [],
-        }
+        },
       })
       expect(persistent).to.be.true
     })
@@ -397,7 +397,7 @@ describe("DeployCommand", () => {
         opts: {
           ...defaultDeployOpts,
           forward: true,
-        }
+        },
       })
       expect(persistent).to.be.true
     })

--- a/core/test/unit/src/commands/get/get-config.ts
+++ b/core/test/unit/src/commands/get/get-config.ts
@@ -497,7 +497,7 @@ describe("GetConfigCommand", () => {
       })
 
       const expectedModuleConfigs = (await garden.resolveModules({ log })).map((m) => m._config)
-      const actualEnabledServiceConfig = res.result?.moduleConfigs[0].serviceConfigs[0];
+      const actualEnabledServiceConfig = res.result?.moduleConfigs[0].serviceConfigs[0]
       const expectedEnabledServiceConfig = expectedModuleConfigs[0].serviceConfigs.filter((s) => !s.disabled)[0]
 
       expect(actualEnabledServiceConfig).to.deep.equal(expectedEnabledServiceConfig)

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -3714,7 +3714,7 @@ describe("Garden", () => {
       expect(test.getInternal()).to.eql(internal)
     })
 
-    it.only("throws with helpful message if action type doesn't exist", async () => {
+    it("throws with helpful message if action type doesn't exist", async () => {
       const garden = await TestGarden.factory(pathFoo, {
         config: createProjectConfig({
           name: "test",
@@ -3737,10 +3737,7 @@ describe("Garden", () => {
       ])
 
       await expectError(() => garden.resolveModules({ log: garden.log }), {
-        contains: [
-          "Unrecognized action type 'invalidtype'",
-          "Are you missing a provider configuration?",
-        ],
+        contains: ["Unrecognized action type 'invalidtype'", "Are you missing a provider configuration?"],
       })
     })
 

--- a/core/test/unit/src/router/build.ts
+++ b/core/test/unit/src/router/build.ts
@@ -20,7 +20,6 @@ describe("build actions", () => {
   let graph: ConfigGraph
   let log: ActionLog
   let actionRouter: ActionRouter
-  // eslint-disable-next-line no-unused
   let returnWrongOutputsCfgKey: string
   let resolvedBuildAction: ResolvedBuildAction
   let module: GardenModule

--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -18,8 +18,6 @@ import { ConfigContext } from "../../../src/config/template-contexts/base"
 import { expectError } from "../../helpers"
 import { dedent } from "../../../src/util/string"
 
-/* eslint-disable no-invalid-template-strings */
-
 class TestContext extends ConfigContext {
   constructor(context) {
     super()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes missing linting for the `core/test` directory. This meant that e.g. `.only` directives were not caught, despite our intention to fail the linting on the presence of exclusive tests.

**Special notes for your reviewer**:

Previously, in `core`, we were only linting the `src/` directory. Now we will lint the `test/` directory too.
