### PR TITLE
fix(dev): fix crash on very narrow terminals

### DIFF
--- a/core/src/logger/util.ts
+++ b/core/src/logger/util.ts
@@ -74,7 +74,7 @@ interface DividerOpts {
   padding?: number
 }
 
-const getSideDividerWidth = (width: number, titleWidth: number) => (width - titleWidth) / 2
+const getSideDividerWidth = (width: number, titleWidth: number) => Math.max((width - titleWidth) / 2, 1)
 const getNumberOfCharsPerWidth = (char: string, width: number) => width / stringWidth(char)
 
 // Adapted from https://github.com/JureSotosek/ink-divider


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Before this fix, commands in a dev command session would fail with an error if the terminal width was less than the length of the command (including opts and args).

**Which issue(s) this PR fixes**:

Fixes #4912.