### PR TITLE
fix: allow listing disabled actions in get actions cmd

### DIFF
--- a/core/src/actions/base.ts
+++ b/core/src/actions/base.ts
@@ -481,8 +481,8 @@ export abstract class BaseAction<
     return this.dependencies
   }
 
-  getDependencies(): Action[] {
-    return this.dependencies.map((d) => this.graph.getActionByRef(d))
+  getDependencies(opts?: GetActionOpts): Action[] {
+    return this.dependencies.map((d) => this.graph.getActionByRef(d, opts))
   }
 
   hasDependency(refOrString: string | ActionReference) {

--- a/core/src/commands/get/get-actions.ts
+++ b/core/src/commands/get/get-actions.ts
@@ -198,7 +198,7 @@ export class GetActionsCommand extends Command {
           ...tmp,
           path: getRelativeActionConfigPath(garden.projectRoot, a),
           dependencies: a
-            .getDependencies()
+            .getDependencies({ includeDisabled: true })
             .map((d) => d.key())
             .sort(),
           dependents: graph


### PR DESCRIPTION
**What this PR does / why we need it**:
`get actions --detail` command basically doesn't work in case one of the actions is disabled. Ran into this multiple times and it's so annoying.  With this PR, it stops throwing error for get actions, if an action is disabled. 

**Which issue(s) this PR fixes**:

Fixes #4937

**Special notes for your reviewer**:
