### PR TITLE
chore(analytics): add top of last stack trace to error metadata

### DIFF
--- a/core/test/unit/src/exceptions.ts
+++ b/core/test/unit/src/exceptions.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2018-2023 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from "chai"
+import { GardenBaseError, GardenErrorStackTrace, RuntimeError, getStackTraceMetadata } from "../../../src/exceptions"
+
+describe("GardenError", () => {
+  it("should return stack trace metadata", async () => {
+    let error: GardenBaseError
+
+    try {
+      throw new RuntimeError("test exception", {})
+    } catch (err) {
+      error = err
+    }
+
+    const metadata = getStackTraceMetadata(error)
+
+    const expected: GardenErrorStackTrace = { relativeFileName: "exceptions.ts", functionName: "Context.<anonymous>" }
+    expect(metadata).to.eql(expected)
+  })
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

This adds minimal stack trace data from the code location where garden fails. It helps pinpoint at least the file and function where the error was thrown. 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
