### PR TITLE
chore: disable analytics for WS server commands

### DIFF
--- a/core/src/server/server.ts
+++ b/core/src/server/server.ts
@@ -48,6 +48,8 @@ export const defaultWatchServerPort = 9777
 
 const skipLogsForCommands = ["autocomplete"]
 
+const skipAnalyticsForCommands = ["sync status"]
+
 interface WebsocketCloseEvent {
   code: number
   message: string
@@ -558,6 +560,10 @@ export class GardenServer extends EventEmitter {
         const printLogs = !internal && !skipLogsForCommands.includes(command.getFullName())
         const requestLog = this.log.createLog({ name: "garden-server" })
         const cmdNameStr = chalk.bold.white(command.getFullName())
+
+        if (skipAnalyticsForCommands.includes(command.getFullName())) {
+          command.enableAnalytics = false
+        }
 
         // TODO: convert to async/await (this was previously in a sync method)
         command


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Filters out defined commands from analytics when requested through the websocket server.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
