### PR TITLE
chore: use `safe-json-stringify` in logging and output rendering

### DIFF
--- a/core/src/cli/autocomplete.ts
+++ b/core/src/cli/autocomplete.ts
@@ -12,6 +12,7 @@ import { ConfigDump } from "../garden"
 import { Log } from "../logger/log-entry"
 import { parseCliArgs, pickCommand } from "./helpers"
 import { globalDisplayOptions, globalGardenInstanceOptions, globalOptions, Parameter, Parameters } from "./params"
+import stringify from "json-stringify-safe"
 
 export interface AutocompleteSuggestion {
   // What's being suggested in the last item in the split array
@@ -110,7 +111,7 @@ export class Autocompleter {
   }
 
   private debug(msg: any) {
-    this.enableDebug && this.log.silly(typeof msg === "string" ? msg : JSON.stringify(msg))
+    this.enableDebug && this.log.silly(typeof msg === "string" ? msg : stringify(msg))
   }
 
   private matchCommandNames(commands: Command[], input: string) {

--- a/core/src/cli/params.ts
+++ b/core/src/cli/params.ts
@@ -29,7 +29,7 @@ export const OUTPUT_RENDERERS = {
   },
   yaml: (data: DeepPrimitiveMap) => {
     // Convert data to JSON object so that `safeDumpYaml` renders any errors.
-    return safeDumpYaml(JSON.parse(JSON.stringify(data)), { noRefs: true })
+    return safeDumpYaml(JSON.parse(stringify(data)), { noRefs: true })
   },
 }
 

--- a/core/src/cloud/buffered-event-stream.ts
+++ b/core/src/cloud/buffered-event-stream.ts
@@ -7,6 +7,7 @@
  */
 
 import Bluebird from "bluebird"
+import stringify from "json-stringify-safe"
 
 import { Events, EventName, GardenEventAnyListener, shouldStreamEvent } from "../events/events"
 import { LogMetadata, Log, LogEntry, LogContext } from "../logger/log-entry"
@@ -318,7 +319,7 @@ export class BufferedEventStream {
         const targetUrl = `${target.host}/${path}`
         this.log.silly(`Flushing ${description} to ${targetUrl}`)
         this.log.silly(`--------`)
-        this.log.silly(`data: ${JSON.stringify(data)}`)
+        this.log.silly(`data: ${stringify(data)}`)
         this.log.silly(`--------`)
 
         const headers = makeAuthHeader(target.clientAuthToken || "")
@@ -387,11 +388,11 @@ export class BufferedEventStream {
     const batch: B[] = []
     let batchBytes = 0
     while (batchBytes < this.maxBatchBytes && buffered.length > 0) {
-      let nextRecordBytes = Buffer.from(JSON.stringify(buffered[0])).length
+      let nextRecordBytes = Buffer.from(stringify(buffered[0])).length
       if (nextRecordBytes > this.maxBatchBytes) {
         this.log.error(`Event or log entry too large to flush (${nextRecordBytes} bytes), dropping it.`)
         // Note: This must be a silly log to avoid recursion
-        this.log.silly(JSON.stringify(buffered[0]))
+        this.log.silly(stringify(buffered[0]))
         buffered.shift() // Drop first record.
         continue
       }

--- a/core/src/logger/renderers.ts
+++ b/core/src/logger/renderers.ts
@@ -8,6 +8,7 @@
 
 import logSymbols from "log-symbols"
 import chalk from "chalk"
+import stringify from "json-stringify-safe"
 import stripAnsi from "strip-ansi"
 import { isArray, repeat, trim } from "lodash"
 import stringWidth = require("string-width")
@@ -119,7 +120,7 @@ export function renderData(entry: LogEntry): string {
     const asYaml = safeDumpYaml(data, { noRefs: true })
     return highlightYaml(asYaml)
   }
-  return JSON.stringify(data, null, 2)
+  return stringify(data, null, 2)
 }
 
 export function renderSection(entry: LogEntry): string {

--- a/core/src/logger/writers/json-file-writer.ts
+++ b/core/src/logger/writers/json-file-writer.ts
@@ -6,6 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import stringify from "json-stringify-safe"
 import winston from "winston"
 import { LogEntry } from "../log-entry"
 import { LogLevel } from "../logger"
@@ -16,7 +17,7 @@ export function renderAsJson(level: LogLevel, entry: LogEntry): string | null {
   if (level >= entry.level) {
     const jsonEntry = formatForJson(entry)
     const empty = !(jsonEntry.msg || jsonEntry.data)
-    return empty ? null : JSON.stringify(jsonEntry)
+    return empty ? null : stringify(jsonEntry)
   }
   return null
 }

--- a/core/src/logger/writers/json-terminal-writer.ts
+++ b/core/src/logger/writers/json-terminal-writer.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { LogMetadata, LogEntry } from "../log-entry"
+import stringify from "json-stringify-safe"
+import { LogEntry, LogMetadata } from "../log-entry"
 import { Logger } from "../logger"
 import { Writer } from "./base"
 import { formatForJson } from "../renderers"
@@ -29,7 +30,7 @@ export class JsonTerminalWriter extends Writer {
     if (level >= entry.level) {
       const jsonEntry = formatForJson(entry)
       const empty = !(jsonEntry.msg || jsonEntry.data)
-      return empty ? null : JSON.stringify(jsonEntry)
+      return empty ? null : stringify(jsonEntry)
     }
     return null
   }

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -44,6 +44,7 @@ import { V1PodSpec, V1Container, V1Pod, V1ContainerStatus, V1PodStatus } from "@
 import { RunResult } from "../../plugin/base"
 import { LogLevel } from "../../logger/logger"
 import { getResourceEvents } from "./status/events"
+import stringify from "json-stringify-safe"
 
 /**
  * When a `podSpec` is passed to `runAndCopy`, only these fields will be used for the runner's pod spec
@@ -564,7 +565,7 @@ async function runWithArtifacts({
           })
         } else {
           throw new RuntimeError({
-            message: `Failed to start Pod ${runner.podName}: ${JSON.stringify(status.resource.status, null, 2)}`,
+            message: `Failed to start Pod ${runner.podName}: ${stringify(status.resource.status, null, 2)}`,
             detail: errorMetadata,
           })
         }
@@ -1248,7 +1249,7 @@ export class PodRunner extends PodRunnerParams {
           // Print Pod status if case of too generic and non-informative error in the terminated state
           if (!terminatedContainerState?.message && terminatedContainerState?.reason === "Error") {
             if (!!podStatus) {
-              const podStatusDesc = "PodStatus:\n" + JSON.stringify(podStatus, null, 2)
+              const podStatusDesc = "PodStatus:\n" + stringify(podStatus, null, 2)
               errorDesc += podStatusDesc + "\n\n"
             }
           }

--- a/core/src/plugins/kubernetes/status/pod.ts
+++ b/core/src/plugins/kubernetes/status/pod.ts
@@ -13,6 +13,7 @@ import { V1Pod, V1Status } from "@kubernetes/client-node"
 import { ResourceStatus } from "./status"
 import chalk from "chalk"
 import { DeployState, combineStates } from "../../../types/service"
+import stringify from "json-stringify-safe"
 
 export const POD_LOG_LINES = 30
 
@@ -148,7 +149,7 @@ export async function getPodLogs({
     }
 
     if (typeof log === "object") {
-      log = JSON.stringify(log)
+      log = stringify(log)
     }
 
     // the API returns undefined if no logs have been output, for some reason

--- a/core/src/plugins/kubernetes/status/pod.ts
+++ b/core/src/plugins/kubernetes/status/pod.ts
@@ -97,12 +97,11 @@ export async function getPodLogs({
   }
 
   return Bluebird.map(podContainers, async (containerName) => {
-    let log = ""
-
     const follow = false
     const insecureSkipTLSVerify = false
     const pretty = undefined
 
+    let log: any
     try {
       log = await api.core.readNamespacedPodLog(
         pod.metadata!.name!,

--- a/core/src/watch.ts
+++ b/core/src/watch.ts
@@ -13,6 +13,7 @@ import EventEmitter2 from "eventemitter2"
 import { EventBus } from "./events/events"
 import { Stats } from "fs"
 import { join } from "path"
+import stringify from "json-stringify-safe"
 
 let watcher: Watcher | undefined
 
@@ -86,7 +87,7 @@ export class Watcher extends EventEmitter2 {
         this.ready = true
       })
       .on("all", (name, path, payload) => {
-        this.log.silly(`FSWatcher event: ${name} ${path} ${JSON.stringify(payload)}`)
+        this.log.silly(`FSWatcher event: ${name} ${path} ${stringify(payload)}`)
         this.routeEvent(name, path, payload)
       })
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
Replace `JSON.stringify` with [`json-stringify-safe`](https://github.com/moll/json-stringify-safe) - a lightweight wrapper on top of `JSON.stringify`. [NPM trends](https://npmtrends.com/circular-json-vs-fast-safe-stringify-vs-json-stringify-safe) show it as the most frequently used library.

**Which issue(s) this PR fixes**:

This might address #4592

**Special notes for your reviewer**:
