### PR TITLE
refactor: rename ephemeral-kubernetes provider to garden-kubernetes

### DIFF
--- a/core/src/plugins/kubernetes/container/ingress.ts
+++ b/core/src/plugins/kubernetes/container/ingress.ts
@@ -20,7 +20,7 @@ import { V1Ingress, V1Secret } from "@kubernetes/client-node"
 import { Log } from "../../../logger/log-entry"
 import chalk from "chalk"
 import { Resolved } from "../../../actions/types"
-import { isProviderEphemeralKubernetes } from "../ephemeral/ephemeral"
+import { isProviderGardenKubernetes } from "../garden-kubernetes/garden-kubernetes"
 
 // Ingress API versions in descending order of preference
 export const supportedIngressApiVersions = ["networking.k8s.io/v1", "networking.k8s.io/v1beta1", "extensions/v1beta1"]
@@ -187,8 +187,8 @@ async function getIngress(
   let protocol: ServiceProtocol = !!certificate ? "https" : "http"
   let port = !!certificate ? provider.config.ingressHttpsPort : provider.config.ingressHttpPort
 
-  // ephemeral-kubernetes ingresses should always be https
-  if (isProviderEphemeralKubernetes(provider)) {
+  // garden-kubernetes ingresses should always be https
+  if (isProviderGardenKubernetes(provider)) {
     protocol = "https"
     port = provider.config.ingressHttpsPort
   }

--- a/core/src/plugins/kubernetes/garden-kubernetes/garden-kubernetes.ts
+++ b/core/src/plugins/kubernetes/garden-kubernetes/garden-kubernetes.ts
@@ -13,7 +13,7 @@ import { KubernetesProvider } from "../config"
 import { joi, joiIdentifier } from "../../../config/common"
 
 const providerUrl = "./kubernetes.md"
-export const EPHEMERAL_KUBERNETES_PROVIDER_NAME = "ephemeral-kubernetes"
+export const GARDEN_KUBERNETES_PROVIDER_NAME = "garden-kubernetes"
 
 const outputsSchema = joi.object().keys({
   "app-namespace": joiIdentifier().required().description("The primary namespace used for resource deployments."),
@@ -26,12 +26,17 @@ const outputsSchema = joi.object().keys({
 
 export const gardenPlugin = () =>
   createGardenPlugin({
-    name: EPHEMERAL_KUBERNETES_PROVIDER_NAME,
+    name: GARDEN_KUBERNETES_PROVIDER_NAME,
     base: "kubernetes",
     docs: dedent`
-    The \`${EPHEMERAL_KUBERNETES_PROVIDER_NAME}\` provider is a specialized version of the [\`kubernetes\` provider](${providerUrl}) that allows to deploy applications to one of the ephemeral Kubernetes clusters provided by Garden.
+    {% hint style="warning" %}
+    This feature is still experimental and can be accessed starting from Garden **v0.13.14**.
+    Please let us know if you encounter any issues.
+    {% endhint %}
 
-    For information about using ephemeral Kubernetes clusters, please refer to [Ephemeral Kubernetes clusters guide](../../basics/ephemeral-clusters.md)
+    The \`${GARDEN_KUBERNETES_PROVIDER_NAME}\` provider is a specialized version of the [\`kubernetes\` provider](${providerUrl}) that allows to deploy applications to one of the ephemeral Kubernetes clusters provided by Garden.
+
+    For information about using ephemeral Kubernetes clusters, please refer to [Garden Managed Kubernetes Clusters guide](../../guides/garden-managed-kubernetes-clusters.md)
   `,
     configSchema: configSchema(),
     outputsSchema,
@@ -40,6 +45,6 @@ export const gardenPlugin = () =>
     },
   })
 
-export function isProviderEphemeralKubernetes(provider: KubernetesProvider) {
-  return provider?.name === EPHEMERAL_KUBERNETES_PROVIDER_NAME
+export function isProviderGardenKubernetes(provider: KubernetesProvider) {
+  return provider?.name === GARDEN_KUBERNETES_PROVIDER_NAME
 }

--- a/core/src/plugins/kubernetes/init.ts
+++ b/core/src/plugins/kubernetes/init.ts
@@ -35,7 +35,7 @@ import { mapValues, omit } from "lodash"
 import { getIngressApiVersion, supportedIngressApiVersions } from "./container/ingress"
 import { Log } from "../../logger/log-entry"
 import { DeployStatusMap } from "../../plugin/handlers/Deploy/get-status"
-import { isProviderEphemeralKubernetes } from "./ephemeral/ephemeral"
+import { isProviderGardenKubernetes } from "./garden-kubernetes/garden-kubernetes"
 
 const dockerAuthSecretType = "kubernetes.io/dockerconfigjson"
 const dockerAuthDocsLink = `
@@ -232,8 +232,8 @@ export async function prepareSystem({
   }
 
   // We require manual init if we're installing any system services to remote clusters unless the remote cluster
-  // is an ephemeral-cluster, to avoid conflicts between users or unnecessary work.
-  if (!clusterInit && remoteCluster && !isProviderEphemeralKubernetes(provider)) {
+  // is a garden ephemeral cluster, to avoid conflicts between users or unnecessary work.
+  if (!clusterInit && remoteCluster && !isProviderGardenKubernetes(provider)) {
     const initCommand = chalk.white.bold(`garden --env=${ctx.environmentName} plugins kubernetes cluster-init`)
 
     if (combinedState === "ready") {

--- a/core/src/plugins/kubernetes/status/ingress.ts
+++ b/core/src/plugins/kubernetes/status/ingress.ts
@@ -8,7 +8,7 @@
 
 import { ServiceIngress, ServiceProtocol } from "../../../types/service"
 import { KubernetesProvider } from "../config"
-import { isProviderEphemeralKubernetes } from "../ephemeral/ephemeral"
+import { isProviderGardenKubernetes } from "../garden-kubernetes/garden-kubernetes"
 import { KubernetesIngress, KubernetesResource } from "../types"
 
 /**
@@ -43,8 +43,8 @@ export function getK8sIngresses(resources: KubernetesResource[], provider?: Kube
         }
 
         let protocol: ServiceProtocol = tlsHosts.includes(rule.host) ? "https" : "http"
-        // ephemeral-kubernetes ingresses should always be https
-        if (provider && isProviderEphemeralKubernetes(provider)) {
+        // garden-kubernetes ingresses should always be https
+        if (provider && isProviderGardenKubernetes(provider)) {
           protocol = "https"
         }
 

--- a/core/src/plugins/plugins.ts
+++ b/core/src/plugins/plugins.ts
@@ -13,7 +13,10 @@ export const getSupportedPlugins = () => [
   { name: "hadolint", callback: () => require("./hadolint/hadolint").gardenPlugin.getSpec() },
   { name: "kubernetes", callback: () => require("./kubernetes/kubernetes").gardenPlugin() },
   { name: "local-kubernetes", callback: () => require("./kubernetes/local/local").gardenPlugin() },
-  { name: "ephemeral-kubernetes", callback: () => require("./kubernetes/ephemeral/ephemeral").gardenPlugin() },
+  {
+    name: "garden-kubernetes",
+    callback: () => require("./kubernetes/garden-kubernetes/garden-kubernetes").gardenPlugin(),
+  },
   { name: "openshift", callback: () => require("./openshift/openshift").gardenPlugin() },
   { name: "octant", callback: () => require("./octant/octant").gardenPlugin() },
   { name: "otel-collector", callback: () => require("./otel-collector/otel-collector").gardenPlugin.getSpec() },

--- a/core/test/unit/src/plugins/kubernetes/ephemeral.ts
+++ b/core/test/unit/src/plugins/kubernetes/ephemeral.ts
@@ -10,14 +10,14 @@ import { expect } from "chai"
 import { providerFromConfig } from "../../../../../src/config/provider"
 import { Garden } from "../../../../../src/garden"
 import { getRootLogger } from "../../../../../src/logger/logger"
-import { configureProvider } from "../../../../../src/plugins/kubernetes/ephemeral/config"
-import { gardenPlugin } from "../../../../../src/plugins/kubernetes/ephemeral/ephemeral"
+import { configureProvider } from "../../../../../src/plugins/kubernetes/garden-kubernetes/config"
+import { gardenPlugin } from "../../../../../src/plugins/kubernetes/garden-kubernetes/garden-kubernetes"
 import { TempDirectory, expectError, makeTempDir, makeTestGardenA } from "../../../../helpers"
 import { FakeCloudApi } from "../../../../helpers/api"
 
-describe("ephemeral-kubernetes configureProvider", () => {
+describe("garden-kubernetes configureProvider", () => {
   const basicConfig = {
-    name: "ephemeral-kubernetes",
+    name: "garden-kubernetes",
   }
 
   let tmpDir: TempDirectory
@@ -64,7 +64,7 @@ describe("ephemeral-kubernetes configureProvider", () => {
         }),
       (err) => {
         expect(err.message).to.contain(
-          "You are not logged in. You must be logged into Garden Cloud in order to use ephemeral-kubernetes provider"
+          "You are not logged in. You must be logged into Garden Cloud in order to use garden-kubernetes provider"
         )
       }
     )
@@ -79,7 +79,7 @@ describe("ephemeral-kubernetes configureProvider", () => {
           ...basicConfig,
         }),
       (err) => {
-        expect(err.message).to.equal("ephemeral-kubernetes provider is currently not supported for Garden Enterprise.")
+        expect(err.message).to.equal("garden-kubernetes provider is currently not supported for Garden Enterprise.")
       }
     )
   })

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,6 @@
 * [How Garden Works](./basics/how-garden-works.md)
 * [Quickstart Guide](./basics/quickstart.md)
 * [Core Concepts](./basics/core-concepts.md)
-* [Start a Free Kubernetes Cluster](./basics/ephemeral-clusters.md)
 * [Use Cases](./basics/use-cases.md)
 * [Adopting Garden](./basics/adopting-garden.md)
 * [Garden vs Other Tools](./basics/garden-vs-other-tools.md)
@@ -83,11 +82,12 @@
 
 * [Migrating to Bonsai](./guides/migrating-to-bonsai.md)
 * [Installing Garden](./guides/installation.md)
-* [Code Synchronization](./guides/code-synchronization.md)
 * [Connecting a local application to a Kubernetes cluster (Local Mode)](./guides/running-service-in-local-mode.md)
+* [Code Synchronization](./guides/code-synchronization.md)
 * [Environments and namespaces](./guides/namespaces.md)
 * [Migrating from Docker Compose to Garden](./guides/migrating-from-docker-compose.md)
 * [Using Garden in CI](./guides/using-garden-in-ci.md)
+* [Garden Managed Kubernetes Clusters](./guides/garden-managed-kubernetes-clusters.md)
 
 ## 🌼 Advanced
 
@@ -101,8 +101,8 @@
   * [`conftest-kubernetes`](./reference/providers/conftest-kubernetes.md)
   * [`conftest`](./reference/providers/conftest.md)
   * [`container`](./reference/providers/container.md)
-  * [`ephemeral-kubernetes`](./reference/providers/ephemeral-kubernetes.md)
   * [`exec`](./reference/providers/exec.md)
+  * [`garden-kubernetes`](./reference/providers/garden-kubernetes.md)
   * [`hadolint`](./reference/providers/hadolint.md)
   * [`jib`](./reference/providers/jib.md)
   * [`kubernetes`](./reference/providers/kubernetes.md)

--- a/docs/guides/garden-managed-kubernetes-clusters.md
+++ b/docs/guides/garden-managed-kubernetes-clusters.md
@@ -1,15 +1,16 @@
 ---
-title: Start a Free Kubernetes Cluster
-order: 4
+title: Garden Managed Kubernetes Clusters
+order: 8
 ---
 
-# Ephemeral Kubernetes Clusters
+# Garden Managed Kubernetes Clusters
 
 {% hint style="warning" %}
-This feature is still experimental. Please let us know if you have any questions or if any issues come up!
+This feature is still experimental and can be accessed starting from Garden **v0.13.14**.
+Please let us know if you encounter any issues.
 {% endhint %}
 
-At Garden, we're committed to reducing the friction with getting started and trialing our tooling with your projects. To make Garden adoption more accessible and convenient, we've introduced **Ephemeral Kubernetes Clusters**. We designed this feature to provide you with a hassle-free way to explore Garden's capabilities on Kubernetes without needing to configure or provision a local or remote cluster.
+At Garden, we're committed to reducing the friction with getting started and trialing our tooling with your projects. To make Garden adoption more accessible and convenient, we've introduced **Ephemeral Kubernetes Clusters**, fully managed by Garden. We designed this feature to provide you with a hassle-free way to explore Garden's capabilities on Kubernetes without needing to configure or provision a local or remote cluster.
 
 The Ephemeral Kubernetes Clusters are provided for free to all users in our **Community Tier**. These clusters are meant for short-term use and to allow you to run and test your applications with Garden on a Kubernetes remote cluster.
 
@@ -24,15 +25,15 @@ If you need to destroy the cluster before its maximum lifetime of 4 hours expire
 To get started with Ephemeral Kubernetes Clusters, follow these steps:
 
 1. Login to Garden Cloud by running `garden login` from your project root.
-2. Configure the `ephemeral-kubernetes` provider in your project's configuration file. Here's an example configuration:
+2. Configure the `garden-kubernetes` provider in your project's configuration file. Here's an example configuration:
 
 ```yaml
 providers:
-  - name: ephemeral-kubernetes
+  - name: garden-kubernetes
     environments: [remote]
 
 ```
-In the above configuration, we configure `ephemeral-kubernetes` for the `remote` environment.
+In the above configuration, we configure `garden-kubernetes` for the `remote` environment.
 
 ## Deploy your project on ephemeral cluster
 
@@ -50,7 +51,7 @@ Ephemeral Kubernetes Clusters fully support ingresses and each cluster is assign
 
 ### Configuring ingress
 
-If you want to refer to the hostname that is assigned dynamically when the cluster is created, you can refer to that using the output `${providers.ephemeral-kubernetes.outputs.default-hostname}`. This can be useful if, for example, you want to expose an ingress on a subdomain of the default hostname.
+If you want to refer to the hostname that is assigned dynamically when the cluster is created, you can refer to that using the output `${providers.garden-kubernetes.outputs.default-hostname}`. This can be useful if, for example, you want to expose an ingress on a subdomain of the default hostname.
 
 For example, if you wish to expose `api` on `api.<default-hostname>`, you can use the following configuration for ingresses:
 
@@ -59,7 +60,7 @@ For example, if you wish to expose `api` on `api.<default-hostname>`, you can us
 ingresses:
     - path: /
       port: http
-      hostname: api.${providers.ephemeral-kubernetes.outputs.default-hostname}
+      hostname: api.${providers.garden-kubernetes.outputs.default-hostname}
 ```
 
 ### Authentication for ingress
@@ -76,19 +77,19 @@ Ingress URLs are not shareable at the moment however it is planned to be support
 
 Once your ephemeral cluster is created, the kubeconfig file for that cluster is stored on your local machine. The path to the kubeconfig file is shown in the logs when you deploy your project using Garden and looks like following:
 ```
-kubeconfig for ephemeral cluster saved at path: /garden/examples/ephemeral-cluster-demo/.garden/ephemeral-kubernetes/<cluster-id>-kubeconfig.yaml
+kubeconfig for ephemeral cluster saved at path: /garden/examples/ephemeral-cluster-demo/.garden/garden-kubernetes/<cluster-id>-kubeconfig.yaml
 ```
 
 This kubeconfig file allows you to interact with the cluster using `kubectl` or other Kubernetes tools.
 
 ## Limitations
 
-As of today, the ephemeral-kubernetes provider has the following limitations:
+As of today, the garden-kubernetes provider has the following limitations:
 
 - Local docker builds are currently not supported. In-cluster building with Kaniko is the only supported building method and it is configured by default at the provider level.
 
-## Example projects using the `ephemeral-kubernetes` provider
+## Example projects using the `garden-kubernetes` provider
 
-To demonstrate the use of the `ephemeral-kubernetes` provider, we have added an example project: [ephemeral-cluster-demo](https://github.com/garden-io/garden/tree/main/examples) under our examples collection. Check out the `ephemeral-cluster-demo` example and README at: https://github.com/garden-io/garden/tree/main/examples/ephemeral-cluster-demo
+To demonstrate the use of the `garden-kubernetes` provider, we have added an example project: [ephemeral-cluster-demo](https://github.com/garden-io/garden/tree/main/examples) under our examples collection. Check out the `ephemeral-cluster-demo` example and README at: https://github.com/garden-io/garden/tree/main/examples/ephemeral-cluster-demo
 
 

--- a/docs/guides/migrating-from-docker-compose.md
+++ b/docs/guides/migrating-from-docker-compose.md
@@ -1,3 +1,8 @@
+---
+title: Migrating from Docker Compose to Garden
+order: 6
+---
+
 # Migrating from Docker Compose to Garden
 
 If you already have an application configured to use Docker Compose and want to migrate it to Garden, you can do so by

--- a/docs/guides/namespaces.md
+++ b/docs/guides/namespaces.md
@@ -1,6 +1,11 @@
+---
+title: Environments and namespaces
+order: 5
+---
+
 # Environments and namespaces
 
-Every Garden project has one or more environments that are defined in the project level Garden configuration. Teams often define environments such as `dev`, `ci`, and `prod`. 
+Every Garden project has one or more environments that are defined in the project level Garden configuration. Teams often define environments such as `dev`, `ci`, and `prod`.
 
 Each environment can be broken down into several "namespaces", and each Garden run operates in a specific namespace. (This is not to be confused with a Kubernetes Namespace resource, although you will often use the same name for your Garden namespace and your Kubernetes Namespace.)
 
@@ -24,7 +29,7 @@ Below is an opinionated guide on configuring environments and namespaces and the
 
 1. Add any of ``dev``, `ci`, `preview` and `prod` environments to your project.
 2. For namespaces in the `dev` environment, template in the user’s name.
-3. For namespaces in the `ci` environment, template in the build number from your CI runner. 
+3. For namespaces in the `ci` environment, template in the build number from your CI runner.
 4. For namespaces in the `preview` environment, template in the PR number.
 5. Use a deterministic namespace for your `prod` environment.
 6. In the `kubernetes` provider config, set `namespace: ${environment.namespace}`. This ensures the Kubernetes namespace corresponds to the Garden namespace.

--- a/docs/guides/using-garden-in-ci.md
+++ b/docs/guides/using-garden-in-ci.md
@@ -1,3 +1,8 @@
+---
+title: Using Garden in CI
+order: 7
+---
+
 # Using Garden in CI
 
 In this guide we'll demonstrate how Garden can fit into your continuous integration (CI) pipeline. Simply by adding extra environments to the project configuration, you can use Garden for local development _and_ for testing and deploying your project in CI. This approach has several benefits:

--- a/docs/reference/providers/garden-kubernetes.md
+++ b/docs/reference/providers/garden-kubernetes.md
@@ -1,15 +1,20 @@
 ---
-title: "`ephemeral-kubernetes` Provider"
-tocTitle: "`ephemeral-kubernetes`"
+title: "`garden-kubernetes` Provider"
+tocTitle: "`garden-kubernetes`"
 ---
 
-# `ephemeral-kubernetes` Provider
+# `garden-kubernetes` Provider
 
 ## Description
 
-The `ephemeral-kubernetes` provider is a specialized version of the [`kubernetes` provider](./kubernetes.md) that allows to deploy applications to one of the ephemeral Kubernetes clusters provided by Garden.
+{% hint style="warning" %}
+This feature is still experimental and can be accessed starting from Garden **v0.13.14**.
+Please let us know if you encounter any issues.
+{% endhint %}
 
-For information about using ephemeral Kubernetes clusters, please refer to [Ephemeral Kubernetes clusters guide](../../basics/ephemeral-clusters.md)
+The `garden-kubernetes` provider is a specialized version of the [`kubernetes` provider](./kubernetes.md) that allows to deploy applications to one of the ephemeral Kubernetes clusters provided by Garden.
+
+For information about using ephemeral Kubernetes clusters, please refer to [Garden Managed Kubernetes Clusters guide](../../guides/garden-managed-kubernetes-clusters.md)
 
 Below is the full schema reference for the provider configuration. For an introduction to configuring a Garden project with providers, please look at our [configuration guide](../../using-garden/configuration-overview.md).
 
@@ -29,7 +34,7 @@ providers:
     environments:
 
     # The name of the provider plugin to use.
-    name: ephemeral-kubernetes
+    name: garden-kubernetes
 
     # Specify which namespace to deploy services to (defaults to the project name). Note that the framework generates
     # other namespaces as well with this name as a prefix.
@@ -100,15 +105,15 @@ providers:
 
 The name of the provider plugin to use.
 
-| Type     | Default                  | Required |
-| -------- | ------------------------ | -------- |
-| `string` | `"ephemeral-kubernetes"` | Yes      |
+| Type     | Default               | Required |
+| -------- | --------------------- | -------- |
+| `string` | `"garden-kubernetes"` | Yes      |
 
 Example:
 
 ```yaml
 providers:
-  - name: "ephemeral-kubernetes"
+  - name: "garden-kubernetes"
 ```
 
 ### `providers[].namespace`
@@ -174,7 +179,7 @@ Set this to null or false to skip installing/enabling the `nginx` ingress contro
 
 ## Outputs
 
-The following keys are available via the `${providers.<provider-name>}` template string key for `ephemeral-kubernetes` providers.
+The following keys are available via the `${providers.<provider-name>}` template string key for `garden-kubernetes` providers.
 
 ### `${providers.<provider-name>.outputs.app-namespace}`
 

--- a/examples/ephemeral-cluster-demo/README.md
+++ b/examples/ephemeral-cluster-demo/README.md
@@ -1,17 +1,12 @@
-# Demo project with using Ephemeral Cluster
+# Simple demo project using a Garden Managed Kubernetes Cluster
 
-A basic demo showing the use of Ephemeral Clusters.
+This example project demonstrates how to use Garden's `garden-kubernetes` provider for deploying an application to one of the ephemeral Kubernetes clusters provided by Garden.
 
+For information about ephemeral Kubernetes clusters, [`check out the docs.`](../../docs/guides/garden-managed-kubernetes-clusters.md)
 
-# Simple demo project using Ephemeral Cluster
+## Configuring garden-kubernetes
 
-This example project demonstrates how to use Garden's ephemeral-kubernetes provider for deploying an application to one of the ephemeral Kubernetes clusters provided by Garden.
-
-For information about ephemeral Kubernetes clusters, [`check out the docs.`](../../docs/basics/ephemeral-clusters.md)
-
-## Configuring ephemeral kubernetes
-
-The project configuration of this application, which is specified in `garden.yml`, declares 2 environments `local` and `remote`. And for the `remote` environment `ephemeral-kubernetes` provider is configured as following:
+The project configuration of this application, which is specified in `garden.yml`, declares an environment `remote` and configures `garden-kubernetes` provider for the `remote` environment as following:
 
 ```yaml
 ...
@@ -19,8 +14,8 @@ environments:
   - name: remote # <-- remote environment name
 
 providers:
-  # setting ephemeral-kubernetes provider for remote environment
-  - name: ephemeral-kubernetes
+  # setting garden-kubernetes provider for remote environment
+  - name: garden-kubernetes
     environments: [remote]
 ...
 ```

--- a/examples/ephemeral-cluster-demo/frontend/frontend.garden.yml
+++ b/examples/ephemeral-cluster-demo/frontend/frontend.garden.yml
@@ -21,10 +21,10 @@ spec:
   ingresses:
     - path: /
       port: http
-      hostname: frontend.${providers.ephemeral-kubernetes.outputs.default-hostname}
+      hostname: frontend.${providers.garden-kubernetes.outputs.default-hostname}
     - path: /call-backend
       port: http
-      hostname: frontend.${providers.ephemeral-kubernetes.outputs.default-hostname}
+      hostname: frontend.${providers.garden-kubernetes.outputs.default-hostname}
 
 ---
 

--- a/examples/ephemeral-cluster-demo/garden.yml
+++ b/examples/ephemeral-cluster-demo/garden.yml
@@ -4,7 +4,7 @@ name: ephemeral-cluster-demo
 environments:
   - name: remote
 providers:
-  - name: ephemeral-kubernetes
+  - name: garden-kubernetes
     environments: [remote]
 variables:
   userId: ${kebabCase(local.username)}


### PR DESCRIPTION
**What this PR does / why we need it**:
Renames `ephemeral-kubernetes` provider to `garden-kubernetes` and corresponding updates in docs/example.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
