### PR TITLE
fix: remove rsync dependency from homebrew formula

### DIFF
--- a/scripts/install-osx-dependencies.sh
+++ b/scripts/install-osx-dependencies.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # install/update homebrew dependencies
-BREW_DEPS="jq cmake git kubectl helm rsync icu4c pkg-config dep git-chglog parallel"
+BREW_DEPS="jq cmake git kubectl helm icu4c pkg-config dep git-chglog parallel"
 
 brew update
 brew tap git-chglog/git-chglog

--- a/scripts/install-osx-dependencies.sh
+++ b/scripts/install-osx-dependencies.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # install/update homebrew dependencies
-BREW_DEPS="jq cmake git kubectl helm icu4c pkg-config dep git-chglog parallel"
+BREW_DEPS="jq cmake git kubectl helm icu4c pkg-config git-chglog parallel"
 
 brew update
 brew tap git-chglog/git-chglog

--- a/support/homebrew-formula.rb.j2
+++ b/support/homebrew-formula.rb.j2
@@ -4,8 +4,6 @@ class GardenCli < Formula
 
   version "{{version}}"
 
-  depends_on "rsync"
-
   # Determine architecture
   if Hardware::CPU.arm?
     url "{{armTarballUrl}}"


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
According to our install guide we only depend on rsync on Windows.

See also https://docs.garden.io/guides/installation

**Which issue(s) this PR fixes**:

Fixes https://github.com/garden-io/homebrew-garden/issues/8

**Special notes for your reviewer**:
