### PR TITLE
improvement(jib): support JDK 21 LTS version

### DIFF
--- a/docs/reference/action-types/Build/jib-container.md
+++ b/docs/reference/action-types/Build/jib-container.md
@@ -372,9 +372,9 @@ The chosen version will be downloaded by Garden and used to define `JAVA_HOME` e
 
 To use an arbitrary JDK distribution, please use the `jdkPath` configuration option.
 
-| Type     | Allowed Values | Default | Required |
-| -------- | -------------- | ------- | -------- |
-| `number` | 8, 11, 13, 17  | `11`    | Yes      |
+| Type     | Allowed Values    | Default | Required |
+| -------- | ----------------- | ------- | -------- |
+| `number` | 8, 11, 13, 17, 21 | `11`    | Yes      |
 
 ### `spec.jdkPath`
 

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -922,9 +922,9 @@ The chosen version will be downloaded by Garden and used to define `JAVA_HOME` e
 
 To use an arbitrary JDK distribution, please use the `jdkPath` configuration option.
 
-| Type     | Allowed Values | Default | Required |
-| -------- | -------------- | ------- | -------- |
-| `number` | 8, 11, 13, 17  | `11`    | Yes      |
+| Type     | Allowed Values    | Default | Required |
+| -------- | ----------------- | ------- | -------- |
+| `number` | 8, 11, 13, 17, 21 | `11`    | Yes      |
 
 ### `build.jdkPath`
 

--- a/plugins/jib/src/index.ts
+++ b/plugins/jib/src/index.ts
@@ -55,7 +55,7 @@ const jibBuildSchemaKeys = () => ({
   jdkVersion: joi
     .number()
     .integer()
-    .valid(8, 11, 13, 17)
+    .valid(8, 11, 13, 17, 21)
     .default(11)
     .description(
       dedent`

--- a/plugins/jib/src/openjdk.ts
+++ b/plugins/jib/src/openjdk.ts
@@ -123,6 +123,33 @@ const jdk17Version: JdkVersion = {
   },
 }
 
+const jdk21Version: JdkVersion = {
+  lookupName: "openjdk-21",
+  description: "The OpenJDK 21 library.",
+  baseUrl: "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/",
+  versionName: "jdk-21.0.1+12",
+  mac_amd64: {
+    filename: "OpenJDK21U-jdk_x64_mac_hotspot_21.0.1_12.tar.gz",
+    sha256: "35f3cbc86d7ff0a01facefd741d5cfb675867e0a5ec137f62ba071d2511a45c9",
+  },
+  mac_arm64: {
+    filename: "OpenJDK21U-jdk_aarch64_mac_hotspot_21.0.1_12.tar.gz",
+    sha256: "0d29257c9bcb5f20f5c4643ef9437f36b10376863eddaf6248d09093796c6b30",
+  },
+  linux_amd64: {
+    filename: "OpenJDK21U-jdk_x64_linux_hotspot_21.0.1_12.tar.gz",
+    sha256: "1a6fa8abda4c5caed915cfbeeb176e7fbd12eb6b222f26e290ee45808b529aa1",
+  },
+  linux_arm64: {
+    filename: "OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.1_12.tar.gz",
+    sha256: "e184dc29a6712c1f78754ab36fb48866583665fa345324f1a79e569c064f95e9",
+  },
+  windows: {
+    filename: "OpenJDK21U-jdk_x64_windows_hotspot_21.0.1_12.zip",
+    sha256: "36555fd6a1a628abf8063b7781309895a94680c13a0e620013ff44bfdc18d8bd",
+  },
+}
+
 function openJdkSpec(jdkVersion: JdkVersion): PluginToolSpec {
   const macBuilds: ToolBuildSpec[] = [
     {
@@ -196,4 +223,5 @@ export const openJdkSpecs: PluginToolSpec[] = [
   openJdkSpec(jdk11Version),
   openJdkSpec(jdk13Version),
   openJdkSpec(jdk17Version),
+  openJdkSpec(jdk21Version),
 ]


### PR DESCRIPTION
Add the possibility to use JDK 21 for running the jib action type.

**What this PR does / why we need it**:
This changeset adds the ability to use JDK 21 for the jib action type.

**Special notes for your reviewer**:
This is effectively a copy of https://github.com/garden-io/garden/commit/3f3c91f31db7abed0553802d2149e18197ad3210 , just with JDK 21 instead of JDK 17.