### PR TITLE
0.12 fix self update command

### DIFF
--- a/core/src/commands/self-update.ts
+++ b/core/src/commands/self-update.ts
@@ -162,7 +162,7 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
     Examples:
 
        garden self-update               # update to the latest minor Garden CLI version
-       garden self-update edge          # switch to the latest edge build of garden 0.12 (which is created anytime a PR is merged to the 0.12 branch)
+       garden self-update edge-acorn    # switch to the latest edge build of garden 0.12 (which is created anytime a PR is merged to the 0.12 branch)
        garden self-update edge-bonsai   # switch to the latest edge build of garden Bonsai (0.13) (which is created anytime a PR is merged to main)
        garden self-update 0.12.24       # switch to the exact version 0.12.24 of the CLI
        garden self-update --major       # install the latest version, even if it's a major bump

--- a/core/test/unit/src/commands/self-update.ts
+++ b/core/test/unit/src/commands/self-update.ts
@@ -374,8 +374,8 @@ describe("SelfUpdateCommand", () => {
         expectAccepted({ tag_name: "0.13.0", draft: false, prerelease: false }, semver.parse("0.12.50")!, "major")
       })
 
-      it("should accept the same stable major version", () => {
-        expectAccepted({ tag_name: "0.13.0", draft: false, prerelease: false }, semver.parse("0.13.0")!, "major")
+      it("should skip the same stable major version", () => {
+        expectSkipped({ tag_name: "0.13.0", draft: false, prerelease: false }, semver.parse("0.13.0")!, "major")
       })
 
       it("should skip an older stable major version", () => {

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -3431,7 +3431,7 @@ Defaults to the latest minor release version, but you can also request a specifi
 Examples:
 
    garden self-update               # update to the latest minor Garden CLI version
-   garden self-update edge          # switch to the latest edge build of garden 0.12 (which is created anytime a PR is merged to the 0.12 branch)
+   garden self-update edge-acorn    # switch to the latest edge build of garden 0.12 (which is created anytime a PR is merged to the 0.12 branch)
    garden self-update edge-bonsai   # switch to the latest edge build of garden Bonsai (0.13) (which is created anytime a PR is merged to main)
    garden self-update 0.12.24       # switch to the exact version 0.12.24 of the CLI
    garden self-update --major       # install the latest version, even if it's a major bump


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #4570

**Special notes for your reviewer**:
Will be ported to the `main` branch as well.

It would be nice to add some tests for logic inside the `GitHubReleaseApi.findRelease` function. It does some calls to GitHub API. Usage of the real calls in the tests will cause rate limit errors. So, the code could be refactored to split data fetching from the processing logic. Or the calls could be mocked. I'd prefer to add the tests and do the necessary refactoring in a separate PR.

This was tested manually. And we still have the unit tests for the individual search predicates.