### PR TITLE
chore: return list of suggested commands in `get config` output

### DIFF
--- a/core/src/commands/base.ts
+++ b/core/src/commands/base.ts
@@ -84,6 +84,48 @@ export interface RunCommandParams<A extends Parameters = {}, O extends Parameter
   parentSessionId: string | null
 }
 
+export interface SuggestedCommand {
+  description: string
+  source?: string
+  gardenCommand?: string
+  shellCommand?: {
+    command: string
+    args: string[]
+    cwd: string
+  }
+  openUrl?: string
+  icon?: {
+    name: string
+    src?: string
+  }
+}
+
+export const suggestedCommandSchema = createSchema({
+  name: "suggested-command",
+  keys: () => ({
+    description: joi.string().required().description("Short description of what the command does."),
+    source: joi.string().description("The source of the suggestion, e.g. a plugin name."),
+    gardenCommand: joi.string().description("A Garden command to run (including arguments)."),
+    shellCommand: joi
+      .object()
+      .keys({
+        command: joi.string().required().description("The shell command to run (without arguments)."),
+        args: joi.array().items(joi.string()).required().description("Arguments to pass to the command."),
+        cwd: joi.string().required().description("Absolute path to run the shell command in."),
+      })
+      .description("A shell command to run."),
+    openUrl: joi.string().description("A URL to open in a browser window."),
+    icon: joi
+      .object()
+      .keys({
+        name: joi.string().required().description("A string reference (and alt text) for the icon."),
+        src: joi.string().description("A URI for the image. May be a data URI."),
+      })
+      .description("The icon to display next to the command, where applicable (e.g. in dashboard or Garden Desktop)."),
+  }),
+  xor: [["gardenCommand", "shellCommand", "openUrl"]],
+})
+
 type DataCallback = (data: string) => void
 
 export abstract class Command<A extends Parameters = {}, O extends Parameters = {}, R = any> {

--- a/core/src/commands/get/get-config.ts
+++ b/core/src/commands/get/get-config.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { Command, CommandResult, CommandParams } from "../base"
+import { Command, CommandResult, CommandParams, suggestedCommandSchema } from "../base"
 import { ConfigDump } from "../../garden"
 import { environmentNameSchema, projectSourceSchema } from "../../config/project"
 import { joiIdentifier, joiVariables, joiArray, joi, joiStringMap } from "../../config/common"
@@ -65,6 +65,9 @@ export class GetConfigCommand extends Command<{}, Opts, ConfigDump> {
       projectId: joi.string().optional().description("The project ID (Garden Cloud only)."),
       domain: joi.string().optional().description("The Garden Cloud domain (Garden Cloud only)."),
       sources: joi.array().items(projectSourceSchema()).description("All configured external project sources."),
+      suggestedCommands: joiArray(suggestedCommandSchema()).description(
+        "A list of suggested commands to run in the project."
+      ),
     })
 
   options = getConfigOptions

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -148,6 +148,7 @@ import { convertTemplatedModuleToRender, RenderTemplateConfig, renderConfigTempl
 import { MonitorManager } from "./monitors/manager"
 import { AnalyticsHandler } from "./analytics/analytics"
 import { getGardenInstanceKey } from "./server/helpers"
+import { SuggestedCommand } from "./commands/base"
 
 const defaultLocalAddress = "localhost"
 
@@ -638,7 +639,9 @@ export class Garden {
   }
 
   getRawProviderConfigs({ names, allowMissing = false }: { names?: string[]; allowMissing?: boolean } = {}) {
-    return names ? findByNames({ names, entries: this.providerConfigs, description: "provider", allowMissing }) : this.providerConfigs
+    return names
+      ? findByNames({ names, entries: this.providerConfigs, description: "provider", allowMissing })
+      : this.providerConfigs
   }
 
   async resolveProvider(log: Log, name: string) {
@@ -1299,7 +1302,7 @@ export class Garden {
         }
 
         for (const config of actionConfigs) {
-          this.addActionConfig((config as unknown) as BaseActionConfig)
+          this.addActionConfig(config as unknown as BaseActionConfig)
           actionsCount++
         }
       }
@@ -1595,7 +1598,21 @@ export class Garden {
       projectId: this.projectId,
       domain: this.cloudDomain,
       sources: this.projectSources,
+      suggestedCommands: await this.getSuggestedCommands(),
     }
+  }
+
+  public async getSuggestedCommands(): Promise<SuggestedCommand[]> {
+    const suggestions: SuggestedCommand[] = [
+      {
+        description: "Deploy the whole project",
+        gardenCommand: "deploy",
+      }
+    ]
+
+    // TODO: call plugin handlers to get plugin-specific suggestions
+
+    return suggestions
   }
 
   /** Returns whether the user is logged in to the Garden Cloud */
@@ -1951,6 +1968,7 @@ export interface ConfigDump {
   projectId?: string
   domain?: string
   sources: SourceConfig[]
+  suggestedCommands: SuggestedCommand[]
 }
 
 export interface GetConfigGraphParams {

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -2781,6 +2781,39 @@ sources:
     # A remote repository URL. Currently only supports git servers. Must contain a hash suffix pointing to a specific
     # branch or tag, with the format: <git remote url>#<branch|tag>
     repositoryUrl:
+
+# A list of suggested commands to run in the project.
+suggestedCommands:
+  - # Short description of what the command does.
+    description:
+
+    # The source of the suggestion, e.g. a plugin name.
+    source:
+
+    # A Garden command to run (including arguments).
+    gardenCommand:
+
+    # A shell command to run.
+    shellCommand:
+      # The shell command to run (without arguments).
+      command:
+
+      # Arguments to pass to the command.
+      args:
+
+      # Absolute path to run the shell command in.
+      cwd:
+
+    # A URL to open in a browser window.
+    openUrl:
+
+    # The icon to display next to the command, where applicable (e.g. in dashboard or Garden Desktop).
+    icon:
+      # A string reference (and alt text) for the icon.
+      name:
+
+      # A URI for the image. May be a data URI.
+      src:
 ```
 
 ### garden get linked-repos


### PR DESCRIPTION
To be used in Garden Desktop. This is quick and dirty just to unblock client dev, will fill in project/plugin-specific suggestions later.
