### PR TITLE
fix: dev command not working with some plugins

### DIFF
--- a/core/src/commands/dev.tsx
+++ b/core/src/commands/dev.tsx
@@ -82,6 +82,7 @@ Use ${chalk.bold("up/down")} arrow keys to scroll through your command history.
 
   async action(params: ActionParams): Promise<CommandResult> {
     const { log } = params
+    this.setProps(params.garden.sessionId, params.cli?.plugins || [])
 
     const logger = log.root
     const terminalWriter = logger.getWriters().display

--- a/core/src/commands/serve.ts
+++ b/core/src/commands/serve.ts
@@ -80,6 +80,11 @@ export class ServeCommand<
     return false
   }
 
+  protected setProps(sessionId: string, plugins: GardenPluginReference[]) {
+    this.sessionId = sessionId
+    this.plugins = plugins
+  }
+
   async action({
     garden,
     log,
@@ -87,8 +92,7 @@ export class ServeCommand<
     cli,
   }: CommandParams<ServeCommandArgs, ServeCommandOpts>): Promise<CommandResult<R>> {
     const sessionId = garden.sessionId
-    this.sessionId = sessionId
-    this.plugins = cli?.plugins || []
+    this.setProps(sessionId, cli?.plugins || [])
 
     const projectConfig = await findProjectConfig({ log, path: garden.projectRoot })
 


### PR DESCRIPTION
Dev command wasn't working if a few plugins outside of garden core were initialized (incl. terraform and pulumi).

Fixed by properly setting class plugins and session id params on action call.

closes https://github.com/garden-io/garden/issues/4529

Took me a shameful lot of time to get to the bottom of this but at least I'm more familiar with the `GardenInstanceManager` singleton and `serve` command now.

cc @worldofgeese 