### PR TITLE
feat(cli): add `get files` command to see files included in actions

### DIFF
--- a/core/src/commands/get/get-files.ts
+++ b/core/src/commands/get/get-files.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2018-2023 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { fromPairs } from "lodash"
+import { StringsParameter } from "../../cli/params"
+import { joi } from "../../config/common"
+import { printHeader } from "../../logger/util"
+import { Command, CommandParams, CommandResult } from "../base"
+import chalk from "chalk"
+
+const getFilesArgs = {
+  keys: new StringsParameter({
+    help: "One or more action keys (e.g. deploy.api), separated by spaces. If omitted, all actions are queried.",
+    spread: true,
+  }),
+}
+
+type Args = typeof getFilesArgs
+type Opts = {}
+
+interface Result {
+  [key: string]: string[]
+}
+
+/**
+ * An abstract base class for get actions subcommands
+ * e.g. get builds, deploys, runs, tests.
+ * These commands are same as calling get actions command with option kind
+ */
+export class GetFilesCommand extends Command<Args, Opts> {
+  name = "files"
+  help = "List all files from all or specified actions."
+
+  description = "This is useful to diagnose issues with ignores, include and exclude for a given action."
+
+  arguments = getFilesArgs
+
+  outputsSchema = () => joi.object().pattern(joi.string(), joi.array().items(joi.string()).required())
+
+  printHeader({ log }) {
+    printHeader(log, "Get Files", "🗂️")
+  }
+
+  async action({ garden, log, args }: CommandParams<Args, Opts>): Promise<CommandResult<Result>> {
+    const graph = await garden.getConfigGraph({ log, emit: false })
+    const actions = graph.getActions({ refs: args.keys?.length ? args.keys : undefined })
+
+    const result = fromPairs(
+      actions.map((a) => {
+        const key = a.key()
+        const files = a.getFullVersion().files
+
+        log.info("")
+        log.info(chalk.cyanBright(key))
+        log.info(files.length ? files.map((f) => "- " + f).join("\n") : "(none)")
+
+        return [key, files]
+      })
+    )
+
+    log.info("")
+
+    return {
+      result,
+    }
+  }
+}

--- a/core/src/commands/get/get-files.ts
+++ b/core/src/commands/get/get-files.ts
@@ -27,11 +27,6 @@ interface Result {
   [key: string]: string[]
 }
 
-/**
- * An abstract base class for get actions subcommands
- * e.g. get builds, deploys, runs, tests.
- * These commands are same as calling get actions command with option kind
- */
 export class GetFilesCommand extends Command<Args, Opts> {
   name = "files"
   help = "List all files from all or specified actions."

--- a/core/src/commands/get/get.ts
+++ b/core/src/commands/get/get.ts
@@ -24,6 +24,7 @@ import { GetWorkflowsCommand } from "./get-workflows"
 import { GetActionsCommand } from "./get-actions"
 import { GetDeploysCommand } from "./get-deploys"
 import { GetBuildsCommand } from "./get-builds"
+import { GetFilesCommand } from "./get-files"
 
 export class GetCommand extends CommandGroup {
   name = "get"
@@ -34,6 +35,7 @@ export class GetCommand extends CommandGroup {
     GetConfigCommand,
     GetDoddiCommand,
     GetEysiCommand,
+    GetFilesCommand,
     GetLinkedReposCommand,
     GetOutputsCommand,
     GetModulesCommand,

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -2783,6 +2783,29 @@ suggestedCommands:
       src:
 ```
 
+### garden get files
+
+**List all files from all or specified actions.**
+
+This is useful to diagnose issues with ignores, include and exclude for a given action.
+
+#### Usage
+
+    garden get files [keys] 
+
+#### Arguments
+
+| Argument | Required | Description |
+| -------- | -------- | ----------- |
+  | `keys` | No | One or more action keys (e.g. deploy.api), separated by spaces. If omitted, all actions are queried.
+
+
+#### Outputs
+
+```yaml
+<name>:
+```
+
 ### garden get linked-repos
 
 **Outputs a list of all linked remote sources, actions and modules for this project.**


### PR DESCRIPTION
Came up in a customer conversation. Quite basic but also handy.