### PR TITLE
chore(circleci): improve npm and node cache hits

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -110,8 +110,6 @@ commands:
       - run: npm ci --prefer-offline --cache ~/.npm --no-audit
 
       - save_cache:
-          # We need the arch in the key because CircleCI stores the absolute paths, so restore would fail
-          # on a different operating system (project directory is different between windows/linux/macos)
           key: npm-v4-<<parameters.context>>-{{ checksum "package-lock.json" }}
           paths:
             - ~/.npm

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -104,17 +104,29 @@ commands:
       - restore_cache:
           keys:
             # Prefer using the NPM cache for the package-lock hash, but fall back to any other cache too
-            - npm-v3-<<parameters.context>>-{{ checksum "package-lock.json" }}
-            - npm-v3-<<parameters.context>>
+            - npm-v4-<<parameters.context>>-{{ checksum "package-lock.json" }}
+            - npm-v4-<<parameters.context>>
 
       - run: npm ci --prefer-offline --cache ~/.npm --no-audit
 
       - save_cache:
           # We need the arch in the key because CircleCI stores the absolute paths, so restore would fail
           # on a different operating system (project directory is different between windows/linux/macos)
-          key: npm-v3-<<parameters.context>>-{{ checksum "package-lock.json" }}
+          key: npm-v4-<<parameters.context>>-{{ checksum "package-lock.json" }}
           paths:
             - ~/.npm
+            - node_modules
+            - cli/node_modules
+            - core/node_modules
+            - e2e/node_modules
+            - plugins/conftest/node_modules
+            - plugins/conftest-container/node_modules
+            - plugins/conftest-kubernetes/node_modules
+            - plugins/jib/node_modules
+            - plugins/maven-container/node_modules
+            - plugins/pulumi/node_modules
+            - plugins/terraform/node_modules
+            - sdk/node_modules
 
   configure_git:
     description: Configure git (needed for some tests)

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -21,7 +21,7 @@ parameters:
     GARDEN_DISABLE_ANALYTICS: "true"
     GARDEN_K8S_BUILD_SYNC_MODE: "mutagen"
 
-  shared-machine-config: &shared-machine-config
+  ubuntu-vm-runner: &ubuntu-vm-runner
     image: "ubuntu-2204:2023.02.1"
     docker_layer_caching: true
 
@@ -34,7 +34,7 @@ parameters:
     image: gardendev/circleci-runner:18.15.0-1@sha256:c830e29ab30a1c5b08cba4d041d3325ef6958aebeba1b10b1ee9566d7b1a4d42
 
   # Configuration for our node jobs
-  node-config: &node-config
+  docker-runner: &docker-runner
     docker:
       - <<: *runner-image
         environment:
@@ -98,29 +98,23 @@ commands:
       context:
         description: Set this to vm if installing in a VM, to avoid conflicting caches with the docker runs
         type: string
-        default: docker
     steps:
+      # See also https://github.com/CircleCI-Public/node-orb/issues/158#issuecomment-1461095390
+      - run: rm -rf ~/.npm
       - restore_cache:
           keys:
-            - npm-v2-<<parameters.context>>-{{ checksum "package-lock.json" }}
+            # Prefer using the NPM cache for the package-lock hash, but fall back to any other cache too
+            - npm-v3-<<parameters.context>>-{{ checksum "package-lock.json" }}
+            - npm-v3-<<parameters.context>>
 
-      - run: npm ci
+      - run: npm ci --prefer-offline --cache ~/.npm --no-audit
 
       - save_cache:
-          key: npm-v2-<<parameters.context>>-{{ checksum "package-lock.json" }}
+          # We need the arch in the key because CircleCI stores the absolute paths, so restore would fail
+          # on a different operating system (project directory is different between windows/linux/macos)
+          key: npm-v3-<<parameters.context>>-{{ checksum "package-lock.json" }}
           paths:
-            - node_modules
-            - cli/node_modules
-            - core/node_modules
-            - e2e/node_modules
-            - plugins/conftest/node_modules
-            - plugins/conftest-container/node_modules
-            - plugins/conftest-kubernetes/node_modules
-            - plugins/jib/node_modules
-            - plugins/maven-container/node_modules
-            - plugins/pulumi/node_modules
-            - plugins/terraform/node_modules
-            - sdk/node_modules
+            - ~/.npm
 
   configure_git:
     description: Configure git (needed for some tests)
@@ -267,14 +261,20 @@ commands:
           e.g. when creating unstable releases. The script defaults to using the version from core/package.json.
         type: string
         default: ""
+      context:
+        description: Set this to the operating system, to avoid conflicting caches with the docker runs
+        type: string
     steps:
       - *attach-workspace
-      - run:
-          name: NPM install
-          command: npm ci
-      # restore node cache
+
+      - npm_install:
+          context: <<parameters.context>>
+
       - restore_cache:
-          key: node-cache-v1
+          keys:
+            - node-cache-v2-<<parameters.context>>-{{ checksum "cli/src/build-pkg.ts" }}
+            - node-cache-v2-<<parameters.context>>
+
       - run:
           name: Run dist script
           command: |
@@ -285,11 +285,13 @@ commands:
             source "$HOME/.cargo/env"
 
             npm run dist -- --version "<<parameters.version>>" <<parameters.targets>>
+
       # We cache the node archives because the NodeJS download mirror is unreliable
       - save_cache:
-          key: node-cache-v1
+          key: node-cache-v2-<<parameters.context>>-{{ checksum "cli/src/build-pkg.ts" }}
           paths:
             - garden-sea/tmp/node
+
       - persist_to_workspace:
           root: ./
           paths:
@@ -331,10 +333,11 @@ commands:
 #
 jobs:
   build:
-    <<: *node-config
+    <<: *docker-runner
     steps:
       - checkout
-      - npm_install
+      - npm_install:
+          context: docker
       - run:
           name: build
           command: |
@@ -381,12 +384,12 @@ jobs:
       - run_npm_dist:
           version: <<parameters.version>>
           targets: "macos-amd64 macos-arm64"
+          context: vm-macos
       - fail_fast
 
   build-dist-linux-windows:
     machine:
-      image: ubuntu-2204:current
-      docker_layer_caching: true
+      <<: *ubuntu-vm-runner
     resource_class: large
     parameters:
       version:
@@ -404,14 +407,16 @@ jobs:
       - run_npm_dist:
           version: <<parameters.version>>
           targets: "linux-amd64 linux-arm64 alpine-amd64 windows-amd64"
+          context: vm-ubuntu
       - fail_fast
 
   lint:
-    <<: *node-config
+    <<: *docker-runner
     resource_class: large
     steps:
       - checkout
-      - npm_install
+      - npm_install:
+          context: docker
       - *attach-workspace
       - run:
           name: lint
@@ -419,10 +424,11 @@ jobs:
       - fail_fast
 
   check-docs:
-    <<: *node-config
+    <<: *docker-runner
     steps:
       - checkout
-      - npm_install
+      - npm_install:
+          context: docker
       - *attach-workspace
       - run:
           name: Make sure generated docs are up-to-date
@@ -430,10 +436,11 @@ jobs:
       - fail_fast
 
   check-package-licenses:
-    <<: *node-config
+    <<: *docker-runner
     steps:
       - checkout
-      - npm_install
+      - npm_install:
+          context: docker
       - *attach-workspace
       - run:
           name: Make sure dependency licenses are okay
@@ -443,12 +450,13 @@ jobs:
       - fail_fast
 
   test-framework:
-    <<: *node-config
+    <<: *docker-runner
     resource_class: large
     steps:
       - checkout
       - *remote-docker
-      - npm_install
+      - npm_install:
+          context: docker
       - *attach-workspace
       - configure_git
       - run:
@@ -461,7 +469,7 @@ jobs:
       - fail_fast
 
   e2e-project:
-    <<: *node-config
+    <<: *docker-runner
     parameters:
       project:
         description: The example project to test
@@ -472,7 +480,8 @@ jobs:
         default: testing
     steps:
       - checkout
-      - npm_install
+      - npm_install:
+          context: docker
       - configure_remote_cluster
       - docker_login
       - *attach-workspace
@@ -489,7 +498,7 @@ jobs:
 
   test-dockerhub:
     machine:
-      <<: *shared-machine-config
+      <<: *ubuntu-vm-runner
     resource_class: xlarge
     steps:
       # Only run test-dockerhub if path-filter noticed changes in ./support/*
@@ -512,7 +521,7 @@ jobs:
 
   dockerhub-release:
     machine:
-      <<: *shared-machine-config
+      <<: *ubuntu-vm-runner
     resource_class: xlarge
     steps:
       - update_buildx
@@ -651,7 +660,7 @@ jobs:
       - fail_fast
 
   test-dist:
-    <<: *node-config
+    <<: *docker-runner
     steps:
       # Need to checkout to run example project
       - checkout
@@ -676,7 +685,7 @@ jobs:
 
   test-plugins:
     machine:
-      <<: *shared-machine-config
+      <<: *ubuntu-vm-runner
     parameters:
       kindNodeImage:
         description: The kind node image to use
@@ -692,7 +701,7 @@ jobs:
           kindNodeImage: <<parameters.kindNodeImage>>
       - configure_git
       - npm_install:
-          context: vm
+          context: vm-ubuntu
       - *attach-workspace
       # Restore Maven cache
       - restore_cache:
@@ -711,7 +720,7 @@ jobs:
 
   test-kind:
     machine:
-      <<: *shared-machine-config
+      <<: *ubuntu-vm-runner
     parameters:
       kindNodeImage:
         description: The kind node image to use
@@ -727,7 +736,7 @@ jobs:
           kindNodeImage: <<parameters.kindNodeImage>>
       - configure_git
       - npm_install:
-          context: vm
+          context: vm-ubuntu
       - *attach-workspace
       - run:
           name: Integ tests
@@ -744,7 +753,7 @@ jobs:
 
   test-microk8s:
     machine:
-      <<: *shared-machine-config
+      <<: *ubuntu-vm-runner
     resource_class: large
     parameters:
       kubernetesVersion:
@@ -793,7 +802,7 @@ jobs:
             echo "********* env prepped! *********"
       - configure_git
       - npm_install:
-          context: vm
+          context: vm-ubuntu
       - *attach-workspace
       - run:
           name: Integ tests
@@ -810,7 +819,7 @@ jobs:
 
   test-minikube:
     machine:
-      <<: *shared-machine-config
+      <<: *ubuntu-vm-runner
     resource_class: large
     parameters:
       minikubeVersion:
@@ -845,7 +854,7 @@ jobs:
       - docker_login
       - configure_git
       - npm_install:
-          context: vm
+          context: vm-ubuntu
       - *attach-workspace
       - run:
           name: Install Minikube Executable
@@ -890,7 +899,7 @@ jobs:
 
   test-k3s:
     machine:
-      <<: *shared-machine-config
+      <<: *ubuntu-vm-runner
     resource_class: large
     parameters:
       k3sVersion:
@@ -912,7 +921,7 @@ jobs:
       - docker_login
       - configure_git
       - npm_install:
-          context: vm
+          context: vm-ubuntu
       - *attach-workspace
       - run:
           name: Install K3s and start cluster


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
- Save ~/.npm folder in npm_install cache and use --prefer-offline
  option (node_modules are always nuked by npm ci)
- Always save caches with context parameter, as paths differ on
  different runners.
- Rename some variables to make the circleci config more clear
- Remove "~/.npm" before restoring cache to avoid permission errors (See also https://github.com/CircleCI-Public/node-orb/issues/158#issuecomment-1461095390)

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
