### PR TITLE
refactor: move mode checks to `getForwardablePorts`

### DIFF
--- a/core/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/src/plugins/kubernetes/helm/deployment.ts
@@ -148,7 +148,7 @@ export const helmDeploy: DeployActionHandler<"deploy", HelmDeployAction> = async
   })
 
   // Local mode has its own port-forwarding configuration
-  const forwardablePorts = mode === "local" && spec.localMode ? [] : getForwardablePorts(manifests, action)
+  const forwardablePorts = getForwardablePorts(manifests, action, mode)
 
   // Make sure port forwards work after redeployment
   killPortForwards(action, forwardablePorts || [], log)

--- a/core/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/src/plugins/kubernetes/helm/deployment.ts
@@ -148,7 +148,7 @@ export const helmDeploy: DeployActionHandler<"deploy", HelmDeployAction> = async
   })
 
   // Local mode has its own port-forwarding configuration
-  const forwardablePorts = getForwardablePorts(manifests, action, mode)
+  const forwardablePorts = getForwardablePorts({ resources: manifests, parentAction: action, mode })
 
   // Make sure port forwards work after redeployment
   killPortForwards(action, forwardablePorts || [], log)

--- a/core/src/plugins/kubernetes/helm/handlers.ts
+++ b/core/src/plugins/kubernetes/helm/handlers.ts
@@ -54,7 +54,6 @@ export const helmModuleHandlers: Partial<ModuleActionHandlers<HelmModule>> = {
     //       sets a `build.dependencies[].copy` directive.
 
     let deployAction: HelmDeployConfig | null = null
-    let deployDep: string | null = null
 
     // If this Helm module has `skipDeploy = true`, there won't be a service config for us to convert here.
     if (service) {
@@ -66,7 +65,6 @@ export const helmModuleHandlers: Partial<ModuleActionHandlers<HelmModule>> = {
         convertBuildDependency,
         prepareRuntimeDependencies,
       })
-      deployDep = `deploy.${deployAction.name}`
       actions.push(deployAction)
     }
 

