### PR TITLE
0.12 backport: improvement: using new release endpoint for self-update

### DIFF
--- a/core/src/cli/helpers.ts
+++ b/core/src/cli/helpers.ts
@@ -20,7 +20,7 @@ import { ParameterValues, Parameter, Parameters } from "./params"
 import { InternalError, ParameterError } from "../exceptions"
 import { getPackageVersion, removeSlice } from "../util/util"
 import { LogEntry } from "../logger/log-entry"
-import { STATIC_DIR, VERSION_CHECK_URL, gardenEnv } from "../constants"
+import { STATIC_DIR, gardenEnv } from "../constants"
 import { printWarningMessage } from "../logger/util"
 import { GlobalConfigStore, globalConfigKeys } from "../config-store"
 import { got } from "../util/http"
@@ -98,7 +98,7 @@ export async function checkForUpdates(config: GlobalConfigStore, logger: LogEntr
     headers["X-ci-name"] = ci.name
   }
 
-  const res = await got(`${VERSION_CHECK_URL}?${qs.stringify(query)}`, { headers }).json<any>()
+  const res = await got(`${gardenEnv.GARDEN_VERSION_CHECK_ENDPOINT}?${qs.stringify(query)}`, { headers }).json<any>()
   const configObj = await config.get()
   const showMessage =
     configObj.lastVersionCheck && moment().subtract(1, "days").isAfter(moment(configObj.lastVersionCheck.lastRun))

--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -47,8 +47,7 @@ export const SUPPORTED_ARCHITECTURES: SupportedArchitecture[] = ["x64", "arm64"]
 export const SEGMENT_DEV_API_KEY = "D3DUZ3lBSDO3krnuIO7eYDdtlDAjooKW" // ggignore
 export const SEGMENT_PROD_API_KEY = "b6ovUD9A0YjQqT3ZWetWUbuZ9OmGxKMa" // ggignore
 
-export const DOCS_BASE_URL = "https://docs.garden.io/v/acorn-0.12"
-export const VERSION_CHECK_URL = "https://get.garden.io/version"
+export const DOCS_BASE_URL = "https://docs.garden.io"
 
 export const DEFAULT_GARDEN_CLOUD_DOMAIN = "https://app.garden.io"
 
@@ -83,4 +82,14 @@ export const gardenEnv = {
   // issues on terminals we haven't tested. We can remove again in v0.13.
   GARDEN_LEGACY_FANCY_LOG_RENDER: env.get("GARDEN_LEGACY_FANCY_LOG_RENDER").required(false).asBool(),
   GARDEN_CLOUD_DOMAIN: env.get("GARDEN_CLOUD_DOMAIN").required(false).asUrlString(),
+  GARDEN_VERSION_CHECK_ENDPOINT: env
+    .get("GARDEN_VERSION_CHECK_ENDPOINT")
+    .required(false)
+    .default("https://get.garden.io/version")
+    .asUrlString(),
+  GARDEN_RELEASES_ENDPOINT: env
+    .get("GARDEN_RELEASES_ENDPOINT")
+    .required(false)
+    .default("https://get.garden.io/releases")
+    .asUrlString(),
 }

--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -47,7 +47,7 @@ export const SUPPORTED_ARCHITECTURES: SupportedArchitecture[] = ["x64", "arm64"]
 export const SEGMENT_DEV_API_KEY = "D3DUZ3lBSDO3krnuIO7eYDdtlDAjooKW" // ggignore
 export const SEGMENT_PROD_API_KEY = "b6ovUD9A0YjQqT3ZWetWUbuZ9OmGxKMa" // ggignore
 
-export const DOCS_BASE_URL = "https://docs.garden.io"
+export const DOCS_BASE_URL = "https://docs.garden.io/v/acorn-0.12"
 
 export const DEFAULT_GARDEN_CLOUD_DOMAIN = "https://app.garden.io"
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -3455,6 +3455,7 @@ Examples:
   | `--force` |  | boolean | Install the Garden CLI even if the specified or detected latest version is the same as the current version.
   | `--install-dir` |  | string | Specify an installation directory, instead of using the directory of the Garden CLI being used. Implies --force.
   | `--platform` |  | `macos` `linux` `windows`  | Override the platform, instead of detecting it automatically.
+  | `--architecture` |  | `arm64` `amd64`  | Override the architecture, instead of detecting it automatically.
   | `--major` |  | boolean | Install the latest major version of Garden. Falls back to the current version if the greater major version does not exist.
 
 Note! If you use a non-stable version (i.e. pre-release, or draft, or edge), then the latest possible major version will be installed.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -3455,7 +3455,6 @@ Examples:
   | `--force` |  | boolean | Install the Garden CLI even if the specified or detected latest version is the same as the current version.
   | `--install-dir` |  | string | Specify an installation directory, instead of using the directory of the Garden CLI being used. Implies --force.
   | `--platform` |  | `macos` `linux` `windows`  | Override the platform, instead of detecting it automatically.
-  | `--architecture` |  | `arm64` `amd64`  | Override the architecture, instead of detecting it automatically.
   | `--major` |  | boolean | Install the latest major version of Garden. Falls back to the current version if the greater major version does not exist.
 
 Note! If you use a non-stable version (i.e. pre-release, or draft, or edge), then the latest possible major version will be installed.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

This is a 0.12 backport of #5229. Tests and code are ported over. ARM support was excluded from the backport since its only available from 0.13.12.

**Which issue(s) this PR fixes**:

Fixes #4893 

**Special notes for your reviewer**:
