### PR TITLE
fix(commands): print log command metadata in secondary color

### DIFF
--- a/core/src/commands/logs.ts
+++ b/core/src/commands/logs.ts
@@ -174,9 +174,10 @@ export class LogsCommand extends Command<Args, Opts> {
       details = ` (from the last '${since}' for each service)`
     }
 
+    const style = styles.accent
     log.info("")
-    log.info(styles.accent.bold("Service logs" + details + ":"))
-    log.info(styles.accent.bold(renderDivider()))
+    log.info(style("Service logs" + details + ":"))
+    log.info(renderDivider({ color: style }))
 
     const resolvedActions = await garden.resolveActions({ actions, graph, log })
 
@@ -217,7 +218,7 @@ export class LogsCommand extends Command<Args, Opts> {
         entry.monitor.logEntry(entry)
       })
 
-      log.info(styles.accent.bold(renderDivider()))
+      log.info(renderDivider({ color: style }))
 
       return {
         result: sorted.map((e) => omit(e, "monitor")),

--- a/core/src/monitors/logs.ts
+++ b/core/src/monitors/logs.ts
@@ -233,12 +233,12 @@ export class LogMonitor extends Monitor {
       out += `${sectionStyle(padSection(entry.name, maxDeployName))} → `
     }
     if (timestamp) {
-      out += `${styles.primary(timestamp)} → `
+      out += `${styles.secondary(timestamp)} → `
     }
     if (tags) {
-      out += styles.primary("[" + tags + "] ")
+      out += styles.secondary("[" + tags + "] ")
     }
-    // If the line doesn't have ansi encoding, we color it white to prevent logger from applying styles.
+
     out += hasAnsi(serviceLog) ? serviceLog : styles.primary(serviceLog)
 
     return out


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

A user pointed out that we no longer print log command metadata (i.e. tags and timestamps) in grey. This fixes that.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
