### PR TITLE
fix: do not error if actionSources are empty

### DIFF
--- a/core/src/commands/update-remote/actions.ts
+++ b/core/src/commands/update-remote/actions.ts
@@ -113,19 +113,21 @@ export async function updateRemoteActions({
     })
   }
 
-  await pMap(
-    actionSources,
-    ({ name, repositoryUrl }) => {
-      return garden.vcs.updateRemoteSource({
-        name,
-        url: repositoryUrl,
-        sourceType: "action",
-        log,
-        failOnPrompt: opts.parallel,
-      })
-    },
-    { concurrency: opts.parallel ? actionSources.length : 1 }
-  )
+  if (actionSources.length > 0) {
+    await pMap(
+      actionSources,
+      ({ name, repositoryUrl }) => {
+        return garden.vcs.updateRemoteSource({
+          name,
+          url: repositoryUrl,
+          sourceType: "action",
+          log,
+          failOnPrompt: opts.parallel,
+        })
+      },
+      { concurrency: opts.parallel ? actionSources.length : 1 }
+    )
+  }
 
   await pruneRemoteSources({
     gardenDirPath: garden.gardenDirPath,


### PR DESCRIPTION
**What this PR does / why we need it**:
When there were no `actionSources` during a remote update, `pMap` was still called but the concurrency would have been set to 0.
That would cause an error and lead to it failing.
Now we only call the map if the `actionSources` are actually there.

**Which issue(s) this PR fixes**:

fixes https://github.com/garden-io/garden/issues/5035
**Special notes for your reviewer**:
