### PR TITLE
fix: remove duplicate accessModes key from pvc provider module and action

### DIFF
--- a/core/src/plugins/base-volume.ts
+++ b/core/src/plugins/base-volume.ts
@@ -17,7 +17,7 @@ export interface BaseVolumeSpec extends ModuleSpec {
   accessModes: VolumeAccessMode[]
 }
 
-export const baseVolumeSpecKeys = () => ({
+export const accessModesSchemaKeys = () => ({
   accessModes: joi
     .sparseArray()
     .items(joi.string().allow("ReadOnlyMany", "ReadWriteOnce", "ReadWriteMany"))
@@ -35,7 +35,7 @@ export const baseVolumeSpecKeys = () => ({
 
 export const baseVolumeSpecSchema = () =>
   baseModuleSpecSchema().keys({
-    ...baseVolumeSpecKeys(),
+    ...accessModesSchemaKeys(),
   })
 
 export const gardenPlugin = () =>

--- a/core/src/plugins/kubernetes/volumes/configmap.ts
+++ b/core/src/plugins/kubernetes/volumes/configmap.ts
@@ -8,7 +8,7 @@
 
 import { joiIdentifier, joi, joiSparseArray, joiStringMap } from "../../../config/common"
 import { dedent } from "../../../util/string"
-import { BaseVolumeSpec, baseVolumeSpecKeys } from "../../base-volume"
+import { BaseVolumeSpec, accessModesSchemaKeys } from "../../base-volume"
 import { V1ConfigMap } from "@kubernetes/client-node"
 import { ModuleTypeDefinition } from "../../../plugin/plugin"
 import { baseBuildSpecSchema } from "../../../config/module"
@@ -32,7 +32,7 @@ export interface ConfigmapDeploySpec extends BaseVolumeSpec {
 }
 
 const commonSpecKeys = () => ({
-  ...baseVolumeSpecKeys(),
+  ...accessModesSchemaKeys(),
   namespace: joiIdentifier().description(
     "The namespace to deploy the ConfigMap in. Note that any module referencing the ConfigMap must be in the same namespace, so in most cases you should leave this unset."
   ),

--- a/core/src/plugins/kubernetes/volumes/persistentvolumeclaim.ts
+++ b/core/src/plugins/kubernetes/volumes/persistentvolumeclaim.ts
@@ -8,7 +8,6 @@
 
 import { joiIdentifier, joi, joiSparseArray, createSchema } from "../../../config/common"
 import { dedent } from "../../../util/string"
-import { BaseVolumeSpec, baseVolumeSpecKeys, VolumeAccessMode } from "../../base-volume"
 import { V1PersistentVolumeClaimSpec, V1PersistentVolumeClaim } from "@kubernetes/client-node"
 import { readFileSync } from "fs-extra"
 import { join } from "path"
@@ -26,23 +25,17 @@ import { getKubernetesDeployStatus, kubernetesDeploy } from "../kubernetes-type/
 import { Resolved } from "../../../actions/types"
 import { KUBECTL_DEFAULT_TIMEOUT } from "../kubectl"
 
-export interface PersistentVolumeClaimDeploySpec extends BaseVolumeSpec {
+export interface PersistentVolumeClaimDeploySpec {
   namespace?: string
   spec: V1PersistentVolumeClaimSpec
 }
 
 const commonSpecKeys = () => ({
-  ...baseVolumeSpecKeys(),
   namespace: joiIdentifier().description(
     "The namespace to deploy the PVC in. Note that any module referencing the PVC must be in the same namespace, so in most cases you should leave this unset."
   ),
-  spec: joi
-    .object()
-    .jsonSchema({ ...jsonSchema().properties.spec, type: "object" })
-    .required()
-    .description(
-      "The spec for the PVC. This is passed directly to the created PersistentVolumeClaim resource. Note that the spec schema may include (or even require) additional fields, depending on the used `storageClass`. See the [PersistentVolumeClaim docs](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims) for details."
-    ),
+  // TODO: validation for this doesn't work, but kubernetes does the validation for us on apply
+  spec: kubernetesPVCSchema,
 })
 
 interface PersistentVolumeClaimSpec extends PersistentVolumeClaimDeploySpec {
@@ -54,11 +47,25 @@ type PersistentVolumeClaimModule = GardenModule<PersistentVolumeClaimSpec, Persi
 type PersistentVolumeClaimActionConfig = DeployActionConfig<"persistentvolumeclaim", PersistentVolumeClaimDeploySpec>
 type PersistentVolumeClaimAction = DeployAction<PersistentVolumeClaimActionConfig, {}>
 
-// Need to use a sync read to avoid having to refactor createGardenPlugin()
-// The `persistentvolumeclaim.json` file is copied from the handy
-// kubernetes-json-schema repo (https://github.com/instrumenta/kubernetes-json-schema/tree/master/v1.17.0-standalone).
-const jsonSchema = () =>
-  JSON.parse(readFileSync(join(STATIC_DIR, "kubernetes", "persistentvolumeclaim.json")).toString())
+const getPVCJsonSchema = () => {
+  // Need to use a sync read to avoid having to refactor createGardenPlugin()
+  // The `persistentvolumeclaim.json` file is copied from the handy
+  // kubernetes-json-schema repo (https://github.com/instrumenta/kubernetes-json-schema/tree/master/v1.17.0-standalone).
+  const jsonSchemaRaw = () =>
+    JSON.parse(readFileSync(join(STATIC_DIR, "kubernetes", "persistentvolumeclaim.json")).toString())
+
+  const jsonSchema = { ...jsonSchemaRaw().properties.spec, type: "object" }
+
+  return jsonSchema
+}
+
+const kubernetesPVCSchema = joi
+  .object()
+  .jsonSchema(getPVCJsonSchema())
+  .required()
+  .description(
+    "The spec for the PVC. This is passed directly to the created PersistentVolumeClaim resource. Note that the spec schema may include (or even require) additional fields, depending on the used `storageClass`. See the [PersistentVolumeClaim docs](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims) for details."
+  )
 
 export const persistentvolumeclaimDeployDefinition = (): DeployActionDefinition<PersistentVolumeClaimAction> => ({
   name: "persistentvolumeclaim",
@@ -72,9 +79,6 @@ export const persistentvolumeclaimDeployDefinition = (): DeployActionDefinition<
     configure: async ({ config }) => {
       // No need to scan for files
       config.include = []
-
-      // Copy the access modes field to match the BaseVolumeSpec schema
-      config.spec.accessModes = <VolumeAccessMode[]>config.spec.spec.accessModes || ["ReadWriteOnce"]
 
       return { config, supportedModes: {} }
     },
@@ -161,7 +165,6 @@ export const pvcModuleDefinition = (): ModuleTypeDefinition => ({
               dependencies: prepareRuntimeDependencies(module.spec.dependencies, dummyBuild),
 
               spec: {
-                accessModes: module.spec.accessModes,
                 namespace: module.spec.namespace,
                 spec: module.spec.spec,
               },

--- a/docs/reference/action-types/Deploy/persistentvolumeclaim.md
+++ b/docs/reference/action-types/Deploy/persistentvolumeclaim.md
@@ -153,16 +153,6 @@ build:
 kind:
 
 spec:
-  # A list of access modes supported by the volume when mounting. At least one must be specified. The available modes
-  # are as follows:
-  #
-  #  ReadOnlyMany  - May be mounted as a read-only volume, concurrently by multiple targets.
-  #  ReadWriteOnce - May be mounted as a read-write volume by a single target at a time.
-  #  ReadWriteMany - May be mounted as a read-write volume, concurrently by multiple targets.
-  #
-  # At least one mode must be specified.
-  accessModes:
-
   # The namespace to deploy the PVC in. Note that any module referencing the PVC must be in the same namespace, so in
   # most cases you should leave this unset.
   namespace:
@@ -447,22 +437,6 @@ This would mean that instead of looking for manifest files relative to this acti
 | Type     | Required |
 | -------- | -------- |
 | `object` | No       |
-
-### `spec.accessModes[]`
-
-[spec](#spec) > accessModes
-
-A list of access modes supported by the volume when mounting. At least one must be specified. The available modes are as follows:
-
- ReadOnlyMany  - May be mounted as a read-only volume, concurrently by multiple targets.
- ReadWriteOnce - May be mounted as a read-write volume by a single target at a time.
- ReadWriteMany - May be mounted as a read-write volume, concurrently by multiple targets.
-
-At least one mode must be specified.
-
-| Type            | Required |
-| --------------- | -------- |
-| `array[string]` | No       |
 
 ### `spec.namespace`
 

--- a/docs/reference/module-types/persistentvolumeclaim.md
+++ b/docs/reference/module-types/persistentvolumeclaim.md
@@ -156,16 +156,6 @@ varfile:
 # List of services and tasks to deploy/run before deploying this PVC.
 dependencies: []
 
-# A list of access modes supported by the volume when mounting. At least one must be specified. The available modes
-# are as follows:
-#
-#  ReadOnlyMany  - May be mounted as a read-only volume, concurrently by multiple targets.
-#  ReadWriteOnce - May be mounted as a read-write volume by a single target at a time.
-#  ReadWriteMany - May be mounted as a read-write volume, concurrently by multiple targets.
-#
-# At least one mode must be specified.
-accessModes:
-
 # The namespace to deploy the PVC in. Note that any module referencing the PVC must be in the same namespace, so in
 # most cases you should leave this unset.
 namespace:
@@ -525,20 +515,6 @@ List of services and tasks to deploy/run before deploying this PVC.
 | Type            | Default | Required |
 | --------------- | ------- | -------- |
 | `array[string]` | `[]`    | No       |
-
-### `accessModes[]`
-
-A list of access modes supported by the volume when mounting. At least one must be specified. The available modes are as follows:
-
- ReadOnlyMany  - May be mounted as a read-only volume, concurrently by multiple targets.
- ReadWriteOnce - May be mounted as a read-write volume by a single target at a time.
- ReadWriteMany - May be mounted as a read-write volume, concurrently by multiple targets.
-
-At least one mode must be specified.
-
-| Type            | Required |
-| --------------- | -------- |
-| `array[string]` | No       |
 
 ### `namespace`
 


### PR DESCRIPTION
The schema validation for the jsonSchema generated spec actually doesn't work but I don't want to spend more time on this and k8s validates it on apply anyway