### PR TITLE
fix(pulumi): return correct responses for pulumi plugin commands

### DIFF
--- a/core/src/graph/nodes.ts
+++ b/core/src/graph/nodes.ts
@@ -271,7 +271,11 @@ export class ProcessTaskNode<T extends Task = Task> extends TaskNode<T> {
     const dependencyResults = this.getDependencyResults()
 
     try {
-      const processResult: TaskResultType<T> = await this.task.process({ status, dependencyResults, statusOnly: false })
+      const processResult: TaskResultType<T> = await this.task.process({
+        status,
+        dependencyResults,
+        statusOnly: false,
+      })
       this.task.emit("processed", { result: processResult })
       if (processResult.state === "ready") {
         const msg = `${this.task.getDescription()} is ready.`
@@ -304,7 +308,10 @@ export class StatusTaskNode<T extends Task = Task> extends TaskNode<T> {
     const dependencyResults = this.getDependencyResults()
 
     try {
-      const result: TaskResultType<T> = await this.task.getStatus({ statusOnly: this.statusOnly, dependencyResults })
+      const result: TaskResultType<T> = await this.task.getStatus({
+        statusOnly: this.statusOnly,
+        dependencyResults,
+      })
       this.task.emit("statusResolved", { result })
       if (!this.task.force && result?.state === "ready") {
         const msg = `${this.task.getDescription()} status is ready.`

--- a/plugins/pulumi/src/commands.ts
+++ b/plugins/pulumi/src/commands.ts
@@ -115,12 +115,12 @@ const pulumiCommandSpecs: PulumiCommandSpec[] = [
             operationCounts,
             modifiedPlanPath,
             previewUrl,
-          }
+          },
         }
       } else {
         return {
           state: "ready",
-          outputs: {}
+          outputs: {},
         }
       }
     },
@@ -175,7 +175,7 @@ const pulumiCommandSpecs: PulumiCommandSpec[] = [
       // do nothing and return ready if allowDestory is not set
       return {
         state: "ready",
-        outputs: {}
+        outputs: {},
       }
     },
   },


### PR DESCRIPTION
**What this PR does / why we need it**:
This enforces responses of type ValidResultType for the pulumi plugin commands for actions. Previously, the plugin commands for actions were not returning anything, resulting in runtime errors. The TS compiler didn't catch these due to the pulumi plugin command responses typed as `any`.
**Which issue(s) this PR fixes**:

Fixes #5118
Fixes #5084

**Special notes for your reviewer**:
