### PR TITLE
chore: kubernetes with local context including colima

### DIFF
--- a/core/src/plugins/kubernetes/local/config.ts
+++ b/core/src/plugins/kubernetes/local/config.ts
@@ -27,7 +27,7 @@ import { getK8sClientServerVersions, K8sClientServerVersions } from "../util"
 // TODO: split this into separate plugins to handle Docker for Mac and Minikube
 // note: this is in order of preference, in case neither is set as the current kubectl context
 // and none is explicitly configured in the garden.yml
-const supportedContexts = ["docker-for-desktop", "docker-desktop", "microk8s", "minikube", "kind-kind"]
+const supportedContexts = ["docker-for-desktop", "docker-desktop", "microk8s", "minikube", "kind-kind", "colima"]
 const nginxServices = ["ingress-controller", "default-backend"]
 
 function isSupportedContext(context: string) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

[Colima](https://github.com/abiosoft/colima) is a popular container runtime for MacOS with built-in kubernetes support. This adds `colima` as a supported context for the local k8s plugin.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
