### PR TITLE
fix(pulumi): fix process dependency resolution in plugin command

### DIFF
--- a/plugins/pulumi/src/commands.ts
+++ b/plugins/pulumi/src/commands.ts
@@ -249,7 +249,10 @@ class PulumiPluginCommandTask extends PluginActionTask<PulumiDeploy, PulumiComma
     return this.action.longDescription()
   }
 
-  resolveDependencies() {
+  /**
+   * Override the base method to be sure that `garden plugins pulumi preview` happens in dependency order.
+   */
+  override resolveProcessDependencies() {
     const pulumiDeployNames = this.graph
       .getDeploys()
       .filter((d) => d.type === "pulumi")


### PR DESCRIPTION
**What this PR does / why we need it**:
Method `resolveDependencies` was unused before this fix. However, it was implemented to handle the process dependencies. This commit renames it to override the corresponding method of the parent class, as it was initially intended.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
