### PR TITLE
0.12 fix(template): allow `null` as a valid argument in helper functions

### DIFF
--- a/core/src/template-string/functions.ts
+++ b/core/src/template-string/functions.ts
@@ -476,11 +476,13 @@ export function callHelperFunction({
   const resolvedArgs: any[] = []
 
   for (const arg of args) {
-    if (arg._error) {
+    // arg can be null here because some helpers allow nulls as valid args
+    if (arg && arg._error) {
       return arg
     }
 
-    if (arg && arg.resolved) {
+    // allow nulls as valid arg values
+    if (arg && arg.resolved !== undefined) {
       resolvedArgs.push(arg.resolved)
     } else {
       resolvedArgs.push(arg)

--- a/core/src/template-string/functions.ts
+++ b/core/src/template-string/functions.ts
@@ -9,7 +9,7 @@
 import { v4 as uuidv4 } from "uuid"
 import { createHash } from "crypto"
 import { TemplateStringError } from "../exceptions"
-import { keyBy, mapValues, escapeRegExp, trim, isEmpty, camelCase, kebabCase, isArrayLike, isString } from "lodash"
+import { camelCase, escapeRegExp, isArrayLike, isEmpty, isString, kebabCase, keyBy, mapValues, trim } from "lodash"
 import { joi, JoiDescription, joiPrimitive, Primitive } from "../config/common"
 import Joi from "@hapi/joi"
 import { validateSchema } from "../config/validation"

--- a/core/src/template-string/functions.ts
+++ b/core/src/template-string/functions.ts
@@ -133,7 +133,10 @@ const helperFunctionSpecs: TemplateHelperFunction[] = [
     name: "isEmpty",
     description: "Returns true if the given value is an empty string, object, array, null or undefined.",
     arguments: {
-      value: joi.alternatives(joi.object(), joi.array(), joi.string()).allow(null).description("The value to check."),
+      value: joi
+        .alternatives(joi.object(), joi.array(), joi.string().allow(""))
+        .allow(null)
+        .description("The value to check."),
     },
     outputSchema: joi.boolean(),
     exampleArguments: [

--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -1197,6 +1197,20 @@ describe("resolveTemplateString", async () => {
       })
     })
 
+    context("isEmpty", () => {
+      context("allows nulls", () => {
+        it("resolves null as 'true'", () => {
+          const res = resolveTemplateString("${isEmpty(null)}", new TestContext({}))
+          expect(res).to.be.true
+        })
+
+        it("resolves references to null as 'true'", () => {
+          const res = resolveTemplateString("${isEmpty(a)}", new TestContext({ a: null }))
+          expect(res).to.be.true
+        })
+      })
+    })
+
     context("slice", () => {
       it("allows numeric indices", () => {
         const res = resolveTemplateString("${slice(foo, 0, 3)}", new TestContext({ foo: "abcdef" }))

--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -1209,6 +1209,18 @@ describe("resolveTemplateString", async () => {
           expect(res).to.be.true
         })
       })
+
+      context("allows empty strings", () => {
+        it("resolves an empty string as 'true'", () => {
+          const res = resolveTemplateString("${isEmpty('')}", new TestContext({}))
+          expect(res).to.be.true
+        })
+
+        it("resolves a reference to an empty string as 'true'", () => {
+          const res = resolveTemplateString("${isEmpty(a)}", new TestContext({ a: "" }))
+          expect(res).to.be.true
+        })
+      })
     })
 
     context("slice", () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
Fixes handling of `null` values as helper function arguments and allows empty strings as valid args in `isEmpty()` helper function.

**Which issue(s) this PR fixes**:

Fixes #3398

**Special notes for your reviewer**:
The original issue was reported in Garden 0.12. This fixes the `0.12` branch, and the fix still needs to be ported to the `main` branch. The 0.13 PR is #4810.