### PR TITLE
docs: remove gif from quickstart guide

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -9,8 +9,6 @@ order: 1
 An interactive quickstart is also available by logging in to the Garden dashboard. With the dashboard you can access command history, stream logs in real-time, view the status of your builds, tests, and deploys, visualize your dependency graph, and manage your free ephemeral clusters. To get started, [launch the Garden Web Dashboard](https://app.garden.io).
 {% endhint %}
 
-![Short tour of the features of the Garden dashboard including command history, visualized dependency graph, and the Garden dev console](https://ce-content.s3.fr-par.scw.cloud/web-dashboard-gif.gif)
-
 ## Quickstart
 
 Garden is an all-in-one DevOps automation platform that enables you to build, test, and deploy your applications and infrastructure in a single, unified workflow.
@@ -92,13 +90,13 @@ Next, start the **dev console** by running:
 garden dev
 ```
 
-Now you are ready to deploy, run:
+Finally, let's deploy the project in sync mode which enables live code reloading:
 
 ```sh
-deploy
+deploy --sync
 ```
 
-You should now be able to visit the example project at the link output by Garden.
+You can now visit the example project via the link output by Garden.
 
 The quickstart also comes with some tests of the unit and end-to-end variety. To run your unit test, just run `test unit`. To run your end-to-end test, run `test e2e`. Easy!
 
@@ -106,7 +104,7 @@ The project itself doubles as an interactive guide that walks you through some c
 
 {% hint style="info" %}
 You can run all the same commands with the CLI directly without starting the dev console. Simply run `garden login` or `garden
-deploy` from your terminal. This is e.g. how you'd use Garden in CI.
+deploy --sync` from your terminal. This is e.g. how you'd use Garden in CI.
 {% endhint %}
 
 ## Next Steps


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first pull request, please read our contributor guidelines in the https://github.com/garden-io/garden/blob/main/CONTRIBUTING.md file.
2. Please label this pull request according to what type of issue you are addressing (see "What type of PR is this?" below)
3. Ensure you have added or run the appropriate tests for your PR.
4. If the PR is unfinished, add `WIP:` at the beginning of the title or use the GitHub Draft PR feature.
5. Please add at least two reviewers to the PR. Currently active maintainers are: @edvald, @thsig, @eysi09, @shumailxyz, @stefreak, @TimBeyer, @mkhq, and @vvagaytsev.
-->

**What this PR does / why we need it**:

Removes the dashboard gif from the quickstart guide. 

The gif is a bit distracting and pushes the actual content of the guide below the initial view port which may discourage users from following along.

The gif is also not really relevant to the _quickstart_ guide, rather it's a tour of the dashboard.

We now have that tour on the Dashboard docs page at: https://docs.garden.io/using-garden/dashboard

The Quickstart example repo itself now also includes a gif that actually demonstrates the steps of the guide: https://github.com/garden-io/quickstart-example

So with the above in mind, I think we can remove this one.

Also, this commit adds the `--sync` flag to the deploy command in the guide which is the intended behaviour.
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
