### PR TITLE
fix: allow generated files in build actions

### DIFF
--- a/core/src/vcs/vcs.ts
+++ b/core/src/vcs/vcs.ts
@@ -57,6 +57,12 @@ export async function validateGitInstall() {
 
 export interface TreeVersion {
   contentHash: string
+  /**
+   * Important! Do not use the files to determine if a file will exist when performing an action.
+   * Other mechanisms, e.g. the build command itself and `copyFrom` might affect available files at runtime.
+   *
+   * See also https://github.com/garden-io/garden/issues/5201
+   */
   files: string[]
 }
 

--- a/core/test/unit/src/plugins/container/build.ts
+++ b/core/test/unit/src/plugins/container/build.ts
@@ -18,6 +18,7 @@ import { ContainerProvider, gardenPlugin } from "../../../../../src/plugins/cont
 import { containerHelpers } from "../../../../../src/plugins/container/helpers"
 import { joinWithPosix } from "../../../../../src/util/fs"
 import { getDataDir, TestGarden, makeTestGarden } from "../../../../helpers"
+import { createFile } from "fs-extra"
 
 context("build.ts", () => {
   const projectRoot = getDataDir("test-project-container")
@@ -85,6 +86,7 @@ context("build.ts", () => {
       sinon.replace(action, "getOutputs", () => ({ localImageId: "some/image" }))
 
       const buildPath = action.getBuildPath()
+      await createFile(join(buildPath, "Dockerfile"))
 
       const cmdArgs = getCmdArgs(action, buildPath)
       sinon.replace(containerHelpers, "dockerCli", async ({ cwd, args, ctx: _ctx }) => {
@@ -109,6 +111,7 @@ context("build.ts", () => {
       sinon.replace(action, "getOutputs", () => ({ localImageId: "some/image" }))
 
       const buildPath = action.getBuildPath()
+      await createFile(join(buildPath, "docker-dir/Dockerfile"))
 
       const cmdArgs = getCmdArgs(action, buildPath)
       sinon.replace(containerHelpers, "dockerCli", async ({ cwd, args, ctx: _ctx }) => {

--- a/plugins/jib/src/index.ts
+++ b/plugins/jib/src/index.ts
@@ -206,11 +206,7 @@ export const gardenPlugin = () =>
               let projectType = spec.projectType
 
               if (!projectType) {
-                projectType = detectProjectType({
-                  actionName: action.name,
-                  actionBasePath: action.basePath(),
-                  actionFiles: action.getFullVersion().files,
-                })
+                projectType = await detectProjectType(action)
                 statusLine.info(`Detected project type ${projectType}`)
               }
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
In the container and jib-container build actions, we checked for the
existance of files checked in to version control for certain checks.

Garden allows for files to be injected into the build action dynamically
at run time, e.g. by using `copyFrom` and `generateFiles`.

We want to check for actual presence of files in the action's build
directory instead of checking for the files that are included from
version control.

**Which issue(s) this PR fixes**:

Fixes #5201

**Special notes for your reviewer**:
