### PR TITLE
Fix exec command strings

### DIFF
--- a/core/src/commands/exec.ts
+++ b/core/src/commands/exec.ts
@@ -29,6 +29,10 @@ const execArgs = {
       return Object.keys(configDump.actionConfigs.Deploy)
     },
   }),
+  command: new StringParameter({
+    help: "The command to run.",
+    required: false,
+  }),
 }
 
 const execOpts = {
@@ -57,12 +61,15 @@ export class ExecCommand extends Command<Args, Opts> {
   override description = dedent`
     Finds an active container for a deployed Deploy and executes the given command within the container.
     Supports interactive shells.
+    You can specify the command to run as a parameter, or pass it after a \`--\` separator. For commands
+    with arguments or quoted substrings, use the \`--\` separator.
 
     _NOTE: This command may not be supported for all action types._
 
     Examples:
 
-         garden exec my-service -- /bin/sh   # runs a shell in the my-service Deploy's container
+         garden exec my-service /bin/sh   # runs an interactive shell in the my-service Deploy's container
+         garden exec my-service -- /bin/sh -c echo "hello world" # prints "hello world" in the my-service Deploy's container and exits
   `
 
   override arguments = execArgs
@@ -160,6 +167,6 @@ export class ExecCommand extends Command<Args, Opts> {
   }
 
   private getCommand(args: ParameterValues<Args>) {
-    return args["--"] || []
+    return args.command ? args.command.split(" ") : args["--"] || []
   }
 }

--- a/core/src/commands/exec.ts
+++ b/core/src/commands/exec.ts
@@ -30,7 +30,7 @@ const execArgs = {
     },
   }),
   command: new StringParameter({
-    help: "The command to run.",
+    help: "The use of the positional command argument is deprecated. Use  `--` followed by your command instead.",
     required: false,
   }),
 }
