### PR TITLE
test: use more precise time comparison

### DIFF
--- a/core/src/util/testing.ts
+++ b/core/src/util/testing.ts
@@ -8,7 +8,7 @@
 
 import { GlobalOptions, globalOptions, ParameterValues } from "../cli/params"
 import cloneDeep from "fast-copy"
-import { isEqual, keyBy, set, mapValues } from "lodash"
+import { isEqual, keyBy, set, mapValues, round } from "lodash"
 import { Garden, GardenOpts, GardenParams, GetConfigGraphParams, resolveGardenParams } from "../garden"
 import { DeepPrimitiveMap, StringMap } from "../config/common"
 import { ModuleConfig } from "../config/module"
@@ -533,4 +533,11 @@ export function captureStream(stream: NodeJS.WritableStream) {
       return buf
     },
   }
+}
+
+export function equalWithPrecision(a: number, b: number, precision: number): boolean {
+  const rawDiff = Math.abs(a - b)
+  const diff = round(rawDiff, precision)
+  const eps = Math.pow(10, -precision)
+  return diff <= eps
 }

--- a/core/test/unit/src/build-staging/helpers.ts
+++ b/core/test/unit/src/build-staging/helpers.ts
@@ -20,7 +20,8 @@ import { realpath, symlink, writeFile, readFile, mkdir, ensureFile, ensureDir } 
 import { expect } from "chai"
 import { expectError } from "../../../helpers"
 import { sleep } from "../../../../src/util/util"
-import { round, sortBy } from "lodash"
+import { sortBy } from "lodash"
+import { equalWithPrecision } from "../../../../src/util/testing"
 
 describe("build staging helpers", () => {
   let statsHelper: FileStatsHelper
@@ -86,7 +87,7 @@ describe("build staging helpers", () => {
       const statA = await statsHelper.extendedStat({ path: a })
       const statB = await statsHelper.extendedStat({ path: b })
 
-      expect(round(statA?.mtimeMs!, 2)).to.equal(round(statB?.mtimeMs!, 2))
+      expect(equalWithPrecision(statA?.mtimeMs!, statB?.mtimeMs!, 2)).to.be.true
     })
 
     it("skips if file at target exists and has same mtime and size", async () => {

--- a/core/test/unit/src/build-staging/helpers.ts
+++ b/core/test/unit/src/build-staging/helpers.ts
@@ -8,15 +8,15 @@
 
 import { join } from "path"
 import {
-  FileStatsHelper,
-  ExtendedStats,
-  ResolveSymlinkParams,
   cloneFileAsync,
-  scanDirectoryForClone,
+  ExtendedStats,
+  FileStatsHelper,
   MappedPaths,
+  ResolveSymlinkParams,
+  scanDirectoryForClone,
 } from "../../../../src/build-staging/helpers"
-import { TempDirectory, makeTempDir } from "../../../../src/util/fs"
-import { realpath, symlink, writeFile, readFile, mkdir, ensureFile, ensureDir } from "fs-extra"
+import { makeTempDir, TempDirectory } from "../../../../src/util/fs"
+import { ensureDir, ensureFile, mkdir, readFile, realpath, symlink, writeFile } from "fs-extra"
 import { expect } from "chai"
 import { expectError } from "../../../helpers"
 import { sleep } from "../../../../src/util/util"


### PR DESCRIPTION
**What this PR does / why we need it**:
This approach covers the edge case
when 2 numeric values are in the same precision vicinity, but get rounded to the different values.

E.g. `a = 0.514` and `b = 0.516`.
The diff is `0.002`,
but the diff between rounded values was `0.01` before this fix.

This is a tiny fix, but without it, the CI fails from time to time. That could cost ~35m of waiting time in the merge queue.

CI failure example: https://app.circleci.com/pipelines/github/garden-io/garden/21172/workflows/b60898fb-d5d9-43f0-abab-ce3b99e9fd07/jobs/412425

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
