### PR TITLE
fix(template): respect project level variables in action config context

### DIFF
--- a/core/src/template-string/template-string.ts
+++ b/core/src/template-string/template-string.ts
@@ -7,29 +7,29 @@
  */
 
 import chalk from "chalk"
-import { GardenBaseError, ConfigurationError, TemplateStringError } from "../exceptions"
+import { ConfigurationError, GardenBaseError, TemplateStringError } from "../exceptions"
 import {
   ConfigContext,
-  ContextResolveOpts,
-  ScanContext,
-  ContextResolveOutput,
   ContextKeySegment,
+  ContextResolveOpts,
+  ContextResolveOutput,
   GenericContext,
+  ScanContext,
 } from "../config/template-contexts/base"
-import { difference, uniq, isPlainObject, isNumber, cloneDeep, isString } from "lodash"
+import { cloneDeep, difference, isNumber, isPlainObject, isString, uniq } from "lodash"
 import {
-  Primitive,
-  StringMap,
-  isPrimitive,
-  objectSpreadKey,
+  ActionReference,
   arrayConcatKey,
+  arrayForEachFilterKey,
   arrayForEachKey,
   arrayForEachReturnKey,
-  arrayForEachFilterKey,
-  ActionReference,
+  conditionalElseKey,
   conditionalKey,
   conditionalThenKey,
-  conditionalElseKey,
+  isPrimitive,
+  objectSpreadKey,
+  Primitive,
+  StringMap,
 } from "../config/common"
 import { profile } from "../util/profiling"
 import { dedent, deline, naturalList, titleize, truncate } from "../util/string"

--- a/core/test/data/test-projects/template-strings/garden.yml
+++ b/core/test/data/test-projects/template-strings/garden.yml
@@ -1,0 +1,24 @@
+apiVersion: garden.io/v1
+kind: Project
+name: template-strings
+environments:
+  - name: default
+    variables:
+      includeEnvFiles:
+        - 'aFileFromEnvConfig'
+providers:
+  - name: test-plugin
+    environments: [ default ]
+variables:
+  includeProjectFiles:
+    - 'aFileFromProjectConfig'
+
+---
+kind: Deploy
+type: exec
+name: test-deploy
+include:
+  - $concat: ${var.includeEnvFiles}
+  - $concat: ${var.includeProjectFiles}
+spec:
+  deployCommand: [ "sh", "-c", "echo", "foo" ]

--- a/core/test/unit/src/template-string/template-strings-e2e.ts
+++ b/core/test/unit/src/template-string/template-strings-e2e.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2018-2023 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { getDataDir, makeTestGarden, TestGarden } from "../../../helpers"
+import { expect } from "chai"
+
+describe("template-strings", () => {
+  context("cross-context variable references", () => {
+    let dataDir: string
+    let garden: TestGarden
+
+    before(async () => {
+      dataDir = getDataDir("test-projects", "template-strings")
+      garden = await makeTestGarden(dataDir)
+    })
+
+    it("should resolve variables from project-level and environment-level configs", async () => {
+      const graph = await garden.getConfigGraph({ log: garden.log, emit: false })
+      const deployAction = graph.getDeploy("test-deploy")
+      expect(deployAction.getConfig().include).to.eql(["aFileFromEnvConfig", "aFileFromProjectConfig"])
+    })
+  })
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:
The regression was introduced in #4659.
In that PR `this.variables` field was overwritten with the action-level values. It caused the erasure `this.variables = garden.variables` assignment in the super-class constructor.

**Which issue(s) this PR fixes**:

Fixes #4830

**Special notes for your reviewer**:
See individual commits. There is more explanation in the commit messages.
