### PR TITLE
fix: re-init the analytics handler metadata on project switch

### DIFF
--- a/core/src/analytics/analytics.ts
+++ b/core/src/analytics/analytics.ts
@@ -368,13 +368,15 @@ export class AnalyticsHandler {
   }
 
   static async init(garden: Garden, log: Log) {
-    if (!AnalyticsHandler.instance) {
+    // Ensure that we re-initialize the analytics metadata when switching projects
+    if (!AnalyticsHandler.instance || AnalyticsHandler.instance.garden?.projectName !== garden.projectName) {
       // We're passing this explictliy to that it's easier to overwrite and test
       // in actual CI.
       const ciInfo = {
         isCi: ci.isCI,
         ciName: ci.name,
       }
+
       AnalyticsHandler.instance = await AnalyticsHandler.factory({ garden, log, ciInfo })
     } else {
       /**

--- a/core/src/commands/base.ts
+++ b/core/src/commands/base.ts
@@ -243,7 +243,7 @@ export abstract class Command<A extends Parameters = {}, O extends Parameters = 
       analytics = await garden.getAnalyticsHandler()
     }
 
-    analytics?.trackCommand(this.getFullName())
+    analytics?.trackCommand(this.getFullName(), parentSessionId || undefined)
 
     const allOpts = <ParameterValues<GlobalOptions & O>>{
       ...mapValues(globalOptions, (opt) => opt.defaultValue),
@@ -310,11 +310,23 @@ export abstract class Command<A extends Parameters = {}, O extends Parameters = 
 
       // Track the result of the command run
       const allErrors = result.errors || []
-      analytics?.trackCommandResult(this.getFullName(), allErrors, commandStartTime, result.exitCode)
+      analytics?.trackCommandResult(
+        this.getFullName(),
+        allErrors,
+        commandStartTime,
+        result.exitCode,
+        parentSessionId || undefined
+      )
 
       cloudEventStream.emit("sessionCompleted", {})
     } catch (err) {
-      analytics?.trackCommandResult(this.getFullName(), [err], commandStartTime || new Date(), 1)
+      analytics?.trackCommandResult(
+        this.getFullName(),
+        [err],
+        commandStartTime || new Date(),
+        1,
+        parentSessionId || undefined
+      )
       cloudEventStream.emit("sessionFailed", {})
       throw err
     } finally {

--- a/core/src/commands/dev.tsx
+++ b/core/src/commands/dev.tsx
@@ -190,7 +190,9 @@ Use ${chalk.bold("up/down")} arrow keys to scroll through your command history.
     const _this = this
     const { garden, log, opts } = params
 
-    const manager = this.getManager(log)
+    // override the session for this manager to ensure we inherit from
+    // the initial garden dummy instance
+    const manager = this.getManager(log, garden.sessionId)
 
     const cl = new CommandLine({
       log,

--- a/core/src/commands/serve.ts
+++ b/core/src/commands/serve.ts
@@ -88,6 +88,7 @@ export class ServeCommand<
     let defaultGarden: Garden | undefined
 
     const manager = this.getManager(log)
+
     manager.defaultProjectRoot = projectConfig?.path || process.cwd()
     manager.defaultEnv = opts.env
 
@@ -130,7 +131,9 @@ export class ServeCommand<
           key: "web-app",
           log,
           message: chalk.green(
-            `🌿 Explore logs, past commands, and your dependency graph in the Garden web App. Log in with ${chalk.cyan("garden login")}.`
+            `🌿 Explore logs, past commands, and your dependency graph in the Garden web App. Log in with ${chalk.cyan(
+              "garden login"
+            )}.`
           ),
         })
       }
@@ -211,14 +214,15 @@ export class ServeCommand<
     })
   }
 
-  getManager(log: Log): GardenInstanceManager {
+  getManager(log: Log, initialSessionId: string | undefined = undefined): GardenInstanceManager {
     if (!this._manager) {
       this._manager = GardenInstanceManager.getInstance({
         log,
-        sessionId: this.sessionId || uuidv4(),
+        sessionId: this.sessionId || initialSessionId || uuidv4(),
         serveCommand: this,
       })
     }
+
     return this._manager
   }
 

--- a/core/test/unit/src/analytics/analytics.ts
+++ b/core/test/unit/src/analytics/analytics.ts
@@ -424,6 +424,7 @@ describe("AnalyticsHandler", () => {
           system: analytics["systemConfig"],
           isCI: analytics["isCI"],
           sessionId: analytics["sessionId"],
+          parentSessionId: analytics["sessionId"],
           firstRunAt: basicConfig.firstRunAt,
           latestRunAt: now,
           isRecurringUser: false,
@@ -468,6 +469,7 @@ describe("AnalyticsHandler", () => {
           isCI: true,
           ciName: "foo",
           sessionId: analytics["sessionId"],
+          parentSessionId: analytics["sessionId"],
           firstRunAt: basicConfig.firstRunAt,
           latestRunAt: now,
           isRecurringUser: false,
@@ -529,6 +531,7 @@ describe("AnalyticsHandler", () => {
           system: analytics["systemConfig"],
           isCI: analytics["isCI"],
           sessionId: analytics["sessionId"],
+          parentSessionId: analytics["sessionId"],
           firstRunAt: basicConfig.firstRunAt,
           latestRunAt: now,
           isRecurringUser: false,
@@ -578,6 +581,57 @@ describe("AnalyticsHandler", () => {
           system: analytics["systemConfig"],
           isCI: analytics["isCI"],
           sessionId: analytics["sessionId"],
+          parentSessionId: analytics["sessionId"],
+          firstRunAt: basicConfig.firstRunAt,
+          latestRunAt: now,
+          isRecurringUser: false,
+          projectMetadata: {
+            modulesCount: 0,
+            moduleTypes: [],
+            tasksCount: 0,
+            servicesCount: 0,
+            testsCount: 0,
+            actionsCount: 0,
+            buildActionCount: 0,
+            testActionCount: 0,
+            deployActionCount: 0,
+            runActionCount: 0,
+          },
+        },
+      })
+    })
+    it("should override the parentSessionId", async () => {
+      scope.post(`/v1/batch`).reply(200)
+
+      const root = getDataDir("test-projects", "login", "has-domain-and-id")
+      garden = await makeTestGarden(root)
+      garden.vcsInfo.originUrl = remoteOriginUrl
+
+      await garden.globalConfigStore.set("analytics", basicConfig)
+      const now = freezeTime()
+      analytics = await AnalyticsHandler.factory({ garden, log: garden.log, ciInfo })
+
+      const event = analytics.trackCommand("testCommand", "test-parent-session")
+
+      expect(event).to.eql({
+        type: "Run Command",
+        properties: {
+          name: "testCommand",
+          projectId: AnalyticsHandler.hash(remoteOriginUrl),
+          projectIdV2: AnalyticsHandler.hashV2(remoteOriginUrl),
+          projectName: AnalyticsHandler.hash("has-domain-and-id"),
+          projectNameV2: AnalyticsHandler.hashV2("has-domain-and-id"),
+          enterpriseDomain: AnalyticsHandler.hash("https://example.invalid"),
+          enterpriseDomainV2: AnalyticsHandler.hashV2("https://example.invalid"),
+          enterpriseProjectId: AnalyticsHandler.hash("dummy-id"),
+          enterpriseProjectIdV2: AnalyticsHandler.hashV2("dummy-id"),
+          isLoggedIn: false,
+          customer: undefined,
+          ciName: analytics["ciName"],
+          system: analytics["systemConfig"],
+          isCI: analytics["isCI"],
+          sessionId: analytics["sessionId"],
+          parentSessionId: "test-parent-session",
           firstRunAt: basicConfig.firstRunAt,
           latestRunAt: now,
           isRecurringUser: false,
@@ -627,6 +681,7 @@ describe("AnalyticsHandler", () => {
           system: analytics["systemConfig"],
           isCI: analytics["isCI"],
           sessionId: analytics["sessionId"],
+          parentSessionId: analytics["sessionId"],
           firstRunAt: basicConfig.firstRunAt,
           latestRunAt: now,
           isRecurringUser: false,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

When analytics is initialized the first time it has a dummy garden instance. This instance is not aware of a cloud connection which means all subsequent commands will not be associated with a possibly logged in user. This change ensures that we reload the analytics metadata when the garden instance is a proper instance.

The second commit introduces a parentSessionId and includes that explicitly when tracking events. We also ensure that the sessionId from the dummy garden instance created when starting the `dev` command is brought over into the instance manager. The initial sessionId is sent in the first track event, before `action` is called on dev and the following serve command. Without this we would not be able to consistently follow a complete dev command session.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
