### PR TITLE
fix(core): log exec provider resolution at info level

### DIFF
--- a/core/src/tasks/resolve-provider.ts
+++ b/core/src/tasks/resolve-provider.ts
@@ -41,7 +41,7 @@ import type { Log } from "../logger/log-entry.js"
  * resolved per se. A bit hacky but this is just a cosmetic change.
  */
 function getProviderLog(providerName: string, log: Log) {
-  const verboseLogProviders = ["exec", "templated", "container"]
+  const verboseLogProviders = ["templated", "container"]
   const fixLevel = verboseLogProviders.includes(providerName) ? LogLevel.verbose : undefined
   return log.createLog({ name: providerName, fixLevel })
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Reverts an earlier commit where we set the log level for exec providers to verbose which means logs from init scripts aren't visible.

That was a mistake and this fixes that.

My apologies.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
