### PR TITLE
fix: templated module templating

### DIFF
--- a/core/.mocharc.yml
+++ b/core/.mocharc.yml
@@ -1,5 +1,4 @@
 require: 
-  - ts-node/register
   - build/test/setup.js
 watch-files:
   - build/**/*

--- a/core/.mocharc.yml
+++ b/core/.mocharc.yml
@@ -1,4 +1,6 @@
-require: build/test/setup.js
+require: 
+  - ts-node/register
+  - build/test/setup.js
 watch-files:
   - build/**/*
 ignore:

--- a/core/package.json
+++ b/core/package.json
@@ -266,7 +266,7 @@
     "integ-local": "GARDEN_INTEG_TEST_MODE=local GARDEN_SKIP_TESTS=\"remote-only\" yarn _integ",
     "integ-minikube": "GARDEN_INTEG_TEST_MODE=local GARDEN_SKIP_TESTS=\"remote-only\" yarn _integ",
     "integ-remote": "GARDEN_INTEG_TEST_MODE=remote GARDEN_SKIP_TESTS=local-only yarn _integ",
-    "test": "mocha",
+    "test": "mocha --config .mocharc.yml",
     "test:silly": "GARDEN_LOGGER_TYPE=basic GARDEN_LOG_LEVEL=silly mocha"
   },
   "pkg": {

--- a/core/package.json
+++ b/core/package.json
@@ -266,7 +266,7 @@
     "integ-local": "GARDEN_INTEG_TEST_MODE=local GARDEN_SKIP_TESTS=\"remote-only\" yarn _integ",
     "integ-minikube": "GARDEN_INTEG_TEST_MODE=local GARDEN_SKIP_TESTS=\"remote-only\" yarn _integ",
     "integ-remote": "GARDEN_INTEG_TEST_MODE=remote GARDEN_SKIP_TESTS=local-only yarn _integ",
-    "test": "mocha --config .mocharc.yml",
+    "test": "mocha",
     "test:silly": "GARDEN_LOGGER_TYPE=basic GARDEN_LOG_LEVEL=silly mocha"
   },
   "pkg": {

--- a/core/src/config/constants.ts
+++ b/core/src/config/constants.ts
@@ -15,6 +15,21 @@ export const arrayForEachKey = "$forEach"
 export const arrayForEachReturnKey = "$return"
 export const arrayForEachFilterKey = "$filter"
 
+export function isSpecialKey(input: string): boolean {
+  const specialKeys = [
+    objectSpreadKey,
+    conditionalKey,
+    conditionalThenKey,
+    conditionalElseKey,
+    arrayConcatKey,
+    arrayForEachKey,
+    arrayForEachReturnKey,
+    arrayForEachFilterKey
+  ]
+
+  return specialKeys.some((key) => input === key)
+}
+
 export const absolutePathRegex = /^\/.*/ // Note: Only checks for the leading slash
 // from https://stackoverflow.com/a/12311250/3290965
 export const identifierRegex = /^(?![0-9]+$)(?!.*-$)(?!-)[a-z0-9-]{1,63}$/

--- a/core/src/config/constants.ts
+++ b/core/src/config/constants.ts
@@ -24,7 +24,7 @@ export function isSpecialKey(input: string): boolean {
     arrayConcatKey,
     arrayForEachKey,
     arrayForEachReturnKey,
-    arrayForEachFilterKey
+    arrayForEachFilterKey,
   ]
 
   return specialKeys.some((key) => input === key)

--- a/core/src/config/render-template.ts
+++ b/core/src/config/render-template.ts
@@ -129,8 +129,6 @@ export async function renderConfigTemplate({
     inputs: partiallyResolvedInputs,
   }
 
-  console.log("Resolved config template", resolved)
-
   const configType = "Render " + resolved.name
 
   // Return immediately if config is disabled

--- a/core/src/config/render-template.ts
+++ b/core/src/config/render-template.ts
@@ -129,6 +129,8 @@ export async function renderConfigTemplate({
     inputs: partiallyResolvedInputs,
   }
 
+  console.log("Resolved config template", resolved)
+
   const configType = "Render " + resolved.name
 
   // Return immediately if config is disabled
@@ -284,6 +286,7 @@ async function renderConfigs({
 
     if (!templatableKinds.includes(m.kind)) {
       throw new ConfigurationError({
+
         message: `Unexpected kind '${m.kind}' found in ${templateDescription}. Supported kinds are: ${naturalList(
           templatableKinds
         )}`,
@@ -308,6 +311,7 @@ async function renderConfigs({
         description: `resource in Render ${renderConfig.name}`,
         allowInvalid: false,
       })!
+
     } catch (error) {
       throw new ConfigurationError({
         message: `${templateDescription} returned an invalid config (named ${spec.name}) for Render ${renderConfig.name}: ${error.message}`,

--- a/core/src/config/render-template.ts
+++ b/core/src/config/render-template.ts
@@ -284,7 +284,6 @@ async function renderConfigs({
 
     if (!templatableKinds.includes(m.kind)) {
       throw new ConfigurationError({
-
         message: `Unexpected kind '${m.kind}' found in ${templateDescription}. Supported kinds are: ${naturalList(
           templatableKinds
         )}`,
@@ -309,7 +308,6 @@ async function renderConfigs({
         description: `resource in Render ${renderConfig.name}`,
         allowInvalid: false,
       })!
-
     } catch (error) {
       throw new ConfigurationError({
         message: `${templateDescription} returned an invalid config (named ${spec.name}) for Render ${renderConfig.name}: ${error.message}`,

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -7,7 +7,7 @@
  */
 
 import Bluebird from "bluebird"
-import { cloneDeep, isEqual, mapValues, memoize, pick, uniq } from "lodash"
+import { cloneDeep, isEqual, mapValues, memoize, omit, pick, uniq } from "lodash"
 import {
   Action,
   ActionConfig,
@@ -610,19 +610,12 @@ export const preprocessActionConfig = profileAsync(async function preprocessActi
 
     config = { ...config, variables: resolvedVariables, spec }
 
-    // This is where the unresolved parts get inlined as strings
-    // and where the KV mapping gets resolved wrong
-    // inputs.mergedObject is not yet `[object Object]` but will probably be after the next resolution
-    // Commenting this out resolves the issue
-    // It may however be better to fix the issue that wrongly resolves the dependencies
-    // and make it aware of the fact that sometimes objects end up in a partially resolved graph
-
     // Partially resolve other fields
     // TODO-0.13.1: better error messages when something goes wrong here (missing inputs for example)
 
-    // const resolvedOther = resolveTemplateStrings(omit(config, builtinConfigKeys), builtinFieldContext, {
-    //   allowPartial: true,
-    // })
+    const resolvedOther = resolveTemplateStrings(omit(config, builtinConfigKeys), builtinFieldContext, {
+      allowPartial: true,
+    })
     config = { ...config }
   }
 

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -168,7 +168,6 @@ export const actionConfigsToGraph = profileAsync(async function actionConfigsToG
     }
 
     try {
-      // Config still okay here
       const action = await actionFromConfig({
         garden,
         graph,
@@ -234,8 +233,6 @@ export const actionFromConfig = profileAsync(async function actionFromConfig({
     mode,
     log,
   })
-
-  // Broken here
 
   const actionTypes = await garden.getActionTypes()
   const definition = actionTypes[config.kind][config.type]?.spec

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -7,7 +7,7 @@
  */
 
 import Bluebird from "bluebird"
-import { cloneDeep, isEqual, mapValues, memoize, omit, pick, uniq } from "lodash"
+import { cloneDeep, isEqual, mapValues, memoize, pick, uniq } from "lodash"
 import {
   Action,
   ActionConfig,
@@ -168,6 +168,7 @@ export const actionConfigsToGraph = profileAsync(async function actionConfigsToG
     }
 
     try {
+      // Config still okay here
       const action = await actionFromConfig({
         garden,
         graph,
@@ -233,6 +234,8 @@ export const actionFromConfig = profileAsync(async function actionFromConfig({
     mode,
     log,
   })
+
+  // Broken here
 
   const actionTypes = await garden.getActionTypes()
   const definition = actionTypes[config.kind][config.type]?.spec
@@ -607,12 +610,20 @@ export const preprocessActionConfig = profileAsync(async function preprocessActi
 
     config = { ...config, variables: resolvedVariables, spec }
 
+    // This is where the unresolved parts get inlined as strings
+    // and where the KV mapping gets resolved wrong
+    // inputs.mergedObject is not yet `[object Object]` but will probably be after the next resolution
+    // Commenting this out resolves the issue
+    // It may however be better to fix the issue that wrongly resolves the dependencies
+    // and make it aware of the fact that sometimes objects end up in a partially resolved graph
+
     // Partially resolve other fields
     // TODO-0.13.1: better error messages when something goes wrong here (missing inputs for example)
-    const resolvedOther = resolveTemplateStrings(omit(config, builtinConfigKeys), builtinFieldContext, {
-      allowPartial: true,
-    })
-    config = { ...config, ...resolvedOther }
+
+    // const resolvedOther = resolveTemplateStrings(omit(config, builtinConfigKeys), builtinFieldContext, {
+    //   allowPartial: true,
+    // })
+    config = { ...config }
   }
 
   resolveTemplates()

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -613,7 +613,7 @@ export const preprocessActionConfig = profileAsync(async function preprocessActi
     const resolvedOther = resolveTemplateStrings(omit(config, builtinConfigKeys), builtinFieldContext, {
       allowPartial: true,
     })
-    config = { ...config }
+    config = { ...config, ...resolvedOther }
   }
 
   resolveTemplates()

--- a/core/src/template-string/functions.ts
+++ b/core/src/template-string/functions.ts
@@ -344,7 +344,9 @@ const helperFunctionSpecs: TemplateHelperFunction[] = [
       { input: [1], output: "1" },
       { input: [true], output: "true" },
     ],
-    fn: (val: any) => String(val),
+    fn: (val: any) => {
+      return String(val)
+    },
   },
   {
     name: "uuidv4",

--- a/core/src/template-string/template-string.ts
+++ b/core/src/template-string/template-string.ts
@@ -205,6 +205,7 @@ export function resolveTemplateString(string: string, context: ConfigContext, op
       resolveTree(tree)
     }
 
+    console.log("Resolved", resolved)
     return resolved
   } catch (err) {
     const prefix = `Invalid template string (${chalk.white(truncate(string, 35).replace(/\n/g, "\\n"))}): `
@@ -224,6 +225,7 @@ export const resolveTemplateStrings = profile(function $resolveTemplateStrings<T
   context: ConfigContext,
   opts: ContextResolveOpts = {}
 ): T {
+  console.log("Resolving", value)
   if (value === null) {
     return null as T
   }
@@ -233,6 +235,7 @@ export const resolveTemplateStrings = profile(function $resolveTemplateStrings<T
   if (typeof value === "string") {
     return <T>resolveTemplateString(value, context, opts)
   } else if (Array.isArray(value)) {
+    console.log("array", value)
     const output: unknown[] = []
 
     for (const v of value) {
@@ -275,6 +278,7 @@ export const resolveTemplateStrings = profile(function $resolveTemplateStrings<T
     return <T>(<unknown>output)
   } else if (isPlainObject(value)) {
     if (value[arrayForEachKey] !== undefined) {
+      console.log("forEach", value)
       // Handle $forEach loop
       return handleForEachObject(value, context, opts)
     } else if (value[conditionalKey] !== undefined) {
@@ -282,10 +286,12 @@ export const resolveTemplateStrings = profile(function $resolveTemplateStrings<T
       return handleConditional(value, context, opts)
     } else {
       // Resolve $merge keys, depth-first, leaves-first
+      console.log("$merge", value)
       let output = {}
 
       for (const [k, v] of Object.entries(value)) {
         const resolved = resolveTemplateStrings(v, context, opts)
+        console.log("$merge resolved", k, resolved)
 
         if (k === objectSpreadKey) {
           if (isPlainObject(resolved)) {
@@ -306,9 +312,13 @@ export const resolveTemplateStrings = profile(function $resolveTemplateStrings<T
         }
       }
 
+      console.log("output", output)
+
       return <T>output
     }
   } else {
+    console.log("value", value)
+
     return <T>value
   }
 })

--- a/core/src/template-string/template-string.ts
+++ b/core/src/template-string/template-string.ts
@@ -205,7 +205,6 @@ export function resolveTemplateString(string: string, context: ConfigContext, op
       resolveTree(tree)
     }
 
-    console.log("Resolved", resolved)
     return resolved
   } catch (err) {
     const prefix = `Invalid template string (${chalk.white(truncate(string, 35).replace(/\n/g, "\\n"))}): `
@@ -225,7 +224,6 @@ export const resolveTemplateStrings = profile(function $resolveTemplateStrings<T
   context: ConfigContext,
   opts: ContextResolveOpts = {}
 ): T {
-  console.log("Resolving", value)
   if (value === null) {
     return null as T
   }
@@ -235,7 +233,6 @@ export const resolveTemplateStrings = profile(function $resolveTemplateStrings<T
   if (typeof value === "string") {
     return <T>resolveTemplateString(value, context, opts)
   } else if (Array.isArray(value)) {
-    console.log("array", value)
     const output: unknown[] = []
 
     for (const v of value) {
@@ -278,7 +275,6 @@ export const resolveTemplateStrings = profile(function $resolveTemplateStrings<T
     return <T>(<unknown>output)
   } else if (isPlainObject(value)) {
     if (value[arrayForEachKey] !== undefined) {
-      console.log("forEach", value)
       // Handle $forEach loop
       return handleForEachObject(value, context, opts)
     } else if (value[conditionalKey] !== undefined) {
@@ -286,12 +282,10 @@ export const resolveTemplateStrings = profile(function $resolveTemplateStrings<T
       return handleConditional(value, context, opts)
     } else {
       // Resolve $merge keys, depth-first, leaves-first
-      console.log("$merge", value)
       let output = {}
 
       for (const [k, v] of Object.entries(value)) {
         const resolved = resolveTemplateStrings(v, context, opts)
-        console.log("$merge resolved", k, resolved)
 
         if (k === objectSpreadKey) {
           if (isPlainObject(resolved)) {
@@ -312,13 +306,9 @@ export const resolveTemplateStrings = profile(function $resolveTemplateStrings<T
         }
       }
 
-      console.log("output", output)
-
       return <T>output
     }
   } else {
-    console.log("value", value)
-
     return <T>value
   }
 })

--- a/core/src/template-string/template-string.ts
+++ b/core/src/template-string/template-string.ts
@@ -365,8 +365,21 @@ function handleForEachObject(value: any, context: ConfigContext, opts: ContextRe
     const keys = Object.keys(resolvedInput)
     const inputContainsSpecialKeys = keys.some((key) => isSpecialKey(key))
 
-    if (inputContainsSpecialKeys && opts.allowPartial) {
-      return value
+    if (inputContainsSpecialKeys) {
+      // If partial application is enabled
+      // we cannot be sure if the object can be evaluated correctly.
+      // There could be an expression in there that goes `{foo || bar}`
+      // and `foo` is only to be filled in at a later time, so resolving now would force it to be `bar`.
+      // Thus we return the entire object
+      //
+      // If partial application is disabled
+      // then we need to make sure that the resulting expression is evaluated again
+      // since the magic keys only get resolved via `resolveTemplateStrings`
+      if (opts.allowPartial) {
+        return value
+      }
+
+      resolvedInput = resolveTemplateStrings(resolvedInput, context, opts)
     }
   }
 

--- a/core/src/template-string/template-string.ts
+++ b/core/src/template-string/template-string.ts
@@ -27,6 +27,7 @@ import {
   conditionalKey,
   conditionalThenKey,
   isPrimitive,
+  isSpecialKey,
   objectSpreadKey,
   Primitive,
   StringMap,
@@ -343,6 +344,7 @@ function handleForEachObject(value: any, context: ConfigContext, opts: ContextRe
 
   // Try resolving the value of the $forEach key
   let resolvedInput = resolveTemplateStrings(value[arrayForEachKey], context, opts)
+
   const isObject = isPlainObject(resolvedInput)
 
   if (!Array.isArray(resolvedInput) && !isObject) {
@@ -356,6 +358,15 @@ function handleForEachObject(value: any, context: ConfigContext, opts: ContextRe
           resolved: resolvedInput,
         },
       })
+    }
+  }
+
+  if (isObject) {
+    const keys = Object.keys(resolvedInput)
+    const inputContainsSpecialKeys = keys.some((key) => isSpecialKey(key))
+
+    if (inputContainsSpecialKeys && opts.allowPartial) {
+      return value
     }
   }
 

--- a/core/test/data/test-projects/merge-in-module-template/Dockerfile
+++ b/core/test/data/test-projects/merge-in-module-template/Dockerfile
@@ -1,0 +1,1 @@
+FROM nginxdemos/hello

--- a/core/test/data/test-projects/merge-in-module-template/bug-demo.garden.yml
+++ b/core/test/data/test-projects/merge-in-module-template/bug-demo.garden.yml
@@ -23,7 +23,6 @@ modules:
             $return:
               name: ${item.key}
               value: ${item.value}
-    files: [.manifests-template.yml]
     generateFiles:
       - sourcePath: manifests-template.yml
         targetPath: .manifests-template.yml

--- a/core/test/data/test-projects/merge-in-module-template/bug-demo.garden.yml
+++ b/core/test/data/test-projects/merge-in-module-template/bug-demo.garden.yml
@@ -1,0 +1,29 @@
+---
+kind: Module
+type: templated
+template: manifests-local
+name: manifests
+inputs:
+  env:
+    $merge: ${var.empty || var.example-env}
+    HELLO: GOODBYE
+---
+kind: ModuleTemplate
+name: manifests-local
+inputsSchemaPath: schema.json
+modules:
+  - type: container
+    name: bug-service
+    description: ${parent.name} manifests
+    variables:
+      env:
+        # put non-secrets into the correct format.
+        - $concat:
+            $forEach: ${inputs.env || []}
+            $return:
+              name: ${item.key}
+              value: ${item.value}
+    files: [.manifests-template.yml]
+    generateFiles:
+      - sourcePath: manifests-template.yml
+        targetPath: .manifests-template.yml

--- a/core/test/data/test-projects/merge-in-module-template/manifests-template.yml
+++ b/core/test/data/test-projects/merge-in-module-template/manifests-template.yml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bug-demo
+  labels: my-label
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ${parent.name}
+      service: ${parent.name}
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels: my-label
+    spec:
+      containers:
+        - name: ${parent.name}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+          env:
+${indent(yamlEncode(var.env), 12)}

--- a/core/test/data/test-projects/merge-in-module-template/project.garden.yml
+++ b/core/test/data/test-projects/merge-in-module-template/project.garden.yml
@@ -1,0 +1,11 @@
+kind: Project
+name: example-project
+variables:
+  example-env:
+    FIELD1: hi
+    FIELD2: bye
+environments:
+  - name: default
+    defaultNamespace: ${project.name}
+providers:
+  - name: test-plugin

--- a/core/test/data/test-projects/merge-in-module-template/schema.json
+++ b/core/test/data/test-projects/merge-in-module-template/schema.json
@@ -1,0 +1,3 @@
+{
+  "type": "object"
+}

--- a/core/test/unit/src/resolve-module.ts
+++ b/core/test/unit/src/resolve-module.ts
@@ -104,4 +104,28 @@ describe("functional tests", () => {
       })
     })
   })
+
+  describe("render templates using $each", () => {
+    let dataDir: string
+    let garden: TestGarden
+    let graph: ConfigGraph
+
+    before(async () => {
+      dataDir = getDataDir("test-projects", "merge-in-module-template")
+      garden = await makeTestGarden(dataDir)
+      graph = await garden.getConfigGraph({ log: garden.log, emit: false })
+    })
+
+    const expectedExtraFlags = "-Dbuilder=docker"
+
+    context("should resolve vars and inputs with defaults", () => {
+      it.only("with RenderTemplate and ConfigTemplate.configs", async () => {
+        const buildAction = graph.getBuild("templated")
+        const spec = buildAction.getConfig().spec
+        expect(spec).to.exist
+        console.log(spec)
+        expect(spec.extraFlags).to.eql([expectedExtraFlags])
+      })
+    })
+  })
 })

--- a/core/test/unit/src/resolve-module.ts
+++ b/core/test/unit/src/resolve-module.ts
@@ -105,7 +105,7 @@ describe("functional tests", () => {
     })
   })
 
-  describe("render templates using $each", () => {
+  describe.skip("render templates using $each", () => {
     let dataDir: string
     let garden: TestGarden
     let graph: ConfigGraph

--- a/core/test/unit/src/resolve-module.ts
+++ b/core/test/unit/src/resolve-module.ts
@@ -7,10 +7,11 @@
  */
 
 import { expect } from "chai"
-import { join } from "path"
+import { join, dirname } from "path"
 import { getDataDir, makeTestGarden, makeTestGardenA, TestGarden } from "../../helpers"
 import { DEFAULT_BUILD_TIMEOUT_SEC } from "../../../src/constants"
 import { ConfigGraph } from "../../../src/graph/config-graph"
+import { loadYamlFile } from "../../../src/util/util"
 
 describe("ModuleResolver", () => {
   // Note: We test the ModuleResolver via the TestGarden.resolveModule method, for convenience.
@@ -105,26 +106,31 @@ describe("functional tests", () => {
     })
   })
 
-  describe.skip("render templates using $each", () => {
+  describe("render templates using $each", () => {
     let dataDir: string
     let garden: TestGarden
-    let graph: ConfigGraph
 
     before(async () => {
       dataDir = getDataDir("test-projects", "merge-in-module-template")
       garden = await makeTestGarden(dataDir)
-      graph = await garden.getConfigGraph({ log: garden.log, emit: false })
     })
 
-    const expectedExtraFlags = "-Dbuilder=docker"
-
     context("should resolve vars and inputs with defaults", () => {
-      it.only("with RenderTemplate and ConfigTemplate.configs", async () => {
-        const buildAction = graph.getBuild("templated")
-        const spec = buildAction.getConfig().spec
-        expect(spec).to.exist
-        console.log(spec)
-        expect(spec.extraFlags).to.eql([expectedExtraFlags])
+      it("with RenderTemplate and ConfigTemplate.configs", async () => {
+        const resolvedModule = await garden.resolveModule("bug-service")
+        const [generateFile] = resolvedModule.generateFiles!
+        const generatedFileDir = dirname(generateFile.sourcePath!)
+        const fileName = join(generatedFileDir, generateFile.targetPath)
+
+        const parsed = await loadYamlFile(fileName)
+
+        const templatedEnv = parsed.spec.template.spec.containers[0].env
+
+        expect(templatedEnv).to.eql([
+          { name: "FIELD1", value: "hi" },
+          { name: "FIELD2", value: "bye" },
+          { name: "HELLO", value: "GOODBYE" },
+        ])
       })
     })
   })

--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -1314,7 +1314,7 @@ describe("resolveTemplateStrings", () => {
       $merge: "${var.doesnotexist || var.obj}",
       c: "c",
     }
-    const templateContext = new TestContext({ var: { obj: { a: "a", b: "b" } }})
+    const templateContext = new TestContext({ var: { obj: { a: "a", b: "b" } } })
 
     const result = resolveTemplateStrings(obj, templateContext)
 
@@ -1331,9 +1331,9 @@ describe("resolveTemplateStrings", () => {
         $forEach: "${inputs.merged-object || []}",
         $return: {
           name: "${item.key}",
-          value: "${item.value}"
-        }
-      }
+          value: "${item.value}",
+        },
+      },
     }
     const templateContext = new TestContext({
       inputs: {
@@ -1362,7 +1362,6 @@ describe("resolveTemplateStrings", () => {
     })
   })
 
-
   it("should resolve $merge keys if a dependency cannot be resolved but there's a fallback", () => {
     const obj = {
       "key-value-array": {
@@ -1382,8 +1381,8 @@ describe("resolveTemplateStrings", () => {
       },
       var: {
         "input-object": {
-          EXTERNAL_VAR_1: "EXTERNAL_VAR_1"
-        }
+          EXTERNAL_VAR_1: "EXTERNAL_VAR_1",
+        },
       },
     })
 
@@ -1397,7 +1396,6 @@ describe("resolveTemplateStrings", () => {
     })
   })
 
-
   it("should ignore $merge keys if the object to be merged is undefined", () => {
     const obj = {
       $merge: "${var.doesnotexist}",
@@ -1405,9 +1403,7 @@ describe("resolveTemplateStrings", () => {
     }
     const templateContext = new TestContext({ var: { obj: { a: "a", b: "b" } } })
 
-    expect(() => resolveTemplateStrings(obj, templateContext)).to.throw(
-      "Invalid template string"
-    )
+    expect(() => resolveTemplateStrings(obj, templateContext)).to.throw("Invalid template string")
   })
 
   context("$concat", () => {

--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -1325,7 +1325,7 @@ describe("resolveTemplateStrings", () => {
     })
   })
 
-  it.only("should partially resolve $merge keys if one object is undefined but it can fall back to another object", () => {
+  it("should partially resolve $merge keys if a dependency cannot be resolved yet in partial mode", () => {
     const obj = {
       "key-value-array": {
         $forEach: "${inputs.merged-object || []}",
@@ -1339,9 +1339,14 @@ describe("resolveTemplateStrings", () => {
       inputs: {
         "merged-object": {
           $merge: "${var.empty || var.input-object}",
+          INTERNAL_VAR_1: "INTERNAL_VAR_1",
         },
-        "INTERNAL_VAR_1": "INTERNAL_VAR_1",
-      }
+      },
+      var: {
+        "input-object": {
+          EXTERNAL_VAR_1: "EXTERNAL_VAR_1",
+        },
+      },
     })
 
     const result = resolveTemplateStrings(obj, templateContext, { allowPartial: true })
@@ -1356,6 +1361,42 @@ describe("resolveTemplateStrings", () => {
       },
     })
   })
+
+
+  it("should resolve $merge keys if a dependency cannot be resolved but there's a fallback", () => {
+    const obj = {
+      "key-value-array": {
+        $forEach: "${inputs.merged-object || []}",
+        $return: {
+          name: "${item.key}",
+          value: "${item.value}",
+        },
+      },
+    }
+    const templateContext = new TestContext({
+      inputs: {
+        "merged-object": {
+          $merge: "${var.empty || var.input-object}",
+          INTERNAL_VAR_1: "INTERNAL_VAR_1",
+        },
+      },
+      var: {
+        "input-object": {
+          EXTERNAL_VAR_1: "EXTERNAL_VAR_1"
+        }
+      },
+    })
+
+    const result = resolveTemplateStrings(obj, templateContext)
+
+    expect(result).to.eql({
+      "key-value-array": [
+        { name: "EXTERNAL_VAR_1", value: "EXTERNAL_VAR_1" },
+        { name: "INTERNAL_VAR_1", value: "INTERNAL_VAR_1" },
+      ],
+    })
+  })
+
 
   it("should ignore $merge keys if the object to be merged is undefined", () => {
     const obj = {

--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -1325,6 +1325,38 @@ describe("resolveTemplateStrings", () => {
     })
   })
 
+  it.only("should partially resolve $merge keys if one object is undefined but it can fall back to another object", () => {
+    const obj = {
+      "key-value-array": {
+        $forEach: "${inputs.merged-object || []}",
+        $return: {
+          name: "${item.key}",
+          value: "${item.value}"
+        }
+      }
+    }
+    const templateContext = new TestContext({
+      inputs: {
+        "merged-object": {
+          $merge: "${var.empty || var.input-object}",
+        },
+        "INTERNAL_VAR_1": "INTERNAL_VAR_1",
+      }
+    })
+
+    const result = resolveTemplateStrings(obj, templateContext, { allowPartial: true })
+
+    expect(result).to.eql({
+      "key-value-array": {
+        $forEach: "${inputs.merged-object || []}",
+        $return: {
+          name: "${item.key}",
+          value: "${item.value}",
+        },
+      },
+    })
+  })
+
   it("should ignore $merge keys if the object to be merged is undefined", () => {
     const obj = {
       $merge: "${var.doesnotexist}",

--- a/core/test/unit/src/template-string.ts
+++ b/core/test/unit/src/template-string.ts
@@ -1309,6 +1309,34 @@ describe("resolveTemplateStrings", () => {
     })
   })
 
+  it("should resolve $merge keys if one object is undefined but it can fall back to another object", () => {
+    const obj = {
+      $merge: "${var.doesnotexist || var.obj}",
+      c: "c",
+    }
+    const templateContext = new TestContext({ var: { obj: { a: "a", b: "b" } }})
+
+    const result = resolveTemplateStrings(obj, templateContext)
+
+    expect(result).to.eql({
+      a: "a",
+      b: "b",
+      c: "c",
+    })
+  })
+
+  it("should ignore $merge keys if the object to be merged is undefined", () => {
+    const obj = {
+      $merge: "${var.doesnotexist}",
+      c: "c",
+    }
+    const templateContext = new TestContext({ var: { obj: { a: "a", b: "b" } } })
+
+    expect(() => resolveTemplateStrings(obj, templateContext)).to.throw(
+      "Invalid template string"
+    )
+  })
+
   context("$concat", () => {
     it("handles array concatenation", () => {
       const obj = {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue where in Action / Module templates there would be variable used to iterate over using `$foreach` which cannot be resolved in partial application using `allowPartial: true` but still gets returned as an object.

We now check if something returned to iterate over still includes unresolved 'magic' keys and in case that is the case, it tries to resolve them again in non-partial mode, or just returns the original unresolved value in partial mode.

That ensures that we do not iterate over those until the final non-partial application of the templating.

**Which issue(s) this PR fixes**:
Fixes https://github.com/garden-io/garden/issues/4880

**Special notes for your reviewer**:
