### PR TITLE
fix(core): input validation for module templates

### DIFF
--- a/core/src/config/render-template.ts
+++ b/core/src/config/render-template.ts
@@ -114,7 +114,7 @@ export async function renderConfigTemplate({
   templates: { [name: string]: ConfigTemplateConfig }
 }): Promise<RenderConfigTemplateResult> {
   // Resolve template strings for fields. Note that inputs are partially resolved, and will be fully resolved later
-  // when resolving the resolving the resulting modules. Inputs that are used in module names must however be resolvable
+  // when resolving the resulting modules. Inputs that are used in module names must however be resolvable
   // immediately.
   const loggedIn = garden.isLoggedIn()
   const enterpriseDomain = garden.cloudApi?.domain

--- a/core/src/resolve-module.ts
+++ b/core/src/resolve-module.ts
@@ -314,7 +314,7 @@ export class ModuleResolver {
    */
   async resolveModuleConfig(config: ModuleConfig, dependencies: GardenModule[]): Promise<ModuleConfig> {
     const garden = this.garden
-    let inputs = {}
+    let inputs = cloneDeep(config.inputs || {})
 
     const buildPath = this.garden.buildStaging.getBuildPath(config)
 
@@ -328,7 +328,7 @@ export class ModuleResolver {
       buildPath,
       parentName: config.parentName,
       templateName: config.templateName,
-      inputs: config.inputs,
+      inputs,
       graphResults: this.graphResults,
       partialRuntimeResolution: true,
     }
@@ -350,7 +350,7 @@ export class ModuleResolver {
       )
 
       inputs = validateWithPath({
-        config: cloneDeep(config.inputs || {}),
+        config: inputs,
         configType: `inputs for module ${config.name}`,
         path: config.configPath || config.path,
         schema: template.inputsSchema,
@@ -374,7 +374,7 @@ export class ModuleResolver {
     const configContext = new ModuleConfigContext({
       ...templateContextParams,
       variables: { ...garden.variables, ...resolvedModuleVariables },
-      inputs: { ...config.inputs },
+      inputs: { ...inputs },
     })
 
     config = resolveTemplateStrings({ ...config, inputs: {}, variables: {} }, configContext, {

--- a/core/test/data/test-projects/template-configs/garden.yml
+++ b/core/test/data/test-projects/template-configs/garden.yml
@@ -15,6 +15,10 @@ kind: Module
 type: templated
 template: k8s-container
 name: templated-module-based
+inputs:
+  # If the template string isn't resolved ahead of input validation, it will fail
+  # (since the schema expects a boolean value here, not a string).
+  some_flag: ${environment.name == "default"}
 
 ---
 kind: RenderTemplate

--- a/core/test/data/test-projects/template-configs/schema.json
+++ b/core/test/data/test-projects/template-configs/schema.json
@@ -4,6 +4,10 @@
     "builder": {
       "type": "string",
       "default": "standard"
+    },
+    "some_flag": {
+      "type": "boolean",
+      "default": false
     }
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Before this fix, we weren't performing a partial resolution pass on module template inputs before validating them against the input schema. This looks like it was a simple oversight (there's definitely no point in partially resolving an always-empty object).

This would result in validation errors e.g. when the schema declares a boolean field but the unresolved template is still a string value.

**Which issue(s) this PR fixes**:

Fixes #4946.

**Special notes for your reviewer**:

While looking at the code around input resolution and validation, I noticed that we never apply the input schema (as defined in e.g. `schema.json`) against the fully resolved inputs.

It looks like the idea here is to allow the user to pass through template strings that reference e.g. runtime values, which get resolved later in the flow.

If that's the case, then this may cause some surprising behaviour, since a template string for an input value that's supposed to resolve e.g. to a number or a boolean will fail validation because it's still a (template) string. CC @edvald 

If this is the way we intend it to be, we should mention this wrinkle in our guide for config templates.