### PR TITLE
fix(sync-mode): use the same source path schemas for all action types

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -1084,8 +1084,24 @@ jobs:
           command: |
             .\dist\windows-amd64\garden.exe deploy --root .\examples\demo-project\ --logger-type basic --log-level silly --env remote --force-build --var userId=$env:CIRCLE_BUILD_NUM-win
       - run:
-          name: Cleanup
+          name: Cleanup demo-project
           command: (kubectl delete namespace --wait=false demo-project-testing-$env:CIRCLE_BUILD_NUM-win) -or $true
+          when: always
+      - run:
+          name: Validate vote-helm project # to validate the sync mode paths on Windows with action-based configs
+          command: |
+            .\dist\windows-amd64\garden.exe validate --root .\e2e\projects\vote-helm\ --logger-type basic --log-level silly --env testing --var userId=$env:CIRCLE_BUILD_NUM-win
+      - run:
+          name: Cleanup vote-helm project
+          command: (kubectl delete namespace --wait=false vote-helm-testing-$env:CIRCLE_BUILD_NUM-win) -or $true
+          when: always
+      - run:
+          name: Validate vote-helm-modules project # to validate the sync mode paths on Windows with module-based configs
+          command: |
+            .\dist\windows-amd64\garden.exe validate --root .\e2e\projects\vote-helm-modules\ --logger-type basic --log-level silly --env testing --var userId=$env:CIRCLE_BUILD_NUM-win
+      - run:
+          name: Cleanup vote-helm-modules project
+          command: (kubectl delete namespace --wait=false vote-helm-modules-testing-$env:CIRCLE_BUILD_NUM-win) -or $true
           when: always
       - fail_fast
 

--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -31,6 +31,7 @@ import type { RunAction, RunActionConfig } from "../../actions/run.js"
 import { memoize } from "lodash-es"
 import type Joi from "@hapi/joi"
 import type { OctalPermissionMask } from "../kubernetes/types.js"
+import { templateStringLiteral } from "../../docs/common.js"
 
 export const defaultDockerfileName = "Dockerfile"
 
@@ -237,13 +238,21 @@ export const syncDefaultGroupSchema = memoize(() =>
     .description("Set the default group on files and directories at the target. " + ownerDocs)
 )
 
