### PR TITLE
fix(cloud): do not fetch secrets on community tier

### DIFF
--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -1852,11 +1852,11 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
         }
       }
 
-      if (cloudProject) {
+      // Fetch Secrets. Not supported on the community tier (i.e. when config.domain is not set).
+      if (cloudProject && config.domain) {
         // ensure we use the fetched/created project ID
         cloudProjectId = cloudProject.id
 
-        // Only fetch secrets if the projectId exists in the cloud API instance
         try {
           secrets = await wrapActiveSpan(
             "getSecrets",
@@ -1872,7 +1872,8 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
         } catch (err) {
           cloudLog.debug(`Fetching secrets failed with error: ${err}`)
         }
-      } else {
+        // User is on enterprise domain but project could not be found
+      } else if (config.domain) {
         cloudLog.info(
           chalk.yellow(
             wordWrap(


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Before this fix, we'd log a warning about secrets not existing for users on the community tier when in fact we shouldn't be attempting to fetch them in the first place.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
