### PR TITLE
fix(git): fix `exclude` files handling in `subtree` Git repo scan mode

### DIFF
--- a/core/src/vcs/git-repo.ts
+++ b/core/src/vcs/git-repo.ts
@@ -35,8 +35,8 @@ const getIncludeExcludeFiles: IncludeExcludeFilesHandler<GitRepoGetFilesParams, 
   // Make sure action config is not mutated.
   let exclude = !params.exclude ? [] : [...params.exclude]
 
-  // Do the same normalization of the excluded paths like in GitHandler.
-  // This might be redundant because the non-normalized paths will be handled by augmentGlobs below.
+  // Do the same normalization of the excluded paths like in `GitHandler`.
+  // This might be redundant because the non-normalized paths will be handled by `augmentGlobs` below.
   // But this brings no harm and makes the implementation more clear.
   exclude = exclude.map(normalize)
 

--- a/core/src/vcs/git-repo.ts
+++ b/core/src/vcs/git-repo.ts
@@ -12,7 +12,7 @@ import { isDirectory, matchPath } from "../util/fs.js"
 import fsExtra from "fs-extra"
 import { pathToCacheContext } from "../cache.js"
 import { FileTree } from "./file-tree.js"
-import { sep } from "path"
+import { normalize, sep } from "path"
 
 const { pathExists } = fsExtra
 
@@ -36,6 +36,12 @@ const getIncludeExcludeFiles: IncludeExcludeFilesHandler<GitRepoGetFilesParams, 
   if (!exclude) {
     exclude = []
   }
+
+  // Make sure action config is not mutated.
+  // Do the same normalization of the excluded paths like in GitHandler.
+  // This might be redundant because the non-normalized paths will be handled by augmentGlobs below.
+  // But this brings no harm and makes the implementation more clear.
+  exclude = [...exclude.map(normalize)]
 
   // We allow just passing a path like `foo` as include and exclude params
   // Those need to be converted to globs, but we don't want to touch existing globs

--- a/core/src/vcs/git-repo.ts
+++ b/core/src/vcs/git-repo.ts
@@ -31,17 +31,14 @@ const getIncludeExcludeFiles: IncludeExcludeFilesHandler<GitRepoGetFilesParams, 
   params
 ) => {
   const { include, path, scanFromProjectRoot } = params
-  let { exclude } = params
-
-  if (!exclude) {
-    exclude = []
-  }
 
   // Make sure action config is not mutated.
+  let exclude = !params.exclude ? [] : [...params.exclude]
+
   // Do the same normalization of the excluded paths like in GitHandler.
   // This might be redundant because the non-normalized paths will be handled by augmentGlobs below.
   // But this brings no harm and makes the implementation more clear.
-  exclude = [...exclude.map(normalize)]
+  exclude = exclude.map(normalize)
 
   // We allow just passing a path like `foo` as include and exclude params
   // Those need to be converted to globs, but we don't want to touch existing globs

--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -81,13 +81,11 @@ interface GitSubTreeIncludeExcludeFiles extends BaseIncludeExcludeFiles {
 const getIncludeExcludeFiles: IncludeExcludeFilesHandler<GetFilesParams, GitSubTreeIncludeExcludeFiles> = async (
   params: GetFilesParams
 ) => {
-  let { include, exclude } = params
-
-  if (!exclude) {
-    exclude = []
-  }
+  let include = params.include
 
   // Make sure action config is not mutated.
+  let exclude = !params.exclude ? [] : [...params.exclude]
+
   // It looks like paths with redundant '.' and '..' parts
   // do not work well along with --exclude and --glob-pathspecs flags.
   exclude = [...exclude.map(normalize), "**/.garden/**/*"]

--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -7,7 +7,7 @@
  */
 
 import { performance } from "perf_hooks"
-import { isAbsolute, join, posix, relative, resolve } from "path"
+import { isAbsolute, join, normalize, posix, relative, resolve } from "path"
 import { isString } from "lodash-es"
 import fsExtra from "fs-extra"
 import { PassThrough } from "stream"
@@ -223,7 +223,10 @@ export class GitHandler extends VcsHandler {
 
     if (!hasIncludes) {
       for (const p of exclude) {
-        lsFilesCommonArgs.push("--exclude", p)
+        // It looks like paths with redundant '.' and '..' parts
+        // do not work well along with --exclude and --glob-pathspecs flags.
+        const normalizedPath = normalize(p)
+        lsFilesCommonArgs.push("--exclude", normalizedPath)
       }
     }
 

--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -349,7 +349,8 @@ export class GitHandler extends VcsHandler {
         return
       }
 
-      if (hasIncludes && !matchPath(filePath, undefined, exclude)) {
+      const passesExclusionFilter = matchPath(filePath, undefined, exclude)
+      if (hasIncludes && !passesExclusionFilter) {
         return
       }
 
@@ -717,8 +718,9 @@ export async function augmentGlobs(basePath: string, globs?: string[]): Promise<
       }
 
       try {
-        const isDir = (await stat(joinWithPosix(basePath, pattern))).isDirectory()
-        return isDir ? posix.join(pattern, "**", "*") : pattern
+        const path = joinWithPosix(basePath, pattern)
+        const stats = await stat(path)
+        return stats.isDirectory() ? posix.join(pattern, "**", "*") : pattern
       } catch {
         return pattern
       }

--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -86,8 +86,11 @@ const getIncludeExcludeFiles: IncludeExcludeFilesHandler<GetFilesParams, GitSubT
   if (!exclude) {
     exclude = []
   }
-  // Make sure action config is not mutated
-  exclude = [...exclude, "**/.garden/**/*"]
+
+  // Make sure action config is not mutated.
+  // It looks like paths with redundant '.' and '..' parts
+  // do not work well along with --exclude and --glob-pathspecs flags.
+  exclude = [...exclude.map(normalize), "**/.garden/**/*"]
 
   // Apply the include patterns to the ls-files queries. We use the --glob-pathspecs flag
   // to make sure the path handling is consistent with normal POSIX-style globs used generally by Garden.
@@ -241,10 +244,7 @@ export class GitHandler extends VcsHandler {
 
     if (!hasIncludes) {
       for (const p of exclude) {
-        // It looks like paths with redundant '.' and '..' parts
-        // do not work well along with --exclude and --glob-pathspecs flags.
-        const normalizedPath = normalize(p)
-        lsFilesCommonArgs.push("--exclude", normalizedPath)
+        lsFilesCommonArgs.push("--exclude", p)
       }
     }
 

--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -86,8 +86,10 @@ const getIncludeExcludeFiles: IncludeExcludeFilesHandler<GetFilesParams, GitSubT
   // Make sure action config is not mutated.
   let exclude = !params.exclude ? [] : [...params.exclude]
 
-  // It looks like paths with redundant '.' and '..' parts
-  // do not work well along with --exclude and --glob-pathspecs flags.
+  // It looks like relative paths with redundant '.' and '..' parts
+  // do not work well along with `--exclude` and `--glob-pathspecs` flags.
+  // So, we need to normalize paths like './dir' to be just 'dir',
+  // otherwise such dirs won't be excluded by `--exclude` flag applied with `--glob-pathspecs`.
   exclude = [...exclude.map(normalize), "**/.garden/**/*"]
 
   // Apply the include patterns to the ls-files queries. We use the --glob-pathspecs flag

--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -11,7 +11,15 @@ import { isAbsolute, join, normalize, posix, relative, resolve } from "path"
 import { isString } from "lodash-es"
 import fsExtra from "fs-extra"
 import { PassThrough } from "stream"
-import type { GetFilesParams, RemoteSourceParams, VcsFile, VcsHandlerParams, VcsInfo } from "./vcs.js"
+import type {
+  BaseIncludeExcludeFiles,
+  GetFilesParams,
+  IncludeExcludeFilesHandler,
+  RemoteSourceParams,
+  VcsFile,
+  VcsHandlerParams,
+  VcsInfo,
+} from "./vcs.js"
 import { VcsHandler } from "./vcs.js"
 import type { GardenError } from "../exceptions.js"
 import { ChildProcessError, ConfigurationError, isErrnoException, RuntimeError } from "../exceptions.js"
@@ -64,6 +72,37 @@ export function parseGitUrl(url: string) {
 
 export interface GitCli {
   (...args: (string | undefined)[]): Promise<string[]>
+}
+
+interface GitSubTreeIncludeExcludeFiles extends BaseIncludeExcludeFiles {
+  hasIncludes: boolean
+}
+
+const getIncludeExcludeFiles: IncludeExcludeFilesHandler<GetFilesParams, GitSubTreeIncludeExcludeFiles> = async (
+  params: GetFilesParams
+) => {
+  let { include, exclude } = params
+
+  if (!exclude) {
+    exclude = []
+  }
+  // Make sure action config is not mutated
+  exclude = [...exclude, "**/.garden/**/*"]
+
+  // Apply the include patterns to the ls-files queries. We use the --glob-pathspecs flag
+  // to make sure the path handling is consistent with normal POSIX-style globs used generally by Garden.
+
+  // Due to an issue in git, we can unfortunately only use _either_ include or exclude patterns in the
+  // ls-files commands, but not both. Trying both just ignores the exclude patterns.
+
+  if (include?.includes("**/*")) {
+    // This is redundant
+    include = undefined
+  }
+
+  const hasIncludes = !!include?.length
+
+  return { include, exclude, hasIncludes }
 }
 
 interface Submodule {
@@ -153,19 +192,13 @@ export class GitHandler extends VcsHandler {
    * so that {@link getFiles} won't refer to the method in the subclass.
    */
   async _getFiles(params: GetFilesParams): Promise<VcsFile[]> {
-    const { log, path, pathDescription = "directory", filter, failOnPrompt = false } = params
-    let { include, exclude } = params
-
-    if (include && include.length === 0) {
+    if (params.include && params.include.length === 0) {
       // No need to proceed, nothing should be included
       return []
     }
 
-    if (!exclude) {
-      exclude = []
-    }
-    // Make sure action config is not mutated
-    exclude = [...exclude, "**/.garden/**/*"]
+    const { log, path, pathDescription = "directory", filter, failOnPrompt = false } = params
+    const { exclude, hasIncludes, include } = await getIncludeExcludeFiles(params)
 
     const gitLog = log
       .createLog({ name: "git" })
@@ -202,21 +235,6 @@ export class GitHandler extends VcsHandler {
         // The output here is relative to the git root, and not the directory `path`
         .map((modifiedRelPath) => resolve(gitRoot, modifiedRelPath))
     )
-
-    const absExcludes = exclude.map((p) => resolve(path, p))
-
-    // Apply the include patterns to the ls-files queries. We use the --glob-pathspecs flag
-    // to make sure the path handling is consistent with normal POSIX-style globs used generally by Garden.
-
-    // Due to an issue in git, we can unfortunately only use _either_ include or exclude patterns in the
-    // ls-files commands, but not both. Trying both just ignores the exclude patterns.
-
-    if (include?.includes("**/*")) {
-      // This is redundant
-      include = undefined
-    }
-
-    const hasIncludes = !!include?.length
 
     const globalArgs = ["--glob-pathspecs"]
     const lsFilesCommonArgs = ["--cached", "--exclude", this.gardenDirPath]
@@ -259,11 +277,12 @@ export class GitHandler extends VcsHandler {
       // Need to automatically add `**/*` to directory paths, to match git behavior when filtering.
       const augmentedIncludes = await augmentGlobs(path, include)
       const augmentedExcludes = await augmentGlobs(path, exclude)
+      const absExcludes = exclude.map((p) => resolve(path, p))
 
       // Resolve submodules
       // TODO: see about optimizing this, avoiding scans when we're sure they'll not match includes/excludes etc.
       submoduleFiles = submodulePaths.map(async (submodulePath) => {
-        if (!submodulePath.startsWith(path) || absExcludes?.includes(submodulePath)) {
+        if (!submodulePath.startsWith(path) || absExcludes.includes(submodulePath)) {
           return []
         }
 

--- a/core/src/vcs/vcs.ts
+++ b/core/src/vcs/vcs.ts
@@ -34,6 +34,7 @@ import type { Garden } from "../garden.js"
 import { Profile } from "../util/profiling.js"
 
 import AsyncLock from "async-lock"
+
 const scanLock = new AsyncLock()
 
 export const versionStringPrefix = "v-"
@@ -120,6 +121,15 @@ export interface GetFilesParams {
   failOnPrompt?: boolean
   scanRoot: string | undefined
 }
+
+export interface BaseIncludeExcludeFiles {
+  include?: string[]
+  exclude: string[]
+}
+
+export type IncludeExcludeFilesHandler<T extends GetFilesParams, R extends BaseIncludeExcludeFiles> = (
+  params: T
+) => Promise<R>
 
 export interface GetTreeVersionParams {
   log: Log

--- a/core/test/data/test-projects/include-exclude/module-b/dir1/foo.txt
+++ b/core/test/data/test-projects/include-exclude/module-b/dir1/foo.txt
@@ -1,0 +1,1 @@
+I'm in the excluded dir. I should be excluded too.

--- a/core/test/data/test-projects/include-exclude/module-b/dir2/bar.txt
+++ b/core/test/data/test-projects/include-exclude/module-b/dir2/bar.txt
@@ -1,0 +1,1 @@
+I'm in the excluded dir. I should be excluded.

--- a/core/test/data/test-projects/include-exclude/module-b/garden.yml
+++ b/core/test/data/test-projects/include-exclude/module-b/garden.yml
@@ -1,4 +1,5 @@
 kind: Module
 name: module-b
 type: test
-exclude: ["nope.*"]
+# test both dir name and relative path
+exclude: ["nope.*", "./dir1", "dir2"]

--- a/core/test/unit/src/vcs/git.ts
+++ b/core/test/unit/src/vcs/git.ts
@@ -562,15 +562,15 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
             const testParams = [
               {
                 name: "without globs",
-                pathBuilder: (subDirName: string) => subDirName,
+                pathBuilder: (...subDirNames: string[]) => subDirNames.at(-1)!,
               },
               {
                 name: "with prefix globs",
-                pathBuilder: (subDirName: string) => join("**", subDirName),
+                pathBuilder: (...subDirNames: string[]) => join("**", subDirNames.at(-1)!),
               },
               {
                 name: "with full globs",
-                pathBuilder: (subDirName: string) => join("**", subDirName, "**", "*"),
+                pathBuilder: (...subDirNames: string[]) => join("**", subDirNames.at(-1)!, "**", "*"),
               },
             ]
 
@@ -617,7 +617,7 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
                     path: tmpPath,
                     scanRoot: undefined,
                     include: undefined, // when include: [], getFiles() always returns an empty result
-                    exclude: [testParam.pathBuilder(excludedSubDirectoryName)],
+                    exclude: [testParam.pathBuilder(notExcludedDirName, excludedSubDirectoryName)],
                     log,
                   })
                 )

--- a/core/test/unit/src/vcs/git.ts
+++ b/core/test/unit/src/vcs/git.ts
@@ -426,18 +426,18 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
       // When ONLY exclude filter is defined,
       // the exclusion paths with and without glob prefix **/ works in the same way.
       context("when only exclude filter is specified", () => {
-        const testParams = [
-          {
-            name: "without globs",
-            pathBuilder: (path: string) => path,
-          },
-          {
-            name: "with globs",
-            pathBuilder: (path: string) => join("**", path),
-          },
-        ]
-
         context("should filter out files that match the exclude filter", () => {
+          const testParams = [
+            {
+              name: "without globs",
+              pathBuilder: (path: string) => path,
+            },
+            {
+              name: "with globs",
+              pathBuilder: (path: string) => join("**", path),
+            },
+          ]
+
           for (const testParam of testParams) {
             it(testParam.name, async () => {
               // FIXME
@@ -488,6 +488,17 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
         context(
           "should filter out all files from directories (including their sub-directories) that match the exclude filter",
           () => {
+            const testParams = [
+              {
+                name: "without globs",
+                pathBuilder: (path: string) => path,
+              },
+              {
+                name: "with globs",
+                pathBuilder: (path: string) => join("**", path),
+              },
+            ]
+
             for (const testParam of testParams) {
               it(testParam.name, async () => {
                 // FIXME

--- a/core/test/unit/src/vcs/git.ts
+++ b/core/test/unit/src/vcs/git.ts
@@ -494,8 +494,12 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
                 pathBuilder: (path: string) => path,
               },
               {
-                name: "with globs",
+                name: "with prefix globs",
                 pathBuilder: (path: string) => join("**", path),
+              },
+              {
+                name: "with full globs",
+                pathBuilder: (path: string) => join("**", path, "**", "*"),
               },
             ]
 

--- a/core/test/unit/src/vcs/git.ts
+++ b/core/test/unit/src/vcs/git.ts
@@ -519,7 +519,9 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
               it(testParam.name, async () => {
                 // FIXME
                 if (handler.name === "git-repo") {
-                  return
+                  if (testParam.name === "with prefix globs") {
+                    return
+                  }
                 }
 
                 // doesn't match file exclusion pattern -> should be included
@@ -595,7 +597,9 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
               it(testParam.name, async () => {
                 // FIXME
                 if (handler.name === "git-repo") {
-                  return
+                  if (testParam.name === "without globs" || testParam.name === "with prefix globs") {
+                    return
+                  }
                 }
 
                 // doesn't match file exclusion pattern -> should be included

--- a/core/test/unit/src/vcs/git.ts
+++ b/core/test/unit/src/vcs/git.ts
@@ -500,6 +500,10 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
                 name: "with full globs",
                 pathBuilder: (subDirName: string) => join("**", subDirName, "**", "*"),
               },
+              {
+                name: "with redundant relative path",
+                pathBuilder: (subDirName: string) => `./${subDirName}`,
+              },
             ]
 
             /*
@@ -571,6 +575,10 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
               {
                 name: "with full globs",
                 pathBuilder: (...subDirNames: string[]) => join("**", subDirNames.at(-1)!, "**", "*"),
+              },
+              {
+                name: "with redundant relative path",
+                pathBuilder: (...subDirNames: string[]) => `./${subDirNames.join("/")}`,
               },
             ]
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #5317

**Special notes for your reviewer**:
Based on test fixes made in #5472.
See individual commits for details.
