### PR TITLE
fix: helm module to action conversion: do not require version with name

### DIFF
--- a/core/src/plugins/kubernetes/helm/config.ts
+++ b/core/src/plugins/kubernetes/helm/config.ts
@@ -153,7 +153,6 @@ const helmChartSpecSchema = () =>
       url: joi.string().uri().description("An absolute URL to a packaged URL."),
       version: helmChartVersionSchema(),
     })
-    .with("name", ["version"])
     .without("path", ["name", "repo", "version", "url"])
     .without("url", ["name", "repo", "version", "path"])
     .xor("name", "path", "url")
@@ -163,7 +162,7 @@ const helmChartSpecSchema = () =>
 
   If the chart is defined in the same directory as the action, you can skip this, and the chart sources will be detected. If the chart is in the source tree but in a sub-directory, you should set \`chart.path\` to the directory path, relative to the action directory.
 
-  If the chart is remote, you must specify \`chart.name\` and \`chart.version\, and optionally \`chart.repo\` (if the chart is not in the default "stable" repo).
+  If the chart is remote, you can specify \`chart.name\` and \`chart.version\, and optionally \`chart.repo\` (if the chart is not in the default "stable" repo).
 
   You may also specify an absolute URL to a packaged chart via \`chart.url\`.
 

--- a/core/test/data/test-projects/helm-name-version-regression/garden.yml
+++ b/core/test/data/test-projects/helm-name-version-regression/garden.yml
@@ -1,0 +1,16 @@
+kind: Project
+apiVersion: garden.io/v0
+name: repro
+environments:
+  - name: default
+providers:
+  - name: local-kubernetes
+
+---
+kind: Module
+description: mailhog service
+type: helm
+name: mailhog
+# version is not specified
+repo: https://codecentric.github.io/helm-charts
+chart: mailhog

--- a/core/test/integ/src/plugins/kubernetes/helm/config.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/config.ts
@@ -10,7 +10,7 @@ import { resolve } from "path"
 import { expect } from "chai"
 import { cloneDeep, omit } from "lodash"
 
-import { expectError, TestGarden } from "../../../../../helpers"
+import { expectError, getDataDir, makeTestGarden, TestGarden, withDefaultGlobalOpts } from "../../../../../helpers"
 import { PluginContext } from "../../../../../../src/plugin-context"
 import { dedent } from "../../../../../../src/util/string"
 import { ModuleConfig } from "../../../../../../src/config/module"
@@ -18,7 +18,12 @@ import { apply } from "json-merge-patch"
 import { getHelmTestGarden } from "./common"
 import { defaultHelmTimeout } from "../../../../../../src/plugins/kubernetes/helm/module-config"
 import stripAnsi = require("strip-ansi")
-import { DEFAULT_BUILD_TIMEOUT_SEC, DEFAULT_DEPLOY_TIMEOUT_SEC, GardenApiVersion } from "../../../../../../src/constants"
+import {
+  DEFAULT_BUILD_TIMEOUT_SEC,
+  DEFAULT_DEPLOY_TIMEOUT_SEC,
+  GardenApiVersion,
+} from "../../../../../../src/constants"
+import { ValidateCommand } from "../../../../../../src/commands/validate"
 
 describe("configureHelmModule", () => {
   let garden: TestGarden
@@ -219,5 +224,17 @@ describe("configureHelmModule", () => {
         api: Helm module 'api' both contains sources and specifies a base module. Since Helm charts cannot currently be merged, please either remove the sources or the \`base\` reference in your module config.
       `)
     )
+  })
+
+  it("should pass validation with a chart name but no version specified", async () => {
+    const projectRoot = getDataDir("test-projects", "helm-name-version-regression")
+    const g = await makeTestGarden(projectRoot)
+    const command = new ValidateCommand()
+    await command.action({
+      garden: g,
+      log: g.log,
+      args: {},
+      opts: withDefaultGlobalOpts({}),
+    })
   })
 })

--- a/docs/reference/action-types/Deploy/helm.md
+++ b/docs/reference/action-types/Deploy/helm.md
@@ -208,7 +208,7 @@ spec:
   # detected. If the chart is in the source tree but in a sub-directory, you should set `chart.path` to the directory
   # path, relative to the action directory.
   #
