### PR TITLE
fix(config): throw error if multiple project configs are found

### DIFF
--- a/core/test/data/test-project-multiple-project-configs/garden.yml
+++ b/core/test/data/test-project-multiple-project-configs/garden.yml
@@ -1,0 +1,13 @@
+apiVersion: garden.io/v1
+kind: Project
+name: another-test-project
+environments:
+  - name: local
+  - name: other
+providers:
+  - name: test-plugin
+    environments: [local]
+  - name: test-plugin-b
+    environments: [local]
+variables:
+  some: variable

--- a/core/test/data/test-project-multiple-project-configs/project.garden.yml
+++ b/core/test/data/test-project-multiple-project-configs/project.garden.yml
@@ -1,0 +1,13 @@
+apiVersion: garden.io/v1
+kind: Project
+name: test-project
+environments:
+  - name: local
+  - name: other
+providers:
+  - name: test-plugin
+    environments: [local]
+  - name: test-plugin-b
+    environments: [local]
+variables:
+  some: variable

--- a/core/test/unit/src/config/base.ts
+++ b/core/test/unit/src/config/base.ts
@@ -32,6 +32,7 @@ const projectPathMultipleModules = getDataDir("test-projects", "multiple-module-
 const modulePathAMultiple = resolve(projectPathMultipleModules, "module-a")
 
 const projectPathDuplicateProjects = getDataDir("test-project-duplicate-project-config")
+const projectPathMultipleProjects = getDataDir("test-project-multiple-project-configs")
 const logger = getRootLogger()
 const log = logger.createLog()
 
@@ -580,9 +581,15 @@ describe("findProjectConfig", async () => {
     expect(project && project.path).to.eq(customConfigPath)
   })
 
-  it("should throw an error if multiple projects are found", async () => {
+  it("should throw an error if multiple projects are found in same config file", async () => {
     await expectError(async () => await findProjectConfig({ log, path: projectPathDuplicateProjects }), {
-      contains: "Multiple project declarations found",
+      contains: "Multiple project declarations found in",
+    })
+  })
+
+  it("should throw an error if multiple projects are found in multiple config files", async () => {
+    await expectError(async () => await findProjectConfig({ log, path: projectPathMultipleProjects }), {
+      contains: "Multiple project declarations found at paths",
     })
   })
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
throw an error if multiple project configs are found across multiple files in a dir (e.g. in garden.yml and project.garden.yml)

**Which issue(s) this PR fixes**:

Fixes #3210

**Special notes for your reviewer**:
