### PR TITLE
feat: respect NO_COLOR env var

### DIFF
--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -62,6 +62,8 @@ export const DEFAULT_BROWSER_DIVIDER_WIDTH = 80
  */
 export const gardenEnv = {
   ANALYTICS_DEV: env.get("ANALYTICS_DEV").required(false).asBool(),
+  // Support the NO_COLOR env var (see https://no-color.org/)
+  NO_COLOR: env.get("NO_COLOR").required(false).default("false").asBool(),
   GARDEN_AUTH_TOKEN: env.get("GARDEN_AUTH_TOKEN").required(false).asString(),
   GARDEN_CACHE_TTL: env.get("GARDEN_CACHE_TTL").required(false).asInt(),
   GARDEN_DB_DIR: env.get("GARDEN_DB_DIR").required(false).default(GARDEN_GLOBAL_PATH).asString(),

--- a/core/src/logger/log-entry.ts
+++ b/core/src/logger/log-entry.ts
@@ -20,7 +20,7 @@ import { renderDuration } from "./util.js"
 import { styles } from "./styles.js"
 import { getStyle } from "./renderers.js"
 
-export type LogSymbol = keyof typeof logSymbols | "empty" | "cached"
+export type LogSymbol = keyof typeof logSymbols | "empty"
 export type TaskLogStatus = "active" | "success" | "error"
 
 export interface LogMetadata {

--- a/core/src/logger/renderers.ts
+++ b/core/src/logger/renderers.ts
@@ -71,11 +71,6 @@ export function renderSymbol(entry: LogEntry): string {
     return "  "
   }
 
-  if (symbol === "cached") {
-    return styles.highlightSecondary.bold("🞦 ")
-    // return styles.highlightSecondary.bold("🌸")
-  }
-
   // Always show symbol with sections
   if (!symbol && section) {
     symbol = "info"

--- a/core/src/logger/renderers.ts
+++ b/core/src/logger/renderers.ts
@@ -20,6 +20,7 @@ import { logLevelMap, LogLevel } from "./logger.js"
 import { toGardenError } from "../exceptions.js"
 import { styles } from "./styles.js"
 import type { Chalk } from "chalk"
+import { gardenEnv } from "../constants.js"
 
 type RenderFn = (entry: LogEntry, logger: Logger) => string
 
@@ -162,7 +163,7 @@ export function formatForTerminal(entry: LogEntry, logger: Logger): string {
     return ""
   }
 
-  return combineRenders(entry, logger, [
+  const formattedMsg = combineRenders(entry, logger, [
     renderTimestamp,
     renderSymbol,
     renderSection,
@@ -171,6 +172,11 @@ export function formatForTerminal(entry: LogEntry, logger: Logger): string {
     renderData,
     () => "\n",
   ])
+
+  if (gardenEnv.NO_COLOR) {
+    return stripAnsi(formattedMsg)
+  }
+  return formattedMsg
 }
 
 export function cleanForJSON(input?: string | string[]): string {

--- a/core/test/unit/src/logger/renderers.ts
+++ b/core/test/unit/src/logger/renderers.ts
@@ -29,6 +29,7 @@ import { highlightYaml, safeDumpYaml } from "../../../../src/util/serialization.
 import { freezeTime } from "../../../helpers.js"
 import format from "date-fns/format/index.js"
 import { styles } from "../../../../src/logger/styles.js"
+import { gardenEnv } from "../../../../src/constants.js"
 
 const logger: Logger = getRootLogger()
 
@@ -121,6 +122,20 @@ describe("renderers", () => {
       const entry = logger.createLog().debug({ msg: "hello world" }).getLatestEntry()
 
       expect(formatForTerminal(entry, logger)).to.equal(`${styles.secondary("[debug] hello world")}\n`)
+    })
+    context("NO_COLOR=true", () => {
+      before(() => {
+        gardenEnv.NO_COLOR = true
+      })
+      after(() => {
+        gardenEnv.NO_COLOR = false
+      })
+      it("should not use ANSI terminal colors", () => {
+        const entry = logger.createLog({ name: "test-log" }).info({ msg: "hello world" }).getLatestEntry()
+
+        const sectionWithPadding = "test-log".padEnd(SECTION_PADDING, " ")
+        expect(formatForTerminal(entry, logger)).to.equal(`ℹ ${sectionWithPadding} → hello world\n`)
+      })
     })
     context("basic", () => {
       before(() => {

--- a/docs/misc/faq.md
+++ b/docs/misc/faq.md
@@ -258,12 +258,8 @@ local kubernetes provider it might work.
 
 ### How do I disable terminal colors?
 
-Garden uses the [Chalk NPM package](https://github.com/chalk/chalk) under the hood which picks a color setting based on what colors your terminal supports.
+You can disable terminal colors with the `NO_COLOR` environment variable. For example:
 
-You can override this behavior with the `FORCE_COLOR` environment variable. For example:
-
-- `FORCE_COLOR=0 garden deploy # No colors`
-- `FORCE_COLOR=1 garden deploy # 16 colors`
-- `FORCE_COLOR=2 garden deploy # 256 colors`
-- `FORCE_COLOR=3 garden deploy # Truecolor (16 million)`
-
+```console
+NO_COLOR=1 garden deploy
+```


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

A quick fix to ensure Garden respects the `NO_COLOR` env var and doesn't print colored logs if it's set. We should also this as a CLI flag but this is a start.

A second commit also removes unused code that got accidentally left in. 

**Which issue(s) this PR fixes**:

Fixes #2420

**Special notes for your reviewer**:
