### PR TITLE
introduce --target option for exec command to target specific container in pod

### DIFF
--- a/core/src/plugin/handlers/Deploy/exec.ts
+++ b/core/src/plugin/handlers/Deploy/exec.ts
@@ -16,6 +16,7 @@ import { Executed } from "../../../actions/types"
 interface ExecInDeployParams<T extends DeployAction> extends PluginDeployActionParamsBase<T> {
   command: string[]
   interactive: boolean
+  target?: string
 }
 
 export interface ExecInDeployResult {

--- a/core/src/plugins/kubernetes/container/deployment.ts
+++ b/core/src/plugins/kubernetes/container/deployment.ts
@@ -40,6 +40,7 @@ import {
 } from "../types"
 import { k8sGetContainerDeployStatus, ContainerServiceStatus } from "./status"
 import { emitNonRepeatableWarning } from "../../../warnings"
+import { K8_POD_DEFAULT_CONTAINER_ANNOTATION_KEY } from "../run"
 
 export const DEFAULT_CPU_REQUEST = "10m"
 export const DEFAULT_MEMORY_REQUEST = "90Mi" // This is the minimum in some clusters - or so they tell me
@@ -492,6 +493,9 @@ function workloadConfig({
   }
 
   const { annotations, daemon } = action.getSpec()
+  // Add default-container annotation in generated manifest
+  // so exec respects it in case of multiple containers in pod
+  annotations[K8_POD_DEFAULT_CONTAINER_ANNOTATION_KEY] = action.name
 
   return {
     kind: daemon ? "DaemonSet" : "Deployment",

--- a/core/src/plugins/kubernetes/container/exec.ts
+++ b/core/src/plugins/kubernetes/container/exec.ts
@@ -16,7 +16,7 @@ import { DeployActionHandler } from "../../../plugin/action-types"
 import { k8sGetContainerDeployStatus } from "./status"
 
 export const execInContainer: DeployActionHandler<"exec", ContainerDeployAction> = async (params) => {
-  const { ctx, log, action, command, interactive } = params
+  const { ctx, log, action, command, interactive, target: containerName } = params
   const k8sCtx = <KubernetesPluginContext>ctx
   const provider = k8sCtx.provider
   const status = await k8sGetContainerDeployStatus({
@@ -43,6 +43,7 @@ export const execInContainer: DeployActionHandler<"exec", ContainerDeployAction>
     log,
     namespace,
     workload: status.detail?.detail.workload,
+    containerName,
     command,
     interactive,
   })

--- a/core/src/plugins/kubernetes/kubernetes-type/common.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/common.ts
@@ -52,7 +52,7 @@ export async function getManifests({
 
   // remove *List objects
   const manifests = rawManifests.flatMap((manifest) => {
-    if (manifest.kind.endsWith("List")) {
+    if (manifest?.kind?.endsWith("List")) {
       if (!manifest.items || manifest.items.length === 0) {
         // empty list
         return []

--- a/core/src/plugins/kubernetes/kubernetes-type/exec.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/exec.ts
@@ -17,7 +17,7 @@ import { getKubernetesDeployStatus } from "./handlers"
 import chalk from "chalk"
 
 export const execInKubernetesDeploy: DeployActionHandler<"exec", KubernetesDeployAction> = async (params) => {
-  const { ctx, log, action, command, interactive } = params
+  const { ctx, log, action, command, interactive, target: containerName } = params
   const k8sCtx = <KubernetesPluginContext>ctx
   const provider = k8sCtx.provider
 
@@ -64,5 +64,5 @@ export const execInKubernetesDeploy: DeployActionHandler<"exec", KubernetesDeplo
     })
   }
 
-  return execInWorkload({ ctx, provider, log, namespace, workload: target, command, interactive })
+  return execInWorkload({ ctx, provider, log, namespace, workload: target, containerName, command, interactive })
 }

--- a/core/src/plugins/kubernetes/logs.ts
+++ b/core/src/plugins/kubernetes/logs.ts
@@ -72,9 +72,7 @@ export async function streamK8sLogs(params: GetAllLogsParams) {
     const pods = await getAllPods(api, params.defaultNamespace, params.resources)
     let tail = params.tail
     if (!tail) {
-      const containers = pods.flatMap((pod) => {
-        return pod.spec!.containers.map((c) => c.name).filter((n) => !n.match(/garden-/))
-      })
+      const containers = pods.flatMap((pod) => containerNamesForLogging(pod))
       tail = Math.floor(maxLogLinesInMemory / containers.length)
 
       params.log.debug(`Tail parameter not set explicitly. Setting to ${tail} to prevent log overflow.`)

--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -252,6 +252,7 @@ export async function execInWorkload({
   namespace,
   workload,
   command,
+  containerName,
   streamLogs = false,
   interactive,
 }: {
@@ -261,6 +262,7 @@ export async function execInWorkload({
   namespace: string
   workload: KubernetesWorkload | KubernetesPod
   command: string[]
+  containerName?: string
   streamLogs?: boolean
   interactive: boolean
 }) {
@@ -285,6 +287,7 @@ export async function execInWorkload({
     timeoutSec: 999999,
     tty: interactive,
     buffer: true,
+    containerName,
   }
 
   if (streamLogs) {

--- a/core/test/integ/src/plugins/kubernetes/container/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/deployment.ts
@@ -51,6 +51,7 @@ import { ResolvedDeployAction } from "../../../../../../src/actions/deploy"
 import { ActionRouter } from "../../../../../../src/router/router"
 import { ActionMode } from "../../../../../../src/actions/types"
 import { createActionLog } from "../../../../../../src/logger/log-entry"
+import { K8_POD_DEFAULT_CONTAINER_ANNOTATION_KEY } from "../../../../../../src/plugins/kubernetes/run"
 
 describe("kubernetes container deployment handlers", () => {
   let garden: TestGarden
@@ -289,7 +290,9 @@ describe("kubernetes container deployment handlers", () => {
           selector: { matchLabels: { [gardenAnnotationKey("action")]: action.key() } },
           template: {
             metadata: {
-              annotations: {},
+              annotations: {
+                [K8_POD_DEFAULT_CONTAINER_ANNOTATION_KEY]: "simple-service",
+              },
               labels: getDeploymentLabels(action),
             },
             spec: {
@@ -331,7 +334,10 @@ describe("kubernetes container deployment handlers", () => {
       const action = await resolveDeployAction("simple-service")
       const namespace = provider.config.namespace!.name!
 
-      action["_config"].spec.annotations = { "annotation.key": "someValue" }
+      action["_config"].spec.annotations = {
+        "annotation.key": "someValue",
+        [K8_POD_DEFAULT_CONTAINER_ANNOTATION_KEY]: "simple-service",
+      }
 
       const resource = await createWorkloadManifest({
         ctx,

--- a/core/test/unit/src/commands/exec.ts
+++ b/core/test/unit/src/commands/exec.ts
@@ -27,6 +27,7 @@ describe("ExecCommand", () => {
       args,
       opts: withDefaultGlobalOpts({
         interactive: false,
+        target: "",
       }),
     })
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1361,6 +1361,7 @@ Examples:
 | Argument | Alias | Type | Description |
 | -------- | ----- | ---- | ----------- |
   | `--interactive` |  | boolean | Set to false to skip interactive mode and just output the command result
+  | `--target` |  | string | Specify name of the target if a Deploy action consists of multiple components. _NOTE: This option is only relevant in certain scenarios and will be ignored otherwise._ For Kubernetes deploy actions, this is useful if a Deployment includes multiple containers, such as sidecar containers. By default, the container with &#x60;kubectl.kubernetes.io/default-container&#x60; annotation or the first container is picked.
 
 #### Outputs
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduces a flag `--target` in `exec` command. This is useful when a Deploy action consists of multiple underlying components and user wants to target a specific one.

At the moment, this flag is only supported for kubernetes-exec and container-exec. When a pod has multiple containers, user can use `target` flag to exec into a specific container. Additionally, if no container name is provided, it respects the annotation `kubectl.kubernetes.io/default-container` and defaults to that container. The existing behavior is still the default: it picks the first container in Pod.

This PR also adds the default container annotation in the manifests generated with `container` type.

**Which issue(s) this PR fixes**:

Fixes #3039

**Special notes for your reviewer**: