### PR TITLE
fix: handle and retry DNS errors

### DIFF
--- a/core/src/analytics/analytics.ts
+++ b/core/src/analytics/analytics.ts
@@ -23,7 +23,7 @@ import { Profile } from "../util/profiling"
 import { ModuleConfig } from "../config/module"
 import { UserResult } from "@garden-io/platform-api-types"
 import { uuidv4 } from "../util/random"
-import { GardenError, NodeJSErrnoErrorCodes, StackTraceMetadata } from "../exceptions"
+import { GardenError, NodeJSErrnoException, StackTraceMetadata } from "../exceptions"
 import { ActionConfigMap } from "../actions/types"
 import { actionKinds } from "../actions/types"
 import { getResultErrorProperties } from "./helpers"
@@ -163,7 +163,7 @@ export type AnalyticsGardenErrorDetail = {
   /**
    * If this error was caused by an underlying NodeJSErrnoException, this will be the code.
    */
-  code?: NodeJSErrnoErrorCodes
+  code?: NodeJSErrnoException["code"]
 
   stackTrace?: StackTraceMetadata
 }

--- a/core/test/unit/src/exceptions.ts
+++ b/core/test/unit/src/exceptions.ts
@@ -36,7 +36,6 @@ describe("isErrnoException", async () => {
 
     if (isErrnoException(err)) {
       expect(err.code).to.equal("ENOENT")
-      expect(err.errno).to.equal(os.constants.errno.ENOENT) // for sanity
     } else {
       expect.fail("should have been an NodeJSErrnoException")
     }
@@ -54,7 +53,6 @@ describe("isErrnoException", async () => {
 
     if (isErrnoException(err)) {
       expect(err.code).to.equal(dns.NOTFOUND)
-      expect(dns.NOTFOUND).to.equal("ENOTFOUND") // for sanity
     } else {
       expect.fail("should have been an NodeJSErrnoException")
     }

--- a/core/test/unit/src/exceptions.ts
+++ b/core/test/unit/src/exceptions.ts
@@ -21,7 +21,6 @@ import { testFlags } from "../../../src/util/util"
 import { readFile } from "fs-extra"
 import { resolve4 } from "dns/promises"
 import dns from "node:dns"
-import os from "node:os"
 
 describe("isErrnoException", async () => {
   it("should return true for file not found errors", async () => {


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
DNS error codes are not included in the OS error constants
(os.constants) / https://nodejs.org/docs/latest-v18.x/api/os.html#error-constants

This PR adds DNS error codes to the list of handled errno errors.

**Which issue(s) this PR fixes**:

Fixes https://github.com/garden-io/garden/issues/5217
