### PR TITLE
fix: avoid crash during kubectl retry

### DIFF
--- a/core/src/plugins/kubernetes/api.ts
+++ b/core/src/plugins/kubernetes/api.ts
@@ -965,7 +965,7 @@ export const KUBECTL_RETRY_OPTS: RetryOpts = {
   maxRetries: 3,
   minTimeoutMs: 300,
   // forceRetry is important, because shouldRetry cannot handle ChildProcessError.
-  forceRetry: true
+  forceRetry: true,
 }
 
 export async function getKubeConfig(log: Log, ctx: PluginContext, provider: KubernetesProvider) {
@@ -985,7 +985,7 @@ export async function getKubeConfig(log: Log, ctx: PluginContext, provider: Kube
             log,
             args,
           }),
-          KUBECTL_RETRY_OPTS,
+        KUBECTL_RETRY_OPTS
       )
     }
     return load(kubeConfigStr)!

--- a/core/src/plugins/kubernetes/api.ts
+++ b/core/src/plugins/kubernetes/api.ts
@@ -961,6 +961,13 @@ function getGroupBasePath(apiVersion: string) {
   return apiVersion.includes("/") ? `/apis/${apiVersion}` : `/api/${apiVersion}`
 }
 
+export const KUBECTL_RETRY_OPTS: RetryOpts = {
+  maxRetries: 3,
+  minTimeoutMs: 300,
+  // forceRetry is important, because shouldRetry cannot handle ChildProcessError.
+  forceRetry: true
+}
+
 export async function getKubeConfig(log: Log, ctx: PluginContext, provider: KubernetesProvider) {
   let kubeConfigStr: string
 
@@ -978,7 +985,7 @@ export async function getKubeConfig(log: Log, ctx: PluginContext, provider: Kube
             log,
             args,
           }),
-        { forceRetry: true }
+          KUBECTL_RETRY_OPTS,
       )
     }
     return load(kubeConfigStr)!

--- a/core/src/plugins/kubernetes/kubectl.ts
+++ b/core/src/plugins/kubernetes/kubectl.ts
@@ -109,7 +109,8 @@ export async function apply({
 
   const input = Buffer.from(encodeYamlMulti(manifests))
 
-  log.debug(`Applying Kubernetes manifests:\n${input.toString()}`)
+  const manifestLogLevel = "debug" as const
+  log[manifestLogLevel](`Applying Kubernetes manifests:\n${input.toString()}`)
 
   let args = ["apply"]
   dryRun && args.push("--dry-run")
@@ -128,7 +129,7 @@ export async function apply({
           args,
           input,
         }),
-        KUBECTL_RETRY_OPTS
+      KUBECTL_RETRY_OPTS
     )
   } catch (e) {
     if (e instanceof ChildProcessError) {
@@ -138,7 +139,7 @@ export async function apply({
 
           ${e.details.output}
 
-          Use the option "--log-level verbose" to see the kubernetes manifests that we attempted to apply through "kubectl apply".
+          Use the option "--log-level ${manifestLogLevel}" to see the kubernetes manifests that we attempted to apply through "kubectl apply".
           `,
       })
     }

--- a/core/src/plugins/kubernetes/kubectl.ts
+++ b/core/src/plugins/kubernetes/kubectl.ts
@@ -15,7 +15,7 @@ import { dedent, gardenAnnotationKey } from "../../util/string"
 import { getResourceKey, hashManifest } from "./util"
 import { PluginToolSpec } from "../../plugin/tools"
 import { PluginContext } from "../../plugin-context"
-import { KubeApi, KubernetesError } from "./api"
+import { KUBECTL_RETRY_OPTS, KubeApi, KubernetesError } from "./api"
 import { pathExists } from "fs-extra"
 import { ChildProcessError, ConfigurationError } from "../../exceptions"
 import { requestWithRetry, RetryOpts } from "./retry"
@@ -57,8 +57,6 @@ export interface ApplyParams {
 }
 
 export const KUBECTL_DEFAULT_TIMEOUT = 300
-
-const KUBECTL_DEFAULT_RETRY_OPTS: RetryOpts = { maxRetries: 3, minTimeoutMs: 300 }
 
 export async function apply({
   log,
@@ -130,7 +128,7 @@ export async function apply({
           args,
           input,
         }),
-      KUBECTL_DEFAULT_RETRY_OPTS
+        KUBECTL_RETRY_OPTS
     )
   } catch (e) {
     if (e instanceof ChildProcessError) {
@@ -199,7 +197,7 @@ export async function deleteResourceKeys({
     log,
     `kubectl ${args.join(" ")}`,
     () => kubectl(ctx, provider).stdout({ namespace, args, log }),
-    KUBECTL_DEFAULT_RETRY_OPTS
+    KUBECTL_RETRY_OPTS
   )
 }
 
@@ -228,7 +226,7 @@ export async function deleteObjectsBySelector({
     log,
     `kubectl ${args.join(" ")}`,
     () => kubectl(ctx, provider).stdout({ namespace, args, log }),
-    KUBECTL_DEFAULT_RETRY_OPTS
+    KUBECTL_RETRY_OPTS
   )
 }
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
- fix: use forceRetry when using requestWithRetry with kubectl command
- fix: use correct manifest loglevel in the error message

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
