### PR TITLE
0.12 back-port: chore: fix type error in the release script

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -287,7 +287,7 @@ async function updateChangelog(version: string) {
   const changelogPath = "./CHANGELOG.md";
   // TODO: Use readStream and pipe
   const changelog = await readFile(changelogPath)
-  const nextChangelogEntry = getChangelog(version)
+  const nextChangelogEntry = await getChangelog(version)
   return new Promise((resolve, reject) => {
     const writeStream = createWriteStream(changelogPath)
     writeStream.write(nextChangelogEntry)


### PR DESCRIPTION
Fix type error introduced in #4827.

(cherry picked from commit ec774b7022c33bc3934bffd1c470e12f98b778b6)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
Cherry-pick #4847 to `0.12`.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
