### PR TITLE
improvement: more useful "create project" yaml

### DIFF
--- a/core/test/unit/src/commands/create/create-project.ts
+++ b/core/test/unit/src/commands/create/create-project.ts
@@ -59,8 +59,17 @@ describe("CreateProjectCommand", () => {
         apiVersion: GardenApiVersion.v1,
         kind: "Project",
         name,
-        environments: [{ name: "default" }],
-        providers: [{ name: "local-kubernetes" }],
+        defaultEnvironment: "local",
+        environments: [
+          { name: "local", defaultNamespace: "garden-local" },
+          { name: "remote", defaultNamespace: "garden-remote-${local.username}" },
+          { name: "staging", production: true, defaultNamespace: "staging" },
+        ],
+        providers: [
+          { name: "local-kubernetes", environments: ["local"] },
+          { name: "kubernetes", environments: ["remote"], context: null },
+          { name: "kubernetes", environments: ["staging"], context: null },
+        ],
       },
     ])
   })
@@ -130,8 +139,17 @@ describe("CreateProjectCommand", () => {
         apiVersion: GardenApiVersion.v1,
         kind: "Project",
         name: "foo",
-        environments: [{ name: "default" }],
-        providers: [{ name: "local-kubernetes" }],
+        defaultEnvironment: "local",
+        environments: [
+          { name: "local", defaultNamespace: "garden-local" },
+          { name: "remote", defaultNamespace: "garden-remote-${local.username}" },
+          { name: "staging", production: true, defaultNamespace: "staging" },
+        ],
+        providers: [
+          { name: "local-kubernetes", environments: ["local"] },
+          { name: "kubernetes", environments: ["remote"], context: null },
+          { name: "kubernetes", environments: ["staging"], context: null },
+        ],
       },
     ])
   })
@@ -164,8 +182,17 @@ describe("CreateProjectCommand", () => {
         apiVersion: GardenApiVersion.v1,
         kind: "Project",
         name,
-        environments: [{ name: "default" }],
-        providers: [{ name: "local-kubernetes" }],
+        defaultEnvironment: "local",
+        environments: [
+          { name: "local", defaultNamespace: "garden-local" },
+          { name: "remote", defaultNamespace: "garden-remote-${local.username}" },
+          { name: "staging", production: true, defaultNamespace: "staging" },
+        ],
+        providers: [
+          { name: "local-kubernetes", environments: ["local"] },
+          { name: "kubernetes", environments: ["remote"], context: null },
+          { name: "kubernetes", environments: ["staging"], context: null },
+        ],
       },
     ])
   })

--- a/docs/k8s-plugins/remote-k8s/README.md
+++ b/docs/k8s-plugins/remote-k8s/README.md
@@ -17,7 +17,7 @@ To use the (remote) `kubernetes` plugin, you'll need the following:
 
 The following pages walk you through setting these up step-by-step, but feel free to skip over the steps you don't need.
 
-Also note that there are a lot of ways to create these resources so feel free to use whatever approach you find most useful. 
+Also note that there are a lot of ways to create these resources so feel free to use whatever approach you find most useful.
 
 At the end of these steps, you should have the following values at hand:
 

--- a/docs/tutorials/your-first-project/1-initialize-a-project.md
+++ b/docs/tutorials/your-first-project/1-initialize-a-project.md
@@ -30,14 +30,37 @@ This will create a basic boilerplate project configuration in the current direct
 ```yaml
 apiVersion: garden.io/v1
 kind: Project
-name: demo-project
+name: demo-project-start
+
+defaultEnvironment: local
+
 environments:
-  - name: default
+  - name: local
+    defaultNamespace: garden-local
+
+  - name: remote
+    defaultNamespace: garden-remote-${local.username}
+
+  - name: staging
+    production: true
+    defaultNamespace: staging
+
 providers:
   - name: local-kubernetes
+    environments:
+      - local
+
+  - name: kubernetes
+    environments:
+      - remote
+  - name: kubernetes
+    environments:
+      - staging
 ```
 
-We have one environment (`default`) and a single provider. We'll get back to this later.
+We have three environments (`local`, `remote` and `staging`) and also three provider configurations, one for each environment.
+
+For this step, we'll focus on the `local` environment. You can ignore the others for now.
 
 Next, let's create action configs for each of our two applications, starting with `backend`.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The previous yaml generated by the docs-generator looked like this:

```yaml
# Documentation about Garden projects can be found at https://docs.garden.io/using-garden/projects
# Reference for Garden projects can be found at https://docs.garden.io/reference/project-config

# The Garden apiVersion for this project.
#
# The value garden.io/v0 is the default for backwards compatibility with
# Garden Acorn (0.12) when not explicitly specified.
#
# Configuring garden.io/v1 explicitly in your project configuration allows
# you to start using the new Action configs introduced in Garden Bonsai (0.13).
#
# Note that the value garden.io/v1 will break compatibility of your project
# with Garden Acorn (0.12).
apiVersion: garden.io/v1

# Indicate what kind of config this is.
kind: Project

# The name of the project.
name: foobar

# A list of environments to configure for the project.
environments:
  - # The name of the environment.
    name: default

# A list of providers that should be used for this project, and their configuration. Please refer to individual
# plugins/providers for details on how to configure them.
providers:
  - # The name of the provider plugin to use.
    name: local-kubernetes
```

While it is cool that we are re-using the descriptions from our docs,
there are some problems with this yaml code:
- The comments often do not add any valuable information. For example
  it's already clear that `name: foobar` is the name of the project.
- Another problem is that the description in the reference docs is not
  necessarily the information a user needs when getting started. This
becomes apparent in the comment above `apiVersion`, for example.

This commit simplifies the `create project` command implementation to
just write a file with hardcoded yaml. The comments are hand-crafted for
a good getting-started experience.

This commit also updates the docs that refer to the "create project"
command.

The new yaml looks like this:
```yaml
# Documentation about Garden projects can be found at https://docs.garden.io/using-garden/projects
# Reference for Garden projects can be found at https://docs.garden.io/reference/project-config

apiVersion: garden.io/v1
kind: Project
name: test

defaultEnvironment: local

# Environments typically represent different stages of your development and deployment process.
environments:
  # Use this environment to develop in your local Kubernetes solution of choice.
  # Installation instructions and list of supported local Kubernetes environments: https://docs.garden.io/kubernetes-plugins/local-k8s/install
  - name: local
    defaultNamespace: garden-local

  # Use this environment to develop in remote, production-like environments that scale with your stack.
  # This means you don't need any dependencies on your local machine, even the builds can be performed remotely.
  # It enables sharing build and test caches with your entire team, which can significantly speed up pipelines and development.
  - name: remote
    defaultNamespace: garden-remote-${local.username}

  - name: staging
    # Ask before performing potentially destructive commands like "deploy".
    production: true
    defaultNamespace: staging

# Providers make action types available in your Garden configuration and tell Garden how to connect with your infrastructure.
# For example the kubernetes and local-kubernetes providers allow you to use the container, helm and kubernetes action types.
# All available providers and their configuration options are listed in the reference docs: https://docs.garden.io/reference/providers
providers:
  - name: local-kubernetes
    environments:
      - local

  # To configure the remote kubernetes providers, follow the steps at https://docs.garden.io/kubernetes-plugins/remote-k8s
  - name: kubernetes
    environments:
      - remote
    context: # ... your remote development kubecontext here
  - name: kubernetes
    environments:
      - staging
    context: # ... your staging kubecontext here

# Next step: Define actions to tell Garden how to build, test and deploy your code.
# You can find out more here: https://docs.garden.io/using-garden/actions
```
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
