### PR TITLE
fix(examples): use yaml 1.1 octal numbers in kubernetes manifest files

### DIFF
--- a/examples/kubernetes-deploy/redis/redis.yml
+++ b/examples/kubernetes-deploy/redis/redis.yml
@@ -242,7 +242,7 @@ spec:
         - name: health
           configMap:
             name: redis-health
-            defaultMode: 0o755
+            defaultMode: 0755
         - name: config
           configMap:
             name: redis
@@ -350,7 +350,7 @@ spec:
         - name: health
           configMap:
             name: redis-health
-            defaultMode: 0o755
+            defaultMode: 0755
         - name: config
           configMap:
             name: redis


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
Kubernetes only supports YAML 1.1, and we recently fixed a bug to read kubernetes manifests using the correct YAML version (#5184)

We accidentally did not update the example to use the old-style octal numbers. Searching for `0o` gives no further results at least in the garden repo.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
