### PR TITLE
docs: fix wrong use of helm deploy in docs about kubernetes deploy

### DIFF
--- a/docs/k8s-plugins/action-types/kubernetes.md
+++ b/docs/k8s-plugins/action-types/kubernetes.md
@@ -188,7 +188,7 @@ spec:
 ## Linking container builds and kubernetes deploy actions
 
 When your project also contains one or more `container` build actions that build the images used by a `kubernetes` deploy,
-you want to make sure the containers are built ahead of deploying the Helm chart, and that the correct image tag is used when deploying.
+you want to make sure the containers are built ahead of deploying the Kubernetes manifest, and that the correct image tag is used when deploying.
 
 ```yaml
 kind: Build
@@ -200,7 +200,7 @@ name: worker-image
 ```yaml
 kind: Deploy
 description: Kubernetes deploy for the worker container
-type: helm
+type: kubernetes
 name: worker-deploy
 dependencies: [build.worker-image]
 spec:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
The docs about the Kubernetes deploy action had a little mistake where the action was a helm type instead of kubernetes.
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
