### PR TITLE
refactor(git): move include/exclude files processing to a dedicated function

### DIFF
--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -18,7 +18,7 @@ const extractedRoot = process.env.GARDEN_SEA_EXTRACTED_ROOT
 
 export const gitScanModes = ["repo", "subtree"] as const
 export type GitScanMode = (typeof gitScanModes)[number]
-export const defaultGitScanMode: GitScanMode = "subtree"
+export const defaultGitScanMode: GitScanMode = "repo"
 
 export const GARDEN_CORE_ROOT = !!extractedRoot
   ? resolve(extractedRoot, "src", "core")
@@ -74,7 +74,11 @@ export const gardenEnv = {
   GARDEN_ENVIRONMENT: env.get("GARDEN_ENVIRONMENT").required(false).asString(),
   GARDEN_EXPERIMENTAL_BUILD_STAGE: env.get("GARDEN_EXPERIMENTAL_BUILD_STAGE").required(false).asBool(),
   GARDEN_GE_SCHEDULED: env.get("GARDEN_GE_SCHEDULED").required(false).asBool(),
-  GARDEN_GIT_SCAN_MODE: env.get("GARDEN_GIT_SCAN_MODE").required(false).default("repo").asEnum(gitScanModes),
+  GARDEN_GIT_SCAN_MODE: env
+    .get("GARDEN_GIT_SCAN_MODE")
+    .required(false)
+    .default(defaultGitScanMode)
+    .asEnum(gitScanModes),
   GARDEN_LEGACY_BUILD_STAGE: env.get("GARDEN_LEGACY_BUILD_STAGE").required(false).asBool(),
   GARDEN_LOG_LEVEL: env.get("GARDEN_LOG_LEVEL").required(false).asString(),
   GARDEN_LOGGER_TYPE: env.get("GARDEN_LOGGER_TYPE").required(false).asString(),

--- a/core/src/vcs/git-repo.ts
+++ b/core/src/vcs/git-repo.ts
@@ -6,16 +6,46 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { GitHandler, augmentGlobs } from "./git.js"
-import type { GetFilesParams, VcsFile } from "./vcs.js"
+import { augmentGlobs, GitHandler } from "./git.js"
+import type { BaseIncludeExcludeFiles, GetFilesParams, IncludeExcludeFilesHandler, VcsFile } from "./vcs.js"
 import { isDirectory, matchPath } from "../util/fs.js"
 import fsExtra from "fs-extra"
-const { pathExists } = fsExtra
 import { pathToCacheContext } from "../cache.js"
 import { FileTree } from "./file-tree.js"
 import { sep } from "path"
 
+const { pathExists } = fsExtra
+
 type ScanRepoParams = Pick<GetFilesParams, "log" | "path" | "pathDescription" | "failOnPrompt">
+
+interface GitRepoGetFilesParams extends GetFilesParams {
+  scanFromProjectRoot: boolean
+}
+
+interface GitRepoIncludeExcludeFiles extends BaseIncludeExcludeFiles {
+  augmentedIncludes: string[]
+}
+
+const getIncludeExcludeFiles: IncludeExcludeFilesHandler<GitRepoGetFilesParams, GitRepoIncludeExcludeFiles> = async (
+  params
+) => {
+  const { include, path, scanFromProjectRoot } = params
+  let { exclude } = params
+
+  if (!exclude) {
+    exclude = []
+  }
+
+  // We allow just passing a path like `foo` as include and exclude params
+  // Those need to be converted to globs, but we don't want to touch existing globs
+  const augmentedIncludes = include ? await augmentGlobs(path, include) : ["**/*"]
+  const augmentedExcludes = await augmentGlobs(path, exclude || [])
+  if (scanFromProjectRoot) {
+    augmentedExcludes.push("**/.garden/**/*")
+  }
+
+  return { include, exclude, augmentedIncludes, augmentedExcludes }
+}
 
 export class GitRepoHandler extends GitHandler {
   override name = "git-repo"
@@ -58,20 +88,16 @@ export class GitRepoHandler extends GitHandler {
 
     const moduleFiles = fileTree.getFilesAtPath(path)
 
-    // We allow just passing a path like `foo` as include and exclude params
-    // Those need to be converted to globs, but we don't want to touch existing globs
-    const include = params.include ? await augmentGlobs(path, params.include) : ["**/*"]
-    const exclude = await augmentGlobs(path, params.exclude || [])
-
-    if (scanRoot === this.garden?.projectRoot) {
-      exclude.push("**/.garden/**/*")
-    }
+    const scanFromProjectRoot = scanRoot === this.garden?.projectRoot
+    const { augmentedExcludes, augmentedIncludes } = await getIncludeExcludeFiles({ ...params, scanFromProjectRoot })
 
     log.debug(
-      `Found ${moduleFiles.length} files in module path, filtering by ${include.length} include and ${exclude.length} exclude globs`
+      `Found ${moduleFiles.length} files in module path, filtering by ${augmentedIncludes.length} include and ${augmentedExcludes.length} exclude globs`
     )
-    log.silly(() => `Include globs: ${include.join(", ")}`)
-    log.silly(() => (exclude.length > 0 ? `Exclude globs: ${exclude.join(", ")}` : "No exclude globs"))
+    log.silly(() => `Include globs: ${augmentedIncludes.join(", ")}`)
+    log.silly(() =>
+      augmentedExcludes.length > 0 ? `Exclude globs: ${augmentedExcludes.join(", ")}` : "No exclude globs"
+    )
 
     const filtered = moduleFiles.filter(({ path: p }) => {
       if (filter && !filter(p)) {
@@ -83,7 +109,7 @@ export class GitRepoHandler extends GitHandler {
       // but that caused issues with the glob matching on windows due to backslashes
       const relativePath = p.replace(`${path}${sep}`, "")
       log.silly(() => `Checking if ${relativePath} matches include/exclude globs`)
-      return matchPath(relativePath, include, exclude)
+      return matchPath(relativePath, augmentedIncludes, augmentedExcludes)
     })
 
     log.debug(`Found ${filtered.length} files in module path after glob matching`)

--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -152,15 +152,10 @@ export class GitHandler extends VcsHandler {
    * we need to name the function that recurses in here differently from {@link getFiles}
    * so that {@link getFiles} won't refer to the method in the subclass.
    */
-  async _getFiles({
-    log,
-    path,
-    pathDescription = "directory",
-    include,
-    exclude,
-    filter,
-    failOnPrompt = false,
-  }: GetFilesParams): Promise<VcsFile[]> {
+  async _getFiles(params: GetFilesParams): Promise<VcsFile[]> {
+    const { log, path, pathDescription = "directory", filter, failOnPrompt = false } = params
+    let { include, exclude,  } = params
+
     if (include && include.length === 0) {
       // No need to proceed, nothing should be included
       return []

--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -143,14 +143,14 @@ export class GitHandler extends VcsHandler {
    * Returns a list of files, along with file hashes, under the given path, taking into account the configured
    * .ignore files, and the specified include/exclude filters.
    */
-  async getFiles(params: GetFilesParams): Promise<VcsFile[]> {
+  override async getFiles(params: GetFilesParams): Promise<VcsFile[]> {
     return this._getFiles(params)
   }
 
   /**
-   * In order for `GitRepoHandler` not to enter infinite recursion when scanning submodules,
-   * we need to name the function that recurses in here differently from `getFiles` so that `this.getFiles` won't refer
-   * to the method in the subclass.
+   * In order for {@link GitRepoHandler} not to enter infinite recursion when scanning submodules,
+   * we need to name the function that recurses in here differently from {@link getFiles}
+   * so that {@link getFiles} won't refer to the method in the subclass.
    */
   async _getFiles({
     log,

--- a/core/src/vcs/vcs.ts
+++ b/core/src/vcs/vcs.ts
@@ -169,6 +169,12 @@ export abstract class VcsHandler {
 
   abstract getRepoRoot(log: Log, path: string): Promise<string>
 
+  /**
+   * Scans the repository returns the list of the tracked files.
+   * Applies Garden's exclude/include filters and .dotignore files.
+   *
+   * Does NOT sort the results by paths and filenames.
+   */
   abstract getFiles(params: GetFilesParams): Promise<VcsFile[]>
 
   abstract ensureRemoteSource(params: RemoteSourceParams): Promise<string>

--- a/core/src/vcs/vcs.ts
+++ b/core/src/vcs/vcs.ts
@@ -34,6 +34,7 @@ import type { Garden } from "../garden.js"
 import { Profile } from "../util/profiling.js"
 
 import AsyncLock from "async-lock"
+
 const scanLock = new AsyncLock()
 
 export const versionStringPrefix = "v-"
@@ -120,6 +121,18 @@ export interface GetFilesParams {
   failOnPrompt?: boolean
   scanRoot: string | undefined
 }
+
+export interface BaseIncludeExcludeFiles {
+  include?: string[]
+  exclude: string[]
+
+  augmentedIncludes?: string[]
+  augmentedExcludes: string[]
+}
+
+export type IncludeExcludeFilesHandler<T extends GetFilesParams, R extends BaseIncludeExcludeFiles> = (
+  params: T
+) => Promise<R>
 
 export interface GetTreeVersionParams {
   log: Log

--- a/core/test/unit/src/vcs/vcs.ts
+++ b/core/test/unit/src/vcs/vcs.ts
@@ -50,7 +50,7 @@ export class TestVcsHandler extends VcsHandler {
     return "/foo"
   }
 
-  async getFiles(_: GetFilesParams): Promise<VcsFile[]> {
+  override async getFiles(_: GetFilesParams): Promise<VcsFile[]> {
     return []
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Shipping it separately as a pre-requisite for #5472 to make that PR more lightweight and easier to review.
I've also found some issues in the Git repo handler tests setup. I'll create a separate PR to address those issues.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
Exclude/include files processing was implemented as a standalone function becaise the processing logic does not use any state of the `VcsHandler` class.