### PR TITLE
fix(git): fix confusing error messages on exit code 128

### DIFF
--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -140,7 +140,7 @@ export class GitHandler extends VcsHandler {
               err.details.stderr +
               `\nIt looks like you're using Git 2.36.0 or newer and the repo directory containing "${path}" is owned by someone else. If this is intentional you can run "git config --global --add safe.directory '<repo root>'" and try again.`,
           })
-        } else if (err.details.code === 128) {
+        } else if (err.details.code === 128 && err.details.stderr.toLowerCase().includes("fatal: not a git repository")) {
           // Throw nice error when we detect that we're not in a repo root
           throw new RuntimeError({
             message: notInRepoRootErrorMessage(path),

--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -10,10 +10,8 @@ import { performance } from "perf_hooks"
 import { isAbsolute, join, posix, relative, resolve } from "path"
 import { isString } from "lodash-es"
 import fsExtra from "fs-extra"
-
-const { createReadStream, ensureDir, lstat, pathExists, readlink, realpath, stat } = fsExtra
 import { PassThrough } from "stream"
-import type { GetFilesParams, RemoteSourceParams, VcsFile, VcsInfo, VcsHandlerParams } from "./vcs.js"
+import type { GetFilesParams, RemoteSourceParams, VcsFile, VcsHandlerParams, VcsInfo } from "./vcs.js"
 import { VcsHandler } from "./vcs.js"
 import { ChildProcessError, ConfigurationError, isErrnoException, RuntimeError } from "../exceptions.js"
 import { getStatsType, joinWithPosix, matchPath } from "../util/fs.js"
@@ -33,6 +31,8 @@ import type { ExecaError } from "execa"
 import { execa } from "execa"
 import hasha from "hasha"
 import { styles } from "../logger/styles.js"
+
+const { createReadStream, ensureDir, lstat, pathExists, readlink, realpath, stat } = fsExtra
 
 const submoduleErrorSuggestion = `Perhaps you need to run ${styles.underline(`git submodule update --recursive`)}?`
 

--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -144,7 +144,11 @@ export class GitHandler extends VcsHandler {
         } else if (err.details.code === 128 && gitErrorContains(err, "fatal: not a git repository")) {
           // Throw nice error when we detect that we're not in a repo root
           throw new RuntimeError({
-            message: notInRepoRootErrorMessage(path),
+            message: deline`
+    Path ${path} is not in a git repository root. Garden must be run from within a git repo.
+    Please run \`git init\` if you're starting a new project and repository, or move the project to an
+    existing repository, and try again.
+  `,
           })
         } else {
           throw err
@@ -693,12 +697,6 @@ export class GitHandler extends VcsHandler {
 
 const gitErrorContains = (err: ChildProcessError, substring: string) =>
   err.details.stderr.toLowerCase().includes(substring.toLowerCase())
-
-const notInRepoRootErrorMessage = (path: string) => deline`
-    Path ${path} is not in a git repository root. Garden must be run from within a git repo.
-    Please run \`git init\` if you're starting a new project and repository, or move the project to an
-    existing repository, and try again.
-  `
 
 /**
  * Given a list of POSIX-style globs/paths and a `basePath`, find paths that point to a directory and append `**\/*`

--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -684,14 +684,6 @@ function gitErrorContains(err: ChildProcessError, substring: string): boolean {
 export function explainGitError(err: ChildProcessError, path: string): GardenError {
   // handle some errors with exit codes 128 in a specific manner
   if (err.details.code === 128) {
-    if (gitErrorContains(err, "fatal: unsafe repository")) {
-      // Throw nice error when we detect that we're not in a repo root
-      return new RuntimeError({
-        message:
-          err.details.stderr +
-          `\nIt looks like you're using Git 2.36.0 or newer and the repo directory containing "${path}" is owned by someone else. If this is intentional you can run "git config --global --add safe.directory '<repo root>'" and try again.`,
-      })
-    }
     if (gitErrorContains(err, "fatal: not a git repository")) {
       // Throw nice error when we detect that we're not in a repo root
       return new RuntimeError({

--- a/core/test/unit/src/vcs/git.ts
+++ b/core/test/unit/src/vcs/git.ts
@@ -1006,18 +1006,6 @@ describe("git", () => {
     context("on error code 128", () => {
       const exitCode = 128
 
-      it("should throw a nice error when given repo is unsafe", async () => {
-        const stderr = `fatal: unsafe repository ('${path}' is owned by someone else)`
-        const gitError = getChildProcessError(exitCode, stderr)
-
-        const explainedGitError = explainGitError(gitError, path)
-        expect(explainedGitError).to.be.instanceof(RuntimeError)
-        expect(explainedGitError.message).to.eql(
-          stderr +
-            `\nIt looks like you're using Git 2.36.0 or newer and the repo directory containing "${path}" is owned by someone else. If this is intentional you can run "git config --global --add safe.directory '<repo root>'" and try again.`
-        )
-      })
-
       it("should throw a nice error when given a path outside of a repo", async () => {
         const stderr = "fatal: not a git repository (or any of the parent directories): .git"
         const gitError = getChildProcessError(exitCode, stderr)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
This PR introduces a more precise error message examination for Git exit code 128.

**Which issue(s) this PR fixes**:

Fixes #5434

**Special notes for your reviewer**:
