### PR TITLE
fix(remote-building): use "Recreate" strategy garden-util (kaniko) and garden-buildkit deployments

### DIFF
--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -385,6 +385,11 @@ export function getBuildkitDeployment(
           app: buildkitDeploymentName,
         },
       },
+      strategy: {
+        // Note: When updating the deployment, we make sure to kill off old buildkit pods before new pods are started.
+        // This is important because with multiple running Pods we might end up syncing or building to the wrong Pod.
+        type: "Recreate",
+      },
       template: {
         metadata: {
           labels: {

--- a/core/src/plugins/kubernetes/container/build/common.ts
+++ b/core/src/plugins/kubernetes/container/build/common.ts
@@ -479,6 +479,11 @@ export function getUtilManifests(
           app: utilDeploymentName,
         },
       },
+      strategy: {
+        // Note: When updating the deployment, we make sure to kill off old buildkit pods before new pods are started.
+        // This is important because with multiple running Pods we might end up syncing or building to the wrong Pod.
+        type: "Recreate",
+      },
       template: {
         metadata: {
           labels: {

--- a/core/test/unit/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/build/buildkit.ts
@@ -73,6 +73,10 @@ describe("buildkit build", () => {
         },
       })
 
+      expect(result.spec.strategy).eql({
+        type: "Recreate",
+      })
+
       expect(result.spec.template.spec?.containers.length === 2)
 
       expect(result.spec.template.spec?.containers[0]).eql({

--- a/core/test/unit/src/plugins/kubernetes/container/build/common.ts
+++ b/core/test/unit/src/plugins/kubernetes/container/build/common.ts
@@ -68,6 +68,9 @@ describe("common build", () => {
           spec: {
             replicas: 1,
             selector: { matchLabels: { app: "garden-util" } },
+            strategy: {
+              type: "Recreate",
+            },
             template: {
               metadata: { labels: { app: "garden-util" }, annotations: undefined },
               spec: {


### PR DESCRIPTION
We need to use the "[Recreate](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#recreate-deployment)" strategy for garden-util and garden-buildkit deployments, because
otherwise we can run into issues where multiple Pods are running at the same time

Also with the latest main I often get an error "Could not find a running Pod in Deployment garden-buildkit in namespace xxx" – this change fixes that too.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

e.g. Fixes #2570

**Special notes for your reviewer**:
The remote tests are covering this issue, but they are currently disabled in CI. Enabling them is out of scope for this PR, but will be addressed in #5103