### PR TITLE
fix: remove read lock from config get

### DIFF
--- a/core/src/config-store/base.ts
+++ b/core/src/config-store/base.ts
@@ -30,18 +30,13 @@ export abstract class ConfigStore<T extends z.ZodObject<any>> {
   async get<S extends keyof I<T>>(section: S): Promise<I<T>[S]>
   async get<S extends keyof I<T>, K extends keyof I<T>[S]>(section: S, key: K): Promise<I<T>[S][K]>
   async get<S extends keyof I<T>, K extends keyof I<T>[S]>(section?: S, key?: K) {
-    const release = await this.lock()
-    try {
-      const config = await this.readConfig()
-      if (section === undefined) {
-        return config
-      } else if (key === undefined) {
-        return config[section]
-      } else {
-        return config[section][key]
-      }
-    } finally {
-      await release()
+    const config = await this.readConfig()
+    if (section === undefined) {
+      return config
+    } else if (key === undefined) {
+      return config[section]
+    } else {
+      return config[section][key]
     }
   }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

This removes the lock when reading from a global or local config file. The read lock can lead to dead-lock in situations where we trigger concurrent reads, e.g. in projects having multiple modules with linked sources. @nilium has provided a reproducible example here: https://github.com/nilium/garden-locker, see discord thread for more details: https://discord.com/channels/817392104711651328/1151269956240031826

__Is it safe to remove the read lock?__

- Concurrent reads are safe since they don't modify the state of the config.

- Writes need the lock since they perform a read + write of the config, which in the case of concurrent writes could result in a trace with R1, R2, W2, W1. Process 1 overwrites the values from process 2 leading to a potentially incorrect state.

- Write operations are atomic, we either read the state before or after the write. A concurrent read should not be able to read a partial state of the config.

- Config data is always validated against the schema and throws an error in case of failure. 

__Note of caution__

- Since this happened for concurrent reads, it will also happen for concurrent writes. In the example project provided by @nilium (https://github.com/nilium/garden-locker), there were in total 12 modules with remote sources (referenced by `repositoryUrl`).

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
