### PR TITLE
fix(pulumi): remove PULUMI_EXPERIMENTAL flag due to side effects

### DIFF
--- a/plugins/pulumi/cli.ts
+++ b/plugins/pulumi/cli.ts
@@ -13,12 +13,7 @@ import { ConfigurationError, RuntimeError } from "@garden-io/sdk/exceptions"
 import { Log, PluginContext, PluginToolSpec } from "@garden-io/sdk/types"
 import { PulumiProvider } from "./config"
 
-/**
- * We're using functionality in the pulumi CLI that's experimental as of February 2022, which is enabled by
- * setting the `PULUMI_EXPERIMENTAL` env var to `true` when calling the command.
- */
 export const defaultPulumiEnv = {
-  PULUMI_EXPERIMENTAL: "true",
   // This suppresses the "warning: A new version of Pulumi is available" output when running pulumi commands.
   PULUMI_SKIP_UPDATE_CHECK: "true",
   // TODO: Make user explicitly pick which (or all) env vars to merge in here?
@@ -306,7 +301,7 @@ export const pulumiCliSPecs: PluginToolSpec[] = [
   },
 ]
 
-export const supportedVersions = pulumiCliSPecs.map(s => s.version)
+export const supportedVersions = pulumiCliSPecs.map((s) => s.version)
 
 // Default to latest pulumi version
 export const defaultPulumiVersion = "3.64.0"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

The `PULUMI_EXPERIMENTAL` flag has been originally added in https://github.com/garden-io/garden/commit/9f639397050f1277c93502572ee9c5bcda9ccfb8 as part of implementing the plugin.

However, this can cause side effects, see e.g. https://github.com/pulumi/pulumi/issues/11587 and the slack thread on our #internal-support channel.

**Which issue(s) this PR fixes**:

Fixes `pulumi up` issues with `violates properties plan`

**Special notes for your reviewer**:

This needs thorough testing to make sure all of the Pulumi functionality works and to verify that none of the CLI methods we use are no longer considered experimental.