### PR TITLE
fix: properly wait for k8s deploys to complete

### DIFF
--- a/core/src/plugins/kubernetes/status/workload.ts
+++ b/core/src/plugins/kubernetes/status/workload.ts
@@ -196,7 +196,7 @@ async function getRolloutStatus(workload: Workload) {
     const status = <V1StatefulSetStatus>workload.status
     const workloadSpec = <Required<V1StatefulSetSpec>>workload.spec
 
-    const replicas = status.replicas || 0
+    const replicas = (workload.spec as V1StatefulSetSpec).replicas || 0
     const updated = status.updatedReplicas || 0
     const ready = status.readyReplicas || 0
 
@@ -221,7 +221,7 @@ async function getRolloutStatus(workload: Workload) {
 
     const desired = deploymentSpec.replicas === undefined ? 1 : deploymentSpec.replicas
     const updated = status.updatedReplicas || 0
-    const replicas = status.replicas || 0
+    const replicas = (workload.spec as any).replicas || 0
     const available = status.availableReplicas || 0
 
     if (updated < desired) {

--- a/core/src/plugins/kubernetes/status/workload.ts
+++ b/core/src/plugins/kubernetes/status/workload.ts
@@ -196,7 +196,7 @@ async function getRolloutStatus(workload: Workload) {
     const status = <V1StatefulSetStatus>workload.status
     const workloadSpec = <Required<V1StatefulSetSpec>>workload.spec
 
-    const replicas = (workload.spec as V1StatefulSetSpec).replicas || 0
+    const replicas = workloadSpec.replicas || 0
     const updated = status.updatedReplicas || 0
     const ready = status.readyReplicas || 0
 
@@ -221,7 +221,7 @@ async function getRolloutStatus(workload: Workload) {
 
     const desired = deploymentSpec.replicas === undefined ? 1 : deploymentSpec.replicas
     const updated = status.updatedReplicas || 0
-    const replicas = (workload.spec as any).replicas || 0
+    const replicas = deploymentSpec.replicas || 0
     const available = status.availableReplicas || 0
 
     if (updated < desired) {


### PR DESCRIPTION
We were getting the desired replica count from the status API
response [1] which has the current replica count, not the desired amount.

Desired amount is specified in the spec [2].

1. https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/stateful-set-v1/#StatefulSetStatus
2. https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/stateful-set-v1/#StatefulSetSpec