### PR TITLE
improvement(logger): various tweaks to log lines

### DIFF
--- a/core/src/plugins/kubernetes/status/status.ts
+++ b/core/src/plugins/kubernetes/status/status.ts
@@ -289,6 +289,7 @@ export async function waitForResources({
     .createLog({
       // TODO: Avoid setting fallback, the action name should be known
       name: actionName || "<kubernetes>",
+      origin: "kubernetes",
     })
     .info(waitingMsg)
   emitLog(waitingMsg)


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Various tweaks to log lines. Namely:

- Show provider name in the section for `ephemeral-kubernetes`
- Add origin to K8s logs
- Add origin to build util logs

Note that adding `origin` to a given log context means that it'll be printed with the log line.

So instead of:

`deploy.api => Deployment/web: Started container web`

We print:

`deploy.api => [kubernetes] Deployment/web: Started container web`

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
