### PR TITLE
feat(core): added sync restart command

### DIFF
--- a/core/src/commands/sync/sync-restart.ts
+++ b/core/src/commands/sync/sync-restart.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2018-2023 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { StringsParameter } from "../../cli/params"
+import { joi } from "../../config/common"
+import { printHeader } from "../../logger/util"
+import { dedent, naturalList } from "../../util/string"
+import { Command, CommandParams, CommandResult } from "../base"
+import Bluebird from "bluebird"
+import chalk from "chalk"
+import { createActionLog } from "../../logger/log-entry"
+import { startSyncWithoutDeploy } from "./sync-start"
+
+const syncRestartArgs = {
+  names: new StringsParameter({
+    help: "The name(s) of one or more Deploy(s) (or services if using modules) whose syncs you want to restart. You may specify multiple names, separated by spaces. To restart all possible syncs, specify '*' as an argument.",
+    required: true,
+    spread: true,
+    getSuggestions: ({ configDump }) => {
+      return Object.keys(configDump.actionConfigs.Deploy)
+    },
+  }),
+}
+type Args = typeof syncRestartArgs
+
+const syncRestartOpts = {}
+type Opts = typeof syncRestartOpts
+
+export class SyncRestartCommand extends Command<Args, Opts> {
+  name = "restart"
+  help = "Restart any active syncs to the given Deploy action(s)."
+
+  protected = true
+
+  arguments = syncRestartArgs
+  options = syncRestartOpts
+
+  description = dedent`
+    Restarts one or more active syncs.
+
+    Examples:
+        # Restart syncing to the 'api' Deploy
+        garden sync restart api
+
+        # Restart all active syncs
+        garden sync restart
+  `
+
+  outputsSchema = () => joi.object()
+
+  printHeader({ log }) {
+    printHeader(log, "Restarting sync(s)", "🔁")
+  }
+
+  async action(params: CommandParams<Args, Opts>): Promise<CommandResult<{}>> {
+    const { garden, log, args } = params
+
+    const names = args.names || []
+
+    if (names.length === 0) {
+      log.warn({ msg: `No names specified. Aborting. Please specify '*' if you'd like to restart all active syncs.` })
+      return { result: {} }
+    }
+
+    const graph = await garden.getConfigGraph({
+      log,
+      emit: true,
+      actionModes: {
+        sync: names.map((n) => "deploy." + n),
+      },
+    })
+
+    let actions = graph.getDeploys({ includeNames: names })
+
+    if (actions.length === 0) {
+      log.warn({
+        msg: `No enabled Deploy actions found (matching argument(s) ${naturalList(
+          names.map((n) => `'${n}'`)
+        )}). Aborting.`,
+      })
+      return { result: {} }
+    }
+
+    actions = actions.filter((action) => {
+      if (!action.supportsMode("sync")) {
+        if (names.includes(action.name)) {
+          log.warn(chalk.yellow(`${action.longDescription()} does not support syncing.`))
+        }
+        return false
+      }
+      return true
+    })
+
+    if (actions.length === 0) {
+      log.warn(chalk.yellow(`No matched action supports syncing. Aborting.`))
+      return {}
+    }
+
+    const router = await garden.getActionRouter()
+
+    const syncControlLog = log.createLog({ name: "sync-reset" })
+
+    syncControlLog.info({ symbol: "info", msg: "Stopping active syncs..." })
+
+    await Bluebird.map(actions, async (action) => {
+      const actionLog = createActionLog({ log, actionName: action.name, actionKind: action.kind })
+      await router.deploy.stopSync({ log: actionLog, action, graph })
+    })
+    syncControlLog.info({ symbol: "success", msg: chalk.green("Active syncs stopped") })
+
+    syncControlLog.info({ symbol: "info", msg: "Starting stopped syncs..." })
+
+    await startSyncWithoutDeploy({
+      actions,
+      graph,
+      garden,
+      command: this,
+      log,
+      monitor: false,
+      stopOnExit: false,
+    })
+
+    log.info(chalk.green("\nDone!"))
+
+    return {}
+  }
+}

