### PR TITLE
fix(core): resolve templates in `source.path`

### DIFF
--- a/core/test/data/test-projects/action-source-path/project.garden.yml
+++ b/core/test/data/test-projects/action-source-path/project.garden.yml
@@ -1,6 +1,8 @@
 apiVersion: garden.io/v1
 kind: Project
 name: action-source-path
+variables:
+  sourcePath: "../"
 environments:
   - name: local
 providers:

--- a/core/test/data/test-projects/action-source-path/some-dir/with-source.garden.yml
+++ b/core/test/data/test-projects/action-source-path/some-dir/with-source.garden.yml
@@ -2,6 +2,6 @@ kind: Build
 type: test
 name: with-source
 source:
-  path: ../
+  path: ${var.sourcePath}
 include: [some-dir/**/*]
 exclude: [some-dir/tps-report.txt]


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Before this fix, we weren't resolving template strings on the optional `source.path` action config field. This caused errors when `git` was called on a path that still had unresolved template strings.

This was fixed by preprocessing action configs (which resolves template strings on them) before passing the paths to the VCS helper that computes minimal roots.