### PR TITLE
fix(logger): log exec build/deploy actions at info level

### DIFF
--- a/core/src/graph/solver.ts
+++ b/core/src/graph/solver.ts
@@ -506,12 +506,12 @@ export class GraphSolver extends TypedEventEmitter<SolverEvents> {
 
   private logError(log: Log, err: Error, errMessagePrefix: string) {
     const error = toGardenError(err)
-    const msg = renderMessageWithDivider({
+    const { msg, rawMsg } = renderMessageWithDivider({
       prefix: errMessagePrefix,
       msg: error.explain(errMessagePrefix),
       isError: true,
     })
-    log.error({ msg, error, showDuration: false })
+    log.error({ msg, rawMsg, error, showDuration: false })
     const divider = renderDivider()
     log.silly(
       chalk.gray(`Full error with stack trace and wrapped errors:\n${divider}\n${error.toString(true)}\n${divider}`)

--- a/core/src/plugins/exec/build.ts
+++ b/core/src/plugins/exec/build.ts
@@ -73,7 +73,7 @@ export const execBuildHandler = execBuild.addHandler("build", async ({ action, l
     output.outputs.log = output.detail?.buildLog
 
     const prefix = `Finished building ${chalk.white(action.name)}. Here is the full output:`
-    log.verbose(
+    log.info(
       renderMessageWithDivider({
         prefix,
         msg: output.detail?.buildLog,

--- a/core/src/plugins/exec/deploy.ts
+++ b/core/src/plugins/exec/deploy.ts
@@ -196,7 +196,7 @@ execDeploy.addHandler("deploy", async (params) => {
 
     if (result.outputLog) {
       const prefix = `Finished deploying ${chalk.white(action.name)}. Here is the output:`
-      log.verbose(
+      log.info(
         renderMessageWithDivider({
           prefix,
           msg: result.outputLog,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Previously these actions were logged at the verbose level which doesn't really make sense imo.

In particular since other exec actions are on the info level so to the end user it'll be confusing that some exec results get logged and others not.

Also updated the various places where we render a divider to make sure we also include a browser friendly version.


**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
