### PR TITLE
ci: omit a single link check in CI

### DIFF
--- a/markdown-link-check-config.json
+++ b/markdown-link-check-config.json
@@ -13,6 +13,10 @@
     {
       "pattern": "^https://docs\\.github\\.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads$",
       "reason": "Ignore this particular GitHub URL, it fails consistently with HTTP 403 code despite the link works fine"
+    },
+    {
+      "pattern": "^https://support.apple.com/en-us/HT211861$",
+      "reason": "Ignore this particular URL to Apple Rosetta guide. CI reports it as a dead one quite regularly despite the link is alive."
     }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
CI reports this link as a dead one quite often:

```console
 ERROR: 1 dead links found!
[✖] https://support.apple.com/en-us/HT211861 → Status: 0
```

The link is alive. Skip it to avoid false positive alarms in CI.

Some recent failure examples:
* https://app.circleci.com/pipelines/github/garden-io/garden/21128/workflows/dc36583b-49a0-4834-82c3-8cb176a606a4/jobs/411027
* https://app.circleci.com/pipelines/github/garden-io/garden/21128/workflows/722802a6-3440-40e2-ba46-1bb0aa2d26fa/jobs/410993
* https://app.circleci.com/pipelines/github/garden-io/garden/21128/workflows/33d42493-9c66-4d56-8854-c0748258e4dc/jobs/410982
* https://app.circleci.com/pipelines/github/garden-io/garden/21109/workflows/e39819ba-8816-47da-b00c-5cb5d5d3c890/jobs/410387

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
