### PR TITLE
fix(core): reintroduce kind-specific cmd outputs

### DIFF
--- a/core/src/commands/deploy.ts
+++ b/core/src/commands/deploy.ts
@@ -18,6 +18,7 @@ import {
   PrepareParams,
   processCommandResultSchema,
   ProcessCommandResult,
+  emptyActionResults,
 } from "./base"
 import { printEmoji, printHeader } from "../logger/util"
 import { watchParameter, watchRemovedWarning } from "./helpers"
@@ -214,7 +215,7 @@ export class DeployCommand extends Command<Args, Opts> {
 
     if (deployActions.length === 0) {
       log.error({ msg: "Nothing to deploy. Aborting." })
-      return { result: { aborted: true, success: true, graphResults: {} } }
+      return { result: { aborted: true, success: true, ...emptyActionResults } }
     }
 
     const skipRuntimeDependencies = opts["skip-dependencies"]
@@ -224,7 +225,7 @@ export class DeployCommand extends Command<Args, Opts> {
         list of names when using the --skip-dependencies option.
       `
       log.error({ msg: errMsg })
-      return { result: { aborted: true, success: false, graphResults: {} } }
+      return { result: { aborted: true, success: false, ...emptyActionResults } }
     }
 
     const force = opts.force

--- a/core/src/commands/publish.ts
+++ b/core/src/commands/publish.ts
@@ -13,7 +13,7 @@ import {
   handleProcessResults,
   ProcessCommandResult,
   processCommandResultSchema,
-  processCommandResultKeys,
+  resultMetadataKeys,
 } from "./base"
 import { PublishTask } from "../tasks/publish"
 import { printHeader } from "../logger/util"
@@ -86,7 +86,7 @@ export class PublishCommand extends Command<Args, Opts, ProcessCommandResult> {
 
   outputsSchema = () =>
     processCommandResultSchema().keys({
-      published: joiIdentifierMap(publishResultSchema().keys(processCommandResultKeys())).description(
+      published: joiIdentifierMap(publishResultSchema().keys(resultMetadataKeys())).description(
         "A map of all builds that were published (or scheduled/attempted for publishing) and the results."
       ),
     })

--- a/core/src/commands/sync/sync-status.ts
+++ b/core/src/commands/sync/sync-status.ts
@@ -88,6 +88,7 @@ export class SyncStatusCommand extends Command<Args, Opts> {
 
   async action({ garden, log, args, opts }: CommandParams<Args, Opts>): Promise<SyncStatusCommandResult> {
     const router = await garden.getActionRouter()
+    // TODO: Use regular graph and resolve only the needed Deploys below
     const graph = await garden.getResolvedConfigGraph({ log, emit: true })
     const skipDetail = opts["skip-detail"]
 

--- a/core/src/graph/results.ts
+++ b/core/src/graph/results.ts
@@ -194,6 +194,7 @@ function filterResultForExport(result: any) {
 
       // from DeployStatus
       "createdAt",
+      "mode",
       "syncMode",
       "localMode",
       "namespaceStatuses",

--- a/core/src/types/service.ts
+++ b/core/src/types/service.ts
@@ -186,7 +186,7 @@ export const forwardablePortKeys = () => ({
     .description("The protocol to use for URLs pointing at the port. This can be any valid URI protocol."),
 })
 
-const forwardablePortSchema = createSchema({
+export const forwardablePortSchema = createSchema({
   name: "forwardable-port",
   keys: forwardablePortKeys,
 })

--- a/core/test/unit/src/commands/build.ts
+++ b/core/test/unit/src/commands/build.ts
@@ -38,6 +38,7 @@ describe("BuildCommand", () => {
       opts: withDefaultGlobalOpts({ "watch": false, "force": true, "with-dependants": false }),
     })
 
+    const err = command.outputsSchema().validate(result).error
     expect(command.outputsSchema().validate(result).error).to.be.undefined
 
     const graph = await garden.getResolvedConfigGraph({ log, emit: false })

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -74,8 +74,325 @@ aborted:
 # Set to false if the command execution was unsuccessful.
 success:
 
-# A map of all raw graph results. Avoid using this programmatically if you can, and use more structured keys instead.
-graphResults:
+# A map of all executed Builds (or Builds scheduled/attempted) and information about the them.
+build:
+  <Build name>:
+    # The full log from the build.
+    buildLog:
+
+    # Set to true if the build was fetched from a remote registry.
+    fetched:
+
+    # Set to true if the build was performed, false if it was already built, or fetched from a registry
+    fresh:
+
+    # Additional information, specific to the provider.
+    details:
+
+    # Set to true if the action was not attempted, e.g. if a dependency failed.
+    aborted:
+
+    # The duration of the action's execution in msec, if applicable.
+    durationMsec:
+
+    # Whether the action was succeessfully executed.
+    success:
+
+    # An error message, if the action's execution failed.
+    error:
+
+    # The version of the task's inputs, before any resolution or execution happens. For action tasks, this will
+    # generally be the unresolved version.
+    inputVersion:
+
+    # Alias for `inputVersion`. The version of the task's inputs, before any resolution or execution happens. For
+    # action tasks, this will generally be the unresolved version.
+    version:
+
+    # A map of values output from the action's execution.
+    outputs:
+      <name>:
+
+  <Build name>:
+    # The full log from the build.
+    buildLog:
+
+    # Set to true if the build was fetched from a remote registry.
+    fetched:
+
+    # Set to true if the build was performed, false if it was already built, or fetched from a registry
+    fresh:
+
+    # Additional information, specific to the provider.
+    details:
+
+    # Set to true if the action was not attempted, e.g. if a dependency failed.
+    aborted:
+
+    # The duration of the action's execution in msec, if applicable.
+    durationMsec:
+
+    # Whether the action was succeessfully executed.
+    success:
+
+    # An error message, if the action's execution failed.
+    error:
+
+    # The version of the task's inputs, before any resolution or execution happens. For action tasks, this will
+    # generally be the unresolved version.
+    inputVersion:
+
+    # Alias for `inputVersion`. The version of the task's inputs, before any resolution or execution happens. For
+    # action tasks, this will generally be the unresolved version.
+    version:
+
+    # A map of values output from the action's execution.
+    outputs:
+      <name>:
+
+# A map of all executed Deploys (or Deployments scheduled/attempted) and the Deploy status.
+deploy:
+  <Deploy name>:
+    # When the service was first deployed by the provider.
+    createdAt:
+
+    # When the service was first deployed by the provider.
+    updatedAt:
+
+    # The mode the action is deployed in.
+    mode:
+
+    # The ID used for the service by the provider (if not the same as the service name).
+    externalId:
+
+    # The provider version of the deployed service (if different from the Garden module version.
+    externalVersion:
+
+    # A list of ports that can be forwarded to from the Garden agent by the provider.
+    forwardablePorts:
+      - # A descriptive name for the port. Should correspond to user-configured ports where applicable.
+        name:
+
+        # The preferred local port to use for forwarding.
+        preferredLocalPort:
+
+        # The protocol of the port.
+        protocol:
+
+        # The target name/hostname to forward to (defaults to the service name).
+        targetName:
+
+        # The target port on the service.
+        targetPort:
+
+        # The protocol to use for URLs pointing at the port. This can be any valid URI protocol.
+        urlProtocol:
+
+    # List of currently deployed ingress endpoints for the service.
+    ingresses:
+      - # The port number that the service is exposed on internally.
+        # This defaults to the first specified port for the service.
+        port:
+
+        # The ingress path that should be matched to route to this service.
+        path:
+
+        # The protocol to use for the ingress.
+        protocol:
+
+        # The hostname where the service can be accessed.
+        hostname:
+
+    # Latest status message of the service (if any).
+    lastMessage:
+
+    # Latest error status message of the service (if any).
+    lastError:
+
+    # How many replicas of the service are currently running.
+    runningReplicas:
+
+    # The current deployment status of the service.
+    state:
+
+    # Set to true if the action was not attempted, e.g. if a dependency failed.
+    aborted:
+
+    # The duration of the action's execution in msec, if applicable.
+    durationMsec:
+
+    # Whether the action was succeessfully executed.
+    success:
+
+    # An error message, if the action's execution failed.
+    error:
+
+    # The version of the task's inputs, before any resolution or execution happens. For action tasks, this will
+    # generally be the unresolved version.
+    inputVersion:
+
+    # Alias for `inputVersion`. The version of the task's inputs, before any resolution or execution happens. For
+    # action tasks, this will generally be the unresolved version.
+    version:
+
+    # A map of values output from the action's execution.
+    outputs:
+      <name>:
+
+  <Deploy name>:
+    # When the service was first deployed by the provider.
+    createdAt:
+
+    # When the service was first deployed by the provider.
+    updatedAt:
+
+    # The mode the action is deployed in.
+    mode:
+
+    # The ID used for the service by the provider (if not the same as the service name).
+    externalId:
+
+    # The provider version of the deployed service (if different from the Garden module version.
+    externalVersion:
+
+    # A list of ports that can be forwarded to from the Garden agent by the provider.
+    forwardablePorts:
+      - # A descriptive name for the port. Should correspond to user-configured ports where applicable.
+        name:
+
+        # The preferred local port to use for forwarding.
+        preferredLocalPort:
+
+        # The protocol of the port.
+        protocol:
+
+        # The target name/hostname to forward to (defaults to the service name).
+        targetName:
+
+        # The target port on the service.
+        targetPort:
+
+        # The protocol to use for URLs pointing at the port. This can be any valid URI protocol.
+        urlProtocol:
+
+    # List of currently deployed ingress endpoints for the service.
+    ingresses:
+      - # The port number that the service is exposed on internally.
+        # This defaults to the first specified port for the service.
+        port:
+
+        # The ingress path that should be matched to route to this service.
+        path:
+
+        # The protocol to use for the ingress.
+        protocol:
+
+        # The hostname where the service can be accessed.
+        hostname:
+
+    # Latest status message of the service (if any).
+    lastMessage:
+
+    # Latest error status message of the service (if any).
+    lastError:
+
+    # How many replicas of the service are currently running.
+    runningReplicas:
+
+    # The current deployment status of the service.
+    state:
+
+    # Set to true if the action was not attempted, e.g. if a dependency failed.
+    aborted:
+
+    # The duration of the action's execution in msec, if applicable.
+    durationMsec:
+
+    # Whether the action was succeessfully executed.
+    success:
+
+    # An error message, if the action's execution failed.
+    error:
+
+    # The version of the task's inputs, before any resolution or execution happens. For action tasks, this will
+    # generally be the unresolved version.
+    inputVersion:
+
+    # Alias for `inputVersion`. The version of the task's inputs, before any resolution or execution happens. For
+    # action tasks, this will generally be the unresolved version.
+    version:
+
+    # A map of values output from the action's execution.
+    outputs:
+      <name>:
+
+# A map of all Tests that were executed (or scheduled/attempted) and the Test results.
+test:
+  <Test name>:
+    # Whether the module was successfully run.
+    success:
+
+    # The exit code of the run (if applicable).
+    exitCode:
+
+    # When the module run was started.
+    startedAt:
+
+    # When the module run was completed.
+    completedAt:
+
+    # The output log from the run.
+    log:
+
+  <Test name>:
+    # Whether the module was successfully run.
+    success:
+
+    # The exit code of the run (if applicable).
+    exitCode:
+
+    # When the module run was started.
+    startedAt:
+
+    # When the module run was completed.
+    completedAt:
+
+    # The output log from the run.
+    log:
+
+# A map of all Runs that were executed (or scheduled/attempted) and the Run results.
+run:
+  <Run name>:
+    # Whether the module was successfully run.
+    success:
+
+    # The exit code of the run (if applicable).
+    exitCode:
+
+    # When the module run was started.
+    startedAt:
+
+    # When the module run was completed.
+    completedAt:
+
+    # The output log from the run.
+    log:
+
+  <Run name>:
+    # Whether the module was successfully run.
+    success:
+
+    # The exit code of the run (if applicable).
+    exitCode:
+
+    # When the module run was started.
+    startedAt:
+
+    # When the module run was completed.
+    completedAt:
+
+    # The output log from the run.
+    log:
 ```
 
 ### garden cloud secrets list
@@ -717,8 +1034,325 @@ aborted:
 # Set to false if the command execution was unsuccessful.
 success:
 
-# A map of all raw graph results. Avoid using this programmatically if you can, and use more structured keys instead.
-graphResults:
+# A map of all executed Builds (or Builds scheduled/attempted) and information about the them.
+build:
+  <Build name>:
+    # The full log from the build.
+    buildLog:
+
+    # Set to true if the build was fetched from a remote registry.
+    fetched:
+
+    # Set to true if the build was performed, false if it was already built, or fetched from a registry
+    fresh:
+
+    # Additional information, specific to the provider.
+    details:
+
+    # Set to true if the action was not attempted, e.g. if a dependency failed.
+    aborted:
+
+    # The duration of the action's execution in msec, if applicable.
+    durationMsec:
+
+    # Whether the action was succeessfully executed.
+    success:
+
+    # An error message, if the action's execution failed.
+    error:
+
+    # The version of the task's inputs, before any resolution or execution happens. For action tasks, this will
+    # generally be the unresolved version.
+    inputVersion:
+
+    # Alias for `inputVersion`. The version of the task's inputs, before any resolution or execution happens. For
+    # action tasks, this will generally be the unresolved version.
+    version:
+
+    # A map of values output from the action's execution.
+    outputs:
+      <name>:
+
+  <Build name>:
+    # The full log from the build.
+    buildLog:
+
+    # Set to true if the build was fetched from a remote registry.
+    fetched:
+
+    # Set to true if the build was performed, false if it was already built, or fetched from a registry
+    fresh:
+
+    # Additional information, specific to the provider.
+    details:
+
+    # Set to true if the action was not attempted, e.g. if a dependency failed.
+    aborted:
+
+    # The duration of the action's execution in msec, if applicable.
+    durationMsec:
+
+    # Whether the action was succeessfully executed.
+    success:
+
+    # An error message, if the action's execution failed.
+    error:
+
+    # The version of the task's inputs, before any resolution or execution happens. For action tasks, this will
+    # generally be the unresolved version.
+    inputVersion:
+
+    # Alias for `inputVersion`. The version of the task's inputs, before any resolution or execution happens. For
+    # action tasks, this will generally be the unresolved version.
+    version:
+
+    # A map of values output from the action's execution.
+    outputs:
+      <name>:
+
+# A map of all executed Deploys (or Deployments scheduled/attempted) and the Deploy status.
+deploy:
+  <Deploy name>:
+    # When the service was first deployed by the provider.
+    createdAt:
+
+    # When the service was first deployed by the provider.
+    updatedAt:
+
+    # The mode the action is deployed in.
+    mode:
+
+    # The ID used for the service by the provider (if not the same as the service name).
+    externalId:
+
+    # The provider version of the deployed service (if different from the Garden module version.
+    externalVersion:
+
+    # A list of ports that can be forwarded to from the Garden agent by the provider.
+    forwardablePorts:
+      - # A descriptive name for the port. Should correspond to user-configured ports where applicable.
+        name:
+
+        # The preferred local port to use for forwarding.
+        preferredLocalPort:
+
+        # The protocol of the port.
+        protocol:
+
+        # The target name/hostname to forward to (defaults to the service name).
+        targetName:
+
+        # The target port on the service.
+        targetPort:
+
+        # The protocol to use for URLs pointing at the port. This can be any valid URI protocol.
+        urlProtocol:
+
+    # List of currently deployed ingress endpoints for the service.
+    ingresses:
+      - # The port number that the service is exposed on internally.
+        # This defaults to the first specified port for the service.
+        port:
+
+        # The ingress path that should be matched to route to this service.
+        path:
+
+        # The protocol to use for the ingress.
+        protocol:
+
+        # The hostname where the service can be accessed.
+        hostname:
+
+    # Latest status message of the service (if any).
+    lastMessage:
+
+    # Latest error status message of the service (if any).
+    lastError:
+
+    # How many replicas of the service are currently running.
+    runningReplicas:
+
+    # The current deployment status of the service.
+    state:
+
+    # Set to true if the action was not attempted, e.g. if a dependency failed.
+    aborted:
+
+    # The duration of the action's execution in msec, if applicable.
+    durationMsec:
+
+    # Whether the action was succeessfully executed.
+    success:
+
+    # An error message, if the action's execution failed.
+    error:
+
+    # The version of the task's inputs, before any resolution or execution happens. For action tasks, this will
+    # generally be the unresolved version.
+    inputVersion:
+
+    # Alias for `inputVersion`. The version of the task's inputs, before any resolution or execution happens. For
+    # action tasks, this will generally be the unresolved version.
+    version:
+
+    # A map of values output from the action's execution.
+    outputs:
+      <name>:
+
+  <Deploy name>:
+    # When the service was first deployed by the provider.
+    createdAt:
+
+    # When the service was first deployed by the provider.
+    updatedAt:
+
+    # The mode the action is deployed in.
+    mode:
+
+    # The ID used for the service by the provider (if not the same as the service name).
+    externalId:
+
+    # The provider version of the deployed service (if different from the Garden module version.
+    externalVersion:
+
+    # A list of ports that can be forwarded to from the Garden agent by the provider.
+    forwardablePorts:
+      - # A descriptive name for the port. Should correspond to user-configured ports where applicable.
+        name:
+
+        # The preferred local port to use for forwarding.
+        preferredLocalPort:
+
+        # The protocol of the port.
+        protocol:
+
+        # The target name/hostname to forward to (defaults to the service name).
+        targetName:
+
+        # The target port on the service.
+        targetPort:
+
+        # The protocol to use for URLs pointing at the port. This can be any valid URI protocol.
+        urlProtocol:
+
+    # List of currently deployed ingress endpoints for the service.
+    ingresses:
+      - # The port number that the service is exposed on internally.
+        # This defaults to the first specified port for the service.
+        port:
+
+        # The ingress path that should be matched to route to this service.
+        path:
+
+        # The protocol to use for the ingress.
+        protocol:
+
+        # The hostname where the service can be accessed.
+        hostname:
+
+    # Latest status message of the service (if any).
+    lastMessage:
+
+    # Latest error status message of the service (if any).
+    lastError:
+
+    # How many replicas of the service are currently running.
+    runningReplicas:
+
+    # The current deployment status of the service.
+    state:
+
+    # Set to true if the action was not attempted, e.g. if a dependency failed.
+    aborted:
+
+    # The duration of the action's execution in msec, if applicable.
+    durationMsec:
+
+    # Whether the action was succeessfully executed.
+    success:
+
+    # An error message, if the action's execution failed.
+    error:
+
+    # The version of the task's inputs, before any resolution or execution happens. For action tasks, this will
+    # generally be the unresolved version.
+    inputVersion:
+
+    # Alias for `inputVersion`. The version of the task's inputs, before any resolution or execution happens. For
+    # action tasks, this will generally be the unresolved version.
+    version:
+
+    # A map of values output from the action's execution.
+    outputs:
+      <name>:
+
+# A map of all Tests that were executed (or scheduled/attempted) and the Test results.
+test:
+  <Test name>:
+    # Whether the module was successfully run.
+    success:
+
+    # The exit code of the run (if applicable).
+    exitCode:
+
+    # When the module run was started.
+    startedAt:
+
+    # When the module run was completed.
+    completedAt:
+
+    # The output log from the run.
+    log:
+
+  <Test name>:
+    # Whether the module was successfully run.
+    success:
+
+    # The exit code of the run (if applicable).
+    exitCode:
+
+    # When the module run was started.
+    startedAt:
+
+    # When the module run was completed.
+    completedAt:
+
+    # The output log from the run.
+    log:
+
+# A map of all Runs that were executed (or scheduled/attempted) and the Run results.
+run:
+  <Run name>:
+    # Whether the module was successfully run.
+    success:
+
+    # The exit code of the run (if applicable).
+    exitCode:
+
+    # When the module run was started.
+    startedAt:
+
+    # When the module run was completed.
+    completedAt:
+
+    # The output log from the run.
+    log:
+
+  <Run name>:
+    # Whether the module was successfully run.
+    success:
+
+    # The exit code of the run (if applicable).
+    exitCode:
+
+    # When the module run was started.
+    startedAt:
+
+    # When the module run was completed.
+    completedAt:
+
+    # The output log from the run.
+    log:
 ```
 
 ### garden exec
@@ -3249,19 +3883,331 @@ aborted:
 # Set to false if the command execution was unsuccessful.
 success:
 
-# A map of all raw graph results. Avoid using this programmatically if you can, and use more structured keys instead.
-graphResults:
+# A map of all executed Builds (or Builds scheduled/attempted) and information about the them.
+build:
+  <Build name>:
+    # The full log from the build.
+    buildLog:
+
+    # Set to true if the build was fetched from a remote registry.
+    fetched:
+
+    # Set to true if the build was performed, false if it was already built, or fetched from a registry
+    fresh:
+
+    # Additional information, specific to the provider.
+    details:
+
+    # Set to true if the action was not attempted, e.g. if a dependency failed.
+    aborted:
+
+    # The duration of the action's execution in msec, if applicable.
+    durationMsec:
+
+    # Whether the action was succeessfully executed.
+    success:
+
+    # An error message, if the action's execution failed.
+    error:
+
+    # The version of the task's inputs, before any resolution or execution happens. For action tasks, this will
+    # generally be the unresolved version.
+    inputVersion:
+
+    # Alias for `inputVersion`. The version of the task's inputs, before any resolution or execution happens. For
+    # action tasks, this will generally be the unresolved version.
+    version:
+
+    # A map of values output from the action's execution.
+    outputs:
+      <name>:
+
+  <Build name>:
+    # The full log from the build.
+    buildLog:
+
+    # Set to true if the build was fetched from a remote registry.
+    fetched:
+
+    # Set to true if the build was performed, false if it was already built, or fetched from a registry
+    fresh:
+
+    # Additional information, specific to the provider.
+    details:
+
+    # Set to true if the action was not attempted, e.g. if a dependency failed.
+    aborted:
+
+    # The duration of the action's execution in msec, if applicable.
+    durationMsec:
+
+    # Whether the action was succeessfully executed.
+    success:
+
+    # An error message, if the action's execution failed.
+    error:
+
+    # The version of the task's inputs, before any resolution or execution happens. For action tasks, this will
+    # generally be the unresolved version.
+    inputVersion:
+
+    # Alias for `inputVersion`. The version of the task's inputs, before any resolution or execution happens. For
+    # action tasks, this will generally be the unresolved version.
+    version:
+
+    # A map of values output from the action's execution.
+    outputs:
+      <name>:
+
+# A map of all executed Deploys (or Deployments scheduled/attempted) and the Deploy status.
+deploy:
+  <Deploy name>:
+    # When the service was first deployed by the provider.
+    createdAt:
+
+    # When the service was first deployed by the provider.
+    updatedAt:
+
+    # The mode the action is deployed in.
+    mode:
+
+    # The ID used for the service by the provider (if not the same as the service name).
+    externalId:
+
+    # The provider version of the deployed service (if different from the Garden module version.
+    externalVersion:
+
+    # A list of ports that can be forwarded to from the Garden agent by the provider.
+    forwardablePorts:
+      - # A descriptive name for the port. Should correspond to user-configured ports where applicable.
+        name:
+
+        # The preferred local port to use for forwarding.
+        preferredLocalPort:
+
+        # The protocol of the port.
+        protocol:
+
+        # The target name/hostname to forward to (defaults to the service name).
+        targetName:
+
+        # The target port on the service.
+        targetPort:
+
+        # The protocol to use for URLs pointing at the port. This can be any valid URI protocol.
+        urlProtocol:
+
+    # List of currently deployed ingress endpoints for the service.
+    ingresses:
+      - # The port number that the service is exposed on internally.
+        # This defaults to the first specified port for the service.
+        port:
+
+        # The ingress path that should be matched to route to this service.
+        path:
+
+        # The protocol to use for the ingress.
+        protocol:
+
+        # The hostname where the service can be accessed.
+        hostname:
+
+    # Latest status message of the service (if any).
+    lastMessage:
+
+    # Latest error status message of the service (if any).
+    lastError:
+
+    # How many replicas of the service are currently running.
+    runningReplicas:
+
+    # The current deployment status of the service.
+    state:
+
+    # Set to true if the action was not attempted, e.g. if a dependency failed.
+    aborted:
+
+    # The duration of the action's execution in msec, if applicable.
+    durationMsec:
+
+    # Whether the action was succeessfully executed.
+    success:
+
+    # An error message, if the action's execution failed.
+    error:
+
+    # The version of the task's inputs, before any resolution or execution happens. For action tasks, this will
+    # generally be the unresolved version.
+    inputVersion:
+
+    # Alias for `inputVersion`. The version of the task's inputs, before any resolution or execution happens. For
+    # action tasks, this will generally be the unresolved version.
+    version:
+
+    # A map of values output from the action's execution.
+    outputs:
+      <name>:
+
+  <Deploy name>:
+    # When the service was first deployed by the provider.
+    createdAt:
+
+    # When the service was first deployed by the provider.
+    updatedAt:
+
+    # The mode the action is deployed in.
+    mode:
+
+    # The ID used for the service by the provider (if not the same as the service name).
+    externalId:
+
+    # The provider version of the deployed service (if different from the Garden module version.
+    externalVersion:
+
+    # A list of ports that can be forwarded to from the Garden agent by the provider.
+    forwardablePorts:
+      - # A descriptive name for the port. Should correspond to user-configured ports where applicable.
+        name:
+
+        # The preferred local port to use for forwarding.
+        preferredLocalPort:
+
+        # The protocol of the port.
+        protocol:
+
+        # The target name/hostname to forward to (defaults to the service name).
+        targetName:
+
+        # The target port on the service.
+        targetPort:
+
+        # The protocol to use for URLs pointing at the port. This can be any valid URI protocol.
+        urlProtocol:
+
+    # List of currently deployed ingress endpoints for the service.
+    ingresses:
+      - # The port number that the service is exposed on internally.
+        # This defaults to the first specified port for the service.
+        port:
+
+        # The ingress path that should be matched to route to this service.
+        path:
+
+        # The protocol to use for the ingress.
+        protocol:
+
+        # The hostname where the service can be accessed.
+        hostname:
+
+    # Latest status message of the service (if any).
+    lastMessage:
+
+    # Latest error status message of the service (if any).
+    lastError:
+
+    # How many replicas of the service are currently running.
+    runningReplicas:
+
+    # The current deployment status of the service.
+    state:
+
+    # Set to true if the action was not attempted, e.g. if a dependency failed.
+    aborted:
+
+    # The duration of the action's execution in msec, if applicable.
+    durationMsec:
+
+    # Whether the action was succeessfully executed.
+    success:
+
+    # An error message, if the action's execution failed.
+    error:
+
+    # The version of the task's inputs, before any resolution or execution happens. For action tasks, this will
+    # generally be the unresolved version.
+    inputVersion:
+
+    # Alias for `inputVersion`. The version of the task's inputs, before any resolution or execution happens. For
+    # action tasks, this will generally be the unresolved version.
+    version:
+
+    # A map of values output from the action's execution.
+    outputs:
+      <name>:
+
+# A map of all Tests that were executed (or scheduled/attempted) and the Test results.
+test:
+  <Test name>:
+    # Whether the module was successfully run.
+    success:
+
+    # The exit code of the run (if applicable).
+    exitCode:
+
+    # When the module run was started.
+    startedAt:
+
+    # When the module run was completed.
+    completedAt:
+
+    # The output log from the run.
+    log:
+
+  <Test name>:
+    # Whether the module was successfully run.
+    success:
+
+    # The exit code of the run (if applicable).
+    exitCode:
+
+    # When the module run was started.
+    startedAt:
+
+    # When the module run was completed.
+    completedAt:
+
+    # The output log from the run.
+    log:
+
+# A map of all Runs that were executed (or scheduled/attempted) and the Run results.
+run:
+  <Run name>:
+    # Whether the module was successfully run.
+    success:
+
+    # The exit code of the run (if applicable).
+    exitCode:
+
+    # When the module run was started.
+    startedAt:
+
+    # When the module run was completed.
+    completedAt:
+
+    # The output log from the run.
+    log:
+
+  <Run name>:
+    # Whether the module was successfully run.
+    success:
+
+    # The exit code of the run (if applicable).
+    exitCode:
+
+    # When the module run was started.
+    startedAt:
+
+    # When the module run was completed.
+    completedAt:
+
+    # The output log from the run.
+    log:
 
 # A map of all builds that were published (or scheduled/attempted for publishing) and the results.
 published:
   <name>:
     # The state of the action.
     state:
-
-    # Structured outputs from the execution, as defined by individual action/module types, to be made available for
-    # dependencies and in templating.
-    outputs:
-      <name>:
 
     # Set to true if the action handler is running a process persistently and attached to the Garden process after
     # returning.
@@ -3277,14 +4223,29 @@ published:
       # The published artifact identifier, if applicable.
       identifier:
 
-    # Set to true if the action was not attempted, e.g. if a dependency failed or parameters were incorrect.
+    # Set to true if the action was not attempted, e.g. if a dependency failed.
     aborted:
 
-    # Whether the action was succeessful.
+    # The duration of the action's execution in msec, if applicable.
+    durationMsec:
+
+    # Whether the action was succeessfully executed.
     success:
 
-    # An error message, if the action failed.
+    # An error message, if the action's execution failed.
     error:
+
+    # The version of the task's inputs, before any resolution or execution happens. For action tasks, this will
+    # generally be the unresolved version.
+    inputVersion:
+
+    # Alias for `inputVersion`. The version of the task's inputs, before any resolution or execution happens. For
+    # action tasks, this will generally be the unresolved version.
+    version:
+
+    # A map of values output from the action's execution.
+    outputs:
+      <name>:
 ```
 
 ### garden run
@@ -3331,8 +4292,325 @@ aborted:
 # Set to false if the command execution was unsuccessful.
 success:
 
-# A map of all raw graph results. Avoid using this programmatically if you can, and use more structured keys instead.
-graphResults:
+# A map of all executed Builds (or Builds scheduled/attempted) and information about the them.
+build:
+  <Build name>:
+    # The full log from the build.
+    buildLog:
+
+    # Set to true if the build was fetched from a remote registry.
+    fetched:
+
+    # Set to true if the build was performed, false if it was already built, or fetched from a registry
+    fresh:
+
+    # Additional information, specific to the provider.
+    details:
+
+    # Set to true if the action was not attempted, e.g. if a dependency failed.
+    aborted:
+
+    # The duration of the action's execution in msec, if applicable.
+    durationMsec:
+
+    # Whether the action was succeessfully executed.
+    success:
+
+    # An error message, if the action's execution failed.
+    error:
+
+    # The version of the task's inputs, before any resolution or execution happens. For action tasks, this will
+    # generally be the unresolved version.
+    inputVersion:
+
+    # Alias for `inputVersion`. The version of the task's inputs, before any resolution or execution happens. For
+    # action tasks, this will generally be the unresolved version.
+    version:
+
+    # A map of values output from the action's execution.
+    outputs:
+      <name>:
+
+  <Build name>:
+    # The full log from the build.
+    buildLog:
+
+    # Set to true if the build was fetched from a remote registry.
+    fetched:
+
+    # Set to true if the build was performed, false if it was already built, or fetched from a registry
+    fresh:
+
+    # Additional information, specific to the provider.
+    details:
+
+    # Set to true if the action was not attempted, e.g. if a dependency failed.
+    aborted:
+
+    # The duration of the action's execution in msec, if applicable.
+    durationMsec:
+
+    # Whether the action was succeessfully executed.
+    success:
+
+    # An error message, if the action's execution failed.
+    error:
+
+    # The version of the task's inputs, before any resolution or execution happens. For action tasks, this will
+    # generally be the unresolved version.
+    inputVersion:
+
+    # Alias for `inputVersion`. The version of the task's inputs, before any resolution or execution happens. For
+    # action tasks, this will generally be the unresolved version.
+    version:
+
+    # A map of values output from the action's execution.
+    outputs:
+      <name>:
+
+# A map of all executed Deploys (or Deployments scheduled/attempted) and the Deploy status.
+deploy:
+  <Deploy name>:
+    # When the service was first deployed by the provider.
+    createdAt:
+
+    # When the service was first deployed by the provider.
+    updatedAt:
+
+    # The mode the action is deployed in.
+    mode:
+
+    # The ID used for the service by the provider (if not the same as the service name).
+    externalId:
+
+    # The provider version of the deployed service (if different from the Garden module version.
+    externalVersion:
+
+    # A list of ports that can be forwarded to from the Garden agent by the provider.
+    forwardablePorts:
+      - # A descriptive name for the port. Should correspond to user-configured ports where applicable.
+        name:
+
+        # The preferred local port to use for forwarding.
+        preferredLocalPort:
+
+        # The protocol of the port.
+        protocol:
+
+        # The target name/hostname to forward to (defaults to the service name).
+        targetName:
+
+        # The target port on the service.
+        targetPort:
+
+        # The protocol to use for URLs pointing at the port. This can be any valid URI protocol.
+        urlProtocol:
+
+    # List of currently deployed ingress endpoints for the service.
+    ingresses:
+      - # The port number that the service is exposed on internally.
+        # This defaults to the first specified port for the service.
+        port:
+
+        # The ingress path that should be matched to route to this service.
+        path:
+
+        # The protocol to use for the ingress.
+        protocol:
+
+        # The hostname where the service can be accessed.
+        hostname:
+
+    # Latest status message of the service (if any).
+    lastMessage:
+
+    # Latest error status message of the service (if any).
+    lastError:
+
+    # How many replicas of the service are currently running.
+    runningReplicas:
+
+    # The current deployment status of the service.
+    state:
+
+    # Set to true if the action was not attempted, e.g. if a dependency failed.
+    aborted:
+
+    # The duration of the action's execution in msec, if applicable.
+    durationMsec:
+
+    # Whether the action was succeessfully executed.
+    success:
+
+    # An error message, if the action's execution failed.
+    error:
+
+    # The version of the task's inputs, before any resolution or execution happens. For action tasks, this will
+    # generally be the unresolved version.
+    inputVersion:
+
+    # Alias for `inputVersion`. The version of the task's inputs, before any resolution or execution happens. For
+    # action tasks, this will generally be the unresolved version.
+    version:
+
+    # A map of values output from the action's execution.
+    outputs:
+      <name>:
+
+  <Deploy name>:
+    # When the service was first deployed by the provider.
+    createdAt:
+
+    # When the service was first deployed by the provider.
+    updatedAt:
+
+    # The mode the action is deployed in.
+    mode:
+
+    # The ID used for the service by the provider (if not the same as the service name).
+    externalId:
+
+    # The provider version of the deployed service (if different from the Garden module version.
+    externalVersion:
+
+    # A list of ports that can be forwarded to from the Garden agent by the provider.
+    forwardablePorts:
+      - # A descriptive name for the port. Should correspond to user-configured ports where applicable.
+        name:
+
+        # The preferred local port to use for forwarding.
+        preferredLocalPort:
+
+        # The protocol of the port.
+        protocol:
+
+        # The target name/hostname to forward to (defaults to the service name).
+        targetName:
+
+        # The target port on the service.
+        targetPort:
+
+        # The protocol to use for URLs pointing at the port. This can be any valid URI protocol.
+        urlProtocol:
+
+    # List of currently deployed ingress endpoints for the service.
+    ingresses:
+      - # The port number that the service is exposed on internally.
+        # This defaults to the first specified port for the service.
+        port:
+
+        # The ingress path that should be matched to route to this service.
+        path:
+
+        # The protocol to use for the ingress.
+        protocol:
+
+        # The hostname where the service can be accessed.
+        hostname:
+
+    # Latest status message of the service (if any).
+    lastMessage:
+
+    # Latest error status message of the service (if any).
+    lastError:
+
+    # How many replicas of the service are currently running.
+    runningReplicas:
+
+    # The current deployment status of the service.
+    state:
+
+    # Set to true if the action was not attempted, e.g. if a dependency failed.
+    aborted:
+
+    # The duration of the action's execution in msec, if applicable.
+    durationMsec:
+
+    # Whether the action was succeessfully executed.
+    success:
+
+    # An error message, if the action's execution failed.
+    error:
+
+    # The version of the task's inputs, before any resolution or execution happens. For action tasks, this will
+    # generally be the unresolved version.
+    inputVersion:
+
+    # Alias for `inputVersion`. The version of the task's inputs, before any resolution or execution happens. For
+    # action tasks, this will generally be the unresolved version.
+    version:
+
+    # A map of values output from the action's execution.
+    outputs:
+      <name>:
+
+# A map of all Tests that were executed (or scheduled/attempted) and the Test results.
+test:
+  <Test name>:
+    # Whether the module was successfully run.
+    success:
+
+    # The exit code of the run (if applicable).
+    exitCode:
+
+    # When the module run was started.
+    startedAt:
+
+    # When the module run was completed.
+    completedAt:
+
+    # The output log from the run.
+    log:
+
+  <Test name>:
+    # Whether the module was successfully run.
+    success:
+
+    # The exit code of the run (if applicable).
+    exitCode:
+
+    # When the module run was started.
+    startedAt:
+
+    # When the module run was completed.
+    completedAt:
+
+    # The output log from the run.
+    log:
+
+# A map of all Runs that were executed (or scheduled/attempted) and the Run results.
+run:
+  <Run name>:
+    # Whether the module was successfully run.
+    success:
+
+    # The exit code of the run (if applicable).
+    exitCode:
+
+    # When the module run was started.
+    startedAt:
+
+    # When the module run was completed.
+    completedAt:
+
+    # The output log from the run.
+    log:
+
+  <Run name>:
+    # Whether the module was successfully run.
+    success:
+
+    # The exit code of the run (if applicable).
+    exitCode:
+
+    # When the module run was started.
+    startedAt:
+
+    # When the module run was completed.
+    completedAt:
+
+    # The output log from the run.
+    log:
 ```
 
 ### garden workflow
@@ -3604,8 +4882,325 @@ aborted:
 # Set to false if the command execution was unsuccessful.
 success:
 
-# A map of all raw graph results. Avoid using this programmatically if you can, and use more structured keys instead.
-graphResults:
+# A map of all executed Builds (or Builds scheduled/attempted) and information about the them.
+build:
+  <Build name>:
+    # The full log from the build.
+    buildLog:
+
+    # Set to true if the build was fetched from a remote registry.
+    fetched:
+
+    # Set to true if the build was performed, false if it was already built, or fetched from a registry
+    fresh:
+
+    # Additional information, specific to the provider.
+    details:
+
+    # Set to true if the action was not attempted, e.g. if a dependency failed.
+    aborted:
+
+    # The duration of the action's execution in msec, if applicable.
+    durationMsec:
+
+    # Whether the action was succeessfully executed.
+    success:
+
+    # An error message, if the action's execution failed.
+    error:
+
+    # The version of the task's inputs, before any resolution or execution happens. For action tasks, this will
+    # generally be the unresolved version.
+    inputVersion:
+
+    # Alias for `inputVersion`. The version of the task's inputs, before any resolution or execution happens. For
+    # action tasks, this will generally be the unresolved version.
+    version:
+
+    # A map of values output from the action's execution.
+    outputs:
+      <name>:
+
+  <Build name>:
+    # The full log from the build.
+    buildLog:
+
+    # Set to true if the build was fetched from a remote registry.
+    fetched:
+
+    # Set to true if the build was performed, false if it was already built, or fetched from a registry
+    fresh:
+
+    # Additional information, specific to the provider.
+    details:
+
+    # Set to true if the action was not attempted, e.g. if a dependency failed.
+    aborted:
+
+    # The duration of the action's execution in msec, if applicable.
+    durationMsec:
+
+    # Whether the action was succeessfully executed.
+    success:
+
+    # An error message, if the action's execution failed.
+    error:
+
+    # The version of the task's inputs, before any resolution or execution happens. For action tasks, this will
+    # generally be the unresolved version.
+    inputVersion:
+
+    # Alias for `inputVersion`. The version of the task's inputs, before any resolution or execution happens. For
+    # action tasks, this will generally be the unresolved version.
+    version:
+
+    # A map of values output from the action's execution.
+    outputs:
+      <name>:
+
+# A map of all executed Deploys (or Deployments scheduled/attempted) and the Deploy status.
+deploy:
+  <Deploy name>:
+    # When the service was first deployed by the provider.
+    createdAt:
+
+    # When the service was first deployed by the provider.
+    updatedAt:
+
+    # The mode the action is deployed in.
+    mode:
+
+    # The ID used for the service by the provider (if not the same as the service name).
+    externalId:
+
+    # The provider version of the deployed service (if different from the Garden module version.
+    externalVersion:
+
+    # A list of ports that can be forwarded to from the Garden agent by the provider.
+    forwardablePorts:
+      - # A descriptive name for the port. Should correspond to user-configured ports where applicable.
+        name:
+
+        # The preferred local port to use for forwarding.
+        preferredLocalPort:
+
+        # The protocol of the port.
+        protocol:
+
+        # The target name/hostname to forward to (defaults to the service name).
+        targetName:
+
+        # The target port on the service.
+        targetPort:
+
+        # The protocol to use for URLs pointing at the port. This can be any valid URI protocol.
+        urlProtocol:
+
+    # List of currently deployed ingress endpoints for the service.
+    ingresses:
+      - # The port number that the service is exposed on internally.
+        # This defaults to the first specified port for the service.
+        port:
+
+        # The ingress path that should be matched to route to this service.
+        path:
+
+        # The protocol to use for the ingress.
+        protocol:
+
+        # The hostname where the service can be accessed.
+        hostname:
+
+    # Latest status message of the service (if any).
+    lastMessage:
+
+    # Latest error status message of the service (if any).
+    lastError:
+
+    # How many replicas of the service are currently running.
+    runningReplicas:
+
+    # The current deployment status of the service.
+    state:
+
+    # Set to true if the action was not attempted, e.g. if a dependency failed.
+    aborted:
+
+    # The duration of the action's execution in msec, if applicable.
+    durationMsec:
+
+    # Whether the action was succeessfully executed.
+    success:
+
+    # An error message, if the action's execution failed.
+    error:
+
+    # The version of the task's inputs, before any resolution or execution happens. For action tasks, this will
+    # generally be the unresolved version.
+    inputVersion:
+
+    # Alias for `inputVersion`. The version of the task's inputs, before any resolution or execution happens. For
+    # action tasks, this will generally be the unresolved version.
+    version:
+
+    # A map of values output from the action's execution.
+    outputs:
+      <name>:
+
+  <Deploy name>:
+    # When the service was first deployed by the provider.
+    createdAt:
+
+    # When the service was first deployed by the provider.
+    updatedAt:
+
+    # The mode the action is deployed in.
+    mode:
+
+    # The ID used for the service by the provider (if not the same as the service name).
+    externalId:
+
+    # The provider version of the deployed service (if different from the Garden module version.
+    externalVersion:
+
+    # A list of ports that can be forwarded to from the Garden agent by the provider.
+    forwardablePorts:
+      - # A descriptive name for the port. Should correspond to user-configured ports where applicable.
+        name:
+
+        # The preferred local port to use for forwarding.
+        preferredLocalPort:
+
+        # The protocol of the port.
+        protocol:
+
+        # The target name/hostname to forward to (defaults to the service name).
+        targetName:
+
+        # The target port on the service.
+        targetPort:
+
+        # The protocol to use for URLs pointing at the port. This can be any valid URI protocol.
+        urlProtocol:
+
+    # List of currently deployed ingress endpoints for the service.
+    ingresses:
+      - # The port number that the service is exposed on internally.
+        # This defaults to the first specified port for the service.
+        port:
+
+        # The ingress path that should be matched to route to this service.
+        path:
+
+        # The protocol to use for the ingress.
+        protocol:
+
+        # The hostname where the service can be accessed.
+        hostname:
+
+    # Latest status message of the service (if any).
+    lastMessage:
+
+    # Latest error status message of the service (if any).
+    lastError:
+
+    # How many replicas of the service are currently running.
+    runningReplicas:
+
+    # The current deployment status of the service.
+    state:
+
+    # Set to true if the action was not attempted, e.g. if a dependency failed.
+    aborted:
+
+    # The duration of the action's execution in msec, if applicable.
+    durationMsec:
+
+    # Whether the action was succeessfully executed.
+    success:
+
+    # An error message, if the action's execution failed.
+    error:
+
+    # The version of the task's inputs, before any resolution or execution happens. For action tasks, this will
+    # generally be the unresolved version.
+    inputVersion:
+
+    # Alias for `inputVersion`. The version of the task's inputs, before any resolution or execution happens. For
+    # action tasks, this will generally be the unresolved version.
+    version:
+
+    # A map of values output from the action's execution.
+    outputs:
+      <name>:
+
+# A map of all Tests that were executed (or scheduled/attempted) and the Test results.
+test:
+  <Test name>:
+    # Whether the module was successfully run.
+    success:
+
+    # The exit code of the run (if applicable).
+    exitCode:
+
+    # When the module run was started.
+    startedAt:
+
+    # When the module run was completed.
+    completedAt:
+
+    # The output log from the run.
+    log:
+
+  <Test name>:
+    # Whether the module was successfully run.
+    success:
+
+    # The exit code of the run (if applicable).
+    exitCode:
+
+    # When the module run was started.
+    startedAt:
+
+    # When the module run was completed.
+    completedAt:
+
+    # The output log from the run.
+    log:
+
+# A map of all Runs that were executed (or scheduled/attempted) and the Run results.
+run:
+  <Run name>:
+    # Whether the module was successfully run.
+    success:
+
+    # The exit code of the run (if applicable).
+    exitCode:
+
+    # When the module run was started.
+    startedAt:
+
+    # When the module run was completed.
+    completedAt:
+
+    # The output log from the run.
+    log:
+
+  <Run name>:
+    # Whether the module was successfully run.
+    success:
+
+    # The exit code of the run (if applicable).
+    exitCode:
+
+    # When the module run was started.
+    startedAt:
+
+    # When the module run was completed.
+    completedAt:
+
+    # The output log from the run.
+    log:
 ```
 
 ### garden tools


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

In 0.12, we included keys for build, deploys and tasks in the command result for commnds that used the task graph (e.g. the build & deploy commands).

In 0.13, we initially removed these in favour of the `graphResults` object. Here, we reintroduce them (with most fields still there). This should prevent breakages e.g. in workflows where referencing command outputs is relatively common.

In a future PR, we should get rid of the `graphResults` key entirely from command results. Doing so will require reworking some of our unit tests (since some suites rely on the dependency structure of the results to verify which tasks were actually run).


**Which issue(s) this PR fixes**:

Fixes #4324