### PR TITLE
0.12-Backport: fix(template-strings): do not apply helper functions on unresolved string

### DIFF
--- a/core/src/template-string/functions.ts
+++ b/core/src/template-string/functions.ts
@@ -512,13 +512,13 @@ export function callHelperFunction({
 
       // do not apply helper function for an unresolved template string
       if (maybeTemplateString(value)) {
-        const _error = new TemplateStringError(`Function '${functionName}' cannot be applied on unresolved string`, {
-          functionName,
-          text,
-        })
         if (allowPartial) {
           return { resolved: "${" + text + "}" }
         } else {
+          const _error = new TemplateStringError(`Function '${functionName}' cannot be applied on unresolved string`, {
+            functionName,
+            text,
+          })
           return { _error }
         }
       }

--- a/core/src/template-string/functions.ts
+++ b/core/src/template-string/functions.ts
@@ -16,6 +16,7 @@ import { validateSchema } from "../config/validation"
 import { safeLoad, safeLoadAll } from "js-yaml"
 import { safeDumpYaml } from "../util/util"
 import indentString from "indent-string"
+import { maybeTemplateString } from "./template-string"
 
 interface ExampleArgument {
   input: any[]
@@ -508,6 +509,19 @@ export function callHelperFunction({
         context: `argument '${argName}' for ${functionName} helper function`,
         ErrorClass: TemplateStringError,
       })
+
+      // do not apply helper function for an unresolved template string
+      if (maybeTemplateString(value)) {
+        const _error = new TemplateStringError(`Function '${functionName}' cannot be applied on unresolved string`, {
+          functionName,
+          text,
+        })
+        if (allowPartial) {
+          return { resolved: "${" + text + "}" }
+        } else {
+          return { _error }
+        }
+      }
     } catch (_error) {
       if (allowPartial) {
         return { resolved: text }

--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -1137,6 +1137,13 @@ describe("resolveTemplateString", async () => {
       )
     })
 
+    it("does not apply helper function on unresolved template string and returns string as-is, when allowPartial=true", () => {
+      const res = resolveTemplateString("${base64Encode('${environment.namespace}')}", new TestContext({}), {
+        allowPartial: true,
+      })
+      expect(res).to.equal("${base64Encode('${environment.namespace}')}")
+    })
+
     context("concat", () => {
       it("allows empty strings", () => {
         const res = resolveTemplateString("${concat('', '')}", new TestContext({}))

--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -16,7 +16,7 @@ import {
 import { ConfigContext } from "../../../src/config/template-contexts/base"
 import { expectError } from "../../helpers"
 import stripAnsi = require("strip-ansi")
-import { dedent } from "../../../src/util/string"
+import { dedent, deline } from "../../../src/util/string"
 
 /* tslint:disable:no-invalid-template-strings */
 
@@ -1137,12 +1137,16 @@ describe("resolveTemplateString", async () => {
       )
     })
 
-    it("does not apply helper function on unresolved template string and returns string as-is, when allowPartial=true", () => {
-      const res = resolveTemplateString("${base64Encode('${environment.namespace}')}", new TestContext({}), {
-        allowPartial: true,
-      })
-      expect(res).to.equal("${base64Encode('${environment.namespace}')}")
-    })
+    it(
+      deline`does not apply helper function on unresolved template string and
+        returns string as-is, when allowPartial=true`,
+      () => {
+        const res = resolveTemplateString("${base64Encode('${environment.namespace}')}", new TestContext({}), {
+          allowPartial: true,
+        })
+        expect(res).to.equal("${base64Encode('${environment.namespace}')}")
+      }
+    )
 
     context("concat", () => {
       it("allows empty strings", () => {


### PR DESCRIPTION

**What this PR does / why we need it**:
cherrypicks #4692 into 0.12

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
