### PR TITLE
fix(server): ensure logs are displayed in dev command

### DIFF
--- a/core/src/server/commands.ts
+++ b/core/src/server/commands.ts
@@ -7,7 +7,7 @@
  */
 
 import type Joi from "@hapi/joi"
-import { getLogLevelChoices, LoggerBase, LogLevel, ServerLogger, VoidLogger } from "../logger/logger"
+import { getLogLevelChoices, LogLevel } from "../logger/logger"
 import stringArgv from "string-argv"
 import { Command, CommandParams, CommandResult, ConsoleCommand } from "../commands/base"
 import { createSchema, joi } from "../config/common"
@@ -395,13 +395,7 @@ export async function resolveRequest({
     }
   }
 
-  let serverLogger: LoggerBase
-  if (internal) {
-    // TODO: Consider using a logger that logs at the silly level but doesn't emit anything.
-    serverLogger = new VoidLogger({ level: LogLevel.info })
-  } else {
-    serverLogger = command?.getServerLogger() || new ServerLogger({ rootLogger: log.root, level: log.root.level })
-  }
+  const serverLogger = command?.getServerLogger() || log.root
 
   const cmdLog = serverLogger.createLog({})
 

--- a/core/src/server/server.ts
+++ b/core/src/server/server.ts
@@ -595,6 +595,7 @@ export class GardenServer extends EventEmitter {
               garden,
               sessionId: requestId,
               parentSessionId: this.sessionId,
+              overrideLogLevel: internal ? LogLevel.silly : undefined
             })
           })
           // Here we check if the command has active monitors and if so,
@@ -676,7 +677,8 @@ export class GardenServer extends EventEmitter {
     } else if (requestType === "loadConfig") {
       // Emit the config graph for the project (used for the Cloud dashboard)
       const resolved = await this.resolveRequest(ctx, omit(request, "type"))
-      let { garden, log } = resolved
+      let { garden, log: _log } = resolved
+      const log = _log.createLog({ fixLevel: LogLevel.silly })
 
       const cloudApi = await this.manager.getCloudApi({
         log,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

This fixes an issue that was there all along but wasn't exposed until we fixed a separate issue with the instance manager (#4649). Until then the instance manager wasn't re-using instance properly and masking the underlying problem.

Before this particular fix, we were setting the log level on the Garden instances which doesn't work if we're re-using them. So either logs that shouldn't be visible were, or vice versa.

This fixes that by not tampering with the log level on the Garden instance but rather optionally overwriting it when running a given command.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
