### PR TITLE
feat: add ARM64 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,8 +237,9 @@ commands:
       - run:
           name: Install Codesigning utility (needed for ARM64 on MacOS)
           command: |
-            sudo apt-get update
-            sudo apt install ldid
+            curl -Lo ldid https://github.com/ProcursusTeam/ldid/releases/download/v2.1.5-procursus7/ldid_linux_x86_64
+            chmod +x ldid
+            sudo mv ldid /usr/local/bin
       - run:
           name: Run dist script
           command: yarn run dist --version "<<parameters.version>>"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,6 +241,12 @@ commands:
             chmod +x ldid
             sudo mv ldid /usr/local/bin
       - run:
+          name: Setup buildx and qemu for cross-platform builds
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y qemu-user-static
+            sudo apt-get install -y binfmt-support
+      - run:
           name: Run dist script
           command: yarn run dist --version "<<parameters.version>>"
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -773,6 +773,40 @@ jobs:
           command: dist/macos-amd64/garden deploy --root examples/demo-project --logger-type basic -l=silly --env remote --var userId=$CIRCLE_BUILD_NUM-macos
       - cleanup_remote_cluster:
           filter: $CIRCLE_BUILD_NUM-macos
+  test-macos-arm:
+    macos:
+      xcode: "13.4.1"
+    resource_class: macos.m1.medium.gen1
+    steps:
+      - checkout
+      - *attach-workspace
+      - run:
+          name: brew install
+          command: brew install docker kubectl git
+      # Upgrade git to the latest version.
+      # This step ensures that Garden is always tested to be compatible with the latest git.
+      - run:
+          name: Upgrade git
+          command: brew upgrade git
+      - run:
+          name: Install gcloud SDK
+          command: |
+            cd $HOME
+            curl -LO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-411.0.0-darwin-arm.tar.gz
+            tar xzf google-cloud-sdk-411.0.0-darwin-arm.tar.gz
+            echo 'export PATH=$HOME/google-cloud-sdk/bin:$PATH' >> $BASH_ENV
+      - docker_login
+      - run:
+          name: Install gke-gcloud-auth-plugin
+          command: |
+            gcloud --quiet components install gke-gcloud-auth-plugin
+            echo 'export USE_GKE_GCLOUD_AUTH_PLUGIN=True' >> $BASH_ENV
+      - configure_remote_cluster
+      - run:
+          name: Deploy demo-project
+          command: dist/macos-arm64/garden deploy --root examples/demo-project --logger-type basic -l=silly --env remote --var userId=$CIRCLE_BUILD_NUM-macos-arm
+      - cleanup_remote_cluster:
+          filter: $CIRCLE_BUILD_NUM-macos-arm
 
   test-windows:
     executor: win/default
@@ -832,6 +866,9 @@ workflows:
           <<: *only-internal-prs
           requires: [build-dist]
       - test-macos:
+          <<: *only-internal-prs
+          requires: [build-dist]
+      - test-macos-arm:
           <<: *only-internal-prs
           requires: [build-dist]
       - test-dockerhub:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,6 +235,11 @@ commands:
           keys:
             - pkg-v3-{{ checksum "yarn.lock" }}
       - run:
+          name: Install Codesigning utility (needed for ARM64 on MacOS)
+          command: |
+            sudo apt-get update
+            sudo apt install ldid
+      - run:
           name: Run dist script
           command: yarn run dist --version "<<parameters.version>>"
       - persist_to_workspace:
@@ -250,7 +255,7 @@ commands:
       - run:
           # No need to store the raw files as artifacts, we just want the archives
           name: Cleanup
