### PR TITLE
fix(api): visible and better error when fetching secrets 404s

### DIFF
--- a/core/src/cloud/api.ts
+++ b/core/src/cloud/api.ts
@@ -32,6 +32,7 @@ import { add } from "date-fns"
 import { LogLevel } from "../logger/logger"
 import { makeAuthHeader } from "./auth"
 import { StringMap } from "../config/common"
+import chalk from "chalk"
 
 const gardenClientName = "garden-core"
 const gardenClientVersion = getPackageVersion()
@@ -772,13 +773,41 @@ export class CloudApi {
       if (!(err instanceof GotHttpError)) {
         throw err
       }
+      // This happens if an environment or project does not exist
       if (err.response.statusCode === 404) {
-        log.debug(dedent`
-          No secrets were received from ${distroName}.
+        const errorHeaderMsg = chalk.red(`Unable to read secrets from ${distroName}.`)
+        const errorDetailMsg = chalk.white(dedent`
+          Either the environment ${chalk.bold.whiteBright(environmentName)} does not exist in ${distroName},
+          or no project matches the project ID ${chalk.bold.whiteBright(
+            projectId
+          )} in your project level garden.yml file.
 
-          Either the environment ${environmentName} does not exist in ${distroName}, or no project with the id in your project configuration exists in ${distroName}.
+          💡Suggestion:
 
-          Please visit ${this.domain} to review the environments and projects currently in the system.
+          Visit ${chalk.underline(this.domain)} to review existing environments and projects.
+
+          First check whether an environment with name ${environmentName} exists for this project. You
+          can view the list of environments and the project ID on the project's Settings page.
+
+          ${chalk.bold.whiteBright(
+            "If the environment does not exist"
+          )}, you can either create one from the Settings page or update
+          the environments in your project level garden.yml config to match one that already exists.
+
+          ${chalk.bold.whiteBright(
+            "If a project with this ID does not exist"
+          )}, it's likely because the ID has been changed in the
+          project level garden.yml config file or the project has been deleted from ${distroName}.
+
+          Either update the ID in the project level garden.yml config file to match one of an
+          existing project or import a new project from the Projects page and replace the ID in your
+          project configuration with the ID of the new project.
+        `)
+
+        log.error(dedent`
+          ${errorHeaderMsg}
+
+          ${errorDetailMsg}\n
           `)
       } else {
         throw err


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Before this fix, 404 errors that happened when fetching secrets were logged at a debug level and not visible to users.

This fixes that and improves the error message. 

 Related to #5275 because fixing that will reduce the chance of this error surfacing in the first place. 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
