### PR TITLE
fix(core): more narrow set of config fields to hash for module versions

### DIFF
--- a/core/src/vcs/vcs.ts
+++ b/core/src/vcs/vcs.ts
@@ -8,7 +8,7 @@
 
 import Joi from "@hapi/joi"
 import normalize = require("normalize-path")
-import { sortBy, omit } from "lodash"
+import { sortBy, pick } from "lodash"
 import { createHash } from "crypto"
 import { validateSchema } from "../config/validation"
 import { join, relative, isAbsolute } from "path"
@@ -294,7 +294,7 @@ export function hashModuleVersion(
   // build output.
   const configToHash =
     moduleConfig.buildConfig ||
-    omit(moduleConfig, ["configPath", "path", "outputs", "serviceConfigs", "taskConfigs", "testConfigs"])
+    pick(moduleConfig, ["apiVersion", "name", "spec", "type", "variables", "varfile", "inputs"])
 
   const configString = serializeConfig(configToHash)
 

--- a/core/test/unit/src/vcs/vcs.ts
+++ b/core/test/unit/src/vcs/vcs.ts
@@ -366,7 +366,7 @@ describe("getModuleVersionString", () => {
     const garden = await makeTestGarden(projectRoot, { noCache: true })
     const module = await garden.resolveModule("module-a")
 
-    const fixedVersionString = "v-48acad3a28"
+    const fixedVersionString = "v-65a5457ccb"
     expect(module.version.versionString).to.eql(fixedVersionString)
 
     delete process.env.TEST_ENV_VAR


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR cherry-picks 2 commits from the `main` branch:
* c17a6cfbd89384a7415cf259ce53b28c3e1c90ea
* 57d884a55f1175f491ada85fd158a3b74b5118a8

**Which issue(s) this PR fixes**:
This is a pre-requisite for #5180 and should fix the [test-framework failures](https://app.circleci.com/pipelines/github/garden-io/garden/20816/workflows/42ec6f01-8f92-4e35-9e92-fad2b4012d46/jobs/400864).

Prior to this PR, individual test case `"should return module version if there are no dependencies"` from [`core/test/unit/src/garden.ts`](https://github.com/garden-io/garden/blob/main/core/test/unit/src/garden.ts) was failing, while the whole test suite was passing without errors.

Now, both scenarios pass without failures.

**Special notes for your reviewer**:
Some amendments had been made to the original commits that had been cherry-picked.

The `test-framework` CI step must pass. The rest failures are expected.