### PR TITLE
fix(cloud): send correct action version in status event payload

### DIFF
--- a/core/src/tasks/base.ts
+++ b/core/src/tasks/base.ts
@@ -432,7 +432,10 @@ export function emitGetStatusEvents<
       const donePayload = makeActionCompletePayload({
         result,
         startedAt,
-        action: this.action,
+        // Use executedAction instead of this.action here for correct version
+        // as executedAction is the resolved action and this.action is unresolved.
+        // The action is resolved in method.apply and getStatus handlers use the resolved action.
+        action: result.executedAction,
         operation: methodName,
         force: this.force,
         sessionId: this.garden.sessionId,

--- a/core/test/unit/src/tasks/deploy.ts
+++ b/core/test/unit/src/tasks/deploy.ts
@@ -140,7 +140,7 @@ describe("DeployTask", () => {
       },
     ])
 
-    graph = await garden.getConfigGraph({ log: garden.log, emit: false })
+    graph = await garden.getResolvedConfigGraph({ log: garden.log, emit: false })
   })
 
   after(async () => {

--- a/core/test/unit/src/tasks/test.ts
+++ b/core/test/unit/src/tasks/test.ts
@@ -19,7 +19,7 @@ describe("TestTask", () => {
 
   beforeEach(async () => {
     garden = await makeTestGarden(getDataDir("test-project-test-deps"))
-    graph = await garden.getConfigGraph({ log: garden.log, emit: false })
+    graph = await garden.getResolvedConfigGraph({ log: garden.log, emit: false })
     log = garden.log
   })
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Use resolved action for version calculation when sending the get status results event to cloud. Before this, we were not using the resolved action when preparing the payload, and there was the version mismatch between the action version in the cloud event and the action version stored in k8s Configmap.

The status handlers for all action types ([test](https://github.com/garden-io/garden/blob/main/core/src/tasks/test.ts#L76), [build](https://github.com/garden-io/garden/blob/main/core/src/tasks/build.ts#L50), [deploy](https://github.com/garden-io/garden/blob/main/core/src/tasks/deploy.ts#L79), [run](https://github.com/garden-io/garden/blob/main/core/src/tasks/run.ts#L58)) already use the resolved action.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
