### PR TITLE
fix(cloud): properly handle dev delegation

### DIFF
--- a/core/src/cloud/api.ts
+++ b/core/src/cloud/api.ts
@@ -586,6 +586,7 @@ export class CloudApi {
     localServerPort,
     environment,
     namespace,
+    isDevCommand,
   }: {
     parentSessionId: string | undefined
     sessionId: string
@@ -594,6 +595,7 @@ export class CloudApi {
     localServerPort?: number
     environment: string
     namespace: string
+    isDevCommand?: boolean
   }): Promise<CloudSession | undefined> {
     let session = this.registeredSessions.get(sessionId)
 
@@ -610,6 +612,7 @@ export class CloudApi {
         projectUid: projectId,
         environment,
         namespace,
+        isDevCommand,
       }
       this.log.debug(`Registering session with ${this.distroName} for ${projectId} in ${environment}/${namespace}.`)
       const res: CloudSessionResponse = await this.post("sessions", {

--- a/core/src/cloud/api.ts
+++ b/core/src/cloud/api.ts
@@ -595,7 +595,7 @@ export class CloudApi {
     localServerPort?: number
     environment: string
     namespace: string
-    isDevCommand?: boolean
+    isDevCommand: boolean
   }): Promise<CloudSession | undefined> {
     let session = this.registeredSessions.get(sessionId)
 

--- a/core/src/commands/deploy.ts
+++ b/core/src/commands/deploy.ts
@@ -21,7 +21,7 @@ import {
   emptyActionResults,
 } from "./base"
 import { printEmoji, printHeader } from "../logger/util"
-import { watchParameter, watchRemovedWarning } from "./helpers"
+import { getCmdOptionForDev, watchParameter, watchRemovedWarning } from "./helpers"
 import { DeployTask } from "../tasks/deploy"
 import { naturalList } from "../util/string"
 import { StringsParameter, BooleanParameter } from "../cli/params"
@@ -178,8 +178,7 @@ export class DeployCommand extends Command<Args, Opts> {
     const monitor = this.maybePersistent(params)
     if (monitor && !params.parentCommand) {
       // Then we're not in the dev command yet, so we call that instead with the appropriate initial command.
-      // TODO: Abstract this delegation process into a helper if we write more commands that do this sort of thing.
-      params.opts.cmd = ["deploy " + params.args.$all!.join(" ")]
+      params.opts.cmd = getCmdOptionForDev("deploy", params)
       const devCmd = new DevCommand()
       devCmd.printHeader(params)
       await devCmd.prepare(params)

--- a/core/src/commands/helpers.ts
+++ b/core/src/commands/helpers.ts
@@ -19,9 +19,14 @@ import { ActionKind } from "../actions/types"
 import isGlob from "is-glob"
 import { ParameterError } from "../exceptions"
 import { naturalList } from "../util/string"
+import { CommandParams } from "./base"
 
 export function makeGetTestOrTaskLog(actions: (TestAction | RunAction)[]) {
   return actions.map((t) => prettyPrintTestOrTask(t)).join("\n")
+}
+
+export function getCmdOptionForDev(commandName: string, params: CommandParams) {
+  return [commandName + " " + params.args.$all?.join(" ")]
 }
 
 export function prettyPrintWorkflow(workflow: WorkflowConfig): string {

--- a/core/src/commands/serve.ts
+++ b/core/src/commands/serve.ts
@@ -166,6 +166,7 @@ export class ServeCommand<
             localServerPort: this.server.port,
             environment: defaultGarden.environmentName,
             namespace: defaultGarden.namespace,
+            isDevCommand: false,
           })
         }
       }

--- a/core/src/commands/up.ts
+++ b/core/src/commands/up.ts
@@ -13,6 +13,7 @@ import { deployArgs, DeployCommand, deployOpts } from "./deploy"
 import { serveOpts } from "./serve"
 import { DevCommand } from "./dev"
 import type { LoggerType } from "../logger/logger"
+import { getCmdOptionForDev } from "./helpers"
 
 const upArgs = {
   ...deployArgs,
@@ -51,7 +52,7 @@ export class UpCommand extends Command<UpArgs, UpOpts> {
       cmd = new DeployCommand()
       params.opts.logs = true
     } else {
-      params.opts.cmd = ["deploy --logs " + params.args.$all!.join(" ")]
+      params.opts.cmd = getCmdOptionForDev("deploy --logs", params)
     }
 
     cmd.printHeader(params)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

When a command is run with an option that results in it being run inside the `dev` command instead (e.g. `garden deploy --sync`), we now register the initial command session with Cloud as a `dev` command with the `--cmd` option set appropriately. This is useful for Cloud when listing command sessions created this way.

For good measure, we include an explicit `isDevCommand` parameter with the session registration request to Cloud to make this setup more robust against future changes (instead of inferring whether the command is a `dev` command from the `commandInfo` map).

**Special notes for your reviewer**:

I've verified that including the `isDevCommand` param in the registration request doesn't result in errors (it will be ignored by the API until implemented there). So there shouldn't be any compatibility problems in the meantime.