### PR TITLE
fix: restore azure devops support for dockerhub images

### DIFF
--- a/support/alpine.Dockerfile
+++ b/support/alpine.Dockerfile
@@ -28,6 +28,11 @@ RUN apk add --no-cache \
   groff \
   py3-crcmod
 
+# Add tools required for Azure DevOps. See also https://github.com/microsoft/azure-pipelines-agent/blob/master/docs/design/non-glibc-containers.md
+RUN apk add --no-cache --virtual .pipeline-deps readline linux-pam  \
+  && apk add bash sudo shadow \
+  && apk del .pipeline-deps
+
 ENV USER=root
 ENV HOME=/root
 

--- a/support/alpine.Dockerfile
+++ b/support/alpine.Dockerfile
@@ -31,7 +31,12 @@ RUN apk add --no-cache \
 ENV USER=root
 ENV HOME=/root
 
-ENTRYPOINT ["/garden/garden"]
+# We do not set an entrypoint here for compatibility with Azure DevOps pipelines.
+# See also https://learn.microsoft.com/en-us/azure/devops/pipelines/process/container-phases?view=azure-devops#linux-based-containers
+ENTRYPOINT []
+
+# Required by Azure DevOps to tell the system where node is installed
+LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/local/bin/node"
 
 FROM garden-alpine-base-root as garden-alpine-base-rootless
 
@@ -122,9 +127,6 @@ COPY --chown=$USER:root --from=garden-azure-base /usr/local/bin/az /usr/local/bi
 COPY --chown=$USER:root --from=garden-azure-base /usr/local/bin/kubectl /usr/local/bin/kubectl
 COPY --chown=$USER:root --from=garden-azure-base /usr/local/bin/kubelogin /usr/local/bin/kubelogin
 
-# Required by Azure DevOps to tell the system where node is installed
-LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/local/bin/node"
-
 #
 # garden-aws
 #
@@ -181,6 +183,3 @@ COPY --chown=$USER:root --from=garden-azure-base /azure-cli /azure-cli
 COPY --chown=$USER:root --from=garden-azure-base /usr/local/bin/az /usr/local/bin/az
 COPY --chown=$USER:root --from=garden-azure-base /usr/local/bin/kubectl /usr/local/bin/kubectl
 COPY --chown=$USER:root --from=garden-azure-base /usr/local/bin/kubelogin /usr/local/bin/kubelogin
-
-# Required by Azure DevOps to tell the system where node is installed
-LABEL "com.azure.dev.pipelines.agent.handler.node.path"="/usr/local/bin/node"

--- a/support/buster.Dockerfile
+++ b/support/buster.Dockerfile
@@ -28,7 +28,9 @@ RUN set -ex; \
 ENV USER=root
 ENV HOME=/root
 
-ENTRYPOINT ["/garden/garden"]
+# We do not set an entrypoint here for compatibility with Azure DevOps pipelines.
+# See also https://learn.microsoft.com/en-us/azure/devops/pipelines/process/container-phases?view=azure-devops#linux-based-containers
+ENTRYPOINT []
 
 FROM buster-base-root as buster-base-rootless
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
We do not need an ENTRYPOINT, and azure devops only supports images
without it.

**Which issue(s) this PR fixes**:

Fixes #4818

**Special notes for your reviewer**:
