### PR TITLE
fix: allow to use `parent.name` template in templated modules

### DIFF
--- a/core/src/resolve-module.ts
+++ b/core/src/resolve-module.ts
@@ -850,6 +850,9 @@ function inheritModuleToAction(module: GardenModule, action: ActionConfig) {
   if (module.templateName) {
     action.internal.templateName = module.templateName
   }
+  if (module.parentName) {
+    action.internal.parentName = module.parentName
+  }
   if (module.inputs) {
     action.internal.inputs = module.inputs
   }


### PR DESCRIPTION
closes https://github.com/garden-io/garden/issues/4816