### PR TITLE
fix: microk8s issues (and all the integ tests)

### DIFF
--- a/core/src/plugins/kubernetes/logs.ts
+++ b/core/src/plugins/kubernetes/logs.ts
@@ -338,7 +338,8 @@ export class K8sLogFollower<T extends LogEntryBase> {
     } catch (e) {
       if (e instanceof KubernetesError) {
         this.log.silly(`<Encountered error while fetching Pod status for ${description}. Reason: ${e.message}>`)
-        if (e.statusCode === 404) {
+        // retry once if the pod status query returned 404
+        if (e.statusCode === 404 && prevStatus === "error") {
           stopRetrying("The pod or the namespace does not exist")
         }
       } else {

--- a/core/test/integ/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/build/buildkit.ts
@@ -23,7 +23,7 @@ import { buildDockerAuthConfig } from "../../../../../../../src/plugins/kubernet
 import { buildkitDeploymentName, dockerAuthSecretKey } from "../../../../../../../src/plugins/kubernetes/constants"
 import { grouped } from "../../../../../../helpers"
 
-grouped("cluster-buildkit").describe("ensureBuildkit", () => {
+grouped("cluster-buildkit", "remote-only").describe("ensureBuildkit", () => {
   let garden: Garden
   let provider: KubernetesProvider
   let ctx: PluginContext


### PR DESCRIPTION
First commit fixes [this test failure](https://app.circleci.com/pipelines/github/garden-io/garden/17859/workflows/69bf2bb2-0617-4fa3-aa16-a59658881c34/jobs/311020?invite=true#step-112-515). This is also fixes a real bug for users.

second commit fixes [this test case](https://app.circleci.com/pipelines/github/garden-io/garden/17859/workflows/69bf2bb2-0617-4fa3-aa16-a59658881c34/jobs/311020?invite=true#step-112-508). cluster buildkit is not supported on microk8s. There's a conversation to be had about allowing to run the buildkit tests on minikube but that's unrelated to this pr.

third commit fixes an infinite retry loop and [these flaky tests](https://app.circleci.com/pipelines/github/garden-io/garden/18355/workflows/c81b92d3-e133-479c-b4d7-e928a2a932ca/jobs/324610?invite=true#step-110-531)


Failing plugin tests will be fixed separately and are tracked via [this item](https://github.com/orgs/garden-io/projects/7/views/1?pane=issue&itemId=30767681)