### PR TITLE
fix: pulumi module validation

### DIFF
--- a/docs/reference/module-types/pulumi.md
+++ b/docs/reference/module-types/pulumi.md
@@ -156,6 +156,10 @@ variables:
 # varfiles exist).
 varfile:
 
+# The names of any services that this service depends on at runtime, and the names of any tasks that should be
+# executed before this service is deployed.
+dependencies: []
+
 # If set to true, Garden will destroy the stack when calling `garden cleanup namespace` or `garden cleanup deploy
 # <deploy action name>`.
 # This is useful to prevent unintentional destroys in production or shared environments.
@@ -523,6 +527,14 @@ Example:
 ```yaml
 varfile: "my-module.env"
 ```
+
+### `dependencies[]`
+
+The names of any services that this service depends on at runtime, and the names of any tasks that should be executed before this service is deployed.
+
+| Type            | Default | Required |
+| --------------- | ------- | -------- |
+| `array[string]` | `[]`    | No       |
 
 ### `allowDestroy`
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Adds a separate spec for Pulumi modules and actions, so that we can validate old configurations correctly.

**Which issue(s) this PR fixes**:

Fixes https://github.com/garden-io/garden/issues/4468

**Special notes for your reviewer**:

Taking inspiration from the terraform plugin, and how the module and action validation is handled there.
Pardon the seemingly large changes due to moving the `.keys()` call outside the function for reuse purposes - it is mostly indents.
