### PR TITLE
improvement(build): update moby/buildkit to v0.12.2

### DIFF
--- a/images/buildkit/Dockerfile
+++ b/images/buildkit/Dockerfile
@@ -1,4 +1,4 @@
-FROM moby/buildkit:v0.10.5@sha256:ca9d86324a000a0cc6d93ae9d0d5a9df750a194d0d43644c3a71fc6230ceba44 as buildkit
+FROM moby/buildkit:v0.12.2@sha256:8ea9857f95c2a0402c245bb0e94f36e2b5b4a1cb05e7ed322c213ed50607ce62 as buildkit
 
 RUN apk add --no-cache wget
 

--- a/images/buildkit/Dockerfile
+++ b/images/buildkit/Dockerfile
@@ -16,7 +16,7 @@ RUN wget "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/
   chmod +x /usr/local/bin/docker-credential-gcr && \
   rm docker-credential-gcr_linux_amd64-2.0.1.tar.gz
 
-FROM moby/buildkit:v0.10.5-rootless@sha256:3a5eca9b8d5d0e6cdcd0e756d607bf7386cd1b61950daf63afadee79b43ba8bf as buildkit-rootless
+FROM moby/buildkit:v0.12.2-rootless@sha256:0919807170af622451887366c17408dc9a946d04c6fe4fcca3071f9637f8598f as buildkit-rootless
 
 COPY --from=buildkit /usr/local/bin/docker-credential-ecr-login /usr/local/bin/docker-credential-ecr-login
 COPY --from=buildkit /usr/local/bin/docker-credential-gcr /usr/local/bin/docker-credential-gcr


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

This PR upgrades the moby/buildkit to [v0.12.2](https://github.com/moby/buildkit/releases/tag/v0.12.2), which, among other improvements, adds the `--secret` flag which will allow secrets to be mounted into buildkit builds without including them in the final image layers. This is a security improvement, as it helps prevent secrets from leaking out in the image layers, if used properly by end users.

Technically, the secrets flag was added in [v0.12.0](https://github.com/moby/buildkit/releases/tag/v0.12.0), but I am assuming that it would be a better use of everyone's time if we went directly to the most recent Z release.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
