### PR TITLE
fix(self-update): fix target release finding machinery

### DIFF
--- a/core/src/commands/self-update.ts
+++ b/core/src/commands/self-update.ts
@@ -90,27 +90,64 @@ interface SelfUpdateResult {
 /**
  * Utilities and wrappers on top of GitHub REST API.
  */
-namespace GitHubReleaseApi {
+export namespace GitHubReleaseApi {
+  export type Pagination = { pageNumber: number; pageSize: number }
+
+  export async function fetchReleases({ pageNumber, pageSize }: Pagination) {
+    const results: any[] = await got(
+      `https://api.github.com/repos/garden-io/garden/releases?page=${pageNumber}&per_page=${[pageSize]}`
+    ).json()
+    return results
+  }
+
   /**
    * Traverse the Garden releases on GitHub and get the first one matching the given predicate.
    *
-   * @param predicate the predicate to identify the wanted release
+   * @param primaryPredicate the primary predicate to identify the wanted release
+   * @param fallbackPredicates the list of fallback predicates to be used if the primary one returns no result
+   * @param fetcher the optional function to override the default release fetching machinery
    */
-  export async function findRelease(predicate: (any: any) => boolean) {
-    const releasesPerPage = 100
-    let page = 1
+  export async function findRelease({
+    primaryPredicate,
+    fallbackPredicates = [],
+    fetcher = fetchReleases,
+  }: {
+    primaryPredicate: (any: any) => boolean
+    fallbackPredicates?: ((any: any) => boolean)[]
+    fetcher?: (pagination: Pagination) => Promise<any[]>
+  }) {
+    const pageSize = 100
+    let pageNumber = 1
     let fetchedReleases: any[]
+    /*
+    Stores already fetched releases. This will be used with the fallback predicates.
+    It is a memory consumer, but also a trade-off to avoid GitHub API rate limit errors.
+    This will not eat gigs of RAM.
+    */
+    let allReleases: any[] = []
     do {
-      fetchedReleases = await got(
-        `https://api.github.com/repos/garden-io/garden/releases?page=${page}&per_page=${releasesPerPage}`
-      ).json()
+      /*
+      This returns the releases ordered by 'published_at' field.
+      It means that there are 2 ordered subsequences of 0.12.x and 0.13.x releases in the result list,
+      but the list itself is not properly ordered.
+      */
+      fetchedReleases = await fetcher({ pageNumber, pageSize })
       for (const release of fetchedReleases) {
-        if (predicate(release)) {
+        if (primaryPredicate(release)) {
           return release
         }
       }
-      page++
+      allReleases.push(...fetchedReleases)
+      pageNumber++
     } while (fetchedReleases.length > 0)
+
+    for (const fallbackPredicate of fallbackPredicates) {
+      for (const release of allReleases) {
+        if (fallbackPredicate(release)) {
+          return release
+        }
+      }
+    }
 
     return undefined
   }
@@ -162,7 +199,7 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
     Examples:
 
        garden self-update               # update to the latest minor Garden CLI version
-       garden self-update edge          # switch to the latest edge build of garden 0.12 (which is created anytime a PR is merged to the 0.12 branch)
+       garden self-update edge-acorn    # switch to the latest edge build of garden 0.12 (which is created anytime a PR is merged to the 0.12 branch)
        garden self-update edge-bonsai   # switch to the latest edge build of garden Bonsai (0.13) (which is created anytime a PR is merged to main)
        garden self-update 0.12.24       # switch to the exact version 0.12.24 of the CLI
        garden self-update --major       # install the latest version, even if it's a major bump
@@ -422,7 +459,13 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
     }
 
     const targetVersionPredicate = this.getTargetVersionPredicate(currentSemVer, versionScope)
-    const targetRelease = await GitHubReleaseApi.findRelease(targetVersionPredicate)
+    const fallbackVersionPredicate = this.getTargetVersionPredicate(currentSemVer, "patch")
+    // Currently we support only semver minor and patch versions, so we use patch as a fallback predicate.
+    // TODO Core 1.0 implement proper fallback predicates for all semver version parts.
+    const targetRelease = await GitHubReleaseApi.findRelease({
+      primaryPredicate: targetVersionPredicate,
+      fallbackPredicates: [fallbackVersionPredicate],
+    })
 
     if (!targetRelease) {
       throw new RuntimeError(
@@ -448,19 +491,23 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
       }
 
       switch (versionScope) {
+        // TODO Core 1.0: review these semantics and make tjhe necessary corrections
         case "major": {
-          // TODO Core 1.0 major release: remove this check
           if (tagSemVer.major === currentSemVer.major) {
-            return tagSemVer.minor >= currentSemVer.minor
+            return tagSemVer.minor > currentSemVer.minor
           }
           return tagSemVer.major >= currentSemVer.major
         }
         case "minor":
-          return tagSemVer.major === currentSemVer.major && tagSemVer.minor >= currentSemVer.minor
+          return tagSemVer.major === currentSemVer.major && tagSemVer.minor > currentSemVer.minor
         case "patch":
           return (
             tagSemVer.major === currentSemVer.major &&
             tagSemVer.minor === currentSemVer.minor &&
+            /*
+            On the patch level of the same major.minor version the version history is linear and properly sorted.
+            So, we can use the >= condition here.
+            */
             tagSemVer.patch >= currentSemVer.patch
           )
         default: {

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -4936,7 +4936,7 @@ Defaults to the latest minor release version, but you can also request a specifi
 Examples:
 
    garden self-update               # update to the latest minor Garden CLI version
-   garden self-update edge          # switch to the latest edge build of garden 0.12 (which is created anytime a PR is merged to the 0.12 branch)
+   garden self-update edge-acorn    # switch to the latest edge build of garden 0.12 (which is created anytime a PR is merged to the 0.12 branch)
    garden self-update edge-bonsai   # switch to the latest edge build of garden Bonsai (0.13) (which is created anytime a PR is merged to main)
    garden self-update 0.12.24       # switch to the exact version 0.12.24 of the CLI
    garden self-update --major       # install the latest version, even if it's a major bump


### PR DESCRIPTION
* chore: fix edge tag name in usage examples

* refactor: better release finding machinery

Ability to use multiple fallback search predicates.

* fix(self-update): fix target release finding machinery

Use strict greater-than comparison in major and minor version scope predicates.

* refactor: ability to override GitHub release fetching machinery

* test: add some tests for `GitHubReleaseApi.findRelease`

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
Cherry-picks #4576 to `main`.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
