### PR TITLE
chore: fix edge version

### DIFF
--- a/core/src/util/util.ts
+++ b/core/src/util/util.ts
@@ -117,6 +117,7 @@ export function registerCleanupFunction(name: string, func: HookCallback) {
 }
 
 export function getPackageVersion(): string {
+  // This code will be replaced by the version number during the build process in rollup.config.js. Please update the rollup config as well if you change the following line.
   const { version } = corePackageJson as { version: string }
   return version
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -48,8 +48,16 @@ export default {
         }
       }
     },
-
-    // we import the package.json file for version number detection
+    // Hack: Replace version in `getPackageVersion()` function, because the `json()` plugin below somehow loads the wrong package.json file.
+    replace({
+      include: [/core.*\.js/],
+      values: {
+        "const { version } = corePackageJson": `const version = ${JSON.stringify(process.env.GARDEN_CORE_VERSION || "0.0.0-dev")}`,
+      },
+      delimiters: ["", ""],
+    }),
+    // we import the package.json file for version number detection, but for some reasons rollup reads the package.json files in ./ instead of in ./garden-sea/tmp/source/
+    // That's why we also need the hack above unfortunately...
     json(),
 
     // NOTE: You may need the following hacks if we ever decide to update ink to the latest version


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
Currently edge versions pretend to be production version. This was a regression introduced in #5233 

This commit fixes that, to ensure that we do not confuse edge builds
with production builds and to ensure that our analytics is correct.

**Which issue(s) this PR fixes**:

Currently edge builds pretend to be production builds:
```
steffen@MacBook-Pro-3 garden % garden self-update edge-bonsai
Update Garden 🗞️

No installation directory specified via --install-dir option. Garden will be re-installed to the current installation directory: /opt/homebrew/Cellar/garden-cli/0.13.19/libexec
Checking for target and latest versions...
Current Garden version: 0.13.20
Target Garden version to be installed: edge-bonsai
Latest release version: 0.13.20

Downloading version edge-bonsai from https://download.garden.io/core/edge-bonsai/garden-edge-bonsai-macos-arm64.tar.gz...
Backing up prior installation to /opt/homebrew/Cellar/garden-cli/0.13.19/libexec/.backup/0.13.20...
Extracting to installation directory /opt/homebrew/Cellar/garden-cli/0.13.19/libexec...

Done!
steffen@MacBook-Pro-3 garden % garden version
garden version: 0.13.20
```
**Special notes for your reviewer**:
