### PR TITLE
refactor: improved plugin definition SDK interface, phase 1

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -143,7 +143,8 @@
     "ws": "^8.12.1",
     "yaml": "^2.2.2",
     "yaml-lint": "^1.2.4",
-    "zod": "^3.20.6"
+    "zod": "^3.20.6",
+    "zod-to-json-schema": "^3.21.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.6.5",

--- a/core/src/actions/build.ts
+++ b/core/src/actions/build.ts
@@ -26,6 +26,7 @@ import type {
   ExecutedActionWrapperParams,
   ExecutedAction,
   ResolvedAction,
+  GetOutputValueType,
 } from "./types"
 import {
   baseActionConfigSchema,
@@ -147,8 +148,9 @@ export const buildActionConfigSchema = createSchema({
 
 export class BuildAction<
   C extends BuildActionConfig<any, any> = BuildActionConfig<any, any>,
-  O extends {} = any
-> extends BaseAction<C, O> {
+  StaticOutputs extends {} = any,
+  RuntimeOutputs extends {} = any
+> extends BaseAction<C, StaticOutputs, RuntimeOutputs> {
   kind: "Build"
 
   /**
@@ -185,10 +187,11 @@ export class BuildAction<
 // TODO: see if we can avoid the duplication here with ResolvedRuntimeAction
 export class ResolvedBuildAction<
     C extends BuildActionConfig<any, any> = BuildActionConfig<any, any>,
-    Outputs extends {} = any
+    StaticOutputs extends {} = any,
+    RuntimeOutputs extends {} = any
   >
-  extends BuildAction<C, Outputs>
-  implements ResolvedActionExtension<C, Outputs>
+  extends BuildAction<C, StaticOutputs, RuntimeOutputs>
+  implements ResolvedActionExtension<C, StaticOutputs, RuntimeOutputs>
 {
   protected graph: ResolvedConfigGraph
   protected readonly params: ResolvedActionWrapperParams<C>
@@ -228,8 +231,8 @@ export class ResolvedBuildAction<
     return key ? this._config.spec[key] : this._config.spec
   }
 
-  getOutput<K extends keyof Outputs>(key: K) {
-    return this._staticOutputs[key]
+  getOutput<K extends keyof StaticOutputs>(key: K): GetOutputValueType<K, StaticOutputs, RuntimeOutputs> {
+    return <any>this._staticOutputs[<keyof StaticOutputs>key]
   }
 
   getOutputs() {
@@ -243,26 +246,30 @@ export class ResolvedBuildAction<
 
 export class ExecutedBuildAction<
     C extends BuildActionConfig<any, any> = BuildActionConfig<any, any>,
-    O extends {} = any
+    StaticOutputs extends {} = any,
+    RuntimeOutputs extends {} = any
   >
-  extends ResolvedBuildAction<C, O>
-  implements ExecutedActionExtension<C, O>
+  extends ResolvedBuildAction<C, StaticOutputs, RuntimeOutputs>
+  implements ExecutedActionExtension<C, StaticOutputs, RuntimeOutputs>
 {
   protected readonly executed: true
-  private readonly status: ActionStatus<this, any, O>
+  private readonly status: ActionStatus<this, any, RuntimeOutputs>
 
-  constructor(params: ExecutedActionWrapperParams<C, O>) {
+  constructor(params: ExecutedActionWrapperParams<C, StaticOutputs, RuntimeOutputs>) {
     super(params)
     this.status = params.status
     this.executed = true
   }
 
-  getOutput<K extends keyof O>(key: K) {
-    return this.status.outputs[key] || this._staticOutputs[key]
+  getOutput<K extends keyof (StaticOutputs & RuntimeOutputs)>(
+    key: K
+  ): GetOutputValueType<K, StaticOutputs, RuntimeOutputs> {
+    // FIXME: unsure how to avoid the any cast here, but usage is unaffected
+    return <any>(this.status.outputs[<any>key] || this._staticOutputs[<keyof StaticOutputs>key])
   }
 
   getOutputs() {
-    return this.status.outputs
+    return { ...this._staticOutputs, ...this.status.outputs }
   }
 }
 

--- a/core/src/actions/deploy.ts
+++ b/core/src/actions/deploy.ts
@@ -33,21 +33,27 @@ export const deployActionConfigSchema = memoize(() =>
   })
 )
 
-export class DeployAction<S extends DeployActionConfig = any, O extends {} = any> extends RuntimeAction<S, O> {
+export class DeployAction<
+  C extends DeployActionConfig = any,
+  StaticOutputs extends {} = any,
+  RuntimeOutputs extends {} = any
+> extends RuntimeAction<C, StaticOutputs, RuntimeOutputs> {
   kind: "Deploy"
 }
 
-export class ResolvedDeployAction<S extends DeployActionConfig = any, O extends {} = any> extends ResolvedRuntimeAction<
-  S,
-  O
-> {
+export class ResolvedDeployAction<
+  C extends DeployActionConfig = any,
+  StaticOutputs extends {} = any,
+  RuntimeOutputs extends {} = any
+> extends ResolvedRuntimeAction<C, StaticOutputs, RuntimeOutputs> {
   kind: "Deploy"
 }
 
-export class ExecutedDeployAction<S extends DeployActionConfig = any, O extends {} = any> extends ExecutedRuntimeAction<
-  S,
-  O
-> {
+export class ExecutedDeployAction<
+  C extends DeployActionConfig = any,
+  StaticOutputs extends {} = any,
+  RuntimeOutputs extends {} = any
+> extends ExecutedRuntimeAction<C, StaticOutputs, RuntimeOutputs> {
   kind: "Deploy"
 }
 

--- a/core/src/actions/run.ts
+++ b/core/src/actions/run.ts
@@ -33,21 +33,27 @@ export const runActionConfigSchema = memoize(() =>
   })
 )
 
-export class RunAction<C extends RunActionConfig = RunActionConfig, O extends {} = any> extends RuntimeAction<C, O> {
+export class RunAction<
+  C extends RunActionConfig = RunActionConfig,
+  StaticOutputs extends {} = any,
+  RuntimeOutputs extends {} = any
+> extends RuntimeAction<C, StaticOutputs, RuntimeOutputs> {
   kind: "Run"
 }
 
 export class ResolvedRunAction<
   C extends RunActionConfig = RunActionConfig,
-  O extends {} = any
-> extends ResolvedRuntimeAction<C, O> {
+  StaticOutputs extends {} = any,
+  RuntimeOutputs extends {} = any
+> extends ResolvedRuntimeAction<C, StaticOutputs, RuntimeOutputs> {
   kind: "Run"
 }
 
 export class ExecutedRunAction<
   C extends RunActionConfig = RunActionConfig,
-  O extends {} = any
-> extends ExecutedRuntimeAction<C, O> {
+  StaticOutputs extends {} = any,
+  RuntimeOutputs extends {} = any
+> extends ExecutedRuntimeAction<C, StaticOutputs, RuntimeOutputs> {
   kind: "Run"
 }
 

--- a/core/src/actions/test.ts
+++ b/core/src/actions/test.ts
@@ -33,21 +33,27 @@ export const testActionConfigSchema = memoize(() =>
   })
 )
 
-export class TestAction<C extends TestActionConfig = any, O extends {} = any> extends RuntimeAction<C, O> {
+export class TestAction<
+  C extends TestActionConfig = any,
+  StaticOutputs extends {} = any,
+  RuntimeOutputs extends {} = any
+> extends RuntimeAction<C, StaticOutputs, RuntimeOutputs> {
   kind: "Test"
 }
 
-export class ResolvedTestAction<C extends TestActionConfig = any, O extends {} = any> extends ResolvedRuntimeAction<
-  C,
-  O
-> {
+export class ResolvedTestAction<
+  C extends TestActionConfig = any,
+  StaticOutputs extends {} = any,
+  RuntimeOutputs extends {} = any
+> extends ResolvedRuntimeAction<C, StaticOutputs, RuntimeOutputs> {
   kind: "Test"
 }
 
-export class ExecutedTestAction<C extends TestActionConfig = any, O extends {} = any> extends ExecutedRuntimeAction<
-  C,
-  O
-> {
+export class ExecutedTestAction<
+  C extends TestActionConfig = any,
+  StaticOutputs extends {} = any,
+  RuntimeOutputs extends {} = any
+> extends ExecutedRuntimeAction<C, StaticOutputs, RuntimeOutputs> {
   kind: "Test"
 }
 

--- a/core/src/actions/types.ts
+++ b/core/src/actions/types.ts
@@ -159,25 +159,35 @@ export interface ActionWrapperParams<C extends BaseActionConfig> {
   variables: DeepPrimitiveMap
 }
 
-export interface ResolveActionParams<C extends BaseActionConfig, Outputs extends {} = any> {
+export interface ResolveActionParams<C extends BaseActionConfig, StaticOutputs extends {} = any> {
   resolvedGraph: ResolvedConfigGraph
   dependencyResults: GraphResults
   executedDependencies: ExecutedAction[]
   resolvedDependencies: ResolvedAction[]
   spec: C["spec"]
-  staticOutputs: Outputs
+  staticOutputs: StaticOutputs
   inputs: DeepPrimitiveMap
   variables: DeepPrimitiveMap
 }
 
-export type ResolvedActionWrapperParams<C extends BaseActionConfig> = ActionWrapperParams<C> & ResolveActionParams<C>
+export type ResolvedActionWrapperParams<
+  C extends BaseActionConfig,
+  StaticOutputs extends {} = any
+> = ActionWrapperParams<C> & ResolveActionParams<C, StaticOutputs>
 
-export interface ExecuteActionParams<C extends BaseActionConfig = BaseActionConfig, O extends {} = any> {
-  status: ActionStatus<BaseAction<C, O>, any>
+export interface ExecuteActionParams<
+  C extends BaseActionConfig = BaseActionConfig,
+  StaticOutputs extends {} = any,
+  RuntimeOutputs extends {} = any
+> {
+  status: ActionStatus<BaseAction<C, StaticOutputs>, any, RuntimeOutputs>
 }
 
-export type ExecutedActionWrapperParams<C extends BaseActionConfig, O extends {}> = ResolvedActionWrapperParams<C> &
-  ExecuteActionParams<C, O>
+export type ExecutedActionWrapperParams<
+  C extends BaseActionConfig,
+  StaticOutputs extends {} = any,
+  RuntimeOutputs extends {} = any
+> = ResolvedActionWrapperParams<C, StaticOutputs> & ExecuteActionParams<C, StaticOutputs, RuntimeOutputs>
 
 export type GetActionOutputType<T> = T extends BaseAction<any, infer O> ? O : any
 
@@ -191,23 +201,23 @@ export type ResolvedAction = ResolvedBuildAction | ResolvedDeployAction | Resolv
 export type ExecutedAction = ExecutedBuildAction | ExecutedDeployAction | ExecutedRunAction | ExecutedTestAction
 
 export type Resolved<T extends BaseAction> = T extends BuildAction
-  ? ResolvedBuildAction<T["_config"], T["_outputs"]>
+  ? ResolvedBuildAction<T["_config"], T["_staticOutputs"], T["_runtimeOutputs"]>
   : T extends DeployAction
-  ? ResolvedDeployAction<T["_config"], T["_outputs"]>
+  ? ResolvedDeployAction<T["_config"], T["_staticOutputs"], T["_runtimeOutputs"]>
   : T extends RunAction
-  ? ResolvedRunAction<T["_config"], T["_outputs"]>
+  ? ResolvedRunAction<T["_config"], T["_staticOutputs"], T["_runtimeOutputs"]>
   : T extends TestAction
-  ? ResolvedTestAction<T["_config"], T["_outputs"]>
+  ? ResolvedTestAction<T["_config"], T["_staticOutputs"], T["_runtimeOutputs"]>
   : T
 
 export type Executed<T extends BaseAction> = T extends BuildAction
-  ? ExecutedBuildAction<T["_config"], T["_outputs"]>
+  ? ExecutedBuildAction<T["_config"], T["_staticOutputs"], T["_runtimeOutputs"]>
   : T extends DeployAction
-  ? ExecutedDeployAction<T["_config"], T["_outputs"]>
+  ? ExecutedDeployAction<T["_config"], T["_staticOutputs"], T["_runtimeOutputs"]>
   : T extends RunAction
-  ? ExecutedRunAction<T["_config"], T["_outputs"]>
+  ? ExecutedRunAction<T["_config"], T["_staticOutputs"], T["_runtimeOutputs"]>
   : T extends TestAction
-  ? ExecutedTestAction<T["_config"], T["_outputs"]>
+  ? ExecutedTestAction<T["_config"], T["_staticOutputs"], T["_runtimeOutputs"]>
   : T
 
 export type ActionReferenceMap = {
@@ -223,3 +233,10 @@ export type ActionConfigMap = {
 export interface ActionConfigsByKey {
   [key: string]: ActionConfig
 }
+
+export type GetOutputValueType<K, StaticOutputs, RuntimeOutputs> = K extends keyof StaticOutputs
+  ? StaticOutputs[K]
+  : K extends keyof RuntimeOutputs
+  ? RuntimeOutputs[K] | undefined
+  : never
+

--- a/core/src/config-store/global.ts
+++ b/core/src/config-store/global.ts
@@ -75,7 +75,7 @@ const globalConfigSchema = z.object({
     passed: z.boolean().optional().describe("Whether the last check passed the requirements."),
   }),
 })
-
+type conf = typeof globalConfigSchema
 export type GlobalConfig = z.infer<typeof globalConfigSchema>
 export type AnalyticsGlobalConfig = GlobalConfig["analytics"]
 export type ClientAuthToken = z.infer<typeof clientAuthTokenSchema>

--- a/core/src/config-store/global.ts
+++ b/core/src/config-store/global.ts
@@ -75,7 +75,7 @@ const globalConfigSchema = z.object({
     passed: z.boolean().optional().describe("Whether the last check passed the requirements."),
   }),
 })
-type conf = typeof globalConfigSchema
+
 export type GlobalConfig = z.infer<typeof globalConfigSchema>
 export type AnalyticsGlobalConfig = GlobalConfig["analytics"]
 export type ClientAuthToken = z.infer<typeof clientAuthTokenSchema>

--- a/core/src/config/common.ts
+++ b/core/src/config/common.ts
@@ -16,15 +16,23 @@ import { DOCS_BASE_URL, GardenApiVersion } from "../constants"
 import { ActionKind, actionKinds, actionKindsLower } from "../actions/types"
 import { ConfigurationError, InternalError } from "../exceptions"
 import type { ConfigContextType } from "./template-contexts/base"
+import { z } from "zod"
+import {
+  gitUrlRegex,
+  objectSpreadKey,
+  arrayConcatKey,
+  arrayForEachKey,
+  arrayForEachFilterKey,
+  arrayForEachReturnKey,
+  identifierRegex,
+  joiIdentifierDescription,
+  userIdentifierRegex,
+  variableNameRegex,
+  envVarRegex,
+} from "./constants"
 
-export const objectSpreadKey = "$merge"
-export const conditionalKey = "$if"
-export const conditionalThenKey = "$then"
-export const conditionalElseKey = "$else"
-export const arrayConcatKey = "$concat"
-export const arrayForEachKey = "$forEach"
-export const arrayForEachReturnKey = "$return"
-export const arrayForEachFilterKey = "$filter"
+// Avoid chasing moved references
+export * from "./constants"
 
 const ajv = new Ajv({ allErrors: true, useDefaults: true, strict: false })
 addFormats(ajv)
@@ -143,6 +151,7 @@ export interface CustomObjectSchema extends Joi.ObjectSchema {
   concat(schema: object): this
 
   jsonSchema(schema: object): this
+  zodSchema(schema: z.ZodObject<any>): this
 }
 
 export interface GitUrlSchema extends Joi.StringSchema {
@@ -423,6 +432,37 @@ joi = joi.extend({
         }
       },
     },
+
+    zodSchema: {
+      method(zodSchema: z.ZodObject<any>) {
+        // eslint-disable-next-line no-invalid-this
+        this.$_setFlag("zodSchema", zodSchema)
+        // eslint-disable-next-line no-invalid-this
+        return this.$_addRule(<any>{ name: "zodSchema", args: { zodSchema } })
+      },
+      args: [
+        {
+          name: "zodSchema",
+          assert: (value) => {
+            return !!value
+          },
+          message: "must be a valid Zod object schema",
+        },
+      ],
+      validate(value, helpers, args) {
+        const schema = args.zodSchema as z.ZodObject<any>
+
+        try {
+          return schema.parse(value)
+        } catch (error) {
+          // TODO: customize the error output here to make it a bit nicer
+          const outputError = helpers.error("validation")
+          outputError.message = error.message
+          outputError.zodError = error
+          return outputError
+        }
+      },
+    },
   },
 })
 
@@ -651,18 +691,6 @@ export const joiPrimitive = () =>
     .alternatives()
     .try(joi.string().allow("").allow(null), joi.number(), joi.boolean())
     .description("Number, string or boolean")
-
-export const absolutePathRegex = /^\/.*/ // Note: Only checks for the leading slash
-// from https://stackoverflow.com/a/12311250/3290965
-export const identifierRegex = /^(?![0-9]+$)(?!.*-$)(?!-)[a-z0-9-]{1,63}$/
-export const userIdentifierRegex = /^(?!garden)(?=.{1,63}$)[a-z][a-z0-9]*(-[a-z0-9]+)*$/
-export const envVarRegex = /^(?!garden)[a-z_][a-z0-9_\.]*$/i
-export const gitUrlRegex = /(?:git|ssh|https?|git@[-\w.]+):(\/\/)?(.*?)(\/?|\#[-\d\w._\/]+?)$/
-export const variableNameRegex = /[a-zA-Z][a-zA-Z0-9_\-]*/i
-
-export const joiIdentifierDescription =
-  "valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and dashes, must start with a letter, " +
-  "and cannot end with a dash) and must not be longer than 63 characters."
 
 /**
  * Add a joi.actionReference() type, wrapping the parseActionReference() function and returning it as a parsed object.
@@ -949,4 +977,16 @@ export function describeSchema(schema: Joi.ObjectSchema): SchemaDescription {
     keys: Object.keys(desc.keys || {}),
     metadata: metadataFromDescription(desc),
   }
+}
+
+export function zodObjectToJoi(schema: z.ZodObject<any>): Joi.ObjectSchema {
+  let wrapped = joi.object().zodSchema(schema)
+  if (schema.description) {
+    wrapped = wrapped.description(schema.description)
+  }
+  const example = schema.getExample()
+  if (example) {
+    wrapped = wrapped.example(example)
+  }
+  return wrapped
 }

--- a/core/src/config/constants.ts
+++ b/core/src/config/constants.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2018-2023 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+export const objectSpreadKey = "$merge"
+export const conditionalKey = "$if"
+export const conditionalThenKey = "$then"
+export const conditionalElseKey = "$else"
+export const arrayConcatKey = "$concat"
+export const arrayForEachKey = "$forEach"
+export const arrayForEachReturnKey = "$return"
+export const arrayForEachFilterKey = "$filter"
+
+export const absolutePathRegex = /^\/.*/ // Note: Only checks for the leading slash
+// from https://stackoverflow.com/a/12311250/3290965
+export const identifierRegex = /^(?![0-9]+$)(?!.*-$)(?!-)[a-z0-9-]{1,63}$/
+export const userIdentifierRegex = /^(?!garden)(?=.{1,63}$)[a-z][a-z0-9]*(-[a-z0-9]+)*$/
+export const envVarRegex = /^(?!garden)[a-z_][a-z0-9_\.]*$/i
+export const gitUrlRegex = /(?:git|ssh|https?|git@[-\w.]+):(\/\/)?(.*?)(\/?|\#[-\d\w._\/]+?)$/
+export const variableNameRegex = /[a-zA-Z][a-zA-Z0-9_\-]*/i
+
+export const joiIdentifierDescription =
+  "valid RFC1035/RFC1123 (DNS) label (may contain lowercase letters, numbers and dashes, must start with a letter, " +
+  "and cannot end with a dash) and must not be longer than 63 characters."

--- a/core/src/config/provider.ts
+++ b/core/src/config/provider.ts
@@ -27,6 +27,27 @@ import { DashboardPage, dashboardPagesSchema } from "../plugin/handlers/Provider
 import type { ActionState } from "../actions/types"
 import { ValidResultType } from "../tasks/base"
 import { uuidv4 } from "../util/random"
+import { s } from "./zod"
+
+// TODO: dedupe from the joi schema below
+export const baseProviderConfigSchemaZod = s.object({
+  name: s.identifier().describe("The name of the provider plugin to use."),
+  dependencies: s
+    .sparseArray(s.identifier())
+    .default([])
+    .describe("List other providers that should be resolved before this one.")
+    .example(["exec"]),
+  environments: s
+    .sparseArray(s.userIdentifier())
+    .optional()
+    .describe(
+      deline`
+        If specified, this provider will only be used in the listed environments. Note that an empty array effectively
+        disables the provider. To use a provider in all environments, omit this field.
+      `
+    )
+    .example(["dev", "stage"]),
+})
 
 export interface BaseProviderConfig {
   name: string

--- a/core/src/config/zod.ts
+++ b/core/src/config/zod.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2018-2023 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Schema, z } from "zod"
+import { identifierRegex, joiIdentifierDescription, userIdentifierRegex } from "./constants"
+
+// Add metadata support to schemas. See https://github.com/colinhacks/zod/issues/273#issuecomment-1434077058
+declare module "zod" {
+  interface ZodType {
+    getMetadata(): Record<string, any>
+    setMetadata(meta: Record<string, any>): this
+    getExample(): any
+    example(value: any): this
+  }
+}
+Schema.prototype.getMetadata = function () {
+  return this._def.meta
+}
+Schema.prototype.setMetadata = function (meta: Record<string, any>) {
+  const This = (this as any).constructor
+  return new This({
+    ...this._def,
+    meta,
+  })
+}
+Schema.prototype.getExample = function () {
+  return this._def.example
+}
+Schema.prototype.example = function (example: any) {
+  const This = (this as any).constructor
+  return new This({
+    ...this._def,
+    example,
+  })
+}
+
+// Add custom methods
+// TODO: get to full parity with custom joi methods+types (just doing it gradually as needed for now)
+
+export interface PosixPathOpts {
+  absoluteOnly?: boolean
+  allowGlobs?: boolean
+  filenameOnly?: boolean
+  relativeOnly?: boolean
+  subPathOnly?: boolean
+}
+
+type GardenSchema = typeof z & {
+  posixPath: (opts: PosixPathOpts) => z.ZodEffects<z.ZodString, string, string>
+  identifier: () => z.ZodString
+  userIdentifier: () => z.ZodString
+  sparseArray: <T extends z.ZodTypeAny>(
+    schema: T,
+    params?: z.RawCreateParams
+  ) => z.ZodEffects<z.ZodArray<T, "many">, T["_output"][], T["_input"][]>
+}
+
+// This should be imported instead of z because we augment zod with custom methods
+export const s = z as GardenSchema
+
+s.posixPath = (opts: PosixPathOpts = {}) => {
+  return z
+    .string()
+    .superRefine((value, ctx) => {
+      if (opts.absoluteOnly && !value.startsWith("/")) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Path must be absolute (i.e. start with /).`,
+        })
+      }
+      if (!opts.allowGlobs && (value.includes("*") || value.includes("?"))) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Path cannot include globs or wildcards.",
+        })
+      }
+      if (opts.filenameOnly && value.includes("/")) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Must be a filename (may not contain slashes).",
+        })
+      }
+      if (opts.relativeOnly && value.startsWith("/")) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Must be a relative path (may not start with a slash).",
+        })
+      }
+      if (opts.subPathOnly && value.includes("..")) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Must be a sub-path (may not include '..').",
+        })
+      }
+    })
+    .setMetadata({
+      // Picked up when converting to joi schemas
+      posixPath: opts,
+    })
+}
+
+s.identifier = () => {
+  return z
+    .string({
+      errorMap: (issue, ctx) => {
+        if (issue.code === z.ZodIssueCode.invalid_string && issue.validation === "regex") {
+          return { message: "Expected a valid identifier. Should be a " + joiIdentifierDescription }
+        }
+        return { message: ctx.defaultError }
+      },
+    })
+    .regex(identifierRegex)
+}
+
+s.userIdentifier = () => {
+  return z
+    .string({
+      errorMap: (issue, ctx) => {
+        if (issue.code === z.ZodIssueCode.invalid_string && issue.validation === "regex") {
+          return {
+            message:
+              "Expected a valid identifier (that also cannot start with 'garden'). Should be a " +
+              joiIdentifierDescription,
+          }
+        }
+        return { message: ctx.defaultError }
+      },
+    })
+    .regex(userIdentifierRegex)
+}
+
+s.sparseArray = <T extends z.ZodTypeAny>(schema: T, params?: z.RawCreateParams) => {
+  return s.array(schema, params).transform((value) => value.filter((v: any) => v !== undefined && v !== null))
+}

--- a/core/src/docs/json-schema.ts
+++ b/core/src/docs/json-schema.ts
@@ -12,19 +12,21 @@ import { ValidationError } from "../exceptions"
 import { safeDumpYaml } from "../util/serialization"
 
 export class JsonKeyDescription<T = any> extends BaseKeyDescription<T> {
-  private schema: any
-  private allowedValues?: string[]
+  schema: any
+  allowedValues?: string[]
 
   constructor({
     schema,
     name,
     level,
     parent,
+    required = false,
   }: {
     schema: any
     name: string | undefined
     level: number
     parent?: BaseKeyDescription
+    required?: boolean
   }) {
     super(name, level, parent)
 
@@ -44,7 +46,7 @@ export class JsonKeyDescription<T = any> extends BaseKeyDescription<T> {
     this.description = schema.description
     this.experimental = !!schema["x-garden-experimental"]
     this.internal = !!schema["x-garden-internal"]
-    this.required = false
+    this.required = required
 
     if (schema.enum) {
       this.allowedValuesOnly = true

--- a/core/src/events/util.ts
+++ b/core/src/events/util.ts
@@ -144,7 +144,7 @@ export function makeActionCompletePayload<
   A extends Action,
   R extends ValidExecutionActionResultType = {
     state: ActionState
-    outputs: A["_outputs"]
+    outputs: A["_runtimeOutputs"]
     detail: any
     version: string
   }

--- a/core/src/plugin/action-types.ts
+++ b/core/src/plugin/action-types.ts
@@ -54,8 +54,8 @@ export type ActionTypeHandler<
   base?: ActionTypeHandler<K, N, P, R>
 }
 
-export type GetActionTypeParams<T> = T extends ActionTypeHandlerSpec<any, any, any> ? T["_paramsType"] : null
-export type GetActionTypeResults<T> = T extends ActionTypeHandlerSpec<any, any, any> ? T["_resultType"] : null
+export type GetActionTypeParams<T> = T extends ActionTypeHandlerSpec<any, any, any> ? T["_paramsType"] : {}
+export type GetActionTypeResults<T> = T extends ActionTypeHandlerSpec<any, any, any> ? T["_resultType"] : {}
 export type GetActionTypeHandler<T, N> = T extends ActionTypeHandlerSpec<any, any, any>
   ? ActionTypeHandler<T["_kindType"], N, T["_paramsType"], T["_resultType"]>
   : ActionTypeHandler<any, N, any, any>
@@ -164,7 +164,7 @@ export type BuildActionDefinition<C extends BuildAction = BuildAction> = ActionT
 
 // DEPLOY //
 
-type DeployActionDescriptions<C extends DeployAction = DeployAction> = BaseHandlers<C> & {
+export type DeployActionDescriptions<C extends DeployAction = DeployAction> = BaseHandlers<C> & {
   delete: DeleteDeploy<C>
   deploy: DoDeployAction<C>
   exec: ExecInDeploy<C>
@@ -198,7 +198,7 @@ export type DeployActionDefinition<C extends DeployAction = DeployAction> = Acti
 
 // RUN //
 
-type RunActionDescriptions<C extends RunAction = RunAction> = BaseHandlers<C> & {
+export type RunActionDescriptions<C extends RunAction = RunAction> = BaseHandlers<C> & {
   getResult: GetRunActionResult<C>
   run: RunRunAction<C>
 }
@@ -217,7 +217,7 @@ export type RunActionDefinition<C extends RunAction = RunAction> = ActionTypeDef
 
 // TEST //
 
-type TestActionDescriptions<C extends TestAction = TestAction> = BaseHandlers<C> & {
+export type TestActionDescriptions<C extends TestAction = TestAction> = BaseHandlers<C> & {
   getResult: GetTestActionResult<C>
   run: RunTestAction<C>
 }
@@ -248,18 +248,6 @@ export interface ActionClassMap {
   Deploy: DeployAction
   Run: RunAction
   Test: TestAction
-}
-
-export type ActionTypeParams = {
-  [K in ActionKind]: {
-    [H in keyof ActionTypeDescriptions[K]]: GetActionTypeParams<ActionTypeDescriptions[K][H]>
-  }
-}
-
-export type ActionTypeResults = {
-  [K in ActionKind]: {
-    [H in keyof ActionTypeDescriptions[K]]: GetActionTypeResults<ActionTypeDescriptions[K][H]>
-  }
 }
 
 export type ActionTypeHandlers = {

--- a/core/src/plugin/base.ts
+++ b/core/src/plugin/base.ts
@@ -17,6 +17,7 @@ import type { TestAction } from "../actions/test"
 import { NamespaceStatus, namespaceStatusSchema } from "../types/namespace"
 import Joi from "@hapi/joi"
 import { memoize } from "lodash"
+import { BaseProviderConfig } from "../config/provider"
 
 export interface ActionHandlerParamsBase<O = any> {
   base?: ActionHandler<any, O>
@@ -33,11 +34,11 @@ export type WrappedActionHandler<P extends ActionHandlerParamsBase, O> = ActionH
   pluginName: string
 }
 
-export interface PluginActionContextParams extends ActionHandlerParamsBase {
-  ctx: PluginContext
+export interface PluginActionContextParams<C extends BaseProviderConfig = any> extends ActionHandlerParamsBase {
+  ctx: PluginContext<C>
 }
 
-export interface PluginActionParamsBase extends PluginActionContextParams {
+export interface PluginActionParamsBase<C extends BaseProviderConfig = any> extends PluginActionContextParams<C> {
   log: Log
 }
 

--- a/core/src/plugin/command.ts
+++ b/core/src/plugin/command.ts
@@ -13,11 +13,12 @@ import { moduleSchema } from "../types/module"
 import { logEntrySchema } from "./base"
 import { Garden } from "../garden"
 import { ConfigGraph } from "../graph/config-graph"
+import { BaseProviderConfig } from "../config/provider"
 
 // TODO: parse args and opts with a schema
-export interface PluginCommandParams {
+export interface PluginCommandParams<C extends BaseProviderConfig = any> {
   garden: Garden
-  ctx: PluginContext
+  ctx: PluginContext<C>
   args: string[]
   log: Log
   graph: ConfigGraph
@@ -50,15 +51,15 @@ export const pluginCommandResultSchema = createSchema({
   }),
 })
 
-export interface PluginCommandHandler<T extends object = object> {
-  (params: PluginCommandParams): PluginCommandResult<T> | Promise<PluginCommandResult<T>>
+export interface PluginCommandHandler<C extends BaseProviderConfig = any, T extends object = object> {
+  (params: PluginCommandParams<C>): PluginCommandResult<T> | Promise<PluginCommandResult<T>>
 }
 
-export interface PluginCommand {
-  base?: PluginCommand
+export interface PluginCommand<C extends BaseProviderConfig = any, T extends object = object> {
+  base?: PluginCommand<any>
   name: string
   description: string
-  handler: PluginCommandHandler
+  handler: PluginCommandHandler<C, T>
   resolveGraph?: boolean
   title?: string | ((params: { args: string[]; environmentName: string }) => string | Promise<string>)
 }

--- a/core/src/plugin/handlers/Provider/augmentGraph.ts
+++ b/core/src/plugin/handlers/Provider/augmentGraph.ts
@@ -10,11 +10,11 @@ import { PluginActionParamsBase, projectActionParamsSchema } from "../../base"
 import { dedent } from "../../../util/string"
 import { joi, joiArray, joiIdentifierMap } from "../../../config/common"
 import { baseModuleSpecSchema } from "../../../config/module"
-import { providerSchema, ProviderMap } from "../../../config/provider"
+import { providerSchema, ProviderMap, BaseProviderConfig } from "../../../config/provider"
 import { BaseAction, baseActionConfigSchema } from "../../../actions/base"
-import { ActionKind, BaseActionConfig } from "../../../actions/types"
+import type { ActionKind, BaseActionConfig } from "../../../actions/types"
 
-export interface AugmentGraphParams extends PluginActionParamsBase {
+export interface AugmentGraphParams<C extends BaseProviderConfig = any> extends PluginActionParamsBase<C> {
   actions: BaseAction[]
   providers: ProviderMap
 }

--- a/core/src/plugin/handlers/Provider/cleanupEnvironment.ts
+++ b/core/src/plugin/handlers/Provider/cleanupEnvironment.ts
@@ -10,8 +10,9 @@ import { PluginActionParamsBase, projectActionParamsSchema } from "../../base"
 import { dedent } from "../../../util/string"
 import { joi } from "../../../config/common"
 import { NamespaceStatus, namespaceStatusesSchema } from "../../../types/namespace"
+import type { BaseProviderConfig } from "../../../config/provider"
 
-export interface CleanupEnvironmentParams extends PluginActionParamsBase {}
+export interface CleanupEnvironmentParams<C extends BaseProviderConfig = any> extends PluginActionParamsBase<C> {}
 
 export interface CleanupEnvironmentResult {
   namespaceStatuses?: NamespaceStatus[]

--- a/core/src/plugin/handlers/Provider/configureProvider.ts
+++ b/core/src/plugin/handlers/Provider/configureProvider.ts
@@ -7,7 +7,7 @@
  */
 
 import { projectNameSchema, projectRootSchema } from "../../../config/project"
-import { GenericProviderConfig, providerConfigBaseSchema, providerSchema, ProviderMap } from "../../../config/provider"
+import { BaseProviderConfig, providerConfigBaseSchema, providerSchema, ProviderMap } from "../../../config/provider"
 import { PluginActionParamsBase, projectActionParamsSchema } from "../../base"
 import { joiArray, joi, joiIdentifier, joiIdentifierMap } from "../../../config/common"
 import { moduleConfigSchema, ModuleConfig } from "../../../config/module"
@@ -17,7 +17,7 @@ import { Log } from "../../../logger/log-entry"
 import { configStoreSchema, LocalConfigStore } from "../../../config-store/local"
 
 // Note: These are the only plugin handler params that don't inherit from PluginActionParamsBase
-export interface ConfigureProviderParams<T extends GenericProviderConfig = any> extends PluginActionParamsBase {
+export interface ConfigureProviderParams<T extends BaseProviderConfig = any> extends PluginActionParamsBase {
   config: T
   configStore: LocalConfigStore
   dependencies: ProviderMap
@@ -29,7 +29,7 @@ export interface ConfigureProviderParams<T extends GenericProviderConfig = any> 
   base?: ActionHandler<ConfigureProviderParams<T>, ConfigureProviderResult<T>>
 }
 
-export interface ConfigureProviderResult<T extends GenericProviderConfig = GenericProviderConfig> {
+export interface ConfigureProviderResult<T extends BaseProviderConfig = any> {
   config: T
   moduleConfigs?: ModuleConfig[]
 }

--- a/core/src/plugin/handlers/Provider/getDashboardPage.ts
+++ b/core/src/plugin/handlers/Provider/getDashboardPage.ts
@@ -10,6 +10,7 @@ import { PluginActionParamsBase, projectActionParamsSchema } from "../../base"
 import { dedent } from "../../../util/string"
 import { joi, joiIdentifier, joiArray, createSchema } from "../../../config/common"
 import { memoize } from "lodash"
+import type { BaseProviderConfig } from "../../../config/provider"
 
 export interface DashboardPage {
   name: string
@@ -47,7 +48,7 @@ export const dashboardPagesSchema = memoize(() =>
     .unique("name")
 )
 
-export interface GetDashboardPageParams extends PluginActionParamsBase {
+export interface GetDashboardPageParams<C extends BaseProviderConfig = any> extends PluginActionParamsBase<C> {
   page: DashboardPage
 }
 

--- a/core/src/plugin/handlers/Provider/getDebugInfo.ts
+++ b/core/src/plugin/handlers/Provider/getDebugInfo.ts
@@ -9,6 +9,7 @@
 import { projectActionParamsSchema, PluginActionParamsBase } from "../../base"
 import { dedent } from "../../../util/string"
 import { joi } from "../../../config/common"
+import { BaseProviderConfig } from "../../../config/provider"
 
 export interface DebugInfo {
   info: any
@@ -18,7 +19,7 @@ export interface DebugInfoMap {
   [key: string]: DebugInfo
 }
 
-export interface GetDebugInfoParams extends PluginActionParamsBase {
+export interface GetDebugInfoParams<C extends BaseProviderConfig = any> extends PluginActionParamsBase<C> {
   includeProject: boolean
 }
 

--- a/core/src/plugin/handlers/Provider/getEnvironmentStatus.ts
+++ b/core/src/plugin/handlers/Provider/getEnvironmentStatus.ts
@@ -10,8 +10,9 @@ import { PluginActionParamsBase, projectActionParamsSchema } from "../../base"
 import { dedent } from "../../../util/string"
 import { environmentStatusSchema } from "../../../config/status"
 import type { NamespaceStatus } from "../../../types/namespace"
+import type { BaseProviderConfig } from "../../../config/provider"
 
-export interface GetEnvironmentStatusParams extends PluginActionParamsBase {}
+export interface GetEnvironmentStatusParams<C extends BaseProviderConfig = any> extends PluginActionParamsBase<C> {}
 
 export interface EnvironmentStatus<O extends {} = any, D extends {} = any> {
   ready: boolean

--- a/core/src/plugin/handlers/Provider/prepareEnvironment.ts
+++ b/core/src/plugin/handlers/Provider/prepareEnvironment.ts
@@ -11,15 +11,18 @@ import { EnvironmentStatus } from "./getEnvironmentStatus"
 import { dedent } from "../../../util/string"
 import { joi } from "../../../config/common"
 import { environmentStatusSchema } from "../../../config/status"
+import type { GenericProviderConfig } from "../../../config/provider"
 
-export interface PrepareEnvironmentParams<T extends EnvironmentStatus = EnvironmentStatus>
-  extends PluginActionParamsBase {
+export interface PrepareEnvironmentParams<
+  C extends GenericProviderConfig = any,
+  T extends EnvironmentStatus = EnvironmentStatus
+> extends PluginActionParamsBase<C> {
   status: T
   force: boolean
 }
 
-export interface PrepareEnvironmentResult {
-  status: EnvironmentStatus
+export interface PrepareEnvironmentResult<O extends {} = any, D extends {} = any> {
+  status: EnvironmentStatus<O, D>
 }
 
 export const prepareEnvironment = () => ({

--- a/core/src/plugin/plugin.ts
+++ b/core/src/plugin/plugin.ts
@@ -53,8 +53,8 @@ const pluginDependencySchema = createSchema({
 
 export interface GardenPluginSpec {
   name: string
-  base?: string
-  docs?: string
+  base?: string | null
+  docs?: string | null
 
   configSchema?: Joi.ObjectSchema
   outputsSchema?: Joi.ObjectSchema
@@ -105,7 +105,7 @@ export const pluginSchema = createSchema({
   description: "The schema for Garden plugins.",
   keys: () => ({
     name: joiIdentifier().required().description("The name of the plugin."),
-    base: joiIdentifier().description(dedent`
+    base: joiIdentifier().allow(null).description(dedent`
       Name of a plugin to use as a base for this plugin. If you specify this, your provider will inherit all of the
       schema and functionality from the base plugin. Please review other fields for information on how individual
       fields can be overridden or extended.
@@ -123,7 +123,7 @@ export const pluginSchema = createSchema({
       dependency may result in a match with multiple other plugins, if they share a matching base plugin.
     `),
 
-    docs: joi.string().description(dedent`
+    docs: joi.string().allow(null).description(dedent`
       A description of the provider, in markdown format. Please provide a useful introduction, and link to any
       other relevant documentation, such as guides, examples and module types.
     `),

--- a/core/src/plugin/providers.ts
+++ b/core/src/plugin/providers.ts
@@ -32,31 +32,32 @@ import { getDebugInfo, DebugInfo, GetDebugInfoParams } from "./handlers/Provider
 import { AugmentGraphResult, AugmentGraphParams, augmentGraph } from "./handlers/Provider/augmentGraph"
 import { GetDashboardPageParams, GetDashboardPageResult, getDashboardPage } from "./handlers/Provider/getDashboardPage"
 import { baseHandlerSchema } from "./handlers/base/base"
+import type { BaseProviderConfig } from "../config/provider"
 
-export type ProviderHandlers = {
-  [P in keyof ProviderActionParams]: ActionHandler<ProviderActionParams[P], ProviderActionOutputs[P]>
+export type ProviderHandlers<C extends BaseProviderConfig = any, O extends object = any> = {
+  [P in keyof ProviderActionParams]: ActionHandler<ProviderActionParams<C>[P], ProviderActionOutputs<C, O>[P]>
 }
 
 export type ProviderActionName = keyof ProviderHandlers
 
-export interface ProviderActionParams {
-  configureProvider: ConfigureProviderParams
-  augmentGraph: AugmentGraphParams
+export interface ProviderActionParams<C extends BaseProviderConfig = any> {
+  configureProvider: ConfigureProviderParams<C>
+  augmentGraph: AugmentGraphParams<C>
 
-  getEnvironmentStatus: GetEnvironmentStatusParams
-  prepareEnvironment: PrepareEnvironmentParams
-  cleanupEnvironment: CleanupEnvironmentParams
+  getEnvironmentStatus: GetEnvironmentStatusParams<C>
+  prepareEnvironment: PrepareEnvironmentParams<C>
+  cleanupEnvironment: CleanupEnvironmentParams<C>
 
-  getDashboardPage: GetDashboardPageParams
-  getDebugInfo: GetDebugInfoParams
+  getDashboardPage: GetDashboardPageParams<C>
+  getDebugInfo: GetDebugInfoParams<C>
 }
 
-export interface ProviderActionOutputs {
-  configureProvider: ConfigureProviderResult
+export interface ProviderActionOutputs<C extends BaseProviderConfig = any, O extends object = any> {
+  configureProvider: ConfigureProviderResult<C>
   augmentGraph: AugmentGraphResult
 
-  getEnvironmentStatus: EnvironmentStatus
-  prepareEnvironment: PrepareEnvironmentResult
+  getEnvironmentStatus: EnvironmentStatus<O>
+  prepareEnvironment: PrepareEnvironmentResult<O>
   cleanupEnvironment: CleanupEnvironmentResult
 
   getDashboardPage: GetDashboardPageResult

--- a/core/src/plugin/sdk.ts
+++ b/core/src/plugin/sdk.ts
@@ -1,0 +1,326 @@
+/*
+ * Copyright (C) 2018-2023 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { z } from "zod"
+import { BaseAction } from "../actions/base"
+import { BuildAction } from "../actions/build"
+import { DeployAction } from "../actions/deploy"
+import { RunAction } from "../actions/run"
+import { TestAction } from "../actions/test"
+import { BaseActionConfig } from "../actions/types"
+import { joi, zodObjectToJoi } from "../config/common"
+import { BaseProviderConfig, baseProviderConfigSchemaZod } from "../config/provider"
+import { s } from "../config/zod"
+import { ValidationError } from "../exceptions"
+import {
+  ActionKind,
+  ActionTypeDefinition,
+  ActionTypeHandler,
+  ActionTypeHandlers,
+  BuildActionDescriptions,
+  DeployActionDescriptions,
+  RunActionDescriptions,
+  TestActionDescriptions,
+  GetActionTypeParams,
+  GetActionTypeResults,
+} from "./action-types"
+import { PluginCommand } from "./command"
+import { DashboardPage } from "./handlers/Provider/getDashboardPage"
+import type {
+  ActionHandler,
+  GardenPluginSpec,
+  PluginActionParamsBase,
+  PluginDependency,
+  ProviderActionOutputs,
+  ProviderActionParams,
+  ProviderHandlers,
+} from "./plugin"
+import { PluginToolSpec } from "./tools"
+
+type ObjectBaseZod = z.ZodObject<{}>
+
+type FilledPluginSpec = Required<GardenPluginSpec>
+
+type GardenSdkPluginSpec = Pick<
+  GardenPluginSpec,
+  "name" | "base" | "docs" | "dependencies" | "createModuleTypes" | "extendModuleTypes"
+>
+
+export class GardenSdkPlugin {
+  private spec: FilledPluginSpec
+
+  constructor(spec: GardenSdkPluginSpec) {
+    this.spec = {
+      name: spec.name,
+      base: spec.base || null,
+      docs: spec.docs || null,
+
+      configSchema: joi.object(),
+      outputsSchema: joi.object(),
+
+      dependencies: spec.dependencies || [],
+
+      handlers: {},
+      commands: [],
+      tools: [],
+      dashboardPages: [],
+
+      createModuleTypes: spec.createModuleTypes || [],
+      extendModuleTypes: spec.extendModuleTypes || [],
+
+      createActionTypes: {},
+      extendActionTypes: {},
+    }
+  }
+
+  getSpec(): Required<GardenPluginSpec> {
+    return this.spec
+  }
+
+  createProvider<C extends ObjectBaseZod, O extends ObjectBaseZod>(configSchema: C, outputsSchema: O) {
+    const provider = createProvider(this, configSchema, outputsSchema)
+    this.setProvider(provider)
+    return provider
+  }
+
+  setProvider(provider: GardenSdkProvider<any, any>) {
+    this.spec.configSchema = zodObjectToJoi(provider.getConfigSchema())
+    this.spec.outputsSchema = zodObjectToJoi(provider.getOutputsSchema())
+  }
+
+  setBase(base: string) {
+    this.spec.base = base
+  }
+
+  setDocs(docs: string) {
+    this.spec.docs = docs
+  }
+
+  addDependency(dep: PluginDependency) {
+    this.spec.dependencies.push(dep)
+  }
+
+  addTool(spec: PluginToolSpec) {
+    this.spec.tools.push(spec)
+  }
+
+  addDashboardPage(spec: DashboardPage) {
+    this.spec.dashboardPages.push(spec)
+  }
+}
+
+class GardenSdkProvider<ProviderConfigType extends BaseProviderConfig, ProviderOutputsType extends {}> {
+  _configType: ProviderConfigType
+  _outputsType: ProviderOutputsType
+
+  constructor(
+    private readonly spec: FilledPluginSpec,
+    private readonly configSchema: ObjectBaseZod,
+    private readonly outputsSchema: ObjectBaseZod
+  ) {}
+
+  getConfigSchema() {
+    return baseProviderConfigSchemaZod.merge(this.configSchema)
+  }
+
+  getOutputsSchema() {
+    return this.outputsSchema
+  }
+
+  addHandler<T extends keyof ProviderHandlers>(
+    type: T,
+    handler: ActionHandler<
+      ProviderActionParams<ProviderConfigType>[T],
+      ProviderActionOutputs<ProviderConfigType, ProviderOutputsType>[T]
+    >
+  ) {
+    // TODO: work out how to lose any cast
+    this.spec.handlers[type] = <any>handler
+  }
+
+  addCommand(command: PluginCommand<ProviderConfigType>) {
+    this.spec.commands.push(command)
+  }
+
+  createActionType<
+    K extends ActionKind,
+    SpecSchema extends ObjectBaseZod,
+    StaticOutputsSchema extends ObjectBaseZod,
+    RuntimeOutputsSchema extends ObjectBaseZod
+  >(params: {
+    kind: K
+    name: string
+    docs: string
+    specSchema: SpecSchema
+    staticOutputsSchema: StaticOutputsSchema
+    runtimeOutputsSchema: RuntimeOutputsSchema
+  }): GardenSdkActionDefinition<
+    GardenSdkProvider<ProviderConfigType, ProviderOutputsType>,
+    K,
+    z.infer<SpecSchema>,
+    z.infer<StaticOutputsSchema>,
+    z.infer<RuntimeOutputsSchema>
+  > {
+    const def = createActionType({ ...params, provider: this })
+    this.addActionType(def)
+    return def
+  }
+
+  addActionType(def: GardenSdkActionDefinition<any, any, any, any, any>) {
+    if (!this.spec.createActionTypes[def.kind]) {
+      this.spec.createActionTypes[def.kind] = []
+    }
+    this.spec.createActionTypes[def.kind]!.push(<any>def.getSpec()) // FIXME
+  }
+}
+
+type GetActionType<
+  K extends ActionKind,
+  SpecType extends {},
+  StaticOutputsType extends {},
+  RuntimeOutputsType extends {}
+> = K extends "Build"
+  ? BuildAction<BaseActionConfig<K, any, SpecType>, StaticOutputsType, RuntimeOutputsType>
+  : K extends "Deploy"
+  ? DeployAction<BaseActionConfig<K, any, SpecType>, StaticOutputsType, RuntimeOutputsType>
+  : K extends "Run"
+  ? RunAction<BaseActionConfig<K, any, SpecType>, StaticOutputsType, RuntimeOutputsType>
+  : K extends "Test"
+  ? TestAction<BaseActionConfig<K, any, SpecType>, StaticOutputsType, RuntimeOutputsType>
+  : never
+
+type GetActionTypeDescriptions<A extends BaseAction> = A extends BuildAction
+  ? BuildActionDescriptions<A>
+  : A extends DeployAction
+  ? DeployActionDescriptions<A>
+  : A extends RunAction
+  ? RunActionDescriptions<A>
+  : A extends TestAction
+  ? TestActionDescriptions<A>
+  : never
+
+export class GardenSdkActionDefinition<
+  P extends GardenSdkProvider<any, any>,
+  Kind extends ActionKind,
+  SpecType extends {},
+  StaticOutputsType extends {},
+  RuntimeOutputsType extends {}
+> {
+  constructor(
+    protected provider: P,
+    protected actionSpec: ActionTypeDefinition<ActionTypeHandlers[Kind]>,
+    public readonly kind: Kind,
+    public readonly name: string,
+    public readonly docs: string
+  ) {}
+
+  getSpec() {
+    return this.actionSpec
+  }
+
+  addHandler<
+    HandlerType extends keyof GetActionTypeDescriptions<
+      GetActionType<Kind, SpecType, StaticOutputsType, RuntimeOutputsType>
+    >
+  >(
+    type: HandlerType,
+    handler: ActionTypeHandler<
+      Kind,
+      HandlerType,
+      GetActionTypeParams<
+        GetActionTypeDescriptions<GetActionType<Kind, SpecType, StaticOutputsType, RuntimeOutputsType>>[HandlerType]
+      > &
+        PluginActionParamsBase<P["_configType"]>,
+      GetActionTypeResults<
+        GetActionTypeDescriptions<GetActionType<Kind, SpecType, StaticOutputsType, RuntimeOutputsType>>[HandlerType]
+      >
+    >
+  ) {
+    // TODO: work out how to lose any casts
+    const handlers = <any>this.actionSpec.handlers
+    handlers[type] = <any>handler
+  }
+}
+
+interface CreateGardenPluginCallbackParams {
+  plugin: GardenSdkPlugin
+  s: typeof s
+}
+type CreateGardenPluginCallback = (params: CreateGardenPluginCallbackParams) => void
+
+function createProvider<C extends ObjectBaseZod, O extends ObjectBaseZod>(
+  plugin: GardenSdkPlugin,
+  configSchema: C,
+  outputsSchema: O
+) {
+  // Make sure base provider config properties are not overridden
+  const baseKeys = Object.keys(baseProviderConfigSchemaZod.shape)
+  for (const key of Object.keys(configSchema.shape)) {
+    if (baseKeys.includes(key)) {
+      throw new ValidationError(
+        `Attempted to re-define built-in provider config field '${key}'. Built-in fields may not be overridden.`,
+        { key }
+      )
+    }
+  }
+  const spec = plugin.getSpec()
+  const mergedProviderSchema = baseProviderConfigSchemaZod.merge(configSchema)
+  const provider = new GardenSdkProvider<BaseProviderConfig & z.infer<C>, z.infer<O>>(
+    spec,
+    mergedProviderSchema,
+    outputsSchema
+  )
+  return provider
+}
+
+function createActionType<
+  P extends GardenSdkProvider<any, any>,
+  K extends ActionKind,
+  SpecSchema extends ObjectBaseZod,
+  StaticOutputsSchema extends ObjectBaseZod,
+  RuntimeOutputsSchema extends ObjectBaseZod
+>({
+  provider,
+  kind,
+  name,
+  docs,
+  specSchema,
+  staticOutputsSchema,
+  runtimeOutputsSchema,
+}: {
+  provider: P
+  kind: K
+  name: string
+  docs: string
+  specSchema: SpecSchema
+  staticOutputsSchema: StaticOutputsSchema
+  runtimeOutputsSchema: RuntimeOutputsSchema
+}): GardenSdkActionDefinition<P, K, z.infer<SpecSchema>, z.infer<StaticOutputsSchema>, z.infer<RuntimeOutputsSchema>> {
+  const actionSpec: ActionTypeDefinition<ActionTypeHandlers[K]> = {
+    name,
+    docs,
+    schema: zodObjectToJoi(specSchema),
+    staticOutputsSchema: zodObjectToJoi(staticOutputsSchema),
+    runtimeOutputsSchema: zodObjectToJoi(runtimeOutputsSchema),
+    handlers: {},
+  }
+  return new GardenSdkActionDefinition(provider, actionSpec, kind, name, docs)
+}
+
+export const sdk = {
+  schema: s,
+  s, // Shorthand
+
+  createGardenPlugin(spec: GardenSdkPluginSpec, cb?: CreateGardenPluginCallback) {
+    const plugin = new GardenSdkPlugin(spec)
+    cb && cb({ plugin, s })
+    return plugin
+  },
+  createProvider,
+  createActionType,
+}

--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -990,7 +990,7 @@ export interface ContainerBuildActionSpec {
 }
 
 export type ContainerBuildActionConfig = BuildActionConfig<"container", ContainerBuildActionSpec>
-export type ContainerBuildAction = BuildAction<ContainerBuildActionConfig, ContainerBuildOutputs>
+export type ContainerBuildAction = BuildAction<ContainerBuildActionConfig, ContainerBuildOutputs, {}>
 
 export const containerBuildSpecKeys = memoize(() => ({
   localId: joi

--- a/core/src/plugins/container/publish.ts
+++ b/core/src/plugins/container/publish.ts
@@ -16,6 +16,7 @@ export const publishContainerBuild: BuildActionHandler<"publish", ContainerBuild
   log,
   tag,
 }) => {
+  const outputs = action.getOutputs()
   const localId = action.getOutput("localImageId")
   const remoteId = containerHelpers.getPublicImageId(action, tag)
 

--- a/core/src/plugins/container/publish.ts
+++ b/core/src/plugins/container/publish.ts
@@ -16,7 +16,6 @@ export const publishContainerBuild: BuildActionHandler<"publish", ContainerBuild
   log,
   tag,
 }) => {
-  const outputs = action.getOutputs()
   const localId = action.getOutput("localImageId")
   const remoteId = containerHelpers.getPublicImageId(action, tag)
 

--- a/core/src/plugins/exec/config.ts
+++ b/core/src/plugins/exec/config.ts
@@ -75,7 +75,7 @@ export interface ExecBuildActionSpec extends CommonKeys {
 }
 
 export type ExecBuildConfig = BuildActionConfig<"exec", ExecBuildActionSpec>
-export type ExecBuild = BuildAction<ExecBuildConfig, ExecOutputs>
+export type ExecBuild = BuildAction<ExecBuildConfig, ExecOutputs, {}>
 
 export const execBuildActionSchema = createSchema({
   name: "exec:Build",

--- a/core/src/plugins/hadolint/hadolint.ts
+++ b/core/src/plugins/hadolint/hadolint.ts
@@ -8,7 +8,6 @@
 
 import { join, resolve } from "path"
 import { pathExists, readFile } from "fs-extra"
-import { providerConfigBaseSchema, GenericProviderConfig, Provider } from "../../config/provider"
 import { joi } from "../../config/common"
 import { dedent, splitLines, naturalList } from "../../util/string"
 import { STATIC_DIR } from "../../constants"
@@ -18,46 +17,14 @@ import { ConfigurationError } from "../../exceptions"
 import { defaultDockerfileName } from "../container/config"
 import { baseBuildSpecSchema } from "../../config/module"
 import { getGitHubUrl } from "../../docs/common"
-import { createGardenPlugin } from "../../plugin/plugin"
 import { TestAction, TestActionConfig } from "../../actions/test"
-import { TestActionDefinition } from "../../plugin/action-types"
 import { mayContainTemplateString } from "../../template-string/template-string"
 import { BaseAction } from "../../actions/base"
 import { BuildAction } from "../../actions/build"
+import { sdk } from "../../plugin/sdk"
 
 const defaultConfigPath = join(STATIC_DIR, "hadolint", "default.hadolint.yaml")
 const configFilename = ".hadolint.yaml"
-
-interface HadolintProviderConfig extends GenericProviderConfig {
-  autoInject: boolean
-  testFailureThreshold: "error" | "warning" | "none"
-}
-
-interface HadolintProvider extends Provider<HadolintProviderConfig> {}
-
-const configSchema = providerConfigBaseSchema()
-  .keys({
-    autoInject: joi
-      .boolean()
-      .default(true)
-      .description(
-        dedent`
-          By default, the provider automatically creates a \`hadolint\` Test for every \`container\` Build in your
-          project. Set this to \`false\` to disable this behavior.
-        `
-      ),
-    testFailureThreshold: joi
-      .string()
-      .allow("error", "warning", "none")
-      .default("error")
-      .description(
-        dedent`
-          Set this to \`"warning"\` if you'd like tests to be marked as failed if one or more warnings are returned.
-          Set to \`"none"\` to always mark the tests as successful.
-        `
-      ),
-  })
-  .unknown(false)
 
 interface HadolintTestSpec {
   dockerfilePath: string
@@ -73,236 +40,18 @@ const gitHubUrl = getGitHubUrl("examples/hadolint")
 
 const defaultHadolintTimeoutSec = 10
 
-export const gardenPlugin = () =>
-  createGardenPlugin({
+export const gardenPlugin = sdk.createGardenPlugin(
+  {
     name: "hadolint",
     dependencies: [{ name: "container" }],
     docs: dedent`
-    This provider creates a [\`hadolint\`](../action-types/Test/hadolint.md) Test action type, and (by default) generates one such action for each \`container\` Build that contains a Dockerfile in your project. Each Test runs [hadolint](https://github.com/hadolint/hadolint) against the Dockerfile in question, in order to ensure that the Dockerfile is valid and follows best practices.
+      This provider creates a [\`hadolint\`](../action-types/Test/hadolint.md) Test action type, and (by default) generates one such action for each \`container\` Build that contains a Dockerfile in your project. Each Test runs [hadolint](https://github.com/hadolint/hadolint) against the Dockerfile in question, in order to ensure that the Dockerfile is valid and follows best practices.
 
-    To configure \`hadolint\`, you can use \`.hadolint.yaml\` config files. For each Test, we first look for one in the relevant action's root. If none is found there, we check the project root, and if none is there we fall back to default configuration. Note that for reasons of portability, we do not fall back to global/user configuration files.
+      To configure \`hadolint\`, you can use \`.hadolint.yaml\` config files. For each Test, we first look for one in the relevant action's root. If none is found there, we check the project root, and if none is there we fall back to default configuration. Note that for reasons of portability, we do not fall back to global/user configuration files.
 
-    See the [hadolint docs](https://github.com/hadolint/hadolint#configure) for details on how to configure it, and the [hadolint example project](${gitHubUrl}) for a usage example.
-  `,
-    configSchema,
-    handlers: {
-      augmentGraph: async ({ ctx, actions }) => {
-        const provider = ctx.provider as HadolintProvider
+      See the [hadolint docs](https://github.com/hadolint/hadolint#configure) for details on how to configure it, and the [hadolint example project](${gitHubUrl}) for a usage example.
+    `,
 
-        if (!provider.config.autoInject) {
-          return {}
-        }
-
-        const allTestNames = new Set(actions.filter((a) => a.kind === "Test").map((m) => m.name))
-
-        const existingHadolintDockerfiles = actions
-          .filter(isHadolintTest)
-          // Can't really reason about templated dockerfile spec field
-          .filter((a) => !mayContainTemplateString(a.getConfig("spec").dockerfilePath))
-          .map((a) => resolve(a.basePath(), a.getConfig("spec").dockerfilePath))
-
-        const pickCompatibleAction = (action: BaseAction): action is BuildAction | HadolintTest => {
-          // Make sure we don't step on an existing custom hadolint module
-          if (isHadolintTest(action)) {
-            const dockerfilePath = action.getConfig("spec").dockerfilePath
-            if (
-              !mayContainTemplateString(dockerfilePath) &&
-              existingHadolintDockerfiles.includes(resolve(action.basePath(), dockerfilePath))
-            ) {
-              return false
-            }
-          }
-
-          // Pick all container or container-based modules
-          return action.kind === "Build" && action.isCompatible("container")
-        }
-
-        const makeHadolintTestAction = (action: BuildAction | HadolintTest): HadolintTestConfig => {
-          const baseName = "hadolint-" + action.name
-
-          let name = baseName
-          let i = 2
-
-          while (allTestNames.has(name)) {
-            name = `${baseName}-${i++}`
-          }
-
-          allTestNames.add(name)
-
-          const dockerfilePath =
-            (isHadolintTest(action) ? action.getConfig("spec").dockerfilePath : action.getConfig("spec").dockerfile) ||
-            defaultDockerfileName
-
-          const include = mayContainTemplateString(dockerfilePath) ? undefined : [dockerfilePath]
-
-          return {
-            kind: "Test",
-            type: "hadolint",
-            name,
-            description: `hadolint test for '${action.longDescription()}' (auto-generated)`,
-            include,
-            internal: {
-              basePath: action.basePath(),
-            },
-            timeout: action.getConfig().timeout,
-            spec: {
-              dockerfilePath,
-            },
-          }
-        }
-
-        return {
-          addActions: actions.filter(pickCompatibleAction).map(makeHadolintTestAction),
-        }
-      },
-    },
-    createActionTypes: {
-      Test: [
-        <TestActionDefinition<HadolintTest>>{
-          name: "hadolint",
-          docs: dedent`
-          Runs \`hadolint\` on the specified Dockerfile.
-
-          > Note: In most cases, you'll let the [provider](../../providers/hadolint.md) create this action type automatically, but you may in some cases want or need to manually specify a Dockerfile to lint.
-
-          To configure \`hadolint\`, you can use \`.hadolint.yaml\` config files. For each test, we first look for one in the action source directory. If none is found there, we check the project root, and if none is there we fall back to   configuration. Note that for reasons of portability, we do not fall back to global/user configuration files.
-
-          See the [hadolint docs](https://github.com/hadolint/hadolint#configure) for details on how to configure it.
-          `,
-          schema: joi.object().keys({
-            dockerfilePath: joi
-              .posixPath()
-              .relativeOnly()
-              .subPathOnly()
-              .required()
-              .description("POSIX-style path to a Dockerfile that you want to lint with `hadolint`."),
-          }),
-          handlers: {
-            configure: async ({ ctx, config }) => {
-              let dockerfilePath = config.spec.dockerfilePath
-
-              if (!config.include) {
-                config.include = []
-              }
-
-              if (!config.include.includes(dockerfilePath)) {
-                try {
-                  dockerfilePath = ctx.resolveTemplateStrings(dockerfilePath)
-                } catch (error) {
-                  throw new ConfigurationError(
-                    `The spec.dockerfilePath field contains a template string which could not be resolved. Note that some template variables are not available for the field. Error: ${error}`,
-                    { config, error }
-                  )
-                }
-                config.include.push(dockerfilePath)
-              }
-
-              return { config, supportedModes: {} }
-            },
-
-            run: async ({ ctx, log, action }) => {
-              const spec = action.getSpec()
-              const dockerfilePath = join(action.basePath(), spec.dockerfilePath)
-              const startedAt = new Date()
-              let dockerfile: string
-
-              try {
-                dockerfile = (await readFile(dockerfilePath)).toString()
-              } catch {
-                throw new ConfigurationError(`hadolint: Could not find Dockerfile at ${spec.dockerfilePath}`, {
-                  actionPath: action.basePath(),
-                  ...spec,
-                })
-              }
-
-              let configPath: string
-              const moduleConfigPath = join(action.basePath(), configFilename)
-              const projectConfigPath = join(ctx.projectRoot, configFilename)
-
-              if (await pathExists(moduleConfigPath)) {
-                // Prefer configuration from the module root
-                configPath = moduleConfigPath
-              } else if (await pathExists(projectConfigPath)) {
-                // 2nd preference is configuration in project root
-                configPath = projectConfigPath
-              } else {
-                // Fall back to empty default config
-                configPath = defaultConfigPath
-              }
-
-              const args = ["--config", configPath, "--format", "json", dockerfilePath]
-              const result = await ctx.tools["hadolint.hadolint"].exec({ log, args, ignoreError: true })
-
-              let success = true
-
-              const parsed = JSON.parse(result.stdout)
-              const errors = parsed.filter((p: any) => p.level === "error")
-              const warnings = parsed.filter((p: any) => p.level === "warning")
-              const provider = ctx.provider as HadolintProvider
-
-              const resultCategories: string[] = []
-              let formattedResult = "OK"
-
-              if (errors.length > 0) {
-                resultCategories.push(`${errors.length} error(s)`)
-              }
-
-              if (warnings.length > 0) {
-                resultCategories.push(`${warnings.length} warning(s)`)
-              }
-
-              let formattedHeader = `hadolint reported ${naturalList(resultCategories)}`
-
-              if (parsed.length > 0) {
-                const dockerfileLines = splitLines(dockerfile)
-
-                formattedResult =
-                  `${formattedHeader}:\n\n` +
-                  parsed
-                    .map((msg: any) => {
-                      const color = msg.level === "error" ? chalk.bold.red : chalk.bold.yellow
-                      const rawLine = dockerfileLines[msg.line - 1]
-                      const linePrefix = padEnd(`${msg.line}:`, 5, " ")
-                      const columnCursorPosition = (msg.column || 1) + linePrefix.length
-
-                      return dedent`
-                      ${color(msg.code + ":")} ${chalk.bold(msg.message || "")}
-                      ${linePrefix}${chalk.gray(rawLine)}
-                      ${chalk.gray(padStart("^", columnCursorPosition, "-"))}
-                    `
-                    })
-                    .join("\n")
-              }
-
-              const threshold = provider.config.testFailureThreshold
-
-              if (warnings.length > 0 && threshold === "warning") {
-                success = false
-              } else if (errors.length > 0 && threshold !== "none") {
-                success = false
-              } else if (warnings.length > 0) {
-                log.warn(chalk.yellow(formattedHeader))
-              }
-
-              return {
-                state: "ready",
-                detail: {
-                  testName: action.name,
-                  moduleName: action.moduleName(),
-                  command: ["hadolint", ...args],
-                  version: action.versionString(),
-                  success,
-                  startedAt,
-                  completedAt: new Date(),
-                  log: formattedResult,
-                },
-                outputs: {},
-              }
-            },
-          },
-        },
-      ],
-    },
     createModuleTypes: [
       {
         name: "hadolint",
@@ -358,34 +107,270 @@ export const gardenPlugin = () =>
         },
       },
     ],
-    tools: [
-      {
-        name: "hadolint",
-        version: "2.12.0",
-        description: "A Dockerfile linter.",
-        type: "binary",
-        _includeInGardenImage: false,
-        builds: [
-          // this version has no arm support yet. If you add a later release, please add the "arm64" architecture.
-          {
-            platform: "darwin",
-            architecture: "amd64",
-            url: "https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Darwin-x86_64",
-            sha256: "2a5b7afcab91645c39a7cebefcd835b865f7488e69be24567f433dfc3d41cd27",
+  },
+  ({ plugin, s }) => {
+    plugin.addTool({
+      name: "hadolint",
+      version: "2.12.0",
+      description: "A Dockerfile linter.",
+      type: "binary",
+      _includeInGardenImage: false,
+      builds: [
+        // this version has no arm support yet. If you add a later release, please add the "arm64" architecture.
+        {
+          platform: "darwin",
+          architecture: "amd64",
+          url: "https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Darwin-x86_64",
+          sha256: "2a5b7afcab91645c39a7cebefcd835b865f7488e69be24567f433dfc3d41cd27",
+        },
+        {
+          platform: "linux",
+          architecture: "amd64",
+          url: "https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64",
+          sha256: "56de6d5e5ec427e17b74fa48d51271c7fc0d61244bf5c90e828aab8362d55010",
+        },
+        {
+          platform: "windows",
+          architecture: "amd64",
+          url: "https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Windows-x86_64.exe",
+          sha256: "ed89a156290e15452276b2b4c84efa688a5183d3b578bfaec7cfdf986f0632a8",
+        },
+      ],
+    })
+
+    const providerConfigSchema = s.object({
+      autoInject: s
+        .boolean()
+        .default(true)
+        .describe(
+          dedent`
+          By default, the provider automatically creates a \`hadolint\` Test for every \`container\` Build in your
+          project. Set this to \`false\` to disable this behavior.
+          `
+        ),
+      testFailureThreshold: s
+        .enum(["error", "warning", "none"])
+        .default("error")
+        .describe(
+          dedent`
+          Set this to \`"warning"\` if you'd like tests to be marked as failed if one or more warnings are returned.
+          Set to \`"none"\` to always mark the tests as successful.
+          `
+        ),
+    })
+
+    const provider = plugin.createProvider(providerConfigSchema, s.object({}))
+
+    provider.addHandler("augmentGraph", async ({ ctx, actions }) => {
+      if (!ctx.provider.config.autoInject) {
+        return {}
+      }
+
+      const allTestNames = new Set(actions.filter((a) => a.kind === "Test").map((m) => m.name))
+
+      const existingHadolintDockerfiles = actions
+        .filter(isHadolintTest)
+        // Can't really reason about templated dockerfile spec field
+        .filter((a) => !mayContainTemplateString(a.getConfig("spec").dockerfilePath))
+        .map((a) => resolve(a.basePath(), a.getConfig("spec").dockerfilePath))
+
+      const pickCompatibleAction = (action: BaseAction): action is BuildAction | HadolintTest => {
+        // Make sure we don't step on an existing custom hadolint module
+        if (isHadolintTest(action)) {
+          const dockerfilePath = action.getConfig("spec").dockerfilePath
+          if (
+            !mayContainTemplateString(dockerfilePath) &&
+            existingHadolintDockerfiles.includes(resolve(action.basePath(), dockerfilePath))
+          ) {
+            return false
+          }
+        }
+
+        // Pick all container or container-based modules
+        return action.kind === "Build" && action.isCompatible("container")
+      }
+
+      const makeHadolintTestAction = (action: BuildAction | HadolintTest): HadolintTestConfig => {
+        const baseName = "hadolint-" + action.name
+
+        let name = baseName
+        let i = 2
+
+        while (allTestNames.has(name)) {
+          name = `${baseName}-${i++}`
+        }
+
+        allTestNames.add(name)
+
+        const dockerfilePath =
+          (isHadolintTest(action) ? action.getConfig("spec").dockerfilePath : action.getConfig("spec").dockerfile) ||
+          defaultDockerfileName
+
+        const include = mayContainTemplateString(dockerfilePath) ? undefined : [dockerfilePath]
+
+        return {
+          kind: "Test",
+          type: "hadolint",
+          name,
+          description: `hadolint test for '${action.longDescription()}' (auto-generated)`,
+          include,
+          internal: {
+            basePath: action.basePath(),
           },
-          {
-            platform: "linux",
-            architecture: "amd64",
-            url: "https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64",
-            sha256: "56de6d5e5ec427e17b74fa48d51271c7fc0d61244bf5c90e828aab8362d55010",
+          timeout: action.getConfig().timeout,
+          spec: {
+            dockerfilePath,
           },
-          {
-            platform: "windows",
-            architecture: "amd64",
-            url: "https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Windows-x86_64.exe",
-            sha256: "ed89a156290e15452276b2b4c84efa688a5183d3b578bfaec7cfdf986f0632a8",
-          },
-        ],
-      },
-    ],
-  })
+        }
+      }
+
+      return {
+        addActions: actions.filter(pickCompatibleAction).map(makeHadolintTestAction),
+      }
+    })
+
+    const hadolintTest = provider.createActionType({
+      kind: "Test",
+      name: "hadolint",
+      docs: dedent`
+        Runs \`hadolint\` on the specified Dockerfile.
+
+        > Note: In most cases, you'll let the [provider](../../providers/hadolint.md) create this action type automatically, but you may in some cases want or need to manually specify a Dockerfile to lint.
+
+        To configure \`hadolint\`, you can use \`.hadolint.yaml\` config files. For each test, we first look for one in the action source directory. If none is found there, we check the project root, and if none is there we fall back to   configuration. Note that for reasons of portability, we do not fall back to global/user configuration files.
+
+        See the [hadolint docs](https://github.com/hadolint/hadolint#configure) for details on how to configure it.
+      `,
+      specSchema: s
+        .object({
+          dockerfilePath: s
+            .posixPath({ relativeOnly: true, subPathOnly: true })
+            .describe("POSIX-style path to a Dockerfile that you want to lint with `hadolint`."),
+        })
+        .required(),
+      staticOutputsSchema: s.object({}),
+      runtimeOutputsSchema: s.object({}),
+    })
+
+    hadolintTest.addHandler("configure", async ({ ctx, config }) => {
+      let dockerfilePath = config.spec.dockerfilePath
+
+      if (!config.include) {
+        config.include = []
+      }
+
+      if (!config.include.includes(dockerfilePath)) {
+        try {
+          dockerfilePath = ctx.resolveTemplateStrings(dockerfilePath)
+        } catch (error) {
+          throw new ConfigurationError(
+            `The spec.dockerfilePath field contains a template string which could not be resolved. Note that some template variables are not available for the field. Error: ${error}`,
+            { config, error }
+          )
+        }
+        config.include.push(dockerfilePath)
+      }
+
+      return { config, supportedModes: {} }
+    })
+
+    hadolintTest.addHandler("run", async ({ ctx, log, action }) => {
+      const spec = action.getSpec()
+      const dockerfilePath = join(action.basePath(), spec.dockerfilePath)
+      const startedAt = new Date()
+      let dockerfile: string
+
+      try {
+        dockerfile = (await readFile(dockerfilePath)).toString()
+      } catch {
+        throw new ConfigurationError(`hadolint: Could not find Dockerfile at ${spec.dockerfilePath}`, {
+          actionPath: action.basePath(),
+          ...spec,
+        })
+      }
+
+      let configPath: string
+      const moduleConfigPath = join(action.basePath(), configFilename)
+      const projectConfigPath = join(ctx.projectRoot, configFilename)
+
+      if (await pathExists(moduleConfigPath)) {
+        // Prefer configuration from the module root
+        configPath = moduleConfigPath
+      } else if (await pathExists(projectConfigPath)) {
+        // 2nd preference is configuration in project root
+        configPath = projectConfigPath
+      } else {
+        // Fall back to empty default config
+        configPath = defaultConfigPath
+      }
+
+      const args = ["--config", configPath, "--format", "json", dockerfilePath]
+      const result = await ctx.tools["hadolint.hadolint"].exec({ log, args, ignoreError: true })
+
+      let success = true
+
+      const parsed = JSON.parse(result.stdout)
+      const errors = parsed.filter((p: any) => p.level === "error")
+      const warnings = parsed.filter((p: any) => p.level === "warning")
+
+      const resultCategories: string[] = []
+      let formattedResult = "OK"
+
+      if (errors.length > 0) {
+        resultCategories.push(`${errors.length} error(s)`)
+      }
+
+      if (warnings.length > 0) {
+        resultCategories.push(`${warnings.length} warning(s)`)
+      }
+
+      let formattedHeader = `hadolint reported ${naturalList(resultCategories)}`
+
+      if (parsed.length > 0) {
+        const dockerfileLines = splitLines(dockerfile)
+
+        formattedResult =
+          `${formattedHeader}:\n\n` +
+          parsed
+            .map((msg: any) => {
+              const color = msg.level === "error" ? chalk.bold.red : chalk.bold.yellow
+              const rawLine = dockerfileLines[msg.line - 1]
+              const linePrefix = padEnd(`${msg.line}:`, 5, " ")
+              const columnCursorPosition = (msg.column || 1) + linePrefix.length
+
+              return dedent`
+              ${color(msg.code + ":")} ${chalk.bold(msg.message || "")}
+              ${linePrefix}${chalk.gray(rawLine)}
+              ${chalk.gray(padStart("^", columnCursorPosition, "-"))}
+            `
+            })
+            .join("\n")
+      }
+
+      const threshold = ctx.provider.config.testFailureThreshold
+
+      if (warnings.length > 0 && threshold === "warning") {
+        success = false
+      } else if (errors.length > 0 && threshold !== "none") {
+        success = false
+      } else if (warnings.length > 0) {
+        log.warn(chalk.yellow(formattedHeader))
+      }
+
+      return {
+        state: "ready",
+        detail: {
+          testName: action.name,
+          moduleName: action.moduleName(),
+          command: ["hadolint", ...args],
+          version: action.versionString(),
+          success,
+          startedAt,
+          completedAt: new Date(),
+          log: formattedResult,
+        },
+        outputs: {},
+      }
+    })
+  }
+)

--- a/core/src/plugins/kubernetes/init.ts
+++ b/core/src/plugins/kubernetes/init.ts
@@ -180,7 +180,7 @@ export async function getIngressMisconfigurationWarnings(
  * Deploys system services (if any)
  */
 export async function prepareEnvironment(
-  params: PrepareEnvironmentParams<KubernetesEnvironmentStatus>
+  params: PrepareEnvironmentParams<KubernetesConfig, KubernetesEnvironmentStatus>
 ): Promise<PrepareEnvironmentResult> {
   const { ctx, log, status } = params
   const k8sCtx = <KubernetesPluginContext>ctx
@@ -198,7 +198,7 @@ export async function prepareSystem({
   force,
   status,
   clusterInit,
-}: PrepareEnvironmentParams<KubernetesEnvironmentStatus> & { clusterInit: boolean }) {
+}: PrepareEnvironmentParams<KubernetesConfig, KubernetesEnvironmentStatus> & { clusterInit: boolean }) {
   const k8sCtx = <KubernetesPluginContext>ctx
   const provider = k8sCtx.provider
   const variables = getKubernetesSystemVariables(provider.config)
@@ -290,7 +290,10 @@ export async function prepareSystem({
   return {}
 }
 
-export async function cleanupEnvironment({ ctx, log }: CleanupEnvironmentParams): Promise<CleanupEnvironmentResult> {
+export async function cleanupEnvironment({
+  ctx,
+  log,
+}: CleanupEnvironmentParams<KubernetesConfig>): Promise<CleanupEnvironmentResult> {
   const k8sCtx = <KubernetesPluginContext>ctx
   const provider = k8sCtx.provider
   const api = await KubeApi.factory(log, ctx, provider)

--- a/core/src/plugins/plugins.ts
+++ b/core/src/plugins/plugins.ts
@@ -10,7 +10,7 @@
 export const getSupportedPlugins = () => [
   { name: "container", callback: () => require("./container/container").gardenPlugin() },
   { name: "exec", callback: () => require("./exec/exec").gardenPlugin() },
-  { name: "hadolint", callback: () => require("./hadolint/hadolint").gardenPlugin() },
+  { name: "hadolint", callback: () => require("./hadolint/hadolint").gardenPlugin.getSpec() },
   { name: "kubernetes", callback: () => require("./kubernetes/kubernetes").gardenPlugin() },
   { name: "local-kubernetes", callback: () => require("./kubernetes/local/local").gardenPlugin() },
   { name: "openshift", callback: () => require("./openshift/openshift").gardenPlugin() },

--- a/core/src/tasks/base.ts
+++ b/core/src/tasks/base.ts
@@ -392,7 +392,7 @@ export function emitGetStatusEvents<
   A extends Action,
   R extends ValidExecutionActionResultType = {
     state: ActionState
-    outputs: A["_outputs"]
+    outputs: A["_runtimeOutputs"]
     detail: any
     version: string
   }
@@ -421,7 +421,10 @@ export function emitGetStatusEvents<
     const startedAt = new Date().toISOString()
 
     // First we emit the "getting-status" event
-    this.garden.events.emit(eventName, makeActionGetStatusPayload({ action: this.action, force: this.force, startedAt }))
+    this.garden.events.emit(
+      eventName,
+      makeActionGetStatusPayload({ action: this.action, force: this.force, startedAt })
+    )
 
     try {
       const result = (await method.apply(this, args)) as R & ExecuteActionOutputs<A>
@@ -462,7 +465,7 @@ export function emitProcessingEvents<
   A extends Action,
   R extends ValidExecutionActionResultType = {
     state: ActionState
-    outputs: A["_outputs"]
+    outputs: A["_runtimeOutputs"]
     detail: any
     version: string
   }
@@ -523,7 +526,7 @@ export abstract class ExecuteActionTask<
   T extends Action,
   O extends ValidExecutionActionResultType = {
     state: ActionState
-    outputs: T["_outputs"]
+    outputs: T["_runtimeOutputs"]
     detail: any
     version: string
   }

--- a/core/test/integ/src/plugins/kubernetes/commands/pull-image.ts
+++ b/core/test/integ/src/plugins/kubernetes/commands/pull-image.ts
@@ -39,7 +39,7 @@ describe("pull-image plugin command", () => {
   }
 
   async function removeImage(action: BuildAction) {
-    const imageId = action._outputs["local-image-id"]
+    const imageId = action._staticOutputs["local-image-id"]
     try {
       await containerHelpers.dockerCli({
         cwd: "/tmp",
@@ -53,7 +53,7 @@ describe("pull-image plugin command", () => {
   }
 
   async function ensureImagePulled(action: BuildAction) {
-    const imageId = action._outputs["local-image-id"]
+    const imageId = action._staticOutputs["local-image-id"]
     const imageHash = await containerHelpers.dockerCli({
       cwd: action.getBuildPath(),
       args: ["run", imageId, "echo", "ok"],
@@ -91,8 +91,8 @@ describe("pull-image plugin command", () => {
     it("should pull the image", async () => {
       await removeImage(action)
       await pullBuild({
-        localId: action._outputs["local-image-id"],
-        remoteId: action._outputs["deployment-image-id"],
+        localId: action._staticOutputs["local-image-id"],
+        remoteId: action._staticOutputs["deployment-image-id"],
         ctx: ctx as KubernetesPluginContext,
         action,
         log: garden.log,
@@ -124,8 +124,8 @@ describe("pull-image plugin command", () => {
     it("should pull the image", async () => {
       await removeImage(action)
       await pullBuild({
-        localId: action._outputs["local-image-id"],
-        remoteId: action._outputs["deployment-image-id"],
+        localId: action._staticOutputs["local-image-id"],
+        remoteId: action._staticOutputs["deployment-image-id"],
         ctx: ctx as KubernetesPluginContext,
         action,
         log: garden.log,

--- a/docs/reference/action-types/Test/hadolint.md
+++ b/docs/reference/action-types/Test/hadolint.md
@@ -392,9 +392,9 @@ Set a timeout for the test to complete, in seconds.
 
 POSIX-style path to a Dockerfile that you want to lint with `hadolint`.
 
-| Type        | Required |
-| ----------- | -------- |
-| `posixPath` | Yes      |
+| Type     | Required |
+| -------- | -------- |
+| `string` | Yes      |
 
 
 ## Outputs

--- a/docs/reference/providers/hadolint.md
+++ b/docs/reference/providers/hadolint.md
@@ -59,30 +59,15 @@ The name of the provider plugin to use.
 | -------- | -------- |
 | `string` | Yes      |
 
-Example:
-
-```yaml
-providers:
-  - name: "local-kubernetes"
-```
-
 ### `providers[].dependencies[]`
 
 [providers](#providers) > dependencies
 
 List other providers that should be resolved before this one.
 
-| Type            | Default | Required |
-| --------------- | ------- | -------- |
-| `array[string]` | `[]`    | No       |
-
-Example:
-
-```yaml
-providers:
-  - dependencies:
-      - exec
-```
+| Type    | Default | Required |
+| ------- | ------- | -------- |
+| `array` | `[]`    | No       |
 
 ### `providers[].environments[]`
 
@@ -90,18 +75,9 @@ providers:
 
 If specified, this provider will only be used in the listed environments. Note that an empty array effectively disables the provider. To use a provider in all environments, omit this field.
 
-| Type            | Required |
-| --------------- | -------- |
-| `array[string]` | No       |
-
-Example:
-
-```yaml
-providers:
-  - environments:
-      - dev
-      - stage
-```
+| Type    | Required |
+| ------- | -------- |
+| `array` | No       |
 
 ### `providers[].autoInject`
 
@@ -121,7 +97,7 @@ project. Set this to `false` to disable this behavior.
 Set this to `"warning"` if you'd like tests to be marked as failed if one or more warnings are returned.
 Set to `"none"` to always mark the tests as successful.
 
-| Type     | Default   | Required |
-| -------- | --------- | -------- |
-| `string` | `"error"` | No       |
+| Type     | Allowed Values             | Default   | Required |
+| -------- | -------------------------- | --------- | -------- |
+| `string` | "error", "warning", "none" | `"error"` | No       |
 

--- a/plugins/jib/util.ts
+++ b/plugins/jib/util.ts
@@ -39,7 +39,7 @@ interface JibModuleSpec extends ContainerModuleSpec {
 
 export type JibBuildActionSpec = ContainerBuildActionSpec & JibBuildSpec
 export type JibBuildConfig = BuildActionConfig<"jib-container", JibBuildActionSpec>
-export type JibBuildAction = BuildAction<JibBuildConfig, ContainerBuildOutputs>
+export type JibBuildAction = BuildAction<JibBuildConfig, ContainerBuildOutputs, {}>
 
 export type JibContainerModule = GardenModule<JibModuleSpec>
 export type JibPluginType = "gradle" | "maven"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11957,6 +11957,11 @@ zip-stream@^4.1.0:
     compress-commons "^4.1.0"
     readable-stream "^3.6.0"
 
+zod-to-json-schema@^3.21.1:
+  version "3.21.1"
+  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.21.1.tgz#a24b2737bf361fc516c92421eb59988b6e2fc046"
+  integrity sha512-y5g0MPxDq+YG/T+cHGPYH4PcBpyCqwK6wxeJ76MR563y0gk/14HKfebq8xHiItY7lkc9GDFygCnkvNDTvAhYAg==
+
 zod@^3.20.6:
   version "3.20.6"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.20.6.tgz#2f2f08ff81291d47d99e86140fedb4e0db08361a"


### PR DESCRIPTION
This introduces a more friendly wrapper for defining plugins. One of the key benefits is that plugin authors don't need to think as much about types and implicitly get solid type-safety when defining handlers.

To start, the `hadolint` plugin has been ported to the new SDK.

This will need more iteration, particularly relating to ease of use when defining a plugin and its handlers across multiple modules. A good next step will be to convert the `exec` plugin. Once this is more fleshed out we'll also want to document this more thoroughly.

The implementation involves using Zod schemas instead of the non-typesafe Joi schemas. The underlying framework is unchanged in those terms, and the Zod schemas are wrapped with a custom Joi method. This allows gradual migration.
