### PR TITLE
chore: remove unneeded otel jaeger workaround from rollup.config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -115,11 +115,6 @@ export default {
       // for .node native modules and eventually, in the future, possibly external plugins
       ignoreDynamicRequires: true,
       ignore: (id) => {
-        // https://github.com/open-telemetry/opentelemetry-js/issues/3759
-        if (id === "@opentelemetry/exporter-jaeger") {
-          return true
-        }
-
         if (id.endsWith(".node")) {
           return true
         }


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Since we merged #5487, OpenTelemetry does not depend on jaeger anymore.
