### PR TITLE
0.12 back-port: chore: fix changelog generation

### DIFF
--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -1,0 +1,20 @@
+#!/usr/bin/env ts-node
+
+import execa from "execa"
+import { resolve } from "path"
+
+const gardenRoot = resolve(__dirname, "..")
+
+export async function getChangelog(curReleaseTag: string) {
+  try {
+    return (
+      await execa(
+        "git-chglog",
+        ["--tag-filter-pattern", "^\\d+\\.\\d+\\.\\d+$", "--sort", "semver", `${curReleaseTag}..${curReleaseTag}`],
+        { cwd: gardenRoot }
+      )
+    ).stdout
+  } catch (err) {
+    throw new Error(`Error generating changelog: ${err}`)
+  }
+}

--- a/scripts/draft-release-notes.ts
+++ b/scripts/draft-release-notes.ts
@@ -1,27 +1,13 @@
 #!/usr/bin/env ts-node
 
-import execa from "execa"
 import { writeFile } from "fs-extra"
 import { execSync } from "child_process"
 import { resolve } from "path"
 import { dedent } from "@garden-io/sdk/util/string"
+import { getChangelog } from "./changelog"
 import parseArgs = require("minimist")
 
 const gardenRoot = resolve(__dirname, "..")
-
-async function getChangelog(curReleaseTag: string) {
-  try {
-    return (
-      await execa(
-        "git-chglog",
-        ["--tag-filter-pattern", "^\\d+\\.\\d+\\.\\d+$", "--sort", "semver", `${curReleaseTag}..${curReleaseTag}`],
-        { cwd: gardenRoot }
-      )
-    ).stdout
-  } catch (err) {
-    throw new Error(`Error generating changelog: ${err}`)
-  }
-}
 
 function getContributors(prevReleaseTag: string, curReleaseTag: string) {
   try {

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -10,6 +10,7 @@ import { resolve, relative } from "path"
 import { readFile, createWriteStream, writeFile } from "fs-extra"
 import { getPackages } from "./script-utils"
 import Bluebird = require("bluebird")
+
 const replace = require("replace-in-file")
 
 type ReleaseType = "minor" | "patch" | "preminor" | "prepatch" | "prerelease"
@@ -288,7 +289,7 @@ async function updateChangelog(version: string) {
   const nextChangelogEntry = (
     await execa(
       "git-chglog",
-      ["--tag-filter-pattern", "^\\d+\\.\\d+\\.\\d+$", "--sort", "semver", "--next-tag", version, version],
+      ["--tag-filter-pattern", "^\\d+\\.\\d+\\.\\d+$", "--sort", "semver", `${version}..${version}`],
       { cwd: gardenRoot }
     )
   ).stdout

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -4,11 +4,12 @@ import execa from "execa"
 import semver from "semver"
 import inquirer from "inquirer"
 import chalk from "chalk"
+import { relative, resolve } from "path"
+import { createWriteStream, readFile, writeFile } from "fs-extra"
+import { getPackages } from "./script-utils"
+import { getChangelog } from "./changelog"
 import parseArgs = require("minimist")
 import deline = require("deline")
-import { resolve, relative } from "path"
-import { readFile, createWriteStream, writeFile } from "fs-extra"
-import { getPackages } from "./script-utils"
 import Bluebird = require("bluebird")
 
 const replace = require("replace-in-file")
@@ -286,13 +287,7 @@ async function updateChangelog(version: string) {
   const changelogPath = "./CHANGELOG.md";
   // TODO: Use readStream and pipe
   const changelog = await readFile(changelogPath)
-  const nextChangelogEntry = (
-    await execa(
-      "git-chglog",
-      ["--tag-filter-pattern", "^\\d+\\.\\d+\\.\\d+$", "--sort", "semver", `${version}..${version}`],
-      { cwd: gardenRoot }
-    )
-  ).stdout
+  const nextChangelogEntry = getChangelog(version)
   return new Promise((resolve, reject) => {
     const writeStream = createWriteStream(changelogPath)
     writeStream.write(nextChangelogEntry)


### PR DESCRIPTION
Aligned with `draft-release-notes.ts` script.
Used explicit version range instead of experimental `--next-tag` flag.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
Cherry-picks #4827 to the `0.12` branch.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
