### PR TITLE
improvement(server): also send sessions events over ws

### DIFF
--- a/core/src/commands/base.ts
+++ b/core/src/commands/base.ts
@@ -372,7 +372,7 @@ export abstract class Command<A extends Parameters = {}, O extends Parameters = 
         try {
           if (cloudSession && this.streamEvents) {
             log.silly(`Connecting Garden instance events to Cloud API`)
-            cloudEventStream.emit("commandInfo", {
+            garden.events.emit("commandInfo", {
               ...commandInfo,
               environmentName: garden.environmentName,
               environmentId: cloudSession.environmentId,
@@ -384,6 +384,7 @@ export abstract class Command<A extends Parameters = {}, O extends Parameters = 
               vcsBranch: garden.vcsInfo.branch,
               vcsCommitHash: garden.vcsInfo.commitHash,
               vcsOriginUrl: garden.vcsInfo.originUrl,
+              sessionId: garden.sessionId,
             })
           }
 
@@ -421,9 +422,9 @@ export abstract class Command<A extends Parameters = {}, O extends Parameters = 
           )
 
           if (allErrors.length > 0) {
-            cloudEventStream.emit("sessionFailed", {})
+            garden.events.emit("sessionFailed", {})
           } else {
-            cloudEventStream.emit("sessionCompleted", {})
+            garden.events.emit("sessionCompleted", {})
           }
         } catch (err) {
           analytics?.trackCommandResult(
@@ -433,7 +434,7 @@ export abstract class Command<A extends Parameters = {}, O extends Parameters = 
             1,
             parentSessionId || undefined
           )
-          cloudEventStream.emit("sessionFailed", {})
+          garden.events.emit("sessionFailed", {})
           throw err
         } finally {
           if (parentSessionId) {

--- a/core/src/server/server.ts
+++ b/core/src/server/server.ts
@@ -687,14 +687,12 @@ export class GardenServer extends EventEmitter {
         command
           .prepare(prepareParams)
           .then(() => {
-            if (!isInternal) {
+            if (persistent) {
               send("commandStart", {
                 ...commandResponseBase,
                 args,
                 opts,
               })
-            }
-            if (persistent) {
               this.activePersistentRequests[requestId] = { command, connection }
 
               command.subscribe((data: any) => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

Before this change, we only POSTed session events over http but did not send over ws.

It's actually useful to do that as well so that we can better display currently running commands on the live page.

NOTE: Also reverted a change to the "commandStart" event from the following commit: a1742a6d7cea4425803399a511346ab54415d91d since we're now reading this data via "commandInfo" events

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
