### PR TITLE
fix(cli): print correct link to web dashboard

### DIFF
--- a/core/src/cloud/api.ts
+++ b/core/src/cloud/api.ts
@@ -447,8 +447,7 @@ export class CloudApi {
       this.log.debug({ msg: `Failed to refresh the token.` })
       const detail = is401Error(err) ? { statusCode: err.response.statusCode } : {}
       throw new CloudApiTokenRefreshError(
-        `An error occurred while verifying client auth token with ${getCloudDistributionName(this.domain)}: ${
-          err.message
+        `An error occurred while verifying client auth token with ${getCloudDistributionName(this.domain)}: ${err.message
         }`,
         detail
       )
@@ -682,8 +681,7 @@ export class CloudApi {
     } catch (err) {
       if (!is401Error(err)) {
         throw new CloudApiError(
-          `An error occurred while verifying client auth token with ${getCloudDistributionName(this.domain)}: ${
-            err.message
+          `An error occurred while verifying client auth token with ${getCloudDistributionName(this.domain)}: ${err.message
           }`,
           {}
         )
@@ -697,21 +695,13 @@ export class CloudApi {
     return new URL(`/projects/${projectId}`, this.domain)
   }
 
-  getCommandResultUrl({
-    projectId,
-    sessionId,
-    userId,
-    shortId,
-  }: {
-    projectId: string
-    sessionId: string
-    userId: string
-    shortId?: string
-  }) {
-    let path = `/projects/${projectId}?sessionId=${sessionId}&userId=${userId}`
-    if (shortId) {
-      path = `/go/${shortId}`
-    }
+  getCommandResultUrl({ projectId, sessionId, userId }: { projectId: string; sessionId: string; userId: string }) {
+    const path = `/projects/${projectId}?sessionId=${sessionId}&userId=${userId}`
+    return new URL(path, this.domain)
+  }
+
+  getLivePageUrl({ shortId }: { shortId: string }) {
+    const path = `/go/${shortId}`
     return new URL(path, this.domain)
   }
 

--- a/core/src/commands/base.ts
+++ b/core/src/commands/base.ts
@@ -314,17 +314,14 @@ export abstract class Command<A extends Parameters = {}, O extends Parameters = 
       const distroName = getCloudDistributionName(cloudSession.api.domain)
       const userId = (await cloudSession.api.getProfile()).id
       const commandResultUrl = cloudSession.api.getCommandResultUrl({
-        shortId: cloudSession.shortId,
         sessionId: garden.sessionId,
         projectId: cloudSession.projectId,
         userId,
       }).href
       const cloudLog = log.createLog({ name: getCloudLogSectionName(distroName) })
 
-      const msg = dedent`🌸  Connected to ${distroName}. View logs and command results at: ${chalk.cyan(
-        commandResultUrl
-      )}\n`
-      cloudLog.info(msg)
+      // FIXME: We need a shortened URL for this
+      cloudLog.info(`View command results at:\n${chalk.cyan(commandResultUrl)}\n`)
     }
 
     let analytics: AnalyticsHandler | undefined

--- a/core/src/commands/serve.ts
+++ b/core/src/commands/serve.ts
@@ -9,7 +9,7 @@
 import { Command, CommandResult, CommandParams } from "./base"
 import { startServer } from "../server/server"
 import { IntegerParameter, StringsParameter } from "../cli/params"
-import { printHeader } from "../logger/util"
+import { printEmoji, printHeader } from "../logger/util"
 import { dedent } from "../util/string"
 import { CommandLine } from "../cli/command-line"
 import { GardenInstanceManager } from "../server/instance-manager"
@@ -157,7 +157,7 @@ export class ServeCommand<
         }
 
         if (projectId && defaultGarden) {
-          await cloudApi.registerSession({
+          const session = await cloudApi.registerSession({
             parentSessionId: undefined,
             projectId,
             // Use the process (i.e. parent command) session ID for the serve command session
@@ -168,6 +168,16 @@ export class ServeCommand<
             namespace: defaultGarden.namespace,
             isDevCommand: false,
           })
+          if (session?.shortId) {
+            const distroName = getCloudDistributionName(cloudDomain)
+            const livePageUrl = cloudApi.getLivePageUrl({ shortId: session.shortId })
+            const msg = dedent`${printEmoji("🌸", log)}Connected to ${distroName} ${printEmoji("🌸", log)}
+              Follow the link below to stream logs, run commands, and more from your web dashboard ${printEmoji(
+              "👇",
+              log
+            )} \n\n${chalk.cyan(livePageUrl)}\n`
+            log.info(chalk.white(msg))
+          }
         }
       }
     } catch (err) {


### PR DESCRIPTION
**What this PR does / why we need it**:

From commit message:

Before this fix we were printing links to the live page for command
results. This fixes that but in turn we need to deal with the
unshortened link until we add link shortening support for command
results page.

See also: https://github.com/garden-io/garden/issues/4683

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
