### PR TITLE
docs: fix docs base url

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
   <img src="docs/logo.png" align="center">
 </p>
 <div align="center">
-  <a href="https://docs.garden.io/basics/5-min-quickstart/?utm_source=github">Quickstart</a>
+  <a href="https://docs.garden.io/v/acorn-0.12/basics/quickstart/?utm_source=github">Quickstart</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://garden.io/?utm_source=github">Website</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://docs.garden.io/?utm_source=github">Docs</a>
+  <a href="https://docs.garden.io/v/acorn-0.12/?utm_source=github">Docs</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://github.com/garden-io/garden/tree/0.12.64/examples">Examples</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
@@ -36,7 +36,7 @@ _If you’re using Garden or if you like the project, please ★ star this repos
 
 ### **Getting started**
 
-The fastest way to get started with Garden is by following our [quickstart guide](https://docs.garden.io/basics/quickstart).
+The fastest way to get started with Garden is by following our [quickstart guide](https://docs.garden.io/v/acorn-0.12/basics/quickstart).
 
 ### **Who should use Garden?**
 
@@ -64,7 +64,7 @@ Afterwards, the entire team benefits:
 
 ### **How does it work?**
 
-Garden Core is a standalone binary that can run from CI or from a developer’s machine. It allows you to codify a complete description of your stack, including how it's built, deployed and tested, using the [Stack Graph](https://docs.garden.io/basics/stack-graph)—making your workflows **reproducible and portable**.
+Garden Core is a standalone binary that can run from CI or from a developer’s machine. It allows you to codify a complete description of your stack, including how it's built, deployed and tested, using the [Stack Graph](https://docs.garden.io/v/acorn-0.12/basics/stack-graph)—making your workflows **reproducible and portable**.
 
 With the Stack Graph, each part of your stack describes itself using simple, intuitive YAML declarations, without changing any of your existing code. Garden collects all of your declarations—even across multiple repositories—into a full graph of your stack.
 
@@ -92,11 +92,11 @@ garden dev
 
 The Stack Graph is pluggable so how these actions are actually executed depends on the plugins used. Our Kubernetes plugin is currently the most popular, and chances are that’s what you’re here for. To learn more about how Garden works with Kubernetes, check out:
 
-- [Kubernetes Plugins documentation](https://docs.garden.io/guides/remote-kubernetes).
+- [Kubernetes Plugins documentation](https://docs.garden.io/v/acorn-0.12/guides/remote-kubernetes).
 
 And for a deeper dive on how Garden works in general, we recommend:
 
-- [This guide on how Garden works](https://docs.garden.io/basics/how-garden-works).
+- [This guide on how Garden works](https://docs.garden.io/v/acorn-0.12/basics/how-garden-works).
 - [This video series on the Stack Graph and getting started with Garden](https://www.youtube.com/watch?app=desktop&v=3gMJWGV0WE8).
 
 ### **Plugins**
@@ -136,7 +136,7 @@ We are trying to make Garden the best tool possible, and data on how it’s bein
 
 When you use Garden, we collect information about the commands you run, the tasks being executed, the project and operating system. We care about your privacy and we take special care to anonymize all the information. For example, we hash module names, and use randomly generated IDs to identify projects.
 
-If you are curious to see an example of the data we collect or if you would like to update your preference, please visit the [Telemetry](https://docs.garden.io/misc/telemetry) page.
+If you are curious to see an example of the data we collect or if you would like to update your preference, please visit the [Telemetry](https://docs.garden.io/v/acorn-0.12/misc/telemetry) page.
 
 ### **License**
 

--- a/docs/misc/faq.md
+++ b/docs/misc/faq.md
@@ -9,7 +9,7 @@ title: FAQ
 
 ### How do I include multiple modules with multiple Dockerfiles in the same directory?
 
-You will have to use the module-level [`include`](https://docs.garden.io/v/acorn-0.12/reference/module-types/container#include) directive to specify which files belong to each module. You will also have to provide the path to the Dockerfile with the [`dockerfile`](https://docs.garden.io/reference/module-types/container#dockerfile) directive.
+You will have to use the module-level [`include`](https://docs.garden.io/v/acorn-0.12/reference/module-types/container#include) directive to specify which files belong to each module. You will also have to provide the path to the Dockerfile with the [`dockerfile`](https://docs.garden.io/v/acorn-0.12/reference/module-types/container#dockerfile) directive.
 
 If the module only has a Dockerfile but no other files, say because it's a 3rd party image, you should set `include: []`.
 
@@ -229,7 +229,7 @@ See [this section](https://docs.garden.io/v/acorn-0.12/k8s-plugins/module-types/
 
 ### How do I mount secrets as volumes?
 
-You'll need to use the [`kubernetes`](https://docs.garden.io/v/acorn-0.12/reference/module-types/kubernetes) or [`helm`](https://docs.garden.io/reference/module-types/helm) module types for that. Here's the official [Kubernetes guide](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod) for mounting secrets as files.
+You'll need to use the [`kubernetes`](https://docs.garden.io/v/acorn-0.12/reference/module-types/kubernetes) or [`helm`](https://docs.garden.io/v/acorn-0.12/reference/module-types/helm) module types for that. Here's the official [Kubernetes guide](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod) for mounting secrets as files.
 
 ### Can I use Kubernetes secrets as `buildArgs`?
 

--- a/docs/terraform-plugin/about.md
+++ b/docs/terraform-plugin/about.md
@@ -50,7 +50,7 @@ garden --env=<env-name> plugins terraform apply-root -- -auto-approve
 
 ### Exec Provider
 
-One way to inject variables into new terraform manifests is to add an [exec provider](https://docs.garden.io/reference/providers/exec) that calls an [initScript](https://docs.garden.io/reference/providers/exec#providers-.initscript) in the project.garden.yaml file. Exec providers allow us to run scripts while initiating other providers. An `initScript` runs in the project root when initializing those providers.
+One way to inject variables into new terraform manifests is to add an [exec provider](https://docs.garden.io/v/acorn-0.12/reference/providers/exec) that calls an [initScript](https://docs.garden.io/v/acorn-0.12/reference/providers/exec#providers-.initscript) in the project.garden.yaml file. Exec providers allow us to run scripts while initiating other providers. An `initScript` runs in the project root when initializing those providers.
 
 In this sample `terraform/backend.tf` manifest, we need to replace the `key` based on which environment we are building.
 

--- a/docs/using-garden/tasks.md
+++ b/docs/using-garden/tasks.md
@@ -169,7 +169,7 @@ source directory instead.
 
 ### Kubernetes and Helm Modules
 
-Because a Kubernetes or Helm module can contain any number of Kubernetes resources, a `serviceResource` needs to be specified to determine the pod spec for the task pod. You can see the whole pod spec used in the reference docs for [kubernetes](https://docs.garden.io/reference/module-types/kubernetes#tasks-.resource) and [helm modules](https://docs.garden.io/reference/module-types/helm#tasks-.resource). Please note that the `startupProbe`, `livenessProbe` and `readinessProbe` are stripped from your pod spec. Health checks for your application might fail when the container is used for testing because the main process usually running in that container is replaced by the task command.
+Because a Kubernetes or Helm module can contain any number of Kubernetes resources, a `serviceResource` needs to be specified to determine the pod spec for the task pod. You can see the whole pod spec used in the reference docs for [kubernetes](https://docs.garden.io/v/acorn-0.12/reference/module-types/kubernetes#tasks-.resource) and [helm modules](https://docs.garden.io/v/acorn-0.12/reference/module-types/helm#tasks-.resource). Please note that the `startupProbe`, `livenessProbe` and `readinessProbe` are stripped from your pod spec. Health checks for your application might fail when the container is used for testing because the main process usually running in that container is replaced by the task command.
 
 ## Further Reading
 

--- a/docs/using-garden/tests.md
+++ b/docs/using-garden/tests.md
@@ -144,7 +144,7 @@ source directory instead.
 
 ### Kubernetes and Helm Modules
 
-Because a Kubernetes or Helm module can contain any number of Kubernetes resources, a `serviceResource` needs to be specified to determine the pod spec for the test pod. You can see the whole pod spec used in the reference docs for [kubernetes](https://docs.garden.io/reference/module-types/kubernetes#tests-.resource) and [helm modules](https://docs.garden.io/reference/module-types/helm#tests-.resource). Please note that the `startupProbe`, `livenessProbe` and `readinessProbe` are stripped from your pod spec. Health checks for your application might fail when the container is used for testing because the main process usually running in that container is replaced by the test command.
+Because a Kubernetes or Helm module can contain any number of Kubernetes resources, a `serviceResource` needs to be specified to determine the pod spec for the test pod. You can see the whole pod spec used in the reference docs for [kubernetes](https://docs.garden.io/v/acorn-0.12/reference/module-types/kubernetes#tests-.resource) and [helm modules](https://docs.garden.io/v/acorn-0.12/reference/module-types/helm#tests-.resource). Please note that the `startupProbe`, `livenessProbe` and `readinessProbe` are stripped from your pod spec. Health checks for your application might fail when the container is used for testing because the main process usually running in that container is replaced by the test command.
 
 ## Next Steps
 

--- a/docs/using-garden/variables-and-templating.md
+++ b/docs/using-garden/variables-and-templating.md
@@ -695,7 +695,7 @@ Here the output from `prep-task` is copied to an environment variable for `my-se
 
 For a practical use case, you might for example make a task that provisions some infrastructure or prepares some data, and then passes information about it to services.
 
-Different module types expose different output keys for their services and tasks. Please refer to the [module type reference docs](https://docs.garden.io/reference/module-types) for details.
+Different module types expose different output keys for their services and tasks. Please refer to the [module type reference docs](https://docs.garden.io/v/acorn-0.12/reference/module-types) for details.
 
 ## Next steps
 

--- a/examples/argocd/README.md
+++ b/examples/argocd/README.md
@@ -48,12 +48,12 @@ helm:
 ```
 ArgoCD image updater by default uses the same repo credential that ArgoCD would use, to commit above changes. We use a GitHub App that has been installed on the repo.
 
-ArgoCD watches updates to the GitHub repo. Once the image tag has been updated, changes are sync'd via the [App of apps](https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/#app-of-apps-pattern) pattern. 
+ArgoCD watches updates to the GitHub repo. Once the image tag has been updated, changes are sync'd via the [App of apps](https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/#app-of-apps-pattern) pattern.
 
 In the current example; A dedicated `values-prod.yaml` file has been created per service, which will be used by ArgoCD to overwrite default values and then sync to the Prod cluster.
 
 ## Setup
-- To get started, set up two GKE clusters - one for development and continuous integration (Dev/CI) and another for production (Prod). Refer to our comprehensive documentation for detailed instructions on using the [remote Kubernetes plugin](https://docs.garden.io/kubernetes-plugins/remote-k8s) with Garden.io.
+- To get started, set up two GKE clusters - one for development and continuous integration (Dev/CI) and another for production (Prod). Refer to our comprehensive documentation for detailed instructions on using the [remote Kubernetes plugin](https://docs.garden.io/v/acorn-0.12/kubernetes-plugins/remote-k8s) with Garden.io.
 - For the __api__ and __web__ services, create repositories on Docker Hub to simplify the deployment process.
 - For ease of use, we'll be using the same cluster for both the Dev and CI workloads. However, you can also choose to use separate clusters depending on your requirements.
 

--- a/examples/base-image/README.md
+++ b/examples/base-image/README.md
@@ -23,7 +23,7 @@ build:
 
 This ensures that the `base-image` is built ahead of the `backend`.
 
-We also use [build arguments](https://docs.docker.com/engine/reference/builder/#arg) in the Dockerfile and the [`garden.yml`](https://docs.garden.io/reference/module-types/container#buildargs) config so that the correct base image version is used:
+We also use [build arguments](https://docs.docker.com/engine/reference/builder/#arg) in the Dockerfile and the [`garden.yml`](https://docs.garden.io/v/acorn-0.12/reference/module-types/container#buildargs) config so that the correct base image version is used:
 
 ```yaml
 # In backend/garden.yml

--- a/examples/build-dependencies/README.md
+++ b/examples/build-dependencies/README.md
@@ -11,7 +11,7 @@ Our [`openfaas` example project](../openfaas) demonstrates this same pattern wit
 To achieve this, we:
 
 1. wrap the shared files/directories in an `exec` module
-2. reference it in the [build dependency](https://docs.garden.io/reference/module-types/container#build-dependencies) field of the consuming modules.
+2. reference it in the [build dependency](https://docs.garden.io/v/acorn-0.12/reference/module-types/container#build-dependencies) field of the consuming modules.
 
 ## Project Structure
 

--- a/examples/conftest/README.md
+++ b/examples/conftest/README.md
@@ -18,4 +18,4 @@ For the example, we've copied the [kubernetes example](https://github.com/instru
 
 To test this, simply run `garden test` in this directory. You should quickly see a few tests failing because resources don't match the policies defined under the `policy` directory.
 
-Note that you could also manually specify tests using the [conftest module type](https://docs.garden.io/reference/module-types/conftest).
+Note that you could also manually specify tests using the [conftest module type](https://docs.garden.io/v/acorn-0.12/reference/module-types/conftest).

--- a/examples/demo-project/README.md
+++ b/examples/demo-project/README.md
@@ -2,6 +2,6 @@
 
 A very basic demo project for Garden.
 
-Take a look at the [getting started](https://docs.garden.io/basics/quickstart) guide to see how this project is set up.
+Take a look at the [getting started](https://docs.garden.io/v/acorn-0.12/basics/quickstart) guide to see how this project is set up.
 
 For a more advanced project check out the [vote](../vote) example project.

--- a/examples/hadolint/README.md
+++ b/examples/hadolint/README.md
@@ -1,6 +1,6 @@
 # hadolint project
 
-A simple variation on the [demo-project](../demo-project/README.md) that adds the [hadolint provider](https://docs.garden.io/reference/providers/hadolint). This generates an additional Dockerfile linting test for each `container` module in your project that contains a Dockerfile.
+A simple variation on the [demo-project](../demo-project/README.md) that adds the [hadolint provider](https://docs.garden.io/v/acorn-0.12/reference/providers/hadolint). This generates an additional Dockerfile linting test for each `container` module in your project that contains a Dockerfile.
 
 To test it, run `garden dev` in this directory, and wait for the initial processing to complete. Notice the two tests that are added and run by the `hadolint` provider.
 

--- a/examples/istio/README.md
+++ b/examples/istio/README.md
@@ -28,7 +28,7 @@ cd istio-1.0.6
 
 ### Step 2 - Change default Istio port (optional)
 
-When initializing a project that uses the `local-kubernetes` provider, Garden will install a Nginx ingress controller into the `garden-system` namespace, unless the [`setupIngressController`](https://docs.garden.io/reference/providers/local-kubernetes#project-environments-providers-setupingresscontroller) directive is set to false. In this example we have done just that:
+When initializing a project that uses the `local-kubernetes` provider, Garden will install a Nginx ingress controller into the `garden-system` namespace, unless the [`setupIngressController`](https://docs.garden.io/v/acorn-0.12/reference/providers/local-kubernetes#project-environments-providers-setupingresscontroller) directive is set to false. In this example we have done just that:
 
 ```yaml
     providers:
@@ -86,6 +86,6 @@ To verify that it works, open `http://localhost:8080/productpage` in your browse
 
 The `details`, `productpage` and `ratings` services are Garden container modules that point to remote container images.
 
-The `reviews` service is a [Helm module](https://docs.garden.io/reference/module-types/helm). That's because in the original Bookinfo example, the `reviews` service has three versions that each get deployed and routed to in a round robin fashion. So to stay true to the example, and because Garden doesn't currently support multiple deployments for a single service, we use the original example manifests and deploy them via the Helm plugin.
+The `reviews` service is a [Helm module](https://docs.garden.io/v/acorn-0.12/reference/module-types/helm). That's because in the original Bookinfo example, the `reviews` service has three versions that each get deployed and routed to in a round robin fashion. So to stay true to the example, and because Garden doesn't currently support multiple deployments for a single service, we use the original example manifests and deploy them via the Helm plugin.
 
 The `gateway` service is a also Helm module, that wraps the Istio Gateway. It contains the Custom Resource Definitions (CRDs) needed for Istio to handle routing for our project.

--- a/examples/jib-container/README.md
+++ b/examples/jib-container/README.md
@@ -1,6 +1,6 @@
 # jib-container example
 
-This simple example showcases the [`jib-container` module type](https://docs.garden.io/reference/module-types/jib-container), which uses [Jib](https://github.com/GoogleContainerTools/jib) to build the container images instead of a normal Docker build.
+This simple example showcases the [`jib-container` module type](https://docs.garden.io/v/acorn-0.12/reference/module-types/jib-container), which uses [Jib](https://github.com/GoogleContainerTools/jib) to build the container images instead of a normal Docker build.
 
 The example services are adapted from the examples from the [Jib repository](https://github.com/GoogleContainerTools/jib/tree/master/examples).
 

--- a/examples/kubernetes-module/README.md
+++ b/examples/kubernetes-module/README.md
@@ -19,4 +19,4 @@ and check that the password matches the one in the project `garden.yml` file.
 ## Further reading
 
 There's not much more to it, but you can check out the module type
-[reference](https://docs.garden.io/reference/module-types/kubernetes) for more details.
+[reference](https://docs.garden.io/v/acorn-0.12/reference/module-types/kubernetes) for more details.

--- a/examples/kustomize/README.md
+++ b/examples/kustomize/README.md
@@ -13,4 +13,4 @@ To run the example, simply run `garden deploy` with a local Kubernetes cluster r
 
 ## Further reading
 
-Check out the module type [reference](https://docs.garden.io/reference/module-types/kubernetes) for more details.
+Check out the module type [reference](https://docs.garden.io/v/acorn-0.12/reference/module-types/kubernetes) for more details.

--- a/examples/local-service/README.md
+++ b/examples/local-service/README.md
@@ -39,7 +39,7 @@ services:
 
 In the config above the local module is always enabled when in dev mode but you can choose to conditionally enable it as well.
 
-You could e.g. use [command line variables](https://docs.garden.io/using-garden/variables-and-templating#variable-files-varfiles) to control whether the local module should be enabled or create a custom command.
+You could e.g. use [command line variables](https://docs.garden.io/v/acorn-0.12/using-garden/variables-and-templating#variable-files-varfiles) to control whether the local module should be enabled or create a custom command.
 
 ## Usage
 
@@ -51,7 +51,7 @@ yarn install
 cd ..
 ```
 
-Assuming you've [set _your_ K8s context](https://docs.garden.io/kubernetes-plugins/remote-k8s), you can start the project with:
+Assuming you've [set _your_ K8s context](https://docs.garden.io/v/acorn-0.12/kubernetes-plugins/remote-k8s), you can start the project with:
 
 ```console
 garden dev

--- a/examples/remote-k8s/README.md
+++ b/examples/remote-k8s/README.md
@@ -2,9 +2,9 @@
 
 This project shows how you can configure Garden to work against a remote Kubernetes cluster, in addition to a local
 cluster. We also go through how to configure TLS for your `container` services, and set up
-[in-cluster building](https://docs.garden.io/kubernetes-plugins/advanced/in-cluster-building).
+[in-cluster building](https://docs.garden.io/v/acorn-0.12/kubernetes-plugins/advanced/in-cluster-building).
 
-The example follows the [Remote Kubernetes guide](https://docs.garden.io/guides/remote-kubernetes). Please look
+The example follows the [Remote Kubernetes guide](https://docs.garden.io/v/acorn-0.12/guides/remote-kubernetes). Please look
 at the guide for more details on how to configure your own project.
 
 ## Setup

--- a/examples/remote-local-hybrid/README.md
+++ b/examples/remote-local-hybrid/README.md
@@ -84,14 +84,14 @@ Hello from local frontend
 
 ## Advanced
 
-It's also possible to run local services with `garden deploy` or `garden dev` by using the [`services` spec](https://docs.garden.io/reference/module-types/exec#services) on `exec` modules.
+It's also possible to run local services with `garden deploy` or `garden dev` by using the [`services` spec](https://docs.garden.io/v/acorn-0.12/reference/module-types/exec#services) on `exec` modules.
 
 However, it requires a bit of work, since currently Garden will wait for the process to exit (which never happens for long running processes).
 
 You can conceptually work around this by doing the following:
 
-1. Write a script that runs the process in the background and stores the PID, and call it via the [`deployCommand` field](https://docs.garden.io/reference/module-types/exec#services-.deploycommand).
-2. Have another script for killing the process based on the store PID and call it via the [`cleanupCommand` field](https://docs.garden.io/reference/module-types/exec#services-.cleanupcommand).
-3. Optionally use the [`statusCommand` field](https://docs.garden.io/reference/module-types/exec#services-.statuscommand) to skip running the process if it's already running.
+1. Write a script that runs the process in the background and stores the PID, and call it via the [`deployCommand` field](https://docs.garden.io/v/acorn-0.12/reference/module-types/exec#services-.deploycommand).
+2. Have another script for killing the process based on the store PID and call it via the [`cleanupCommand` field](https://docs.garden.io/v/acorn-0.12/reference/module-types/exec#services-.cleanupcommand).
+3. Optionally use the [`statusCommand` field](https://docs.garden.io/v/acorn-0.12/reference/module-types/exec#services-.statuscommand) to skip running the process if it's already running.
 
 Obviously, this is a bit convoluted, and adding Garden native support for this workflow is on our short-term roadmap.

--- a/examples/remote-sources/README.md
+++ b/examples/remote-sources/README.md
@@ -1,6 +1,6 @@
 # Remote sources example project
 
-This example demonstrates how you can import remote sources and remote modules into a Garden project. Take a look at the [Using Remote Sources](https://docs.garden.io/advanced/using-remote-sources) section of our docs for more details.
+This example demonstrates how you can import remote sources and remote modules into a Garden project. Take a look at the [Using Remote Sources](https://docs.garden.io/v/acorn-0.12/advanced/using-remote-sources) section of our docs for more details.
 
 ## About
 

--- a/examples/vote/README.md
+++ b/examples/vote/README.md
@@ -65,4 +65,4 @@ To run the workflow:
 garden run workflow full-test
 ```
 
-For more complex use-cases and additional configuration options please refer to the [docs](https://docs.garden.io/using-garden/workflows).
+For more complex use-cases and additional configuration options please refer to the [docs](https://docs.garden.io/v/acorn-0.12/using-garden/workflows).


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
Fixes base docs URL to point to `https://docs.garden.io/v/acorn-0.12` in 0.12 documentation.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
The `check-docs` CI step must pass.