### PR TITLE
improvement(logger): use 'white' as primary color

### DIFF
--- a/core/src/logger/styles.ts
+++ b/core/src/logger/styles.ts
@@ -12,7 +12,7 @@ import chalk from "chalk"
  * A map of all the colors we use to render text in the terminal.
  */
 const theme = {
-  primary: chalk.grey,
+  primary: chalk.white,
   secondary: chalk.grey,
   accent: chalk.white,
   highlight: chalk.cyan,


### PR DESCRIPTION


<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Before this commit, our primary log color was chalk.grey and people generally agree that it's too vague.

This commit changes the primary log color we've been using since we first released Garden to chalk.white for better accessibility and more fun.

In general we can make this configurable. But I figured I'd just bite the bullet.

See also discussion in: https://github.com/garden-io/garden/pull/5464

**Which issue(s) this PR fixes**:

Fixes #5464

**Special notes for your reviewer**:
