### PR TITLE
fix(pulumi): propagate resolved action context to pulumi plugin commands

### DIFF
--- a/plugins/pulumi/src/commands.ts
+++ b/plugins/pulumi/src/commands.ts
@@ -369,8 +369,6 @@ function makePulumiCommand({ name, commandDescription, beforeFn, runFn, afterFn 
 
       const pulumiProvider = ctx.provider as PulumiProvider
       const actions = graph.getDeploys({ names }).filter((a) => a.type === "pulumi")
-      // Provider resolution is a heavy operation.
-      // Resolve providers only once and pass those to each PulumiPluginCommandTask to be created.
       const resolvedProviders = await garden.resolveProviders(log)
 
       const tasks = await Promise.all(

--- a/plugins/pulumi/src/commands.ts
+++ b/plugins/pulumi/src/commands.ts
@@ -40,7 +40,8 @@ import { TemplatableConfigContext } from "@garden-io/core/build/src/config/templ
 import { ActionTaskProcessParams, ValidResultType } from "@garden-io/core/build/src/tasks/base"
 import { deletePulumiDeploy } from "./handlers"
 import { ActionLog, createActionLog, Log } from "@garden-io/core/build/src/logger/log-entry"
-import { ActionConfigContext } from "@garden-io/core/build/src/config/template-contexts/actions"
+import { ActionSpecContext } from "@garden-io/core/build/src/config/template-contexts/actions"
+import { ProviderMap } from "@garden-io/core/build/src/config/provider"
 
 type PulumiBaseParams = Omit<PulumiParams, "action">
 
@@ -181,15 +182,23 @@ const pulumiCommandSpecs: PulumiCommandSpec[] = [
   },
 ]
 
-const makePluginContextForDeploy = async (params: PulumiParams & { garden: Garden; graph: ConfigGraph }) => {
-  const { garden, provider, ctx, action } = params
-  const templateContext = new ActionConfigContext({
+const makePluginContextForDeploy = async (
+  params: PulumiParams & {
+    garden: Garden
+    graph: ConfigGraph
+    resolvedProviders: ProviderMap
+  }
+) => {
+  const { garden, graph, provider, resolvedProviders, ctx, action } = params
+  const templateContext = new ActionSpecContext({
     garden,
-    config: action.getConfig(),
-    thisContextParams: {
-      name: action.name,
-      mode: action.mode(),
-    },
+    resolvedProviders,
+    action,
+    partialRuntimeResolution: false,
+    modules: graph.getModules(),
+    resolvedDependencies: action.getResolvedDependencies(),
+    executedDependencies: action.getExecutedDependencies(),
+    inputs: action.getInternal().inputs || {},
     variables: action.getVariables(),
   })
   const ctxForDeploy = await garden.getPluginContext({ provider, templateContext, events: ctx.events })
@@ -206,6 +215,7 @@ interface PulumiPluginCommandTaskParams {
   skipRuntimeDependencies: boolean
   runFn: PulumiRunFn
   pulumiParams: PulumiBaseParams
+  resolvedProviders: ProviderMap
 }
 
 export type PulumiCommandResult = ValidResultType
@@ -217,6 +227,7 @@ class PulumiPluginCommandTask extends PluginActionTask<PulumiDeploy, PulumiComma
   commandDescription: string
   override skipRuntimeDependencies: boolean
   runFn: PulumiRunFn
+  resolvedProviders: ProviderMap
 
   constructor({
     garden,
@@ -228,6 +239,7 @@ class PulumiPluginCommandTask extends PluginActionTask<PulumiDeploy, PulumiComma
     skipRuntimeDependencies = false,
     runFn,
     pulumiParams,
+    resolvedProviders,
   }: PulumiPluginCommandTaskParams) {
     super({
       garden,
@@ -243,6 +255,7 @@ class PulumiPluginCommandTask extends PluginActionTask<PulumiDeploy, PulumiComma
     this.pulumiParams = pulumiParams
     const provider = <PulumiProvider>pulumiParams.ctx.provider
     this.concurrencyLimit = provider.config.pluginTaskConcurrencyLimit
+    this.resolvedProviders = resolvedProviders
   }
 
   getDescription() {
@@ -275,6 +288,7 @@ class PulumiPluginCommandTask extends PluginActionTask<PulumiDeploy, PulumiComma
         skipRuntimeDependencies: this.skipRuntimeDependencies,
         runFn: this.runFn,
         pulumiParams: this.pulumiParams,
+        resolvedProviders: this.resolvedProviders,
       })
     })
 
@@ -288,7 +302,11 @@ class PulumiPluginCommandTask extends PluginActionTask<PulumiDeploy, PulumiComma
   async process({ dependencyResults }: ActionTaskProcessParams<PulumiDeploy, PulumiCommandResult>) {
     this.log.info(chalk.gray(`Running ${chalk.white(this.commandDescription)}`))
 
-    const params = { ...this.pulumiParams, action: this.getResolvedAction(this.action, dependencyResults) }
+    const params = {
+      ...this.pulumiParams,
+      action: this.getResolvedAction(this.action, dependencyResults),
+      resolvedProviders: this.resolvedProviders,
+    }
 
     try {
       await selectStack(params)
@@ -349,9 +367,11 @@ function makePulumiCommand({ name, commandDescription, beforeFn, runFn, afterFn 
 
       beforeFn && (await beforeFn({ ctx, log }))
 
-      const provider = ctx.provider as PulumiProvider
-
+      const pulumiProvider = ctx.provider as PulumiProvider
       const actions = graph.getDeploys({ names }).filter((a) => a.type === "pulumi")
+      // Provider resolution is a heavy operation.
+      // Resolve providers only once and pass those to each PulumiPluginCommandTask to be created.
+      const resolvedProviders = await garden.resolveProviders(log)
 
       const tasks = await Promise.all(
         actions.map(async (action) => {
@@ -359,14 +379,15 @@ function makePulumiCommand({ name, commandDescription, beforeFn, runFn, afterFn 
           const actionLog = createActionLog({ log, actionName: action.name, actionKind: action.kind })
 
           const pulumiParams: PulumiBaseParams = {
-            ctx: await garden.getPluginContext({ provider, templateContext, events: ctx.events }),
-            provider,
+            ctx: await garden.getPluginContext({ provider: pulumiProvider, templateContext, events: ctx.events }),
+            provider: pulumiProvider,
             log: actionLog,
           }
 
           return new PulumiPluginCommandTask({
             garden,
             graph,
+            resolvedProviders,
             log: actionLog,
             action,
             commandName: name,

--- a/plugins/pulumi/test/test-project-k8s/k8s-deployment/varfile1.yaml
+++ b/plugins/pulumi/test/test-project-k8s/k8s-deployment/varfile1.yaml
@@ -1,1 +1,2 @@
 pulumi-k8s-test:appName: api-varfile1-override
+pulumi-k8s-test:nsName: ${actions["k8s-namespace"].name}-varfile2-override

--- a/plugins/pulumi/test/test-project-k8s/k8s-deployment/varfile2.yaml
+++ b/plugins/pulumi/test/test-project-k8s/k8s-deployment/varfile2.yaml
@@ -1,1 +1,2 @@
 pulumi-k8s-test:appName: api-varfile2-override
+pulumi-k8s-test:nsName: ${actions["k8s-namespace"].name}-varfile2-override


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
This fixes the regressions introduced in `0.13`. In `0.12`, references to `${modules.*}` in the Pulumi varfiles were possible.
This PR fixes `0.13` to use:
* the `${actions.*}` references in Pulumi varfiles
* the `${modules.*}` references with module-based configs

**Which issue(s) this PR fixes**:

Fixes #5083

**Special notes for your reviewer**:
