### PR TITLE
fix(template-strings): do not apply helper functions on unresolved string

### DIFF
--- a/core/src/template-string/functions.ts
+++ b/core/src/template-string/functions.ts
@@ -16,6 +16,7 @@ import { validateSchema } from "../config/validation"
 import { load, loadAll } from "js-yaml"
 import { safeDumpYaml } from "../util/serialization"
 import indentString from "indent-string"
+import { maybeTemplateString } from "./template-string"
 
 interface ExampleArgument {
   input: any[]
@@ -508,6 +509,19 @@ export function callHelperFunction({
         context: `argument '${argName}' for ${functionName} helper function`,
         ErrorClass: TemplateStringError,
       })
+
+      // do not apply helper function for an unresolved template string
+      if (maybeTemplateString(value)) {
+        const _error = new TemplateStringError(`Function '${functionName}' cannot be applied on unresolved string`, {
+          functionName,
+          text,
+        })
+        if (allowPartial) {
+          return { resolved: "${" + text + "}" }
+        } else {
+          return { _error }
+        }
+      }
     } catch (_error) {
       if (allowPartial) {
         return { resolved: text }

--- a/core/src/template-string/functions.ts
+++ b/core/src/template-string/functions.ts
@@ -512,13 +512,13 @@ export function callHelperFunction({
 
       // do not apply helper function for an unresolved template string
       if (maybeTemplateString(value)) {
-        const _error = new TemplateStringError(`Function '${functionName}' cannot be applied on unresolved string`, {
-          functionName,
-          text,
-        })
         if (allowPartial) {
           return { resolved: "${" + text + "}" }
         } else {
+          const _error = new TemplateStringError(`Function '${functionName}' cannot be applied on unresolved string`, {
+            functionName,
+            text,
+          })
           return { _error }
         }
       }

--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -1053,6 +1053,13 @@ describe("resolveTemplateString", () => {
       })
     })
 
+    it("does not apply helper function on unresolved template string and returns string as-is, when allowPartial=true", () => {
+      const res = resolveTemplateString("${base64Encode('${environment.namespace}')}", new TestContext({}), {
+        allowPartial: true,
+      })
+      expect(res).to.equal("${base64Encode('${environment.namespace}')}")
+    })
+
     context("concat", () => {
       it("allows empty strings", () => {
         const res = resolveTemplateString("${concat('', '')}", new TestContext({}))


### PR DESCRIPTION
**What this PR does / why we need it**:
Before this fix, helper functions were being applied even on resolved string and the unsubstituted string was considered the string itself for helper function. 

Basically, in the [first resolveTemplateStrings of module](https://github.com/garden-io/garden/blob/main/core/src/resolve-module.ts#L358), when only `inputs` are available and keys like `environment` are missing, unresolved strings are fine as `allowPartial` is set to `true`. However, the helper functions were still being applied.

For example, for a template string like  
```
TEST:  "base64Encode(\"${environment.namespace}\")"`
```
base64Encode was being called for `environment.namespace` instead of the actual value and resulted in wrong values. So before the [2nd resolveTemplateStrings of module](https://github.com/garden-io/garden/blob/main/core/src/resolve-module.ts#L363), when the module context is available, there was no `base64Encode(\"${environment.namespace}\")` left to be resolved.

The workaround mentioned in original issue #4614 
`TEST: "${environment && base64Encode(\"${environment.namespace}\")}"` 
works because of the `environment &&`. Even though the `base64Encode` is applied on `environment.namespace`, the overall expression fails due to `environment` missing in first pass.

I added a check before helper functions are applied to not apply helper on unresolved string. Had to wrap `text` in `${}` so it's returned as an expression to be resolved later. In case, `allowPartial` is set to `false`, it returns error. 

**Which issue(s) this PR fixes**:

Fixes #4614 

**Special notes for your reviewer**:
I am not sure if we can avoid this check altogether and instead extend the actual parser to address this issue. 🤔 