### PR TITLE
fix(sync): fix status bug for `kubernetes` deploys

### DIFF
--- a/core/src/commands/sync/sync-status.ts
+++ b/core/src/commands/sync/sync-status.ts
@@ -17,7 +17,7 @@ import { Command, CommandParams } from "../base"
 import { createActionLog, Log } from "../../logger/log-entry"
 import { PluginEventBroker } from "../../plugin-context"
 import { resolvedActionToExecuted } from "../../actions/helpers"
-import { GetSyncStatusResult } from "../../plugin/handlers/Deploy/get-sync-status"
+import { GetSyncStatusResult, SyncState } from "../../plugin/handlers/Deploy/get-sync-status"
 import { isEmpty, omit } from "lodash"
 import { Garden } from "../.."
 import { ResolvedDeployAction } from "../../actions/deploy"
@@ -126,6 +126,19 @@ export class SyncStatusCommand extends Command<Args, Opts> {
   }
 }
 
+function stateStyle(state: SyncState, msg: string) {
+  const styleFn = {
+    "active": chalk.green,
+    "failed": chalk.red,
+    "not-active": chalk.yellow,
+  }[state] || chalk.bold.dim
+  return styleFn(msg)
+}
+
+function describeState(state: SyncState) {
+  return state.replace("-", " ")
+}
+
 export async function getSyncStatuses({
   deployActions,
   skipDetail,
@@ -182,30 +195,28 @@ export async function getSyncStatuses({
       })
       syncStatus["syncs"] = sorted
 
-      const styleFn =
-        {
-          "active": chalk.green,
-          "failed": chalk.red,
-          "not-active": chalk.yellow,
-        }[syncStatus.state] || chalk.bold.dim
-
       const verbMap = {
         "active": "is",
         "failed": "has",
         "not-active": "is",
       }
 
-      log.info(`The ${chalk.cyan(action.name)} Deploy has ${chalk.cyan(syncStatus.syncs.length)} syncs(s) configured:`)
+      const syncCount = syncStatus.syncs.length
+      const pluralizedSyncs = syncCount === 1 ? "sync" : "syncs"
+      log.info(
+        `The ${chalk.cyan(action.name)} Deploy action has ${chalk.cyan(syncCount)} ${pluralizedSyncs} configured:`
+      )
       const leftPad = "  →"
       syncs.forEach((sync, idx) => {
         const state = sync.state
         log.info(
-          `${leftPad} Sync from ${chalk.cyan(sync.source)} to ${chalk.cyan(sync.target)} ${verbMap[state]} ${styleFn(
-            state
+          `${leftPad} Sync from ${chalk.cyan(sync.source)} to ${chalk.cyan(sync.target)} ${verbMap[state]} ${stateStyle(
+            state,
+            describeState(state)
           )}`
         )
         sync.mode && log.info(chalk.bold(`${leftPad} Mode: ${sync.mode}`))
-        sync.syncCount && log.info(chalk.bold(`${leftPad} Sync count: ${sync.syncCount}`))
+        sync.syncCount && log.info(chalk.bold(`${leftPad} Number of completed syncs: ${sync.syncCount}`))
         if (state === "failed" && sync.message) {
           log.info(`${chalk.bold(leftPad)} ${chalk.yellow(sync.message)}`)
         }

--- a/core/src/plugins/kubernetes/container/sync.ts
+++ b/core/src/plugins/kubernetes/container/sync.ts
@@ -20,7 +20,7 @@ export const k8sContainerStartSync: DeployActionHandler<"startSync", ContainerDe
   const { ctx, action, log } = params
   const k8sCtx = <KubernetesPluginContext>ctx
 
-  const { target, syncs, manifests } = getSyncs(action)
+  const { target, syncs, deployedResources } = getSyncs(action)
 
   if (syncs.length === 0) {
     return {}
@@ -36,7 +36,7 @@ export const k8sContainerStartSync: DeployActionHandler<"startSync", ContainerDe
     basePath: action.basePath(),
     defaultNamespace,
     defaultTarget: target,
-    manifests,
+    deployedResources,
     syncs,
   })
 
@@ -66,7 +66,7 @@ export const k8sContainerGetSyncStatus: DeployActionHandler<"getSyncStatus", Con
   const { ctx, log, action, monitor } = params
   const k8sCtx = <KubernetesPluginContext>ctx
 
-  const { target, syncs, manifests } = getSyncs(action)
+  const { target, syncs, deployedResources } = getSyncs(action)
 
   const defaultNamespace = await getAppNamespace(k8sCtx, log, k8sCtx.provider)
 
@@ -78,7 +78,7 @@ export const k8sContainerGetSyncStatus: DeployActionHandler<"getSyncStatus", Con
     basePath: action.basePath(),
     defaultNamespace,
     defaultTarget: target,
-    manifests,
+    deployedResources,
     syncs,
     monitor,
   })
@@ -87,14 +87,14 @@ export const k8sContainerGetSyncStatus: DeployActionHandler<"getSyncStatus", Con
 function getSyncs(action: Executed<ContainerDeployAction>): {
   syncs: KubernetesDeployDevModeSyncSpec[]
   target?: KubernetesTargetResourceSpec | undefined
-  manifests: KubernetesResource[]
+  deployedResources: KubernetesResource[]
 } {
   const status = action.getStatus()
   const sync = action.getSpec("sync")
   const workload = status.detail.detail.workload
 
   if (!sync?.paths || !workload) {
-    return { syncs: [], manifests: [] }
+    return { syncs: [], deployedResources: [] }
   }
 
   const target = {
@@ -109,5 +109,5 @@ function getSyncs(action: Executed<ContainerDeployAction>): {
     target,
   }))
 
-  return { syncs, target, manifests: status.detail.remoteResources }
+  return { syncs, target, deployedResources: status.detail.remoteResources }
 }

--- a/core/src/plugins/kubernetes/helm/sync.ts
+++ b/core/src/plugins/kubernetes/helm/sync.ts
@@ -43,7 +43,7 @@ export const helmStartSync: DeployActionHandler<"startSync", HelmDeployAction> =
     defaultTarget: spec.defaultTarget,
     basePath: action.basePath(),
     defaultNamespace: namespace,
-    manifests: deployedResources,
+    deployedResources,
     syncs: spec.sync.paths,
   })
 
@@ -71,7 +71,7 @@ export const helmGetSyncStatus: DeployActionHandler<"getSyncStatus", HelmDeployA
     provider: k8sCtx.provider,
   })
 
-  const resources = await getDeployedChartResources({ ctx: k8sCtx, action, releaseName, log })
+  const deployedResources = await getDeployedChartResources({ ctx: k8sCtx, action, releaseName, log })
 
   return getSyncStatus({
     ctx: k8sCtx,
@@ -81,7 +81,7 @@ export const helmGetSyncStatus: DeployActionHandler<"getSyncStatus", HelmDeployA
     defaultTarget: spec.defaultTarget,
     basePath: action.basePath(),
     defaultNamespace: namespace,
-    manifests: resources,
+    deployedResources,
     syncs: spec.sync.paths,
     monitor,
   })

--- a/core/src/plugins/kubernetes/kubernetes-type/sync.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/sync.ts
@@ -10,6 +10,7 @@ import { DeployActionHandler } from "../../../plugin/action-types"
 import { KubeApi } from "../api"
 import { KubernetesPluginContext } from "../config"
 import { getActionNamespace } from "../namespace"
+import { getDeployedResources } from "../status/status"
 import { getSyncStatus, startSyncs } from "../sync"
 import { getManifests } from "./common"
 import { KubernetesDeployAction } from "./config"
@@ -35,6 +36,7 @@ export const kubernetesStartSync: DeployActionHandler<"startSync", KubernetesDep
   })
 
   const manifests = await getManifests({ ctx, api, log, action, defaultNamespace: namespace })
+  const deployedResources = await getDeployedResources({ ctx, provider, manifests, log })
 
   await startSyncs({
     ctx: k8sCtx,
@@ -44,7 +46,7 @@ export const kubernetesStartSync: DeployActionHandler<"startSync", KubernetesDep
     defaultTarget: spec.defaultTarget,
     basePath: action.basePath(),
     defaultNamespace: namespace,
-    manifests,
+    deployedResources,
     syncs: spec.sync.paths,
   })
 
@@ -74,6 +76,7 @@ export const kubernetesGetSyncStatus: DeployActionHandler<"getSyncStatus", Kuber
   })
 
   const manifests = await getManifests({ ctx, api, log, action, defaultNamespace: namespace })
+  const deployedResources = await getDeployedResources({ ctx, provider, manifests, log })
 
   return getSyncStatus({
     ctx: k8sCtx,
@@ -83,7 +86,7 @@ export const kubernetesGetSyncStatus: DeployActionHandler<"getSyncStatus", Kuber
     defaultTarget: spec.defaultTarget,
     basePath: action.basePath(),
     defaultNamespace: namespace,
-    manifests,
+    deployedResources,
     syncs: spec.sync.paths,
     monitor,
   })

--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -495,7 +495,7 @@ interface StartSyncsParams extends StopSyncsParams {
   action: Resolved<SyncableRuntimeAction>
   basePath: string
   actionDefaults: SyncDefaults
-  manifests: KubernetesResource[]
+  deployedResources: KubernetesResource[]
   defaultNamespace: string
   syncs: KubernetesDeployDevModeSyncSpec[]
 }
@@ -517,7 +517,7 @@ export function getLocalSyncPath(sourcePath: string, basePath: string) {
 }
 
 export async function startSyncs(params: StartSyncsParams) {
-  const { ctx, log, basePath, action, manifests, defaultNamespace, actionDefaults, defaultTarget, syncs } = params
+  const { ctx, log, basePath, action, deployedResources, defaultNamespace, actionDefaults, defaultTarget, syncs } = params
 
   if (syncs.length === 0) {
     return
@@ -541,7 +541,7 @@ export async function startSyncs(params: StartSyncsParams) {
       ctx,
       log,
       provider,
-      manifests,
+      manifests: deployedResources,
       action,
       query: resourceSpec,
     })
@@ -627,7 +627,7 @@ export async function getSyncStatus(params: GetSyncStatusParams): Promise<GetSyn
     log,
     basePath,
     action,
-    manifests,
+    deployedResources,
     defaultNamespace,
     actionDefaults,
     defaultTarget,
@@ -662,7 +662,7 @@ export async function getSyncStatus(params: GetSyncStatusParams): Promise<GetSyn
         ctx,
         log,
         provider,
-        manifests,
+        manifests: deployedResources,
         action,
         query: resourceSpec,
       })


### PR DESCRIPTION
**What this PR does / why we need it**:

Before this fix, the `sync status` command would always show the status of active syncs for `kubernetes` Deploys as `not-active`.

This was because we were passing deployed resources for `container` and `helm` deploys when starting syncs and getting sync statuses, but passing local manifests for `kubernetes` deploys.

Fixes #4511