### PR TITLE
chore: add a per-command flag to disable analytics, starting with autocomplete

### DIFF
--- a/core/src/server/commands.ts
+++ b/core/src/server/commands.ts
@@ -61,6 +61,8 @@ export class AutocompleteCommand extends ConsoleCommand<AutocompleteArguments> {
 
   arguments = autocompleteArguments
 
+  enableAnalytics = false
+
   constructor(private manager: GardenInstanceManager) {
     super(manager)
   }

--- a/core/test/setup.ts
+++ b/core/test/setup.ts
@@ -21,6 +21,12 @@ initTestLogger()
 // Global hooks
 exports.mochaHooks = {
   async beforeAll() {
+    // override fetch to handle node 18 issue when using nock
+    // https://github.com/nock/nock/issues/2336
+    // TODO: remove when we move to node 20
+    const fetch = require("node-fetch")
+    globalThis.fetch = fetch
+
     getDefaultProfiler().setEnabled(true)
     gardenEnv.GARDEN_DISABLE_ANALYTICS = true
     testFlags.expandErrors = true

--- a/core/test/unit/src/cli/analytics.ts
+++ b/core/test/unit/src/cli/analytics.ts
@@ -14,13 +14,11 @@ import { GlobalConfigStore } from "../../../../src/config-store/global"
 import { TestGarden, enableAnalytics, makeTestGardenA } from "../../../helpers"
 import { Command } from "../../../../src/commands/base"
 import { isEqual } from "lodash"
-import { getRootLogger } from "../../../../src/logger/logger"
 
 // TODO: These tests are skipped because they fail repeatedly in CI, but works fine locally
 describe("cli analytics", () => {
   let cli: GardenCli
   const globalConfigStore = new GlobalConfigStore()
-  const log = getRootLogger().createLog()
 
   beforeEach(async () => {
     cli = new GardenCli()
@@ -52,7 +50,7 @@ describe("cli analytics", () => {
     }
   }
 
-  it("should access the version check service", async () => {
+  it.skip("should access the version check service", async () => {
     const scope = nock("https://get.garden.io")
     scope.get("/version").query(true).reply(200)
 
@@ -64,7 +62,7 @@ describe("cli analytics", () => {
     expect(scope.done()).to.not.throw
   })
 
-  it("should wait for queued analytic events to flush", async () => {
+  it.skip("should wait for queued analytic events to flush", async () => {
     const scope = nock("https://api.segment.io")
 
     // Each command run result in two events:
@@ -100,7 +98,7 @@ describe("cli analytics", () => {
     expect(scope.done()).to.not.throw
   })
 
-  it("should not send analytics if disabled for command", async () => {
+  it.skip("should not send analytics if disabled for command", async () => {
     const scope = nock("https://api.segment.io")
 
     scope.post(`/v1/batch`).reply(201)

--- a/core/test/unit/src/cli/analytics.ts
+++ b/core/test/unit/src/cli/analytics.ts
@@ -52,7 +52,7 @@ describe("cli analytics", () => {
     }
   }
 
-  it.skip("should access the version check service", async () => {
+  it("should access the version check service", async () => {
     const scope = nock("https://get.garden.io")
     scope.get("/version").query(true).reply(200)
 
@@ -64,7 +64,7 @@ describe("cli analytics", () => {
     expect(scope.done()).to.not.throw
   })
 
-  it.skip("should wait for queued analytic events to flush", async () => {
+  it("should wait for queued analytic events to flush", async () => {
     const scope = nock("https://api.segment.io")
 
     // Each command run result in two events:
@@ -98,5 +98,20 @@ describe("cli analytics", () => {
     await cli.run({ args: ["test-command"], exitOnError: false })
 
     expect(scope.done()).to.not.throw
+  })
+
+  it("should not send analytics if disabled for command", async () => {
+    const scope = nock("https://api.segment.io")
+
+    scope.post(`/v1/batch`).reply(201)
+
+    const command = new TestCommand()
+    command.enableAnalytics = false
+
+    cli.addCommand(command)
+
+    await cli.run({ args: ["test-command"], exitOnError: false })
+
+    expect(scope.isDone()).to.equal(false)
   })
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

This introduces a flag per command to disable analytics. Initially we use this for autocomplete.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

There is a temporary fix for an issue with nock and node 18 to make sure we use a compatible fetch. This can be removed when we move to node 20.