### PR TITLE
fix(cloud): send "sessionFailed" event if result has errors

### DIFF
--- a/core/src/cloud/api.ts
+++ b/core/src/cloud/api.ts
@@ -94,8 +94,8 @@ export type ApiFetchResponse<T> = T & {
 
 // TODO: Read this from the `api-types` package once the session registration logic has been released in Cloud.
 export interface CloudSessionResponse {
-  environmentId: number
-  namespaceId: number
+  environmentId: string
+  namespaceId: string
   shortId: string
 }
 

--- a/core/src/cloud/buffered-event-stream.ts
+++ b/core/src/cloud/buffered-event-stream.ts
@@ -83,8 +83,8 @@ interface ApiBatchBase {
 
 export interface ApiEventBatch extends ApiBatchBase {
   events: StreamEvent[]
-  environmentId?: number
-  namespaceId?: number
+  environmentId?: string
+  namespaceId?: string
   // TODO: Remove the `environment` and `namespace` params once we no longer need to support Cloud/Enterprise
   // versions that expect them.
   environment: string

--- a/core/src/commands/base.ts
+++ b/core/src/commands/base.ts
@@ -420,7 +420,11 @@ export abstract class Command<A extends Parameters = {}, O extends Parameters = 
             parentSessionId || undefined
           )
 
-          cloudEventStream.emit("sessionCompleted", {})
+          if (allErrors.length > 0) {
+            cloudEventStream.emit("sessionFailed", {})
+          } else {
+            cloudEventStream.emit("sessionCompleted", {})
+          }
         } catch (err) {
           analytics?.trackCommandResult(
             this.getFullName(),

--- a/core/src/events/events.ts
+++ b/core/src/events/events.ts
@@ -156,11 +156,11 @@ export type GraphResultEventPayload = Omit<GraphResult, "result" | "task" | "dep
 export interface CommandInfoPayload extends CommandInfo {
   // Contains additional context for the command info available during init
   environmentName: string
-  environmentId: number | undefined
+  environmentId?: string
   projectName: string
   projectId: string
   namespaceName: string
-  namespaceId: number | undefined
+  namespaceId?: string
   coreVersion: string
   vcsBranch: string
   vcsCommitHash: string


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Previously we'd send a "sessionCompleted" event which caused Cloud to display the wrong command status.

This is really just a quickfix since it's urgent but we should add some tests here.  

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
