### PR TITLE
chore: remove output flag hint from sync status

### DIFF
--- a/core/src/commands/sync/sync-status.ts
+++ b/core/src/commands/sync/sync-status.ts
@@ -99,15 +99,6 @@ export class SyncStatusCommand extends Command<Args, Opts> {
       .getDeploys({ includeDisabled: false, names: args.names })
       .sort((a, b) => (a.name > b.name ? 1 : -1))
 
-    log.info("")
-    log.info(
-      chalk.white(deline`
-      Getting sync statuses. For more detailed debug information, run this command with
-      the \`--output json\` or \`--output yaml\` flags.
-    `)
-    )
-    log.info("")
-
     const syncStatuses = await getSyncStatuses({ garden, graph, skipDetail, log, deployActions })
 
     if (isEmpty(syncStatuses) && args.names && args.names.length > 0) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes https://github.com/garden-io/garden/issues/4748

**Special notes for your reviewer**:

Added a breakpoint in the debugger and looked around, did not find any obvious variables/flags denoting that we would be within an interactive `garden dev` repl. Removing the hint message entirely, instead of only in dev mode.