### PR TITLE
feat: allow arm installs for self-update to bonsai-edge

### DIFF
--- a/core/src/commands/self-update.ts
+++ b/core/src/commands/self-update.ts
@@ -311,7 +311,11 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
 
       let architecture = getArchitecture()
 
-      if (architecture === "arm64" && semver.lt(desiredVersion, ARM64_INTRODUCTION_VERSION)) {
+      if (
+        architecture === "arm64" &&
+        desiredVersion !== "edge-bonsai" &&
+        semver.lt(desiredVersion, ARM64_INTRODUCTION_VERSION)
+      ) {
         if (platform === "macos") {
           architecture = "amd64"
           log.info(


### PR DESCRIPTION
**What this PR does / why we need it**:
Ensures that self-update to bonsai-edge keeps installing arm builds if available.
This should always work since there won't be any more versions without an ARM build unless we remove the option altogether.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
