### PR TITLE
Store action type in cloud

### DIFF
--- a/core/src/actions/types.ts
+++ b/core/src/actions/types.ts
@@ -130,7 +130,7 @@ export interface ActionDependencyAttributes {
   needsExecutedOutputs: boolean // Set to true if action cannot be resolved without the dependency executed
 }
 
-export type ActionDependency = ActionReference & ActionDependencyAttributes
+export type ActionDependency = ActionReference & ActionDependencyAttributes & { type: string }
 
 export interface ActionModes {
   sync?: boolean

--- a/core/src/cloud/api.ts
+++ b/core/src/cloud/api.ts
@@ -573,7 +573,7 @@ export class CloudApi {
 
   async get<T>(path: string, opts: ApiFetchOptions = {}) {
     const { headers, retry, retryDescription, maxRetries } = opts
-    return await this.apiFetch<T>(path, {
+    return this.apiFetch<T>(path, {
       method: "GET",
       headers: headers || {},
       retry: retry === false ? false : true, // defaults to true unless false is explicitly passed
@@ -683,7 +683,7 @@ export class CloudApi {
     }
   }
 
-  async getProjectById(projectId: string): Promise<CloudProject | undefined> {
+  async getProjectById(projectId: string) {
     const existing = this.projects.get(projectId)
 
     if (existing) {

--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -79,6 +79,7 @@ export const gardenEnv = {
   GARDEN_WORKFLOW_RUN_UID: env.get("GARDEN_WORKFLOW_RUN_UID").required(false).asString(),
   GARDEN_CLOUD_DOMAIN: env.get("GARDEN_CLOUD_DOMAIN").required(false).asUrlString(),
   GARDEN_ENABLE_TRACING: env.get("GARDEN_ENABLE_TRACING").required(false).default("true").asBool(),
+  GARDEN_STORE_ACTION_TYPE: env.get("GARDEN_STORE_ACTION_TYPE").required(false).default("false").asBool(),
   GARDEN_VERSION_CHECK_ENDPOINT: env
     .get("GARDEN_VERSION_CHECK_ENDPOINT")
     .required(false)

--- a/core/src/events/util.ts
+++ b/core/src/events/util.ts
@@ -14,6 +14,7 @@ import { Events, ActionStatusEventName } from "./events"
 import { pick } from "lodash"
 import { BuildState } from "../plugin/handlers/Build/get-status"
 import { ActionStatusDetailedState, ActionCompleteState } from "./action-status-events"
+import { gardenEnv } from "../constants"
 
 type ActionKind = "build" | "deploy" | "run" | "test"
 
@@ -68,12 +69,17 @@ export function makeActionStatusPayloadBase({
   startedAt: string
   sessionId: string
 }) {
+  // Due to an old bug, we were confusing type and kind in both Core and API.
+  // Latest versions of the API now handle this correctly, across all Core versions
+  // but there older versions still running that don't but are pending an update.
+  // Until then, this is "feature flagged".
+  const actionType = gardenEnv.GARDEN_STORE_ACTION_TYPE ? action.type : action.kind.toLowerCase()
   return {
     actionName: action.name,
     actionVersion: action.versionString(),
     // NOTE: The type/kind needs to be lower case in the event payload
-    actionType: action.kind.toLowerCase(),
     actionKind: action.kind.toLowerCase(),
+    actionType,
     actionUid: action.uid,
     moduleName: action.moduleName(),
     sessionId,

--- a/core/src/events/util.ts
+++ b/core/src/events/util.ts
@@ -71,8 +71,9 @@ export function makeActionStatusPayloadBase({
 }) {
   // Due to an old bug, we were confusing type and kind in both Core and API.
   // Latest versions of the API now handle this correctly, across all Core versions
-  // but there older versions still running that don't but are pending an update.
+  // but there are older versions still running that don't but are pending an update.
   // Until then, this is "feature flagged".
+  // TODO: Remove feature flag and always store action type.
   const actionType = gardenEnv.GARDEN_STORE_ACTION_TYPE ? action.type : action.kind.toLowerCase()
   return {
     actionName: action.name,

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -707,8 +707,6 @@ function dependenciesFromActionConfig(
           message: `${description} references depdendency ${depKey}, but no such action could be found`,
         })
       }
-      // FIXME @eysi: We're setting the "parent" config type as the dep type which is not correct
-      // and we need to the dep type.
       return {
         kind,
         name,

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -700,9 +700,23 @@ function dependenciesFromActionConfig(
   const deps: ActionDependency[] = config.dependencies.map((d) => {
     try {
       const { kind, name } = parseActionReference(d)
+      const depKey = actionReferenceToString(d)
+      const depConfig = configsByKey[depKey]
+      if (!depConfig) {
+        throw new ConfigurationError({
+          message: `${description} references depdendency ${depKey}, but no such action could be found`,
+        })
+      }
       // FIXME @eysi: We're setting the "parent" config type as the dep type which is not correct
       // and we need to the dep type.
-      return { kind, name, type: config.type, explicit: true, needsExecutedOutputs: false, needsStaticOutputs: false }
+      return {
+        kind,
+        name,
+        type: depConfig.type,
+        explicit: true,
+        needsExecutedOutputs: false,
+        needsStaticOutputs: false,
+      }
     } catch (error) {
       throw new ValidationError({
         message: `Invalid dependency specified: ${error}`,

--- a/core/src/graph/config-graph.ts
+++ b/core/src/graph/config-graph.ts
@@ -36,6 +36,7 @@ export type RenderedEdge = { dependant: RenderedNode; dependency: RenderedNode }
 export interface RenderedNode {
   kind: ActionKind
   name: string
+  type: string
   moduleName?: string
   key: string
   disabled: boolean
@@ -462,19 +463,20 @@ export abstract class BaseConfigGraph<
 
   protected addActionInternal<K extends ActionKind>(action: Action) {
     this.actions[action.kind][action.name] = <PickTypeByKind<K, B, D, R, T>>action
-    const node = this.getNode(action.kind, action.name, action.isDisabled())
+    const node = this.getNode(action.kind, action.type, action.name, action.isDisabled())
 
     for (const dep of action.getDependencyReferences()) {
       this.addRelation({
         dependant: node,
         dependencyKind: dep.kind,
+        dependencyType: dep.type,
         dependencyName: dep.name,
       })
     }
   }
 
   // Idempotent.
-  protected getNode(kind: ActionKind, name: string, disabled: boolean) {
+  protected getNode(kind: ActionKind, type: string, name: string, disabled: boolean) {
     const key = nodeKey(kind, name)
     const existingNode = this.dependencyGraph[key]
     if (existingNode) {
@@ -483,7 +485,7 @@ export abstract class BaseConfigGraph<
       }
       return existingNode
     } else {
-      const newNode = new ConfigGraphNode(kind, name, disabled)
+      const newNode = new ConfigGraphNode(kind, type, name, disabled)
       this.dependencyGraph[key] = newNode
       return newNode
     }
@@ -493,13 +495,15 @@ export abstract class BaseConfigGraph<
   protected addRelation({
     dependant,
     dependencyKind,
+    dependencyType,
     dependencyName,
   }: {
     dependant: ConfigGraphNode
     dependencyKind: ActionKind
+    dependencyType: string
     dependencyName: string
   }) {
-    const dependency = this.getNode(dependencyKind, dependencyName, false)
+    const dependency = this.getNode(dependencyKind, dependencyType, dependencyName, false)
     dependant.addDependency(dependency)
     dependency.addDependant(dependant)
   }
@@ -524,11 +528,12 @@ export class MutableConfigGraph extends ConfigGraph {
     const dependant = this.getActionByRef(by)
     const dependency = this.getActionByRef(on)
 
-    dependant.addDependency({ kind: dependency.kind, name: dependency.name, ...attributes })
+    dependant.addDependency({ kind: dependency.kind, type: dependency.type, name: dependency.name, ...attributes })
 
     this.addRelation({
-      dependant: this.getNode(dependant.kind, dependant.name, dependant.isDisabled()),
+      dependant: this.getNode(dependant.kind, dependant.type, dependant.name, dependant.isDisabled()),
       dependencyKind: dependency.kind,
+      dependencyType: dependency.type,
       dependencyName: dependency.name,
     })
   }
@@ -549,6 +554,7 @@ export class ConfigGraphNode {
 
   constructor(
     public kind: ActionKind,
+    public type: string,
     public name: string,
     public disabled: boolean
   ) {
@@ -559,6 +565,7 @@ export class ConfigGraphNode {
   render(): RenderedNode {
     return {
       name: this.name,
+      type: this.type,
       kind: this.kind,
       key: this.name,
       disabled: this.disabled,

--- a/core/test/helpers/api.ts
+++ b/core/test/helpers/api.ts
@@ -69,7 +69,7 @@ export class FakeCloudApi extends CloudApi {
     }
   }
 
-  override async getProjectById(_: string): Promise<CloudProject | undefined> {
+  override async getProjectById(_: string): Promise<CloudProject> {
     return {
       id: apiProjectId,
       name: apiProjectName,

--- a/core/test/unit/src/actions/action-configs-to-graph.ts
+++ b/core/test/unit/src/actions/action-configs-to-graph.ts
@@ -241,6 +241,7 @@ describe("actionConfigsToGraph", () => {
         explicit: true,
         kind: "Build",
         name: "foo",
+        type: "test",
         needsExecutedOutputs: false,
         needsStaticOutputs: false,
       },
@@ -288,6 +289,7 @@ describe("actionConfigsToGraph", () => {
       {
         explicit: true,
         kind: "Build",
+        type: "test",
         name: "foo",
         needsExecutedOutputs: false,
         needsStaticOutputs: false,
@@ -337,6 +339,7 @@ describe("actionConfigsToGraph", () => {
       {
         explicit: false,
         kind: "Build",
+        type: "test",
         name: "foo",
         fullRef: ["actions", "build", "foo", "version"],
         needsExecutedOutputs: false,
@@ -387,6 +390,7 @@ describe("actionConfigsToGraph", () => {
       {
         explicit: false,
         kind: "Build",
+        type: "test",
         name: "foo",
         fullRef: ["actions", "build", "foo", "outputs", "bar"],
         needsExecutedOutputs: true,
@@ -437,6 +441,7 @@ describe("actionConfigsToGraph", () => {
       {
         explicit: false,
         kind: "Build",
+        type: "container",
         name: "foo",
         fullRef: ["actions", "build", "foo", "outputs", "deploymentImageName"],
         needsExecutedOutputs: false,

--- a/core/test/unit/src/config-graph.ts
+++ b/core/test/unit/src/config-graph.ts
@@ -1567,7 +1567,7 @@ describe("ConfigGraph (module-based configs)", () => {
 describe("ConfigGraphNode", () => {
   describe("render", () => {
     it("should render a build node", () => {
-      const node = new ConfigGraphNode("Build", "module-a", false)
+      const node = new ConfigGraphNode("Build", "container", "module-a", false)
       const res = node.render()
       expect(res).to.eql({
         kind: "Build",
@@ -1578,7 +1578,7 @@ describe("ConfigGraphNode", () => {
     })
 
     it("should render a deploy node", () => {
-      const node = new ConfigGraphNode("Deploy", "service-a", false)
+      const node = new ConfigGraphNode("Deploy", "container", "service-a", false)
       const res = node.render()
       expect(res).to.eql({
         kind: "Deploy",
@@ -1589,7 +1589,7 @@ describe("ConfigGraphNode", () => {
     })
 
     it("should render a run node", () => {
-      const node = new ConfigGraphNode("Run", "task-a", false)
+      const node = new ConfigGraphNode("Run", "container", "task-a", false)
       const res = node.render()
       expect(res).to.eql({
         kind: "Run",
@@ -1600,7 +1600,7 @@ describe("ConfigGraphNode", () => {
     })
 
     it("should render a test node", () => {
-      const node = new ConfigGraphNode("Test", "module-a.test-a", false)
+      const node = new ConfigGraphNode("Test", "container", "module-a.test-a", false)
       const res = node.render()
       expect(res).to.eql({
         kind: "Test",
@@ -1611,7 +1611,7 @@ describe("ConfigGraphNode", () => {
     })
 
     it("should indicate if the node is disabled", () => {
-      const node = new ConfigGraphNode("Test", "module-a.test-a", true)
+      const node = new ConfigGraphNode("Test", "container", "module-a.test-a", true)
       const res = node.render()
       expect(res).to.eql({
         kind: "Test",

--- a/core/test/unit/src/config-graph.ts
+++ b/core/test/unit/src/config-graph.ts
@@ -1477,98 +1477,84 @@ describe("ConfigGraph (module-based configs)", () => {
       expect(rendered.nodes).to.include.deep.members([
         {
           kind: "Build",
-          type: "test",
           name: "module-a",
           key: "module-a",
           disabled: false,
         },
         {
           kind: "Build",
-          type: "test",
           name: "module-b",
           key: "module-b",
           disabled: false,
         },
         {
           kind: "Build",
-          type: "test",
           name: "module-c",
           key: "module-c",
           disabled: false,
         },
         {
           kind: "Test",
-          type: "test",
           name: "module-c-unit",
           key: "module-c-unit",
           disabled: false,
         },
         {
           kind: "Test",
-          type: "test",
           name: "module-c-integ",
           key: "module-c-integ",
           disabled: false,
         },
         {
           kind: "Run",
-          type: "test",
           name: "task-c",
           key: "task-c",
           disabled: false,
         },
         {
           kind: "Deploy",
-          type: "test",
           name: "service-c",
           key: "service-c",
           disabled: false,
         },
         {
           kind: "Test",
-          type: "test",
           name: "module-a-unit",
           key: "module-a-unit",
           disabled: false,
         },
         {
           kind: "Test",
-          type: "test",
           name: "module-a-integration",
           key: "module-a-integration",
           disabled: false,
         },
         {
           kind: "Run",
-          type: "test",
           name: "task-a",
           key: "task-a",
           disabled: false,
         },
         {
           kind: "Test",
-          type: "test",
           name: "module-b-unit",
           key: "module-b-unit",
           disabled: false,
         },
         {
           kind: "Run",
-          type: "test",
           name: "task-b",
           key: "task-b",
           disabled: false,
         },
         {
           kind: "Deploy",
-          type: "test",
           name: "service-a",
           key: "service-a",
           disabled: false,
         },
         {
           kind: "Deploy",
-          type: "test",
           name: "service-b",
           key: "service-b",
           disabled: false,
@@ -1585,7 +1571,6 @@ describe("ConfigGraphNode", () => {
       const res = node.render()
       expect(res).to.eql({
         kind: "Build",
-        type: "container",
         name: "module-a",
         key: "module-a",
         disabled: false,
@@ -1597,7 +1582,6 @@ describe("ConfigGraphNode", () => {
       const res = node.render()
       expect(res).to.eql({
         kind: "Deploy",
-        type: "container",
         name: "service-a",
         key: "service-a",
         disabled: false,
@@ -1609,7 +1593,6 @@ describe("ConfigGraphNode", () => {
       const res = node.render()
       expect(res).to.eql({
         kind: "Run",
-        type: "container",
         name: "task-a",
         key: "task-a",
         disabled: false,
@@ -1621,7 +1604,6 @@ describe("ConfigGraphNode", () => {
       const res = node.render()
       expect(res).to.eql({
         kind: "Test",
-        type: "container",
         name: "module-a.test-a",
         key: "module-a.test-a",
         disabled: false,
@@ -1633,7 +1615,6 @@ describe("ConfigGraphNode", () => {
       const res = node.render()
       expect(res).to.eql({
         kind: "Test",
-        type: "container",
         name: "module-a.test-a",
         key: "module-a.test-a",
         disabled: true,

--- a/core/test/unit/src/config-graph.ts
+++ b/core/test/unit/src/config-graph.ts
@@ -1477,84 +1477,98 @@ describe("ConfigGraph (module-based configs)", () => {
       expect(rendered.nodes).to.include.deep.members([
         {
           kind: "Build",
+          type: "test",
           name: "module-a",
           key: "module-a",
           disabled: false,
         },
         {
           kind: "Build",
+          type: "test",
           name: "module-b",
           key: "module-b",
           disabled: false,
         },
         {
           kind: "Build",
+          type: "test",
           name: "module-c",
           key: "module-c",
           disabled: false,
         },
         {
           kind: "Test",
+          type: "test",
           name: "module-c-unit",
           key: "module-c-unit",
           disabled: false,
         },
         {
           kind: "Test",
+          type: "test",
           name: "module-c-integ",
           key: "module-c-integ",
           disabled: false,
         },
         {
           kind: "Run",
+          type: "test",
           name: "task-c",
           key: "task-c",
           disabled: false,
         },
         {
           kind: "Deploy",
+          type: "test",
           name: "service-c",
           key: "service-c",
           disabled: false,
         },
         {
           kind: "Test",
+          type: "test",
           name: "module-a-unit",
           key: "module-a-unit",
           disabled: false,
         },
         {
           kind: "Test",
+          type: "test",
           name: "module-a-integration",
           key: "module-a-integration",
           disabled: false,
         },
         {
           kind: "Run",
+          type: "test",
           name: "task-a",
           key: "task-a",
           disabled: false,
         },
         {
           kind: "Test",
+          type: "test",
           name: "module-b-unit",
           key: "module-b-unit",
           disabled: false,
         },
         {
           kind: "Run",
+          type: "test",
           name: "task-b",
           key: "task-b",
           disabled: false,
         },
         {
           kind: "Deploy",
+          type: "test",
           name: "service-a",
           key: "service-a",
           disabled: false,
         },
         {
           kind: "Deploy",
+          type: "test",
           name: "service-b",
           key: "service-b",
           disabled: false,
@@ -1571,6 +1585,7 @@ describe("ConfigGraphNode", () => {
       const res = node.render()
       expect(res).to.eql({
         kind: "Build",
+        type: "container",
         name: "module-a",
         key: "module-a",
         disabled: false,
@@ -1582,6 +1597,7 @@ describe("ConfigGraphNode", () => {
       const res = node.render()
       expect(res).to.eql({
         kind: "Deploy",
+        type: "container",
         name: "service-a",
         key: "service-a",
         disabled: false,
@@ -1593,6 +1609,7 @@ describe("ConfigGraphNode", () => {
       const res = node.render()
       expect(res).to.eql({
         kind: "Run",
+        type: "container",
         name: "task-a",
         key: "task-a",
         disabled: false,
@@ -1604,6 +1621,7 @@ describe("ConfigGraphNode", () => {
       const res = node.render()
       expect(res).to.eql({
         kind: "Test",
+        type: "container",
         name: "module-a.test-a",
         key: "module-a.test-a",
         disabled: false,
@@ -1615,6 +1633,7 @@ describe("ConfigGraphNode", () => {
       const res = node.render()
       expect(res).to.eql({
         kind: "Test",
+        type: "container",
         name: "module-a.test-a",
         key: "module-a.test-a",
         disabled: true,

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -726,9 +726,8 @@ describe("Garden", () => {
           expect(expectedLog.length).to.eql(1)
           expect(expectedLog[0].level).to.eql(1)
           const cleanMsg = stripAnsi(expectedLog[0].msg || "").replace("\n", " ")
-          expect(cleanMsg).to
-            .eql(deline`Logged in to ${fakeCloudDomain}, but could not find remote project '${projectName}'.
-            Command results for this command run will not be available in Garden Enterprise.`)
+          const expected = `Logged in to ${fakeCloudDomain}, but could not find remote project '${projectName}'. Command results for this command run will not be available in Garden Enterprise.`
+          expect(cleanMsg).to.eql(expected)
           expect(garden.cloudDomain).to.eql(fakeCloudDomain)
           expect(garden.projectId).to.eql(undefined)
           expect(scope.isDone()).to.be.true

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -9,6 +9,8 @@
 import { expect } from "chai"
 import td from "testdouble"
 import tmp from "tmp-promise"
+import nock from "nock"
+
 import { join, resolve } from "path"
 import { Garden } from "../../../src/garden"
 import {
@@ -39,13 +41,18 @@ import { createGardenPlugin, ProviderActionName } from "../../../src/plugin/plug
 import { ConfigureProviderParams } from "../../../src/plugin/handlers/Provider/configureProvider"
 import { ProjectConfig, defaultNamespace } from "../../../src/config/project"
 import { ModuleConfig, baseModuleSpecSchema } from "../../../src/config/module"
-import { DEFAULT_BUILD_TIMEOUT_SEC, GardenApiVersion, gardenEnv } from "../../../src/constants"
+import {
+  DEFAULT_BUILD_TIMEOUT_SEC,
+  DEFAULT_GARDEN_CLOUD_DOMAIN,
+  GardenApiVersion,
+  gardenEnv,
+} from "../../../src/constants"
 import { providerConfigBaseSchema } from "../../../src/config/provider"
 import { keyBy, set, mapValues, omit, cloneDeep } from "lodash"
 import { joi } from "../../../src/config/common"
 import { defaultDotIgnoreFile, makeTempDir } from "../../../src/util/fs"
 import { realpath, writeFile, readFile, remove, pathExists, mkdirp, copy } from "fs-extra"
-import { dedent, randomString } from "../../../src/util/string"
+import { dedent, deline, randomString } from "../../../src/util/string"
 import { getLinkedSources, addLinkedSources } from "../../../src/util/ext-source-util"
 import { dump } from "js-yaml"
 import { TestVcsHandler } from "./vcs/vcs"
@@ -54,6 +61,12 @@ import { convertExecModule } from "../../../src/plugins/exec/convert"
 import { getLogMessages } from "../../../src/util/testing"
 import { TreeCache } from "../../../src/cache"
 import { omitUndefined } from "../../../src/util/objects"
+import { CloudApi, CloudProject } from "../../../src/cloud/api"
+import { GlobalConfigStore } from "../../../src/config-store/global"
+import { getRootLogger } from "../../../src/logger/logger"
+import { add } from "date-fns"
+import { uuidv4 } from "../../../src/util/random"
+import stripAnsi from "strip-ansi"
 
 // TODO-G2: change all module config based tests to be action-based.
 
@@ -571,6 +584,309 @@ describe("Garden", () => {
       } finally {
         gardenEnv.GARDEN_PROXY_DEFAULT_ADDRESS = saveEnv
       }
+    })
+    it("should have domain and id if set in project config", async () => {
+      const projectId = uuidv4()
+      const projectName = "test"
+      const envName = "default"
+      const config: ProjectConfig = createProjectConfig({
+        name: projectName,
+        id: projectId,
+        domain: "https://example.com",
+        path: pathFoo,
+      })
+
+      const garden = await TestGarden.factory(pathFoo, {
+        config,
+        environmentString: envName,
+      })
+
+      expect(garden.cloudDomain).to.eql("https://example.com")
+      expect(garden.projectId).to.eql(projectId)
+    })
+    it("should use default cloud domain if not set in project config", async () => {
+      const projectName = "test"
+      const envName = "default"
+      const config: ProjectConfig = createProjectConfig({
+        name: projectName,
+        path: pathFoo,
+      })
+
+      const garden = await TestGarden.factory(pathFoo, {
+        config,
+        environmentString: envName,
+      })
+
+      expect(garden.cloudDomain).to.eql(DEFAULT_GARDEN_CLOUD_DOMAIN)
+      expect(garden.projectId).to.eql(undefined)
+    })
+    context("user is logged in", () => {
+      let configStoreTmpDir: tmp.DirectoryResult
+      const log = getRootLogger().createLog()
+
+      const makeCloudApi = async (domain: string) => {
+        const globalConfigStore = new GlobalConfigStore(configStoreTmpDir.path)
+        const validityMs = 604800000
+        await globalConfigStore.set("clientAuthTokens", domain, {
+          token: "fake-token",
+          refreshToken: "fake-refresh-token",
+          validity: add(new Date(), { seconds: validityMs / 1000 }),
+        })
+        return CloudApi.factory({ log, cloudDomain: domain, globalConfigStore })
+      }
+
+      before(async () => {
+        configStoreTmpDir = await makeTempDir()
+      })
+
+      after(async () => {
+        await configStoreTmpDir.cleanup()
+        nock.cleanAll()
+      })
+
+      // This means the logged in user is on a commerical edition
+      context("domain is set", () => {
+        const fakeCloudDomain = "https://example.com"
+        const scope = nock(fakeCloudDomain)
+        const projectId = uuidv4()
+        const projectName = "test"
+        const envName = "default"
+        const cloudProject: CloudProject = {
+          id: projectId,
+          name: projectName,
+          repositoryUrl: "",
+          environments: [
+            {
+              id: uuidv4(),
+              name: envName,
+            },
+          ],
+        }
+        const config: ProjectConfig = createProjectConfig({
+          name: projectName,
+          id: projectId,
+          path: pathFoo,
+          domain: fakeCloudDomain, // <-- Domain is set
+        })
+
+        it("should use the configured cloud domain and fetch project", async () => {
+          scope.get("/api/token/verify").reply(200, {})
+          scope.get(`/api/projects/uid/${projectId}`).reply(200, { data: cloudProject })
+
+          const cloudApi = await makeCloudApi(fakeCloudDomain)
+
+          const garden = await TestGarden.factory(pathFoo, {
+            config,
+            environmentString: envName,
+            cloudApi,
+          })
+
+          expect(garden.cloudDomain).to.eql(fakeCloudDomain)
+          expect(garden.projectId).to.eql(projectId)
+          expect(scope.isDone()).to.be.true
+        })
+        it("should fetch secrets", async () => {
+          scope.get("/api/token/verify").reply(200, {})
+          scope.get(`/api/projects/uid/${projectId}`).reply(200, { data: cloudProject })
+          scope
+            .get(`/api/secrets/projectUid/${projectId}/env/${envName}`)
+            .reply(200, { data: { SECRET_KEY: "secret-val" } })
+
+          const cloudApi = await makeCloudApi(fakeCloudDomain)
+
+          const garden = await TestGarden.factory(pathFoo, {
+            config,
+            environmentString: envName,
+            cloudApi,
+          })
+
+          expect(garden.secrets).to.eql({ SECRET_KEY: "secret-val" })
+          expect(scope.isDone()).to.be.true
+        })
+        it("should log a warning if logged in but project ID is missing", async () => {
+          scope.get("/api/token/verify").reply(200, {})
+
+          getRootLogger()["entries"] = []
+          const log = getRootLogger().createLog()
+
+          const cloudApi = await makeCloudApi(fakeCloudDomain)
+
+          const garden = await TestGarden.factory(pathFoo, {
+            config: {
+              ...config,
+              id: undefined,
+            },
+            log,
+            environmentString: envName,
+            cloudApi,
+          })
+
+          const expectedLog = log.root.getLogEntries().filter((l) => l.msg?.includes(`Logged in to ${fakeCloudDomain}`))
+
+          expect(expectedLog.length).to.eql(1)
+          expect(expectedLog[0].level).to.eql(1)
+          const cleanMsg = stripAnsi(expectedLog[0].msg || "").replace("\n", " ")
+          expect(cleanMsg).to
+            .eql(deline`Logged in to ${fakeCloudDomain}, but could not find remote project '${projectName}'.
+            Command results for this command run will not be available in Garden Enterprise.`)
+          expect(garden.cloudDomain).to.eql(fakeCloudDomain)
+          expect(garden.projectId).to.eql(undefined)
+          expect(scope.isDone()).to.be.true
+        })
+        it("should throw if project with ID can't be found", async () => {
+          scope.get("/api/token/verify").reply(200, {})
+          scope.get(`/api/projects/uid/${projectId}`).reply(404, {})
+          getRootLogger()["entries"] = []
+
+          const cloudApi = await makeCloudApi(fakeCloudDomain)
+
+          let error: Error | undefined
+          try {
+            await TestGarden.factory(pathFoo, {
+              config,
+              environmentString: envName,
+              cloudApi,
+            })
+          } catch (err) {
+            if (err instanceof Error) {
+              error = err
+            }
+          }
+
+          const expectedLog = log.root.getLogEntries().filter((l) => l.msg?.includes(`Fetching project with ID=`))
+
+          expect(expectedLog.length).to.eql(1)
+          expect(expectedLog[0].level).to.eql(0)
+          const cleanMsg = stripAnsi(expectedLog[0].msg || "").replace("\n", " ")
+          expect(cleanMsg).to.eql(
+            `Fetching project with ID=${projectId} failed with error: HTTPError: Response code 404 (Not Found)`
+          )
+          expect(error).to.exist
+          expect(error!.message).to.eql("Response code 404 (Not Found)")
+          expect(scope.isDone()).to.be.true
+        })
+      })
+
+      // This means the logged in user is on the community edition
+      context("domain is NOT set", () => {
+        const scope = nock(DEFAULT_GARDEN_CLOUD_DOMAIN)
+        const projectId = uuidv4()
+        const projectName = "test"
+        const envName = "default"
+        const cloudProject: CloudProject = {
+          id: projectId,
+          name: projectName,
+          repositoryUrl: "",
+          environments: [
+            {
+              id: uuidv4(),
+              name: envName,
+            },
+          ],
+        }
+        const config: ProjectConfig = createProjectConfig({
+          name: projectName,
+          path: pathFoo,
+        })
+
+        it("should use the community dashboard domain", async () => {
+          scope.get("/api/token/verify").reply(200, {})
+          scope.get(`/api/projects`).reply(200, { data: [cloudProject] })
+
+          const cloudApi = await makeCloudApi(DEFAULT_GARDEN_CLOUD_DOMAIN)
+
+          const garden = await TestGarden.factory(pathFoo, {
+            config,
+            environmentString: envName,
+            cloudApi,
+          })
+
+          expect(garden.cloudDomain).to.eql(DEFAULT_GARDEN_CLOUD_DOMAIN)
+          expect(garden.projectId).to.eql(projectId)
+          expect(scope.isDone()).to.be.true
+        })
+        it("should throw if project ID is set in config", async () => {
+          scope.get("/api/token/verify").reply(200, {})
+
+          const cloudApi = await makeCloudApi(DEFAULT_GARDEN_CLOUD_DOMAIN)
+
+          let error: Error | undefined
+          try {
+            await TestGarden.factory(pathFoo, {
+              config: {
+                ...config,
+                id: uuidv4(), // <--- ID is set when it shouldn't
+              },
+              environmentString: envName,
+              cloudApi,
+            })
+          } catch (err) {
+            if (err instanceof Error) {
+              error = err
+            }
+          }
+
+          expect(error).to.exist
+          expect(error!.message.replace("\n", " ")).to.eql(deline`
+            Invalid field 'id' found in project configuration at path tmp. The 'id'
+            field should only be set if using a commerical edition of Garden. Please remove to continue
+            using the Garden community edition.
+          `)
+          expect(scope.isDone()).to.be.true
+        })
+        it("should throw if unable to fetch or create project", async () => {
+          scope.get("/api/token/verify").reply(200, {})
+          scope.get(`/api/projects`).reply(500, {})
+          getRootLogger()["entries"] = []
+
+          const cloudApi = await makeCloudApi(DEFAULT_GARDEN_CLOUD_DOMAIN)
+
+          let error: Error | undefined
+          try {
+            await TestGarden.factory(pathFoo, {
+              config,
+              environmentString: envName,
+              cloudApi,
+            })
+          } catch (err) {
+            if (err instanceof Error) {
+              error = err
+            }
+          }
+
+          const expectedLog = log.root.getLogEntries().filter((l) => l.msg?.includes(`failed with error`))
+
+          expect(expectedLog.length).to.eql(1)
+          expect(expectedLog[0].level).to.eql(0)
+          const cleanMsg = stripAnsi(expectedLog[0].msg || "").replace("\n", " ")
+          expect(cleanMsg).to.eql(
+            `Fetching or creating project ${projectName} from ${DEFAULT_GARDEN_CLOUD_DOMAIN} failed with error: HTTPError: Response code 500 (Internal Server Error)`
+          )
+          expect(error).to.exist
+          expect(error!.message).to.eql("Response code 500 (Internal Server Error)")
+          expect(scope.isDone()).to.be.true
+        })
+        it("should not fetch secrets", async () => {
+          scope.get("/api/token/verify").reply(200, {})
+          scope.get(`/api/projects`).reply(200, { data: [cloudProject] })
+          scope
+            .get(`/api/secrets/projectUid/${projectId}/env/${envName}`)
+            .reply(200, { data: { SECRET_KEY: "secret-val" } })
+
+          const cloudApi = await makeCloudApi(DEFAULT_GARDEN_CLOUD_DOMAIN)
+
+          const garden = await TestGarden.factory(pathFoo, {
+            config,
+            environmentString: envName,
+            cloudApi,
+          })
+
+          expect(garden.cloudDomain).to.eql(DEFAULT_GARDEN_CLOUD_DOMAIN)
+          expect(garden.projectId).to.eql(projectId)
+          expect(garden.secrets).to.eql({})
+          expect(scope.isDone()).to.be.false // <--- False because the secret endpoint isn't called
+        })
+      })
     })
   })
 

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -4655,6 +4655,7 @@ describe("Garden", () => {
         {
           explicit: true,
           kind: "Build",
+          type: "foo",
           name: "foo",
           needsExecutedOutputs: false,
           needsStaticOutputs: false,
@@ -4717,6 +4718,7 @@ describe("Garden", () => {
         {
           explicit: true,
           kind: "Build",
+          type: "test",
           name: "foo",
           needsExecutedOutputs: false,
           needsStaticOutputs: false,
@@ -4846,6 +4848,7 @@ describe("Garden", () => {
         {
           explicit: true,
           kind: "Build",
+          type: "foo",
           name: "foo",
           needsExecutedOutputs: false,
           needsStaticOutputs: false,

--- a/core/test/unit/src/plugins/container/container.ts
+++ b/core/test/unit/src/plugins/container/container.ts
@@ -111,15 +111,15 @@ describe("plugins.container", () => {
           basePath: "module-a",
         },
       },
-      convertBuildDependency: () => ({ kind: "Build", name: "buildDep" }),
-      convertRuntimeDependencies: () => [{ kind: "Deploy", name: "runtimeDep" }],
+      convertBuildDependency: () => ({ kind: "Build", type: "container", name: "buildDep" }),
+      convertRuntimeDependencies: () => [{ kind: "Deploy", type: "container", name: "runtimeDep" }],
       convertTestName: () => "testName",
       ctx,
       dummyBuild: undefined,
       log,
       module,
       prepareRuntimeDependencies: prepareRuntimeDependencies
-        ? () => [{ kind: "Deploy", name: "preopRuntimeDep" }]
+        ? () => [{ kind: "Deploy", type: "container", name: "preopRuntimeDep" }]
         : () => [],
       services,
       tasks,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

There's a bit of history here. 

Garden has a concept of action _kinds_ and action _types_, both of which we want to store in display in the dashboard UI. 

Due to some legacy issues, were confusing the two and the API didn't support payload with the action type set correctly. 

This has since been fixed in the API but be never updated the Core payload until. 

However, there are older instances of the API still running that haven't been updated to support this payload yet, so we feature flag it for now. We should be able to move the feature flag very soon. 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

We should squash the commits before merging. 