### PR TITLE
fix(garden): ensure namespace is resolved when getting instance key

### DIFF
--- a/core/src/config/project.ts
+++ b/core/src/config/project.ts
@@ -658,6 +658,7 @@ export const pickEnvironment = profileAsync(async function _pickEnvironment({
   return {
     environmentName: environment,
     namespace,
+    defaultNamespace: environmentConfig.defaultNamespace,
     production: !!environmentConfig.production,
     providers: Object.values(mergedProviders),
     variables,

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -180,6 +180,7 @@ export interface GardenParams {
   dotIgnoreFile: string
   proxy: ProxyConfig
   environmentName: string
+  resolvedDefaultNamespace: string | null
   namespace: string
   gardenDirPath: string
   globalConfigStore?: GlobalConfigStore
@@ -245,6 +246,14 @@ export class Garden {
   public readonly projectName: string
   public readonly projectApiVersion: string
   public readonly environmentName: string
+  /**
+   * The resolved default namespace as defined in the Project config for the current environment.
+   */
+  public readonly resolvedDefaultNamespace: string | null
+  /**
+   * The actual namespace for the Garden instance. This is by default the namespace defined in the Project config
+   * for the current environment but can be overwritten with the `--env` flag.
+   */
   public readonly namespace: string
   public readonly variables: DeepPrimitiveMap
   // Any variables passed via the `--var` CLI option (maintained here so that they can be used during module resolution
@@ -281,6 +290,7 @@ export class Garden {
     this.cloudDomain = params.cloudDomain
     this.sessionId = params.sessionId
     this.environmentName = params.environmentName
+    this.resolvedDefaultNamespace = params.resolvedDefaultNamespace
     this.namespace = params.namespace
     this.gardenDirPath = params.gardenDirPath
     this.log = params.log
@@ -1506,12 +1516,12 @@ export class Garden {
   public getInstanceKeyParams() {
     let namespace: string | undefined
 
-    let defaultNs = this.getEnvironmentConfig().defaultNamespace
+    // This is either the default namespace defined in the Project config for the current environment or, as a fall back,
+    // the hard coded "default" value.
+    const defaultNs = this.resolvedDefaultNamespace || defaultNamespace
 
-    if (defaultNs === undefined) {
-      defaultNs = defaultNamespace
-    }
-
+    // this.namespace is the actual namespace for this Garden instance, and is either set
+    // via the `--env` flag or defined in the Project config.
     if (this.namespace !== defaultNs) {
       namespace = this.namespace
     }
@@ -1887,6 +1897,7 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
     projectRoot,
     projectName,
     environmentName,
+    resolvedDefaultNamespace: pickedEnv.defaultNamespace,
     namespace,
     variables,
     variableOverrides,

--- a/core/test/unit/src/config/project.ts
+++ b/core/test/unit/src/config/project.ts
@@ -548,6 +548,7 @@ describe("pickEnvironment", () => {
       })
     ).to.eql({
       environmentName: "default",
+      defaultNamespace: "default",
       namespace: "default",
       providers: [
         { name: "exec" },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Before this fix, the namespace we read from the project config when creating the instance key wasn't resolved. This caused down stream issues for the instance manager.

**Which issue(s) this PR fixes**:

Fixes #4597 

**Special notes for your reviewer**:
