### PR TITLE
improvement(k8s): ensure retries for most frequent `kubectl` calls

### DIFF
--- a/core/src/plugins/kubernetes/api.ts
+++ b/core/src/plugins/kubernetes/api.ts
@@ -9,8 +9,6 @@
 import { IncomingMessage } from "http"
 import { ReadStream } from "tty"
 import Bluebird from "bluebird"
-import chalk from "chalk"
-import httpStatusCodes from "http-status-codes"
 import {
   ApiextensionsV1Api,
   ApisApi,
@@ -18,7 +16,6 @@ import {
   CoreApi,
   CoreV1Api,
   Exec,
-  HttpError,
   KubeConfig,
   KubernetesObject,
   Log as K8sLog,
@@ -36,7 +33,7 @@ import { load } from "js-yaml"
 import { readFile } from "fs-extra"
 import WebSocket from "isomorphic-ws"
 import pRetry from "p-retry"
-import { Omit, sleep, StringCollector } from "../../util/util"
+import { Omit, StringCollector } from "../../util/util"
 import { flatten, isObject, isPlainObject, keyBy, omitBy } from "lodash"
 import { ConfigurationError, GardenBaseError, RuntimeError } from "../../exceptions"
 import {
@@ -49,16 +46,16 @@ import {
 } from "./types"
 import { Log } from "../../logger/log-entry"
 import { kubectl } from "./kubectl"
-import { deline, urlJoin } from "../../util/string"
+import { urlJoin } from "../../util/string"
 import { KubernetesProvider } from "./config"
 import { StringMap } from "../../config/common"
 import { PluginContext } from "../../plugin-context"
 import { PassThrough, Readable, Writable } from "stream"
 import { getExecExitCode } from "./status/pod"
 import { labelSelectorToString } from "./util"
-import { LogLevel } from "../../logger/logger"
 import { safeDumpYaml } from "../../util/serialization"
 import AsyncLock from "async-lock"
+import { requestWithRetry, RetryOpts } from "./retry"
 import request = require("request-promise")
 import requestErrors = require("request-promise/errors")
 
@@ -1026,110 +1023,3 @@ function handleRequestPromiseError(name: string, err: Error) {
     return wrapError(name, err)
   }
 }
-
-/**
- * The flag {@code forceRetry} can be used to avoid {@link shouldRetry} helper call in case if the error code
- * or the error message pattern is unknown.
- */
-type RetryOpts = { maxRetries?: number; minTimeoutMs?: number; forceRetry?: boolean }
-
-/**
- * Helper function for retrying failed k8s API requests, using exponential backoff.
- *
- * Note: When using the Got library, don't use this helper, but instead rely on Got's built-in retry functionality.
- *
- * Only retries the request when it fails with an error that matches certain status codes and/or error
- * message contents (see the `shouldRetry` helper for details).
- *
- * The rationale here is that some errors occur because of network issues, intermittent timeouts etc.
- * and should be retried automatically.
- */
-async function requestWithRetry<R>(log: Log, description: string, req: () => Promise<R>, opts?: RetryOpts): Promise<R> {
-  const maxRetries = opts?.maxRetries ?? 5
-  const minTimeoutMs = opts?.minTimeoutMs ?? 500
-  const forceRetry = opts?.forceRetry ?? false
-  let retryLog: Log | undefined = undefined
-  const retry = async (usedRetries: number): Promise<R> => {
-    try {
-      return await req()
-    } catch (err) {
-      if (forceRetry || shouldRetry(err)) {
-        retryLog = retryLog || log.createLog({ fixLevel: LogLevel.debug })
-        if (usedRetries <= maxRetries) {
-          const sleepMsec = minTimeoutMs + usedRetries * minTimeoutMs
-          retryLog.info(deline`
-            ${description} failed with error '${err.message}', retrying in ${sleepMsec}ms
-            (${usedRetries}/${maxRetries})
-          `)
-          await sleep(sleepMsec)
-          return await retry(usedRetries + 1)
-        } else {
-          if (usedRetries === maxRetries) {
-            retryLog.info(chalk.red(`Kubernetes API: Maximum retry count exceeded`))
-          }
-          throw err
-        }
-      } else {
-        throw err
-      }
-    }
-  }
-  const result = await retry(1)
-  return result
-}
-
-/**
- * This helper determines whether an error thrown by a k8s API request should result in the request being retried.
- *
- * Looks for a list of matching error messages. Also checks for status codes for the following error classes:
- * - `KubernetesError` (when handling wrapped k8s API errors)
- * - `requestErrors.StatusCodeError` (when using the `request` library)
- *
- * Add more error codes / regexes / filters etc. here as needed.
- */
-function shouldRetry(err: any): boolean {
-  const msg = err.message || ""
-  let code: number | undefined = undefined
-
-  if (err instanceof requestErrors.StatusCodeError || err instanceof KubernetesError || err instanceof HttpError) {
-    code = err.statusCode
-  }
-
-  return (
-    (code && statusCodesForRetry.includes(code)) ||
-    err.code === "ECONNRESET" || // <- socket hang up
-    !!errorMessageRegexesForRetry.find((regex) => msg.match(regex))
-  )
-}
-
-export const statusCodesForRetry: number[] = [
-  httpStatusCodes.REQUEST_TIMEOUT,
-  httpStatusCodes.TOO_MANY_REQUESTS,
-
-  httpStatusCodes.INTERNAL_SERVER_ERROR,
-  httpStatusCodes.BAD_GATEWAY,
-  httpStatusCodes.SERVICE_UNAVAILABLE,
-  httpStatusCodes.GATEWAY_TIMEOUT,
-
-  // Cloudflare-specific status codes
-  521, // Web Server Is Down
-  522, // Connection Timed Out
-  524, // A Timeout Occurred
-]
-
-const errorMessageRegexesForRetry = [
-  /ETIMEDOUT/,
-  /ENOTFOUND/,
-  /EAI_AGAIN/,
-  /ECONNRESET/,
-  /socket hang up/,
-  // This usually isn't retryable
-  // However on github actions there seems to be flakiness
-  // And connections get refused temporarily only
-  // So we retry those as well
-  /ECONNREFUSED/,
-  // This can happen if etcd is overloaded
-  // (rpc error: code = ResourceExhausted desc = etcdserver: throttle: too many requests)
-  /too many requests/,
-  /Unable to connect to the server/,
-]

--- a/core/src/plugins/kubernetes/api.ts
+++ b/core/src/plugins/kubernetes/api.ts
@@ -942,14 +942,15 @@ export async function getKubeConfig(log: Log, ctx: PluginContext, provider: Kube
     if (provider.config.kubeconfig) {
       kubeConfigStr = (await readFile(provider.config.kubeconfig)).toString()
     } else {
+      const args = ["config", "view", "--raw"]
       // We use kubectl for this, to support merging multiple paths in the KUBECONFIG env var
       kubeConfigStr = await requestWithRetry(
         log,
-        "",
+        `kubectl ${args.join(" ")}`,
         () =>
           kubectl(ctx, provider).stdout({
             log,
-            args: ["config", "view", "--raw"],
+            args,
           }),
         { forceRetry: true }
       )

--- a/core/src/plugins/kubernetes/retry.ts
+++ b/core/src/plugins/kubernetes/retry.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2018-2023 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import chalk from "chalk"
+import httpStatusCodes from "http-status-codes"
+import { HttpError } from "@kubernetes/client-node"
+import { sleep } from "../../util/util"
+import { Log } from "../../logger/log-entry"
+import { deline } from "../../util/string"
+import { LogLevel } from "../../logger/logger"
+import { KubernetesError } from "./api"
+import requestErrors = require("request-promise/errors")
+
+/**
+ * The flag {@code forceRetry} can be used to avoid {@link shouldRetry} helper call in case if the error code
+ * or the error message pattern is unknown.
+ */
+export type RetryOpts = { maxRetries?: number; minTimeoutMs?: number; forceRetry?: boolean }
+
+/**
+ * Helper function for retrying failed k8s API requests, using exponential backoff.
+ *
+ * Note: When using the Got library, don't use this helper, but instead rely on Got's built-in retry functionality.
+ *
+ * Only retries the request when it fails with an error that matches certain status codes and/or error
+ * message contents (see the `shouldRetry` helper for details).
+ *
+ * The rationale here is that some errors occur because of network issues, intermittent timeouts etc.
+ * and should be retried automatically.
+ */
+export async function requestWithRetry<R>(log: Log, description: string, req: () => Promise<R>, opts?: RetryOpts): Promise<R> {
+  const maxRetries = opts?.maxRetries ?? 5
+  const minTimeoutMs = opts?.minTimeoutMs ?? 500
+  const forceRetry = opts?.forceRetry ?? false
+  let retryLog: Log | undefined = undefined
+  const retry = async (usedRetries: number): Promise<R> => {
+    try {
+      return await req()
+    } catch (err) {
+      if (forceRetry || shouldRetry(err)) {
+        retryLog = retryLog || log.createLog({ fixLevel: LogLevel.debug })
+        if (usedRetries <= maxRetries) {
+          const sleepMsec = minTimeoutMs + usedRetries * minTimeoutMs
+          retryLog.info(deline`
+            ${description} failed with error '${err.message}', retrying in ${sleepMsec}ms
+            (${usedRetries}/${maxRetries})
+          `)
+          await sleep(sleepMsec)
+          return await retry(usedRetries + 1)
+        } else {
+          if (usedRetries === maxRetries) {
+            retryLog.info(chalk.red(`Kubernetes API: Maximum retry count exceeded`))
+          }
+          throw err
+        }
+      } else {
+        throw err
+      }
+    }
+  }
+  const result = await retry(1)
+  return result
+}
+
+/**
+ * This helper determines whether an error thrown by a k8s API request should result in the request being retried.
+ *
+ * Looks for a list of matching error messages. Also checks for status codes for the following error classes:
+ * - `KubernetesError` (when handling wrapped k8s API errors)
+ * - `requestErrors.StatusCodeError` (when using the `request` library)
+ *
+ * Add more error codes / regexes / filters etc. here as needed.
+ */
+export function shouldRetry(err: any): boolean {
+  const msg = err.message || ""
+  let code: number | undefined = undefined
+
+  if (err instanceof requestErrors.StatusCodeError || err instanceof KubernetesError || err instanceof HttpError) {
+    code = err.statusCode
+  }
+
+  return (
+    (code && statusCodesForRetry.includes(code)) ||
+    err.code === "ECONNRESET" || // <- socket hang up
+    !!errorMessageRegexesForRetry.find((regex) => msg.match(regex))
+  )
+}
+
+export const statusCodesForRetry: number[] = [
+  httpStatusCodes.REQUEST_TIMEOUT,
+  httpStatusCodes.TOO_MANY_REQUESTS,
+
+  httpStatusCodes.INTERNAL_SERVER_ERROR,
+  httpStatusCodes.BAD_GATEWAY,
+  httpStatusCodes.SERVICE_UNAVAILABLE,
+  httpStatusCodes.GATEWAY_TIMEOUT,
+
+  // Cloudflare-specific status codes
+  521, // Web Server Is Down
+  522, // Connection Timed Out
+  524, // A Timeout Occurred
+]
+
+const errorMessageRegexesForRetry = [
+  /ETIMEDOUT/,
+  /ENOTFOUND/,
+  /EAI_AGAIN/,
+  /ECONNRESET/,
+  /socket hang up/,
+  // This usually isn't retryable
+  // However on github actions there seems to be flakiness
+  // And connections get refused temporarily only
+  // So we retry those as well
+  /ECONNREFUSED/,
+  // This can happen if etcd is overloaded
+  // (rpc error: code = ResourceExhausted desc = etcdserver: throttle: too many requests)
+  /too many requests/,
+  /Unable to connect to the server/,
+]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
A follow-up PR for #4657. The original PR introduced an error message pattern to enable retries for k3s deployment errors. However, the retries didn't work because the deployment was done over the `kubectl` command instead of `KubeApi`.

This PR wraps the most frequently used `kubectl` calls into the retry machinery that is used in `KubeApi`. The retry settings are customized to avoid too-long retry intervals.

**Which issue(s) this PR fixes**:

Fixes #4460

**Special notes for your reviewer**:
See individual commits for details. Most of the changes are related to the dedicated refactoring commit https://github.com/garden-io/garden/pull/4749/commits/707d176c250fae41440f7f0d32e2edbf4c7752ff.

I tested the fix twice with Google CloudShell and got no errors like in the original issue.
