### PR TITLE
feat(cloud): display short url for command result

### DIFF
--- a/core/src/cloud/api.ts
+++ b/core/src/cloud/api.ts
@@ -700,8 +700,19 @@ export class CloudApi {
     return new URL(`/projects/${projectId}`, this.domain)
   }
 
-  getCommandResultUrl({ projectId, sessionId, userId }: { projectId: string; sessionId: string; userId: string }) {
-    const path = `/projects/${projectId}?sessionId=${sessionId}&userId=${userId}`
+  getCommandResultUrl({
+    projectId,
+    sessionId,
+    userId,
+    shortId,
+  }: {
+    projectId: string
+    sessionId: string
+    userId: string
+    shortId: string
+  }) {
+    // fallback to full url if shortid is missing
+    const path = shortId ? `/go/command/${shortId}` : `/projects/${projectId}/commands/${sessionId}`
     return new URL(path, this.domain)
   }
 

--- a/core/src/commands/base.ts
+++ b/core/src/commands/base.ts
@@ -332,11 +332,11 @@ export abstract class Command<A extends Parameters = {}, O extends Parameters = 
             sessionId: garden.sessionId,
             projectId: cloudSession.projectId,
             userId,
+            shortId: cloudSession.shortId,
           }).href
           const cloudLog = log.createLog({ name: getCloudLogSectionName(distroName) })
 
-          // FIXME: We need a shortened URL for this
-          cloudLog.info(`View command results at:\n${chalk.cyan(commandResultUrl)}\n`)
+          cloudLog.info(`View command results at: ${chalk.cyan(commandResultUrl)}\n`)
         }
 
         let analytics: AnalyticsHandler | undefined


### PR DESCRIPTION
**What this PR does / why we need it**:
Show shorter cloud url for command result

**Which issue(s) this PR fixes**:

Fixes #4683

**Special notes for your reviewer**:
