### PR TITLE
fix: show correct deploy name in logs error output in case of unknown deploy

### DIFF
--- a/core/src/commands/logs.ts
+++ b/core/src/commands/logs.ts
@@ -161,7 +161,7 @@ export class LogsCommand extends Command<Args, Opts> {
       let msg: string
       if (args.names) {
         msg = `Deploy(s) ${naturalList(args.names.map((s) => `"${s}"`))} not found. Available Deploys: ${naturalList(
-          allDeploys.map((s) => `"${s}"`)
+          allDeploys.map((s) => `"${s.name}"`)
         )}.`
       } else {
         msg = "No Deploys found in project."

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -18,7 +18,7 @@ gulp.task("check-licenses", () =>
     gulpLicenseCheck({
       path: licenseHeaderPath,
       blocking: true,
-      logInfo: true,
+      logInfo: false,
       logError: true,
     })
   )


### PR DESCRIPTION
**What this PR does / why we need it**:
Shows proper list of deploy names instead of `[object Object]` in error output.

Additionally, disables info output for license check plugin that was enabled by mistake in #4553

**Which issue(s) this PR fixes**:

Fixes #4594 

**Special notes for your reviewer**:
