### PR TITLE
improvement(plugins): debug log manifest dump

### DIFF
--- a/core/src/plugins/kubernetes/kubectl.ts
+++ b/core/src/plugins/kubernetes/kubectl.ts
@@ -111,7 +111,7 @@ export async function apply({
 
   const input = Buffer.from(encodeYamlMulti(manifests))
 
-  log.verbose(`Applying Kubernetes manifests:\n${input.toString()}`)
+  log.debug(`Applying Kubernetes manifests:\n${input.toString()}`)
 
   let args = ["apply"]
   dryRun && args.push("--dry-run")


### PR DESCRIPTION
Before this we were printing all the manifests we were applying at the verbose level which imo is too low a level and can make the logs very noisy.

Noticed this e.g. when streaming logs via the dashboard.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Assigning @stefreak since you added this. Not sure if it was intentional or not, but don't you agree that this should be debug as opposed to verbose?