### PR TITLE
chore(example): remove `imagePullPolicy` from `templated-k8s-container`

### DIFF
--- a/examples/templated-k8s-container/template/garden.yml
+++ b/examples/templated-k8s-container/template/garden.yml
@@ -52,7 +52,6 @@ configs:
                 containers:
                   - name: main
                     image: ${actions.build["${parent.name}"].outputs.deployment-image-id}
-                    imagePullPolicy: "Always"
                     ports:
                       - name: http
                         containerPort: ${inputs.containerPort}


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a very simple PR to fix Garden attempting to pull from a non-existent Docker registry. Garden should always build and push our templated image.

The `imagePullPolicy: "Always"` setting in Kubernetes means that it will always attempt to pull the image from a Docker registry.

Since we're using the templated `Build` image for our manifest, I've removed this line, which automatically sets `ImagePullPolicy: IfNotPresent`, our desired behavior.