### PR TITLE
fix(sync-mode): showing undefined when sync status is not-deployed

### DIFF
--- a/core/src/commands/sync/sync-status.ts
+++ b/core/src/commands/sync/sync-status.ts
@@ -192,6 +192,7 @@ export async function getSyncStatuses({
         "active": "is",
         "failed": "has",
         "not-active": "is",
+        "not-deployed": "is",
       }
 
       const syncCount = syncStatus.syncs.length

--- a/core/src/commands/sync/sync-status.ts
+++ b/core/src/commands/sync/sync-status.ts
@@ -128,6 +128,16 @@ function stateStyle(state: SyncState, msg: string) {
   return styleFn(msg)
 }
 
+const verbMap: { [key in SyncState]: string } = {
+  "active": "is",
+  "failed": "has",
+  "not-active": "is",
+  "not-deployed": "is",
+  "unknown": "is",
+  "not-configured": "is",
+  "outdated": "is",
+}
+
 function describeState(state: SyncState) {
   return state.replace("-", " ")
 }
@@ -187,13 +197,6 @@ export async function getSyncStatuses({
         return keyA > keyB ? 1 : -1
       })
       syncStatus["syncs"] = sorted
-
-      const verbMap = {
-        "active": "is",
-        "failed": "has",
-        "not-active": "is",
-        "not-deployed": "is",
-      }
 
       const syncCount = syncStatus.syncs.length
       const pluralizedSyncs = syncCount === 1 ? "sync" : "syncs"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

The sync status command would show strings with undefined when the status was 'not-deployed'.

```
The api Deploy action has 1 sync configured:
  → Sync from .../api to /app/api undefined not deployed
  → Mode: one-way-replica
```

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
