### PR TITLE
ci: fix e2e vote-module test

### DIFF
--- a/e2e/projects/vote-modules/vote/Dockerfile
+++ b/e2e/projects/vote-modules/vote/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.22.6-alpine
+FROM node:14-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
**What this PR does / why we need it**:
An attempt to resolve the failing e2e vote-module tests. Updates the node version in vote-module test project. 

The test seemed to be failing due to some dependencies issue in the vote `build` and since the dependencies layer was cached by kaniko, every build of `vote` resulted in bad dependencies.

Updating node version should result in invalidating of the kaniko dependencies layer cache and fetch dependencies again.
