### PR TITLE
fix: fix regression in sync status cmd arg handling

### DIFF
--- a/core/src/commands/sync/sync-status.ts
+++ b/core/src/commands/sync/sync-status.ts
@@ -78,11 +78,8 @@ export class SyncStatusCommand extends Command<Args> {
     const router = await garden.getActionRouter()
     const graph = await garden.getResolvedConfigGraph({ log, emit: true })
 
-    // We default to getting the sync status for all actions
-    const names = args.names || ["*"]
-
     const deployActions = graph
-      .getDeploys({ includeDisabled: false, names })
+      .getDeploys({ includeDisabled: false, names: args.names })
       .sort((a, b) => (a.name > b.name ? 1 : -1))
     // This is fairly arbitrary
     const concurrency = 5


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Fixes a recent regression in the args handling for the new `sync status` command.
