### PR TITLE
fix: prevent crash due to unresolved alias in yaml

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -162,7 +162,7 @@
     "wrap-ansi": "^7.0.0",
     "write-file-atomic": "^5.0.0",
     "ws": "^8.12.1",
-    "yaml": "^2.2.2",
+    "yaml": "^2.3.2",
     "yaml-lint": "^1.2.4",
     "zod": "^3.20.6",
     "zod-to-json-schema": "^3.21.1"

--- a/core/src/config/base.ts
+++ b/core/src/config/base.ts
@@ -101,6 +101,11 @@ export async function loadAndValidateYaml(content: string, path: string): Promis
       if (doc.errors.length > 0) {
         throw doc.errors[0]
       }
+      // Workaround: Call toJS might throw an error that is not listed in the errors above.
+      // See also https://github.com/eemeli/yaml/issues/497
+      // We call this here to catch this error early and prevent crashes later on.
+      doc.toJS()
+
       doc.source = content
       return doc
     })

--- a/core/src/config/base.ts
+++ b/core/src/config/base.ts
@@ -26,7 +26,7 @@ import { emitNonRepeatableWarning } from "../warnings"
 import { ActionKind, actionKinds } from "../actions/types"
 import { mayContainTemplateString } from "../template-string/template-string"
 import { Log } from "../logger/log-entry"
-import { Document, parseAllDocuments } from "yaml"
+import { Document, DocumentOptions, parseAllDocuments } from "yaml"
 import { dedent, deline } from "../util/string"
 
 export const configTemplateKind = "ConfigTemplate"
