### PR TITLE
forgotten cherry-pick from 0.12: chore: move away from k8s javascript client fork (#3967)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,13 +94,12 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - yarn-v6-<<parameters.context>>-{{ checksum "yarn.lock" }}
-            - yarn-v6-<<parameters.context>>
+            - yarn-v7-<<parameters.context>>-{{ checksum "yarn.lock" }}
 
       - run: yarn
 
       - save_cache:
-          key: yarn-v6-<<parameters.context>>-{{ checksum "yarn.lock" }}
+          key: yarn-v7-<<parameters.context>>-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
 
@@ -232,13 +231,9 @@ commands:
       - checkout
       - npm_install
       - *attach-workspace
-      - run:
-          # Need this to make sure pkg cache is scoped to specific pkg version
-          name: Get pkg version
-          command: jq '.devDependencies.pkg' cli/package.json > .pkgversion
       - restore_cache:
           keys:
-            - pkg-v1-{{ checksum ".pkgversion" }}
+            - pkg-v3-{{ checksum "yarn.lock" }}
       - run:
           name: Run dist script
           command: yarn run dist --version "<<parameters.version>>"
@@ -249,7 +244,7 @@ commands:
             # Needed for the alpine docker build
             - tmp/pkg/
       - save_cache:
-          key: pkg-v1-{{ checksum ".pkgversion" }}
+          key: pkg-v3-{{ checksum "yarn.lock" }}
           paths:
             - tmp/pkg-fetch
       - run:

--- a/core/package.json
+++ b/core/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@codenamize/codenamize": "^1.1.1",
     "@hapi/joi": "git+https://github.com/garden-io/joi.git#master",
-    "@kubernetes/client-node": "git+https://github.com/garden-io/javascript.git#master",
+    "@kubernetes/client-node": "=0.18.0",
     "@opentelemetry/api": "^1.4.1",
     "@opentelemetry/sdk-trace-base": "^1.14.0",
     "@opentelemetry/sdk-node": "^0.40.0",

--- a/core/src/plugins/kubernetes/api.ts
+++ b/core/src/plugins/kubernetes/api.ts
@@ -20,7 +20,7 @@ import {
   KubernetesObject,
   Log as K8sLog,
   NetworkingV1Api,
-  PolicyV1beta1Api,
+  PolicyV1Api,
   RbacAuthorizationV1Api,
   V1APIGroup,
   V1APIResource,
@@ -86,7 +86,7 @@ type K8sApi =
   | CoreApi
   | CoreV1Api
   | NetworkingV1Api
-  | PolicyV1beta1Api
+  | PolicyV1Api
   | RbacAuthorizationV1Api
 type K8sApiConstructor<T extends K8sApi> = new (basePath?: string) => T
 
@@ -97,7 +97,7 @@ const apiTypes: { [key: string]: K8sApiConstructor<any> } = {
   coreApi: CoreApi,
   extensions: ApiextensionsV1Api,
   networking: NetworkingV1Api,
-  policy: PolicyV1beta1Api,
+  policy: PolicyV1Api,
   rbac: RbacAuthorizationV1Api,
 }
 
@@ -191,7 +191,7 @@ export class KubeApi {
   public coreApi: WrappedApi<CoreApi>
   public extensions: WrappedApi<ApiextensionsV1Api>
   public networking: WrappedApi<NetworkingV1Api>
-  public policy: WrappedApi<PolicyV1beta1Api>
+  public policy: WrappedApi<PolicyV1Api>
   public rbac: WrappedApi<RbacAuthorizationV1Api>
 
   constructor(

--- a/core/src/plugins/kubernetes/namespace.ts
+++ b/core/src/plugins/kubernetes/namespace.ts
@@ -285,7 +285,7 @@ export async function prepareNamespaces({ ctx, log }: GetEnvironmentStatusParams
       message: dedent`
       Unable to connect to Kubernetes cluster. Got error:
 
-      ${err.message}
+      ${err.stack}
     `,
       detail: { providerConfig: k8sCtx.provider.config },
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -617,9 +617,10 @@
   dependencies:
     "@jsdevtools/file-path-filter" "^3.0.2"
 
-"@kubernetes/client-node@git+https://github.com/garden-io/javascript.git#master":
+"@kubernetes/client-node@=0.18.0":
   version "0.18.0"
-  resolved "git+https://github.com/garden-io/javascript.git#9c3fd5fbccc753813b33564ab8d63bc8c4b19a4f"
+  resolved "https://registry.yarnpkg.com/@kubernetes/client-node/-/client-node-0.18.0.tgz#b1002f3c19fb7509ce521ea78f500589f8e3e047"
+  integrity sha512-Mp6q0OkZQBp+HslIgvHYpsPJk8z6mch231QWtIZQHvs+PaTE6mkUfusYE8fNw3jMjru5mVO/JDz6PTjB9YT2rQ==
   dependencies:
     "@types/js-yaml" "^4.0.1"
     "@types/node" "^10.12.0"
@@ -636,11 +637,11 @@
     stream-buffers "^3.0.2"
     tar "^6.1.11"
     tmp-promise "^3.0.2"
-    tslib "^1.9.3"
-    underscore "^1.9.1"
+    tslib "^2.4.1"
+    underscore "^1.13.6"
     ws "^7.3.1"
   optionalDependencies:
-    openid-client "^5.1.6"
+    openid-client "^5.3.0"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -7058,10 +7059,10 @@ join-component@^1.1.0:
   resolved "https://registry.yarnpkg.com/join-component/-/join-component-1.1.0.tgz#b8417b750661a392bee2c2537c68b2a9d4977cd5"
   integrity sha1-uEF7dQZho5K+4sJTfGiyqdSXfNU=
 
-jose@^4.10.0:
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/jose/-/jose-4.11.0.tgz#1c7f5c7806383d3e836434e8f49da531cb046a9d"
-  integrity sha512-wLe+lJHeG8Xt6uEubS4x0LVjS/3kXXu9dGoj9BNnlhYq7Kts0Pbb2pvv5KiI0yaKH/eaiR0LUOBhOVo9ktd05A==
+jose@^4.14.4:
+  version "4.14.4"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-4.14.4.tgz#59e09204e2670c3164ee24cbfe7115c6f8bff9ca"
+  integrity sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g==
 
 jquery-extend@~2.0.3:
   version "2.0.3"
@@ -8566,10 +8567,10 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-hash@^2.0.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.1.1.tgz#9447d0279b4fcf80cff3259bf66a1dc73afabe09"
-  integrity sha512-VOJmgmS+7wvXf8CjbQmimtCnEx3IAoLxI3fp2fbWehxrWBcAQFbk+vcwb6vzR0VZv/eNCJ/27j151ZTwqW/JeQ==
+object-hash@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
+  integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
 
 object-hash@^3.0.0:
   version "3.0.0"
@@ -8686,10 +8687,10 @@ object.values@^1.1.6:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
-oidc-token-hash@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz#ae6beec3ec20f0fd885e5400d175191d6e2f10c6"
-  integrity sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ==
+oidc-token-hash@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz#9a229f0a1ce9d4fc89bcaee5478c97a889e7b7b6"
+  integrity sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==
 
 on-finished@2.4.1, on-finished@^2.3.0:
   version "2.4.1"
@@ -8753,15 +8754,15 @@ opencollective-postinstall@^2.0.2:
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
   integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
 
-openid-client@^5.1.6:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/openid-client/-/openid-client-5.2.1.tgz#dd26298aca237625298ef34ff11ad9276917df28"
-  integrity sha512-KPxqWnxobG/70Cxqyvd43RWfCfHedFnCdHSBpw5f7WnTnuBAeBnvot/BIo+brrcTr0wyAYUlL/qejQSGwWtdIg==
+openid-client@^5.3.0:
+  version "5.4.3"
+  resolved "https://registry.yarnpkg.com/openid-client/-/openid-client-5.4.3.tgz#c75d2f6d07a25d383a72c8ff34605a36b7e2cd73"
+  integrity sha512-sVQOvjsT/sbSfYsQI/9liWQGVZH/Pp3rrtlGEwgk/bbHfrUDZ24DN57lAagIwFtuEu+FM9Ev7r85s8S/yPjimQ==
   dependencies:
-    jose "^4.10.0"
+    jose "^4.14.4"
     lru-cache "^6.0.0"
-    object-hash "^2.0.1"
-    oidc-token-hash "^5.0.1"
+    object-hash "^2.2.0"
+    oidc-token-hash "^5.0.3"
 
 opentracing@^0.14.4:
   version "0.14.7"
@@ -11419,10 +11420,15 @@ ts-stream@^3.0.0:
   dependencies:
     "@types/node" "*"
 
-tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.4.1:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.0.tgz#b295854684dbda164e181d259a22cd779dcd7bc3"
+  integrity sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==
 
 tsscmp@1.0.6:
   version "1.0.6"
@@ -11594,7 +11600,7 @@ unc-path-regex@^0.1.2:
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
   integrity sha1-5z3T17DXxe2G+6xrCufYxqadUPo=
 
-underscore@^1.9.1:
+underscore@^1.13.6, underscore@^1.9.1:
   version "1.13.6"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
   integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
* chore: move away from k8s javascript client fork

The changes in the fork have been released. We can move away from the
fork.

* ci: make sure to use fresh cache when yarn.lock changes

This is to avoid running into caching issues

* fix: pin down version to 0.18.0

We had to pin the version to 0.18.0 because with 0.18.1 we ran into a problem due to kubernetes client's migration from execa to child_process.spawnSync, see also https://github.com/kubernetes-client/javascript/issues/1013


**Which issue(s) this PR fixes**:

Makes it possible to merge https://github.com/garden-io/garden-platform/pull/2694

**Special notes for your reviewer**:
