### PR TITLE
0.12 back-port: allow custom `mvnd` binaries and concurrent Maven builds

### DIFF
--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -78,7 +78,6 @@ export const gardenEnv = {
   GARDEN_SERVER_HOSTNAME: env.get("GARDEN_SERVER_HOSTNAME").required(false).asUrlString(),
   GARDEN_SKIP_TESTS: env.get("GARDEN_SKIP_TESTS").required(false).default("").asString(),
   GARDEN_HARD_CONCURRENCY_LIMIT: env.get("GARDEN_HARD_CONCURRENCY_LIMIT").required(false).default(50).asInt(),
-  GARDEN_TASK_CONCURRENCY_LIMIT: env.get("GARDEN_TASK_CONCURRENCY_LIMIT").required(false).default(6).asInt(),
   GARDEN_WORKFLOW_RUN_UID: env.get("GARDEN_WORKFLOW_RUN_UID").required(false).asString(),
   // Allow users to fallback to "legacy" fancy writer render logic in case recent changes introduce
   // issues on terminals we haven't tested. We can remove again in v0.13.

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -120,6 +120,12 @@ build:
   # To ensure a system JDK usage, please set `jdkPath` to `${local.env.JAVA_HOME}`.
   mavendPath:
 
+  # [EXPERIMENTAL] Enable/disable concurrent Maven and Maven Daemon builds.
+  #
+  # Note! Concurrent builds can be unstable. This option is disabled by default.
+  # This option must be configured for each Build action individually.
+  concurrentMavenBuilds: false
+
   # Specify extra flags to pass to maven/gradle when building the container image.
   extraFlags:
 
@@ -1040,6 +1046,23 @@ To ensure a system JDK usage, please set `jdkPath` to `${local.env.JAVA_HOME}`.
 | Type     | Required |
 | -------- | -------- |
 | `string` | No       |
+
+### `build.concurrentMavenBuilds`
+
+[build](#build) > concurrentMavenBuilds
+
+{% hint style="warning" %}
+**Experimental**: this is an experimental feature and the API might change in the future.
+{% endhint %}
+
+[EXPERIMENTAL] Enable/disable concurrent Maven and Maven Daemon builds.
+
+Note! Concurrent builds can be unstable. This option is disabled by default.
+This option must be configured for each Build action individually.
+
+| Type      | Default | Required |
+| --------- | ------- | -------- |
+| `boolean` | `false` | No       |
 
 ### `build.extraFlags[]`
 

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -111,6 +111,13 @@ build:
   # Defines the Maven phases to be executed during the Garden build step.
   mavenPhases:
 
+  # Defines the location of the custom executable Maven Daemon binary.
+  #
+  # **Note!** Either `jdkVersion` or `jdkPath` will be used to define `JAVA_HOME` environment variable for the custom
+  # Maven Daemon.
+  # To ensure a system JDK usage, please set `jdkPath` to `${local.env.JAVA_HOME}`.
+  mavendPath:
+
   # Specify extra flags to pass to maven/gradle when building the container image.
   extraFlags:
 
@@ -1016,6 +1023,19 @@ Defines the Maven phases to be executed during the Garden build step.
 | Type            | Default       | Required |
 | --------------- | ------------- | -------- |
 | `array[string]` | `["compile"]` | No       |
+
+### `build.mavendPath`
+
+[build](#build) > mavendPath
+
+Defines the location of the custom executable Maven Daemon binary.
+
+**Note!** Either `jdkVersion` or `jdkPath` will be used to define `JAVA_HOME` environment variable for the custom Maven Daemon.
+To ensure a system JDK usage, please set `jdkPath` to `${local.env.JAVA_HOME}`.
+
+| Type     | Required |
+| -------- | -------- |
+| `string` | No       |
 
 ### `build.extraFlags[]`
 

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -113,6 +113,8 @@ build:
 
   # Defines the location of the custom executable Maven Daemon binary.
   #
+  # If not provided, then Maven Daemon 0.9.0 will be downloaded and used.
+  #
   # **Note!** Either `jdkVersion` or `jdkPath` will be used to define `JAVA_HOME` environment variable for the custom
   # Maven Daemon.
   # To ensure a system JDK usage, please set `jdkPath` to `${local.env.JAVA_HOME}`.
@@ -1029,6 +1031,8 @@ Defines the Maven phases to be executed during the Garden build step.
 [build](#build) > mavendPath
 
 Defines the location of the custom executable Maven Daemon binary.
+
+If not provided, then Maven Daemon 0.9.0 will be downloaded and used.
 
 **Note!** Either `jdkVersion` or `jdkPath` will be used to define `JAVA_HOME` environment variable for the custom Maven Daemon.
 To ensure a system JDK usage, please set `jdkPath` to `${local.env.JAVA_HOME}`.

--- a/examples/jib-container/spring-boot/spring-boot.garden.yml
+++ b/examples/jib-container/spring-boot/spring-boot.garden.yml
@@ -3,12 +3,13 @@ type: jib-container
 name: spring-boot
 build:
   # The example provides both gradle and maven configuration, you can switch to gradle here.
-  projectType: maven
+  projectType: mavend
   # Push to local docker daemon when running a local cluster
   # Note: You could also specify a deploymentRegistry or set the `image` field if you prefer to push to a registry,
   #       but that'll obviously be much slower.
   dockerBuild: ${environment.name == "local"}
   mavenPhases: [ "clean", "package" ]
+  mavendPath: /opt/homebrew/bin/mvnd
 services:
   - name: spring-boot
     ports:

--- a/plugins/jib/build-tool-base.ts
+++ b/plugins/jib/build-tool-base.ts
@@ -65,6 +65,7 @@ export interface BuildToolParams {
   log: LogEntry
   openJdkPath: string
   binaryPath?: string
+  concurrentMavenBuilds?: boolean
   outputStream?: Writable
 }
 

--- a/plugins/jib/build-tool-base.ts
+++ b/plugins/jib/build-tool-base.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2018-2023 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { LogEntry, PluginContext } from "@garden-io/sdk/types"
+import { Writable } from "node:stream"
+import execa from "execa"
+import { RuntimeError } from "@garden-io/core/build/src/exceptions"
+
+export interface CheckVersionParams {
+  binaryPath: string
+  toolName: string
+  configFieldName: string
+}
+
+export function baseErrorMessage({ binaryPath, configFieldName }: CheckVersionParams): string {
+  return `Gradle binary path "${binaryPath}" is incorrect! Please check the \`${configFieldName}\` configuration option.`
+}
+
+export async function getBuildToolVersion(params: CheckVersionParams) {
+  const { binaryPath, toolName } = params
+  try {
+    const res = await execa(binaryPath, ["--version"])
+    return res.stdout
+  } catch (error) {
+    const composeErrorMessage = (err: any): string => {
+      if (err.code === "EACCES") {
+        return `${baseErrorMessage(
+          params
+        )} It looks like the ${toolName} path defined in the config is not an executable binary.`
+      } else if (err.code === "ENOENT") {
+        return `${baseErrorMessage(params)} The ${toolName} path defined in the configuration does not exist.`
+      } else {
+        return baseErrorMessage(params)
+      }
+    }
+    throw new RuntimeError(composeErrorMessage(error), { binaryPath })
+  }
+}
+
+export interface VerifyBinaryParams extends CheckVersionParams {
+  outputVerificationString: string
+}
+
+export async function verifyBinaryPath(params: VerifyBinaryParams) {
+  const { binaryPath, toolName, outputVerificationString } = params
+  const versionOutput = await getBuildToolVersion(params)
+  const isMaven = versionOutput.toLowerCase().includes(outputVerificationString)
+  if (!isMaven) {
+    throw new RuntimeError(
+      `${baseErrorMessage(params)} It looks like the ${toolName} path points to a wrong executable binary.`,
+      { binaryPath }
+    )
+  }
+}
+
+export interface BuildToolParams {
+  ctx: PluginContext
+  args: string[]
+  cwd: string
+  log: LogEntry
+  openJdkPath: string
+  binaryPath?: string
+  outputStream?: Writable
+}
+
+export function runBuildTool({
+  binaryPath,
+  args,
+  cwd,
+  openJdkPath,
+  outputStream,
+}: {
+  binaryPath: string
+  args: string[]
+  cwd: string
+  openJdkPath: string
+  outputStream?: Writable
+}) {
+  const res = execa(binaryPath, args, {
+    cwd,
+    env: {
+      JAVA_HOME: openJdkPath,
+    },
+  })
+
+  if (outputStream) {
+    res.stdout?.pipe(outputStream)
+    res.stderr?.pipe(outputStream)
+  }
+
+  return res
+}

--- a/plugins/jib/gradle.ts
+++ b/plugins/jib/gradle.ts
@@ -6,13 +6,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import execa from "execa"
 import { find } from "lodash"
-import { LogEntry, PluginContext, PluginToolSpec } from "@garden-io/sdk/types"
-import { PluginError, RuntimeError } from "@garden-io/core/build/src/exceptions"
+import { PluginContext, PluginToolSpec } from "@garden-io/sdk/types"
+import { PluginError } from "@garden-io/core/build/src/exceptions"
 import { resolve } from "path"
 import { pathExists } from "fs-extra"
-import { Writable } from "stream"
+import { runBuildTool, BuildToolParams, verifyBinaryPath, VerifyBinaryParams } from "./build-tool-base"
 
 export const gradleVersion = "7.5.1"
 
@@ -67,44 +66,13 @@ export function getGradleTool(ctx: PluginContext) {
   return tool
 }
 
-const baseErrorMessage = (gradlePath: string): string =>
-  `Gradle binary path "${gradlePath}" is incorrect! Please check the \`gradlePath\` configuration option.`
-
-async function checkGradleVersion(gradlePath: string) {
-  try {
-    const res = await execa(gradlePath, ["--version"])
-    return res.stdout
-  } catch (err) {
-    const composeErrorMessage = (err: any): string => {
-      if (err.code === "EACCES") {
-        return `${baseErrorMessage(
-          gradlePath
-        )} It looks like the Gradle path defined in the config is not an executable binary.`
-      } else if (err.code === "ENOENT") {
-        return `${baseErrorMessage(gradlePath)} The Gradle path defined in the configuration does not exist.`
-      } else {
-        return baseErrorMessage(gradlePath)
-      }
-    }
-    throw new RuntimeError(composeErrorMessage(err), { gradlePath })
-  }
-}
-
 let gradlePathValid = false
 
-async function verifyGradlePath(gradlePath: string) {
+async function verifyGradlePath(params: VerifyBinaryParams) {
   if (gradlePathValid) {
     return
   }
-
-  const versionOutput = await checkGradleVersion(gradlePath)
-  const isGradle = versionOutput.toLowerCase().includes("gradle")
-  if (!isGradle) {
-    throw new RuntimeError(
-      `${baseErrorMessage(gradlePath)} It looks like the Gradle path points to a non-Gradle executable binary.`,
-      { gradlePath }
-    )
-  }
+  await verifyBinaryPath(params)
   gradlePathValid = true
 }
 
@@ -115,29 +83,17 @@ async function verifyGradlePath(gradlePath: string) {
  * If no explicit binary specific, then a `./gradlew` script will be used if it's available in the specified directory.
  * Otherwise, the Gradle distribution will be downloaded and used.
  */
-export async function gradle({
-  ctx,
-  args,
-  cwd,
-  log,
-  openJdkPath,
-  gradlePath,
-  outputStream,
-}: {
-  ctx: PluginContext
-  args: string[]
-  cwd: string
-  log: LogEntry
-  openJdkPath: string
-  gradlePath?: string
-  outputStream: Writable
-}) {
+export async function gradle({ ctx, args, cwd, log, openJdkPath, binaryPath, outputStream }: BuildToolParams) {
   let effectiveGradlePath: string
-
-  if (!!gradlePath) {
-    log.verbose(`Using explicitly specified Gradle binary from ${gradlePath}`)
-    effectiveGradlePath = gradlePath
-    await verifyGradlePath(effectiveGradlePath)
+  if (!!binaryPath) {
+    log.verbose(`Using explicitly specified Gradle binary from ${binaryPath}`)
+    effectiveGradlePath = binaryPath
+    await verifyGradlePath({
+      binaryPath,
+      toolName: "Gradle",
+      configFieldName: "gradlePath",
+      outputVerificationString: "gradle",
+    })
   } else {
     const gradlewPath = resolve(cwd, process.platform === "win32" ? "gradlew.bat" : "gradlew")
     if (await pathExists(gradlewPath)) {
@@ -155,16 +111,5 @@ export async function gradle({
   }
 
   log.debug(`Execing ${effectiveGradlePath} ${args.join(" ")}`)
-
-  const res = execa(effectiveGradlePath, args, {
-    cwd,
-    env: {
-      JAVA_HOME: openJdkPath,
-    },
-  })
-
-  res.stdout?.pipe(outputStream)
-  res.stderr?.pipe(outputStream)
-
-  return res
+  return runBuildTool({ binaryPath: effectiveGradlePath, args, cwd, openJdkPath, outputStream })
 }

--- a/plugins/jib/index.ts
+++ b/plugins/jib/index.ts
@@ -116,6 +116,12 @@ const jibModuleSchema = () =>
         .items(joi.string())
         .default(["compile"])
         .description("Defines the Maven phases to be executed during the Garden build step."),
+      mavendPath: joi.string().optional().description(dedent`
+        Defines the location of the custom executable Maven Daemon binary.
+
+        **Note!** Either \`jdkVersion\` or \`jdkPath\` will be used to define \`JAVA_HOME\` environment variable for the custom Maven Daemon.
+        To ensure a system JDK usage, please set \`jdkPath\` to \`${systemJdkGardenEnvVar}\`.
+      `),
       extraFlags: joi
         .sparseArray()
         .items(joi.string())
@@ -269,6 +275,7 @@ export const gardenPlugin = () =>
                 cwd: module.path,
                 args: [...mavenPhases, ...args],
                 openJdkPath,
+                mavendPath: module.spec.build.mavendPath,
                 outputStream,
               })
             } else {

--- a/plugins/jib/index.ts
+++ b/plugins/jib/index.ts
@@ -265,7 +265,7 @@ export const gardenPlugin = () =>
                 cwd: module.path,
                 args: [...mavenPhases, ...args],
                 openJdkPath,
-                mavenPath: module.spec.build.mavenPath,
+                binaryPath: module.spec.build.mavenPath,
                 outputStream,
               })
             } else if (projectType === "mavend") {
@@ -275,7 +275,7 @@ export const gardenPlugin = () =>
                 cwd: module.path,
                 args: [...mavenPhases, ...args],
                 openJdkPath,
-                mavendPath: module.spec.build.mavendPath,
+                binaryPath: module.spec.build.mavendPath,
                 outputStream,
               })
             } else {
@@ -285,7 +285,7 @@ export const gardenPlugin = () =>
                 cwd: module.path,
                 args,
                 openJdkPath,
-                gradlePath: module.spec.build.gradlePath,
+                binaryPath: module.spec.build.gradlePath,
                 outputStream,
               })
             }

--- a/plugins/jib/index.ts
+++ b/plugins/jib/index.ts
@@ -124,6 +124,18 @@ const jibModuleSchema = () =>
         **Note!** Either \`jdkVersion\` or \`jdkPath\` will be used to define \`JAVA_HOME\` environment variable for the custom Maven Daemon.
         To ensure a system JDK usage, please set \`jdkPath\` to \`${systemJdkGardenEnvVar}\`.
       `),
+      concurrentMavenBuilds: joi
+        .boolean()
+        .optional()
+        .default(false)
+        .description(
+          dedent`
+      [EXPERIMENTAL] Enable/disable concurrent Maven and Maven Daemon builds.
+
+      Note! Concurrent builds can be unstable. This option is disabled by default.
+      This option must be configured for each Build action individually.`
+        )
+        .meta({ experimental: true }),
       extraFlags: joi
         .sparseArray()
         .items(joi.string())
@@ -268,6 +280,7 @@ export const gardenPlugin = () =>
                 args: [...mavenPhases, ...args],
                 openJdkPath,
                 binaryPath: module.spec.build.mavenPath,
+                concurrentMavenBuilds: module.spec.build.concurrentMavenBuilds,
                 outputStream,
               })
             } else if (projectType === "mavend") {
@@ -278,6 +291,7 @@ export const gardenPlugin = () =>
                 args: [...mavenPhases, ...args],
                 openJdkPath,
                 binaryPath: module.spec.build.mavendPath,
+                concurrentMavenBuilds: module.spec.build.concurrentMavenBuilds,
                 outputStream,
               })
             } else {

--- a/plugins/jib/index.ts
+++ b/plugins/jib/index.ts
@@ -12,7 +12,7 @@ import { dedent } from "@garden-io/sdk/util/string"
 
 import { openJdkSpecs } from "./openjdk"
 import { mavenSpec, mvn, mvnVersion } from "./maven"
-import { mavendSpec, mvnd } from "./mavend"
+import { mavendSpec, mvnd, mvndVersion } from "./mavend"
 import { gradle, gradleSpec, gradleVersion } from "./gradle"
 
 // TODO: gradually get rid of these core dependencies, move some to SDK etc.
@@ -118,6 +118,8 @@ const jibModuleSchema = () =>
         .description("Defines the Maven phases to be executed during the Garden build step."),
       mavendPath: joi.string().optional().description(dedent`
         Defines the location of the custom executable Maven Daemon binary.
+
+        If not provided, then Maven Daemon ${mvndVersion} will be downloaded and used.
 
         **Note!** Either \`jdkVersion\` or \`jdkPath\` will be used to define \`JAVA_HOME\` environment variable for the custom Maven Daemon.
         To ensure a system JDK usage, please set \`jdkPath\` to \`${systemJdkGardenEnvVar}\`.

--- a/plugins/jib/mavend.ts
+++ b/plugins/jib/mavend.ts
@@ -9,7 +9,7 @@
 import AsyncLock from "async-lock"
 import { LogEntry, PluginContext, PluginToolSpec } from "@garden-io/sdk/types"
 import { find } from "lodash"
-import { PluginError } from "@garden-io/core/build/src/exceptions"
+import { PluginError, RuntimeError } from "@garden-io/core/build/src/exceptions"
 import { Writable } from "node:stream"
 import execa from "execa"
 
@@ -100,6 +100,47 @@ export function getMvndTool(ctx: PluginContext) {
   return tool
 }
 
+const baseErrorMessage = (mvnPath: string): string =>
+  `Maven Daemon binary path "${mvnPath}" is incorrect! Please check the \`mavendPath\` configuration option.`
+
+async function checkMavendVersion(mvndPath: string) {
+  try {
+    const res = await execa(mvndPath, ["--version"])
+    return res.stdout
+  } catch (err) {
+    const composeErrorMessage = (err: any): string => {
+      if (err.code === "EACCES") {
+        return `${baseErrorMessage(
+          mvndPath
+        )} It looks like the Maven Daemon path defined in the config is not an executable binary.`
+      } else if (err.code === "ENOENT") {
+        return `${baseErrorMessage(mvndPath)} The Maven Daemon path defined in the configuration does not exist.`
+      } else {
+        return baseErrorMessage(mvndPath)
+      }
+    }
+    throw new RuntimeError(composeErrorMessage(err), { mvndPath })
+  }
+}
+
+let mavendPathValid = false
+
+async function verifyMavendPath(mvndPath: string) {
+  if (mavendPathValid) {
+    return
+  }
+
+  const versionOutput = await checkMavendVersion(mvndPath)
+  const isMavend = versionOutput.toLowerCase().includes("mvnd")
+  if (!isMavend) {
+    throw new RuntimeError(
+      `${baseErrorMessage(mvndPath)} It looks like the Maven Daemon path points to a non-Maven executable binary.`,
+      { mvndPath }
+    )
+  }
+  mavendPathValid = true
+}
+
 /**
  * Run mavend with the specified args in the specified directory.
  */
@@ -109,6 +150,7 @@ export async function mvnd({
   cwd,
   log,
   openJdkPath,
+  mavendPath,
   outputStream,
 }: {
   ctx: PluginContext
@@ -116,14 +158,19 @@ export async function mvnd({
   cwd: string
   log: LogEntry
   openJdkPath: string
+  mavendPath?: string
   outputStream?: Writable
 }) {
   let mvndPath: string
-  log.verbose(`The Maven Daemon binary hasn't been specified explicitly. Maven ${mvndVersion} will be used by default.`)
-
-  const tool = getMvndTool(ctx)
-  mvndPath = await tool.getPath(log)
-
+  if (!!mavendPath) {
+    log.verbose(`Using explicitly specified Maven Daemon binary from ${mavendPath}`)
+    mvndPath = mavendPath
+    await verifyMavendPath(mvndPath)
+  } else {
+    log.verbose(`The Maven Daemon binary hasn't been specified explicitly. Maven ${mvndVersion} will be used by default.`)
+    const tool = getMvndTool(ctx)
+    mvndPath = await tool.getPath(log)
+  }
   return buildLock.acquire("mvnd", async () => {
     log.debug(`Execing ${mvndPath} ${args.join(" ")}`)
 

--- a/plugins/jib/mavend.ts
+++ b/plugins/jib/mavend.ts
@@ -14,7 +14,7 @@ import { BuildToolParams, runBuildTool, verifyBinaryPath, VerifyBinaryParams } f
 
 const buildLock = new AsyncLock()
 
-const mvndVersion = "0.9.0"
+export const mvndVersion = "0.9.0"
 
 const mvndSpec = {
   description: "The Maven Daemon CLI.",

--- a/plugins/jib/mavend.ts
+++ b/plugins/jib/mavend.ts
@@ -112,7 +112,16 @@ async function verifyMavendPath(params: VerifyBinaryParams) {
 /**
  * Run mavend with the specified args in the specified directory.
  */
-export async function mvnd({ ctx, args, cwd, log, openJdkPath, binaryPath, outputStream }: BuildToolParams) {
+export async function mvnd({
+  ctx,
+  args,
+  cwd,
+  log,
+  openJdkPath,
+  binaryPath,
+  concurrentMavenBuilds,
+  outputStream,
+}: BuildToolParams) {
   let mvndPath: string
   if (!!binaryPath) {
     log.verbose(`Using explicitly specified Maven Daemon binary from ${binaryPath}`)
@@ -133,7 +142,11 @@ export async function mvnd({ ctx, args, cwd, log, openJdkPath, binaryPath, outpu
 
   log.debug(`Execing ${mvndPath} ${args.join(" ")}`)
   const params = { binaryPath: mvndPath, args, cwd, openJdkPath, outputStream }
-  return buildLock.acquire("mvnd", async () => {
+  if (concurrentMavenBuilds) {
     return runBuildTool(params)
-  })
+  } else {
+    return buildLock.acquire("mvnd", async () => {
+      return runBuildTool(params)
+    })
+  }
 }

--- a/plugins/jib/mavend.ts
+++ b/plugins/jib/mavend.ts
@@ -60,7 +60,7 @@ export const mavendSpec: PluginToolSpec = {
     {
       platform: "darwin",
       architecture: "amd64",
-      sha256: mvndSpec.linux.sha256,
+      sha256: mvndSpec.darwin_amd64.sha256,
       url: `${mvndSpec.baseUrl}${mvndSpec.darwin_amd64.filename}`,
       extract: {
         format: "tar",
@@ -70,7 +70,7 @@ export const mavendSpec: PluginToolSpec = {
     {
       platform: "darwin",
       architecture: "aarch64",
-      sha256: mvndSpec.linux.sha256,
+      sha256: mvndSpec.darwin_aarch64.sha256,
       url: `${mvndSpec.baseUrl}${mvndSpec.darwin_aarch64.filename}`,
       extract: {
         format: "tar",
@@ -81,7 +81,7 @@ export const mavendSpec: PluginToolSpec = {
       platform: "windows",
       architecture: "amd64",
       url: `${mvndSpec.baseUrl}${mvndSpec.windows.filename}`,
-      sha256: "d53e045bc5c02aad179fae2fbc565d953354880db6661a8fab31f3a718d7b62c",
+      sha256: mvndSpec.windows.sha256,
       extract: {
         format: "zip",
         targetPath: mvndSpec.windows.targetPath,

--- a/plugins/jib/mavend.ts
+++ b/plugins/jib/mavend.ts
@@ -7,11 +7,10 @@
  */
 
 import AsyncLock from "async-lock"
-import { LogEntry, PluginContext, PluginToolSpec } from "@garden-io/sdk/types"
+import { PluginContext, PluginToolSpec } from "@garden-io/sdk/types"
 import { find } from "lodash"
-import { PluginError, RuntimeError } from "@garden-io/core/build/src/exceptions"
-import { Writable } from "node:stream"
-import execa from "execa"
+import { PluginError } from "@garden-io/core/build/src/exceptions"
+import { BuildToolParams, runBuildTool, verifyBinaryPath, VerifyBinaryParams } from "./build-tool-base"
 
 const buildLock = new AsyncLock()
 
@@ -100,92 +99,41 @@ export function getMvndTool(ctx: PluginContext) {
   return tool
 }
 
-const baseErrorMessage = (mvnPath: string): string =>
-  `Maven Daemon binary path "${mvnPath}" is incorrect! Please check the \`mavendPath\` configuration option.`
-
-async function checkMavendVersion(mvndPath: string) {
-  try {
-    const res = await execa(mvndPath, ["--version"])
-    return res.stdout
-  } catch (err) {
-    const composeErrorMessage = (err: any): string => {
-      if (err.code === "EACCES") {
-        return `${baseErrorMessage(
-          mvndPath
-        )} It looks like the Maven Daemon path defined in the config is not an executable binary.`
-      } else if (err.code === "ENOENT") {
-        return `${baseErrorMessage(mvndPath)} The Maven Daemon path defined in the configuration does not exist.`
-      } else {
-        return baseErrorMessage(mvndPath)
-      }
-    }
-    throw new RuntimeError(composeErrorMessage(err), { mvndPath })
-  }
-}
-
 let mavendPathValid = false
 
-async function verifyMavendPath(mvndPath: string) {
+async function verifyMavendPath(params: VerifyBinaryParams) {
   if (mavendPathValid) {
     return
   }
-
-  const versionOutput = await checkMavendVersion(mvndPath)
-  const isMavend = versionOutput.toLowerCase().includes("mvnd")
-  if (!isMavend) {
-    throw new RuntimeError(
-      `${baseErrorMessage(mvndPath)} It looks like the Maven Daemon path points to a non-Maven executable binary.`,
-      { mvndPath }
-    )
-  }
+  await verifyBinaryPath(params)
   mavendPathValid = true
 }
 
 /**
  * Run mavend with the specified args in the specified directory.
  */
-export async function mvnd({
-  ctx,
-  args,
-  cwd,
-  log,
-  openJdkPath,
-  mavendPath,
-  outputStream,
-}: {
-  ctx: PluginContext
-  args: string[]
-  cwd: string
-  log: LogEntry
-  openJdkPath: string
-  mavendPath?: string
-  outputStream?: Writable
-}) {
+export async function mvnd({ ctx, args, cwd, log, openJdkPath, binaryPath, outputStream }: BuildToolParams) {
   let mvndPath: string
-  if (!!mavendPath) {
-    log.verbose(`Using explicitly specified Maven Daemon binary from ${mavendPath}`)
-    mvndPath = mavendPath
-    await verifyMavendPath(mvndPath)
+  if (!!binaryPath) {
+    log.verbose(`Using explicitly specified Maven Daemon binary from ${binaryPath}`)
+    mvndPath = binaryPath
+    await verifyMavendPath({
+      binaryPath,
+      toolName: "Maven Daemon",
+      configFieldName: "mavendPath",
+      outputVerificationString: "mvnd",
+    })
   } else {
-    log.verbose(`The Maven Daemon binary hasn't been specified explicitly. Maven ${mvndVersion} will be used by default.`)
+    log.verbose(
+      `The Maven Daemon binary hasn't been specified explicitly. Maven ${mvndVersion} will be used by default.`
+    )
     const tool = getMvndTool(ctx)
     mvndPath = await tool.getPath(log)
   }
+
+  log.debug(`Execing ${mvndPath} ${args.join(" ")}`)
+  const params = { binaryPath: mvndPath, args, cwd, openJdkPath, outputStream }
   return buildLock.acquire("mvnd", async () => {
-    log.debug(`Execing ${mvndPath} ${args.join(" ")}`)
-
-    const res = execa(mvndPath, args, {
-      cwd,
-      env: {
-        JAVA_HOME: openJdkPath,
-      },
-    })
-
-    if (outputStream) {
-      res.stdout?.pipe(outputStream)
-      res.stderr?.pipe(outputStream)
-    }
-
-    return res
+    return runBuildTool(params)
   })
 }

--- a/plugins/jib/util.ts
+++ b/plugins/jib/util.ts
@@ -20,6 +20,7 @@ interface JibModuleBuildSpec extends ContainerBuildSpec {
   tarOnly?: boolean
   tarFormat: "docker" | "oci"
   mavenPath?: string
+  mavendPath?: string
   mavenPhases: string[]
   gradlePath?: string
 }
@@ -29,7 +30,7 @@ interface JibModuleSpec extends ContainerModuleSpec {
 }
 
 export type JibContainerModule = GardenModule<JibModuleSpec>
-export type JibPluginType = "gradle" | "maven"
+export type JibPluginType = "gradle" | "maven" | "mavend"
 
 const gradlePaths = [
   "build.gradle",
@@ -41,6 +42,7 @@ const gradlePaths = [
   "gradlew.cmd",
 ]
 const mavenPaths = ["pom.xml", ".mvn"]
+const mavendPaths = ["pom.xml", ".mvnd"]
 
 export function detectProjectType(module: GardenModule): JibPluginType {
   const moduleFiles = module.version.files
@@ -58,6 +60,13 @@ export function detectProjectType(module: GardenModule): JibPluginType {
     const path = resolve(module.path, filename)
     if (moduleFiles.includes(path)) {
       return "maven"
+    }
+  }
+
+  for (const filename of mavendPaths) {
+    const path = resolve(module.path, filename)
+    if (moduleFiles.includes(path)) {
+      return "mavend"
     }
   }
 

--- a/plugins/jib/util.ts
+++ b/plugins/jib/util.ts
@@ -22,6 +22,7 @@ interface JibModuleBuildSpec extends ContainerBuildSpec {
   mavenPath?: string
   mavendPath?: string
   mavenPhases: string[]
+  concurrentMavenBuilds?: boolean
   gradlePath?: string
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
Cherry-pick #4695 and #4709 to `0.12`.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
