### PR TITLE
fix(k8s): fix regression in  sync stop logic

### DIFF
--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -804,7 +804,7 @@ export async function getSyncStatus(params: GetSyncStatusParams): Promise<GetSyn
 }
 
 function getSyncKeyPrefix(ctx: PluginContext, action: SupportedRuntimeAction) {
-  return `k8s--${ctx.environmentName}--${ctx.namespace}--${action.name}--`
+  return kebabCase(`k8s--${ctx.environmentName}--${ctx.namespace}--${action.name}--`)
 }
 
 /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

A recent change introduced kebab-casing for the sync keys used with Mutagen, but this wasn't applied in the sync prefix helper. This led to syncs not being stopped by the `sync stop` command.