### PR TITLE
chore(test): update remote source repo link

### DIFF
--- a/e2e/projects/remote-sources-modules/garden.yml
+++ b/e2e/projects/remote-sources-modules/garden.yml
@@ -4,7 +4,7 @@ name: remote-sources-modules
 sources:
   - name: web-services
     # use #your-branch to specify a branch, #v0.3.0 for a tag or a full length commit SHA1
-    repositoryUrl: https://github.com/garden-io/garden-example-remote-sources-web-services.git#v0.4.0
+    repositoryUrl: https://github.com/garden-io/garden-example-remote-sources-web-services.git#0.4
   - name: db-services
     repositoryUrl: https://github.com/garden-io/garden-example-remote-sources-db-services.git#v0.3.0
 environments:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
This PR changes the repository URL of the `web-services` remote sources to the [`0.14` branch](https://github.com/garden-io/garden-example-remote-sources-web-services#0.4). That branch is a module-based version of the project.

**Special notes for your reviewer**:
This only fixes the Python runtime errors in `api` module in [e2e-vote-modules](https://app.circleci.com/pipelines/github/garden-io/garden/18749/workflows/6348dc30-0a6d-45bf-bb14-407ad1742a0e/jobs/337115). The e2e tests are still flaky.