@@ -64,7 +64,8 @@ export class ExecCommand extends Command<Args, Opts> {
     You can specify the command to run as a parameter, or pass it after a \`--\` separator. For commands
     with arguments or quoted substrings, use the \`--\` separator.
 
-    _NOTE: This command may not be supported for all action types._
+    _NOTE: This command may not be supported for all action types. The use of the positional command argument
+    is deprecated. Use  \`--\` followed by your command instead._
 
     Examples:
 

--- a/core/test/integ/src/plugins/kubernetes/commands/exec.ts
+++ b/core/test/integ/src/plugins/kubernetes/commands/exec.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2018-2023 Garden Technologies, Inc. <info@garden.io>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+import { expect } from "chai"
+import { ExecCommand } from "../../../../../../src/commands/exec.js"
+import type { ConfigGraph } from "../../../../../../src/graph/config-graph.js"
+import type { ContainerDeployAction } from "../../../../../../src/plugins/container/config.js"
+import { DeployTask } from "../../../../../../src/tasks/deploy.js"
+import type { TestGarden } from "../../../../../helpers.js"
+import { expectError, withDefaultGlobalOpts } from "../../../../../helpers.js"
+import { getContainerTestGarden } from "../container/container.js"
+import { CommandError } from "../../../../../../src/exceptions.js"
+
+describe("runExecCommand", () => {
+  let garden: TestGarden
+  let cleanup: (() => void) | undefined
+  let graph: ConfigGraph
+
+  before(async () => {
+    ;({ garden, cleanup } = await getContainerTestGarden("local"))
+    const action = await resolveDeployAction("simple-service")
+    const deployTask = new DeployTask({
+      garden,
+      graph,
+      log: garden.log,
+      action,
+      force: true,
+      forceBuild: false,
+    })
+    await garden.processTasks({ tasks: [deployTask], log: garden.log, throwOnError: true })
+  })
+
+  async function resolveDeployAction(name: string) {
+    graph = await garden.getConfigGraph({ log: garden.log, emit: false, actionModes: { default: ["deploy." + name] } })
+    return garden.resolveAction<ContainerDeployAction>({ action: graph.getDeploy(name), log: garden.log, graph })
+  }
+
+  after(async () => {
+    if (cleanup) {
+      cleanup()
+    }
+  })
+
+  it("should exec a simple command in a running service", async () => {
+    const execCommand = new ExecCommand()
+    const args = { deploy: "simple-service" }
+    args["--"] = "echo ok"
+
+    const { result, errors } = await execCommand.action({
+      garden,
+      log: garden.log,
+      args,
+      opts: withDefaultGlobalOpts({
+        interactive: false,
+        target: "",
+      }),
+    })
+
+    if (errors) {
+      throw errors[0]
+    }
+    expect(result?.output).to.equal("ok")
+  })
+
+  it("should exec a command with a quoted substring in a running service", async () => {
+    const execCommand = new ExecCommand()
+    const args = { deploy: "simple-service" }
+    args["--"] = 'echo "ok, lots of text"'
+
+    const { result, errors } = await execCommand.action({
+      garden,
+      log: garden.log,
+      args,
+      opts: withDefaultGlobalOpts({
+        interactive: false,
+        target: "",
+      }),
+    })
+
+    if (errors) {
+      throw errors[0]
+    }
+    expect(result?.output).to.equal("ok, lots of text")
+  })
+
+  it("should throw if no command was specified", async () => {
+    const execCommand = new ExecCommand()
+    const args = { deploy: "simple-service" }
+    await expectError(
+      () =>
+        execCommand.action({
+          garden,
+          log: garden.log,
+          args,
+          opts: withDefaultGlobalOpts({
+            interactive: false,
+            target: "",
+          }),
+        }),
+      (err) =>
+        expect(err).to.be.instanceOf(CommandError).with.property("message", "No command specified. Nothing to execute.")
+    )
+  })
+})

--- a/core/test/integ/src/plugins/kubernetes/commands/exec.ts
+++ b/core/test/integ/src/plugins/kubernetes/commands/exec.ts
@@ -45,31 +45,10 @@ describe("runExecCommand", () => {
     }
   })
 
-  it("should exec a simple command in a running service", async () => {
+  it("should exec a command in a running service", async () => {
     const execCommand = new ExecCommand()
     const args = { deploy: "simple-service" }
-    args["--"] = "echo ok"
-
-    const { result, errors } = await execCommand.action({
-      garden,
-      log: garden.log,
-      args,
-      opts: withDefaultGlobalOpts({
-        interactive: false,
-        target: "",
-      }),
-    })
-
-    if (errors) {
-      throw errors[0]
-    }
-    expect(result?.output).to.equal("ok")
-  })
-
-  it("should exec a command with a quoted substring in a running service", async () => {
-    const execCommand = new ExecCommand()
-    const args = { deploy: "simple-service" }
-    args["--"] = 'echo "ok, lots of text"'
+    args["--"] = ["echo", "ok, lots of text"]
 
     const { result, errors } = await execCommand.action({
       garden,

--- a/core/test/integ/src/plugins/kubernetes/commands/exec.ts
+++ b/core/test/integ/src/plugins/kubernetes/commands/exec.ts
@@ -45,9 +45,9 @@ describe("runExecCommand", () => {
     }
   })
 
-  it("should exec a command in a running service", async () => {
+  it("should exec a command in a running service using the -- separator", async () => {
     const execCommand = new ExecCommand()
-    const args = { deploy: "simple-service" }
+    const args = { deploy: "simple-service", command: "" }
     args["--"] = ["echo", "ok, lots of text"]
 
     const { result, errors } = await execCommand.action({
@@ -66,9 +66,29 @@ describe("runExecCommand", () => {
     expect(result?.output).to.equal("ok, lots of text")
   })
 
+  it("should exec a command in a running service without the -- separator", async () => {
+    const execCommand = new ExecCommand()
+    const args = { deploy: "simple-service", command: "echo hello" }
+
+    const { result, errors } = await execCommand.action({
+      garden,
+      log: garden.log,
+      args,
+      opts: withDefaultGlobalOpts({
+        interactive: false,
+        target: "",
+      }),
+    })
+
+    if (errors) {
+      throw errors[0]
+    }
+    expect(result?.output).to.equal("hello")
+  })
+
   it("should throw if no command was specified", async () => {
     const execCommand = new ExecCommand()
-    const args = { deploy: "simple-service" }
+    const args = { deploy: "simple-service", command: "" }
     await expectError(
       () =>
         execCommand.action({

--- a/core/test/unit/src/cli/helpers.ts
+++ b/core/test/unit/src/cli/helpers.ts
@@ -298,7 +298,7 @@ describe("processCliArgs", () => {
 
   it("ignores cliOnly options when cli=false", () => {
     const cmd = new ExecCommand()
-    const { opts } = parseAndProcess(["my-service", "echo 'test'", "--interactive=true"], cmd, false)
+    const { opts } = parseAndProcess(["my-service", "--", "echo 'test'", "--interactive=true"], cmd, false)
     expect(opts.interactive).to.be.false
   })
 
@@ -317,13 +317,13 @@ describe("processCliArgs", () => {
 
   it("prefers defaultValue value over cliDefault when cli=false", () => {
     const cmd = new ExecCommand()
-    const { opts } = parseAndProcess(["my-service", "echo 'test'"], cmd, false)
+    const { opts } = parseAndProcess(["my-service", "--", "echo 'test'"], cmd, false)
     expect(opts.interactive).to.be.false
   })
 
   it("prefers cliDefault value over defaultValue when cli=true", () => {
     const cmd = new ExecCommand()
-    const { opts } = parseAndProcess(["my-service", "echo 'test'"], cmd, true)
+    const { opts } = parseAndProcess(["my-service", "--", "echo 'test'"], cmd, true)
     expect(opts.interactive).to.be.true
   })
 

--- a/core/test/unit/src/commands/exec.ts
+++ b/core/test/unit/src/commands/exec.ts
@@ -17,7 +17,8 @@ describe("ExecCommand", () => {
     const garden = await makeTestGardenA()
     const log = garden.log
 
-    const args = { deploy: "service-a", command: ["echo", "ok"] }
+    const args = { deploy: "service-a" }
+    args["--"] = ["echo", "ok"]
 
     command.printHeader({ log, args })
 

--- a/core/test/unit/src/commands/exec.ts
+++ b/core/test/unit/src/commands/exec.ts
@@ -17,7 +17,7 @@ describe("ExecCommand", () => {
     const garden = await makeTestGardenA()
     const log = garden.log
 
-    const args = { deploy: "service-a" }
+    const args = { deploy: "service-a", command: "" }
     args["--"] = ["echo", "ok"]
 
     command.printHeader({ log, args })

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1346,22 +1346,26 @@ run:
 
 Finds an active container for a deployed Deploy and executes the given command within the container.
 Supports interactive shells.
+You can specify the command to run as a parameter, or pass it after a `--` separator. For commands
+with arguments or quoted substrings, use the `--` separator.
 
 _NOTE: This command may not be supported for all action types._
 
 Examples:
 
-     garden exec my-service -- /bin/sh   # runs a shell in the my-service Deploy's container
+     garden exec my-service /bin/sh   # runs an interactive shell in the my-service Deploy's container
+     garden exec my-service -- /bin/sh -c echo "hello world" # prints "hello world" in the my-service Deploy's container and exits
 
 #### Usage
 
-    garden exec <deploy> [options]
+    garden exec <deploy> [command] [options]
 
 #### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `deploy` | Yes | The running Deploy action to exec the command in.
+  | `command` | No | The command to run.
 
 #### Options
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1349,7 +1349,8 @@ Supports interactive shells.
 You can specify the command to run as a parameter, or pass it after a `--` separator. For commands
 with arguments or quoted substrings, use the `--` separator.
 
-_NOTE: This command may not be supported for all action types._
+_NOTE: This command may not be supported for all action types. The use of the positional command argument
+is deprecated. Use  `--` followed by your command instead._
 
 Examples:
 
@@ -1365,7 +1366,7 @@ Examples:
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `deploy` | Yes | The running Deploy action to exec the command in.
-  | `command` | No | The command to run.
+  | `command` | No | The use of the positional command argument is deprecated. Use  &#x60;--&#x60; followed by your command instead.
 
 #### Options
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1351,18 +1351,17 @@ _NOTE: This command may not be supported for all action types._
 
 Examples:
 
-     garden exec my-service /bin/sh   # runs a shell in the my-service Deploy's container
+     garden exec my-service -- /bin/sh   # runs a shell in the my-service Deploy's container
 
 #### Usage
 
-    garden exec <deploy> <command> [options]
+    garden exec <deploy> [options]
 
 #### Arguments
 
 | Argument | Required | Description |
 | -------- | -------- | ----------- |
   | `deploy` | Yes | The running Deploy action to exec the command in.
-  | `command` | Yes | The command to run.
 
 #### Options
 

--- a/docs/using-garden/using-the-cli.md
+++ b/docs/using-garden/using-the-cli.md
@@ -72,7 +72,7 @@ garden deploy my-deploy --sync=*
 ### Executing a command in a running `Deploy` container
 
 ```sh
-garden exec my-deploy <command>
+garden exec my-deploy -- <command>
 ```
 
 ### Executing an interactive shell in a running `Deploy` container
@@ -80,7 +80,7 @@ garden exec my-deploy <command>
 _Note: This assumes that `sh` is available in the container._
 
 ```sh
-garden exec my-deploy sh
+garden exec my-deploy -- sh
 ```
 
 ### Getting the status of your `Deploy`s


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
Fixes the garden exec command, which wasn't working when given more than two arguments e.g. `garden exec backend "ls -la"` would fail with executable file not found, while `garden exec backend ls`  succeeds. If not quoting the command with two arguments, garden would interpret the `-la` as a garden argument and fail as well.

This PR restores the behavior for the command argument as it was in 0.12.x which means that commands are getting split which still fails in cases where there are quoted substrings see #2957. 
It also  introduces the option to use `--` as a separator to specify commands the same way kubectl does it. Using the `--` separator results in quoted strings to be interpreted as one argument.
e.g.:
`garden exec debian -- /bin/sh -c echo "hello world"`

Adding a deprecation warning for using the command argument without the `--` separator.


**Which issue(s) this PR fixes**:

Fixes #2957

**Special notes for your reviewer**:
