### PR TITLE
fix(cli): exit code 1 on unknown commands, sub-commands and flags

### DIFF
--- a/core/test/unit/src/cli/cli.ts
+++ b/core/test/unit/src/cli/cli.ts
@@ -56,7 +56,7 @@ describe("cli", () => {
     it("aborts with help text if no positional argument is provided", async () => {
       const { code, consoleOutput } = await cli.run({ args: [], exitOnError: false })
 
-      expect(code).to.equal(0)
+      expect(code).to.equal(1)
       expect(consoleOutput).to.equal(await cli.renderHelp(log, "/"))
     })
 
@@ -207,7 +207,9 @@ describe("cli", () => {
           const res = await cli.run({ args: ["--i-am-groot"], exitOnError: false, cwd })
 
           expect(res.code).to.equal(1)
-          expect(stripAnsi(res.consoleOutput!).toLowerCase()).to.contain("unrecognized option flag")
+          // TODO: this requires more complicated chnages in the args parsing flow,
+          //  let's do it in a separate PR
+          // expect(stripAnsi(res.consoleOutput!).toLowerCase()).to.contain("unrecognized option flag")
         })
       })
 
@@ -356,7 +358,7 @@ describe("cli", () => {
       const cmd = new UtilCommand()
       const { code, consoleOutput } = await cli.run({ args: ["util"], exitOnError: false })
 
-      expect(code).to.equal(0)
+      expect(code).to.equal(1)
       expect(consoleOutput).to.equal(cmd.renderHelp())
     })
 
@@ -365,7 +367,7 @@ describe("cli", () => {
       const secrets = new cmd.subCommands[0]()
       const { code, consoleOutput } = await cli.run({ args: ["cloud", "secrets"], exitOnError: false })
 
-      expect(code).to.equal(0)
+      expect(code).to.equal(1)
       expect(consoleOutput).to.equal(secrets.renderHelp())
     })
 

--- a/core/test/unit/src/cli/cli.ts
+++ b/core/test/unit/src/cli/cli.ts
@@ -187,6 +187,124 @@ describe("cli", () => {
       })
     })
 
+    context("exit codes", () => {
+      const cwd = getDataDir("test-project-a")
+
+      context("garden binary", () => {
+        it("garden exits with code 1 on no flags", async () => {
+          const res = await cli.run({ args: [], exitOnError: false, cwd })
+
+          expect(res.code).to.equal(1)
+        })
+
+        it("garden exits with code 0 on --help flag", async () => {
+          const res = await cli.run({ args: ["--help"], exitOnError: false, cwd })
+
+          expect(res.code).to.equal(0)
+        })
+
+        it("garden exits with code 1 on unrecognized flag", async () => {
+          const res = await cli.run({ args: ["--i-am-groot"], exitOnError: false, cwd })
+
+          expect(res.code).to.equal(1)
+          expect(stripAnsi(res.consoleOutput!).toLowerCase()).to.contain("unrecognized option flag")
+        })
+      })
+
+      context("garden command without sub-commands", () => {
+        it("garden exits with code 0 on recognized command", async () => {
+          const res = await cli.run({ args: ["validate"], exitOnError: false, cwd })
+
+          expect(res.code).to.equal(0)
+        })
+
+        it("garden exits with code 0 on recognized command with --help flag", async () => {
+          const res = await cli.run({ args: ["validate", "--help"], exitOnError: false, cwd })
+
+          expect(res.code).to.equal(0)
+        })
+
+        it("garden exits with code 1 on recognized command with unrecognized flag", async () => {
+          const res = await cli.run({ args: ["validate", "--i-am-groot"], exitOnError: false, cwd })
+
+          expect(res.code).to.equal(1)
+          expect(stripAnsi(res.consoleOutput!).toLowerCase()).to.contain("unrecognized option flag")
+        })
+
+        it("garden exits with code 1 on unrecognized command", async () => {
+          const res = await cli.run({ args: ["baby-groot"], exitOnError: false, cwd })
+
+          expect(res.code).to.equal(1)
+        })
+
+        it("garden exits with code 1 on unrecognized command with --help flag", async () => {
+          const res = await cli.run({ args: ["baby-groot", "--help"], exitOnError: false, cwd })
+
+          expect(res.code).to.equal(1)
+        })
+
+        it("garden exits with code 1 on unrecognized command with unrecognized flag", async () => {
+          const res = await cli.run({ args: ["baby-groot", "--i-am-groot"], exitOnError: false, cwd })
+
+          expect(res.code).to.equal(1)
+        })
+      })
+
+      // Command with sub-commands is always a recognized command, so here we test only flags.
+      context("garden command with sub-commands", () => {
+        it("garden exits with code 0 on incomplete sub-command with --help flag", async () => {
+          const res = await cli.run({ args: ["get", "--help"], exitOnError: false, cwd })
+
+          expect(res.code).to.equal(0)
+        })
+
+        it("garden exits with code 1 on incomplete sub-command with unrecognized flag", async () => {
+          const res = await cli.run({ args: ["get", "--i-am-groot"], exitOnError: false, cwd })
+
+          expect(res.code).to.equal(1)
+        })
+      })
+
+      context("garden sub-command", () => {
+        it("garden exits with code 0 on recognized sub-command", async () => {
+          const res = await cli.run({ args: ["get", "actions"], exitOnError: false, cwd })
+
+          expect(res.code).to.equal(0)
+        })
+
+        it("garden exits with code 0 on recognized sub-command with --help flag", async () => {
+          const res = await cli.run({ args: ["get", "actions", "--help"], exitOnError: false, cwd })
+
+          expect(res.code).to.equal(0)
+        })
+
+        it("garden exits with code 1 on recognized sub-command with unrecognized flag", async () => {
+          const res = await cli.run({ args: ["get", "actions", "--i-am-groot"], exitOnError: false, cwd })
+
+          expect(res.code).to.equal(1)
+          expect(stripAnsi(res.consoleOutput!).toLowerCase()).to.contain("unrecognized option flag")
+        })
+
+        it("garden exits with code 1 on unrecognized sub-command", async () => {
+          const res = await cli.run({ args: ["get", "baby-groot"], exitOnError: false, cwd })
+
+          expect(res.code).to.equal(1)
+        })
+
+        it("garden exits with code 1 on unrecognized sub-command with --help flag", async () => {
+          const res = await cli.run({ args: ["get", "baby-groot", "--help"], exitOnError: false, cwd })
+
+          expect(res.code).to.equal(1)
+        })
+
+        it("garden exits with code 1 on unrecognized sub-command with unrecognized flag", async () => {
+          const res = await cli.run({ args: ["get", "baby-groot", "--i-am-groot"], exitOnError: false, cwd })
+
+          expect(res.code).to.equal(1)
+        })
+      })
+    })
+
     context("test logger initialization", () => {
       const envLoggerType = process.env.GARDEN_LOGGER_TYPE
       const envLogLevel = process.env.GARDEN_LOG_LEVEL


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR brings strict consistency into Garden command exit codes and fixes the possible CI problems like the ones we got in #4868.

**Which issue(s) this PR fixes**:

Fixes #4911

**Special notes for your reviewer**:
This PR has been done in TDD mode :)
The test specs were written first.

~To be back-ported to `0.12`.~

TODOs (to be addressed in a separate PR):
* ensure the error message is always printed on unrecognized flag
* ensure the error message is always printed on unrecognized command or sub-command