--- a/core/src/commands/sync/sync-start.ts
+++ b/core/src/commands/sync/sync-start.ts
@@ -24,7 +24,7 @@ import { Garden } from "../.."
 const syncStartArgs = {
   names: new StringsParameter({
     help: "The name(s) of one or more Deploy(s) (or services if using modules) to sync. You may specify multiple names, separated by spaces. To start all possible syncs, specify '*' as an argument.",
-    required: true,
+    required: false,
     spread: true,
     getSuggestions: ({ configDump }) => {
       return Object.keys(configDump.actionConfigs.Deploy)
@@ -67,13 +67,13 @@ export class SyncStartCommand extends Command<Args, Opts> {
         garden sync start api --deploy
 
         # start syncing to every Deploy already deployed in sync mode
-        garden sync start '*'
+        garden sync start
 
         # start syncing to every Deploy that supports it, deploying if needed
         garden sync start '*' --deploy
 
         # start syncing to every Deploy that supports it, deploying if needed including runtime dependencies
-        garden sync start '*' --deploy --include-dependencies
+        garden sync start --deploy --include-dependencies
 
         # start syncing to the 'api' and 'worker' Deploys
         garden sync start api worker
@@ -95,12 +95,8 @@ export class SyncStartCommand extends Command<Args, Opts> {
   async action(params: CommandParams<Args, Opts>): Promise<CommandResult<{}>> {
     const { garden, log, args, opts } = params
 
-    const names = args.names || []
-
-    if (names.length === 0) {
-      log.warn({ msg: `No names specified. Aborting. Please specify '*' if you'd like to start all possible syncs.` })
-      return { result: {} }
-    }
+    // We default to starting syncs for all Deploy actions
+    const names = args.names || ["*"]
 
     // We want to stop any started syncs on exit if we're calling `sync start` from inside the `dev` command.
     const stopOnExit = !!params.commandLine

--- a/core/src/commands/sync/sync-start.ts
+++ b/core/src/commands/sync/sync-start.ts
@@ -16,7 +16,10 @@ import Bluebird from "bluebird"
 import chalk from "chalk"
 import { ParameterError, RuntimeError } from "../../exceptions"
 import { SyncMonitor } from "../../monitors/sync"
-import { createActionLog } from "../../logger/log-entry"
+import { Log, createActionLog } from "../../logger/log-entry"
+import { DeployAction } from "../../actions/deploy"
+import { ConfigGraph } from "../../graph/config-graph"
+import { Garden } from "../.."
 
 const syncStartArgs = {
   names: new StringsParameter({
@@ -167,75 +170,103 @@ export class SyncStartCommand extends Command<Args, Opts> {
       return {}
     } else {
       // Don't deploy, just start syncs
-      const tasks = actions.map((action) => {
-        return new DeployTask({
-          garden,
-          graph,
-          log,
-          action,
-          force: false,
-          forceActions: [],
-          skipRuntimeDependencies: true,
-          startSync: true,
-        })
+      await startSyncWithoutDeploy({
+        actions,
+        graph,
+        garden,
+        command: this,
+        log,
+        monitor: opts.monitor,
+        stopOnExit,
       })
-
-      const statusResult = await garden.processTasks({ log, tasks, statusOnly: true })
-      let someSyncStarted = false
-
-      const router = await garden.getActionRouter()
-
-      await Bluebird.map(tasks, async (task) => {
-        const action = task.action
-        const result = statusResult.results.getResult(task)
-
-        const mode = result?.result?.detail?.mode
-        const state = result?.result?.detail?.state
-        const executedAction = result?.result?.executedAction
-        const actionLog = createActionLog({ log, actionName: action.name, actionKind: action.kind })
-
-        if (executedAction && (state === "outdated" || state === "ready")) {
-          if (mode !== "sync") {
-            actionLog.warn(
-              chalk.yellow(
-                `Not deployed in sync mode, cannot start sync. Try running this command with \`--deploy\` set.`
-              )
-            )
-            return
-          }
-          // Attempt to start sync even if service is outdated but in sync mode
-          try {
-            await router.deploy.startSync({ log: actionLog, action: executedAction, graph })
-            someSyncStarted = true
-
-            if (opts.monitor) {
-              const monitor = new SyncMonitor({ garden, log, action: executedAction, graph, stopOnExit })
-              garden.monitors.addAndSubscribe(monitor, this)
-            }
-          } catch (error) {
-            actionLog.warn(
-              chalk.yellow(dedent`
-                Failed starting sync for ${action.longDescription()}: ${error}
-
-                You may need to re-deploy the action. Try running this command with \`--deploy\` set, or running \`garden deploy --sync\` before running this command again.
-              `)
-            )
-          }
-        } else {
-          actionLog.warn(chalk.yellow(`${action.longDescription()} is not deployed, cannot start sync.`))
-        }
-      })
-
-      if (!someSyncStarted) {
-        throw new RuntimeError(`Could not start any sync. Aborting.`, {
-          actionKeys,
-        })
-      }
-
       if (garden.monitors.getAll().length === 0) {
         log.info(chalk.green("\nDone!"))
       }
       return {}
     }
+  }
+}
+
+export async function startSyncWithoutDeploy({
+  actions,
+  graph,
+  garden,
+  command,
+  log,
+  monitor,
+  stopOnExit
+}: {
+  actions: DeployAction[]
+  graph: ConfigGraph
+  garden: Garden
+  command: Command
+  log: Log
+  monitor: boolean
+  stopOnExit: boolean
+}) {
+  const actionKeys = actions.map((a) => a.key())
+  const tasks = actions.map((action) => {
+    return new DeployTask({
+      garden,
+      graph,
+      log,
+      action,
+      force: false,
+      forceActions: [],
+      skipRuntimeDependencies: true,
+      startSync: true,
+    })
+  })
+
+  const statusResult = await garden.processTasks({ log, tasks, statusOnly: true })
+  let someSyncStarted = false
+
+  const router = await garden.getActionRouter()
+
+  await Bluebird.map(tasks, async (task) => {
+    const action = task.action
+    const result = statusResult.results.getResult(task)
+
+    const mode = result?.result?.detail?.mode
+    const state = result?.result?.detail?.state
+    const executedAction = result?.result?.executedAction
+    const actionLog = createActionLog({ log, actionName: action.name, actionKind: action.kind })
+
+    if (executedAction && (state === "outdated" || state === "ready")) {
+      if (mode !== "sync") {
+        actionLog.warn(
+          chalk.yellow(
+            `Not deployed in sync mode, cannot start sync. Try running this command with \`--deploy\` set.`
+          )
+        )
+        return
+      }
+      // Attempt to start sync even if service is outdated but in sync mode
+      try {
+        await router.deploy.startSync({ log: actionLog, action: executedAction, graph })
+        someSyncStarted = true
+
+        if (monitor) {
+          const monitor = new SyncMonitor({ garden, log, action: executedAction, graph, stopOnExit })
+          garden.monitors.addAndSubscribe(monitor, command)
+        }
+      } catch (error) {
+        actionLog.warn(
+          chalk.yellow(dedent`
+            Failed starting sync for ${action.longDescription()}: ${error}
+
+            You may need to re-deploy the action. Try running this command with \`--deploy\` set, or running \`garden deploy --sync\` before running this command again.
+          `)
+        )
+      }
+    } else {
+      actionLog.warn(chalk.yellow(`${action.longDescription()} is not deployed, cannot start sync.`))
+    }
+  })
+
+  if (!someSyncStarted) {
+    throw new RuntimeError(`Could not start any sync. Aborting.`, {
+      actionKeys,
+    })
   }
 }

--- a/core/src/commands/sync/sync-status.ts
+++ b/core/src/commands/sync/sync-status.ts
@@ -90,7 +90,7 @@ export class SyncStatusCommand extends Command<Args> {
     log.info(
       chalk.white(deline`
       Getting sync statuses. For more detailed debug information, run this command with
-      the \`--json\` or \`--yaml\` flags.
+      the \`--output json\` or \`--outputyaml\` flags.
     `)
     )
     log.info("")

--- a/core/src/commands/sync/sync-status.ts
+++ b/core/src/commands/sync/sync-status.ts
@@ -78,8 +78,11 @@ export class SyncStatusCommand extends Command<Args> {
     const router = await garden.getActionRouter()
     const graph = await garden.getResolvedConfigGraph({ log, emit: true })
 
+    // We default to getting the sync status for all actions
+    const names = args.names || ["*"]
+
     const deployActions = graph
-      .getDeploys({ includeDisabled: false, names: args.names })
+      .getDeploys({ includeDisabled: false, names })
       .sort((a, b) => (a.name > b.name ? 1 : -1))
     // This is fairly arbitrary
     const concurrency = 5
@@ -90,7 +93,7 @@ export class SyncStatusCommand extends Command<Args> {
     log.info(
       chalk.white(deline`
       Getting sync statuses. For more detailed debug information, run this command with
-      the \`--output json\` or \`--outputyaml\` flags.
+      the \`--output json\` or \`--output yaml\` flags.
     `)
     )
     log.info("")

--- a/core/src/commands/sync/sync-status.ts
+++ b/core/src/commands/sync/sync-status.ts
@@ -136,18 +136,28 @@ export class SyncStatusCommand extends Command<Args> {
             "not-active": chalk.yellow,
           }[syncStatus.state] || chalk.bold.dim
 
+        const verbMap = {
+          "active": "is",
+          "failed": "has",
+          "not-active": "is",
+        }
+
         log.info(
           `The ${chalk.cyan(action.name)} Deploy has ${chalk.cyan(syncStatus.syncs.length)} syncs(s) configured:`
         )
         const leftPad = "  →"
         syncs.forEach((sync, idx) => {
+          const state = sync.state
           log.info(
-            `${leftPad} Sync from ${chalk.cyan(sync.source)} to ${chalk.cyan(sync.target)} is ${styleFn(
-              syncStatus.state
+            `${leftPad} Sync from ${chalk.cyan(sync.source)} to ${chalk.cyan(sync.target)} ${verbMap[state]} ${styleFn(
+              state
             )}`
           )
           sync.mode && log.info(chalk.bold(`${leftPad} Mode: ${sync.mode}`))
           sync.syncCount && log.info(chalk.bold(`${leftPad} Sync count: ${sync.syncCount}`))
+          if (state === "failed" && sync.message) {
+            log.info(`${chalk.bold(leftPad)} ${chalk.yellow(sync.message)}`)
+          }
           idx !== syncs.length - 1 && log.info("")
         })
         log.info("")

--- a/core/src/commands/sync/sync-stop.ts
+++ b/core/src/commands/sync/sync-stop.ts
@@ -17,8 +17,8 @@ import { createActionLog } from "../../logger/log-entry"
 
 const syncStopArgs = {
   names: new StringsParameter({
-    help: "The name(s) of one or more Deploy(s) (or services if using modules) to sync. You may specify multiple names, separated by spaces. To start all possible syncs, specify '*' as an argument.",
-    required: true,
+    help: "The name(s) of one or more Deploy(s) (or services if using modules) to sync. You may specify multiple names, separated by spaces. To start all possible syncs, run the command with no arguments.",
+    required: false,
     spread: true,
     getSuggestions: ({ configDump }) => {
       return Object.keys(configDump.actionConfigs.Deploy)
@@ -49,7 +49,7 @@ export class SyncStopCommand extends Command<Args, Opts> {
         garden sync stop api
 
         # stop all active syncs
-        garden sync stop '*'
+        garden sync stop
   `
 
   outputsSchema = () => joi.object()
@@ -61,12 +61,8 @@ export class SyncStopCommand extends Command<Args, Opts> {
   async action(params: CommandParams<Args, Opts>): Promise<CommandResult<{}>> {
     const { garden, log, args } = params
 
-    const names = args.names || []
-
-    if (names.length === 0) {
-      log.warn({ msg: `No names specified. Aborting. Please specify '*' if you'd like to stop all active syncs.` })
-      return { result: {} }
-    }
+    // We default to stopping all syncs.
+    const names = args.names || ["*"]
 
     const graph = await garden.getConfigGraph({
       log,

--- a/core/src/commands/sync/sync.ts
+++ b/core/src/commands/sync/sync.ts
@@ -7,6 +7,7 @@
  */
 
 import { CommandGroup } from "../base"
+import { SyncRestartCommand } from "./sync-restart"
 import { SyncStartCommand } from "./sync-start"
 import { SyncStatusCommand } from "./sync-status"
 import { SyncStopCommand } from "./sync-stop"
@@ -15,5 +16,5 @@ export class SyncCommand extends CommandGroup {
   name = "sync"
   help = "Manage synchronization to running actions."
 
-  subCommands = [SyncStartCommand, SyncStopCommand, SyncStatusCommand]
+  subCommands = [SyncStartCommand, SyncStopCommand, SyncRestartCommand, SyncStatusCommand]
 }

--- a/core/src/plugin/handlers/Deploy/get-sync-status.ts
+++ b/core/src/plugin/handlers/Deploy/get-sync-status.ts
@@ -22,6 +22,7 @@ export interface SyncStatus {
   source: string
   target: string
   state: SyncState
+  message?: string
   /**
    * ISO format date string
    */
@@ -75,6 +76,7 @@ export const getSyncStatusResultSchema = createSchema({
         lastSyncAt: joi.string().description("ISO format date string for the last successful sync event. May not be availabe for all plugins."),
         syncCount: joi.number().description("The number of successful syncs. May not be availabe for all plugins."),
         mode: syncModeSchema(),
+        message: joi.string().description("An optional message describing the latest status or error relating to this sync.")
       })
     ).description("Should include an entry for every configured sync, also when their target isn't deployed in sync mode."),
     error: joi.string().description("Set to an error message if the sync is failed."),

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -3513,6 +3513,31 @@ Examples:
 
 
 
+### garden sync restart
+
+**Restart any active syncs to the given Deploy action(s).**
+
+Restarts one or more active syncs.
+
+Examples:
+    # Restart syncing to the 'api' Deploy
+    garden sync restart api
+
+    # Restart all active syncs
+    garden sync restart
+
+#### Usage
+
+    garden sync restart <names> 
+
+#### Arguments
+
+| Argument | Required | Description |
+| -------- | -------- | ----------- |
+  | `names` | Yes | The name(s) of one or more Deploy(s) (or services if using modules) whose syncs you want to restart. You may specify multiple names, separated by spaces. To restart all possible syncs, specify &#x27;*&#x27; as an argument.
+
+
+
 ### garden sync status
 
 **Get sync statuses.**

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -3455,13 +3455,13 @@ Examples:
     garden sync start api --deploy
 
     # start syncing to every Deploy already deployed in sync mode
-    garden sync start '*'
+    garden sync start
 
     # start syncing to every Deploy that supports it, deploying if needed
     garden sync start '*' --deploy
 
     # start syncing to every Deploy that supports it, deploying if needed including runtime dependencies
-    garden sync start '*' --deploy --include-dependencies
+    garden sync start --deploy --include-dependencies
 
     # start syncing to the 'api' and 'worker' Deploys
     garden sync start api worker
@@ -3471,13 +3471,13 @@ Examples:
 
 #### Usage
 
-    garden sync start <names> [options]
+    garden sync start [names] [options]
 
 #### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
-  | `names` | Yes | The name(s) of one or more Deploy(s) (or services if using modules) to sync. You may specify multiple names, separated by spaces. To start all possible syncs, specify &#x27;*&#x27; as an argument.
+  | `names` | No | The name(s) of one or more Deploy(s) (or services if using modules) to sync. You may specify multiple names, separated by spaces. To start all possible syncs, specify &#x27;*&#x27; as an argument.
 
 #### Options
 
@@ -3499,17 +3499,17 @@ Examples:
     garden sync stop api
 
     # stop all active syncs
-    garden sync stop '*'
+    garden sync stop
 
 #### Usage
 
-    garden sync stop <names> 
+    garden sync stop [names] 
 
 #### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
-  | `names` | Yes | The name(s) of one or more Deploy(s) (or services if using modules) to sync. You may specify multiple names, separated by spaces. To start all possible syncs, specify &#x27;*&#x27; as an argument.
+  | `names` | No | The name(s) of one or more Deploy(s) (or services if using modules) to sync. You may specify multiple names, separated by spaces. To start all possible syncs, run the command with no arguments.
 
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

feat(core): added sync restart command

This command stops and starts any active syncs for the relevant Deploy actions.

This is useful for recovering from error states for syncing tools.

Also added diagnostic message logging for failure states to the `sync status` command.

For Mutagen-based syncs, we provide clear information to the user why the sync has been halted, and suggest running the `garden sync reset` command after making sure that the relevant directories are in the expected state.

**Which issue(s) this PR fixes**:

This addresses sporadic reports we've gotten from our users where code syncing stops working due to a failure condition in Mutagen (e.g. when the user deletes or moves the source dir). Here, both the diagnostics and the call-to-action are made clear and simple.