### PR TITLE
chore: print version of the fetched tool

### DIFF
--- a/core/src/util/ext-tools.ts
+++ b/core/src/util/ext-tools.ts
@@ -328,7 +328,7 @@ export class PluginTool extends CliWrapper {
       }
 
       debug && debug.success("Done")
-      downloadLog.success(`Fetched ${this.name}`)
+      downloadLog.success(`Fetched ${this.name} ${this.spec.version}`)
     })
   }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
Just prints the version of a downloaded plugin tool along with its name.

Output before:
```
✔ build.spring-boot    → Fetched maven (took 7.3 sec)
```

Output after:
```
✔ build.spring-boot    → Fetched maven 3.8.8 (took 7.3 sec)
```

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
