### PR TITLE
refactor: garden error takes named params instead of positional

### DIFF
--- a/core/src/actions/base.ts
+++ b/core/src/actions/base.ts
@@ -729,10 +729,10 @@ export abstract class ResolvedRuntimeAction<
       const buildAction = this.getResolvedDependencies().find((a) => a.kind === "Build" && a.name === buildName)
 
       if (!buildAction) {
-        throw new InternalError(
-          `Could not find build dependency '${buildName}' specified on the build field on ${this.longDescription()}.`,
-          { action: this.key(), buildName }
-        )
+        throw new InternalError({
+          message: `Could not find build dependency '${buildName}' specified on the build field on ${this.longDescription()}.`,
+          detail: { action: this.key(), buildName },
+        })
       }
 
       return <T>buildAction

--- a/core/src/build-staging/build-staging.ts
+++ b/core/src/build-staging/build-staging.ts
@@ -73,7 +73,7 @@ export class BuildStaging {
     })
   }
 
-  async actionBuildPathExists(action: BuildAction ) {
+  async actionBuildPathExists(action: BuildAction) {
     const buildPath = action.getBuildPath()
     return this.createdPaths.has(buildPath) || pathExists(buildPath)
   }
@@ -85,21 +85,29 @@ export class BuildStaging {
       const sourceBuild = action.getDependency({ kind: "Build", name: copy.build })
 
       if (!sourceBuild) {
-        throw new ConfigurationError(
-          `${action.longDescription()} specifies build '${copy.build}' in \`copyFrom\` which could not be found.`,
-          { actionKey: action.key(), copy }
-        )
+        throw new ConfigurationError({
+          message: `${action.longDescription()} specifies build '${
+            copy.build
+          }' in \`copyFrom\` which could not be found.`,
+          detail: { actionKey: action.key(), copy },
+        })
       }
 
       if (isAbsolute(copy.sourcePath)) {
-        throw new ConfigurationError(`Source path in build dependency copy spec must be a relative path`, {
-          copySpec: copy,
+        throw new ConfigurationError({
+          message: `Source path in build dependency copy spec must be a relative path`,
+          detail: {
+            copySpec: copy,
+          },
         })
       }
 
       if (isAbsolute(copy.targetPath)) {
-        throw new ConfigurationError(`Target path in build dependency copy spec must be a relative path`, {
-          copySpec: copy,
+        throw new ConfigurationError({
+          message: `Target path in build dependency copy spec must be a relative path`,
+          detail: {
+            copySpec: copy,
+          },
         })
       }
 
@@ -162,29 +170,38 @@ export class BuildStaging {
     let { sourceRoot, targetRoot, sourceRelPath, targetRelPath, withDelete, log, files } = params
 
     if (targetRelPath && hasMagic(targetRelPath)) {
-      throw new ConfigurationError(`Build staging: Target path (${targetRelPath}) must not contain wildcards`, {
-        sourceRoot,
-        targetRoot,
-        sourceRelPath,
-        targetRelPath,
+      throw new ConfigurationError({
+        message: `Build staging: Target path (${targetRelPath}) must not contain wildcards`,
+        detail: {
+          sourceRoot,
+          targetRoot,
+          sourceRelPath,
+          targetRelPath,
+        },
       })
     }
 
     if (sourceRelPath && isAbsolute(sourceRelPath)) {
-      throw new InternalError(`Build staging: Got absolute path for sourceRelPath`, {
-        sourceRoot,
-        targetRoot,
-        sourceRelPath,
-        targetRelPath,
+      throw new InternalError({
+        message: `Build staging: Got absolute path for sourceRelPath`,
+        detail: {
+          sourceRoot,
+          targetRoot,
+          sourceRelPath,
+          targetRelPath,
+        },
       })
     }
 
     if (targetRelPath && isAbsolute(targetRelPath)) {
-      throw new InternalError(`Build staging: Got absolute path for targetRelPath`, {
-        sourceRoot,
-        targetRoot,
-        sourceRelPath,
-        targetRelPath,
+      throw new InternalError({
+        message: `Build staging: Got absolute path for targetRelPath`,
+        detail: {
+          sourceRoot,
+          targetRoot,
+          sourceRelPath,
+          targetRelPath,
+        },
       })
     }
 
@@ -193,12 +210,15 @@ export class BuildStaging {
     // Source root must exist and be a directory
     let sourceStat = await statsHelper.extendedStat({ path: sourceRoot })
     if (!sourceStat || !(sourceStat.isDirectory() || sourceStat.target?.isDirectory())) {
-      throw new InternalError(`Build staging: Source root ${sourceRoot} must exist and be a directory`, {
-        sourceRoot,
-        sourceStat,
-        targetRoot,
-        sourceRelPath,
-        targetRelPath,
+      throw new InternalError({
+        message: `Build staging: Source root ${sourceRoot} must exist and be a directory`,
+        detail: {
+          sourceRoot,
+          sourceStat,
+          targetRoot,
+          sourceRelPath,
+          targetRelPath,
+        },
       })
     }
 
@@ -250,8 +270,11 @@ export class BuildStaging {
 
     // Throw if source path ends with a slash but is not a directory
     if (sourceShouldBeDirectory && !sourceIsDirectory) {
-      throw new ConfigurationError(`Build staging: Expected source path ${sourceRoot + "/"} to be a directory`, {
-        sourcePath: sourceRoot + "/",
+      throw new ConfigurationError({
+        message: `Build staging: Expected source path ${sourceRoot + "/"} to be a directory`,
+        detail: {
+          sourcePath: sourceRoot + "/",
+        },
       })
     }
 
@@ -260,21 +283,24 @@ export class BuildStaging {
 
     // Throw if target path ends with a slash but is not a directory
     if (targetShouldBeDirectory && targetStat && !targetStat.isDirectory()) {
-      throw new ConfigurationError(
-        `Build staging: Expected target path ${targetPath + "/"} to not exist or be a directory`,
-        {
+      throw new ConfigurationError({
+        message: `Build staging: Expected target path ${targetPath + "/"} to not exist or be a directory`,
+        detail: {
           targetPath: targetPath + "/",
-        }
-      )
+        },
+      })
     }
 
     // Throw if file list is specified and source+target are not both directories
     if (files && (!sourceStat?.isDirectory() || !targetStat?.isDirectory())) {
-      throw new InternalError(`Build staging: Both source and target must be directories when specifying a file list`, {
-        sourceRoot,
-        sourceStat,
-        targetPath,
-        targetStat,
+      throw new InternalError({
+        message: `Build staging: Both source and target must be directories when specifying a file list`,
+        detail: {
+          sourceRoot,
+          sourceStat,
+          targetPath,
+          targetStat,
+        },
       })
     }
 
@@ -297,19 +323,19 @@ export class BuildStaging {
     // If source is not a file but target exists as a file, we need to handle that specifically
     if (targetIsFile) {
       if (sourceContainsWildcard) {
-        throw new ConfigurationError(
-          `Build staging: Attempting to copy multiple files from ${sourceRoot} to ${targetPath}, but a file exists at target path`,
-          { sourcePath: sourceRoot, sourceStat, targetPath, targetStat }
-        )
+        throw new ConfigurationError({
+          message: `Build staging: Attempting to copy multiple files from ${sourceRoot} to ${targetPath}, but a file exists at target path`,
+          detail: { sourcePath: sourceRoot, sourceStat, targetPath, targetStat },
+        })
       } else if (withDelete) {
         // Source is a directory, delete file at target and create directory in its place before continuing
         await remove(targetPath)
         await ensureDir(targetPath)
       } else {
-        throw new ConfigurationError(
-          `Build staging: Attempting to copy directory from ${sourceRoot} to ${targetPath}, but a file exists at target path`,
-          { sourcePath: sourceRoot, sourceStat, targetPath, targetStat }
-        )
+        throw new ConfigurationError({
+          message: `Build staging: Attempting to copy directory from ${sourceRoot} to ${targetPath}, but a file exists at target path`,
+          detail: { sourcePath: sourceRoot, sourceStat, targetPath, targetStat },
+        })
       }
     }
 

--- a/core/src/build-staging/helpers.ts
+++ b/core/src/build-staging/helpers.ts
@@ -66,7 +66,9 @@ export function cloneFile({ from, to, allowDelete, statsHelper }: CloneFileParam
       }
 
       if (!sourceStats.isFile()) {
-        return done(new FilesystemError(`Attempted to copy non-file ${from}`, { from, to, sourceStats }))
+        return done(
+          new FilesystemError({ message: `Attempted to copy non-file ${from}`, detail: { from, to, sourceStats } })
+        )
       }
 
       if (targetStats) {
@@ -82,15 +84,15 @@ export function cloneFile({ from, to, allowDelete, statsHelper }: CloneFileParam
             })
           } else {
             return done(
-              new FilesystemError(
-                `Build staging: Failed copying file ${from} to ${to} because a directory exists at the target path`,
-                {
+              new FilesystemError({
+                message: `Build staging: Failed copying file ${from} to ${to} because a directory exists at the target path`,
+                detail: {
                   sourcePath: from,
                   targetPath: to,
                   sourceStats,
                   targetStats,
-                }
-              )
+                },
+              })
             )
           }
         }
@@ -368,7 +370,13 @@ export class FileStatsHelper {
         // Symlink target not found, so we ignore it
         return cb(null, null)
       } else if (readlinkErr) {
-        return cb(new InternalError(`Error reading symlink: ${readlinkErr.message}`, { path, readlinkErr }), null)
+        return cb(
+          new InternalError({
+            message: `Error reading symlink: ${readlinkErr.message}`,
+            detail: { path, readlinkErr },
+          }),
+          null
+        )
       }
 
       // Ignore absolute symlinks unless specifically allowed
@@ -409,7 +417,7 @@ export class FileStatsHelper {
 
   private assertAbsolute(path: string) {
     if (!isAbsolute(path)) {
-      throw new InternalError(`Must specify absolute path (got ${path})`, { path })
+      throw new InternalError({ message: `Must specify absolute path (got ${path})`, detail: { path } })
     }
   }
 }

--- a/core/src/cache.ts
+++ b/core/src/cache.ts
@@ -78,16 +78,22 @@ export class TreeCache {
 
   set(log: Log, key: CacheKey, value: CacheValue, ...contexts: CacheContext[]) {
     if (key.length === 0) {
-      throw new ParameterError(`Cache key must have at least one part`, {
-        key,
-        contexts,
+      throw new ParameterError({
+        message: `Cache key must have at least one part`,
+        detail: {
+          key,
+          contexts,
+        },
       })
     }
 
     if (contexts.length === 0) {
-      throw new ParameterError(`Must specify at least one context`, {
-        key,
-        contexts,
+      throw new ParameterError({
+        message: `Must specify at least one context`,
+        detail: {
+          key,
+          contexts,
+        },
       })
     }
 
@@ -111,9 +117,12 @@ export class TreeCache {
       let node = this.contextTree
 
       if (context.length === 0) {
-        throw new ParameterError(`Context key must have at least one part`, {
-          key,
-          context,
+        throw new ParameterError({
+          message: `Context key must have at least one part`,
+          detail: {
+            key,
+            context,
+          },
         })
       }
 
@@ -149,7 +158,7 @@ export class TreeCache {
   getOrThrow(log: Log, key: CacheKey): CacheValue {
     const value = this.get(log, key)
     if (value === undefined) {
-      throw new NotFoundError(`Could not find key ${key} in cache`, { key })
+      throw new NotFoundError({ message: `Could not find key ${key} in cache`, detail: { key } })
     }
     return value
   }
@@ -163,7 +172,7 @@ export class TreeCache {
       pairs = Array.from(node.entries).map((stringKey) => {
         const entry = this.cache.get(stringKey)
         if (!entry) {
-          throw new InternalError(`Invalid reference found in cache: ${stringKey}`, { stringKey })
+          throw new InternalError({ message: `Invalid reference found in cache: ${stringKey}`, detail: { stringKey } })
         }
         return <[CacheKey, CacheValue]>[entry.key, entry.value]
       })

--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -155,7 +155,7 @@ ${renderCommands(commands)}
 
     if (this.commands[fullName]) {
       // For now we don't allow multiple definitions of the same command. We may want to revisit this later.
-      throw new PluginError(`Multiple definitions of command "${fullName}"`, {})
+      throw new PluginError({ message: `Multiple definitions of command "${fullName}"`, detail: {} })
     }
 
     this.commands[fullName] = command
@@ -167,7 +167,7 @@ ${renderCommands(commands)}
     const dupKeys: string[] = intersection(optKeys, globalKeys)
 
     if (dupKeys.length > 0) {
-      throw new PluginError(`Global option(s) ${dupKeys.join(" ")} cannot be redefined`, {})
+      throw new PluginError({ message: `Global option(s) ${dupKeys.join(" ")} cannot be redefined`, detail: {} })
     }
   }
 

--- a/core/src/cli/helpers.ts
+++ b/core/src/cli/helpers.ts
@@ -58,12 +58,13 @@ export function helpTextMaxWidth() {
 
 export async function checkForStaticDir() {
   if (!(await pathExists(STATIC_DIR))) {
-    throw new InternalError(
-      `Could not find the static data directory. Garden is packaged with a data directory ` +
+    throw new InternalError({
+      message:
+        `Could not find the static data directory. Garden is packaged with a data directory ` +
         `called 'static', which should be located next to your garden binary. Please try reinstalling, ` +
         `and make sure the release archive is fully extracted to the target directory.`,
-      {}
-    )
+      detail: {},
+    })
   }
 }
 
@@ -282,9 +283,12 @@ export function processCliArgs<A extends Parameters, O extends Parameters>({
     } else {
       const expected = argKeys.length > 0 ? "only " + naturalList(argKeys.map((key) => chalk.white.bold(key))) : "none"
 
-      throw new ParameterError(`Unexpected positional argument "${argVal}" (expected ${expected})`, {
-        expectedKeys: argKeys,
-        extraValue: argVal,
+      throw new ParameterError({
+        message: `Unexpected positional argument "${argVal}" (expected ${expected})`,
+        detail: {
+          expectedKeys: argKeys,
+          extraValue: argVal,
+        },
       })
     }
 
@@ -300,10 +304,13 @@ export function processCliArgs<A extends Parameters, O extends Parameters>({
         processedArgs[argKey] = validated
       }
     } catch (error) {
-      throw new ParameterError(`Invalid value for argument ${chalk.white.bold(argKey)}: ${error.message}`, {
-        error,
-        key: argKey,
-        value: argVal,
+      throw new ParameterError({
+        message: `Invalid value for argument ${chalk.white.bold(argKey)}: ${error.message}`,
+        detail: {
+          error,
+          key: argKey,
+          value: argVal,
+        },
       })
     }
   }
@@ -364,7 +371,10 @@ export function processCliArgs<A extends Parameters, O extends Parameters>({
   }
 
   if (errors.length > 0) {
-    throw new ParameterError(chalk.red.bold(errors.join("\n")), { parsedArgs, processedArgs, processedOpts, errors })
+    throw new ParameterError({
+      message: chalk.red.bold(errors.join("\n")),
+      detail: { parsedArgs, processedArgs, processedOpts, errors },
+    })
   }
 
   // To ensure that `command.params` behaves intuitively in template strings, we don't want to add option keys with

--- a/core/src/cli/params.ts
+++ b/core/src/cli/params.ts
@@ -201,32 +201,35 @@ export class DurationParameter extends Parameter<string> {
       )} and length is an integer. For example '1d', '10m', '20s'.
     `
     if (parts.length !== 2) {
-      throw new ParameterError(`Could not parse "${input}" as duration`, {
-        expectedType,
-        input,
+      throw new ParameterError({
+        message: `Could not parse "${input}" as duration`,
+        detail: {
+          expectedType,
+          input,
+        },
       })
     }
     const length = parseInt(parts[0], 10)
     const unit = parts[1]
     if (isNaN(length)) {
-      throw new ParameterError(
-        `Could not parse "${input}" as duration, length must be an integer. Received ${length}`,
-        {
+      throw new ParameterError({
+        message: `Could not parse "${input}" as duration, length must be an integer. Received ${length}`,
+        detail: {
           expectedType,
           input,
-        }
-      )
+        },
+      })
     }
     if (!validDurationUnits.includes(unit)) {
-      throw new ParameterError(
-        `Could not parse "${input}" as duration, unit must be one of ${validDurationUnits.join(
+      throw new ParameterError({
+        message: `Could not parse "${input}" as duration, unit must be one of ${validDurationUnits.join(
           ", "
         )}. Received ${unit}`,
-        {
+        detail: {
           expectedType,
           input,
-        }
-      )
+        },
+      })
     }
     return input
   }
@@ -248,9 +251,12 @@ export class IntegerParameter extends Parameter<number> {
   coerce(input: string) {
     const output = parseInt(input, 10)
     if (isNaN(output)) {
-      throw new ParameterError(`Could not parse "${input}" as integer`, {
-        expectedType: "integer",
-        input,
+      throw new ParameterError({
+        message: `Could not parse "${input}" as integer`,
+        detail: {
+          expectedType: "integer",
+          input,
+        },
       })
     }
     return output
@@ -284,13 +290,15 @@ export class ChoicesParameter extends Parameter<string> {
     if (this.choices.includes(input)) {
       return input
     } else {
-      throw new ParameterError(
-        `"${input}" is not a valid argument (should be any of ${this.choices.map((c) => `"${c}"`).join(", ")})`,
-        {
+      throw new ParameterError({
+        message: `"${input}" is not a valid argument (should be any of ${this.choices
+          .map((c) => `"${c}"`)
+          .join(", ")})`,
+        detail: {
           expectedType: `One of: ${this.choices.join(", ")}`,
           input,
-        }
-      )
+        },
+      })
     }
   }
 
@@ -314,7 +322,7 @@ export class BooleanParameter extends Parameter<boolean> {
     } else if (input === false || input === "false" || input === "0" || input === "no" || input === 0) {
       return false
     } else {
-      throw new ParameterError(`Invalid boolean value: '${input}'`, { input })
+      throw new ParameterError({ message: `Invalid boolean value: '${input}'`, detail: { input } })
     }
   }
 }

--- a/core/src/cloud/api.ts
+++ b/core/src/cloud/api.ts
@@ -219,12 +219,12 @@ export class CloudApi {
     if (gardenEnv.GARDEN_AUTH_TOKEN) {
       // Throw if using an invalid "CI" access token
       if (!tokenIsValid) {
-        throw new CloudApiError(
-          deline`
+        throw new CloudApiError({
+          message: deline`
             The provided access token is expired or has been revoked, please create a new
             one from the ${distroName} UI.`,
-          {}
-        )
+          detail: {},
+        })
       }
     } else {
       // Refresh the token if it's invalid.
@@ -257,7 +257,7 @@ export class CloudApi {
         yet been created in ${distroName}, or that there's a problem with your account's VCS username / login
         credentials.
       `
-      throw new CloudApiError(errMsg, { tokenResponse })
+      throw new CloudApiError({ message: errMsg, detail: { tokenResponse } })
     }
     try {
       const validityMs = tokenResponse.tokenValidity || 604800000
@@ -268,10 +268,10 @@ export class CloudApi {
       })
       log.debug("Saved client auth token to config store")
     } catch (error) {
-      throw new CloudApiError(
-        `An error occurred while saving client auth token to local config db:\n${error.message}`,
-        { tokenResponse }
-      )
+      throw new CloudApiError({
+        message: `An error occurred while saving client auth token to local config db:\n${error.message}`,
+        detail: { tokenResponse },
+      })
     }
   }
 
@@ -362,12 +362,12 @@ export class CloudApi {
 
     // Expect a single project, otherwise we fail with an error
     if (projects.length > 1) {
-      throw new CloudApiDuplicateProjectsError(
-        deline`Found an unexpected state with multiple projects using the same name, ${projectName}.
+      throw new CloudApiDuplicateProjectsError({
+        message: deline`Found an unexpected state with multiple projects using the same name, ${projectName}.
         Please make sure there is only one project with the given name.
         Projects can be deleted through the Garden Cloud UI at ${this.domain}`,
-        {}
-      )
+        detail: {},
+      })
     }
 
     return projects[0]
@@ -446,11 +446,12 @@ export class CloudApi {
     } catch (err) {
       this.log.debug({ msg: `Failed to refresh the token.` })
       const detail = is401Error(err) ? { statusCode: err.response.statusCode } : {}
-      throw new CloudApiTokenRefreshError(
-        `An error occurred while verifying client auth token with ${getCloudDistributionName(this.domain)}: ${err.message
+      throw new CloudApiTokenRefreshError({
+        message: `An error occurred while verifying client auth token with ${getCloudDistributionName(this.domain)}: ${
+          err.message
         }`,
-        detail
-      )
+        detail,
+      })
     }
   }
 
@@ -531,9 +532,12 @@ export class CloudApi {
     const res = await got<T>(url.href, requestOptions)
 
     if (!isObject(res.body)) {
-      throw new CloudApiError(`Unexpected API response`, {
-        path,
-        body: res?.body,
+      throw new CloudApiError({
+        message: `Unexpected API response`,
+        detail: {
+          path,
+          body: res?.body,
+        },
       })
     }
 
@@ -680,11 +684,12 @@ export class CloudApi {
       valid = true
     } catch (err) {
       if (!is401Error(err)) {
-        throw new CloudApiError(
-          `An error occurred while verifying client auth token with ${getCloudDistributionName(this.domain)}: ${err.message
-          }`,
-          {}
-        )
+        throw new CloudApiError({
+          message: `An error occurred while verifying client auth token with ${getCloudDistributionName(
+            this.domain
+          )}: ${err.message}`,
+          detail: {},
+        })
       }
     }
     this.log.debug(`Checked client auth token with ${getCloudDistributionName(this.domain)} - valid: ${valid}`)

--- a/core/src/cloud/workflow-lifecycle.ts
+++ b/core/src/cloud/workflow-lifecycle.ts
@@ -59,8 +59,11 @@ export async function registerWorkflowRun({
           CLI version is compatible with your version of Garden Cloud. See error.log for details
           on the failed registration request payload.
         `
-        throw new CloudApiError(errMsg, {
-          requestData,
+        throw new CloudApiError({
+          message: errMsg,
+          detail: {
+            requestData,
+          },
         })
       } else {
         log.error(`An error occurred while registering workflow run: ${err.message}`)
@@ -71,11 +74,14 @@ export async function registerWorkflowRun({
     if (res?.workflowRunUid && res?.status === "success") {
       return res.workflowRunUid
     } else {
-      throw new CloudApiError(`Error while registering workflow run: Request failed with status ${res?.status}`, {
-        status: res?.status,
-        workflowRunUid: res?.workflowRunUid,
+      throw new CloudApiError({
+        message: `Error while registering workflow run: Request failed with status ${res?.status}`,
+        detail: {
+          status: res?.status,
+          workflowRunUid: res?.workflowRunUid,
+        },
       })
     }
   }
-  throw new CloudApiError("Error while registering workflow run: Couldn't initialize API.", {})
+  throw new CloudApiError({ message: "Error while registering workflow run: Couldn't initialize API.", detail: {} })
 }

--- a/core/src/commands/base.ts
+++ b/core/src/commands/base.ts
@@ -210,9 +210,12 @@ export abstract class Command<A extends Parameters = {}, O extends Parameters = 
     if (this.arguments && this.options) {
       for (const key of Object.keys(this.options)) {
         if (key in this.arguments) {
-          throw new InternalError(`Key ${key} is defined in both options and arguments for command ${commandName}`, {
-            commandName,
-            key,
+          throw new InternalError({
+            message: `Key ${key} is defined in both options and arguments for command ${commandName}`,
+            detail: {
+              commandName,
+              key,
+            },
           })
         }
       }
@@ -226,18 +229,24 @@ export abstract class Command<A extends Parameters = {}, O extends Parameters = 
 
       // Make sure arguments don't have default values
       if (arg.defaultValue) {
-        throw new InternalError(`A positional argument cannot have a default value`, {
-          commandName,
-          arg,
+        throw new InternalError({
+          message: `A positional argument cannot have a default value`,
+          detail: {
+            commandName,
+            arg,
+          },
         })
       }
 
       if (arg.required) {
         // Make sure required arguments don't follow optional ones
         if (foundOptional) {
-          throw new InternalError(`A required argument cannot follow an optional one`, {
-            commandName,
-            arg,
+          throw new InternalError({
+            message: `A required argument cannot follow an optional one`,
+            detail: {
+              commandName,
+              arg,
+            },
           })
         }
       } else {
@@ -246,9 +255,12 @@ export abstract class Command<A extends Parameters = {}, O extends Parameters = 
 
       // Make sure only last argument is spread
       if (arg.spread && i < args.length - 1) {
-        throw new InternalError(`Only the last command argument can set spread to true`, {
-          commandName,
-          arg,
+        throw new InternalError({
+          message: `Only the last command argument can set spread to true`,
+          detail: {
+            commandName,
+            arg,
+          },
         })
       }
     }
@@ -297,7 +309,8 @@ export abstract class Command<A extends Parameters = {}, O extends Parameters = 
         // `deploy --sync`) are also not registered here, since the `dev` command will have been registered already,
         // and the `deploy --sync` command which is subsequently run interactively in the `dev` session will register
         // itself (it will have a parent command, so the last condition in this expression will not match).
-        const skipRegistration = !["dev", "serve"].includes(this.name) && this.maybePersistent(params) && !params.parentCommand
+        const skipRegistration =
+          !["dev", "serve"].includes(this.name) && this.maybePersistent(params) && !params.parentCommand
 
         if (!skipRegistration && garden.cloudApi && garden.projectId && this.streamEvents) {
           cloudSession = await garden.cloudApi.registerSession({
@@ -1064,7 +1077,11 @@ export async function handleProcessResults(
       return f && f.error && isGardenError(f.error) ? [f.error as GardenError] : []
     })
 
-    const error = new RuntimeError(`${failedCount} ${taskType} action(s) failed!`, { results: failed }, wrappedErrors)
+    const error = new RuntimeError({
+      message: `${failedCount} ${taskType} action(s) failed!`,
+      detail: { results: failed },
+      wrappedErrors,
+    })
     return { result, errors: [error] }
   }
 

--- a/core/src/commands/cloud/groups/groups.ts
+++ b/core/src/commands/cloud/groups/groups.ts
@@ -63,7 +63,7 @@ export class GroupsListCommand extends Command<{}, Opts> {
 
     const api = garden.cloudApi
     if (!api) {
-      throw new ConfigurationError(noApiMsg("list", "users"), {})
+      throw new ConfigurationError({ message: noApiMsg("list", "users"), detail: {} })
     }
 
     const res = await api.get<ListGroupsResponse>(`/groups`)

--- a/core/src/commands/cloud/helpers.ts
+++ b/core/src/commands/cloud/helpers.ts
@@ -153,7 +153,7 @@ export function handleBulkOperationResult<T>({
 
   // Ensure command exits with code 1.
   if (errors.length > 0) {
-    throw new CommandError("Command failed.", { errors })
+    throw new CommandError({ message: "Command failed.", detail: { errors } })
   }
 
   return { result: results }

--- a/core/src/commands/cloud/secrets/secrets-create.ts
+++ b/core/src/commands/cloud/secrets/secrets-create.ts
@@ -83,22 +83,25 @@ export class SecretsCreateCommand extends Command<Args, Opts> {
     let secrets: StringMap
 
     if (userId !== undefined && !envName) {
-      throw new CommandError(
-        `Got user ID but not environment name. Secrets scoped to users must be scoped to environments as well.`,
-        {
+      throw new CommandError({
+        message: `Got user ID but not environment name. Secrets scoped to users must be scoped to environments as well.`,
+        detail: {
           args,
           opts,
-        }
-      )
+        },
+      })
     }
 
     if (fromFile) {
       try {
         secrets = dotenv.parse(await readFile(fromFile))
       } catch (err) {
-        throw new CommandError(`Unable to read secrets from file at path ${fromFile}: ${err.message}`, {
-          args,
-          opts,
+        throw new CommandError({
+          message: `Unable to read secrets from file at path ${fromFile}: ${err.message}`,
+          detail: {
+            args,
+            opts,
+          },
         })
       }
     } else if (args.secrets) {
@@ -108,24 +111,27 @@ export class SecretsCreateCommand extends Command<Args, Opts> {
           Object.assign(acc, secret)
           return acc
         } catch (err) {
-          throw new CommandError(`Unable to read secret from argument ${keyValPair}: ${err.message}`, {
-            args,
-            opts,
+          throw new CommandError({
+            message: `Unable to read secret from argument ${keyValPair}: ${err.message}`,
+            detail: {
+              args,
+              opts,
+            },
           })
         }
       }, {})
     } else {
-      throw new CommandError(
-        dedent`
+      throw new CommandError({
+        message: dedent`
         No secrets provided. Either provide secrets directly to the command or via the --from-file flag.
       `,
-        { args, opts }
-      )
+        detail: { args, opts },
+      })
     }
 
     const api = garden.cloudApi
     if (!api) {
-      throw new ConfigurationError(noApiMsg("create", "secrets"), {})
+      throw new ConfigurationError({ message: noApiMsg("create", "secrets"), detail: {} })
     }
 
     let project: CloudProject | undefined
@@ -135,10 +141,10 @@ export class SecretsCreateCommand extends Command<Args, Opts> {
     }
 
     if (!project) {
-      throw new CloudApiError(
-        `Project ${garden.projectName} is not a ${getCloudDistributionName(api.domain)} project`,
-        {}
-      )
+      throw new CloudApiError({
+        message: `Project ${garden.projectName} is not a ${getCloudDistributionName(api.domain)} project`,
+        detail: {},
+      })
     }
 
     let environmentId: string | undefined
@@ -146,9 +152,12 @@ export class SecretsCreateCommand extends Command<Args, Opts> {
     if (envName) {
       const environment = project.environments.find((e) => e.name === envName)
       if (!environment) {
-        throw new CloudApiError(`Environment with name ${envName} not found in project`, {
-          environmentName: envName,
-          availableEnvironmentNames: project.environments.map((e) => e.name),
+        throw new CloudApiError({
+          message: `Environment with name ${envName} not found in project`,
+          detail: {
+            environmentName: envName,
+            availableEnvironmentNames: project.environments.map((e) => e.name),
+          },
         })
       }
       environmentId = environment.id
@@ -158,8 +167,11 @@ export class SecretsCreateCommand extends Command<Args, Opts> {
     if (userId) {
       const user = await api.get(`/users/${userId}`)
       if (!user) {
-        throw new CloudApiError(`User with ID ${userId} not found.`, {
-          userId,
+        throw new CloudApiError({
+          message: `User with ID ${userId} not found.`,
+          detail: {
+            userId,
+          },
         })
       }
     }

--- a/core/src/commands/cloud/secrets/secrets-delete.ts
+++ b/core/src/commands/cloud/secrets/secrets-delete.ts
@@ -43,8 +43,11 @@ export class SecretsDeleteCommand extends Command<Args> {
   async action({ garden, args, log, opts }: CommandParams<Args>): Promise<CommandResult<DeleteResult[]>> {
     const secretsToDelete = args.ids || []
     if (secretsToDelete.length === 0) {
-      throw new CommandError(`No secret IDs provided.`, {
-        args,
+      throw new CommandError({
+        message: `No secret IDs provided.`,
+        detail: {
+          args,
+        },
       })
     }
 
@@ -54,7 +57,7 @@ export class SecretsDeleteCommand extends Command<Args> {
 
     const api = garden.cloudApi
     if (!api) {
-      throw new ConfigurationError(noApiMsg("delete", "secrets"), {})
+      throw new ConfigurationError({ message: noApiMsg("delete", "secrets"), detail: {} })
     }
 
     const cmdLog = log.createLog({ name: "secrets-command" })

--- a/core/src/commands/cloud/secrets/secrets-list.ts
+++ b/core/src/commands/cloud/secrets/secrets-list.ts
@@ -62,7 +62,7 @@ export class SecretsListCommand extends Command<{}, Opts> {
 
     const api = garden.cloudApi
     if (!api) {
-      throw new ConfigurationError(noApiMsg("list", "secrets"), {})
+      throw new ConfigurationError({ message: noApiMsg("list", "secrets"), detail: {} })
     }
 
     let project: CloudProject | undefined
@@ -72,10 +72,10 @@ export class SecretsListCommand extends Command<{}, Opts> {
     }
 
     if (!project) {
-      throw new CloudApiError(
-        `Project ${garden.projectName} is not a ${getCloudDistributionName(api.domain)} project`,
-        {}
-      )
+      throw new CloudApiError({
+        message: `Project ${garden.projectName} is not a ${getCloudDistributionName(api.domain)} project`,
+        detail: {},
+      })
     }
 
     let page = 0

--- a/core/src/commands/cloud/users/users-create.ts
+++ b/core/src/commands/cloud/users/users-create.ts
@@ -88,9 +88,12 @@ export class UsersCreateCommand extends Command<Args, Opts> {
       try {
         users = dotenv.parse(await readFile(fromFile))
       } catch (err) {
-        throw new CommandError(`Unable to read users from file at path ${fromFile}: ${err.message}`, {
-          args,
-          opts,
+        throw new CommandError({
+          message: `Unable to read users from file at path ${fromFile}: ${err.message}`,
+          detail: {
+            args,
+            opts,
+          },
         })
       }
     } else if (args.users) {
@@ -100,24 +103,27 @@ export class UsersCreateCommand extends Command<Args, Opts> {
           Object.assign(acc, user)
           return acc
         } catch (err) {
-          throw new CommandError(`Unable to read user from argument ${keyValPair}: ${err.message}`, {
-            args,
-            opts,
+          throw new CommandError({
+            message: `Unable to read user from argument ${keyValPair}: ${err.message}`,
+            detail: {
+              args,
+              opts,
+            },
           })
         }
       }, {})
     } else {
-      throw new CommandError(
-        dedent`
+      throw new CommandError({
+        message: dedent`
         No users provided. Either provide users directly to the command or via the --from-file flag.
       `,
-        { args, opts }
-      )
+        detail: { args, opts },
+      })
     }
 
     const api = garden.cloudApi
     if (!api) {
-      throw new ConfigurationError(noApiMsg("create", "users"), {})
+      throw new ConfigurationError({ message: noApiMsg("create", "users"), detail: {} })
     }
 
     const cmdLog = log.createLog({ name: "users-command" })

--- a/core/src/commands/cloud/users/users-delete.ts
+++ b/core/src/commands/cloud/users/users-delete.ts
@@ -44,8 +44,11 @@ export class UsersDeleteCommand extends Command<Args> {
   async action({ garden, args, log, opts }: CommandParams<Args>): Promise<CommandResult<DeleteResult[]>> {
     const usersToDelete = args.ids || []
     if (usersToDelete.length === 0) {
-      throw new CommandError(`No user IDs provided.`, {
-        args,
+      throw new CommandError({
+        message: `No user IDs provided.`,
+        detail: {
+          args,
+        },
       })
     }
 
@@ -55,7 +58,7 @@ export class UsersDeleteCommand extends Command<Args> {
 
     const api = garden.cloudApi
     if (!api) {
-      throw new ConfigurationError(noApiMsg("delete", "user"), {})
+      throw new ConfigurationError({ message: noApiMsg("delete", "user"), detail: {} })
     }
 
     const cmdLog = log.createLog({ name: "users-command" })

--- a/core/src/commands/cloud/users/users-list.ts
+++ b/core/src/commands/cloud/users/users-list.ts
@@ -54,7 +54,7 @@ export class UsersListCommand extends Command<{}, Opts> {
 
     const api = garden.cloudApi
     if (!api) {
-      throw new ConfigurationError(noApiMsg("list", "users"), {})
+      throw new ConfigurationError({ message: noApiMsg("list", "users"), detail: {} })
     }
 
     let project: CloudProject | undefined
@@ -64,10 +64,10 @@ export class UsersListCommand extends Command<{}, Opts> {
     }
 
     if (!project) {
-      throw new CloudApiError(
-        `Project ${garden.projectName} is not a ${getCloudDistributionName(api.domain)} project`,
-        {}
-      )
+      throw new CloudApiError({
+        message: `Project ${garden.projectName} is not a ${getCloudDistributionName(api.domain)} project`,
+        detail: {},
+      })
     }
 
     // Make a best effort VCS provider guess. We should have an API endpoint for this or return with the response.

--- a/core/src/commands/create/create-module.ts
+++ b/core/src/commands/create/create-module.ts
@@ -105,7 +105,7 @@ export class CreateModuleCommand extends Command<CreateModuleArgs, CreateModuleO
     const configDir = resolve(process.cwd(), opts.dir)
 
     if (!(await isDirectory(configDir))) {
-      throw new ParameterError(`${configDir} is not a directory`, { configDir })
+      throw new ParameterError({ message: `${configDir} is not a directory`, detail: { configDir } })
     }
 
     const configPath = join(configDir, opts.filename)
@@ -149,7 +149,7 @@ export class CreateModuleCommand extends Command<CreateModuleArgs, CreateModuleO
     }
 
     if (!type) {
-      throw new ParameterError(`Must specify --type if --interactive=false`, {})
+      throw new ParameterError({ message: `Must specify --type if --interactive=false`, detail: {} })
     }
 
     presetValues.kind = "Module"
@@ -160,23 +160,26 @@ export class CreateModuleCommand extends Command<CreateModuleArgs, CreateModuleO
       const configs = await loadConfigResources(log, configDir, configPath)
 
       if (configs.filter((c) => c.kind === "Module" && c.name === name).length > 0) {
-        throw new CreateError(
-          chalk.red(
+        throw new CreateError({
+          message: chalk.red(
             `A Garden module named ${chalk.white.bold(name)} already exists in ${chalk.white.bold(configPath)}`
           ),
-          {
+          detail: {
             configDir,
             configPath,
-          }
-        )
+          },
+        })
       }
     }
 
     const definition = allModuleTypes[type]
 
     if (!definition) {
-      throw new ParameterError(`Could not find module type ${chalk.white.bold(type)}`, {
-        availableTypes: Object.keys(allModuleTypes),
+      throw new ParameterError({
+        message: `Could not find module type ${chalk.white.bold(type)}`,
+        detail: {
+          availableTypes: Object.keys(allModuleTypes),
+        },
       })
     }
 

--- a/core/src/commands/create/create-project.ts
+++ b/core/src/commands/create/create-project.ts
@@ -107,7 +107,7 @@ export class CreateProjectCommand extends Command<CreateProjectArgs, CreateProje
     const configDir = resolve(process.cwd(), opts.dir)
 
     if (!(await isDirectory(configDir))) {
-      throw new ParameterError(`${configDir} is not a directory`, { configDir })
+      throw new ParameterError({ message: `${configDir} is not a directory`, detail: { configDir } })
     }
 
     const configPath = join(configDir, opts.filename)
@@ -117,7 +117,10 @@ export class CreateProjectCommand extends Command<CreateProjectArgs, CreateProje
       const configs = await loadConfigResources(log, configDir, configPath)
 
       if (configs.filter((c) => c.kind === "Project").length > 0) {
-        throw new CreateError(`A Garden project already exists in ${configPath}`, { configDir, configPath })
+        throw new CreateError({
+          message: `A Garden project already exists in ${configPath}`,
+          detail: { configDir, configPath },
+        })
       }
     }
 

--- a/core/src/commands/custom.ts
+++ b/core/src/commands/custom.ts
@@ -50,7 +50,7 @@ function convertArgSpec(spec: CustomCommandOption) {
   } else if (spec.type === "boolean") {
     return new BooleanParameter(params)
   } else {
-    throw new ConfigurationError(`Unexpected parameter type '${spec.type}'`, { spec })
+    throw new ConfigurationError({ message: `Unexpected parameter type '${spec.type}'`, detail: { spec } })
   }
 }
 
@@ -152,7 +152,12 @@ export class CustomCommandWrapper extends Command {
       if (res.exitCode !== 0) {
         return {
           exitCode: res.exitCode,
-          errors: [new RuntimeError(`Command exited with code ${res.exitCode}`, { exitCode: res.exitCode, command })],
+          errors: [
+            new RuntimeError({
+              message: `Command exited with code ${res.exitCode}`,
+              detail: { exitCode: res.exitCode, command },
+            }),
+          ],
         }
       }
 
@@ -180,7 +185,7 @@ export class CustomCommandWrapper extends Command {
 
       // Doing runtime check to avoid updating hundreds of test invocations with a new required param, sorry. - JE
       if (!cli) {
-        throw new InternalError(`Missing cli argument in custom command wrapper.`, {})
+        throw new InternalError({ message: `Missing cli argument in custom command wrapperd.`, detail: {} })
       }
 
       // Pass explicitly set global opts with the command, if they're not set in the command itself.

--- a/core/src/commands/dev.tsx
+++ b/core/src/commands/dev.tsx
@@ -93,12 +93,12 @@ Use ${chalk.bold("up/down")} arrow keys to scroll through your command history.
     if (terminalWriter.type === "ink") {
       inkWriter = terminalWriter as InkTerminalWriter
     } else {
-      throw new ParameterError(`This command can only be used with the ink logger type`, {
+      throw new ParameterError({ message: `This command can only be used with the ink logger type`, detail: {
         writerTypes: {
           terminalWriter: terminalWriter.type,
           fileWriters: logger.getWriters().file.map((w) => w.type),
         },
-      })
+      }})
     }
 
     const commandLine = await this.initCommandHandler(params)

--- a/core/src/commands/exec.ts
+++ b/core/src/commands/exec.ts
@@ -98,30 +98,33 @@ export class ExecCommand extends Command<Args, Opts> {
           )}. If this command fails, you may need to re-deploy it with the ${chalk.whiteBright("deploy")} command.`
         )
         break
-        case "outdated":
-          // check if deployment is in sync mode
-          const syncStatus = (
-            await router.deploy.getSyncStatus({
-              log: actionLog,
-              action: executed,
-              monitor: false,
-              graph,
-            })
-          ).result
-          const deploySync = syncStatus?.syncs?.[0]
-          // if there is an active sync, the state is likely to be outdated so do not display this warning
-          if (!(deploySync?.syncCount && deploySync?.syncCount > 0 && deploySync?.state === "active" )) {
-            log.warn(
-              `The current state of ${action.key()} is ${chalk.whiteBright(
-                deployState
-              )}. If this command fails, you may need to re-deploy it with the ${chalk.whiteBright("deploy")} command.`
-            )
-          }
-          break
+      case "outdated":
+        // check if deployment is in sync mode
+        const syncStatus = (
+          await router.deploy.getSyncStatus({
+            log: actionLog,
+            action: executed,
+            monitor: false,
+            graph,
+          })
+        ).result
+        const deploySync = syncStatus?.syncs?.[0]
+        // if there is an active sync, the state is likely to be outdated so do not display this warning
+        if (!(deploySync?.syncCount && deploySync?.syncCount > 0 && deploySync?.state === "active")) {
+          log.warn(
+            `The current state of ${action.key()} is ${chalk.whiteBright(
+              deployState
+            )}. If this command fails, you may need to re-deploy it with the ${chalk.whiteBright("deploy")} command.`
+          )
+        }
+        break
       // Only fail if the deployment is missing or stopped.
       case "missing":
       case "stopped":
-        throw new NotFoundError(`${action.key()} status is ${deployState}. Cannot execute command.`, { deployState })
+        throw new NotFoundError({
+          message: `${action.key()} status is ${deployState}. Cannot execute command.`,
+          detail: { deployState },
+        })
       case "ready":
         // Nothing to report/throw, the deployment is ready
         break

--- a/core/src/commands/get/get-debug-info.ts
+++ b/core/src/commands/get/get-debug-info.ts
@@ -45,10 +45,10 @@ export async function collectBasicDebugInfo(root: string, gardenDirPath: string,
   // Find project definition
   const projectConfig = await findProjectConfig({ log, path: root, allowInvalid: true })
   if (!projectConfig) {
-    throw new ValidationError(
-      "Couldn't find a Project definition. Please run this command from the root of your Garden project.",
-      {}
-    )
+    throw new ValidationError({
+      message: "Couldn't find a Project definition. Please run this command from the root of your Garden project.",
+      detail: {},
+    })
   }
 
   // Create temporary folder inside .garden/ at root of project

--- a/core/src/commands/get/get-test-result.ts
+++ b/core/src/commands/get/get-test-result.ts
@@ -111,22 +111,25 @@ export function getTestActionFromArgs(graph: ConfigGraph, args: ParameterValues<
     try {
       module = graph.getModule(args.name, true)
     } catch (err) {
-      throw new ParameterError(
-        `Two arguments were provided, so we looked for a Module named '${moduleName}, but could not find it.`,
-        {
+      throw new ParameterError({
+        message: `Two arguments were provided, so we looked for a Module named '${moduleName}, but could not find it.`,
+        detail: {
           moduleName,
           testName,
-        }
-      )
+        },
+      })
     }
 
     const testConfig = findByName(module.testConfigs, args.moduleTestName)
 
     if (!testConfig) {
-      throw new ParameterError(`Could not find test "${testName}" in module ${moduleName}`, {
-        moduleName,
-        testName,
-        availableTests: getNames(module.testConfigs),
+      throw new ParameterError({
+        message: `Could not find test "${testName}" in module ${moduleName}`,
+        detail: {
+          moduleName,
+          testName,
+          availableTests: getNames(module.testConfigs),
+        },
       })
     }
 

--- a/core/src/commands/helpers.ts
+++ b/core/src/commands/helpers.ts
@@ -132,7 +132,7 @@ export const validateActionSearchResults = ({
 
   names?.forEach((n) => {
     if (!isGlob(n) && !actions.find((a) => a.name === n)) {
-      throw new ParameterError(`${actionKind} action "${n}" was not found.`, { ...errData })
+      throw new ParameterError({ message: `${actionKind} action "${n}" was not found.`, detail: { ...errData } })
     }
   })
 
@@ -141,7 +141,7 @@ export const validateActionSearchResults = ({
     if (names) {
       argumentsMsg = ` (matching argument(s) ${naturalList(names.map((n) => `'${n}'`))})`
     }
-    throw new ParameterError(`No ${actionKind} actions were found${argumentsMsg}.`, { errData })
+    throw new ParameterError({ message: `No ${actionKind} actions were found${argumentsMsg}.`, detail: { errData } })
   }
   return { shouldAbort: false }
 }

--- a/core/src/commands/link/action.ts
+++ b/core/src/commands/link/action.ts
@@ -71,13 +71,14 @@ export class LinkActionCommand extends Command<Args> {
     const key = action.key()
 
     if (!action.hasRemoteSource()) {
-      throw new ParameterError(
-        `Expected action ${chalk.underline(key)} to have a remote source.` +
+      throw new ParameterError({
+        message:
+          `Expected action ${chalk.underline(key)} to have a remote source.` +
           ` Did you mean to use the "link source" command?`,
-        {
+        detail: {
           actionKey: key,
-        }
-      )
+        },
+      })
     }
 
     const absPath = resolve(garden.projectRoot, path)

--- a/core/src/commands/link/module.ts
+++ b/core/src/commands/link/module.ts
@@ -74,14 +74,15 @@ export class LinkModuleCommand extends Command<Args> {
     if (!isRemote) {
       const modulesWithRemoteSource = graph.getModules().filter(moduleHasRemoteSource).sort()
 
-      throw new ParameterError(
-        `Expected module(s) ${chalk.underline(moduleName)} to have a remote source.` +
+      throw new ParameterError({
+        message:
+          `Expected module(s) ${chalk.underline(moduleName)} to have a remote source.` +
           ` Did you mean to use the "link source" command?`,
-        {
+        detail: {
           modulesWithRemoteSource,
           input: module,
-        }
-      )
+        },
+      })
     }
 
     const absPath = resolve(garden.projectRoot, path)

--- a/core/src/commands/link/source.ts
+++ b/core/src/commands/link/source.ts
@@ -74,14 +74,15 @@ export class LinkSourceCommand extends Command<Args> {
     if (!projectSourceToLink) {
       const availableRemoteSources = projectSources.map((s) => s.name).sort()
 
-      throw new ParameterError(
-        `Remote source ${chalk.underline(sourceName)} not found in project config.` +
+      throw new ParameterError({
+        message:
+          `Remote source ${chalk.underline(sourceName)} not found in project config.` +
           ` Did you mean to use the "link module" command?`,
-        {
+        detail: {
           availableRemoteSources,
           input: sourceName,
-        }
-      )
+        },
+      })
     }
 
     const absPath = resolve(garden.projectRoot, path)

--- a/core/src/commands/login.ts
+++ b/core/src/commands/login.ts
@@ -64,12 +64,12 @@ export class LoginCommand extends Command<{}, Opts> {
 
       // Fail if this is not run within a garden project
       if (!projectConfig) {
-        throw new ConfigurationError(
-          `Not a project directory (or any of the parent directories): ${garden.projectRoot}`,
-          {
+        throw new ConfigurationError({
+          message: `Not a project directory (or any of the parent directories): ${garden.projectRoot}`,
+          detail: {
             root: garden.projectRoot,
-          }
-        )
+          },
+        })
       }
     }
 
@@ -131,7 +131,12 @@ export async function login(log: Log, cloudDomain: string, events: EventBus) {
 
     const timeout = setTimeout(() => {
       timedOut = true
-      reject(new TimeoutError(`Timed out after ${loginTimeoutSec} seconds, waiting for web login response.`, {}))
+      reject(
+        new TimeoutError({
+          message: `Timed out after ${loginTimeoutSec} seconds, waiting for web login response.`,
+          detail: {},
+        })
+      )
     }, loginTimeoutSec * 1000)
 
     events.once("receivedToken", (tokenResponse: AuthTokenResponse) => {
@@ -145,7 +150,7 @@ export async function login(log: Log, cloudDomain: string, events: EventBus) {
   })
   await server.close()
   if (!response) {
-    throw new InternalError(`Error: Did not receive an auth token after logging in.`, {})
+    throw new InternalError({ message: `Error: Did not receive an auth token after logging in.`, detail: {} })
   }
 
   return response

--- a/core/src/commands/logout.ts
+++ b/core/src/commands/logout.ts
@@ -51,12 +51,12 @@ export class LogOutCommand extends Command<{}, Opts> {
 
       // Fail if this is not run within a garden project
       if (!projectConfig) {
-        throw new ConfigurationError(
-          `Not a project directory (or any of the parent directories): ${garden.projectRoot}`,
-          {
+        throw new ConfigurationError({
+          message: `Not a project directory (or any of the parent directories): ${garden.projectRoot}`,
+          detail: {
             root: garden.projectRoot,
-          }
-        )
+          },
+        })
       }
     }
 

--- a/core/src/commands/logs.ts
+++ b/core/src/commands/logs.ts
@@ -139,13 +139,13 @@ export class LogsCommand extends Command<Args, Opts> {
           return tagGroup.split(",").map((t: string) => {
             const parsed = Object.entries(dotenv.parse(t))[0]
             if (!parsed) {
-              throw new ParameterError(parameterErrorMsg, { tags: tag })
+              throw new ParameterError({ message: parameterErrorMsg, detail: { tags: tag } })
             }
             return parsed
           })
         })
       } catch {
-        throw new ParameterError(parameterErrorMsg, { tags: tag })
+        throw new ParameterError({ message: parameterErrorMsg, detail: { tags: tag } })
       }
     }
 
@@ -166,7 +166,7 @@ export class LogsCommand extends Command<Args, Opts> {
       } else {
         msg = "No Deploys found in project."
       }
-      throw new CommandError(msg, { args, opts, availableDeploys: allDeployNames })
+      throw new CommandError({ message: msg, detail: { args, opts, availableDeploys: allDeployNames } })
     }
 
     let details: string = ""

--- a/core/src/commands/plugins.ts
+++ b/core/src/commands/plugins.ts
@@ -81,9 +81,12 @@ export class PluginsCommand extends Command<Args> {
     if (!command) {
       return {
         errors: [
-          new ParameterError(`Could not find command '${args.command}' on plugin ${args.plugin}`, {
-            args,
-            availableCommands: plugin.commands.map((c) => c.name),
+          new ParameterError({
+            message: `Could not find command '${args.command}' on plugin ${args.plugin}`,
+            detail: {
+              args,
+              availableCommands: plugin.commands.map((c) => c.name),
+            },
           }),
         ],
       }

--- a/core/src/commands/run.ts
+++ b/core/src/commands/run.ts
@@ -142,10 +142,10 @@ export class RunCommand extends Command<Args, Opts> {
     const skipRuntimeDependencies = opts["skip-dependencies"]
 
     if (!names && !opts.module) {
-      throw new ParameterError(
-        `A name argument or --module must be specified. If you really want to perform every Run in the project, please specify '*' as an argument.`,
-        { args, opts }
-      )
+      throw new ParameterError({
+        message: `A name argument or --module must be specified. If you really want to perform every Run in the project, please specify '*' as an argument.`,
+        detail: { args, opts },
+      })
     }
 
     // Validate module names if specified.
@@ -215,11 +215,11 @@ function maybeOldRunCommand(names: string[], args: any, opts: any, log: Log, par
   const firstArg = names[0]
   if (["module", "service", "task", "test", "workflow"].includes(firstArg)) {
     if (firstArg === "module" || firstArg === "service") {
-      throw new ParameterError(
-        `Error: The ${chalk.white("garden run " + firstArg)} command has been removed.
+      throw new ParameterError({
+        message: `Error: The ${chalk.white("garden run " + firstArg)} command has been removed.
       Please define a Run action instead, or use the underlying tools (e.g. Docker or Kubernetes) directly.`,
-        { args, opts }
-      )
+        detail: { args, opts },
+      })
     }
     if (firstArg === "task") {
       log.warn(

--- a/core/src/commands/self-update.ts
+++ b/core/src/commands/self-update.ts
@@ -56,7 +56,7 @@ export type SelfUpdateArgs = typeof selfUpdateArgs
 export type SelfUpdateOpts = typeof selfUpdateOpts
 
 const versionScopes = ["major", "minor", "patch"] as const
-export type VersionScope = typeof versionScopes[number]
+export type VersionScope = (typeof versionScopes)[number]
 
 function getVersionScope(opts: ParameterValues<GlobalOptions & SelfUpdateOpts>): VersionScope {
   if (opts["major"]) {
@@ -160,8 +160,11 @@ export namespace GitHubReleaseApi {
     const latestVersionRes: any = await got("https://api.github.com/repos/garden-io/garden/releases/latest").json()
     const latestVersion = latestVersionRes.tag_name
     if (!latestVersion) {
-      throw new RuntimeError(`Unable to detect the latest Garden version: ${latestVersionRes}`, {
-        response: latestVersionRes,
+      throw new RuntimeError({
+        message: `Unable to detect the latest Garden version: ${latestVersionRes}`,
+        detail: {
+          response: latestVersionRes,
+        },
       })
     }
 
@@ -452,10 +455,10 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
 
     // The current version is necessary, it's not possible to proceed without its value
     if (!currentSemVer) {
-      throw new RuntimeError(
-        `Unexpected current version: ${currentVersion}. Please make sure it is either a valid (semver) release version.`,
-        {}
-      )
+      throw new RuntimeError({
+        message: `Unexpected current version: ${currentVersion}. Please make sure it is either a valid (semver) release version.`,
+        detail: {},
+      })
     }
 
     const targetVersionPredicate = this.getTargetVersionPredicate(currentSemVer, versionScope)
@@ -468,10 +471,10 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
     })
 
     if (!targetRelease) {
-      throw new RuntimeError(
-        `Unable to find the latest Garden version greater or equal than ${currentVersion} for the scope: ${versionScope}`,
-        {}
-      )
+      throw new RuntimeError({
+        message: `Unable to find the latest Garden version greater or equal than ${currentVersion} for the scope: ${versionScope}`,
+        detail: {},
+      })
     }
 
     return targetRelease.tag_name

--- a/core/src/commands/sync/sync-start.ts
+++ b/core/src/commands/sync/sync-start.ts
@@ -136,7 +136,7 @@ export class SyncStartCommand extends Command<Args, Opts> {
     const actionKeys = actions.map((a) => a.key())
 
     if (actions.length === 0) {
-      throw new ParameterError(`No matched action supports syncing. Aborting.`, { actionKeys })
+      throw new ParameterError({ message: `No matched action supports syncing. Aborting.`, detail: { actionKeys } })
     }
 
     if (opts.deploy) {
@@ -190,7 +190,7 @@ export async function startSyncWithoutDeploy({
   command,
   log,
   monitor,
-  stopOnExit
+  stopOnExit,
 }: {
   actions: DeployAction[]
   graph: ConfigGraph
@@ -231,9 +231,7 @@ export async function startSyncWithoutDeploy({
     if (executedAction && (state === "outdated" || state === "ready")) {
       if (mode !== "sync") {
         actionLog.warn(
-          chalk.yellow(
-            `Not deployed in sync mode, cannot start sync. Try running this command with \`--deploy\` set.`
-          )
+          chalk.yellow(`Not deployed in sync mode, cannot start sync. Try running this command with \`--deploy\` set.`)
         )
         return
       }
@@ -261,8 +259,11 @@ export async function startSyncWithoutDeploy({
   })
 
   if (!someSyncStarted) {
-    throw new RuntimeError(`Could not start any sync. Aborting.`, {
-      actionKeys,
+    throw new RuntimeError({
+      message: `Could not start any sync. Aborting.`,
+      detail: {
+        actionKeys,
+      },
     })
   }
 }

--- a/core/src/commands/test.ts
+++ b/core/src/commands/test.ts
@@ -205,9 +205,12 @@ export class TestCommand extends Command<Args, Opts> {
     )
 
     if (opts.interactive && tasks.length !== 1) {
-      throw new ParameterError(`The --interactive/-i option can only be used if a single test is selected.`, {
-        args,
-        opts,
+      throw new ParameterError({
+        message: `The --interactive/-i option can only be used if a single test is selected.`,
+        detail: {
+          args,
+          opts,
+        },
       })
     }
 

--- a/core/src/commands/tools.ts
+++ b/core/src/commands/tools.ts
@@ -103,10 +103,10 @@ export class ToolsCommand extends Command<Args, Opts> {
       pluginName = split[0]
       toolName = split[1]
     } else {
-      throw new ParameterError(
-        `Invalid tool name argument. Please specify either a tool name (no periods) or <plugin name>.<tool name>.`,
-        { args }
-      )
+      throw new ParameterError({
+        message: `Invalid tool name argument. Please specify either a tool name (no periods) or <plugin name>.<tool name>.`,
+        detail: { args },
+      })
     }
 
     // We're executing a tool
@@ -117,7 +117,7 @@ export class ToolsCommand extends Command<Args, Opts> {
       plugins = plugins.filter((p) => p.name === pluginName)
 
       if (plugins.length === 0) {
-        throw new ParameterError(`Could not find plugin ${pluginName}.`, { availablePlugins })
+        throw new ParameterError({ message: `Could not find plugin ${pluginName}.`, detail: { availablePlugins } })
       }
     } else {
       // Place configured providers at the top for preference, if applicable
@@ -145,7 +145,7 @@ export class ToolsCommand extends Command<Args, Opts> {
     const matchedNames = matchedTools.map(({ plugin, tool }) => `${plugin.name}.${tool.name}`)
 
     if (matchedTools.length === 0) {
-      throw new ParameterError(`Could not find tool ${args.tool}.`, { args })
+      throw new ParameterError({ message: `Could not find tool ${args.tool}.`, detail: { args } })
     }
 
     if (matchedTools.length > 1) {

--- a/core/src/commands/update-remote/actions.ts
+++ b/core/src/commands/update-remote/actions.ts
@@ -104,9 +104,12 @@ export async function updateRemoteActions({
       .filter((a) => a.hasRemoteSource())
       .sort()
 
-    throw new ParameterError(`Expected action(s) ${chalk.underline(diff.join(","))} to have a remote source.`, {
-      actionsWithRemoteSource,
-      input: keys ? keys.sort() : undefined,
+    throw new ParameterError({
+      message: `Expected action(s) ${chalk.underline(diff.join(","))} to have a remote source.`,
+      detail: {
+        actionsWithRemoteSource,
+        input: keys ? keys.sort() : undefined,
+      },
     })
   }
 

--- a/core/src/commands/update-remote/modules.ts
+++ b/core/src/commands/update-remote/modules.ts
@@ -100,9 +100,12 @@ export async function updateRemoteModules({
   if (diff.length > 0) {
     const modulesWithRemoteSource = graph.getModules().filter(moduleHasRemoteSource).sort()
 
-    throw new ParameterError(`Expected module(s) ${chalk.underline(diff.join(","))} to have a remote source.`, {
-      modulesWithRemoteSource,
-      input: moduleNames ? moduleNames.sort() : undefined,
+    throw new ParameterError({
+      message: `Expected module(s) ${chalk.underline(diff.join(","))} to have a remote source.`,
+      detail: {
+        modulesWithRemoteSource,
+        input: moduleNames ? moduleNames.sort() : undefined,
+      },
     })
   }
 

--- a/core/src/commands/update-remote/sources.ts
+++ b/core/src/commands/update-remote/sources.ts
@@ -93,13 +93,15 @@ export async function updateRemoteSources({
   // TODO: Make external modules a cli type to avoid validation repetition
   const diff = difference(sources, names)
   if (diff.length > 0) {
-    throw new ParameterError(
-      `Expected source(s) ${chalk.underline(diff.join(","))} to be specified in the project garden.yml config.`,
-      {
+    throw new ParameterError({
+      message: `Expected source(s) ${chalk.underline(
+        diff.join(",")
+      )} to be specified in the project garden.yml config.`,
+      detail: {
         remoteSources: projectSources.map((s) => s.name).sort(),
         input: sources ? sources.sort() : undefined,
-      }
-    )
+      },
+    })
   }
 
   const promises: Promise<void>[] = []

--- a/core/src/commands/util/fetch-tools.ts
+++ b/core/src/commands/util/fetch-tools.ts
@@ -64,10 +64,10 @@ export class FetchToolsCommand extends Command<{}, FetchToolsOpts> {
       const projectRoot = await findProjectConfig({ log, path: garden.projectRoot })
 
       if (!projectRoot) {
-        throw new RuntimeError(
-          `Could not find project config in the current directory, or anywhere above. Please use the --all parameter if you'd like to fetch tools for all registered providers.`,
-          { root: garden.projectRoot }
-        )
+        throw new RuntimeError({
+          message: `Could not find project config in the current directory, or anywhere above. Please use the --all parameter if you'd like to fetch tools for all registered providers.`,
+          detail: { root: garden.projectRoot },
+        })
       }
 
       if (garden instanceof DummyGarden) {

--- a/core/src/commands/util/mutagen.ts
+++ b/core/src/commands/util/mutagen.ts
@@ -41,10 +41,10 @@ export class MutagenCommand extends Command<{}, {}> {
     const projectRoot = await findProjectConfig({ log, path: garden.projectRoot })
 
     if (!projectRoot) {
-      throw new RuntimeError(
-        `Could not find project config in the current directory, or anywhere above. Please run this command within a Garden project directory.`,
-        { root: garden.projectRoot }
-      )
+      throw new RuntimeError({
+        message: `Could not find project config in the current directory, or anywhere above. Please run this command within a Garden project directory.`,
+        detail: { root: garden.projectRoot },
+      })
     }
 
     const mutagenDir = join(projectRoot.path, DEFAULT_GARDEN_DIR_NAME, MUTAGEN_DIR_NAME)

--- a/core/src/config-store/base.ts
+++ b/core/src/config-store/base.ts
@@ -95,10 +95,12 @@ export abstract class ConfigStore<T extends z.ZodObject<any>> {
       const record = config[section]?.[key]
 
       if (!record) {
-        throw new InternalError(
-          `The config store does not contain a record for key '${String(section)}.${String(key)}. Cannot update.'`,
-          { section, key, value }
-        )
+        throw new InternalError({
+          message: `The config store does not contain a record for key '${String(section)}.${String(
+            key
+          )}. Cannot update.'`,
+          detail: { section, key, value },
+        })
       }
 
       if (value) {
@@ -142,14 +144,14 @@ export abstract class ConfigStore<T extends z.ZodObject<any>> {
       return this.schema.parse(data)
     } catch (error) {
       const configPath = this.getConfigPath()
-      throw new InternalError(
-        `Validation error(s) when ${context} configuration file at ${configPath}:\n${dump(error.message)}`,
-        {
+      throw new InternalError({
+        message: `Validation error(s) when ${context} configuration file at ${configPath}:\n${dump(error.message)}`,
+        detail: {
           error,
           configPath,
           data,
-        }
-      )
+        },
+      })
     }
   }
 

--- a/core/src/config/common.ts
+++ b/core/src/config/common.ts
@@ -514,10 +514,10 @@ const actionRefParseError = (reference: any) => {
 
   const refStr = JSON.stringify(reference)
 
-  return new ConfigurationError(
-    `Could not parse ${refStr} as a valid action reference. An action reference should be a "<kind>.<name>" string, where <kind> is one of ${validActionKinds} and <name> is a valid name of an action. You may also specify an object with separate kind and name fields.`,
-    { reference }
-  )
+  return new ConfigurationError({
+    message: `Could not parse ${refStr} as a valid action reference. An action reference should be a "<kind>.<name>" string, where <kind> is one of ${validActionKinds} and <name> is a valid name of an action. You may also specify an object with separate kind and name fields.`,
+    detail: { reference },
+  })
 }
 
 interface SchemaKeys {
@@ -559,7 +559,7 @@ export function createSchema(spec: CreateSchemaParams): CreateSchemaOutput {
   let { name } = spec
 
   if (schemaRegistry[name]) {
-    throw new InternalError(`Object schema ${name} defined multiple times`, { name })
+    throw new InternalError({ message: `Object schema ${name} defined multiple times`, detail: { name } })
   }
 
   schemaRegistry[name] = { spec }

--- a/core/src/config/config-template.ts
+++ b/core/src/config/config-template.ts
@@ -88,22 +88,22 @@ export async function resolveConfigTemplate(
     try {
       inputsJsonSchema = JSON.parse((await readFile(path)).toString())
     } catch (error) {
-      throw new ConfigurationError(
-        `Unable to read inputs schema for ${configTemplateKind} ${validated.name}: ${error}`,
-        {
+      throw new ConfigurationError({
+        message: `Unable to read inputs schema for ${configTemplateKind} ${validated.name}: ${error}`,
+        detail: {
           path,
           error,
-        }
-      )
+        },
+      })
     }
 
     const type = inputsJsonSchema?.type
 
     if (type !== "object") {
-      throw new ConfigurationError(
-        `Inputs schema for ${configTemplateKind} ${validated.name} has type ${type}, but should be "object".`,
-        { path, type }
-      )
+      throw new ConfigurationError({
+        message: `Inputs schema for ${configTemplateKind} ${validated.name} has type ${type}, but should be "object".`,
+        detail: { path, type },
+      })
     }
   }
 

--- a/core/src/config/project.ts
+++ b/core/src/config/project.ts
@@ -423,9 +423,12 @@ export function getDefaultEnvironmentName(defaultName: string, config: ProjectCo
     return environments[0].name
   } else {
     if (!findByName(environments, defaultName)) {
-      throw new ConfigurationError(`The specified default environment ${defaultName} is not defined`, {
-        defaultEnvironment: defaultName,
-        availableEnvironments: getNames(environments),
+      throw new ConfigurationError({
+        message: `The specified default environment ${defaultName} is not defined`,
+        detail: {
+          defaultEnvironment: defaultName,
+          availableEnvironments: getNames(environments),
+        },
       })
     }
     return defaultName
@@ -583,17 +586,17 @@ export const pickEnvironment = profileAsync(async function _pickEnvironment({
   if (!environmentConfig) {
     const definedEnvironments = getNames(environments)
 
-    throw new ParameterError(
-      `Project ${projectName} does not specify environment ${environment} (found ${naturalList(
+    throw new ParameterError({
+      message: `Project ${projectName} does not specify environment ${environment} (found ${naturalList(
         definedEnvironments.map((e) => `'${e}'`)
       )})`,
-      {
+      detail: {
         projectName,
         environmentName: environment,
         namespace,
         definedEnvironments,
-      }
-    )
+      },
+    })
   }
 
   const projectVarfileVars = await loadVarfile({
@@ -680,12 +683,12 @@ export function getNamespace(environmentConfig: EnvironmentConfig, namespace: st
     const envHighlight = chalk.white.bold(envName)
     const exampleFlag = chalk.white(`--env=${chalk.bold("some-namespace.")}${envName}`)
 
-    throw new ParameterError(
-      `Environment ${envHighlight} has defaultNamespace set to null, and no explicit namespace was specified. Please either set a defaultNamespace or explicitly set a namespace at runtime (e.g. ${exampleFlag}).`,
-      {
+    throw new ParameterError({
+      message: `Environment ${envHighlight} has defaultNamespace set to null, and no explicit namespace was specified. Please either set a defaultNamespace or explicitly set a namespace at runtime (e.g. ${exampleFlag}).`,
+      detail: {
         environmentConfig,
-      }
-    )
+      },
+    })
   }
 
   return namespace
@@ -695,7 +698,10 @@ export function parseEnvironment(env: string): ParsedEnvironment {
   const result = joi.environment().validate(env, { errors: { label: false } })
 
   if (result.error) {
-    throw new ValidationError(`Invalid environment specified (${env}): ${result.error.message}`, { env })
+    throw new ValidationError({
+      message: `Invalid environment specified (${env}): ${result.error.message}`,
+      detail: { env },
+    })
   }
 
   // Note: This is validated above to be either one or two parts

--- a/core/src/config/provider.ts
+++ b/core/src/config/provider.ts
@@ -181,13 +181,13 @@ export function getProviderTemplateReferences(config: GenericProviderConfig) {
     if (key[0] === "providers") {
       const providerName = key[1] as string
       if (!providerName) {
-        throw new ConfigurationError(
-          deline`
+        throw new ConfigurationError({
+          message: deline`
           Invalid template key '${key.join(".")}' in configuration for provider '${config.name}'. You must
           specify a provider name as well (e.g. \${providers.my-provider}).
         `,
-          { config, key: key.join(".") }
-        )
+          detail: { config, key: key.join(".") },
+        })
       }
       deps.push(providerName)
     }

--- a/core/src/config/template-contexts/base.ts
+++ b/core/src/config/template-contexts/base.ts
@@ -95,14 +95,14 @@ export abstract class ConfigContext {
     opts.stack = [...(opts.stack || [])]
 
     if (opts.stack.includes(fullPath)) {
-      throw new ConfigurationError(
-        `Circular reference detected when resolving key ${path} (${opts.stack.join(" -> ")})`,
-        {
+      throw new ConfigurationError({
+        message: `Circular reference detected when resolving key ${path} (${opts.stack.join(" -> ")})`,
+        detail: {
           nodePath,
           fullPath,
           opts,
-        }
-      )
+        },
+      })
     }
 
     // keep track of which resolvers have been called, in order to detect circular references
@@ -125,11 +125,14 @@ export abstract class ConfigContext {
       if (typeof nextKey === "string" && nextKey.startsWith("_")) {
         value = undefined
       } else if (isPrimitive(value)) {
-        throw new ConfigurationError(`Attempted to look up key ${JSON.stringify(nextKey)} on a ${typeof value}.`, {
-          value,
-          nodePath,
-          fullPath,
-          opts,
+        throw new ConfigurationError({
+          message: `Attempted to look up key ${JSON.stringify(nextKey)} on a ${typeof value}.`,
+          detail: {
+            value,
+            nodePath,
+            fullPath,
+            opts,
+          },
         })
       } else if (value instanceof Map) {
         available = [...value.keys()]
@@ -142,14 +145,14 @@ export abstract class ConfigContext {
       if (typeof value === "function") {
         // call the function to resolve the value, then continue
         if (opts.stack.includes(stackEntry)) {
-          throw new ConfigurationError(
-            `Circular reference detected when resolving key ${stackEntry} (from ${opts.stack.join(" -> ")})`,
-            {
+          throw new ConfigurationError({
+            message: `Circular reference detected when resolving key ${stackEntry} (from ${opts.stack.join(" -> ")})`,
+            detail: {
               nodePath,
               fullPath,
               opts,
-            }
-          )
+            },
+          })
         }
 
         opts.stack.push(stackEntry)
@@ -202,16 +205,22 @@ export abstract class ConfigContext {
       if (this._alwaysAllowPartial) {
         // We use a separate exception type when contexts are specifically indicating that unresolvable keys should
         // be passed through. This is caught in the template parser code.
-        throw new TemplateStringPassthroughException(message, {
-          nodePath,
-          fullPath,
-          opts,
+        throw new TemplateStringPassthroughException({
+          message,
+          detail: {
+            nodePath,
+            fullPath,
+            opts,
+          },
         })
       } else if (opts.allowPartial) {
-        throw new TemplateStringMissingKeyException(message, {
-          nodePath,
-          fullPath,
-          opts,
+        throw new TemplateStringMissingKeyException({
+          message,
+          detail: {
+            nodePath,
+            fullPath,
+            opts,
+          },
         })
       } else {
         // Otherwise we return the undefined value, so that any logical expressions can be evaluated appropriately.
@@ -300,7 +309,7 @@ export class ErrorContext extends ConfigContext {
   }
 
   resolve({}): ContextResolveOutput {
-    throw new ConfigurationError(this.message, {})
+    throw new ConfigurationError({ message: this.message, detail: {} })
   }
 }
 

--- a/core/src/config/validation.ts
+++ b/core/src/config/validation.ts
@@ -141,12 +141,15 @@ export const validateSchema = profile(function $validateSchema<T>(
       errorDescription += `. Available keys: ${Object.keys(schema.describe().keys).join(", ")})`
     }
 
-    throw new ErrorClass(`${msgPrefix}: ${errorDescription}`, {
-      value,
-      context,
-      schemaMetadata,
-      errorDescription,
-      errorDetails,
+    throw new ErrorClass({
+      message: `${msgPrefix}: ${errorDescription}`,
+      detail: {
+        value,
+        context,
+        schemaMetadata,
+        errorDescription,
+        errorDetails,
+      },
     })
   }
 

--- a/core/src/config/workflow.ts
+++ b/core/src/config/workflow.ts
@@ -441,7 +441,7 @@ function validateTriggers(config: WorkflowConfig, environmentConfigs: Environmen
       ${environmentNames.join(", ")}
     `
 
-    throw new ConfigurationError(msg, { invalidTriggers })
+    throw new ConfigurationError({ message: msg, detail: { invalidTriggers } })
   }
 }
 
@@ -452,7 +452,10 @@ export function populateNamespaceForTriggers(config: WorkflowConfig, environment
       trigger.namespace = getNamespace(environmentConfigForTrigger!, trigger.namespace)
     }
   } catch (err) {
-    throw new ConfigurationError(`Invalid namespace in trigger for workflow ${config.name}: ${err.message}`, { err })
+    throw new ConfigurationError({
+      message: `Invalid namespace in trigger for workflow ${config.name}: ${err.message}`,
+      detail: { err },
+    })
   }
 }
 

--- a/core/src/docs/json-schema.ts
+++ b/core/src/docs/json-schema.ts
@@ -43,7 +43,7 @@ export class JsonKeyDescription<T = any> extends BaseKeyDescription<T> {
     this.type = getType(schema)
 
     if (!this.type) {
-      throw new ValidationError(`Missing type property on JSON Schema`, { schema })
+      throw new ValidationError({ message: `Missing type property on JSON Schema`, detail: { schema } })
     }
 
     this.allowedValuesOnly = false

--- a/core/src/docs/template-strings.ts
+++ b/core/src/docs/template-strings.ts
@@ -123,10 +123,10 @@ export function writeTemplateStringReferenceDocs(docsRoot: string) {
         // This implicitly tests the helpers at documentation render time
         if (!example.skipTest && !isEqual(computedOutput, example.output)) {
           const renderedComputed = JSON.stringify(computedOutput)
-          throw new InternalError(
-            `Test failed for ${spec.name} helper. Expected input args ${example.input} to resolve to ${renderedResult}, got ${renderedComputed}`,
-            { spec }
-          )
+          throw new InternalError({
+            message: `Test failed for ${spec.name} helper. Expected input args ${example.input} to resolve to ${renderedResult}, got ${renderedComputed}`,
+            detail: { spec },
+          })
         }
 
         return {

--- a/core/src/exceptions.ts
+++ b/core/src/exceptions.ts
@@ -49,7 +49,7 @@ export abstract class GardenBaseError<D extends object = any> extends Error impl
   constructor({ message, detail, stack, wrappedErrors }: GardenErrorParams<D>) {
     super(message)
     this.detail = detail
-    this.stack = stack
+    this.stack = stack || this.stack
     this.wrappedErrors = wrappedErrors
   }
 

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -86,7 +86,7 @@ export const actionConfigsToGraph = profileAsync(async function actionConfigsToG
 
   function addConfig(config: ActionConfig) {
     if (!actionKinds.includes(config.kind)) {
-      throw new ConfigurationError(`Unknown action kind: ${config.kind}`, { config })
+      throw new ConfigurationError({ message: `Unknown action kind: ${config.kind}`, detail: { config } })
     }
 
     const key = actionReferenceToString(config)
@@ -161,13 +161,14 @@ export const actionConfigsToGraph = profileAsync(async function actionConfigsToG
 
       graph.addAction(action)
     } catch (error) {
-      throw new ConfigurationError(
-        chalk.redBright(
-          `\nError processing config for ${chalk.white.bold(config.kind)} action ${chalk.white.bold(config.name)}:\n`
-        ) + chalk.red(error.message),
-        { config },
-        error
-      )
+      throw new ConfigurationError({
+        message:
+          chalk.redBright(
+            `\nError processing config for ${chalk.white.bold(config.kind)} action ${chalk.white.bold(config.name)}:\n`
+          ) + chalk.red(error.message),
+        detail: { config },
+        wrappedErrors: [error],
+      })
     }
   })
 
@@ -242,24 +243,24 @@ export const actionFromConfig = profileAsync(async function actionFromConfig({
     })
 
     if (availableKinds.length > 0) {
-      throw new ConfigurationError(
-        deline`
+      throw new ConfigurationError({
+        message: deline`
         Unrecognized ${config.type} action of kind ${config.kind} (defined at ${configPath}).
         There are no ${config.type} ${config.kind} actions, did you mean to specify a ${naturalList(availableKinds, {
           trailingWord: "or a",
         })} action(s)?
         `,
-        { config, configuredActionTypes: Object.keys(actionTypes) }
-      )
+        detail: { config, configuredActionTypes: Object.keys(actionTypes) },
+      })
     }
 
-    throw new ConfigurationError(
-      deline`
+    throw new ConfigurationError({
+      message: deline`
       Unrecognized action type '${config.type}' (defined at ${configPath}).
       Are you missing a provider configuration?
       `,
-      { config, configuredActionTypes: Object.keys(actionTypes) }
-    )
+      detail: { config, configuredActionTypes: Object.keys(actionTypes) },
+    })
   }
 
   const dependencies = dependenciesFromActionConfig(log, config, configsByKey, definition, templateContext)
@@ -304,15 +305,15 @@ export const actionFromConfig = profileAsync(async function actionFromConfig({
 })
 
 export function actionNameConflictError(configA: ActionConfig, configB: ActionConfig, rootPath: string) {
-  return new ConfigurationError(
-    dedent`
+  return new ConfigurationError({
+    message: dedent`
     Found two actions of the same name and kind:
       - ${describeActionConfigWithPath(configA, rootPath)}
       - ${describeActionConfigWithPath(configB, rootPath)}
     Please rename one of the two to avoid the conflict.
     `,
-    { configA, configB }
-  )
+    detail: { configA, configB },
+  })
 }
 
 /**
@@ -500,12 +501,12 @@ export const preprocessActionConfig = profileAsync(async function preprocessActi
 
     // Note: This shouldn't happen in normal user flows
     if (!template) {
-      throw new InternalError(
-        `${description} references template '${
+      throw new InternalError({
+        message: `${description} references template '${
           config.internal.templateName
         }' which cannot be found. Available templates: ${naturalList(Object.keys(garden.configTemplates)) || "(none)"}`,
-        { templateName }
-      )
+        detail: { templateName },
+      })
     }
 
     // Validate inputs schema
@@ -570,10 +571,10 @@ export const preprocessActionConfig = profileAsync(async function preprocessActi
   // -> Throw if trying to modify no-template fields
   for (const field of noTemplateFields) {
     if (!isEqual(config[field], updatedConfig[field])) {
-      throw new PluginError(
-        `Configure handler for ${description} attempted to modify the ${field} field, which is not allowed. Please report this as a bug.`,
-        { config, field, original: config[field], modified: updatedConfig[field] }
-      )
+      throw new PluginError({
+        message: `Configure handler for ${description} attempted to modify the ${field} field, which is not allowed. Please report this as a bug.`,
+        detail: { config, field, original: config[field], modified: updatedConfig[field] },
+      })
     }
   }
 
@@ -593,10 +594,10 @@ export const preprocessActionConfig = profileAsync(async function preprocessActi
   try {
     resolveTemplates()
   } catch (error) {
-    throw new ConfigurationError(
-      `Configure handler for ${config.type} ${config.kind} set a templated value on a config field which could not be resolved. This may be a bug in the plugin, please report this. Error: ${error}`,
-      { config, error }
-    )
+    throw new ConfigurationError({
+      message: `Configure handler for ${config.type} ${config.kind} set a templated value on a config field which could not be resolved. This may be a bug in the plugin, please report this. Error: ${error}`,
+      detail: { config, error },
+    })
   }
 
   return { config, supportedModes, templateContext: builtinFieldContext }
@@ -620,7 +621,10 @@ function dependenciesFromActionConfig(
       const { kind, name } = parseActionReference(d)
       return { kind, name, explicit: true, needsExecutedOutputs: false, needsStaticOutputs: false }
     } catch (error) {
-      throw new ValidationError(`Invalid dependency specified: ${error.message}`, { error, config })
+      throw new ValidationError({
+        message: `Invalid dependency specified: ${error.message}`,
+        detail: { error, config },
+      })
     }
   })
 
@@ -636,10 +640,10 @@ function dependenciesFromActionConfig(
       const buildKey = actionReferenceToString(ref)
 
       if (!configsByKey[buildKey]) {
-        throw new ConfigurationError(
-          `${description} references Build ${copyFrom.build} in the \`copyFrom\` field, but no such Build action could be found`,
-          { config, buildName: copyFrom.build }
-        )
+        throw new ConfigurationError({
+          message: `${description} references Build ${copyFrom.build} in the \`copyFrom\` field, but no such Build action could be found`,
+          detail: { config, buildName: copyFrom.build },
+        })
       }
 
       addDep(ref, { explicit: true, needsExecutedOutputs: false, needsStaticOutputs: false })
@@ -650,10 +654,10 @@ function dependenciesFromActionConfig(
     const buildKey = actionReferenceToString(ref)
 
     if (!configsByKey[buildKey]) {
-      throw new ConfigurationError(
-        `${description} references Build ${config.build} in the \`build\` field, but no such Build action could be found`,
-        { config, buildName: config.build }
-      )
+      throw new ConfigurationError({
+        message: `${description} references Build ${config.build} in the \`build\` field, but no such Build action could be found`,
+        detail: { config, buildName: config.build },
+      })
     }
 
     addDep(ref, { explicit: true, needsExecutedOutputs: false, needsStaticOutputs: false })

--- a/core/src/graph/common.ts
+++ b/core/src/graph/common.ts
@@ -62,7 +62,7 @@ export class DependencyGraph<T> extends DepGraph<T> {
       const cycles = this.detectMinimalCircularDependencies()
       const description = cyclesToString(cycles)
       const errMsg = `\nCircular dependencies detected: \n\n${description}\n`
-      throw new ConfigurationError(errMsg, { "circular-dependencies": description, cycles })
+      throw new ConfigurationError({ message: errMsg, detail: { "circular-dependencies": description, cycles } })
     }
   }
 

--- a/core/src/graph/config-graph.ts
+++ b/core/src/graph/config-graph.ts
@@ -180,14 +180,20 @@ export abstract class BaseConfigGraph<
     const action = this.actions[kind][name]
 
     if (!action) {
-      throw new GraphError(`Could not find ${kind} action ${name}.`, {
-        available: this.getNamesByKind(),
+      throw new GraphError({
+        message: `Could not find ${kind} action ${name}.`,
+        detail: {
+          available: this.getNamesByKind(),
+        },
       })
     }
 
     if (action.isDisabled() && !opts.includeDisabled) {
-      throw new GraphError(`${action.longDescription()} is disabled.`, {
-        config: action.getConfig(),
+      throw new GraphError({
+        message: `${action.longDescription()} is disabled.`,
+        detail: {
+          config: action.getConfig(),
+        },
       })
     }
 
@@ -242,9 +248,12 @@ export abstract class BaseConfigGraph<
     if (!ignoreMissing && names && names.length > found.length) {
       const missing = difference(names, foundNames)
 
-      throw new GraphError(`Could not find one or more ${kind} actions: ${naturalList(missing)}`, {
-        names,
-        missing,
+      throw new GraphError({
+        message: `Could not find one or more ${kind} actions: ${naturalList(missing)}`,
+        detail: {
+          names,
+          missing,
+        },
       })
     }
 
@@ -287,7 +296,10 @@ export abstract class BaseConfigGraph<
     const group = this.groups[name]
 
     if (!group) {
-      throw new GraphError(`Could not find Group ${name}`, { availableGroups: Object.keys(this.groups) })
+      throw new GraphError({
+        message: `Could not find Group ${name}`,
+        detail: { availableGroups: Object.keys(this.groups) },
+      })
     }
 
     return group

--- a/core/src/graph/modules.ts
+++ b/core/src/graph/modules.ts
@@ -110,16 +110,16 @@ export class ModuleGraph {
         if (this.serviceConfigs[serviceName]) {
           const [moduleA, moduleB] = [moduleKey, this.serviceConfigs[serviceName].moduleKey].sort()
 
-          throw new ConfigurationError(
-            deline`
+          throw new ConfigurationError({
+            message: deline`
             Service names must be unique - the service name '${serviceName}' is declared multiple times
             (in modules '${moduleA}' and '${moduleB}')`,
-            {
+            detail: {
               serviceName,
               moduleA,
               moduleB,
-            }
-          )
+            },
+          })
         }
 
         // Make sure service source modules are added as build dependencies for the module
@@ -145,16 +145,16 @@ export class ModuleGraph {
         if (this.taskConfigs[taskName]) {
           const [moduleA, moduleB] = [moduleKey, this.taskConfigs[taskName].moduleKey].sort()
 
-          throw new ConfigurationError(
-            deline`
+          throw new ConfigurationError({
+            message: deline`
             Task names must be unique - the task name '${taskName}' is declared multiple times (in modules
             '${moduleA}' and '${moduleB}')`,
-            {
+            detail: {
               taskName,
               moduleA,
               moduleB,
-            }
-          )
+            },
+          })
         }
 
         this.taskConfigs[taskName] = { type: "task", moduleKey, config: taskConfig }
@@ -269,7 +269,7 @@ export class ModuleGraph {
     if (cycles.length > 0) {
       const description = validationGraph.cyclesToString(cycles)
       const errMsg = `\nCircular dependencies detected: \n\n${description}\n`
-      throw new ConfigurationError(errMsg, { "circular-dependencies": description })
+      throw new ConfigurationError({ message: errMsg, detail: { "circular-dependencies": description } })
     }
   }
 
@@ -743,10 +743,13 @@ export function detectMissingDependencies(moduleConfigs: ModuleConfig[]) {
   if (missingDepDescriptions.length > 0) {
     const errMsg = "Unknown dependencies detected.\n\n" + indentString(missingDepDescriptions.join("\n\n"), 2) + "\n"
 
-    throw new ConfigurationError(errMsg, {
-      unknownDependencies: missingDepDescriptions,
-      availableModules: Array.from(moduleNames),
-      availableServicesAndTasks: Array.from(runtimeNames),
+    throw new ConfigurationError({
+      message: errMsg,
+      detail: {
+        unknownDependencies: missingDepDescriptions,
+        availableModules: Array.from(moduleNames),
+        availableServicesAndTasks: Array.from(runtimeNames),
+      },
     })
   }
 }
@@ -765,14 +768,14 @@ function parseTestKey(key: string) {
 }
 
 function serviceTaskConflict(conflictingName: string, moduleWithTask: string, moduleWithService: string) {
-  return new ConfigurationError(
-    deline`
+  return new ConfigurationError({
+    message: deline`
     Service and task names must be mutually unique - the name '${conflictingName}' is used for a task in
     '${moduleWithTask}' and for a service in '${moduleWithService}'`,
-    {
+    detail: {
       conflictingName,
       moduleWithTask,
       moduleWithService,
-    }
-  )
+    },
+  })
 }

--- a/core/src/graph/nodes.ts
+++ b/core/src/graph/nodes.ts
@@ -260,8 +260,11 @@ export class ProcessTaskNode<T extends Task = Task> extends TaskNode<T> {
     const statusResult = this.getDependencyResult(statusTask) as GraphResultFromTask<T>
 
     if (statusResult === undefined) {
-      throw new InternalError(`Attempted to execute ${this.describe()} before resolving status.`, {
-        nodeKey: this.getKey(),
+      throw new InternalError({
+        message: `Attempted to execute ${this.describe()} before resolving status.`,
+        detail: {
+          nodeKey: this.getKey(),
+        },
       })
     }
 
@@ -361,7 +364,7 @@ export class GraphNodeError extends GardenBaseError<GraphNodeErrorDetail> {
           nextDep = null
         } else if (result?.aborted) {
           message += chalk.yellow(`\n↳ ${nextDep.describe()} [ABORTED]`)
-          if (result.error instanceof GraphNodeError && result.error.detail.failedDependency) {
+          if (result.error instanceof GraphNodeError && result.error.detail?.failedDependency) {
             nextDep = result.error.detail.failedDependency
           } else {
             nextDep = null
@@ -375,10 +378,10 @@ export class GraphNodeError extends GardenBaseError<GraphNodeErrorDetail> {
       message = `${node.describe()} failed: ${error}`
     }
 
-    super(message, params)
+    super({ message, detail: params })
   }
 
   aborted() {
-    return this.detail.aborted
+    return this.detail?.aborted
   }
 }

--- a/core/src/graph/results.ts
+++ b/core/src/graph/results.ts
@@ -109,13 +109,13 @@ export class GraphResults<B extends Task = Task> {
   private checkKey(key: string) {
     if (!this.tasks.has(key)) {
       const taskKeys = Array.from(this.tasks.keys())
-      throw new InternalError(
-        `GraphResults object does not have task ${key}. Available keys: [${taskKeys.join(", ")}]`,
-        {
+      throw new InternalError({
+        message: `GraphResults object does not have task ${key}. Available keys: [${taskKeys.join(", ")}]`,
+        detail: {
           key,
           taskKeys,
-        }
-      )
+        },
+      })
     }
   }
 }
@@ -217,7 +217,7 @@ function filterResultForExport(result: any) {
       "success",
       "exitCode",
       "startedAt",
-      "completedAt",
+      "completedAt"
     ),
     detail: filteredDetail,
   }

--- a/core/src/graph/solver.ts
+++ b/core/src/graph/solver.ts
@@ -138,7 +138,12 @@ export class GraphSolver extends TypedEventEmitter<SolverEvents> {
           results.setResult(request.task, result)
 
           if (throwOnError && result.error) {
-            cleanup({ error: new GraphError(`Failed to ${result.description}: ${result.error}`, { results }) })
+            cleanup({
+              error: new GraphError({
+                message: `Failed to ${result.description}: ${result.error}`,
+                detail: { results },
+              }),
+            })
             return
           }
 
@@ -167,7 +172,7 @@ export class GraphSolver extends TypedEventEmitter<SolverEvents> {
               msg += `\n ↳ ${r.description}: ${r?.error ? r.error.message : "[ABORTED]"}`
             }
 
-            error = new GraphError(msg, { results })
+            error = new GraphError({ message: msg, detail: { results } })
           }
 
           cleanup({ error: null })
@@ -495,7 +500,7 @@ export class GraphSolver extends TypedEventEmitter<SolverEvents> {
     const msg = renderMessageWithDivider({
       prefix: errMessagePrefix,
       msg: errorMessage,
-      isError: true
+      isError: true,
     })
     log.error({ msg, error, showDuration: false })
     const divider = renderDivider()

--- a/core/src/logger/logger.ts
+++ b/core/src/logger/logger.ts
@@ -51,10 +51,10 @@ export function parseLogLevel(level: string): LogLevel {
     lvl = LogLevel[level]
   }
   if (!getNumericLogLevels().includes(lvl)) {
-    throw new InternalError(
-      `Unexpected log level, expected one of ${getLogLevelChoices().join(", ")}, got ${level}`,
-      {}
-    )
+    throw new InternalError({
+      message: `Unexpected log level, expected one of ${getLogLevelChoices().join(", ")}, got ${level}`,
+      detail: {},
+    })
   }
   return lvl
 }
@@ -293,7 +293,7 @@ export abstract class LoggerBase implements Logger {
    */
   getLogEntries(): LogEntry[] {
     if (!this.storeEntries) {
-      throw new InternalError(`Cannot get entries when storeEntries=false`, {})
+      throw new InternalError({ message: `Cannot get entries when storeEntries=false`, detail: {} })
     }
     return this.entries
   }
@@ -305,7 +305,7 @@ export abstract class LoggerBase implements Logger {
    */
   getLatestEntry() {
     if (!this.storeEntries) {
-      throw new InternalError(`Cannot get entries when storeEntries=false`, {})
+      throw new InternalError({ message: `Cannot get entries when storeEntries=false`, detail: {} })
     }
     return this.entries.slice(-1)[0]
   }
@@ -341,7 +341,7 @@ export class RootLogger extends LoggerBase {
    */
   static getInstance() {
     if (!RootLogger.instance) {
-      throw new InternalError("Logger not initialized", {})
+      throw new InternalError({ message: "Logger not initialized", detail: {} })
     }
     return RootLogger.instance
   }
@@ -362,7 +362,7 @@ export class RootLogger extends LoggerBase {
       try {
         config.level = parseLogLevel(gardenEnv.GARDEN_LOG_LEVEL)
       } catch (err) {
-        throw new CommandError(`Invalid log level set for GARDEN_LOG_LEVEL: ${err.message}`, {})
+        throw new CommandError({ message: `Invalid log level set for GARDEN_LOG_LEVEL: ${err.message}`, detail: {} })
       }
     }
 
@@ -371,9 +371,12 @@ export class RootLogger extends LoggerBase {
       const loggerTypeFromEnv = <LoggerType>gardenEnv.GARDEN_LOGGER_TYPE
 
       if (!LOGGER_TYPES.has(loggerTypeFromEnv)) {
-        throw new ParameterError(`Invalid logger type specified: ${loggerTypeFromEnv}`, {
-          loggerType: gardenEnv.GARDEN_LOGGER_TYPE,
-          availableTypes: LOGGER_TYPES,
+        throw new ParameterError({
+          message: `Invalid logger type specified: ${loggerTypeFromEnv}`,
+          detail: {
+            loggerType: gardenEnv.GARDEN_LOGGER_TYPE,
+            availableTypes: LOGGER_TYPES,
+          },
         })
       }
 
@@ -475,7 +478,6 @@ export class ServerLogger extends LoggerBase {
 }
 
 export class VoidLogger extends LoggerBase {
-
   log() {
     // No op
   }

--- a/core/src/logger/writers/file-writer.ts
+++ b/core/src/logger/writers/file-writer.ts
@@ -67,7 +67,10 @@ export class FileWriter extends Writer {
   static async factory(config: FileWriterConfig) {
     const { logFilePath, truncatePrevious } = config
     if (!isAbsolute(logFilePath)) {
-      throw new InternalError(`FileWriter expected absolute log file path, got ${logFilePath}`, { logFilePath })
+      throw new InternalError({
+        message: `FileWriter expected absolute log file path, got ${logFilePath}`,
+        detail: { logFilePath },
+      })
     }
     await ensureDir(dirname(logFilePath))
     if (truncatePrevious) {

--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -797,11 +797,17 @@ export function parseSyncListResult(res: ExecaReturnValue): SyncSession[] {
   try {
     parsed = JSON.parse(res.stdout)
   } catch (err) {
-    throw new MutagenError(`Could not parse response from mutagen sync list: ${res.stdout}`, { res })
+    throw new MutagenError({
+      message: `Could not parse response from mutagen sync list: ${res.stdout}`,
+      detail: { res },
+    })
   }
 
   if (!Array.isArray(parsed)) {
-    throw new MutagenError(`Unexpected response from mutagen sync list: ${parsed}`, { res, parsed })
+    throw new MutagenError({
+      message: `Unexpected response from mutagen sync list: ${parsed}`,
+      detail: { res, parsed },
+    })
   }
 
   return parsed
@@ -817,8 +823,7 @@ export const mutagenCliSpec: PluginToolSpec = {
     {
       platform: "darwin",
       architecture: "amd64",
-      url:
-        "https://github.com/garden-io/mutagen/releases/download/v0.15.0-garden-1/mutagen_darwin_amd64_v0.15.0.tar.gz",
+      url: "https://github.com/garden-io/mutagen/releases/download/v0.15.0-garden-1/mutagen_darwin_amd64_v0.15.0.tar.gz",
       sha256: "370bf71e28f94002453921fda83282280162df7192bd07042bf622bf54507e3f",
       extract: {
         format: "tar",
@@ -828,8 +833,7 @@ export const mutagenCliSpec: PluginToolSpec = {
     {
       platform: "darwin",
       architecture: "arm64",
-      url:
-        "https://github.com/garden-io/mutagen/releases/download/v0.15.0-garden-1/mutagen_darwin_arm64_v0.15.0.tar.gz",
+      url: "https://github.com/garden-io/mutagen/releases/download/v0.15.0-garden-1/mutagen_darwin_arm64_v0.15.0.tar.gz",
       sha256: "a0a7be8bb37266ea184cb580004e1741a17c8165b2032ce4b191f23fead821a0",
       extract: {
         format: "tar",

--- a/core/src/plugin/sdk.ts
+++ b/core/src/plugin/sdk.ts
@@ -309,10 +309,10 @@ function createProvider<
   const baseKeys = Object.keys(baseProviderConfigSchemaZod.shape)
   for (const key of Object.keys(configSchema.shape)) {
     if (baseKeys.includes(key)) {
-      throw new ValidationError(
-        `Attempted to re-define built-in provider config field '${key}'. Built-in fields may not be overridden.`,
-        { key }
-      )
+      throw new ValidationError({
+        message: `Attempted to re-define built-in provider config field '${key}'. Built-in fields may not be overridden.`,
+        detail: { key },
+      })
     }
   }
 

--- a/core/src/plugins/container/build.ts
+++ b/core/src/plugins/container/build.ts
@@ -42,13 +42,13 @@ export const buildContainer: BuildActionHandler<"build", ContainerBuildAction> =
 
   // make sure we can build the thing
   if (!hasDockerfile) {
-    throw new ConfigurationError(
-      dedent`
+    throw new ConfigurationError({
+      message: dedent`
       Dockerfile not found at ${spec.dockerfile || defaultDockerfileName} for build ${action.name}.
       Please make sure the file exists, and is not excluded by include/exclude fields or .gardenignore files.
     `,
-      { spec }
-    )
+      detail: { spec },
+    })
   }
 
   const outputs = action.getOutputs()

--- a/core/src/plugins/container/container.ts
+++ b/core/src/plugins/container/container.ts
@@ -67,9 +67,12 @@ export async function configureContainerModule({ log, moduleConfig }: ConfigureM
       const ingressPort = ingress.port
 
       if (!portsByName[ingressPort]) {
-        throw new ConfigurationError(`Service ${name} does not define port ${ingressPort} defined in ingress`, {
-          definedPorts,
-          ingressPort,
+        throw new ConfigurationError({
+          message: `Service ${name} does not define port ${ingressPort} defined in ingress`,
+          detail: {
+            definedPorts,
+            ingressPort,
+          },
         })
       }
     }
@@ -78,10 +81,10 @@ export async function configureContainerModule({ log, moduleConfig }: ConfigureM
       const healthCheckHttpPort = spec.healthCheck.httpGet.port
 
       if (!portsByName[healthCheckHttpPort]) {
-        throw new ConfigurationError(
-          `Service ${name} does not define port ${healthCheckHttpPort} defined in httpGet health check`,
-          { definedPorts, healthCheckHttpPort }
-        )
+        throw new ConfigurationError({
+          message: `Service ${name} does not define port ${healthCheckHttpPort} defined in httpGet health check`,
+          detail: { definedPorts, healthCheckHttpPort },
+        })
       }
     }
 
@@ -89,10 +92,10 @@ export async function configureContainerModule({ log, moduleConfig }: ConfigureM
       const healthCheckTcpPort = spec.healthCheck.tcpPort
 
       if (!portsByName[healthCheckTcpPort]) {
-        throw new ConfigurationError(
-          `Service ${name} does not define port ${healthCheckTcpPort} defined in tcpPort health check`,
-          { definedPorts, healthCheckTcpPort }
-        )
+        throw new ConfigurationError({
+          message: `Service ${name} does not define port ${healthCheckTcpPort} defined in tcpPort health check`,
+          detail: { definedPorts, healthCheckTcpPort },
+        })
       }
     }
 
@@ -425,13 +428,13 @@ export const gardenPlugin = () =>
                 const ingressPort = ingress.port
 
                 if (!portsByName[ingressPort]) {
-                  throw new ConfigurationError(
-                    `${action.longDescription()} does not define port ${ingressPort} defined in ingress`,
-                    {
+                  throw new ConfigurationError({
+                    message: `${action.longDescription()} does not define port ${ingressPort} defined in ingress`,
+                    detail: {
                       definedPorts,
                       ingressPort,
-                    }
-                  )
+                    },
+                  })
                 }
               }
 
@@ -439,10 +442,10 @@ export const gardenPlugin = () =>
                 const healthCheckHttpPort = spec.healthCheck.httpGet.port
 
                 if (!portsByName[healthCheckHttpPort]) {
-                  throw new ConfigurationError(
-                    `${action.longDescription()} does not define port ${healthCheckHttpPort} defined in httpGet health check`,
-                    { definedPorts, healthCheckHttpPort }
-                  )
+                  throw new ConfigurationError({
+                    message: `${action.longDescription()} does not define port ${healthCheckHttpPort} defined in httpGet health check`,
+                    detail: { definedPorts, healthCheckHttpPort },
+                  })
                 }
               }
 
@@ -450,10 +453,10 @@ export const gardenPlugin = () =>
                 const healthCheckTcpPort = spec.healthCheck.tcpPort
 
                 if (!portsByName[healthCheckTcpPort]) {
-                  throw new ConfigurationError(
-                    `${action.longDescription()} does not define port ${healthCheckTcpPort} defined in tcpPort health check`,
-                    { definedPorts, healthCheckTcpPort }
-                  )
+                  throw new ConfigurationError({
+                    message: `${action.longDescription()} does not define port ${healthCheckTcpPort} defined in tcpPort health check`,
+                    detail: { definedPorts, healthCheckTcpPort },
+                  })
                 }
               }
 
@@ -593,37 +596,40 @@ function validateRuntimeCommon(action: Resolved<ContainerRuntimeAction>) {
   const { image, volumes } = action.getSpec()
 
   if (!build && !image) {
-    throw new ConfigurationError(`${action.longDescription()} must specify one of \`build\` or \`spec.image\``, {
-      actionKey: action.key(),
+    throw new ConfigurationError({
+      message: `${action.longDescription()} must specify one of \`build\` or \`spec.image\``,
+      detail: {
+        actionKey: action.key(),
+      },
     })
   } else if (build && image) {
-    throw new ConfigurationError(
-      `${action.longDescription()} specifies both \`build\` and \`spec.image\`. Only one may be specified.`,
-      {
+    throw new ConfigurationError({
+      message: `${action.longDescription()} specifies both \`build\` and \`spec.image\`. Only one may be specified.`,
+      detail: {
         actionKey: action.key(),
-      }
-    )
+      },
+    })
   } else if (build) {
     const buildAction = action.getDependency({ kind: "Build", name: build }, { includeDisabled: true })
     if (buildAction && !buildAction?.isCompatible("container")) {
-      throw new ConfigurationError(
-        `${action.longDescription()} build field must specify a container Build, or a compatible type.`,
-        {
+      throw new ConfigurationError({
+        message: `${action.longDescription()} build field must specify a container Build, or a compatible type.`,
+        detail: {
           actionKey: action.key(),
           buildActionName: build,
-        }
-      )
+        },
+      })
     }
   }
 
   for (const volume of volumes) {
     if (volume.action && !action.hasDependency(volume.action)) {
-      throw new ConfigurationError(
-        `${action.longDescription()} references action ${
+      throw new ConfigurationError({
+        message: `${action.longDescription()} references action ${
           volume.action
         } under \`spec.volumes\` but does not declare a dependency on it. Please add an explicit dependency on the volume action.`,
-        { volume }
-      )
+        detail: { volume },
+      })
     }
   }
 }

--- a/core/src/plugins/container/helpers.ts
+++ b/core/src/plugins/container/helpers.ts
@@ -170,8 +170,11 @@ const helpers = {
       // Otherwise, return the configured image ID.
       return moduleConfig.spec.image
     } else {
-      throw new ConfigurationError(`Module ${moduleConfig.name} neither specifies image nor provides Dockerfile`, {
-        spec: moduleConfig.spec,
+      throw new ConfigurationError({
+        message: `Module ${moduleConfig.name} neither specifies image nor provides Dockerfile`,
+        detail: {
+          spec: moduleConfig.spec,
+        },
       })
     }
   },
@@ -216,8 +219,11 @@ const helpers = {
         tag,
       }
     } else {
-      throw new ConfigurationError(`Invalid container image tag: ${imageId}`, {
-        imageId,
+      throw new ConfigurationError({
+        message: `Invalid container image tag: ${imageId}`,
+        detail: {
+          imageId,
+        },
       })
     }
   },
@@ -261,8 +267,11 @@ const helpers = {
       const output = res.stdout.trim()
 
       if (!output) {
-        throw new RuntimeError(`Unexpected docker version output: ${res.all.trim()}`, {
-          output,
+        throw new RuntimeError({
+          message: `Unexpected docker version output: ${res.all.trim()}`,
+          detail: {
+            output,
+          },
         })
       }
 
@@ -277,14 +286,14 @@ const helpers = {
    */
   checkDockerServerVersion(version: DockerVersion) {
     if (!version.server) {
-      throw new RuntimeError(`Docker server is not running or cannot be reached.`, version)
+      throw new RuntimeError({ message: `Docker server is not running or cannot be reached.`, detail: version })
     } else if (!checkMinDockerVersion(version.server, minDockerVersion.server!)) {
-      throw new RuntimeError(
-        `Docker server needs to be version ${minDockerVersion.server} or newer (got ${version.server})`,
-        {
+      throw new RuntimeError({
+        message: `Docker server needs to be version ${minDockerVersion.server} or newer (got ${version.server})`,
+        detail: {
           ...version,
-        }
-      )
+        },
+      })
     }
   },
 
@@ -322,10 +331,13 @@ const helpers = {
       })
       return res
     } catch (err) {
-      throw new RuntimeError(`Unable to run docker command: ${err.message}`, {
-        err,
-        args,
-        cwd,
+      throw new RuntimeError({
+        message: `Unable to run docker command: ${err.message}`,
+        detail: {
+          err,
+          args,
+          cwd,
+        },
       })
     }
   },

--- a/core/src/plugins/exec/deploy.ts
+++ b/core/src/plugins/exec/deploy.ts
@@ -279,8 +279,8 @@ export async function deployPersistentExecService({
           }
         }
 
-        throw new TimeoutError(
-          dedent`Timed out waiting for local service ${deployName} to be ready.
+        throw new TimeoutError({
+          message: dedent`Timed out waiting for local service ${deployName} to be ready.
 
           Garden timed out waiting for the command ${chalk.gray(spec.statusCommand)}
           to return status code 0 (success) after waiting for ${spec.statusTimeout} seconds.
@@ -292,13 +292,13 @@ export async function deployPersistentExecService({
           In case the service just needs more time to become ready, you can adjust the ${chalk.gray("timeout")} value
           in your service definition to a value that is greater than the time needed for your service to become ready.
           `,
-          {
+          detail: {
             deployName,
             statusCommand: spec.statusCommand,
             pid: proc.pid,
             statusTimeout: spec.statusTimeout,
-          }
-        )
+          },
+        })
       }
 
       const result = await execRunCommand({

--- a/core/src/plugins/exec/exec.ts
+++ b/core/src/plugins/exec/exec.ts
@@ -105,10 +105,13 @@ execProvider.addHandler("prepareEnvironment", async ({ ctx, log }) => {
         throw error
       }
 
-      throw new RuntimeError(`exec provider init script exited with code ${error.exitCode}`, {
-        exitCode: error.exitCode,
-        stdout: error.stdout,
-        stderr: error.stderr,
+      throw new RuntimeError({
+        message: `exec provider init script exited with code ${error.exitCode}`,
+        detail: {
+          exitCode: error.exitCode,
+          stdout: error.stdout,
+          stderr: error.stderr,
+        },
       })
     }
   }

--- a/core/src/plugins/exec/moduleConfig.ts
+++ b/core/src/plugins/exec/moduleConfig.ts
@@ -61,17 +61,17 @@ export async function configureExecModule({
       .filter((d) => !!d.copy)
       .map((d) => d.name)
       .join(", ")
-    throw new ConfigurationError(
-      dedent`
+    throw new ConfigurationError({
+      message: dedent`
       Invalid exec module configuration: Module ${moduleConfig.name} copies ${buildDependenciesWithCopySpec}
 
       A local exec module cannot have a build dependency with a copy spec.
     `,
-      {
+      detail: {
         buildDependenciesWithCopySpec,
         buildConfig: moduleConfig.build,
-      }
-    )
+      },
+    })
   }
 
   // All the config keys that affect the build version

--- a/core/src/plugins/hadolint/hadolint.ts
+++ b/core/src/plugins/hadolint/hadolint.ts
@@ -264,10 +264,10 @@ hadolintTest.addHandler("configure", async ({ ctx, config }) => {
     try {
       dockerfilePath = ctx.resolveTemplateStrings(dockerfilePath)
     } catch (error) {
-      throw new ConfigurationError(
-        `The spec.dockerfilePath field contains a template string which could not be resolved. Note that some template variables are not available for the field. Error: ${error}`,
-        { config, error }
-      )
+      throw new ConfigurationError({
+        message: `The spec.dockerfilePath field contains a template string which could not be resolved. Note that some template variables are not available for the field. Error: ${error}`,
+        detail: { config, error },
+      })
     }
     config.include.push(dockerfilePath)
   }
@@ -284,9 +284,12 @@ hadolintTest.addHandler("run", async ({ ctx, log, action }) => {
   try {
     dockerfile = (await readFile(dockerfilePath)).toString()
   } catch {
-    throw new ConfigurationError(`hadolint: Could not find Dockerfile at ${spec.dockerfilePath}`, {
-      actionPath: action.basePath(),
-      ...spec,
+    throw new ConfigurationError({
+      message: `hadolint: Could not find Dockerfile at ${spec.dockerfilePath}`,
+      detail: {
+        actionPath: action.basePath(),
+        ...spec,
+      },
     })
   }
 

--- a/core/src/plugins/kubernetes/api.ts
+++ b/core/src/plugins/kubernetes/api.ts
@@ -193,9 +193,12 @@ export class KubeApi {
     const cluster = this.config.getCurrentCluster()
 
     if (!cluster) {
-      throw new ConfigurationError(`Could not read cluster from kubeconfig for context ${context}`, {
-        context,
-        config,
+      throw new ConfigurationError({
+        message: `Could not read cluster from kubeconfig for context ${context}`,
+        detail: {
+          context,
+          config,
+        },
       })
     }
 
@@ -263,9 +266,12 @@ export class KubeApi {
     const group = apiInfo.groupMap[apiVersion]
 
     if (!group) {
-      throw new KubernetesError(`Unrecognized apiVersion: ${apiVersion}`, {
-        apiVersion,
-        resource,
+      throw new KubernetesError({
+        message: `Unrecognized apiVersion: ${apiVersion}`,
+        detail: {
+          apiVersion,
+          resource,
+        },
       })
     }
 
@@ -540,9 +546,12 @@ export class KubeApi {
     const resourceInfo = await this.getApiResourceInfo(log, apiVersion, kind)
 
     if (!resourceInfo) {
-      const err = new KubernetesError(`Unrecognized resource type ${apiVersion}/${kind}`, {
-        apiVersion,
-        kind,
+      const err = new KubernetesError({
+        message: `Unrecognized resource type ${apiVersion}/${kind}`,
+        detail: {
+          apiVersion,
+          kind,
+        },
       })
       err.statusCode = 404
       throw err
@@ -567,8 +576,11 @@ export class KubeApi {
     const apiVersion = manifest.apiVersion
 
     if (!apiVersion) {
-      throw new KubernetesError(`Missing apiVersion on resource`, {
-        manifest,
+      throw new KubernetesError({
+        message: `Missing apiVersion on resource`,
+        detail: {
+          manifest,
+        },
       })
     }
 
@@ -577,8 +589,11 @@ export class KubeApi {
     }
 
     if (!namespace) {
-      throw new KubernetesError(`Missing namespace on resource and no namespace specified`, {
-        manifest,
+      throw new KubernetesError({
+        message: `Missing namespace on resource and no namespace specified`,
+        detail: {
+          manifest,
+        },
       })
     }
 
@@ -861,7 +876,10 @@ export class KubeApi {
             return
           }
 
-          throw new KubernetesError(`Failed to create Pod ${pod.metadata.name}: ${error.message}`, { error })
+          throw new KubernetesError({
+            message: `Failed to create Pod ${pod.metadata.name}: ${error.message}`,
+            detail: { error },
+          })
         },
       }
     )
@@ -932,8 +950,11 @@ export async function getKubeConfig(log: Log, ctx: PluginContext, provider: Kube
     }
     return load(kubeConfigStr)!
   } catch (error) {
-    throw new RuntimeError(`Unable to load kubeconfig: ${error}`, {
-      error,
+    throw new RuntimeError({
+      message: `Unable to load kubeconfig: ${error}`,
+      detail: {
+        error,
+      },
     })
   }
 }
@@ -967,9 +988,12 @@ function wrapError(name: string, err: any) {
   if (!err.message || err.name === "HttpError") {
     const response = err.response || {}
     const body = response.body || err.body
-    const wrapped = new KubernetesError(`Got error from Kubernetes API (${name}) - ${body.message}`, {
-      body,
-      request: omitBy(response.request, (v, k) => isObject(v) || k[0] === "_"),
+    const wrapped = new KubernetesError({
+      message: `Got error from Kubernetes API (${name}) - ${body.message}`,
+      detail: {
+        body,
+        request: omitBy(response.request, (v, k) => isObject(v) || k[0] === "_"),
+      },
     })
     wrapped.statusCode = err.statusCode
     return wrapped
@@ -980,8 +1004,11 @@ function wrapError(name: string, err: any) {
 
 function handleRequestPromiseError(name: string, err: Error) {
   if (err instanceof requestErrors.StatusCodeError) {
-    const wrapped = new KubernetesError(`StatusCodeError from Kubernetes API (${name}) - ${err.message}`, {
-      body: err.error,
+    const wrapped = new KubernetesError({
+      message: `StatusCodeError from Kubernetes API (${name}) - ${err.message}`,
+      detail: {
+        body: err.error,
+      },
     })
     wrapped.statusCode = err.statusCode
 
@@ -1090,5 +1117,5 @@ const errorMessageRegexesForRetry = [
   // This can happen if etcd is overloaded
   // (rpc error: code = ResourceExhausted desc = etcdserver: throttle: too many requests)
   /too many requests/,
-  /Unable to connect to the server/
+  /Unable to connect to the server/,
 ]

--- a/core/src/plugins/kubernetes/commands/pull-image.ts
+++ b/core/src/plugins/kubernetes/commands/pull-image.ts
@@ -41,16 +41,22 @@ export const pullImage: PluginCommand = {
     const provider = k8sCtx.provider
 
     if (provider.config.buildMode === "local-docker") {
-      throw new PluginError(`Cannot pull images with buildMode=local-docker`, {
-        provider,
+      throw new PluginError({
+        message: `Cannot pull images with buildMode=local-docker`,
+        detail: {
+          provider,
+        },
       })
     }
 
     const buildsToPull = graph.getBuilds({ names: args.length > 0 ? args : undefined }).filter((b) => {
       const valid = b.isCompatible("container")
       if (!valid && args.includes(b.name)) {
-        throw new ParameterError(chalk.red(`Build ${chalk.white(b.name)} is not a container build.`), {
-          name: b.name,
+        throw new ParameterError({
+          message: chalk.red(`Build ${chalk.white(b.name)} is not a container build.`),
+          detail: {
+            name: b.name,
+          },
         })
       }
       return valid
@@ -189,10 +195,13 @@ async function pullFromExternalRegistry({ ctx, log, localId, remoteId }: PullPar
     log.debug(`Loading image to local docker with ID ${localId}`)
     await loadImage({ ctx, runner, log })
   } catch (err) {
-    throw new RuntimeError(`Failed pulling image ${remoteId}: ${err.message}`, {
-      err,
-      remoteId,
-      localId,
+    throw new RuntimeError({
+      message: `Failed pulling image ${remoteId}: ${err.message}`,
+      detail: {
+        err,
+        remoteId,
+        localId,
+      },
     })
   } finally {
     await runner.stop()

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -184,7 +184,10 @@ export async function skopeoBuildStatus({
 
   if (!deploymentRegistry) {
     // This is validated in the provider configure handler, so this is an internal error if it happens
-    throw new InternalError(`Expected configured deploymentRegistry for remote build`, { config: provider.config })
+    throw new InternalError({
+      message: `Expected configured deploymentRegistry for remote build`,
+      detail: { config: provider.config },
+    })
   }
 
   const outputs = k8sGetContainerBuildActionOutputs({ action, provider })
@@ -230,9 +233,12 @@ export async function skopeoBuildStatus({
     if (res.exitCode !== 0 && !skopeoManifestUnknown(res.stderr)) {
       const output = res.allLogs || err.message
 
-      throw new RuntimeError(`Unable to query registry for image status: ${output}`, {
-        command: skopeoCommand,
-        output,
+      throw new RuntimeError({
+        message: `Unable to query registry for image status: ${output}`,
+        detail: {
+          command: skopeoCommand,
+          output,
+        },
       })
     }
     return { state: "unknown", outputs, detail: {} }

--- a/core/src/plugins/kubernetes/container/build/kaniko.ts
+++ b/core/src/plugins/kubernetes/container/build/kaniko.ts
@@ -7,7 +7,12 @@
  */
 
 import { V1PodSpec } from "@kubernetes/client-node"
-import { skopeoDaemonContainerName, dockerAuthSecretKey, k8sUtilImageName, defaultKanikoImageName } from "../../constants"
+import {
+  skopeoDaemonContainerName,
+  dockerAuthSecretKey,
+  k8sUtilImageName,
+  defaultKanikoImageName,
+} from "../../constants"
 import { KubeApi } from "../../api"
 import { Log } from "../../../../logger/log-entry"
 import { KubernetesProvider, KubernetesPluginContext } from "../../config"
@@ -159,7 +164,10 @@ export const kanikoBuild: BuildHandler = async (params) => {
   const buildLog = buildRes.log
 
   if (kanikoBuildFailed(buildRes)) {
-    throw new BuildError(`Failed building ${chalk.bold(action.name)}:\n\n${buildLog}`, { buildLog })
+    throw new BuildError({
+      message: `Failed building ${chalk.bold(action.name)}:\n\n${buildLog}`,
+      detail: { buildLog },
+    })
   }
 
   log.silly(buildLog)
@@ -183,7 +191,7 @@ export const getKanikoFlags = (flags?: string[], topLevelFlags?: string[]): stri
   const flagToKey = (flag: string) => {
     const found = flag.match(/--([a-zA-Z]*)/)
     if (found === null) {
-      throw new ConfigurationError(`Invalid format for a kaniko flag`, { flag })
+      throw new ConfigurationError({ message: `Invalid format for a kaniko flag`, detail: { flag } })
     }
     return found[0]
   }

--- a/core/src/plugins/kubernetes/container/deployment.ts
+++ b/core/src/plugins/kubernetes/container/deployment.ts
@@ -615,12 +615,12 @@ export function configureVolumes(
       const volumeAction = action.getDependency(volume.action)
 
       if (!volumeAction) {
-        throw new ConfigurationError(
-          `${action.longDescription()} specifies action '${
+        throw new ConfigurationError({
+          message: `${action.longDescription()} specifies action '${
             volume.action.name
           }' on volume '${volumeName}' but the Deploy action could not be found. Please make sure it is specified as a dependency on the action.`,
-          { volume }
-        )
+          detail: { volume },
+        })
       }
 
       if (volumeAction.isCompatible("persistentvolumeclaim")) {
@@ -638,13 +638,13 @@ export function configureVolumes(
           },
         })
       } else {
-        throw new ConfigurationError(
-          chalk.red(deline`${action.longDescription()} specifies a unsupported config
+        throw new ConfigurationError({
+          message: chalk.red(deline`${action.longDescription()} specifies a unsupported config
           ${chalk.white(volumeAction.name)} for volume mount ${chalk.white(volumeName)}. Only \`persistentvolumeclaim\`
           and \`configmap\` action are supported at this time.
           `),
-          { volumeSpec: volume }
-        )
+          detail: { volumeSpec: volume },
+        })
       }
     } else {
       volumes.push({
@@ -705,16 +705,16 @@ export async function handleChangedSelector({
     "spec.selector"
   )} and needs to be deleted before redeploying.`
   if (production && !force) {
-    throw new DeploymentError(
-      `${msgPrefix} Since this environment has production = true, Garden won't automatically delete this resource. To do so, use the ${chalk.white(
+    throw new DeploymentError({
+      message: `${msgPrefix} Since this environment has production = true, Garden won't automatically delete this resource. To do so, use the ${chalk.white(
         "--force"
       )} flag when deploying e.g. with the ${chalk.white(
         "garden deploy"
       )} command. You can also delete the resource from your cluster manually and try again.`,
-      {
+      detail: {
         deployName: action.name,
-      }
-    )
+      },
+    })
   } else {
     if (production && force) {
       log.warn(

--- a/core/src/plugins/kubernetes/container/exec.ts
+++ b/core/src/plugins/kubernetes/container/exec.ts
@@ -28,9 +28,12 @@ export const execInContainer: DeployActionHandler<"exec", ContainerDeployAction>
 
   // TODO: this check should probably live outside of the plugin
   if (!status.detail?.detail.workload || !includes(["ready", "outdated"], status.detail?.state)) {
-    throw new DeploymentError(`${action.longDescription()} is not running`, {
-      name: action.name,
-      state: status.state,
+    throw new DeploymentError({
+      message: `${action.longDescription()} is not running`,
+      detail: {
+        name: action.name,
+        state: status.state,
+      },
     })
   }
 

--- a/core/src/plugins/kubernetes/container/handlers.ts
+++ b/core/src/plugins/kubernetes/container/handlers.ts
@@ -99,14 +99,15 @@ export function validateDeploySpec(
     const hostname = ingressSpec.hostname || provider.config.defaultHostname
 
     if (!hostname) {
-      throw new ConfigurationError(
-        `No hostname configured for one of the ingresses on service/deploy ${name}. ` +
+      throw new ConfigurationError({
+        message:
+          `No hostname configured for one of the ingresses on service/deploy ${name}. ` +
           `Please configure a default hostname or specify a hostname for the ingress.`,
-        {
+        detail: {
           name,
           ingressSpec,
-        }
-      )
+        },
+      })
     }
 
     // make sure the hostname is set

--- a/core/src/plugins/kubernetes/container/util.ts
+++ b/core/src/plugins/kubernetes/container/util.ts
@@ -45,8 +45,11 @@ export function getDeployedImageId(action: Resolved<ContainerRuntimeAction>, pro
       provider.config.deploymentRegistry
     )
   } else {
-    throw new ConfigurationError(`${action.longDescription()} specifies neither a \`build\` nor \`spec.image\``, {
-      config: action.getConfig(),
+    throw new ConfigurationError({
+      message: `${action.longDescription()} specifies neither a \`build\` nor \`spec.image\``,
+      detail: {
+        config: action.getConfig(),
+      },
     })
   }
 }

--- a/core/src/plugins/kubernetes/helm/common.ts
+++ b/core/src/plugins/kubernetes/helm/common.ts
@@ -144,8 +144,11 @@ export async function prepareTemplates({ ctx, action, log }: PrepareTemplatesPar
     }
   } else {
     // This will generally be caught at schema validation
-    throw new ConfigurationError(`${action.longDescription()} specifies none of chart.name, chart.path nor chart.url`, {
-      chartSpec: chart,
+    throw new ConfigurationError({
+      message: `${action.longDescription()} specifies none of chart.name, chart.path nor chart.url`,
+      detail: {
+        chartSpec: chart,
+      },
     })
   }
 
@@ -217,19 +220,19 @@ export function getBaseModule(module: HelmModule): HelmModule | undefined {
   const baseModule = module.buildDependencies[module.spec.base]
 
   if (!baseModule) {
-    throw new PluginError(
-      deline`Helm module '${module.name}' references base module '${module.spec.base}'
+    throw new PluginError({
+      message: deline`Helm module '${module.name}' references base module '${module.spec.base}'
       but it is missing from the module's build dependencies.`,
-      { moduleName: module.name, baseModuleName: module.spec.base }
-    )
+      detail: { moduleName: module.name, baseModuleName: module.spec.base },
+    })
   }
 
   if (baseModule.type !== "helm") {
-    throw new ConfigurationError(
-      deline`Helm module '${module.name}' references base module '${module.spec.base}'
+    throw new ConfigurationError({
+      message: deline`Helm module '${module.name}' references base module '${module.spec.base}'
       which is a '${baseModule.type}' module, but should be a helm module.`,
-      { moduleName: module.name, baseModuleName: module.spec.base, baseModuleType: baseModule.type }
-    )
+      detail: { moduleName: module.name, baseModuleName: module.spec.base, baseModuleType: baseModule.type },
+    })
   }
 
   return baseModule
@@ -248,10 +251,10 @@ export async function getChartPath(action: Resolved<HelmRuntimeAction>) {
   if (chartSpec.path) {
     // Path is explicitly specified
     if (!chartExists) {
-      throw new ConfigurationError(
-        `${action.longDescription()} has explicitly set \`chart.path\` but no ${helmChartYamlFilename} file can be found in directory '${chartDir}.`,
-        { spec: action.getSpec() }
-      )
+      throw new ConfigurationError({
+        message: `${action.longDescription()} has explicitly set \`chart.path\` but no ${helmChartYamlFilename} file can be found in directory '${chartDir}.`,
+        detail: { spec: action.getSpec() },
+      })
     }
     return chartDir
   } else if (chartSpec.name || chartSpec.url) {
@@ -261,10 +264,10 @@ export async function getChartPath(action: Resolved<HelmRuntimeAction>) {
     // Chart exists at the module build path
     return chartDir
   } else {
-    throw new ConfigurationError(
-      `${action.longDescription()} has explicitly set \`chart.path\` but no ${helmChartYamlFilename} file can be found in directory '${chartDir}.`,
-      { spec: action.getSpec() }
-    )
+    throw new ConfigurationError({
+      message: `${action.longDescription()} has explicitly set \`chart.path\` but no ${helmChartYamlFilename} file can be found in directory '${chartDir}.`,
+      detail: { spec: action.getSpec() },
+    })
   }
 }
 
@@ -322,10 +325,10 @@ export async function renderHelmTemplateString({
 }): Promise<string> {
   // TODO: see if we can lift this limitation
   if (!chartPath) {
-    throw new ConfigurationError(
-      `Referencing Helm template strings is currently only supported for local Helm charts`,
-      {}
-    )
+    throw new ConfigurationError({
+      message: `Referencing Helm template strings is currently only supported for local Helm charts`,
+      detail: {},
+    })
   }
 
   const relPath = join("templates", cryptoRandomString({ length: 16 }) + ".yaml")

--- a/core/src/plugins/kubernetes/helm/exec.ts
+++ b/core/src/plugins/kubernetes/helm/exec.ts
@@ -26,14 +26,14 @@ export const execInHelmDeploy: DeployActionHandler<"exec", HelmDeployAction> = a
   const defaultTarget = action.getSpec("defaultTarget")
 
   if (!defaultTarget) {
-    throw new ConfigurationError(
-      `${action.longDescription()} does not specify a defaultTarget. Please configure this in order to be able to use this command with. This is currently necessary for the ${chalk.white(
+    throw new ConfigurationError({
+      message: `${action.longDescription()} does not specify a defaultTarget. Please configure this in order to be able to use this command with. This is currently necessary for the ${chalk.white(
         "exec"
       )} command to work with helm Deploy actions.`,
-      {
+      detail: {
         name: action.name,
-      }
-    )
+      },
+    })
   }
 
   const status = await getHelmDeployStatus({
@@ -60,9 +60,12 @@ export const execInHelmDeploy: DeployActionHandler<"exec", HelmDeployAction> = a
 
   // TODO: this check should probably live outside of the plugin
   if (!target || !includes(["ready", "outdated"], status.detail?.state)) {
-    throw new DeploymentError(`${action.longDescription()} is not running`, {
-      name: action.name,
-      state: status.detail?.state || status.state,
+    throw new DeploymentError({
+      message: `${action.longDescription()} is not running`,
+      detail: {
+        name: action.name,
+        state: status.detail?.state || status.state,
+      },
     })
   }
 

--- a/core/src/plugins/kubernetes/helm/helm-pod.ts
+++ b/core/src/plugins/kubernetes/helm/helm-pod.ts
@@ -139,7 +139,10 @@ export async function runOrTestWithChart(
 
   if (!resourceSpec) {
     // Note: This will generally be caught in schema validation.
-    throw new ConfigurationError(`${action.longDescription()} specified neither podSpec nor resource.`, { spec })
+    throw new ConfigurationError({
+      message: `${action.longDescription()} specified neither podSpec nor resource.`,
+      detail: { spec },
+    })
   }
   const k8sCtx = <KubernetesPluginContext>ctx
   const preparedTemplates = await prepareTemplates({

--- a/core/src/plugins/kubernetes/helm/module-config.ts
+++ b/core/src/plugins/kubernetes/helm/module-config.ts
@@ -215,14 +215,14 @@ export async function configureHelmModule({
 
   if (base) {
     if (containsSources) {
-      throw new ConfigurationError(
-        deline`
+      throw new ConfigurationError({
+        message: deline`
         Helm module '${moduleConfig.name}' both contains sources and specifies a base module.
         Since Helm charts cannot currently be merged, please either remove the sources or
         the \`base\` reference in your module config.
       `,
-        { moduleConfig }
-      )
+        detail: { moduleConfig },
+      })
     }
 
     // We copy the chart on build

--- a/core/src/plugins/kubernetes/jib-container.ts
+++ b/core/src/plugins/kubernetes/jib-container.ts
@@ -74,7 +74,10 @@ async function buildAndPushViaRemote(params: BuildActionParams<"build", Containe
   const { tarPath } = baseResult.details
 
   if (!tarPath) {
-    throw new PluginError(`Expected details.tarPath from the jib-container build handler.`, { baseResult })
+    throw new PluginError({
+      message: `Expected details.tarPath from the jib-container build handler.`,
+      detail: { baseResult },
+    })
   }
 
   // Push to util or buildkit deployment on remote, and push to registry from there to make sure auth/access is
@@ -119,7 +122,7 @@ async function buildAndPushViaRemote(params: BuildActionParams<"build", Containe
       })
       deploymentName = buildkitDeploymentName
     } else {
-      throw new ConfigurationError(`Unexpected buildMode ${buildMode}`, { buildMode })
+      throw new ConfigurationError({ message: `Unexpected buildMode ${buildMode}`, detail: { buildMode } })
     }
 
     // Sync the archive to the remote

--- a/core/src/plugins/kubernetes/kubectl.ts
+++ b/core/src/plugins/kubernetes/kubectl.ts
@@ -217,7 +217,10 @@ class Kubectl extends PluginTool {
       const exists = await pathExists(override)
 
       if (!exists) {
-        throw new ConfigurationError(`Could not find configured kubectlPath: ${override}`, { kubectlPath: override })
+        throw new ConfigurationError({
+          message: `Could not find configured kubectlPath: ${override}`,
+          detail: { kubectlPath: override },
+        })
       }
 
       return override

--- a/core/src/plugins/kubernetes/kubernetes-type/common.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/common.ts
@@ -59,8 +59,11 @@ export async function getManifests({
         // at least the first manifest has a kind: seems to be a valid List
         return manifest.items as KubernetesResource[]
       } else {
-        throw new PluginError("Failed to read Kubernetes manifest: Encountered an invalid List manifest", {
-          manifest,
+        throw new PluginError({
+          message: "Failed to read Kubernetes manifest: Encountered an invalid List manifest",
+          detail: {
+            manifest,
+          },
         })
       }
     }
@@ -144,13 +147,13 @@ export async function readManifests(
 
     for (const arg of disallowedKustomizeArgs) {
       if (extraArgs.includes(arg)) {
-        throw new ConfigurationError(
-          `kustomize.extraArgs must not include any of ${disallowedKustomizeArgs.join(", ")}`,
-          {
+        throw new ConfigurationError({
+          message: `kustomize.extraArgs must not include any of ${disallowedKustomizeArgs.join(", ")}`,
+          detail: {
             spec,
             extraArgs,
-          }
-        )
+          },
+        })
       }
     }
 
@@ -162,9 +165,12 @@ export async function readManifests(
       })
       kustomizeManifests = loadAll(kustomizeOutput)
     } catch (error) {
-      throw new PluginError(`Failed resolving kustomize manifests: ${error.message}`, {
-        error,
-        spec,
+      throw new PluginError({
+        message: `Failed resolving kustomize manifests: ${error.message}`,
+        detail: {
+          error,
+          spec,
+        },
       })
     }
   }
@@ -182,7 +188,7 @@ export function gardenNamespaceAnnotationValue(namespaceName: string) {
 
 export function convertServiceResource(
   module: KubernetesModule | HelmModule,
-  serviceResourceSpec?: ServiceResourceSpec,
+  serviceResourceSpec?: ServiceResourceSpec
 ): KubernetesTargetResourceSpec | null {
   const s = serviceResourceSpec || module.spec.serviceResource
 
@@ -219,7 +225,10 @@ export async function runOrTestWithPod(
 
     if (!resourceSpec) {
       // Note: This will generally be caught in schema validation.
-      throw new ConfigurationError(`${action.longDescription()} specified neither podSpec nor resource.`, { spec })
+      throw new ConfigurationError({
+        message: `${action.longDescription()} specified neither podSpec nor resource.`,
+        detail: { spec },
+      })
     }
     const k8sCtx = <KubernetesPluginContext>ctx
     const provider = k8sCtx.provider
@@ -236,10 +245,10 @@ export async function runOrTestWithPod(
     podSpec = getResourcePodSpec(target)
     container = getResourceContainer(target, resourceSpec.containerName)
   } else if (!container) {
-    throw new ConfigurationError(
-      `${action.longDescription()} specified a podSpec without containers. Please make sure there is at least one container in the spec.`,
-      { spec }
-    )
+    throw new ConfigurationError({
+      message: `${action.longDescription()} specified a podSpec without containers. Please make sure there is at least one container in the spec.`,
+      detail: { spec },
+    })
   }
 
   return runAndCopy({

--- a/core/src/plugins/kubernetes/kubernetes-type/deploy.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/deploy.ts
@@ -54,10 +54,10 @@ export const kubernetesDeployDefinition = (): DeployActionDefinition<KubernetesD
         try {
           files = ctx.resolveTemplateStrings(files)
         } catch (error) {
-          throw new ConfigurationError(
-            `The spec.files field contains a template string which could not be resolved. Note that some template variables are not available for the field. Error: ${error}`,
-            { config, error }
-          )
+          throw new ConfigurationError({
+            message: `The spec.files field contains a template string which could not be resolved. Note that some template variables are not available for the field. Error: ${error}`,
+            detail: { config, error },
+          })
         }
         config.include = uniq([...config.include, ...files])
       }

--- a/core/src/plugins/kubernetes/kubernetes-type/exec.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/exec.ts
@@ -25,14 +25,14 @@ export const execInKubernetesDeploy: DeployActionHandler<"exec", KubernetesDeplo
   const defaultTarget = action.getSpec("defaultTarget")
 
   if (!defaultTarget) {
-    throw new ConfigurationError(
-      `${action.longDescription()} does not specify a defaultTarget. Please configure this in order to be able to use this command with. This is currently necessary for the ${chalk.white(
+    throw new ConfigurationError({
+      message: `${action.longDescription()} does not specify a defaultTarget. Please configure this in order to be able to use this command with. This is currently necessary for the ${chalk.white(
         "exec"
       )} command to work with kubernetes Deploy actions.`,
-      {
+      detail: {
         name: action.name,
-      }
-    )
+      },
+    })
   }
 
   const status = await getKubernetesDeployStatus({
@@ -55,9 +55,12 @@ export const execInKubernetesDeploy: DeployActionHandler<"exec", KubernetesDeplo
 
   // TODO: this check should probably live outside of the plugin
   if (!target || !includes(["ready", "outdated"], status.detail?.state)) {
-    throw new DeploymentError(`${action.longDescription()} is not running`, {
-      name: action.name,
-      state: status.state,
+    throw new DeploymentError({
+      message: `${action.longDescription()} is not running`,
+      detail: {
+        name: action.name,
+        state: status.state,
+      },
     })
   }
 

--- a/core/src/plugins/kubernetes/kubernetes-type/kubernetes-exec.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/kubernetes-exec.ts
@@ -148,15 +148,15 @@ async function readAndExec({
     })
   } catch (err) {
     if (err.statusCode === 404) {
-      throw new ConfigurationError(
-        chalk.red(
+      throw new ConfigurationError({
+        message: chalk.red(
           deline`${action.longDescription()} specifies target resource ${targetKind}/${targetName}, which could not
           be found in namespace ${namespace}. Hint: This action may be missing a dependency on a Deploy in this
           project that deploys the target resource. If so, adding that dependency will ensure that the Deploy is run
           before this action.`
         ),
-        { resource, namespace }
-      )
+        detail: { resource, namespace },
+      })
     } else {
       throw err
     }

--- a/core/src/plugins/kubernetes/kubernetes.ts
+++ b/core/src/plugins/kubernetes/kubernetes.ts
@@ -78,8 +78,11 @@ export async function configureProvider({
   }
 
   if (config.name !== "local-kubernetes" && !config.deploymentRegistry) {
-    throw new ConfigurationError(`kubernetes: must specify deploymentRegistry in config`, {
-      config,
+    throw new ConfigurationError({
+      message: `kubernetes: must specify deploymentRegistry in config`,
+      detail: {
+        config,
+      },
     })
   }
 

--- a/core/src/plugins/kubernetes/local-mode.ts
+++ b/core/src/plugins/kubernetes/local-mode.ts
@@ -120,7 +120,10 @@ export class KeyPair {
     try {
       return (await readFile(filePath)).toString()
     } catch (err) {
-      throw new ConfigurationError(`Could not read public key file from path ${filePath}; cause: ${err}`, err)
+      throw new ConfigurationError({
+        message: `Could not read public key file from path ${filePath}; cause: ${err}`,
+        detail: err,
+      })
     }
   }
 
@@ -145,7 +148,7 @@ export class ProxySshKeystore {
 
   private constructor() {
     if (!!ProxySshKeystore.instance) {
-      throw new RuntimeError("Cannot init singleton twice, use ProxySshKeystore.getInstance()", {})
+      throw new RuntimeError({ message: "Cannot init singleton twice, use ProxySshKeystore.getInstance()", detail: {} })
     }
     this.serviceKeyPairs = new Map<string, KeyPair>()
     this.localSshPorts = new Set<number>()
@@ -265,7 +268,10 @@ export class LocalModeProcessRegistry {
 
   private constructor() {
     if (!!LocalModeProcessRegistry.instance) {
-      throw new RuntimeError("Cannot init singleton twice, use LocalModeProcessRegistry.getInstance()", {})
+      throw new RuntimeError({
+        message: "Cannot init singleton twice, use LocalModeProcessRegistry.getInstance()",
+        detail: {},
+      })
     }
     this.recoverableProcesses = []
     this.state = "ready"
@@ -308,19 +314,19 @@ export class LocalModeProcessRegistry {
 
 function validateContainerPorts(container: V1Container, spec: ContainerLocalModeSpec): V1ContainerPort[] {
   if (!container.ports || container.ports.length === 0) {
-    throw new ConfigurationError(
-      `Cannot configure the local mode for container ${container.name}: it does not expose any ports.`,
-      { container }
-    )
+    throw new ConfigurationError({
+      message: `Cannot configure the local mode for container ${container.name}: it does not expose any ports.`,
+      detail: { container },
+    })
   }
 
   const remotePorts = new Set<number>(spec.ports.map((p) => p.remote))
   const matchingPorts = container.ports.filter((portSpec) => remotePorts.has(portSpec.containerPort))
   if (!matchingPorts || matchingPorts.length === 0) {
-    throw new ConfigurationError(
-      `Cannot configure the local mode for container ${container.name}: it does not expose any ports that match local mode port-forward configuration.`,
-      { container, remotePorts }
-    )
+    throw new ConfigurationError({
+      message: `Cannot configure the local mode for container ${container.name}: it does not expose any ports that match local mode port-forward configuration.`,
+      detail: { container, remotePorts },
+    })
   }
   return matchingPorts
 }
@@ -820,7 +826,10 @@ export async function startServiceInLocalMode(configParams: StartLocalModeParams
 
   // Validate the target
   if (!isConfiguredForLocalMode(targetResource)) {
-    throw new ConfigurationError(`Resource ${targetResourceId} is not deployed in local mode`, { targetResource })
+    throw new ConfigurationError({
+      message: `Resource ${targetResourceId} is not deployed in local mode`,
+      detail: { targetResource },
+    })
   }
 
   log.info({

--- a/core/src/plugins/kubernetes/local/kind.ts
+++ b/core/src/plugins/kubernetes/local/kind.ts
@@ -73,7 +73,10 @@ export async function loadImageToKind(imageId: string, config: KubernetesConfig,
       await exec("kind", ["load", "docker-image", imageId, `--name=${clusterName}`])
     }
   } catch (err) {
-    throw new RuntimeError(`An attempt to load image ${imageId} into the kind cluster failed: ${err.message}`, { err })
+    throw new RuntimeError({
+      message: `An attempt to load image ${imageId} into the kind cluster failed: ${err.message}`,
+      detail: { err },
+    })
   }
 }
 

--- a/core/src/plugins/kubernetes/local/microk8s.ts
+++ b/core/src/plugins/kubernetes/local/microk8s.ts
@@ -42,9 +42,12 @@ export async function configureMicrok8sAddons(log: Log, addons: string[]) {
   }
 
   if (!status.includes("microk8s is running")) {
-    throw new RuntimeError(`Unable to get microk8s status. Is the cluster installed and running?`, {
-      status,
-      statusCommandResult,
+    throw new RuntimeError({
+      message: `Unable to get microk8s status. Is the cluster installed and running?`,
+      detail: {
+        status,
+        statusCommandResult,
+      },
     })
   }
 
@@ -138,8 +141,11 @@ export async function loadImageToMicrok8s({
       }
     })
   } catch (err) {
-    throw new RuntimeError(`An attempt to load image ${imageId} into the microk8s cluster failed: ${err.message}`, {
-      err,
+    throw new RuntimeError({
+      message: `An attempt to load image ${imageId} into the microk8s cluster failed: ${err.message}`,
+      detail: {
+        err,
+      },
     })
   }
 }

--- a/core/src/plugins/kubernetes/namespace.ts
+++ b/core/src/plugins/kubernetes/namespace.ts
@@ -80,11 +80,11 @@ export async function ensureNamespace(
         if (n.metadata.name === namespace.name) {
           result.remoteResource = n
           if (n.status.phase === "Terminating") {
-            throw new KubernetesError(
-              dedent`Namespace "${n.metadata.name}" is in "Terminating" state so Garden is unable to create it.
+            throw new KubernetesError({
+              message: dedent`Namespace "${n.metadata.name}" is in "Terminating" state so Garden is unable to create it.
             Please try again once the namespace has terminated.`,
-              {}
-            )
+              detail: {},
+            })
           }
         }
       }
@@ -113,10 +113,10 @@ export async function ensureNamespace(
           })
           result.created = true
         } catch (error) {
-          throw new KubernetesError(
-            `Namespace ${namespace.name} doesn't exist and Garden was unable to create it. You may need to create it manually or ask an administrator to do so.`,
-            { error }
-          )
+          throw new KubernetesError({
+            message: `Namespace ${namespace.name} doesn't exist and Garden was unable to create it. You may need to create it manually or ask an administrator to do so.`,
+            detail: { error },
+          })
         }
       } else if (namespaceNeedsUpdate(result.remoteResource, namespace)) {
         // Make sure annotations and labels are set correctly if the namespace already exists
@@ -268,14 +268,14 @@ export async function prepareNamespaces({ ctx, log }: GetEnvironmentStatusParams
   } catch (err) {
     log.error("Error")
 
-    throw new DeploymentError(
-      dedent`
+    throw new DeploymentError({
+      message: dedent`
       Unable to connect to Kubernetes cluster. Got error:
 
       ${err.message}
     `,
-      { providerConfig: k8sCtx.provider.config }
-    )
+      detail: { providerConfig: k8sCtx.provider.config },
+    })
   }
 
   const ns = await getNamespaceStatus({ ctx: k8sCtx, log, provider: k8sCtx.provider })
@@ -314,8 +314,11 @@ export async function deleteNamespaces(namespaces: string[], api: KubeApi, log?:
 
     const now = new Date().getTime()
     if (now - startTime > KUBECTL_DEFAULT_TIMEOUT * 1000) {
-      throw new TimeoutError(`Timed out waiting for namespace ${namespaces.join(", ")} delete to complete`, {
-        namespaces,
+      throw new TimeoutError({
+        message: `Timed out waiting for namespace ${namespaces.join(", ")} delete to complete`,
+        detail: {
+          namespaces,
+        },
       })
     }
   }

--- a/core/src/plugins/kubernetes/port-forward.ts
+++ b/core/src/plugins/kubernetes/port-forward.ts
@@ -134,9 +134,12 @@ export async function getPortForward({
         }
         if (!resolved) {
           reject(
-            new RuntimeError(`Port forward exited with code ${code} before establishing connection:\n\n${output}`, {
-              code,
-              portForward,
+            new RuntimeError({
+              message: `Port forward exited with code ${code} before establishing connection:\n\n${output}`,
+              detail: {
+                code,
+                portForward,
+              },
             })
           )
         }

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -322,15 +322,15 @@ export async function prepareRunPodSpec({
 
   if (getArtifacts) {
     if (!command) {
-      throw new ConfigurationError(
-        deline`
+      throw new ConfigurationError({
+        message: deline`
         ${description} specifies artifacts to export, but doesn't
         explicitly set a \`command\`. The kubernetes provider currently requires an explicit command to be set for
         tests and tasks that export artifacts, because the image's entrypoint cannot be inferred in that execution
         mode. Please set the \`command\` field and try again.
         `,
-        errorMetadata
-      )
+        detail: errorMetadata,
+      })
     }
 
     // We start the container with a named pipe and tail that, to get the logs from the actual command
@@ -552,21 +552,21 @@ async function runWithArtifacts({
         const message = containerStatus?.state?.terminated?.message || containerStatus?.state?.waiting?.message
 
         if (message?.includes("not found")) {
-          throw new ConfigurationError(
-            deline`
+          throw new ConfigurationError({
+            message: deline`
               ${description} specifies artifacts to export, but the image doesn't
               contain the sh binary. In order to copy artifacts out of Kubernetes containers, both sh and tar need to
               be installed in the image.
 
               Original error message:
               ${message}`,
-            errorMetadata
-          )
+            detail: errorMetadata,
+          })
         } else {
-          throw new RuntimeError(
-            `Failed to start Pod ${runner.podName}: ${JSON.stringify(status.resource.status, null, 2)}`,
-            errorMetadata
-          )
+          throw new RuntimeError({
+            message: `Failed to start Pod ${runner.podName}: ${JSON.stringify(status.resource.status, null, 2)}`,
+            detail: errorMetadata,
+          })
         }
       }
     }
@@ -595,13 +595,13 @@ async function runWithArtifacts({
       //   stdout,
       //   stderr,
       // })
-      throw new ConfigurationError(
-        deline`
+      throw new ConfigurationError({
+        message: deline`
         ${description} specifies artifacts to export, but the image doesn't
         contain the tar binary. In order to copy artifacts out of Kubernetes containers, both sh and tar need to
         be installed in the image.`,
-        errorMetadata
-      )
+        detail: errorMetadata,
+      })
     }
 
     // Escape the command, so that we can safely pass it as a single string
@@ -739,7 +739,7 @@ function newExitCodePodRunnerError(podErrorDetails: PodErrorDetails): PodRunnerE
   const errorMessage = !!logs
     ? `Command exited with code ${exitCode}:\n${logs}`
     : `Command exited with code ${exitCode}.`
-  return new PodRunnerError(errorMessage, omit(podErrorDetails, "logs"))
+  return new PodRunnerError({ message: errorMessage, detail: omit(podErrorDetails, "logs") })
 }
 
 interface RunAndWaitResult {
@@ -772,8 +772,11 @@ export class PodRunner extends PodRunnerParams {
     const spec = params.pod.spec
 
     if (!spec.containers || spec.containers.length === 0) {
-      throw new PluginError(`Pod spec for PodRunner must contain at least one container`, {
-        spec,
+      throw new PluginError({
+        message: `Pod spec for PodRunner must contain at least one container`,
+        detail: {
+          spec,
+        },
       })
     }
 
@@ -923,10 +926,11 @@ export class PodRunner extends PodRunnerParams {
           // if the pod has been deleted during execution we might run into a 404 error.
           // Convert it to Garden NotFoundError and fetch the logs for more details.
           if (e.statusCode === 404) {
-            throw new NotFoundError(
-              "Could not find Pod while waiting for it to complete. The Pod might have been evicted or deleted.",
-              await notFoundErrorDetails()
-            )
+            throw new NotFoundError({
+              message:
+                "Could not find Pod while waiting for it to complete. The Pod might have been evicted or deleted.",
+              detail: await notFoundErrorDetails(),
+            })
           }
         }
 
@@ -951,7 +955,7 @@ export class PodRunner extends PodRunnerParams {
       // Garden computes is "stopped". However, in those instances the exitReason is still "OOMKilled"
       // and we handle that case specifically here.
       if (exitCode === 137 || exitReason === "OOMKilled") {
-        throw new OutOfMemoryError("Pod container was OOMKilled.", await podErrorDetails())
+        throw new OutOfMemoryError({ message: "Pod container was OOMKilled.", detail: await podErrorDetails() })
       }
 
       if (state === "unhealthy") {
@@ -969,7 +973,7 @@ export class PodRunner extends PodRunnerParams {
             return exitCode
           }
         } else {
-          throw new PodRunnerError(`Failed to start Pod ${podName}.`, await podErrorDetails())
+          throw new PodRunnerError({ message: `Failed to start Pod ${podName}.`, detail: await podErrorDetails() })
         }
       }
 
@@ -988,7 +992,10 @@ export class PodRunner extends PodRunnerParams {
       const elapsed = (new Date().getTime() - startedAt.getTime()) / 1000
 
       if (timeoutSec && elapsed > timeoutSec) {
-        throw new TimeoutError(`Command timed out after ${timeoutSec} seconds.`, await podErrorDetails())
+        throw new TimeoutError({
+          message: `Command timed out after ${timeoutSec} seconds.`,
+          detail: await podErrorDetails(),
+        })
       }
 
       await sleep(800)
@@ -1061,7 +1068,7 @@ export class PodRunner extends PodRunnerParams {
 
     if (result.timedOut) {
       const errorDetails: PodErrorDetails = { logs: await collectLogs(), result }
-      throw new TimeoutError(`Command timed out after ${timeoutSec} seconds.`, errorDetails)
+      throw new TimeoutError({ message: `Command timed out after ${timeoutSec} seconds.`, detail: errorDetails })
     }
 
     if (result.exitCode === 137) {
@@ -1070,7 +1077,7 @@ export class PodRunner extends PodRunnerParams {
         exitCode: result.exitCode,
         result,
       }
-      throw new OutOfMemoryError("Pod container was OOMKilled.", errorDetails)
+      throw new OutOfMemoryError({ message: "Pod container was OOMKilled.", detail: errorDetails })
     }
 
     // the Pod might have been killed – if the process exits with code zero when
@@ -1108,7 +1115,7 @@ export class PodRunner extends PodRunnerParams {
       some(events, (event) => event.reason === "Killing" && (!event.lastTimestamp || event.lastTimestamp > afterTime))
     ) {
       const details: PodErrorDetails = { podEvents: events }
-      throw new NotFoundError("Pod has been killed or evicted.", details)
+      throw new NotFoundError({ message: "Pod has been killed or evicted.", detail: details })
     }
   }
 
@@ -1187,7 +1194,7 @@ export class PodRunner extends PodRunnerParams {
   }) {
     // Some types and predicates to identify known errors
     const knownErrorTypes = ["out-of-memory", "not-found", "timeout", "pod-runner", "kubernetes"] as const
-    type KnownErrorType = typeof knownErrorTypes[number]
+    type KnownErrorType = (typeof knownErrorTypes)[number]
     // A known error is always an instance of a subclass of GardenBaseError
     type KnownError = Error & {
       message: string

--- a/core/src/plugins/kubernetes/secrets.ts
+++ b/core/src/plugins/kubernetes/secrets.ts
@@ -20,13 +20,14 @@ export async function readSecret(api: KubeApi, secretRef: ProviderSecretRef) {
     return await api.core.readNamespacedSecret(secretRef.name, secretRef.namespace)
   } catch (err) {
     if (err.statusCode === 404) {
-      throw new ConfigurationError(
-        `Could not find secret '${secretRef.name}' in namespace '${secretRef.namespace}'. ` +
+      throw new ConfigurationError({
+        message:
+          `Could not find secret '${secretRef.name}' in namespace '${secretRef.namespace}'. ` +
           `Have you correctly configured your secrets?`,
-        {
+        detail: {
           secretRef,
-        }
-      )
+        },
+      })
     } else {
       throw err
     }

--- a/core/src/plugins/kubernetes/status/service.ts
+++ b/core/src/plugins/kubernetes/status/service.ts
@@ -58,9 +58,12 @@ export async function waitForServiceEndpoints(
       }
 
       if (new Date().getTime() - start > timeout) {
-        throw new TimeoutError(`Timed out waiting for Service '${serviceName}' Endpoints to resolve to correct Pods`, {
-          service,
-          pods,
+        throw new TimeoutError({
+          message: `Timed out waiting for Service '${serviceName}' Endpoints to resolve to correct Pods`,
+          detail: {
+            service,
+            pods,
+          },
         })
       }
 

--- a/core/src/plugins/kubernetes/status/status.ts
+++ b/core/src/plugins/kubernetes/status/status.ts
@@ -246,9 +246,12 @@ export async function waitForResources({
         }
 
         emitLog(msg)
-        throw new DeploymentError(msg, {
-          serviceName: actionName,
-          status,
+        throw new DeploymentError({
+          message: msg,
+          detail: {
+            serviceName: actionName,
+            status,
+          },
         })
       }
 
@@ -277,7 +280,7 @@ export async function waitForResources({
         Timed out waiting for ${actionName || "resources"} to deploy after ${timeoutSec} seconds
       `
       emitLog(deploymentErrMsg)
-      throw new DeploymentError(deploymentErrMsg, { statuses })
+      throw new DeploymentError({ message: deploymentErrMsg, detail: { statuses } })
     }
   }
 

--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -338,13 +338,13 @@ export async function configureSyncMode({
   for (const override of spec.overrides || []) {
     const target = override.target || defaultTarget
     if (!target) {
-      throw new ConfigurationError(
-        dedent`Sync override configuration on ${action.longDescription()} doesn't specify a target, and none is set as a default.
+      throw new ConfigurationError({
+        message: dedent`Sync override configuration on ${action.longDescription()} doesn't specify a target, and none is set as a default.
         Either specify a target via the \`spec.sync.overrides[].target\` or \`spec.defaultTarget\``,
-        {
+        detail: {
           override,
-        }
-      )
+        },
+      })
     }
     if (target.kind && target.name) {
       const key = targetKey(target)
@@ -357,10 +357,10 @@ export async function configureSyncMode({
     const target = sync.target || defaultTarget
 
     if (!target) {
-      throw new ConfigurationError(
-        `Sync configuration on ${action.longDescription()} doesn't specify a target, and none is set as a default.`,
-        { sync }
-      )
+      throw new ConfigurationError({
+        message: `Sync configuration on ${action.longDescription()} doesn't specify a target, and none is set as a default.`,
+        detail: { sync },
+      })
     }
 
     if (target.podSelector) {

--- a/core/src/plugins/kubernetes/system.ts
+++ b/core/src/plugins/kubernetes/system.ts
@@ -135,9 +135,12 @@ export async function prepareSystemServices({
     })
 
     if (error) {
-      throw new PluginError(`${provider.name} — an error occurred when configuring environment:\n${error}`, {
-        error,
-        results,
+      throw new PluginError({
+        message: `${provider.name} — an error occurred when configuring environment:\n${error}`,
+        detail: {
+          error,
+          results,
+        },
       })
     }
   }

--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -108,8 +108,11 @@ export function getSelectorFromResource(resource: KubernetesWorkload): { [key: s
   }
 
   // No selector found.
-  throw new ConfigurationError(`No selector found for ${resource.metadata.name} while retrieving pods.`, {
-    resource,
+  throw new ConfigurationError({
+    message: `No selector found for ${resource.metadata.name} while retrieving pods.`,
+    detail: {
+      resource,
+    },
   })
 }
 
@@ -268,8 +271,11 @@ export async function execInWorkload({
 
   if (!pod) {
     // This should not happen because of the prior status check, but checking to be sure
-    throw new DeploymentError(`Could not find running pod for ${getResourceKey(workload)}`, {
-      workload,
+    throw new DeploymentError({
+      message: `Could not find running pod for ${getResourceKey(workload)}`,
+      detail: {
+        workload,
+      },
     })
   }
 
@@ -395,11 +401,14 @@ export async function upsertConfigMap({
   const serializedData = serializeValues(data)
 
   if (base64(JSON.stringify(serializedData)).length > MAX_CONFIGMAP_DATA_SIZE) {
-    throw new KubernetesError(`Attempting to store too much data in ConfigMap ${key}`, {
-      key,
-      namespace,
-      labels,
-      data,
+    throw new KubernetesError({
+      message: `Attempting to store too much data in ConfigMap ${key}`,
+      detail: {
+        key,
+        namespace,
+        labels,
+        data,
+      },
     })
   }
 
@@ -455,9 +464,12 @@ export function prepareEnvVars(env: ContainerEnvVars): V1EnvVar[] {
         return { name, value: "null" }
       } else if (typeof value === "object") {
         if (!value.secretRef.key) {
-          throw new ConfigurationError(`kubernetes: Must specify \`key\` on secretRef for env variable ${name}`, {
-            name,
-            value,
+          throw new ConfigurationError({
+            message: `kubernetes: Must specify \`key\` on secretRef for env variable ${name}`,
+            detail: {
+              name,
+              value,
+            },
           })
         }
         return {
@@ -491,9 +503,12 @@ export async function getRunningDeploymentPod({
   const pods = await getWorkloadPods(api, namespace, resource)
   const pod = sample(pods.filter((p) => checkPodStatus(p) === "ready"))
   if (!pod) {
-    throw new PluginError(`Could not find a running Pod in Deployment ${deploymentName}`, {
-      deploymentName,
-      namespace,
+    throw new PluginError({
+      message: `Could not find a running Pod in Deployment ${deploymentName}`,
+      detail: {
+        deploymentName,
+        namespace,
+      },
     })
   }
 
@@ -584,13 +599,13 @@ export async function getTargetResource({
     const pod = sample(pods)
     if (!pod) {
       const selectorStr = getSelectorString(query.podSelector)
-      throw new ConfigurationError(
-        chalk.red(
+      throw new ConfigurationError({
+        message: chalk.red(
           `Could not find any Pod matching provided podSelector (${selectorStr}) for target in ` +
             `${action.longDescription()}`
         ),
-        { query }
-      )
+        detail: { query },
+      })
     }
     return pod
   }
@@ -601,7 +616,7 @@ export async function getTargetResource({
 
   if (!targetKind) {
     // This should be caught in config/schema validation
-    throw new InternalError(`Neither kind nor podSelector set in resource query`, { query })
+    throw new InternalError({ message: `Neither kind nor podSelector set in resource query`, detail: { query } })
   }
 
   // Look in the specified manifests, if provided
@@ -628,31 +643,34 @@ export async function getTargetResource({
       target = find(<SyncableResource[]>applicableChartResources, (o) => o.metadata.name === targetName)!
 
       if (!target) {
-        throw new ConfigurationError(
-          chalk.red(
+        throw new ConfigurationError({
+          message: chalk.red(
             deline`${action.longDescription()} does not contain specified ${targetKind}
             ${chalk.white(targetName)}`
           ),
-          { query, chartResourceNames }
-        )
+          detail: { query, chartResourceNames },
+        })
       }
     } else {
       if (applicableChartResources.length === 0) {
-        throw new ConfigurationError(`${action.longDescription()} contains no ${targetKind}s.`, {
-          query,
-          chartResourceNames,
+        throw new ConfigurationError({
+          message: `${action.longDescription()} contains no ${targetKind}s.`,
+          detail: {
+            query,
+            chartResourceNames,
+          },
         })
       }
 
       if (applicableChartResources.length > 1) {
-        throw new ConfigurationError(
-          chalk.red(
+        throw new ConfigurationError({
+          message: chalk.red(
             deline`${action.longDescription()} contains multiple ${targetKind}s.
             You must specify a resource name in the appropriate config in order to identify the correct ${targetKind}
             to use.`
           ),
-          { query, chartResourceNames }
-        )
+          detail: { query, chartResourceNames },
+        })
       }
 
       target = <SyncableResource>applicableChartResources[0]
@@ -667,12 +685,12 @@ export async function getTargetResource({
     return target
   } catch (err) {
     if (err.statusCode === 404) {
-      throw new ConfigurationError(
-        chalk.red(
+      throw new ConfigurationError({
+        message: chalk.red(
           deline`${action.longDescription()} specifies target resource ${targetKind}/${targetName}, which could not be found in namespace ${namespace}.`
         ),
-        { query, namespace }
-      )
+        detail: { query, namespace },
+      })
     } else {
       throw err
     }
@@ -693,7 +711,7 @@ export async function readTargetResource({
 
   if (!targetName) {
     // This should be caught in config/schema validation
-    throw new InternalError(`Must specify name in resource/target query`, { query })
+    throw new InternalError({ message: `Must specify name in resource/target query`, detail: { query } })
   }
 
   if (targetKind === "Deployment") {
@@ -704,7 +722,7 @@ export async function readTargetResource({
     return api.apps.readNamespacedStatefulSet(targetName, namespace)
   } else {
     // This should be caught in config/schema validation
-    throw new InternalError(`Unsupported kind specified in resource/target query`, { query })
+    throw new InternalError({ message: `Unsupported kind specified in resource/target query`, detail: { query } })
   }
 }
 
@@ -719,15 +737,21 @@ export function getResourceContainer(resource: SyncableResource, containerName?:
   const containers = getResourcePodSpec(resource)?.containers || []
 
   if (containers.length === 0) {
-    throw new ConfigurationError(`${kind} ${resource.metadata.name} has no containers configured.`, { resource })
+    throw new ConfigurationError({
+      message: `${kind} ${resource.metadata.name} has no containers configured.`,
+      detail: { resource },
+    })
   }
 
   const container = containerName ? findByName(containers, containerName) : containers[0]
 
   if (!container) {
-    throw new ConfigurationError(`Could not find container '${containerName}' in ${kind} '${name}'`, {
-      resource,
-      containerName,
+    throw new ConfigurationError({
+      message: `Could not find container '${containerName}' in ${kind} '${name}'`,
+      detail: {
+        resource,
+        containerName,
+      },
     })
   }
 
@@ -769,8 +793,11 @@ export function getK8sProvider(providers: ProviderMap): KubernetesProvider {
   const provider = Object.values(providers).find((p) => p.name === "kubernetes" || p.name === "local-kubernetes")
 
   if (!provider) {
-    throw new ConfigurationError(`Could not find a configured kubernetes (or local-kubernetes) provider`, {
-      configuredProviders: Object.keys(providers),
+    throw new ConfigurationError({
+      message: `Could not find a configured kubernetes (or local-kubernetes) provider`,
+      detail: {
+        configuredProviders: Object.keys(providers),
+      },
     })
   }
 

--- a/core/src/router/base.ts
+++ b/core/src/router/base.ts
@@ -228,7 +228,10 @@ export abstract class BaseActionRouter<K extends ActionKind> extends BaseRouter 
 
   async configure({ config, log }: { config: BaseActionConfig; log: Log }) {
     if (config.kind !== this.kind) {
-      throw new InternalError(`Attempted to call ${this.kind} handler for ${config.kind} action`, {})
+      throw new InternalError({
+        message: `Attempted to call ${this.kind} handler for ${config.kind} action`,
+        detail: {},
+      })
     }
 
     // TODO: work out why this cast is needed
@@ -273,7 +276,10 @@ export abstract class BaseActionRouter<K extends ActionKind> extends BaseRouter 
     log.silly(`Getting '${String(handlerType)}' handler for ${action.longDescription()}`)
 
     if (action.kind !== this.kind) {
-      throw new InternalError(`Attempted to call ${this.kind} handler for ${action.kind} action`, {})
+      throw new InternalError({
+        message: `Attempted to call ${this.kind} handler for ${action.kind} action`,
+        detail: {},
+      })
     }
 
     const handler = await this.getHandler({
@@ -361,14 +367,14 @@ export abstract class BaseActionRouter<K extends ActionKind> extends BaseRouter 
       <WrappedActionTypeHandler<ActionTypeClasses<K>[T], any>>(<unknown>(async (...args: any[]) => {
         const result = await handler["apply"](plugin, args)
         if (result === undefined) {
-          throw new PluginError(
-            `Got empty response from ${actionType}.${String(handlerType)} handler on ${pluginName} provider`,
-            {
+          throw new PluginError({
+            message: `Got empty response from ${actionType}.${String(handlerType)} handler on ${pluginName} provider`,
+            detail: {
               args,
               handlerType,
               pluginName,
-            }
-          )
+            },
+          })
         }
         const kind = this.kind
         return validateSchema(result, schema, {
@@ -459,11 +465,12 @@ export abstract class BaseActionRouter<K extends ActionKind> extends BaseRouter 
         }
 
         // This should never happen
-        throw new InternalError(
-          `Unable to find any matching configuration when selecting ${actionType}/${String(handlerType)} handler ` +
+        throw new InternalError({
+          message:
+            `Unable to find any matching configuration when selecting ${actionType}/${String(handlerType)} handler ` +
             `(please report this as a bug).`,
-          { handlers, configs }
-        )
+          detail: { handlers, configs },
+        })
       } else {
         return filtered[0]
       }
@@ -487,16 +494,19 @@ export abstract class BaseActionRouter<K extends ActionKind> extends BaseRouter 
       }
 
       if (pluginName) {
-        throw new PluginError(
-          `Plugin '${pluginName}' does not have a '${String(handlerType)}' handler for action type '${actionType}'.`,
-          errorDetails
-        )
+        throw new PluginError({
+          message: `Plugin '${pluginName}' does not have a '${String(
+            handlerType
+          )}' handler for action type '${actionType}'.`,
+          detail: errorDetails,
+        })
       } else {
-        throw new ParameterError(
-          `No '${String(handlerType)}' handler configured for ${this.kind} type '${actionType}' in environment ` +
+        throw new ParameterError({
+          message:
+            `No '${String(handlerType)}' handler configured for ${this.kind} type '${actionType}' in environment ` +
             `'${this.garden.environmentName}'. Are you missing a provider configuration?`,
-          errorDetails
-        )
+          detail: errorDetails,
+        })
       }
     }
   }

--- a/core/src/router/module.ts
+++ b/core/src/router/module.ts
@@ -181,14 +181,14 @@ export class ModuleRouter extends BaseRouter {
       <WrappedModuleActionHandlers[T]>(async (...args: any[]) => {
         const result = await handler.apply(plugin, args)
         if (result === undefined) {
-          throw new PluginError(
-            `Got empty response from ${moduleType}.${handlerType} handler on ${pluginName} provider`,
-            {
+          throw new PluginError({
+            message: `Got empty response from ${moduleType}.${handlerType} handler on ${pluginName} provider`,
+            detail: {
               args,
               handlerType,
               pluginName,
-            }
-          )
+            },
+          })
         }
         return validateSchema(result, schema, {
           context: `${handlerType} handler output from provider ${pluginName} for module type ${moduleType} `,
@@ -293,11 +293,12 @@ export class ModuleRouter extends BaseRouter {
         }
 
         // This should never happen
-        throw new InternalError(
-          `Unable to find any matching configuration when selecting ${moduleType}/${handlerType} handler ` +
+        throw new InternalError({
+          message:
+            `Unable to find any matching configuration when selecting ${moduleType}/${handlerType} handler ` +
             `(please report this as a bug).`,
-          { handlers, configs }
-        )
+          detail: { handlers, configs },
+        })
       } else {
         return filtered[0]
       }
@@ -318,16 +319,17 @@ export class ModuleRouter extends BaseRouter {
       }
 
       if (pluginName) {
-        throw new PluginError(
-          `Plugin '${pluginName}' does not have a '${handlerType}' handler for module type '${moduleType}'.`,
-          errorDetails
-        )
+        throw new PluginError({
+          message: `Plugin '${pluginName}' does not have a '${handlerType}' handler for module type '${moduleType}'.`,
+          detail: errorDetails,
+        })
       } else {
-        throw new ParameterError(
-          `No '${handlerType}' handler configured for module type '${moduleType}' in environment ` +
+        throw new ParameterError({
+          message:
+            `No '${handlerType}' handler configured for module type '${moduleType}' in environment ` +
             `'${this.garden.environmentName}'. Are you missing a provider configuration?`,
-          errorDetails
-        )
+          detail: errorDetails,
+        })
       }
     }
   }

--- a/core/src/router/provider.ts
+++ b/core/src/router/provider.ts
@@ -241,10 +241,13 @@ export class ProviderRouter extends BaseRouter {
       async (...args: any[]) => {
         const result = await handler.apply(plugin, args)
         if (result === undefined) {
-          throw new PluginError(`Got empty response from ${handlerType} handler on ${pluginName} provider`, {
-            args,
-            handlerType,
-            pluginName,
+          throw new PluginError({
+            message: `Got empty response from ${handlerType} handler on ${pluginName} provider`,
+            detail: {
+              args,
+              handlerType,
+              pluginName,
+            },
           })
         }
         return validateSchema(result, schema, { context: `${handlerType} output from plugin ${pluginName}` })
@@ -309,13 +312,17 @@ export class ProviderRouter extends BaseRouter {
     }
 
     if (pluginName) {
-      throw new PluginError(`Plugin '${pluginName}' does not have a '${handlerType}' handler.`, errorDetails)
+      throw new PluginError({
+        message: `Plugin '${pluginName}' does not have a '${handlerType}' handler.`,
+        detail: errorDetails,
+      })
     } else {
-      throw new ParameterError(
-        `No '${handlerType}' handler configured in environment '${this.garden.environmentName}'. ` +
+      throw new ParameterError({
+        message:
+          `No '${handlerType}' handler configured in environment '${this.garden.environmentName}'. ` +
           `Are you missing a provider configuration?`,
-        errorDetails
-      )
+        detail: errorDetails,
+      })
     }
   }
 }

--- a/core/src/tasks/base.ts
+++ b/core/src/tasks/base.ts
@@ -271,12 +271,12 @@ export abstract class BaseActionTask<T extends Action, O extends ValidResultType
       if (dep.needsExecutedOutputs) {
         if (disabled && action.kind !== "Build") {
           // TODO-0.13.1: Need to handle conditional references, over in dependenciesFromAction()
-          throw new GraphError(
-            `${this.action.longDescription()} depends on one or more runtime outputs from action ${
+          throw new GraphError({
+            message: `${this.action.longDescription()} depends on one or more runtime outputs from action ${
               action.key
             }, which is disabled. Please either remove the reference or enable the action.`,
-            { dependant: this.action.key(), dependency: action.key() }
-          )
+            detail: { dependant: this.action.key(), dependency: action.key() },
+          })
         }
         return [this.getExecuteTask(action)]
       } else if (dep.explicit) {
@@ -323,10 +323,10 @@ export abstract class BaseActionTask<T extends Action, O extends ValidResultType
     const result = dependencyResults.getResult(resolveTask)
 
     if (!result) {
-      throw new InternalError(
-        `Could not find resolved action '${action.key()}' when processing task '${this.getBaseKey()}'.`,
-        { taskType: this.type, action: action.key() }
-      )
+      throw new InternalError({
+        message: `Could not find resolved action '${action.key()}' when processing task '${this.getBaseKey()}'.`,
+        detail: { taskType: this.type, action: action.key() },
+      })
     }
 
     return <Resolved<T>>result.outputs.resolvedAction
@@ -341,10 +341,10 @@ export abstract class BaseActionTask<T extends Action, O extends ValidResultType
     const result = dependencyResults.getResult(execTask)
 
     if (!result) {
-      throw new InternalError(
-        `Could not find executed action '${action.key()}' when processing task '${this.getBaseKey()}'.`,
-        { taskType: this.type, action: action.key() }
-      )
+      throw new InternalError({
+        message: `Could not find executed action '${action.key()}' when processing task '${this.getBaseKey()}'.`,
+        detail: { taskType: this.type, action: action.key() },
+      })
     }
 
     return <Executed<T>>result.result?.executedAction
@@ -404,7 +404,7 @@ export function emitGetStatusEvents<
   const method = descriptor.value
 
   if (!method) {
-    throw new RuntimeError("No method to decorate", {})
+    throw new RuntimeError({ message: "No method to decorate", detail: {} })
   }
 
   descriptor.value = async function (this: ExecuteActionTask<A>, ...args: [ActionTaskStatusParams<A>]) {
@@ -479,7 +479,7 @@ export function emitProcessingEvents<
   const method = descriptor.value
 
   if (!method) {
-    throw new RuntimeError("No method to decorate", {})
+    throw new RuntimeError({ message: "No method to decorate", detail: {} })
   }
 
   descriptor.value = async function (this: ExecuteActionTask<A>, ...args: [ActionTaskStatusParams<A>]) {

--- a/core/src/tasks/helpers.ts
+++ b/core/src/tasks/helpers.ts
@@ -50,7 +50,7 @@ export function getExecuteTaskForAction<T extends Action>(
     return new test.TestTask({ ...baseParams, action })
   } else {
     // Shouldn't happen
-    throw new InternalError(`Unexpected action kind`, {})
+    throw new InternalError({ message: `Unexpected action kind`, detail: {} })
   }
 }
 

--- a/core/src/tasks/resolve-action.ts
+++ b/core/src/tasks/resolve-action.ts
@@ -243,7 +243,7 @@ export class ResolveActionTask<T extends Action> extends BaseActionTask<T, Resol
 
     if (!actionType) {
       // This should be caught way earlier in normal usage, so it's an internal error
-      throw new InternalError(`Could not find type definition for ${description}.`, { kind, type })
+      throw new InternalError({ message: `Could not find type definition for ${description}.`, detail: { kind, type } })
     }
 
     const path = this.action.basePath()

--- a/core/src/tasks/resolve-provider.ts
+++ b/core/src/tasks/resolve-provider.ts
@@ -118,11 +118,12 @@ export class ResolveProviderTask extends BaseTask<Provider> {
       const matched = matchDependencies(dep.name)
 
       if (matched.length === 0 && !dep.optional) {
-        throw new ConfigurationError(
-          `Provider '${this.config.name}' depends on provider '${dep.name}', which is not configured. ` +
+        throw new ConfigurationError({
+          message:
+            `Provider '${this.config.name}' depends on provider '${dep.name}', which is not configured. ` +
             `You need to add '${dep.name}' to your project configuration for the '${this.config.name}' to work.`,
-          { config: this.config, missingProviderName: dep.name }
-        )
+          detail: { config: this.config, missingProviderName: dep.name },
+        })
       }
     })
 
@@ -395,10 +396,10 @@ export class ResolveProviderTask extends BaseTask<Provider> {
     }
 
     if (!status.ready) {
-      throw new PluginError(
-        `Provider ${pluginName} reports status as not ready and could not prepare the configured environment.`,
-        { name: pluginName, status, provider: tmpProvider }
-      )
+      throw new PluginError({
+        message: `Provider ${pluginName} reports status as not ready and could not prepare the configured environment.`,
+        detail: { name: pluginName, status, provider: tmpProvider },
+      })
     }
 
     if (!status.disableCache) {

--- a/core/src/template-string/functions.ts
+++ b/core/src/template-string/functions.ts
@@ -108,10 +108,10 @@ const helperFunctionSpecs: TemplateHelperFunction[] = [
       } else if (Array.isArray(arg1) && Array.isArray(arg2)) {
         return [...arg1, ...arg2]
       } else {
-        throw new TemplateStringError(
-          `Both terms need to be either arrays or strings (got ${typeof arg1} and ${typeof arg2}).`,
-          { arg1, arg2 }
-        )
+        throw new TemplateStringError({
+          message: `Both terms need to be either arrays or strings (got ${typeof arg1} and ${typeof arg2}).`,
+          detail: { arg1, arg2 },
+        })
       }
     },
   },
@@ -275,9 +275,12 @@ const helperFunctionSpecs: TemplateHelperFunction[] = [
 
         const result = Number.parseInt(value, 10)
         if (Number.isNaN(result)) {
-          throw new TemplateStringError(`${name} index must be a number or a numeric string (got "${value}")`, {
-            name,
-            value,
+          throw new TemplateStringError({
+            message: `${name} index must be a number or a numeric string (got "${value}")`,
+            detail: {
+              name,
+              value,
+            },
           })
         }
         return result
@@ -393,13 +396,13 @@ const helperFunctionSpecs: TemplateHelperFunction[] = [
     fn: (value: any, multiDocument?: boolean) => {
       if (multiDocument) {
         if (!isArrayLike(value)) {
-          throw new TemplateStringError(
-            `yamlEncode: Set multiDocument=true but value is not an array (got ${typeof value})`,
-            {
+          throw new TemplateStringError({
+            message: `yamlEncode: Set multiDocument=true but value is not an array (got ${typeof value})`,
+            detail: {
               value,
               multiDocument,
-            }
-          )
+            },
+          })
         }
         return "---" + value.map(safeDumpYaml).join("---")
       } else {
@@ -466,10 +469,10 @@ export function callHelperFunction({
 
   if (!spec) {
     const availableFns = Object.keys(helperFunctions).join(", ")
-    const _error = new TemplateStringError(
-      `Could not find helper function '${functionName}'. Available helper functions: ${availableFns}`,
-      { functionName, text }
-    )
+    const _error = new TemplateStringError({
+      message: `Could not find helper function '${functionName}'. Available helper functions: ${availableFns}`,
+      detail: { functionName, text },
+    })
     return { _error }
   }
 
@@ -496,10 +499,13 @@ export function callHelperFunction({
 
     if (value === undefined && schemaDescription.flags?.presence === "required") {
       return {
-        _error: new TemplateStringError(`Missing argument '${argName}' for ${functionName} helper function.`, {
-          text,
-          missingArgumentName: argName,
-          missingArgumentIndex: i,
+        _error: new TemplateStringError({
+          message: `Missing argument '${argName}' for ${functionName} helper function.`,
+          detail: {
+            text,
+            missingArgumentName: argName,
+            missingArgumentIndex: i,
+          },
         }),
       }
     }
@@ -515,9 +521,12 @@ export function callHelperFunction({
         if (allowPartial) {
           return { resolved: "${" + text + "}" }
         } else {
-          const _error = new TemplateStringError(`Function '${functionName}' cannot be applied on unresolved string`, {
-            functionName,
-            text,
+          const _error = new TemplateStringError({
+            message: `Function '${functionName}' cannot be applied on unresolved string`,
+            detail: {
+              functionName,
+              text,
+            },
           })
           return { _error }
         }
@@ -537,9 +546,12 @@ export function callHelperFunction({
     const resolved = spec.fn(...resolvedArgs)
     return { resolved }
   } catch (error) {
-    const _error = new TemplateStringError(`Error from helper function ${functionName}: ${error.message}`, {
-      error,
-      text,
+    const _error = new TemplateStringError({
+      message: `Error from helper function ${functionName}: ${error.message}`,
+      detail: {
+        error,
+        text,
+      },
     })
     return { _error }
   }

--- a/core/src/template-string/parser.pegjs
+++ b/core/src/template-string/parser.pegjs
@@ -93,9 +93,9 @@ FormatString
       }
 
       if (e && e.block && allowUndefined) {
-        const _error = new TemplateStringError("Cannot specify optional suffix in if-block.", {
+        const _error = new TemplateStringError({ message: "Cannot specify optional suffix in if-block.", detail: {
           text: text(),
-        })
+        }})
         return { _error }
       }
 
@@ -115,9 +115,9 @@ FormatString
         } else if (e && e._error) {
           return e
         } else {
-          const _error = new TemplateStringError(e.message || "Unable to resolve one or more keys.", {
+          const _error = new TemplateStringError({ message: e.message || "Unable to resolve one or more keys.", detail: {
             text: text(),
-          })
+          }})
           return { _error }
         }
       }
@@ -126,7 +126,7 @@ FormatString
 
 InvalidFormatString
   = Prefix? FormatStart .* {
-  	throw new TemplateStringError("Unable to parse as valid template string.", {})
+      throw new TemplateStringError({ message: "Unable to parse as valid template string.", detail: {}})
   }
 
 EscapeStart
@@ -170,8 +170,8 @@ MemberExpression
         "[" __ e:Expression __ "]" {
           if (e.resolved && !isPrimitive(e.resolved)) {
             const _error = new TemplateStringError(
-              `Expression in bracket must resolve to a primitive (got ${typeof e}).`,
-              { text: e.resolved }
+              { message: `Expression in bracket must resolve to a primitive (got ${typeof e}).`,
+              detail: { text: e.resolved }}
             )
             return { _error }
           }
@@ -290,10 +290,10 @@ ContainsExpression
 
       if (!isPrimitive(tail)) {
         return {
-          _error: new TemplateStringError(
-            `The right-hand side of a 'contains' operator must be a string, number, boolean or null (got ${typeof tail}).`,
-            {}
-          )
+          _error: new TemplateStringError({
+            message:`The right-hand side of a 'contains' operator must be a string, number, boolean or null (got ${typeof tail}).`,
+            detail: {}
+          })
         }
       }
 
@@ -309,10 +309,10 @@ ContainsExpression
         return head.includes(tail.toString())
       } else {
         return {
-          _error: new TemplateStringError(
-            `The left-hand side of a 'contains' operator must be a string, array or object (got ${headType}).`,
-            {}
-          )
+          _error: new TemplateStringError({
+            message: `The left-hand side of a 'contains' operator must be a string, array or object (got ${headType}).`,
+            detail: {}
+          })
         }
       }
     }

--- a/core/src/types/module.ts
+++ b/core/src/types/module.ts
@@ -200,9 +200,12 @@ export function getModuleTypeBases(
 
   if (!base) {
     const name = moduleType.name
-    throw new RuntimeError(`Unable to find base module type '${moduleType.base}' for module type '${name}'`, {
-      name,
-      moduleTypes,
+    throw new RuntimeError({
+      message: `Unable to find base module type '${moduleType.base}' for module type '${name}'`,
+      detail: {
+        name,
+        moduleTypes,
+      },
     })
   }
 

--- a/core/src/types/test.ts
+++ b/core/src/types/test.ts
@@ -74,7 +74,10 @@ export function testFromModule<M extends GardenModule = GardenModule>(
   const config = findByName(module.testConfigs, name)
 
   if (!config) {
-    throw new NotFoundError(`Could not find test ${name} in module ${module.name}`, { module, name })
+    throw new NotFoundError({
+      message: `Could not find test ${name} in module ${module.name}`,
+      detail: { module, name },
+    })
   }
 
   return testFromConfig(module, config, graph)

--- a/core/src/util/ext-source-util.ts
+++ b/core/src/util/ext-source-util.ts
@@ -114,7 +114,7 @@ export async function removeLinkedSources({
     if (!currentNames.includes(name)) {
       const msgType = sourceType === "project" ? "source" : titleize(sourceType)
       const msg = `${titleize(msgType)} ${chalk.underline(name)} is not linked. Did you mean to unlink a ${msgType}?`
-      throw new ParameterError(msg, { currentlyLinked: currentNames, input: names })
+      throw new ParameterError({ message: msg, detail: { currentlyLinked: currentNames, input: names } })
     }
   }
 

--- a/core/src/util/ext-tools.ts
+++ b/core/src/util/ext-tools.ts
@@ -171,10 +171,13 @@ export class CliWrapper {
           // we use `stdout` for the error output instead (in case information relevant to the user is included there).
           const errOutput = stderr.length > 0 ? stderr : stdout
           reject(
-            new RuntimeError(`${errorPrefix}:\n${errOutput}`, {
-              stdout,
-              stderr,
-              code,
+            new RuntimeError({
+              message: `${errorPrefix}:\n${errOutput}`,
+              detail: {
+                stdout,
+                stderr,
+                code,
+              },
             })
           )
         }
@@ -249,15 +252,15 @@ export class PluginTool extends CliWrapper {
     }
 
     if (!buildSpec) {
-      throw new ConfigurationError(
-        `Command ${spec.name} doesn't have a spec for this platform/architecture (${platform}-${architecture})`,
-        {
+      throw new ConfigurationError({
+        message: `Command ${spec.name} doesn't have a spec for this platform/architecture (${platform}-${architecture})`,
+        detail: {
           spec,
           platform,
           architecture,
           darwinARM,
-        }
-      )
+        },
+      })
     }
 
     this.buildSpec = buildSpec
@@ -310,10 +313,10 @@ export class PluginTool extends CliWrapper {
         await this.fetch(tmpPath, log)
 
         if (this.buildSpec.extract && !(await pathExists(targetAbsPath))) {
-          throw new ConfigurationError(
-            `Archive ${this.buildSpec.url} does not contain a file or directory at ${this.targetSubpath}`,
-            { name: this.name, spec: this.spec }
-          )
+          throw new ConfigurationError({
+            message: `Archive ${this.buildSpec.url} does not contain a file or directory at ${this.targetSubpath}`,
+            detail: { name: this.name, spec: this.spec },
+          })
         }
 
         await move(tmpPath, this.versionPath, { overwrite: true })
@@ -363,10 +366,13 @@ export class PluginTool extends CliWrapper {
 
         if (this.buildSpec.sha256 && sha256 !== this.buildSpec.sha256) {
           reject(
-            new DownloadError(`Invalid checksum from ${this.buildSpec.url} (got ${sha256})`, {
-              name: this.name,
-              spec: this.spec,
-              sha256,
+            new DownloadError({
+              message: `Invalid checksum from ${this.buildSpec.url} (got ${sha256})`,
+              detail: {
+                name: this.name,
+                spec: this.spec,
+                sha256,
+              },
             })
           )
         }
@@ -393,9 +399,12 @@ export class PluginTool extends CliWrapper {
           extractor.on("close", () => resolve())
         } else {
           reject(
-            new ParameterError(`Invalid archive format: ${format}`, {
-              name: this.name,
-              spec: this.spec,
+            new ParameterError({
+              message: `Invalid archive format: ${format}`,
+              detail: {
+                name: this.name,
+                spec: this.spec,
+              },
             })
           )
           return

--- a/core/src/util/fs.ts
+++ b/core/src/util/fs.ts
@@ -301,7 +301,7 @@ export async function getWorkingCopyId(gardenDirPath: string) {
  */
 export async function isDirectory(path: string) {
   if (!(await pathExists(path))) {
-    throw new FilesystemError(`Path ${path} does not exist`, { path })
+    throw new FilesystemError({ message: `Path ${path} does not exist`, detail: { path } })
   }
 
   const stat = await lstat(path)

--- a/core/src/util/streams.ts
+++ b/core/src/util/streams.ts
@@ -51,7 +51,7 @@ export class SortedStreamIntersection<T> extends Readable {
         this.lastValues[i] = value
 
         if (lastValue !== undefined && this.comparisonFn(lastValue, value) > 0) {
-          this.emit("error", new InternalError(`Received unordered stream`, { streamIndex: i }))
+          this.emit("error", new InternalError({ message: `Received unordered stream`, detail: { streamIndex: i } }))
           return
         }
 

--- a/core/src/util/testing.ts
+++ b/core/src/util/testing.ts
@@ -130,14 +130,14 @@ export class TestEventBus extends EventBus {
       }
     }
 
-    throw new TestError(
-      dedent`
+    throw new TestError({
+      message: dedent`
       Expected event in log with name '${name}' and payload ${JSON.stringify(payload)}.
       Logged events:
       ${this.eventLog.map((e) => JSON.stringify(e)).join("\n")}
     `,
-      { name, payload }
-    )
+      detail: { name, payload },
+    })
   }
 }
 
@@ -344,7 +344,10 @@ export class TestGarden extends Garden {
     const config = findByName(modules, name)
 
     if (!config) {
-      throw new TestError(`Could not find module config ${name}`, { name, available: getNames(modules) })
+      throw new TestError({
+        message: `Could not find module config ${name}`,
+        detail: { name, available: getNames(modules) },
+      })
     }
 
     return config

--- a/core/src/util/util.ts
+++ b/core/src/util/util.ts
@@ -223,16 +223,16 @@ export async function exec(cmd: string, args: string[], opts: ExecOpts = {}) {
     return res
   } catch (err) {
     if (err.code === "EMFILE" || err.errno === "EMFILE") {
-      throw new RuntimeError(
-        dedent`
+      throw new RuntimeError({
+        message: dedent`
         Received EMFILE (Too many open files) error when running ${cmd}.
 
         This may mean there are too many files in the project, and that you need to exclude large dependency directories. Please see ${DOCS_BASE_URL}/using-garden/configuration-overview#including-excluding-files-and-directories for information on how to do that.
 
         This can also be due to limits on open file descriptors being too low. Here is one guide on how to configure those limits for different platforms: https://docs.riak.com/riak/kv/latest/using/performance/open-files-limit/index.html
         `,
-        { error: err }
-      )
+        detail: { error: err },
+      })
     }
 
     const error = <execa.ExecaError>err
@@ -304,7 +304,7 @@ export function spawn(cmd: string, args: string[], opts: SpawnOpts = {}) {
 
   if (tty) {
     if (data) {
-      throw new ParameterError(`Cannot pipe to stdin when tty=true`, { cmd, args, opts })
+      throw new ParameterError({ message: `Cannot pipe to stdin when tty=true`, detail: { cmd, args, opts } })
     }
     _process.stdin.setEncoding("utf8")
     // raw mode is not available if we're running without a TTY
@@ -350,7 +350,9 @@ export function spawn(cmd: string, args: string[], opts: SpawnOpts = {}) {
     if (timeout > 0) {
       _timeout = setTimeout(() => {
         proc.kill("SIGKILL")
-        _reject(new TimeoutError(`${cmd} timed out after ${timeout} seconds.`, { cmd, args, opts }))
+        _reject(
+          new TimeoutError({ message: `${cmd} timed out after ${timeout} seconds.`, detail: { cmd, args, opts } })
+        )
       }, timeout * 1000)
     }
 
@@ -359,7 +361,7 @@ export function spawn(cmd: string, args: string[], opts: SpawnOpts = {}) {
       if ((<any>err).code === "ENOENT") {
         msg = `${msg} Please make sure '${cmd}' is installed and in the $PATH.`
       }
-      _reject(new RuntimeError(msg, { cmd, args, opts, result, err }))
+      _reject(new RuntimeError({ message: msg, detail: { cmd, args, opts, result, err } }))
     })
 
     proc.on("close", (code) => {
@@ -376,7 +378,7 @@ export function spawn(cmd: string, args: string[], opts: SpawnOpts = {}) {
           output: result.all || result.stdout || result.stderr || "",
           error: result.stderr || "",
         })
-        _reject(new RuntimeError(msg, { cmd, args, opts, result }))
+        _reject(new RuntimeError({ message: msg, detail: { cmd, args, opts, result } }))
       }
     })
   })
@@ -515,9 +517,12 @@ export function pickKeys<T extends object, U extends keyof T>(obj: T, keys: U[],
   const missing = difference(<string[]>keys, Object.keys(picked))
 
   if (missing.length) {
-    throw new ParameterError(`Could not find ${description}(s): ${missing.map((k, _) => k).join(", ")}`, {
-      missing,
-      available: Object.keys(obj),
+    throw new ParameterError({
+      message: `Could not find ${description}(s): ${missing.map((k, _) => k).join(", ")}`,
+      detail: {
+        missing,
+        available: Object.keys(obj),
+      },
     })
   }
 
@@ -539,7 +544,10 @@ export function findByNames<T extends ObjectWithName>({
   const missing = difference(names, available)
 
   if (missing.length && !allowMissing) {
-    throw new ParameterError(`Could not find ${description}(s): ${missing.join(", ")}`, { available, missing })
+    throw new ParameterError({
+      message: `Could not find ${description}(s): ${missing.join(", ")}`,
+      detail: { available, missing },
+    })
   }
 
   return entries.filter(({ name }) => names.includes(name))
@@ -558,9 +566,12 @@ export function hashString(s: string, length?: number): string {
 export function pushToKey(obj: object, key: string, value: any) {
   if (obj[key]) {
     if (!isArray(obj[key])) {
-      throw new RuntimeError(`Value at '${key}' is not an array`, {
-        obj,
-        key,
+      throw new RuntimeError({
+        message: `Value at '${key}' is not an array`,
+        detail: {
+          obj,
+          key,
+        },
       })
     }
     obj[key].push(value)

--- a/core/src/util/validateInstall.ts
+++ b/core/src/util/validateInstall.ts
@@ -20,14 +20,14 @@ type BinaryVersionCheckParams = {
 }
 
 function versionCheckError(params: BinaryVersionCheckParams, msg: string, detail: object): RuntimeError {
-  return new RuntimeError(
-    deline`
+  return new RuntimeError({
+    message: deline`
       ${msg}
       Please make sure ${params.name} (version ${params.minVersion} or later) is installed and on your PATH.
       More about garden installation and requirements can be found in our documentation at ${DOCS_BASE_URL}/guides/installation
       `,
-    detail
-  )
+    detail,
+  })
 }
 
 async function execVersionCheck(params: BinaryVersionCheckParams): Promise<string> {

--- a/core/src/vcs/vcs.ts
+++ b/core/src/vcs/vcs.ts
@@ -278,10 +278,13 @@ async function readVersionFile(path: string, schema: Joi.Schema): Promise<any> {
   try {
     return validateSchema(JSON.parse(versionFileContents), schema)
   } catch (error) {
-    throw new ConfigurationError(`Unable to parse ${path} as valid version file`, {
-      path,
-      versionFileContents,
-      error,
+    throw new ConfigurationError({
+      message: `Unable to parse ${path} as valid version file`,
+      detail: {
+        path,
+        versionFileContents,
+        error,
+      },
     })
   }
 }

--- a/core/src/watch.ts
+++ b/core/src/watch.ts
@@ -55,8 +55,11 @@ export class Watcher extends EventEmitter2 {
       try {
         require("fsevents")
       } catch (error) {
-        throw new InternalError(`Unable to load fsevents module: ${error}`, {
-          error,
+        throw new InternalError({
+          message: `Unable to load fsevents module: ${error}`,
+          detail: {
+            error,
+          },
         })
       }
     }

--- a/core/test/helpers.ts
+++ b/core/test/helpers.ts
@@ -210,7 +210,10 @@ export const makeTestGarden = profileAsync(async function _makeTestGarden(
         opts.config.path = targetRoot
       }
       if (opts.config?.configPath) {
-        throw new ConfigurationError(`Please don't set the configPath here :) Messes with the temp dir business.`, {})
+        throw new ConfigurationError({
+          message: `Please don't set the configPath here :) Messes with the temp dir business.`,
+          detail: {},
+        })
       }
     }
     targetRoot = join(testProjectTempDirs[projectRoot].path, "project")

--- a/core/test/integ/src/plugins/kubernetes/local-mode.ts
+++ b/core/test/integ/src/plugins/kubernetes/local-mode.ts
@@ -125,7 +125,7 @@ describe("local mode deployments and ssh tunneling behavior", () => {
           )
         }
         if (!res) {
-          throw new RuntimeError("Port-forwarding is still not running", {})
+          throw new RuntimeError({ message: "Port-forwarding is still not running", detail: {} })
         }
         return res
       },

--- a/core/test/unit/src/commands/login.ts
+++ b/core/test/unit/src/commands/login.ts
@@ -251,7 +251,7 @@ describe("LoginCommand", () => {
     await CloudApi.saveAuthToken(garden.log, garden.globalConfigStore, testToken, garden.cloudDomain!)
     td.replace(CloudApi.prototype, "checkClientAuthToken", async () => false)
     td.replace(CloudApi.prototype, "refreshToken", async () => {
-      throw new CloudApiError("bummer", { statusCode: 401 })
+      throw new CloudApiError({ message: "bummer", detail: { statusCode: 401 } })
     })
 
     const savedToken = await CloudApi.getStoredAuthToken(garden.log, garden.globalConfigStore, garden.cloudDomain!)

--- a/core/test/unit/src/exceptions.ts
+++ b/core/test/unit/src/exceptions.ts
@@ -20,7 +20,7 @@ describe("GardenError", () => {
     let error: GardenBaseError
 
     try {
-      throw new RuntimeError("test exception", {})
+      throw new RuntimeError({ message: "test exception" })
     } catch (err) {
       error = err
     }
@@ -43,7 +43,7 @@ describe("GardenError", () => {
   })
 
   it("should handle empty stack trace", async () => {
-    const error = new RuntimeError("test exception", {})
+    const error = new RuntimeError({ message: "test exception" })
 
     error.stack = ""
     const stackTrace = getStackTraceMetadata(error)
@@ -51,7 +51,7 @@ describe("GardenError", () => {
   })
 
   it("should return list of stack trace entries", async () => {
-    const error = new RuntimeError("test exception", {})
+    const error = new RuntimeError({ message: "test exception" })
 
     error.stack = `Error: test exception
     at Context.<anonymous> (/path/to/src/utils/exceptions.ts:17:13)
@@ -67,13 +67,13 @@ describe("GardenError", () => {
   })
 
   it("should return wrapped stack trace metadata", async () => {
-    const wrappedError = new ConfigurationError("config exception", {})
+    const wrappedError = new ConfigurationError({ message: "test exception" })
     wrappedError.stack = `Error: config exception
     at Context.<anonymous> (/path/to/src/utils/exceptions.ts:17:13)
     at Test.Runnable.run (/path/to/node_modules/mocha/lib/runnable.js:354:5)
     at processImmediate (node:internal/timers:471:21)`
 
-    const error = new RuntimeError("test exception", {}, [wrappedError])
+    const error = new RuntimeError({ message: "test exception", wrappedErrors: [wrappedError] })
 
     const stackTrace = getStackTraceMetadata(error)
 

--- a/core/test/unit/src/logger/renderers.ts
+++ b/core/test/unit/src/logger/renderers.ts
@@ -55,7 +55,7 @@ describe("renderers", () => {
   })
   describe("renderError", () => {
     it("should render error object if present", () => {
-      const error: GardenError = {
+      const error: GardenError<{ foo: string; _internal: string }> = {
         name: "test",
         message: "hello error",
         type: "a",
@@ -145,7 +145,9 @@ describe("renderers", () => {
         const now = freezeTime()
         const entry = logger.createLog().info("hello world").getLatestEntry()
 
-        expect(formatForTerminal(entry, logger)).to.equal(`${chalk.gray(format(now, "HH:mm:ss"))} ${msgStyle("hello world")}\n`)
+        expect(formatForTerminal(entry, logger)).to.equal(
+          `${chalk.gray(format(now, "HH:mm:ss"))} ${msgStyle("hello world")}\n`
+        )
       })
       after(() => {
         logger.showTimestamps = false

--- a/core/test/unit/src/logger/writers/file-writer.ts
+++ b/core/test/unit/src/logger/writers/file-writer.ts
@@ -30,7 +30,7 @@ describe("FileWriter", () => {
     it("should render error object if passed", () => {
       const entry = logger
         .createLog()
-        .error({ error: new RuntimeError("oh no", { foo: "bar" }) })
+        .error({ error: new RuntimeError({ message: "oh no", detail: { foo: "bar" } }) })
         .getLatestEntry()
       const expectedOutput = stripAnsi(renderError(entry))
       expect(render(LogLevel.info, entry)).to.equal(expectedOutput)

--- a/e2e/run-garden.ts
+++ b/e2e/run-garden.ts
@@ -281,9 +281,12 @@ export class GardenWatch {
       const now = new Date().getTime()
       if (now - startTime > timeout * 1000) {
         const log = this.renderLog()
-        error = new TimeoutError(`Timed out waiting for test steps. Logs:\n${log}`, {
-          logEntries: this.logEntries,
-          log,
+        error = new TimeoutError({
+          message: `Timed out waiting for test steps. Logs:\n${log}`,
+          detail: {
+            logEntries: this.logEntries,
+            log,
+          },
         })
         break
       }
@@ -361,9 +364,12 @@ export class GardenWatch {
       const now = new Date().getTime()
       if (now - startTime > 10 * DEFAULT_CHECK_INTERVAL_MS) {
         const log = this.renderLog()
-        throw new TimeoutError(`Timed out waiting for garden command to terminate. Log:\n${log}`, {
-          logEntries: this.logEntries,
-          log,
+        throw new TimeoutError({
+          message: `Timed out waiting for garden command to terminate. Log:\n${log}`,
+          detail: {
+            logEntries: this.logEntries,
+            log,
+          },
         })
       }
     }
@@ -374,37 +380,37 @@ export class GardenWatch {
       const hasCondition = !!condition
       const hasAction = !!action
       if (!hasCondition && !hasAction) {
-        throw new ParameterError(
-          deline`
+        throw new ParameterError({
+          message: deline`
           GardenWatch: step ${description} in testSteps defines neither a condition nor an action.
           Steps must define either a condition or an action.`,
-          { testSteps }
-        )
+          detail: { testSteps },
+        })
       }
       if (hasCondition && hasAction) {
-        throw new ParameterError(
-          deline`
+        throw new ParameterError({
+          message: deline`
           GardenWatch: step ${description} in testSteps defines both a condition and an action.
           Steps must define either a condition or an action, but not both.`,
-          { testSteps }
-        )
+          detail: { testSteps },
+        })
       }
     }
 
     if (testSteps.length === 0) {
-      throw new ParameterError(
-        deline`
+      throw new ParameterError({
+        message: deline`
         GardenWatch: run method called with an empty testSteps array. At least one test step must be provided.`,
-        {}
-      )
+        detail: {},
+      })
     }
 
     if (!testSteps[testSteps.length - 1].condition) {
-      throw new ParameterError(
-        deline`
+      throw new ParameterError({
+        message: deline`
         GardenWatch: The last element of testSteps must be a condition, not an action.`,
-        { testSteps }
-      )
+        detail: { testSteps },
+      })
     }
   }
 }

--- a/plugins/conftest/index.ts
+++ b/plugins/conftest/index.ts
@@ -228,10 +228,10 @@ export const gardenPlugin = () =>
                 try {
                   files = ctx.resolveTemplateStrings(files)
                 } catch (error) {
-                  throw new ConfigurationError(
-                    `The spec.files field contains a template string which could not be resolved. Note that some template variables are not available for the field. Error: ${error}`,
-                    { config, error }
-                  )
+                  throw new ConfigurationError({
+                    message: `The spec.files field contains a template string which could not be resolved. Note that some template variables are not available for the field. Error: ${error}`,
+                    detail: { config, error },
+                  })
                 }
                 config.include = uniq([...config.include, ...files])
               }
@@ -256,21 +256,21 @@ export const gardenPlugin = () =>
               )
 
               if (!sourceAction) {
-                throw new ConfigurationError(
-                  `Must specify a helm Deploy action in the \`helmDeploy\` field. Could not find Deploy action '${spec.helmDeploy}'.`,
-                  {
+                throw new ConfigurationError({
+                  message: `Must specify a helm Deploy action in the \`helmDeploy\` field. Could not find Deploy action '${spec.helmDeploy}'.`,
+                  detail: {
                     helmDeployRef: spec.helmDeploy,
-                  }
-                )
+                  },
+                })
               }
               if (sourceAction.type !== "helm") {
-                throw new ConfigurationError(
-                  `Must specify a helm Deploy action in the \`helmDeploy\` field. Deploy action '${spec.helmDeploy}' has type '${sourceAction.type}'.`,
-                  {
+                throw new ConfigurationError({
+                  message: `Must specify a helm Deploy action in the \`helmDeploy\` field. Deploy action '${spec.helmDeploy}' has type '${sourceAction.type}'.`,
+                  detail: {
                     helmDeployRef: spec.helmDeploy,
                     foundDeployType: sourceAction.type,
-                  }
-                )
+                  },
+                })
               }
 
               const templates = await renderTemplates({
@@ -473,7 +473,7 @@ function parseConftestResult(provider: ConftestProvider, log: Log, result: Execa
   try {
     parsed = JSON.parse(result.stdout)
   } catch (err) {
-    throw new PluginError(`Error running conftest: ${result.all}`, { result })
+    throw new PluginError({ message: `Error running conftest: ${result.all}`, detail: { result } })
   }
 
   const allFailures = parsed.filter((p: any) => p.failures?.length > 0)

--- a/plugins/jib/build-tool-base.ts
+++ b/plugins/jib/build-tool-base.ts
@@ -38,7 +38,7 @@ export async function getBuildToolVersion(params: CheckVersionParams) {
         return baseErrorMessage(params)
       }
     }
-    throw new RuntimeError(composeErrorMessage(error), { binaryPath })
+    throw new RuntimeError({ message: composeErrorMessage(error), detail: { binaryPath } })
   }
 }
 
@@ -51,10 +51,10 @@ export async function verifyBinaryPath(params: VerifyBinaryParams) {
   const versionOutput = await getBuildToolVersion(params)
   const isMaven = versionOutput.toLowerCase().includes(outputVerificationString)
   if (!isMaven) {
-    throw new RuntimeError(
-      `${baseErrorMessage(params)} It looks like the ${toolName} path points to a wrong executable binary.`,
-      { binaryPath }
-    )
+    throw new RuntimeError({
+      message: `${baseErrorMessage(params)} It looks like the ${toolName} path points to a wrong executable binary.`,
+      detail: { binaryPath },
+    })
   }
 }
 

--- a/plugins/jib/gradle.ts
+++ b/plugins/jib/gradle.ts
@@ -61,7 +61,7 @@ export function getGradleTool(ctx: PluginContext) {
   const tool = find(ctx.tools, (_, k) => k.endsWith(".gradle"))
 
   if (!tool) {
-    throw new PluginError(`Could not find configured gradle tool`, { tools: ctx.tools })
+    throw new PluginError({ message: `Could not find configured gradle tool`, detail: { tools: ctx.tools } })
   }
 
   return tool

--- a/plugins/jib/maven.ts
+++ b/plugins/jib/maven.ts
@@ -64,7 +64,7 @@ export function getMvnTool(ctx: PluginContext) {
   const tool = find(ctx.tools, (_, k) => k.endsWith(".maven"))
 
   if (!tool) {
-    throw new PluginError(`Could not find configured maven tool`, { tools: ctx.tools })
+    throw new PluginError({ message: `Could not find configured maven tool`, detail: { tools: ctx.tools } })
   }
 
   return tool

--- a/plugins/jib/mavend.ts
+++ b/plugins/jib/mavend.ts
@@ -94,7 +94,7 @@ export function getMvndTool(ctx: PluginContext) {
   const tool = find(ctx.tools, (_, k) => k.endsWith(".mavend"))
 
   if (!tool) {
-    throw new PluginError(`Could not find configured maven daemon tool`, { tools: ctx.tools })
+    throw new PluginError({ message: `Could not find configured maven daemon tool`, detail: { tools: ctx.tools } })
   }
 
   return tool

--- a/plugins/jib/util.ts
+++ b/plugins/jib/util.ts
@@ -84,7 +84,10 @@ export function detectProjectType(action: BuildAction): JibPluginType {
     }
   }
 
-  throw new ConfigurationError(`Could not detect a gradle or maven project to build ${action.name}`, {})
+  throw new ConfigurationError({
+    message: `Could not detect a gradle or maven project to build ${action.name}`,
+    detail: {},
+  })
 }
 
 export function getBuildFlags(action: Resolved<JibBuildAction>, projectType: JibModuleBuildSpec["projectType"]) {

--- a/plugins/pulumi/cli.ts
+++ b/plugins/pulumi/cli.ts
@@ -29,9 +29,12 @@ export function pulumi(ctx: PluginContext, provider: PulumiProvider) {
     const cli = ctx.tools["pulumi.pulumi-" + version.replace(/\./g, "-")]
 
     if (!cli) {
-      throw new ConfigurationError(`Unsupported pulumi version: ${version}`, {
-        version,
-        supportedVersions,
+      throw new ConfigurationError({
+        message: `Unsupported pulumi version: ${version}`,
+        detail: {
+          version,
+          supportedVersions,
+        },
       })
     }
 
@@ -48,7 +51,10 @@ export class GlobalPulumi extends CliWrapper {
     try {
       return await which("pulumi")
     } catch (err) {
-      throw new RuntimeError(`Pulumi version is set to null, and pulumi CLI could not be found on PATH`, {})
+      throw new RuntimeError({
+        message: `Pulumi version is set to null, and pulumi CLI could not be found on PATH`,
+        detail: {},
+      })
     }
   }
 }

--- a/plugins/pulumi/handlers.ts
+++ b/plugins/pulumi/handlers.ts
@@ -45,8 +45,11 @@ export const configurePulumiModule: ModuleActionHandlers["configure"] = async ({
     const exists = await pathExists(absRoot)
 
     if (!exists) {
-      throw new ConfigurationError(`Pulumi: configured working directory '${root}' does not exist`, {
-        moduleConfig,
+      throw new ConfigurationError({
+        message: `Pulumi: configured working directory '${root}' does not exist`,
+        detail: {
+          moduleConfig,
+        },
       })
     }
   }
@@ -59,16 +62,22 @@ export const configurePulumiModule: ModuleActionHandlers["configure"] = async ({
   // Check to avoid using `orgName` or `cacheStatus: true` with non-pulumi managed backends
   if (!backendUrl.startsWith("https://")) {
     if (orgName) {
-      throw new ConfigurationError("Pulumi: orgName is not supported for self-managed backends", {
-        moduleConfig,
-        providerConfig: provider.config,
+      throw new ConfigurationError({
+        message: "Pulumi: orgName is not supported for self-managed backends",
+        detail: {
+          moduleConfig,
+          providerConfig: provider.config,
+        },
       })
     }
 
     if (moduleConfig.spec.cacheStatus) {
-      throw new ConfigurationError("Pulumi: `cacheStatus: true` is not supported for self-managed backends", {
-        moduleConfig,
-        providerConfig: provider.config,
+      throw new ConfigurationError({
+        message: "Pulumi: `cacheStatus: true` is not supported for self-managed backends",
+        detail: {
+          moduleConfig,
+          providerConfig: provider.config,
+        },
       })
     }
   }

--- a/plugins/pulumi/helpers.ts
+++ b/plugins/pulumi/helpers.ts
@@ -250,13 +250,13 @@ export async function applyConfig(params: PulumiParams & { previewDirPath?: stri
       return loadPulumiVarfile({ action, ctx, log, varfilePath })
     })
   } catch (err) {
-    throw new FilesystemError(
-      `An error occurred while reading pulumi varfiles for action ${action.name}: ${err.message}`,
-      {
+    throw new FilesystemError({
+      message: `An error occurred while reading pulumi varfiles for action ${action.name}: ${err.message}`,
+      detail: {
         pulumiVarfiles: spec.pulumiVarfiles,
         actionName: action.name,
-      }
-    )
+      },
+    })
   }
 
   log.debug(`merging config for action ${action.name}`)
@@ -307,9 +307,12 @@ async function readPulumiPlan(module: PulumiDeploy, planPath: string): Promise<P
     return plan
   } catch (err) {
     const errMsg = `An error occurred while reading a pulumi plan file at ${planPath}: ${err.message}`
-    throw new FilesystemError(errMsg, {
-      planPath,
-      moduleName: module.name,
+    throw new FilesystemError({
+      message: errMsg,
+      detail: {
+        planPath,
+        moduleName: module.name,
+      },
     })
   }
 }
@@ -504,10 +507,13 @@ async function loadPulumiVarfile({
   if (!isYamlFile) {
     const errMsg = deline`
       Unable to load varfile at path ${resolvedPath}: Expected file extension to be .yml or .yaml, got ${ext}. Pulumi varfiles must be YAML files.`
-    throw new ConfigurationError(errMsg, {
-      actionName: action.name,
-      resolvedPath,
-      varfilePath,
+    throw new ConfigurationError({
+      message: errMsg,
+      detail: {
+        actionName: action.name,
+        resolvedPath,
+        varfilePath,
+      },
     })
   }
 
@@ -518,10 +524,13 @@ async function loadPulumiVarfile({
     return parsed as DeepPrimitiveMap
   } catch (error) {
     const errMsg = `Unable to load varfile at '${resolvedPath}': ${error}`
-    throw new ConfigurationError(errMsg, {
-      actionName: action.name,
-      error,
-      resolvedPath,
+    throw new ConfigurationError({
+      message: errMsg,
+      detail: {
+        actionName: action.name,
+        error,
+        resolvedPath,
+      },
     })
   }
 }

--- a/plugins/pulumi/index.ts
+++ b/plugins/pulumi/index.ts
@@ -68,8 +68,11 @@ export const gardenPlugin = () =>
                 const exists = await pathExists(absRoot)
 
                 if (!exists) {
-                  throw new ConfigurationError(`Pulumi: configured working directory '${root}' does not exist`, {
-                    root,
+                  throw new ConfigurationError({
+                    message: `Pulumi: configured working directory '${root}' does not exist`,
+                    detail: {
+                      root,
+                    },
                   })
                 }
               }

--- a/plugins/terraform/cli.ts
+++ b/plugins/terraform/cli.ts
@@ -21,9 +21,12 @@ export function terraform(ctx: PluginContext, provider: TerraformProvider) {
     const cli = ctx.tools["terraform.terraform-" + version.replace(/\./g, "-")]
 
     if (!cli) {
-      throw new ConfigurationError(`Unsupported Terraform version: ${version}`, {
-        version,
-        supportedVersions,
+      throw new ConfigurationError({
+        message: `Unsupported Terraform version: ${version}`,
+        detail: {
+          version,
+          supportedVersions,
+        },
       })
     }
 
@@ -40,7 +43,10 @@ export class GlobalTerraform extends CliWrapper {
     try {
       return await which("terraform")
     } catch (err) {
-      throw new RuntimeError(`Terraform version is set to null, and terraform CLI could not be found on PATH`, {})
+      throw new RuntimeError({
+        message: `Terraform version is set to null, and terraform CLI could not be found on PATH`,
+        detail: {},
+      })
     }
   }
 }

--- a/plugins/terraform/commands.ts
+++ b/plugins/terraform/commands.ts
@@ -34,8 +34,11 @@ function makeRootCommand(commandName: string): PluginCommand {
       const provider = ctx.provider as TerraformProvider
 
       if (!provider.config.initRoot) {
-        throw new ConfigurationError(`terraform provider does not have an ${chalk.underline("initRoot")} configured`, {
-          config: provider.config,
+        throw new ConfigurationError({
+          message: `terraform provider does not have an ${chalk.underline("initRoot")} configured`,
+          detail: {
+            config: provider.config,
+          },
         })
       }
 
@@ -112,15 +115,18 @@ function makeActionCommand(commandName: string): PluginCommand {
 
 function findAction(graph: ConfigGraph, name: string): TerraformDeploy {
   if (!name) {
-    throw new ParameterError(`The first command argument must be an action name.`, { name })
+    throw new ParameterError({ message: `The first command argument must be an action name.`, detail: { name } })
   }
 
   const action = graph.getDeploy(name)
 
   if (!action.isCompatible("terraform")) {
-    throw new ParameterError(chalk.red(`Action ${chalk.white(name)} is not a terraform action (got ${action.type}).`), {
-      name,
-      type: action.type,
+    throw new ParameterError({
+      message: chalk.red(`Action ${chalk.white(name)} is not a terraform action (got ${action.type}).`),
+      detail: {
+        name,
+        type: action.type,
+      },
     })
   }
 

--- a/plugins/terraform/common.ts
+++ b/plugins/terraform/common.ts
@@ -100,7 +100,7 @@ export async function tfValidate(params: TerraformParams) {
         errorMsg += dedent`\n\n${resultErrors.join("\n")}`
       }
 
-      throw new ConfigurationError(errorMsg, { failedResponse: retryRes || res, initError })
+      throw new ConfigurationError({ message: errorMsg, detail: { failedResponse: retryRes || res, initError } })
     }
   }
 }
@@ -178,10 +178,13 @@ export async function getStackStatus(params: TerraformParamsWithVariables): Prom
     return "outdated"
   } else {
     statusLog.error(`Failed running plan`)
-    throw new PluginError(`Unexpected exit code from \`terraform plan\`: ${plan.exitCode}`, {
-      exitCode: plan.exitCode,
-      stderr: plan.stderr,
-      stdout: plan.stdout,
+    throw new PluginError({
+      message: `Unexpected exit code from \`terraform plan\`: ${plan.exitCode}`,
+      detail: {
+        exitCode: plan.exitCode,
+        stderr: plan.stderr,
+        stdout: plan.stdout,
+      },
     })
   }
 }
@@ -225,10 +228,13 @@ export async function applyStack(params: TerraformParamsWithVariables) {
         _resolve()
       } else {
         reject(
-          new RuntimeError(`Error when applying Terraform stack:\n${stderr}`, {
-            stdout,
-            stderr,
-            code,
+          new RuntimeError({
+            message: `Error when applying Terraform stack:\n${stderr}`,
+            detail: {
+              stdout,
+              stderr,
+              code,
+            },
           })
         )
       }

--- a/plugins/terraform/index.ts
+++ b/plugins/terraform/index.ts
@@ -100,10 +100,10 @@ export const gardenPlugin = () =>
           const exists = await pathExists(absRoot)
 
           if (!exists) {
-            throw new ConfigurationError(
-              `Terraform: configured initRoot config directory '${config.initRoot}' does not exist`,
-              { config, projectRoot }
-            )
+            throw new ConfigurationError({
+              message: `Terraform: configured initRoot config directory '${config.initRoot}' does not exist`,
+              detail: { config, projectRoot },
+            })
           }
         }
 
@@ -151,8 +151,11 @@ export const gardenPlugin = () =>
                 const exists = await pathExists(absRoot)
 
                 if (!exists) {
-                  throw new ConfigurationError(`Terraform: configured root directory '${root}' does not exist`, {
-                    root,
+                  throw new ConfigurationError({
+                    message: `Terraform: configured root directory '${root}' does not exist`,
+                    detail: {
+                      root,
+                    },
                   })
                 }
               }

--- a/plugins/terraform/module.ts
+++ b/plugins/terraform/module.ts
@@ -42,8 +42,11 @@ export const configureTerraformModule: ModuleActionHandlers<TerraformModule>["co
     const exists = await pathExists(absRoot)
 
     if (!exists) {
-      throw new ConfigurationError(`Terraform: configured working directory '${root}' does not exist`, {
-        moduleConfig,
+      throw new ConfigurationError({
+        message: `Terraform: configured working directory '${root}' does not exist`,
+        detail: {
+          moduleConfig,
+        },
       })
     }
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

This changes the `GardenBaseError` constructor to take named params instead of positional. Increases type safety and will make future refactorings/improvements easier. The important change is in `core/src/exceptions.ts`, the rest is just fall-out from that.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
