### PR TITLE
fix(k8s): stringify output when throwing registry query error

### DIFF
--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -230,7 +230,7 @@ export async function skopeoBuildStatus({
     if (res.exitCode !== 0 && !skopeoManifestUnknown(res.stderr)) {
       const output = res.allLogs || err.message
 
-      throw new RuntimeError(`Unable to query registry for image status: ${output}`, {
+      throw new RuntimeError(`Unable to query registry for image status: ${JSON.stringify(output)}`, {
         command: skopeoCommand,
         output,
       })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Otherwise we print:

Unable to query registry for image status: Non-error was
thrown: "[object Object]".

We also need to port this to 0.12. 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
