### PR TITLE
improvement(logger): better provider resolution lifecycle logs

### DIFF
--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -224,6 +224,7 @@ ${renderCommands(commands)}
     } = parsedOpts
 
     const parsedCliVars = parseCliVarFlags(cliVars)
+    const gardenLog = log.createLog({ name: "garden" })
 
     // Some commands may set their own logger type so we update the logger config here,
     // once we've resolved the command.
@@ -241,6 +242,7 @@ ${renderCommands(commands)}
       // Init Cloud API (if applicable)
       let cloudApi: CloudApi | undefined
 
+      gardenLog.info("Initializing...")
       if (!command.noProject) {
         const config = await this.getProjectConfig(log, workingDir)
         const cloudDomain = getGardenCloudDomain(config?.domain)
@@ -302,7 +304,6 @@ ${renderCommands(commands)}
 
       contextOpts.persistent = persistent
       // TODO: Link to Cloud namespace page here.
-      const nsLog = log.createLog({ name: "garden" })
 
       try {
         if (command.noProject) {
@@ -321,9 +322,7 @@ ${renderCommands(commands)}
             })
           }
 
-          nsLog.info(
-            `Running in Garden environment ${styles.highlight(`${garden.environmentName}.${garden.namespace}`)}`
-          )
+          gardenLog.info(`Running in environment ${styles.highlight(`${garden.environmentName}.${garden.namespace}`)}`)
 
           if (!cloudApi && garden.projectId) {
             log.info("")

--- a/core/src/commands/deploy.ts
+++ b/core/src/commands/deploy.ts
@@ -174,6 +174,7 @@ export class DeployCommand extends Command<Args, Opts> {
     const { garden, log, args, opts } = params
 
     this.garden = garden
+    const commandLog = log.createLog({ name: "garden" })
 
     if (opts.watch) {
       await watchRemovedWarning(garden, log)
@@ -206,7 +207,7 @@ export class DeployCommand extends Command<Args, Opts> {
       const bold = disabled.map((d) => styles.accent(d))
       const msg =
         disabled.length === 1 ? `Deploy action ${bold} is disabled` : `Deploy actions ${naturalList(bold)} are disabled`
-      log.info(styles.primary(msg))
+      commandLog.info(msg)
     }
 
     const skipRuntimeDependencies = opts["skip-dependencies"]
@@ -226,7 +227,7 @@ export class DeployCommand extends Command<Args, Opts> {
     deployActions = deployActions.filter((s) => !s.isDisabled() && !skipped.includes(s.name))
 
     if (deployActions.length === 0) {
-      log.error({ msg: "Nothing to deploy. Aborting." })
+      commandLog.error({ msg: "Nothing to deploy. Aborting." })
       return { result: { aborted: true, success: true, ...emptyActionResults } }
     }
 

--- a/core/src/plugins/kubernetes/init.ts
+++ b/core/src/plugins/kubernetes/init.ts
@@ -40,6 +40,7 @@ import { mapValues } from "lodash-es"
 import { getIngressApiVersion, supportedIngressApiVersions } from "./container/ingress.js"
 import type { Log } from "../../logger/log-entry.js"
 import { ingressControllerInstall, ingressControllerReady } from "./nginx/ingress-controller.js"
+import { styles } from "../../logger/styles.js"
 
 const dockerAuthSecretType = "kubernetes.io/dockerconfigjson"
 const dockerAuthDocsLink = `
@@ -92,9 +93,11 @@ export async function getEnvironmentStatus({
   }
 
   if (provider.config.setupIngressController === "nginx") {
+    log.info(`Ensuring ${styles.highlight("nginx")} Ingress Controller...`)
     const ingressControllerReadiness = await ingressControllerReady(ctx, log)
     result.ready = ingressControllerReadiness
     detail.systemReady = ingressControllerReadiness
+    log.info(`${styles.highlight("nginx")} Ingress Controller ready`)
   } else {
     // We only need to warn about missing ingress classes if we're not using garden installed nginx
     const ingressApiVersion = await getIngressApiVersion(log, api, supportedIngressApiVersions)
@@ -106,6 +109,7 @@ export async function getEnvironmentStatus({
     )
     ingressWarnings.forEach((w) => log.warn(w))
   }
+
   return result
 }
 

--- a/core/src/plugins/kubernetes/local/config.ts
+++ b/core/src/plugins/kubernetes/local/config.ts
@@ -57,12 +57,11 @@ export async function configureProvider(params: ConfigureProviderParams<LocalKub
   const { base, log, projectName, ctx } = params
 
   const { config } = await base!(params)
-  const providerLog = log.createLog({ name: config.name })
 
   const provider = ctx.provider as KubernetesProvider
   provider.config = config
 
-  const kubeConfig: any = await getKubeConfig(providerLog, ctx, provider)
+  const kubeConfig: any = await getKubeConfig(log, ctx, provider)
 
   const currentContext = kubeConfig["current-context"]!
 
@@ -71,14 +70,14 @@ export async function configureProvider(params: ConfigureProviderParams<LocalKub
     if (currentContext && isSupportedContext(currentContext)) {
       // prefer current context if set and supported
       config.context = currentContext
-      providerLog.debug(`Using current context: ${config.context}`)
+      log.info(`Using current context: ${config.context}`)
     } else {
       const availableContexts = kubeConfig.contexts?.map((c: any) => c.name) || []
 
       for (const context of availableContexts) {
         if (isSupportedContext(context)) {
           config.context = context
-          providerLog.debug(`Using detected context: ${config.context}`)
+          log.info(`Using detected context: ${config.context}`)
           break
         }
       }
@@ -86,14 +85,14 @@ export async function configureProvider(params: ConfigureProviderParams<LocalKub
 
     if (!config.context && kubeConfig.contexts?.length > 0) {
       config.context = kubeConfig.contexts[0]!.name
-      providerLog.debug(`No kubectl context auto-detected, using first available: ${config.context}`)
+      log.info(`No kubectl context auto-detected, using first available: ${config.context}`)
     }
   }
 
   // TODO: change this in 0.13 to use the current context
   if (!config.context) {
     config.context = supportedContexts[0]
-    providerLog.debug(`No kubectl context configured, using default: ${config.context}`)
+    log.info(`No kubectl context configured, using default: ${config.context}`)
   }
 
   if (config.context === "minikube") {

--- a/core/src/tasks/base.ts
+++ b/core/src/tasks/base.ts
@@ -480,7 +480,7 @@ export function logAndEmitGetStatusEvents<
       if (result.state === "ready" && !willRerun) {
         log.success({ msg: `Already ${logStrings.ready}`, showDuration: false })
       } else if (result.state === "ready" && willRerun) {
-        log.info(`${styledName} is already ${logStrings.ready}, will force ${logStrings.force}`)
+        log.warn(`${styledName} is already ${logStrings.ready}, will force ${logStrings.force}`)
       } else {
         const stateStr = result.detail?.state || displayState(result.state)
         log.warn(`Status is '${stateStr}', ${styledName} ${logStrings.notReady}`)

--- a/core/test/unit/src/cli/cli.ts
+++ b/core/test/unit/src/cli/cli.ts
@@ -1063,9 +1063,10 @@ describe("cli", () => {
 
         const { code } = await cli.run({ args: ["test-command"], exitOnError: false })
 
-        expect(code).to.equal(1)
         const output = stripAnsi(hook.captured())
+        expect(code).to.equal(1)
         expect(output).to.eql(dedent`
+          ℹ garden                    → Initializing...
           Error message
 
           See .garden/error.log for detailed error message\n`)
@@ -1092,8 +1093,9 @@ describe("cli", () => {
         expect(code).to.equal(1)
         const outputLines = stripAnsi(hook.captured()).split("\n")
 
-        const firstSevenLines = outputLines.slice(0, 7).join("\n")
-        expect(firstSevenLines).to.eql(dedent`
+        const firstEightLines = outputLines.slice(0, 8).join("\n")
+        expect(firstEightLines).to.eql(dedent`
+          ℹ garden                    → Initializing...
           Encountered an unexpected Garden error. This is likely a bug 🍂
 
           You can help by reporting this on GitHub: https://github.com/garden-io/garden/issues/new?labels=bug,crash&template=CRASH.md&title=Crash%3A%20Cannot%20read%20property%20foo%20of%20undefined.
@@ -1103,7 +1105,7 @@ describe("cli", () => {
           TypeError: Cannot read property foo of undefined.
         `)
 
-        const firstStackTraceLine = outputLines[7]
+        const firstStackTraceLine = outputLines[8]
         expect(firstStackTraceLine).to.contain("at TestCommand.action (")
 
         const lastLine = outputLines[outputLines.length - 2] // the last line is empty due to trailing newline

--- a/plugins/terraform/src/index.ts
+++ b/plugins/terraform/src/index.ts
@@ -28,6 +28,7 @@ import type { ConvertModuleParams } from "@garden-io/core/build/src/plugin/handl
 import type { TerraformProvider, TerraformProviderConfig } from "./provider.js"
 import { terraformProviderConfigSchema } from "./provider.js"
 import type { PluginContext } from "@garden-io/core/build/src/plugin-context.js"
+import { styles } from "@garden-io/core/build/src/logger/styles.js"
 
 // Need to make these variables to avoid escaping issues
 const deployOutputsTemplateString = "${deploys.<deploy-name>.outputs.<key>}"
@@ -51,7 +52,7 @@ export const gardenPlugin = () =>
       prepareEnvironment,
       cleanupEnvironment,
 
-      async configureProvider({ config, projectRoot }) {
+      async configureProvider({ config, projectRoot, log }) {
         // Make sure the configured root path exists, if it is set
         if (config.initRoot) {
           const absRoot = join(projectRoot, config.initRoot)
@@ -62,6 +63,7 @@ export const gardenPlugin = () =>
               message: `Terraform: configured initRoot config directory '${config.initRoot}' does not exist`,
             })
           }
+          log.info(`Using Terraform root config at path ${styles.highlight(absRoot)}`)
         }
 
         return { config }

--- a/plugins/terraform/src/init.ts
+++ b/plugins/terraform/src/init.ts
@@ -76,7 +76,6 @@ export const prepareEnvironment: ProviderHandlers["prepareEnvironment"] = async 
 
 export const cleanupEnvironment: ProviderHandlers["cleanupEnvironment"] = async ({ ctx, log }) => {
   const provider = ctx.provider as TerraformProvider
-  const providerLog = log.createLog({ name: provider.name })
 
   if (!provider.config.initRoot) {
     // Nothing to do!
@@ -84,7 +83,7 @@ export const cleanupEnvironment: ProviderHandlers["cleanupEnvironment"] = async 
   }
 
   if (!provider.config.allowDestroy) {
-    providerLog.warn("allowDestroy is set to false. Not calling terraform destroy for root stack.")
+    log.warn("allowDestroy is set to false. Not calling terraform destroy for root stack.")
     return {}
   }
 
@@ -92,10 +91,10 @@ export const cleanupEnvironment: ProviderHandlers["cleanupEnvironment"] = async 
   const variables = provider.config.variables
   const workspace = provider.config.workspace || null
 
-  await setWorkspace({ ctx, provider, root, log: providerLog, workspace })
+  await setWorkspace({ ctx, provider, root, log, workspace })
 
   const args = ["destroy", "-auto-approve", "-input=false", ...(await prepareVariables(root, variables))]
-  await terraform(ctx, provider).exec({ log: providerLog, args, cwd: root })
+  await terraform(ctx, provider).exec({ log, args, cwd: root })
 
   return {}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

This commits add more logging around the provider resolution phase of the Garden initialization. Also ensures that the log context passed to the plugin handlers has the provider name set.

For context, these log improvements I've been making are part of the "getting started" video work. The idea there is to explain how Garden works and we need better lifecycle logging to support that.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