+const exampleActionRef = templateStringLiteral("actions.build.my-container-image.sourcePath")
+
 export const syncSourcePathSchema = memoize(() =>
   joi
     .string()
     .default(".")
     .description(
       deline`
-        POSIX-style or Windows path of the directory to sync to the target. Defaults to the config's directory if no value is provided.
+        POSIX-style or Windows-style local path of the directory to sync to the target.
+        Can be either absolute or relative to the source directory where the Deploy action is defined.
+
+        This should generally be a templated path to another action's source path (e.g. ${exampleActionRef}), or a relative path.
+        If a path is hard-coded, you must make sure the path exists, and that it is reliably the correct path for every user.
+
+        Defaults to the Deploy action's config's directory if no value is provided.
         `
     )
     .example("src")

--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -237,6 +237,17 @@ export const syncDefaultGroupSchema = memoize(() =>
     .description("Set the default group on files and directories at the target. " + ownerDocs)
 )
 
+export const syncSourcePathSchema = memoize(() =>
+  joi
+    .string()
+    .default(".")
+    .description(
+      deline`
+        POSIX-style or Windows path of the directory to sync to the target. Defaults to the config's directory if no value is provided.
+        `
+    )
+    .example("src")
+)
 export const syncTargetPathSchema = memoize(() =>
   joi
     .posixPath()
@@ -254,15 +265,7 @@ export const syncTargetPathSchema = memoize(() =>
 const containerSyncSchema = createSchema({
   name: "container-sync",
   keys: () => ({
-    source: joi
-      .string()
-      .default(".")
-      .description(
-        deline`
-        POSIX-style or Windows path of the directory to sync to the target. Defaults to the config's directory if no value is provided.
-        `
-      )
-      .example("src"),
+    source: syncSourcePathSchema(),
     target: syncTargetPathSchema(),
     exclude: syncExcludeSchema(),
     mode: syncModeSchema(),

--- a/core/src/plugins/container/config.ts
+++ b/core/src/plugins/container/config.ts
@@ -239,6 +239,8 @@ export const syncDefaultGroupSchema = memoize(() =>
 )
 
 const exampleActionRef = templateStringLiteral("actions.build.my-container-image.sourcePath")
+const backSlash = "`\\`"
+const forwardSlash = "`/`"
 
 export const syncSourcePathSchema = memoize(() =>
   joi
@@ -246,11 +248,11 @@ export const syncSourcePathSchema = memoize(() =>
     .default(".")
     .description(
       deline`
-        POSIX-style or Windows-style local path of the directory to sync to the target.
-        Can be either absolute or relative to the source directory where the Deploy action is defined.
+        Path to a local directory to be synchronized with the target.
 
         This should generally be a templated path to another action's source path (e.g. ${exampleActionRef}), or a relative path.
-        If a path is hard-coded, you must make sure the path exists, and that it is reliably the correct path for every user.
+
+        If a path is hard-coded, we recommend sticking with relative paths here, and using forward slashes (${forwardSlash}) as a delimiter, as Windows-style paths with back slashes (${backSlash}) and absolute paths will work on some platforms, but they are not portable and will not work for users on other platforms.
 
         Defaults to the Deploy action's config's directory if no value is provided.
         `

--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -24,6 +24,7 @@ import {
   syncDefaultOwnerSchema,
   syncExcludeSchema,
   syncModeSchema,
+  syncSourcePathSchema,
   syncTargetPathSchema,
 } from "../container/moduleConfig.js"
 import { dedent, gardenAnnotationKey } from "../../util/string.js"
@@ -58,7 +59,6 @@ import type { PluginContext } from "../../plugin-context.js"
 import type { SyncConfig, SyncSession } from "../../mutagen.js"
 import { mutagenAgentPath, Mutagen, haltedStatuses, mutagenStatusDescriptions } from "../../mutagen.js"
 import { k8sSyncUtilImageName } from "./constants.js"
-import { templateStringLiteral } from "../../docs/common.js"
 import { relative, resolve } from "path"
 import type { Resolved } from "../../actions/types.js"
 import { isAbsolute } from "path"
@@ -136,8 +136,6 @@ export interface KubernetesDeployDevModeSyncSpec extends DevModeSyncOptions {
   containerName?: string
 }
 
-const exampleActionRef = templateStringLiteral("actions.build.my-container-image.sourcePath")
-
 export const kubernetesDeploySyncPathSchema = () =>
   joi
     .object()
@@ -145,16 +143,7 @@ export const kubernetesDeploySyncPathSchema = () =>
       target: targetResourceSpecSchema().description(
         "The Kubernetes resource to sync to. If specified, this is used instead of `spec.defaultTarget`."
       ),
-      sourcePath: joi
-        .posixPath()
-        .default(".")
-        .description(
-          dedent`
-          The local path to sync from, either absolute or relative to the source directory where the Deploy action is defined.
-
-          This should generally be a templated path to another action's source path (e.g. ${exampleActionRef}), or a relative path. If a path is hard-coded, you must make sure the path exists, and that it is reliably the correct path for every user.
-          `
-        ),
+      sourcePath: syncSourcePathSchema(),
       containerPath: syncTargetPathSchema(),
 
       exclude: syncExcludeSchema(),

--- a/docs/reference/action-types/Deploy/container.md
+++ b/docs/reference/action-types/Deploy/container.md
@@ -556,7 +556,9 @@ Specify one or more source files or directories to automatically sync with the r
 
 [spec](#spec) > [sync](#specsync) > [paths](#specsyncpaths) > source
 
-POSIX-style or Windows path of the directory to sync to the target. Defaults to the config's directory if no value is provided.
+POSIX-style or Windows-style local path of the directory to sync to the target. Can be either absolute or relative to the source directory where the Deploy action is defined.
+This should generally be a templated path to another action's source path (e.g. `${actions.build.my-container-image.sourcePath}`), or a relative path. If a path is hard-coded, you must make sure the path exists, and that it is reliably the correct path for every user.
+Defaults to the Deploy action's config's directory if no value is provided.
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |

--- a/docs/reference/action-types/Deploy/container.md
+++ b/docs/reference/action-types/Deploy/container.md
@@ -556,8 +556,9 @@ Specify one or more source files or directories to automatically sync with the r
 
 [spec](#spec) > [sync](#specsync) > [paths](#specsyncpaths) > source
 
-POSIX-style or Windows-style local path of the directory to sync to the target. Can be either absolute or relative to the source directory where the Deploy action is defined.
-This should generally be a templated path to another action's source path (e.g. `${actions.build.my-container-image.sourcePath}`), or a relative path. If a path is hard-coded, you must make sure the path exists, and that it is reliably the correct path for every user.
+Path to a local directory to be synchronized with the target.
+This should generally be a templated path to another action's source path (e.g. `${actions.build.my-container-image.sourcePath}`), or a relative path.
+If a path is hard-coded, we recommend sticking with relative paths here, and using forward slashes (`/`) as a delimiter, as Windows-style paths with back slashes (`\`) and absolute paths will work on some platforms, but they are not portable and will not work for users on other platforms.
 Defaults to the Deploy action's config's directory if no value is provided.
 
 | Type     | Default | Required |

--- a/docs/reference/action-types/Deploy/helm.md
+++ b/docs/reference/action-types/Deploy/helm.md
@@ -647,8 +647,9 @@ The name of a container in the target. Specify this if the target contains more 
 
 [spec](#spec) > [sync](#specsync) > [paths](#specsyncpaths) > sourcePath
 
-POSIX-style or Windows-style local path of the directory to sync to the target. Can be either absolute or relative to the source directory where the Deploy action is defined.
-This should generally be a templated path to another action's source path (e.g. `${actions.build.my-container-image.sourcePath}`), or a relative path. If a path is hard-coded, you must make sure the path exists, and that it is reliably the correct path for every user.
+Path to a local directory to be synchronized with the target.
+This should generally be a templated path to another action's source path (e.g. `${actions.build.my-container-image.sourcePath}`), or a relative path.
+If a path is hard-coded, we recommend sticking with relative paths here, and using forward slashes (`/`) as a delimiter, as Windows-style paths with back slashes (`\`) and absolute paths will work on some platforms, but they are not portable and will not work for users on other platforms.
 Defaults to the Deploy action's config's directory if no value is provided.
 
 | Type     | Default | Required |

--- a/docs/reference/action-types/Deploy/helm.md
+++ b/docs/reference/action-types/Deploy/helm.md
@@ -647,13 +647,24 @@ The name of a container in the target. Specify this if the target contains more 
 
 [spec](#spec) > [sync](#specsync) > [paths](#specsyncpaths) > sourcePath
 
-The local path to sync from, either absolute or relative to the source directory where the Deploy action is defined.
-
+POSIX-style or Windows-style local path of the directory to sync to the target. Can be either absolute or relative to the source directory where the Deploy action is defined.
 This should generally be a templated path to another action's source path (e.g. `${actions.build.my-container-image.sourcePath}`), or a relative path. If a path is hard-coded, you must make sure the path exists, and that it is reliably the correct path for every user.
+Defaults to the Deploy action's config's directory if no value is provided.
 
-| Type        | Default | Required |
-| ----------- | ------- | -------- |
-| `posixPath` | `"."`   | No       |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `string` | `"."`   | No       |
+
+Example:
+
+```yaml
+spec:
+  ...
+  sync:
+    ...
+    paths:
+      - sourcePath: "src"
+```
 
 ### `spec.sync.paths[].containerPath`
 

--- a/docs/reference/action-types/Deploy/kubernetes.md
+++ b/docs/reference/action-types/Deploy/kubernetes.md
@@ -684,13 +684,24 @@ The name of a container in the target. Specify this if the target contains more 
 
 [spec](#spec) > [sync](#specsync) > [paths](#specsyncpaths) > sourcePath
 
-The local path to sync from, either absolute or relative to the source directory where the Deploy action is defined.
-
+POSIX-style or Windows-style local path of the directory to sync to the target. Can be either absolute or relative to the source directory where the Deploy action is defined.
 This should generally be a templated path to another action's source path (e.g. `${actions.build.my-container-image.sourcePath}`), or a relative path. If a path is hard-coded, you must make sure the path exists, and that it is reliably the correct path for every user.
+Defaults to the Deploy action's config's directory if no value is provided.
 
-| Type        | Default | Required |
-| ----------- | ------- | -------- |
-| `posixPath` | `"."`   | No       |
+| Type     | Default | Required |
+| -------- | ------- | -------- |
+| `string` | `"."`   | No       |
+
+Example:
+
+```yaml
+spec:
+  ...
+  sync:
+    ...
+    paths:
+      - sourcePath: "src"
+```
 
 ### `spec.sync.paths[].containerPath`
 

--- a/docs/reference/action-types/Deploy/kubernetes.md
+++ b/docs/reference/action-types/Deploy/kubernetes.md
@@ -684,8 +684,9 @@ The name of a container in the target. Specify this if the target contains more 
 
 [spec](#spec) > [sync](#specsync) > [paths](#specsyncpaths) > sourcePath
 
-POSIX-style or Windows-style local path of the directory to sync to the target. Can be either absolute or relative to the source directory where the Deploy action is defined.
-This should generally be a templated path to another action's source path (e.g. `${actions.build.my-container-image.sourcePath}`), or a relative path. If a path is hard-coded, you must make sure the path exists, and that it is reliably the correct path for every user.
+Path to a local directory to be synchronized with the target.
+This should generally be a templated path to another action's source path (e.g. `${actions.build.my-container-image.sourcePath}`), or a relative path.
+If a path is hard-coded, we recommend sticking with relative paths here, and using forward slashes (`/`) as a delimiter, as Windows-style paths with back slashes (`\`) and absolute paths will work on some platforms, but they are not portable and will not work for users on other platforms.
 Defaults to the Deploy action's config's directory if no value is provided.
 
 | Type     | Default | Required |

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -312,11 +312,12 @@ services:
 
       # Specify one or more source files or directories to automatically sync with the running container.
       paths:
-        - # POSIX-style or Windows-style local path of the directory to sync to the target. Can be either absolute or
-          # relative to the source directory where the Deploy action is defined.
+        - # Path to a local directory to be synchronized with the target.
           # This should generally be a templated path to another action's source path (e.g.
-          # `${actions.build.my-container-image.sourcePath}`), or a relative path. If a path is hard-coded, you must
-          # make sure the path exists, and that it is reliably the correct path for every user.
+          # `${actions.build.my-container-image.sourcePath}`), or a relative path.
+          # If a path is hard-coded, we recommend sticking with relative paths here, and using forward slashes (`/`)
+          # as a delimiter, as Windows-style paths with back slashes (`\`) and absolute paths will work on some
+          # platforms, but they are not portable and will not work for users on other platforms.
           # Defaults to the Deploy action's config's directory if no value is provided.
           source: .
 
@@ -1413,8 +1414,9 @@ Specify one or more source files or directories to automatically sync with the r
 
 [services](#services) > [sync](#servicessync) > [paths](#servicessyncpaths) > source
 
-POSIX-style or Windows-style local path of the directory to sync to the target. Can be either absolute or relative to the source directory where the Deploy action is defined.
-This should generally be a templated path to another action's source path (e.g. `${actions.build.my-container-image.sourcePath}`), or a relative path. If a path is hard-coded, you must make sure the path exists, and that it is reliably the correct path for every user.
+Path to a local directory to be synchronized with the target.
+This should generally be a templated path to another action's source path (e.g. `${actions.build.my-container-image.sourcePath}`), or a relative path.
+If a path is hard-coded, we recommend sticking with relative paths here, and using forward slashes (`/`) as a delimiter, as Windows-style paths with back slashes (`\`) and absolute paths will work on some platforms, but they are not portable and will not work for users on other platforms.
 Defaults to the Deploy action's config's directory if no value is provided.
 
 | Type     | Default | Required |

--- a/docs/reference/module-types/container.md
+++ b/docs/reference/module-types/container.md
@@ -312,8 +312,12 @@ services:
 
       # Specify one or more source files or directories to automatically sync with the running container.
       paths:
-        - # POSIX-style or Windows path of the directory to sync to the target. Defaults to the config's directory if
-          # no value is provided.
+        - # POSIX-style or Windows-style local path of the directory to sync to the target. Can be either absolute or
+          # relative to the source directory where the Deploy action is defined.
+          # This should generally be a templated path to another action's source path (e.g.
+          # `${actions.build.my-container-image.sourcePath}`), or a relative path. If a path is hard-coded, you must
+          # make sure the path exists, and that it is reliably the correct path for every user.
+          # Defaults to the Deploy action's config's directory if no value is provided.
           source: .
 
           # POSIX-style absolute path to sync to inside the container. The root path (i.e. "/") is not allowed.
@@ -1409,7 +1413,9 @@ Specify one or more source files or directories to automatically sync with the r
 
 [services](#services) > [sync](#servicessync) > [paths](#servicessyncpaths) > source
 
-POSIX-style or Windows path of the directory to sync to the target. Defaults to the config's directory if no value is provided.
+POSIX-style or Windows-style local path of the directory to sync to the target. Can be either absolute or relative to the source directory where the Deploy action is defined.
+This should generally be a templated path to another action's source path (e.g. `${actions.build.my-container-image.sourcePath}`), or a relative path. If a path is hard-coded, you must make sure the path exists, and that it is reliably the correct path for every user.
+Defaults to the Deploy action's config's directory if no value is provided.
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -243,8 +243,12 @@ sync:
 
   # Specify one or more source files or directories to automatically sync with the running container.
   paths:
-    - # POSIX-style or Windows path of the directory to sync to the target. Defaults to the config's directory if no
-      # value is provided.
+    - # POSIX-style or Windows-style local path of the directory to sync to the target. Can be either absolute or
+      # relative to the source directory where the Deploy action is defined.
+      # This should generally be a templated path to another action's source path (e.g.
+      # `${actions.build.my-container-image.sourcePath}`), or a relative path. If a path is hard-coded, you must make
+      # sure the path exists, and that it is reliably the correct path for every user.
+      # Defaults to the Deploy action's config's directory if no value is provided.
       source: .
 
       # POSIX-style absolute path to sync to inside the container. The root path (i.e. "/") is not allowed.
@@ -1099,7 +1103,9 @@ Specify one or more source files or directories to automatically sync with the r
 
 [sync](#sync) > [paths](#syncpaths) > source
 
-POSIX-style or Windows path of the directory to sync to the target. Defaults to the config's directory if no value is provided.
+POSIX-style or Windows-style local path of the directory to sync to the target. Can be either absolute or relative to the source directory where the Deploy action is defined.
+This should generally be a templated path to another action's source path (e.g. `${actions.build.my-container-image.sourcePath}`), or a relative path. If a path is hard-coded, you must make sure the path exists, and that it is reliably the correct path for every user.
+Defaults to the Deploy action's config's directory if no value is provided.
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |

--- a/docs/reference/module-types/helm.md
+++ b/docs/reference/module-types/helm.md
@@ -243,11 +243,12 @@ sync:
 
   # Specify one or more source files or directories to automatically sync with the running container.
   paths:
-    - # POSIX-style or Windows-style local path of the directory to sync to the target. Can be either absolute or
-      # relative to the source directory where the Deploy action is defined.
+    - # Path to a local directory to be synchronized with the target.
       # This should generally be a templated path to another action's source path (e.g.
-      # `${actions.build.my-container-image.sourcePath}`), or a relative path. If a path is hard-coded, you must make
-      # sure the path exists, and that it is reliably the correct path for every user.
+      # `${actions.build.my-container-image.sourcePath}`), or a relative path.
+      # If a path is hard-coded, we recommend sticking with relative paths here, and using forward slashes (`/`) as a
+      # delimiter, as Windows-style paths with back slashes (`\`) and absolute paths will work on some platforms, but
+      # they are not portable and will not work for users on other platforms.
       # Defaults to the Deploy action's config's directory if no value is provided.
       source: .
 
@@ -1103,8 +1104,9 @@ Specify one or more source files or directories to automatically sync with the r
 
 [sync](#sync) > [paths](#syncpaths) > source
 
-POSIX-style or Windows-style local path of the directory to sync to the target. Can be either absolute or relative to the source directory where the Deploy action is defined.
-This should generally be a templated path to another action's source path (e.g. `${actions.build.my-container-image.sourcePath}`), or a relative path. If a path is hard-coded, you must make sure the path exists, and that it is reliably the correct path for every user.
+Path to a local directory to be synchronized with the target.
+This should generally be a templated path to another action's source path (e.g. `${actions.build.my-container-image.sourcePath}`), or a relative path.
+If a path is hard-coded, we recommend sticking with relative paths here, and using forward slashes (`/`) as a delimiter, as Windows-style paths with back slashes (`\`) and absolute paths will work on some platforms, but they are not portable and will not work for users on other platforms.
 Defaults to the Deploy action's config's directory if no value is provided.
 
 | Type     | Default | Required |

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -380,11 +380,12 @@ services:
 
       # Specify one or more source files or directories to automatically sync with the running container.
       paths:
-        - # POSIX-style or Windows-style local path of the directory to sync to the target. Can be either absolute or
-          # relative to the source directory where the Deploy action is defined.
+        - # Path to a local directory to be synchronized with the target.
           # This should generally be a templated path to another action's source path (e.g.
-          # `${actions.build.my-container-image.sourcePath}`), or a relative path. If a path is hard-coded, you must
-          # make sure the path exists, and that it is reliably the correct path for every user.
+          # `${actions.build.my-container-image.sourcePath}`), or a relative path.
+          # If a path is hard-coded, we recommend sticking with relative paths here, and using forward slashes (`/`)
+          # as a delimiter, as Windows-style paths with back slashes (`\`) and absolute paths will work on some
+          # platforms, but they are not portable and will not work for users on other platforms.
           # Defaults to the Deploy action's config's directory if no value is provided.
           source: .
 
@@ -1628,8 +1629,9 @@ Specify one or more source files or directories to automatically sync with the r
 
 [services](#services) > [sync](#servicessync) > [paths](#servicessyncpaths) > source
 
-POSIX-style or Windows-style local path of the directory to sync to the target. Can be either absolute or relative to the source directory where the Deploy action is defined.
-This should generally be a templated path to another action's source path (e.g. `${actions.build.my-container-image.sourcePath}`), or a relative path. If a path is hard-coded, you must make sure the path exists, and that it is reliably the correct path for every user.
+Path to a local directory to be synchronized with the target.
+This should generally be a templated path to another action's source path (e.g. `${actions.build.my-container-image.sourcePath}`), or a relative path.
+If a path is hard-coded, we recommend sticking with relative paths here, and using forward slashes (`/`) as a delimiter, as Windows-style paths with back slashes (`\`) and absolute paths will work on some platforms, but they are not portable and will not work for users on other platforms.
 Defaults to the Deploy action's config's directory if no value is provided.
 
 | Type     | Default | Required |

--- a/docs/reference/module-types/jib-container.md
+++ b/docs/reference/module-types/jib-container.md
@@ -380,8 +380,12 @@ services:
 
       # Specify one or more source files or directories to automatically sync with the running container.
       paths:
-        - # POSIX-style or Windows path of the directory to sync to the target. Defaults to the config's directory if
-          # no value is provided.
+        - # POSIX-style or Windows-style local path of the directory to sync to the target. Can be either absolute or
+          # relative to the source directory where the Deploy action is defined.
+          # This should generally be a templated path to another action's source path (e.g.
+          # `${actions.build.my-container-image.sourcePath}`), or a relative path. If a path is hard-coded, you must
+          # make sure the path exists, and that it is reliably the correct path for every user.
+          # Defaults to the Deploy action's config's directory if no value is provided.
           source: .
 
           # POSIX-style absolute path to sync to inside the container. The root path (i.e. "/") is not allowed.
@@ -1624,7 +1628,9 @@ Specify one or more source files or directories to automatically sync with the r
 
 [services](#services) > [sync](#servicessync) > [paths](#servicessyncpaths) > source
 
-POSIX-style or Windows path of the directory to sync to the target. Defaults to the config's directory if no value is provided.
+POSIX-style or Windows-style local path of the directory to sync to the target. Can be either absolute or relative to the source directory where the Deploy action is defined.
+This should generally be a templated path to another action's source path (e.g. `${actions.build.my-container-image.sourcePath}`), or a relative path. If a path is hard-coded, you must make sure the path exists, and that it is reliably the correct path for every user.
+Defaults to the Deploy action's config's directory if no value is provided.
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -269,11 +269,12 @@ sync:
 
   # Specify one or more source files or directories to automatically sync with the running container.
   paths:
-    - # POSIX-style or Windows-style local path of the directory to sync to the target. Can be either absolute or
-      # relative to the source directory where the Deploy action is defined.
+    - # Path to a local directory to be synchronized with the target.
       # This should generally be a templated path to another action's source path (e.g.
-      # `${actions.build.my-container-image.sourcePath}`), or a relative path. If a path is hard-coded, you must make
-      # sure the path exists, and that it is reliably the correct path for every user.
+      # `${actions.build.my-container-image.sourcePath}`), or a relative path.
+      # If a path is hard-coded, we recommend sticking with relative paths here, and using forward slashes (`/`) as a
+      # delimiter, as Windows-style paths with back slashes (`\`) and absolute paths will work on some platforms, but
+      # they are not portable and will not work for users on other platforms.
       # Defaults to the Deploy action's config's directory if no value is provided.
       source: .
 
@@ -1154,8 +1155,9 @@ Specify one or more source files or directories to automatically sync with the r
 
 [sync](#sync) > [paths](#syncpaths) > source
 
-POSIX-style or Windows-style local path of the directory to sync to the target. Can be either absolute or relative to the source directory where the Deploy action is defined.
-This should generally be a templated path to another action's source path (e.g. `${actions.build.my-container-image.sourcePath}`), or a relative path. If a path is hard-coded, you must make sure the path exists, and that it is reliably the correct path for every user.
+Path to a local directory to be synchronized with the target.
+This should generally be a templated path to another action's source path (e.g. `${actions.build.my-container-image.sourcePath}`), or a relative path.
+If a path is hard-coded, we recommend sticking with relative paths here, and using forward slashes (`/`) as a delimiter, as Windows-style paths with back slashes (`\`) and absolute paths will work on some platforms, but they are not portable and will not work for users on other platforms.
 Defaults to the Deploy action's config's directory if no value is provided.
 
 | Type     | Default | Required |

--- a/docs/reference/module-types/kubernetes.md
+++ b/docs/reference/module-types/kubernetes.md
@@ -269,8 +269,12 @@ sync:
 
   # Specify one or more source files or directories to automatically sync with the running container.
   paths:
-    - # POSIX-style or Windows path of the directory to sync to the target. Defaults to the config's directory if no
-      # value is provided.
+    - # POSIX-style or Windows-style local path of the directory to sync to the target. Can be either absolute or
+      # relative to the source directory where the Deploy action is defined.
+      # This should generally be a templated path to another action's source path (e.g.
+      # `${actions.build.my-container-image.sourcePath}`), or a relative path. If a path is hard-coded, you must make
+      # sure the path exists, and that it is reliably the correct path for every user.
+      # Defaults to the Deploy action's config's directory if no value is provided.
       source: .
 
       # POSIX-style absolute path to sync to inside the container. The root path (i.e. "/") is not allowed.
@@ -1150,7 +1154,9 @@ Specify one or more source files or directories to automatically sync with the r
 
 [sync](#sync) > [paths](#syncpaths) > source
 
-POSIX-style or Windows path of the directory to sync to the target. Defaults to the config's directory if no value is provided.
+POSIX-style or Windows-style local path of the directory to sync to the target. Can be either absolute or relative to the source directory where the Deploy action is defined.
+This should generally be a templated path to another action's source path (e.g. `${actions.build.my-container-image.sourcePath}`), or a relative path. If a path is hard-coded, you must make sure the path exists, and that it is reliably the correct path for every user.
+Defaults to the Deploy action's config's directory if no value is provided.
 
 | Type     | Default | Required |
 | -------- | ------- | -------- |


### PR DESCRIPTION
**What this PR does / why we need it**:
This unifies the way we validate the sync mode's source paths for all action types.

**Which issue(s) this PR fixes**:

Fixes #4982
Fixes #5031

**Special notes for your reviewer**:

I tested and verified the changes on the Windows machine. I tried both relative and absolute Windows paths as a sync-mode source path.

I also added 2 test cases for Windows in 40ec1ea0b6f38ea9ac37ab57055cc8e29f50aca1.
Verified the failure of those tests manually and in [CI](https://app.circleci.com/pipelines/github/garden-io/garden/21852/workflows/460299a5-632f-4e11-803c-68d11368279a/jobs/433221).

See individual commits for details.