### PR TITLE
fix(cloud): emit stable action uids across phases

### DIFF
--- a/core/src/actions/base.ts
+++ b/core/src/actions/base.ts
@@ -60,7 +60,6 @@ import { PickTypeByKind } from "../graph/config-graph"
 import { DeployAction } from "./deploy"
 import { TestAction } from "./test"
 import { RunAction } from "./run"
-import { uuidv4 } from "../util/random"
 import { createActionLog, Log } from "../logger/log-entry"
 import { joinWithPosix } from "../util/fs"
 import { LinkedSource } from "../config-store/local"
@@ -326,6 +325,7 @@ export abstract class BaseAction<
   public readonly kind: C["kind"]
   public readonly type: C["type"]
   public readonly name: string
+  public readonly uid: string
 
   protected resolved: boolean
   protected executed: boolean
@@ -353,6 +353,7 @@ export abstract class BaseAction<
     this.kind = params.config.kind
     this.type = params.config.type
     this.name = params.config.name
+    this.uid = params.uid
     this.baseBuildDirectory = params.baseBuildDirectory
     this.compatibleTypes = params.compatibleTypes
     this.dependencies = params.dependencies
@@ -547,14 +548,6 @@ export abstract class BaseAction<
   @Memoize()
   configVersion() {
     return versionStringPrefix + hashStrings([this.stringifyConfig()])
-  }
-
-  /**
-   * We use memoization to lazy-generate the uid to avoid unnecessary overhead when initializing every action.
-   */
-  @Memoize()
-  getUid() {
-    return uuidv4()
   }
 
   /**

--- a/core/src/actions/types.ts
+++ b/core/src/actions/types.ts
@@ -146,6 +146,10 @@ export interface ActionWrapperParams<C extends BaseActionConfig> {
   baseBuildDirectory: string // <project>/.garden/build by default
   compatibleTypes: string[]
   config: C
+  // It's not ideal that we're passing this here, but since we reuse the params of the base action in
+  // `actionToResolved` and `resolvedActionToExecuted`, it's probably clearest and least magical to pass it in
+  // explicitly at action creation time (which only happens in a very few places in the code base anyway).
+  uid: string
   dependencies: ActionDependency[]
   graph: ConfigGraph
   linkedSource: LinkedSource | null

--- a/core/src/events/util.ts
+++ b/core/src/events/util.ts
@@ -73,7 +73,7 @@ export function makeActionStatusPayloadBase({
     // NOTE: The type/kind needs to be lower case in the event payload
     actionType: action.kind.toLowerCase(),
     actionKind: action.kind.toLowerCase(),
-    actionUid: action.getUid(),
+    actionUid: action.uid,
     moduleName: action.moduleName(),
     startedAt,
     operation,

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -63,6 +63,7 @@ import { ConfigContext } from "../config/template-contexts/base"
 import { LinkedSource, LinkedSourceMap } from "../config-store/local"
 import { relative } from "path"
 import { profileAsync } from "../util/profiling"
+import { uuidv4 } from "../util/random"
 
 export const actionConfigsToGraph = profileAsync(async function actionConfigsToGraph({
   garden,
@@ -277,6 +278,7 @@ export const actionFromConfig = profileAsync(async function actionFromConfig({
     baseBuildDirectory: garden.buildStaging.buildDirPath,
     compatibleTypes,
     config,
+    uid: uuidv4(),
     dependencies,
     graph,
     projectRoot: garden.projectRoot,

--- a/core/src/router/build.ts
+++ b/core/src/router/build.ts
@@ -32,7 +32,7 @@ export const buildRouter = (baseParams: BaseRouterParams) =>
     build: async (params) => {
       const { action, garden, router } = params
 
-      const actionUid = action.getUid()
+      const actionUid = action.uid
       params.events = params.events || new PluginEventBroker(garden)
 
       const actionName = action.name

--- a/core/src/router/deploy.ts
+++ b/core/src/router/deploy.ts
@@ -19,7 +19,7 @@ export const deployRouter = (baseParams: BaseRouterParams) =>
     deploy: async (params) => {
       const { router, action, garden } = params
 
-      const actionUid = action.getUid()
+      const actionUid = action.uid
       params.events = params.events || new PluginEventBroker(garden)
 
       const actionName = action.name

--- a/core/src/router/run.ts
+++ b/core/src/router/run.ts
@@ -20,7 +20,7 @@ export const runRouter = (baseParams: BaseRouterParams) =>
     run: async (params) => {
       const { garden, router, action } = params
 
-      const actionUid = action.getUid()
+      const actionUid = action.uid
       const tmpDir = await tmp.dir({ unsafeCleanup: true })
       const artifactsPath = normalizePath(await realpath(tmpDir.path))
 

--- a/core/src/router/test.ts
+++ b/core/src/router/test.ts
@@ -22,7 +22,7 @@ export const testRouter = (baseParams: BaseRouterParams) =>
 
       const tmpDir = await makeTempDir()
       const artifactsPath = normalizePath(await realpath(tmpDir.path))
-      const actionUid = action.getUid()
+      const actionUid = action.uid
 
       const actionName = action.name
       const actionType = API_ACTION_TYPE


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Before this fix, `log` events emitted by router methods wouldn't include the same `actionUid` as the status events emitted by the `emitGetStatusEvents` and `emitProcessingEvents` helpers. This led to those action logs not loading in Cloud.

This was because the memoized `getUid()` instance method on the `BaseTask` didn't result in the UID being passed on to the resolved (and later, the executed) action, since those are initalized with the same constructor params as their parent action.

This was fixed by explicitly including the `uid` in the base action constructor params, which means that it gets passed on to the resolved and executed phases of the action (if any).