### PR TITLE
docs: make sure git clone command works on windows

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -72,7 +72,8 @@ For more detailed installation instructions, please see our [Installation guide]
 Next, we clone the example project from GitHub and change into the project directory:
 
 ```sh
-git clone https://github.com/garden-io/quickstart-example.git && cd quickstart-example
+git clone https://github.com/garden-io/quickstart-example.git
+cd quickstart-example
 ```
 
 ### Step 3 — Deploy the project


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
Otherwise I get this error on windows:

```
PS Z:\Documents> git clone https://github.com/garden-io/quickstart-example.git && cd quickstart-example
At line:1 char:63
+ ...  clone https://github.com/garden-io/quickstart-example.git && cd quic ...
+                                                                ~~
The token '&&' is not a valid statement separator in this version.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : InvalidEndOfLine
```

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
