### PR TITLE
improvement: always offer -f as alias with --force

### DIFF
--- a/core/src/commands/deploy.ts
+++ b/core/src/commands/deploy.ts
@@ -50,7 +50,7 @@ export const deployArgs = {
 }
 
 export const deployOpts = {
-  "force": new BooleanParameter({ help: "Force re-deploy." }),
+  "force": new BooleanParameter({ help: "Force re-deploy.", aliases: ["f"] }),
   "force-build": new BooleanParameter({ help: "Force re-build of build dependencies." }),
   "watch": watchParameter,
   "sync": new StringsParameter({

--- a/core/src/commands/run.ts
+++ b/core/src/commands/run.ts
@@ -45,6 +45,7 @@ const runArgs = {
 const runOpts = {
   "force": new BooleanParameter({
     help: "Run even if the action is disabled for the environment, and/or a successful result is found in cache.",
+    aliases: ["f"],
   }),
   "force-build": new BooleanParameter({
     help: "Force re-build of Build dependencies before running.",

--- a/core/src/commands/self-update.ts
+++ b/core/src/commands/self-update.ts
@@ -34,6 +34,7 @@ const selfUpdateArgs = {
 const selfUpdateOpts = {
   "force": new BooleanParameter({
     help: `Install the Garden CLI even if the specified or detected latest version is the same as the current version.`,
+    aliases: ["f"],
   }),
   "install-dir": new StringParameter({
     help: `Specify an installation directory, instead of using the directory of the Garden CLI being used. Implies --force.`,


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
`build` offered the `-f` alias for `--force`, but all other commands did
not. I found myself trying to run `garden deploy -f` multiple times and
it failed, so let's just make it consistent.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
