### PR TITLE
fix: don't use var file when path is unresolved

### DIFF
--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -462,10 +462,12 @@ export const preprocessActionConfig = profileAsync(async function preprocessActi
   const description = describeActionConfig(config)
   const templateName = config.internal.templateName
 
+  // in pre-processing, only use varfiles that are not template strings
+  const resolvedVarFiles = config.varfiles?.filter((f) => !maybeTemplateString(f))
   const variables = await mergeVariables({
     basePath: config.internal.basePath,
     variables: config.variables,
-    varfiles: config.varfiles,
+    varfiles: resolvedVarFiles,
   })
   const resolvedVariables = resolveTemplateStrings(
     variables,


### PR DESCRIPTION
**What this PR does / why we need it**:
in action pre-processing, only use the var files that are not template strings as those are resolved and populated later.

**Which issue(s) this PR fixes**:

Fixes #4702

**Special notes for your reviewer**:
