### PR TITLE
fix(k8s): read tls-server-name correctly from kubeconfig

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -28,7 +28,7 @@
     "@codenamize/codenamize": "^1.1.1",
     "@hapi/joi": "git+https://github.com/garden-io/joi.git#master",
     "@jsdevtools/readdir-enhanced": "^6.0.4",
-    "@kubernetes/client-node": "github:davidgamero/javascript#c17ff3193dbd111b9e5b5db939647af70005381e",
+    "@kubernetes/client-node": "github:garden-io/javascript#60f0ea6de09777ceabd5afc3e306801fd0b025cc",
     "@opentelemetry/api": "^1.6.0",
     "@opentelemetry/core": "^1.17.1",
     "@opentelemetry/exporter-trace-otlp-http": "0.43.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1544,7 +1544,7 @@
         "@hapi/joi": "git+https://github.com/garden-io/joi.git#master",
         "@homebridge/node-pty-prebuilt-multiarch": "0.11.8",
         "@jsdevtools/readdir-enhanced": "^6.0.4",
-        "@kubernetes/client-node": "github:davidgamero/javascript#c17ff3193dbd111b9e5b5db939647af70005381e",
+        "@kubernetes/client-node": "github:garden-io/javascript#60f0ea6de09777ceabd5afc3e306801fd0b025cc",
         "@opentelemetry/api": "^1.6.0",
         "@opentelemetry/core": "^1.17.1",
         "@opentelemetry/exporter-trace-otlp-http": "0.43.0",
@@ -2889,8 +2889,8 @@
     },
     "core/node_modules/@kubernetes/client-node": {
       "version": "1.0.0-rc3",
-      "resolved": "git+ssh://git@github.com/davidgamero/javascript.git#c17ff3193dbd111b9e5b5db939647af70005381e",
-      "integrity": "sha512-zsVvAfTSltL5+Vo8rau/IsyjEO97ked4gf4JLOajvXZ6upOheoFPGAxbNUeUGVfJypehzKxmwKuiCCQ7xP8ARg==",
+      "resolved": "git+ssh://git@github.com/garden-io/javascript.git#60f0ea6de09777ceabd5afc3e306801fd0b025cc",
+      "integrity": "sha512-VzXsPGsvi4j5gxBU1pduliaguBl8qVczx6jgYbKB13m9HKt+fyGltobKLu7XRhZnnlzd8hAiH8HpOqg+/gT82Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/js-yaml": "^4.0.1",


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
We switch to internal kubernetes-client/javascript fork where we fixed
this issue upstream in commit https://github.com/kubernetes-client/javascript/pull/1436/commits/60f0ea6de09777ceabd5afc3e306801fd0b025cc

See also https://github.com/kubernetes-client/javascript/pull/1436

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
