### PR TITLE
improvement(api): send action type to cloud

### DIFF
--- a/core/src/actions/types.ts
+++ b/core/src/actions/types.ts
@@ -134,7 +134,7 @@ export interface ActionDependencyAttributes {
   needsExecutedOutputs: boolean // Set to true if action cannot be resolved without the dependency executed
 }
 
-export type ActionDependency = ActionReference & ActionDependencyAttributes
+export type ActionDependency = ActionReference & ActionDependencyAttributes & { type: string }
 
 export interface ActionModes {
   sync?: boolean

--- a/core/src/events/util.ts
+++ b/core/src/events/util.ts
@@ -75,8 +75,8 @@ export function makeActionStatusPayloadBase({
     actionName: action.name,
     actionVersion: action.versionString(),
     // NOTE: The type/kind needs to be lower case in the event payload
-    actionType: action.kind.toLowerCase(),
     actionKind: action.kind.toLowerCase(),
+    actionType: action.type,
     actionUid: action.uid,
     moduleName: action.moduleName(),
     sessionId,

--- a/core/src/util/testing.ts
+++ b/core/src/util/testing.ts
@@ -300,9 +300,23 @@ export class TestGarden extends Garden {
     this.addActionConfig(config)
   }
 
+  /**
+   * Replace all module configs with the one provided.
+   */
   setModuleConfigs(moduleConfigs: PartialModuleConfig[]) {
     this.state.configsScanned = true
     this.moduleConfigs = keyBy(moduleConfigs.map(moduleConfigWithDefaults), "name")
+  }
+
+  /**
+   * Merge the provided module configs with the existing ones.
+   */
+  mergeModuleConfigs(moduleConfigs: PartialModuleConfig[]) {
+    this.state.configsScanned = true
+    this.moduleConfigs = {
+      ...this.moduleConfigs,
+      ...keyBy(moduleConfigs.map(moduleConfigWithDefaults), "name"),
+    }
   }
 
   setActionConfigs(actionConfigs: PartialActionConfig[]) {

--- a/core/test/data/test-projects/kubernetes-type/module-simple/garden.yml
+++ b/core/test/data/test-projects/kubernetes-type/module-simple/garden.yml
@@ -43,7 +43,6 @@ tasks:
     command: [sh, -c, "echo ok"]
 
 ---
-
 kind: Run
 name: echo-run-exec
 type: kubernetes-exec
@@ -56,7 +55,6 @@ spec:
   command: [echo, ok]
 
 ---
-
 kind: Test
 name: echo-test-exec
 type: kubernetes-exec

--- a/core/test/integ/src/plugins/kubernetes/kubernetes-type/handlers.ts
+++ b/core/test/integ/src/plugins/kubernetes/kubernetes-type/handlers.ts
@@ -115,7 +115,7 @@ describe("kubernetes-type handlers", () => {
   }
 
   async function deployInNamespace({ nsName, deployName }: { nsName: string; deployName: string }) {
-    garden.setModuleConfigs([withNamespace(nsModuleConfig, nsName)])
+    garden.mergeModuleConfigs([withNamespace(nsModuleConfig, nsName)])
     const graph = await garden.getConfigGraph({ log, emit: false })
     const action = graph.getDeploy(deployName)
     const resolvedAction = await garden.resolveAction<KubernetesDeployAction>({ action, log: garden.log, graph })

--- a/core/test/unit/src/actions/action-configs-to-graph.ts
+++ b/core/test/unit/src/actions/action-configs-to-graph.ts
@@ -237,6 +237,7 @@ describe("actionConfigsToGraph", () => {
         explicit: true,
         kind: "Build",
         name: "foo",
+        type: "test",
         needsExecutedOutputs: false,
         needsStaticOutputs: false,
       },
@@ -283,6 +284,7 @@ describe("actionConfigsToGraph", () => {
       {
         explicit: true,
         kind: "Build",
+        type: "test",
         name: "foo",
         needsExecutedOutputs: false,
         needsStaticOutputs: false,
@@ -331,6 +333,7 @@ describe("actionConfigsToGraph", () => {
       {
         explicit: false,
         kind: "Build",
+        type: "test",
         name: "foo",
         fullRef: ["actions", "build", "foo", "version"],
         needsExecutedOutputs: false,
@@ -380,6 +383,7 @@ describe("actionConfigsToGraph", () => {
       {
         explicit: false,
         kind: "Build",
+        type: "test",
         name: "foo",
         fullRef: ["actions", "build", "foo", "outputs", "bar"],
         needsExecutedOutputs: true,
@@ -429,6 +433,7 @@ describe("actionConfigsToGraph", () => {
       {
         explicit: false,
         kind: "Build",
+        type: "container",
         name: "foo",
         fullRef: ["actions", "build", "foo", "outputs", "deploymentImageName"],
         needsExecutedOutputs: false,

--- a/core/test/unit/src/config-graph.ts
+++ b/core/test/unit/src/config-graph.ts
@@ -29,6 +29,7 @@ import { DEFAULT_BUILD_TIMEOUT_SEC, GARDEN_CORE_ROOT, GardenApiVersion } from ".
 import type tmp from "tmp-promise"
 import type { ActionKind, BaseActionConfig } from "../../../src/actions/types.js"
 import { GraphError, ParameterError } from "../../../src/exceptions.js"
+import { sortBy } from "lodash-es"
 
 const makeAction = ({
   basePath,
@@ -1476,90 +1477,112 @@ describe("ConfigGraph (module-based configs)", () => {
   describe("render", () => {
     it("should render config graph nodes with test names", () => {
       const rendered = graphA.render()
-      expect(rendered.nodes).to.include.deep.members([
+      const sortedNodes = sortBy(rendered.nodes, "key")
+      expect(sortedNodes).to.include.deep.members([
         {
           kind: "Build",
           name: "module-a",
           key: "module-a",
           disabled: false,
-        },
-        {
-          kind: "Build",
-          name: "module-b",
-          key: "module-b",
-          disabled: false,
-        },
-        {
-          kind: "Build",
-          name: "module-c",
-          key: "module-c",
-          disabled: false,
-        },
-        {
-          kind: "Test",
-          name: "module-c-unit",
-          key: "module-c-unit",
-          disabled: false,
-        },
-        {
-          kind: "Test",
-          name: "module-c-integ",
-          key: "module-c-integ",
-          disabled: false,
-        },
-        {
-          kind: "Run",
-          name: "task-c",
-          key: "task-c",
-          disabled: false,
-        },
-        {
-          kind: "Deploy",
-          name: "service-c",
-          key: "service-c",
-          disabled: false,
-        },
-        {
-          kind: "Test",
-          name: "module-a-unit",
-          key: "module-a-unit",
-          disabled: false,
+          type: "test",
         },
         {
           kind: "Test",
           name: "module-a-integration",
           key: "module-a-integration",
           disabled: false,
+          type: "test",
         },
         {
-          kind: "Run",
-          name: "task-a",
-          key: "task-a",
+          kind: "Test",
+          name: "module-a-unit",
+          key: "module-a-unit",
           disabled: false,
+          type: "test",
+        },
+        {
+          kind: "Build",
+          name: "module-b",
+          key: "module-b",
+          disabled: false,
+          type: "test",
         },
         {
           kind: "Test",
           name: "module-b-unit",
           key: "module-b-unit",
           disabled: false,
+          type: "test",
         },
         {
-          kind: "Run",
-          name: "task-b",
-          key: "task-b",
+          kind: "Build",
+          name: "module-c",
+          key: "module-c",
           disabled: false,
+          type: "test",
+        },
+        {
+          kind: "Test",
+          name: "module-c-integ",
+          key: "module-c-integ",
+          disabled: false,
+          type: "test",
+        },
+        {
+          kind: "Test",
+          name: "module-c-unit",
+          key: "module-c-unit",
+          disabled: false,
+          type: "test",
         },
         {
           kind: "Deploy",
           name: "service-a",
           key: "service-a",
           disabled: false,
+          type: "test",
         },
         {
           kind: "Deploy",
           name: "service-b",
           key: "service-b",
           disabled: false,
+          type: "test",
+        },
+        {
+          kind: "Deploy",
+          name: "service-c",
+          key: "service-c",
+          disabled: false,
+          type: "test",
+        },
+        {
+          kind: "Run",
+          name: "task-a",
+          key: "task-a",
+          disabled: false,
+          type: "test",
+        },
+        {
+          name: "task-a2",
+          kind: "Run",
+          key: "task-a2",
+          disabled: false,
+          type: "test",
+        },
+        {
+          kind: "Run",
+          name: "task-b",
+          key: "task-b",
+          disabled: false,
+          type: "test",
+        },
+        {
+          kind: "Run",
+          name: "task-c",
+          key: "task-c",
+          disabled: false,
+          type: "test",
         },
       ])
     })
@@ -1569,57 +1592,62 @@ describe("ConfigGraph (module-based configs)", () => {
 describe("ConfigGraphNode", () => {
   describe("render", () => {
     it("should render a build node", () => {
-      const node = new ConfigGraphNode("Build", "module-a", false)
+      const node = new ConfigGraphNode("Build", "container", "module-a", false)
       const res = node.render()
       expect(res).to.eql({
         kind: "Build",
         name: "module-a",
         key: "module-a",
         disabled: false,
+        type: "container",
       })
     })
 
     it("should render a deploy node", () => {
-      const node = new ConfigGraphNode("Deploy", "service-a", false)
+      const node = new ConfigGraphNode("Deploy", "container", "service-a", false)
       const res = node.render()
       expect(res).to.eql({
         kind: "Deploy",
         name: "service-a",
         key: "service-a",
         disabled: false,
+        type: "container",
       })
     })
 
     it("should render a run node", () => {
-      const node = new ConfigGraphNode("Run", "task-a", false)
+      const node = new ConfigGraphNode("Run", "container", "task-a", false)
       const res = node.render()
       expect(res).to.eql({
         kind: "Run",
         name: "task-a",
         key: "task-a",
         disabled: false,
+        type: "container",
       })
     })
 
     it("should render a test node", () => {
-      const node = new ConfigGraphNode("Test", "module-a.test-a", false)
+      const node = new ConfigGraphNode("Test", "container", "module-a.test-a", false)
       const res = node.render()
       expect(res).to.eql({
         kind: "Test",
         name: "module-a.test-a",
         key: "module-a.test-a",
         disabled: false,
+        type: "container",
       })
     })
 
     it("should indicate if the node is disabled", () => {
-      const node = new ConfigGraphNode("Test", "module-a.test-a", true)
+      const node = new ConfigGraphNode("Test", "container", "module-a.test-a", true)
       const res = node.render()
       expect(res).to.eql({
         kind: "Test",
         name: "module-a.test-a",
         key: "module-a.test-a",
         disabled: true,
+        type: "container",
       })
     })
   })

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -4895,6 +4895,7 @@ describe("Garden", () => {
         {
           explicit: true,
           kind: "Build",
+          type: "foo",
           name: "foo",
           needsExecutedOutputs: false,
           needsStaticOutputs: false,
@@ -4957,6 +4958,7 @@ describe("Garden", () => {
         {
           explicit: true,
           kind: "Build",
+          type: "test",
           name: "foo",
           needsExecutedOutputs: false,
           needsStaticOutputs: false,
@@ -5086,6 +5088,7 @@ describe("Garden", () => {
         {
           explicit: true,
           kind: "Build",
+          type: "foo",
           name: "foo",
           needsExecutedOutputs: false,
           needsStaticOutputs: false,

--- a/core/test/unit/src/plugins/container/container.ts
+++ b/core/test/unit/src/plugins/container/container.ts
@@ -118,15 +118,15 @@ describe("plugins.container", () => {
           basePath: "module-a",
         },
       },
-      convertBuildDependency: () => ({ kind: "Build", name: "buildDep" }),
-      convertRuntimeDependencies: () => [{ kind: "Deploy", name: "runtimeDep" }],
+      convertBuildDependency: () => ({ kind: "Build", type: "container", name: "buildDep" }),
+      convertRuntimeDependencies: () => [{ kind: "Deploy", type: "container", name: "runtimeDep" }],
       convertTestName: () => "testName",
       ctx,
       dummyBuild: undefined,
       log,
       module,
       prepareRuntimeDependencies: prepareRuntimeDependencies
-        ? () => [{ kind: "Deploy", name: "preopRuntimeDep" }]
+        ? () => [{ kind: "Deploy", type: "container", name: "preopRuntimeDep" }]
         : () => [],
       services,
       tasks,

--- a/core/test/unit/src/tasks/build.ts
+++ b/core/test/unit/src/tasks/build.ts
@@ -119,7 +119,7 @@ describe("BuildTask", () => {
           payload: {
             actionName: "test-build",
             actionVersion,
-            actionType: "build",
+            actionType: "test",
             actionKind: "build",
             actionUid,
             moduleName: null,
@@ -137,7 +137,7 @@ describe("BuildTask", () => {
           payload: {
             actionName: "test-build",
             actionVersion,
-            actionType: "build",
+            actionType: "test",
             actionKind: "build",
             actionUid,
             moduleName: null,
@@ -156,7 +156,7 @@ describe("BuildTask", () => {
           payload: {
             actionName: "test-build",
             actionVersion,
-            actionType: "build",
+            actionType: "test",
             actionKind: "build",
             actionUid,
             moduleName: null,
@@ -174,7 +174,7 @@ describe("BuildTask", () => {
           payload: {
             actionName: "test-build",
             actionVersion,
-            actionType: "build",
+            actionType: "test",
             actionKind: "build",
             actionUid,
             moduleName: null,

--- a/core/test/unit/src/tasks/deploy.ts
+++ b/core/test/unit/src/tasks/deploy.ts
@@ -216,7 +216,7 @@ describe("DeployTask", () => {
           payload: {
             actionName: "test-deploy",
             actionVersion,
-            actionType: "deploy",
+            actionType: "test",
             actionKind: "deploy",
             actionUid,
             moduleName: null,
@@ -234,7 +234,7 @@ describe("DeployTask", () => {
           payload: {
             actionName: "test-deploy",
             actionVersion,
-            actionType: "deploy",
+            actionType: "test",
             actionKind: "deploy",
             actionUid,
             moduleName: null,
@@ -258,7 +258,7 @@ describe("DeployTask", () => {
           payload: {
             actionName: "test-deploy",
             actionVersion,
-            actionType: "deploy",
+            actionType: "test",
             actionKind: "deploy",
             actionUid,
             moduleName: null,
@@ -276,7 +276,7 @@ describe("DeployTask", () => {
           payload: {
             actionName: "test-deploy",
             actionVersion,
-            actionType: "deploy",
+            actionType: "test",
             actionKind: "deploy",
             actionUid,
             moduleName: null,

--- a/core/test/unit/src/tasks/run.ts
+++ b/core/test/unit/src/tasks/run.ts
@@ -163,7 +163,7 @@ describe("RunTask", () => {
           payload: {
             actionName: "test",
             actionVersion,
-            actionType: "run",
+            actionType: "test",
             actionKind: "run",
             actionUid,
             moduleName: null,
@@ -181,7 +181,7 @@ describe("RunTask", () => {
           payload: {
             actionName: "test",
             actionVersion,
-            actionType: "run",
+            actionType: "test",
             actionKind: "run",
             actionUid,
             moduleName: null,
@@ -200,7 +200,7 @@ describe("RunTask", () => {
           payload: {
             actionName: "test",
             actionVersion,
-            actionType: "run",
+            actionType: "test",
             actionKind: "run",
             actionUid,
             moduleName: null,
@@ -218,7 +218,7 @@ describe("RunTask", () => {
           payload: {
             actionName: "test",
             actionVersion,
-            actionType: "run",
+            actionType: "test",
             actionKind: "run",
             actionUid,
             moduleName: null,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Sends the action type to cloud so that it can e.g. be displayed in the graph UI and in command results in general. 

We weren't doing that previously because a bit of a legacy baggage but that has been resolved. 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Garden Cloud itself was updated awhile ago to handle this data so this only required Core fixes. 
