### PR TITLE
improvement(cloud): only emit statuses when processing

### DIFF
--- a/core/src/router/build.ts
+++ b/core/src/router/build.ts
@@ -18,42 +18,16 @@ const API_ACTION_TYPE = "build"
 export const buildRouter = (baseParams: BaseRouterParams) =>
   createActionRouter("Build", baseParams, {
     getStatus: async (params) => {
-      const { router, action, garden } = params
-      const actionType = API_ACTION_TYPE
+      const { router, action } = params
 
-      const startedAt = new Date().toISOString()
-
-      // Then an actual build won't take place, so we emit a build status event to that effect.
-      const actionVersion = action.versionString()
-      const payloadAttrs = {
-        moduleName: action.moduleName(),
-        actionName: action.name,
-        actionType,
-        actionUid: action.getUid(),
-        actionVersion,
-        startedAt,
-      }
-
-      garden.events.emit("buildStatus", {
-        ...payloadAttrs,
-        state: "getting-status",
-        status: { state: "fetching" },
-      })
       const statusOutput = await router.callHandler({
         params,
         handlerType: "getStatus",
         defaultHandler: async () => ({ state: <ActionState>"unknown", detail: {}, outputs: {} }),
       })
       const status = statusOutput.result
-      const { state } = status
 
       await router.validateActionOutputs(action, "runtime", status.outputs)
-      garden.events.emit("buildStatus", {
-        ...payloadAttrs,
-        completedAt: new Date().toISOString(),
-        state: stateForCacheStatusEvent(state),
-        status: { state: state === "ready" ? "fetched" : "outdated" },
-      })
       return statusOutput
     },
 

--- a/core/src/router/deploy.ts
+++ b/core/src/router/deploy.ts
@@ -131,35 +131,10 @@ export const deployRouter = (baseParams: BaseRouterParams) =>
     },
 
     getStatus: async (params) => {
-      const { garden, router, action } = params
-      const actionName = action.name
-      const actionVersion = action.versionString()
-      const actionType = API_ACTION_TYPE
-
-      const payloadAttrs = {
-        actionName,
-        actionVersion,
-        actionType,
-        actionUid: action.getUid(),
-        moduleName: action.moduleName(),
-        startedAt: new Date().toISOString(),
-      }
-
-      garden.events.emit("deployStatus", {
-        ...payloadAttrs,
-        state: "getting-status",
-        status: { state: "unknown" },
-      })
+      const { router, action } = params
 
       const output = await router.callHandler({ params, handlerType: "getStatus" })
       const result = output.result
-
-      garden.events.emit("deployStatus", {
-        ...payloadAttrs,
-        completedAt: new Date().toISOString(),
-        state: stateForCacheStatusEvent(result.state),
-        status: omit(result.detail, "detail"),
-      })
 
       router.emitNamespaceEvents(result.detail?.namespaceStatuses)
 

--- a/core/src/router/run.ts
+++ b/core/src/router/run.ts
@@ -100,28 +100,7 @@ export const runRouter = (baseParams: BaseRouterParams) =>
     },
 
     getResult: async (params) => {
-      const { garden, router, action } = params
-
-      const actionName = action.name
-      const actionVersion = action.versionString()
-      const actionType = API_ACTION_TYPE
-
-      const moduleName = action.moduleName()
-
-      const payloadAttrs = {
-        actionName,
-        actionVersion,
-        actionType,
-        moduleName,
-        actionUid: action.getUid(),
-        startedAt: new Date().toISOString(),
-      }
-
-      garden.events.emit("runStatus", {
-        ...payloadAttrs,
-        state: "getting-status",
-        status: { state: "unknown" },
-      })
+      const { router, action } = params
 
       const output = await router.callHandler({
         params,
@@ -129,13 +108,6 @@ export const runRouter = (baseParams: BaseRouterParams) =>
         defaultHandler: async () => ({ state: <ActionState>"unknown", detail: null, outputs: {} }),
       })
       const { result } = output
-
-      garden.events.emit("runStatus", {
-        ...payloadAttrs,
-        state: stateForCacheStatusEvent(result.state),
-        completedAt: new Date().toISOString(),
-        status: runStatusForEventPayload(result.detail),
-      })
 
       if (result) {
         await router.validateActionOutputs(action, "runtime", result.outputs)

--- a/core/src/router/test.ts
+++ b/core/src/router/test.ts
@@ -100,26 +100,7 @@ export const testRouter = (baseParams: BaseRouterParams) =>
     },
 
     getResult: async (params) => {
-      const { garden, router, action } = params
-
-      const actionName = action.name
-      const actionVersion = action.versionString()
-      const actionType = API_ACTION_TYPE
-
-      const payloadAttrs = {
-        actionName,
-        actionVersion,
-        actionType,
-        moduleName: action.moduleName(),
-        actionUid: action.getUid(),
-        startedAt: new Date().toISOString(),
-      }
-
-      garden.events.emit("testStatus", {
-        ...payloadAttrs,
-        state: "getting-status",
-        status: { state: "unknown" },
-      })
+      const { router, action } = params
 
       const output = await router.callHandler({
         params,
@@ -127,13 +108,6 @@ export const testRouter = (baseParams: BaseRouterParams) =>
         defaultHandler: async () => ({ state: <ActionState>"unknown", detail: null, outputs: {} }),
       })
       const { result } = output
-
-      garden.events.emit("testStatus", {
-        ...payloadAttrs,
-        state: stateForCacheStatusEvent(result.state),
-        completedAt: new Date().toISOString(),
-        status: runStatusForEventPayload(result.detail),
-      })
 
       if (result) {
         await router.validateActionOutputs(action, "runtime", result.outputs)

--- a/core/test/unit/src/router/build.ts
+++ b/core/test/unit/src/router/build.ts
@@ -42,28 +42,6 @@ describe("build actions", () => {
       const { result } = await actionRouter.build.getStatus({ log, action: resolvedBuildAction, graph })
       expect(result.outputs.foo).to.eql("bar")
     })
-
-    it("should emit buildStatus events", async () => {
-      garden.events.eventLog = []
-      await actionRouter.build.getStatus({ log, action: resolvedBuildAction, graph })
-
-      const event1 = garden.events.eventLog[0]
-      const event2 = garden.events.eventLog[1]
-
-      expect(event1).to.exist
-      expect(event1.name).to.eql("buildStatus")
-      expect(event1.payload.moduleName).to.eql("module-a")
-      expect(event1.payload.actionUid).to.be.ok
-      expect(event1.payload.state).to.eql("getting-status")
-      expect(event1.payload.status.state).to.eql("fetching")
-
-      expect(event2).to.exist
-      expect(event2.name).to.eql("buildStatus")
-      expect(event2.payload.moduleName).to.eql("module-a")
-      expect(event2.payload.actionUid).to.eql(event1.payload.actionUid)
-      expect(event2.payload.state).to.eql("cached")
-      expect(event2.payload.status.state).to.eql("fetched")
-    })
   })
 
   describe("build", () => {

--- a/core/test/unit/src/router/deploy.ts
+++ b/core/test/unit/src/router/deploy.ts
@@ -56,34 +56,6 @@ describe("deploy actions", () => {
       })
     })
 
-    it("should emit serviceStatus events", async () => {
-      garden.events.eventLog = []
-      await actionRouter.deploy.getStatus({
-        log,
-        action: resolvedDeployAction,
-        graph,
-      })
-      const event1 = garden.events.eventLog[0]
-      const event2 = garden.events.eventLog[1]
-
-      expect(event1).to.exist
-      expect(event2).to.exist
-
-      expect(event1.name).to.eql("deployStatus")
-      expect(event1.payload.actionVersion).to.eql(resolvedDeployAction.versionString())
-      expect(event1.payload.moduleName).to.eql("module-a")
-      expect(event1.payload.actionUid).to.be.ok
-      expect(event1.payload.state).to.eql("getting-status")
-      expect(event1.payload.status.state).to.eql("unknown")
-
-      expect(event2.name).to.eql("deployStatus")
-      expect(event2.payload.actionVersion).to.eql(resolvedDeployAction.versionString())
-      expect(event2.payload.moduleName).to.eql("module-a")
-      expect(event2.payload.actionUid).to.eql(event1.payload.actionUid)
-      expect(event2.payload.state).to.eql("cached")
-      expect(event2.payload.status.state).to.eql("ready")
-    })
-
     it("should throw if the outputs don't match the service outputs schema of the plugin", async () => {
       resolvedDeployAction._config[returnWrongOutputsCfgKey] = true
       await expectError(

--- a/core/test/unit/src/router/run.ts
+++ b/core/test/unit/src/router/run.ts
@@ -72,31 +72,6 @@ describe("run actions", () => {
       expect(result).to.eql(taskResult)
     })
 
-    it("should emit a runStatus event", async () => {
-      garden.events.eventLog = []
-      await actionRouter.run.getResult({
-        log,
-        action: resolvedRunAction,
-        graph,
-      })
-      const event1 = garden.events.eventLog[0]
-      const event2 = garden.events.eventLog[1]
-
-      expect(event1).to.exist
-      expect(event1.name).to.eql("runStatus")
-      expect(event1.payload.moduleName).to.eql("module-a")
-      expect(event1.payload.actionUid).to.be.ok
-      expect(event1.payload.state).to.eql("getting-status")
-      expect(event1.payload.status.state).to.eql("unknown")
-
-      expect(event2).to.exist
-      expect(event2.name).to.eql("runStatus")
-      expect(event2.payload.moduleName).to.eql("module-a")
-      expect(event2.payload.actionUid).to.eql(event1.payload.actionUid)
-      expect(event2.payload.state).to.eql("cached")
-      expect(event2.payload.status.state).to.eql("succeeded")
-    })
-
     it("should throw if the outputs don't match the task outputs schema of the plugin", async () => {
       resolvedRunAction._config[returnWrongOutputsCfgKey] = true
       await expectError(() => actionRouter.run.getResult({ log, action: resolvedRunAction, graph }), {

--- a/core/test/unit/src/router/test.ts
+++ b/core/test/unit/src/router/test.ts
@@ -177,32 +177,4 @@ describe("test actions", () => {
       expect(result.state).to.eql("ready")
     })
   })
-
-  it("should emit testStatus events", async () => {
-    const action = await garden.resolveAction({ action: graph.getTest("module-a-unit"), log, graph })
-    garden.events.eventLog = []
-
-    await actionRouter.test.getResult({
-      log,
-      action,
-      graph,
-    })
-    const event1 = garden.events.eventLog[0]
-    const event2 = garden.events.eventLog[1]
-
-    expect(event1).to.exist
-    expect(event2).to.exist
-
-    expect(event1.name).to.eql("testStatus")
-    expect(event1.payload.moduleName).to.eql("module-a")
-    expect(event1.payload.actionUid).to.be.ok
-    expect(event1.payload.state).to.eql("getting-status")
-    expect(event1.payload.status.state).to.eql("unknown")
-
-    expect(event2.name).to.eql("testStatus")
-    expect(event1.payload.moduleName).to.eql("module-a")
-    expect(event2.payload.actionUid).to.eql(event1.payload.actionUid)
-    expect(event2.payload.state).to.eql("cached")
-    expect(event2.payload.status.state).to.eql("succeeded")
-  })
 })


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

This dramatically cuts down on the number of events when used in conjunction with the live mode UI, and is more in line with where the product is going (we no longer need to keep namespace statuses up to date).