### PR TITLE
fix(helm): expose ingresses of resources deployed with helm

### DIFF
--- a/core/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/src/plugins/kubernetes/helm/deployment.ts
@@ -21,6 +21,7 @@ import { ConfiguredLocalMode, configureLocalMode, startServiceInLocalMode } from
 import { DeployActionHandler } from "../../../plugin/action-types"
 import { HelmDeployAction } from "./config"
 import { isEmpty } from "lodash"
+import { getK8sIngresses } from "../status/ingress"
 
 export const helmDeploy: DeployActionHandler<"deploy", HelmDeployAction> = async (params) => {
   const { ctx, action, log, force } = params
@@ -166,6 +167,8 @@ export const helmDeploy: DeployActionHandler<"deploy", HelmDeployAction> = async
     })
     attached = true
   }
+  // Get ingresses of deployed resources
+  const ingresses = getK8sIngresses(manifests)
 
   return {
     state: "ready",
@@ -173,6 +176,7 @@ export const helmDeploy: DeployActionHandler<"deploy", HelmDeployAction> = async
       forwardablePorts,
       state: "ready",
       version: action.versionString(),
+      ingresses,
       detail: { remoteResources: statuses.map((s) => s.resource) },
     },
     attached,


### PR DESCRIPTION
**What this PR does / why we need it**:

Before this fix, ingresses of resources deployed with helm were missing in response of deploy and therefore, were not being shown in cli output as well as on the cloud.

Fixes #4732 
