### PR TITLE
improvement(logger): render timestamp as local time string

### DIFF
--- a/core/src/logger/renderers.ts
+++ b/core/src/logger/renderers.ts
@@ -12,6 +12,7 @@ import stripAnsi from "strip-ansi"
 import { isArray, repeat } from "lodash"
 import stringWidth = require("string-width")
 import hasAnsi = require("has-ansi")
+import format from "date-fns/format"
 
 import { LogEntry } from "./log-entry"
 import { JsonLogEntry } from "./writers/json-terminal-writer"
@@ -79,11 +80,8 @@ export function renderTimestamp(entry: LogEntry, logger: Logger): string {
   if (!logger.showTimestamps) {
     return ""
   }
-  return `[${getTimestamp(entry)}] `
-}
-
-export function getTimestamp(entry: LogEntry): string {
-  return entry.timestamp
+  const formattedDate = format(new Date(entry.timestamp), "HH:mm:ss")
+  return chalk.gray(formattedDate) + " "
 }
 
 export function getSection(entry: LogEntry): string | null {
@@ -189,7 +187,7 @@ export function cleanWhitespace(str: string) {
 
 // TODO: Include individual message states with timestamp
 export function formatForJson(entry: LogEntry): JsonLogEntry {
-  const { msg, metadata } = entry
+  const { msg, metadata, timestamp } = entry
   const errorDetail = entry.error && entry ? formatGardenErrorWithDetail(toGardenError(entry.error)) : undefined
   const section = renderSection(entry)
 
@@ -199,7 +197,7 @@ export function formatForJson(entry: LogEntry): JsonLogEntry {
     metadata,
     // TODO @eysi: Should we include the section here or rather just show the context?
     section: cleanForJSON(section),
-    timestamp: getTimestamp(entry),
+    timestamp,
     level: logLevelMap[entry.level],
   }
   if (errorDetail) {

--- a/core/test/unit/src/logger/renderers.ts
+++ b/core/test/unit/src/logger/renderers.ts
@@ -30,6 +30,7 @@ import stripAnsi = require("strip-ansi")
 import { highlightYaml, safeDumpYaml } from "../../../../src/util/serialization"
 import { freezeTime } from "../../../helpers"
 import chalk = require("chalk")
+import format from "date-fns/format"
 
 const logger: Logger = getRootLogger()
 
@@ -145,7 +146,7 @@ describe("renderers", () => {
         const now = freezeTime()
         const entry = logger.createLog().info("hello world").getLatestEntry()
 
-        expect(formatForTerminal(entry, logger)).to.equal(`[${now.toISOString()}] ${msgStyle("hello world")}\n`)
+        expect(formatForTerminal(entry, logger)).to.equal(`${chalk.gray(format(now, "HH:mm:ss"))} ${msgStyle("hello world")}\n`)
       })
       after(() => {
         logger.showTimestamps = false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Before:

<img width="516" alt="Screenshot 2023-05-20 at 12 47 05" src="https://github.com/garden-io/garden/assets/5373776/a0cb970a-54d2-4837-bf50-759dbdc3bf58">

After:

<img width="389" alt="Screenshot 2023-05-20 at 13 08 14" src="https://github.com/garden-io/garden/assets/5373776/0c680fd8-3fff-46f9-9fb4-2669e0135275">

I know people have strong opinions on timestamps, here I'm using 24 hour time with the format "HH:mm:ss" but happy to revise.

We could also make it configureable for that matter but this feels like a good start.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
