### PR TITLE
chore(analytics): improve error reporting structure

### DIFF
--- a/core/src/analytics/analytics.ts
+++ b/core/src/analytics/analytics.ts
@@ -643,7 +643,7 @@ export class AnalyticsHandler {
           // the first wrapped error
           wrapped: e.wrappedErrors?.at(0) ? getErrorDetail(e.wrappedErrors?.at(0)!) : undefined,
           // recursively get all the leaf errors and select the first one
-          leaf: getLeafErrors(e).at(0),
+          leaf: e.wrappedErrors ? getLeafErrors(e).at(0) : undefined,
         }
       } catch (err) {
         this.log.silly(`Failed to get analytics error detail from ${e}, ${e.wrappedErrors?.at(0)}, ${err}`)

--- a/core/src/analytics/analytics.ts
+++ b/core/src/analytics/analytics.ts
@@ -135,7 +135,7 @@ interface EventBase {
   properties: PropertiesBase
 }
 
-interface CommandEvent extends EventBase {
+export interface CommandEvent extends EventBase {
   type: "Run Command"
   properties: PropertiesBase & {
     name: string
@@ -163,7 +163,7 @@ type AnalyticsGardenError = {
   leaf?: AnalyticsGardenErrorDetail
 }
 
-interface CommandResultEvent extends EventBase {
+export interface CommandResultEvent extends EventBase {
   type: "Command Result"
   properties: PropertiesBase & {
     name: string
@@ -217,7 +217,7 @@ interface ApiRequestBody {
   command: string
 }
 
-type AnalyticsEvent =
+export type AnalyticsEvent =
   | CommandEvent
   | CommandResultEvent
   | ApiEvent

--- a/core/src/analytics/helpers.ts
+++ b/core/src/analytics/helpers.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2018-2023 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { GardenBaseError, GardenError, getStackTraceMetadata } from "../exceptions"
+import { AnalyticsGardenError, AnalyticsGardenErrorDetail } from "./analytics"
+
+function getErrorDetail(error: GardenError): AnalyticsGardenErrorDetail {
+  const stackTrace = getStackTraceMetadata(error)
+  const firstEntry = stackTrace.metadata.at(0)
+
+  return {
+    errorType: error.type,
+    context: error.context,
+    stackTrace: firstEntry,
+  }
+}
+
+function getLeafErrors(error: GardenError): AnalyticsGardenErrorDetail[] {
+  if (!error.wrappedErrors || error.wrappedErrors.length === 0) {
+    return [getErrorDetail(error)]
+  } else {
+    return error.wrappedErrors.flatMap(getLeafErrors)
+  }
+}
+
+function getAnalyticsError(error: GardenError): AnalyticsGardenError {
+  return {
+    // details of the root error
+    error: getErrorDetail(error),
+    // the first wrapped error
+    wrapped: error.wrappedErrors?.at(0) ? getErrorDetail(error.wrappedErrors?.at(0)!) : undefined,
+    // recursively get all the leaf errors and select the first one
+    leaf: error.wrappedErrors ? getLeafErrors(error).at(0) : undefined,
+  }
+}
+
+export function getResultErrorProperties(errors: GardenBaseError[]): {
+  errors: string[]
+  lastError?: AnalyticsGardenError
+} {
+  const allErrorMetadata: AnalyticsGardenError[] = errors.flatMap(getAnalyticsError)
+
+  // capture the unique top level errors
+  const allErrors = [
+    ...new Set<string>(
+      allErrorMetadata.map((e) => {
+        return e.error.errorType
+      })
+    ),
+  ]
+
+  return {
+    errors: allErrors,
+    lastError: allErrorMetadata.at(-1),
+  }
+}

--- a/core/src/exceptions.ts
+++ b/core/src/exceptions.ts
@@ -17,6 +17,7 @@ export interface GardenError<D extends object = any> extends Error {
   detail?: D
   stack?: string
   wrappedErrors?: GardenError[]
+  context?: GardenErrorContext
 }
 
 export function isGardenError(err: any): err is GardenError {
@@ -26,6 +27,7 @@ export function isGardenError(err: any): err is GardenError {
 export type StackTraceMetadata = {
   functionName: string
   relativeFileName?: string
+  lineNumber?: number
 }
 
 export type GardenErrorStackTrace = {
@@ -38,6 +40,11 @@ export interface GardenErrorParams<D extends object = any> {
   readonly detail?: D
   readonly stack?: string
   readonly wrappedErrors?: GardenError[]
+  readonly context?: GardenErrorContext
+}
+
+export type GardenErrorContext = {
+  taskType?: string
 }
 
 export abstract class GardenBaseError<D extends object = any> extends Error implements GardenError<D> {
@@ -45,12 +52,14 @@ export abstract class GardenBaseError<D extends object = any> extends Error impl
   public message: string
   public detail?: D
   public wrappedErrors?: GardenError<any>[]
+  public context?: GardenErrorContext
 
-  constructor({ message, detail, stack, wrappedErrors }: GardenErrorParams<D>) {
+  constructor({ message, detail, stack, wrappedErrors, context }: GardenErrorParams<D>) {
     super(message)
     this.detail = detail
     this.stack = stack || this.stack
     this.wrappedErrors = wrappedErrors
+    this.context = context
   }
 
   toString() {
@@ -247,10 +256,13 @@ function getStackTraceFromString(stack: string): StackTraceMetadata[] {
       relativeFileName = filePath.slice(lastFilePos)
     }
 
+    let lineNumber = parseInt(atLine[3], 10) || -1
+
     return [
       {
         functionName,
         relativeFileName,
+        lineNumber,
       },
     ]
   })

--- a/core/src/graph/nodes.ts
+++ b/core/src/graph/nodes.ts
@@ -7,7 +7,7 @@
  */
 
 import { Task, ValidResultType } from "../tasks/base"
-import { GardenBaseError, InternalError } from "../exceptions"
+import { GardenBaseError, InternalError, isGardenError } from "../exceptions"
 import { GraphResult, GraphResultFromTask, GraphResults } from "./results"
 import type { GraphSolver } from "./solver"
 import { ValuesType } from "utility-types"
@@ -378,7 +378,8 @@ export class GraphNodeError extends GardenBaseError<GraphNodeErrorDetail> {
       message = `${node.describe()} failed: ${error}`
     }
 
-    super({ message, detail: params })
+    const wrappedErrors = isGardenError(error) ? [error] : []
+    super({ message, detail: params, wrappedErrors, context: { taskType: node.task.type } })
   }
 
   aborted() {

--- a/core/src/graph/results.ts
+++ b/core/src/graph/results.ts
@@ -245,8 +245,22 @@ function filterErrorForExport(error: any) {
     "success",
     "type"
   )
+
+  // recursively go through the wrappedErrors
+  const allWrappedErrors = error.wrappedErrors || []
+  const filteredWrappedErrors = allWrappedErrors.flatMap((e) => {
+    const filteredError = filterErrorForExport(e)
+
+    if (!filteredError) {
+      return []
+    } else {
+      return [filteredError]
+    }
+  })
+
   return {
     ...pick(error, "message", "type", "stack"),
     detail: filteredDetail,
+    wrappedErrors: filteredWrappedErrors,
   }
 }

--- a/core/test/unit/src/analytics/analytics.ts
+++ b/core/test/unit/src/analytics/analytics.ts
@@ -13,7 +13,7 @@ import { validate as validateUuid } from "uuid"
 
 import { makeTestGardenA, TestGarden, enableAnalytics, getDataDir, makeTestGarden, freezeTime } from "../../../helpers"
 import { FakeCloudApi, apiProjectName, apiRemoteOriginUrl } from "../../../helpers/api"
-import { AnalyticsHandler, getAnonymousUserId } from "../../../../src/analytics/analytics"
+import { AnalyticsHandler, CommandResultEvent, getAnonymousUserId } from "../../../../src/analytics/analytics"
 import {
   DEFAULT_BUILD_TIMEOUT_SEC,
   DEFAULT_GARDEN_CLOUD_DOMAIN,
@@ -777,74 +777,40 @@ describe("AnalyticsHandler", () => {
           ],
         }),
       ]
-      const event = analytics.trackCommandResult("testCommand", errors, startTime, 0)
+      const eventOrFalse = analytics.trackCommandResult("testCommand", errors, startTime, 0)
 
-      expect(event).to.eql({
-        type: "Command Result",
-        properties: {
-          name: "testCommand",
-          result: "failure",
-          exitCode: 0,
-          durationMsec: 60000,
-          errors: ["runtime"],
-          lastError: {
-            error: {
-              errorType: "runtime",
-              context: undefined,
-              stackTrace: {
-                functionName: "Testing.runtime",
-                relativeFileName: "utils/exec.ts",
-                lineNumber: 17,
-              },
-            },
-            wrapped: {
-              errorType: "configuration",
-              context: undefined,
-              stackTrace: {
-                functionName: "Testing.configuration",
-                relativeFileName: "garden.ts",
-                lineNumber: 42,
-              },
-            },
-            leaf: {
-              errorType: "deployment",
-              context: undefined,
-              stackTrace: {
-                functionName: "Testing.deployment",
-                relativeFileName: "plugins/kubernetes.ts",
-                lineNumber: 12,
-              },
-            },
+      expect(eventOrFalse).to.not.eql(false)
+
+      const event = eventOrFalse as CommandResultEvent
+
+      expect(event.properties.result).to.eql("failure")
+      expect(event.properties.errors).to.eql(["runtime"])
+      expect(event.properties.lastError).to.deep.equal({
+        error: {
+          errorType: "runtime",
+          context: undefined,
+          stackTrace: {
+            functionName: "Testing.runtime",
+            relativeFileName: "utils/exec.ts",
+            lineNumber: 17,
           },
-          projectId: AnalyticsHandler.hash(apiRemoteOriginUrl),
-          projectIdV2: AnalyticsHandler.hashV2(apiRemoteOriginUrl),
-          projectName: apiProjectName,
-          projectNameV2,
-          enterpriseProjectId: undefined,
-          enterpriseProjectIdV2: undefined,
-          enterpriseDomain: AnalyticsHandler.hash(DEFAULT_GARDEN_CLOUD_DOMAIN),
-          enterpriseDomainV2: AnalyticsHandler.hashV2(DEFAULT_GARDEN_CLOUD_DOMAIN),
-          isLoggedIn: false,
-          customer: undefined,
-          ciName: analytics["ciName"],
-          system: analytics["systemConfig"],
-          isCI: analytics["isCI"],
-          sessionId: analytics["sessionId"],
-          parentSessionId: analytics["sessionId"],
-          firstRunAt: basicConfig.firstRunAt,
-          latestRunAt: startTime,
-          isRecurringUser: false,
-          projectMetadata: {
-            modulesCount: 3,
-            moduleTypes: ["test"],
-            tasksCount: 4,
-            servicesCount: 3,
-            testsCount: 5,
-            actionsCount: 0,
-            buildActionCount: 0,
-            testActionCount: 0,
-            deployActionCount: 0,
-            runActionCount: 0,
+        },
+        wrapped: {
+          errorType: "configuration",
+          context: undefined,
+          stackTrace: {
+            functionName: "Testing.configuration",
+            relativeFileName: "garden.ts",
+            lineNumber: 42,
+          },
+        },
+        leaf: {
+          errorType: "deployment",
+          context: undefined,
+          stackTrace: {
+            functionName: "Testing.deployment",
+            relativeFileName: "plugins/kubernetes.ts",
+            lineNumber: 12,
           },
         },
       })
@@ -876,60 +842,27 @@ describe("AnalyticsHandler", () => {
           at processImmediate (node:internal/timers:471:21)`,
         }),
       ]
-      const event = analytics.trackCommandResult("testCommand", errors, startTime, 0)
 
-      expect(event).to.eql({
-        type: "Command Result",
-        properties: {
-          name: "testCommand",
-          result: "failure",
-          exitCode: 0,
-          durationMsec: 60000,
-          errors: ["runtime", "configuration"],
-          lastError: {
-            error: {
-              errorType: "configuration",
-              context: undefined,
-              stackTrace: {
-                functionName: "Testing.configuration",
-                relativeFileName: "garden.ts",
-                lineNumber: 42,
-              },
-            },
-            leaf: undefined,
-            wrapped: undefined,
-          },
-          projectId: AnalyticsHandler.hash(apiRemoteOriginUrl),
-          projectIdV2: AnalyticsHandler.hashV2(apiRemoteOriginUrl),
-          projectName: apiProjectName,
-          projectNameV2,
-          enterpriseProjectId: undefined,
-          enterpriseProjectIdV2: undefined,
-          enterpriseDomain: AnalyticsHandler.hash(DEFAULT_GARDEN_CLOUD_DOMAIN),
-          enterpriseDomainV2: AnalyticsHandler.hashV2(DEFAULT_GARDEN_CLOUD_DOMAIN),
-          isLoggedIn: false,
-          customer: undefined,
-          ciName: analytics["ciName"],
-          system: analytics["systemConfig"],
-          isCI: analytics["isCI"],
-          sessionId: analytics["sessionId"],
-          parentSessionId: analytics["sessionId"],
-          firstRunAt: basicConfig.firstRunAt,
-          latestRunAt: startTime,
-          isRecurringUser: false,
-          projectMetadata: {
-            modulesCount: 3,
-            moduleTypes: ["test"],
-            tasksCount: 4,
-            servicesCount: 3,
-            testsCount: 5,
-            actionsCount: 0,
-            buildActionCount: 0,
-            testActionCount: 0,
-            deployActionCount: 0,
-            runActionCount: 0,
+      const eventOrFalse = analytics.trackCommandResult("testCommand", errors, startTime, 0)
+
+      expect(eventOrFalse).to.not.eql(false)
+
+      const event = eventOrFalse as CommandResultEvent
+
+      expect(event.properties.result).to.eql("failure")
+      expect(event.properties.errors).to.eql(["runtime", "configuration"])
+      expect(event.properties.lastError).to.deep.equal({
+        error: {
+          errorType: "configuration",
+          context: undefined,
+          stackTrace: {
+            functionName: "Testing.configuration",
+            relativeFileName: "garden.ts",
+            lineNumber: 42,
           },
         },
+        leaf: undefined,
+        wrapped: undefined,
       })
     })
   })

--- a/core/test/unit/src/analytics/analytics.ts
+++ b/core/test/unit/src/analytics/analytics.ts
@@ -674,7 +674,7 @@ describe("AnalyticsHandler", () => {
   describe("trackCommandResult", () => {
     beforeEach(async () => {
       garden = await makeTestGardenA()
-      garden.vcsInfo.originUrl = remoteOriginUrl
+      garden.vcsInfo.originUrl = apiRemoteOriginUrl
       await enableAnalytics(garden)
     })
 
@@ -706,9 +706,9 @@ describe("AnalyticsHandler", () => {
           durationMsec: 60000,
           errors: [],
           lastError: undefined,
-          projectId: AnalyticsHandler.hash(remoteOriginUrl),
-          projectIdV2: AnalyticsHandler.hashV2(remoteOriginUrl),
-          projectName,
+          projectId: AnalyticsHandler.hash(apiRemoteOriginUrl),
+          projectIdV2: AnalyticsHandler.hashV2(apiRemoteOriginUrl),
+          projectName: apiProjectName,
           projectNameV2,
           enterpriseProjectId: undefined,
           enterpriseProjectIdV2: undefined,
@@ -816,9 +816,9 @@ describe("AnalyticsHandler", () => {
               },
             },
           },
-          projectId: AnalyticsHandler.hash(remoteOriginUrl),
-          projectIdV2: AnalyticsHandler.hashV2(remoteOriginUrl),
-          projectName,
+          projectId: AnalyticsHandler.hash(apiRemoteOriginUrl),
+          projectIdV2: AnalyticsHandler.hashV2(apiRemoteOriginUrl),
+          projectName: apiProjectName,
           projectNameV2,
           enterpriseProjectId: undefined,
           enterpriseProjectIdV2: undefined,
@@ -899,9 +899,9 @@ describe("AnalyticsHandler", () => {
             leaf: undefined,
             wrapped: undefined,
           },
-          projectId: AnalyticsHandler.hash(remoteOriginUrl),
-          projectIdV2: AnalyticsHandler.hashV2(remoteOriginUrl),
-          projectName,
+          projectId: AnalyticsHandler.hash(apiRemoteOriginUrl),
+          projectIdV2: AnalyticsHandler.hashV2(apiRemoteOriginUrl),
+          projectName: apiProjectName,
           projectNameV2,
           enterpriseProjectId: undefined,
           enterpriseProjectIdV2: undefined,

--- a/core/test/unit/src/exceptions.ts
+++ b/core/test/unit/src/exceptions.ts
@@ -16,6 +16,17 @@ import {
 } from "../../../src/exceptions"
 
 describe("GardenError", () => {
+  // helper to avoid dealing with changing line numbers
+  const filterTrace = (metadata) => {
+    return metadata.map((m) => {
+      return {
+        functionName: m.functionName,
+        lineNumber: undefined,
+        relativeFileName: m.relativeFileName,
+      }
+    })
+  }
+
   it("should return stack trace metadata", async () => {
     let error: GardenBaseError
 
@@ -30,16 +41,24 @@ describe("GardenError", () => {
     const expectedSubset: StackTraceMetadata[] = [
       {
         relativeFileName: "exceptions.ts",
+        lineNumber: undefined,
         functionName: "Context.<anonymous>",
       },
       {
         functionName: "Test.Runnable.run",
+        lineNumber: undefined,
         relativeFileName: "mocha/lib/runnable.js",
       },
     ]
 
     expect(stackTrace).to.not.be.undefined
-    expect(stackTrace!.metadata).to.deep.include.members(expectedSubset)
+
+    // make sure we set line numbers
+    // we avoid testing them in deep equals since they are not reliable for tests
+    expect(stackTrace.metadata.at(0)).to.not.be.undefined
+    expect(stackTrace.metadata.at(0)?.lineNumber).to.not.be.undefined
+
+    expect(filterTrace(stackTrace.metadata)).to.deep.include.members(expectedSubset)
   })
 
   it("should handle empty stack trace", async () => {
@@ -59,10 +78,10 @@ describe("GardenError", () => {
     at processImmediate (node:internal/timers:471:21)`
 
     const stackTrace = getStackTraceMetadata(error)
-    expect(stackTrace.metadata).to.eql([
-      { relativeFileName: "utils/exceptions.ts", functionName: "Context.<anonymous>" },
-      { relativeFileName: "mocha/lib/runnable.js", functionName: "Test.Runnable.run" },
-      { relativeFileName: "timers", functionName: "processImmediate" },
+    expect(filterTrace(stackTrace.metadata)).to.eql([
+      { relativeFileName: "utils/exceptions.ts", lineNumber: undefined, functionName: "Context.<anonymous>" },
+      { relativeFileName: "mocha/lib/runnable.js", lineNumber: undefined, functionName: "Test.Runnable.run" },
+      { relativeFileName: "timers", lineNumber: undefined, functionName: "processImmediate" },
     ])
   })
 
@@ -78,10 +97,10 @@ describe("GardenError", () => {
     const stackTrace = getStackTraceMetadata(error)
 
     expect(stackTrace.wrappedMetadata).to.have.length(1)
-    expect(stackTrace.wrappedMetadata?.at(0)).to.eql([
-      { relativeFileName: "utils/exceptions.ts", functionName: "Context.<anonymous>" },
-      { relativeFileName: "mocha/lib/runnable.js", functionName: "Test.Runnable.run" },
-      { relativeFileName: "timers", functionName: "processImmediate" },
+    expect(filterTrace(stackTrace.wrappedMetadata?.at(0))).to.eql([
+      { relativeFileName: "utils/exceptions.ts", lineNumber: undefined, functionName: "Context.<anonymous>" },
+      { relativeFileName: "mocha/lib/runnable.js", lineNumber: undefined, functionName: "Test.Runnable.run" },
+      { relativeFileName: "timers", lineNumber: undefined, functionName: "processImmediate" },
     ])
   })
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Garden errors are aggregated in several steps when executing a graph. This PR simplifies the error reporting in analytics by only including the `lastError`. This is the last error added to the list of errors in the results of a graph execution. The struct reported back in analytics has detailed data on three levels:

- `error`, which refers to the top-most error
- `wrapped`, the first wrapped error in the top-most error
- `leaf`, the first leaf found when recursively iterating through wrapped errors. This is the most specific error and should provide a good indication of the error cause.

In addition to the new structure, we also started on an error context struct which can contain specific fields that would help identify task-types or plugins that typically lead to a failed execution.

Additional care has been taken to avoid reporting back any sensitive data. E.g. we opt-out of including task names which could simplify analysis.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

- This changes the graph export to include wrapped errors recursively, its not entirely clear to me what the implications can be? 
