### PR TITLE
docs: actualize contributing guides

### DIFF
--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -115,7 +115,7 @@ We use [Circle CI](https://circleci.com) for integration and end-to-end testing.
 ## License/copyright headers
 
 Every source file must include the contents of `support/license-header.txt` at the top. This is
-automatically checked during CI. You can run the check with `npm run check-licenses`.
+automatically checked during CI. Since it's defined as an eslint rule, you can run the check with `npm run lint`.
 
 ## Release process
 

--- a/docs/contributing/contributing-docs.md
+++ b/docs/contributing/contributing-docs.md
@@ -32,7 +32,7 @@ There's a few things you'll need to make your first contribution to the docs:
 Create a branch to hold your work, change any files you wish to change, save them, then commit them to your branch. Try and keep your branches focused around a specific theme. Your commits will need to be prepended with a *keyword* that follows the Conventional Commits specification, e.g. `docs: added docs contributor page`. See our documentation for [a list of Conventional Commit keywords](./README.md#commit-messages).
 
 {% hint style="warning" %}
-*Before pushing your changes*, run `yarn; yarn build; yarn generate-docs` to refresh the Table of Contents contained at `../docs/README.md` with any additions or changes you've made.
+*Before pushing your changes*, run `npm run build` to refresh the Table of Contents contained at `../docs/README.md` with any additions or changes you've made.
 
 If you've moved or renamed files, refer to [Moving or renaming files](#moving-or-renaming-files).
 {% endhint %}
@@ -65,7 +65,7 @@ You'll also need to find and replace all instances of links within the `garden` 
 Instead, change all the relative URLs inside `docs/`, [submit your PR](./README.md#contributing-guidelines), then make a new PR to update these absolute URLs. This is to avoid broken links.
 {% endhint %}
 
-Finally, run `yarn; yarn build; yarn generate-docs` to regenerate the Table of Contents.
+Finally, run `npm run build` to regenerate the Table of Contents.
 
 ### Absolute URLs vs relative URLs and when to use them
 

--- a/docs/contributing/garden-dev-env-setup.md
+++ b/docs/contributing/garden-dev-env-setup.md
@@ -40,17 +40,8 @@ If you are an [asdf](https://asdf-vm.com/) user, running [install-asdf-dependenc
 Install Node modules for the root package, and `core` package:
 
 ```sh
-yarn install # To install root dependencies
-yarn run bootstrap # To bootstrap packages
-```
-
-from the root directory
-
-You may need to install the Node modules in the core package manually due to [lerna/lerna#1457](https://github.com/lerna/lerna/issues/1457).
-
-```sh
-cd core
-yarn
+npm install # To install root dependencies
+npm run bootstrap # To bootstrap packages
 ```
 
 ## Developing Garden
@@ -60,7 +51,7 @@ yarn
 Before running Garden for the first time, you need to do an initial build by running
 
 ```sh
-yarn build
+npm run build
 ```
 
 from the root directory.
@@ -70,7 +61,7 @@ from the root directory.
 To develop the CLI, run the `dev` command in your console:
 
 ```sh
-yarn dev
+npm run dev
 ```
 
 This will link it to your global `node_modules` folder, and then watch for

--- a/examples/local-service/README.md
+++ b/examples/local-service/README.md
@@ -43,7 +43,7 @@ build: frontend-local
 
 spec:
   persistent: true # <--- Runs the deployCommand in persistent mode
-  deployCommand: [ "yarn", "run", "dev" ] # <--- This is the command Garden runs to start the process in sync mode
+  deployCommand: [ "npm", "run", "dev" ] # <--- This is the command Garden runs to start the process in sync mode
   statusCommand: [ ./check-local-status.sh ] # <--- Optionally set a status command that checks whether the local service is ready
   env: ${actions.deploy.frontend.var.env} # <--- Reference the env variable defined above
 ```
@@ -57,12 +57,12 @@ control whether the `local-frontend` deploy action should be enabled or create a
 
 ## Usage
 
-If you want to run the frontend service locally you'll need to have yarn installed and also have to install the packages
-for the frontend project
+If you want to run the frontend service locally you'll need to have `npm` installed and also have to install the
+packages for the frontend project
 
 ```console
 cd frontend
-yarn install
+npm install
 cd ..
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes made in this PR:
- replace `yarn` references with `npm` in the contributing guides and in the relevant examples
- actualize instructions on license header check
- actualize instructions on docs generation

**Which issue(s) this PR fixes**:

This PR restores some of the changes made in #5132 and #5182 that were accidentally reverted in #5108.

**Special notes for your reviewer**:
