### PR TITLE
fix: print the output of Run and Test actions on the info log level

### DIFF
--- a/core/src/plugins/exec/deploy.ts
+++ b/core/src/plugins/exec/deploy.ts
@@ -195,7 +195,7 @@ execDeploy.addHandler("deploy", async (params) => {
     })
 
     if (result.outputLog) {
-      const prefix = `Finished deploying service ${chalk.white(action.name)}. Here is the output:`
+      const prefix = `Finished deploying ${chalk.white(action.name)}. Here is the output:`
       log.verbose(
         renderMessageWithDivider({
           prefix,

--- a/core/src/plugins/exec/run.ts
+++ b/core/src/plugins/exec/run.ts
@@ -50,7 +50,7 @@ execRun.addHandler("run", async ({ artifactsPath, log, action, ctx }) => {
 
   if (outputLog) {
     const prefix = `Finished running ${chalk.white(action.name)}. Here is the full output:`
-    log.verbose(
+    log.info(
       renderMessageWithDivider({
         prefix,
         msg: outputLog,

--- a/core/src/plugins/exec/run.ts
+++ b/core/src/plugins/exec/run.ts
@@ -49,7 +49,7 @@ execRun.addHandler("run", async ({ artifactsPath, log, action, ctx }) => {
   const { chalk } = sdk.util
 
   if (outputLog) {
-    const prefix = `Finished running task ${chalk.white(action.name)}. Here is the full output:`
+    const prefix = `Finished running ${chalk.white(action.name)}. Here is the full output:`
     log.verbose(
       renderMessageWithDivider({
         prefix,

--- a/core/src/plugins/exec/test.ts
+++ b/core/src/plugins/exec/test.ts
@@ -44,7 +44,7 @@ execTest.addHandler("run", async ({ log, action, artifactsPath, ctx }) => {
 
   if (result.outputLog) {
     const prefix = `Finished executing ${chalk.white(action.key())}. Here is the full output:`
-    log.verbose(
+    log.info(
       renderMessageWithDivider({
         prefix,
         msg: result.outputLog,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
This PR prints the Run and Test action output on the INFO log level, just like in 0.12.

**Which issue(s) this PR fixes**:

Fixes #4983

**Special notes for your reviewer**:
We can also consider introducing a flag called `--show-output` and enable it by default for Run and test actions.