### PR TITLE
test: fix flaky test for deploy logs

### DIFF
--- a/core/test/integ/src/plugins/kubernetes/container/logs.ts
+++ b/core/test/integ/src/plugins/kubernetes/container/logs.ts
@@ -80,7 +80,8 @@ describe("kubernetes", () => {
         follow: false,
       })
 
-      expect(entries[0].msg).to.include("Server running...")
+      const deployLog = entries.find((e) => e.msg.includes("Server running..."))
+      expect(deployLog).to.exist
     })
     describe("K8sLogsFollower", () => {
       let logsFollower: K8sLogFollower<DeployLogEntry>


### PR DESCRIPTION
**What this PR does / why we need it**:
This test is flaky because the order of log entries isn't always stable now.
Thus we find the correct log line first and then assert that it exists.
Actually all the following tests in this file did the same pattern, so maybe something like this has been the case in the past as well and only this test somehow survived.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
