### PR TITLE
fix: ensure build context on ´ready´ status builds

### DIFF
--- a/core/src/build-staging/build-staging.ts
+++ b/core/src/build-staging/build-staging.ts
@@ -73,6 +73,11 @@ export class BuildStaging {
     })
   }
 
+  async actionBuildPathExists({ action }: { action: BuildAction }) {
+    const buildPath = action.getBuildPath()
+    return this.createdPaths.has(buildPath) || pathExists(buildPath)
+  }
+
   async syncDependencyProducts(action: BuildAction, log: Log) {
     const buildPath = action.getBuildPath()
 

--- a/core/src/build-staging/build-staging.ts
+++ b/core/src/build-staging/build-staging.ts
@@ -73,7 +73,7 @@ export class BuildStaging {
     })
   }
 
-  async actionBuildPathExists({ action }: { action: BuildAction }) {
+  async actionBuildPathExists(action: BuildAction ) {
     const buildPath = action.getBuildPath()
     return this.createdPaths.has(buildPath) || pathExists(buildPath)
   }

--- a/core/src/tasks/build.ts
+++ b/core/src/tasks/build.ts
@@ -71,7 +71,7 @@ export class BuildTask extends ExecuteActionTask<BuildAction, BuildStatus> {
   }
 
   private async ensureBuildContext(action: ResolvedBuildAction<BuildActionConfig>) {
-    const buildContextExists = await this.garden.buildStaging.actionBuildPathExists({ action })
+    const buildContextExists = await this.garden.buildStaging.actionBuildPathExists(action)
     if (!buildContextExists) {
       await this.buildStaging(action)
     }


### PR DESCRIPTION
Ensure build context being available even if the plugin handler returns `ready` status for the action. For example if a container is already built but the build context has additional files needed for the Deploy.

closes: https://github.com/garden-io/garden/issues/4513
