### PR TITLE
fix(cloud): ensure cloud project id is set on garden class

### DIFF
--- a/core/src/cloud/api.ts
+++ b/core/src/cloud/api.ts
@@ -573,7 +573,7 @@ export class CloudApi {
 
   async get<T>(path: string, opts: ApiFetchOptions = {}) {
     const { headers, retry, retryDescription, maxRetries } = opts
-    return await this.apiFetch<T>(path, {
+    return this.apiFetch<T>(path, {
       method: "GET",
       headers: headers || {},
       retry: retry === false ? false : true, // defaults to true unless false is explicitly passed
@@ -683,7 +683,7 @@ export class CloudApi {
     }
   }
 
-  async getProjectById(projectId: string): Promise<CloudProject | undefined> {
+  async getProjectById(projectId: string) {
     const existing = this.projects.get(projectId)
 
     if (existing) {

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -1816,7 +1816,7 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
     // If true, then user is logged in and we fetch the remote project and secrets (if applicable)
     if (!opts.noEnterprise && cloudApi) {
       const distroName = getCloudDistributionName(cloudApi.domain)
-      const useCommunityDashboard = !config.domain
+      const isCommunityEdition = !config.domain
       const cloudLog = log.createLog({ name: getCloudLogSectionName(distroName) })
 
       cloudLog.verbose(`Connecting to ${distroName}...`)
@@ -1827,11 +1827,11 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
         log: cloudLog,
         projectName,
         projectRoot,
-        useCommunityDashboard,
+        isCommunityEdition,
       })
 
       // Fetch Secrets. Not supported on the community edition.
-      if (cloudProject && !useCommunityDashboard) {
+      if (cloudProject && !isCommunityEdition) {
         try {
           secrets = await wrapActiveSpan(
             "getSecrets",
@@ -1968,14 +1968,14 @@ async function getCloudProject({
   cloudApi,
   config,
   log,
-  useCommunityDashboard,
+  isCommunityEdition,
   projectRoot,
   projectName,
 }: {
   cloudApi: CloudApi
   config: ProjectConfig
   log: Log
-  useCommunityDashboard: boolean
+  isCommunityEdition: boolean
   projectRoot: string
   projectName: string
 }) {
@@ -1983,7 +1983,7 @@ async function getCloudProject({
   const projectIdFromConfig = config.id
 
   // If logged into community edition, throw if ID is set
-  if (projectIdFromConfig && useCommunityDashboard) {
+  if (projectIdFromConfig && isCommunityEdition) {
     const msg = wordWrap(
       deline`
         Invalid field 'id' found in project configuration at path ${projectRoot}. The 'id'
@@ -1996,7 +1996,7 @@ async function getCloudProject({
   }
 
   // If logged into community edition, return project or throw if it can't be fetched/created
-  if (useCommunityDashboard) {
+  if (isCommunityEdition) {
     log.debug(`Fetching or creating project ${projectName} from ${cloudApi.domain}`)
     try {
       const cloudProject = await cloudApi.getOrCreateProjectByName(projectName)

--- a/core/test/helpers/api.ts
+++ b/core/test/helpers/api.ts
@@ -69,7 +69,7 @@ export class FakeCloudApi extends CloudApi {
     }
   }
 
-  override async getProjectById(_: string): Promise<CloudProject | undefined> {
+  override async getProjectById(_: string): Promise<CloudProject> {
     return {
       id: apiProjectId,
       name: apiProjectName,

--- a/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
+++ b/core/test/integ/src/plugins/kubernetes/helm/deployment.ts
@@ -21,13 +21,12 @@ import { KubeApi } from "../../../../../../src/plugins/kubernetes/api"
 import { buildHelmModules, getHelmLocalModeTestGarden, getHelmTestGarden } from "./common"
 import { ConfigGraph } from "../../../../../../src/graph/config-graph"
 import { isWorkload } from "../../../../../../src/plugins/kubernetes/util"
-import { CloudApi } from "../../../../../../src/cloud/api"
 import { getRootLogger } from "../../../../../../src/logger/logger"
 import { LocalModeProcessRegistry, ProxySshKeystore } from "../../../../../../src/plugins/kubernetes/local-mode"
 import { HelmDeployAction } from "../../../../../../src/plugins/kubernetes/helm/config"
-import { GlobalConfigStore } from "../../../../../../src/config-store/global"
 import { createActionLog } from "../../../../../../src/logger/log-entry"
 import { NamespaceStatus } from "../../../../../../src/types/namespace"
+import { FakeCloudApi } from "../../../../../helpers/api"
 
 describe("helmDeploy in local-mode", () => {
   let garden: TestGarden
@@ -281,11 +280,9 @@ describe("helmDeploy", () => {
   })
 
   it("should mark a chart that has been paused by Garden Cloud AEC as outdated", async () => {
-    const fakeCloudApi = new CloudApi({
-      log: getRootLogger().createLog(),
-      domain: "https://test.cloud.garden.io",
-      globalConfigStore: new GlobalConfigStore(),
-    })
+    const log = getRootLogger().createLog()
+    const fakeCloudApi = await FakeCloudApi.factory({ log })
+
     const projectRoot = getDataDir("test-projects", "helm")
     const gardenWithCloudApi = await makeTestGarden(projectRoot, { cloudApi: fakeCloudApi, noCache: true })
 

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -9,6 +9,8 @@
 import { expect } from "chai"
 import td from "testdouble"
 import tmp from "tmp-promise"
+import nock from "nock"
+
 import { join, resolve } from "path"
 import { Garden } from "../../../src/garden"
 import {
@@ -39,13 +41,18 @@ import { createGardenPlugin, ProviderActionName } from "../../../src/plugin/plug
 import { ConfigureProviderParams } from "../../../src/plugin/handlers/Provider/configureProvider"
 import { ProjectConfig, defaultNamespace } from "../../../src/config/project"
 import { ModuleConfig, baseModuleSpecSchema } from "../../../src/config/module"
-import { DEFAULT_BUILD_TIMEOUT_SEC, GardenApiVersion, gardenEnv } from "../../../src/constants"
+import {
+  DEFAULT_BUILD_TIMEOUT_SEC,
+  DEFAULT_GARDEN_CLOUD_DOMAIN,
+  GardenApiVersion,
+  gardenEnv,
+} from "../../../src/constants"
 import { providerConfigBaseSchema } from "../../../src/config/provider"
 import { keyBy, set, mapValues, omit, cloneDeep } from "lodash"
 import { joi } from "../../../src/config/common"
 import { defaultDotIgnoreFile, makeTempDir } from "../../../src/util/fs"
 import { realpath, writeFile, readFile, remove, pathExists, mkdirp, copy } from "fs-extra"
-import { dedent, randomString } from "../../../src/util/string"
+import { dedent, deline, randomString } from "../../../src/util/string"
 import { getLinkedSources, addLinkedSources } from "../../../src/util/ext-source-util"
 import { dump } from "js-yaml"
 import { TestVcsHandler } from "./vcs/vcs"
@@ -54,6 +61,12 @@ import { convertExecModule } from "../../../src/plugins/exec/convert"
 import { getLogMessages } from "../../../src/util/testing"
 import { TreeCache } from "../../../src/cache"
 import { omitUndefined } from "../../../src/util/objects"
+import { CloudApi, CloudProject } from "../../../src/cloud/api"
+import { GlobalConfigStore } from "../../../src/config-store/global"
+import { getRootLogger } from "../../../src/logger/logger"
+import { add } from "date-fns"
+import { uuidv4 } from "../../../src/util/random"
+import stripAnsi from "strip-ansi"
 
 // TODO-G2: change all module config based tests to be action-based.
 
@@ -571,6 +584,309 @@ describe("Garden", () => {
       } finally {
         gardenEnv.GARDEN_PROXY_DEFAULT_ADDRESS = saveEnv
       }
+    })
+    it("should have domain and id if set in project config", async () => {
+      const projectId = uuidv4()
+      const projectName = "test"
+      const envName = "default"
+      const config: ProjectConfig = createProjectConfig({
+        name: projectName,
+        id: projectId,
+        domain: "https://example.com",
+        path: pathFoo,
+      })
+
+      const garden = await TestGarden.factory(pathFoo, {
+        config,
+        environmentString: envName,
+      })
+
+      expect(garden.cloudDomain).to.eql("https://example.com")
+      expect(garden.projectId).to.eql(projectId)
+    })
+    it("should use default cloud domain if not set in project config", async () => {
+      const projectName = "test"
+      const envName = "default"
+      const config: ProjectConfig = createProjectConfig({
+        name: projectName,
+        path: pathFoo,
+      })
+
+      const garden = await TestGarden.factory(pathFoo, {
+        config,
+        environmentString: envName,
+      })
+
+      expect(garden.cloudDomain).to.eql(DEFAULT_GARDEN_CLOUD_DOMAIN)
+      expect(garden.projectId).to.eql(undefined)
+    })
+    context("user is logged in", () => {
+      let configStoreTmpDir: tmp.DirectoryResult
+      const log = getRootLogger().createLog()
+
+      const makeCloudApi = async (domain: string) => {
+        const globalConfigStore = new GlobalConfigStore(configStoreTmpDir.path)
+        const validityMs = 604800000
+        await globalConfigStore.set("clientAuthTokens", domain, {
+          token: "fake-token",
+          refreshToken: "fake-refresh-token",
+          validity: add(new Date(), { seconds: validityMs / 1000 }),
+        })
+        return CloudApi.factory({ log, cloudDomain: domain, globalConfigStore })
+      }
+
+      before(async () => {
+        configStoreTmpDir = await makeTempDir()
+      })
+
+      after(async () => {
+        await configStoreTmpDir.cleanup()
+        nock.cleanAll()
+      })
+
+      // This means the logged in user is on a commerical edition
+      context("domain is set", () => {
+        const fakeCloudDomain = "https://example.com"
+        const scope = nock(fakeCloudDomain)
+        const projectId = uuidv4()
+        const projectName = "test"
+        const envName = "default"
+        const cloudProject: CloudProject = {
+          id: projectId,
+          name: projectName,
+          repositoryUrl: "",
+          environments: [
+            {
+              id: uuidv4(),
+              name: envName,
+            },
+          ],
+        }
+        const config: ProjectConfig = createProjectConfig({
+          name: projectName,
+          id: projectId,
+          path: pathFoo,
+          domain: fakeCloudDomain, // <-- Domain is set
+        })
+
+        it("should use the configured cloud domain and fetch project", async () => {
+          scope.get("/api/token/verify").reply(200, {})
+          scope.get(`/api/projects/uid/${projectId}`).reply(200, { data: cloudProject })
+
+          const cloudApi = await makeCloudApi(fakeCloudDomain)
+
+          const garden = await TestGarden.factory(pathFoo, {
+            config,
+            environmentString: envName,
+            cloudApi,
+          })
+
+          expect(garden.cloudDomain).to.eql(fakeCloudDomain)
+          expect(garden.projectId).to.eql(projectId)
+          expect(scope.isDone()).to.be.true
+        })
+        it("should fetch secrets", async () => {
+          scope.get("/api/token/verify").reply(200, {})
+          scope.get(`/api/projects/uid/${projectId}`).reply(200, { data: cloudProject })
+          scope
+            .get(`/api/secrets/projectUid/${projectId}/env/${envName}`)
+            .reply(200, { data: { SECRET_KEY: "secret-val" } })
+
+          const cloudApi = await makeCloudApi(fakeCloudDomain)
+
+          const garden = await TestGarden.factory(pathFoo, {
+            config,
+            environmentString: envName,
+            cloudApi,
+          })
+
+          expect(garden.secrets).to.eql({ SECRET_KEY: "secret-val" })
+          expect(scope.isDone()).to.be.true
+        })
+        it("should log a warning if logged in but project ID is missing", async () => {
+          scope.get("/api/token/verify").reply(200, {})
+
+          getRootLogger()["entries"] = []
+          const log = getRootLogger().createLog()
+
+          const cloudApi = await makeCloudApi(fakeCloudDomain)
+
+          const garden = await TestGarden.factory(pathFoo, {
+            config: {
+              ...config,
+              id: undefined,
+            },
+            log,
+            environmentString: envName,
+            cloudApi,
+          })
+
+          const expectedLog = log.root.getLogEntries().filter((l) => l.msg?.includes(`Logged in to ${fakeCloudDomain}`))
+
+          expect(expectedLog.length).to.eql(1)
+          expect(expectedLog[0].level).to.eql(1)
+          const cleanMsg = stripAnsi(expectedLog[0].msg || "").replace("\n", " ")
+          expect(cleanMsg).to
+            .eql(deline`Logged in to ${fakeCloudDomain}, but could not find remote project '${projectName}'.
+            Command results for this command run will not be available in Garden Enterprise.`)
+          expect(garden.cloudDomain).to.eql(fakeCloudDomain)
+          expect(garden.projectId).to.eql(undefined)
+          expect(scope.isDone()).to.be.true
+        })
+        it("should throw if project with ID can't be found", async () => {
+          scope.get("/api/token/verify").reply(200, {})
+          scope.get(`/api/projects/uid/${projectId}`).reply(404, {})
+          getRootLogger()["entries"] = []
+
+          const cloudApi = await makeCloudApi(fakeCloudDomain)
+
+          let error: Error | undefined
+          try {
+            await TestGarden.factory(pathFoo, {
+              config,
+              environmentString: envName,
+              cloudApi,
+            })
+          } catch (err) {
+            if (err instanceof Error) {
+              error = err
+            }
+          }
+
+          const expectedLog = log.root.getLogEntries().filter((l) => l.msg?.includes(`Fetching project with ID=`))
+
+          expect(expectedLog.length).to.eql(1)
+          expect(expectedLog[0].level).to.eql(0)
+          const cleanMsg = stripAnsi(expectedLog[0].msg || "").replace("\n", " ")
+          expect(cleanMsg).to.eql(
+            `Fetching project with ID=${projectId} failed with error: HTTPError: Response code 404 (Not Found)`
+          )
+          expect(error).to.exist
+          expect(error!.message).to.eql("Response code 404 (Not Found)")
+          expect(scope.isDone()).to.be.true
+        })
+      })
+
+      // This means the logged in user is on the community edition
+      context("domain is NOT set", () => {
+        const scope = nock(DEFAULT_GARDEN_CLOUD_DOMAIN)
+        const projectId = uuidv4()
+        const projectName = "test"
+        const envName = "default"
+        const cloudProject: CloudProject = {
+          id: projectId,
+          name: projectName,
+          repositoryUrl: "",
+          environments: [
+            {
+              id: uuidv4(),
+              name: envName,
+            },
+          ],
+        }
+        const config: ProjectConfig = createProjectConfig({
+          name: projectName,
+          path: pathFoo,
+        })
+
+        it("should use the community dashboard domain", async () => {
+          scope.get("/api/token/verify").reply(200, {})
+          scope.get(`/api/projects`).reply(200, { data: [cloudProject] })
+
+          const cloudApi = await makeCloudApi(DEFAULT_GARDEN_CLOUD_DOMAIN)
+
+          const garden = await TestGarden.factory(pathFoo, {
+            config,
+            environmentString: envName,
+            cloudApi,
+          })
+
+          expect(garden.cloudDomain).to.eql(DEFAULT_GARDEN_CLOUD_DOMAIN)
+          expect(garden.projectId).to.eql(projectId)
+          expect(scope.isDone()).to.be.true
+        })
+        it("should throw if project ID is set in config", async () => {
+          scope.get("/api/token/verify").reply(200, {})
+
+          const cloudApi = await makeCloudApi(DEFAULT_GARDEN_CLOUD_DOMAIN)
+
+          let error: Error | undefined
+          try {
+            await TestGarden.factory(pathFoo, {
+              config: {
+                ...config,
+                id: uuidv4(), // <--- ID is set when it shouldn't
+              },
+              environmentString: envName,
+              cloudApi,
+            })
+          } catch (err) {
+            if (err instanceof Error) {
+              error = err
+            }
+          }
+
+          expect(error).to.exist
+          expect(error!.message.replace("\n", " ")).to.eql(deline`
+            Invalid field 'id' found in project configuration at path tmp. The 'id'
+            field should only be set if using a commerical edition of Garden. Please remove to continue
+            using the Garden community edition.
+          `)
+          expect(scope.isDone()).to.be.true
+        })
+        it("should throw if unable to fetch or create project", async () => {
+          scope.get("/api/token/verify").reply(200, {})
+          scope.get(`/api/projects`).reply(500, {})
+          getRootLogger()["entries"] = []
+
+          const cloudApi = await makeCloudApi(DEFAULT_GARDEN_CLOUD_DOMAIN)
+
+          let error: Error | undefined
+          try {
+            await TestGarden.factory(pathFoo, {
+              config,
+              environmentString: envName,
+              cloudApi,
+            })
+          } catch (err) {
+            if (err instanceof Error) {
+              error = err
+            }
+          }
+
+          const expectedLog = log.root.getLogEntries().filter((l) => l.msg?.includes(`failed with error`))
+
+          expect(expectedLog.length).to.eql(1)
+          expect(expectedLog[0].level).to.eql(0)
+          const cleanMsg = stripAnsi(expectedLog[0].msg || "").replace("\n", " ")
+          expect(cleanMsg).to.eql(
+            `Fetching or creating project ${projectName} from ${DEFAULT_GARDEN_CLOUD_DOMAIN} failed with error: HTTPError: Response code 500 (Internal Server Error)`
+          )
+          expect(error).to.exist
+          expect(error!.message).to.eql("Response code 500 (Internal Server Error)")
+          expect(scope.isDone()).to.be.true
+        })
+        it("should not fetch secrets", async () => {
+          scope.get("/api/token/verify").reply(200, {})
+          scope.get(`/api/projects`).reply(200, { data: [cloudProject] })
+          scope
+            .get(`/api/secrets/projectUid/${projectId}/env/${envName}`)
+            .reply(200, { data: { SECRET_KEY: "secret-val" } })
+
+          const cloudApi = await makeCloudApi(DEFAULT_GARDEN_CLOUD_DOMAIN)
+
+          const garden = await TestGarden.factory(pathFoo, {
+            config,
+            environmentString: envName,
+            cloudApi,
+          })
+
+          expect(garden.cloudDomain).to.eql(DEFAULT_GARDEN_CLOUD_DOMAIN)
+          expect(garden.projectId).to.eql(projectId)
+          expect(garden.secrets).to.eql({})
+          expect(scope.isDone()).to.be.false // <--- False because the secret endpoint isn't called
+        })
+      })
     })
   })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

This commit fixes a regression introduced with:
https://github.com/garden-io/garden/pull/5291

That commit was just a tiny tweak to a couple of lines of code to improve error messages but actually ended up breaking the core <> cloud interaction for the community tier dashboard.

The underlying reason is the fact that this particular code was quite convoluted and not tested well enough.

So this commit refactors the cloud init logic to make it more readable and adds a handful of tests to prevent these kind of regressions from happening again.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

~I'm flagging as draft since there are some changes around the init logic for the community dashboard that I'd like to get feedback on. Specifically we now fail fast as opposed to logging a warning if an `id` is set or if fetching/creating a project fails.~ (cc @mkhq) This is ready for review. 

Also, this needs to be merged before our next release. Current `main` won't work with the community dashboard as is. 