-  # If the chart is remote, you must specify `chart.name` and `chart.version\, and optionally `chart.repo` (if the
+  # If the chart is remote, you can specify `chart.name` and `chart.version\, and optionally `chart.repo` (if the
   # chart is not in the default "stable" repo).
   #
   # You may also specify an absolute URL to a packaged chart via `chart.url`.
@@ -804,7 +804,7 @@ Specify the Helm chart to use.
 
 If the chart is defined in the same directory as the action, you can skip this, and the chart sources will be detected. If the chart is in the source tree but in a sub-directory, you should set `chart.path` to the directory path, relative to the action directory.
 
-If the chart is remote, you must specify `chart.name` and `chart.version\, and optionally `chart.repo` (if the chart is not in the default "stable" repo).
+If the chart is remote, you can specify `chart.name` and `chart.version\, and optionally `chart.repo` (if the chart is not in the default "stable" repo).
 
 You may also specify an absolute URL to a packaged chart via `chart.url`.
 

--- a/docs/reference/action-types/Run/helm-pod.md
+++ b/docs/reference/action-types/Run/helm-pod.md
@@ -192,7 +192,7 @@ spec:
   # detected. If the chart is in the source tree but in a sub-directory, you should set `chart.path` to the directory
   # path, relative to the action directory.
   #
-  # If the chart is remote, you must specify `chart.name` and `chart.version\, and optionally `chart.repo` (if the
+  # If the chart is remote, you can specify `chart.name` and `chart.version\, and optionally `chart.repo` (if the
   # chart is not in the default "stable" repo).
   #
   # You may also specify an absolute URL to a packaged chart via `chart.url`.
@@ -658,7 +658,7 @@ Specify the Helm chart to use.
 
 If the chart is defined in the same directory as the action, you can skip this, and the chart sources will be detected. If the chart is in the source tree but in a sub-directory, you should set `chart.path` to the directory path, relative to the action directory.
 
-If the chart is remote, you must specify `chart.name` and `chart.version\, and optionally `chart.repo` (if the chart is not in the default "stable" repo).
+If the chart is remote, you can specify `chart.name` and `chart.version\, and optionally `chart.repo` (if the chart is not in the default "stable" repo).
 
 You may also specify an absolute URL to a packaged chart via `chart.url`.
 

--- a/docs/reference/action-types/Test/helm-pod.md
+++ b/docs/reference/action-types/Test/helm-pod.md
@@ -192,7 +192,7 @@ spec:
   # detected. If the chart is in the source tree but in a sub-directory, you should set `chart.path` to the directory
   # path, relative to the action directory.
   #
-  # If the chart is remote, you must specify `chart.name` and `chart.version\, and optionally `chart.repo` (if the
+  # If the chart is remote, you can specify `chart.name` and `chart.version\, and optionally `chart.repo` (if the
   # chart is not in the default "stable" repo).
   #
   # You may also specify an absolute URL to a packaged chart via `chart.url`.
@@ -658,7 +658,7 @@ Specify the Helm chart to use.
 
 If the chart is defined in the same directory as the action, you can skip this, and the chart sources will be detected. If the chart is in the source tree but in a sub-directory, you should set `chart.path` to the directory path, relative to the action directory.
 
-If the chart is remote, you must specify `chart.name` and `chart.version\, and optionally `chart.repo` (if the chart is not in the default "stable" repo).
+If the chart is remote, you can specify `chart.name` and `chart.version\, and optionally `chart.repo` (if the chart is not in the default "stable" repo).
 
 You may also specify an absolute URL to a packaged chart via `chart.url`.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes https://github.com/garden-io/garden/issues/4461

**Special notes for your reviewer**:
Validated locally using the example from the mentioned issue
```
gdev deploy
Deploy 🚀

Project is configured with `apiVersion: garden.io/v0`, running with backwards compatibility.
ℹ garden               → Running in Garden environment default.default
ℹ providers            → Getting status...
✔ providers            → Cached (took 0.7 sec)
ℹ providers            → Run with --force-refresh to force a refresh of provider statuses.
ℹ graph                → Resolving actions and modules...
✔ graph                → Done (took 0 sec)
ℹ deploy.mailhog       → missing
ℹ deploy.mailhog       → Deploying version v-68d2bc1af2...
ℹ deploy.mailhog       → Waiting for resources to be ready...
ℹ deploy.mailhog       → Resources ready
✔ deploy.mailhog       → Done (took 5.8 sec)

Done! ✔️
```
