### PR TITLE
fix: render (log) errors

### DIFF
--- a/core/src/cli/command-line.ts
+++ b/core/src/cli/command-line.ts
@@ -94,7 +94,7 @@ export function logCommandSuccess({ commandName, log, width }: { commandName: st
 }
 
 export function logCommandOutputErrors({ errors, log, width }: { errors: Error[]; log: Log; width: number }) {
-  renderCommandErrors(getRootLogger(), errors, log)
+  renderCommandErrors(log.root, errors, log)
   log.error({ msg: renderDivider({ width, color: chalk.red }) })
 }
 

--- a/core/src/cli/command-line.ts
+++ b/core/src/cli/command-line.ts
@@ -20,8 +20,7 @@ import { findProjectConfig } from "../config/base"
 import { toGardenError } from "../exceptions"
 import { Garden } from "../garden"
 import type { Log } from "../logger/log-entry"
-import { getRootLogger } from "../logger/logger"
-import { renderDivider } from "../logger/util"
+import { getTermWidth, renderDivider } from "../logger/util"
 import { getGardenForRequest } from "../server/commands"
 import type { GardenInstanceManager } from "../server/instance-manager"
 import { TypedEventEmitter } from "../util/events"
@@ -457,15 +456,10 @@ export class CommandLine extends TypedEventEmitter<CommandLineEvents> {
     this.renderCommandLine()
   }
 
-  getTermWidth() {
-    // TODO: accept stdout in constructor
-    return process.stdout?.columns || 100
-  }
-
   private printWithDividers(text: string, title: string) {
     let width = max(text.split("\n").map((l) => stringWidth(l.trimEnd()))) || 0
     width += 2
-    const termWidth = this.getTermWidth()
+    const termWidth = getTermWidth()
     const minWidth = stringWidth(title) + 10
 
     if (width > termWidth) {
@@ -668,7 +662,7 @@ ${chalk.white.underline("Keys:")}
     opts: ParameterValues<any>
   }) {
     const id = uuidv4()
-    const width = this.getTermWidth() - 2
+    const width = getTermWidth() - 2
 
     const prepareParams = {
       log: this.log,

--- a/core/src/cli/helpers.ts
+++ b/core/src/cli/helpers.ts
@@ -546,7 +546,6 @@ export function renderCommandErrors(logger: Logger, errors: Error[], log?: Log) 
 
   for (const error of gardenErrors) {
     errorLog.error({
-      msg: error.message,
       error,
     })
     // Output error details to console when log level is silly

--- a/core/src/logger/renderers.ts
+++ b/core/src/logger/renderers.ts
@@ -50,7 +50,7 @@ export function renderError(entry: LogEntry): string {
   if (error) {
     const noAnsiErr = stripAnsi(error.message || "")
     const noAnsiMsg = stripAnsi(msg || "")
-    // render error only if message doesn't laready contain it
+    // render error only if message doesn't already contain it
     if (!noAnsiMsg?.includes(trim(noAnsiErr, "\n"))) {
       out = "\n\n" + chalk.red(error.message)
     }

--- a/core/src/logger/util.ts
+++ b/core/src/logger/util.ts
@@ -99,7 +99,7 @@ const getNumberOfCharsPerWidth = (char: string, width: number) => width / string
 
 // Adapted from https://github.com/JureSotosek/ink-divider
 export function renderDivider({
-  width = 80,
+  width = undefined,
   char = "─",
   titlePadding = 1,
   color,
@@ -107,6 +107,9 @@ export function renderDivider({
   padding = 0,
 }: DividerOpts = {}) {
   const pad = " "
+  if (!width) {
+    width = getTermWidth()
+  }
 
   if (!color) {
     color = chalk.white
@@ -122,6 +125,11 @@ export function renderDivider({
   const paddingString = pad.repeat(padding)
 
   return paddingString + dividerSideString + titleString + dividerSideString + paddingString
+}
+
+export const getTermWidth = () => {
+  // TODO: accept stdout as param
+  return process.stdout?.columns || 100
 }
 
 export function renderDuration(duration: number): string {

--- a/core/test/unit/src/logger/renderers.ts
+++ b/core/test/unit/src/logger/renderers.ts
@@ -66,8 +66,7 @@ describe("renderers", () => {
       }
       const log = logger.createLog().info({ msg: "foo", error })
       const rendered = renderError(log.entries[0])
-      expect(rendered).to.include("Error: hello error")
-      expect(rendered).to.include("Error Details:")
+      expect(rendered).to.include("hello error")
     })
   })
   describe("renderSection", () => {


### PR DESCRIPTION
See commits for details.

A bunch of test assertions might fail, will need to fix separately if so.

This also completes this https://github.com/orgs/garden-io/projects/5/views/1?pane=issue&itemId=28914020 <- was erroring out just as expected, it's just that the error was not shown.