### PR TITLE
Error logging improvements

### DIFF
--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -1799,6 +1799,7 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
   const loggedIn = !!cloudApi
 
   config = resolveProjectConfig({
+    log,
     defaultEnvironmentName: configDefaultEnvironment,
     config,
     artifactsPath,

--- a/core/src/logger/renderers.ts
+++ b/core/src/logger/renderers.ts
@@ -172,7 +172,6 @@ export function formatForTerminal(entry: LogEntry, logger: Logger): string {
     renderSymbol,
     renderSection,
     renderMsg,
-    renderError,
     renderData,
     () => "\n",
   ])

--- a/core/src/template-string/template-string.ts
+++ b/core/src/template-string/template-string.ts
@@ -6,6 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import chalk from "chalk"
 import { GardenBaseError, ConfigurationError, TemplateStringError } from "../exceptions"
 import {
   ConfigContext,
@@ -200,7 +201,7 @@ export function resolveTemplateString(string: string, context: ConfigContext, op
 
     return resolved
   } catch (err) {
-    const prefix = `Invalid template string (${truncate(string, 35).replace(/\n/g, "\\n")}): `
+    const prefix = `Invalid template string (${chalk.white(truncate(string, 35).replace(/\n/g, "\\n"))}): `
     const message = err.message.startsWith(prefix) ? err.message : prefix + err.message
 
     throw new TemplateStringError(message, {})

--- a/core/test/unit/src/config/project.ts
+++ b/core/test/unit/src/config/project.ts
@@ -24,6 +24,7 @@ import { createProjectConfig, expectError } from "../../../helpers"
 import { realpath, writeFile } from "fs-extra"
 import { dedent } from "../../../../src/util/string"
 import { resolve, join } from "path"
+import { getRootLogger } from "../../../../src/logger/logger"
 
 const enterpriseDomain = "https://garden.mydomain.com"
 const commandInfo = { name: "test", args: {}, opts: {} }
@@ -33,6 +34,8 @@ const vcsInfo = {
   commitHash: "abcdefgh",
   originUrl: "https://example.com/foo",
 }
+
+const log = getRootLogger().createLog()
 
 describe("resolveProjectConfig", () => {
   it("should pass through a canonical project config", async () => {
@@ -45,6 +48,7 @@ describe("resolveProjectConfig", () => {
 
     expect(
       resolveProjectConfig({
+        log,
         defaultEnvironmentName: "default",
         config,
         artifactsPath: "/tmp",
@@ -105,6 +109,7 @@ describe("resolveProjectConfig", () => {
 
     expect(
       resolveProjectConfig({
+        log,
         defaultEnvironmentName: defaultEnvironment,
         config,
         artifactsPath: "/tmp",
@@ -178,6 +183,7 @@ describe("resolveProjectConfig", () => {
 
     expect(
       resolveProjectConfig({
+        log,
         defaultEnvironmentName: defaultEnvironment,
         config,
         artifactsPath: "/tmp",
@@ -238,6 +244,7 @@ describe("resolveProjectConfig", () => {
     })
 
     const result = resolveProjectConfig({
+      log,
       defaultEnvironmentName: defaultEnvironment,
       config,
       artifactsPath: "/tmp",
@@ -270,6 +277,7 @@ describe("resolveProjectConfig", () => {
 
     expect(
       resolveProjectConfig({
+        log,
         defaultEnvironmentName: defaultEnvironment,
         config,
         artifactsPath: "/tmp",
@@ -318,6 +326,7 @@ describe("resolveProjectConfig", () => {
 
     expect(
       resolveProjectConfig({
+        log,
         defaultEnvironmentName,
         config,
         artifactsPath: "/tmp",
@@ -352,6 +361,7 @@ describe("resolveProjectConfig", () => {
 
     expect(
       resolveProjectConfig({
+        log,
         defaultEnvironmentName,
         config,
         artifactsPath: "/tmp",
@@ -403,6 +413,7 @@ describe("resolveProjectConfig", () => {
 
     expect(
       resolveProjectConfig({
+        log,
         defaultEnvironmentName: defaultEnvironment,
         config,
         artifactsPath: "/tmp",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

**improvement(core): project conf. validation errors**

Improved the error logging for the case where template string resolution fails during project config resolution.

Previously, it wasn't obvious where the failing template string came from when the validation error is in the project config (unlike template errors in action configs, where the error logging was already pretty good).

**fix(core): don't log error details in terminal renderer**

The error logging in Bonsai had become extremely verbose. This was because we were rendering error details in the terminal renderer when an error object was provided to `log.error`.

**Which issue(s) this PR fixes**:

Fixes #4305 and #4308.