### PR TITLE
test: make testFlags.expandErrors work with mocha error renderer

### DIFF
--- a/core/src/exceptions.ts
+++ b/core/src/exceptions.ts
@@ -92,7 +92,6 @@ export abstract class GardenError extends Error {
 
   constructor({ message, wrappedErrors, taskType, code }: GardenErrorParams) {
     super(message.trim())
-    this.stack = this.stack
     this.wrappedErrors = wrappedErrors
     this.taskType = taskType
     this.code = code

--- a/core/src/exceptions.ts
+++ b/core/src/exceptions.ts
@@ -57,7 +57,6 @@ export type GardenErrorStackTrace = {
 
 export interface GardenErrorParams {
   message: string
-  readonly stack?: string
   readonly wrappedErrors?: GardenError[]
 
   /**
@@ -86,25 +85,41 @@ export abstract class GardenError extends Error {
 
   public wrappedErrors?: GardenError[]
 
-  constructor({ message, stack, wrappedErrors, taskType, code }: GardenErrorParams) {
+  /**
+   * Necessary to make testFlags.expandErrors work.
+   */
+  private unexpandedStack: string | undefined
+
+  constructor({ message, wrappedErrors, taskType, code }: GardenErrorParams) {
     super(message.trim())
-    this.stack = stack || this.stack
+    this.stack = this.stack
     this.wrappedErrors = wrappedErrors
     this.taskType = taskType
     this.code = code
+
+    if (testFlags.expandErrors) {
+      this.unexpandedStack = this.stack
+      this.stack = this.toString(true)
+    }
   }
 
   override toString(verbose = false): string {
-    if (verbose || testFlags.expandErrors) {
-      const errorDetails = `${this.stack || this.message}\n\nError type: ${this.type}${
-        this.code ? `\nUnderlying error code: ${this.code}` : ""
+    if (verbose) {
+      let errorDetails = `${this.unexpandedStack || this.stack || this.message}`
+
+      // type can be undefined when running the tests, as the abstract type gets initialized after the ABC constructor finishes.
+      if (this.type) {
+        errorDetails += `\nError type: ${this.type}`
       }
-`
+
+      if (this.code) {
+        errorDetails += `\nUnderlying error code: ${this.code}`
+      }
 
       if (this.wrappedErrors) {
-        return `${errorDetails}\nWrapped errors:\n${this.wrappedErrors?.map(
-          (e) => `⮑ ${indentString(e.toString(verbose), 3).trim()}`
-        )}`
+        return `${errorDetails}\nWrapped errors:\n${this.wrappedErrors
+          ?.map((e) => `⮑  ${indentString(e.toString(verbose), 4).trim()}`)
+          .join("\n")}`
       } else {
         return errorDetails
       }
@@ -358,7 +373,10 @@ export class InternalError extends GardenError {
 
     message = message ? stripAnsi(message) : ""
 
-    return new InternalError({ message: prefix ? `${stripAnsi(prefix)}: ${message}` : message, stack, code })
+    const err = new InternalError({ message: prefix ? `${stripAnsi(prefix)}: ${message}` : message, code })
+    err.stack = stack
+
+    return err
   }
 
   override explain(context?: string): string {

--- a/core/src/graph/nodes.ts
+++ b/core/src/graph/nodes.ts
@@ -348,11 +348,9 @@ export class GraphNodeError extends GraphError {
   constructor({ resultError, node }: GraphNodeErrorParams) {
     const message = `${node.describe()} failed: ${resultError}`
     const wrappedErrors = [toGardenError(resultError)]
-    const stack = resultError.stack
 
     super({
       message,
-      stack,
       wrappedErrors,
       taskType: node.task.type,
     })

--- a/core/src/resolve-module.ts
+++ b/core/src/resolve-module.ts
@@ -209,15 +209,10 @@ export class ModuleResolver {
         const errorStr = Object.entries(errors)
           .map(([name, err]) => `${chalk.white.bold(name)}: ${err.message}`)
           .join("\n")
-        const errorStack = Object.entries(errors)
-          .map(([name, err]) => `${chalk.white.bold(name)}: ${err.stack || err.message}`)
-          .join("\n\n")
-
         const msg = `Failed resolving one or more modules:\n\n${errorStr}`
 
         const combined = new ConfigurationError({
           message: chalk.red(msg),
-          stack: errorStack,
           wrappedErrors: Object.values(errors),
         })
         throw combined

--- a/core/test/unit/src/analytics/analytics.ts
+++ b/core/test/unit/src/analytics/analytics.ts
@@ -750,33 +750,35 @@ describe("AnalyticsHandler", () => {
       analytics = await AnalyticsHandler.factory({ garden, log: garden.log, ciInfo })
 
       timekeeper.travel(startTime.getTime() + 60000)
+
       const errors = [
         new RuntimeError({
           message: "Testing Runtime",
-          stack: `Error: Testing Runtime
-          at Testing.runtime (/path/to/src/utils/exec.ts:17:13)
-          at Test.Runnable.run (/path/to/node_modules/mocha/lib/runnable.js:354:5)
-          at processImmediate (node:internal/timers:471:21)`,
           wrappedErrors: [
             new ConfigurationError({
               message: "Testing Configuration",
-              stack: `Error: Testing Configuration
-              at Testing.configuration (/path/to/src/garden.ts:42:13)
-              at Test.Runnable.run (/path/to/node_modules/mocha/lib/runnable.js:354:5)
-              at processImmediate (node:internal/timers:471:21)`,
               wrappedErrors: [
                 new DeploymentError({
                   message: "Testing Deployment",
-                  stack: `Error: Testing Deployment
-                  at Testing.deployment (/path/to/src/plugins/kubernetes.ts:12:13)
-                  at Test.Runnable.run (/path/to/node_modules/mocha/lib/runnable.js:354:5)
-                  at processImmediate (node:internal/timers:471:21)`,
                 }),
               ],
             }),
           ],
         }),
       ]
+      errors[0].stack = `Error: Testing Runtime
+      at Testing.runtime (/path/to/src/utils/exec.ts:17:13)
+      at Test.Runnable.run (/path/to/node_modules/mocha/lib/runnable.js:354:5)
+      at processImmediate (node:internal/timers:471:21)`
+      errors[0].wrappedErrors![0].stack = `Error: Testing Configuration
+      at Testing.configuration (/path/to/src/garden.ts:42:13)
+      at Test.Runnable.run (/path/to/node_modules/mocha/lib/runnable.js:354:5)
+      at processImmediate (node:internal/timers:471:21)`
+      errors[0].wrappedErrors![0].wrappedErrors![0].stack = `Error: Testing Deployment
+      at Testing.deployment (/path/to/src/plugins/kubernetes.ts:12:13)
+      at Test.Runnable.run (/path/to/node_modules/mocha/lib/runnable.js:354:5)
+      at processImmediate (node:internal/timers:471:21)`
+
       const eventOrFalse = analytics.trackCommandResult("testCommand", errors, startTime, 0)
 
       expect(eventOrFalse).to.not.eql(false)
@@ -832,19 +834,19 @@ describe("AnalyticsHandler", () => {
       const errors = [
         new RuntimeError({
           message: "Testing Runtime",
-          stack: `Error: Testing Runtime
-          at Testing.runtime (/path/to/src/utils/exec.ts:17:13)
-          at Test.Runnable.run (/path/to/node_modules/mocha/lib/runnable.js:354:5)
-          at processImmediate (node:internal/timers:471:21)`,
         }),
         new ConfigurationError({
           message: "Testing Configuration",
-          stack: `Error: Testing Configuration
-          at Testing.configuration (/path/to/src/garden.ts:42:13)
-          at Test.Runnable.run (/path/to/node_modules/mocha/lib/runnable.js:354:5)
-          at processImmediate (node:internal/timers:471:21)`,
         }),
       ]
+      errors[0].stack = `Error: Testing Runtime
+      at Testing.runtime (/path/to/src/utils/exec.ts:17:13)
+      at Test.Runnable.run (/path/to/node_modules/mocha/lib/runnable.js:354:5)
+      at processImmediate (node:internal/timers:471:21)`
+      errors[1].stack = `Error: Testing Configuration
+      at Testing.configuration (/path/to/src/garden.ts:42:13)
+      at Test.Runnable.run (/path/to/node_modules/mocha/lib/runnable.js:354:5)
+      at processImmediate (node:internal/timers:471:21)`
 
       const eventOrFalse = analytics.trackCommandResult("testCommand", errors, startTime, 0)
 

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -1947,7 +1947,7 @@ describe("Garden", () => {
       await expectError(
         () => garden.resolveProviders(garden.log),
         (err) => {
-          expectFuzzyMatch(err.toString(), [
+          expectFuzzyMatch(err.toString(true), [
             "Failed resolving one or more providers:",
             "- test",
             "Error validating provider configuration",
@@ -1981,7 +1981,7 @@ describe("Garden", () => {
       await expectError(
         () => garden.resolveProviders(garden.log),
         (err) => {
-          expectFuzzyMatch(err.toString(), [
+          expectFuzzyMatch(err.toString(true), [
             "Failed resolving one or more providers:",
             "- test",
             "Error validating provider configuration",
@@ -2189,7 +2189,7 @@ describe("Garden", () => {
         await expectError(
           () => garden.resolveProviders(garden.log),
           (err) => {
-            expectFuzzyMatch(err.toString(), [
+            expectFuzzyMatch(err.toString(true), [
               "Failed resolving one or more providers:",
               "- test",
               "Error validating provider configuration",
@@ -2229,7 +2229,7 @@ describe("Garden", () => {
         await expectError(
           () => garden.resolveProviders(garden.log),
           (err) => {
-            expectFuzzyMatch(err.toString(), [
+            expectFuzzyMatch(err.toString(true), [
               "Failed resolving one or more providers:",
               "- test",
               "Error validating provider configuration",


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
Changes GardenError to expand the stack in the initializer already, so
that errors are always rendered expanded in mocha tests.

This greatly eases test development.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
