### PR TITLE
fix: stream events from plugin commands

### DIFF
--- a/core/src/commands/plugins.ts
+++ b/core/src/commands/plugins.ts
@@ -39,6 +39,7 @@ export class PluginsCommand extends Command<Args> {
   name = "plugins"
   help = "Plugin-specific commands."
   override aliases = ["plugin"]
+  override streamEvents = true
 
   override description = dedent`
     Execute a command defined by a plugin in your project.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
We were not streaming events from plugin commands such as `garden plugins terraform` or `garden plugins pulumi` to Garden Cloud or the Web Dashboard. This PR fixes this.
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
