### PR TITLE
docs: add orbstack to supported local Kubernetes providers

### DIFF
--- a/core/src/plugins/kubernetes/local/config.ts
+++ b/core/src/plugins/kubernetes/local/config.ts
@@ -37,6 +37,7 @@ const supportedContexts = [
   "colima",
   "rancher-desktop",
   "k3d-k3s-default",
+  "orbstack",
 ]
 const nginxServices = ["ingress-controller", "default-backend"]
 

--- a/docs/k8s-plugins/local-k8s/install.md
+++ b/docs/k8s-plugins/local-k8s/install.md
@@ -149,6 +149,10 @@ In your `project.garden.yml` file, add the following configuration under your `l
       namespace: ${kebabCase(local.username)}
 ```
 
+## Orbstack
+
+[Orbstack's native Kubernetes offering](https://docs.orbstack.dev/kubernetes/) works seamlessly with Garden. Follow the official installation instructions [here](https://docs.orbstack.dev/quick-start).
+
 ## A note on networking for k3s, k3d and Rancher Desktop
 
 K3s and its derivatives use the [Service Load Balancer](https://docs.k3s.io/networking#service-load-balancer) (ServiceLB) as a LoadBalancer controller. ServiceLB is ingress controller agnostic. By default, Garden installs an NGINX ingress controller to expose domains on common ports.

--- a/docs/k8s-plugins/local-k8s/install.md
+++ b/docs/k8s-plugins/local-k8s/install.md
@@ -149,9 +149,9 @@ In your `project.garden.yml` file, add the following configuration under your `l
       namespace: ${kebabCase(local.username)}
 ```
 
-## Orbstack
+## OrbStack
 
-[Orbstack's native Kubernetes offering](https://docs.orbstack.dev/kubernetes/) works seamlessly with Garden. Follow the official installation instructions [here](https://docs.orbstack.dev/quick-start).
+[OrbStack's native Kubernetes offering](https://docs.orbstack.dev/kubernetes/) works seamlessly with Garden. Follow OrbStack's official instructions [to spin up its native Kubernetes cluster](https://docs.orbstack.dev/kubernetes/).
 
 ## A note on networking for k3s, k3d and Rancher Desktop
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
Adds [orbstack's new native local Kubernetes offering](https://docs.orbstack.dev/kubernetes/) to the list of supported local Kubernetes providers. It is super fast, easy to use and works out of the box since it uses K3s.
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
