### PR TITLE
0.12 back-port: chore: fix missing tag error in changelog generation

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -7,7 +7,6 @@ import chalk from "chalk"
 import { relative, resolve } from "path"
 import { createWriteStream, readFile, writeFile } from "fs-extra"
 import { getPackages } from "./script-utils"
-import { getChangelog } from "./changelog"
 import parseArgs = require("minimist")
 import deline = require("deline")
 import Bluebird = require("bluebird")
@@ -287,7 +286,13 @@ async function updateChangelog(version: string) {
   const changelogPath = "./CHANGELOG.md";
   // TODO: Use readStream and pipe
   const changelog = await readFile(changelogPath)
-  const nextChangelogEntry = await getChangelog(version)
+  const nextChangelogEntry = (
+    await execa(
+      "git-chglog",
+      ["--tag-filter-pattern", "^\\d+\\.\\d+\\.\\d+$", "--sort", "semver", "--next-tag", version, version],
+      { cwd: gardenRoot }
+    )
+  ).stdout
   return new Promise((resolve, reject) => {
     const writeStream = createWriteStream(changelogPath)
     writeStream.write(nextChangelogEntry)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
Reverts #4828 and #4847<F69.
Function `getChangelog` can't be used
because the target tag doesn't exist when we generate the changelog.

(cherry picked from commit 3c15d08c387f371cef339a87045ba23c1b3ead23)

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
