### PR TITLE
improvement(ephemeral-kubernetes): tweak text in error message

### DIFF
--- a/core/src/plugins/kubernetes/ephemeral/config.ts
+++ b/core/src/plugins/kubernetes/ephemeral/config.ts
@@ -49,7 +49,9 @@ export async function configureProvider(params: ConfigureProviderParams<Kubernet
 
   if (!ctx.cloudApi) {
     throw new ConfigurationError({
-      message: `You are not logged in. You must be logged into Garden Cloud in order to use ${EPHEMERAL_KUBERNETES_PROVIDER_NAME} provider.`,
+      message: `You are not logged in. You must log in with the ${styles.command(
+        "garden login"
+      )} command to use the ${EPHEMERAL_KUBERNETES_PROVIDER_NAME} plugin`,
     })
   }
   if (ctx.cloudApi && ctx.cloudApi?.domain !== DEFAULT_GARDEN_CLOUD_DOMAIN) {

--- a/core/test/unit/src/plugins/kubernetes/ephemeral.ts
+++ b/core/test/unit/src/plugins/kubernetes/ephemeral.ts
@@ -15,6 +15,7 @@ import { gardenPlugin } from "../../../../../src/plugins/kubernetes/ephemeral/ep
 import type { TempDirectory } from "../../../../helpers.js"
 import { expectError, makeTempDir, makeTestGardenA } from "../../../../helpers.js"
 import { FakeCloudApi } from "../../../../helpers/api.js"
+import { styles } from "../../../../../src/logger/styles.js"
 
 describe("ephemeral-kubernetes configureProvider", () => {
   const basicConfig = {
@@ -65,7 +66,9 @@ describe("ephemeral-kubernetes configureProvider", () => {
         }),
       (err) => {
         expect(err.message).to.contain(
-          "You are not logged in. You must be logged into Garden Cloud in order to use ephemeral-kubernetes provider"
+          `You are not logged in. You must log in with the ${styles.command(
+            "garden login"
+          )} command to use the ephemeral-kubernetes plugin`
         )
       }
     )


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

The error message contained the hard coded string 'Garden Cloud'. We should instead use the 'getCloudDistributionName' helper.

In this case we can also just skip a reference to the distro name to keep things simple.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
