### PR TITLE
improvement(core): log stderr from exec as info

### DIFF
--- a/core/src/util/util.ts
+++ b/core/src/util/util.ts
@@ -667,7 +667,14 @@ export async function runScript({
     log.error(line.toString())
   })
   errorStream.on("data", (line: Buffer) => {
-    log.error(line.toString())
+    // NOTE: We're intentionally logging stderr streams at the "info" level
+    // because some tools will write to stderr even if it's not an actual error.
+    // So rendering it as such will look confusing to the user.
+    // An example of this is the gcloud CLI tool. If run from e.g. the exec
+    // provider init script, Garden would log those lines as errors if we don't
+    // use the info level here.
+    // Actual error are handled specifically.
+    log.info(line.toString())
   })
   // Workaround for https://github.com/vercel/pkg/issues/897
   env.PKG_EXECPATH = ""


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Before this change, we logged stderr streams from
init scripts as errors but now we log it at the info level.

The reason is that some tools, e.g. gcloud, write to stderr even if it's
not an actual error.

In the case of an actual error the script exits with a non-zero
code and that's handled specifically.

So this is really just a cosmetic change to how exec provider logs are
rendered.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
