### PR TITLE
fix: escape rsync special characters in filenames on windows (#4434)

### DIFF
--- a/core/src/util/sync.ts
+++ b/core/src/util/sync.ts
@@ -52,8 +52,13 @@ export async function syncWithOptions({
       // Workaround for this issue: https://stackoverflow.com/questions/1813907
       opts.push("--include-from=-", "--exclude=*", "--delete-excluded")
 
-      // -> Make sure the file list is anchored (otherwise filenames are matched as patterns)
-      files = files.map((f) => "/" + f)
+      files = files.map((f) => {
+        // -> Make sure the file list is anchored (otherwise filenames are matched as patterns)
+        let filename = "/" + f
+        // -> Escape rsync include/exclude wildcard characters https://linux.die.net/man/1/rsync
+        filename = filename.replaceAll(/(\[|\?|\*)/g, "\\$1")
+        return filename
+      })
 
       input = "/**/\n" + files.join("\n")
     }

--- a/core/test/unit/src/build-staging/build-staging.ts
+++ b/core/test/unit/src/build-staging/build-staging.ts
@@ -656,5 +656,51 @@ function commonSyncTests(legacyBuildSync: boolean) {
 
       expect(await listFiles(targetRoot)).to.eql(["subdir/a"])
     })
+
+    it("correctly handles special characters in the file name, withDelete true", async () => {
+      const specialFilenames = ["[id].vue", "*foo", "bla?"]
+      const a = join(tmpPath, "a")
+      const b = join(tmpPath, "b")
+      await ensureDir(a)
+      for (const filename of specialFilenames) {
+        await writeFile(join(a, filename), "foo")
+      }
+      await ensureDir(b)
+      await sync({
+        log,
+        sourceRoot: tmpPath,
+        sourceRelPath: "a/",
+        files: specialFilenames,
+        targetRoot: b,
+        withDelete: true,
+      })
+      for (const filename of specialFilenames) {
+        const data = (await readFile(join(b, filename))).toString()
+        expect(data).to.equal("foo")
+      }
+    })
+
+    it("correctly handles special characters in the file name, withDelete false", async () => {
+      const specialFilenames = ["[id].vue", "*foo", "bla?"]
+      const a = join(tmpPath, "a")
+      const b = join(tmpPath, "b")
+      await ensureDir(a)
+      for (const filename of specialFilenames) {
+        await writeFile(join(a, filename), "foo")
+      }
+      await ensureDir(b)
+      await sync({
+        log,
+        sourceRoot: tmpPath,
+        sourceRelPath: "a/",
+        files: specialFilenames,
+        targetRoot: b,
+        withDelete: false,
+      })
+      for (const filename of specialFilenames) {
+        const data = (await readFile(join(b, filename))).toString()
+        expect(data).to.equal("foo")
+      }
+    })
   })
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes https://github.com/garden-io/garden/issues/4018
Cherry-picking https://github.com/garden-io/garden/pull/4434 for 0.12 🌸 

**Special notes for your reviewer**:

Let's cut a release for 0.12 some time this week or early next week.
Do we have any other bugfixes / patches to backport?