-          command: rm -rf dist/*-amd64
+          command: rm -rf dist/*-amd64 && rm -rf dist/*-arm64
       - store_artifacts:
           path: dist
           destination: dist

--- a/cli/package.json
+++ b/cli/package.json
@@ -31,7 +31,7 @@
     "@garden-io/garden-terraform": "*",
     "chalk": "^4.1.2",
     "patch-package": "^6.5.1",
-    "pkg": "5.7.0"
+    "pkg": "5.8.1"
   },
   "devDependencies": {
     "@types/chai": "^4.3.4",

--- a/cli/src/build-pkg.ts
+++ b/cli/src/build-pkg.ts
@@ -317,7 +317,7 @@ async function pkgCommon({
       "--output",
       resolve(targetPath, binFilename),
     ],
-    { env: { PKG_CACHE_PATH: pkgFetchTmpDir }, stdio: "inherit" }
+    { env: { PKG_CACHE_PATH: pkgFetchTmpDir } }
   )
 
   console.log(` - ${targetName} -> static`)

--- a/cli/src/build-pkg.ts
+++ b/cli/src/build-pkg.ts
@@ -306,7 +306,12 @@ async function pkgCommon({
       sourcePath,
       "--compress",
       "Brotli",
+      // We do not need to compile to bytecode and obfuscate the source
       "--public",
+      "--public-packages",
+      "*",
+      // We include all native binaries required manually
+      "--no-native-build",
       "--options",
       nodeOptions.join(","),
       "--output",

--- a/cli/src/build-pkg.ts
+++ b/cli/src/build-pkg.ts
@@ -312,7 +312,7 @@ async function pkgCommon({
       "--output",
       resolve(targetPath, binFilename),
     ],
-    { env: { PKG_CACHE_PATH: pkgFetchTmpDir } }
+    { env: { PKG_CACHE_PATH: pkgFetchTmpDir }, stdio: "inherit" }
   )
 
   console.log(` - ${targetName} -> static`)

--- a/cli/src/build-pkg.ts
+++ b/cli/src/build-pkg.ts
@@ -162,7 +162,10 @@ async function pkgMacos({ targetName, sourcePath, pkgType, version }: TargetHand
   // This might happen concurrently for multiple targets
   // so we only do it once and then wait for that process to complete
   if (!fsEventsCopied) {
-    fsEventsCopied = copy(resolve(GARDEN_CORE_ROOT, "lib", "fsevents"), resolve(tmpDirPath, "cli", "node_modules", "fsevents"))
+    fsEventsCopied = copy(
+      resolve(GARDEN_CORE_ROOT, "lib", "fsevents"),
+      resolve(tmpDirPath, "cli", "node_modules", "fsevents")
+    )
   }
   await fsEventsCopied
 

--- a/cli/src/build-pkg.ts
+++ b/cli/src/build-pkg.ts
@@ -48,7 +48,9 @@ interface TargetSpec {
 
 const targets: { [name: string]: TargetSpec } = {
   "macos-amd64": { pkgType: "node18-macos-x64", handler: pkgMacos, nodeBinaryPlatform: "darwin" },
+  "macos-arm64": { pkgType: "node18-macos-arm64", handler: pkgMacos, nodeBinaryPlatform: "darwin" },
   "linux-amd64": { pkgType: "node18-linux-x64", handler: pkgLinux, nodeBinaryPlatform: "linux" },
+  "linux-arm64": { pkgType: "node18-linux-arm64", handler: pkgLinux, nodeBinaryPlatform: "linux" },
   "windows-amd64": { pkgType: "node18-win-x64", handler: pkgWindows, nodeBinaryPlatform: "win32" },
   "alpine-amd64": { pkgType: "node18-alpine-x64", handler: pkgAlpine, nodeBinaryPlatform: "linuxmusl" },
 }

--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -868,6 +868,16 @@ export const mutagenCliSpec: PluginToolSpec = {
       },
     },
     {
+      platform: "linux",
+      architecture: "arm64",
+      url: "https://github.com/garden-io/mutagen/releases/download/v0.15.0-garden-1/mutagen_linux_arm64_v0.15.0.tar.gz",
+      sha256: "80f108fc316223d8c3d1a48def18192e666b33a334b75aa3ebcc95938b774e64",
+      extract: {
+        format: "tar",
+        targetPath: "mutagen",
+      },
+    },
+    {
       platform: "windows",
       architecture: "amd64",
       url: "https://github.com/garden-io/mutagen/releases/download/v0.15.0-garden-1/mutagen_windows_amd64_v0.15.0.zip",

--- a/core/src/plugins/container/container.ts
+++ b/core/src/plugins/container/container.ts
@@ -578,6 +578,16 @@ export const gardenPlugin = () =>
             },
           },
           {
+            platform: "linux",
+            architecture: "arm64",
+            url: "https://download.docker.com/linux/static/stable/aarch64/docker-24.0.4.tgz",
+            sha256: "193a8e1f051adce6a30a4c8486ce9b39929b9633a0da8c96444c9239859f4354",
+            extract: {
+              format: "tar",
+              targetPath: "docker/docker",
+            },
+          },
+          {
             platform: "windows",
             architecture: "amd64",
             url: "https://github.com/rgl/docker-ce-windows-binaries-vagrant/releases/download/v24.0.4/docker-24.0.4.zip",

--- a/core/src/plugins/hadolint/hadolint.ts
+++ b/core/src/plugins/hadolint/hadolint.ts
@@ -131,6 +131,12 @@ gardenPlugin.addTool({
       sha256: "56de6d5e5ec427e17b74fa48d51271c7fc0d61244bf5c90e828aab8362d55010",
     },
     {
+      platform: "linux",
+      architecture: "arm64",
+      url: "https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-arm64",
+      sha256: "5798551bf19f33951881f15eb238f90aef023f11e7ec7e9f4c37961cb87c5df6",
+    },
+    {
       platform: "windows",
       architecture: "amd64",
       url: "https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Windows-x86_64.exe",

--- a/core/src/plugins/kubernetes/helm/helm-cli.ts
+++ b/core/src/plugins/kubernetes/helm/helm-cli.ts
@@ -53,6 +53,16 @@ export const helm3Spec: PluginToolSpec = {
       },
     },
     {
+      platform: "linux",
+      architecture: "arm64",
+      url: `https://get.helm.sh/helm-v${HELM_VERSION}-linux-arm64.tar.gz`,
+      sha256: "658839fed8f9be2169f5df68e55cb2f0aa731a50df454caf183186766800bbd0",
+      extract: {
+        format: "tar",
+        targetPath: "linux-arm64/helm",
+      },
+    },
+    {
       platform: "windows",
       architecture: "amd64",
       url: `https://get.helm.sh/helm-v${HELM_VERSION}-windows-amd64.zip`,

--- a/core/src/plugins/kubernetes/kubectl.ts
+++ b/core/src/plugins/kubernetes/kubectl.ts
@@ -351,6 +351,12 @@ export const kubectlSpec: PluginToolSpec = {
       sha256: "d7da739e4977657a3b3c84962df49493e36b09cc66381a5e36029206dd1e01d0",
     },
     {
+      platform: "linux",
+      architecture: "arm64",
+      url: "https://storage.googleapis.com/kubernetes-release/release/v1.23.3/bin/linux/arm64/kubectl",
+      sha256: "6708d7a701b3d9ab3b359c6be27a3012b1c486fa1e81f79e5bdc71ffca2c38f9",
+    },
+    {
       platform: "windows",
       architecture: "amd64",
       url: "https://storage.googleapis.com/kubernetes-release/release/v1.23.3/bin/windows/amd64/kubectl.exe",

--- a/core/src/plugins/kubernetes/kubernetes-type/kustomize.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/kustomize.ts
@@ -71,6 +71,16 @@ export const kustomizeSpec: PluginToolSpec = {
       },
     },
     {
+      platform: "linux",
+      architecture: "arm64",
+      url: "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.5.2/kustomize_v4.5.2_linux_arm64.tar.gz",
+      sha256: "7924d2c1c41976859558c7a1b8009c0d8cc63ebce242b8d4314d332236966481",
+      extract: {
+        format: "tar",
+        targetPath: "kustomize",
+      },
+    },
+    {
       platform: "windows",
       architecture: "amd64",
       url: "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.5.2/kustomize_v4.5.2_windows_amd64.tar.gz",

--- a/core/src/plugins/octant/octant.ts
+++ b/core/src/plugins/octant/octant.ts
@@ -113,18 +113,18 @@ export const gardenPlugin = () =>
           {
             platform: "linux",
             architecture: "arm64",
-            url: "https://github.com/vmware-tanzu/octant/releases/download/v0.25.1/octant_0.25.1_Linux-ARM64.tar.gz",
-            sha256: "56d736a61b3c9acc9e83c54ec702b75d70cf9f3860c660dd2467b03b5845bf05",
+            url: "https://github.com/vmware-tanzu/octant/releases/download/v0.25.1/octant_0.25.1_Linux-arm64.tar.gz",
+            sha256: "a3eb4973a0c869267e3916bd43e0b41b2bbc73b898376b795a617299c7b2a623",
             extract: {
               format: "tar",
-              targetPath: "octant_0.25.1_Linux-ARM64/octant",
+              targetPath: "octant_0.25.1_Linux-arm64/octant",
             },
           },
           {
             platform: "linux",
             architecture: "amd64",
             url: "https://github.com/vmware-tanzu/octant/releases/download/v0.25.1/octant_0.25.1_Linux-64bit.tar.gz",
-            sha256: "02a404d2f16e669b63df088e45b2fe57ada97d859d3253c86974d56b8bb8807f",
+            sha256: "b12bb6752e43f4e0fe54278df8e98dee3439c4066f66cdb7a0ca4a1c7d8eaa1e",
             extract: {
               format: "tar",
               targetPath: "octant_0.25.1_Linux-64bit/octant",

--- a/core/src/plugins/octant/octant.ts
+++ b/core/src/plugins/octant/octant.ts
@@ -21,6 +21,8 @@ export const gardenPlugin = () =>
     name: "octant",
     dependencies: [{ name: "kubernetes" }],
     docs: dedent`
+    **DEPRECATED:** This plugin will be removed in a future version.
+
     Adds [Octant](https://github.com/vmware-tanzu/octant) to the Garden dashboard, as well as a \`garden tools octant\` command.
   `,
     dashboardPages: [
@@ -83,41 +85,59 @@ export const gardenPlugin = () =>
     tools: [
       {
         name: "octant",
-        version: "0.15.0",
+        version: "0.25.1",
         description: "A web admin UI for Kubernetes.",
         type: "binary",
         _includeInGardenImage: false,
         builds: [
-          // this version has no arm support yet. If you add a later release, please add the "arm64" architecture.
+          {
+            platform: "darwin",
+            architecture: "arm64",
+            url: "https://github.com/vmware-tanzu/octant/releases/download/v0.25.1/octant_0.25.1_macOS-arm64.tar.gz",
+            sha256: "9528d1a3e00f1bf0180457a347aac6963dfdc3faa3a85970b93932a352fb38cf",
+            extract: {
+              format: "tar",
+              targetPath: "octant_0.25.1_macOS-arm64/octant",
+            },
+          },
           {
             platform: "darwin",
             architecture: "amd64",
-            url: "https://github.com/vmware-tanzu/octant/releases/download/v0.15.0/octant_0.15.0_macOS-64bit.tar.gz",
-            sha256: "63d03320e058eab4ef7ace6eb17c00e56f8fab85a202843295922535d28693a8",
+            url: "https://github.com/vmware-tanzu/octant/releases/download/v0.25.1/octant_0.25.1_macOS-64bit.tar.gz",
+            sha256: "97b1510362d99c24eeef98b61ca327e6e5323c99a1c774bc8e60751d3c923b33",
             extract: {
               format: "tar",
-              targetPath: "octant_0.15.0_macOS-64bit/octant",
+              targetPath: "octant_0.25.1_macOS-64bit/octant",
             },
           },
-          // this version has no arm support yet. If you add a later release, please add the "arm64" architecture.
+          {
+            platform: "linux",
+            architecture: "arm64",
+            url: "https://github.com/vmware-tanzu/octant/releases/download/v0.25.1/octant_0.25.1_Linux-ARM64.tar.gz",
+            sha256: "56d736a61b3c9acc9e83c54ec702b75d70cf9f3860c660dd2467b03b5845bf05",
+            extract: {
+              format: "tar",
+              targetPath: "octant_0.25.1_Linux-ARM64/octant",
+            },
+          },
           {
             platform: "linux",
             architecture: "amd64",
-            url: "https://github.com/vmware-tanzu/octant/releases/download/v0.15.0/octant_0.15.0_Linux-64bit.tar.gz",
-            sha256: "475c420c42f4d5f44650b1fb383f7e830e3939cbcc28e84ef49a6269dc3f658e",
+            url: "https://github.com/vmware-tanzu/octant/releases/download/v0.25.1/octant_0.25.1_Linux-64bit.tar.gz",
+            sha256: "02a404d2f16e669b63df088e45b2fe57ada97d859d3253c86974d56b8bb8807f",
             extract: {
               format: "tar",
-              targetPath: "octant_0.15.0_Linux-64bit/octant",
+              targetPath: "octant_0.25.1_Linux-64bit/octant",
             },
           },
           {
             platform: "windows",
             architecture: "amd64",
-            url: "https://github.com/vmware-tanzu/octant/releases/download/v0.15.0/octant_0.15.0_Windows-64bit.zip",
-            sha256: "963f50c196a56390127b01eabb49abaf0604f49a8c879ce4f28562d8d825b84d",
+            url: "https://github.com/vmware-tanzu/octant/releases/download/v0.25.1/octant_0.25.1_Windows-64bit.zip",
+            sha256: "b1e8f372f64c79ff04d69d19f11773936b67447a3abd5a496fbdfef10b6b6d19",
             extract: {
               format: "tar",
-              targetPath: "octant_0.15.0_Windows-64bit/octant.exe",
+              targetPath: "octant_0.25.1_Windows-64bit/octant.exe",
             },
           },
         ],

--- a/core/src/plugins/octant/octant.ts
+++ b/core/src/plugins/octant/octant.ts
@@ -99,6 +99,7 @@ export const gardenPlugin = () =>
               targetPath: "octant_0.15.0_macOS-64bit/octant",
             },
           },
+          // this version has no arm support yet. If you add a later release, please add the "arm64" architecture.
           {
             platform: "linux",
             architecture: "amd64",

--- a/core/src/plugins/otel-collector/otel-collector.ts
+++ b/core/src/plugins/otel-collector/otel-collector.ts
@@ -85,6 +85,16 @@ gardenPlugin.addTool({
       },
     },
     {
+      platform: "linux",
+      architecture: "arm4",
+      url: "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.80.0/otelcol-contrib_0.80.0_linux_arm64.tar.gz",
+      sha256: "19d878166dbc39821f11b6a7c2ed896726c8d5ac6c15108b66d8e874efa8db85",
+      extract: {
+        format: "tar",
+        targetPath: "otelcol-contrib",
+      },
+    },
+    {
       platform: "windows",
       architecture: "amd64",
       url: "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.80.0/otelcol-contrib_0.80.0_windows_amd64.tar.gz",

--- a/core/src/util/util.ts
+++ b/core/src/util/util.ts
@@ -618,16 +618,17 @@ const platformMap = {
 }
 
 const archMap = {
-  x32: "386",
-  x64: "amd64",
-  arm64: "arm64",
+  x32: "386" as const,
+  x64: "amd64" as const,
 }
+
+export type Architecture = Exclude<NodeJS.Architecture, keyof typeof archMap> | (typeof archMap)[keyof typeof archMap]
 
 export function getPlatform() {
   return platformMap[process.platform] || process.platform
 }
 
-export function getArchitecture() {
+export function getArchitecture(): Architecture {
   const arch = process.arch
   return archMap[arch] || arch
 }

--- a/core/src/util/util.ts
+++ b/core/src/util/util.ts
@@ -620,6 +620,7 @@ const platformMap = {
 const archMap = {
   x32: "386",
   x64: "amd64",
+  arm64: "arm64",
 }
 
 export function getPlatform() {

--- a/docs/reference/providers/octant.md
+++ b/docs/reference/providers/octant.md
@@ -7,6 +7,8 @@ tocTitle: "`octant`"
 
 ## Description
 
+**DEPRECATED:** This plugin will be removed in a future version.
+
 Adds [Octant](https://github.com/vmware-tanzu/octant) to the Garden dashboard, as well as a `garden tools octant` command.
 
 Below is the full schema reference for the provider configuration. For an introduction to configuring a Garden project with providers, please look at our [configuration guide](../../using-garden/configuration-overview.md).

--- a/plugins/conftest/index.ts
+++ b/plugins/conftest/index.ts
@@ -421,6 +421,7 @@ export const gardenPlugin = () =>
               targetPath: "conftest",
             },
           },
+          // this version has no arm support yet. If you add a later release, please add the "arm64" architecture.
           {
             platform: "linux",
             architecture: "amd64",

--- a/plugins/jib/gradle.ts
+++ b/plugins/jib/gradle.ts
@@ -46,6 +46,11 @@ export const gradleSpec: PluginToolSpec = {
       ...spec,
     },
     {
+      platform: "linux",
+      architecture: "arm64",
+      ...spec,
+    },
+    {
       platform: "windows",
       architecture: "amd64",
       ...spec,

--- a/plugins/jib/maven.ts
+++ b/plugins/jib/maven.ts
@@ -47,6 +47,11 @@ export const mavenSpec: PluginToolSpec = {
       ...spec,
     },
     {
+      platform: "linux",
+      architecture: "arm64",
+      ...spec,
+    },
+    {
       platform: "windows",
       architecture: "amd64",
       ...spec,

--- a/plugins/jib/mavend.ts
+++ b/plugins/jib/mavend.ts
@@ -19,7 +19,9 @@ export const mvndVersion = "0.9.0"
 const mvndSpec = {
   description: "The Maven Daemon CLI.",
   baseUrl: `https://github.com/apache/maven-mvnd/releases/download/${mvndVersion}/`,
-  linux: {
+  // 0.9.0 has no ARM64 build for linux yet
+  // Should be fixed once 1.0.0 is released
+  linux_amd64: {
     filename: `maven-mvnd-${mvndVersion}-linux-amd64.tar.gz`,
     sha256: "64acc68f2a3e25a0662eb62bf87cf2641706245505572ca1d20f933c7190f148",
     targetPath: `maven-mvnd-${mvndVersion}-linux-amd64/bin/mvnd`,
@@ -50,11 +52,11 @@ export const mavendSpec: PluginToolSpec = {
     {
       platform: "linux",
       architecture: "amd64",
-      sha256: mvndSpec.linux.sha256,
-      url: `${mvndSpec.baseUrl}${mvndSpec.linux.filename}`,
+      sha256: mvndSpec.linux_amd64.sha256,
+      url: `${mvndSpec.baseUrl}${mvndSpec.linux_amd64.filename}`,
       extract: {
         format: "tar",
-        targetPath: mvndSpec.linux.targetPath,
+        targetPath: mvndSpec.linux_amd64.targetPath,
       },
     },
     {

--- a/plugins/jib/openjdk.ts
+++ b/plugins/jib/openjdk.ts
@@ -21,7 +21,8 @@ interface JdkVersion {
   versionName: string
   mac_amd64: JdkBinary
   mac_arm64?: JdkBinary
-  linux: JdkBinary
+  linux_amd64: JdkBinary
+  linux_arm64: JdkBinary
   windows: JdkBinary
 }
 
@@ -34,9 +35,13 @@ const jdk8Version: JdkVersion = {
     filename: "OpenJDK8U-jdk_x64_mac_hotspot_8u292b10.tar.gz",
     sha256: "5646fbe9e4138c902c910bb7014d41463976598097ad03919e4848634c7e8007",
   },
-  linux: {
+  linux_amd64: {
     filename: "OpenJDK8U-jdk_x64_linux_hotspot_8u292b10.tar.gz",
     sha256: "0949505fcf42a1765558048451bb2a22e84b3635b1a31dd6191780eeccaa4ada",
+  },
+  linux_arm64: {
+    filename: "OpenJDK8U-jdk_aarch64_linux_hotspot_8u292b10.tar.gz",
+    sha256: "a29edaf66221f7a51353d3f28e1ecf4221268848260417bc562d797e514082a8",
   },
   windows: {
     filename: "OpenJDK8U-jdk_x64_windows_hotspot_8u292b10.zip",
@@ -53,9 +58,13 @@ const jdk11Version: JdkVersion = {
     filename: "OpenJDK11U-jdk_x64_mac_hotspot_11.0.9.1_1.tar.gz",
     sha256: "96bc469f9b02a3b84382a0685b0bd7935e1ad1bd82a0aab9befb5b42a17cbd77",
   },
-  linux: {
+  linux_amd64: {
     filename: "OpenJDK11U-jdk_x64_linux_hotspot_11.0.9.1_1.tar.gz",
     sha256: "e388fd7f3f2503856d0b04fde6e151cbaa91a1df3bcebf1deddfc3729d677ca3",
+  },
+  linux_arm64: {
+    filename: "OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.9.1_1.tar.gz",
+    sha256: "e96d665a39800b160f8ed4de03eada2969c650752faaf7cc83fa643e28dce337",
   },
   windows: {
     filename: "OpenJDK11U-jdk_x64_windows_hotspot_11.0.9.1_1.zip",
@@ -72,9 +81,13 @@ const jdk13Version: JdkVersion = {
     filename: "OpenJDK13U-jdk_x64_mac_hotspot_13_33.tar.gz",
     sha256: "f948be96daba250b6695e22cb51372d2ba3060e4d778dd09c89548889783099f",
   },
-  linux: {
+  linux_amd64: {
     filename: "OpenJDK13U-jdk_x64_linux_hotspot_13_33.tar.gz",
     sha256: "e562caeffa89c834a69a44242d802eae3523875e427f07c05b1902c152638368",
+  },
+  linux_arm64: {
+    filename: "OpenJDK13U-jdk_aarch64_linux_hotspot_13_33.tar.gz",
+    sha256: "2365b7fbba8d9125fb091933aad9f38f8cc1fbb0217cdec9ec75d2000f6d451a",
   },
   windows: {
     filename: "OpenJDK13U-jdk_x64_windows_hotspot_13_33.zip",
@@ -95,9 +108,13 @@ const jdk17Version: JdkVersion = {
     filename: "OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.4.1_1.tar.gz",
     sha256: "3a976943a9e6a635e68e2b06bd093fc096aad9f5894acda673d3bea0cb3a6f38",
   },
-  linux: {
+  linux_amd64: {
     filename: "OpenJDK17U-jdk_x64_linux_hotspot_17.0.4.1_1.tar.gz",
     sha256: "5fbf8b62c44f10be2efab97c5f5dbf15b74fae31e451ec10abbc74e54a04ff44",
+  },
+  linux_arm64: {
+    filename: "OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.4.1_1.tar.gz",
+    sha256: "2e4137529319cd7935f74e1289025b7b4c794c0fb47a3d138adffbd1bbc0ea58",
   },
   windows: {
     filename: "OpenJDK17U-jdk_x64_windows_hotspot_17.0.4.1_1.zip",
@@ -141,8 +158,18 @@ function openJdkSpec(jdkVersion: JdkVersion): PluginToolSpec {
       {
         platform: "linux",
         architecture: "amd64",
-        url: jdkVersion.baseUrl + jdkVersion.linux.filename,
-        sha256: jdkVersion.linux.sha256,
+        url: jdkVersion.baseUrl + jdkVersion.linux_amd64.filename,
+        sha256: jdkVersion.linux_amd64.sha256,
+        extract: {
+          format: "tar",
+          targetPath: jdkVersion.versionName,
+        },
+      },
+      {
+        platform: "linux",
+        architecture: "arm64",
+        url: jdkVersion.baseUrl + jdkVersion.linux_arm64.filename,
+        sha256: jdkVersion.linux_arm64.sha256,
         extract: {
           format: "tar",
           targetPath: jdkVersion.versionName,

--- a/plugins/pulumi/cli.ts
+++ b/plugins/pulumi/cli.ts
@@ -98,6 +98,16 @@ export const pulumiCliSPecs: PluginToolSpec[] = [
         },
       },
       {
+        platform: "linux",
+        architecture: "arm64",
+        url: "https://github.com/pulumi/pulumi/releases/download/v3.70.0/pulumi-v3.70.0-linux-arm64.tar.gz",
+        sha256: "042849d0aaa16b46f5e8ad062e684219ec803f9b56e8719c04f2469f63b530f4",
+        extract: {
+          format: "tar",
+          targetPath: "pulumi/pulumi",
+        },
+      },
+      {
         platform: "windows",
         architecture: "amd64",
         url: "https://github.com/pulumi/pulumi/releases/download/v3.70.0/pulumi-v3.70.0-windows-x64.zip",
@@ -141,6 +151,16 @@ export const pulumiCliSPecs: PluginToolSpec[] = [
         architecture: "amd64",
         url: "https://github.com/pulumi/pulumi/releases/download/v3.64.0/pulumi-v3.64.0-linux-x64.tar.gz",
         sha256: "2560cce127c838c8367541e9493ec12ae9a3144884f98c2afb99b01a14b6b0f7",
+        extract: {
+          format: "tar",
+          targetPath: "pulumi/pulumi",
+        },
+      },
+      {
+        platform: "linux",
+        architecture: "arm64",
+        url: "https://github.com/pulumi/pulumi/releases/download/v3.64.0/pulumi-v3.64.0-linux-arm64.tar.gz",
+        sha256: "aee09cb70fcffba8c70878fff196d655d76cb7bf56623bb89b0e06efc2e58e79",
         extract: {
           format: "tar",
           targetPath: "pulumi/pulumi",

--- a/plugins/terraform/cli.ts
+++ b/plugins/terraform/cli.ts
@@ -155,6 +155,16 @@ export const terraformCliSpecs: PluginToolSpec[] = [
         },
       },
       {
+        platform: "linux",
+        architecture: "arm64",
+        url: "https://releases.hashicorp.com/terraform/0.14.7/terraform_0.14.7_linux_arm64.zip",
+        sha256: "0a621f1dc411953b955aaf2d7d46b2f350bd3a85a2284ec994ae41419844120b",
+        extract: {
+          format: "zip",
+          targetPath: "terraform",
+        },
+      },
+      {
         platform: "windows",
         architecture: "amd64",
         url: "https://releases.hashicorp.com/terraform/0.14.7/terraform_0.14.7_windows_amd64.zip",
@@ -197,6 +207,16 @@ export const terraformCliSpecs: PluginToolSpec[] = [
         architecture: "amd64",
         url: "https://releases.hashicorp.com/terraform/1.0.5/terraform_1.0.5_linux_amd64.zip",
         sha256: "7ce24478859ab7ca0ba4d8c9c12bb345f52e8efdc42fa3ef9dd30033dbf4b561",
+        extract: {
+          format: "zip",
+          targetPath: "terraform",
+        },
+      },
+      {
+        platform: "linux",
+        architecture: "arm64",
+        url: "https://releases.hashicorp.com/terraform/1.0.5/terraform_1.0.5_linux_arm64.zip",
+        sha256: "f6c56ebb17d6109d908c2936bbdab74f6f7813c542db85ef6cef3dd020359eb2",
         extract: {
           format: "zip",
           targetPath: "terraform",
@@ -251,6 +271,16 @@ export const terraformCliSpecs: PluginToolSpec[] = [
         },
       },
       {
+        platform: "linux",
+        architecture: "arm64",
+        url: "https://releases.hashicorp.com/terraform/1.2.9/terraform_1.2.9_linux_arm64.zip",
+        sha256: "6da7bf01f5a72e61255c2d80eddeba51998e2bb1f50a6d81b0d3b71e70e18531",
+        extract: {
+          format: "zip",
+          targetPath: "terraform",
+        },
+      },
+      {
         platform: "windows",
         architecture: "amd64",
         url: "https://releases.hashicorp.com/terraform/1.2.9/terraform_1.2.9_windows_amd64.zip",
@@ -294,6 +324,16 @@ export const terraformCliSpecs: PluginToolSpec[] = [
         architecture: "amd64",
         url: "https://releases.hashicorp.com/terraform/1.4.6/terraform_1.4.6_linux_amd64.zip",
         sha256: "e079db1a8945e39b1f8ba4e513946b3ab9f32bd5a2bdf19b9b186d22c5a3d53b",
+        extract: {
+          format: "zip",
+          targetPath: "terraform",
+        },
+      },
+      {
+        platform: "linux",
+        architecture: "arm64",
+        url: "https://releases.hashicorp.com/terraform/1.4.6/terraform_1.4.6_linux_arm64.zip",
+        sha256: "b38f5db944ac4942f11ceea465a91e365b0636febd9998c110fbbe95d61c3b26",
         extract: {
           format: "zip",
           targetPath: "terraform",

--- a/scripts/draft-release-notes.ts
+++ b/scripts/draft-release-notes.ts
@@ -35,7 +35,9 @@ Download the Garden binary for your platform from below or simply run \`garden s
 
 * [Garden v${version} for Alpine AMD64 (tar.gz)](https://download.garden.io/core/${version}/garden-${version}-alpine-amd64.tar.gz)
 * [Garden v${version} for Linux AMD64 (tar.gz)](https://download.garden.io/core/${version}/garden-${version}-linux-amd64.tar.gz)
+* [Garden v${version} for Linux ARM64 (tar.gz)](https://download.garden.io/core/${version}/garden-${version}-linux-arm64.tar.gz)
 * [Garden v${version} for MacOS AMD64 (tar.gz)](https://download.garden.io/core/${version}/garden-${version}-macos-amd64.tar.gz)
+* [Garden v${version} for MacOS ARM64 (tar.gz)](https://download.garden.io/core/${version}/garden-${version}-macos-arm64.tar.gz)
 * [Garden v${version} for Windows AMD64 (.zip)](https://download.garden.io/core/${version}/garden-${version}-windows-amd64.zip)
 
 ## Changelog

--- a/support/install.sh
+++ b/support/install.sh
@@ -30,12 +30,29 @@ else
   GARDEN_VERSION=$(curl -sL https://github.com/garden-io/garden/releases/latest -H "Accept: application/json" | jsonValue tag_name 1)
 fi
 
+# Detect OS
 if [ "$(uname -s)" = "Darwin" ]; then
   OS=macos
 else
   OS=`ldd 2>&1|grep musl >/dev/null && echo "alpine" || echo "linux"`
 fi
-PLATFORM=${OS}-amd64
+
+# Detect architecture
+ARCH=$(uname -m)
+case $ARCH in
+  x86_64)
+    ARCH=amd64
+    ;;
+  arm64 | aarch64)
+    ARCH=arm64
+    ;;
+  *)
+    echo "Unsupported architecture: $ARCH"
+    exit 1
+    ;;
+esac
+
+PLATFORM="${OS}-${ARCH}"
 
 filename="garden-${GARDEN_VERSION}-${PLATFORM}.tar.gz"
 url="https://download.garden.io/core/${GARDEN_VERSION}/${filename}"

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,6 +60,15 @@
     json5 "^2.2.2"
     semver "^6.3.1"
 
+"@babel/generator@7.18.2":
+  version "7.18.2"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.18.2.tgz#33873d6f89b21efe2da63fe554460f3df1c5880d"
+  integrity sha512-W1lG5vUwFvfMd8HVXqdfbuG7RuaSrTCCD8cl8fP8wOivdbtbIg2Db3IWUcgvfxKbbn6ZBGYRW/Zk1MIwK49mgw==
+  dependencies:
+    "@babel/types" "^7.18.2"
+    "@jridgewell/gen-mapping" "^0.3.0"
+    jsesc "^2.5.1"
+
 "@babel/generator@^7.22.7", "@babel/generator@^7.22.9":
   version "7.22.9"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.22.9.tgz#572ecfa7a31002fa1de2a9d91621fd895da8493d"
@@ -133,12 +142,12 @@
   dependencies:
     "@babel/types" "^7.22.5"
 
-"@babel/helper-string-parser@^7.22.5":
+"@babel/helper-string-parser@^7.18.10", "@babel/helper-string-parser@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz#533f36457a25814cf1df6488523ad547d784a99f"
   integrity sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==
 
-"@babel/helper-validator-identifier@^7.16.7", "@babel/helper-validator-identifier@^7.22.5":
+"@babel/helper-validator-identifier@^7.18.6", "@babel/helper-validator-identifier@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz#9544ef6a33999343c8740fa51350f30eeaaaf193"
   integrity sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==
@@ -166,10 +175,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@7.17.10":
-  version "7.17.10"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.10.tgz#873b16db82a8909e0fbd7f115772f4b739f6ce78"
-  integrity sha512-n2Q6i+fnJqzOaq2VkdXxy2TCPCWQZHiCo0XqmrCvDWcZQKRyZzYi4Z0yxlBuN0w+r2ZHmre+Q087DSrw3pbJDQ==
+"@babel/parser@7.18.4":
+  version "7.18.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.4.tgz#6774231779dd700e0af29f6ad8d479582d7ce5ef"
+  integrity sha512-FDge0dFazETFcxGw/EXzOkN8uJp0PC7Qbm+Pe9T+av2zlBpOgunFHkQPPn+eRuClU73JF+98D531UgayY89tow==
 
 "@babel/parser@^7.20.15", "@babel/parser@^7.22.5", "@babel/parser@^7.22.7":
   version "7.22.7"
@@ -208,12 +217,22 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@7.17.10":
-  version "7.17.10"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.17.10.tgz#d35d7b4467e439fcf06d195f8100e0fea7fc82c4"
-  integrity sha512-9O26jG0mBYfGkUYCYZRnBwbVLd1UZOICEr2Em6InB6jVfsAv1GKgwXHmrSg+WFWDmeKTA6vyTZiN8tCSM5Oo3A==
+"@babel/types@7.19.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.19.0.tgz#75f21d73d73dc0351f3368d28db73465f4814600"
+  integrity sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.16.7"
+    "@babel/helper-string-parser" "^7.18.10"
+    "@babel/helper-validator-identifier" "^7.18.6"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.18.2":
+  version "7.22.10"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.22.10.tgz#4a9e76446048f2c66982d1a989dd12b8a2d2dc03"
+  integrity sha512-obaoigiLrlDZ7TUQln/8m4mSqIW2QFeOrCQc9r+xsaHGNoplVNYlRVpsfE8Vj35GEm2ZH4ZhrNYogs/3fj85kg==
+  dependencies:
+    "@babel/helper-string-parser" "^7.22.5"
+    "@babel/helper-validator-identifier" "^7.22.5"
     to-fast-properties "^2.0.0"
 
 "@babel/types@^7.22.5":
@@ -3983,6 +4002,11 @@ detect-libc@^1.0.3:
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==
 
+detect-libc@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.2.tgz#8ccf2ba9315350e1241b88d0ac3b0e1fbd99605d"
+  integrity sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==
+
 detect-node@^2.0.4:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
@@ -4397,17 +4421,6 @@ escodegen@^1.13.0:
     estraverse "^4.2.0"
     esutils "^2.0.2"
     optionator "^0.8.1"
-  optionalDependencies:
-    source-map "~0.6.1"
-
-escodegen@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-2.1.0.tgz#ba93bbb7a43986d29d6041f99f5262da773e2e17"
-  integrity sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==
-  dependencies:
-    esprima "^4.0.1"
-    estraverse "^5.2.0"
-    esutils "^2.0.2"
   optionalDependencies:
     source-map "~0.6.1"
 
@@ -8063,7 +8076,7 @@ node-abi@^2.21.0:
   dependencies:
     semver "^5.4.1"
 
-node-abi@^3.45.0:
+node-abi@^3.3.0, node-abi@^3.45.0:
   version "3.45.0"
   resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.45.0.tgz#f568f163a3bfca5aacfce1fbeee1fa2cc98441f5"
   integrity sha512-iwXuFrMAcFVi/ZoZiqq8BzAdsLw9kxDfTC0HMyjXfSL/6CSDAGD5UmR7azrAgWV1zKYq7dUUMj4owusBWKLsiQ==
@@ -8964,10 +8977,10 @@ pkg-dir@^5.0.0:
   dependencies:
     find-up "^5.0.0"
 
-pkg-fetch@3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/pkg-fetch/-/pkg-fetch-3.4.1.tgz#be68bb9f7fdb0f6ed995abc518ab2e35aa64d2fd"
-  integrity sha512-fS4cdayCa1r4jHkOKGPJKnS9PEs6OWZst+s+m0+CmhmPZObMnxoRnf9T9yUWl+lzM2b5aJF7cnQIySCT7Hq8Dg==
+pkg-fetch@3.4.2:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/pkg-fetch/-/pkg-fetch-3.4.2.tgz#6f68ebc54842b73f8c0808959a9df3739dcb28b7"
+  integrity sha512-0+uijmzYcnhC0hStDjm/cl2VYdrmVVBpe7Q8k9YBojxmR5tG8mvR9/nooQq3QSXiQqORDVOTY3XqMEqJVIzkHA==
   dependencies:
     chalk "^4.1.2"
     fs-extra "^9.1.0"
@@ -8978,23 +8991,23 @@ pkg-fetch@3.4.1:
     tar-fs "^2.1.1"
     yargs "^16.2.0"
 
-pkg@5.7.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/pkg/-/pkg-5.7.0.tgz#6422df05e8aa147764be6ef912921d0fa719ea95"
-  integrity sha512-PTiAjNq/CGAtK5qUBR6pjheqnipTFjeecgSgIKEcAOJA4GpmZeOZC8pMOoT0rfes5vHsmcFo7wbSRTAmXQurrg==
+pkg@5.8.1:
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/pkg/-/pkg-5.8.1.tgz#862020f3c0575638ef7d1146f951a54d65ddc984"
+  integrity sha512-CjBWtFStCfIiT4Bde9QpJy0KeH19jCfwZRJqHFDFXfhUklCx8JoFmMj3wgnEYIwGmZVNkhsStPHEOnrtrQhEXA==
   dependencies:
-    "@babel/parser" "7.17.10"
-    "@babel/types" "7.17.10"
+    "@babel/generator" "7.18.2"
+    "@babel/parser" "7.18.4"
+    "@babel/types" "7.19.0"
     chalk "^4.1.2"
-    escodegen "^2.0.0"
     fs-extra "^9.1.0"
     globby "^11.1.0"
     into-stream "^6.0.0"
     is-core-module "2.9.0"
     minimist "^1.2.6"
     multistream "^4.1.0"
-    pkg-fetch "3.4.1"
-    prebuild-install "6.1.4"
+    pkg-fetch "3.4.2"
+    prebuild-install "7.1.1"
     resolve "^1.22.0"
     stream-meter "^1.0.4"
 
@@ -9040,7 +9053,25 @@ postinstall-postinstall@^2.1.0:
   resolved "https://registry.yarnpkg.com/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz#4f7f77441ef539d1512c40bd04c71b06a4704ca3"
   integrity sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==
 
-prebuild-install@6.1.4, prebuild-install@^6.0.0:
+prebuild-install@7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.1.tgz#de97d5b34a70a0c81334fd24641f2a1702352e45"
+  integrity sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==
+  dependencies:
+    detect-libc "^2.0.0"
+    expand-template "^2.0.3"
+    github-from-package "0.0.0"
+    minimist "^1.2.3"
+    mkdirp-classic "^0.5.3"
+    napi-build-utils "^1.0.1"
+    node-abi "^3.3.0"
+    pump "^3.0.0"
+    rc "^1.2.7"
+    simple-get "^4.0.0"
+    tar-fs "^2.0.0"
+    tunnel-agent "^0.6.0"
+
+prebuild-install@^6.0.0:
   version "6.1.4"
   resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-6.1.4.tgz#ae3c0142ad611d58570b89af4986088a4937e00f"
   integrity sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==
@@ -10148,6 +10179,15 @@ simple-get@^3.0.3:
   integrity sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==
   dependencies:
     decompress-response "^4.2.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
+
+simple-get@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.1.tgz#4a39db549287c979d352112fa03fd99fd6bc3543"
+  integrity sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==
+  dependencies:
+    decompress-response "^6.0.0"
     once "^1.3.1"
     simple-concat "^1.0.0"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds ARM64 support for MacOS and Linux.
Not all dependencies are supported yet - specifically for the jib plugin on Linux - but those that are have been added.
It also updates the install script to pick the correct architecture, and it updates the self-updater to update to the ARM version when available and pick the AMD64 version otherwise.

Homebrew still requires an update to the formula to pick based on the architecture, but I believe we can do that separately which will also be a bit easier once the builds already exist. The homebrew formula is updated by a github action which doesn't support two different binaries right now, so that needs changes as well.

I have tested the ARM build for MacOS on MacOS and the Linux one inside a VM.

**Which issue(s) this PR fixes**:

Resolves https://github.com/garden-io/garden/issues/1547

**Special notes for your reviewer**:
