### PR TITLE
feat: add config field and override param for require login

### DIFF
--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -278,7 +278,7 @@ ${renderCommands(commands)}
             }
           } else {
             // unhandled error when creating the cloud api
-            log.info("")
+            gardenInitLog?.info("")
 
             throw err
           }

--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -16,7 +16,7 @@ import { shutdown, getPackageVersion } from "../util/util.js"
 import type { Command, CommandResult, BuiltinArgs } from "../commands/base.js"
 import { CommandGroup } from "../commands/base.js"
 import type { GardenError } from "../exceptions.js"
-import { PluginError, RuntimeError, toGardenError } from "../exceptions.js"
+import { PluginError, toGardenError } from "../exceptions.js"
 import type { GardenOpts } from "../garden.js"
 import { Garden, makeDummyGarden } from "../garden.js"
 import { getRootLogger, getTerminalWriterType, LogLevel, parseLogLevel, RootLogger } from "../logger/logger.js"
@@ -274,29 +274,6 @@ ${renderCommands(commands)}
             // unhandled error when creating the cloud api
             throw err
           }
-        }
-
-        // If there is an ID in the project config and the user is not logged in (no cloudApi)
-        // 0.13 => check if login is required based on the `requireLogin` config value
-        if (!cloudApi && config && config.id) {
-          log.info("")
-
-          // fallback to false if no variables are set
-          // TODO-0.14: requireLogin should default to true
-          const isLoginRequired = (gardenEnv.GARDEN_REQUIRE_LOGIN_OVERRIDE ?? config.requireLogin) || false
-          if (isLoginRequired) {
-            log.warn(dedent`
-            You are running this in a project with a Garden Cloud ID and logging in is required.
-            Please log in via the ${styles.command("garden login")} command.`)
-            throw new RuntimeError({ message: "" })
-          } else {
-            log.warn(
-              `Warning: You are not logged in into Garden Cloud. Please log in via the ${styles.command(
-                "garden login"
-              )} command.`
-            )
-          }
-          log.info("")
         }
       }
 

--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -278,6 +278,8 @@ ${renderCommands(commands)}
             }
           } else {
             // unhandled error when creating the cloud api
+            log.info("")
+
             throw err
           }
         }

--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -256,7 +256,13 @@ ${renderCommands(commands)}
         const distroName = getCloudDistributionName(cloudDomain)
 
         try {
-          cloudApi = await this.cloudApiFactory({ log, cloudDomain, globalConfigStore })
+          cloudApi = await this.cloudApiFactory({
+            log,
+            cloudDomain,
+            globalConfigStore,
+            projectId: config?.id,
+            requireLogin: config?.requireLogin,
+          })
         } catch (err) {
           if (err instanceof CloudApiTokenRefreshError) {
             log.warn(dedent`

--- a/core/src/cloud/api.ts
+++ b/core/src/cloud/api.ts
@@ -218,7 +218,7 @@ export class CloudApi {
     globalConfigStore,
     skipLogging = false,
     projectId = undefined,
-    requireLogin = false,
+    requireLogin = undefined,
   }: CloudApiFactoryParams) {
     const distroName = getCloudDistributionName(cloudDomain)
     const fixLevel = skipLogging ? LogLevel.silly : undefined
@@ -235,7 +235,7 @@ export class CloudApi {
     const isLoginRequired: boolean =
       gardenEnv.GARDEN_REQUIRE_LOGIN_OVERRIDE !== undefined
         ? gardenEnv.GARDEN_REQUIRE_LOGIN_OVERRIDE
-        : projectId !== undefined && requireLogin
+        : projectId !== undefined && requireLogin === true
 
     // Base case when the user is not logged in to cloud and the
     // criteria for cloud login is not required:

--- a/core/src/cloud/api.ts
+++ b/core/src/cloud/api.ts
@@ -230,7 +230,7 @@ export class CloudApi {
     skipLogging = false,
     projectId = undefined,
     requireLogin = undefined,
-  }: CloudApiFactoryParams) {
+  }: CloudApiFactoryParams): Promise<CloudApi> {
     const distroName = getCloudDistributionName(cloudDomain)
     const fixLevel = skipLogging ? LogLevel.silly : undefined
     const cloudFactoryLog = log.createLog({ fixLevel, name: getCloudLogSectionName(distroName), showDuration: true })

--- a/core/src/cloud/api.ts
+++ b/core/src/cloud/api.ts
@@ -167,8 +167,8 @@ export interface CloudApiFactoryParams {
   cloudDomain: string
   globalConfigStore: GlobalConfigStore
   skipLogging?: boolean
-  projectId?: string
-  requireLogin?: boolean
+  projectId: string | undefined
+  requireLogin: boolean | undefined
 }
 
 export type CloudApiFactory = (params: CloudApiFactoryParams) => Promise<CloudApi | undefined>
@@ -285,13 +285,13 @@ export class CloudApi {
         // 0.13 => check if login is required based on the `requireLogin` config value
         if (projectId && isLoginRequired) {
           const message = dedent`
-            You are running this in a project with a Garden ID and logging in is required.
+            You are running this in a project with a Garden Cloud ID and logging in is required.
             Please log in via the ${styles.command("garden login")} command.`
 
           throw new CloudApiError({ message })
         } else {
           cloudFactoryLog.warn(
-            `Warning: You are not logged in into Garden Cloud. Please log in via the ${styles.command(
+            `Warning: You are not logged in to Garden Cloud. Please log in via the ${styles.command(
               "garden login"
             )} command.`
           )

--- a/core/src/commands/login.ts
+++ b/core/src/commands/login.ts
@@ -11,7 +11,7 @@ import { Command } from "./base.js"
 import { printHeader } from "../logger/util.js"
 import dedent from "dedent"
 import type { AuthTokenResponse } from "../cloud/api.js"
-import { CloudApi, getGardenCloudDomain } from "../cloud/api.js"
+import { CloudApi, CloudApiNoTokenError, CloudApiTokenRefreshError, getGardenCloudDomain } from "../cloud/api.js"
 import type { Log } from "../logger/log-entry.js"
 import { ConfigurationError, TimeoutError, InternalError, CloudApiError } from "../exceptions.js"
 import { AuthRedirectServer } from "../cloud/auth.js"
@@ -86,8 +86,6 @@ export class LoginCommand extends Command<{}, Opts> {
     // should use the default domain or not. The token lifecycle ends on logout.
     const cloudDomain: string = getGardenCloudDomain(projectConfig?.domain)
 
-    const distroName = getCloudDistributionName(cloudDomain)
-
     try {
       const cloudApi = await CloudApi.factory({
         log,
@@ -98,24 +96,27 @@ export class LoginCommand extends Command<{}, Opts> {
         requireLogin: undefined,
       })
 
-      if (cloudApi) {
-        log.success({ msg: `You're already logged in to ${cloudDomain}.` })
-        cloudApi.close()
-        return {}
-      }
+      log.success({ msg: `You're already logged in to ${cloudDomain}.` })
+      cloudApi.close()
+      return {}
     } catch (err) {
       if (!(err instanceof CloudApiError)) {
         throw err
       }
-      if (err.responseStatusCode === 401) {
+
+      if (err instanceof CloudApiTokenRefreshError) {
         const msg = dedent`
-          Looks like your session token is invalid. If you were previously logged into a different instance
-          of ${distroName}, log out first before logging in.
+          Your login token for ${cloudDomain} has expired and could not be refreshed.
+          Try to log out first before logging in.
         `
         log.warn(msg)
         log.info("")
       }
-      throw err
+
+      // This is expected if the user has not logged in
+      if (!(err instanceof CloudApiNoTokenError)) {
+        throw err
+      }
     }
 
     log.info({ msg: `Logging in to ${cloudDomain}...` })

--- a/core/src/commands/login.ts
+++ b/core/src/commands/login.ts
@@ -89,7 +89,14 @@ export class LoginCommand extends Command<{}, Opts> {
     const distroName = getCloudDistributionName(cloudDomain)
 
     try {
-      const cloudApi = await CloudApi.factory({ log, cloudDomain, skipLogging: true, globalConfigStore })
+      const cloudApi = await CloudApi.factory({
+        log,
+        cloudDomain,
+        skipLogging: true,
+        globalConfigStore,
+        projectId: undefined,
+        requireLogin: undefined,
+      })
 
       if (cloudApi) {
         log.success({ msg: `You're already logged in to ${cloudDomain}.` })

--- a/core/src/commands/logout.ts
+++ b/core/src/commands/logout.ts
@@ -9,7 +9,7 @@
 import type { CommandParams, CommandResult } from "./base.js"
 import { Command } from "./base.js"
 import { printHeader } from "../logger/util.js"
-import { CloudApi, getGardenCloudDomain } from "../cloud/api.js"
+import { CloudApi, CloudApiNoTokenError, getGardenCloudDomain } from "../cloud/api.js"
 import { getCloudDistributionName } from "../util/cloud.js"
 import { dedent, deline } from "../util/string.js"
 import { ConfigurationError } from "../exceptions.js"
@@ -82,17 +82,16 @@ export class LogOutCommand extends Command<{}, Opts> {
         requireLogin: undefined,
       })
 
-      if (!cloudApi) {
-        return {}
-      }
-
       await cloudApi.post("token/logout", { headers: { Cookie: `rt=${token?.refreshToken}` } })
       cloudApi.close()
     } catch (err) {
-      const msg = dedent`
+      // This is expected if the user never logged in
+      if (!(err instanceof CloudApiNoTokenError)) {
+        const msg = dedent`
       The following issue occurred while logging out from ${distroName} (your session will be cleared regardless): ${err}\n
       `
-      log.warn(msg)
+        log.warn(msg)
+      }
     } finally {
       await CloudApi.clearAuthToken(log, garden.globalConfigStore, cloudDomain)
       log.success(`Successfully logged out from ${cloudDomain}.`)

--- a/core/src/commands/logout.ts
+++ b/core/src/commands/logout.ts
@@ -78,6 +78,8 @@ export class LogOutCommand extends Command<{}, Opts> {
         cloudDomain,
         skipLogging: true,
         globalConfigStore: garden.globalConfigStore,
+        projectId: undefined,
+        requireLogin: undefined,
       })
 
       if (!cloudApi) {

--- a/core/src/commands/serve.ts
+++ b/core/src/commands/serve.ts
@@ -157,7 +157,13 @@ export class ServeCommand<
     }
 
     try {
-      const cloudApi = await manager.getCloudApi({ log, cloudDomain, globalConfigStore: garden.globalConfigStore })
+      const cloudApi = await manager.getCloudApi({
+        log,
+        cloudDomain,
+        globalConfigStore: garden.globalConfigStore,
+        projectId: projectConfig?.id,
+        requireLogin: projectConfig?.requireLogin,
+      })
       const isLoggedIn = !!cloudApi
       const isCommunityEdition = cloudDomain === DEFAULT_GARDEN_CLOUD_DOMAIN
 

--- a/core/src/config/project.ts
+++ b/core/src/config/project.ts
@@ -208,6 +208,7 @@ export interface ProjectConfig extends BaseGardenResource {
   path: string
   id?: string
   domain?: string
+  requireLogin?: boolean
   configPath?: string
   proxy?: ProxyConfig
   defaultEnvironment: string
@@ -323,6 +324,13 @@ export const projectSchema = createSchema({
       .uri()
       .meta({ internal: true })
       .description("The domain to use for cloud features. Should be the full API/backend URL."),
+    // TODO: Refer to enterprise documentation for more details.
+    requireLogin: joi
+      .boolean()
+      .default(false)
+      .meta({ internal: true })
+      .description("Whether the project requires login to Garden Cloud."),
+
     // Note: We provide a different schema below for actual validation, but need to define it this way for docs
     // because joi.alternatives() isn't handled well in the doc generation.
     environments: joi

--- a/core/src/config/project.ts
+++ b/core/src/config/project.ts
@@ -327,7 +327,6 @@ export const projectSchema = createSchema({
     // TODO: Refer to enterprise documentation for more details.
     requireLogin: joi
       .boolean()
-      .default(false)
       .meta({ internal: true })
       .description("Whether the project requires login to Garden Cloud."),
 

--- a/core/src/constants.ts
+++ b/core/src/constants.ts
@@ -105,4 +105,5 @@ export const gardenEnv = {
   // GARDEN_CLOUD_BUILDER will always override the config; That's why it doesn't have a default.
   // FIXME: If the environment variable is not set, asBool returns undefined, unlike the type suggests. That's why we cast to `boolean | undefined`.
   GARDEN_CLOUD_BUILDER: env.get("GARDEN_CLOUD_BUILDER").required(false).asBool() as boolean | undefined,
+  GARDEN_REQUIRE_LOGIN_OVERRIDE: env.get("GARDEN_REQUIRE_LOGIN_OVERRIDE").required(false).asBool(),
 }

--- a/core/src/server/instance-manager.ts
+++ b/core/src/server/instance-manager.ts
@@ -12,7 +12,7 @@ import { Autocompleter } from "../cli/autocomplete.js"
 import { parseCliVarFlags } from "../cli/helpers.js"
 import type { ParameterObject, ParameterValues } from "../cli/params.js"
 import type { CloudApiFactory, CloudApiFactoryParams } from "../cloud/api.js"
-import { CloudApi, getGardenCloudDomain } from "../cloud/api.js"
+import { CloudApi, CloudApiNoTokenError, getGardenCloudDomain } from "../cloud/api.js"
 import type { Command } from "../commands/base.js"
 import { getBuiltinCommands, flattenCommands } from "../commands/commands.js"
 import { getCustomCommands } from "../commands/custom.js"
@@ -202,7 +202,16 @@ export class GardenInstanceManager {
     let api = this.cloudApis.get(cloudDomain)
 
     if (!api) {
-      api = await this.cloudApiFactory(params)
+      try {
+        api = await this.cloudApiFactory(params)
+      } catch (err) {
+        // handles the case when the user should not be logged in
+        // otherwise we throw any error that can occure while
+        // authenticating
+        if (!(err instanceof CloudApiNoTokenError)) {
+          throw err
+        }
+      }
       api && this.cloudApis.set(cloudDomain, api)
     }
 

--- a/core/src/server/instance-manager.ts
+++ b/core/src/server/instance-manager.ts
@@ -366,6 +366,8 @@ export class GardenInstanceManager {
         log,
         cloudDomain: getGardenCloudDomain(projectConfig.domain),
         globalConfigStore,
+        projectId: projectConfig.id,
+        requireLogin: projectConfig.requireLogin,
       })
     }
 

--- a/core/src/server/server.ts
+++ b/core/src/server/server.ts
@@ -871,6 +871,8 @@ export class GardenServer extends EventEmitter {
         log,
         cloudDomain: getGardenCloudDomain(garden.cloudDomain),
         globalConfigStore: garden.globalConfigStore,
+        projectId: garden.projectId,
+        requireLogin: undefined, // the user should be logged in for this
       })
 
       // Use the server session ID. That is, the "main" session ID that belongs to the parent serve command.

--- a/core/test/unit/src/cloud/api.ts
+++ b/core/test/unit/src/cloud/api.ts
@@ -97,18 +97,23 @@ describe("CloudApi", () => {
 
       scope.get("/api/token/verify").reply(404)
 
-      const api = await CloudApi.factory({
-        log,
-        globalConfigStore,
-        cloudDomain,
-        projectId: undefined,
-        requireLogin: undefined,
-      })
+      await expectError(
+        async () =>
+          await CloudApi.factory({
+            log,
+            globalConfigStore,
+            cloudDomain,
+            projectId: undefined,
+            requireLogin: undefined,
+          }),
+        {
+          type: "cloud-api",
+          contains: "No auth token available for",
+        }
+      )
 
       // we don't expect a request to verify the token
       expect(scope.isDone()).to.be.false
-
-      expect(api).to.be.undefined
     })
 
     it("should return a CloudApi instance if there is a valid token", async () => {
@@ -136,17 +141,22 @@ describe("CloudApi", () => {
 
       scope.get("/api/token/verify").reply(200, {})
 
-      const api = await CloudApi.factory({
-        log,
-        globalConfigStore,
-        cloudDomain,
-        projectId: "test",
-        requireLogin: false,
-      })
+      await expectError(
+        async () =>
+          await CloudApi.factory({
+            log,
+            globalConfigStore,
+            cloudDomain,
+            projectId: "test",
+            requireLogin: false,
+          }),
+        {
+          type: "cloud-api",
+          contains: "No auth token available for",
+        }
+      )
 
       expect(scope.isDone()).to.be.false
-
-      expect(api).to.be.undefined
     })
 
     it("should not return a CloudApi instance with an invalid token when require login is false", async () => {
@@ -157,17 +167,22 @@ describe("CloudApi", () => {
       scope.get("/api/token/verify").reply(401, {})
       scope.get("/api/token/refresh").reply(401, {})
 
-      const api = await CloudApi.factory({
-        log,
-        globalConfigStore,
-        cloudDomain,
-        projectId: "test",
-        requireLogin: false,
-      })
+      await expectError(
+        async () =>
+          await CloudApi.factory({
+            log,
+            globalConfigStore,
+            cloudDomain,
+            projectId: "test",
+            requireLogin: false,
+          }),
+        {
+          type: "cloud-api",
+          contains: "The auth token could not be refreshed for",
+        }
+      )
 
       expect(scope.isDone()).to.be.true
-
-      expect(api).to.be.undefined
     })
 
     it("should throw an error when the token is invalid and require login is true", async () => {
@@ -187,7 +202,10 @@ describe("CloudApi", () => {
             projectId: "test",
             requireLogin: true,
           }),
-        "cloud-api"
+        {
+          type: "cloud-api",
+          contains: "You are running this in a project with a Garden Cloud ID and logging in is required.",
+        }
       )
 
       expect(scope.isDone()).to.be.true
@@ -206,16 +224,22 @@ describe("CloudApi", () => {
       gardenEnv.GARDEN_REQUIRE_LOGIN_OVERRIDE = false
 
       try {
-        const api = await CloudApi.factory({
-          log,
-          globalConfigStore,
-          cloudDomain,
-          projectId: "test",
-          requireLogin: true,
-        })
+        await expectError(
+          async () =>
+            await CloudApi.factory({
+              log,
+              globalConfigStore,
+              cloudDomain,
+              projectId: "test",
+              requireLogin: true,
+            }),
+          {
+            type: "cloud-api",
+            contains: "The auth token could not be refreshed for",
+          }
+        )
 
         expect(scope.isDone()).to.be.true
-        expect(api).to.be.undefined
       } finally {
         gardenEnv.GARDEN_REQUIRE_LOGIN_OVERRIDE = overrideEnvBackup
       }
@@ -243,7 +267,10 @@ describe("CloudApi", () => {
               projectId: "test",
               requireLogin: true,
             }),
-          "cloud-api"
+          {
+            type: "cloud-api",
+            contains: "You are running this in a project with a Garden Cloud ID and logging in is required.",
+          }
         )
 
         expect(scope.isDone()).to.be.true

--- a/core/test/unit/src/cloud/api.ts
+++ b/core/test/unit/src/cloud/api.ts
@@ -97,7 +97,13 @@ describe("CloudApi", () => {
 
       scope.get("/api/token/verify").reply(404)
 
-      const api = await CloudApi.factory({ log, globalConfigStore, cloudDomain })
+      const api = await CloudApi.factory({
+        log,
+        globalConfigStore,
+        cloudDomain,
+        projectId: undefined,
+        requireLogin: undefined,
+      })
 
       // we don't expect a request to verify the token
       expect(scope.isDone()).to.be.false
@@ -116,6 +122,8 @@ describe("CloudApi", () => {
         log,
         globalConfigStore,
         cloudDomain,
+        projectId: undefined,
+        requireLogin: undefined,
       })
 
       expect(scope.isDone()).to.be.true

--- a/core/test/unit/src/cloud/api.ts
+++ b/core/test/unit/src/cloud/api.ts
@@ -13,6 +13,8 @@ import { CloudApi } from "../../../../src/cloud/api.js"
 import { uuidv4 } from "../../../../src/util/random.js"
 import { randomString } from "../../../../src/util/string.js"
 import { GlobalConfigStore } from "../../../../src/config-store/global.js"
+import nock from "nock"
+import { expectError } from "../../../helpers.js"
 
 describe("CloudApi", () => {
   const log = getRootLogger().createLog()
@@ -65,6 +67,181 @@ describe("CloudApi", () => {
     it("should not throw an exception if no auth token exists", async () => {
       await CloudApi.clearAuthToken(log, globalConfigStore, domain)
       await CloudApi.clearAuthToken(log, globalConfigStore, domain)
+    })
+  })
+
+  describe("factory", async () => {
+    let cloudDomain: string
+
+    const storeToken = async () => {
+      const testToken = {
+        token: uuidv4(),
+        refreshToken: uuidv4(),
+        tokenValidity: 9999,
+      }
+      await CloudApi.saveAuthToken(log, globalConfigStore, testToken, cloudDomain)
+    }
+
+    beforeEach(async () => {
+      cloudDomain = "https://garden." + randomString()
+    })
+
+    afterEach(async () => {
+      await CloudApi.clearAuthToken(log, globalConfigStore, cloudDomain)
+
+      nock.cleanAll()
+    })
+
+    it("should not return a CloudApi instance without an auth token", async () => {
+      const scope = nock(cloudDomain)
+
+      scope.get("/api/token/verify").reply(404)
+
+      const api = await CloudApi.factory({ log, globalConfigStore, cloudDomain })
+
+      // we don't expect a request to verify the token
+      expect(scope.isDone()).to.be.false
+
+      expect(api).to.be.undefined
+    })
+
+    it("should return a CloudApi instance if there is a valid token", async () => {
+      const scope = nock(cloudDomain)
+
+      scope.get("/api/token/verify").reply(200, {})
+
+      await storeToken()
+
+      const api = await CloudApi.factory({
+        log,
+        globalConfigStore,
+        cloudDomain,
+      })
+
+      expect(scope.isDone()).to.be.true
+
+      expect(api).to.be.instanceOf(CloudApi)
+    })
+
+    it("should not return a CloudApi instance without a token even if there is a project id and require login is false", async () => {
+      const scope = nock(cloudDomain)
+
+      scope.get("/api/token/verify").reply(200, {})
+
+      const api = await CloudApi.factory({
+        log,
+        globalConfigStore,
+        cloudDomain,
+        projectId: "test",
+        requireLogin: false,
+      })
+
+      expect(scope.isDone()).to.be.false
+
+      expect(api).to.be.undefined
+    })
+
+    it("should not return a CloudApi instance with an invalid token when require login is false", async () => {
+      const scope = nock(cloudDomain)
+
+      // store a token, but return that its invalid and fail the refresh
+      await storeToken()
+      scope.get("/api/token/verify").reply(401, {})
+      scope.get("/api/token/refresh").reply(401, {})
+
+      const api = await CloudApi.factory({
+        log,
+        globalConfigStore,
+        cloudDomain,
+        projectId: "test",
+        requireLogin: false,
+      })
+
+      expect(scope.isDone()).to.be.true
+
+      expect(api).to.be.undefined
+    })
+
+    it("should throw an error when the token is invalid and require login is true", async () => {
+      const scope = nock(cloudDomain)
+
+      // store a token, but return that its invalid and fail the refresh
+      await storeToken()
+      scope.get("/api/token/verify").reply(401, {})
+      scope.get("/api/token/refresh").reply(401, {})
+
+      await expectError(
+        async () =>
+          CloudApi.factory({
+            log,
+            globalConfigStore,
+            cloudDomain,
+            projectId: "test",
+            requireLogin: true,
+          }),
+        "cloud-api"
+      )
+
+      expect(scope.isDone()).to.be.true
+    })
+
+    it("should not return a CloudApi instance when GARDEN_REQUIRE_LOGIN_OVERRIDE is false", async () => {
+      const scope = nock(cloudDomain)
+
+      // store a token, but return that its invalid and fail the refresh
+      await storeToken()
+      scope.get("/api/token/verify").reply(401, {})
+      scope.get("/api/token/refresh").reply(401, {})
+
+      const overrideEnvBackup = gardenEnv.GARDEN_REQUIRE_LOGIN_OVERRIDE
+
+      gardenEnv.GARDEN_REQUIRE_LOGIN_OVERRIDE = false
+
+      try {
+        const api = await CloudApi.factory({
+          log,
+          globalConfigStore,
+          cloudDomain,
+          projectId: "test",
+          requireLogin: true,
+        })
+
+        expect(scope.isDone()).to.be.true
+        expect(api).to.be.undefined
+      } finally {
+        gardenEnv.GARDEN_REQUIRE_LOGIN_OVERRIDE = overrideEnvBackup
+      }
+    })
+
+    it("should throw an error when GARDEN_REQUIRE_LOGIN_OVERRIDE is true", async () => {
+      const scope = nock(cloudDomain)
+
+      // store a token, but return that its invalid and fail the refresh
+      await storeToken()
+      scope.get("/api/token/verify").reply(401, {})
+      scope.get("/api/token/refresh").reply(401, {})
+
+      const overrideEnvBackup = gardenEnv.GARDEN_REQUIRE_LOGIN_OVERRIDE
+
+      gardenEnv.GARDEN_REQUIRE_LOGIN_OVERRIDE = true
+
+      try {
+        await expectError(
+          async () =>
+            CloudApi.factory({
+              log,
+              globalConfigStore,
+              cloudDomain,
+              projectId: "test",
+              requireLogin: true,
+            }),
+          "cloud-api"
+        )
+
+        expect(scope.isDone()).to.be.true
+      } finally {
+        gardenEnv.GARDEN_REQUIRE_LOGIN_OVERRIDE = overrideEnvBackup
+      }
     })
   })
 })

--- a/core/test/unit/src/garden.ts
+++ b/core/test/unit/src/garden.ts
@@ -743,7 +743,13 @@ describe("Garden", () => {
           refreshToken: "fake-refresh-token",
           validity: add(new Date(), { seconds: validityMs / 1000 }),
         })
-        return CloudApi.factory({ log, cloudDomain: domain, globalConfigStore })
+        return CloudApi.factory({
+          log,
+          cloudDomain: domain,
+          globalConfigStore,
+          projectId: undefined,
+          requireLogin: undefined,
+        })
       }
 
       before(async () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

This introduces a new Project-level config parameter that can force users of a project to login via Garden Cloud when **there is a connected cloud project**. The main use case is when a team is using garden together with Garden Cloud and would like to make sure that all users are logged in. Since making this change would be breaking, we introduce a config field + an env. var, `GARDEN_REQUIRE_LOGIN_OVERRIDE`, to override the config. The default value of the config field is `false`, which does not require the user to login. When transitioning to 0.14, we will make the default value `true`. Note, when there is no cloud project configured through the `id`-field in the Project-level config, garden works as usual without cloud and enforced login.


When the config contains `requireLogin: true` or `GARDEN_REQUIRE_LOGIN_OVERRIDE=true` and a user is not logged in to their cloud instance, the user will be notified that they need to be logged in. See example below:

<img width="554" alt="Screenshot 2023-12-12 at 12 18 35" src="https://github.com/garden-io/garden/assets/111101/fe172237-09d3-477a-8713-67c4edc973a4">

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
