### PR TITLE
chore(examples): fix octal numbers in manifest

### DIFF
--- a/examples/kubernetes-deploy/redis/redis.yml
+++ b/examples/kubernetes-deploy/redis/redis.yml
@@ -242,7 +242,7 @@ spec:
         - name: health
           configMap:
             name: redis-health
-            defaultMode: 0755
+            defaultMode: 0o755
         - name: config
           configMap:
             name: redis
@@ -350,7 +350,7 @@ spec:
         - name: health
           configMap:
             name: redis-health
-            defaultMode: 0755
+            defaultMode: 0o755
         - name: config
           configMap:
             name: redis


### PR DESCRIPTION
**What this PR does / why we need it**:

Before this fix, the `kubernetes-deploy` example failed to deploy because of a problem with the way octal numbers in manifests were parsed.