### PR TITLE
chore(server): restore the previous default server port number `9777`

### DIFF
--- a/core/src/commands/serve.ts
+++ b/core/src/commands/serve.ts
@@ -23,7 +23,7 @@ import { Garden } from "../garden"
 import { GardenPluginReference } from "../plugin/plugin"
 import { CommandError, ParameterError, isEAddrInUseException, isErrnoException } from "../exceptions"
 
-export const defaultServerPort = 9700
+export const defaultServerPort = 9777
 
 export const serveArgs = {}
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1008,7 +1008,7 @@ This always takes the precedence over sync mode if there are any conflicts, i.e.
   | `--forward` |  | boolean | Create port forwards and leave process running after deploying. This is implied if any of --sync / --local or --logs are set.
   | `--logs` |  | boolean | Stream logs from the requested Deploy(s) (or services if using modules) during deployment, and leave the log streaming process running after deploying. Note: This option implies the --forward option.
   | `--timestamps` |  | boolean | Show timestamps with log output. Should be used with the &#x60;--logs&#x60; option (has no effect if that option is not used).
-  | `--port` |  | number | The port number for the server to listen on (defaults to 9700 if available).
+  | `--port` |  | number | The port number for the server to listen on (defaults to 9777 if available).
 
 #### Outputs
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Patches #5163 to avoid any potential regression. The default server port number is now reverted back to `9777`, as before #5163.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
