### PR TITLE
fix: respect spec.publishId for publishing image

### DIFF
--- a/plugins/jib/index.ts
+++ b/plugins/jib/index.ts
@@ -16,7 +16,7 @@ import { mavendSpec, mvnd, mvndVersion } from "./mavend"
 import { gradle, gradleSpec, gradleVersion } from "./gradle"
 
 // TODO: gradually get rid of these core dependencies, move some to SDK etc.
-import { providerConfigBaseSchema, GenericProviderConfig, Provider } from "@garden-io/core/build/src/config/provider"
+import { GenericProviderConfig, Provider, providerConfigBaseSchema } from "@garden-io/core/build/src/config/provider"
 import { getGitHubUrl } from "@garden-io/core/build/src/docs/common"
 import {
   containerBuildSpecSchema,
@@ -205,7 +205,11 @@ export const gardenPlugin = () =>
               let projectType = spec.projectType
 
               if (!projectType) {
-                projectType = detectProjectType(action)
+                projectType = detectProjectType({
+                  actionName: action.name,
+                  actionBasePath: action.basePath(),
+                  actionFiles: action.getFullVersion().files,
+                })
                 statusLine.info(`Detected project type ${projectType}`)
               }
 

--- a/plugins/jib/test/util.ts
+++ b/plugins/jib/test/util.ts
@@ -37,26 +37,37 @@ describe("util", function () {
 
   describe("detectProjectType", () => {
     it("returns gradle if action files include a gradle config", () => {
-      action._config.internal.basePath = "/foo"
-      action["_treeVersion"].files = ["/foo/build.gradle"]
-
-      expect(detectProjectType(action)).to.equal("gradle")
+      expect(
+        detectProjectType({
+          actionName: "foo",
+          actionBasePath: "/foo",
+          actionFiles: ["/foo/build.gradle"],
+        })
+      ).to.equal("gradle")
     })
 
     it("returns maven if action files include a maven config", () => {
-      action._config.internal.basePath = "/foo"
-      action["_treeVersion"].files = ["/foo/pom.xml"]
-
-      expect(detectProjectType(action)).to.equal("maven")
+      expect(
+        detectProjectType({
+          actionName: "foo",
+          actionBasePath: "/foo",
+          actionFiles: ["/foo/pom.xml"],
+        })
+      ).to.equal("maven")
     })
 
     it("throws if no maven or gradle config is in the action file list", () => {
-      action._config.internal.basePath = "/foo"
-      action["_treeVersion"].files = []
-
-      void expectError(() => detectProjectType(action), {
-        contains: "Could not detect a gradle or maven project to build foo",
-      })
+      void expectError(
+        () =>
+          detectProjectType({
+            actionName: "foo",
+            actionBasePath: "/foo",
+            actionFiles: [],
+          }),
+        {
+          contains: "Could not detect a gradle or maven project to build foo",
+        }
+      )
     })
   })
 

--- a/plugins/jib/util.ts
+++ b/plugins/jib/util.ts
@@ -58,34 +58,40 @@ const gradlePaths = [
 const mavenPaths = ["pom.xml", ".mvn"]
 const mavendPaths = ["pom.xml", ".mvnd"]
 
-export function detectProjectType(action: BuildAction): JibPluginType {
-  const actionFiles = action.getFullVersion().files
-
+export function detectProjectType({
+  actionName,
+  actionBasePath,
+  actionFiles,
+}: {
+  actionName: string
+  actionBasePath: string
+  actionFiles: string[]
+}): JibPluginType {
   // TODO: support the Jib CLI
 
   for (const filename of gradlePaths) {
-    const path = resolve(action.basePath(), filename)
+    const path = resolve(actionBasePath, filename)
     if (actionFiles.includes(path)) {
       return "gradle"
     }
   }
 
   for (const filename of mavenPaths) {
-    const path = resolve(action.basePath(), filename)
+    const path = resolve(actionBasePath, filename)
     if (actionFiles.includes(path)) {
       return "maven"
     }
   }
 
   for (const filename of mavendPaths) {
-    const path = resolve(module.path, filename)
+    const path = resolve(actionBasePath, filename)
     if (actionFiles.includes(path)) {
       return "mavend"
     }
   }
 
   throw new ConfigurationError({
-    message: `Could not detect a gradle or maven project to build ${action.name}`,
+    message: `Could not detect a gradle or maven project to build ${actionName}`,
     detail: {},
   })
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Respect the `spec.publishId` for publishing the image using `garden publish`.

**Which issue(s) this PR fixes**:
Fixes #4796

**Special notes for your reviewer**:
