### PR TITLE
test: retry flaky test

### DIFF
--- a/core/test/unit/src/commands/self-update.ts
+++ b/core/test/unit/src/commands/self-update.ts
@@ -416,7 +416,10 @@ describe("SelfUpdateCommand", () => {
     expect(scope.isDone()).to.be.true
   })
 
-  it(`handles --platform=windows and zip archives correctly`, async () => {
+  it(`handles --platform=windows and zip archives correctly`, async function () {
+    // retry because of flaky test
+    // eslint-disable-next-line no-invalid-this
+    this.retries(3)
     const scope = nock("https://get.garden.io")
     scope.get("/releases/latest").reply(200, { tag_name: "edge" })
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Retry the flaky selfUpdateCommand test. Hopefully this helps, otherwise we can consider retrying the whole SelfUpdateCommand tests.

Had to convert the arrow function for this to work properly otherwise arrow function[ cannot access the mocha context](https://mochajs.org/#arrow-functions).

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
