### PR TITLE
docs: add all supported local k8s distros to overview

### DIFF
--- a/docs/k8s-plugins/local-k8s/README.md
+++ b/docs/k8s-plugins/local-k8s/README.md
@@ -17,6 +17,9 @@ The officially supported variants of local Kubernetes are the latest stable vers
 - [Minikube](https://github.com/kubernetes/minikube)
 - [MicroK8s](https://microk8s.io)
 - [KinD](https://github.com/kubernetes-sigs/kind)
+- [K3s](https://k3s.io)
+- [Rancher Desktop](https://rancherdesktop.io)
+- [Orbstack](https://orbstack.dev)
 
 Other distributions may also work, but are not routinely tested or explicitly supported. Please don't hesitate to file issues, PRs or requests for your distribution of choice!
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
Just saw that we forgot to add K3s and friends to our overview of supported local-k8s distros.
However we are not (yet) routinely testing against these distros in CI. Not mentioning them at all in this overview also seems wrong though.
EDIT: we have tests for K3s, which should cover sufficiently for rancher desktop and orbstack, who both use K3s under the hood.
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
