### PR TITLE
chore: fire warnings on too long sync paths

### DIFF
--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -60,9 +60,15 @@ const restartInstructions = (description: string) => deline`
 
 export const mutagenStatusDescriptions = {
   "disconnected": "Sync disconnected",
-  "halted-on-root-emptied": `Sync halted because either the source or target directory was emptied. ${restartInstructions("made sure they're not empty")}`,
-  "halted-on-root-deletion": `Sync halted because either the source or target was deleted. ${restartInstructions("made sure they exist")}`,
-  "halted-on-root-type-change": `Sync halted because either the source or target changed type (e.g. from a directory to a file or vice versa). ${restartInstructions("made sure their type is what it should be")}`,
+  "halted-on-root-emptied": `Sync halted because either the source or target directory was emptied. ${restartInstructions(
+    "made sure they're not empty"
+  )}`,
+  "halted-on-root-deletion": `Sync halted because either the source or target was deleted. ${restartInstructions(
+    "made sure they exist"
+  )}`,
+  "halted-on-root-type-change": `Sync halted because either the source or target changed type (e.g. from a directory to a file or vice versa). ${restartInstructions(
+    "made sure their type is what it should be"
+  )}`,
   "connecting-alpha": "Sync connected to source",
   "connecting-beta": "Sync connected to target",
   "watching": "Watching for changes",
@@ -89,7 +95,7 @@ type MutagenStatus = keyof typeof mutagenStatusDescriptions
 export const haltedStatuses: MutagenStatus[] = [
   "halted-on-root-emptied",
   "halted-on-root-deletion",
-  "halted-on-root-type-change"
+  "halted-on-root-type-change",
 ]
 
 export interface SyncConfig {
@@ -791,7 +797,8 @@ export const mutagenCliSpec: PluginToolSpec = {
     {
       platform: "darwin",
       architecture: "amd64",
-      url: "https://github.com/garden-io/mutagen/releases/download/v0.15.0-garden-1/mutagen_darwin_amd64_v0.15.0.tar.gz",
+      url:
+        "https://github.com/garden-io/mutagen/releases/download/v0.15.0-garden-1/mutagen_darwin_amd64_v0.15.0.tar.gz",
       sha256: "370bf71e28f94002453921fda83282280162df7192bd07042bf622bf54507e3f",
       extract: {
         format: "tar",
@@ -801,7 +808,8 @@ export const mutagenCliSpec: PluginToolSpec = {
     {
       platform: "darwin",
       architecture: "arm64",
-      url: "https://github.com/garden-io/mutagen/releases/download/v0.15.0-garden-1/mutagen_darwin_arm64_v0.15.0.tar.gz",
+      url:
+        "https://github.com/garden-io/mutagen/releases/download/v0.15.0-garden-1/mutagen_darwin_arm64_v0.15.0.tar.gz",
       sha256: "a0a7be8bb37266ea184cb580004e1741a17c8165b2032ce4b191f23fead821a0",
       extract: {
         format: "tar",

--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -782,7 +782,7 @@ export function getMutagenEnv({ dataDir, log }: { dataDir: string; log: Log }) {
   if (dataDir.length > MUTAGEN_DATA_DIRECTORY_LENGTH_LIMIT) {
     emitNonRepeatableWarning(
       log,
-      `Your Garden project path looks too long, that might cause errors while starting the syncs. Consider using a shorter path (no longer than 70 characters).`
+      `Your Garden project path looks too long, that might cause errors while starting the syncs. Consider using a shorter path (no longer than ${MUTAGEN_DATA_DIRECTORY_LENGTH_LIMIT} characters).`
     )
   }
   return {

--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -640,7 +640,7 @@ export class Mutagen {
           await sleep(2000 + loops * 500)
         } else {
           this.log.warn(
-            `Consider making your Garden project path shorter. The mutagen could fail because of the Unix socket path length limitation. The Garden project length is recommened to be no longer than ${MUTAGEN_DATA_DIRECTORY_LENGTH_LIMIT} characters. The actual value depends on the platform and the mutagen version.`
+            `Consider making your Garden project path shorter. Syncing could fail because of Unix socket path length limitations. It's recommended that the Garden project path does not exceed ${MUTAGEN_DATA_DIRECTORY_LENGTH_LIMIT} characters. The actual value depends on the platform and the mutagen version.`
           )
           throw err
         }

--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -639,7 +639,8 @@ export class Mutagen {
           await this.ensureDaemon()
           await sleep(2000 + loops * 500)
         } else {
-          this.log.warn(
+          emitNonRepeatableWarning(
+            this.log,
             `Consider making your Garden project path shorter. Syncing could fail because of Unix socket path length limitations. It's recommended that the Garden project path does not exceed ${MUTAGEN_DATA_DIRECTORY_LENGTH_LIMIT} characters. The actual value depends on the platform and the mutagen version.`
           )
           throw err

--- a/core/src/plugins/kubernetes/commands/sync.ts
+++ b/core/src/plugins/kubernetes/commands/sync.ts
@@ -84,7 +84,12 @@ export const syncPause: PluginCommand = {
       log.info(`Pausing ${activeSyncSessionNames.length} syncs.`)
       for (const sessionName of activeSyncSessionNames) {
         log.debug(`Pausing sync session ${sessionName}`)
-        await mutagen.exec({ cwd: dataDir, log, env: getMutagenEnv(dataDir), args: ["sync", "pause", sessionName] })
+        await mutagen.exec({
+          cwd: dataDir,
+          log,
+          env: getMutagenEnv({ dataDir, log }),
+          args: ["sync", "pause", sessionName],
+        })
       }
     }
 
@@ -125,7 +130,12 @@ export const syncResume: PluginCommand = {
       log.info(`Resuming ${pausedSyncSessionNames.length} syncs.`)
       for (const sessionName of pausedSyncSessionNames) {
         log.debug(`Resuming sync session ${sessionName}`)
-        await mutagen.exec({ cwd: dataDir, log, env: getMutagenEnv(dataDir), args: ["sync", "resume", sessionName] })
+        await mutagen.exec({
+          cwd: dataDir,
+          log,
+          env: getMutagenEnv({ dataDir, log }),
+          args: ["sync", "resume", sessionName],
+        })
       }
     }
 
@@ -138,7 +148,7 @@ async function getMutagenSyncSessions({ mutagen, dataDir, log }: { mutagen: Plug
   const res = await mutagen.exec({
     cwd: dataDir,
     log,
-    env: getMutagenEnv(dataDir),
+    env: getMutagenEnv({ dataDir, log }),
     args: ["sync", "list", "--template={{ json . }}"],
   })
   return parseSyncListResult(res)

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -127,7 +127,7 @@ export async function syncToBuildSync(params: SyncToSharedBuildSyncParams) {
       log,
       key,
       logSection: action.key(),
-      sourceDescription: `Module ${action.name} build path`,
+      sourceDescription: `${action.kind} ${action.name} build path`,
       targetDescription: "Build sync Pod",
       config: {
         alpha: sourcePath,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
Add some warnings on too-long sync paths to make the error details more informative. See individual commits for details.

**Which issue(s) this PR fixes**:

Mitigates #4527

**Special notes for your reviewer**:
I skipped the FAQ docs update. The warnings are visible well enough to users. And this problem occurs not that often for be a Frequently asked question :)

The commits will be squashed before the merge.