### PR TITLE
fix(exec): fix delete handler for persistent mode

### DIFF
--- a/core/src/plugins/exec/deploy.ts
+++ b/core/src/plugins/exec/deploy.ts
@@ -11,7 +11,7 @@ import { join } from "path"
 import split2 = require("split2")
 import { PrimitiveMap } from "../../config/common"
 import { dedent } from "../../util/string"
-import { ExecOpts, sleep, spawn } from "../../util/util"
+import { ExecOpts, sleep } from "../../util/util"
 import { TimeoutError } from "../../exceptions"
 import { Log } from "../../logger/log-entry"
 import execa from "execa"

--- a/core/src/plugins/exec/exec.ts
+++ b/core/src/plugins/exec/exec.ts
@@ -30,7 +30,7 @@ import { runResultToActionState } from "../../actions/base"
 import { BuildStatus } from "../../plugin/handlers/Build/get-status"
 import { convertExecModule } from "./convert"
 import { copyArtifacts, execRun } from "./common"
-import { execDeployAction, deleteExecDeploy, getExecDeployLogs, getExecDeployStatus } from "./deploy"
+import { deployExec, deleteExecDeploy, getExecDeployLogs, getExecDeployStatus } from "./deploy"
 
 export interface ExecProviderConfig extends GenericProviderConfig {}
 
@@ -165,7 +165,7 @@ export const execPlugin = () =>
     name: "exec",
     docs: dedent`
       A simple provider that allows running arbitrary scripts when initializing providers, and provides the exec
-      module type.
+      action types.
 
       _Note: This provider is always loaded when running Garden. You only need to explicitly declare it in your provider
       configuration if you want to configure a script for it to run._
@@ -202,7 +202,7 @@ export const execPlugin = () =>
               return { config, supportedModes: { sync: !!config.spec.persistent } }
             },
 
-            deploy: execDeployAction,
+            deploy: deployExec,
             delete: deleteExecDeploy,
             getLogs: getExecDeployLogs,
             getStatus: getExecDeployStatus,

--- a/core/src/process.ts
+++ b/core/src/process.ts
@@ -76,7 +76,7 @@ export async function registerProcess(
 
 /**
  * Kills the process with the provided pid, and any of its child processes.
- * 
+ *
  * `signalName` should be a POSIX kill signal, e.g. + `INT` or `KILL`
  *
  * See: https://github.com/sindresorhus/execa/issues/96#issuecomment-776280798

--- a/core/src/router/deploy.ts
+++ b/core/src/router/deploy.ts
@@ -198,7 +198,7 @@ export const deployRouter = (baseParams: BaseRouterParams) =>
         params,
         handlerType: "startSync",
         defaultHandler: async () => {
-          log.warn(chalk.yellow(`No startSync handler available for action type ${action.type}`))
+          log.debug(chalk.yellow(`No startSync handler available for action type ${action.type}`))
           return {}
         },
       })
@@ -211,7 +211,7 @@ export const deployRouter = (baseParams: BaseRouterParams) =>
         params,
         handlerType: "stopSync",
         defaultHandler: async () => {
-          log.warn(chalk.yellow(`No stopSync handler available for action type ${action.type}`))
+          log.debug(chalk.yellow(`No stopSync handler available for action type ${action.type}`))
           return {}
         },
       })

--- a/core/test/integ/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/build/buildkit.ts
@@ -7,7 +7,11 @@
  */
 
 import { getContainerTestGarden } from "../container"
-import { ClusterBuildkitCacheConfig, KubernetesPluginContext, KubernetesProvider } from "../../../../../../../src/plugins/kubernetes/config"
+import {
+  ClusterBuildkitCacheConfig,
+  KubernetesPluginContext,
+  KubernetesProvider
+} from "../../../../../../../src/plugins/kubernetes/config"
 import { Garden } from "../../../../../../../src"
 import { PluginContext } from "../../../../../../../src/plugin-context"
 import {

--- a/core/test/unit/src/plugins/exec/exec.ts
+++ b/core/test/unit/src/plugins/exec/exec.ts
@@ -6,10 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { spawn } from "child_process"
 import { expect } from "chai"
 import { join } from "path"
-import psTree from "ps-tree"
 
 import { Garden } from "../../../../../src/garden"
 import { ExecProvider, gardenPlugin } from "../../../../../src/plugins/exec/exec"

--- a/docs/reference/providers/exec.md
+++ b/docs/reference/providers/exec.md
@@ -8,7 +8,7 @@ tocTitle: "`exec`"
 ## Description
 
 A simple provider that allows running arbitrary scripts when initializing providers, and provides the exec
-module type.
+action types.
 
 _Note: This provider is always loaded when running Garden. You only need to explicitly declare it in your provider
 configuration if you want to configure a script for it to run._


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Before this fix, `exec` Deploys that were deployed with `persistent: true` in their config weren't being terminated when deleted (e.g. via the `cleanup deployment` command).

This was fixed by killing child processes of the PID as well.

Also removed some noisy warning logs when including `exec` Deploys in a sync-related command.

The `exec` plugin doesn't define `syncStart` or `syncStop` handlers, since it uses the `persistent: boolean` config flag for a similar purpose.

Here, we raise the log level for the "No startSync/stopSync handler available for action type exec" log lines to `debug`.