### PR TITLE
perf(git): optimize git scan when exclude but no include filter is set

### DIFF
--- a/core/test/unit/src/vcs/git.ts
+++ b/core/test/unit/src/vcs/git.ts
@@ -270,7 +270,7 @@ export const commonGitHandlerTests = (handlerCls: new (params: VcsHandlerParams)
       ).to.eql([])
     })
 
-    it("should respect include and exclude patterns, if both are specified", async () => {
+    it("should respect include and exclude filters, if both are specified", async () => {
       const moduleDir = resolve(tmpPath, "module-a")
       const pathA = resolve(moduleDir, "yes.txt")
       const pathB = resolve(tmpPath, "no.txt")


### PR DESCRIPTION
This can be a major optimization in certain cases.

The reason this wasn't done previously was due to a git ls-files issue but we missed out on this path when no includes are used, in which case the issue doesn't come up.

Usually includes are much more specific than excludes in configs, so this approach should cover a lot of user scenarios.

It is still more optimal to use `.gardenignore` files over exclude patterns where possible, but using excludes in configs is obviously  a common and supported use case, and not always possible to use the ignore files (say, if many actions/modules share a directory and need different exclusions).

Fixes #4763