### PR TITLE
test: restore docs checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -902,8 +902,8 @@ workflows:
           requires: [build]
       - lint:
           requires: [build]
-      # - check-docs:
-      #     requires: [build]
+      - check-docs:
+          requires: [build]
       - check-package-licenses:
           requires: [build]
       - test-framework:


### PR DESCRIPTION
We disabled the checks to push through a big docs PR that briefly invalidated some URLs. We restore those here. In the future, contributors will read through our contributors to the docs page.