### PR TITLE
fix(git): fix `exclude` filter in `repo` Git scan mode

### DIFF
--- a/core/src/vcs/git.ts
+++ b/core/src/vcs/git.ts
@@ -367,9 +367,11 @@ export class GitHandler extends VcsHandler {
         return
       }
 
-      const passesExclusionFilter = matchPath(filePath, undefined, exclude)
-      if (hasIncludes && !passesExclusionFilter) {
-        return
+      if (hasIncludes) {
+        const passesExclusionFilter = matchPath(filePath, undefined, exclude)
+        if (!passesExclusionFilter) {
+          return
+        }
       }
 
       // We push to the output array if it passes through the exclude filters.

--- a/core/test/unit/src/plugins/container/container.ts
+++ b/core/test/unit/src/plugins/container/container.ts
@@ -40,9 +40,9 @@ import {
   DEFAULT_TEST_TIMEOUT_SEC,
   GardenApiVersion,
 } from "../../../../../src/constants.js"
-import { resolve } from "path"
+import { join, resolve } from "path"
 import type { ConvertModuleParams } from "../../../../../src/plugin/handlers/Module/convert.js"
-import { omit } from "lodash-es"
+import { omit, remove } from "lodash-es"
 import type { GardenTask } from "../../../../../src/types/task.js"
 import { taskFromConfig } from "../../../../../src/types/task.js"
 import type { GardenService } from "../../../../../src/types/service.js"
@@ -151,7 +151,11 @@ describe("plugins.container", () => {
 
     it("returns the dummy Build action if no Dockerfile and an exec Build is needed", async () => {
       const module = graph.getModule("module-a") as ContainerModule
-      module.version.files.pop() // remove automatically picked up Dockerfile
+
+      // remove automatically picked up Dockerfile
+      const defaultDockerfilePath = join(module.path, defaultDockerfileName)
+      remove(module.version.files, (f) => f === defaultDockerfilePath)
+
       const dummyBuild: ExecBuildConfig = {
         internal: {
           basePath: ".",

--- a/core/test/unit/src/vcs/git.ts
+++ b/core/test/unit/src/vcs/git.ts
@@ -427,14 +427,25 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
       // the exclusion paths with and without glob prefix **/ works in the same way.
       context("when only exclude filter is specified", () => {
         context("should filter out files that match the exclude filter", () => {
+          const excludedFilenameNoExt = "foo"
+          const excludedFilenameTxt = `${excludedFilenameNoExt}.txt`
+          const excludedFilenameWildcard = `${excludedFilenameNoExt}.*`
           const testParams = [
             {
-              name: "without globs",
-              pathBuilder: (path: string) => path,
+              name: "by exact filename without globs",
+              pathBuilder: () => excludedFilenameTxt,
             },
             {
-              name: "with globs",
-              pathBuilder: (path: string) => join("**", path),
+              name: "by exact filename with prefix globs",
+              pathBuilder: () => join("**", excludedFilenameTxt),
+            },
+            {
+              name: "by filename with wildcard extension without prefix globs",
+              pathBuilder: () => excludedFilenameWildcard,
+            },
+            {
+              name: "by filename with wildcard extension with prefix globs",
+              pathBuilder: () => join("**", excludedFilenameWildcard),
             },
           ]
 
@@ -472,7 +483,7 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
                   path: tmpPath,
                   scanRoot: undefined,
                   include: undefined,
-                  exclude: [testParam.pathBuilder("foo.*")],
+                  exclude: [testParam.pathBuilder()],
                   log,
                 })
               )

--- a/core/test/unit/src/vcs/git.ts
+++ b/core/test/unit/src/vcs/git.ts
@@ -441,11 +441,11 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
           for (const testParam of testParams) {
             it(testParam.name, async () => {
               // FIXME
-              if (handler.name === "git-repo") {
-                if (testParam.name === "without globs") {
-                  return
-                }
-              }
+              // if (handler.name === "git-repo") {
+              //   if (testParam.name === "without globs") {
+              //     return
+              //   }
+              // }
 
               // matches file exclusion pattern -> should be excluded
               const excludedByFilename = resolve(tmpPath, "foo.txt")
@@ -518,11 +518,11 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
             for (const testParam of testParams) {
               it(testParam.name, async () => {
                 // FIXME
-                if (handler.name === "git-repo") {
-                  if (testParam.name === "with prefix globs") {
-                    return
-                  }
-                }
+                // if (handler.name === "git-repo") {
+                //   if (testParam.name === "with prefix globs") {
+                //     return
+                //   }
+                // }
 
                 // doesn't match file exclusion pattern -> should be included
                 const notExcludedByFilename = resolve(tmpPath, "bar.txt")
@@ -596,11 +596,11 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
             for (const testParam of testParams) {
               it(testParam.name, async () => {
                 // FIXME
-                if (handler.name === "git-repo") {
-                  if (testParam.name === "without globs" || testParam.name === "with prefix globs") {
-                    return
-                  }
-                }
+                // if (handler.name === "git-repo") {
+                //   if (testParam.name === "without globs" || testParam.name === "with prefix globs") {
+                //     return
+                //   }
+                // }
 
                 // doesn't match file exclusion pattern -> should be included
                 const notExcludedByFilename = resolve(tmpPath, "bar.txt")

--- a/core/test/unit/src/vcs/git.ts
+++ b/core/test/unit/src/vcs/git.ts
@@ -362,16 +362,16 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
                 const testParams = [
                   {
                     name: "when directory is included by exact relative path",
-                    pathBuilder: (subDirName: string, deepDirName) => join(subDirName, deepDirName),
+                    pathBuilder: (subDirName: string, deepDirName: string) => join(subDirName, deepDirName),
                   },
                   {
                     name: "when directory is included by relative path with globs",
-                    pathBuilder: (subDirName: string, deepDirName) => join(subDirName, deepDirName, "**", "*"),
+                    pathBuilder: (subDirName: string, deepDirName: string) => join(subDirName, deepDirName, "**", "*"),
                   },
                   {
                     name: "when directory is included by name with globs",
                     // FIXME: shouldn't just '**/deepdir' work well too?
-                    pathBuilder: (_subDirName: string, deepDirName) => join("**", deepDirName, "**", "*"),
+                    pathBuilder: (_subDirName: string, deepDirName: string) => join("**", deepDirName, "**", "*"),
                   },
                 ]
 

--- a/core/test/unit/src/vcs/git.ts
+++ b/core/test/unit/src/vcs/git.ts
@@ -362,16 +362,17 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
                 const testParams = [
                   {
                     name: "when directory is included by exact relative path",
-                    pathBuilder: (subDirName: string, deepDirName: string) => join(subDirName, deepDirName),
+                    inclusionBuilder: (subDirName: string, deepDirName: string) => join(subDirName, deepDirName),
                   },
                   {
                     name: "when directory is included by relative path with globs",
-                    pathBuilder: (subDirName: string, deepDirName: string) => join(subDirName, deepDirName, "**", "*"),
+                    inclusionBuilder: (subDirName: string, deepDirName: string) =>
+                      join(subDirName, deepDirName, "**", "*"),
                   },
                   {
                     name: "when directory is included by name with globs",
                     // FIXME: shouldn't just '**/deepdir' work well too?
-                    pathBuilder: (_subDirName: string, deepDirName: string) => join("**", deepDirName, "**", "*"),
+                    inclusionBuilder: (_subDirName: string, deepDirName: string) => join("**", deepDirName, "**", "*"),
                   },
                 ]
 
@@ -386,7 +387,7 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
                     const path = resolve(deepDir, "foo.txt")
                     await createFile(path)
 
-                    const include = [testParam.pathBuilder(subdirName, deepDirName)]
+                    const include = [testParam.inclusionBuilder(subdirName, deepDirName)]
                     const files = (
                       await handler.getFiles({
                         path: tmpPath,
@@ -433,19 +434,19 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
           const testParams = [
             {
               name: "by exact filename without globs",
-              pathBuilder: () => excludedFilenameTxt,
+              exclusionBuilder: () => excludedFilenameTxt,
             },
             {
               name: "by exact filename with prefix globs",
-              pathBuilder: () => join("**", excludedFilenameTxt),
+              exclusionBuilder: () => join("**", excludedFilenameTxt),
             },
             {
               name: "by filename with wildcard extension without prefix globs",
-              pathBuilder: () => excludedFilenameWildcard,
+              exclusionBuilder: () => excludedFilenameWildcard,
             },
             {
               name: "by filename with wildcard extension with prefix globs",
-              pathBuilder: () => join("**", excludedFilenameWildcard),
+              exclusionBuilder: () => join("**", excludedFilenameWildcard),
             },
           ]
 
@@ -483,7 +484,7 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
                   path: tmpPath,
                   scanRoot: undefined,
                   include: undefined,
-                  exclude: [testParam.pathBuilder()],
+                  exclude: [testParam.exclusionBuilder()],
                   log,
                 })
               )
@@ -501,19 +502,19 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
             const testParams = [
               {
                 name: "without globs",
-                pathBuilder: (subDirName: string) => subDirName,
+                exclusionBuilder: (subDirName: string) => subDirName,
               },
               {
                 name: "with prefix globs",
-                pathBuilder: (subDirName: string) => join("**", subDirName),
+                exclusionBuilder: (subDirName: string) => join("**", subDirName),
               },
               {
                 name: "with full globs",
-                pathBuilder: (subDirName: string) => join("**", subDirName, "**", "*"),
+                exclusionBuilder: (subDirName: string) => join("**", subDirName, "**", "*"),
               },
               {
                 name: "with redundant relative path",
-                pathBuilder: (subDirName: string) => `./${subDirName}`,
+                exclusionBuilder: (subDirName: string) => `./${subDirName}`,
               },
             ]
 
@@ -562,7 +563,7 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
                     path: tmpPath,
                     scanRoot: undefined,
                     include: undefined, // when include: [], getFiles() always returns an empty result
-                    exclude: [testParam.pathBuilder(excludedDirName)],
+                    exclude: [testParam.exclusionBuilder(excludedDirName)],
                     log,
                   })
                 )
@@ -579,19 +580,19 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
             const testParams = [
               {
                 name: "without globs",
-                pathBuilder: (...subDirNames: string[]) => subDirNames.at(-1)!,
+                exclusionBuilder: (...subDirNames: string[]) => subDirNames.at(-1)!,
               },
               {
                 name: "with prefix globs",
-                pathBuilder: (...subDirNames: string[]) => join("**", subDirNames.at(-1)!),
+                exclusionBuilder: (...subDirNames: string[]) => join("**", subDirNames.at(-1)!),
               },
               {
                 name: "with full globs",
-                pathBuilder: (...subDirNames: string[]) => join("**", subDirNames.at(-1)!, "**", "*"),
+                exclusionBuilder: (...subDirNames: string[]) => join("**", subDirNames.at(-1)!, "**", "*"),
               },
               {
                 name: "with redundant relative path",
-                pathBuilder: (...subDirNames: string[]) => `./${subDirNames.join("/")}`,
+                exclusionBuilder: (...subDirNames: string[]) => `./${subDirNames.join("/")}`,
               },
             ]
 
@@ -640,7 +641,7 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
                     path: tmpPath,
                     scanRoot: undefined,
                     include: undefined, // when include: [], getFiles() always returns an empty result
-                    exclude: [testParam.pathBuilder(notExcludedDirName, excludedSubDirectoryName)],
+                    exclude: [testParam.exclusionBuilder(notExcludedDirName, excludedSubDirectoryName)],
                     log,
                   })
                 )

--- a/core/test/unit/src/vcs/git.ts
+++ b/core/test/unit/src/vcs/git.ts
@@ -371,7 +371,7 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
                   },
                   {
                     name: "when directory is included by name with globs",
-                    // FIXME: shouldn't just '**/deepdir' work well too?
+                    // FIXME-GITREPOHANDLER: shouldn't just '**/deepdir' work well too?
                     inclusionBuilder: (_subDirName: string, deepDirName: string) => join("**", deepDirName, "**", "*"),
                   },
                 ]
@@ -452,13 +452,6 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
 
           for (const testParam of testParams) {
             it(testParam.name, async () => {
-              // FIXME
-              // if (handler.name === "git-repo") {
-              //   if (testParam.name === "without globs") {
-              //     return
-              //   }
-              // }
-
               // matches file exclusion pattern -> should be excluded
               const excludedByFilename = resolve(tmpPath, "foo.txt")
               await createFile(excludedByFilename)
@@ -529,13 +522,6 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
               */
             for (const testParam of testParams) {
               it(testParam.name, async () => {
-                // FIXME
-                // if (handler.name === "git-repo") {
-                //   if (testParam.name === "with prefix globs") {
-                //     return
-                //   }
-                // }
-
                 // doesn't match file exclusion pattern -> should be included
                 const notExcludedByFilename = resolve(tmpPath, "bar.txt")
 
@@ -607,13 +593,6 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
               */
             for (const testParam of testParams) {
               it(testParam.name, async () => {
-                // FIXME
-                // if (handler.name === "git-repo") {
-                //   if (testParam.name === "without globs" || testParam.name === "with prefix globs") {
-                //     return
-                //   }
-                // }
-
                 // doesn't match file exclusion pattern -> should be included
                 const notExcludedByFilename = resolve(tmpPath, "bar.txt")
 
@@ -1392,6 +1371,8 @@ const commonGitHandlerTests = (gitScanMode: GitScanMode) => {
   })
 }
 
+// FIXME-GITREPOHANDLER: revisit these tests and disk-based configs,
+//  inspect the scenarios when both include and exclude filters are defined.s
 const getTreeVersionTests = (gitScanMode: GitScanMode) => {
   const gitHandlerCls = getGitHandlerCls(gitScanMode)
   describe("getTreeVersion", () => {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR aligns the `exclude` file filter behavior between `GitRepoHandler` and `GitHandler`.
Also, it adds a few more test cases to cover more scenarios.

The behavior of `GitHandler` was taken as a reference, because it's been there for a long time before we switched the default repo scanner to `GitRepoHandler` in #5399 ([0.13.20](https://github.com/garden-io/garden/releases/tag/0.13.20)).

**Which issue(s) this PR fixes**:

Fixes _some_ of the [`GitRepoHandler` test failures](https://app.circleci.com/pipelines/github/garden-io/garden/22567/workflows/4c86af6d-1ab2-4f3e-9502-1d8460251de2/jobs/453884) that were introduced in #5472. Those were enabled only for `GitHandler` that passed all the tests.

**Special notes for your reviewer**:
