### PR TITLE
fix: crash on yaml highlighting

### DIFF
--- a/core/src/util/serialization.ts
+++ b/core/src/util/serialization.ts
@@ -10,11 +10,10 @@ import { mapValues } from "lodash-es"
 import fsExtra from "fs-extra"
 import type { DumpOptions } from "js-yaml"
 import { dump, load } from "js-yaml"
-import highlightModule from "cli-highlight"
+import { default as highlightModule } from "cli-highlight"
 import { styles } from "../logger/styles.js"
 
 const { readFile, writeFile } = fsExtra
-const highlight = highlightModule.default
 
 export async function dumpYaml(yamlPath: string, data: any) {
   return writeFile(yamlPath, safeDumpYaml(data, { noRefs: true }))
@@ -35,7 +34,7 @@ export function encodeYamlMulti(objects: object[]) {
 }
 
 export function highlightYaml(s: string) {
-  return highlight(s, {
+  return highlightModule.highlight(s, {
     language: "yaml",
     theme: {
       keyword: styles.accent.italic,


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #5442

**Special notes for your reviewer**:
Fixed the function import in the same way as in #5421.

@stefreak this should fix #5442. I was not able to reproduce that issue. Could you please double-check the repro example and try out the fix?