### PR TITLE
fix(cli): override nested variables using dot notation

### DIFF
--- a/core/test/unit/src/cli/cli.ts
+++ b/core/test/unit/src/cli/cli.ts
@@ -819,10 +819,12 @@ describe("cli", () => {
       cli.addCommand(command)
 
       const { result } = await cli.run({
-        args: ["test-command-var", "--var", 'key-a=value-a,key-b="value with quotes"'],
+        args: ["test-command-var", "--var", 'key-a=value-a,key-b="value with quotes",key-c.key-d=nested-value'],
         exitOnError: false,
       })
-      expect(result).to.eql({ variables: { "key-a": "value-a", "key-b": "value with quotes" } })
+      expect(result).to.eql({
+        variables: { "key-a": "value-a", "key-b": "value with quotes", "key-c": { "key-d": "nested-value" } },
+      })
     })
 
     it("should output JSON if --output=json", async () => {

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -437,15 +437,31 @@ describe("Garden", () => {
         path: pathFoo,
         environments: [{ name: "default", defaultNamespace: "foo", variables: {} }],
         providers: [{ name: "foo" }],
-        variables: { foo: "default", bar: "something" },
+        variables: {
+          "foo": "default",
+          "bar": "something",
+          "nested": {
+            nestedKey1: "somevalue1",
+            nestedKey2: "someValue2",
+          },
+          "key.withdot": "somevalue3",
+        },
       })
       const garden = await TestGarden.factory(pathFoo, {
         config,
         environmentString: "default",
-        variableOverrides: { foo: "override" },
+        variableOverrides: { "foo": "override", "nested.nestedKey2": "somevalue2new", "key.withdot": "somevalue3new" },
       })
 
-      expect(garden.variables).to.eql({ foo: "override", bar: "something" })
+      expect(garden.variables).to.eql({
+        "foo": "override",
+        "bar": "something",
+        "nested": {
+          nestedKey1: "somevalue1",
+          nestedKey2: "somevalue2new",
+        },
+        "key.withdot": "somevalue3new",
+      })
     })
 
     it("should set the default proxy config if non is specified", async () => {

--- a/docs/using-garden/variables-and-templating.md
+++ b/docs/using-garden/variables-and-templating.md
@@ -457,7 +457,7 @@ name: my-deploy
 # than those in the `variables` field below).
 #
 # If a varfile is defined but not found, an error is thrown in order to prevent misconfigurations silently passing.
-varfiles: 
+varfiles:
   - my-service.${environment.name}.yaml
 variables:
   # This overrides the project-level hostname variable
@@ -492,11 +492,12 @@ The default varfile format will change to YAML in Garden v0.14, since YAML allow
 In the meantime, to use YAML or JSON files, you must explicitly set the varfile name(s) in your project configuration, via the [`varfile`](../reference/project-config.md#varfile) and/or [`environments[].varfile`](../reference/project-config.md#environmentsvarfile) fields.
 {% endhint %}
 
-You can also set variables on the command line, with `--var` flags. Note that while this is handy for ad-hoc invocations, we don't generally recommend relying on this for normal operations, since you lose a bit of visibility within your configuration. But here's one practical example:
+You can also set variables on the command line, with `--var` flags. To override a nested variable, you can use dot notation. Note that while this is handy for ad-hoc invocations, we don't generally recommend relying on this for normal operations, since you lose a bit of visibility within your configuration. But here's one practical example:
 
 ```sh
-# Override two specific variables value and run a task
-garden run my-run --var my-run-arg=foo,some-numeric-var=123
+# Override three specific variables value and run a task.
+# Use dot notation to override nested variables
+garden run my-run --var my-run-arg=foo,some-numeric-var=123,my-nested-vars.var1=bar
 ```
 
 Multiple variables are separated with a comma, and each part is parsed using [dotenv](https://github.com/motdotla/dotenv#rules) syntax.


### PR DESCRIPTION
**What this PR does / why we need it**:
allows to override nested variables using dot notation.

So if there's a config like following:

```
apiVersion: garden.io/v1
kind: Project
name: example-nested-vars
environments:
  - name: local
providers:
  - name: local-kubernetes
    environments: [local]
    namespace: ${project.name}-testing-${var.userId}
variables:
  userId: ${local.username}
  foo:
    bar: something
  somevar.withdot: oldvalue
  examplevar: someoldvalue

```

it's possible to override variable values in garden deploy:
```
garden deploy --var foo.bar=newvalueofbar,somevar.withdot=mynewvalue,examplevar=hello
```

**Which issue(s) this PR fixes**:

Fixes #3873 

**Special notes for your reviewer**:
