### PR TITLE
0.12 back-port: fix: update version hash if a file is renamed

### DIFF
--- a/core/src/vcs/vcs.ts
+++ b/core/src/vcs/vcs.ts
@@ -182,7 +182,8 @@ export abstract class VcsHandler {
           // Don't include the config file in the file list
           .filter((f) => !configPath || f.path !== configPath)
 
-        result.contentHash = hashStrings(files.map((f) => f.hash))
+        // compute hash using <file-relative-path>-<file-hash> to cater for path changes (e.g. renaming)
+        result.contentHash = hashStrings(files.map((f) => `${relative(this.projectRoot, f.path)}-${f.hash}`))
         result.files = files.map((f) => f.path)
       }
 

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -4627,9 +4627,9 @@ describe("Garden", () => {
     })
 
     context("test against fixed version hashes", async () => {
-      const moduleAVersionString = "v-e3eed855ed"
-      const moduleBVersionString = "v-cdfff6b4f2"
-      const moduleCVersionString = "v-9d2afce9e4"
+      const moduleAVersionString = "v-48acad3a28"
+      const moduleBVersionString = "v-68d89c8275"
+      const moduleCVersionString = "v-68421fafcc"
 
       it("should return the same module versions between runtimes", async () => {
         const projectRoot = getDataDir("test-projects", "fixed-version-hashes-1")

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -4627,9 +4627,9 @@ describe("Garden", () => {
     })
 
     context("test against fixed version hashes", async () => {
-      const moduleAVersionString = "v-6f85bdd407"
-      const moduleBVersionString = "v-6e138410f5"
-      const moduleCVersionString = "v-ea24adfffc"
+      const moduleAVersionString = "v-e3eed855ed"
+      const moduleBVersionString = "v-cdfff6b4f2"
+      const moduleCVersionString = "v-9d2afce9e4"
 
       it("should return the same module versions between runtimes", async () => {
         const projectRoot = getDataDir("test-projects", "fixed-version-hashes-1")

--- a/core/test/unit/src/vcs/vcs.ts
+++ b/core/test/unit/src/vcs/vcs.ts
@@ -28,9 +28,10 @@ import { GitHandler } from "../../../../src/vcs/git"
 import { resolve, join } from "path"
 import td from "testdouble"
 import tmp from "tmp-promise"
-import { realpath, readFile, writeFile, rename, rm } from "fs-extra"
+import { realpath, readFile, writeFile, rename } from "fs-extra"
 import { DEFAULT_API_VERSION, GARDEN_VERSIONFILE_NAME } from "../../../../src/constants"
 import { defaultDotIgnoreFiles, fixedProjectExcludes } from "../../../../src/util/fs"
+import { rm } from "fs/promises"
 import { LogEntry } from "../../../../src/logger/log-entry"
 
 export class TestVcsHandler extends VcsHandler {
@@ -365,7 +366,7 @@ describe("getModuleVersionString", () => {
     const garden = await makeTestGarden(projectRoot, { noCache: true })
     const module = await garden.resolveModule("module-a")
 
-    const fixedVersionString = "v-e3eed855ed"
+    const fixedVersionString = "v-48acad3a28"
     expect(module.version.versionString).to.eql(fixedVersionString)
 
     delete process.env.TEST_ENV_VAR


### PR DESCRIPTION
**What this PR does / why we need it**:
cherry picks #4660 to 0.12

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
