### PR TITLE
improvement(logger): update some log lines after style changes

### DIFF
--- a/core/src/actions/base.ts
+++ b/core/src/actions/base.ts
@@ -398,10 +398,12 @@ export abstract class BaseAction<
    * Verbose string description of the action. Useful for logging and error messages.
    */
   longDescription(): string {
-    let d = `${styles.accent(this.kind)} type=${styles.accent.bold(this.type)} name=${styles.accent.bold(this.name)}`
+    let d = `${styles.highlight(this.kind)} type=${styles.highlight.bold(this.type)} name=${styles.highlight.bold(
+      this.name
+    )}`
 
     if (this._moduleName) {
-      d += ` (from module ${styles.accent.bold(this._moduleName)})`
+      d += ` (from module ${styles.highlight.bold(this._moduleName)})`
     }
 
     return d

--- a/core/src/actions/helpers.ts
+++ b/core/src/actions/helpers.ts
@@ -91,7 +91,7 @@ export async function warnOnLinkedActions(garden: Garden, log: Log, actions: Act
 
   const linkedActionsMsg = actions
     .filter((a) => a.isLinked(linkedSources))
-    .map((a) => `${a.longDescription()} linked to path ${styles.accent(a.sourcePath())}`)
+    .map((a) => `${a.longDescription()} linked to path ${styles.highlight(a.sourcePath())}`)
     .map((msg) => "  " + msg) // indent list
 
   if (linkedActionsMsg.length > 0) {

--- a/core/src/cli/cli.ts
+++ b/core/src/cli/cli.ts
@@ -241,7 +241,9 @@ ${renderCommands(commands)}
       const gardenLog = log.createLog({ name: "garden", showDuration: true })
       // Log context for printing the start and finish of Garden initialization when not using the dev console
       const gardenInitLog =
-        command.getFullName() !== "dev" ? log.createLog({ name: "garden", showDuration: true }) : null
+        !command.noProject && command.getFullName() !== "dev" && command.getFullName() !== "serve"
+          ? log.createLog({ name: "garden", showDuration: true })
+          : null
 
       // Init Cloud API (if applicable)
       let cloudApi: CloudApi | undefined

--- a/core/src/cli/command-line.ts
+++ b/core/src/cli/command-line.ts
@@ -43,12 +43,8 @@ import { styles } from "../logger/styles.js"
 
 const defaultMessageDuration = 3000
 const commandLinePrefix = styles.warning("🌼  > ")
-const emptyCommandLinePlaceholder = styles.primary("<enter command> (enter help for more info)")
+const emptyCommandLinePlaceholder = styles.secondary("<enter command> (enter help for more info)")
 const inputHistoryLength = 100
-
-const commandLineStyles = {
-  command: styles.accent.bold,
-}
 
 export type SetStringCallback = (data: string) => void
 
@@ -76,16 +72,15 @@ interface CommandLineEvents {
 function getCmdsRunningMsg(commandNames: string[]) {
   let msg = ""
   if (commandNames.length === 1) {
-    msg = styles.highlight(`Running ${commandLineStyles.command(commandNames[0])} command...`)
+    msg = `Running ${styles.command(commandNames[0])} command...`
   } else if (commandNames.length > 1) {
-    msg =
-      styles.highlight(`Running ${commandNames.length} commands: `) + commandLineStyles.command(commandNames.join(", "))
+    msg = `Running ${commandNames.length} commands: ` + styles.command(commandNames.join(", "))
   }
   return msg
 }
 
 function getCmdSuccessMsg(commandName: string) {
-  return `${styles.highlight(commandName)} command completed successfully!`
+  return `Command ${styles.command(commandName)} completed successfully!`
 }
 
 function getCmdFailMsg(commandName: string) {
@@ -100,7 +95,7 @@ function getCmdFailMsg(commandName: string) {
  * by the web UI.
  */
 function logCommand({ msg, log, width, error }: { msg: string; log: Log; width: number; error: boolean }) {
-  const dividerColor = error ? styles.error : styles.highlight
+  const dividerColor = error ? styles.error : styles.primary
   const dividerOptsBase = { width, title: msg, color: dividerColor, char: "┈" }
   const terminalMsg = renderDivider(dividerOptsBase)
   const rawMsg = renderDivider({ ...dividerOptsBase, width: DEFAULT_BROWSER_DIVIDER_WIDTH })
@@ -429,12 +424,12 @@ export class CommandLine extends TypedEventEmitter<CommandLineEvents> {
     const suggestions = this.getSuggestions(this.currentCommand.length)
 
     if (this.isSuggestedCommand(suggestions)) {
-      renderedCommand = styles.highlight(renderedCommand)
+      renderedCommand = styles.highlightSecondary(renderedCommand)
     }
 
     if (suggestions.length > 0) {
       // Show autocomplete suggestion after string
-      renderedCommand = renderedCommand + styles.primary(suggestions[0].line.substring(renderedCommand.length))
+      renderedCommand = renderedCommand + styles.secondary(suggestions[0].line.substring(renderedCommand.length))
     }
 
     if (renderedCommand.length === 0) {

--- a/core/src/commands/base.ts
+++ b/core/src/commands/base.ts
@@ -284,7 +284,7 @@ export abstract class Command<
         const log = overrideLogLevel ? garden.log.createLog({ fixLevel: overrideLogLevel }) : garden.log
 
         let cloudSession: CloudSession | undefined
-        let cloudLinkMsg: string | undefined
+        let commandResultUrl: string | undefined
 
         // Session registration for the `dev` and `serve` commands is handled in the `serve` command's `action` method,
         // so we skip registering here to avoid duplication.
@@ -312,16 +312,13 @@ export abstract class Command<
 
         if (cloudSession) {
           const distroName = getCloudDistributionName(cloudSession.api.domain)
-          const commandResultUrl = cloudSession.api.getCommandResultUrl({
+          commandResultUrl = cloudSession.api.getCommandResultUrl({
             sessionId: garden.sessionId,
             projectId: cloudSession.projectId,
             shortId: cloudSession.shortId,
           }).href
           const cloudLog = log.createLog({ name: getCloudLogSectionName(distroName) })
-          cloudLinkMsg = `View command results at: \n\n${printEmoji("👉", log)}${styles.link(
-            commandResultUrl
-          )} ${printEmoji("👈", log)} \n`
-          cloudLog.info(cloudLinkMsg)
+          cloudLog.info(`View command results at: ${styles.link(commandResultUrl)}`)
         }
 
         let analytics: AnalyticsHandler | undefined
@@ -433,8 +430,11 @@ export abstract class Command<
         // fire, which may be needed to e.g. capture monitors added in event handlers
         await waitForOutputFlush()
 
-        if (cloudLinkMsg) {
-          log.info("\n" + cloudLinkMsg)
+        if (commandResultUrl) {
+          const msg = `View command results at: \n\n${printEmoji("👉", log)}${styles.link(
+            commandResultUrl
+          )} ${printEmoji("👈", log)}\n`
+          log.info("\n" + msg)
         }
 
         return result

--- a/core/src/commands/create/create-project.ts
+++ b/core/src/commands/create/create-project.ts
@@ -196,9 +196,10 @@ export class CreateProjectCommand extends Command<CreateProjectArgs, CreateProje
 
     await addConfig(configPath, yaml)
 
-    log.info(
-      styles.success(`-> Created new project config in ${styles.accent.bold(relative(process.cwd(), configPath))}`)
-    )
+    log.success({
+      msg: `-> Created new project config in ${styles.highlight(relative(process.cwd(), configPath))}`,
+      showDuration: false,
+    })
 
     const ignoreFilePath = resolve(configDir, ignorefileName)
     let ignoreFileCreated = false
@@ -209,19 +210,18 @@ export class CreateProjectCommand extends Command<CreateProjectArgs, CreateProje
       if (await pathExists(gitIgnorePath)) {
         await copyFile(gitIgnorePath, ignoreFilePath)
         const gitIgnoreRelPath = styles.accent.bold(relative(process.cwd(), ignoreFilePath))
-        log.info(
+        log.success(
           styles.success(
             `-> Copied the .gitignore file at ${gitIgnoreRelPath} to a new .gardenignore in the same directory. Please edit the .gardenignore file if you'd like Garden to include or ignore different files.`
           )
         )
       } else {
         await writeFile(ignoreFilePath, defaultIgnorefile + "\n")
-        const gardenIgnoreRelPath = styles.accent.bold(relative(process.cwd(), ignoreFilePath))
-        log.info(
-          styles.success(
-            `-> Created default .gardenignore file at ${gardenIgnoreRelPath}. Please edit the .gardenignore file to add files or patterns that Garden should ignore when scanning and building.`
-          )
-        )
+        const gardenIgnoreRelPath = styles.highlight(relative(process.cwd(), ignoreFilePath))
+        log.info({
+          msg: `-> Created default .gardenignore file at ${gardenIgnoreRelPath}. Please edit the .gardenignore file to add files or patterns that Garden should ignore when scanning and building.`,
+          showDuration: false,
+        })
       }
 
       ignoreFileCreated = true

--- a/core/src/commands/deploy.ts
+++ b/core/src/commands/deploy.ts
@@ -204,9 +204,11 @@ export class DeployCommand extends Command<Args, Opts> {
     const disabled = deployActions.filter((s) => s.isDisabled()).map((s) => s.name)
 
     if (disabled.length > 0) {
-      const bold = disabled.map((d) => styles.accent(d))
+      const highlight = disabled.map((d) => styles.highlight(d))
       const msg =
-        disabled.length === 1 ? `Deploy action ${bold} is disabled` : `Deploy actions ${naturalList(bold)} are disabled`
+        disabled.length === 1
+          ? `Deploy action ${highlight} is disabled`
+          : `Deploy actions ${naturalList(highlight)} are disabled`
       commandLog.info(msg)
     }
 

--- a/core/src/commands/dev.tsx
+++ b/core/src/commands/dev.tsx
@@ -24,6 +24,7 @@ import type { Log } from "../logger/log-entry.js"
 import { bindActiveContext } from "../util/open-telemetry/context.js"
 import Divider from "../util/ink-divider.js"
 import { styles } from "../logger/styles.js"
+import chalk from "chalk"
 
 const devCommandArgs = {
   ...serveArgs,
@@ -58,16 +59,16 @@ export class DevCommand extends ServeCommand<DevCommandArgs, DevCommandOpts> {
     console.clear()
 
     log.info(
-      styles.highlightSecondary(`
+      chalk.blueBright(`
 ${renderDivider({ color: styles.success, title: styles.success.bold("🌳  garden dev 🌳 "), width })}
 
 ${styles.bold(`Good ${getGreetingTime()}! Welcome to the Garden interactive development console.`)}
 
-Here, you can ${styles.accent("build")}, ${styles.accent("deploy")}, ${styles.accent("test")} and ${styles.accent(
+Here you can ${styles.command("build")}, ${styles.command("deploy")}, ${styles.command("test")} and ${styles.command(
         "run"
       )} anything in your project, start code syncing, stream live logs and more.
 
-Use the command line below to enter Garden commands. Type ${styles.accent("help")} to get a full list of commands.
+Use the command line below to enter Garden commands. Type ${styles.command("help")} to get a full list of commands.
 Use ${styles.bold("up/down")} arrow keys to scroll through your command history.
     `)
     )
@@ -100,7 +101,7 @@ Use ${styles.bold("up/down")} arrow keys to scroll through your command history.
 
     const commandLine = await this.initCommandHandler(params)
 
-    const Dev: FC<{}> = ({}) => {
+    const Dev: FC<{}> = ({ }) => {
       // Stream log output directly to stdout, on top of the Ink components below
       const { stdout, write } = useStdout()
       inkWriter.setWriteCallback(write)
@@ -180,7 +181,7 @@ Use ${styles.bold("up/down")} arrow keys to scroll through your command history.
       log.error(`Failed loading the project: ${error}`)
       log.error({ error: toGardenError(error) })
       this.commandLine?.flashError(
-        `Failed loading the project. See above logs for details. Type ${styles.accent("reload")} to try again.`
+        `Failed loading the project. See above logs for details. Type ${styles.command("reload")} to try again.`
       )
     } finally {
       this.commandLine?.enable()
@@ -219,13 +220,13 @@ Use ${styles.bold("up/down")} arrow keys to scroll through your command history.
         .emitWarning({
           log,
           key: "dev-syncs-active",
-          message: `Syncs started during this session may still be active when this command terminates. You can run ${styles.accent(
+          message: `Syncs started during this session may still be active when this command terminates. You can run ${styles.command(
             "garden sync stop '*'"
-          )} to stop all code syncs. Hint: To stop code syncing when exiting ${styles.accent(
+          )} to stop all code syncs. Hint: To stop code syncing when exiting ${styles.command(
             "garden dev"
-          )}, use ${styles.accent("Ctrl-D")} or the ${styles.accent(`exit`)} command.`,
+          )}, use ${styles.command("Ctrl-D")} or the ${styles.command(`exit`)} command.`,
         })
-        .catch(() => {})
+        .catch(() => { })
         .finally(() => quit())
     }
 

--- a/core/src/commands/exec.ts
+++ b/core/src/commands/exec.ts
@@ -116,9 +116,9 @@ export class ExecCommand extends Command<Args, Opts> {
       case "unhealthy":
       case "unknown":
         log.warn(
-          `The current state of ${action.key()} is ${styles.accent(
+          `The current state of ${action.key()} is ${styles.highlight(
             deployState || "unknown"
-          )}. If this command fails, you may need to re-deploy it with the ${styles.accent("deploy")} command.`
+          )}. If this command fails, you may need to re-deploy it with the ${styles.command("deploy")} command.`
         )
         break
       case "outdated":
@@ -135,9 +135,9 @@ export class ExecCommand extends Command<Args, Opts> {
         // if there is an active sync, the state is likely to be outdated so do not display this warning
         if (!(deploySync?.syncCount && deploySync?.syncCount > 0 && deploySync?.state === "active")) {
           log.warn(
-            `The current state of ${action.key()} is ${styles.accent(
+            `The current state of ${action.key()} is ${styles.highlight(
               deployState
-            )}. If this command fails, you may need to re-deploy it with the ${styles.accent("deploy")} command.`
+            )}. If this command fails, you may need to re-deploy it with the ${styles.command("deploy")} command.`
           )
         }
         break

--- a/core/src/commands/get/get-linked-repos.ts
+++ b/core/src/commands/get/get-linked-repos.ts
@@ -37,7 +37,7 @@ export class GetLinkedReposCommand extends Command {
     log.info("")
 
     if (linkedSources.length === 0) {
-      log.info(styles.accent("No linked sources, actions or modules found for this project."))
+      log.info("No linked sources, actions or modules found for this project.")
     } else {
       const linkedSourcesWithType = [
         ...linkedProjectSources.map((s) => ({ ...s, type: "source" })),

--- a/core/src/commands/get/get-status.ts
+++ b/core/src/commands/get/get-status.ts
@@ -124,7 +124,7 @@ export class GetStatusCommand extends Command {
       if (status.state === "unknown") {
         log.warn(
           deline`
-            Unable to resolve status for Deploy ${styles.accent(name)}. It is likely missing or outdated.
+            Unable to resolve status for Deploy ${styles.highlight(name)}. It is likely missing or outdated.
             This can come up if the deployment has runtime dependencies that are not resolvable, i.e. not deployed or
             invalid.
             `

--- a/core/src/commands/logout.ts
+++ b/core/src/commands/logout.ts
@@ -93,7 +93,7 @@ export class LogOutCommand extends Command<{}, Opts> {
       log.warn(msg)
     } finally {
       await CloudApi.clearAuthToken(log, garden.globalConfigStore, cloudDomain)
-      log.info({ msg: `Successfully logged out from ${cloudDomain}.` })
+      log.success(`Successfully logged out from ${cloudDomain}.`)
     }
     return {}
   }

--- a/core/src/commands/self-update.ts
+++ b/core/src/commands/self-update.ts
@@ -271,17 +271,16 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
     if (!installationDirectory) {
       installationDirectory = dirname(processExecPath)
       log.info(
-        styles.accent(
-          "No installation directory specified via --install-dir option. Garden will be re-installed to the current installation directory: "
-        ) + styles.highlight(installationDirectory)
+        "No installation directory specified via --install-dir option. Garden will be re-installed to the current installation directory: " +
+          styles.highlight(installationDirectory)
       )
     } else {
-      log.info(styles.accent("Installation directory: ") + styles.highlight(installationDirectory))
+      log.info("Installation directory: " + styles.highlight(installationDirectory))
     }
 
     installationDirectory = resolve(installationDirectory)
 
-    log.info(styles.accent("Checking for target and latest versions..."))
+    log.info("Checking for target and latest versions...")
     const latestVersion = await getLatestVersion(log)
 
     if (!desiredVersion) {
@@ -289,9 +288,9 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
       desiredVersion = await this.findTargetVersion(currentVersion, versionScope, latestVersion)
     }
 
-    log.info(styles.accent("Current Garden version: ") + styles.highlight(currentVersion))
-    log.info(styles.accent("Target Garden version to be installed: ") + styles.highlight(desiredVersion))
-    log.info(styles.accent("Latest release version: ") + styles.highlight(latestVersion))
+    log.info("Current Garden version: " + styles.highlight(currentVersion))
+    log.info("Target Garden version to be installed: " + styles.highlight(desiredVersion))
+    log.info("Latest release version: " + styles.highlight(latestVersion))
 
     if (!opts.force && !opts["install-dir"] && desiredVersion === currentVersion) {
       log.warn("")
@@ -380,9 +379,7 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
       const { build, filename, extension, url } = this.getReleaseArtifactDetails(platform, architecture, desiredVersion)
 
       log.info("")
-      log.info(
-        styles.accent(`Downloading version ${styles.highlight(desiredVersion)} from ${styles.underline(url)}...`)
-      )
+      log.info(`Downloading version ${styles.highlight(desiredVersion)} from ${styles.underline(url)}...`)
 
       const tempPath = join(tempDir.path, filename)
 
@@ -401,9 +398,7 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
           try {
             const latestVersions = await getLatestVersions(10, log)
 
-            log.info(
-              styles.accent.bold(`Here are the latest available versions: `) + latestVersions.join(styles.accent(", "))
-            )
+            log.info(`Here are the latest available versions: ` + latestVersions.join(styles.highlight(", ")))
           } catch (err) {
             log.debug(`Could not retrieve the latest available versions, ${err}`)
           }
@@ -429,7 +424,7 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
       await remove(backupPath)
       await mkdirp(backupPath)
 
-      log.info(styles.accent(`Backing up prior installation to ${styles.primary(backupPath)}...`))
+      log.info(`Backing up prior installation to ${styles.primary(backupPath)}...`)
 
       for (const path of await readdir(installationDirectory)) {
         if (path === ".backup") {
@@ -440,7 +435,7 @@ export class SelfUpdateCommand extends Command<SelfUpdateArgs, SelfUpdateOpts> {
       }
 
       // Move the extracted files to the install directory
-      log.info(styles.accent(`Extracting to installation directory ${styles.highlight(installationDirectory)}...`))
+      log.info(`Extracting to installation directory ${styles.highlight(installationDirectory)}...`)
 
       if (extension === "zip") {
         // Note: lazy-loading for startup performance

--- a/core/src/commands/serve.ts
+++ b/core/src/commands/serve.ts
@@ -197,7 +197,7 @@ export class ServeCommand<
                 "👇",
                 log
               )} \n\n${styles.highlight(livePageUrl)}\n`
-            log.info(styles.accent(msg))
+            log.info(msg)
           }
         }
       }

--- a/core/src/commands/set.ts
+++ b/core/src/commands/set.ts
@@ -64,9 +64,9 @@ export class SetDefaultEnvCommand extends Command<SetDefaultEnvArgs, {}> {
     log.info("")
 
     if (args.env) {
-      log.success(styles.accent(`Set the default environment to ${styles.highlight(args.env)}`))
+      log.success(`Set the default environment to ${styles.highlight(args.env)}`)
     } else {
-      log.success(styles.accent("Cleared the default environment"))
+      log.success("Cleared the default environment")
     }
 
     return {}

--- a/core/src/config/template-contexts/actions.ts
+++ b/core/src/config/template-contexts/actions.ts
@@ -302,7 +302,7 @@ export class ActionSpecContext extends OutputConfigContext {
     // Throw specific error when attempting to resolve self
     this.actions[action.kind.toLowerCase()].set(
       name,
-      new ErrorContext(`Action ${styles.accent.bold(action.key())} cannot reference itself.`)
+      new ErrorContext(`Action ${styles.highlight.bold(action.key())} cannot reference itself.`)
     )
 
     if (parentName && templateName) {

--- a/core/src/config/template-contexts/base.ts
+++ b/core/src/config/template-contexts/base.ts
@@ -170,14 +170,16 @@ export abstract class ConfigContext {
 
     if (value === undefined) {
       if (message === undefined) {
-        message = styles.error(`Could not find key ${styles.accent(String(nextKey))}`)
+        message = styles.error(`Could not find key ${styles.highlight(String(nextKey))}`)
         if (nestedNodePath.length > 1) {
-          message += styles.error(" under ") + styles.accent(renderKeyPath(nestedNodePath.slice(0, -1)))
+          message += styles.error(" under ") + styles.highlight(renderKeyPath(nestedNodePath.slice(0, -1)))
         }
         message += styles.error(".")
 
         if (available) {
-          const availableStr = available.length ? naturalList(available.sort().map((k) => styles.accent(k))) : "(none)"
+          const availableStr = available.length
+            ? naturalList(available.sort().map((k) => styles.highlight(k)))
+            : "(none)"
           message += styles.error(" Available keys: " + availableStr + ".")
         }
         const messageFooter = this.getMissingKeyErrorFooter(nextKey, nestedNodePath.slice(0, -1))

--- a/core/src/config/template-contexts/module.ts
+++ b/core/src/config/template-contexts/module.ts
@@ -289,7 +289,7 @@ export class ModuleConfigContext extends OutputConfigContext {
     const { name, path, inputs, parentName, templateName, buildPath } = params
 
     // Throw specific error when attempting to resolve self
-    this.modules.set(name, new ErrorContext(`Config ${styles.accent.bold(name)} cannot reference itself.`))
+    this.modules.set(name, new ErrorContext(`Config ${styles.highlight.bold(name)} cannot reference itself.`))
 
     if (parentName && templateName) {
       this.parent = new ParentContext(this, parentName)

--- a/core/src/garden.ts
+++ b/core/src/garden.ts
@@ -54,7 +54,7 @@ import { GitHandler } from "./vcs/git.js"
 import { BuildStaging } from "./build-staging/build-staging.js"
 import type { ConfigGraph } from "./graph/config-graph.js"
 import { ResolvedConfigGraph } from "./graph/config-graph.js"
-import { getRootLogger } from "./logger/logger.js"
+import { LogLevel, getRootLogger } from "./logger/logger.js"
 import type { GardenPluginSpec } from "./plugin/plugin.js"
 import type { GardenResource } from "./config/base.js"
 import { loadConfigResources, findProjectConfig, configTemplateKind, renderTemplateKind } from "./config/base.js"
@@ -1875,7 +1875,9 @@ export const resolveGardenParams = profileAsync(async function _resolveGardenPar
     if (!opts.noEnterprise && cloudApi) {
       const distroName = getCloudDistributionName(cloudApi.domain)
       const isCommunityEdition = !config.domain
-      const cloudLog = log.createLog({ name: getCloudLogSectionName(distroName) })
+      const cloudLogLevel =
+        opts.commandInfo.name === "dev" || opts.commandInfo.name === "serve" ? LogLevel.debug : undefined
+      const cloudLog = log.createLog({ name: getCloudLogSectionName(distroName), fixLevel: cloudLogLevel })
 
       cloudLog.info(`Connecting to ${distroName}...`)
 

--- a/core/src/graph/actions.ts
+++ b/core/src/graph/actions.ts
@@ -194,7 +194,7 @@ export const actionConfigsToGraph = profileAsync(async function actionConfigsToG
         throw new ConfigurationError({
           message:
             styles.error(
-              `\nError processing config for ${styles.accent.bold(config.kind)} action ${styles.accent.bold(
+              `\nError processing config for ${styles.highlight(config.kind)} action ${styles.highlight(
                 config.name
               )}:\n`
             ) + styles.error(error.message),

--- a/core/src/logger/renderers.ts
+++ b/core/src/logger/renderers.ts
@@ -140,7 +140,7 @@ export function renderSection(entry: LogEntry): string {
   const section = getSection(entry)
 
   if (section && msg) {
-    return `${padSection(styles.section(section))} ${styles.accent.bold("→")} `
+    return `${padSection(styles.section(section))} ${styles.primary.bold("→")} `
   } else if (section) {
     return padSection(styles.section(section))
   }

--- a/core/src/logger/styles.ts
+++ b/core/src/logger/styles.ts
@@ -14,7 +14,7 @@ import chalk from "chalk"
 const theme = {
   primary: chalk.white,
   secondary: chalk.grey,
-  accent: chalk.white,
+  accent: chalk.blueBright,
   highlight: chalk.cyan,
   highlightSecondary: chalk.magenta,
   warning: chalk.yellow,

--- a/core/src/logger/util.ts
+++ b/core/src/logger/util.ts
@@ -63,7 +63,7 @@ export function printHeader(log: any, command: string, emoji: string): void {
 
 export function printFooter(log: any) {
   log.info("") // Print new line before footer
-  return log.info(styles.command("Done!") + " " + printEmoji("✔️", log))
+  return log.info(styles.success(`Done! ${printEmoji("✔️", log)}`))
 }
 
 export function printWarningMessage(log: any, text: string) {

--- a/core/src/monitors/logs.ts
+++ b/core/src/monitors/logs.ts
@@ -239,7 +239,7 @@ export class LogMonitor extends Monitor {
       out += styles.primary("[" + tags + "] ")
     }
     // If the line doesn't have ansi encoding, we color it white to prevent logger from applying styles.
-    out += hasAnsi(serviceLog) ? serviceLog : styles.accent(serviceLog)
+    out += hasAnsi(serviceLog) ? serviceLog : styles.primary(serviceLog)
 
     return out
   }

--- a/core/src/mutagen.ts
+++ b/core/src/mutagen.ts
@@ -916,17 +916,17 @@ async function isValidLocalPath(syncPoint: string) {
 
 function formatSyncConflict(sourceDescription: string, targetDescription: string, conflict: SyncConflict): string {
   return dedent`
-    Sync conflict detected at path ${styles.accent(
+    Sync conflict detected at path ${styles.highlight(
       conflict.root
     )} in sync from ${sourceDescription} to ${targetDescription}.
 
     Until the conflict is resolved, the conflicting paths will not be synced.
 
-    If conflicts come up regularly at this destination, you may want to use either the ${styles.accent(
+    If conflicts come up regularly at this destination, you may want to use either the ${styles.highlight(
       "one-way-replica"
-    )} or ${styles.accent("one-way-replica-reverse")} sync modes instead.
+    )} or ${styles.highlight("one-way-replica-reverse")} sync modes instead.
 
-    See the code synchronization guide for more details: ${styles.accent(syncGuideLink + "#sync-modes")}`
+    See the code synchronization guide for more details: ${styles.link(syncGuideLink + "#sync-modes")}`
 }
 
 /**

--- a/core/src/plugins/exec/build.ts
+++ b/core/src/plugins/exec/build.ts
@@ -72,7 +72,7 @@ export const execBuildHandler = execBuild.addHandler("build", async ({ action, l
   if (output.detail?.buildLog) {
     output.outputs.log = output.detail?.buildLog
 
-    const prefix = `Finished building ${styles.accent(action.name)}. Here is the full output:`
+    const prefix = `Finished building ${styles.highlight(action.name)}. Here is the full output:`
     log.info(
       renderMessageWithDivider({
         prefix,

--- a/core/src/plugins/exec/deploy.ts
+++ b/core/src/plugins/exec/deploy.ts
@@ -200,7 +200,7 @@ execDeploy.addHandler("deploy", async (params) => {
     })
 
     if (result.outputLog) {
-      const prefix = `Finished deploying ${styles.accent(action.name)}. Here is the output:`
+      const prefix = `Finished deploying ${styles.highlight(action.name)}. Here is the output:`
       log.info(
         renderMessageWithDivider({
           prefix,

--- a/core/src/plugins/exec/run.ts
+++ b/core/src/plugins/exec/run.ts
@@ -49,7 +49,7 @@ execRun.addHandler("run", async ({ artifactsPath, log, action, ctx }) => {
   }
 
   if (outputLog) {
-    const prefix = `Finished running ${styles.accent(action.name)}. Here is the full output:`
+    const prefix = `Finished running ${styles.highlight(action.name)}. Here is the full output:`
     log.info(
       renderMessageWithDivider({
         prefix,

--- a/core/src/plugins/exec/test.ts
+++ b/core/src/plugins/exec/test.ts
@@ -41,7 +41,7 @@ execTest.addHandler("run", async ({ log, action, artifactsPath, ctx }) => {
   await copyArtifacts(log, artifacts, action.getBuildPath(), artifactsPath)
 
   if (result.outputLog) {
-    const prefix = `Finished executing ${styles.accent(action.key())}. Here is the full output:`
+    const prefix = `Finished executing ${styles.highlight(action.key())}. Here is the full output:`
     log.info(
       renderMessageWithDivider({
         prefix,

--- a/core/src/plugins/kubernetes/commands/cluster-init.ts
+++ b/core/src/plugins/kubernetes/commands/cluster-init.ts
@@ -17,7 +17,7 @@ export const clusterInit: PluginCommand = {
   description: "[DEPRECATED] Initialize or update cluster-wide Garden services.",
 
   title: ({ environmentName }) => {
-    return `Initializing/updating cluster-wide services for ${styles.accent(environmentName)} environment`
+    return `Initializing/updating cluster-wide services for ${styles.highlight(environmentName)} environment`
   },
 
   handler: async ({ ctx, log }) => {

--- a/core/src/plugins/kubernetes/commands/pull-image.ts
+++ b/core/src/plugins/kubernetes/commands/pull-image.ts
@@ -51,7 +51,7 @@ export const pullImage: PluginCommand = {
       const valid = b.isCompatible("container")
       if (!valid && args.includes(b.name)) {
         throw new ParameterError({
-          message: `Build ${styles.accent(b.name)} is not a container build.`,
+          message: `Build ${styles.highlight(b.name)} is not a container build.`,
         })
       }
       return valid

--- a/core/src/plugins/kubernetes/commands/uninstall-garden-services.ts
+++ b/core/src/plugins/kubernetes/commands/uninstall-garden-services.ts
@@ -16,7 +16,7 @@ export const uninstallGardenServices: PluginCommand = {
   description: "Clean up all installed cluster-wide Garden services.",
 
   title: ({ environmentName }) => {
-    return `Removing cluster-wide services for ${styles.accent(environmentName)} environment`
+    return `Removing cluster-wide services for ${styles.highlight(environmentName)} environment`
   },
 
   handler: async ({ ctx, log }) => {

--- a/core/src/plugins/kubernetes/container/build/buildkit.ts
+++ b/core/src/plugins/kubernetes/container/build/buildkit.ts
@@ -107,7 +107,7 @@ export const buildkitBuildHandler: BuildHandler = async (params) => {
     deploymentName: buildkitDeploymentName,
   })
 
-  log.info(`Buildkit Building image ${localId}...`)
+  log.createLog({ origin: "buildkit" }).info(`Building image ${styles.highlight(localId)}...`)
 
   const logEventContext = {
     origin: "buildkit",
@@ -237,7 +237,7 @@ export async function ensureBuildkit({
 
     // Deploy the buildkit daemon
     deployLog.info(
-      styles.primary(`-> Deploying ${buildkitDeploymentName} daemon in ${namespace} namespace (was ${status.state})`)
+      `Deploying ${buildkitDeploymentName} daemon in ${styles.highlight(namespace)} namespace (was ${status.state})`
     )
 
     await api.upsert({ kind: "Deployment", namespace, log: deployLog, obj: manifest })

--- a/core/src/plugins/kubernetes/container/deployment.ts
+++ b/core/src/plugins/kubernetes/container/deployment.ts
@@ -649,7 +649,7 @@ export function configureVolumes(
       } else {
         throw new ConfigurationError({
           message: deline`${action.longDescription()} specifies a unsupported config
-          ${styles.accent(volumeAction.name)} for volume mount ${styles.accent(
+          ${styles.highlight(volumeAction.name)} for volume mount ${styles.highlight(
             volumeName
           )}. Only \`persistentvolumeclaim\`
           and \`configmap\` action are supported at this time.
@@ -711,14 +711,14 @@ export async function handleChangedSelector({
   production: boolean
   force: boolean
 }) {
-  const msgPrefix = `Deploy ${styles.accent(action.name)} was deployed with a different ${styles.accent(
+  const msgPrefix = `Deploy ${styles.highlight(action.name)} was deployed with a different ${styles.accent(
     "spec.selector"
   )} and needs to be deleted before redeploying.`
   if (production && !force) {
     throw new DeploymentError({
-      message: `${msgPrefix} Since this environment has production = true, Garden won't automatically delete this resource. To do so, use the ${styles.accent(
+      message: `${msgPrefix} Since this environment has production = true, Garden won't automatically delete this resource. To do so, use the ${styles.command(
         "--force"
-      )} flag when deploying e.g. with the ${styles.accent(
+      )} flag when deploying e.g. with the ${styles.command(
         "garden deploy"
       )} command. You can also delete the resource from your cluster manually and try again.`,
     })

--- a/core/src/plugins/kubernetes/helm/exec.ts
+++ b/core/src/plugins/kubernetes/helm/exec.ts
@@ -27,7 +27,7 @@ export const execInHelmDeploy: DeployActionHandler<"exec", HelmDeployAction> = a
 
   if (!defaultTarget) {
     throw new ConfigurationError({
-      message: `${action.longDescription()} does not specify a defaultTarget. Please configure this in order to be able to use this command with. This is currently necessary for the ${styles.accent(
+      message: `${action.longDescription()} does not specify a defaultTarget. Please configure this in order to be able to use this command with. This is currently necessary for the ${styles.command(
         "exec"
       )} command to work with helm Deploy actions.`,
     })

--- a/core/src/plugins/kubernetes/nginx/nginx-helm.ts
+++ b/core/src/plugins/kubernetes/nginx/nginx-helm.ts
@@ -18,6 +18,7 @@ import { checkResourceStatus, waitForResources } from "../status/status.js"
 import { KubeApi } from "../api.js"
 
 import { GardenIngressComponent } from "./ingress-controller-base.js"
+import { styles } from "../../../logger/styles.js"
 
 const HELM_INGRESS_NGINX_REPO = "https://kubernetes.github.io/ingress-nginx"
 const HELM_INGRESS_NGINX_VERSION = "4.0.13"
@@ -64,7 +65,7 @@ export abstract class HelmGardenIngressController extends GardenIngressComponent
       `${valueArgs.join(",")}`,
     ]
 
-    log.info(`Installing nginx in ${namespace} namespace...`)
+    log.info(`Installing ${styles.highlight("nginx")} in ${styles.highlight(namespace)} namespace...`)
     await this.defaultBackend.install(ctx, log)
     await helm({ ctx, namespace, log, args, emitLogEvents: false })
 

--- a/core/src/plugins/kubernetes/status/status.ts
+++ b/core/src/plugins/kubernetes/status/status.ts
@@ -277,7 +277,7 @@ export async function waitForResources({
   const startTime = new Date().getTime()
 
   const logEventContext = {
-    origin: "kubernetes-plugin",
+    origin: "kubernetes",
     level: "verbose" as const,
   }
 

--- a/core/src/plugins/kubernetes/sync.ts
+++ b/core/src/plugins/kubernetes/sync.ts
@@ -861,8 +861,8 @@ async function prepareSync(params: PrepareSyncParams) {
 
   const key = getSyncKey(params, target)
 
-  const localPathDescription = styles.accent(spec.sourcePath)
-  const remoteDestinationDescription = `${styles.accent(spec.containerPath)} in ${styles.accent(resourceName)}`
+  const localPathDescription = styles.highlight(spec.sourcePath)
+  const remoteDestinationDescription = `${styles.highlight(spec.containerPath)} in ${styles.accent(resourceName)}`
 
   const {
     source: orientedSource,

--- a/core/src/plugins/kubernetes/util.ts
+++ b/core/src/plugins/kubernetes/util.ts
@@ -631,7 +631,7 @@ export async function getTargetResource({
       if (!target) {
         throw new ConfigurationError({
           message: dedent`
-            ${action.longDescription()} does not contain specified ${targetKind} ${styles.accent(targetName)}
+            ${action.longDescription()} does not contain specified ${targetKind} ${styles.highlight(targetName)}
 
             The chart does declare the following resources: ${naturalList(chartResourceNames)}
             `,
@@ -795,7 +795,11 @@ export function renderPodEvents(events: CoreV1Event[]): string {
     const name = styles.highlight(`${obj.kind} ${obj.name}:`)
     const msg = `${event.reason} - ${event.message}`
     const colored =
-      event.type === "Error" ? styles.error(msg) : event.type === "Warning" ? styles.warning(msg) : styles.accent(msg)
+      event.type === "Error"
+        ? styles.error(msg)
+        : event.type === "Warning"
+        ? styles.warning(msg)
+        : styles.highlight(msg)
     text += `${name} ${colored}\n`
   }
 

--- a/core/src/resolve-module.ts
+++ b/core/src/resolve-module.ts
@@ -208,7 +208,7 @@ export class ModuleResolver {
     const processLeaves = async () => {
       if (Object.keys(errors).length > 0) {
         const errorStr = Object.entries(errors)
-          .map(([name, err]) => `${styles.accent.bold(name)}: ${err.message}`)
+          .map(([name, err]) => `${styles.highlight.bold(name)}: ${err.message}`)
           .join("\n")
         const msg = `Failed resolving one or more modules:\n\n${errorStr}`
 
@@ -922,7 +922,7 @@ function inheritModuleToAction(module: GardenModule, action: ActionConfig) {
 function missingBuildDependency(moduleName: string, dependencyName: string) {
   return new ConfigurationError({
     message:
-      `Could not find build dependency ${styles.accent(dependencyName)}, ` +
-      `configured in module ${styles.accent(moduleName)}`,
+      `Could not find build dependency ${styles.highlight(dependencyName)}, ` +
+      `configured in module ${styles.highlight(moduleName)}`,
   })
 }

--- a/core/src/router/provider.ts
+++ b/core/src/router/provider.ts
@@ -45,7 +45,6 @@ import { Profile } from "../util/profiling.js"
 import type { GetDashboardPageParams, GetDashboardPageResult } from "../plugin/handlers/Provider/getDashboardPage.js"
 import type { CommonParams, BaseRouterParams } from "./base.js"
 import { BaseRouter } from "./base.js"
-import { styles } from "../logger/styles.js"
 
 /**
  * The ProviderRouter takes care of choosing which plugin should be responsible for handling a provider action,
@@ -176,7 +175,7 @@ export class ProviderRouter extends BaseRouter {
    * Runs cleanupEnvironment for all configured providers
    */
   async cleanupAll(log: Log) {
-    log.info(styles.accent("Cleaning up environments..."))
+    log.info("Cleaning up environments...")
     const environmentStatuses: EnvironmentStatusMap = {}
 
     const providers = await this.garden.resolveProviders(log)

--- a/core/src/router/router.ts
+++ b/core/src/router/router.ts
@@ -25,7 +25,6 @@ import { testRouter } from "./test.js"
 import type { DeployStatus, DeployStatusMap } from "../plugin/handlers/Deploy/get-status.js"
 import type { GetActionOutputsParams, GetActionOutputsResult } from "../plugin/handlers/base/get-outputs.js"
 import type { ActionKind, BaseActionConfig, ResolvedAction } from "../actions/types.js"
-import { styles } from "../logger/styles.js"
 
 export interface DeployManyParams {
   graph: ConfigGraph
@@ -161,7 +160,7 @@ export class ActionRouter extends BaseRouter {
     dependantsFirst?: boolean
     names?: string[]
   }): Promise<DeployStatusMap> {
-    const servicesLog = log.createLog({}).info(styles.accent("Deleting deployments..."))
+    const servicesLog = log.createLog({}).info("Deleting deployments...")
     const deploys = graph.getDeploys({ names })
 
     const tasks = deploys.map((action) => {

--- a/core/src/server/instance-manager.ts
+++ b/core/src/server/instance-manager.ts
@@ -243,11 +243,13 @@ export class GardenInstanceManager {
     garden.events.once("configChanged", (_payload) => {
       if (!garden.needsReload()) {
         garden.needsReload(true)
-        garden.log.info(
-          styles.highlightSecondary.bold(
-            `${styles.accent("→")} Config change detected. Project will be reloaded when the next command is run.`
+        garden.log
+          .createLog({ name: "garden" })
+          .info(
+            styles.highlightSecondary.bold(
+              `Config change detected. Project will be reloaded when the next command is run.`
+            )
           )
-        )
       }
     })
 

--- a/core/src/tasks/base.ts
+++ b/core/src/tasks/base.ts
@@ -483,7 +483,7 @@ export function logAndEmitGetStatusEvents<
         log.info(`${styledName} is already ${styles.highlight(logStrings.ready)}, ${logStrings.force}`)
       } else {
         const stateStr = styles.highlight(result.detail?.state || displayState(result.state))
-        log.info(`Status is '${stateStr}', ${styledName} ${logStrings.notReady}`)
+        log.info(`Status is ${stateStr}, ${styledName} ${logStrings.notReady}`)
       }
 
       // Then an event with the results if the status was successfully retrieved...

--- a/core/test/unit/src/cli/cli.ts
+++ b/core/test/unit/src/cli/cli.ts
@@ -1066,7 +1066,6 @@ describe("cli", () => {
         const output = stripAnsi(hook.captured())
         expect(code).to.equal(1)
         expect(output).to.eql(dedent`
-          ℹ garden                    → Initializing...
           Error message
 
           See .garden/error.log for detailed error message\n`)
@@ -1093,9 +1092,8 @@ describe("cli", () => {
         expect(code).to.equal(1)
         const outputLines = stripAnsi(hook.captured()).split("\n")
 
-        const firstEightLines = outputLines.slice(0, 8).join("\n")
+        const firstEightLines = outputLines.slice(0, 7).join("\n")
         expect(firstEightLines).to.eql(dedent`
-          ℹ garden                    → Initializing...
           Encountered an unexpected Garden error. This is likely a bug 🍂
 
           You can help by reporting this on GitHub: https://github.com/garden-io/garden/issues/new?labels=bug,crash&template=CRASH.md&title=Crash%3A%20Cannot%20read%20property%20foo%20of%20undefined.
@@ -1105,7 +1103,7 @@ describe("cli", () => {
           TypeError: Cannot read property foo of undefined.
         `)
 
-        const firstStackTraceLine = outputLines[8]
+        const firstStackTraceLine = outputLines[7]
         expect(firstStackTraceLine).to.contain("at TestCommand.action (")
 
         const lastLine = outputLines[outputLines.length - 2] // the last line is empty due to trailing newline

--- a/plugins/pulumi/src/commands.ts
+++ b/plugins/pulumi/src/commands.ts
@@ -305,7 +305,7 @@ class PulumiPluginCommandTask extends PluginActionTask<PulumiDeploy, PulumiComma
   }
 
   async process({ dependencyResults }: ActionTaskProcessParams<PulumiDeploy, PulumiCommandResult>) {
-    this.log.info(styles.primary(`Running ${styles.accent(this.commandDescription)}`))
+    this.log.info(`Running ${styles.command(this.commandDescription)}`)
 
     const params = {
       ...this.pulumiParams,

--- a/plugins/terraform/src/commands.ts
+++ b/plugins/terraform/src/commands.ts
@@ -30,7 +30,7 @@ function makeRootCommand(commandName: string): PluginCommand {
   return {
     name: commandName + "-root",
     description: `Runs ${terraformCommand} for the provider root stack, with the provider variables automatically configured as inputs. Positional arguments are passed to the command. If necessary, ${initCommand} is run first.`,
-    title: styles.command(`Running ${styles.accent.bold(terraformCommand)} for project root stack`),
+    title: styles.command(`Running ${styles.command(terraformCommand)} for project root stack`),
     async handler({ ctx, args, log }: PluginCommandParams) {
       const provider = ctx.provider as TerraformProvider
 
@@ -81,7 +81,7 @@ function makeActionCommand(commandName: string): PluginCommand {
 
     title: ({ args }) =>
       styles.command(
-        `Running ${styles.accent.bold(terraformCommand)} for the Deploy action ${styles.accent.bold(args[0] || "")}`
+        `Running ${styles.command(terraformCommand)} for the Deploy action ${styles.accent.bold(args[0] || "")}`
       ),
 
     async handler({ garden, ctx, args, log, graph }) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

The main issue was that the autocomplete suggestion was the same color
as the actual text which has now been fixed.

Beyond that, this replaces most calls to `accent` with `highlight` which
is the better choice for these lines.

It also changes the actual accent color to make it "pop" more. Before it
was the same as the primary color.

Finally I also used the chance to clean up some lines and ensure certain
log lines aren't printed when in dev mode or running `noProject`
commands.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
