### PR TITLE
fix: override action variables via --var cli flag

### DIFF
--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -1996,7 +1996,7 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
 })
 
 // Override variables, also allows to override nested variables using dot notation
-function overrideVariables(variables: DeepPrimitiveMap, overrideVariables: DeepPrimitiveMap): DeepPrimitiveMap {
+export function overrideVariables(variables: DeepPrimitiveMap, overrideVariables: DeepPrimitiveMap): DeepPrimitiveMap {
   let objNew = cloneDeep(variables)
   Object.keys(overrideVariables).forEach((key) => {
     if (objNew.hasOwnProperty(key)) {


### PR DESCRIPTION
**What this PR does / why we need it**:
A follow up PR to #3873 for addressing #4772. Previously, variables set using the --var cli flag only had impact on the
project level variables. 

**Which issue(s) this PR fixes**:

Fixes #4772

**Special notes for your reviewer**:
