### PR TITLE
fix(k8s): return deployed mode in container Deploy status

### DIFF
--- a/core/src/plugins/kubernetes/container/status.ts
+++ b/core/src/plugins/kubernetes/container/status.ts
@@ -47,12 +47,13 @@ export const k8sGetContainerDeployStatus: DeployActionHandler<"getStatus", Conta
     action,
     imageId,
   })
-  const {
-    state,
-    remoteResources,
-    mode: deployedMode,
-    selectorChangedResourceKeys,
-  } = await compareDeployedResources({ ctx: k8sCtx, api, namespace, manifests, log })
+  const { state, remoteResources, deployedMode, selectorChangedResourceKeys } = await compareDeployedResources({
+    ctx: k8sCtx,
+    api,
+    namespace,
+    manifests,
+    log,
+  })
   const ingresses = await getIngresses(action, api, provider)
 
   return prepareContainerDeployStatus({

--- a/core/src/plugins/kubernetes/status/status.ts
+++ b/core/src/plugins/kubernetes/status/status.ts
@@ -381,7 +381,7 @@ export async function waitForResources({
 interface ComparisonResult {
   state: DeployState
   remoteResources: KubernetesResource[]
-  mode: ActionMode
+  deployedMode: ActionMode
   /**
    * These resources have changes in `spec.selector`, and would need to be deleted before redeploying (since Kubernetes
    * doesn't allow updates to immutable fields).
@@ -417,7 +417,7 @@ export async function compareDeployedResources({
   const result: ComparisonResult = {
     state: "unknown",
     remoteResources: <KubernetesResource[]>deployedResources.filter((o) => o !== null),
-    mode: "default",
+    deployedMode: "default",
     selectorChangedResourceKeys: detectChangedSpecSelector(manifestsMap, deployedMap),
   }
 
@@ -469,12 +469,12 @@ export async function compareDeployedResources({
       delete manifest.spec?.template?.metadata?.annotations?.[k8sManifestHashAnnotationKey]
     }
 
-    if (isWorkloadResource(manifest)) {
-      if (isConfiguredForSyncMode(manifest)) {
-        result.mode = "sync"
+    if (deployedResource && isWorkloadResource(deployedResource)) {
+      if (isConfiguredForSyncMode(deployedResource)) {
+        result.deployedMode = "sync"
       }
-      if (isConfiguredForLocalMode(manifest)) {
-        result.mode = "local"
+      if (isConfiguredForLocalMode(deployedResource)) {
+        result.deployedMode = "local"
       }
     }
 

--- a/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
@@ -233,6 +233,7 @@ describe("helmDeploy", () => {
     })
 
     expect(status.state).to.equal("ready")
+    expect(status.detail.mode).to.eql("sync")
     expect(status.detail["values"][".garden"]).to.eql({
       moduleName: "api",
       projectName: garden.projectName,

--- a/core/test/integ/src/plugins/kubernetes/kubernetes-type/handlers.ts
+++ b/core/test/integ/src/plugins/kubernetes/kubernetes-type/handlers.ts
@@ -317,6 +317,7 @@ describe("kubernetes-type handlers", () => {
 
       const status = await getKubernetesDeployStatus(deployParams)
       expect(status.state).to.equal("not-ready")
+      expect(status.detail?.mode).to.equal("sync")
       expect(status.detail?.state).to.equal("outdated")
     })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Before this fix, we were returning the action mode (e.g. `default`, `sync` or `local`) set on the locally generated manifests under `status.detail.mode` for `container` Deploys.

This meant that e.g. the `get status` command would always show the mode as `default`. The fix was to use the action mode set on the deployed resources, like we've been doing for `kubernetes` and `helm` Deploys.

Also added an integ test case for this behavior.

The usefulness of this fix is that it should allow the Cloud UI to rely on the action modes in deploy statuses to show e.g. the mode of Deploys in the graph view.