### PR TITLE
fix: memoize memory leak

### DIFF
--- a/core/src/tasks/base.ts
+++ b/core/src/tasks/base.ts
@@ -160,7 +160,7 @@ export abstract class BaseTask<O extends ValidResultType = ValidResultType> exte
   /**
    * Wrapper around resolveProcessDependencies() that memoizes the results and applies filters.
    */
-  @Memoize()
+  @Memoize((params: ResolveProcessDependenciesParams<O>) => (params.status ? params.status.state : null))
   getProcessDependencies(params: ResolveProcessDependenciesParams<O>): BaseTask[] {
     if (this.skipDependencies) {
       return []


### PR DESCRIPTION
**What this PR does / why we need it**:
Memoize was using an object as a cache key whose identity kept changing. Thus it never returned a cache hit and kept storing new objects in cache. With this fixed, memory consumption becomes a lot more reasonable, plus the cache actually yields the desired performance benefits.

**Which issue(s) this PR fixes**:

Fixes https://github.com/garden-io/garden/issues/4638

**Special notes for your reviewer**:
