### PR TITLE
fix: detect rosetta emulation during self-update

### DIFF
--- a/core/src/commands/self-update.ts
+++ b/core/src/commands/self-update.ts
@@ -13,7 +13,7 @@ import { BooleanParameter, ChoicesParameter, GlobalOptions, ParameterValues, Str
 import { dedent } from "../util/string"
 import { basename, dirname, join, resolve } from "path"
 import chalk from "chalk"
-import { Architecture, getArchitecture, getPackageVersion, getPlatform } from "../util/util"
+import { Architecture, getArchitecture, isDarwinARM, getPackageVersion, getPlatform } from "../util/util"
 import { RuntimeError } from "../exceptions"
 import { makeTempDir } from "../util/fs"
 import { createReadStream, createWriteStream } from "fs"
@@ -310,6 +310,17 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
       }
 
       let architecture = getArchitecture()
+      let isArmInRosetta = isDarwinARM()
+
+      // When running under Rosetta,
+      // the architecture is reported back as amd64
+      // but in this case we want to target an arm64 build
+      // so we override the architecture here
+      // and then check if the version is supported or not
+      // potentially reverting it back to amd64 again
+      if (isArmInRosetta) {
+        architecture = "arm64"
+      }
 
       if (
         architecture === "arm64" &&

--- a/core/src/util/util.ts
+++ b/core/src/util/util.ts
@@ -629,6 +629,10 @@ export function getPlatform() {
 }
 
 export function getArchitecture(): Architecture {
+  // Note: When node is running a x64 build,
+  // process.arch is always x64 even though the underlying CPU architecture may be arm64
+  // To check if we are running under Rosetta,
+  // use the `isDarwinARM` function below
   const arch = process.arch
   return archMap[arch] || arch
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently everyone is running an amd64 build.
That means everyone is running under rosetta at the moment.
Due to the OS always reporting it's x86, it would thus never update to the ARM build if available.
We now detect if we are running under emulation and if so, we request the ARM build if possible.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
