### PR TITLE
fix(circleci): use latest gh cli utility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ orbs:
       docker_layer_caching: true
 
   runner-image: &runner-image
-    image: gardendev/circleci-runner:18.15.0@sha256:cb54c072b823ddd605a24b7d497eb909c0c6a6672af5b8dfeebd45006038e4eb
+    image: gardendev/circleci-runner:18.15.0-1@sha256:c830e29ab30a1c5b08cba4d041d3325ef6958aebeba1b10b1ee9566d7b1a4d42
 
   # Configuration for our node jobs
   node-config: &node-config

--- a/images/circleci-runner/Dockerfile
+++ b/images/circleci-runner/Dockerfile
@@ -34,12 +34,11 @@ COPY --from=ldid /usr/local/bin/ldid /usr/local/bin
 COPY --from=ghr /usr/bin/ghr /usr/bin/
 
 # install gh
-# NOTE: We pin to this version because the latest version does not support the fine-grained access tokens for editing issues (https://github.com/cli/cli/issues/6680)
-# When the issue has been resolved, we can go back to installing the latest version of gh.
-RUN wget https://github.com/cli/cli/releases/download/v2.14.7/gh_2.14.7_linux_amd64.deb && \
-  echo "b7ee6f6eb9fb75621bad26b8de7cf457700c33d2f93065a73a77bb3a7a135036  gh_2.14.7_linux_amd64.deb" | sha256sum -c && \
-  sudo dpkg -i gh_2.14.7_linux_amd64.deb && \
-  rm gh_2.14.7_linux_amd64.deb
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /usr/share/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+  && sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+  && sudo apt-get update \
+  && sudo apt-get install gh -y
 
 # install gcloud
 ENV CLOUDSDK_PYTHON=python3

--- a/images/circleci-runner/garden.yml
+++ b/images/circleci-runner/garden.yml
@@ -2,5 +2,5 @@ kind: Module
 type: container
 name: circleci-runner
 description: Used for the core pipeline in CircleCI
-image: gardendev/circleci-runner:18.15.0
+image: gardendev/circleci-runner:18.15.0-1
 extraFlags: ["--platform", "linux/amd64"]


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @Walther, and @vvagaytsev.
-->

**What this PR does / why we need it**:
github fixed cli/cli#6680
Let's use the latest version of gh in CircleCI. This will also fix the [github-edge-prerelease](https://app.circleci.com/jobs/github/garden-io/garden/362715)

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
