### PR TITLE
improvement(core): ensure SIGINT is honored

### DIFF
--- a/core/src/commands/dev.tsx
+++ b/core/src/commands/dev.tsx
@@ -197,6 +197,12 @@ Let's get your development environment wired up.
     }))
 
     function quitWithWarning() {
+      // We ensure that the process exits at most 5 seconds after a SIGINT / ctrl-c.
+      setTimeout(() => {
+        console.error(chalk.red("\nTimed out waiting for Garden to exit. This is a bug, please report it!"))
+        process.exit(1)
+      }, 5000)
+
       garden
         .emitWarning({
           log,


### PR DESCRIPTION
**What this PR does / why we need it**:

We now exit the process with a nonzero exit code 5 seconds after receiving a `SIGINT` or a control-c keystroke.

This is to ensure that if the Garden process hangs for any reason, it doesn't stay unresponsive for longer than a limited time.