@@ -93,11 +93,16 @@ export const allConfigKinds = ["Module", "Workflow", "Project", configTemplateKi
  * content is not valid YAML.
  *
  * @param content - The contents of the file as a string.
- * @param path - The path to the file.
+ * @param sourceDescription - A description of the location of the yaml file, e.g. "bar.yaml at directory /foo/".
+ * @param version - YAML standard version. Defaults to "1.2"
  */
-export async function loadAndValidateYaml(content: string, path: string): Promise<YamlDocumentWithSource[]> {
+export async function loadAndValidateYaml(
+  content: string,
+  sourceDescription: string,
+  version: DocumentOptions["version"] = "1.2"
+): Promise<YamlDocumentWithSource[]> {
   try {
-    return Array.from(parseAllDocuments(content, { merge: true, strict: false }) || []).map((doc: any) => {
+    return Array.from(parseAllDocuments(content, { merge: true, strict: false, version }) || []).map((doc: any) => {
       if (doc.errors.length > 0) {
         throw doc.errors[0]
       }
@@ -115,13 +120,13 @@ export async function loadAndValidateYaml(content: string, path: string): Promis
       await lint(content)
     } catch (linterErr) {
       throw new ConfigurationError({
-        message: `Could not parse ${basename(path)} in directory ${path} as valid YAML: ${linterErr}`,
+        message: `Could not parse ${sourceDescription} as valid YAML: ${linterErr}`,
       })
     }
     // ... but default to throwing a generic error, in case the error wasn't caught by yaml-lint.
     throw new ConfigurationError({
       message: dedent`
-        Failed to load YAML from ${basename(path)} in directory ${path}.
+        Failed to load YAML from ${sourceDescription}.
 
         Linting the file did not yield any errors. This is all we know: ${loadErr}
       `,
@@ -161,7 +166,7 @@ export async function validateRawConfig({
   projectRoot: string
   allowInvalid?: boolean
 }) {
-  let rawSpecs = await loadAndValidateYaml(rawConfig, configPath)
+  let rawSpecs = await loadAndValidateYaml(rawConfig, `${basename(configPath)} in directory ${dirname(configPath)}`)
 
   // Ignore empty resources
   rawSpecs = rawSpecs.filter(Boolean)

--- a/core/src/config/base.ts
+++ b/core/src/config/base.ts
@@ -102,7 +102,7 @@ export async function loadAndValidateYaml(
   version: DocumentOptions["version"] = "1.2"
 ): Promise<YamlDocumentWithSource[]> {
   try {
-    return Array.from(parseAllDocuments(content, { merge: true, strict: false, version }) || []).map((doc: any) => {
+    return Array.from(parseAllDocuments(content, { merge: true, strict: false, version }) || []).map((doc) => {
       if (doc.errors.length > 0) {
         throw doc.errors[0]
       }
@@ -111,8 +111,10 @@ export async function loadAndValidateYaml(
       // We call this here to catch this error early and prevent crashes later on.
       doc.toJS()
 
-      doc.source = content
-      return doc
+      const docWithSource = doc as YamlDocumentWithSource
+      docWithSource.source = content
+
+      return docWithSource
     })
   } catch (loadErr) {
     // We try to find the error using a YAML linter

--- a/core/src/plugins/kubernetes/kubernetes-type/common.ts
+++ b/core/src/plugins/kubernetes/kubernetes-type/common.ts
@@ -464,10 +464,19 @@ function parseKubernetesManifests(str: string): KubernetesResource[] {
     }
   }
 
-  // TODO: We should use schema validation to make sure that apiVersion, kind and metadata are always defined as required by the type.
-  const manifests = docs.map((d) => d.toJS()) as KubernetesResource[]
+  let manifests: any[]
+  try {
+    manifests = docs.map((d) => d.toJS())
+  } catch (error) {
+    // toJS sometimes throws errors that are not caught by the above error check.
+    // See also https://github.com/eemeli/yaml/issues/497
+    throw new ConfigurationError({
+      message: `Failed to parse Kubernetes manifest: ${error}`,
+    })
+  }
 
-  return expandListManifests(manifests)
+  // TODO: We should use schema validation to make sure that apiVersion, kind and metadata are always defined as required by the type.
+  return expandListManifests(manifests as KubernetesResource[])
 }
 
 /**

--- a/core/test/unit/src/config/validation.ts
+++ b/core/test/unit/src/config/validation.ts
@@ -307,7 +307,7 @@ describe("validateSchema", () => {
       name: bar
     `
 
-    const yamlDocs = await loadAndValidateYaml(yaml, "/foo")
+    const yamlDocs = await loadAndValidateYaml(yaml, "foo.yaml in directory bar")
     const yamlDoc = yamlDocs[1]
 
     const config: any = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3403,7 +3403,7 @@
         "wrap-ansi": "^7.0.0",
         "write-file-atomic": "^5.0.0",
         "ws": "^8.12.1",
-        "yaml": "^2.2.2",
+        "yaml": "^2.3.2",
         "yaml-lint": "^1.2.4",
         "zod": "^3.20.6",
         "zod-to-json-schema": "^3.21.1"

--- a/plugins/pulumi/src/helpers.ts
+++ b/plugins/pulumi/src/helpers.ts
@@ -11,7 +11,7 @@ import { load } from "js-yaml"
 import stripAnsi from "strip-ansi"
 import chalk from "chalk"
 import { merge } from "json-merge-patch"
-import { extname, join, resolve } from "path"
+import { basename, dirname, extname, join, resolve } from "path"
 import { ensureDir, pathExists, readFile } from "fs-extra"
 import {
   ChildProcessError,
@@ -257,7 +257,10 @@ export async function applyConfig(params: PulumiParams & { previewDirPath?: stri
   let stackConfigFileExists: boolean
   try {
     const fileData = await readFile(stackConfigPath)
-    stackConfig = (await loadAndValidateYaml(fileData.toString(), stackConfigPath))[0].toJS()
+    stackConfig = await loadAndValidateYaml(
+      fileData.toString(),
+      `${basename(stackConfigPath)} in directory ${dirname(stackConfigPath)}`
+    )[0].toJS()
     stackConfigFileExists = true
   } catch (err) {
     log.debug(`No pulumi stack configuration file for action ${action.name} found at ${stackConfigPath}`)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
- chore(deps): update yaml to 2.3.2
- fix: prevent crash due to unresolved alias in yaml
- improvement: use loadAndValidateYaml for both kubernetes manifests and garden configs
- test: add tests for loadAndValidateYaml
- improvement: eliminate explicit any in loadAndValidateYaml

**Which issue(s) this PR fixes**:

Fixes #5186

**Special notes for your reviewer**:
This is a workaround for possible upstream bug described in https://github.com/eemeli/yaml/issues/497

Manual test looks like this:

```
% gdev deploy  
Deploy 🚀 

Garden v0.13 (Bonsai) is a major release with significant changes. Please help us improve it by reporting any issues/bugs here:
https://go.garden.io/report-bonsai
→ Run garden util hide-warning 0.13-bonsai to disable this warning.
ℹ garden               → Running in Garden environment local.default
Could not parse frontend.garden.yml in directory /Users/steffen/work/github/garden/examples/demo-project/frontend as valid YAML: YAMLException: unidentified alias "foobar" (2:14)

 1 | kind: Build
 2 | name: *foobar
------------------^
 3 | description: Frontend service container image
 4 | type: container
 ```

and for a kubernetes manifest:
```
% gdev deploy redis
Deploy 🚀

Garden v0.13 (Bonsai) is a major release with significant changes. Please help us improve it by reporting any issues/bugs here:
https://go.garden.io/report-bonsai
→ Run garden util hide-warning 0.13-bonsai to disable this warning.
ℹ garden               → Running in Garden environment local.default
ℹ cloud-dashboard      → View command results at: https://app.garden.io/go/command/RWwxXGFhUl

ℹ providers            → Getting status...
✔ providers            → Cached (took 0.8 sec)
ℹ providers            → Run with --force-refresh to force a refresh of provider statuses.
ℹ graph                → Resolving actions and modules...
✔ graph                → Done (took 0 sec)
ℹ deploy.redis         → missing
ℹ deploy.redis         → Deploying version v-96dc07041c...
✖ deploy.redis         → Failed (took 0 sec)
✖ deploy.redis         → Failed processing Deploy type=kubernetes name=redis (took 0.06 sec). This is what happened:

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Could not parse redis.yml in directory /Users/steffen/work/github/garden/examples/kubernetes-deploy/redis (specified in Deploy type=kubernetes name=redis) as valid YAML: YAMLException: unidentified alias "bar" (4:10)

 1 | ---
 2 | # Source: redis/templates/secret.yaml
 3 | apiVersion: v1
 4 | foo: *bar
--------------^
 5 | kind: Secret
 6 | metadata:
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
1 deploy action(s) failed!

See .garden/error.log for detailed error message
```