### PR TITLE
fix: checkout repo before prerelease

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -495,6 +495,7 @@ jobs:
         description: The version tag/name to set
         type: string
     steps:
+      - checkout
       - *attach-workspace
       - run:
           name: Publish a pre-release on GitHub with the valid edge tag


### PR DESCRIPTION
**What this PR does / why we need it**:
We didn't checkout the code for the prerelease step so the added tagging now fails.
This should fix it.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
