### PR TITLE
ci: first filter for tags then for branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,9 @@ workflows:
             .circleci/.* run-test-dockerhub true
           # By default circleci runs on all branches, but not on all tags.
           # This filter adds all tags to trigger the workflows defined in continue-config.yml
-          # The branches don't need to be added, because they are already included by default.
+          # Adding the branch filter is necessary to first filter for tags.
           filters:
             tags:
-              only:
-                - /.*
+              only: /.*/
+            branches:
+              only: /.*/


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
We need to explicitly filter for tags first before we filter for branches, since otherwise the branch filter evaluates to true and we will never reach the tag filter.
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
