### PR TITLE
refactor: strict typescript

### DIFF
--- a/core/src/actions/base.ts
+++ b/core/src/actions/base.ts
@@ -328,9 +328,15 @@ export abstract class BaseAction<
   protected executed: boolean
 
   // Note: These need to be public because we need to reference the types (a current TS limitation)
+  // We do however also use `_staticOutputs` so that one isn't just for types
   _config: C
-  _staticOutputs: StaticOutputs
-  _runtimeOutputs: RuntimeOutputs
+  abstract _staticOutputs: StaticOutputs
+  // This property is only used for types.
+  // In theory it would be easy to replace it with a type that uses `infer` on BaseAction to grab the correct type
+  // However, TS will sometimes erase unused types and since `RuntimeOutputs` is only used here to store the type
+  // we cannot remove the property without breaking things.
+  // Thus we simply initialize it to `{}` and use it as a type.
+  _runtimeOutputs: RuntimeOutputs = {} as RuntimeOutputs
 
   protected readonly baseBuildDirectory: string
   protected readonly compatibleTypes: string[]
@@ -705,9 +711,12 @@ export abstract class ResolvedRuntimeAction<
   private readonly executedDependencies: ExecutedAction[]
   private readonly resolvedDependencies: ResolvedAction[]
 
+  override _staticOutputs: StaticOutputs
+
   constructor(params: ResolvedActionWrapperParams<Config>) {
     super(params)
 
+    this.params = params
     this.resolved = true
     this.graph = params.resolvedGraph
     this.dependencyResults = params.dependencyResults

--- a/core/src/actions/build.ts
+++ b/core/src/actions/build.ts
@@ -151,7 +151,12 @@ export class BuildAction<
   StaticOutputs extends {} = any,
   RuntimeOutputs extends {} = any,
 > extends BaseAction<C, StaticOutputs, RuntimeOutputs> {
-  override kind: "Build"
+  override kind: "Build" = "Build"
+  // TODO:
+  // `_staticOutputs` is abstract since the base class uses it but doesn't define it in the constructor.
+  // In this case this would also be the case, but the class isn't actually abstract so it needs it to be defined.
+  // We initialize it to `{}` here which is a hack, but otherwise we'd need to also turn this class into an abstract class.
+  override _staticOutputs: StaticOutputs = {} as StaticOutputs
 
   /**
    * Builds from module conversions inherit their version from their parent module. This is done for compatibility
@@ -199,9 +204,11 @@ export class ResolvedBuildAction<
   private readonly dependencyResults: GraphResults
   private readonly executedDependencies: ExecutedAction[]
   private readonly resolvedDependencies: ResolvedAction[]
+  override _staticOutputs: StaticOutputs
 
   constructor(params: ResolvedActionWrapperParams<C>) {
     super(params)
+    this.params = params
     this.graph = params.resolvedGraph
     this.dependencyResults = params.dependencyResults
     this.executedDependencies = params.executedDependencies

--- a/core/src/actions/deploy.ts
+++ b/core/src/actions/deploy.ts
@@ -38,7 +38,8 @@ export class DeployAction<
   StaticOutputs extends {} = any,
   RuntimeOutputs extends {} = any,
 > extends RuntimeAction<C, StaticOutputs, RuntimeOutputs> {
-  override kind: "Deploy"
+  override kind: "Deploy" = "Deploy"
+  override _staticOutputs: StaticOutputs = {} as StaticOutputs
 }
 
 export class ResolvedDeployAction<
@@ -46,7 +47,7 @@ export class ResolvedDeployAction<
   StaticOutputs extends {} = any,
   RuntimeOutputs extends {} = any,
 > extends ResolvedRuntimeAction<C, StaticOutputs, RuntimeOutputs> {
-  override kind: "Deploy"
+  override kind: "Deploy" = "Deploy"
 }
 
 export class ExecutedDeployAction<
@@ -54,7 +55,7 @@ export class ExecutedDeployAction<
   StaticOutputs extends {} = any,
   RuntimeOutputs extends {} = any,
 > extends ExecutedRuntimeAction<C, StaticOutputs, RuntimeOutputs> {
-  override kind: "Deploy"
+  override kind: "Deploy" = "Deploy"
 }
 
 export function isDeployAction(action: Action): action is DeployAction {

--- a/core/src/actions/run.ts
+++ b/core/src/actions/run.ts
@@ -38,7 +38,8 @@ export class RunAction<
   StaticOutputs extends {} = any,
   RuntimeOutputs extends {} = any,
 > extends RuntimeAction<C, StaticOutputs, RuntimeOutputs> {
-  override kind: "Run"
+  override kind: "Run" = "Run"
+  override _staticOutputs: StaticOutputs = {} as StaticOutputs
 }
 
 export class ResolvedRunAction<
@@ -46,7 +47,7 @@ export class ResolvedRunAction<
   StaticOutputs extends {} = any,
   RuntimeOutputs extends {} = any,
 > extends ResolvedRuntimeAction<C, StaticOutputs, RuntimeOutputs> {
-  override kind: "Run"
+  override kind: "Run" = "Run"
 }
 
 export class ExecutedRunAction<
@@ -54,7 +55,7 @@ export class ExecutedRunAction<
   StaticOutputs extends {} = any,
   RuntimeOutputs extends {} = any,
 > extends ExecutedRuntimeAction<C, StaticOutputs, RuntimeOutputs> {
-  override kind: "Run"
+  override kind: "Run" = "Run"
 }
 
 export function isRunAction(action: Action): action is RunAction {

--- a/core/src/actions/test.ts
+++ b/core/src/actions/test.ts
@@ -38,7 +38,8 @@ export class TestAction<
   StaticOutputs extends {} = any,
   RuntimeOutputs extends {} = any,
 > extends RuntimeAction<C, StaticOutputs, RuntimeOutputs> {
-  override kind: "Test"
+  override kind: "Test" = "Test"
+  override _staticOutputs: StaticOutputs = {} as StaticOutputs
 }
 
 export class ResolvedTestAction<
@@ -46,7 +47,7 @@ export class ResolvedTestAction<
   StaticOutputs extends {} = any,
   RuntimeOutputs extends {} = any,
 > extends ResolvedRuntimeAction<C, StaticOutputs, RuntimeOutputs> {
-  override kind: "Test"
+  override kind: "Test" = "Test"
 }
 
 export class ExecutedTestAction<
@@ -54,7 +55,7 @@ export class ExecutedTestAction<
   StaticOutputs extends {} = any,
   RuntimeOutputs extends {} = any,
 > extends ExecutedRuntimeAction<C, StaticOutputs, RuntimeOutputs> {
-  override kind: "Test"
+  override kind: "Test" = "Test"
 }
 
 export function isTestAction(action: Action): action is TestAction {

--- a/core/src/build-staging/helpers.ts
+++ b/core/src/build-staging/helpers.ts
@@ -219,11 +219,15 @@ export class ExtendedStats extends Stats {
   path: string
   target?: ExtendedStats | null
 
+  constructor(path: string, target?: ExtendedStats | null) {
+    super()
+    this.path = path
+    this.target = target
+  }
+
   static fromStats(stats: Stats, path: string, target?: ExtendedStats | null) {
-    const o = new ExtendedStats()
+    const o = new ExtendedStats(path, target)
     Object.assign(o, stats)
-    o.path = path
-    o.target = target
     return o
   }
 }

--- a/core/src/build-staging/rsync.ts
+++ b/core/src/build-staging/rsync.ts
@@ -19,7 +19,7 @@ const versionRegex = /rsync\s+version\s+v?(\d+.\d+.\d+)/
 export class BuildStagingRsync extends BuildStaging {
   private rsyncPath = "rsync"
 
-  private validated: boolean
+  private validated: boolean = false
 
   setRsyncPath(rsyncPath: string) {
     this.rsyncPath = rsyncPath

--- a/core/src/cache.ts
+++ b/core/src/cache.ts
@@ -64,8 +64,8 @@ interface ContextNode {
  *
  */
 export class TreeCache {
-  private cache: CacheEntries
-  private contextTree: ContextNode
+  private cache: CacheEntries = new Map<string, CacheEntry>()
+  private contextTree: ContextNode = makeContextNode([])
 
   constructor() {
     this.clear()

--- a/core/src/cli/autocomplete.ts
+++ b/core/src/cli/autocomplete.ts
@@ -11,7 +11,7 @@ import { Command, CommandGroup } from "../commands/base"
 import { ConfigDump } from "../garden"
 import { Log } from "../logger/log-entry"
 import { parseCliArgs, pickCommand } from "./helpers"
-import { globalDisplayOptions, globalGardenInstanceOptions, globalOptions, Parameter, Parameters } from "./params"
+import { globalDisplayOptions, globalGardenInstanceOptions, globalOptions, Parameter, ParameterObject } from "./params"
 import stringify from "json-stringify-safe"
 
 export interface AutocompleteSuggestion {
@@ -265,7 +265,7 @@ export class Autocompleter {
       return []
     }
 
-    const opts: Parameters = {
+    const opts: ParameterObject = {
       ...(ignoreGlobalFlags ? {} : globalDisplayOptions),
       ...globalGardenInstanceOptions,
       ...command.options,

--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -31,7 +31,7 @@ import {
   renderCommandErrors,
   cliStyles,
 } from "./helpers"
-import { Parameters, globalOptions, OUTPUT_RENDERERS, GlobalOptions, ParameterValues } from "./params"
+import { ParameterObject, globalOptions, OUTPUT_RENDERERS, GlobalOptions, ParameterValues } from "./params"
 import { ProjectResource } from "../config/project"
 import { ERROR_LOG_FILENAME, DEFAULT_GARDEN_DIR_NAME, LOGS_DIR_NAME, gardenEnv } from "../constants"
 import { generateBasicDebugInfoReport } from "../commands/get/get-debug-info"
@@ -74,7 +74,7 @@ export class GardenCli {
   private fileWritersInitialized: boolean = false
   public plugins: GardenPluginReference[]
   private initLogger: boolean
-  public processRecord: GardenProcess
+  public processRecord?: GardenProcess
   protected cloudApiFactory: CloudApiFactory
 
   constructor({ plugins, initLogger = false, cloudApiFactory = CloudApi.factory }: GardenCliParams = {}) {
@@ -91,12 +91,12 @@ export class GardenCli {
       .sort()
       .filter((cmd) => cmd.getPath().length === 1)
 
-    let msg = `
-${cliStyles.heading("USAGE")}
-  garden ${cliStyles.commandPlaceholder()} ${cliStyles.optionsPlaceholder()}
+    let msg = dedent`
+      ${cliStyles.heading("USAGE")}
+        garden ${cliStyles.commandPlaceholder()} ${cliStyles.optionsPlaceholder()}
 
-${cliStyles.heading("COMMANDS")}
-${renderCommands(commands)}
+      ${cliStyles.heading("COMMANDS")}
+      ${renderCommands(commands)}
     `
 
     const customCommands = await this.getCustomCommands(log, workingDir)
@@ -183,7 +183,7 @@ ${renderCommands(commands)}
     return Garden.factory(workingDir, opts)
   }
 
-  async runCommand<A extends Parameters, O extends Parameters>({
+  async runCommand<A extends ParameterObject, O extends ParameterObject>({
     command,
     parsedArgs,
     parsedOpts,
@@ -503,12 +503,12 @@ ${renderCommands(commands)}
       return done(0, command.renderHelp())
     }
 
-    let parsedArgs: BuiltinArgs & ParameterValues<any>
-    let parsedOpts: ParameterValues<any>
+    let parsedArgs: BuiltinArgs & ParameterValues<ParameterObject>
+    let parsedOpts: ParameterValues<GlobalOptions & ParameterObject>
 
     if (command.ignoreOptions) {
       parsedArgs = { $all: args }
-      parsedOpts = mapValues(globalOptions, (spec) => spec.getDefaultValue(true))
+      parsedOpts = mapValues(globalOptions, (spec) => spec.getDefaultValue(true)) as ParameterValues<GlobalOptions>
     } else {
       try {
         const parseResults = processCliArgs({ rawArgs: args, parsedArgs: argv, command, matchedPath, cli: true })

--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -91,13 +91,16 @@ export class GardenCli {
       .sort()
       .filter((cmd) => cmd.getPath().length === 1)
 
-    let msg = dedent`
-      ${cliStyles.heading("USAGE")}
-        garden ${cliStyles.commandPlaceholder()} ${cliStyles.optionsPlaceholder()}
+    // `dedent` has a bug where it doesn't indent correctly
+    // when there's ANSI codes in the beginning of a line.
+    // Thus we have to dedent like this.
+    let msg = `
+${cliStyles.heading("USAGE")}
+  garden ${cliStyles.commandPlaceholder()} ${cliStyles.optionsPlaceholder()}
 
-      ${cliStyles.heading("COMMANDS")}
-      ${renderCommands(commands)}
-    `
+${cliStyles.heading("COMMANDS")}
+${renderCommands(commands)}
+`
 
     const customCommands = await this.getCustomCommands(log, workingDir)
 

--- a/core/src/cli/command-line.ts
+++ b/core/src/cli/command-line.ts
@@ -38,7 +38,6 @@ import {
 import type { GlobalOptions, ParameterObject, ParameterValues } from "./params"
 import { bindActiveContext, withSessionContext } from "../util/open-telemetry/context"
 import { wrapActiveSpan } from "../util/open-telemetry/spans"
-import dedent from "dedent"
 
 const defaultMessageDuration = 3000
 const commandLinePrefix = chalk.yellow("🌼  > ")
@@ -473,11 +472,14 @@ export class CommandLine extends TypedEventEmitter<CommandLineEvents> {
     const char = "┈"
     const color = chalk.bold
 
-    const wrapped = dedent`
-      ${renderDivider({ title: chalk.bold(title), width, char, color })}
-      ${text}
-      ${renderDivider({ width, char, color })}
-    `
+    // `dedent` has a bug where it doesn't indent correctly
+    // when there's ANSI codes in the beginning of a line.
+    // Thus we have to dedent like this.
+    const wrapped = `
+${renderDivider({ title: chalk.bold(title), width, char, color })}
+${text}
+${renderDivider({ width, char, color })}
+`
 
     this.log.info(wrapped)
   }

--- a/core/src/cli/helpers.ts
+++ b/core/src/cli/helpers.ts
@@ -18,7 +18,7 @@ import stringWidth from "string-width"
 import { maxBy, zip } from "lodash"
 import { Logger } from "../logger/logger"
 
-import { ParameterValues, Parameter, Parameters, globalDisplayOptions } from "./params"
+import { ParameterValues, Parameter, ParameterObject, globalDisplayOptions } from "./params"
 import { GardenError, ParameterError, RuntimeError, toGardenError } from "../exceptions"
 import { getPackageVersion, removeSlice } from "../util/util"
 import { Log } from "../logger/log-entry"
@@ -213,7 +213,7 @@ export function parseCliArgs(params: {
  * @param command     The Command that the arguments are for
  * @param cli         Set to false if `cliOnly` options should be ignored
  */
-export function processCliArgs<A extends Parameters, O extends Parameters>({
+export function processCliArgs<A extends ParameterObject, O extends ParameterObject>({
   log,
   rawArgs,
   parsedArgs,
@@ -408,7 +408,7 @@ export function parseCliVarFlags(cliVars: string[] | undefined) {
   return cliVars ? dotenv.parse(cliVars.join("\n")) : {}
 }
 
-export function optionsWithAliasValues<A extends Parameters, O extends Parameters>(
+export function optionsWithAliasValues<A extends ParameterObject, O extends ParameterObject>(
   command: Command<A, O>,
   parsedOpts: DeepPrimitiveMap
 ): DeepPrimitiveMap {
@@ -487,13 +487,13 @@ export function renderCommands(commands: Command[]) {
   })
 }
 
-export function renderArguments(params: Parameters) {
+export function renderArguments(params: ParameterObject) {
   return renderParameters(params, (name, param) => {
     return " " + cliStyles.usagePositional(name, param.required, param.spread)
   })
 }
 
-export function renderOptions(params: Parameters) {
+export function renderOptions(params: ParameterObject) {
   return renderParameters(params, (name, param) => {
     const renderAlias = (alias: string | undefined): string => {
       if (!alias) {
@@ -509,7 +509,7 @@ export function renderOptions(params: Parameters) {
   })
 }
 
-function renderParameters(params: Parameters, formatName: (name: string, param: Parameter<any>) => string) {
+function renderParameters(params: ParameterObject, formatName: (name: string, param: Parameter<any>) => string) {
   const sortedParams = Object.keys(params).sort()
 
   const names = sortedParams.map((name) => formatName(name, params[name]))

--- a/core/src/cli/params.ts
+++ b/core/src/cli/params.ts
@@ -53,7 +53,6 @@ export interface ParameterConstructorParams<T> {
   required?: boolean
   aliases?: string[]
   defaultValue?: T
-  valueName?: string
   hints?: string
   overrides?: string[]
   cliDefault?: T
@@ -68,14 +67,11 @@ export abstract class Parameter<T> {
   abstract type: string
   abstract schema: Joi.Schema
 
-  _valueType: T
-
   defaultValue: T | undefined
   readonly help: string
   readonly required: boolean
   readonly aliases?: string[]
   readonly hints?: string
-  readonly valueName: string
   readonly overrides: string[]
   readonly hidden: boolean
   readonly spread: boolean
@@ -91,7 +87,6 @@ export abstract class Parameter<T> {
     required,
     aliases,
     defaultValue,
-    valueName,
     overrides,
     hints,
     cliDefault,
@@ -106,7 +101,6 @@ export abstract class Parameter<T> {
     this.aliases = aliases
     this.hints = hints
     this.defaultValue = defaultValue
-    this.valueName = valueName || "_valueType"
     this.overrides = overrides || []
     this.cliDefault = cliDefault
     this.cliOnly = cliOnly || false
@@ -354,12 +348,13 @@ export class EnvironmentParameter extends StringOption {
   }
 }
 
-export type Parameters = { [key: string]: Parameter<any> }
-export type ParameterValues<T extends Parameters> = {
-  [P in keyof T]: T[P]["_valueType"]
+export type ParameterObject = { [key: string]: Parameter<any> }
+export type ParameterValueType<P extends Parameter<any>> = P extends Parameter<infer T> ? T : never
+export type ParameterValues<T extends ParameterObject> = {
+  [P in keyof T]: ParameterValueType<T[P]>
 }
 
-export function describeParameters(args?: Parameters) {
+export function describeParameters(args?: ParameterObject) {
   if (!args) {
     return
   }

--- a/core/src/cloud/api.ts
+++ b/core/src/cloud/api.ts
@@ -174,7 +174,7 @@ export type CloudApiFactory = (params: CloudApiFactoryParams) => Promise<CloudAp
  * for cases where the user is not logged in (e.g. the login method itself).
  */
 export class CloudApi {
-  private intervalId: NodeJS.Timer | null
+  private intervalId: NodeJS.Timer | null = null
   private intervalMsec = 4500 // Refresh interval in ms, it needs to be less than refreshThreshold/2
   private apiPrefix = "api"
   private _profile?: GetProfileResponse["data"]

--- a/core/src/cloud/auth.ts
+++ b/core/src/cloud/auth.ts
@@ -28,8 +28,8 @@ export const makeAuthHeader = (clientAuthToken: string) => ({ [authTokenHeader]:
 // TODO: Add analytics tracking
 export class AuthRedirectServer {
   private log: Log
-  private server: Server
-  private app: Koa
+  private server?: Server
+  private app?: Koa
   private enterpriseDomain: string
   private events: EventEmitter2
 
@@ -60,7 +60,12 @@ export class AuthRedirectServer {
 
   async close() {
     this.log.debug("Shutting down redirect server...")
-    return this.server.close()
+
+    if (this.server) {
+      return this.server.close()
+    }
+
+    return undefined
   }
 
   async createApp() {

--- a/core/src/cloud/buffered-event-stream.ts
+++ b/core/src/cloud/buffered-event-stream.ts
@@ -123,7 +123,7 @@ export class BufferedEventStream {
   private workflowRunUid: string | undefined
   private garden: Garden
   private closed: boolean
-  private intervalId: NodeJS.Timer | null
+  private intervalId: NodeJS.Timer | null = null
   private bufferedEvents: StreamEvent[]
   private bufferedLogEntries: LogEntryEventPayload[]
   private eventListener: GardenEventAnyListener

--- a/core/src/commands/create/create-project.ts
+++ b/core/src/commands/create/create-project.ts
@@ -61,7 +61,7 @@ interface CreateProjectResult {
 }
 
 class CreateError extends GardenError {
-  type: "create"
+  type: "create" = "create"
 }
 
 export class CreateProjectCommand extends Command<CreateProjectArgs, CreateProjectOpts> {

--- a/core/src/commands/custom.ts
+++ b/core/src/commands/custom.ts
@@ -12,7 +12,14 @@ import { apply as jsonMerge } from "json-merge-patch"
 import cloneDeep from "fast-copy"
 import { keyBy, mapValues, flatten } from "lodash"
 import { parseCliArgs, prepareMinimistOpts } from "../cli/helpers"
-import { BooleanParameter, globalOptions, IntegerParameter, Parameter, StringParameter } from "../cli/params"
+import {
+  BooleanParameter,
+  globalOptions,
+  IntegerParameter,
+  Parameter,
+  ParameterObject,
+  StringParameter,
+} from "../cli/params"
 import { loadConfigResources } from "../config/base"
 import {
   CommandResource,
@@ -94,7 +101,13 @@ export class CustomCommandWrapper extends Command {
     log.info(chalk.cyan(this.name))
   }
 
-  async action({ garden, cli, log, args, opts }: CommandParams<any, any>): Promise<CommandResult<CustomCommandResult>> {
+  async action({
+    garden,
+    cli,
+    log,
+    args,
+    opts,
+  }: CommandParams<ParameterObject, ParameterObject>): Promise<CommandResult<CustomCommandResult>> {
     // Prepare args/opts for the template context.
     // Prepare the ${args.$rest} variable
     // Note: The fork of minimist is a slightly unfortunate hack to be able to extract all unknown args and flags.

--- a/core/src/commands/get/get-actions.ts
+++ b/core/src/commands/get/get-actions.ts
@@ -101,6 +101,9 @@ const getActionsOpts = {
 export type Args = typeof getActionsArgs
 export type Opts = typeof getActionsOpts
 
+type CmdParams = CommandParams<Args, Opts>
+type foo = CmdParams["opts"]
+
 export class GetActionsCommand extends Command {
   name = "actions"
   help = "Outputs all or specified actions."

--- a/core/src/commands/run.ts
+++ b/core/src/commands/run.ts
@@ -125,7 +125,7 @@ export class RunCommand extends Command<Args, Opts> {
     // Needs to be done before graph init to support lazy init usecases, e.g. workflows
     let names: string[] | undefined = undefined
     if (args.names && args.names.length > 0) {
-      names = args.names
+      names = args.names as string[]
       const result = await maybeOldRunCommand(names, args, opts, log, params)
       // If we get a result from the old-style compatibility runner, early return it instead of continuing
       if (result) {

--- a/core/src/commands/up.ts
+++ b/core/src/commands/up.ts
@@ -29,7 +29,7 @@ type UpOpts = typeof upOpts
 export class UpCommand extends Command<UpArgs, UpOpts> {
   name = "up"
   help = "Spin up your stack with the dev console and streaming logs."
-  emoji: "🚀"
+  emoji = "🚀"
 
   override description = dedent`
     Spin up your stack with the dev console and streaming logs.

--- a/core/src/commands/validate.ts
+++ b/core/src/commands/validate.ts
@@ -15,9 +15,9 @@ import { dedent } from "../util/string"
 export class ValidateCommand extends Command {
   name = "validate"
   help = "Check your garden configuration for errors."
-  emoji: "✔️"
+  emoji = "✔️"
 
-  override aliases: ["scan"]
+  override aliases = ["scan"]
 
   override description = dedent`
     Throws an error and exits with code 1 if something's not right in your garden config files.

--- a/core/src/config/template-contexts/module.ts
+++ b/core/src/config/template-contexts/module.ts
@@ -141,6 +141,12 @@ export class TaskRuntimeContext extends ServiceRuntimeContext {
 
   @schema(joi.string().required().description("The current version of the task.").example(exampleVersion))
   public override version: string
+
+  constructor(root: ConfigContext, outputs: PrimitiveMap, version: string) {
+    super(root, outputs, version)
+    this.outputs = outputs
+    this.version = version
+  }
 }
 
 class RuntimeConfigContext extends ConfigContext {

--- a/core/src/config/template-contexts/project.ts
+++ b/core/src/config/template-contexts/project.ts
@@ -376,6 +376,7 @@ export class EnvironmentConfigContext extends ProjectConfigContext {
   constructor(params: EnvironmentConfigContextParams) {
     super(params)
     this.variables = this.var = params.variables
+    this.secrets = params.secrets
   }
 }
 
@@ -411,6 +412,7 @@ export class RemoteSourceConfigContext extends EnvironmentConfigContext {
 
     const fullEnvName = garden.namespace ? `${garden.namespace}.${garden.environmentName}` : garden.environmentName
     this.environment = new EnvironmentContext(this, garden.environmentName, fullEnvName, garden.namespace)
+    this.variables = this.var = variables
   }
 }
 

--- a/core/src/docs/common.ts
+++ b/core/src/docs/common.ts
@@ -11,14 +11,13 @@ import { DOCS_BASE_URL } from "../constants"
 import { getPackageVersion } from "../util/util"
 
 export abstract class BaseKeyDescription<T = any> {
-  type: string
-  allowedValuesOnly: boolean
-  deprecated: boolean
-  description?: string
-  experimental: boolean
-  internal: boolean
-  required: boolean
-  example?: T
+  abstract type: string
+  abstract internal: boolean
+  abstract description?: string
+  abstract example?: T
+  abstract deprecated: boolean
+  abstract experimental: boolean
+  abstract required: boolean
 
   constructor(
     public name: string | undefined,

--- a/core/src/docs/joi-schema.ts
+++ b/core/src/docs/joi-schema.ts
@@ -17,6 +17,16 @@ import { zodToJsonSchema } from "zod-to-json-schema"
 export class JoiKeyDescription extends BaseKeyDescription {
   private joiDescription: JoiDescription
 
+  override deprecated: boolean
+  override example?: any
+  override experimental: boolean
+  override required: boolean
+  override type: string
+
+  allowedValuesOnly: boolean
+  description?: string
+  internal: boolean
+
   constructor({
     joiDescription,
     name,

--- a/core/src/docs/json-schema.ts
+++ b/core/src/docs/json-schema.ts
@@ -12,8 +12,17 @@ import { ValidationError } from "../exceptions"
 import { safeDumpYaml } from "../util/serialization"
 
 export class JsonKeyDescription<T = any> extends BaseKeyDescription<T> {
+  override type: string
+  override example?: T | undefined
+  override deprecated: boolean
+  override experimental: boolean
+  override required: boolean
+
   schema: any
   allowedValues?: string[]
+  allowedValuesOnly: boolean
+  description?: string
+  internal: boolean
 
   constructor({
     schema,

--- a/core/src/exceptions.ts
+++ b/core/src/exceptions.ts
@@ -84,7 +84,6 @@ export abstract class GardenError extends Error {
    */
   public code?: NodeJSErrnoErrorCodes
 
-  public override message: string
   public wrappedErrors?: GardenError[]
 
   constructor({ message, stack, wrappedErrors, taskType, code }: GardenErrorParams) {

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -226,7 +226,7 @@ interface GardenInstanceState {
 @Profile()
 export class Garden {
   public log: Log
-  private loadedPlugins: GardenPluginSpec[]
+  private loadedPlugins?: GardenPluginSpec[]
   protected actionConfigs: ActionConfigMap
   protected moduleConfigs: ModuleConfigMap
   protected workflowConfigs: WorkflowConfigMap
@@ -244,7 +244,7 @@ export class Garden {
   public readonly vcs: VcsHandler
   public readonly treeCache: TreeCache
   public events: EventBus
-  private tools: { [key: string]: PluginTool }
+  private tools?: { [key: string]: PluginTool }
   public configTemplates: { [name: string]: ConfigTemplateConfig }
   private actionTypeBases: ActionTypeMap<ActionTypeDefinition<any>[]>
   private emittedWarnings: Set<string>
@@ -1980,6 +1980,7 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
 })
 
 // Override variables, also allows to override nested variables using dot notation
+// eslint-disable-next-line @typescript-eslint/no-shadow
 export function overrideVariables(variables: DeepPrimitiveMap, overrideVariables: DeepPrimitiveMap): DeepPrimitiveMap {
   let objNew = cloneDeep(variables)
   Object.keys(overrideVariables).forEach((key) => {

--- a/core/src/logger/logger.ts
+++ b/core/src/logger/logger.ts
@@ -217,7 +217,7 @@ export abstract class LoggerBase implements Logger {
   public entries: LogEntry[]
   public storeEntries: boolean
 
-  protected writers: LoggerWriters
+  protected abstract writers: LoggerWriters
 
   constructor(config: LoggerConfigBase) {
     this.level = config.level
@@ -327,6 +327,7 @@ interface RootLoggerParams extends LoggerConfigBase {
  */
 export class RootLogger extends LoggerBase {
   private static instance?: RootLogger
+  protected override writers: LoggerWriters
 
   private constructor(config: RootLoggerParams) {
     super(config)
@@ -464,6 +465,13 @@ export interface CreateEventLogParams extends CreateLogParams {
  * command logs for server requests are emitted but do not pollute the terminal.
  */
 export class ServerLogger extends LoggerBase {
+  // These aren't actually used,
+  // but need to be defined since they're abstract in the base class
+  protected override writers: LoggerWriters = {
+    display: new QuietWriter(),
+    file: [new QuietWriter()],
+  }
+
   private rootLogger: Logger
   /**
    * The log level to use for terminal output. Defaults to silly.
@@ -486,12 +494,19 @@ export class ServerLogger extends LoggerBase {
 }
 
 export class VoidLogger extends LoggerBase {
+  protected override writers: LoggerWriters = {
+    display: new QuietWriter(),
+    file: [new QuietWriter()],
+  }
+
   override log() {
     // No op
   }
 }
 
 export class EventLogger extends LoggerBase {
+  protected override writers: LoggerWriters
+
   constructor(config: EventLoggerParams) {
     super(config)
     this.writers = {

--- a/core/src/monitors/handler.ts
+++ b/core/src/monitors/handler.ts
@@ -36,6 +36,7 @@ export class HandlerMonitor extends Monitor {
 
   constructor(params: HandlerMonitorParams) {
     super(params)
+    this.type = params.type
     this.events = params.events
     this.action = params.action
     this._key = params.key

--- a/core/src/monitors/sync.ts
+++ b/core/src/monitors/sync.ts
@@ -31,8 +31,8 @@ export class SyncMonitor extends Monitor {
   private graph: ConfigGraph
   private log: Log
   private events: PluginEventBroker
-  private actionLog: ActionLog
-  private router: ActionRouter
+  private actionLog?: ActionLog
+  private router?: ActionRouter
   private stopOnExit: boolean
 
   constructor(params: SyncMonitorParams) {

--- a/core/src/plugin-context.ts
+++ b/core/src/plugin-context.ts
@@ -19,7 +19,7 @@ import { logEntrySchema } from "./plugin/base"
 import { EventEmitter } from "eventemitter3"
 import { CreateEventLogParams, EventLogger, LogLevel, StringLogLevel } from "./logger/logger"
 import { Memoize } from "typescript-memoize"
-import type { ParameterValues } from "./cli/params"
+import type { ParameterObject, ParameterValues } from "./cli/params"
 import { NamespaceStatus } from "./types/namespace"
 
 type WrappedFromGarden = Pick<
@@ -38,8 +38,8 @@ type WrappedFromGarden = Pick<
 
 export interface CommandInfo {
   name: string
-  args: ParameterValues<any>
-  opts: ParameterValues<any>
+  args: ParameterValues<ParameterObject>
+  opts: ParameterValues<ParameterObject>
 }
 
 type ResolveTemplateStringsOpts = Omit<ContextResolveOpts, "stack">

--- a/core/src/plugin/action-types.ts
+++ b/core/src/plugin/action-types.ts
@@ -54,10 +54,14 @@ export type ActionTypeHandler<
   base?: ActionTypeHandler<K, N, P, R>
 }
 
-export type GetActionTypeParams<T> = T extends ActionTypeHandlerSpec<any, any, any> ? T["_paramsType"] : {}
-export type GetActionTypeResults<T> = T extends ActionTypeHandlerSpec<any, any, any> ? T["_resultType"] : {}
-export type GetActionTypeHandler<T, N> = T extends ActionTypeHandlerSpec<any, any, any>
-  ? ActionTypeHandler<T["_kindType"], N, T["_paramsType"], T["_resultType"]>
+export type GetActionTypeParams<T> = T extends ActionTypeHandlerSpec<any, infer ParamsType, any> ? ParamsType : {}
+export type GetActionTypeResults<T> = T extends ActionTypeHandlerSpec<any, any, infer ResultType> ? ResultType : {}
+export type GetActionTypeHandler<T, N> = T extends ActionTypeHandlerSpec<
+  infer KindType,
+  infer ParamsType,
+  infer ResultType
+>
+  ? ActionTypeHandler<KindType, N, ParamsType, ResultType>
   : ActionTypeHandler<any, N, any, any>
 export type WrappedActionTypeHandler<T, N> = GetActionTypeHandler<T, N> & {
   handlerType: N

--- a/core/src/plugin/handlers/base/base.ts
+++ b/core/src/plugin/handlers/base/base.ts
@@ -13,17 +13,27 @@ import { joi, joiVariables } from "../../../config/common"
 
 export type ParamsBase<_ = any> = {}
 
-export abstract class ActionTypeHandlerSpec<K extends ActionKind, P extends ParamsBase, R extends ParamsBase> {
+export type ActionTypeHandlerParamsType<Handler> = Handler extends ActionTypeHandlerSpec<any, infer Params, any>
+  ? Params
+  : never
+export abstract class ActionTypeHandlerSpec<
+  Kind extends ActionKind,
+  Params extends ParamsBase,
+  Result extends ParamsBase,
+> {
   abstract description: string
   abstract paramsSchema: () => Joi.ObjectSchema
   abstract resultSchema: () => Joi.ObjectSchema
 
   required = false
 
-  // These are used internally to map types
-  _kindType: K
-  _paramsType: P
-  _resultType: R
+  // We used to use these types to extract type information
+  // Now we use the generic instead, however TS will erase the generic types
+  // if we aren't using them anywhere.
+  // For that reason they are stored here, but they should never be accessed
+  _kindType?: Kind
+  _paramsType?: Params
+  _resultType?: Result
 
   describe() {
     return {

--- a/core/src/plugins/exec/build.ts
+++ b/core/src/plugins/exec/build.ts
@@ -7,7 +7,7 @@
  */
 
 import { renderMessageWithDivider } from "../../logger/util"
-import { sdk } from "../../plugin/sdk"
+import { GardenSdkActionDefinitionActionType, GardenSdkActionDefinitionConfigType, sdk } from "../../plugin/sdk"
 import { execRunCommand } from "./common"
 import { execCommonSchema, execEnvVarDoc, execRuntimeOutputsSchema, execStaticOutputsSchema } from "./config"
 import { execProvider } from "./exec"
@@ -42,8 +42,8 @@ export const execBuild = execProvider.createActionType({
   runtimeOutputsSchema: execRuntimeOutputsSchema,
 })
 
-export type ExecBuildConfig = typeof execBuild.T.Config
-export type ExecBuild = typeof execBuild.T.Action
+export type ExecBuildConfig = GardenSdkActionDefinitionConfigType<typeof execBuild>
+export type ExecBuild = GardenSdkActionDefinitionActionType<typeof execBuild>
 
 export const execBuildHandler = execBuild.addHandler("build", async ({ action, log, ctx }) => {
   const output: sdk.types.BuildStatus = { state: "ready", outputs: {}, detail: {} }

--- a/core/src/plugins/exec/deploy.ts
+++ b/core/src/plugins/exec/deploy.ts
@@ -34,7 +34,7 @@ import { deployStateToActionState, DeployStatus } from "../../plugin/handlers/De
 import { ActionState, Resolved } from "../../actions/types"
 import { convertCommandSpec, execRunCommand, getDefaultEnvVars } from "./common"
 import { isRunning, killRecursive } from "../../process"
-import { sdk } from "../../plugin/sdk"
+import { GardenSdkActionDefinitionActionType, GardenSdkActionDefinitionConfigType, sdk } from "../../plugin/sdk"
 import { execProvider } from "./exec"
 import { getTracePropagationEnvVars } from "../../util/open-telemetry/propagation"
 import { DeployState } from "../../types/service"
@@ -106,8 +106,8 @@ export const execDeploy = execProvider.createActionType({
   runtimeOutputsSchema: execRuntimeOutputsSchema,
 })
 
-export type ExecDeployConfig = typeof execDeploy.T.Config
-export type ExecDeploy = typeof execDeploy.T.Action
+export type ExecDeployConfig = GardenSdkActionDefinitionConfigType<typeof execDeploy>
+export type ExecDeploy = GardenSdkActionDefinitionActionType<typeof execDeploy>
 
 execDeploy.addHandler("configure", async ({ config }) => {
   return { config, supportedModes: { sync: !!config.spec.persistent } }

--- a/core/src/plugins/exec/run.ts
+++ b/core/src/plugins/exec/run.ts
@@ -8,7 +8,7 @@
 
 import { runResultToActionState } from "../../actions/base"
 import { renderMessageWithDivider } from "../../logger/util"
-import { sdk } from "../../plugin/sdk"
+import { GardenSdkActionDefinitionActionType, GardenSdkActionDefinitionConfigType, sdk } from "../../plugin/sdk"
 import { copyArtifacts, execRunCommand } from "./common"
 import { execRunSpecSchema, execRuntimeOutputsSchema, execStaticOutputsSchema } from "./config"
 import { execProvider } from "./exec"
@@ -24,8 +24,8 @@ export const execRun = execProvider.createActionType({
   runtimeOutputsSchema: execRuntimeOutputsSchema,
 })
 
-export type ExecRunConfig = typeof execRun.T.Config
-export type ExecRun = typeof execRun.T.Action
+export type ExecRunConfig = GardenSdkActionDefinitionConfigType<typeof execRun>
+export type ExecRun = GardenSdkActionDefinitionActionType<typeof execRun>
 
 execRun.addHandler("run", async ({ artifactsPath, log, action, ctx }) => {
   const { command, env, artifacts } = action.getSpec()

--- a/core/src/plugins/exec/test.ts
+++ b/core/src/plugins/exec/test.ts
@@ -8,7 +8,7 @@
 
 import { runResultToActionState } from "../../actions/base"
 import { renderMessageWithDivider } from "../../logger/util"
-import { sdk } from "../../plugin/sdk"
+import { GardenSdkActionDefinitionActionType, GardenSdkActionDefinitionConfigType, sdk } from "../../plugin/sdk"
 import { copyArtifacts, execRunCommand } from "./common"
 import { execRunSpecSchema, execRuntimeOutputsSchema, execStaticOutputsSchema } from "./config"
 import { execProvider } from "./exec"
@@ -28,8 +28,8 @@ export const execTest = execProvider.createActionType({
   runtimeOutputsSchema: execRuntimeOutputsSchema,
 })
 
-export type ExecTestConfig = typeof execTest.T.Config
-export type ExecTest = typeof execTest.T.Action
+export type ExecTestConfig = GardenSdkActionDefinitionConfigType<typeof execTest>
+export type ExecTest = GardenSdkActionDefinitionActionType<typeof execTest>
 
 execTest.addHandler("run", async ({ log, action, artifactsPath, ctx }) => {
   const startedAt = new Date()

--- a/core/src/plugins/kubernetes/run.ts
+++ b/core/src/plugins/kubernetes/run.ts
@@ -670,7 +670,7 @@ async function runWithArtifacts({
   return result
 }
 
-class PodRunnerParams {
+type PodRunnerParams = {
   ctx: PluginContext
   logEventContext?: PluginEventLogContext
   annotations?: { [key: string]: string }
@@ -827,13 +827,27 @@ export interface PodErrorDetails {
   podEvents?: CoreV1Event[]
 }
 
-export class PodRunner extends PodRunnerParams {
+export class PodRunner {
   podName: string
-  running: boolean
-  override logEventContext: PluginEventLogContext | undefined
+
+  ctx: PluginContext
+  logEventContext?: PluginEventLogContext
+  annotations?: { [key: string]: string }
+  api: KubeApi
+  pod: KubernetesPod | KubernetesServerResource<V1Pod>
+  namespace: string
+  provider: KubernetesProvider
 
   constructor(params: PodRunnerParams) {
-    super()
+    const { ctx, logEventContext, annotations, api, pod, namespace, provider } = params
+
+    this.ctx = ctx
+    this.logEventContext = logEventContext
+    this.annotations = annotations
+    this.api = api
+    this.pod = pod
+    this.namespace = namespace
+    this.provider = provider
 
     const spec = params.pod.spec
 
@@ -842,8 +856,6 @@ export class PodRunner extends PodRunnerParams {
         message: `Pod spec for PodRunner must contain at least one container`,
       })
     }
-
-    Object.assign(this, params)
 
     this.podName = this.pod.metadata.name
     this.logEventContext = params.logEventContext

--- a/core/src/router/base.ts
+++ b/core/src/router/base.ts
@@ -40,6 +40,7 @@ import type { ConfigGraph } from "../graph/config-graph"
 import { ActionConfigContext, ActionSpecContext } from "../config/template-contexts/actions"
 import type { NamespaceStatus } from "../types/namespace"
 import { TemplatableConfigContext } from "../config/template-contexts/project"
+import { ParamsBase } from "../plugin/handlers/base/base"
 
 export type CommonParams = keyof PluginActionContextParams
 
@@ -363,7 +364,7 @@ export abstract class BaseActionRouter<K extends ActionKind> extends BaseRouter 
     // Wrap the handler with identifying attributes
     const wrapped = Object.assign(
       <WrappedActionTypeHandler<ActionTypeClasses<K>[T], any>>(<unknown>(async (...args: any[]) => {
-        const result = await handler["apply"](plugin, args)
+        const result = await handler["apply"](plugin, args as [ParamsBase<any>])
         if (result === undefined) {
           throw new PluginError({
             message: `Got empty response from ${actionType}.${String(

--- a/core/src/router/module.ts
+++ b/core/src/router/module.ts
@@ -173,6 +173,9 @@ export class ModuleRouter extends BaseRouter {
     // Wrap the handler with identifying attributes
     const wrapped = Object.assign(
       <WrappedModuleActionHandlers[T]>(async (...args: any[]) => {
+        // TODO:
+        // lots of casting and `any` here since we're using the same wrapper for all handlers.
+        // We should probably have a separate wrapper for each handler type or make it more explicit in another way.
         const result = await handler.apply(plugin, args as any)
         if (result === undefined) {
           throw new PluginError({

--- a/core/src/router/module.ts
+++ b/core/src/router/module.ts
@@ -173,7 +173,7 @@ export class ModuleRouter extends BaseRouter {
     // Wrap the handler with identifying attributes
     const wrapped = Object.assign(
       <WrappedModuleActionHandlers[T]>(async (...args: any[]) => {
-        const result = await handler.apply(plugin, args)
+        const result = await handler.apply(plugin, args as any)
         if (result === undefined) {
           throw new PluginError({
             message: `Got empty response from ${moduleType}.${handlerType} handler (called with ${args.length} args) on ${pluginName} provider.`,

--- a/core/src/router/provider.ts
+++ b/core/src/router/provider.ts
@@ -240,8 +240,11 @@ export class ProviderRouter extends BaseRouter {
 
     // Wrap the handler with identifying attributes
     const wrapped: WrappedPluginHandlers[T] = Object.assign(
+      // TODO:
+      // lots of casting and `any` here since we're using the same wrapper for all handlers.
+      // We should probably have a separate wrapper for each handler type or make it more explicit in another way.
       async (...args: any[]) => {
-        const result = await handler.apply(plugin, args)
+        const result = await handler.apply(plugin, args as any)
         if (result === undefined) {
           throw new PluginError({
             message: `Got empty response from ${handlerType} handler on ${pluginName} provider. Called with ${args.length} args.`,
@@ -250,7 +253,7 @@ export class ProviderRouter extends BaseRouter {
         return validateSchema(result, schema, { context: `${handlerType} output from plugin ${pluginName}` })
       },
       { handlerType, pluginName }
-    )
+    ) as WrappedPluginHandlers[T]
 
     wrapped.base = this.wrapBase(handler.base)
 

--- a/core/src/server/commands.ts
+++ b/core/src/server/commands.ts
@@ -11,7 +11,14 @@ import stringArgv from "string-argv"
 import { Command, CommandParams, CommandResult, ConsoleCommand } from "../commands/base"
 import { createSchema, joi } from "../config/common"
 import { type Log } from "../logger/log-entry"
-import { ParameterValues, ChoicesParameter, StringParameter, StringsParameter, GlobalOptions } from "../cli/params"
+import {
+  ParameterValues,
+  ChoicesParameter,
+  StringParameter,
+  StringsParameter,
+  GlobalOptions,
+  ParameterObject,
+} from "../cli/params"
 import { parseCliArgs, pickCommand, processCliArgs } from "../cli/helpers"
 import type { AutocompleteSuggestion } from "../cli/autocomplete"
 import { naturalList } from "../util/string"
@@ -432,8 +439,8 @@ export async function resolveRequest({
   let command: Command | undefined
   let rest: string[] = []
   let argv: ParsedArgs | undefined
-  let cmdArgs: ParameterValues<any> = {}
-  let cmdOpts: ParameterValues<any> = {}
+  let cmdArgs: ParameterValues<ParameterObject> = {}
+  let cmdOpts: ParameterValues<ParameterObject> = {}
 
   if (request.command) {
     const { commands } = await manager.ensureProjectRootContext(log, projectRoot)

--- a/core/src/server/instance-manager.ts
+++ b/core/src/server/instance-manager.ts
@@ -10,7 +10,7 @@ import AsyncLock from "async-lock"
 import chalk from "chalk"
 import { Autocompleter, AutocompleteSuggestion } from "../cli/autocomplete"
 import { parseCliVarFlags } from "../cli/helpers"
-import { ParameterValues } from "../cli/params"
+import { ParameterObject, ParameterValues } from "../cli/params"
 import { CloudApi, CloudApiFactory, CloudApiFactoryParams, getGardenCloudDomain } from "../cloud/api"
 import type { Command } from "../commands/base"
 import { getBuiltinCommands, flattenCommands } from "../commands/commands"
@@ -75,7 +75,7 @@ export class GardenInstanceManager {
   private defaultProjectRootContext: ProjectRootContext
   public readonly monitors: MonitorManager
   private defaultOpts: Partial<GardenOpts> // Used for testing
-  public readonly serveCommand: ServeCommand
+  public readonly serveCommand?: ServeCommand
 
   /**
    * Events from every managed Garden instance are piped to this EventBus. Each event emitted implicitly includes
@@ -95,6 +95,7 @@ export class GardenInstanceManager {
     plugins,
     cloudApiFactory,
   }: GardenInstanceManagerParams) {
+    this.serveCommand = serveCommand
     this.sessionId = sessionId
     this.instances = new Map()
     this.projectRoots = new Map()
@@ -345,8 +346,8 @@ export class GardenInstanceManager {
     projectConfig: ProjectConfig
     globalConfigStore: GlobalConfigStore
     log: Log
-    args: ParameterValues<any>
-    opts: ParameterValues<any>
+    args: ParameterValues<ParameterObject>
+    opts: ParameterValues<ParameterObject>
     environmentString?: string
     sessionId: string
   }) {

--- a/core/src/util/testing.ts
+++ b/core/src/util/testing.ts
@@ -31,7 +31,14 @@ import { GraphResults } from "../graph/results"
 import { expect } from "chai"
 import { ActionConfig, ActionKind, ActionStatus } from "../actions/types"
 import { WrappedActionRouterHandlers } from "../router/base"
-import { BuiltinArgs, Command, CommandResult } from "../commands/base"
+import {
+  BuiltinArgs,
+  Command,
+  CommandArgsType,
+  CommandOptionsType,
+  CommandResult,
+  CommandResultType,
+} from "../commands/base"
 import { validateSchema } from "../config/validation"
 import { mkdirp, remove } from "fs-extra"
 import { GlobalConfigStore } from "../config-store/global"
@@ -155,11 +162,11 @@ export type TestGardenOpts = Partial<GardenOpts> & {
 
 export class TestGarden extends Garden {
   override events: TestEventBus
-  public override vcs: VcsHandler // Not readonly, to allow overriding with a mocked handler in tests
-  public override secrets: StringMap // Not readonly, to allow setting secrets in tests
-  public override variables: DeepPrimitiveMap // Not readonly, to allow setting variables in tests
-  private repoRoot: string
-  public cacheKey: string
+  public override vcs!: VcsHandler // Not readonly, to allow overriding with a mocked handler in tests
+  public override secrets!: StringMap // Not readonly, to allow setting secrets in tests
+  public override variables!: DeepPrimitiveMap // Not readonly, to allow setting variables in tests
+  private repoRoot!: string
+  public cacheKey!: string
 
   constructor(params: GardenParams) {
     super(params)
@@ -381,16 +388,16 @@ export class TestGarden extends Garden {
     opts,
   }: {
     command: C
-    args: ParameterValues<C["arguments"]> & BuiltinArgs
-    opts: ParameterValues<C["options"]>
-  }): Promise<CommandResult<C["_resultType"]>> {
+    args: ParameterValues<CommandArgsType<C>> & BuiltinArgs
+    opts: ParameterValues<CommandOptionsType<C>>
+  }): Promise<CommandResult<CommandResultType<C>>> {
     const log = this.log
 
     const result = await command.action({
       garden: this,
       log,
       args,
-      opts: <ParameterValues<GlobalOptions> & C["options"]>{
+      opts: <ParameterValues<GlobalOptions> & CommandOptionsType<C>>{
         ...mapValues(globalOptions, (opt) => opt.defaultValue),
         ...opts,
       },

--- a/core/src/util/util.ts
+++ b/core/src/util/util.ts
@@ -697,7 +697,7 @@ export async function streamToString(stream: Readable) {
  */
 export class StringCollector extends Writable {
   private chunks: Buffer[]
-  private error: Error
+  private error?: Error
 
   constructor() {
     super()

--- a/core/test/helpers.ts
+++ b/core/test/helpers.ts
@@ -30,7 +30,7 @@ import { GardenPluginSpec, ProviderHandlers, RegisterPluginParam } from "../src/
 import { Garden } from "../src/garden"
 import { ModuleConfig } from "../src/config/module"
 import { DEFAULT_BUILD_TIMEOUT_SEC, GARDEN_CORE_ROOT, GardenApiVersion, gardenEnv } from "../src/constants"
-import { globalOptions, GlobalOptions, Parameters, ParameterValues } from "../src/cli/params"
+import { globalOptions, GlobalOptions, ParameterObject, ParameterValues } from "../src/cli/params"
 import { ExternalSourceType, getRemoteSourceLocalPath } from "../src/util/ext-source-util"
 import { CommandParams, ProcessCommandResult } from "../src/commands/base"
 import { SuiteFunction, TestFunction } from "mocha"
@@ -299,11 +299,11 @@ export const cleanProject = async (gardenDirPath: string) => {
   return remove(gardenDirPath)
 }
 
-export function withDefaultGlobalOpts<T extends object>(opts: T) {
-  return <ParameterValues<GlobalOptions> & T>extend(
-    mapValues(globalOptions, (opt) => opt.defaultValue),
+export function withDefaultGlobalOpts<T extends object>(opts: T): ParameterValues<GlobalOptions> & T {
+  return extend(
+    mapValues(globalOptions, (opt) => opt.defaultValue!),
     opts
-  )
+  ) as ParameterValues<GlobalOptions> & T
 }
 
 export function setPlatform(platform: string) {
@@ -524,7 +524,7 @@ export function initTestLogger() {
   } catch (_) {}
 }
 
-export function makeCommandParams<T extends Parameters = {}, U extends Parameters = {}>({
+export function makeCommandParams<T extends ParameterObject, U extends ParameterObject>({
   cli,
   garden,
   args,
@@ -534,7 +534,7 @@ export function makeCommandParams<T extends Parameters = {}, U extends Parameter
   garden: Garden
   args: T
   opts: U
-}): CommandParams<T, U> {
+}): CommandParams<ParameterObject, ParameterObject> {
   const log = garden.log
   return {
     cli,

--- a/core/test/unit/src/cli/helpers.ts
+++ b/core/test/unit/src/cli/helpers.ts
@@ -8,7 +8,7 @@
 
 import { expect } from "chai"
 import { optionsWithAliasValues, pickCommand, processCliArgs } from "../../../../src/cli/helpers"
-import { Parameters, StringParameter, StringsParameter } from "../../../../src/cli/params"
+import { ParameterObject, StringParameter, StringsParameter } from "../../../../src/cli/params"
 import { expectError } from "../../../helpers"
 import { getPackageVersion } from "../../../../src/util/util"
 import { GARDEN_CORE_ROOT } from "../../../../src/constants"
@@ -170,7 +170,7 @@ describe("parseCliArgs", () => {
   })
 })
 
-function parseAndProcess<A extends Parameters, O extends Parameters>(
+function parseAndProcess<A extends ParameterObject, O extends ParameterObject>(
   args: string[],
   command: Command<A, O>,
   cli = true

--- a/core/test/unit/src/commands/logs.ts
+++ b/core/test/unit/src/commands/logs.ts
@@ -32,6 +32,7 @@ import { LogMonitor, logMonitorColors } from "../../../../src/monitors/logs"
 import stripAnsi from "strip-ansi"
 import { execDeploySpecSchema } from "../../../../src/plugins/exec/deploy"
 import { joi } from "../../../../src/config/common"
+import { ActionTypeHandlerParamsType } from "../../../../src/plugin/handlers/base/base"
 
 // TODO-G2: rename test cases to match the new graph model semantics
 
@@ -98,7 +99,7 @@ describe("LogsCommand", () => {
   const logMsgWithColor = msgColor(logMsg)
   const color = chalk[logMonitorColors[0]]
 
-  type GetDeployLogsParams = GetDeployLogs["_paramsType"]
+  type GetDeployLogsParams = ActionTypeHandlerParamsType<GetDeployLogs>
 
   const defaultLogsHandler = async ({ stream }: GetDeployLogsParams) => {
     void stream.write({

--- a/core/test/unit/src/commands/publish.ts
+++ b/core/test/unit/src/commands/publish.ts
@@ -20,10 +20,11 @@ import { ConvertModuleParams } from "../../../../src/plugin/handlers/Module/conv
 import { PublishTask } from "../../../../src/tasks/publish"
 import { joi } from "../../../../src/config/common"
 import { execBuildSpecSchema } from "../../../../src/plugins/exec/build"
+import { ActionTypeHandlerParamsType } from "../../../../src/plugin/handlers/base/base"
 
 const projectRootB = getDataDir("test-project-b")
 
-type PublishActionParams = PublishBuildAction["_paramsType"]
+type PublishActionParams = ActionTypeHandlerParamsType<PublishBuildAction>
 type PublishActionResultDetail = PublishActionResult["detail"]
 
 const publishAction = async ({ tag }: PublishActionParams): Promise<PublishActionResultDetail> => {

--- a/core/test/unit/src/config/template-contexts/base.ts
+++ b/core/test/unit/src/config/template-contexts/base.ts
@@ -277,15 +277,15 @@ describe("ConfigContext", () => {
     it("should return a Joi object schema with all described attributes", () => {
       class Nested extends ConfigContext {
         @schema(joi.string().description("Nested description"))
-        nestedKey: string
+        nestedKey?: string
       }
 
       class Context extends ConfigContext {
         @schema(joi.string().description("Some description"))
-        key: string
+        key?: string
 
         @schema(Nested.getSchema().description("A nested context"))
-        nested: Nested
+        nested?: Nested
 
         // this should simply be ignored
         foo = "bar"

--- a/core/test/unit/src/docs/config.ts
+++ b/core/test/unit/src/docs/config.ts
@@ -449,6 +449,12 @@ describe("docs config module", () => {
   describe("renderMarkdownLink", () => {
     it("should return a markdown link with a name and relative path", () => {
       class TestKeyDescription extends BaseKeyDescription {
+        override deprecated: boolean = false
+        override experimental: boolean = false
+        override required: boolean = false
+        override internal: boolean = false
+        override description?: string
+        override example?: any
         override type = "string"
 
         constructor(name: string, level: number) {

--- a/core/test/unit/src/graph/solver.ts
+++ b/core/test/unit/src/graph/solver.ts
@@ -43,7 +43,7 @@ export class TestTask extends BaseTask<TestTaskResult> {
   name: string
   state: ActionState
   callback: TestTaskCallback | null
-  statusCallback: TestTaskCallback | null
+  statusCallback?: TestTaskCallback | null
   dependencies: BaseTask[]
   statusDependencies: BaseTask[]
 

--- a/core/test/unit/src/server/server.ts
+++ b/core/test/unit/src/server/server.ts
@@ -72,7 +72,7 @@ describe("GardenServer", () => {
       serveCommand,
     })
     await gardenServer.start()
-    server = gardenServer["server"]
+    server = gardenServer["server"]!
   })
 
   after(async () => {
@@ -84,7 +84,7 @@ describe("GardenServer", () => {
   })
 
   it("should show no URL on startup", async () => {
-    const line = gardenServer["statusLog"]
+    const line = gardenServer["statusLog"]!
     expect(line.getLatestEntry()).to.be.undefined
   })
 

--- a/e2e/run-garden.ts
+++ b/e2e/run-garden.ts
@@ -197,12 +197,13 @@ export type WatchTestAction = (logEntries: JsonLogEntry[]) => Promise<void>
  * The pre-relase tests contain some good examples to illustrate this flow.
  */
 export class GardenWatch {
-  public proc: ChildProcess
   public logEntries: JsonLogEntry[]
   public checkIntervalMs: number
-  public testSteps: WatchTestStep[]
-  public currentTestStepIdx: number
-  public running: boolean
+  public currentTestStepIdx: number = 0
+  public running: boolean = false
+  public testSteps: WatchTestStep[] = []
+
+  public proc?: ChildProcess
 
   constructor(
     public dir: string,
@@ -352,12 +353,12 @@ export class GardenWatch {
     }
 
     this.running = false
-    this.proc.kill()
+    this.proc!.kill()
 
     const startTime = new Date().getTime()
     while (true) {
       await sleep(DEFAULT_CHECK_INTERVAL_MS)
-      if (this.proc.killed) {
+      if (this.proc!.killed) {
         break
       }
       const now = new Date().getTime()

--- a/sdk/util/cli.ts
+++ b/sdk/util/cli.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { Parameters } from "@garden-io/core/build/src/cli/params"
+import { ParameterObject } from "@garden-io/core/build/src/cli/params"
 import { prepareMinimistOpts } from "@garden-io/core/build/src/cli/helpers"
 import minimist from "minimist"
 
@@ -33,7 +33,7 @@ export {
  */
 export function parsePluginCommandArgs(params: {
   stringArgs: string[]
-  optionSpec: Parameters
+  optionSpec: ParameterObject
   cli: boolean
   skipDefault?: boolean
 }) {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -30,7 +30,8 @@
     "strictFunctionTypes": true,
     "strictNullChecks": true,
     "inlineSourceMap": true,
-    "target": "es2019"
+    "target": "es2019",
+    "strict": true
   },
   "exclude": [
     "core/build",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR puts TS into strict mode.
I had to refactor a whole bunch of types, especially since we're using properties on classes as a way to pass type information along. I manage to get rid of that in most but not all cases.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
