### PR TITLE
fix(k8s): regression in globs in k8s manifest files

### DIFF
--- a/core/src/plugins/kubernetes/kubernetes-type/common.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/common.ts
@@ -131,15 +131,16 @@ export async function readManifests(
   const spec = action.getSpec()
   const specFiles = spec.files
 
-  const regularPaths = specFiles.filter((f) => !isGlob(f)).map((path) => resolve(manifestPath, path))
+  const regularPaths = specFiles.filter((f) => !isGlob(f))
   const missingPaths = await Bluebird.filter(regularPaths, async (regularPath) => {
-    return !(await pathExists(regularPath))
+    const resolvedPath = resolve(manifestPath, regularPath)
+    return !(await pathExists(resolvedPath))
   })
   if (missingPaths.length) {
     throw new ConfigurationError({
       message: `Invalid manifest file path(s) in ${action.kind} action '${
         action.name
-      }'. Cannot find manifest file(s) at ${naturalList(missingPaths)}`,
+      }'. Cannot find manifest file(s) at ${naturalList(missingPaths)} in ${manifestPath} directory.`,
       detail: {
         action: {
           kind: action.kind,
@@ -159,7 +160,7 @@ export async function readManifests(
     throw new ConfigurationError({
       message: `Invalid manifest file path(s) in ${action.kind} action '${
         action.name
-      }'. Cannot find any manifest files for paths ${naturalList(specFiles)}`,
+      }'. Cannot find any manifest files for paths ${naturalList(specFiles)} in ${manifestPath} directory.`,
       detail: {
         action: {
           kind: action.kind,

--- a/core/test/data/test-projects/kubernetes-type/with-build-action/deployment-action.yaml
+++ b/core/test/data/test-projects/kubernetes-type/with-build-action/deployment-action.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: busybox-deployment
+  labels:
+    app: busybox
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: busybox
+  template:
+    metadata:
+      labels:
+        app: busybox
+    spec:
+      containers:
+        - name: busybox
+          image: busybox:1.31.1
+          args: [sh, -c, "while :; do sleep 2073600; done"]
+          env:
+            - name: FOO
+              value: banana
+            - name: BAR
+              value: ""
+            - name: BAZ
+              value: null
+          ports:
+            - containerPort: 80

--- a/core/test/data/test-projects/kubernetes-type/with-build-action/with-build.garden.yml
+++ b/core/test/data/test-projects/kubernetes-type/with-build-action/with-build.garden.yml
@@ -3,4 +3,4 @@ type: kubernetes
 name: with-build-action
 build: exec-build
 spec:
-  files: ["*.yaml"]
+  files: [ "deployment-action.yaml" ]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @Walther, and @vvagaytsev.
-->

**What this PR does / why we need it**:
The regression was introduced in #4516. After that PR, it was possible to silently skip all non-existing files specified in in `spec.files` of a Deploy action of type `kubernetes`.

In `0.13.6` that would fail with error like this:
```console
ENOENT: no such file or directory, open '~/garden/core/test/data/test-projects/kubernetes-type/with-build-action/deployment-action1.yaml'
```

This PR implements some explicit checks for path existence and makes the output a bit more readable:
```console
Invalid manifest file path(s) in Deploy action 'with-build-action'. Cannot find manifest file(s) at ~/garden/core/test/data/test-projects/kubernetes-type/.garden/build/exec-build/deployment-action1.yaml
```

Issues #4505 and #4506 still exist. That's why the deployment can fail even with the existing manifest file. The build directory appears to be empty. It will be fixed in a separate PR.

**Which issue(s) this PR fixes**:

Fixes #4900

**Special notes for your reviewer**:
You can find more detail and explanation in the commit messages.