--- a/core/src/plugins/kubernetes/helm/status.ts
+++ b/core/src/plugins/kubernetes/helm/status.ts
@@ -71,7 +71,7 @@ export const getHelmDeployStatus: DeployActionHandler<"getStatus", HelmDeployAct
   if (state !== "missing") {
     const deployedResources = await getDeployedChartResources({ ctx: k8sCtx, action, releaseName, log })
 
-    forwardablePorts = getForwardablePorts(deployedResources, action, deployedMode)
+    forwardablePorts = getForwardablePorts({ resources: deployedResources, parentAction: action, mode: deployedMode })
     ingresses = getK8sIngresses(deployedResources)
 
     if (state === "ready") {

--- a/core/src/plugins/kubernetes/helm/status.ts
+++ b/core/src/plugins/kubernetes/helm/status.ts
@@ -71,7 +71,7 @@ export const getHelmDeployStatus: DeployActionHandler<"getStatus", HelmDeployAct
   if (state !== "missing") {
     const deployedResources = await getDeployedChartResources({ ctx: k8sCtx, action, releaseName, log })
 
-    forwardablePorts = deployedMode === "local" ? [] : getForwardablePorts(deployedResources, action)
+    forwardablePorts = getForwardablePorts(deployedResources, action, deployedMode)
     ingresses = getK8sIngresses(deployedResources)
 
     if (state === "ready") {

--- a/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
@@ -195,8 +195,7 @@ export const getKubernetesDeployStatus: DeployActionHandler<"getStatus", Kuberne
     log,
   })
 
-  // Local mode has its own port-forwarding configuration
-  const forwardablePorts = deployedMode === "local" ? [] : getForwardablePorts(remoteResources, action)
+  const forwardablePorts = getForwardablePorts(remoteResources, action, deployedMode)
 
   if (state === "ready") {
     // Local mode always takes precedence over sync mode

--- a/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/handlers.ts
@@ -195,7 +195,7 @@ export const getKubernetesDeployStatus: DeployActionHandler<"getStatus", Kuberne
     log,
   })
 
-  const forwardablePorts = getForwardablePorts(remoteResources, action, deployedMode)
+  const forwardablePorts = getForwardablePorts({ resources: remoteResources, parentAction: action, mode: deployedMode })
 
   if (state === "ready") {
     // Local mode always takes precedence over sync mode

--- a/core/src/plugins/kubernetes/port-forward.ts
+++ b/core/src/plugins/kubernetes/port-forward.ts
@@ -221,11 +221,15 @@ function getTargetResourceName(action: SupportedRuntimeAction, targetName?: stri
 /**
  * Returns a list of forwardable ports based on the specified resources.
  */
-export function getForwardablePorts(
-  resources: KubernetesResource[],
-  parentAction: Resolved<KubernetesDeployAction | HelmDeployAction> | undefined,
+export function getForwardablePorts({
+  resources,
+  parentAction,
+  mode,
+}: {
+  resources: KubernetesResource[]
+  parentAction: Resolved<KubernetesDeployAction | HelmDeployAction> | undefined
   mode: ActionMode
-): ForwardablePort[] {
+}): ForwardablePort[] {
   const spec = parentAction?.getSpec()
 
   // Note: Local mode has its own port-forwarding configuration

--- a/core/src/plugins/kubernetes/port-forward.ts
+++ b/core/src/plugins/kubernetes/port-forward.ts
@@ -9,6 +9,7 @@
 import { ChildProcess } from "child_process"
 
 import getPort = require("get-port")
+
 const AsyncLock = require("async-lock")
 import { V1ContainerPort, V1Deployment, V1PodTemplate, V1Service } from "@kubernetes/client-node"
 
@@ -27,7 +28,7 @@ import { KubernetesDeployAction } from "./kubernetes-type/config"
 import { HelmDeployAction } from "./helm/config"
 import { DeployAction } from "../../actions/deploy"
 import { GetPortForwardResult } from "../../plugin/handlers/Deploy/get-port-forward"
-import { Resolved } from "../../actions/types"
+import { ActionMode, Resolved } from "../../actions/types"
 
 // TODO: implement stopPortForward handler
 
@@ -222,9 +223,15 @@ function getTargetResourceName(action: SupportedRuntimeAction, targetName?: stri
  */
 export function getForwardablePorts(
   resources: KubernetesResource[],
-  parentAction: Resolved<KubernetesDeployAction | HelmDeployAction> | undefined
+  parentAction: Resolved<KubernetesDeployAction | HelmDeployAction> | undefined,
+  mode: ActionMode
 ): ForwardablePort[] {
   const spec = parentAction?.getSpec()
+
+  // Note: Local mode has its own port-forwarding configuration
+  if (mode === "local" && !!spec?.localMode) {
+    return []
+  }
 
   if (spec?.portForwards) {
     return spec?.portForwards.map((p) => ({

--- a/core/test/unit/src/plugins/kubernetes/port-forward.ts
+++ b/core/test/unit/src/plugins/kubernetes/port-forward.ts
@@ -16,8 +16,8 @@ import { ResolvedDeployAction } from "../../../../../src/actions/deploy"
 
 describe("getForwardablePorts", () => {
   it("returns all ports for Service resources", () => {
-    const ports = getForwardablePorts(
-      [
+    const ports = getForwardablePorts({
+      resources: [
         {
           apiVersion: "v1",
           kind: "Service",
@@ -29,9 +29,9 @@ describe("getForwardablePorts", () => {
           },
         },
       ],
-      undefined,
-      "default"
-    )
+      parentAction: undefined,
+      mode: "default",
+    })
 
     expect(ports).to.eql([
       {
@@ -64,8 +64,8 @@ describe("getForwardablePorts", () => {
       },
     }
 
-    const ports = getForwardablePorts(
-      [
+    const ports = getForwardablePorts({
+      resources: [
         {
           apiVersion: "v1",
           kind: "Service",
@@ -77,9 +77,9 @@ describe("getForwardablePorts", () => {
           },
         },
       ],
-      action,
-      "default"
-    )
+      parentAction: action,
+      mode: "default",
+    })
 
     expect(ports).to.eql([
       {
@@ -93,8 +93,8 @@ describe("getForwardablePorts", () => {
   })
 
   it("returns all ports for Deployment resources", () => {
-    const ports = getForwardablePorts(
-      [
+    const ports = getForwardablePorts({
+      resources: [
         {
           apiVersion: "apps/v1",
           kind: "Deployment",
@@ -114,9 +114,9 @@ describe("getForwardablePorts", () => {
           },
         },
       ],
-      undefined,
-      "default"
-    )
+      parentAction: undefined,
+      mode: "default",
+    })
 
     expect(ports).to.eql([
       {
@@ -129,8 +129,8 @@ describe("getForwardablePorts", () => {
   })
 
   it("returns all ports for DaemonSet resources", () => {
-    const ports = getForwardablePorts(
-      [
+    const ports = getForwardablePorts({
+      resources: [
         {
           apiVersion: "apps/v1",
           kind: "DaemonSet",
@@ -150,9 +150,9 @@ describe("getForwardablePorts", () => {
           },
         },
       ],
-      undefined,
-      "default"
-    )
+      parentAction: undefined,
+      mode: "default",
+    })
 
     expect(ports).to.eql([
       {
@@ -165,8 +165,8 @@ describe("getForwardablePorts", () => {
   })
 
   it("omits a Deployment port that is already pointed to by a Service resource", () => {
-    const ports = getForwardablePorts(
-      [
+    const ports = getForwardablePorts({
+      resources: [
         {
           apiVersion: "v1",
           kind: "Service",
@@ -204,9 +204,9 @@ describe("getForwardablePorts", () => {
           },
         },
       ],
-      undefined,
-      "default"
-    )
+      parentAction: undefined,
+      mode: "default",
+    })
 
     expect(ports).to.eql([
       {

--- a/core/test/unit/src/plugins/kubernetes/port-forward.ts
+++ b/core/test/unit/src/plugins/kubernetes/port-forward.ts
@@ -29,7 +29,8 @@ describe("getForwardablePorts", () => {
           },
         },
       ],
-      undefined
+      undefined,
+      "default"
     )
 
     expect(ports).to.eql([
@@ -76,7 +77,8 @@ describe("getForwardablePorts", () => {
           },
         },
       ],
-      action
+      action,
+      "default"
     )
 
     expect(ports).to.eql([
@@ -112,7 +114,8 @@ describe("getForwardablePorts", () => {
           },
         },
       ],
-      undefined
+      undefined,
+      "default"
     )
 
     expect(ports).to.eql([
@@ -147,7 +150,8 @@ describe("getForwardablePorts", () => {
           },
         },
       ],
-      undefined
+      undefined,
+      "default"
     )
 
     expect(ports).to.eql([
@@ -200,7 +204,8 @@ describe("getForwardablePorts", () => {
           },
         },
       ],
-      undefined
+      undefined,
+      "default"
     )
 
     expect(ports).to.eql([


### PR DESCRIPTION
**What this PR does / why we need it**:
Just a quick PR to minimize the changeset in #4846. That will make conflict resolution easier.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
