### PR TITLE
fix: include fsevents in core instead of cli

### DIFF
--- a/cli/src/build-pkg.ts
+++ b/cli/src/build-pkg.ts
@@ -186,7 +186,7 @@ async function pkgMacos({ targetName, sourcePath, pkgType, version }: TargetHand
   if (!fsEventsCopied) {
     fsEventsCopied = copy(
       resolve(GARDEN_CORE_ROOT, "lib", "fsevents"),
-      resolve(tmpDirPath, "cli", "node_modules", "fsevents")
+      resolve(tmpDirPath, "core", "node_modules", "fsevents")
     )
   }
   await fsEventsCopied


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Fixes an issue with the built binaries not including fsevents in core/node_modules.

**Which issue(s) this PR fixes**:

Fixes #5146 

**Special notes for your reviewer**:
