### PR TITLE
Update helm version from `3.7.2` to `3.12.0`

### DIFF
--- a/core/src/plugins/kubernetes/helm/helm-cli.ts
+++ b/core/src/plugins/kubernetes/helm/helm-cli.ts
@@ -13,16 +13,18 @@ import { PluginToolSpec } from "../../../plugin/tools"
 import split2 from "split2"
 import { Dictionary, pickBy } from "lodash"
 
+export const HELM_VERSION = "3.7.2"
+
 export const helm3Spec: PluginToolSpec = {
   name: "helm",
-  description: "The Helm CLI (version 3.x).",
+  description: `The Helm CLI (version ${HELM_VERSION}).`,
   type: "binary",
   _includeInGardenImage: true,
   builds: [
     {
       platform: "darwin",
       architecture: "amd64",
-      url: "https://get.helm.sh/helm-v3.7.2-darwin-amd64.tar.gz",
+      url: `https://get.helm.sh/helm-v${HELM_VERSION}-darwin-amd64.tar.gz`,
       sha256: "5a0738afb1e194853aab00258453be8624e0a1d34fcc3c779989ac8dbcd59436",
       extract: {
         format: "tar",
@@ -32,7 +34,7 @@ export const helm3Spec: PluginToolSpec = {
     {
       platform: "darwin",
       architecture: "arm64",
-      url: "https://get.helm.sh/helm-v3.7.2-darwin-arm64.tar.gz",
+      url: `https://get.helm.sh/helm-v${HELM_VERSION}-darwin-arm64.tar.gz`,
       sha256: "260d4b8bffcebc6562ea344dfe88efe252cf9511dd6da3cccebf783773d42aec",
       extract: {
         format: "tar",
@@ -42,7 +44,7 @@ export const helm3Spec: PluginToolSpec = {
     {
       platform: "linux",
       architecture: "amd64",
-      url: "https://get.helm.sh/helm-v3.7.2-linux-amd64.tar.gz",
+      url: `https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz`,
       sha256: "4ae30e48966aba5f807a4e140dad6736ee1a392940101e4d79ffb4ee86200a9e",
       extract: {
         format: "tar",
@@ -52,7 +54,7 @@ export const helm3Spec: PluginToolSpec = {
     {
       platform: "windows",
       architecture: "amd64",
-      url: "https://get.helm.sh/helm-v3.7.2-windows-amd64.zip",
+      url: `https://get.helm.sh/helm-v${HELM_VERSION}-windows-amd64.zip`,
       sha256: "299165f0af46bece9a61b41305cca8e8d5ec5319a4b694589cd71e6b75aca77e",
       extract: {
         format: "zip",

--- a/core/src/plugins/kubernetes/helm/helm-cli.ts
+++ b/core/src/plugins/kubernetes/helm/helm-cli.ts
@@ -13,7 +13,7 @@ import { PluginToolSpec } from "../../../plugin/tools"
 import split2 from "split2"
 import { Dictionary, pickBy } from "lodash"
 
-export const HELM_VERSION = "3.7.2"
+export const HELM_VERSION = "3.12.0"
 
 export const helm3Spec: PluginToolSpec = {
   name: "helm",
@@ -25,7 +25,7 @@ export const helm3Spec: PluginToolSpec = {
       platform: "darwin",
       architecture: "amd64",
       url: `https://get.helm.sh/helm-v${HELM_VERSION}-darwin-amd64.tar.gz`,
-      sha256: "5a0738afb1e194853aab00258453be8624e0a1d34fcc3c779989ac8dbcd59436",
+      sha256: "8223beb796ff19b59e615387d29be8c2025c5d3aea08485a262583de7ba7d708",
       extract: {
         format: "tar",
         targetPath: "darwin-amd64/helm",
@@ -35,7 +35,7 @@ export const helm3Spec: PluginToolSpec = {
       platform: "darwin",
       architecture: "arm64",
       url: `https://get.helm.sh/helm-v${HELM_VERSION}-darwin-arm64.tar.gz`,
-      sha256: "260d4b8bffcebc6562ea344dfe88efe252cf9511dd6da3cccebf783773d42aec",
+      sha256: "879f61d2ad245cb3f5018ab8b66a87619f195904a4df3b077c98ec0780e36c37",
       extract: {
         format: "tar",
         targetPath: "darwin-arm64/helm",
@@ -45,7 +45,7 @@ export const helm3Spec: PluginToolSpec = {
       platform: "linux",
       architecture: "amd64",
       url: `https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz`,
-      sha256: "4ae30e48966aba5f807a4e140dad6736ee1a392940101e4d79ffb4ee86200a9e",
+      sha256: "da36e117d6dbc57c8ec5bab2283222fbd108db86c83389eebe045ad1ef3e2c3b",
       extract: {
         format: "tar",
         targetPath: "linux-amd64/helm",
@@ -55,7 +55,7 @@ export const helm3Spec: PluginToolSpec = {
       platform: "windows",
       architecture: "amd64",
       url: `https://get.helm.sh/helm-v${HELM_VERSION}-windows-amd64.zip`,
-      sha256: "299165f0af46bece9a61b41305cca8e8d5ec5319a4b694589cd71e6b75aca77e",
+      sha256: "52138ba8caec50c358c7aee41aac28d6a8a037878ada3cf5ce6c1049fc772547",
       extract: {
         format: "zip",
         targetPath: "windows-amd64/helm.exe",

--- a/core/src/plugins/kubernetes/helm/helm-cli.ts
+++ b/core/src/plugins/kubernetes/helm/helm-cli.ts
@@ -8,12 +8,10 @@
 
 import { Log } from "../../../logger/log-entry"
 import { KubernetesPluginContext } from "../config"
-import { join } from "path"
-import { GARDEN_GLOBAL_PATH } from "../../../constants"
-import { mkdirp } from "fs-extra"
 import { StringMap } from "../../../config/common"
 import { PluginToolSpec } from "../../../plugin/tools"
 import split2 from "split2"
+import { Dictionary, pickBy } from "lodash"
 
 export const helm3Spec: PluginToolSpec = {
   name: "helm",
@@ -69,7 +67,6 @@ export async function helm({
   namespace,
   log,
   args,
-  version = 3,
   env = {},
   cwd,
   emitLogEvents,
@@ -78,7 +75,6 @@ export async function helm({
   namespace?: string
   log: Log
   args: string[]
-  version?: 2 | 3
   env?: { [key: string]: string }
   cwd?: string
   emitLogEvents: boolean
@@ -89,15 +85,12 @@ export async function helm({
     opts.push("--kubeconfig", ctx.provider.config.kubeconfig)
   }
 
-  const helmHome = join(GARDEN_GLOBAL_PATH, `.helm${version}`)
-  await mkdirp(helmHome)
-
   const cmd = ctx.tools["kubernetes.helm"]
 
+  const processEnv = pickBy(process.env, (v) => v !== undefined) as Dictionary<string>
   const envVars: StringMap = {
-    ...process.env,
+    ...processEnv,
     ...env,
-    HELM_HOME: helmHome,
   }
 
   if (namespace) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
Updates `helm` from the ancient version `3.7.2` to the latest release `3.12.0`.

**Which issue(s) this PR fixes**:

Fixes #3753

**Special notes for your reviewer**:
This is a _potentially_ breaking change. There were some breaking changes in helm CLI and SDK between the versions:
* helm 3.11.1 https://github.com/helm/helm/releases/tag/v3.11.1
* helm 3.9.0 https://github.com/helm/helm/releases/tag/v3.9.0

Those changes might not be breaking for Garden helm provider. We use `install`, `upgrade`, and `template` helm commands, but I haven't faced any issues yet. Tested with `garden deploy` in the [`vote-helm` example](https://github.com/garden-io/garden/tree/main/examples/vote-helm).
