### PR TITLE
fix(k8s) Update default Kaniko version

### DIFF
--- a/core/src/plugins/kubernetes/constants.ts
+++ b/core/src/plugins/kubernetes/constants.ts
@@ -38,7 +38,7 @@ export const k8sSyncUtilImageName: DockerImageWithDigest = "gardendev/k8s-sync:0
 export const k8sReverseProxyImageName: DockerImageWithDigest = "gardendev/k8s-reverse-proxy:0.1.0@sha256:df2976dc67c237114bd9c70e32bfe4d7131af98e140adf6dac29b47b85e07232"
 export const buildkitImageName: DockerImageWithDigest = "gardendev/buildkit:v0.10.5-2@sha256:c2199fcdabc2ad10a266aab5acfb7861d934e4a787071c4d717cfcb1b5ab39ed"
 export const buildkitRootlessImageName: DockerImageWithDigest = "gardendev/buildkit:v0.10.5-2-rootless@sha256:9d9476286f0bc88ec43b139fa093c4416e521c9bc39e39374c1f40b59be44aed"
-export const defaultKanikoImageName: DockerImageWithDigest = "gcr.io/kaniko-project/executor:v1.8.1-debug@sha256:3bc3f3a05f803cac29164ce12617a7be64931748c944f6c419565f500b65e8db"
+export const defaultKanikoImageName: DockerImageWithDigest = "gcr.io/kaniko-project/executor:v1.11.0-debug@sha256:32ba2214921892c2fa7b5f9c4ae6f8f026538ce6b2105a93a36a8b5ee50fe517"
 
 export const buildkitDeploymentName = "garden-buildkit"
 export const buildkitContainerName = "buildkitd"


### PR DESCRIPTION
**What this PR does / why we need it:**
This PR updates the default version of Kaniko used by Garden. Of course, anyone can use a non-default version of Kaniko regardless, but newer versions of K8s cause older versions of Kaniko to error out with the mistaken message that "Kaniko must be run inside a container" when, of course, it is running inside a container. Newer versions of Kaniko should work for older versions of K8s, but I can confirm they also fix the aforementioned bug.

**Special notes for your reviewer:**

I have only tested this change against my current deploy's K8s version (`1.26.3`). It would seem reasonable to want to validate the newer Kaniko version works against select other versions of K8s.