### PR TITLE
improvement(commands): add --skip-detail and --only-deploys flags

### DIFF
--- a/core/test/unit/src/commands/get/get-status.ts
+++ b/core/test/unit/src/commands/get/get-status.ts
@@ -23,7 +23,10 @@ describe("GetStatusCommand", () => {
       const { result } = await garden.runCommand({
         command,
         args: {},
-        opts: {},
+        opts: {
+          "skip-detail": false,
+          "only-deploys": false,
+        },
       })
 
       expect(result).to.eql({
@@ -178,7 +181,10 @@ describe("GetStatusCommand", () => {
         garden,
         log,
         args: {},
-        opts: withDefaultGlobalOpts({}),
+        opts: withDefaultGlobalOpts({
+          "skip-detail": false,
+          "only-deploys": false,
+        }),
       })
 
       const logMessages = getLogMessages(log, (l) => l.level === LogLevel.warn)

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -2537,8 +2537,13 @@ modules:
 
 #### Usage
 
-    garden get status 
+    garden get status [options]
 
+#### Options
+
+| Argument | Alias | Type | Description |
+| -------- | ----- | ---- | ----------- |
+  | `--skip-detail` |  | boolean | Skip plugin specific details. Only applicable when using the --output&#x3D;json|yaml option. Useful for trimming down the output.
 
 #### Outputs
 
@@ -3534,7 +3539,7 @@ Examples:
 
 #### Usage
 
-    garden sync status [names] 
+    garden sync status [names] [options]
 
 #### Arguments
 
@@ -3542,6 +3547,11 @@ Examples:
 | -------- | -------- | ----------- |
   | `names` | No | The name(s) of the Deploy(s) to get the sync status for (skip to get status from all Deploys in the project). You may specify multiple names, separated by space.
 
+#### Options
+
+| Argument | Alias | Type | Description |
+| -------- | ----- | ---- | ----------- |
+  | `--skip-detail` |  | boolean | Skip plugin specific sync details. Only applicable when using the --output&#x3D;json|yaml option. Useful for trimming down the output.
 
 
 ### garden test


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

This commit adds a couple of "internal" flags to the sync status and get status commands that make it easier for Cloud and Desktop to consume their output.

Note that the "garden get status" command will be replaced with a top level "garden status" command and that these changes aren't really meant to be user facing. Rather just to unblock a few things on the Cloud side.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
