### PR TITLE
fix: local-docker build failure when `deploymentRegistry` is enabled

### DIFF
--- a/core/src/build-staging/build-staging.ts
+++ b/core/src/build-staging/build-staging.ts
@@ -136,7 +136,6 @@ export class BuildStaging {
     this.createdPaths.clear()
   }
 
-  // TODO: ensure build path elsewhere?
   getBuildPath(config: BuildActionConfig<string, any> | ModuleConfig): string {
     // We don't stage the build for local exec modules, so the module path is effectively the build path.
     if (config.kind === "Module" && config.type === "exec" && config["local"] === true) {

--- a/core/src/plugins/kubernetes/container/build/local.ts
+++ b/core/src/plugins/kubernetes/container/build/local.ts
@@ -31,7 +31,7 @@ export const getLocalBuildStatus: BuildStatusHandler = async (params) => {
   if (deploymentRegistry) {
     const args = await getManifestInspectArgs(outputs.deploymentImageId, deploymentRegistry)
     const res = await containerHelpers.dockerCli({
-      cwd: action.getBuildPath(),
+      cwd: ctx.projectRoot,
       args,
       log,
       ctx,

--- a/core/src/util/util.ts
+++ b/core/src/util/util.ts
@@ -360,6 +360,7 @@ export function spawn(cmd: string, args: string[], opts: SpawnOpts = {}) {
       let msg = `An error occurred while trying to run '${cmd}' (${err.message}).`
       if ((<any>err).code === "ENOENT") {
         msg = `${msg} Please make sure '${cmd}' is installed and in the $PATH.`
+        cwd && (msg = `${msg} Please make sure '${cwd}' exists and is a valid directory path.`)
       }
       _reject(new RuntimeError({ message: msg, detail: { cmd, args, opts, result, err } }))
     })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
The issue (#4815) happens on the build status check when the active provider has the `deploymentRegistry` configuration.

The action's build directory might not exist on the first build status check.
The underlying `docker` command does not use the action's build directory in any context. So, there is no reason to run the `docker` command from the action's build directory.

The `cwd` for the underlying `docker` command has been changed to the garden project root dir. Just like in a normal local status check in [`imageExistsLocally`](https://github.com/garden-io/garden/blob/main/core/src/plugins/container/helpers.ts#L243).

**Which issue(s) this PR fixes**:

Fixes #4815

**Special notes for your reviewer**:
