### PR TITLE
improvement(logs): add 'rawMsg' field to logEntry

### DIFF
--- a/core/src/cloud/buffered-event-stream.ts
+++ b/core/src/cloud/buffered-event-stream.ts
@@ -15,7 +15,7 @@ import { got } from "../util/http"
 import type { LogLevel } from "../logger/logger"
 import type { Garden } from "../garden"
 import type { CloudSession } from "./api"
-import { getSection } from "../logger/renderers"
+import { getSection, renderError } from "../logger/renderers"
 import { registerCleanupFunction } from "../util/util"
 import { makeAuthHeader } from "./auth"
 
@@ -33,7 +33,7 @@ export type StreamEvent = {
   timestamp: Date
 }
 
-type LogEntryMessage = Pick<LogEntry, "msg" | "symbol" | "data" | "dataFormat"> & {
+type LogEntryMessage = Pick<LogEntry, "msg" | "rawMsg" | "symbol" | "data" | "dataFormat"> & {
   section: string
 }
 
@@ -50,6 +50,7 @@ export interface LogEntryEventPayload {
 export function formatLogEntryForEventStream(entry: LogEntry): LogEntryEventPayload {
   // TODO @eysi: We're sending the section for backwards compatibility but it shouldn't really be needed.
   const section = getSection(entry) || ""
+  const msg = entry.error ? renderError(entry) : entry.msg
   return {
     key: entry.key,
     metadata: entry.metadata,
@@ -58,7 +59,8 @@ export function formatLogEntryForEventStream(entry: LogEntry): LogEntryEventPayl
     context: entry.context,
     message: {
       section,
-      msg: entry.msg,
+      msg,
+      rawMsg: entry.rawMsg,
       symbol: entry.symbol,
       data: entry.data,
       dataFormat: entry.dataFormat,

--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -48,6 +48,8 @@ export const DOCS_BASE_URL = "https://docs.garden.io"
 
 export const DEFAULT_GARDEN_CLOUD_DOMAIN = "https://app.garden.io"
 
+export const DEFAULT_BROWSER_DIVIDER_WIDTH = 80
+
 /**
  * Environment variables, with defaults where appropriate.
  *

--- a/core/src/monitors/logs.ts
+++ b/core/src/monitors/logs.ts
@@ -185,11 +185,15 @@ export class LogMonitor extends Monitor {
 
   logEntry(entry: DeployLogEntry) {
     const levelStr = logLevelMap[entry.level || LogLevel.info] || "info"
-    const msg = this.formatLogMonitorEntry(entry)
+    const rawMsg = entry.msg
+    const terminalMsg = this.formatLogMonitorEntry(entry)
     for (const cmd of this.subscribers) {
-      cmd.emit(this.log, JSON.stringify({ msg, timestamp: entry.timestamp?.getTime(), level: levelStr }))
+      cmd.emit(
+        this.log,
+        JSON.stringify({ msg: terminalMsg, rawMsg, timestamp: entry.timestamp?.getTime(), level: levelStr })
+      )
     }
-    this.log[levelStr]({ msg })
+    this.log[levelStr]({ msg: terminalMsg, rawMsg })
   }
 
   private formatLogMonitorEntry(entry: DeployLogEntry) {

--- a/core/test/unit/src/logger/logger.ts
+++ b/core/test/unit/src/logger/logger.ts
@@ -36,6 +36,7 @@ describe("Logger", () => {
         const log = logger.createLog({ name: "log-context-name" })
         log.info({
           msg: "hello",
+          rawMsg: "hello-browser",
           symbol: "success",
           data: { foo: "bar" },
           dataFormat: "json",
@@ -54,6 +55,7 @@ describe("Logger", () => {
           level: 2,
           message: {
             msg: "hello",
+            rawMsg: "hello-browser",
             section: "log-context-name",
             symbol: "success",
             dataFormat: "json",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

This commit adds a 'rawMsg' field to the log entry message type which can be used for log lines that don't map well between the terminal and the web dashboard.

The dashboard will prefer the 'rawMsg' if set.

This is e.g. used when streaming service logs but prior to this commit we added ansi colors to them which didn't play when e.g. rendering JSON logs in the dashboard.

The commit also use this field for rendering the command start/finish messages which are printed in the dev console and don't render nicely in browser when the divider is too long.

This is perhaps a bit hacky and we should probably just a have a log entry type "separator" that the browser can handle properly. But this does the trick for now.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
