### PR TITLE
fix(jib): make native arm maven usable on ARM macs

### DIFF
--- a/core/src/plugin/tools.ts
+++ b/core/src/plugin/tools.ts
@@ -9,10 +9,11 @@
 import { createSchema, joi, joiIdentifier } from "../config/common"
 import { deline } from "../util/string"
 import { PluginTool } from "../util/ext-tools"
+import { Architecture, Platform } from "../util/util"
 
 export interface ToolBuildSpec {
-  platform: string
-  architecture: string
+  platform: Platform
+  architecture: Architecture
   url: string
   sha256: string
   extract?: {

--- a/core/src/util/util.ts
+++ b/core/src/util/util.ts
@@ -617,7 +617,7 @@ export function isSubdir(path: string, ofPath: string): boolean {
 
 // Used to make the platforms more consistent with other tools
 const platformMap = {
-  win32: "windows",
+  win32: "windows" as const,
 }
 
 const archMap = {
@@ -626,8 +626,11 @@ const archMap = {
 }
 
 export type Architecture = Exclude<NodeJS.Architecture, keyof typeof archMap> | (typeof archMap)[keyof typeof archMap]
+export type Platform =
+  | Exclude<NodeJS.Platform, keyof typeof platformMap>
+  | (typeof platformMap)[keyof typeof platformMap]
 
-export function getPlatform() {
+export function getPlatform(): Platform {
   return platformMap[process.platform] || process.platform
 }
 

--- a/plugins/jib/mavend.ts
+++ b/plugins/jib/mavend.ts
@@ -26,7 +26,7 @@ const mvndSpec = {
     sha256: "64acc68f2a3e25a0662eb62bf87cf2641706245505572ca1d20f933c7190f148",
     targetPath: `maven-mvnd-${mvndVersion}-linux-amd64/bin/mvnd`,
   },
-  darwin_aarch64: {
+  darwin_arm64: {
     filename: `maven-mvnd-${mvndVersion}-darwin-aarch64.tar.gz`,
     sha256: "bca67a44cc3716a7da46926acff41b3864d62e5da6982b9e998eca42d2f9bfac",
     targetPath: `maven-mvnd-${mvndVersion}-darwin-aarch64/bin/mvnd`,
@@ -71,12 +71,12 @@ export const mavendSpec: PluginToolSpec = {
     },
     {
       platform: "darwin",
-      architecture: "aarch64",
-      sha256: mvndSpec.darwin_aarch64.sha256,
-      url: `${mvndSpec.baseUrl}${mvndSpec.darwin_aarch64.filename}`,
+      architecture: "arm64",
+      sha256: mvndSpec.darwin_arm64.sha256,
+      url: `${mvndSpec.baseUrl}${mvndSpec.darwin_arm64.filename}`,
       extract: {
         format: "tar",
-        targetPath: mvndSpec.darwin_aarch64.targetPath,
+        targetPath: mvndSpec.darwin_arm64.targetPath,
       },
     },
     {

--- a/plugins/jib/openjdk.ts
+++ b/plugins/jib/openjdk.ts
@@ -6,6 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import { ToolBuildSpec } from "@garden-io/core/src/plugin/tools"
 import { PluginToolSpec } from "@garden-io/sdk/types"
 import { posix } from "path"
 
@@ -123,7 +124,7 @@ const jdk17Version: JdkVersion = {
 }
 
 function openJdkSpec(jdkVersion: JdkVersion): PluginToolSpec {
-  const macBuilds = [
+  const macBuilds: ToolBuildSpec[] = [
     {
       platform: "darwin",
       architecture: "amd64",


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @Walther, and @vvagaytsev.
-->

**What this PR does / why we need it**:
The native aarch64 build of maven has not been used before this commit,
because the arch was wrongly specified as "aarch64" in the tool spec,
instead of the correct "arm64".

This commit also prevents similar mistakes in the future by improving
the types.

We are allowing platforms and architectures that are not technically supported right now here–
this can be adressed in a future PR if needed.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
