### PR TITLE
chore: remove handler validation todo comment

### DIFF
--- a/core/src/router/base.ts
+++ b/core/src/router/base.ts
@@ -321,9 +321,6 @@ export abstract class BaseActionRouter<K extends ActionKind> extends BaseRouter 
 
     const result: GetActionTypeResults<ActionTypeClasses<K>[T]> = await handler(handlerParams)
 
-    // Validate result
-    // TODO-0.13.0
-
     return { ctx: handlerParams.ctx, result }
   }
 


### PR DESCRIPTION
handler results are already validated here:
https://github.com/garden-io/garden/blob/c16bff6c9e4caa11f26211b0f1af9c2d73009aa3/core/src/router/base.ts#L380

closes [#4544](https://github.com/garden-io/garden/issues/4544)
