### PR TITLE
fix: avoid action execution for the static outputs references of implicit dependencies.

### DIFF
--- a/core/src/actions/types.ts
+++ b/core/src/actions/types.ts
@@ -195,10 +195,6 @@ export type ExecutedActionWrapperParams<
 
 export type GetActionOutputType<T> = T extends BaseAction<any, infer O> ? O : any
 
-export function actionReferenceToString(ref: ActionReference) {
-  return `${ref.kind.toLowerCase()}.${ref.name}`
-}
-
 export type ActionConfig = ValuesType<ActionConfigTypes>
 export type Action = BuildAction | DeployAction | RunAction | TestAction
 export type ResolvedAction = ResolvedBuildAction | ResolvedDeployAction | ResolvedRunAction | ResolvedTestAction

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -742,13 +742,13 @@ function dependenciesFromActionConfig(
     // also avoid execution when referencing the static output keys of the ref action type.
     // e.g. a helm deploy referencing container build static output deploymentImageName
     // ${actions.build.my-container.outputs.deploymentImageName}
-    const actionRef = { name: ref.name, kind: ref.kind }
-    const refActionType = configsByKey[actionReferenceToString(actionRef)]?.type
+    const actionRefKey = actionReferenceToString(ref)
+    const refActionType = configsByKey[actionRefKey]?.type
     let staticOutputKeysForRef: string[] = []
     if (refActionType) {
-      const refDefinition = actionTypes[ref.kind][refActionType]?.spec
-      staticOutputKeysForRef = refDefinition?.staticOutputsSchema
-        ? describeSchema(refDefinition.staticOutputsSchema).keys
+      const refActionSpec = actionTypes[ref.kind][refActionType]?.spec
+      staticOutputKeysForRef = refActionSpec?.staticOutputsSchema
+        ? describeSchema(refActionSpec.staticOutputsSchema).keys
         : []
     }
 

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -742,7 +742,7 @@ function dependenciesFromActionConfig(
     // also avoid execution when referencing the static output keys of the ref action type.
     // e.g. a helm deploy referencing container build static output deploymentImageName
     // ${actions.build.my-container.outputs.deploymentImageName}
-    const actionRef = { name: ref.name, kind: ref.kind}
+    const actionRef = { name: ref.name, kind: ref.kind }
     const refActionType = configsByKey[actionReferenceToString(actionRef)]?.type
     let staticOutputKeysForRef: string[] = []
     if (refActionType) {

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -722,7 +722,7 @@ function dependenciesFromActionConfig(
 
   // Action template references in spec/variables
   // -> We avoid depending on action execution when referencing static output keys
-  const staticKeys = definition?.staticOutputsSchema ? describeSchema(definition.staticOutputsSchema).keys : []
+  const staticOutputKeys = definition?.staticOutputsSchema ? describeSchema(definition.staticOutputsSchema).keys : []
 
   for (const ref of getActionTemplateReferences(config)) {
     let needsExecuted = false
@@ -742,12 +742,12 @@ function dependenciesFromActionConfig(
     // also avoid execution when referencing the static output keys of the ref action type.
     // e.g. a helm deploy referencing container build static output deploymentImageName
     // ${actions.build.my-container.outputs.deploymentImageName}
-    const actionRefKey = actionReferenceToString(ref)
-    const refActionType = configsByKey[actionRefKey]?.type
-    let staticOutputKeysForRef: string[] = []
+    const refActionKey = actionReferenceToString(ref)
+    const refActionType = configsByKey[refActionKey]?.type
+    let refStaticOutputKeys: string[] = []
     if (refActionType) {
       const refActionSpec = actionTypes[ref.kind][refActionType]?.spec
-      staticOutputKeysForRef = refActionSpec?.staticOutputsSchema
+      refStaticOutputKeys = refActionSpec?.staticOutputsSchema
         ? describeSchema(refActionSpec.staticOutputsSchema).keys
         : []
     }
@@ -755,8 +755,8 @@ function dependenciesFromActionConfig(
     if (
       ref.fullRef[3] === "outputs" &&
       outputKey &&
-      !staticKeys?.includes(outputKey) &&
-      !staticOutputKeysForRef?.includes(outputKey)
+      !staticOutputKeys.includes(outputKey) &&
+      !refStaticOutputKeys.includes(outputKey)
     ) {
       needsExecuted = true
     }

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -740,9 +740,10 @@ function dependenciesFromActionConfig(
       }
     }
     // also avoid execution when referencing the static output keys of the ref action type.
-    // e.g. if a helm deploy is referencing container build static output
-    // deploymentImageName: ${actions.build.my-container.outputs.deploymentImageName}
-    const refActionType = configsByKey[`${ref.kind.toLowerCase()}.${ref.name.toLowerCase()}`]?.type
+    // e.g. a helm deploy referencing container build static output deploymentImageName
+    // ${actions.build.my-container.outputs.deploymentImageName}
+    const actionRef = { name: ref.name, kind: ref.kind}
+    const refActionType = configsByKey[actionReferenceToString(actionRef)]?.type
     let staticOutputKeysForRef: string[] = []
     if (refActionType) {
       const refDefinition = actionTypes[ref.kind][refActionType]?.spec

--- a/core/src/plugins/kubernetes/helm/status.ts
+++ b/core/src/plugins/kubernetes/helm/status.ts
@@ -13,7 +13,7 @@ import { getReleaseName, loadTemplate } from "./common"
 import { KubernetesPluginContext } from "../config"
 import { getForwardablePorts } from "../port-forward"
 import { KubernetesResource, KubernetesServerResource } from "../types"
-import { getActionNamespace, getActionNamespaceStatus } from "../namespace"
+import { getActionNamespace } from "../namespace"
 import { getTargetResource, isWorkload } from "../util"
 import { getDeployedResource, isConfiguredForLocalMode } from "../status/status"
 import { KubeApi } from "../api"
@@ -51,13 +51,6 @@ export const getHelmDeployStatus: DeployActionHandler<"getStatus", HelmDeployAct
   const detail: HelmStatusDetail = {}
   let state: DeployState
   let helmStatus: ServiceStatus
-
-  const namespaceStatus = await getActionNamespaceStatus({
-    ctx: k8sCtx,
-    log,
-    action,
-    provider,
-  })
 
   const mode = action.mode()
   let deployedMode: ActionMode = "default"


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR, we avoid marking an action's implicit dependency as needing execution if a static output of dependency is referenced.

**Which issue(s) this PR fixes**:
Fixes #4920

**Special notes for your reviewer**:
