### PR TITLE
Upgrade Helm from version 3.12.0 to 3.12.2 in Garden v 0.12

### DIFF
--- a/core/src/plugins/kubernetes/helm/helm-cli.ts
+++ b/core/src/plugins/kubernetes/helm/helm-cli.ts
@@ -14,7 +14,7 @@ import split2 from "split2"
 import { LogLevel } from "../../../logger/logger"
 import { Dictionary, pickBy } from "lodash"
 
-export const HELM_VERSION = "3.12.0"
+export const HELM_VERSION = "3.12.2"
 
 export const helm3Spec: PluginToolSpec = {
   name: "helm",
@@ -26,7 +26,7 @@ export const helm3Spec: PluginToolSpec = {
       platform: "darwin",
       architecture: "amd64",
       url: `https://get.helm.sh/helm-v${HELM_VERSION}-darwin-amd64.tar.gz`,
-      sha256: "8223beb796ff19b59e615387d29be8c2025c5d3aea08485a262583de7ba7d708",
+      sha256: "6e8bfc84a640e0dc47cc49cfc2d0a482f011f4249e2dff2a7e23c7ef2df1b64e",
       extract: {
         format: "tar",
         targetPath: "darwin-amd64/helm",
@@ -36,7 +36,7 @@ export const helm3Spec: PluginToolSpec = {
       platform: "darwin",
       architecture: "arm64",
       url: `https://get.helm.sh/helm-v${HELM_VERSION}-darwin-arm64.tar.gz`,
-      sha256: "879f61d2ad245cb3f5018ab8b66a87619f195904a4df3b077c98ec0780e36c37",
+      sha256: "b60ee16847e28879ae298a20ba4672fc84f741410f438e645277205824ddbf55",
       extract: {
         format: "tar",
         targetPath: "darwin-arm64/helm",
@@ -46,7 +46,7 @@ export const helm3Spec: PluginToolSpec = {
       platform: "linux",
       architecture: "amd64",
       url: `https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz`,
-      sha256: "da36e117d6dbc57c8ec5bab2283222fbd108db86c83389eebe045ad1ef3e2c3b",
+      sha256: "2b6efaa009891d3703869f4be80ab86faa33fa83d9d5ff2f6492a8aebe97b219",
       extract: {
         format: "tar",
         targetPath: "linux-amd64/helm",
@@ -56,7 +56,7 @@ export const helm3Spec: PluginToolSpec = {
       platform: "windows",
       architecture: "amd64",
       url: `https://get.helm.sh/helm-v${HELM_VERSION}-windows-amd64.zip`,
-      sha256: "52138ba8caec50c358c7aee41aac28d6a8a037878ada3cf5ce6c1049fc772547",
+      sha256: "35dc439baad85728dafd2be0edd4721ae5b770c5cf72c3adf9558b1415a9cae6",
       extract: {
         format: "zip",
         targetPath: "windows-amd64/helm.exe",


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:
change in the version of  Helm CLI to fix the issue of HTTP error code 426 in Gitlab CI pipelines. 

**Which issue(s) this PR fixes**:

This update addresses an issue where Helm fails with HTTP error code 426, as reported on the Helm GitHub repository:
https://github.com/helm/helm/issues/12071

Also, This issue in Gitlab describes some sections of this issue:
https://gitlab.com/gitlab-org/cluster-integration/gitlab-agent/-/issues/279

**Special notes for your reviewer**:
If you feel fine about this change just let me know to prepare another PR for 0.13