### PR TITLE
fix: update version hash if a file is renamed

### DIFF
--- a/core/src/vcs/vcs.ts
+++ b/core/src/vcs/vcs.ts
@@ -230,7 +230,8 @@ export abstract class VcsHandler {
           // Don't include the config file in the file list
           .filter((f) => !configPath || f.path !== configPath)
 
-        result.contentHash = hashStrings(files.map((f) => f.hash))
+        // compute hash using <file-relative-path>-<file-hash> to cater for path changes (e.g. renaming)
+        result.contentHash = hashStrings(files.map((f) => `${relative(this.projectRoot, f.path)}-${f.hash}`))
         result.files = files.map((f) => f.path)
       }
 

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -4641,9 +4641,9 @@ describe("Garden", () => {
     })
 
     context("test against fixed version hashes", async () => {
-      const moduleAVersionString = "v-d3e58c6cb9"
-      const moduleBVersionString = "v-457bae4f58"
-      const moduleCVersionString = "v-12b5e981e0"
+      const moduleAVersionString = "v-e3eed855ed"
+      const moduleBVersionString = "v-cdfff6b4f2"
+      const moduleCVersionString = "v-9d2afce9e4"
 
       it("should return the same module versions between runtimes", async () => {
         const projectRoot = getDataDir("test-projects", "fixed-version-hashes-1")


### PR DESCRIPTION
**What this PR does / why we need it**:
Consider relative file path along with the file hash for version hash calculation. Previously, version was not updated if file is renamed without any change in its content.

**Which issue(s) this PR fixes**:
Considers relative file path in content hash to cater for path changes (e.g. renaming).
Fixes #4661

**Special notes for your reviewer**:
This will probably mark all existing caches invalid due to different versions.
