### PR TITLE
perf(dev): add internal command for getting sync and deploy statuses

### DIFF
--- a/core/src/server/instance-manager.ts
+++ b/core/src/server/instance-manager.ts
@@ -20,7 +20,7 @@ import { ConfigDump, Garden, GardenOpts } from "../garden"
 import type { Log } from "../logger/log-entry"
 import { MonitorManager } from "../monitors/manager"
 import { environmentToString } from "../types/namespace"
-import { AutocompleteCommand, ReloadCommand, LogLevelCommand, HideCommand } from "./commands"
+import { AutocompleteCommand, ReloadCommand, LogLevelCommand, HideCommand, _GetDeployStatusCommand } from "./commands"
 import { getGardenInstanceKey, GardenInstanceKeyParams } from "./helpers"
 
 interface InstanceContext {
@@ -88,6 +88,7 @@ export class GardenInstanceManager {
         new ReloadCommand(serveCommand),
         new LogLevelCommand(),
         new HideCommand(),
+        new _GetDeployStatusCommand(),
       ]),
       ...(extraCommands || []),
     ]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

This is an internal command that's only used by Cloud to get sync and deploy statuses in a single command to prevent Cloud having to call two commands for that data (since it polls for it).

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
