### PR TITLE
ci(dockerhub): fix garden version checks

### DIFF
--- a/support/docker-bake-test.sh
+++ b/support/docker-bake-test.sh
@@ -103,18 +103,18 @@ TEST "run all binaries"
   for variant in bonsai-buster{,-rootless} bonsai-alpine{,-rootless}
     do
     # Garden on vanilla images
-    should_succeed garden --version gardendev/garden:$variant
-    should_succeed garden --version gardendev/garden:$variant
+    should_succeed garden version gardendev/garden:$variant
+    should_succeed garden version gardendev/garden:$variant
   done
 
   for variant in bonsai-alpine{,-rootless}
     do
     # garden
-    should_succeed garden --version gardendev/garden-aws-gcloud-azure:$variant
-    should_succeed garden --version gardendev/garden-aws-gcloud:$variant
-    should_succeed garden --version gardendev/garden-aws:$variant
-    should_succeed garden --version gardendev/garden-gcloud:$variant
-    should_succeed garden --version gardendev/garden-azure:$variant
+    should_succeed garden version gardendev/garden-aws-gcloud-azure:$variant
+    should_succeed garden version gardendev/garden-aws-gcloud:$variant
+    should_succeed garden version gardendev/garden-aws:$variant
+    should_succeed garden version gardendev/garden-gcloud:$variant
+    should_succeed garden version gardendev/garden-azure:$variant
 
     # aws
     should_succeed aws --version gardendev/garden-aws-gcloud-azure:$variant


### PR DESCRIPTION
Use new `garden version` command instead of discontinued `garden --version`.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
Fixes the way of checking the Garden version in the `docker-bake-test.sh` script.

Without this PR the command fails silently with OK exit status like this:

<details>

```console
USAGE
  garden <command> [options]

COMMANDS
  build          Perform your Builds.                                                     
  cleanup        Clean up resources.                                                      
  cloud          Manage Garden Cloud/Enterprise resources such as users, groups and       
                 secrets.                                                                 
  community      Join our community Discord to chat with us!                              
  config         Configure user and project settings.                                     
  create         Create new project or module.                                            
  deploy         Deploy actions to your environment.                                      
  dev            Starts the Garden interactive development console.                       
  exec           Executes a command (such as an interactive shell) in a running service.  
  get            Retrieve and output data and objects, e.g. secrets, status info etc.     
  link           Link a remote source or module to a local path.                          
  login          Log in to Garden Cloud.                                                  
  logout         Log out of Garden Cloud.                                                 
  logs           Retrieves the most recent logs for the specified Deploy(s).              
  options        Print global options.                                                    
  plugins        Plugin-specific commands.                                                
  publish        Build and publish artifacts (e.g. container images) to a remote          
                 registry.                                                                
  run            Perform one or more Run actions                                          
  self-update    Update the Garden CLI.                                                   
  serve          Starts the Garden Core API server for the current project and            
                 environment.                                                             
  set            Set or modify data and configuration values.                             
  sync           Manage synchronization to running actions.                               
  test           Run all or specified Test actions in the project.                        
  tools          Access tools included by providers.                                      
  unlink         Unlink a remote source or module from its local path.                    
  up             Spin up your stack with the dev console and streaming logs.              
  update-remote  Pulls the latest version of remote sources, actions or modules from      
                 their repository.                                                        
  util           Misc utility commands.                                                   
  validate       Check your garden configuration for errors.                              
  version        Shows the current garden version.                                        
  workflow       Run a Workflow.                                                          
    
OK: command run_binary garden --version gardendev/garden:bonsai-buster succeeded as expected
```
</details>

This PR replaces the old-fashioned discontinued `garden --version` with the new `garden version` command.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
