### PR TITLE
fix(k8s): fix paths in requests to kubernetes api

### DIFF
--- a/core/src/plugins/kubernetes/api.ts
+++ b/core/src/plugins/kubernetes/api.ts
@@ -428,10 +428,16 @@ export class KubeApi {
     retryOpts?: RetryOpts
   }): Promise<Response> {
     const baseUrl = this.config.getCurrentCluster()!.server
-    // URL treats paths starting with / as absolute, so we need to remove it. See:
-    // https://developer.mozilla.org/en-US/docs/Learn/Common_questions/Web_mechanics/What_is_a_URL#absolute_urls_vs._relative_urls
+
+    // When using URL with a base path, the merging of the paths doesn't work as you are used to from most node request libraries.
+    // It uses the semantics of browser URLs where a path starting with `/` is seen as absolute and thus it does not get merged with the base path.
+    // See: https://developer.mozilla.org/en-US/docs/Learn/Common_questions/Web_mechanics/What_is_a_URL#absolute_urls_vs._relative_urls
+    // Similarly, when the base path does not ends with a `/`, the last path segment is seen as a resource and also removed from the joined path.
+    // That's why we need to remove the leading `/` from the path and ensure that the base path ends with a `/`.
+
     const relativePath = path.replace(/^\//, "")
     const absoluteBaseUrl = baseUrl.endsWith("/") ? baseUrl : baseUrl + "/"
+
     const url = new URL(relativePath, absoluteBaseUrl)
 
     for (const [key, value] of Object.entries(opts.query ?? {})) {

--- a/core/src/plugins/kubernetes/api.ts
+++ b/core/src/plugins/kubernetes/api.ts
@@ -428,7 +428,11 @@ export class KubeApi {
     retryOpts?: RetryOpts
   }): Promise<Response> {
     const baseUrl = this.config.getCurrentCluster()!.server
-    const url = new URL(path, baseUrl)
+    // URL treats paths starting with / as absolute, so we need to remove it. See:
+    // https://developer.mozilla.org/en-US/docs/Learn/Common_questions/Web_mechanics/What_is_a_URL#absolute_urls_vs._relative_urls
+    const relativePath = path.replace(/^\//, "")
+    const absoluteBaseUrl = baseUrl.endsWith("/") ? baseUrl : baseUrl + "/"
+    const url = new URL(relativePath, absoluteBaseUrl)
 
     for (const [key, value] of Object.entries(opts.query ?? {})) {
       url.searchParams.set(key, value)

--- a/core/test/integ/src/plugins/kubernetes/api.ts
+++ b/core/test/integ/src/plugins/kubernetes/api.ts
@@ -299,6 +299,7 @@ describe("KubeApi", () => {
     let server: Server<typeof IncomingMessage, typeof ServerResponse>
     let wasRetried: boolean
     let reqCount: number
+    let requestUrl: string | undefined
     let statusCodeHandler: () => number
 
     before(async () => {
@@ -306,7 +307,7 @@ describe("KubeApi", () => {
         override getCurrentCluster() {
           return {
             name: "test-cluster",
-            server: `http://${hostname}:${port}/`,
+            server: `http://${hostname}:${port}/clusters/test`,
             skipTLSVerify: true,
           }
         }
@@ -315,6 +316,7 @@ describe("KubeApi", () => {
       api = new KubeApi(log, "test-context", config)
 
       server = createServer((req, res) => {
+        requestUrl = req.url
         let bodyRaw = ""
         reqCount++
         wasRetried = reqCount > 1
@@ -335,6 +337,7 @@ describe("KubeApi", () => {
     beforeEach(() => {
       reqCount = 0
       wasRetried = false
+      requestUrl = ""
       statusCodeHandler = () => {
         throw "implement in test case"
       }
@@ -342,6 +345,28 @@ describe("KubeApi", () => {
 
     after(() => {
       server.close()
+    })
+
+    it("should correctly merge the paths together when absolute paths are used", async () => {
+      statusCodeHandler = () => 200
+      await api.request({
+        log,
+        path: "version",
+        opts: { method: "GET" },
+      })
+
+      expect(requestUrl).to.eql(`/clusters/test/version`)
+    })
+
+    it("should correctly merge the paths together when relative paths are used", async () => {
+      statusCodeHandler = () => 200
+      await api.request({
+        log,
+        path: "/version",
+        opts: { method: "GET" },
+      })
+
+      expect(requestUrl).to.eql(`/clusters/test/version`)
     })
 
     it("should do a basic request without failure", async () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
When using absolute paths in URLs e.g. `/version` for initializing the kubernetes provider, we need to remove the leading slash due to the way URL constructs the full URL. If we don't remove it, it is seen as an absolute path which leads to all other parts of the path to be stripped. For example if this URL is specified in the kubeconfig for a Kubernetes api server

`https://rancher.18.194.162.172.sslip.io/k8s/clusters/c-m-qkrwsnsg`

when adding the `/version` endpoint we get:

`https://rancher.18.194.162.172.sslip.io/version`

This causes the request to fail. Instead we need:

`https://rancher.18.194.162.172.sslip.io/k8s/clusters/c-m-qkrwsnsg/version`

This PR fixes this behavior.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
