### PR TITLE
fix custom commands in dev mode

### DIFF
--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -407,10 +407,6 @@ ${renderCommands(commands)}
       return { argv, code: abortCode, errors, result, consoleOutput }
     }
 
-    if (argv.v || argv.version || argv._[0] === "version") {
-      return done(0, getPackageVersion())
-    }
-
     const workingDir = resolve(cwd || process.cwd(), argv.root || "")
 
     if (!(await pathExists(workingDir))) {

--- a/core/src/commands/commands.ts
+++ b/core/src/commands/commands.ts
@@ -38,6 +38,7 @@ import { UpdateRemoteCommand } from "./update-remote/update-remote"
 import { UtilCommand } from "./util/util"
 import { ValidateCommand } from "./validate"
 import { UpCommand } from "./up"
+import { VersionCommand } from "./version"
 
 export const getCoreCommands = (): (Command | CommandGroup)[] => [
   new BuildCommand(),
@@ -70,6 +71,7 @@ export const getCoreCommands = (): (Command | CommandGroup)[] => [
   new UpdateRemoteCommand(),
   new UtilCommand(),
   new ValidateCommand(),
+  new VersionCommand(),
 ]
 
 export function flattenCommands(commands: (Command | CommandGroup)[]): Command[] {

--- a/core/src/commands/version.ts
+++ b/core/src/commands/version.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2018-2023 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { getPackageVersion } from "../util/util"
+import { Command, CommandResult } from "./base"
+
+interface VersionCommandResult {
+  version: string
+}
+
+export class VersionCommand extends Command {
+  name = "version"
+  aliases = ["v", "V"]
+  help = "Shows the current garden version."
+  noProject = true
+
+  async action({ log }): Promise<CommandResult<VersionCommandResult>> {
+    const version = getPackageVersion()
+    log.info(`garden version: ${version}`)
+
+    return {
+      result: { version },
+    }
+  }
+}

--- a/core/src/server/instance-manager.ts
+++ b/core/src/server/instance-manager.ts
@@ -202,7 +202,7 @@ export class GardenInstanceManager {
   }
 
   async reload(log: Log) {
-    const projectRoots = this.projectRoots.keys()
+    const projectRoots = [...this.projectRoots.keys()]
 
     // Clear existing instances that have no monitors running
     await this.clear()

--- a/core/test/unit/src/cli/cli.ts
+++ b/core/test/unit/src/cli/cli.ts
@@ -14,7 +14,6 @@ import { getDataDir, projectRootA, initTestLogger } from "../../../helpers"
 import { gardenEnv, GARDEN_CORE_ROOT } from "../../../../src/constants"
 import { join, resolve } from "path"
 import { Command, CommandGroup, CommandParams, PrepareParams } from "../../../../src/commands/base"
-import { getPackageVersion } from "../../../../src/util/util"
 import { UtilCommand } from "../../../../src/commands/util/util"
 import { StringParameter } from "../../../../src/cli/params"
 import stripAnsi from "strip-ansi"
@@ -92,27 +91,6 @@ describe("cli", () => {
 
       expect(code).to.equal(0)
       expect(consoleOutput).to.equal(cmd.renderHelp())
-    })
-
-    it("aborts with version text if -V is set", async () => {
-      const { code, consoleOutput } = await cli.run({ args: ["-V"], exitOnError: false })
-
-      expect(code).to.equal(0)
-      expect(consoleOutput).to.equal(getPackageVersion())
-    })
-
-    it("aborts with version text if --version is set", async () => {
-      const { code, consoleOutput } = await cli.run({ args: ["--version"], exitOnError: false })
-
-      expect(code).to.equal(0)
-      expect(consoleOutput).to.equal(getPackageVersion())
-    })
-
-    it("aborts with version text if version is first argument", async () => {
-      const { code, consoleOutput } = await cli.run({ args: ["version"], exitOnError: false })
-
-      expect(code).to.equal(0)
-      expect(consoleOutput).to.equal(getPackageVersion())
     })
 
     it("throws if --root is set, pointing to a non-existent path", async () => {

--- a/core/test/unit/src/commands/version.ts
+++ b/core/test/unit/src/commands/version.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2018-2023 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import { getPackageVersion } from "../../../../src/util/util"
+import { GardenCli } from "../../../../src/cli/cli"
+import { VersionCommand } from "../../../../src/commands/version"
+import { TempDirectory } from "../../../helpers"
+import { makeTempDir } from "../../../helpers"
+import { makeDummyGarden } from "../../../../src/garden"
+
+describe("VersionCommand", () => {
+  let tmpDir: TempDirectory
+  let cli: GardenCli
+
+  beforeEach(async () => {
+    cli = new GardenCli()
+    tmpDir = await makeTempDir({ git: true, initialCommit: false })
+  })
+
+  afterEach(async () => {
+    await tmpDir.cleanup()
+  })
+
+  it("aborts with version text if garden version cmd is run", async () => {
+    const { code, result } = await cli.run({ args: ["version"], exitOnError: false })
+
+    expect(code).to.equal(0)
+    expect(result).to.eql({
+      version: getPackageVersion(),
+    })
+  })
+
+  it("aborts with version text if garden V is run", async () => {
+    const { code, result } = await cli.run({ args: ["V"], exitOnError: false })
+
+    expect(code).to.equal(0)
+    expect(result).to.eql({
+      version: getPackageVersion(),
+    })
+  })
+
+  it("aborts with version text if garden v is run", async () => {
+    const { code, result } = await cli.run({ args: ["v"], exitOnError: false })
+
+    expect(code).to.equal(0)
+    expect(result).to.eql({
+      version: getPackageVersion(),
+    })
+  })
+
+  it("returns version when version command is run", async () => {
+    const command = new VersionCommand()
+    const garden = await makeDummyGarden(tmpDir.path, { commandInfo: { name: "version", args: {}, opts: {} } })
+    const { result } = await command.action({
+      log: garden.log,
+    })
+    expect(result).to.eql({
+      version: getPackageVersion(),
+    })
+  })
+})

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -5794,3 +5794,14 @@ Throws an error and exits with code 1 if something's not right in your garden co
 
 
 
+### garden version
+
+**Shows the current garden version.**
+
+
+#### Usage
+
+    garden version 
+
+
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
- Fixes custom commands not working on first run in dev mode.
- Also uses command artifact for `version` command so it is supported in dev mode and shows up in help.

**Which issue(s) this PR fixes**:

Fixes #4647 

**Special notes for your reviewer**:
The second issue with custom gardenCommands reported in #4647 will be address separately. Tracking that with https://github.com/garden-io/garden/issues/4668
