### PR TITLE
improvement(k8s): less verbose Run/Test errors

### DIFF
--- a/core/src/plugin/base.ts
+++ b/core/src/plugin/base.ts
@@ -120,6 +120,7 @@ export interface RunResult {
   startedAt: Date
   completedAt: Date
   log: string
+  diagnosticErrorMsg?: string
   namespaceStatus?: NamespaceStatus
 }
 
@@ -131,6 +132,10 @@ export const runResultSchema = createSchema({
     startedAt: joi.date().required().description("When the module run was started."),
     completedAt: joi.date().required().description("When the module run was completed."),
     log: joi.string().allow("").default("").description("The output log from the run."),
+    diagnosticErrorMsg: joi
+      .string()
+      .optional()
+      .description("An optional, more detailed diagnostic error message from the plugin."),
   }),
   allowUnknown: true,
 })

--- a/core/src/tasks/run.ts
+++ b/core/src/tasks/run.ts
@@ -123,6 +123,9 @@ export class RunTask extends ExecuteActionTask<RunAction, GetRunResult> {
       taskLog.success(`Done`)
     } else {
       taskLog.error(`Failed!`)
+      if (status.detail?.diagnosticErrorMsg) {
+        this.log.debug(`Additional context for the error:\n\n${status.detail.diagnosticErrorMsg}`)
+      }
       throw new RunTaskError(status.detail?.log)
     }
 

--- a/core/src/tasks/test.ts
+++ b/core/src/tasks/test.ts
@@ -145,6 +145,9 @@ export class TestTask extends ExecuteActionTask<TestAction, GetTestResult> {
       const exitCode = status.detail?.exitCode
       const failedMsg = !!exitCode ? `Failed with code ${exitCode}!` : `Failed!`
       this.log.error(failedMsg)
+      if (status.detail?.diagnosticErrorMsg) {
+        this.log.debug(`Additional context for the error:\n\n${status.detail.diagnosticErrorMsg}`)
+      }
       throw new TestError(status.detail?.log)
     }
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -3340,6 +3340,9 @@ actions:
         # The output log from the run.
         log:
 
+        # An optional, more detailed diagnostic error message from the plugin.
+        diagnosticErrorMsg:
+
   # A map of statuses for each configured Test.
   Test:
     <name>:
@@ -3370,6 +3373,9 @@ actions:
 
         # The output log from the run.
         log:
+
+        # An optional, more detailed diagnostic error message from the plugin.
+        diagnosticErrorMsg:
 ```
 
 ### garden get actions
@@ -3737,6 +3743,9 @@ detail:
   # The output log from the run.
   log:
 
+  # An optional, more detailed diagnostic error message from the plugin.
+  diagnosticErrorMsg:
+
 # Local file paths to any exported artifacts from the Run's execution.
 artifacts:
 ```
@@ -3788,6 +3797,9 @@ detail:
 
   # The output log from the run.
   log:
+
+  # An optional, more detailed diagnostic error message from the plugin.
+  diagnosticErrorMsg:
 
 # Local file paths to any exported artifacts from the test run.
 artifacts:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @Orzelius and @vvagaytsev.
-->

**What this PR does / why we need it**:

We now only log the full pod status on the debug log level and above when a Test or Run fails.

This makes e.g. logs for failing Tests much less verbose by default, which should be a UX improvement.