### PR TITLE
chore: re-enable terraform plugin tests

### DIFF
--- a/plugins/terraform/test/common.ts
+++ b/plugins/terraform/test/common.ts
@@ -16,8 +16,7 @@ import { expect } from "chai"
 import { defaultTerraformVersion, terraform } from "../cli"
 
 for (const terraformVersion of ["0.13.3", defaultTerraformVersion]) {
-  // TODO: re-enable after https://github.com/garden-io/garden/issues/4467 has been fixed
-  describe.skip(`Terraform common with version ${terraformVersion}`, () => {
+  describe(`Terraform common with version ${terraformVersion}`, () => {
     const testRoot = join(__dirname, "test-project")
 
     let root: string

--- a/plugins/terraform/test/terraform.ts
+++ b/plugins/terraform/test/terraform.ts
@@ -23,8 +23,7 @@ import { RunTask } from "@garden-io/core/build/src/tasks/run"
 import { defaultTerraformVersion } from "../cli"
 
 for (const terraformVersion of ["0.13.3", defaultTerraformVersion]) {
-  // TODO: re-enable after https://github.com/garden-io/garden/issues/4467 has been fixed
-  describe.skip(`Terraform provider with terraform ${terraformVersion}`, () => {
+  describe(`Terraform provider with terraform ${terraformVersion}`, () => {
     const testRoot = join(__dirname, "test-project")
     let garden: TestGarden
     let tfRoot: string
@@ -289,8 +288,7 @@ for (const terraformVersion of ["0.13.3", defaultTerraformVersion]) {
     })
   })
 
-  // TODO: re-enable after https://github.com/garden-io/garden/issues/4467 has been fixed
-  describe.skip("Terraform action type", () => {
+  describe("Terraform action type", () => {
     const testRoot = join(__dirname, "test-project-action")
     const tfRoot = join(testRoot, "tf")
     const stateDirPath = join(tfRoot, "terraform.tfstate")
@@ -728,8 +726,7 @@ for (const terraformVersion of ["0.13.3", defaultTerraformVersion]) {
     })
   })
 
-  // TODO: re-enable after https://github.com/garden-io/garden/issues/4467 has been fixed
-  describe.skip("Terraform module type", () => {
+  describe("Terraform module type", () => {
     const testRoot = join(__dirname, "test-project-module")
     const tfRoot = join(testRoot, "tf")
     const stateDirPath = join(tfRoot, "terraform.tfstate")

--- a/plugins/terraform/test/validation.ts
+++ b/plugins/terraform/test/validation.ts
@@ -13,8 +13,7 @@ import { defaultTerraformVersion } from "../cli"
 import { ValidateCommand } from "@garden-io/core/build/src/commands/validate"
 import { withDefaultGlobalOpts } from "@garden-io/core/build/test/helpers"
 
-// TODO: re-enable after https://github.com/garden-io/garden/issues/4467 has been fixed
-describe.skip("terraform validation", () => {
+describe("terraform validation", () => {
   for (const project of ["test-project", "test-project-action", "test-project-module"]) {
     it(`should pass validation for ${project}`, async () => {
       const testRoot = join(__dirname, project)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #4473 

**Special notes for your reviewer**:

We use node version `18.12` in the `circleci-runner` image.
We used to have an `nvm install` step in our CI, which actually updated node to the latest `18.x`. This was removed in https://github.com/garden-io/garden/pull/4451/files

Because of the #4467 issue and https://github.com/ZJONSSON/node-unzipper/issues/271 the `unzipper` extracted binaries can get corrupted when using node version `18.16` and above. After removing the `nvm` steps, we are back to using `18.12` and this should just work again.

Sidenote: in our `support` images, we are referring to node base image hashes that _are_ on `18.16`. We should unify the versions so that our entire repository is synced to the same node version in a separate followup task / pr. Currently, as it stands, those support images can still suffer from #4467 as they are built with a newer node version.